### PR TITLE
Record the receiver a JavaScript member call was written on

### DIFF
--- a/crates/kin-core/src/ref_view.rs
+++ b/crates/kin-core/src/ref_view.rs
@@ -661,6 +661,26 @@ where
 
     parsed_relations.extend(projection_relations);
     for relation in parsed_relations {
+        // A placeholder edge names a destination this repository does not
+        // define, so nothing in the snapshot backs it and admission rejects the
+        // whole view with "unadmitted destination endpoint". Materialize the
+        // target the same way historical delta derivation does, from the
+        // importing entity's language, since a target defined elsewhere has
+        // none of its own.
+        if let Some(destination) = relation.dst.as_entity() {
+            if !snapshot.entities.contains_key(&destination) {
+                let language = relation
+                    .src
+                    .as_entity()
+                    .and_then(|id| snapshot.entities.get(&id))
+                    .map(|entity| entity.language);
+                if let Some(target) = language
+                    .and_then(|language| kin_index::placeholder_target_entity(&relation, language))
+                {
+                    snapshot.entities.insert(destination, target);
+                }
+            }
+        }
         snapshot.relations.insert(relation.id, relation);
     }
 

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -24,8 +24,9 @@ use sha2::{Digest, Sha256};
 use crate::classifier::{FileClassification, FileClassifier};
 use crate::error::{IndexError, Result};
 use crate::linker::{
-    is_external_import_placeholder, link_cross_file_borrowed_with_completeness,
-    ArtifactIdentityMap, FileParseCompletenessMap, FileParseData,
+    is_external_import_placeholder, is_unresolved_receiver_placeholder,
+    link_cross_file_borrowed_with_completeness, split_unresolved_receiver_token,
+    unresolved_receiver_display_name, ArtifactIdentityMap, FileParseCompletenessMap, FileParseData,
 };
 use crate::pipeline::IndexPipeline;
 
@@ -448,7 +449,59 @@ fn external_reference_targets(
             .push(source.language);
     }
 
+    // The second placeholder class: a member call whose receiver resolves to
+    // nothing this repository defines. It carries no import source, because
+    // there is no module to name, so its identity and its display name come
+    // from the member expression the evidence recorded as written.
+    let mut receivers: BTreeMap<EntityId, (String, Vec<LanguageId>)> = BTreeMap::new();
+    for relation in linked {
+        if !is_unresolved_receiver_placeholder(relation) {
+            continue;
+        }
+        let Some(destination) = relation.dst.as_entity() else {
+            continue;
+        };
+        if entities.contains_key(&destination) {
+            continue;
+        }
+        let (Some(source), Some(token)) = (
+            relation.src.as_entity().and_then(|id| entities.get(&id)),
+            relation
+                .evidence
+                .first()
+                .and_then(|evidence| evidence.token.as_deref()),
+        ) else {
+            continue;
+        };
+        let Some((receiver, symbol)) = split_unresolved_receiver_token(token) else {
+            continue;
+        };
+        receivers
+            .entry(destination)
+            .or_insert_with(|| {
+                (
+                    unresolved_receiver_display_name(receiver, symbol),
+                    Vec::new(),
+                )
+            })
+            .1
+            .push(source.language);
+    }
+
     let mut targets = BTreeMap::new();
+    for (destination, (display_name, languages)) in receivers {
+        let fingerprint = fingerprints
+            .entry(destination)
+            .or_insert_with(|| external_reference_fingerprint("", &display_name))
+            .clone();
+        let Some(language) = lowest_language(&languages) else {
+            continue;
+        };
+        targets.insert(
+            destination,
+            external_reference_entity(destination, &display_name, language, fingerprint),
+        );
+    }
     for (destination, (import_source, symbol, languages)) in importers {
         let fingerprint = fingerprints
             .entry(destination)

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -49,7 +49,7 @@ use crate::pipeline::IndexPipeline;
 /// authored to contain until it is admitted again, and reports nothing about
 /// which version authored it. Coupling the dial to graph authority so a
 /// version gap can be detected and refused is open follow-up work.
-pub const HYDRATION_SEMANTICS_VERSION: u32 = 8;
+pub const HYDRATION_SEMANTICS_VERSION: u32 = 9;
 
 /// Semantic graph delta derived for one pre-enrichment change identity.
 ///

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -548,6 +548,45 @@ pub fn is_external_reference_target(entity: &Entity) -> bool {
     entity.role == EntityRole::External && entity.file_origin.is_none()
 }
 
+/// The placeholder entity one placeholder relation's destination stands for,
+/// or `None` when the relation is not a placeholder.
+///
+/// Both placeholder classes are handled here so a caller cannot learn one and
+/// miss the other. That is not hypothetical: the historical ref view re-links
+/// source and inserts the result straight into a snapshot, and admission fails
+/// closed on an endpoint no entity backs, so a synthesis that knew only the
+/// cross-repo class turned a new class of edge into a hard error the moment one
+/// appeared.
+///
+/// The language comes from the caller because a target defined elsewhere has
+/// none of its own; the importing side is the only thing that observed it.
+pub fn placeholder_target_entity(relation: &Relation, language: LanguageId) -> Option<Entity> {
+    let destination = relation.dst.as_entity()?;
+    let token = relation.evidence.first()?.token.as_deref()?;
+    if is_external_import_placeholder(relation) {
+        let import_source = relation.import_source.as_deref()?;
+        let fingerprint = external_reference_fingerprint(import_source, token);
+        return Some(external_reference_entity(
+            destination,
+            token,
+            language,
+            fingerprint,
+        ));
+    }
+    if is_unresolved_receiver_placeholder(relation) {
+        let (receiver, symbol) = split_unresolved_receiver_token(token)?;
+        let name = unresolved_receiver_display_name(receiver, symbol);
+        let fingerprint = external_reference_fingerprint("", &name);
+        return Some(external_reference_entity(
+            destination,
+            &name,
+            language,
+            fingerprint,
+        ));
+    }
+    None
+}
+
 /// Build the external target a cross-repo reference resolves against.
 fn external_reference_entity(
     id: EntityId,

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -61,7 +61,11 @@ pub use linker::{
     CALL_SHAPE_PARSE_COVERAGE_FULL_V1, CALL_SHAPE_PARSE_COVERAGE_INCOMPLETE_V1,
     INCREMENTAL_LINKER_CHECKPOINT_VERSION, KIN_INDEX_CRATE_VERSION,
 };
-pub use linker::{is_external_import_placeholder, EXTERNAL_IMPORT_REFERENCE_RULE};
+pub use linker::{
+    is_external_import_placeholder, is_unresolved_receiver_placeholder,
+    split_unresolved_receiver_token, unresolved_receiver_display_name,
+    EXTERNAL_IMPORT_REFERENCE_RULE, UNRESOLVED_RECEIVER_CALL_RULE,
+};
 pub use overlay::{apply_file_removal, apply_to_graph, ApplyResult};
 pub use pipeline::{
     classify_file_role, normalize_file_path_id, IndexPipeline, IndexedAny, IndexedFile,

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -46,7 +46,8 @@ pub use fingerprint::{
     behavior_equivalence_hash, compute_entity_fingerprint, language_supports_equivalence,
 };
 pub use history::{
-    derive_historical_semantic_deltas, is_external_reference_target, HistoricalSemanticDelta,
+    derive_historical_semantic_deltas, is_external_reference_target, placeholder_target_entity,
+    HistoricalSemanticDelta,
 };
 pub use linker::{
     bare_entity_name, build_projection_derived_relations_for_file,

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -1293,6 +1293,24 @@ fn resolve_one_file(
             continue;
         }
 
+        // (e) Unresolvable receiver. A member call whose receiver names neither
+        // a module this repository owns nor an object whose type any tier
+        // settled has no destination to bind, but it is still a call the source
+        // makes and the reader needs. Recording it as the weakest edge the
+        // linker emits keeps it visible without claiming a resolution; dropping
+        // it made an unresolvable call and an absent one look the same.
+        let repository_defines_symbol = repository_defines_symbol_elsewhere(
+            ctx.entity_by_name.get(dst_lookup),
+            ctx.entity_by_bare_name.get(dst_lookup),
+            src_id,
+        );
+        if let Some(unresolved) =
+            make_unresolved_receiver_relation(rel, src_id, repository_defines_symbol)
+        {
+            accumulate_relation(&mut resolved, &mut relation_indices, unresolved);
+            continue;
+        }
+
         debug!(
             src = %rel.src_name,
             dst = %rel.dst_name,
@@ -3554,6 +3572,26 @@ const EXTERNAL_REFERENCE_KIND_TAG: &str = "ExternalReference";
 /// Calls/References relation also has a non-empty import source and this rule.
 pub const EXTERNAL_IMPORT_REFERENCE_RULE: &str = "external_import_reference";
 
+/// Confidence the unresolved-receiver placeholder tier persists.
+///
+/// Below every tier that settles anything, so `RelationResolution::of` reads it
+/// as `name_only` and nothing that counts by resolution can mistake it for an
+/// edge the linker resolved. It is deliberately the weakest thing the linker
+/// emits: the edge asserts that a call happened and that this repository cannot
+/// say what it reached, which is strictly more than the silence it replaces.
+const UNRESOLVED_RECEIVER_CONFIDENCE: f32 = 0.1;
+
+/// Synthetic tag used to derive a deterministic id for the destination of a
+/// member call whose receiver this repository cannot resolve. Never a real
+/// `EntityKind`, so the id cannot collide with a locally indexed entity, and
+/// distinct from the cross-repo tag so the two placeholder classes never share
+/// a node.
+const UNRESOLVED_RECEIVER_KIND_TAG: &str = "UnresolvedReceiver";
+
+/// Linker evidence rule identifying a member call whose receiver resolves to
+/// nothing this repository defines.
+pub const UNRESOLVED_RECEIVER_CALL_RULE: &str = "unresolved_receiver_call";
+
 /// Returns whether a relation exactly matches the linker's external-import
 /// placeholder contract. This does not inspect graph membership; callers must
 /// separately establish that the destination is absent from the local entity
@@ -3623,6 +3661,160 @@ pub fn is_external_import_placeholder(relation: &Relation) -> bool {
 /// import, not a cross-repo reference: a symbol that fails local resolution
 /// there (e.g. a moved or deleted local definition) must not be mis-attributed
 /// as an external edge. Only module sources that do not resolve locally qualify.
+/// Whether this repository defines the called member on something other than
+/// the caller itself.
+///
+/// The caller is excluded deliberately. `app.handle` in express calls
+/// `this.router.handle`, and the two share a leaf name, so counting the caller
+/// would have the function's own definition stand as proof that the repository
+/// answers to `handle` and suppress the placeholder for the one call it exists
+/// to record. A member whose only local namesake is the caller has still found
+/// no destination here; recursion through an unresolvable receiver is not a
+/// self-call.
+///
+/// Generic over the key type because the batch index borrows its file paths and
+/// the incremental one owns them; the answer depends on neither.
+fn repository_defines_symbol_elsewhere<P>(
+    exact: Option<&Vec<(P, EntityId)>>,
+    bare: Option<&Vec<(P, EntityId)>>,
+    caller: EntityId,
+) -> bool {
+    [exact, bare]
+        .into_iter()
+        .flatten()
+        .any(|candidates| candidates.iter().any(|(_, candidate)| *candidate != caller))
+}
+
+/// Split the member expression an unresolved-receiver placeholder records back
+/// into the receiver it was written on and the member it named.
+///
+/// The evidence carries the expression as written, `this.router.handle`, which
+/// is one lexical token at the evidence site and needs no field used against
+/// its documented meaning to hold it. The receiver is everything before the
+/// final separator and the member is what follows.
+pub fn split_unresolved_receiver_token(token: &str) -> Option<(&str, &str)> {
+    let (receiver, symbol) = token.rsplit_once('.')?;
+    if receiver.is_empty() || symbol.is_empty() {
+        return None;
+    }
+    Some((receiver, symbol))
+}
+
+/// How an unresolved-receiver target is named where a reader will see it.
+///
+/// The full expression is `this.router.handle`, but `this` is the calling
+/// object and says nothing about the destination, so the name keeps the last
+/// receiver segment and the member: `router.handle`. That is what a reader
+/// recognizes in a walk, and it is derived rather than stored so one rule
+/// governs every display of it.
+pub fn unresolved_receiver_display_name(receiver: &str, symbol: &str) -> String {
+    let leaf = receiver.rsplit('.').next().unwrap_or(receiver);
+    let leaf = if leaf.is_empty() { receiver } else { leaf };
+    format!("{leaf}.{symbol}")
+}
+
+/// Whether a relation exactly matches the unresolved-receiver placeholder
+/// contract. Like the cross-repo predicate beside it, this does not inspect
+/// graph membership; a caller establishes separately that the destination is
+/// absent from the local entity set.
+pub fn is_unresolved_receiver_placeholder(relation: &Relation) -> bool {
+    if relation.kind != RelationKind::Calls
+        || relation.origin != RelationOrigin::Inferred
+        || relation.confidence.to_bits() != UNRESOLVED_RECEIVER_CONFIDENCE.to_bits()
+        || relation.import_source.is_some()
+    {
+        return false;
+    }
+    let Some(src) = relation.src.as_entity() else {
+        return false;
+    };
+    let Some(dst) = relation.dst.as_entity() else {
+        return false;
+    };
+    let [evidence] = relation.evidence.as_slice() else {
+        return false;
+    };
+    if evidence.parser_rule.as_deref() != Some(UNRESOLVED_RECEIVER_CALL_RULE)
+        || evidence.source_path.is_some()
+        || evidence.resolved_path.is_some()
+        || evidence.source_span.is_some()
+        || evidence.call_shape.is_some()
+        || evidence.occurrence_count == 0
+    {
+        return false;
+    }
+    let Some(token) = evidence.token.as_deref() else {
+        return false;
+    };
+    if token != token.trim() {
+        return false;
+    }
+    let Some((receiver, symbol)) = split_unresolved_receiver_token(token) else {
+        return false;
+    };
+    let expected_dst = EntityId::from_content(receiver, symbol, UNRESOLVED_RECEIVER_KIND_TAG, 0);
+    dst == expected_dst && relation.id == stable_relation_id(&src, &expected_dst, &relation.kind)
+}
+
+/// Record a member call whose receiver resolves to nothing this repository
+/// defines, instead of dropping it.
+///
+/// `app.handle` in express ends in `this.router.handle(req, res, done)`, the
+/// line the function exists for. `this.router` is a property bound to a package
+/// outside the tree, so no tier above can name a destination, and the call used
+/// to disappear: a reader got every minor callee and missed the hand-off, with
+/// nothing disclosing the omission. An absent call and an unresolvable one were
+/// indistinguishable, which is the failure this repairs.
+///
+/// The placeholder states only what was observed. A call happened, it was
+/// written on this receiver, it named this member, and the destination is not
+/// here. It carries the weakest confidence the linker emits, so it reads as
+/// `name_only` and is excluded from every count that keys on resolution, which
+/// is what keeps presence from becoming fabrication.
+///
+/// `repository_defines_symbol` is what keeps the claim true. When this
+/// repository defines something by that name, the tiers above declined to pick
+/// among the candidates on purpose, and saying the destination is elsewhere
+/// would be a second guess dressed as a fact: `req.copy()` against three local
+/// `copy` methods stays unbound, exactly as before. Only a member this tree
+/// defines nowhere can honestly be called external, which is the express case,
+/// where no `handle` exists outside the `app.handle` that makes the call.
+fn make_unresolved_receiver_relation(
+    rel: &ExtractedRelation,
+    src: EntityId,
+    repository_defines_symbol: bool,
+) -> Option<Relation> {
+    if rel.kind != RelationKind::Calls || repository_defines_symbol {
+        return None;
+    }
+    let receiver = rel
+        .receiver
+        .as_deref()
+        .map(str::trim)
+        .filter(|receiver| !receiver.is_empty() && !receiver.contains(char::is_whitespace))?;
+    let symbol = rel.dst_name.trim();
+    if symbol.is_empty() || symbol.contains('.') {
+        return None;
+    }
+    let dst = EntityId::from_content(receiver, symbol, UNRESOLVED_RECEIVER_KIND_TAG, 0);
+    let id = stable_relation_id(&src, &dst, &rel.kind);
+    Some(Relation {
+        id,
+        kind: rel.kind,
+        src: GraphNodeId::Entity(src),
+        dst: GraphNodeId::Entity(dst),
+        confidence: UNRESOLVED_RECEIVER_CONFIDENCE,
+        origin: RelationOrigin::Inferred,
+        created_in: None,
+        import_source: None,
+        evidence: vec![RelationEvidence {
+            token: Some(format!("{receiver}.{symbol}")),
+            parser_rule: Some(UNRESOLVED_RECEIVER_CALL_RULE.to_string()),
+            ..RelationEvidence::default()
+        }],
+    })
+}
+
 fn make_external_reference_relation<S>(
     rel: &ExtractedRelation,
     src: EntityId,
@@ -5673,6 +5865,21 @@ fn resolve_one_file_incremental(
             make_external_reference_relation(rel, src_id, &file.file_path, &linker.known_files)
         {
             accumulate_relation(&mut resolved, &mut relation_indices, external);
+            continue;
+        }
+
+        // (e) Unresolvable receiver, mirroring the batch resolver. The two
+        // chains must end the same way or an incremental reparse would silently
+        // retract every placeholder the batch pass recorded.
+        let repository_defines_symbol = repository_defines_symbol_elsewhere(
+            linker.entity_by_name.get(dst_lookup),
+            linker.entity_by_bare_name.get(dst_lookup),
+            src_id,
+        );
+        if let Some(unresolved) =
+            make_unresolved_receiver_relation(rel, src_id, repository_defines_symbol)
+        {
+            accumulate_relation(&mut resolved, &mut relation_indices, unresolved);
             continue;
         }
     }
@@ -10763,6 +10970,102 @@ void f();
                 is_default: false,
             }],
         }
+    }
+
+    // ── An unresolvable member call is recorded, not dropped ──────────────
+    //
+    // `app.handle` in express ends in `this.router.handle(...)`, the line the
+    // function exists for, and the receiver is bound to a package outside the
+    // tree. Every tier declines, and the call used to vanish with nothing
+    // disclosing it, so a reader got every minor callee and missed the hand-off.
+
+    #[test]
+    fn a_member_call_this_repository_cannot_resolve_is_recorded_as_unproven() {
+        let caller = py_method("app.handle", "lib/application.js", EntityRole::Source);
+        let files = vec![FileParseData {
+            file_path: "lib/application.js".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![py_receiver_call("app.handle", "this.router", "handle")],
+            imports: vec![],
+        }];
+
+        let result = link_cross_file(&files);
+        let edges = calls_edges_from(&result, &caller);
+
+        assert_eq!(edges.len(), 1, "the call must be recorded: {result:#?}");
+        let edge = edges[0];
+        assert!(
+            is_unresolved_receiver_placeholder(edge),
+            "and recorded as the unresolved-receiver placeholder: {edge:#?}"
+        );
+        assert_eq!(
+            crate::resolution::RelationResolution::of(edge),
+            crate::resolution::RelationResolution::NameOnly,
+            "an unresolvable call must never read as something the linker settled"
+        );
+        assert_ne!(
+            edge.dst,
+            GraphNodeId::Entity(caller.id),
+            "the placeholder destination is not a local entity"
+        );
+        assert_eq!(
+            edge.evidence[0].token.as_deref(),
+            Some("this.router.handle"),
+            "the evidence carries the member expression as written"
+        );
+    }
+
+    /// The claim has to be true, so it is only made when nothing here answers
+    /// to the name. This is the same shape as the case above and must produce
+    /// nothing, because the repository does define a `handle`.
+    #[test]
+    fn a_member_call_whose_name_this_repository_defines_is_left_alone() {
+        let caller = py_method("app.handle", "lib/application.js", EntityRole::Source);
+        let local = py_method("Router.handle", "lib/router.js", EntityRole::Source);
+        let files = vec![
+            FileParseData {
+                file_path: "lib/router.js".to_string(),
+                entities: vec![local],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "lib/application.js".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![py_receiver_call("app.handle", "this.router", "handle")],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+
+        assert!(
+            !calls_edges_from(&result, &caller)
+                .iter()
+                .any(|edge| is_unresolved_receiver_placeholder(edge)),
+            "calling a member this repository defines is not evidence it is elsewhere: {result:#?}"
+        );
+    }
+
+    /// The negative control the fix is worth nothing without: a function that
+    /// makes no such call gains no step. Presence has to come from the source,
+    /// not from the tier existing.
+    #[test]
+    fn a_function_that_makes_no_unresolvable_call_gains_no_placeholder() {
+        let caller = py_method("app.listen", "lib/application.js", EntityRole::Source);
+        let files = vec![FileParseData {
+            file_path: "lib/application.js".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![],
+            imports: vec![],
+        }];
+
+        let result = link_cross_file(&files);
+
+        assert!(
+            calls_edges_from(&result, &caller).is_empty(),
+            "no call was written, so no step may appear: {result:#?}"
+        );
     }
 
     fn calls_edges_from<'a>(result: &'a [Relation], src: &Entity) -> Vec<&'a Relation> {

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -1363,6 +1363,46 @@ fn js_receiver_is_enclosing_owner(
     }
 }
 
+/// The receiver expression a member call is written on, as written.
+///
+/// Only a receiver spelled as one unbroken token is recorded. The field's
+/// consumers read it as a name: the linker splits it at the first `.` and asks
+/// the calling file's imports whether that root is a module or a value, and the
+/// placeholder tier rejects anything holding whitespace. A receiver that is
+/// itself a call, a subscript, a parenthesized expression or a chain broken
+/// across lines answers neither question, and recording its raw text would put
+/// source formatting into an identifier position. Declining leaves such a call
+/// exactly where it was before receivers existed.
+///
+/// `this` is kept rather than dropped. It is not the destination, but it is the
+/// root of the property chain the destination hangs off, and `this.router` is
+/// the receiver the express hand-off is actually written on.
+fn js_call_receiver_text(function: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    let object = function.child_by_field_name("object")?;
+    let text = object.utf8_text(source).ok()?.trim();
+    if text.is_empty() || text.chars().any(char::is_whitespace) {
+        return None;
+    }
+    let usable = text
+        .split('.')
+        .all(|segment| segment == "this" || is_path_identifier_segment(segment));
+    usable.then(|| text.to_string())
+}
+
+/// Whether one dot-separated receiver segment reads as a plain name.
+///
+/// Deliberately the same shape the linker applies to a receiver root, so a
+/// receiver this adapter records is one the linker can classify rather than one
+/// it must immediately discard.
+fn is_path_identifier_segment(segment: &str) -> bool {
+    let mut chars = segment.chars();
+    match chars.next() {
+        Some(c) if c == '_' || c == '$' || c.is_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c == '$' || c.is_alphanumeric())
+}
+
 /// Extract all function/method calls within a function/method body.
 ///
 /// For a `call_expression`, the `function` field is the callee. A
@@ -1379,6 +1419,14 @@ fn js_receiver_is_enclosing_owner(
 /// name matches no entity the linker falls back to the bare leaf, so recall
 /// never drops below the unqualified behavior.
 ///
+/// Every other member call carries its receiver expression as written, which is
+/// what separates a call through an imported module from a call through a value
+/// whose type nothing here settles. Without it the bare leaf is all the linker
+/// has, and matching that leaf against every same-named symbol in the repository
+/// is how `res.send()` acquired a caller it never had. An owner-folded call
+/// records no receiver, because the owner is already in the name; that is the
+/// same split Python's adapter makes for `self`/`cls`.
+///
 /// `new X()` is a `new_expression` (not `call_expression`) and is intentionally
 /// skipped here.
 pub(super) fn extract_calls_from_context(
@@ -1392,7 +1440,7 @@ pub(super) fn extract_calls_from_context(
     for child in node.children(&mut cursor) {
         if child.kind() == "call_expression" {
             if let Some(function) = child.child_by_field_name("function") {
-                let callee_name = match function.kind() {
+                let (callee_name, receiver) = match function.kind() {
                     "member_expression" => {
                         let property = function
                             .child_by_field_name("property")
@@ -1403,13 +1451,13 @@ pub(super) fn extract_calls_from_context(
                                 if !property.is_empty()
                                     && js_receiver_is_enclosing_owner(&function, source, owner) =>
                             {
-                                format!("{owner}.{property}")
+                                (format!("{owner}.{property}"), None)
                             }
-                            _ => property,
+                            _ => (property, js_call_receiver_text(&function, source)),
                         }
                     }
-                    "identifier" => function.utf8_text(source).unwrap_or("").to_string(),
-                    _ => String::new(),
+                    "identifier" => (function.utf8_text(source).unwrap_or("").to_string(), None),
+                    _ => (String::new(), None),
                 };
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
@@ -1417,7 +1465,7 @@ pub(super) fn extract_calls_from_context(
                         // the line the call is written on rather than the line the
                         // caller's definition starts on.
                         site: Some(site_from_node(&child)),
-                        receiver: None,
+                        receiver,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),

--- a/crates/kin-parser/tests/js_ts_call_resolution.rs
+++ b/crates/kin-parser/tests/js_ts_call_resolution.rs
@@ -238,3 +238,135 @@ fn ts_dotted_dst_names_only_ever_name_the_enclosing_owner() {
         );
     }
 }
+
+// ---- Receivers ----
+//
+// A member call also records the expression it was written on. Without it the
+// linker has only the bare leaf, and matching that leaf against every
+// same-named symbol in the repository is what bound `JSON.stringify` to
+// express's own `stringify` and `http.createServer` to a test's own
+// `createServer`. The receiver is what separates a call through an imported
+// module from a call through a value nothing here types.
+
+fn receiver_for<'a>(output: &'a ParseOutput, dst: &str) -> Option<&'a str> {
+    calls(output)
+        .into_iter()
+        .find(|r| r.dst_name == dst)
+        .unwrap_or_else(|| panic!("no Calls edge to `{dst}` in {:?}", dst_names(output)))
+        .receiver
+        .as_deref()
+}
+
+fn receivers_for<'a>(output: &'a ParseOutput, dst: &str) -> Vec<Option<&'a str>> {
+    calls(output)
+        .into_iter()
+        .filter(|r| r.dst_name == dst)
+        .map(|r| r.receiver.as_deref())
+        .collect()
+}
+
+#[test]
+fn js_member_call_records_the_receiver_it_was_written_on() {
+    let output = parse_fixture(&JavaScriptAdapter, "javascript", "calls.js");
+    assert_eq!(
+        receiver_for(&output, "log"),
+        Some("console"),
+        "`console.log(...)` must record `console` as its receiver"
+    );
+    assert_eq!(
+        receiver_for(&output, "handle"),
+        Some("this.router"),
+        "`this.router.handle(...)` must record the whole property chain, \
+         which is the only thing that says the destination is not here"
+    );
+    assert_eq!(
+        receiver_for(&output, "b"),
+        Some("a"),
+        "`a.b()` must record `a` as its receiver"
+    );
+    assert_eq!(
+        receiver_for(&output, "maybe"),
+        Some("obj"),
+        "an optional chain is still a member call and still has a receiver"
+    );
+}
+
+#[test]
+fn js_owner_folded_and_bare_calls_record_no_receiver() {
+    // The owner is already in the callee name, so repeating it as a receiver
+    // would make the linker skip the same-file tier that name exists to reach.
+    // This is the same split the Python adapter makes for `self`/`cls`.
+    let output = parse_fixture(&JavaScriptAdapter, "javascript", "calls.js");
+    assert_eq!(
+        receiver_for(&output, "Greeter.sayHi"),
+        None,
+        "`this.sayHi()` is recorded owner-qualified, so it carries no receiver"
+    );
+    assert_eq!(
+        receiver_for(&output, "Application.own"),
+        None,
+        "`this.own()` is recorded owner-qualified, so it carries no receiver"
+    );
+    assert_eq!(
+        receiver_for(&output, "helperCall"),
+        None,
+        "a bare call has no receiver to record"
+    );
+    assert_eq!(
+        receiver_for(&output, "bare"),
+        None,
+        "a bare call has no receiver to record"
+    );
+}
+
+#[test]
+fn js_receiver_that_is_not_a_name_chain_is_declined() {
+    // The field's consumers read it as a name: the linker splits it at the
+    // first `.` and asks the file's imports about that root. A call, a
+    // subscript or a parenthesized expression answers nothing, and recording
+    // its raw text would put source formatting into an identifier position.
+    let output = parse_fixture(&JavaScriptAdapter, "javascript", "calls.js");
+    assert_eq!(
+        receiver_for(&output, "c"),
+        None,
+        "`a.b().c()` is written on a call, which names no binding"
+    );
+    let run_receivers = receivers_for(&output, "run");
+    assert_eq!(
+        run_receivers.len(),
+        2,
+        "the fixture writes `run` on a subscript and on a call, got {run_receivers:?}"
+    );
+    assert!(
+        run_receivers.iter().all(Option::is_none),
+        "neither `deps[0]` nor `make()` names a binding, got {run_receivers:?}"
+    );
+}
+
+#[test]
+fn ts_member_calls_record_receivers_through_the_same_constructor() {
+    // TypeScript has no call extractor of its own: `typescript.rs` imports
+    // `extract_calls_from_context` from the JavaScript adapter. This pins that,
+    // so a change made for JavaScript cannot silently leave TypeScript behind.
+    let output = parse_fixture(&TypeScriptAdapter, "typescript", "calls.ts");
+    assert_eq!(
+        receiver_for(&output, "log"),
+        Some("console"),
+        "`console.log(...)` must record `console` as its receiver"
+    );
+    assert_eq!(
+        receiver_for(&output, "handle"),
+        Some("this.router"),
+        "`this.router.handle(...)` must record the whole property chain"
+    );
+    assert_eq!(
+        receiver_for(&output, "Application.own"),
+        None,
+        "an owner-folded call carries no receiver in TypeScript either"
+    );
+    assert_eq!(
+        receiver_for(&output, "c"),
+        None,
+        "`a.b().c()` is written on a call, which names no binding"
+    );
+}

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,6 +1,6 @@
 {
   "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what a repository's past is said to contain the next time that repository is admitted. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together. Bumping the version records the decision; it does not migrate, invalidate, or re-enrich a repository that was already admitted, because nothing persists the version beside a graph or compares it when one is opened.",
-  "hydration_semantics_version": 8,
+  "hydration_semantics_version": 9,
   "guarded": [
     {
       "file": "crates/kin-index/src/history.rs",
@@ -19,7 +19,7 @@
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "external_reference_targets",
-      "digest": "sha256:9542f2e28f43ed31d8f66c229992457570c3fc18f07fe2ed5f3d729d8ccf574a",
+      "digest": "sha256:71a383d53839a3ca68a109671b91508d2c2a7ff640a34a44f6f643880bd068c1",
       "reason": "Decides which cross-repo destinations a tree binds an external target for, and derives every field of that target from the importers it collects. Its output is persisted entity state, so a change here restates what a repository's past says about the symbols it reaches through another repository.",
       "owner": "kin-index"
     },

--- a/tests/adapter-fixtures/javascript/calls.js
+++ b/tests/adapter-fixtures/javascript/calls.js
@@ -27,3 +27,17 @@ class Greeter {
         helperCall();
     }
 }
+
+// A property-chain receiver: the express hand-off shape. `this.router` is a
+// property whose value comes from outside this tree, so the callee stays the
+// bare leaf and the receiver is what says where it was read.
+class Application {
+    handle(req, res) {
+        this.router.handle(req, res);
+        this.own();
+        deps[0].run();
+        make().run();
+    }
+
+    own() {}
+}

--- a/tests/adapter-fixtures/typescript/calls.ts
+++ b/tests/adapter-fixtures/typescript/calls.ts
@@ -27,3 +27,17 @@ class Greeter {
         helperCall();
     }
 }
+
+// A property-chain receiver: the express hand-off shape. `this.router` is a
+// property whose value comes from outside this tree, so the callee stays the
+// bare leaf and the receiver is what says where it was read.
+class Application {
+    handle(req: Request, res: Response): void {
+        this.router.handle(req, res);
+        this.own();
+        deps[0].run();
+        make().run();
+    }
+
+    own(): void {}
+}


### PR DESCRIPTION
## The mechanism

`crates/kin-parser/src/languages/javascript.rs` constructed every extracted call with
`receiver: None`, unconditionally. Python and Rust populate that field; JavaScript never
has. Two things follow from it.

The linker loses the only signal that separates a call through an imported module from a
call through a value nothing here types, so a member call arrives as a bare leaf and the
name-matching tiers claim it. That is how `JSON.stringify(code)` at
`lib/response.js:68` acquired a `Calls` edge to express's own `stringify` at line 1026,
how `console.error(err.stack)` acquired one to a local `error` handler, how
`http.createServer(...)` acquired one to a test file's own `createServer`, and how
`arr.forEach(...)` acquired one to axios's exported `forEach`.

And FIR-2486's unresolved-receiver tier, which this branch's first three commits build,
cannot fire for JavaScript at all. A call with no receiver gives the tier nothing to
record, so `this.router.handle(req, res, done)` at `lib/application.js:177` was dropped
rather than carried as an unproven step, and `trace_data_flow` on `app.handle` returned
a walk that simply did not contain the line the function exists for.

## The fix

`extract_calls_from_context` now returns the callee name together with a receiver.

An owner-folded call keeps no receiver. `this.m()` inside a method and `Owner.m()`
naming the enclosing owner are already recorded as `Owner.m`, so the owner is in the
name, and repeating it as a receiver would make the linker skip the same-file tier that
name exists to reach. This is the split Python's adapter makes for `self` and `cls`.

Every other member call carries the object's source text, but only when that text is one
unbroken dot-separated name chain. The field's consumers read it as a name: the linker
splits it at the first `.` and asks the calling file's imports about the root, and the
placeholder tier rejects anything holding whitespace. A receiver that is itself a call,
a subscript, a parenthesized expression or a chain broken across lines answers neither
question, so it is declined rather than stored as raw source text. `this` is kept rather
than dropped, because it is the root of the property chain the destination hangs off and
`this.router` is the receiver the express hand-off is actually written on.

TypeScript needs no separate change and gains the same behavior: `typescript.rs` imports
this function from the JavaScript adapter and calls it at every site that extracts a
call body. The `receiver: None` sites remaining in `typescript.rs` are `Contains`,
`Extends` and `Implements` relations, which have no receiver. One of the new tests pins
the shared path so the two languages cannot drift apart silently.

## Measurement, two corpora asked for and a third for breadth

`receiver_is_object` gates several linker tiers, so populating the field changes which
tier resolves every JavaScript member call. Both arms ran at binaries identical but for
this one file, each sha256-checked. Corpora are pinned by commit:

- `expressjs/express` `a3714473feb3d2908add734d340e7755fd85e0a3` (tree `134de344`), the
  brownfield bar's own pin
- `expressjs/body-parser` `b1f3d588c5dca4b3a4ca7d5d3765c9129118926a` (tree `b77e37b2`)
- `axios/axios` `84a9f3b9a4f3244b8c8e818f557d64c7b964fb25` (tree `53995167`), added
  because body-parser is 13 JavaScript files and axios is 192 plus 25 TypeScript

Call edges by resolution:

| corpus | type_resolved | import_scoped | name_only | total |
|---|---|---|---|---|
| express | 78 to 70 | 0 to 4 | 188 to 190 | 266 to 264 |
| body-parser | 24 to 20 | 0 to 0 | 26 to 45 | 50 to 65 |
| axios | 230 to 227 | 0 to 110 | 387 to 682 | 617 to 1019 |

Call edges by tier, read off the confidence each tier stamps:

| tier | express | body-parser | axios |
|---|---|---|---|
| 1.00 same-file | 72 to 64 | 16 to 12 | 188 to 185 |
| 0.95 import-based cross-file | 6 to 6 | 8 to 8 | 41 to 41 |
| 0.90 receiver-module | 0 to 4 | 0 to 0 | 0 to 110 |
| 0.85 inherited method | 0 to 0 | 0 to 0 | 1 to 1 |
| 0.70 cross-file name match | 35 to 1 | 16 to 0 | 187 to 49 |
| 0.30 bare-name fan-out | 107 to 25 | 0 to 0 | 169 to 49 |
| 0.20 external import reference | 46 to 46 | 10 to 10 | 31 to 31 |
| 0.10 unresolved-receiver placeholder | 0 to 118 | 0 to 35 | 0 to 553 |

Tier migration, counting each `(caller, destination)` call edge once:

| corpus | edge gone entirely | edge new entirely | resolution changed |
|---|---|---|---|
| express | 123 | 121 | 2 |
| body-parser | 20 | 35 | 0 |
| axios | 141 | 555 | 110 |

All 112 migrations are upgrades from `name_only` to `import_scoped`. Nothing migrated
downward.

## Finding: receiver shadowing, a fabrication class that was never filed

Every proven edge this change removes belongs to one unnamed defect, and naming it is
worth more than the fifteen instances. When a call is written on a builtin, a Node core
module or any foreign object, and this repository happens to define a function with the
same leaf name, the bare-leaf tiers bound the call to the local definition. The result
is a false map with no disclosure on it: `res.status` reads as a caller of express's
`stringify`, and `stringify` reads as calling itself, when the source says
`JSON.stringify`. Nothing in the answer said the receiver was never consulted, because
nothing recorded the receiver at all.

Recursion is the sharpest shape of it. Nine of the fifteen are self-edges, where a
function's own definition captured a call it makes on something else entirely, so a
reader tracing the function saw a recursive call the source does not contain.

All fifteen, with the receiver that was ignored and the line it was written on:

| corpus | caller | bound to | actual call site | receiver ignored |
|---|---|---|---|---|
| express | `res.status@lib/response.js` | `stringify@lib/response.js` | `JSON.stringify(code)` at `lib/response.js:68` and `:72` | `JSON` |
| express | `res.cookie@lib/response.js` | `stringify@lib/response.js` | `JSON.stringify(value)` at `lib/response.js:755` | `JSON` |
| express | `stringify@lib/response.js` | itself, at `:1026` | `JSON.stringify(...)` at `lib/response.js:1030` and `:1031` | `JSON` |
| express | `error@examples/error/index.js` | itself, at `:20` | `console.error(err.stack)` at `:22` | `console` |
| express | `format@examples/content-negotiation/index.js` | itself, at `:33` | `res.format(obj)` at `:36` | `res` |
| express | `json@examples/content-negotiation/users.js` | itself, at `:17` | `res.json(users)` at `:18` | `res` |
| express | `count@examples/view-locals/index.js` | itself, at `:48` | `User.count(...)` at `:49` | `User` |
| express | `count2@examples/view-locals/index.js` | `count@...index.js:48` | `User.count(...)` at `:87` | `User` |
| body-parser | `createServer@test/json.js` | itself, at `:766` | `http.createServer(...)` at `:771` | `http` |
| body-parser | `createServer@test/raw.js` | itself, at `:503` | `http.createServer(...)` at `:508` | `http` |
| body-parser | `createServer@test/text.js` | itself, at `:573` | `http.createServer(...)` at `:578` | `http` |
| body-parser | `createServer@test/urlencoded.js` | itself, at `:972` | `http.createServer(...)` at `:977` | `http` |
| axios | `isBuffer@lib/utils.js` | itself, at `:221` | `val.constructor.isBuffer(val)` at `:228` | `val.constructor` |
| axios | `trim@lib/utils.js` | itself, at `:472` | `str.trim()` at `lib/utils.js:473` | `str` |
| axios | `toObjectSet@lib/utils.js` | `forEach@lib/utils.js` | `arr.forEach(...)` at `:916` | `arr` |

Every line above was read in the pinned tree rather than inferred. The four
body-parser helpers sit at different offsets in their files, which is why they are
listed separately rather than collapsed to one line number.

Python already had the defence: `is_unbound_python_builtin_call` refuses to let a bare
call to a name in the builtins table be answered by matching that name elsewhere in the
repository. JavaScript had no equivalent and no receiver to build one from. Recording
the receiver removes the whole class rather than the fifteen cases, because the
receiver-scoped tier now answers before any bare-leaf tier is reached: a receiver bound
to a module outside the tree yields no local edge at all, and a receiver whose type
nothing here settles skips the tiers that match on leaf name alone.

The four new express edges at 0.90 are correct and new: `count`, `count2`, `users` and
`users2` now bind `User.count` and `User.all` in `examples/view-locals/user.js` through
the `require('./user')` the file writes. The 110 axios ones are the same shape at scale,
binding `lib/utils.js` exports through `import utils from "../utils.js"`.

## What unproven recall costs

express loses 123 call edges and gains 121. Of the 123: 51 have a destination in a
different example or test file than the caller, and those files import nothing from each
other, so each is a bare-name fabrication; 8 are the same-file ones above; 64 land in
`lib/`. Of those 64, 45 have a caller in `test/` or `examples/` calling `res.send`,
`app.use`, `res.status` and friends, which are semantically right and now unbound, and
that is the honest cost. The remaining 22 run `lib/` to `lib/` and split four correct
from eighteen fabricated; the eighteen include seven `req.*` getters bound to `res.get`
for `this.app.get('trust proxy fn')` and `logerror` bound to both `req.get` and
`res.get` for `this.get('env')`, which is exactly the fabrication family FIR-2464 named.

The four correct losses are `createApplication` calling `app.handle` and `app.init`,
`res.format` calling `req.accepts`, and `res.sendFile` calling `this.app.enabled`. All
four have a receiver that is a local variable or property holding an in-repo export,
which needs a type answer this repository does not carry. That is FIR-2487's route.

Kin does not count `name_only` as evidence a destination is used, so nothing that counts
moved for the worse, and the proven set got strictly more correct.

## Fabrication controls

706 unresolved-receiver placeholders appear across the three corpora. Every one reads
`name_only` at confidence 0.10, and none has a destination id colliding with a real
entity in its corpus, checked directly rather than assumed.

## Falsification

Four tests were added to `crates/kin-parser/tests/js_ts_call_resolution.rs`, with the
shared fixtures extended by an `Application` class carrying the express hand-off shape, a
subscript receiver and a call receiver. Each was falsified by breaking the behavior it
guards, reading full output and exit codes rather than a pipe:

1. Reverting the change: `js_member_call_records_the_receiver_it_was_written_on` and
   `ts_member_calls_record_receivers_through_the_same_constructor` fail with
   ``` `console.log(...)` must record `console` as its receiver ```, left `None`.
2. Giving the owner-folded branch a receiver:
   `js_owner_folded_and_bare_calls_record_no_receiver` and the TypeScript test fail with
   ``` `this.sayHi()` is recorded owner-qualified, so it carries no receiver ```, left
   `Some("this")`.
3. Dropping the name-chain filter: `js_receiver_that_is_not_a_name_chain_is_declined` and
   the TypeScript test fail with ``` `a.b().c()` is written on a call, which names no
   binding ```, left `Some("a.b()")`.

Falsification 1 alone leaves the two negative tests green, because with no receivers
anywhere "no receiver" is trivially true. That is why 2 and 3 exist: a negative assertion
has to be falsified against a wrong version of the change, not against its absence.

The four pre-existing tests asserting an unresolvable receiver binds nothing were not
touched and still pass.

## Replay semantics

`HYDRATION_SEMANTICS_VERSION` moves with this change. The branch's third commit carries
8 to 9 with the manifest digest, and the parser change lands in the same squash, so one
bump records one semantic epoch rather than two. The guarded surface is `history.rs` and
`semantic_import.rs` functions pinned by digest, none of which this change touches, so
`verify-hydration-semantics.py` passes unchanged.

## Acceptance, measured end to end and falsified

`bin/kin-brownfield-repro` was run twice against the same pinned fixtures, on binaries
that differ only in `crates/kin-parser/src/languages/javascript.rs`. Nothing else about
the two runs differs, and only one check moves.

With the parser file at its pre-change state, check 4 fails:

> CHECK 4 FIR-2464 FAIL the hand-off this.router.handle at lib/application.js:177, the
> last line of app.handle and the edge the question is about, is absent from the walk;
> steps are ['app.enabled', 'req.get', 'res.get', 'create', 'users.get', 'logerror',
> 'app', 'finalhandler', 'app.set', 'req', 'res', 'message']

With the change, check 4 passes on all three of its assertions:

> CHECK 4 FIR-2464 PASS the hand-off router.handle is in the walk
> - no fabricated callee is counted (8 of 18 steps counted)
> - both real callees app.enabled, finalhandler are present
> - the hand-off router.handle is in the walk

The bar's `counted_step` excludes any step whose resolution reads `name_only`, so the
placeholder is in the walk and outside the count, which is the shape the ticket asks
for: present with an honest label, never claimed as resolved.

Every other check is identical across the two arms. Diffing the verdict lines returns
exactly one difference, check 4. Checks 2 and 3, the fabrication controls, pass in
both: "no known bare-name impostor counted as a caller" and
"HTTPDigestAuth.handle_401 counted with reference_lines [312]". Check 7 fails in both
and is FIR-2487's ticket, untouched here. Full run: 8 pass, 1 fail, 0 unreadable.

## Gates

- `cargo nextest run --workspace --no-fail-fast --locked`: 6587 tests run, 6587 passed,
  3 slow, 2 leaky, 12 skipped. The full suite ran; nothing was cancelled early.
- `cargo test --doc --locked`: pass.
- `cargo fmt --all -- --check`: pass.
- `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the
  45-lint debt allow-list from `.github/clippy-allowed-lints.txt`: pass.
- All six `ci.yml` guard scripts pass: `verify-zero-file-search.py`,
  `zero_file_search_guard.sh`, `verify-hydration-semantics.py`,
  `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh` and
  `test-private-repo-coupling.py`.
- `git diff origin/main --stat -- Cargo.lock .cargo/` is empty and
  `git ls-tree -r HEAD --name-only` lists only `.cargo/config.toml` under `.cargo/`.

Run from `.kin-coord/worktrees/jsreceiver-kin` on branch `chore/lane-jsreceiver-kin`,
four commits on `origin/main` at 93f31671.

Closes FIR-2486
