### PR TITLE
Hand the enrichment joins graph-owned documents, and pin kin-lsp to =0.6.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.6.14"
+version = "0.6.16"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "6d926f6fdf0445ce64ef10fdc01c02f9a9905bafdc16e9417160183130a861b0"
+checksum = "5ef67e9479a739aea7286339c3ed34aaf24bd114c38a5b2ff0352b71f97d2581"
 dependencies = [
  "kin-model",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ kin-daemon-spawn = { path = "crates/kin-daemon-spawn" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "=0.6.14", registry = "kin" }
+kin-lsp = { version = "=0.6.16", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1430,6 +1430,7 @@ async fn enrich_single_entity(
     index: &kin_lsp::EntityIndex,
     root: &std::path::Path,
     state: &DaemonState,
+    documents: Option<kin_lsp::DocumentProvider<'_>>,
 ) -> usize {
     let timeout = std::time::Duration::from_secs(5);
     let mut count = 0;
@@ -1465,7 +1466,7 @@ async fn enrich_single_entity(
     // UsesType
     if let Ok(Ok(relations)) = tokio::time::timeout(
         timeout,
-        kin_lsp::enrichment::enrich_entity_uses_type(server, entity_ref, index, root),
+        kin_lsp::enrichment::enrich_entity_uses_type(server, entity_ref, index, root, documents),
     )
     .await
     {
@@ -2520,6 +2521,12 @@ pub async fn run_with_authority_on(
                     return;
                 }
             };
+            let load_document = |path: &str| -> Option<String> {
+                source_view
+                    .load_text(&kin_model::FilePathId::new(path))
+                    .ok()
+            };
+            let documents: Option<kin_lsp::DocumentProvider<'_>> = Some(&load_document);
 
             // Lazily start LSP servers on first use per language.
             let mut servers: std::collections::HashMap<
@@ -2763,7 +2770,7 @@ pub async fn run_with_authority_on(
                         for entity_ref in &file_entities {
                             info!(entity = %entity_ref.name, "querying LSP for entity");
                             total_relations += enrich_single_entity(
-                                server, entity_ref, &index, &lsp_root, &lsp_state,
+                                server, entity_ref, &index, &lsp_root, &lsp_state, documents,
                             )
                             .await;
                         }
@@ -2986,6 +2993,7 @@ pub async fn run_with_authority_on(
                                 &file_content,
                                 &index,
                                 &lsp_root,
+                                documents,
                             )
                             .await
                             .unwrap_or_default();
@@ -2997,7 +3005,7 @@ pub async fn run_with_authority_on(
                             // (definition approach gives References, call hierarchy gives Calls).
                             for entity_ref in &file_entity_refs {
                                 file_relations += enrich_single_entity(
-                                    server, entity_ref, &index, &lsp_root, &lsp_state,
+                                    server, entity_ref, &index, &lsp_root, &lsp_state, documents,
                                 )
                                 .await;
                             }


### PR DESCRIPTION
kin-lsp 0.6.16's member-on-module join queries a position in the module file a receiver resolved to, which is not the file being enriched, and a language server only answers about documents it has been handed. Without a provider the join declined every cross-file candidate on both its arms, which is why Router read zero references after the definitions-pass misattribution fix landed.

enrich_single_entity and the sweep's enrich_file_definitions call gain the optional documents parameter, forwarded to the shared join. The LSP worker builds one closure over its existing graph-owned source view, so every document the join opens carries the same authority as the file being enriched: a repository-relative path resolves through kin_model::FilePathId and GraphOwnedSourceView::load_text, and a path the authority cannot serve declines the candidate rather than reading the working tree. The daemon diff is the compile-verified six-site form carried in kin-lsp#74's body, applied verbatim onto main's file rather than hand-edited.

The pin moves =0.6.14 to =0.6.16 and the lock keeps the sparse registry source and checksum. Gated twice on this exact commit: the DEV-LOCAL full workspace test pass with the sibling kin-lsp at #74's squash, and a registry-only release-check whose own echo reads kin-lsp 0.6.16 up-to-date, RELEASE-CLEAN. Measured effect on kin-lsp's side (kin-lsp#74): bar check 7 reads PASS with Router carrying its two reachable references, createApplication unchanged at exactly 50.

Refs FIR-2487
Refs FIR-2464