### PR TITLE
Move the kin registry pins to kin-db 0.7.36 and kin-vfs-core 0.4.7

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -191,7 +191,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
+          ref: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -665,7 +665,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
+          EXPECTED_VFS_COMMIT: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,7 +528,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
+          ref: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -1154,7 +1154,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
+          EXPECTED_VFS_COMMIT: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1442,7 +1442,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
+          ref: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1510,7 +1510,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
+          EXPECTED_VFS_COMMIT: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1872,7 +1872,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
+      expected_vfs_commit: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.35"
+version = "0.7.36"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "5b18910b72d016935672f59e17477b15ead9ca46e0b66c8692edea58f7c910ac"
+checksum = "f42311f808769f669d86afb5c7ff8a61ca4c80f6a4ddd896e8109cbb48afe7b5"
 dependencies = [
  "bincode",
  "bstr",
@@ -3777,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.4.6"
+version = "0.4.7"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "7f82f2985f00428a2ec1c115cd74cade89785e70565e56407388755e4b104cdf"
+checksum = "710f3abce2a31d8408509fc8c4dac9b3d4c56ea4d29e3d138ae0ea5b7637dd58"
 dependencies = [
  "lru",
  "parking_lot",
@@ -6644,7 +6644,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,8 +155,8 @@ kin-lsp = { version = "=0.6.16", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.35", registry = "kin", default-features = false }
-kin-vfs-core = { version = "=0.4.6", registry = "kin" }
+kin-db = { version = "=0.7.36", registry = "kin", default-features = false }
+kin-vfs-core = { version = "=0.4.7", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -13220,7 +13220,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: 2596a4477cfb0b389d9c52026cf9da8f7ff40138",
+        "expected_vfs_commit: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
Kin now floors on kin-db 0.7.36 and kin-vfs-core 0.4.7, and the immutable kin-vfs release pin advances with them because the second bump cannot land without it.

## What each bump carries

kin-vfs-core 0.4.7 is a version-only publish. Diffing the two published crate tarballs from the kin registry, the only differences between 0.4.6 and 0.4.7 are the sha recorded in `.cargo_vcs_info.json` and the version string in `Cargo.toml` and `Cargo.lock`. No source file changed. The bump exists because kin-vfs bumped its whole workspace version while refreshing its own kin-model pin from 0.7.8 to 0.7.9, and kin-vfs-core inherits that workspace version. Nothing in kin adapts to it.

kin-db 0.7.36 is additive. It adds `VectorIndex::key_set_token` and `VectorIndex::count_present`, and caches the `embedding_status` `indexed` and `total` answer against a graph truth epoch plus the vector index key-set token, so the embed settle loop's repeated polls are served without rescanning graph truth and the index. No public item was removed or changed, so no kin-side adaptation is needed.

## Why the release pin moves in the same change

`release.yml` refuses a release whose lock resolves a different kin-vfs-core than the pinned kin-vfs checkout builds, and `scripts/check-kin-vfs-compat.mjs` runs that same comparison per pull request. The pin at `2596a447` builds kin-vfs-core 0.4.6, so bumping only the floor would fail the gate, and landing them apart would red the release after the tag exists, where no later fix can reach the tag's own workflows.

This advances the pin to `3ad20e675b58d227e3100ef0012ce048dbc1fc5a`, which is the commit recorded inside the published kin-vfs-core 0.4.7 crate's own `.cargo_vcs_info.json`. That is the same convention the 0.4.6 pin move followed: `2596a447` is the sha recorded in the 0.4.7 predecessor's tarball. The pin has eight homes and all eight move together, across `.github/workflows/release.yml` (five), `.github/workflows/rc-build.yml` (two) and `scripts/test-release-workflow-authority.py` (one).

## Gating performed

The DEV-LOCAL lane gate cannot gate this change. `bin/kin-dev` writes `kin-db = { path = ... }` and `kin-vfs-core = { path = ... }` into its `[patch.kin]` superset (bin/kin-dev:601 and :603), so `local-check` and `local-test` resolve both crates by path, never consult the registry, and would pass any version string including one the registry does not serve. This was gated against registry resolution instead:

- `cargo nextest run --workspace --locked --no-fail-fast`: `Summary [356.271s] 6587 tests run: 6587 passed (5 slow, 2 leaky), 12 skipped`. Zero FAIL lines after stripping ANSI, with 6585 PASS lines as the positive control that the strip works.
- `cargo test --doc --locked`: exit 0.
- The build log proves registry resolution rather than a path patch: `Compiling kin-db v0.7.36 (registry `kin`)` and `Compiling kin-vfs-core v0.4.7 (registry `kin`)`, against the control that a workspace member prints a local path, `Compiling kin-core v0.5.43 (/…/crates/kin-core)`.
- Every external `kin-*` lock entry keeps a `sparse+` source and a checksum, checked across all eight of them. The two new checksums match the registry index byte for byte: kin-db `f42311f8…` and kin-vfs-core `710f3abc…`.
- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the ci.yml allowlist, `node scripts/check-kin-vfs-compat.mjs`, `node scripts/check-rc-build-drift.mjs`, `python3 scripts/test-release-workflow-authority.py`, `python3 scripts/verify-zero-file-search.py`, `bash scripts/zero_file_search_guard.sh`, `python3 scripts/verify-hydration-semantics.py`, `bash scripts/check_runtime_boundaries.sh`, `bash scripts/check_private_repo_coupling.sh` and `python3 scripts/test-private-repo-coupling.py` all exit 0.

The compat guard was falsified in both directions rather than merely observed passing. Reverting the pin while holding the lock at 0.4.7, which is exactly the half-done move this change exists to avoid, fails at exit 1 with `Kin resolves kin-vfs-core 0.4.7, but the pinned kin-vfs checkout builds 0.4.6`. Moving only one of release.yml's five sites fails at exit 1 with `release.yml records disagreeing firelock-ai/kin-vfs pins`. Restoring gives `Verified Kin/kin-vfs compatibility at kin-vfs-core 0.4.7 (pinned kin-vfs 3ad20e675…)` at exit 0.

The old version literals and the old pin sha return nothing anywhere in the tree, and the same greps find the new values, so the sweep can fire. A one-character-off variant of the new sha returns HTTP 422 from GitHub, so the ancestry check can also say no.

## One disclosed piece of unrelated lock churn

The re-lock moved `winapi-util 0.1.11` from `windows-sys 0.48.0` to `windows-sys 0.61.2`. That is pre-existing drift on main rather than a consequence of this change: on a pristine `origin/main` tree, a completely no-op re-resolution produces the identical hunk. `winapi-util` declares `windows-sys >=0.48.0, <=0.61`, a range spanning majors, so both satisfy it, and 0.61.2 was already in the lock. The effect is one fewer distinct `windows-sys` build; 0.48.0 remains only for `dirs-sys 0.4.1`.

Closes FIR-2456
