### PR TITLE
Pin the typescript package the JS/TS language server needs

### DIFF
--- a/crates/kin-cli/src/commands/language_servers.rs
+++ b/crates/kin-cli/src/commands/language_servers.rs
@@ -73,6 +73,19 @@ impl LanguageServerRecipe {
     }
 }
 
+/// The typescript package `typescript-language-server` is installed beside.
+///
+/// Pinned to 5.x, and the pin is load-bearing. `typescript-language-server`
+/// runs `tsserver`, which ships as `lib/tsserver.js` inside the typescript
+/// package. TypeScript 7 dropped that entry point: its package exposes only a
+/// `tsc` binary and carries no `lib/tsserver.js`. Installing typescript
+/// unpinned resolves the `latest` dist-tag, which is 7.x, and the server then
+/// answers Kin's `initialize` with "Could not find a valid TypeScript
+/// installation" and exits. Nothing in npm metadata prevents that pairing,
+/// because `typescript-language-server` declares no peer dependency on
+/// typescript at all.
+const TYPESCRIPT_PACKAGE: &str = "typescript@^5";
+
 /// Every language this build can enrich, with the server that enriches it.
 ///
 /// JavaScript and TypeScript are separate rows resolving to one binary and one
@@ -100,7 +113,12 @@ pub(crate) const LANGUAGE_SERVERS: &[LanguageServerRecipe] = &[
         language: LanguageId::TypeScript,
         binaries: &["typescript-language-server", "vtsls"],
         program: "npm",
-        args: &["install", "-g", "typescript-language-server", "typescript"],
+        args: &[
+            "install",
+            "-g",
+            "typescript-language-server",
+            TYPESCRIPT_PACKAGE,
+        ],
         disclosure: "downloads the typescript-language-server and typescript npm packages into \
                      your global npm prefix",
     },
@@ -108,7 +126,12 @@ pub(crate) const LANGUAGE_SERVERS: &[LanguageServerRecipe] = &[
         language: LanguageId::JavaScript,
         binaries: &["typescript-language-server"],
         program: "npm",
-        args: &["install", "-g", "typescript-language-server", "typescript"],
+        args: &[
+            "install",
+            "-g",
+            "typescript-language-server",
+            TYPESCRIPT_PACKAGE,
+        ],
         disclosure: "downloads the typescript-language-server and typescript npm packages into \
                      your global npm prefix",
     },
@@ -474,12 +497,40 @@ mod tests {
         );
         assert_eq!(
             recipe_for(LanguageId::TypeScript).unwrap().command_line(),
-            "npm install -g typescript-language-server typescript"
+            "npm install -g typescript-language-server typescript@^5"
         );
         assert_eq!(
             recipe_for(LanguageId::Rust).unwrap().command_line(),
             "rustup component add rust-analyzer"
         );
+    }
+
+    /// The typescript package must never be installed unpinned.
+    ///
+    /// TypeScript 7 ships no `lib/tsserver.js`, so a bare `typescript`
+    /// argument resolves the `latest` dist-tag to 7.x and the language server
+    /// refuses to initialize. The failure is invisible from the install side:
+    /// `npm install -g` succeeds, `typescript-language-server` lands on PATH,
+    /// and `installed()` reports the language served. Only a start attempt
+    /// disagrees, which is why the pin is asserted here rather than left to a
+    /// runtime check.
+    #[test]
+    fn the_typescript_package_is_pinned_away_from_the_version_without_tsserver() {
+        for language in [LanguageId::TypeScript, LanguageId::JavaScript] {
+            let recipe = recipe_for(language).expect("language must have a recipe");
+            let typescript_arg = recipe
+                .args
+                .iter()
+                .find(|arg| arg.starts_with("typescript@") || **arg == "typescript")
+                .unwrap_or_else(|| panic!("{language}: recipe installs no typescript package"));
+            assert_eq!(
+                *typescript_arg, "typescript@^5",
+                "{language}: the typescript package must carry the 5.x pin. Unpinned, npm \
+                 resolves latest to TypeScript 7, which ships no lib/tsserver.js, and \
+                 typescript-language-server answers initialize with \"Could not find a valid \
+                 TypeScript installation\" and exits."
+            );
+        }
     }
 
     /// One npm package serves both JavaScript and TypeScript, so the advice is
@@ -489,7 +540,7 @@ mod tests {
         let commands = install_commands_for(&[LanguageId::JavaScript, LanguageId::TypeScript]);
         assert_eq!(
             commands,
-            vec!["npm install -g typescript-language-server typescript".to_string()]
+            vec!["npm install -g typescript-language-server typescript@^5".to_string()]
         );
     }
 


### PR DESCRIPTION
## What was wrong

`kin setup` provisions the JavaScript and TypeScript language server with `npm install -g typescript-language-server typescript`, and that last argument carries no version. `typescript-language-server` runs `tsserver`, which ships as `lib/tsserver.js` inside the `typescript` npm package. TypeScript 7 dropped that entry point: the 7.0.2 package contains no `lib/tsserver.js` at all and its `bin` map holds only `tsc`. Since TypeScript 7 became npm's `latest` dist-tag, every `kin setup` has installed the one version of TypeScript the language server cannot use.

The pairing is silent from the install side. `npm install -g` succeeds, `typescript-language-server` lands on PATH, `kin_lsp::discovery` finds it with `which::which`, and `LanguageServerRecipe::installed()` at `crates/kin-cli/src/commands/language_servers.rs:60` reports JavaScript and TypeScript as served. Nothing in npm metadata objects either, because `typescript-language-server@6.0.0` declares no `peerDependencies` on typescript.

Only a start attempt disagrees. The server answers Kin's `initialize` with a JSON-RPC error:

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Request initialize failed with message: Could not find a valid TypeScript installation. Please ensure that the \"typescript\" dependency is installed in the workspace or that a valid `tsserver.path` is specified. Exiting."}}
```

`JsonRpcClient::request` maps a reply carrying `error` to `LspError::JsonRpc`, `kin-lsp/src/lifecycle.rs:67` rewraps it as `InitializeFailed`, and `LspServer::start` returns `Err`. In the daemon's cold sweep the server was then never inserted into the `servers` map, so the start was retried per file. That is the 462 failed starts the npm0543 stranger run recorded on express.

## Evidence

Reproduced in a fresh container built from the same `kin-stranger:1` image that run used, provisioned exactly as its phase 1 did (npm prefix `~/.npm-global`, then the recipe's own command), spawning the server the way `LspServer::start` spawns it and sending Kin's own initialize payload. Same container, same node v22.23.1, same `typescript-language-server@6.0.0`, with the typescript version as the only variable:

| typescript | Kin's initialize | elapsed |
|---|---|---|
| 5.9.3 | OK. `definitionProvider`, `referencesProvider`, `typeDefinitionProvider`, `callHierarchyProvider` all true | 170 ms |
| 7.0.2 | error -32603, "Could not find a valid TypeScript installation" | 78 ms |

A global install is sufficient, so no workspace `node_modules` is required. On 5.9.3 the server names what it resolved:

```
window/logMessage: Using Typescript version (bundled) 5.9.3 from path "/home/dev/.npm-global/lib/node_modules/typescript/lib/tsserver.js"
```

The 78 ms failure matches the shipped evidence, where express logged 462 `starting LSP server` lines 41 to 70 ms apart with zero successes while pyright in the same container started once and was ready in 79 ms.

Resolution check with a control: `npm view typescript@^5 version` tops out at 5.9.3, while bare `npm view typescript version` returns 7.0.2.

## The fix

The package becomes `typescript@^5`, named once as `const TYPESCRIPT_PACKAGE` and used by both the TypeScript and the JavaScript recipe so the two rows cannot drift apart, with a doc comment recording why the pin is load-bearing.

Running the command the fixed recipe emits also repairs a host that already installed the broken pairing, because npm downgrades the global package in place. Verified: a container holding 7.0.2 ran `npm install -g typescript-language-server typescript@^5`, landed 5.9.3, and initialize then succeeded with all four providers.

## Falsification

The pin was reverted to bare `typescript` and the suite re-run. Raw exit 101, three tests red, the new guard failing with its own message:

```
---- the_typescript_package_is_pinned_away_from_the_version_without_tsserver stdout ----
assertion `left == right` failed: typescript: the typescript package must carry the 5.x pin.
Unpinned, npm resolves latest to TypeScript 7, which ships no lib/tsserver.js, and
typescript-language-server answers initialize with "Could not find a valid TypeScript
installation" and exits.
  left: "typescript"
 right: "typescript@^5"

test result: FAILED. 13 passed; 3 failed
```

Restoring the pin returned `16 passed; 0 failed`.

## Gates

Run from the lane worktree, which the gate's own line confirms it tested: `local-test: kin /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/jsserver-kin @ a3fb9547 (chore/lane-jsserver-kin)`.

- `bin/kin-dev local-test kin --no-fail-fast`: exit 0. `Summary [303.447s] 6597 tests run: 6597 passed (3 slow), 12 skipped`, plus 23 doctest binaries green. Zero `FAIL [` lines against a positive control of 6597 `PASS [` lines, and no cancellation line.
- `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the 90-word `.github/clippy-allowed-lints.txt` allow list, exactly as `ci.yml` runs it: exit 0, zero errors.
- `cargo fmt --all -- --check`: exit 0.
- `scripts/verify-zero-file-search.py`: exit 0, 177 files scanned.
- `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh`, `scripts/test-private-repo-coupling.py`: all exit 0.

Tree: `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty after the gate restored the lock.

## Scope note

This is the cause behind FIR-2506, which is already Done. PR 985 fixed the accounting and raised the failure from `debug!` to `warn!`; it did not fix why the start failed.

One correction it produces, recorded on FIR-2514: the nulled stderr is not what hid this. The server wrote zero bytes to stderr in every run. It spoke over JSON-RPC and Kin received the message in full, then discarded it at `debug!`. On current main the daemon prints these words. FIR-2514 stays worth doing for a server that dies before it can frame a reply, but it would not have surfaced this one.

Not fixed here, and named on FIR-2516: `installed()` reports a language served on binary presence alone, so a host already carrying the broken pairing shows no problem in `kin doctor` and `kin setup` will not re-run the recipe. Making the doctor surface disagree with an unusable server is a detection change that deserves its own ticket rather than riding along with a pin.

Closes FIR-2516
