### PR TITLE
Bound the file-level definitions pass in wall time

### DIFF
--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1403,6 +1403,12 @@ struct SweepTally {
     server_unavailable: usize,
     /// Files whose source could not be loaded from graph authority.
     source_unreadable: usize,
+    /// Files whose file-level definitions pass exceeded its wall-clock budget.
+    ///
+    /// Counted rather than merely logged so the sweep's own completion record
+    /// carries it. These files are still visited and still get the per-entity
+    /// arm, so they are not blocked; what they lost is the definitions pass.
+    definitions_over_budget: usize,
     /// Whether the loop stopped before walking every file, on shutdown or on
     /// the background-work supervisor's verdict.
     ///
@@ -1484,6 +1490,61 @@ impl SweepTally {
             return Some("this build enriches no language they are written in");
         }
         Some("the sweep reached none of them")
+    }
+}
+
+/// How long the file-level definitions pass may take for one file.
+///
+/// The pass had no bound of any kind. It is called at its sweep site as
+/// `.await.unwrap_or_default()`, and `locations_at` wraps nothing of its own, so
+/// every query inherits only the JSON-RPC client's own 10-second cap and a
+/// timeout yields an empty result that lets the loop continue to the NEXT
+/// identifier. A file whose language server stops answering therefore costs
+/// identifiers times ten seconds rather than failing, which on a large file is
+/// hours. Its sibling `enrich_single_entity` caps every query at 5 seconds, so
+/// the per-entity arm was bounded and the per-file arm was not.
+///
+/// 120 seconds is chosen from measurement, not taste. On a converted
+/// psf/requests store the whole per-file pass, both arms together, ran to a
+/// median of 1.2 s, a p90 of 12.0 s and a maximum of 62.4 s. The budget sits at
+/// nearly twice the slowest healthy file, so it cannot truncate work that is
+/// merely slow; it exists to turn an unbounded hang into a bounded, counted one.
+fn lsp_file_definitions_budget() -> Duration {
+    duration_from_env_secs("KIN_DAEMON_LSP_FILE_BUDGET_SECS", Duration::from_secs(120))
+}
+
+/// Run the file-level definitions pass under a wall-clock budget.
+///
+/// A pass that overruns yields the empty result the call site already used for
+/// a failed pass, and is counted on the tally so the sweep reports it rather
+/// than losing it. Split out from the call site so the budget decision can be
+/// tested against a provider that never answers, which is the case that
+/// motivated it and the one a live language server will not reproduce on demand.
+async fn file_definitions_within_budget<F, E>(
+    pass: F,
+    budget: Duration,
+    file: &str,
+    tally: &mut SweepTally,
+) -> kin_lsp::file_enrichment::FileEnrichmentResult
+where
+    F: std::future::Future<
+        Output = std::result::Result<kin_lsp::file_enrichment::FileEnrichmentResult, E>,
+    >,
+{
+    match tokio::time::timeout(budget, pass).await {
+        Ok(Ok(result)) => result,
+        // A pass that failed keeps the behaviour the call site always had.
+        Ok(Err(_)) => kin_lsp::file_enrichment::FileEnrichmentResult::default(),
+        Err(_) => {
+            tally.definitions_over_budget += 1;
+            warn!(
+                file = %file,
+                budget_s = budget.as_secs(),
+                "the file-level definitions pass exceeded its budget and was abandoned for \
+                 this file; its language server is not answering"
+            );
+            kin_lsp::file_enrichment::FileEnrichmentResult::default()
+        }
     }
 }
 
@@ -2937,6 +2998,7 @@ pub async fn run_with_authority_on(
                             .lsp_sweep_files_total
                             .store(total_files as u64, std::sync::atomic::Ordering::SeqCst);
                         let mut tally = SweepTally::default();
+                        let file_definitions_budget = lsp_file_definitions_budget();
                         let mut total_relations = 0usize;
                         // Languages whose server refused to start, remembered for
                         // the rest of this sweep. Without it the loop retries the
@@ -3140,16 +3202,20 @@ pub async fn run_with_authority_on(
 
                             // File-level enrichment: query definition at every identifier
                             // to capture ALL relationships (40-50x more than per-entity).
-                            let file_result = kin_lsp::file_enrichment::enrich_file_definitions(
-                                server,
-                                &abs_path,
-                                &file_content,
-                                &index,
-                                &lsp_root,
-                                documents,
+                            let file_result = file_definitions_within_budget(
+                                kin_lsp::file_enrichment::enrich_file_definitions(
+                                    server,
+                                    &abs_path,
+                                    &file_content,
+                                    &index,
+                                    &lsp_root,
+                                    documents,
+                                ),
+                                file_definitions_budget,
+                                &file_id.0,
+                                &mut tally,
                             )
-                            .await
-                            .unwrap_or_default();
+                            .await;
 
                             let mut file_relations =
                                 install_lsp_relations(&lsp_state, &file_result.relations);
@@ -3261,6 +3327,7 @@ pub async fn run_with_authority_on(
                             unsupported_language = tally.unsupported_language,
                             server_unavailable = tally.server_unavailable,
                             source_unreadable = tally.source_unreadable,
+                            definitions_over_budget = tally.definitions_over_budget,
                             not_visited,
                             ended_early = tally.ended_early,
                             unaccounted,
@@ -4813,7 +4880,8 @@ mod lsp_query_column_tests {
 
 #[cfg(test)]
 mod sweep_tally_tests {
-    use super::SweepTally;
+    use super::{file_definitions_within_budget, SweepTally};
+    use std::time::Duration;
 
     /// The number the sweep reports as `files`, and the one `/lsp/sweep/status`
     /// serves as `files_done`, is unchanged in meaning by the tally: a file the
@@ -4826,6 +4894,7 @@ mod sweep_tally_tests {
             unsupported_language: 5,
             server_unavailable: 6,
             source_unreadable: 7,
+            definitions_over_budget: 0,
             ended_early: false,
         };
         assert_eq!(tally.files_processed(), 7);
@@ -4909,6 +4978,94 @@ mod sweep_tally_tests {
             36,
             "36 files left the sweep without reaching any counter and must be visible"
         );
+    }
+
+    /// A provider that never answers is abandoned at its budget and counted.
+    ///
+    /// This is the case the budget exists for and the one a live language server
+    /// will not reproduce on demand: the pass had no bound at all, and every
+    /// query inside it inherits only the client's 10-second cap and yields an
+    /// empty result that lets the loop continue to the next identifier, so a
+    /// dead server costs identifiers times ten seconds instead of failing.
+    #[tokio::test]
+    async fn a_definitions_pass_that_never_answers_is_abandoned_and_counted() {
+        let mut tally = SweepTally::default();
+        let stalled = std::future::pending::<
+            std::result::Result<kin_lsp::file_enrichment::FileEnrichmentResult, ()>,
+        >();
+        let result = file_definitions_within_budget(
+            stalled,
+            Duration::from_millis(60),
+            "src/requests/models.py",
+            &mut tally,
+        )
+        .await;
+        assert_eq!(
+            tally.definitions_over_budget, 1,
+            "a pass abandoned at its budget must be counted, not merely logged"
+        );
+        assert!(
+            result.relations.is_empty(),
+            "an abandoned pass yields the same empty result a failed pass always did"
+        );
+    }
+
+    /// The other direction: a pass that answers inside its budget is handed
+    /// back UNCHANGED and costs the tally nothing.
+    ///
+    /// Without this arm the budget could quietly truncate healthy enrichment and
+    /// every test above would still pass, which is the failure mode that matters
+    /// most here: relations silently going missing look exactly like a corpus
+    /// that had none.
+    #[tokio::test]
+    async fn a_pass_inside_its_budget_is_returned_byte_identical() {
+        use kin_model::{GraphNodeId, Relation, RelationId, RelationKind, RelationOrigin};
+        let src = kin_model::EntityId::new();
+        let dst = kin_model::EntityId::new();
+        let build = || kin_lsp::file_enrichment::FileEnrichmentResult {
+            relations: vec![Relation {
+                id: RelationId::from_bytes([9u8; 16]),
+                kind: RelationKind::References,
+                src: GraphNodeId::Entity(src),
+                dst: GraphNodeId::Entity(dst),
+                confidence: 0.85,
+                origin: RelationOrigin::Lsp,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            }],
+            definitions_resolved: 7,
+            positions_queried: 913,
+        };
+        let expected = build();
+        let mut tally = SweepTally::default();
+        // The pass must take REAL time before answering. An instantly-ready
+        // future is polled once and returned before any budget can apply, so a
+        // test written that way passes even with the budget set to a
+        // nanosecond, and proves nothing about truncation. Found by falsifying
+        // this very test: at a 1 ns budget it stayed green.
+        let healthy = async move {
+            tokio::time::sleep(Duration::from_millis(40)).await;
+            std::result::Result::<_, ()>::Ok(build())
+        };
+        let result = file_definitions_within_budget(
+            healthy,
+            Duration::from_secs(120),
+            "src/requests/models.py",
+            &mut tally,
+        )
+        .await;
+        assert_eq!(
+            tally.definitions_over_budget, 0,
+            "a pass that answered in time must not be counted against the budget"
+        );
+        assert_eq!(
+            result.relations, expected.relations,
+            "a healthy pass must come back with its relations unchanged; a budget that \
+             quietly truncated them would look exactly like a corpus that had none"
+        );
+        assert_eq!(result.definitions_resolved, expected.definitions_resolved);
+        assert_eq!(result.positions_queried, expected.positions_queried);
     }
 
     /// An interrupted sweep is not a miscounted one, and the guard must not


### PR DESCRIPTION
The file-level definitions pass had no bound of any kind, so a file whose language server stopped answering cost identifiers times ten seconds instead of failing. On a large file that is hours of silence.

## The mechanism

`enrich_file_definitions` is awaited at its sweep call site as `.await.unwrap_or_default()` in `crates/kin-daemon/src/daemon.rs`, with no timeout around it. Inside, `locations_at` (`kin-lsp/src/enrichment.rs:463`) wraps nothing of its own, so every query inherits only `JsonRpcClient::request`'s internal 10-second cap, and a timeout there returns an empty `Vec` that lets the loop continue to the NEXT identifier rather than failing the pass.

The asymmetry is the defect. Its sibling `enrich_single_entity` wraps every query in a 5-second `tokio::time::timeout`, so the per-entity arm was bounded and the per-file arm was not.

## The fix

The pass now runs under a wall-clock budget. A file that overruns yields the same empty result a failed pass always did, is counted on the sweep tally as `definitions_over_budget`, and appears in the sweep's completion record, so the loss is reported rather than silent.

The budget is 120 seconds, tunable through `KIN_DAEMON_LSP_FILE_BUDGET_SECS`, and it is chosen from measurement rather than taste. On a converted psf/requests store (6491 commits) the whole per-file pass, both arms together, ran to a median of 1.2 s, a p90 of 12.0 s and a maximum of 62.4 s. So 120 s sits at nearly twice the slowest healthy file and cannot truncate work that is merely slow; it exists to turn an unbounded hang into a bounded, counted one.

## Falsification, both directions

Removing the budget makes the stalled-provider test hang past 150 seconds against a 0.06 s baseline.

Forcing the budget to a nanosecond fails the healthy-pass test with its named message:

```
a pass that answered in time must not be counted against the budget
  left: 1   right: 0
```

The healthy-pass test sleeps before answering, and that detail is load-bearing. Written with an instantly-ready future it passed even at a one-nanosecond budget, because a timeout polls its future once before any deadline applies, which made the test structurally incapable of detecting truncation. It was found by running the second falsification direction rather than trusting the first, and the reason is commented in the test.

## What this does not claim

It does not claim to explain the intermittent sweep stall observed on a real store. That stall was seen on a run without language-server request logging, so its request rate was never measured, and a later instrumented run completed cleanly without stalling. The asymmetry fixed here is a defect on its own terms, proven from the code, and the empirical link to that stall is unproven.

## Gate

`bin/kin-lane run sweepwave kin -- bin/kin-dev local-test kin`, rc=0, with its own resolution line reading `/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/sweepwave-kin @ 6141f44a (chore/lane-sweepwave-capfix)`, so the tree under test is this branch and not the primary. `Summary [330.070s] 6598 tests run: 6598 passed (3 slow, 2 leaky), 12 skipped`; the run count equals the total, so nextest did not cancel early. Zero `FAIL [` lines after stripping ANSI, against a 6596 PASS-line positive control. fmt rc=0, clippy rc=0 with the 45-lint debt allow-list, and all six guard scripts rc=0.

Refs FIR-2493. Deliberately not `Closes`: this is a distinct defect found while measuring that ticket's memory ramp, and none of FIR-2493's own asks are met here. Its memory work is a separate change that has not landed.
