### PR TITLE
Refuse a deletion verdict read off a reference class this host could produce and did not

### DIFF
--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -231,11 +231,28 @@ pub fn observe_cross_file_reference_coverage_for_languages_witnessed<S: EntitySt
         observed_languages.push(*language);
     }
 
+    // Computed before the skip decision, because it is one of the two facts that
+    // decides which classes the verdict rests on. It is reused verbatim below,
+    // so the state the skip reasoned about and the state the payload publishes
+    // can never be two different readings.
+    let enrichment = reference_enrichment(&observed_languages);
+    let references_producible = enrichment.as_str() == Some("available");
+
     // The scan exists to decide the classes the verdict rests on. When the
     // answer already carried a witness for every one of them, running it buys a
     // disclosure about classes nothing decides and costs a language-wide relation
     // walk on the populated path, where there was no scan at all before.
-    let scan_needed = !deciding_classes_all_present(&merged);
+    //
+    // `references` joins that deciding set exactly when this host could have
+    // produced it, which is the same condition
+    // [`crate::negative::absence_coverage_gap`] now gates a certification on.
+    // Leaving it out here would have left that gate a bypass on one of the two
+    // surfaces it was written for: `get_context_pack` passes the witnesses its
+    // own rows carry, so a pack whose dependents group witnessed one cross-file
+    // `Calls` edge skipped the scan, published `references: unknown` instead of
+    // `absent`, and certified on a class nothing had measured. A gate that only
+    // fires when a scan happened to run is not a gate.
+    let scan_needed = !deciding_classes_all_present(&merged, references_producible);
     if scan_needed {
         for (index, language) in observed_languages.iter().enumerate() {
             let (states, examined, budget_exhausted) =
@@ -294,7 +311,7 @@ pub fn observe_cross_file_reference_coverage_for_languages_witnessed<S: EntitySt
             .collect::<Vec<_>>(),
         "classes": Value::Object(classes),
         "cross_file_classes": cross_file,
-        "reference_enrichment": reference_enrichment(&observed_languages),
+        "reference_enrichment": enrichment,
         "budget_exhausted": any_budget_exhausted,
         "entities_examined": examined_total,
         // How each verdict was reached, because "present" from a witness the
@@ -415,12 +432,26 @@ pub fn languages_of(entities: &[Entity]) -> Vec<LanguageId> {
 /// of its own: Kin mints no entity-level `Imports` edge, so a rule that waited
 /// for every requested class would never skip a scan and would report every
 /// answer on every healthy graph as short of coverage.
-fn deciding_classes_all_present(merged: &[(RelationKind, ClassState)]) -> bool {
+fn deciding_classes_all_present(
+    merged: &[(RelationKind, ClassState)],
+    references_producible: bool,
+) -> bool {
     let requested: Vec<String> = merged
         .iter()
         .map(|(kind, _)| class_name(*kind).to_string())
         .collect();
-    let deciding = crate::negative::load_bearing_classes(&requested);
+    let mut deciding = crate::negative::load_bearing_classes(&requested);
+    // `load_bearing_classes` answers the question that holds on any host:
+    // `references` is legitimately absent wherever a language server has not
+    // run, so requiring it everywhere would report every real graph as
+    // inconclusive. On a host that CAN produce it the answer changes, and the
+    // class the verdict rests on has to be measured rather than assumed.
+    if references_producible
+        && requested.iter().any(|class| class == "references")
+        && !deciding.iter().any(|class| class == "references")
+    {
+        deciding.push("references".to_string());
+    }
     if deciding.is_empty() {
         return false;
     }
@@ -1047,6 +1078,73 @@ mod tests {
             ReferenceEnrichment::Unknown,
             "no language observed establishes nothing"
         );
+    }
+
+    /// FIR-2505 / FIR-2492. The scan may not skip the one class the certification
+    /// gate now rests on.
+    ///
+    /// `get_context_pack` passes the witnesses its own rows carry, so a pack
+    /// whose dependents group held a cross-file `Calls` edge used to satisfy the
+    /// deciding set on the spot, skip the language scan, and publish
+    /// `references: unknown`. An `unknown` is not a finding, so
+    /// [`crate::negative::absence_coverage_gap`] had nothing to gate on and
+    /// certified anyway. That is the same false clean the gate was written to
+    /// stop, reached by never measuring instead of by measuring and ignoring.
+    #[test]
+    fn a_producible_reference_class_is_measured_even_when_the_answer_witnessed_calls() {
+        let store = InMemoryGraph::new();
+        let caller = entity("consumer", "lib/consumer.js", LanguageId::JavaScript);
+        let target = entity("Router", "lib/express.js", LanguageId::JavaScript);
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+        let kinds = [
+            RelationKind::Calls,
+            RelationKind::Imports,
+            RelationKind::References,
+        ];
+
+        // A host that can produce reference edges: the class is load-bearing, so
+        // it gets measured and the graph's silence is recorded as a finding.
+        test_support::with_language_servers(&[LanguageId::JavaScript], || {
+            let coverage = observe_cross_file_reference_coverage_witnessed(
+                &store,
+                &target,
+                &kinds,
+                &[RelationKind::Calls],
+            );
+            assert_eq!(coverage["reference_enrichment"], json!("available"));
+            assert_eq!(
+                coverage["scan"], "ran",
+                "the class the verdict rests on must be measured: {coverage}"
+            );
+            assert_eq!(
+                coverage["classes"]["references"],
+                json!("absent"),
+                "a completed scan over a graph holding no cross-file references reports a \
+                 finding, not an unknown: {coverage}"
+            );
+        });
+
+        // The control that keeps this narrow, and the one that proves the host
+        // fact is what moved the decision rather than the change simply forcing
+        // a scan on everything: with no server installed the class was never
+        // producible, it is not load-bearing, and the witnessed skip stands.
+        test_support::with_language_servers(&[], || {
+            let coverage = observe_cross_file_reference_coverage_witnessed(
+                &store,
+                &target,
+                &kinds,
+                &[RelationKind::Calls],
+            );
+            assert_eq!(coverage["reference_enrichment"], json!("no_language_server"));
+            assert_eq!(
+                coverage["scan"], "skipped_answer_witnessed",
+                "an unproducible class must not cost a language-wide walk: {coverage}"
+            );
+        });
     }
 
     /// JavaScript is wired now, so an express-shaped repository must no longer

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -440,18 +440,7 @@ fn deciding_classes_all_present(
         .iter()
         .map(|(kind, _)| class_name(*kind).to_string())
         .collect();
-    let mut deciding = crate::negative::load_bearing_classes(&requested);
-    // `load_bearing_classes` answers the question that holds on any host:
-    // `references` is legitimately absent wherever a language server has not
-    // run, so requiring it everywhere would report every real graph as
-    // inconclusive. On a host that CAN produce it the answer changes, and the
-    // class the verdict rests on has to be measured rather than assumed.
-    if references_producible
-        && requested.iter().any(|class| class == "references")
-        && !deciding.iter().any(|class| class == "references")
-    {
-        deciding.push("references".to_string());
-    }
+    let deciding = crate::negative::deciding_classes(&requested, references_producible);
     if deciding.is_empty() {
         return false;
     }
@@ -1139,7 +1128,10 @@ mod tests {
                 &kinds,
                 &[RelationKind::Calls],
             );
-            assert_eq!(coverage["reference_enrichment"], json!("no_language_server"));
+            assert_eq!(
+                coverage["reference_enrichment"],
+                json!("no_language_server")
+            );
             assert_eq!(
                 coverage["scan"], "skipped_answer_witnessed",
                 "an unproducible class must not cost a language-wide walk: {coverage}"

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1120,6 +1120,14 @@ impl Envelope {
     ///
     /// The reason is honest about which gate held and never claims authority the
     /// envelope did not actually observe.
+    /// The reason names only what THIS function checked: the daemon's own
+    /// flags, which are the sole degraded set an envelope can see. It
+    /// deliberately makes no claim about degraded signals in general, because
+    /// [`crate::negative`] publishes a wider set beside it (the payload's own
+    /// `degradations[]` and the coverage shortfalls its `edge_coverage` names)
+    /// and finishes the sentence there. Claiming the wider silence from here
+    /// shipped in v0.5.43 as `trust_reason` ending "with no degraded signals"
+    /// one field away from a two-element `degraded_signals` array (FIR-2505).
     pub fn negative_trust(&self, class: NegativeClass) -> (bool, &'static str) {
         if self.runtime != Runtime::RepoDaemon {
             return (
@@ -1159,7 +1167,7 @@ impl Envelope {
                 ),
                 Some(_) => (
                     true,
-                    "semantic_authoritative: daemon-owned truth with complete embedding coverage and no degraded signals",
+                    "semantic_authoritative: daemon-owned truth with complete embedding coverage",
                 ),
             },
             NegativeClass::Structural => {
@@ -1176,7 +1184,7 @@ impl Envelope {
                 } else {
                     (
                         true,
-                        "structural_authoritative: daemon graph initialized and loaded with no degraded signals",
+                        "structural_authoritative: daemon graph initialized and loaded",
                     )
                 }
             }

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -654,7 +654,14 @@ fn edge_class_states(
             .unwrap_or(STATE_UNKNOWN);
         classes.insert(class.clone(), json!(state));
     }
-    let decided_by = crate::negative::load_bearing_classes(requested);
+    // The same deciding set the absence gate and the language scan read, so this
+    // block cannot say "the counts here are the whole set" about a graph the
+    // verdict beside it has just called inconclusive. Shipped v0.5.43 published
+    // exactly that pair on expressjs/express (FIR-2505, FIR-2492).
+    let decided_by = crate::negative::deciding_classes(
+        requested,
+        crate::negative::references_producible(payload),
+    );
     let limits = crate::negative::edge_coverage_degradation_labels(tool, payload);
     (classes, decided_by, limits)
 }
@@ -1884,12 +1891,73 @@ mod tests {
         assert_eq!(completeness["bound"], "exact", "{completeness}");
         assert_eq!(completeness["counted"]["reported"], 5);
         assert_eq!(completeness["counted"]["exact"], true);
-        // `imports` and `references` are absent in this fixture and always are
-        // on a real graph, since Kin mints no entity-level import edge. They are
-        // disclosed and they do not decide, which is the only way both
-        // directions of this contract can hold at once.
+        // `imports` is absent here and on every real graph, since Kin mints no
+        // entity-level import edge, so it is disclosed and does not decide.
+        // `references` is absent here too, and does not decide because this
+        // fixture's `reference_enrichment` reads `unknown`: nothing established
+        // that this host could produce the class. Where a host CAN produce it,
+        // `references` does decide (FIR-2505), which is the case the test below
+        // pins. Both directions of this contract hold only because the deciding
+        // set is computed from that fact rather than fixed.
         assert_eq!(completeness["classes"]["imports"], "absent");
         assert_eq!(completeness["decided_by"], json!(["calls"]));
+    }
+
+    /// FIR-2505 and FIR-2492, on the block that carried the sentence. Shipped
+    /// v0.5.43 answered `status: "complete"`, `bound: "exact"`, `decided_by:
+    /// ["calls"]` and "so the counts here are the whole set" on expressjs/express,
+    /// over a graph holding no cross-file reference edge at all, while listing
+    /// that very absence one field away under `limits`.
+    ///
+    /// A verdict and a completeness block disagreeing inside one object is the
+    /// defect FIR-2463 named, so the deciding set is shared and this flips with
+    /// the gate rather than beside it.
+    #[test]
+    fn a_producible_reference_class_that_produced_nothing_makes_the_counts_a_floor() {
+        let payload = ToolCallResult::text(
+            json!({
+                "total_upstream": 0,
+                "references": [],
+                "relation_kinds": ["calls", "imports", "references"],
+                "edge_coverage": {
+                    "scope": "language",
+                    "language": "JavaScript",
+                    "classes": {
+                        "calls": "present",
+                        "imports": "absent",
+                        "references": "absent",
+                    },
+                    "reference_enrichment": "available",
+                    "budget_exhausted": false,
+                },
+                "focal_resolution": {
+                    "addressed_by": "entity_id",
+                    "same_name_candidates": 1,
+                    "matched": "exact_focal_name",
+                    "other_candidates": [],
+                },
+            })
+            .to_string(),
+        );
+        let annotated = finalize(payload, ready_daemon_envelope(), "find_references");
+        let completeness = completeness_of(&annotated);
+
+        assert_eq!(
+            completeness["decided_by"],
+            json!(["calls", "references"]),
+            "a class this host could produce is one the verdict rests on: {completeness}"
+        );
+        assert_eq!(completeness["status"], "partial", "{completeness}");
+        assert_eq!(completeness["bound"], "at_least", "{completeness}");
+        let note = completeness["note"].as_str().unwrap();
+        assert!(
+            !note.contains("the whole set"),
+            "a graph missing the class the question needed does not hold the whole set: {note}"
+        );
+        assert!(
+            note.contains("lower bound"),
+            "the note says what the counts actually are: {note}"
+        );
     }
 
     /// Unobserved is not healthy. A payload carrying no observation leaves every

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -358,6 +358,52 @@ pub(crate) fn load_bearing_classes(requested: &[String]) -> Vec<String> {
     }
 }
 
+/// Whether this answer's own observation says cross-file reference edges were
+/// producible where it ran: this build wires an adapter for the language AND the
+/// host carries the server.
+///
+/// `unsupported` and `no_language_server` are the two ways the class could never
+/// have existed, and [`absence_coverage_gap`] already refuses both by name.
+/// `unknown` is an unread host, and unmeasured is not a finding anywhere else in
+/// this module either.
+pub(crate) fn references_producible(payload: &Value) -> bool {
+    payload
+        .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
+        .and_then(|coverage| coverage.get("reference_enrichment"))
+        .and_then(Value::as_str)
+        == Some("available")
+}
+
+/// The classes this answer's verdict actually rests on: [`load_bearing_classes`]
+/// plus `references` wherever this host could have produced it.
+///
+/// One definition, because three consumers ask the same question and a fourth
+/// answer would only be somewhere for them to drift. [`absence_coverage_gap`]
+/// decides whether an absence may be certified, `deciding_classes_all_present`
+/// in [`crate::edge_coverage`] decides whether the language scan may be skipped,
+/// and `edge_class_states` in [`crate::envelope`] publishes `decided_by` and the
+/// completeness `status` computed from it. Before FIR-2505 all three read
+/// [`load_bearing_classes`] and all three were wrong together, which is how
+/// shipped v0.5.43 answered `status: "complete"`, `bound: "exact"` and "so the
+/// counts here are the whole set" about a graph holding no cross-file reference
+/// edge at all, while listing that very absence one field away under `limits`.
+///
+/// [`load_bearing_classes`] answers the question that holds on any host, and its
+/// narrowing to `calls` is measured rather than assumed. This adds the one fact
+/// that changes the answer: on a host that CAN produce reference edges, their
+/// absence is a finding rather than the ordinary silence of a language server
+/// that never ran.
+pub(crate) fn deciding_classes(requested: &[String], references_producible: bool) -> Vec<String> {
+    let mut deciding = load_bearing_classes(requested);
+    if references_producible
+        && requested.iter().any(|class| class == "references")
+        && !deciding.iter().any(|class| class == "references")
+    {
+        deciding.push("references".to_string());
+    }
+    deciding
+}
+
 /// Why the graph cannot certify this absence, or `None` when every substrate the
 /// claim actually rests on is demonstrably present.
 ///
@@ -443,7 +489,7 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
     let mut gaps: Vec<String> = Vec::new();
 
     if !requested.is_empty() {
-        let required = load_bearing_classes(&requested);
+        let required = deciding_classes(&requested, references_producible(payload));
         let absent = classes_in_state(&required, states, "absent");
         let unknown = classes_in_state(&required, states, "unknown");
         let present = classes_in_state(&requested, states, "present");
@@ -465,11 +511,31 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
                     present.join(", ")
                 )
             };
+            // Which half of "extraction/enrichment" it is, whenever the answer's
+            // own observation can say. A missing `references` class on a host
+            // that wires an adapter AND carries the server is not a capability
+            // the reader has to go install: the edges were producible here and
+            // were not produced, so the sweep is the thing to look at. Saying
+            // only "the gap is in enrichment" sends a reader off to check a
+            // language server already sitting on their PATH.
+            let producible = if absent.iter().any(|class| *class == "references")
+                && references_producible(payload)
+            {
+                format!(
+                    " (a language server for {language} is installed on this host and this build \
+                     wires an adapter for it, so those edges were producible here and were not \
+                     produced; the enrichment sweep is what to look at, not the build's \
+                     capability)"
+                )
+            } else {
+                String::new()
+            };
             gaps.push(format!(
                 "cross_file_edges_absent: the graph holds no cross-file {missing} edges for \
                  {language}{observed}, so a use that reaches the target through {missing} could \
                  not have been found and an empty result says nothing about whether the target is \
-                 used; the gap is in extraction/enrichment for that language, not in the code"
+                 used; the gap is in extraction/enrichment for that language, not in the \
+                 code{producible}"
             ));
         } else if !unknown.is_empty()
             || coverage.get("budget_exhausted").and_then(Value::as_bool) == Some(true)
@@ -478,45 +544,6 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
                 "edge_coverage_unknown: whether the graph holds cross-file {named} edges for \
                  {language} could not be established, so an empty result may mean the query had \
                  no edges to answer from rather than that the target is unused"
-            ));
-        }
-
-        // `references` absent is ordinary wherever a language server has not
-        // run, which is why [`load_bearing_classes`] leaves it out of the set a
-        // certification rests on. It stops being ordinary the moment this build
-        // wires an adapter for the language AND the host carries the server: the
-        // class was producible here, a scan that ran to completion found none of
-        // it, and an absence read off the classes that survived is read off a
-        // gap rather than off evidence.
-        //
-        // That is the exact shape shipped v0.5.43 certified on expressjs/express,
-        // where all ten exports of `lib/express.js` came back `consumer_count: 0`
-        // and `safe_to_conclude_absent: true` with `decided_by: ["calls"]` beside
-        // `references: absent` and `reference_enrichment: available`
-        // (FIR-2505, FIR-2492). A use that reaches an export through a `require`
-        // and a property read is carried by exactly the class that went missing,
-        // so the question the caller asked lived entirely outside the evidence
-        // the verdict rested on.
-        //
-        // Scoped to `references` because that is the class enrichment produces.
-        // `calls` comes from the linker and is already gated above. `imports` is
-        // never minted as an entity-level relation on any language, healthy or
-        // not, so gating on its absence would report every answer on every real
-        // graph as inconclusive, which is the failure mode opposite to this one
-        // and no more useful. And `absent` is only ever written by a scan that
-        // ran to completion: a skipped or budget-exhausted scan leaves `unknown`,
-        // which the branch above already answers.
-        if requested.iter().any(|class| class == "references")
-            && class_state(states, "references") == "absent"
-            && coverage.get("reference_enrichment").and_then(Value::as_str) == Some("available")
-        {
-            gaps.push(format!(
-                "reference_enrichment_unproduced: this build wires a language-server adapter for \
-                 {language} and one is installed on this host, so cross-file reference edges were \
-                 producible for it, and a completed scan of this graph found none; the class that \
-                 carries a use reaching the target from another file is missing rather than empty, \
-                 so an empty result cannot be read as the target being unused and must not be \
-                 acted on as a deletion"
             ));
         }
     }
@@ -3651,14 +3678,36 @@ mod tests {
             let gap = absence_coverage_gap(tool, &payload)
                 .unwrap_or_else(|| panic!("{tool} must not certify the express deletion shape"));
             assert!(
-                gap.contains("reference_enrichment_unproduced"),
-                "{tool} names the produced-nothing gap: {gap}"
+                gap.starts_with("cross_file_edges_absent"),
+                "{tool} names the absent class the verdict rested on: {gap}"
             );
             assert!(
-                gap.contains("JavaScript"),
-                "{tool} names the language the gap is about: {gap}"
+                gap.contains("no cross-file references edges for JavaScript"),
+                "{tool} names the class and the language: {gap}"
+            );
+            // The diagnosis a reader acts on: the server is already installed,
+            // so this is the sweep rather than a missing capability.
+            assert!(
+                gap.contains("were producible here and were not produced"),
+                "{tool} separates an unproduced class from an unproducible one: {gap}"
             );
         }
+        // One verdict. The completeness block is computed from the same deciding
+        // set, so it can no longer call the counts whole while the gate calls the
+        // answer inconclusive. That pair is quoted inside FIR-2492.
+        let negative = negative_for("impact_analysis", &payload, &structural_ready_envelope())
+            .expect("impact_analysis always qualifies");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let advice = negative["advice"].as_str().unwrap();
+        assert!(
+            !advice.contains("authoritative negative"),
+            "the advice must stop telling a caller the row licenses a deletion: {advice}"
+        );
+        assert!(
+            advice.contains("were producible here and were not produced"),
+            "the advice carries the limiting factor a reader acts on: {advice}"
+        );
     }
 
     /// The control FIR-2404's descendants exist to protect: the gate must not
@@ -3692,7 +3741,10 @@ mod tests {
             "entity_impacts": [],
             "edge_coverage": express_deletion_coverage("present", "available")
         });
-        assert_eq!(payload["edge_coverage"]["classes"]["imports"], json!("absent"));
+        assert_eq!(
+            payload["edge_coverage"]["classes"]["imports"],
+            json!("absent")
+        );
         assert_eq!(absence_coverage_gap("impact_analysis", &payload), None);
     }
 
@@ -3714,9 +3766,8 @@ mod tests {
                 .unwrap_or_else(|| panic!("{enrichment} must still be gated"));
             assert!(gap.contains(expected), "{enrichment}: {gap}");
             assert!(
-                !gap.contains("reference_enrichment_unproduced"),
-                "{enrichment} was never producible here, so the produced-nothing gap must not \
-                 claim it was: {gap}"
+                !gap.contains("were producible here and were not produced"),
+                "{enrichment} was never producible here, so nothing may claim it was: {gap}"
             );
         }
     }

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -480,6 +480,45 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
                  no edges to answer from rather than that the target is unused"
             ));
         }
+
+        // `references` absent is ordinary wherever a language server has not
+        // run, which is why [`load_bearing_classes`] leaves it out of the set a
+        // certification rests on. It stops being ordinary the moment this build
+        // wires an adapter for the language AND the host carries the server: the
+        // class was producible here, a scan that ran to completion found none of
+        // it, and an absence read off the classes that survived is read off a
+        // gap rather than off evidence.
+        //
+        // That is the exact shape shipped v0.5.43 certified on expressjs/express,
+        // where all ten exports of `lib/express.js` came back `consumer_count: 0`
+        // and `safe_to_conclude_absent: true` with `decided_by: ["calls"]` beside
+        // `references: absent` and `reference_enrichment: available`
+        // (FIR-2505, FIR-2492). A use that reaches an export through a `require`
+        // and a property read is carried by exactly the class that went missing,
+        // so the question the caller asked lived entirely outside the evidence
+        // the verdict rested on.
+        //
+        // Scoped to `references` because that is the class enrichment produces.
+        // `calls` comes from the linker and is already gated above. `imports` is
+        // never minted as an entity-level relation on any language, healthy or
+        // not, so gating on its absence would report every answer on every real
+        // graph as inconclusive, which is the failure mode opposite to this one
+        // and no more useful. And `absent` is only ever written by a scan that
+        // ran to completion: a skipped or budget-exhausted scan leaves `unknown`,
+        // which the branch above already answers.
+        if requested.iter().any(|class| class == "references")
+            && class_state(states, "references") == "absent"
+            && coverage.get("reference_enrichment").and_then(Value::as_str) == Some("available")
+        {
+            gaps.push(format!(
+                "reference_enrichment_unproduced: this build wires a language-server adapter for \
+                 {language} and one is installed on this host, so cross-file reference edges were \
+                 producible for it, and a completed scan of this graph found none; the class that \
+                 carries a use reaching the target from another file is missing rather than empty, \
+                 so an empty result cannot be read as the target being unused and must not be \
+                 acted on as a deletion"
+            ));
+        }
     }
 
     // A filter that selected a region the graph does not populate answers every
@@ -1245,6 +1284,41 @@ fn structural_coverage_clause(payload: &Value, envelope: &Envelope) -> String {
     }
 }
 
+/// Finish a clean substrate reason by naming the degraded signals this response
+/// actually publishes.
+///
+/// [`crate::envelope::Envelope::negative_trust`] can only see the daemon's own
+/// flags, so it states the substrate verdict and stops. [`degraded_signals`]
+/// publishes a wider set beside it: those flags, plus the payload's own
+/// `degradations[]`, plus the coverage shortfalls the answer's `edge_coverage`
+/// names. Letting the reason claim the wider silence shipped in v0.5.43 as
+/// `trust_reason: "structural_authoritative: daemon graph initialized and loaded
+/// with no degraded signals"` sitting one field away from
+/// `degraded_signals: ["edge_coverage:imports_absent", "edge_coverage:references_absent"]`
+/// on the same object (FIR-2505). That string was not a summary of the field
+/// beside it, it contradicted it.
+///
+/// So the clause is computed from the published array rather than asserted
+/// independently of it, which is the treatment [`build_advice`] already gives
+/// the same fact in its own sentence. A verdict that recites its own disclosures
+/// cannot be read as claiming there were none, and a reader who sees a
+/// non-empty array is told in words why it did not move the verdict.
+///
+/// Applied only to a reason that survived every gate. Once a gap has fired,
+/// [`push_gap`] has replaced the reason with the gap, and appending a silence
+/// clause to a gap would qualify the wrong sentence.
+fn qualify_clean_trust_reason(trust_reason: String, degraded_signals: &[String]) -> String {
+    if degraded_signals.is_empty() {
+        format!("{trust_reason}, with no degraded signals")
+    } else {
+        format!(
+            "{trust_reason}; the disclosed signals [{}] were considered and are not load-bearing \
+             for this claim",
+            degraded_signals.join(", ")
+        )
+    }
+}
+
 /// A human sentence spelling out "absent as-of X, coverage Y%, degraded Z" and
 /// the actionable consequence, so the negative is legible without cross-reading
 /// the envelope. `subject` and `consequence` are passed rather than read off a
@@ -1845,6 +1919,11 @@ pub fn negative_for(
 
     let degraded_signals = degraded_signals(tool, payload, envelope);
     let coverage_clause = coverage_clause(spec.class, payload, envelope);
+    let trust_reason = if trustworthy {
+        qualify_clean_trust_reason(trust_reason, &degraded_signals)
+    } else {
+        trust_reason
+    };
 
     let mut negative = Map::new();
     negative.insert("kind".to_string(), json!(kind));
@@ -1996,6 +2075,17 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
         .map(str::to_string)
         .collect();
 
+    // Same treatment as the retrieval builder, so one surface cannot word this
+    // fact differently from the other. On this path the two sets coincide (a
+    // miss carries no payload, and `negative_trust` is already untrustworthy
+    // whenever a daemon flag is up), so a trustworthy miss reads exactly as it
+    // always did and only the retrieval path's contradiction is repaired.
+    let trust_reason = if trustworthy {
+        qualify_clean_trust_reason(trust_reason, &degraded_signals)
+    } else {
+        trust_reason
+    };
+
     let mut negative = Map::new();
     negative.insert("kind".to_string(), json!(kind));
     negative.insert("subject".to_string(), json!(subject));
@@ -2092,13 +2182,30 @@ mod tests {
     /// artifact-level edge, and mints no entity-level `Imports` edge for any
     /// language. A converted Python repository whose imports resolve cleanly
     /// reports exactly this shape.
+    /// A graph whose enrichment actually delivered, which is the only shape in
+    /// which Kin certifies a deletion.
+    ///
+    /// This fixture read `references: absent` beside `reference_enrichment:
+    /// available` until FIR-2505, and that combination is not a healthy graph.
+    /// It is the express failure shape exactly: a host that could produce
+    /// reference edges, and a graph holding none. The suite's own idea of
+    /// "healthy" was the defect, which is why every gate here passed while
+    /// shipped v0.5.43 certified the deletion of ten live exports.
+    ///
+    /// The numbers come from the enriched arm of the same stranger run that
+    /// caught it. psf/requests, sweep converged: `Entity-to-entity relation
+    /// kinds: Calls: 945, Contains: 483, References: 438, ...` with
+    /// `Cross-file entity relations: 699 of 1943`. The broken express arm on the
+    /// same binary read `Calls: 254, Contains: 75` and no References at all.
+    /// `imports` stays absent because Kin's linker mints no entity-level
+    /// `Imports` relation on any language, healthy or not.
     fn cross_file_edges_observed() -> Value {
         json!({
             "scope": "language",
             "language": "Rust",
             "requested_classes": ["calls", "imports", "references"],
-            "classes": { "calls": "present", "imports": "absent", "references": "absent" },
-            "cross_file_classes": ["calls"],
+            "classes": { "calls": "present", "imports": "absent", "references": "present" },
+            "cross_file_classes": ["calls", "references"],
             "reference_enrichment": "available",
             "budget_exhausted": false,
             "entities_examined": 2,
@@ -3406,6 +3513,14 @@ mod tests {
     /// resolved them, and on Python that something is pyright. The same fixture
     /// with no server installed is the express case wearing a different
     /// language, and it must not certify.
+    ///
+    /// It also carries `references: present`, because the sentence above is not
+    /// true without it. A pyright that resolved this repository's cross-file
+    /// uses left reference edges behind: the enriched arm of stranger run
+    /// npm0543 read `References: 438` on psf/requests with 699 of 1943 relations
+    /// cross-file. This fixture claimed the resolution and denied the edges
+    /// until FIR-2505, which is the same contradiction the express payload
+    /// shipped, and it is why nothing here failed while a deletion was certified.
     #[test]
     fn a_python_graph_that_resolves_its_imports_still_certifies_an_unused_symbol() {
         let mut payload = authoritative_empty_references("function");
@@ -3415,8 +3530,8 @@ mod tests {
             "scope": "language",
             "language": "Python",
             "requested_classes": ["calls", "imports", "references"],
-            "classes": { "calls": "present", "imports": "absent", "references": "absent" },
-            "cross_file_classes": ["calls"],
+            "classes": { "calls": "present", "imports": "absent", "references": "present" },
+            "cross_file_classes": ["calls", "references"],
             "reference_enrichment": "available",
             "budget_exhausted": false,
             "entities_examined": 12,
@@ -3436,15 +3551,25 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("Absence is authoritative"));
-        // Certified, and still honest about the classes it did not observe. The
-        // verdict rests on the resolved calls; saying which classes were empty is
-        // what keeps the next reader from mistaking it for full coverage.
+        // Certified, and still honest about the class it did not observe. The
+        // verdict rests on the resolved calls and references; saying that no
+        // entity-level import edge was seen is what keeps the next reader from
+        // mistaking it for full coverage.
         assert_eq!(
             negative["degraded_signals"],
-            json!([
-                "edge_coverage:imports_absent",
-                "edge_coverage:references_absent"
-            ])
+            json!(["edge_coverage:imports_absent"])
+        );
+        // And FIR-2505's second half on the shape where it bites: an
+        // authoritative verdict that publishes a signal must recite it rather
+        // than claim the response carried none.
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            !reason.contains("no degraded signals"),
+            "a verdict disclosing imports_absent must not claim there were none: {reason}"
+        );
+        assert!(
+            reason.contains("edge_coverage:imports_absent"),
+            "the reason recites what it disclosed: {reason}"
         );
     }
 
@@ -3485,6 +3610,165 @@ mod tests {
         // And an unknown tool inherits nothing: it declares no dependency, so it
         // is neither gated nor granted authority by this map.
         assert!(absence_coverage_gap("some_future_tool", &json!({})).is_none());
+    }
+
+    /// The `edge_coverage` object shipped v0.5.43 certified a deletion on, copied
+    /// verbatim from the isolated stranger run npm0543 against expressjs/express
+    /// at `a3714473feb3`: `impact_analysis` tool_use_id
+    /// `toolu_01VAw8NSCfq74ABm42DAFABu` and `get_context_pack` tool_use_id
+    /// `toolu_011vdWNY8ogtbHfPpec732AR` carry byte-identical `edge_coverage` and
+    /// `_kin.completeness` blocks, which is the evidence that one decision served
+    /// both surfaces (FIR-2505, FIR-2492).
+    fn express_deletion_coverage(references: &str, enrichment: &str) -> Value {
+        json!({
+            "budget_exhausted": false,
+            "classes": { "calls": "present", "imports": "absent", "references": references },
+            "cross_file_classes": ["calls"],
+            "entities_examined": 371,
+            "language": "JavaScript",
+            "reference_enrichment": enrichment,
+            "requested_classes": ["calls", "imports", "references"],
+            "scan": "ran",
+            "scope": "language",
+            "witnessed_by_answer": []
+        })
+    }
+
+    /// FIR-2505 and FIR-2492, the reported direction. All ten exports of
+    /// `lib/express.js` came back `consumer_count: 0`, `safe_to_conclude_absent:
+    /// true` and "safe to treat that entity as unreferenced", on a payload whose
+    /// own `edge_coverage` read `references: absent` beside a language server
+    /// that was available. `express.Router` is referenced 32 times in that
+    /// repository and `express.static` 26 times.
+    #[test]
+    fn a_producible_reference_class_that_produced_nothing_blocks_the_deletion_verdict() {
+        let payload = json!({
+            "entity_impacts": [],
+            "dependents": [],
+            "edge_coverage": express_deletion_coverage("absent", "available")
+        });
+        for tool in ["impact_analysis", "get_context_pack"] {
+            let gap = absence_coverage_gap(tool, &payload)
+                .unwrap_or_else(|| panic!("{tool} must not certify the express deletion shape"));
+            assert!(
+                gap.contains("reference_enrichment_unproduced"),
+                "{tool} names the produced-nothing gap: {gap}"
+            );
+            assert!(
+                gap.contains("JavaScript"),
+                "{tool} names the language the gap is about: {gap}"
+            );
+        }
+    }
+
+    /// The control FIR-2404's descendants exist to protect: the gate must not
+    /// answer "uncertain" to everything. The identical question on a graph whose
+    /// enrichment actually delivered still certifies, so a genuinely dead entity
+    /// stays deletable and the verdict keeps its ability to say yes.
+    #[test]
+    fn an_enriched_graph_still_certifies_the_same_deletion_question() {
+        let payload = json!({
+            "entity_impacts": [],
+            "dependents": [],
+            "edge_coverage": express_deletion_coverage("present", "available")
+        });
+        for tool in ["impact_analysis", "get_context_pack"] {
+            assert_eq!(
+                absence_coverage_gap(tool, &payload),
+                None,
+                "{tool} must still certify when the reference class is present"
+            );
+        }
+    }
+
+    /// The boundary that keeps the gate narrow. Kin's linker mints no
+    /// entity-level `Imports` relation on any language, so `imports: absent` is
+    /// the reading on every real graph including the healthy ones, and gating on
+    /// it would report every answer everywhere as inconclusive. The express
+    /// payload named it as a limit and it is disclosed, not load-bearing.
+    #[test]
+    fn imports_absent_alone_is_never_what_blocks_a_verdict() {
+        let payload = json!({
+            "entity_impacts": [],
+            "edge_coverage": express_deletion_coverage("present", "available")
+        });
+        assert_eq!(payload["edge_coverage"]["classes"]["imports"], json!("absent"));
+        assert_eq!(absence_coverage_gap("impact_analysis", &payload), None);
+    }
+
+    /// A host that could never have produced the class keeps its own reason. The
+    /// new gate is about a class that WAS producible here and was not produced,
+    /// so it must not displace the build-limit and host-limit findings that
+    /// already name a cause an operator can act on.
+    #[test]
+    fn an_unproducible_reference_class_keeps_its_existing_reason() {
+        for (enrichment, expected) in [
+            ("unsupported", "reference_enrichment_unsupported"),
+            ("no_language_server", "reference_enrichment_unsupported"),
+        ] {
+            let payload = json!({
+                "entity_impacts": [],
+                "edge_coverage": express_deletion_coverage("absent", enrichment)
+            });
+            let gap = absence_coverage_gap("impact_analysis", &payload)
+                .unwrap_or_else(|| panic!("{enrichment} must still be gated"));
+            assert!(gap.contains(expected), "{enrichment}: {gap}");
+            assert!(
+                !gap.contains("reference_enrichment_unproduced"),
+                "{enrichment} was never producible here, so the produced-nothing gap must not \
+                 claim it was: {gap}"
+            );
+        }
+    }
+
+    /// FIR-2505's second half. `trust_reason` ended "with no degraded signals" in
+    /// the same object whose `degraded_signals` array held two entries. The
+    /// string was not a summary of the field beside it, it contradicted it.
+    ///
+    /// Asserted on the shape that still certifies, because that is the one where
+    /// the contradiction survives: once a gap fires the reason is the gap and
+    /// makes no claim about silence.
+    #[test]
+    fn a_certified_verdict_recites_its_disclosed_signals_instead_of_denying_them() {
+        let payload = json!({
+            "entity_impacts": [],
+            "edge_coverage": express_deletion_coverage("present", "available")
+        });
+        let negative = negative_for("impact_analysis", &payload, &structural_ready_envelope())
+            .expect("impact_analysis always qualifies");
+        assert_eq!(negative["trust"], json!("authoritative"));
+        let signals = negative["degraded_signals"].as_array().unwrap().clone();
+        assert!(
+            !signals.is_empty(),
+            "this shape discloses imports_absent, or the test is asserting nothing"
+        );
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            !reason.contains("no degraded signals"),
+            "a verdict publishing {signals:?} must not claim there were none: {reason}"
+        );
+        assert!(
+            reason.contains("edge_coverage:imports_absent"),
+            "the reason recites what it disclosed: {reason}"
+        );
+        assert!(
+            reason.contains("structural_authoritative"),
+            "the substrate verdict is kept, not replaced: {reason}"
+        );
+    }
+
+    /// And the other direction: a response with nothing to disclose still says
+    /// so, so the repair adds a fact rather than removing one.
+    #[test]
+    fn a_verdict_with_no_signals_still_says_it_has_none() {
+        let payload = empty_search_page(resolvable_language_scope(Some(12)));
+        let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(negative["degraded_signals"], json!([]));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("no degraded signals"));
     }
 
     /// The language-scope map is the contract, asserted directly rather than
@@ -3651,11 +3935,7 @@ mod tests {
             .contains("degraded"));
         assert_eq!(
             negative["degraded_signals"],
-            json!([
-                "embed_worker_failed",
-                "edge_coverage:imports_absent",
-                "edge_coverage:references_absent"
-            ]),
+            json!(["embed_worker_failed", "edge_coverage:imports_absent"]),
             "the daemon's flag leads, and the answer's own coverage shortfalls follow \
              it rather than being dropped"
         );


### PR DESCRIPTION
`impact_analysis` and `get_context_pack` both certified the deletion of ten live exports of
`lib/express.js` on shipped v0.5.43. This is one root on two surfaces, so it is one change.

## That it is one root

The two archived payloads from stranger run npm0543 carry byte-identical `edge_coverage`
and `_kin.completeness` blocks. `impact_analysis` is tool_use_id
`toolu_01VAw8NSCfq74ABm42DAFABu`, `get_context_pack` is `toolu_011vdWNY8ogtbHfPpec732AR`.
Both read `classes: {calls: present, imports: absent, references: absent}`,
`decided_by: ["calls"]`, `reference_enrichment: "available"`, `scan: "ran"`,
`state: "certified"`, `safe_to_conclude_absent: true`, `limiting_factor: null`. Both tools
declare `reference_classes()` in `absence_cross_file_classes` and both pass through the one
gate `absence_coverage_gap`.

## Mechanism

The gate rested on `load_bearing_classes`, which narrows to `calls`. That narrowing is
correct on any host and is measured rather than assumed: Kin's linker mints no entity-level
`Imports` relation on any language, so `imports` reads absent on every real graph including
healthy ones, and gating on it would report every absence everywhere as inconclusive.

What the set missed is that `references` absent is only ordinary when nothing could have
produced it. The enrichment gate already refuses the two unproducible cases, `unsupported`
and `no_language_server`. It had no case for the third: an adapter wired, the server
installed, and the graph holding none anyway. That is evidence of a gap, not evidence of
absence, and `require('..')` plus a property read is carried by exactly the class that went
missing.

## The discriminator, measured on real graphs

Gating on `references` risks marking everything uncertain, so the threshold was measured on
both arms of the same run rather than assumed. Enriched Python
(`graph-status-requests.txt`): `Calls: 945, Contains: 483, References: 438, ...` with
`Cross-file entity relations: 699 of 1943`. The express arm on the same binary:
`Calls: 254, Contains: 75`, no References at all. A graph whose enrichment delivered reads
`references: present` and still certifies.

## What changed

Three consumers asked the same question and each answered by calling
`load_bearing_classes`: the absence gate, the language scan's skip decision
(`deciding_classes_all_present`), and the completeness block (`edge_class_states`, which
publishes `decided_by` and the `status` computed from it). All three were wrong together,
so all three now read one definition, `deciding_classes(requested, references_producible)`.

Fixing only the gate would have left a response carrying an inconclusive verdict beside
`status: "complete"`, `bound: "exact"` and the note "so the counts here are the whole set".
FIR-2492 quotes that pair as part of the defect.

The scan half closes a live bypass. `get_context_pack` calls the witnessed variant
(`crates/kin-mcp/src/handlers/entities.rs:936`), so a pack whose dependents group witnessed
one cross-file `Calls` edge satisfied the deciding set on the spot, published
`references: unknown` instead of `absent`, and certified on a class nothing had measured.

The absent-class reason now names which half of extraction/enrichment failed, because a
server already on the reader's PATH means the sweep is what to look at rather than the
build's capability.

Second defect in the same object: `trust_reason` ended "with no degraded signals" beside a
two-element `degraded_signals` array. `negative_trust` can only see the daemon's own flags,
so it now states the substrate verdict and stops, and the negative finishes the sentence
from the array it actually publishes, which is the treatment `build_advice` already gave
the same fact.

A query that never asked for `references`, such as `find_references` with
`relation_kinds: ["calls"]`, is untouched.

## The fixture that was itself the bug

The suite's shared healthy-graph fixture `cross_file_edges_observed` read
`references: absent` with `reference_enrichment: available`, which is the express failure
shape rather than a healthy graph. That is why every gate in this module passed while
shipped bytes certified the deletion. Corrected against the enriched-arm numbers above.

## End to end, both directions, on one fixture

Probed through `kin mcp start` rather than the daemon's `/mcp/tools/call` route, which skips
the `_kin`/`negative` envelope this ticket is about. Binaries verified as this branch by a
three-way string probe: a literal the change adds reads 1, a literal it removes reads 0, and
a fabricated control reads 0.

An express-shaped JavaScript fixture (`exports = module.exports = createApplication`,
`exports.Router`, `exports.json`, `exports.static`, a require chain, two consuming files),
run twice with one variable changed.

Sweep on:

```
classes         {"calls":"present","imports":"absent","references":"present"}
decided_by      ["calls","references"]
status / bound  complete / exact
verdict         certified, safe_to_conclude_absent true
```

Sweep off with `KIN_DAEMON_DISABLE_LSP=1`, server still on PATH so the host fact is
unchanged, which is the express shape field for field:

```
classes         {"calls":"present","imports":"absent","references":"absent"}
reference_enr   available
decided_by      ["calls","references"]
status / bound  partial / at_least
verdict         inconclusive, safe_to_conclude_absent false
limiting_factor cross_file_edges_absent: the graph holds no cross-file references edges
                for JavaScript (cross-file calls edges are present and do not stand in for
                references ...)
degraded_signals ["edge_coverage:imports_absent","edge_coverage:references_absent"]
```

The `entity_impacts` rows still carry `consumer_count: 0`, which is honest. What is gone is
the sentence telling a caller that a zero there is an authoritative negative and the entity
is safe to treat as unreferenced. `limiting_factor` is a reason rather than `null`, and the
completeness block no longer calls the counts the whole set. `trust_reason` on the certifying
run reads "...; the disclosed signals [edge_coverage:imports_absent] were considered and are
not load-bearing for this claim", beside that exact array.

## Gates

Post-rebase onto `2a80f4a6`: `cargo nextest run --workspace --no-fail-fast --locked` reports
`6604 tests run: 6604 passed (4 slow, 3 leaky), 12 skipped`, `cargo test --doc --locked`
exit 0, clippy exactly as ci.yml runs it (`RUSTFLAGS=-D warnings`, `--all-targets
--all-features`, 45-lint debt allow-list) exit 0 over 539 units, `cargo fmt --all --check`
exit 0, and all six guard scripts exit 0 including the hydration falsifier on a poisoned
copy. Scope, read with the merge-base form because a bare `git diff origin/main` renders
other lanes' additions as this branch's changes, is exactly the three kin-mcp files.

## Falsification

Eight breaks, each with the named test re-run to a raw exit code and a check that a test
actually ran. All eight fail as required; all five controls pass on the restored tree.

- `deciding_classes` never adds `references`: the gate test, the scan test and the
  completeness test all fail (101).
- Every requested class decides: `imports_absent_alone_is_never_what_blocks_a_verdict` and
  `an_enriched_graph_still_certifies_the_same_deletion_question` fail (101).
- `deciding_classes` ignores the host: the no-server scan control fails (101).
- `trust_reason` always claims silence, and never states the clean case: the two
  reconciliation tests fail (101).

The first falsification pass of this set was invalid and the way it failed is worth
recording: it passed several test-name filters to one `cargo test`, which errors with rc 1
without running anything, and the harness read that as "fails as required". The control run
returning rc 1 on a known-green tree exposed it. The suite now asserts on `running 1 test`
as well as the exit code.

Closes FIR-2505
Closes FIR-2492
