### PR TITLE
Gate the release train on the proof loop's own records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -999,6 +999,7 @@ jobs:
             scripts/check-glibc-floor.test.mjs \
             scripts/check-kin-vfs-compat.test.mjs \
             scripts/check-rc-build-drift.test.mjs \
+            scripts/check-release-proof-artifacts.test.mjs \
             scripts/check-release-version.test.mjs \
             scripts/extract-release-notes.test.mjs \
             scripts/prepare-release.test.mjs \

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -58,7 +58,7 @@ jobs:
       # reads exactly like one that never came, which is the reading that keeps
       # the alarm quiet. The artifact stays, because later cycles need this run
       # to be readable from outside it.
-      marker: ${{ steps.plan.outputs.marker }}
+      marker: ${{ steps.proof.outputs.marker || steps.plan.outputs.marker }}
     steps:
       - name: Mint repository-scoped release branch token
         id: app-token
@@ -653,8 +653,118 @@ jobs:
             -m "Activate protected checks for the automated release PR"
           git push origin "HEAD:refs/heads/${BRANCH}"
 
-      - name: Arm protected auto-merge
+      # A release bump is ready only when the candidate has been proven. On
+      # 2026-08-20 the train merged its own bump kin#986, tagged v0.5.44 and
+      # promoted it to Latest with no preflight record for that candidate and no
+      # stranger run on its bytes. The only thing that had ever stood between
+      # the autonomous cadence and an unproofed cut was a session-local holder
+      # monitor, correctly retired when its pause-era purpose ended, and the
+      # autopilot flew through the open gate the same evening. A gate that lives
+      # in a monitor can always be retired correctly again, so this one lives in
+      # the train.
+      #
+      # Keyed on the pull request head, which is the sha the proof loop judges
+      # and the same sha the arming step below pins the merge to with
+      # --match-head-commit. Gating one sha and merging another would leave open
+      # the window this step exists to close.
+      #
+      # The policy is read from origin/main rather than from the checkout, for
+      # the same reason the release intent resolver is: the branch under
+      # judgement must not be able to lower the bar it is judged against.
+      - name: Require proof-loop artifacts for the candidate
+        id: proof
         if: steps.plan.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.pr.outputs.number }}
+          BASE_TAG: ${{ steps.plan.outputs.base_tag }}
+          MAIN_SHA: ${{ steps.plan.outputs.main_sha }}
+          DRIFT: ${{ steps.plan.outputs.drift }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          head_sha="$(gh pr view "$PR" \
+            --repo "$REPO" \
+            --json headRefOid \
+            --jq .headRefOid)"
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+
+          gate="$RUNNER_TEMP/check-release-proof-artifacts.mjs"
+          git show \
+            "refs/remotes/origin/main:scripts/check-release-proof-artifacts.mjs" \
+            > "$gate"
+          test -s "$gate"
+
+          if out="$(CANDIDATE_SHA="$head_sha" GITHUB_REPOSITORY="$REPO" \
+            node "$gate" 2>&1)"; then
+            echo "held=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${out}"
+            exit 0
+          fi
+
+          # Keep the whole failure on one line rather than its last line. A
+          # multi-line message whose final line is blank reads exactly like a
+          # pass, which is how a guard in this fleet once reported green while
+          # failing.
+          detail="$(printf '%s' "$out" \
+            | tr '\n' ' ' \
+            | sed -e 's/::error:://g' -e 's/  */ /g' -e 's/^ //' -e 's/ $//')"
+          echo "::notice::${detail}"
+
+          # Hold the bump in draft. Standing down is correct here and will be
+          # frequent, but standing down invisibly is how a held rail once sat
+          # for roughly twenty hours, so this writes the same marker the plan
+          # step writes and the alarm job reads.
+          if [ "$(gh pr view "$PR" --repo "$REPO" --json isDraft --jq .isDraft)" != "true" ]; then
+            gh pr ready "$PR" --repo "$REPO" --undo
+          fi
+
+          # One comment per candidate head, not one per cycle: this workflow
+          # runs on a schedule, and a hold that comments every cycle buries the
+          # PR it is trying to explain.
+          existing="$(gh pr view "$PR" --repo "$REPO" \
+            --json comments --jq '.comments[].body' 2>/dev/null || true)"
+          if [ "$(printf '%s' "$existing" | command grep -cF "$head_sha" || true)" -eq 0 ]; then
+            gh pr comment "$PR" --repo "$REPO" --body "$(printf '%s\n\n%s\n' \
+              "Held: the release proof loop has not recorded candidate ${head_sha}." \
+              "${detail}")"
+          fi
+
+          latest_tag="$(gh api "repos/${REPO}/releases/latest" --jq .tag_name 2>/dev/null || true)"
+          marker="$RUNNER_TEMP/release-hold-marker.json"
+          jq -n \
+            --arg detail "$detail" \
+            --arg latest_tag "$latest_tag" \
+            --arg base_tag "$BASE_TAG" \
+            --arg main_sha "$MAIN_SHA" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg run_url "${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}" \
+            --argjson drift "${DRIFT:-0}" \
+            '{
+              schema: "kin.release-hold.v1",
+              state: "held",
+              reason: "proof_artifacts_missing",
+              detail: $detail,
+              blocking_tag: "",
+              latest_tag: $latest_tag,
+              base_tag: $base_tag,
+              drift: $drift,
+              main_sha: $main_sha,
+              run_id: $run_id,
+              run_url: $run_url,
+              failed_release_run_id: null,
+              failed_release_run_url: null,
+              observed_at: (now | todateiso8601)
+            }' > "$marker"
+          {
+            echo "marker<<KIN_RELEASE_HOLD_MARKER"
+            jq -c . "$marker"
+            echo "KIN_RELEASE_HOLD_MARKER"
+            echo "held=true"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Arm protected auto-merge
+        if: steps.plan.outputs.needed == 'true' && steps.proof.outputs.held != 'true'
         env:
           # Register auto-merge as the release App, not GITHUB_TOKEN. GitHub
           # suppresses most workflow events caused by GITHUB_TOKEN; an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2320,11 +2320,34 @@ jobs:
     environment: release
     permissions:
       contents: write
+      # Resolving the pull request behind the tagged commit, which is how the
+      # proof gate below bridges a squash back to the candidate that was proven.
+      pull-requests: read
     steps:
       - name: Checkout release policy
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      # The same evidence the release train requires before it merges a bump,
+      # required again here against the tag actually being promoted. The train's
+      # gate protects the path the train owns; this one protects every other
+      # path into Latest, because a tag reaches Latest through this job no
+      # matter how it was minted. On 2026-08-20 v0.5.44 reached Latest with no
+      # preflight record and no stranger run, and nothing in the train knew the
+      # proof loop existed.
+      #
+      # A squash mints a new commit, so a tag's own sha is never the sha the
+      # proof loop judged: v0.5.44's tag commit a4ffe620 is kin#986's squash,
+      # while the preflight for that line judged the release-next head. The
+      # resolver bridges that through the merged pull request. A commit no
+      # merged pull request produced resolves to nothing and is refused, which
+      # is the intended answer for a hand-pushed tag.
+      - name: Require proof-loop artifacts for the tagged candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESOLVE_FROM_COMMIT: ${{ github.sha }}
+        run: node scripts/check-release-proof-artifacts.mjs
 
       - name: Promote stable tag after public and npm proof
         if: ${{ !contains(github.ref_name, '-') }}

--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// The release train's proof-loop gate.
+//
+// On 2026-08-20 the train ran end to end with nobody at the button: it merged
+// its own version bump, tagged v0.5.44, and promoted to Latest, and no
+// preflight had judged that candidate and no stranger had run on its bytes.
+// The only thing that had ever stood between the autonomous cadence and an
+// unproofed cut was a session-local holder monitor. That monitor was correctly
+// retired when its pause-era purpose ended, and the autopilot flew through the
+// open gate the same evening. A gate that lives in a monitor can always be
+// retired correctly again, so this one lives in the train.
+//
+// Both decision points import this module rather than reimplementing it, so
+// they cannot disagree about what counts as evidence while agreeing that they
+// checked: release-train.yml holds the version bump when the candidate has
+// none, and release.yml refuses to promote a tag that has none.
+//
+// The gate reads the proof loop's own records, not a summary of them. A
+// preflight record names, per leg, the commit that leg judged and the archive
+// sha256 it judged there. A stranger run.env names the archive sha256 the
+// stranger actually ran. Requiring the stranger's archive to appear among the
+// preflight's legs is what links the two: it proves the stranger ran on the
+// bytes the preflight judged FOR THIS COMMIT, rather than on some other build
+// that merely also exists. Two independent existence checks would not.
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+// Records live on an orphan branch rather than on main: they are per-candidate
+// evidence, they arrive after the commit they describe, and writing them to
+// main would put a commit on main for every proof run, which would itself
+// become drift the train then wants to release.
+export const EVIDENCE_REF = 'release-evidence';
+export const PREFLIGHT_SCHEMA = 'kin.release-preflight.v1';
+export const PREFLIGHT_RECORD = 'preflight.json';
+export const STRANGER_RECORD = 'stranger.env';
+
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+const ARCHIVE_SHA = /^[0-9a-f]{64}$/;
+
+export function evidencePath(sha, name) {
+  if (typeof sha !== 'string' || !COMMIT_SHA.test(sha)) {
+    throw new Error(
+      `"${sha}" is not a 40-character commit sha; this gate keys on the ` +
+      'candidate\'s exact commit, and a loose ref would let it answer about ' +
+      'a different build',
+    );
+  }
+  return `evidence/${sha}/${name}`;
+}
+
+// The stranger writes a flat key=value run.env rather than JSON. Values may
+// contain '=', so split on the first one only.
+export function parseRunEnv(text) {
+  const out = {};
+  for (const raw of String(text).split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+    const eq = line.indexOf('=');
+    if (eq <= 0) {
+      continue;
+    }
+    out[line.slice(0, eq)] = line.slice(eq + 1);
+  }
+  return out;
+}
+
+export function judgePreflight(record, sha) {
+  const where = evidencePath(sha, PREFLIGHT_RECORD);
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    throw new Error(`${where} did not parse as a preflight record`);
+  }
+  if (record.schema !== PREFLIGHT_SCHEMA) {
+    throw new Error(
+      `${where} carries schema "${record.schema ?? '<none>'}", not ` +
+      `${PREFLIGHT_SCHEMA}; refusing to read an unknown record as evidence`,
+    );
+  }
+  if (record.verdict !== 'PASS') {
+    throw new Error(
+      `${where} records verdict ${record.verdict ?? '<none>'}, not PASS; ` +
+      'the candidate did not clear preflight',
+    );
+  }
+  // Citability is deliberately NOT the test. kin-release-preflight emits
+  // citable false and lane DEV-LOCAL on every run by design, so requiring
+  // citability would be the mirror of a check that cannot fail: a check that
+  // cannot pass, holding every release forever and looking principled doing
+  // it. allow_dirty carries the same intent and a real run can clear it.
+  if (record.allow_dirty === true) {
+    throw new Error(
+      `${where} was run with allow_dirty, so it judged a build from ` +
+      'uncommitted changes, which is not what any tag can contain',
+    );
+  }
+  const legs = Array.isArray(record.legs) ? record.legs : [];
+  if (legs.length === 0) {
+    throw new Error(`${where} records no legs, so it judged nothing`);
+  }
+  const archives = [];
+  legs.forEach((leg, index) => {
+    const name = leg?.name ?? `leg ${index}`;
+    const result = leg?.result ?? {};
+    const commit = result?.expected?.commit;
+    if (commit !== sha) {
+      throw new Error(
+        `${where} leg "${name}" judged commit ${commit ?? '<none>'}, not ` +
+        `${sha}; the record exists but is about a different build`,
+      );
+    }
+    if (leg?.verdict !== 'PASS') {
+      throw new Error(
+        `${where} leg "${name}" records verdict ${leg?.verdict ?? '<none>'}, ` +
+        'not PASS',
+      );
+    }
+    const archive = result?.archive?.sha256;
+    if (typeof archive !== 'string' || !ARCHIVE_SHA.test(archive)) {
+      throw new Error(
+        `${where} leg "${name}" records no archive sha256, so nothing can ` +
+        'link a stranger run to the bytes it judged',
+      );
+    }
+    archives.push(archive);
+  });
+  return { archives };
+}
+
+export function judgeStranger(env, sha, archives) {
+  const where = evidencePath(sha, STRANGER_RECORD);
+  const archive = env?.archive_sha256;
+  if (!archive) {
+    throw new Error(
+      `${where} carries no archive_sha256, so it does not say which bytes ` +
+      'the stranger ran',
+    );
+  }
+  if (!env?.finished_at) {
+    throw new Error(
+      `${where} carries no finished_at, so the stranger run did not ` +
+      'complete and its verdict is unknown',
+    );
+  }
+  if (!archives.includes(archive)) {
+    throw new Error(
+      `${where} ran archive sha256 ${archive}, which no preflight leg for ` +
+      `${sha} judged (${archives.join(', ')}); the stranger ran, but not on ` +
+      'these bytes',
+    );
+  }
+  return { archive };
+}
+
+// Fails closed. An unreadable record is not a passing check, so a transport
+// failure raises here rather than returning something a caller could mistake
+// for evidence. Absence and unreadability raise different messages on purpose:
+// one means the proof loop never ran, the other means we cannot tell.
+export async function fetchEvidence(
+  sha,
+  name,
+  { repository, token, fetchImpl = fetch } = {},
+) {
+  const path = evidencePath(sha, name);
+  const url =
+    `https://api.github.com/repos/${repository}/contents/${path}?ref=${EVIDENCE_REF}`;
+  const headers = {
+    accept: 'application/vnd.github.raw',
+    'user-agent': 'kin-release-proof-gate',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(url, { headers });
+  } catch (cause) {
+    throw new Error(
+      `could not reach ${repository} to read ${path} on ${EVIDENCE_REF}: ${cause.message}`,
+      { cause },
+    );
+  }
+  if (response.status === 404) {
+    throw new Error(
+      `${path} does not exist on the ${EVIDENCE_REF} branch of ${repository}; ` +
+      'the proof loop has not recorded this candidate, so it cannot be released',
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      `could not read ${path} on ${EVIDENCE_REF}: ` +
+      `HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  return response.text();
+}
+
+// A squash merge mints a new commit, so the sha a tag points at is never the
+// sha the proof loop judged. Preflight runs on the release branch head, and the
+// tag lands on the squash of that branch onto main: v0.5.44's tag commit
+// a4ffe620 is kin#986's squash, while the preflight for that line judged the
+// release-next head. Resolving the originating pull request's head is what
+// connects the two, and it is the only link that survives a squash, because the
+// squash shares no sha, no parent and no tree with the branch it flattened.
+//
+// A commit with no originating pull request resolves to nothing and the caller
+// refuses it. That is the intended answer for a tag minted through a path the
+// train does not own, including a hand-pushed one, which is exactly the case
+// this gate's second decision point exists to catch.
+export async function resolveCandidateSha(
+  commitSha,
+  { repository, token, fetchImpl = fetch } = {},
+) {
+  if (typeof commitSha !== 'string' || !COMMIT_SHA.test(commitSha)) {
+    throw new Error(`"${commitSha}" is not a 40-character commit sha`);
+  }
+  const url = `https://api.github.com/repos/${repository}/commits/${commitSha}/pulls`;
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'kin-release-proof-gate',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(url, { headers });
+  } catch (cause) {
+    throw new Error(
+      `could not reach ${repository} to resolve the pull request behind ${commitSha}: ${cause.message}`,
+      { cause },
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      `could not resolve the pull request behind ${commitSha}: ` +
+      `HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  const pulls = await response.json();
+  const merged = (Array.isArray(pulls) ? pulls : []).filter(
+    (pull) => pull?.merge_commit_sha === commitSha && COMMIT_SHA.test(pull?.head?.sha ?? ''),
+  );
+  if (merged.length === 0) {
+    throw new Error(
+      `no merged pull request produced ${commitSha}, so there is no candidate ` +
+      'branch head whose proof records could be found; a tag minted outside ' +
+      'the release train carries no evidence by construction',
+    );
+  }
+  if (merged.length > 1) {
+    const names = merged.map((pull) => `#${pull.number}`).join(', ');
+    throw new Error(
+      `${commitSha} is claimed as the merge commit of more than one pull ` +
+      `request (${names}); refusing to guess which candidate was proven`,
+    );
+  }
+  return merged[0].head.sha;
+}
+
+// Two callers, one judge. CANDIDATE_SHA names the candidate directly, which is
+// what the release train has before it merges. RESOLVE_FROM_COMMIT names a
+// landed commit to bridge through its merged pull request, which is what the
+// promote gate has: by then the candidate has been squashed and its sha is
+// gone from history.
+export async function main({
+  sha = process.env.CANDIDATE_SHA,
+  resolveFromCommit = process.env.RESOLVE_FROM_COMMIT,
+  repository = process.env.GITHUB_REPOSITORY,
+  env = process.env,
+  fetchImpl = fetch,
+  log = console.log,
+} = {}) {
+  if (!repository) {
+    throw new Error('no repository given; set GITHUB_REPOSITORY');
+  }
+  const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+  const options = { repository, token, fetchImpl };
+
+  if (!sha && resolveFromCommit) {
+    sha = await resolveCandidateSha(resolveFromCommit, options);
+    log(`Resolved candidate ${sha} from landed commit ${resolveFromCommit}`);
+  }
+  if (!sha) {
+    throw new Error(
+      'no candidate given; set CANDIDATE_SHA, or RESOLVE_FROM_COMMIT to bridge ' +
+      'a landed commit through the pull request that produced it',
+    );
+  }
+
+  const preflightText = await fetchEvidence(sha, PREFLIGHT_RECORD, options);
+  let preflight;
+  try {
+    preflight = JSON.parse(preflightText);
+  } catch (cause) {
+    throw new Error(
+      `${evidencePath(sha, PREFLIGHT_RECORD)} is not valid JSON: ${cause.message}`,
+      { cause },
+    );
+  }
+  const { archives } = judgePreflight(preflight, sha);
+
+  const strangerText = await fetchEvidence(sha, STRANGER_RECORD, options);
+  const { archive } = judgeStranger(parseRunEnv(strangerText), sha, archives);
+
+  log(
+    `Verified release proof artifacts for ${sha}: preflight PASS across ` +
+    `${archives.length} leg(s), stranger ran archive sha256 ${archive}`,
+  );
+  return { sha, archives, archive };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -130,6 +130,20 @@ export function judgePreflight(record, sha) {
   return { archives };
 }
 
+// What a satisfied gate does and does not say.
+//
+// This accepts a record from a stranger run that FAILED, and that is deliberate.
+// The tests are that the run finished and that it ran the bytes a preflight leg
+// judged; the arm's own result is not a test, because the doctrine is that the
+// report must EXIST, and "the run found nothing" is a finding about the run
+// rather than about the build. The first real back-fill proves the point rather
+// than leaving it theoretical: rc0545's run.env finished at 2026-08-20T21:35:26Z
+// with its brown arm having exited rc=30, and this function accepts it.
+//
+// So a gate that passes means A STRANGER RUN HAPPENED ON THESE BYTES. It never
+// means the stranger passed. Those two readings are one careless sentence apart
+// in a status update, and only one of them is true. Anyone quoting this gate as
+// evidence of a good release is quoting it wrong.
 export function judgeStranger(env, sha, archives) {
   const where = evidencePath(sha, STRANGER_RECORD);
   const archive = env?.archive_sha256;

--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -144,6 +144,17 @@ export function judgePreflight(record, sha) {
 // means the stranger passed. Those two readings are one careless sentence apart
 // in a status update, and only one of them is true. Anyone quoting this gate as
 // evidence of a good release is quoting it wrong.
+//
+// It also never means the stranger ran EVERYTHING. Nothing below reads the
+// `arms` field, deliberately: a green-only run.env satisfies this function
+// exactly as a two-arm one does, because a gate that demanded every arm would
+// block every budget-constrained release, which is the deferred-instrument
+// problem arriving by another door. The consequence is that a release evidenced
+// by one arm carries less coverage than one evidenced by two, and this gate
+// cannot tell you which you are holding. Where that difference matters it goes
+// in the release note, not here. The two halves of this misreading are
+// neighbours and a reader will meet them together, so they are written
+// together.
 export function judgeStranger(env, sha, archives) {
   const where = evidencePath(sha, STRANGER_RECORD);
   const archive = env?.archive_sha256;

--- a/scripts/check-release-proof-artifacts.test.mjs
+++ b/scripts/check-release-proof-artifacts.test.mjs
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EVIDENCE_REF,
+  PREFLIGHT_RECORD,
+  PREFLIGHT_SCHEMA,
+  STRANGER_RECORD,
+  evidencePath,
+  fetchEvidence,
+  judgePreflight,
+  judgeStranger,
+  main,
+  parseRunEnv,
+  resolveCandidateSha,
+} from './check-release-proof-artifacts.mjs';
+
+const SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
+const ARCHIVE_A = '1'.repeat(64);
+const ARCHIVE_B = '2'.repeat(64);
+const ARCHIVE_UNJUDGED = '3'.repeat(64);
+const REPO = 'firelock-ai/kin';
+
+// Shaped on a real record: .kin-coord/preflight/20260820T112905Z/preflight.json
+// carried schema kin.release-preflight.v1, verdict PASS, citable false, lane
+// DEV-LOCAL, allow_dirty false, and three legs whose expected.commit all
+// agreed while each carried its own archive sha256.
+const preflightRecord = (over = {}) => ({
+  schema: PREFLIGHT_SCHEMA,
+  verdict: 'PASS',
+  citable: false,
+  lane: 'DEV-LOCAL',
+  allow_dirty: false,
+  legs: [
+    {
+      name: 'linux (arm64, debian 12, archive)',
+      verdict: 'PASS',
+      result: { expected: { commit: SHA }, archive: { sha256: ARCHIVE_A } },
+    },
+    {
+      name: 'host (macos-aarch64, archive)',
+      verdict: 'PASS',
+      result: { expected: { commit: SHA }, archive: { sha256: ARCHIVE_B } },
+    },
+  ],
+  ...over,
+});
+
+const strangerEnv = (over = {}) => ({
+  archive_name: 'kin-linux-aarch64.tar.gz',
+  archive_sha256: ARCHIVE_A,
+  finished_at: '2026-08-18T21:53:25Z',
+  ...over,
+});
+
+const throwsWith = (fn, fragment) =>
+  assert.throws(fn, (error) => {
+    assert.match(error.message, fragment);
+    return true;
+  });
+
+test('evidencePath keys on an exact commit sha and refuses a loose ref', () => {
+  assert.equal(
+    evidencePath(SHA, PREFLIGHT_RECORD),
+    `evidence/${SHA}/${PREFLIGHT_RECORD}`,
+  );
+  for (const loose of ['main', 'HEAD', 'v0.5.44', SHA.slice(0, 7), '']) {
+    throwsWith(() => evidencePath(loose, PREFLIGHT_RECORD), /not a 40-character commit sha/);
+  }
+});
+
+test('parseRunEnv reads the stranger key=value record', () => {
+  const parsed = parseRunEnv(
+    [
+      '# a comment',
+      '',
+      'archive_name=kin-linux-aarch64.tar.gz',
+      `archive_sha256=${ARCHIVE_A}`,
+      'vm_capacity=5 vCPU, 12884901888 bytes',
+      'continue_mission=',
+      'image_id=sha256:881ca213=weird',
+    ].join('\n'),
+  );
+  assert.equal(parsed.archive_name, 'kin-linux-aarch64.tar.gz');
+  assert.equal(parsed.archive_sha256, ARCHIVE_A);
+  assert.equal(parsed.vm_capacity, '5 vCPU, 12884901888 bytes');
+  assert.equal(parsed.continue_mission, '');
+  // Values may contain '=': split on the first one only.
+  assert.equal(parsed.image_id, 'sha256:881ca213=weird');
+});
+
+test('judgePreflight accepts a well-formed record and returns its archives', () => {
+  assert.deepEqual(judgePreflight(preflightRecord(), SHA), {
+    archives: [ARCHIVE_A, ARCHIVE_B],
+  });
+});
+
+// Regression guard. kin-release-preflight hardcodes citable false and lane
+// DEV-LOCAL on every run it will ever emit, so a gate requiring citability is
+// a check that cannot pass: it would hold every release forever. This test
+// fails the moment someone reintroduces that rule.
+test('judgePreflight accepts the DEV-LOCAL non-citable record every real run emits', () => {
+  const record = preflightRecord({ citable: false, lane: 'DEV-LOCAL' });
+  assert.doesNotThrow(() => judgePreflight(record, SHA));
+});
+
+test('judgePreflight refuses a record that is not a preflight record', () => {
+  throwsWith(() => judgePreflight(null, SHA), /did not parse as a preflight record/);
+  throwsWith(() => judgePreflight([], SHA), /did not parse as a preflight record/);
+  throwsWith(
+    () => judgePreflight(preflightRecord({ schema: 'kin.something-else.v1' }), SHA),
+    /carries schema "kin\.something-else\.v1", not kin\.release-preflight\.v1/,
+  );
+});
+
+test('judgePreflight refuses a candidate that did not clear preflight', () => {
+  throwsWith(
+    () => judgePreflight(preflightRecord({ verdict: 'FAIL' }), SHA),
+    /records verdict FAIL, not PASS/,
+  );
+  throwsWith(
+    () => judgePreflight(preflightRecord({ verdict: undefined }), SHA),
+    /records verdict <none>, not PASS/,
+  );
+});
+
+test('judgePreflight refuses a run that judged uncommitted changes', () => {
+  throwsWith(
+    () => judgePreflight(preflightRecord({ allow_dirty: true }), SHA),
+    /was run with allow_dirty/,
+  );
+});
+
+test('judgePreflight refuses a record that judged nothing', () => {
+  throwsWith(() => judgePreflight(preflightRecord({ legs: [] }), SHA), /records no legs/);
+  throwsWith(
+    () => judgePreflight(preflightRecord({ legs: undefined }), SHA),
+    /records no legs/,
+  );
+});
+
+// The fabricated-artifact control: a real, well-formed, PASSING record that is
+// simply about a different build. Existence alone must not satisfy the gate.
+test('judgePreflight refuses a real record that is about a different commit', () => {
+  throwsWith(
+    () => judgePreflight(preflightRecord(), OTHER_SHA),
+    new RegExp(`judged commit ${SHA}, not ${OTHER_SHA}`),
+  );
+  const mixed = preflightRecord();
+  mixed.legs[1].result.expected.commit = OTHER_SHA;
+  throwsWith(
+    () => judgePreflight(mixed, SHA),
+    /leg "host \(macos-aarch64, archive\)" judged commit b+, not a+/,
+  );
+});
+
+test('judgePreflight refuses a failing leg under a passing overall verdict', () => {
+  const record = preflightRecord();
+  record.legs[1].verdict = 'FAIL';
+  throwsWith(() => judgePreflight(record, SHA), /leg "host .*" records verdict FAIL, not PASS/);
+});
+
+test('judgePreflight refuses a leg with no archive to link a stranger run to', () => {
+  const record = preflightRecord();
+  delete record.legs[0].result.archive;
+  throwsWith(() => judgePreflight(record, SHA), /records no archive sha256/);
+  const short = preflightRecord();
+  short.legs[0].result.archive.sha256 = 'not-a-sha';
+  throwsWith(() => judgePreflight(short, SHA), /records no archive sha256/);
+});
+
+test('judgeStranger accepts a run on bytes a preflight leg judged', () => {
+  assert.deepEqual(judgeStranger(strangerEnv(), SHA, [ARCHIVE_A, ARCHIVE_B]), {
+    archive: ARCHIVE_A,
+  });
+});
+
+test('judgeStranger refuses a record that names no bytes or never finished', () => {
+  throwsWith(
+    () => judgeStranger(strangerEnv({ archive_sha256: '' }), SHA, [ARCHIVE_A]),
+    /carries no archive_sha256/,
+  );
+  throwsWith(
+    () => judgeStranger(strangerEnv({ finished_at: '' }), SHA, [ARCHIVE_A]),
+    /carries no finished_at/,
+  );
+});
+
+// The chain, not two existence checks: a stranger run that really happened but
+// on some other build must not satisfy this candidate's gate.
+test('judgeStranger refuses a real run on bytes no preflight leg judged', () => {
+  throwsWith(
+    () => judgeStranger(strangerEnv({ archive_sha256: ARCHIVE_UNJUDGED }), SHA, [
+      ARCHIVE_A,
+      ARCHIVE_B,
+    ]),
+    /the stranger ran, but not on these bytes/,
+  );
+});
+
+const stubFetch = (routes) => async (url) => {
+  for (const [fragment, response] of Object.entries(routes)) {
+    if (url.includes(fragment)) {
+      return response;
+    }
+  }
+  return { ok: false, status: 404, statusText: 'Not Found', text: async () => '' };
+};
+
+const ok = (body) => ({ ok: true, status: 200, statusText: 'OK', text: async () => body });
+
+test('fetchEvidence reads a record off the evidence branch', async () => {
+  let seen = '';
+  const text = await fetchEvidence(SHA, PREFLIGHT_RECORD, {
+    repository: REPO,
+    fetchImpl: async (url) => {
+      seen = url;
+      return ok('{}');
+    },
+  });
+  assert.equal(text, '{}');
+  assert.match(seen, new RegExp(`/repos/${REPO}/contents/evidence/${SHA}/${PREFLIGHT_RECORD}`));
+  assert.match(seen, new RegExp(`ref=${EVIDENCE_REF}`));
+});
+
+test('fetchEvidence reports absence as an unrecorded candidate', async () => {
+  await assert.rejects(
+    fetchEvidence(SHA, PREFLIGHT_RECORD, {
+      repository: REPO,
+      fetchImpl: async () => ({ ok: false, status: 404, statusText: 'Not Found' }),
+    }),
+    /the proof loop has not recorded this candidate/,
+  );
+});
+
+// Fails closed: an unreadable answer is not agreement.
+test('fetchEvidence fails closed on transport and server failure', async () => {
+  await assert.rejects(
+    fetchEvidence(SHA, PREFLIGHT_RECORD, {
+      repository: REPO,
+      fetchImpl: async () => {
+        throw new Error('socket hang up');
+      },
+    }),
+    /could not reach firelock-ai\/kin .*socket hang up/,
+  );
+  await assert.rejects(
+    fetchEvidence(SHA, PREFLIGHT_RECORD, {
+      repository: REPO,
+      fetchImpl: async () => ({ ok: false, status: 500, statusText: 'Server Error' }),
+    }),
+    /could not read .*HTTP 500 Server Error/,
+  );
+});
+
+test('main proceeds when both records exist for the exact candidate', async () => {
+  const lines = [];
+  const result = await main({
+    sha: SHA,
+    repository: REPO,
+    env: {},
+    log: (line) => lines.push(line),
+    fetchImpl: stubFetch({
+      [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+      [STRANGER_RECORD]: ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`),
+    }),
+  });
+  assert.equal(result.archive, ARCHIVE_A);
+  assert.deepEqual(result.archives, [ARCHIVE_A, ARCHIVE_B]);
+  assert.match(lines.join('\n'), /Verified release proof artifacts/);
+});
+
+test('main holds a candidate with no preflight record', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({}),
+    }),
+    /the proof loop has not recorded this candidate/,
+  );
+});
+
+test('main holds a candidate whose preflight ran but whose stranger did not', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+      }),
+    }),
+    new RegExp(`evidence/${SHA}/${STRANGER_RECORD} does not exist`),
+  );
+});
+
+test('main holds when the records exist but describe a different build', async () => {
+  await assert.rejects(
+    main({
+      sha: OTHER_SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+        [STRANGER_RECORD]: ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`),
+      }),
+    }),
+    /the record exists but is about a different build/,
+  );
+});
+
+test('main reports unparseable evidence rather than reading it as absent', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({ [PREFLIGHT_RECORD]: ok('not json at all') }),
+    }),
+    /is not valid JSON/,
+  );
+});
+
+const jsonOk = (body) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  json: async () => body,
+});
+
+const RC_HEAD = 'c'.repeat(40);
+
+// Shaped on the real v0.5.44 line: tag commit a4ffe620 is kin#986's squash, and
+// the preflight for it judged the release-next head, a different sha.
+test('resolveCandidateSha bridges a squash to the branch head that was proven', async () => {
+  let seen = '';
+  const head = await resolveCandidateSha(SHA, {
+    repository: REPO,
+    fetchImpl: async (url) => {
+      seen = url;
+      return jsonOk([
+        { number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD } },
+      ]);
+    },
+  });
+  assert.equal(head, RC_HEAD);
+  assert.match(seen, new RegExp(`/repos/${REPO}/commits/${SHA}/pulls`));
+});
+
+// A hand-pushed tag has no originating pull request. That is precisely the
+// "unforeseen path" the promote gate exists to catch, so it must refuse.
+test('resolveCandidateSha refuses a commit no merged pull request produced', async () => {
+  await assert.rejects(
+    resolveCandidateSha(SHA, { repository: REPO, fetchImpl: async () => jsonOk([]) }),
+    /no merged pull request produced/,
+  );
+  // An open pull request that merely touches the commit is not its merge.
+  await assert.rejects(
+    resolveCandidateSha(SHA, {
+      repository: REPO,
+      fetchImpl: async () =>
+        jsonOk([{ number: 1, merge_commit_sha: OTHER_SHA, head: { sha: RC_HEAD } }]),
+    }),
+    /no merged pull request produced/,
+  );
+});
+
+test('resolveCandidateSha refuses to guess between two claimants', async () => {
+  await assert.rejects(
+    resolveCandidateSha(SHA, {
+      repository: REPO,
+      fetchImpl: async () =>
+        jsonOk([
+          { number: 1, merge_commit_sha: SHA, head: { sha: RC_HEAD } },
+          { number: 2, merge_commit_sha: SHA, head: { sha: OTHER_SHA } },
+        ]),
+    }),
+    /claimed as the merge commit of more than one pull request \(#1, #2\)/,
+  );
+});
+
+test('resolveCandidateSha fails closed on transport and server failure', async () => {
+  await assert.rejects(
+    resolveCandidateSha(SHA, {
+      repository: REPO,
+      fetchImpl: async () => {
+        throw new Error('socket hang up');
+      },
+    }),
+    /could not reach .*socket hang up/,
+  );
+  await assert.rejects(
+    resolveCandidateSha(SHA, {
+      repository: REPO,
+      fetchImpl: async () => ({ ok: false, status: 403, statusText: 'Forbidden' }),
+    }),
+    /could not resolve the pull request behind .*HTTP 403 Forbidden/,
+  );
+});
+
+test('resolveCandidateSha refuses a loose ref', async () => {
+  await assert.rejects(
+    resolveCandidateSha('main', { repository: REPO, fetchImpl: async () => jsonOk([]) }),
+    /not a 40-character commit sha/,
+  );
+});
+
+test('main bridges a landed commit to the candidate that was proven', async () => {
+  const lines = [];
+  const result = await main({
+    resolveFromCommit: SHA,
+    repository: REPO,
+    env: {},
+    log: (line) => lines.push(line),
+    fetchImpl: async (url) => {
+      if (url.includes('/pulls')) {
+        return jsonOk([{ number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD } }]);
+      }
+      if (url.includes(PREFLIGHT_RECORD)) {
+        const record = preflightRecord();
+        record.legs.forEach((leg) => {
+          leg.result.expected.commit = RC_HEAD;
+        });
+        return ok(JSON.stringify(record));
+      }
+      return ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`);
+    },
+  });
+  assert.equal(result.sha, RC_HEAD);
+  assert.match(lines.join('\n'), new RegExp(`Resolved candidate ${RC_HEAD} from landed commit ${SHA}`));
+});
+
+test('main refuses when neither a candidate nor a commit to bridge is given', async () => {
+  await assert.rejects(
+    main({ repository: REPO, env: {}, log: () => {}, fetchImpl: async () => ok('') }),
+    /no candidate given/,
+  );
+});


### PR DESCRIPTION
Run against v0.5.44's actual tag commit, this gate prints `Resolved candidate a5a316c8e6320bb25a37f2a3d2c84cb6d276fa63 from landed commit a4ffe620...` and then refuses it for having no proof records. That is this gate catching the exact incident that filed the ticket, on real GitHub data rather than a fixture.

The release train now refuses to merge a version bump or promote a tag unless the proof loop's own records exist for that exact candidate. On 2026-08-20 it did all three with nobody at the button: merged its own bump kin#986, tagged v0.5.44, and promoted to Latest, with no preflight record for the candidate and no stranger run on its bytes.

## The chain rule is the spine of this design

Two independent existence checks would prove only that a preflight happened and that a stranger happened. Requiring the stranger's `archive_sha256` to appear among the preflight legs for the gated commit proves the stranger ran on the bytes the preflight judged FOR THIS RELEASE. That is the sentence the whole ticket exists to make true, and every other rule here is in service of it.

## Why this is not just a missing assertion

The root cause is that the automation had no knowledge the proof loop exists. The only thing that had ever held an unproofed cut was a session-local holder monitor, which was correctly retired when its pause-era purpose ended. A gate that lives in a monitor can always be retired correctly again, so this one lives in the train.

Two facts turned up while building it that the ticket does not cover, and both changed the design.

The evidence was not reachable from CI at all. `.kin-coord/preflight/<stamp>/preflight.json` is an umbrella coordination path: `git ls-files` finds nothing under `.kin-coord` in this repo, and neither `bin/kin-release-preflight` nor `bin/kin-stranger` publishes its record anywhere. Both only consume from GitHub. So the records live solely on the operator's disk, and no Actions job can see them. This change therefore defines a CI-readable, sha-keyed evidence surface, an orphan `release-evidence` branch carrying `evidence/<sha>/preflight.json` and `evidence/<sha>/stranger.env`, read through the contents API. That is the same shape `scripts/check-kin-vfs-compat.mjs` already uses to read another repo's lock at a pinned ref, including its fail-closed behavior, so it inherits a reviewed precedent rather than introducing a new mechanism.

The two decision points do not share a sha. A squash mints a new commit, so the tag's sha is never the sha the proof loop judged. v0.5.44's tag commit `a4ffe620` is kin#986's squash, while the preflight for that line judged the release-next head. The promote gate bridges that through the merged pull request, and a commit no merged pull request produced resolves to nothing and is refused, which is the intended answer for a hand-pushed tag.

## What the gate checks

`scripts/check-release-proof-artifacts.mjs` takes one exact commit and refuses when the record is absent, when the answer is unreadable, when the verdict is not PASS, when the run judged uncommitted changes, when the record is about a different build, or when the stranger's `archive_sha256` matches no archive any preflight leg judged.

Citability is deliberately not the test. `bin/kin-release-preflight` hardcodes `citable: false` and `lane: "DEV-LOCAL"` on every record it emits, so requiring citability would be the mirror of a check that cannot fail: a check that cannot pass, holding every release forever and looking principled doing it. `allow_dirty` carries the same intent and a real run can clear it. A test asserts the DEV-LOCAL non-citable record is accepted, so the unsatisfiable rule cannot be reintroduced quietly.

## Where the gates sit

`release-train.yml` requires the records for the pull request head before it arms auto-merge. That is the same sha the arming step already pins the merge to with `--match-head-commit`, so nothing can land other than what was gated. A hold drafts the bump, comments once per candidate head rather than once per scheduled cycle, and writes the same `kin.release-hold.v1` marker the alarm job reads, because a rail that stands down invisibly is a failure this workflow's own comments record having had.

`release.yml` requires them again in `finalize_release`, before the `--prerelease=false --latest` flip. The job gains `pull-requests: read` for the bridge. This one protects every path into Latest rather than only the path the train owns.

## Gating performed

29 unit tests pass, registered in the `node --test` list ci.yml already runs. `actionlint` exits 0 on all three modified workflows, and rejects a deliberately broken copy as the control. `scripts/test-release-workflow-authority.py`, `check-rc-build-drift.mjs`, `check-kin-vfs-compat.mjs`, `release-hold-alarm.test.mjs`, the full release `node --test` list, `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `verify-hydration-semantics.py`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh` and `test-private-repo-coupling.py` all exit 0. No Rust changed.

## Falsification

Seven mutations, seven named test failures, source byte-identical after each restore. Removing the commit-match check fails `main holds when the records exist but describe a different build`. Removing the `allow_dirty` check fails `judgePreflight refuses a run that judged uncommitted changes`. Removing the stranger archive linkage fails `judgeStranger refuses a real run on bytes no preflight leg judged`. Treating 404 as readable fails `main holds a candidate with no preflight record`. Removing the verdict check fails `judgePreflight refuses a candidate that did not clear preflight`. Dropping the `merge_commit_sha` filter fails `resolveCandidateSha refuses a commit no merged pull request produced`. Dropping the multi-claimant refusal fails `resolveCandidateSha refuses to guess between two claimants`.

Run live against real shas rather than only fixtures. Against main's head it exits 1 with `evidence/bb8bebe3.../preflight.json does not exist on the release-evidence branch`. Against v0.5.44's actual tag commit it prints `Resolved candidate a5a316c8e6320bb25a37f2a3d2c84cb6d276fa63 from landed commit a4ffe620...` and then refuses, which is this gate catching the exact incident that filed the ticket. Against a commit with no merged pull request it refuses at the resolver.

## What this does not do, and the sequencing it needs

This is deliberately `Refs` and not `Closes`. Two pieces of the ticket's acceptance are not in this change.

The publisher does not exist yet. Nothing writes to the `release-evidence` branch, because the proof-loop scripts are umbrella-tracked and that is a kin-ecosystem change. Until it lands, this gate holds every release. That is the current intended state, since the interim hold is already live and #991 is drafted, but it is a decision to take deliberately rather than discover. Landing this first is still right: it satisfies the ticket's own acceptance that an unproofed bump cannot merge or promote, and it fails closed rather than open.

The session holder monitor should not be retired until the publisher is live, or releases will be held by a gate nothing can satisfy with no operator path to satisfy it.

## Do not land this before v0.5.45 cuts

This PR is deliberately held until v0.5.45 has shipped, and the captain submits it only after that. A tag run resolves its workflows from the tag, so if this landed first, kin#991's arming and v0.5.45's promotion would both meet a fail-closed gate with no publisher live and no records posted. The gate would block the very release whose proof loop is running correctly right now with its evidence sitting in local files. It lands with or just before the umbrella publisher, and the first gated release either back-fills its evidence or posts it natively.

Refs FIR-2525


## State at submit, 2026-08-21 00:50Z

The sequencing above is satisfied. v0.5.45 tagged at 00:24:22Z on 657a4e1d, whose tag run carries no copy of this gate. The publisher landed as kin-ecosystem#92 at 23:59Z, and the first real publish ran at 00:41Z: evidence/bb8bebe34057d9a6397db0b2ca49a7d096996800/preflight.json and stranger.env now exist on the release-evidence branch, which that publish created as an orphan branch. So the paragraph that says the publisher does not exist yet described the tree at 20:30Z and no longer describes it. The session holder monitor has been stood down; from this commit forward, holding is done by this gate.
