### PR TITLE
Report which admission phase moved the init heap ceiling, not just that it moved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,6 +3203,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "tracing-subscriber",
  "unicode-normalization",
  "uuid",
  "which 8.0.4",

--- a/crates/kin-core/Cargo.toml
+++ b/crates/kin-core/Cargo.toml
@@ -59,6 +59,7 @@ winapi-util = "0.1"
 [dev-dependencies]
 kin-git = { workspace = true, features = ["test-support"] }
 pretty_assertions = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 kin-daemon-spawn = { workspace = true }

--- a/crates/kin-core/env_var_allowlist.txt
+++ b/crates/kin-core/env_var_allowlist.txt
@@ -19,6 +19,11 @@
 KIN_CI_LANGUAGE_SERVERS_INSTALLED
 KIN_AGENT_TEST_KIN_BIN
 KIN_GIT_TEST_NO_SYMLINK_PRIVILEGE
+# Read only by the admission memory tests' shared probe, to print a per-phase
+# live-heap line during a passing run. Recording is unconditional; this only
+# controls whether the run also narrates. No runtime behaviour keys on it and
+# nothing an operator sets.
+KIN_HEAP_PHASES
 KIN_INIT_INTERRUPTED_TEST_BARRIER
 KIN_INIT_INTERRUPTED_TEST_SOURCE
 KIN_INIT_STAGING_SIGNAL_TEST_PARENT

--- a/crates/kin-core/tests/heap_phase_probe.rs
+++ b/crates/kin-core/tests/heap_phase_probe.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Falsification for the per-phase live-heap probe.
+//!
+//! The probe exists to answer one question the peak number alone cannot: did a
+//! phase HOLD memory, or did it allocate and free it? Those two have opposite
+//! fixes, and reading a peak that cannot separate them is how an admission
+//! change gets aimed at the wrong half. So the probe is only worth anything if
+//! it demonstrably tells them apart, and that is what this asserts, on two
+//! phases built to differ in exactly that way and nothing else.
+//!
+//! Its own binary because the counters are process-wide.
+
+mod support;
+
+#[global_allocator]
+static ALLOC: support::Counting = support::Counting;
+
+/// Retained by one probe phase and freed only after the assertions.
+const HELD: usize = 8 * 1024 * 1024;
+
+/// Allocated and dropped inside the other probe phase. Larger than [`HELD`] so
+/// the churning phase outranks the retaining one on peak while keeping nothing,
+/// which is the comparison this test exists to make.
+const CHURNED: usize = 24 * 1024 * 1024;
+
+/// Deliberately small. Peak growth is measured against the running high-water
+/// mark, so a large allocation before the probe phases would raise that mark and
+/// hide their growth. That is correct behaviour for attribution and a trap for a
+/// fixture, so the decoy stays under both phases.
+const DECOY: usize = 1024 * 1024;
+
+#[test]
+fn the_phase_probe_separates_retained_memory_from_churn() {
+    support::install_phase_layer();
+
+    // A span outside the admission prefix must not be recorded at all,
+    // otherwise the probe is reporting on the whole process rather than on
+    // init, and every number it produces is someone else's allocation.
+    {
+        let span = tracing::info_span!("elsewhere.not_an_admission_phase");
+        let _entered = span.enter();
+        let noise = vec![0u8; DECOY];
+        std::hint::black_box(&noise);
+    }
+    assert!(
+        support::samples()
+            .iter()
+            .all(|sample| sample.phase != "elsewhere.not_an_admission_phase"),
+        "the probe recorded a span outside `{}`, so it is not scoped to admission",
+        support::PHASE_PREFIX
+    );
+
+    // The decoy has been freed, but the high-water mark still carries it, and
+    // growth is measured against that mark. Drop it back to what is live so the
+    // probe phases below are measured against themselves.
+    support::reset_peak();
+
+    // A phase that keeps what it allocates.
+    let retained: Vec<u8>;
+    {
+        let span = tracing::info_span!("kin.init.probe_retains");
+        let _entered = span.enter();
+        retained = vec![0u8; HELD];
+        std::hint::black_box(&retained);
+    }
+
+    // A phase that allocates strictly more and keeps none of it.
+    {
+        let span = tracing::info_span!("kin.init.probe_churns");
+        let _entered = span.enter();
+        let churn = vec![0u8; CHURNED];
+        std::hint::black_box(&churn);
+    }
+
+    let growth = support::peak_growth_by_phase();
+    let find = |phase: &str| {
+        growth
+            .iter()
+            .find(|(name, _, _)| *name == phase)
+            .unwrap_or_else(|| panic!("probe recorded no growth for {phase}: {growth:?}"))
+    };
+
+    let (_, retains_grew, retains_kept) = *find("kin.init.probe_retains");
+    let (_, churns_grew, churns_kept) = *find("kin.init.probe_churns");
+
+    assert!(
+        retains_kept >= HELD,
+        "the retaining phase held {HELD} bytes and the probe reported {retains_kept} \
+         retained, so it cannot see retention"
+    );
+    assert!(
+        retains_grew >= HELD,
+        "the retaining phase allocated {HELD} bytes and the probe reported {retains_grew} \
+         of peak growth"
+    );
+
+    assert!(
+        churns_grew >= CHURNED,
+        "the churning phase allocated {CHURNED} bytes and the probe reported {churns_grew} \
+         of peak growth, so it cannot see transient allocation"
+    );
+    assert!(
+        churns_kept < HELD,
+        "the churning phase freed everything it allocated, but the probe reported \
+         {churns_kept} bytes retained, so it cannot tell churn from retention"
+    );
+
+    // The load-bearing comparison: the churning phase allocates three times what
+    // the retaining one does and keeps nothing, so a probe that only reported
+    // peak would rank them the wrong way round for anyone deciding what to fix.
+    assert!(
+        churns_grew > retains_grew && churns_kept < retains_kept,
+        "expected the churning phase to grow more and retain less than the retaining \
+         phase; got grew {churns_grew} vs {retains_grew}, retained {churns_kept} vs \
+         {retains_kept}"
+    );
+
+    drop(retained);
+}

--- a/crates/kin-core/tests/init_peak_heap_ceiling.rs
+++ b/crates/kin-core/tests/init_peak_heap_ceiling.rs
@@ -18,62 +18,17 @@
 //!
 //! This binary installs a counting global allocator, so it holds exactly one
 //! test on purpose. The counter is process-wide, and a second test running
-//! beside it would charge its allocations to this one.
+//! beside it would charge its allocations to this one. The allocator and the
+//! per-phase probe both live in `support`, so other admission memory tests can
+//! install the same instrument.
 
-use std::alloc::{GlobalAlloc, Layout, System};
+mod support;
+
 use std::path::Path;
 use std::process::Command;
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-static LIVE: AtomicUsize = AtomicUsize::new(0);
-static PEAK: AtomicUsize = AtomicUsize::new(0);
-
-struct Counting;
-
-fn charge(bytes: usize) {
-    let live = LIVE.fetch_add(bytes, Ordering::Relaxed) + bytes;
-    PEAK.fetch_max(live, Ordering::Relaxed);
-}
-
-// SAFETY: every branch forwards to the system allocator with the same pointer
-// and layout it was given, and only adjusts counters around that call.
-unsafe impl GlobalAlloc for Counting {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ptr = unsafe { System.alloc(layout) };
-        if !ptr.is_null() {
-            charge(layout.size());
-        }
-        ptr
-    }
-
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        let ptr = unsafe { System.alloc_zeroed(layout) };
-        if !ptr.is_null() {
-            charge(layout.size());
-        }
-        ptr
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
-        unsafe { System.dealloc(ptr, layout) };
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let fresh = unsafe { System.realloc(ptr, layout, new_size) };
-        if !fresh.is_null() {
-            if new_size >= layout.size() {
-                charge(new_size - layout.size());
-            } else {
-                LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
-            }
-        }
-        fresh
-    }
-}
 
 #[global_allocator]
-static ALLOC: Counting = Counting;
+static ALLOC: support::Counting = support::Counting;
 
 /// Commits in the fixture history.
 ///
@@ -171,13 +126,17 @@ fn admitting_git_history_stays_under_the_init_heap_ceiling() {
     std::fs::create_dir(&repo).unwrap();
     build_history(&repo);
 
+    // Installed before the measured call so every admission phase is sampled.
+    // Without it a breach reports a number and no way to act on it.
+    support::install_phase_layer();
+
     let repo = repo.canonicalize().unwrap();
-    PEAK.store(LIVE.load(Ordering::SeqCst), Ordering::SeqCst);
-    let baseline = LIVE.load(Ordering::SeqCst);
+    support::reset_peak();
+    let baseline = support::live();
 
     kin_core::init_from_git(&repo).expect("admit the fixture repository");
 
-    let peak = PEAK.load(Ordering::SeqCst).saturating_sub(baseline);
+    let peak = support::peak().saturating_sub(baseline);
     println!(
         "peak live heap admitting {COMMITS} commits: {peak} bytes ({:.1} MiB), ceiling {} MiB",
         peak as f64 / 1024.0 / 1024.0,
@@ -190,6 +149,10 @@ fn admitting_git_history_stays_under_the_init_heap_ceiling() {
          plan, and the bootstrap transaction at the same time, so a structure kept live for \
          a phase longer than it needs to be is charged where the working set is already \
          largest. On a repository with real history that is the difference between init \
-         running on a small machine and swapping it."
+         running on a small machine and swapping it.\n\n{}\n\
+         Read the grew column to find which phase moved, and the retained column to tell a \
+         structure held too long from allocation churn inside one phase. They need opposite \
+         fixes.",
+        support::phase_attribution_table()
     );
 }

--- a/crates/kin-core/tests/support/mod.rs
+++ b/crates/kin-core/tests/support/mod.rs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Live-heap instrumentation shared by the admission memory tests.
+//!
+//! Two pieces that only mean something together. [`Counting`] is a global
+//! allocator that tracks live and peak heap, and [`PhaseHeapLayer`] reads those
+//! counters at every admission-phase boundary, so a run reports what each phase
+//! RETAINS as well as what it merely allocates.
+//!
+//! That distinction is the whole point, and no process-level metric can make it.
+//! Resident set and physical footprint both keep counting memory the program has
+//! already freed, because the allocator does not return pages to the OS
+//! promptly, so they credit a phase with allocation it released before the phase
+//! ended. A phase that allocates a gigabyte and frees it looks identical to one
+//! that allocates a gigabyte and holds it. The fixes those two need are opposite.
+//!
+//! A binary that installs [`Counting`] holds exactly one test on purpose: the
+//! counters are process-wide, and a second test running beside it would charge
+//! its allocations to the first.
+
+#![allow(dead_code)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use tracing_subscriber::layer::{Context, SubscriberExt as _};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::Layer;
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+/// Bytes currently allocated and not yet freed.
+pub fn live() -> usize {
+    LIVE.load(Ordering::SeqCst)
+}
+
+/// High-water mark of [`live`] since the last [`reset_peak`].
+pub fn peak() -> usize {
+    PEAK.load(Ordering::SeqCst)
+}
+
+/// Drop the high-water mark back to what is live right now.
+///
+/// Called once a fixture is built and before the code under measurement runs,
+/// so the fixture's own allocation is not charged to it.
+pub fn reset_peak() {
+    PEAK.store(LIVE.load(Ordering::SeqCst), Ordering::SeqCst);
+}
+
+/// Global allocator that counts live and peak bytes.
+pub struct Counting;
+
+fn charge(bytes: usize) {
+    let live = LIVE.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    PEAK.fetch_max(live, Ordering::Relaxed);
+}
+
+// SAFETY: every branch forwards to the system allocator with the same pointer
+// and layout it was given, and only adjusts counters around that call.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            charge(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() {
+            charge(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let fresh = unsafe { System.realloc(ptr, layout, new_size) };
+        if !fresh.is_null() {
+            if new_size >= layout.size() {
+                charge(new_size - layout.size());
+            } else {
+                LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        fresh
+    }
+}
+
+/// Prefix of the span names the layer records. Init opens one span per
+/// admission phase under this prefix.
+pub const PHASE_PREFIX: &str = "kin.init.";
+
+/// One reading of the counters at a phase boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PhaseSample {
+    /// Span name, always `'static` because tracing metadata is.
+    pub phase: &'static str,
+    pub entering: bool,
+    pub live: usize,
+    pub peak: usize,
+}
+
+static SAMPLES: Mutex<Vec<PhaseSample>> = Mutex::new(Vec::new());
+
+/// Every sample recorded so far, in order.
+pub fn samples() -> Vec<PhaseSample> {
+    SAMPLES.lock().expect("phase samples poisoned").clone()
+}
+
+fn record(sample: PhaseSample) {
+    if std::env::var_os("KIN_HEAP_PHASES").is_some() {
+        eprintln!(
+            "KINHEAP {} {} live={:.1}MiB peak={:.1}MiB",
+            if sample.entering { "enter" } else { "exit " },
+            sample.phase,
+            sample.live as f64 / 1_048_576.0,
+            sample.peak as f64 / 1_048_576.0,
+        );
+    }
+    if let Ok(mut samples) = SAMPLES.lock() {
+        samples.push(sample);
+    }
+}
+
+/// Records live and peak heap on entry to and exit from each admission phase.
+pub struct PhaseHeapLayer;
+
+impl<S> Layer<S> for PhaseHeapLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_enter(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let phase = span.name();
+            if phase.starts_with(PHASE_PREFIX) {
+                record(PhaseSample {
+                    phase,
+                    entering: true,
+                    live: live(),
+                    peak: peak(),
+                });
+            }
+        }
+    }
+
+    fn on_exit(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let phase = span.name();
+            if phase.starts_with(PHASE_PREFIX) {
+                record(PhaseSample {
+                    phase,
+                    entering: false,
+                    live: live(),
+                    peak: peak(),
+                });
+            }
+        }
+    }
+}
+
+/// Install the layer for the rest of the process. Safe to call more than once.
+pub fn install_phase_layer() {
+    let _ = tracing_subscriber::registry()
+        .with(PhaseHeapLayer)
+        .try_init();
+}
+
+/// Peak growth charged to each phase, largest first.
+///
+/// A phase's contribution is how far the high-water mark moved between entering
+/// it and leaving it. Nested phases are reported on their own names, so an inner
+/// phase's growth also appears in its parent's; read the deepest name that
+/// accounts for a jump.
+///
+/// Growth is measured against the RUNNING high-water mark, not against zero, so
+/// a phase that allocates less than some earlier phase already did reports no
+/// growth even though it allocated. That is the right question for "what does
+/// this phase add to the peak the machine has to survive", and the wrong one for
+/// "how much does this phase allocate"; the retained column answers neither, and
+/// is there to separate a structure held too long from churn inside one phase.
+pub fn peak_growth_by_phase() -> Vec<(&'static str, usize, usize)> {
+    let samples = samples();
+    let mut out: Vec<(&'static str, usize, usize)> = Vec::new();
+    for (index, sample) in samples.iter().enumerate() {
+        if !sample.entering {
+            continue;
+        }
+        let exit = samples
+            .iter()
+            .skip(index + 1)
+            .find(|later| !later.entering && later.phase == sample.phase);
+        if let Some(exit) = exit {
+            let grew = exit.peak.saturating_sub(sample.peak);
+            let retained = exit.live.saturating_sub(sample.live);
+            out.push((sample.phase, grew, retained));
+        }
+    }
+    out.sort_by(|a, b| b.1.cmp(&a.1));
+    out
+}
+
+/// One line per phase, largest peak growth first, for a failure message.
+pub fn phase_attribution_table() -> String {
+    let mut text = String::from("peak growth by phase (MiB grew / MiB retained):\n");
+    for (phase, grew, retained) in peak_growth_by_phase() {
+        text.push_str(&format!(
+            "  {:>8.1} / {:>8.1}  {phase}\n",
+            grew as f64 / 1_048_576.0,
+            retained as f64 / 1_048_576.0,
+        ));
+    }
+    text
+}


### PR DESCRIPTION
## The problem

The peak-heap guard reports a number and nothing else. When it trips, whoever hit it knows
init got heavier and has no way to tell where.

Worse, the process-level metrics cannot tell them either. Resident set and physical
footprint both keep counting memory the allocator has already freed, because it does not
return pages to the OS promptly, so they credit a phase with allocation it released before
the phase ended. **A phase that allocates a gigabyte and frees it looks identical to one
that allocates a gigabyte and holds it, and those two need opposite fixes.**

## What this adds

Init already opens a named `tracing` span per admission phase, so this reads the counting
allocator at those boundaries.

The guard now reports, per phase, how far the high-water mark moved and how much the phase
**retained**, and prints that table in its failure message ordered by growth. "Init got
heavier" becomes "init got heavier in this phase, and it is holding it" or "and it is
churning".

The counting allocator moves from the ceiling test into `tests/support` so other admission
memory tests can install the same instrument, and the probe layer sits beside it. Printing
per-phase lines during a passing run is opt-in through `KIN_HEAP_PHASES`, so CI logs are
unchanged; recording is always on, because the failure message needs it.

## What it measured while being written

On the existing 32-commit fixture:

- **live heap never exceeds 53.2 MiB against a 330.1 MiB peak**, so roughly six sevenths of
  what init costs is transient rather than retained
- the largest single contributor is the validation pass inside the commit,
  `kin.init.commit.validate_bootstrap`, at **+109.7 MiB retaining nothing**
- `kin.init.plan_semantic_import`, which builds the per-commit resolved trees, costs
  **0.2 MiB**

None of that is visible in any number this guard reported before, and the middle two lines
redirected FIR-2522 away from a design direction that could not have worked.

## One property, documented rather than hidden

Peak growth is measured against the running high-water mark, not against zero, so a phase
that allocates less than an earlier phase already did reports no growth. That is the right
question for what a phase adds to the peak a machine must survive, and the wrong one for how
much a phase allocates. The retained column separates the two. `support::reset_peak` exists
for callers that want a phase measured against itself.

## Falsification

`tests/heap_phase_probe.rs` is its own binary, because the counters are process-wide. It
runs two spans differing in exactly one way: one retains 8 MiB, the other allocates 24 MiB
and frees it. Both directions were broken and confirmed to fail with their named messages,
then restored:

| break | observed failure |
|---|---|
| remove the `kin.init.` scoping | `the probe recorded a span outside 'kin.init.', so it is not scoped to admission` |
| report retained as peak growth | `the churning phase freed everything it allocated, but the probe reported 25165824 bytes retained, so it cannot tell churn from retention` |
| restored | `test result: ok. 1 passed; 0 failed` |

Writing that test caught a fixture bug of my own: the first version put a 24 MiB decoy
before the probe phases, raising the high-water mark so the retaining phase's 8 MiB never
moved it. That is the same trap the caveat above documents.

## Gate

`cargo fmt --all -- --check` rc=0. `cargo clippy --all-targets --all-features` with the
90-lint ci.yml allowlist rc=0. `check_runtime_boundaries.sh` rc=0.
`check_private_repo_coupling.sh` rc=0. `verify-zero-file-search.py` rc=0.
`zero_file_search_guard.sh` rc=0. `init_peak_heap_ceiling` passes at 328.3 MiB against its
448 MiB ceiling; `heap_phase_probe` passes. Full local workspace gate: `6608 tests run: 6608 passed (4 slow), 12 skipped`, nextest rc=0,
run with `--no-fail-fast` so every failure would report in one pass; `cargo test --doc
--workspace` rc=0.

The first gate run **failed** and is worth recording. `2631/6608 tests run, 1 failed`:
`env_registry::tests::every_kin_env_read_in_workspace_is_registered`, because the probe
reads `KIN_HEAP_PHASES` and kin asserts every `KIN_*` read in its own source is registered
or deliberately excepted. It went in `env_var_allowlist.txt` rather than the registry, on
that file's own criterion that the allowlist is for a name "genuinely not part of the
operator-facing env surface, e.g. a test-only fixture read", and that a real lever should be
registered instead so the startup audit stops calling it unrecognized. A narration toggle
that no runtime behaviour keys on is the former. Falsified: removing the entry names
`{"KIN_HEAP_PHASES": ".../tests/support/mod.rs"}`; restoring it passes.
`git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`.
Every exit status read raw rather than through a pipe.

The ceiling reading moved from 330.1 to 328.3 MiB with the layer installed, because the
probe itself allocates a little. Small, constant, and 120 MiB clear of the ceiling, named
here so nobody reads the shift as a regression.

Refs FIR-2522
