### PR TITLE
Size the reconcile loop's first hold-off to a cold commit's arrival

### DIFF
--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -6104,7 +6104,8 @@ mod tests {
             "an eighth of twelve seconds is more than the interval bound allows"
         );
         assert!(
-            commit_yield_grace(&state, Duration::from_secs(60), false) <= COMMIT_YIELD_GRACE_CEILING,
+            commit_yield_grace(&state, Duration::from_secs(60), false)
+                <= COMMIT_YIELD_GRACE_CEILING,
             "no poll cadence may turn the grace into a stall"
         );
     }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1670,6 +1670,60 @@ const COMMIT_YIELD_GRACE_INTERVALS: u32 = 5;
 /// The upper bound on holding off, whatever the other two say.
 const COMMIT_YIELD_GRACE_CEILING: Duration = Duration::from_secs(1);
 
+/// The largest number of poll intervals the first admitting round of a daemon's
+/// life will hold off for.
+///
+/// Eighty rather than five, and the difference is the whole cold-start fix.
+/// The three settled bounds all price the wait against a publication that has
+/// already happened. None of them price the only quantity the wait has to
+/// cover, which is how long a `kin commit` takes to reach this daemon, and on
+/// the first round that quantity is at its largest: `kin init` stops the daemon
+/// it converted with, so the commit after a store build either starts a daemon
+/// itself or meets one whose first tick is still publishing the build's
+/// leftovers, and either way its process is starting from cold.
+///
+/// Expressed in poll intervals rather than seconds so the promise the settled
+/// bound makes still holds here: a loop configured to react faster holds off
+/// proportionally less.
+const COLD_START_COMMIT_YIELD_GRACE_INTERVALS: u32 = 80;
+
+/// The upper bound on the first round's hold-off, whatever the cadence says.
+///
+/// Eight seconds because the window it has to cover was measured at 5,174 ms on
+/// shipped v0.5.43: the tick committed to publishing at 16:04:06.883 and the
+/// commit announced itself at 16:04:12.057, read from
+/// `publish_workspace_admission` and `coordination_gate_wait` in that run's
+/// daemon log. The settled grace cannot exceed 500 ms at the default cadence,
+/// which is ten times short of it.
+///
+/// Safe because it is spent at most once per daemon process and released the
+/// instant a commit announces itself. What it costs when no commit comes is one
+/// ambient admission arriving later than it used to, and nothing waits on that
+/// admission: `/commands/commit` forces its own complete admission of the
+/// working copy and never consults this loop.
+const COLD_START_COMMIT_YIELD_GRACE_CEILING: Duration = Duration::from_secs(8);
+
+/// The one cold-start grace a daemon process gets.
+///
+/// Held by the reconcile loop rather than derived from the publication record,
+/// because a commit that takes the first round leaves that record untouched:
+/// `/commands/commit` publishes its own successor through its own transaction
+/// and never reports one here, so a daemon whose first round yielded would look
+/// exactly as cold on the next round, and the next, forever.
+#[derive(Debug)]
+struct ColdStartGrace(bool);
+
+impl ColdStartGrace {
+    fn new() -> Self {
+        Self(true)
+    }
+
+    /// Take the cold-start grace if this process has not spent it yet.
+    fn claim(&mut self) -> bool {
+        std::mem::replace(&mut self.0, false)
+    }
+}
+
 /// How long a tick holds off before publishing, waiting to see whether a commit
 /// is about to make its publication redundant.
 ///
@@ -1689,16 +1743,35 @@ const COMMIT_YIELD_GRACE_CEILING: Duration = Duration::from_secs(1);
 /// less. And never more than a second.
 ///
 /// A daemon that has not published yet has no measurement to scale by, so it
-/// uses the interval bound alone. That is the protective direction on purpose:
-/// the first publication of a process is exactly the one whose cost is unknown.
-fn commit_yield_grace(state: &DaemonState, interval: Duration) -> Duration {
+/// uses the interval bound alone.
+///
+/// Those three bounds together are why the first commit after a store build
+/// still lost. At the default hundred-millisecond cadence the interval bound is
+/// 500ms and dominates every other term, so no publication cost, however large,
+/// buys a longer wait: an eighth of the 13,358ms publication measured on
+/// shipped v0.5.43 is 1,669ms and the ceiling clipped it to 500. The window it
+/// had to cover on that run was 5,174ms. `cold_start` is the correction, and it
+/// applies to the first admitting round of a process rather than to a cost,
+/// because the quantity that is large on that round is the commit's own
+/// startup, which no publication measurement describes.
+fn commit_yield_grace(state: &DaemonState, interval: Duration, cold_start: bool) -> Duration {
     let ceiling = interval
         .saturating_mul(COMMIT_YIELD_GRACE_INTERVALS)
         .min(COMMIT_YIELD_GRACE_CEILING);
-    match state.last_authority_publication() {
+    let settled = match state.last_authority_publication() {
         Some(last) => (last / COMMIT_YIELD_GRACE_SHARE).min(ceiling),
         None => ceiling,
+    };
+    if !cold_start {
+        return settled;
     }
+    // Never shorter than a settled round would have waited. The cold round is
+    // the one with the most to gain from waiting and the least to lose by it.
+    settled.max(
+        interval
+            .saturating_mul(COLD_START_COMMIT_YIELD_GRACE_INTERVALS)
+            .min(COLD_START_COMMIT_YIELD_GRACE_CEILING),
+    )
 }
 
 /// Report whether this reconcile round should stand down for a commit.
@@ -1711,11 +1784,14 @@ fn commit_yield_grace(state: &DaemonState, interval: Duration) -> Duration {
 /// itself.
 ///
 /// The wait holds no lock. It happens before the round takes the coordination
-/// gate, so the commit it is waiting for is never waiting on it.
+/// gate, so the commit it is waiting for is never waiting on it. That is what
+/// makes `cold_start` affordable: the round that claims it can wait seconds
+/// without any other path in the daemon noticing.
 async fn wait_out_imminent_commit(
     state: &DaemonState,
     interval: Duration,
     consecutive_yields: u32,
+    cold_start: bool,
 ) -> bool {
     if consecutive_yields >= MAX_CONSECUTIVE_COMMIT_YIELDS {
         return false;
@@ -1728,7 +1804,7 @@ async fn wait_out_imminent_commit(
     if state.pending_commits.any() {
         return true;
     }
-    let grace = commit_yield_grace(state, interval);
+    let grace = commit_yield_grace(state, interval, cold_start);
     if grace.is_zero() {
         return false;
     }
@@ -1872,6 +1948,11 @@ pub async fn run_loop(
     // Bounded by MAX_CONSECUTIVE_COMMIT_YIELDS so a commit that never leaves the
     // daemon cannot hold ambient admission off forever.
     let mut commit_yields: u32 = 0;
+    // The one long hold-off this process gets, claimed by the first round that
+    // has anything to admit. That round is the one whose commit is starting a
+    // `kin` process from cold, and the settled bounds are sized for a commit
+    // that is already warm.
+    let mut cold_start_grace = ColdStartGrace::new();
 
     // Register with the self-limit supervisor. Registered here rather than at
     // daemon start so a repository that never runs this loop — filesystem
@@ -2071,11 +2152,17 @@ pub async fn run_loop(
         // the retry ladder. The working stretch is deliberately not ended here
         // either. This path is bounded, and a stretch cleared on a path the loop
         // keeps reaching is a stretch the supervisor can no longer measure.
-        if wait_out_imminent_commit(&state, interval, commit_yields).await {
+        // Claimed here rather than inside the wait, because the claim is about
+        // this round having reached the wait at all: the first round with
+        // events to admit is the cold one whether it ends up standing down or
+        // admitting.
+        let cold_start = cold_start_grace.claim();
+        if wait_out_imminent_commit(&state, interval, commit_yields, cold_start).await {
             commit_yields += 1;
             debug!(
                 consecutive = commit_yields,
                 pending = pending_events.len(),
+                cold_start,
                 "holding this reconcile round for a commit inside the daemon"
             );
             tokio::select! {
@@ -5907,7 +5994,7 @@ mod tests {
         let _commit = state.pending_commits.announce();
 
         assert!(
-            wait_out_imminent_commit(&state, Duration::from_secs(3600), 0).await,
+            wait_out_imminent_commit(&state, Duration::from_secs(3600), 0, false).await,
             "a commit inside the daemon is read directly, not waited for"
         );
     }
@@ -5924,7 +6011,7 @@ mod tests {
 
         let started = std::time::Instant::now();
         assert!(
-            !wait_out_imminent_commit(&state, Duration::from_millis(2), 0).await,
+            !wait_out_imminent_commit(&state, Duration::from_millis(2), 0, false).await,
             "no commit arrived, so the round admits"
         );
         assert!(
@@ -5951,7 +6038,7 @@ mod tests {
         // A 200ms poll interval puts the grace at its one-second ceiling, which
         // is fifty times the arrival above.
         assert!(
-            wait_out_imminent_commit(&state, Duration::from_millis(200), 0).await,
+            wait_out_imminent_commit(&state, Duration::from_millis(200), 0, false).await,
             "a commit that arrives inside the grace takes the round"
         );
         arriving.abort();
@@ -5970,7 +6057,7 @@ mod tests {
 
         for round in 0..MAX_CONSECUTIVE_COMMIT_YIELDS {
             assert!(
-                wait_out_imminent_commit(&state, Duration::from_millis(2), round).await,
+                wait_out_imminent_commit(&state, Duration::from_millis(2), round, false).await,
                 "round {round} is within the bound and stands down"
             );
         }
@@ -5978,7 +6065,8 @@ mod tests {
             !wait_out_imminent_commit(
                 &state,
                 Duration::from_millis(2),
-                MAX_CONSECUTIVE_COMMIT_YIELDS
+                MAX_CONSECUTIVE_COMMIT_YIELDS,
+                false
             )
             .await,
             "past the bound the round admits, however loudly a commit is still announcing itself"
@@ -5995,7 +6083,7 @@ mod tests {
         let interval = Duration::from_millis(100);
 
         assert_eq!(
-            commit_yield_grace(&state, interval),
+            commit_yield_grace(&state, interval, false),
             interval * COMMIT_YIELD_GRACE_INTERVALS,
             "a daemon that has never published has no measurement to scale by and uses the \
              interval bound"
@@ -6003,7 +6091,7 @@ mod tests {
 
         state.record_authority_publication(Duration::from_micros(400));
         assert_eq!(
-            commit_yield_grace(&state, interval),
+            commit_yield_grace(&state, interval, false),
             Duration::from_micros(50),
             "a publication measured in microseconds is not worth a wait measured in \
              milliseconds"
@@ -6011,14 +6099,134 @@ mod tests {
 
         state.record_authority_publication(Duration::from_secs(12));
         assert_eq!(
-            commit_yield_grace(&state, interval),
+            commit_yield_grace(&state, interval, false),
             interval * COMMIT_YIELD_GRACE_INTERVALS,
             "an eighth of twelve seconds is more than the interval bound allows"
         );
         assert!(
-            commit_yield_grace(&state, Duration::from_secs(60)) <= COMMIT_YIELD_GRACE_CEILING,
+            commit_yield_grace(&state, Duration::from_secs(60), false) <= COMMIT_YIELD_GRACE_CEILING,
             "no poll cadence may turn the grace into a stall"
         );
+    }
+
+    /// The window the first round has to cover, measured on shipped v0.5.43.
+    ///
+    /// The tick committed to publishing at 16:04:06.883 and the commit
+    /// announced itself at 16:04:12.057, read from `publish_workspace_admission`
+    /// and `coordination_gate_wait` in that run's daemon log. Every settled
+    /// bound is an order of magnitude under it.
+    const MEASURED_COLD_COMMIT_ARRIVAL: Duration = Duration::from_millis(5174);
+
+    /// The first round of a daemon's life outwaits a cold commit's arrival, and
+    /// no settled round can, however expensive the publication it is protecting.
+    #[test]
+    fn the_first_round_of_a_daemons_life_outwaits_a_cold_commits_arrival() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let interval = Duration::from_millis(100);
+
+        assert!(
+            commit_yield_grace(&state, interval, true) >= MEASURED_COLD_COMMIT_ARRIVAL,
+            "the first round must outwait the arrival that was measured losing this race"
+        );
+
+        // The publication that lost it. An eighth of this is 1,669ms, and the
+        // interval bound clips even that to 500, which is the arithmetic the
+        // cold round exists to escape.
+        state.record_authority_publication(Duration::from_millis(13_358));
+        assert!(
+            commit_yield_grace(&state, interval, false) < MEASURED_COLD_COMMIT_ARRIVAL,
+            "a settled round cannot reach that arrival at any publication cost, which is why \
+             re-tuning the share would not have fixed this"
+        );
+        assert!(
+            commit_yield_grace(&state, interval, true) >= MEASURED_COLD_COMMIT_ARRIVAL,
+            "recording an expensive publication must not shorten the cold round"
+        );
+    }
+
+    /// The cold round keeps the promise the settled bound makes: a loop
+    /// configured to react faster holds off proportionally less.
+    #[test]
+    fn a_faster_configured_loop_holds_off_less_even_on_its_cold_round() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+
+        let fast = commit_yield_grace(&state, Duration::from_millis(10), true);
+        let default = commit_yield_grace(&state, Duration::from_millis(100), true);
+        assert!(
+            fast < default,
+            "a ten-millisecond cadence must not buy the same hold-off as a hundred"
+        );
+        assert!(
+            commit_yield_grace(&state, Duration::from_secs(60), true)
+                <= COLD_START_COMMIT_YIELD_GRACE_CEILING,
+            "no poll cadence may turn the cold round into a stall either"
+        );
+    }
+
+    /// The whole point, stated as behavior rather than arithmetic: a commit that
+    /// arrives after the settled grace has expired still takes the cold round.
+    ///
+    /// Both directions run in one test. An assertion that only the cold round
+    /// stands down would also pass with the wait deleted, if the commit happened
+    /// to be announced by the time `any()` was read; the settled arm is what
+    /// makes that impossible, because it proves the same arrival is missed when
+    /// the round is not cold.
+    ///
+    /// Real timers rather than a paused clock, so the wait exercised here is the
+    /// one production runs. The arrival is five times the 500ms a settled round
+    /// waits at this cadence, which is the margin that keeps a loaded machine
+    /// from deciding the result.
+    #[tokio::test]
+    async fn a_cold_round_stands_down_for_a_commit_a_settled_round_would_have_missed() {
+        const ARRIVES_AFTER: Duration = Duration::from_millis(2500);
+        let interval = Duration::from_millis(100);
+
+        for (cold_start, expected) in [(false, false), (true, true)] {
+            let repo = tempfile::tempdir().unwrap();
+            let state = open_test_state(&repo);
+            let announcing = Arc::clone(&state);
+            let arriving = tokio::spawn(async move {
+                tokio::time::sleep(ARRIVES_AFTER).await;
+                let _commit = announcing.pending_commits.announce();
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+            });
+
+            let started = std::time::Instant::now();
+            let stood_down = wait_out_imminent_commit(&state, interval, 0, cold_start).await;
+            let waited = started.elapsed();
+            arriving.abort();
+
+            assert_eq!(
+                stood_down,
+                expected,
+                "a commit arriving {}ms in must {} the round when cold_start is {cold_start}",
+                ARRIVES_AFTER.as_millis(),
+                if expected { "take" } else { "miss" },
+            );
+            if !cold_start {
+                assert!(
+                    waited < ARRIVES_AFTER,
+                    "the settled round must give up before the commit arrives, or this test \
+                     proves nothing about the cold round; it waited {waited:?} on a machine \
+                     that may simply be too loaded to schedule a 500ms timer"
+                );
+            }
+        }
+    }
+
+    /// One cold round per process, not one per round.
+    #[test]
+    fn the_cold_start_grace_is_spent_once() {
+        let mut grace = ColdStartGrace::new();
+        assert!(grace.claim(), "the first round claims it");
+        assert!(
+            !grace.claim(),
+            "a second claim would let every round hold off for seconds, because a commit that \
+             takes the first round leaves no publication record to mark the process warm"
+        );
+        assert!(!grace.claim(), "and it stays spent");
     }
 }
 


### PR DESCRIPTION
The ambient reconcile tick stands down for a commit that is inside the daemon,
or for one that announces itself while the tick waits out a grace. kin#860 built
that, and it holds. What it cannot reach is the first commit after a store
build, and the reason is arithmetic rather than design.

`commit_yield_grace` (`crates/kin-daemon/src/loop_runner.rs`) bounds the wait
three ways: an eighth of the last publication's cost, at most five poll
intervals, never more than a second. At the default `poll_interval_ms: 100` the
interval bound is 500ms and dominates the other two, so no publication cost buys
a longer wait. This repository's own test already said so, asserting that an
eighth of a twelve-second publication is more than the interval bound allows.

None of those bounds price the quantity the wait actually has to cover, which is
how long a `kin commit` takes to reach the daemon. On the first round of a
daemon's life that quantity is at its largest. `kin init` stops the daemon it
converted with (`crates/kin-cli/src/commands/init.rs:221`), so the commit after
a store build either starts a daemon itself or meets one whose first tick is
still publishing the build's leftovers, and either way its own process is
starting from cold.

## The measurement

On shipped v0.5.43, read from
`.kin-coord/artifacts/fir2347-probe-0543-20260820/probe0-content-neutral.log`
with ANSI stripped:

| row | logged at | elapsed_ms | began at |
|---|---|---|---|
| `phase="publish_workspace_admission"` | 16:04:20.241671Z | 13,358 | 16:04:06.883671Z |
| `phase="coordination_gate_wait"` | 16:04:20.513593Z | 8,456 | 16:04:12.057593Z |

The tick's last stand-down point is immediately before
`publish_workspace_admission` begins (`loop_runner.rs`, the `yields` binding in `exact_tree_admission`); a commit announces
itself immediately before it waits on the coordination gate
(`crates/kin-daemon/src/api.rs:4706`, the first statement in the handler). So the
window was **5,174ms** against a grace capped at **500ms**. The commit then paid
8,456ms of gate wait and published its own successor, and one edit cost two
authority publications.

One correction to the FIR-2347 probe report, which recommended reopening this.
It attributed the collapse to journaled frames making the durable write 61ms.
That is not the quantity the grace scales by: `publish_exact_workspace_tree`
starts its clock before `publish_workspace_tree` and records `started.elapsed()`
after it (`loop_runner.rs:448` and `:468` on this branch), so the recorded value is the whole
13,358ms publication. An eighth of that is 1,669ms, and the interval bound clips
even that to 500. Re-tuning the share would not have fixed this.

## The fix

The first round of a daemon's life that has anything to admit claims a one-time
cold-start grace of `min(interval * 80, 8s)`, and never less than a settled
round would have waited. It is expressed in poll intervals so the settled bound's
promise still holds: a loop configured to react faster holds off proportionally
less. Eight seconds is the ceiling because the window it covers was measured at
5,174ms, which leaves margin without turning the round into a stall.

The claim is a `mem::replace` on a loop-owned flag rather than a read of the
publication record, because a commit that takes the first round leaves that
record untouched: `/commands/commit` publishes through its own transaction and
reports no publication here, so a daemon whose first round yielded would read as
cold on every round afterwards.

What this costs when no commit follows is one ambient admission arriving up to
eight seconds later, once per daemon process. Nothing waits on it. The wait
happens before the coordination gate and holds no lock, and the commit path
forces its own complete admission of the working copy rather than consulting
this loop.

Nothing else changed. The settled bounds, the consecutive-yield bound, and the
second stand-down point at the publication are untouched, because only the cold
round has evidence against it.

## The acceptance measurement did not reproduce, and this PR says so

FIR-2350's acceptance clause asks for publication counts on the racing shape.
This lane built that fixture three ways and the UNFIXED binary produced ONE
publication every time, so there is no before-and-after here:

| fixture | baseline result |
|---|---|
| `kin init`, write one file, commit (the commit starts the daemon) | SINGLE, generation delta 1 |
| plus `kin graph status` first, so a daemon is already serving and watching | SINGLE, generation delta 1 |
| plus a 400-file burst before the probe, to widen the tick's batch | SINGLE, generation delta 1, and ZERO `publish_workspace_admission` rows in the commit window |

Each run used an isolated HOME, TMPDIR and KIN_HOME, `KIN_DAEMON_AUTO_EMBED=0`, a
300-file 7.07 MB corpus, and counted publications two independent ways that must
agree, the `authority.json` `head_generation` delta and ANSI-stripped frame or
snapshot rows in a byte-offset-bounded log window.

The cause is scale rather than the fix. On shipped v0.5.43 the tick's publication
ran 13,358 ms on a 741-file 183 MB store and the commit arrived 5,174 ms INTO it.
A 7 MB store publishes in well under a second, so the tick finishes before a
commit can resolve the daemon and there is no window to lose. The third fixture's
commit window contains no standalone admission row at all, which is that stated
directly. Reproducing the shipped shape needs a store in the 183 MB class, and
`kin init` on the 7 MB corpus already took 67.7 s on a loaded box.

**The non-reproductions are themselves a finding, and the ticket did not have it.**
The first fixture, where `kin commit` starts the daemon itself, cannot lose this
race by construction: the commit announces itself inside the daemon before the
first reconcile tick ever decides anything, so there is nothing to collide with.
The race needs an ALREADY-SERVING daemon whose tick is mid-flight. That bounds the
defect's blast radius to warm-daemon workflows and says the cold path, where a
user's first commit starts the daemon, was always safe.

Two identical SINGLEs across arms would have read as a pass and meant nothing, so
this PR does not claim one. What it rests on instead is the 5,173.9 ms window
measured on shipped bytes, which is what sized the constant, and the deterministic
test below, which composes the race instead of hoping to win one.

## Falsification

Two passes, because the four new tests guard two independent properties and one
break cannot reach both. Each pass predicted which tests would fail and which
must still pass, and the tree was restored and verified byte-identical to the
committed state between them.

Pass one removed the cold branch in `commit_yield_grace` and the once-only claim
in `ColdStartGrace`. Those cannot mask each other, because `ColdStartGrace` is
not used by `commit_yield_grace`, so each failure attributes to its own break.

```
test loop_runner::tests::a_cold_round_stands_down_for_a_commit_a_settled_round_would_have_missed ... FAILED
test loop_runner::tests::a_faster_configured_loop_holds_off_less_even_on_its_cold_round ... ok
test loop_runner::tests::the_cold_start_grace_is_spent_once ... FAILED
test loop_runner::tests::the_first_round_of_a_daemons_life_outwaits_a_cold_commits_arrival ... FAILED
test result: FAILED. 79 passed; 3 failed; 0 ignored; 0 measured; 820 filtered out; finished in 37.35s
```

with these messages:

```
a commit arriving 2500ms in must take the round when cold_start is true
  left: false
 right: true

a second claim would let every round hold off for seconds, because a commit that takes the
first round leaves no publication record to mark the process warm

the first round must outwait the arrival that was measured losing this race
```

`a_faster_configured_loop_holds_off_less_even_on_its_cold_round` passing under
pass one is correct scoping rather than a miss: it guards proportionality and the
ceiling, neither of which pass one removes. Pass two breaks exactly those,
replacing the interval-derived ceiling-bounded cold value with a flat
`Duration::from_secs(9999)`.

Pass two:

```
test loop_runner::tests::a_cold_round_stands_down_for_a_commit_a_settled_round_would_have_missed ... ok
test loop_runner::tests::a_faster_configured_loop_holds_off_less_even_on_its_cold_round ... FAILED
```

the complementary half. Every one of the four new tests has now been shown
failing when its own property is removed and passing when the other pass removes
something else. The tree was verified byte-identical to the committed state
between the passes and again after.

Pass two's run also HUNG, at 0.0 percent CPU, on a pre-existing test:
`a_file_rewritten_in_a_tight_loop_still_reaches_graph_truth` spawns the real
`run_loop` with `poll_interval_ms: 10`, so a flat 9999-second cold grace makes
its first admitting round wait two and three quarter hours. That hang is the
argument for deriving the grace from the poll interval rather than fixing it as
a constant: under this fix the same round waits `min(10ms * 80, 8s)`, 800 ms, and
the test passes.

## Gate

`cargo fmt --all -- --check` clean. Clippy exit 0, `--all-targets --all-features`
under `RUSTFLAGS=-D warnings` with the 45-lint debt allowlist. The five guard
scripts CI runs pass locally: `verify-zero-file-search.py`,
`zero_file_search_guard.sh`, `verify-hydration-semantics.py`,
`check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`, all rc 0.

Workspace, as CI runs it:

```
Summary [ 307.279s] 6591 tests run: 6590 passed (4 slow, 4 leaky), 1 failed, 12 skipped
cargo test --doc --locked: 0 failed
```

The one failure is
`kin-cli::live_graph_durability_disclosure mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit_records_them`,
which refuses on `selected-graph embedding coverage is changing` until a
thirty-second retry bound expires. That test does reach this change: it waits on
ambient admission, and its daemon uses the default 100 ms poll interval, so it
gets the full cold grace. Run alone on the same binary and branch it passes three
times out of three, in 25.91 s, 28.99 s and 27.70 s at load 22.8, 21.6 and 17.2,
against 46.2 s and 50.7 s inside a full run at load 30 to 51. The margin against
the bound is seconds, and contention spends it. A deterministic, load-independent
grace cannot explain a result that flips with load. `.kin-coord/reports/vfspin-20260819.md`
records the same test file failing with the same message on an unrelated change,
once failing and once passing against identical binaries.

Tree hygiene: `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only
`.cargo/config.toml`, and `git diff $(git merge-base HEAD origin/main) --stat --
Cargo.lock .cargo/` is empty.

Refs FIR-2350

The ticket stays open on purpose. The fix is proven and falsified, but the
acceptance clause asks for a product-level publication count on the racing shape,
and this lane could not reproduce that shape at fixture scale. Closing it would
claim a measurement nobody took.
