### PR TITLE
Publish what a language server can do, not that its binary exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.36"
+version = "0.7.38"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "f42311f808769f669d86afb5c7ff8a61ca4c80f6a4ddd896e8109cbb48afe7b5"
+checksum = "9a91460113b99ffac03b62f011d76ce7eb4570b9affde59ede4c24688f061382"
 dependencies = [
  "bincode",
  "bstr",
@@ -3426,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.6.16"
+version = "0.7.0"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "5ef67e9479a739aea7286339c3ed34aaf24bd114c38a5b2ff0352b71f97d2581"
+checksum = "de8108477768a3f1470f7719c0e6cd572efbe71a750edb2f086045e71a9fae60"
 dependencies = [
  "kin-model",
  "serde",
@@ -3501,9 +3501,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.9"
+version = "0.7.10"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "859744dbb2855216be40ea258c0ff608888f00f19435d1bdf3714314176d93d3"
+checksum = "be211911c8cf30d0afd21673f4807f1fe4d7ac288b2324f7cf13c3f7667b4714"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -6644,7 +6644,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.9", registry = "kin" }
+kin-model = { version = "=0.7.10", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -149,13 +149,13 @@ kin-daemon-spawn = { path = "crates/kin-daemon-spawn" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "=0.6.16", registry = "kin" }
+kin-lsp = { version = "=0.7.0", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.36", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.38", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.7", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -277,18 +277,6 @@ fn embedding_coverage_is_measured(_graph: &kin_db::InMemoryGraph) -> bool {
     true
 }
 
-/// Languages whose enrichment server is installed on this host.
-///
-/// The table this probes lives in `crate::commands::language_servers`, beside
-/// the command that installs each one, because a name that drifts between the
-/// probe and the advice produces a doctor row that reports a gap and a fix that
-/// does not close it. Probing here rather than through
-/// `kin_lsp::discovery::discover_servers` keeps the status path off a
-/// subprocess, since discovery runs `--version` on every server it finds.
-pub(crate) fn installed_language_servers() -> HashSet<kin_model::LanguageId> {
-    crate::commands::language_servers::installed_language_servers()
-}
-
 /// The whole-graph relation totals the completeness section reports beside its
 /// per-language reference rows.
 ///
@@ -438,14 +426,23 @@ fn build_graph_status_response(
     // inside the collector, so every edge is counted once, and the
     // language-server probe is attached here rather than in kin-core, which
     // measures graph truth and never probes the host.
-    health.reference_edge_coverage = std::mem::take(&mut health.reference_edge_coverage)
-        .with_totals(graph_relation_totals(
+    let coverage =
+        std::mem::take(&mut health.reference_edge_coverage).with_totals(graph_relation_totals(
             graph,
             &relation_counts,
             total_relations,
             cross_file_relations,
-        ))
-        .with_language_servers(&installed_language_servers());
+        ));
+    // Read the readiness a process with the right to spawn already established,
+    // rather than probing the host from a query path. When nobody has published,
+    // the rows are left at their default, which is unknown: an empty map would
+    // read as every server missing, and reporting a gap nothing looked for is
+    // the mistake this whole area exists to stop.
+    health.reference_edge_coverage =
+        match kin_mcp::edge_coverage::published_language_server_readiness() {
+            Some(readiness) => coverage.with_language_servers(&readiness),
+            None => coverage,
+        };
 
     // File count
     let unique_files: HashSet<_> = entities

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2436,10 +2436,12 @@ async fn check_reference_edge_coverage() -> HealthCheck {
     // read the graph still reports this half, so a repository whose daemon is
     // down does not silently lose the language-server signal that used to have
     // its own row.
-    let missing_servers =
-        missing_language_servers(&crate::commands::graph::installed_language_servers());
-
     let cwd = env::current_dir().unwrap_or_default();
+    // Probed, not looked up on PATH. A binary that resolves and cannot start
+    // serves no language, and a row that reports it as served sends an operator
+    // looking for a problem somewhere else entirely.
+    let readiness = crate::commands::language_servers::probe_language_server_readiness(&cwd).await;
+    let missing_servers = missing_language_servers(&readiness);
     let Some(layout) = kin_core::KinLayout::discover(&cwd) else {
         return HealthCheck::new(
             ID,
@@ -2820,12 +2822,24 @@ async fn check_semantic_query_readiness() -> HealthCheck {
 /// instead: warning about rust-analyzer on a Python-only repository is a row a
 /// reader learns to skip.
 fn missing_language_servers(
-    installed: &std::collections::HashSet<kin_model::LanguageId>,
+    readiness: &kin_core::reference_coverage::LanguageServerReadinessMap,
 ) -> Vec<String> {
+    use kin_core::reference_coverage::LanguageServerReadiness;
     crate::commands::language_servers::language_server_binaries()
         .into_iter()
-        .filter(|(language, _)| !installed.contains(language))
-        .map(|(language, binaries)| format!("{language} ({})", binaries.join(" or ")))
+        .filter_map(|(language, binaries)| match readiness.get(&language) {
+            Some(LanguageServerReadiness::Usable) => None,
+            // A server that is installed and cannot start is NOT reported here.
+            // Telling an operator to install what they already have sends them
+            // to the wrong repair, which is the whole reason the two states are
+            // kept apart.
+            Some(LanguageServerReadiness::Unusable { reason }) => Some(format!(
+                "{language} (installed but it did not start: {reason})"
+            )),
+            Some(LanguageServerReadiness::Absent) | None => {
+                Some(format!("{language} ({})", binaries.join(" or ")))
+            }
+        })
         .collect()
 }
 
@@ -3575,7 +3589,9 @@ mod tests {
     /// carry its own row; folding the two rows must not lose the probe.
     #[test]
     fn doctor_names_the_language_whose_missing_server_costs_cross_file_edges() {
-        let missing = missing_language_servers(&std::collections::HashSet::new());
+        let missing = missing_language_servers(
+            &kin_core::reference_coverage::LanguageServerReadinessMap::new(),
+        );
         let check = coverage_unreadable(
             HealthStatus::Unsupported,
             "no daemon running for this repository",
@@ -3614,10 +3630,15 @@ mod tests {
     /// with every wired language's server installed there is no gap to report.
     #[test]
     fn doctor_reports_no_gap_once_every_wired_language_server_is_installed() {
-        let installed: std::collections::HashSet<kin_model::LanguageId> =
+        let installed: kin_core::reference_coverage::LanguageServerReadinessMap =
             crate::commands::language_servers::language_server_binaries()
                 .into_iter()
-                .map(|(language, _)| language)
+                .map(|(language, _)| {
+                    (
+                        language,
+                        kin_core::reference_coverage::LanguageServerReadiness::Usable,
+                    )
+                })
                 .collect();
         let missing = missing_language_servers(&installed);
         assert!(missing.is_empty(), "{missing:?}");
@@ -3632,12 +3653,58 @@ mod tests {
         assert!(!check.detail.contains("unavailable"), "{}", check.detail);
     }
 
+    /// An installed server that cannot start must not be reported as a missing
+    /// install, and must not be reported as fine either.
+    ///
+    /// This is the state a PATH lookup could not see and the reason the doctor
+    /// row now probes. The dev host produced it on 2026-08-20: a
+    /// typescript-language-server installed beside TypeScript 7, resolving
+    /// perfectly and failing every start. Telling that operator to install what
+    /// they already have sends them to the wrong repair.
+    #[test]
+    fn doctor_separates_a_broken_install_from_a_missing_one() {
+        use kin_core::reference_coverage::{LanguageServerReadiness, LanguageServerReadinessMap};
+        let mut readiness = LanguageServerReadinessMap::new();
+        for (language, _) in crate::commands::language_servers::language_server_binaries() {
+            readiness.insert(language, LanguageServerReadiness::Usable);
+        }
+        readiness.insert(
+            kin_model::LanguageId::JavaScript,
+            LanguageServerReadiness::Unusable {
+                reason: "Could not find a valid TypeScript installation".to_string(),
+            },
+        );
+
+        let missing = missing_language_servers(&readiness);
+        let javascript: Vec<&String> = missing
+            .iter()
+            .filter(|row| row.starts_with("javascript"))
+            .collect();
+        assert_eq!(
+            missing.len(),
+            1,
+            "only the broken language is reported: {missing:?}"
+        );
+        assert!(
+            javascript[0].contains("installed but it did not start"),
+            "the row must say the install is broken rather than absent: {}",
+            javascript[0]
+        );
+        assert!(
+            javascript[0].contains("Could not find a valid TypeScript installation"),
+            "the row must carry the server's own reason, which names the repair: {}",
+            javascript[0]
+        );
+    }
+
     /// A `Stale` row needs attention without failing readiness. A missing
     /// language server degrades a working install; calling it a failure would
     /// turn `kin doctor` red on every host that never installed one.
     #[test]
     fn a_missing_language_server_needs_attention_without_blocking_readiness() {
-        let missing = missing_language_servers(&std::collections::HashSet::new());
+        let missing = missing_language_servers(
+            &kin_core::reference_coverage::LanguageServerReadinessMap::new(),
+        );
         let check = coverage_unreadable(
             HealthStatus::Unsupported,
             "no daemon running for this repository",

--- a/crates/kin-cli/src/commands/language_servers.rs
+++ b/crates/kin-cli/src/commands/language_servers.rs
@@ -23,7 +23,6 @@
 //! download into a shared global prefix, and Kin does not spend a user's
 //! bandwidth or mutate their toolchain on a probe's say-so.
 
-use std::collections::HashSet;
 use std::process::Command;
 
 use kin_model::LanguageId;
@@ -155,15 +154,6 @@ pub(crate) fn language_server_binaries() -> Vec<(LanguageId, &'static [&'static 
     LANGUAGE_SERVERS
         .iter()
         .map(|recipe| (recipe.language, recipe.binaries))
-        .collect()
-}
-
-/// Languages whose enrichment server is installed on this host.
-pub(crate) fn installed_language_servers() -> HashSet<LanguageId> {
-    LANGUAGE_SERVERS
-        .iter()
-        .filter(|recipe| recipe.installed())
-        .map(|recipe| recipe.language)
         .collect()
 }
 
@@ -445,24 +435,38 @@ mod tests {
 
     /// The advice and the runtime must name the same binaries.
     ///
+    /// The advice and the runtime must name the same binaries, asserted against
+    /// the crate that actually launches them.
+    ///
     /// `kin doctor` tells an operator to install a binary and the daemon starts
     /// one; a difference between the two names is advice that leaves the gap
-    /// open while reporting it closed. These are the names in
-    /// `kin_lsp::discovery::KNOWN_SERVERS` and in the daemon's adapter map,
-    /// asserted here because kin-cli cannot see either at compile time.
+    /// open while reporting it closed. This used to restate the names by hand,
+    /// because kin-cli could not see kin-lsp at compile time. It can, and
+    /// kin-lsp now exports the list its own resolver reads, so the expectation
+    /// comes from there instead. A hardcoded copy could agree with nothing and
+    /// still pass.
     #[test]
     fn recipes_name_the_binaries_the_daemon_starts() {
-        for (language, expected) in [
-            (LanguageId::Rust, "rust-analyzer"),
-            (LanguageId::Python, "pyright-langserver"),
-            (LanguageId::TypeScript, "typescript-language-server"),
-            (LanguageId::JavaScript, "typescript-language-server"),
-        ] {
-            let recipe = recipe_for(language).expect("language must have a recipe");
+        let runtime: std::collections::HashMap<LanguageId, Vec<String>> =
+            kin_lsp::registry::ProviderRegistry::with_defaults()
+                .known_binaries()
+                .into_iter()
+                .collect();
+
+        for recipe in LANGUAGE_SERVERS {
+            let expected = runtime.get(&recipe.language).unwrap_or_else(|| {
+                panic!(
+                    "{}: kin-cli advertises an install for a language kin-lsp registers no \
+                     provider for, so the advice names a server nothing will start",
+                    recipe.language
+                )
+            });
+            let advertised: Vec<String> =
+                recipe.binaries.iter().map(|b| (*b).to_string()).collect();
             assert_eq!(
-                recipe.binaries.first().copied(),
-                Some(expected),
-                "{language}: first binary is what the daemon's adapter starts"
+                &advertised, expected,
+                "{}: the install advice and the runtime name different binaries",
+                recipe.language
             );
         }
     }
@@ -796,4 +800,63 @@ mod tests {
             "the advice must not promise a pickup the startup gate cannot deliver"
         );
     }
+}
+
+/// Ask what each enrichable language's server can actually do on this host.
+///
+/// The question every surface here used to answer with `which::which`. A binary
+/// on `PATH` is not a working language server: a host carrying
+/// `typescript-language-server` beside a TypeScript that ships no `tsserver`
+/// resolves fine and fails every start. Only a handshake tells them apart, so
+/// this starts each server and runs one.
+///
+/// Probes run concurrently, so the wait is one probe budget rather than one per
+/// language. Belongs to command paths, which may spawn; a query path must read
+/// the verdict a spawner published instead.
+pub(crate) async fn probe_language_server_readiness(
+    workspace_root: &std::path::Path,
+) -> kin_core::reference_coverage::LanguageServerReadinessMap {
+    use kin_core::reference_coverage::{
+        LanguageServerReadiness, LanguageServerReadinessMap, ENRICHABLE_LANGUAGES,
+    };
+    use kin_lsp::registry::{ProviderGapReason, ProviderRegistry};
+
+    let probes: Vec<_> = ENRICHABLE_LANGUAGES
+        .iter()
+        .copied()
+        .map(|language| {
+            let workspace_root = workspace_root.to_path_buf();
+            tokio::spawn(async move {
+                let registry = ProviderRegistry::with_defaults();
+                let readiness = match kin_lsp::lifecycle::probe_readiness(
+                    &registry,
+                    language,
+                    &workspace_root,
+                    None,
+                )
+                .await
+                {
+                    Ok(_) => LanguageServerReadiness::Usable,
+                    Err(gap) => match gap.reason {
+                        ProviderGapReason::ServerUnusable { message } => {
+                            LanguageServerReadiness::Unusable { reason: message }
+                        }
+                        _ => LanguageServerReadiness::Absent,
+                    },
+                };
+                (language, readiness)
+            })
+        })
+        .collect();
+
+    let mut readiness = LanguageServerReadinessMap::new();
+    for probe in probes {
+        // A probe that did not finish establishes nothing about its language,
+        // and recording it as absent would be a claim this process did not
+        // earn. Leaving it out reads as unknown.
+        if let Ok((language, state)) = probe.await {
+            readiness.insert(language, state);
+        }
+    }
+    readiness
 }

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -11860,7 +11860,7 @@ pub async fn run_wizard(opts: WizardOptions) -> Result<()> {
     // before: the adapter was wired, no server was installed, the daemon logged
     // the failed start at debug level, and every cross-file call fell back to
     // matching names.
-    provision_language_servers_in_wizard(&opts, interactive);
+    provision_language_servers_in_wizard(&opts, interactive).await;
 
     report_notification_identity(interactive);
 
@@ -11884,7 +11884,7 @@ pub async fn run_wizard(opts: WizardOptions) -> Result<()> {
 /// `--install-language-servers` was passed, because an unattended install
 /// should never spend a user's bandwidth on a prefix they share with the rest
 /// of their toolchain.
-fn provision_language_servers_in_wizard(opts: &WizardOptions, interactive: bool) {
+async fn provision_language_servers_in_wizard(opts: &WizardOptions, interactive: bool) {
     let missing = language_servers::missing_enrichable_languages();
     if missing.is_empty() {
         return;
@@ -11895,7 +11895,7 @@ fn provision_language_servers_in_wizard(opts: &WizardOptions, interactive: bool)
         opts.install_language_servers,
         interactive && !opts.install_language_servers,
     );
-    for line in apply_language_server_provisioning(&missing, consent) {
+    for line in apply_language_server_provisioning(&missing, consent).await {
         println!("  {} {line}", style("✓").green());
     }
 }
@@ -12701,7 +12701,43 @@ fn print_human_report(report: &crate::commands::health::HealthReport) {
 /// returned lines are the "what was applied" list both surfaces already print;
 /// anything not applied is printed here instead, because a declined or failed
 /// install is a fact the operator needs and an empty applied-list is not.
-fn apply_language_server_provisioning(
+/// Ask a running daemon to re-probe and re-enrich after a server was installed.
+///
+/// Readiness taken once latches: a daemon that probed before the install would
+/// keep reporting that language unavailable for the rest of its life, and that
+/// stale answer is an input under an agent-facing verdict. The sweep route
+/// re-probes at its start, so one call refreshes the verdict and produces the
+/// edges the new server can finally resolve.
+///
+/// Returns whether a daemon was actually poked, so the caller can fall back to
+/// telling the user to restart when there was none.
+async fn refresh_running_daemon_after_install(cwd: &std::path::Path) -> bool {
+    let Some(layout) = kin_core::KinLayout::discover(cwd) else {
+        return false;
+    };
+    let Some(url) = crate::daemon_client::resolve_daemon_url_if_running_async(&layout).await else {
+        return false;
+    };
+    // For_layout, not from_base_url: the latter resolves the bearer token from
+    // the process working directory, which is the silent-wrong-target class
+    // that made kin init's conversion phase 401 on runners.
+    let Ok(client) = crate::daemon_client::DaemonClient::from_base_url_for_layout(&url, &layout)
+    else {
+        return false;
+    };
+    match client.queue_lsp_sweep().await {
+        Ok(_) => {
+            println!(
+                "  {} asked the running daemon to re-check its language servers and enrich again",
+                style("✓").green()
+            );
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+async fn apply_language_server_provisioning(
     missing: &[kin_model::LanguageId],
     consent: language_servers::InstallConsent,
 ) -> Vec<String> {
@@ -12794,8 +12830,45 @@ fn apply_language_server_provisioning(
         }
     }
 
+    // An install that lands a binary the server cannot run is not a completed
+    // install. `RanButStillMissing` above already refuses to count a zero exit
+    // that left nothing on PATH; this is its sibling, a zero exit that left
+    // something on PATH which cannot start. Both are the same mistake: counting
+    // a command's exit code as the outcome an operator cares about.
+    //
+    // Probed rather than looked up, because binary presence is exactly what
+    // cannot tell these apart, and this is the surface where the wrong answer
+    // ends the interaction with the user believing they are done.
     if installed_any {
-        println!("  {}", language_servers::RESTART_AFTER_INSTALL);
+        use kin_core::reference_coverage::LanguageServerReadiness;
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let readiness = language_servers::probe_language_server_readiness(&cwd).await;
+        let mut unusable = false;
+        for language in missing {
+            if let Some(LanguageServerReadiness::Unusable { reason }) = readiness.get(language) {
+                unusable = true;
+                applied.retain(|line| !line.contains(&language.to_string()));
+                println!(
+                    "  {} the {language} language server installed but did not start: {reason}",
+                    style("✗").red(),
+                );
+            }
+        }
+        if !unusable {
+            // Poke the sweep the daemon already exposes, rather than only
+            // telling the user to restart. That one route re-probes readiness
+            // AND re-enriches, which is exactly what someone wants after
+            // installing a server, and it is why no dedicated route is needed.
+            //
+            // Best effort by design: outside a repository, or with no daemon
+            // running, there is nothing holding a stale verdict to refresh, and
+            // the restart advice below still covers a daemon this process
+            // cannot reach.
+            let refreshed = refresh_running_daemon_after_install(&cwd).await;
+            if !refreshed {
+                println!("  {}", language_servers::RESTART_AFTER_INSTALL);
+            }
+        }
     }
     applied
 }
@@ -12961,7 +13034,7 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
                 install_language_servers,
                 !install_language_servers && is_tty(),
             );
-            for line in apply_language_server_provisioning(&missing, consent) {
+            for line in apply_language_server_provisioning(&missing, consent).await {
                 applied.push(line);
             }
         }

--- a/crates/kin-core/src/reference_coverage.rs
+++ b/crates/kin-core/src/reference_coverage.rs
@@ -57,36 +57,28 @@ pub const ENRICHABLE_LANGUAGES: &[LanguageId] = &[
     LanguageId::JavaScript,
 ];
 
-/// The binaries that provide each enrichable language's server.
+/// What a host's language server can actually do for one language.
 ///
-/// Mirrors `kin_lsp::discovery::KNOWN_SERVERS` for exactly the languages
-/// [`ENRICHABLE_LANGUAGES`] names, and is the ONE table every surface reads:
-/// the doctor row that reports the gap, the install recipes that close it, and
-/// the trust gate that decides whether an empty answer may be certified. Those
-/// three used to be able to disagree, and a probe looking for a binary the
-/// installer never provides is a gap that reports itself closed.
+/// Three states, not two, because a missing server and a present-but-broken one
+/// need different repairs and a surface handed a boolean cannot tell an operator
+/// which it is in. `Unusable` carries the server's own message, which is the
+/// only text that names the repair.
 ///
-/// Probed with a `PATH` lookup rather than through
-/// `kin_lsp::discovery::discover_servers`, which runs `--version` on every
-/// server it finds; a query path must not spawn subprocesses.
-pub const LANGUAGE_SERVER_BINARIES: &[(LanguageId, &[&str])] = &[
-    (LanguageId::Rust, &["rust-analyzer"]),
-    (LanguageId::Python, &["pyright-langserver", "pylsp"]),
-    (
-        LanguageId::TypeScript,
-        &["typescript-language-server", "vtsls"],
-    ),
-    (LanguageId::JavaScript, &["typescript-language-server"]),
-];
-
-/// Languages whose enrichment server is present on this host.
-pub fn installed_language_servers() -> HashSet<LanguageId> {
-    LANGUAGE_SERVER_BINARIES
-        .iter()
-        .filter(|(_, binaries)| binaries.iter().any(|binary| which::which(binary).is_ok()))
-        .map(|(language, _)| *language)
-        .collect()
+/// Produced by whichever process can actually start a server and PUBLISHED to
+/// the query paths, which must not spawn subprocesses to answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LanguageServerReadiness {
+    /// Resolved, completed the initialize handshake, and reported capabilities.
+    Usable,
+    /// A binary was found and the server refused to initialize.
+    Unusable { reason: String },
+    /// No server binary for this language was found at all.
+    Absent,
 }
+
+/// Per-language readiness as published by the process that probed.
+pub type LanguageServerReadinessMap =
+    std::collections::HashMap<LanguageId, LanguageServerReadiness>;
 
 /// Whether cross-file reference evidence is available for one language.
 
@@ -103,6 +95,15 @@ pub enum ReferenceEnrichment {
     /// An adapter is wired but no language server for it is installed, so
     /// reference and override edges cannot be produced on this host.
     NoLanguageServer,
+    /// An adapter is wired and a server binary was found, but the server
+    /// refuses to initialize, so no edge can be produced either.
+    ///
+    /// Kept apart from [`ReferenceEnrichment::NoLanguageServer`] because the
+    /// repairs differ: one is an install, the other is a broken install, and a
+    /// host reporting the wrong one sends an operator to the wrong fix. Binary
+    /// presence alone cannot tell them apart, which is why this state only
+    /// exists once something asks the server to start.
+    LanguageServerUnusable,
     /// This build wires no adapter for the language, so reference and override
     /// edges are unavailable regardless of what is installed.
     Unsupported,
@@ -116,22 +117,27 @@ impl ReferenceEnrichment {
     /// nothing about is noise rather than a finding. `Unknown` is not a gap
     /// either: nothing looked, so nothing was found missing.
     pub fn is_actionable_gap(&self) -> bool {
-        matches!(self, ReferenceEnrichment::NoLanguageServer)
+        matches!(
+            self,
+            ReferenceEnrichment::NoLanguageServer | ReferenceEnrichment::LanguageServerUnusable
+        )
     }
 }
 
 /// Whether the language server for `language` can enrich this host's graph.
 pub fn reference_enrichment_for(
     language: LanguageId,
-    servers_found: &HashSet<LanguageId>,
+    readiness: &LanguageServerReadinessMap,
 ) -> ReferenceEnrichment {
     if !ENRICHABLE_LANGUAGES.contains(&language) {
         return ReferenceEnrichment::Unsupported;
     }
-    if servers_found.contains(&language) {
-        ReferenceEnrichment::Available
-    } else {
-        ReferenceEnrichment::NoLanguageServer
+    match readiness.get(&language) {
+        Some(LanguageServerReadiness::Usable) => ReferenceEnrichment::Available,
+        Some(LanguageServerReadiness::Unusable { .. }) => {
+            ReferenceEnrichment::LanguageServerUnusable
+        }
+        Some(LanguageServerReadiness::Absent) | None => ReferenceEnrichment::NoLanguageServer,
     }
 }
 
@@ -401,11 +407,15 @@ impl ReferenceEdgeCoverage {
         self
     }
 
-    /// Fill in each language's enrichment state from the servers a caller found.
+    /// Fill in each language's enrichment state from the readiness a caller
+    /// probed.
     ///
     /// Kept off the collector because probing the host is not reading the graph,
-    /// and this module measures graph truth alone.
-    pub fn with_language_servers(mut self, servers_found: &HashSet<LanguageId>) -> Self {
+    /// and this module measures graph truth alone. Readiness rather than a set
+    /// of found binaries, because a server that is present and cannot start
+    /// produces exactly as many edges as one that is absent, and only the
+    /// repair differs.
+    pub fn with_language_servers(mut self, readiness: &LanguageServerReadinessMap) -> Self {
         for language in &mut self.languages {
             // The rows carry a language's display name, and kin-model has no
             // parse back from one. Matching against the enrichable set's own
@@ -416,7 +426,7 @@ impl ReferenceEdgeCoverage {
                 .copied()
                 .find(|candidate| candidate.to_string() == language.language);
             language.reference_enrichment = match enrichable {
-                Some(id) => reference_enrichment_for(id, servers_found),
+                Some(id) => reference_enrichment_for(id, readiness),
                 None => ReferenceEnrichment::Unsupported,
             };
         }
@@ -837,28 +847,14 @@ fn read_count(entity: &Entity, key: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-
-    /// Every enrichable language must name the binaries that provide its
-    /// server, and nothing else may.
-    ///
-    /// The two lists feed different surfaces: one decides whether an adapter
-    /// exists, the other decides whether an operator can close the gap and
-    /// whether the trust gate may certify an absence. A language in one and not
-    /// the other is a surface reporting about a language no other surface can
-    /// act on.
-    #[test]
-    fn the_binaries_table_covers_exactly_the_enrichable_languages() {
-        let tabled: std::collections::HashSet<LanguageId> = LANGUAGE_SERVER_BINARIES
+    /// A host where exactly these languages have a usable server.
+    fn usable(languages: &[LanguageId]) -> LanguageServerReadinessMap {
+        languages
             .iter()
-            .map(|(language, _)| *language)
-            .collect();
-        let enrichable: std::collections::HashSet<LanguageId> =
-            ENRICHABLE_LANGUAGES.iter().copied().collect();
-        assert_eq!(tabled, enrichable);
-        for (language, binaries) in LANGUAGE_SERVER_BINARIES {
-            assert!(!binaries.is_empty(), "{language} names no server binary");
-        }
+            .map(|language| (*language, LanguageServerReadiness::Usable))
+            .collect()
     }
+
     use super::*;
     use kin_db::InMemoryGraph;
     use kin_model::entity::{
@@ -1344,7 +1340,7 @@ mod tests {
 
         let filled = unfilled
             .clone()
-            .with_language_servers(&[LanguageId::Go].into_iter().collect());
+            .with_language_servers(&usable(&[LanguageId::Go]));
         assert_eq!(
             filled.languages_missing_a_language_server(),
             vec!["python"],
@@ -1356,8 +1352,8 @@ mod tests {
             "gopls on PATH gives Go nothing: no adapter consumes it"
         );
 
-        let complete = unfilled
-            .with_language_servers(&[LanguageId::Python, LanguageId::Rust].into_iter().collect());
+        let complete =
+            unfilled.with_language_servers(&usable(&[LanguageId::Python, LanguageId::Rust]));
         assert!(complete.languages_missing_a_language_server().is_empty());
     }
 

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -311,6 +311,90 @@ pub(crate) fn reset_vector_index_and_requeue_after_contention_for_test(
 /// for this language", and two surfaces outside the enrichment loop need that
 /// answer to agree with it: the provisioning advice that tells an operator what
 /// to install, and the proof that starts a real server against a fixture.
+/// Probe what each enrichable language's server can actually do, then publish
+/// it for the query paths.
+///
+/// Spawned rather than awaited. Probing means starting each server and running
+/// the initialize handshake, and four languages against the probe budget would
+/// add seconds to daemon startup in the healthy case and far more when a server
+/// hangs. Nothing waits on the answer: until it publishes, every observation
+/// reads the readiness as unknown, which already keeps the absence-trust gate
+/// silent and is the honest state for a daemon that has not finished looking.
+///
+/// Safe against the daemon's own enrichment path by construction, not by
+/// timing. The sweep decides what to start from `lsp_adapter_for` and its own
+/// `servers` map, and enrichment availability comes from `discover_servers`;
+/// neither reads the published verdict, so a probe still in flight cannot
+/// change what the daemon does. The publish is write-only here and consumed
+/// only by kin-mcp.
+///
+/// The probes run concurrently, so the worst case is one probe budget rather
+/// than one per language.
+fn spawn_language_server_readiness_probe(workspace_root: std::path::PathBuf) {
+    use kin_core::reference_coverage::{
+        LanguageServerReadiness, LanguageServerReadinessMap, ENRICHABLE_LANGUAGES,
+    };
+    use kin_lsp::registry::{ProviderGapReason, ProviderRegistry};
+
+    tokio::spawn(async move {
+        // One task per language so the probes overlap: the worst case is one
+        // probe budget rather than one per language.
+        let probes: Vec<_> = ENRICHABLE_LANGUAGES
+            .iter()
+            .copied()
+            .map(|language| {
+                let workspace_root = workspace_root.clone();
+                tokio::spawn(async move {
+                    let registry = ProviderRegistry::with_defaults();
+                    let initialization_options = lsp_adapter_for(language, &workspace_root)
+                        .and_then(|(_, _, init_opts)| init_opts);
+                    let readiness = match kin_lsp::lifecycle::probe_readiness(
+                        &registry,
+                        language,
+                        &workspace_root,
+                        initialization_options,
+                    )
+                    .await
+                    {
+                        Ok(_) => LanguageServerReadiness::Usable,
+                        Err(gap) => match gap.reason {
+                            ProviderGapReason::ServerUnusable { message } => {
+                                LanguageServerReadiness::Unusable { reason: message }
+                            }
+                            _ => LanguageServerReadiness::Absent,
+                        },
+                    };
+                    (language, readiness)
+                })
+            })
+            .collect();
+
+        let mut readiness = LanguageServerReadinessMap::new();
+        for probe in probes {
+            match probe.await {
+                Ok((language, state)) => {
+                    if let LanguageServerReadiness::Unusable { reason } = &state {
+                        warn!(
+                            %language,
+                            %reason,
+                            "a language server is installed but cannot start, so this \
+                             language's cross-file reference edges cannot be produced on \
+                             this host"
+                        );
+                    }
+                    readiness.insert(language, state);
+                }
+                // A probe task that panicked establishes nothing about its
+                // language, and recording it as Absent would be a claim this
+                // process did not earn. Leaving it out reads as unknown.
+                Err(error) => warn!(%error, "a language server readiness probe did not finish"),
+            }
+        }
+
+        kin_mcp::edge_coverage::publish_language_server_readiness(readiness);
+    });
+}
+
 pub fn lsp_adapter_for(
     language: kin_model::LanguageId,
     workspace_root: &std::path::Path,
@@ -1747,9 +1831,12 @@ pub async fn run_with_authority_on(
     // than re-sweeping a converged graph.
     load_lsp_enriched_marker(&state);
 
-    kin_mcp::edge_coverage::publish_installed_language_servers(
-        kin_core::reference_coverage::installed_language_servers(),
-    );
+    // The working directory as the layout already holds it. Deliberately not
+    // canonicalized: a readiness probe asks whether a server starts and
+    // completes a handshake, never resolving a file through this path, so the
+    // filesystem round trip would buy nothing and this is an authority-path
+    // crate where every such call has to earn itself.
+    spawn_language_server_readiness_probe(state.layout.working_dir().to_path_buf());
 
     // Set up LSP enrichment channel before wrapping state in Arc.
     let enrichment_enabled =
@@ -2968,6 +3055,18 @@ pub async fn run_with_authority_on(
 
                     LspEnrichmentMessage::Sweep => {
                         info!("LSP cold sweep started, enriching all entities");
+                        // Re-probe here, not only at daemon start. Readiness
+                        // taken once latches: a user who follows Kin's own
+                        // advice and installs the server it just named leaves a
+                        // long-lived daemon reporting that language unavailable
+                        // for the rest of its life, and the stale answer is an
+                        // input under an agent-facing verdict. A sweep is the
+                        // moment the daemon is about to want servers, so it is
+                        // the firing point that needs no new signal invented.
+                        // Same probe-then-publish as at start, and it overwrites
+                        // rather than merges, because a fresh answer supersedes
+                        // an old one wholesale.
+                        spawn_language_server_readiness_probe(lsp_root.clone());
                         lsp_state
                             .lsp_sweep_running
                             .store(true, std::sync::atomic::Ordering::SeqCst);

--- a/crates/kin-daemon/tests/lsp_reference_enrichment.rs
+++ b/crates/kin-daemon/tests/lsp_reference_enrichment.rs
@@ -21,7 +21,6 @@
 //! and never passes quietly: a proof that silently degrades to a no-op is worse
 //! than no proof, because the run is green either way.
 
-use std::collections::HashSet;
 use std::path::Path;
 use std::time::Duration;
 
@@ -402,9 +401,12 @@ async fn javascript_resolves_a_require_chain_that_a_name_match_cannot() {
 /// a runner where both tests above skip.
 #[test]
 fn without_a_server_an_enrichable_language_reports_an_actionable_gap() {
-    use kin_core::reference_coverage::{reference_enrichment_for, ReferenceEnrichment};
+    use kin_core::reference_coverage::{
+        reference_enrichment_for, LanguageServerReadiness, LanguageServerReadinessMap,
+        ReferenceEnrichment,
+    };
 
-    let none_installed: HashSet<LanguageId> = HashSet::new();
+    let none_installed = LanguageServerReadinessMap::new();
     for language in [
         LanguageId::Python,
         LanguageId::JavaScript,
@@ -425,11 +427,33 @@ fn without_a_server_an_enrichable_language_reports_an_actionable_gap() {
 
     // And with the server present the same call reports the capability rather
     // than the gap, so the row above cannot be an unconditional warning.
-    let mut installed = HashSet::new();
-    installed.insert(LanguageId::JavaScript);
+    let mut installed = LanguageServerReadinessMap::new();
+    installed.insert(LanguageId::JavaScript, LanguageServerReadiness::Usable);
     let state = reference_enrichment_for(LanguageId::JavaScript, &installed);
     assert_eq!(state, ReferenceEnrichment::Available);
     assert!(!state.is_actionable_gap());
+
+    // The state binary presence cannot see: the server is installed and cannot
+    // start. It must read as its own gap rather than as Available, and it must
+    // still be actionable, because a broken install is something an operator
+    // can repair.
+    let mut broken = LanguageServerReadinessMap::new();
+    broken.insert(
+        LanguageId::JavaScript,
+        LanguageServerReadiness::Unusable {
+            reason: "Could not find a valid TypeScript installation".to_string(),
+        },
+    );
+    let state = reference_enrichment_for(LanguageId::JavaScript, &broken);
+    assert_eq!(
+        state,
+        ReferenceEnrichment::LanguageServerUnusable,
+        "an installed server that cannot start must not report as Available"
+    );
+    assert!(
+        state.is_actionable_gap(),
+        "a broken install is a gap an operator can close, so it must be surfaced"
+    );
 }
 
 /// JavaScript and TypeScript must no longer report `Unsupported`.
@@ -440,9 +464,11 @@ fn without_a_server_an_enrichable_language_reports_an_actionable_gap() {
 /// deliberately NOT an actionable gap: a reader is told there is nothing to do.
 #[test]
 fn javascript_no_longer_reports_the_unsupported_state_it_shipped_with() {
-    use kin_core::reference_coverage::{reference_enrichment_for, ReferenceEnrichment};
+    use kin_core::reference_coverage::{
+        reference_enrichment_for, LanguageServerReadinessMap, ReferenceEnrichment,
+    };
 
-    let none_installed: HashSet<LanguageId> = HashSet::new();
+    let none_installed = LanguageServerReadinessMap::new();
     for language in [LanguageId::JavaScript, LanguageId::TypeScript] {
         assert_ne!(
             reference_enrichment_for(language, &none_installed),

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -51,12 +51,10 @@
 //! per-entity `has_references: false` rows are absences inside a populated
 //! response.
 
-use std::collections::HashSet;
-
 use serde_json::{json, Map, Value};
 
 use kin_core::reference_coverage::{
-    reference_enrichment_for, ReferenceEnrichment, ENRICHABLE_LANGUAGES,
+    reference_enrichment_for, LanguageServerReadinessMap, ReferenceEnrichment, ENRICHABLE_LANGUAGES,
 };
 use kin_model::entity::Entity;
 use kin_model::graph::{EntityFilter, EntityStore};
@@ -557,11 +555,11 @@ fn attach_reference_resolution<S: EntityStore>(
 /// straight back to certifying because the build limit had lifted while the host
 /// limit had not.
 ///
-/// So the host is probed here now, through the same `PATH` lookup and the same
-/// table the doctor row and the install recipes read. The weakest language
-/// governs, matching how the class states above merge: one unsupported language
-/// in a batch makes the batch's reference evidence unproducible, and one missing
-/// server makes it unproduced.
+/// So the host is not probed here at all; the readiness a process with the right
+/// to spawn already established is read instead. The weakest language governs,
+/// matching how the class states above merge: one unsupported language in a
+/// batch makes the batch's reference evidence unproducible, and one missing or
+/// unusable server makes it unproduced.
 fn reference_enrichment(languages: &[LanguageId]) -> Value {
     let Some(servers) = published_language_servers() else {
         // Nobody published the host state, so nothing is established about any
@@ -593,18 +591,22 @@ fn build_only_reference_enrichment(languages: &[LanguageId]) -> ReferenceEnrichm
 /// silently stops checking is the one that runs in CI.
 fn weakest_reference_enrichment(
     languages: &[LanguageId],
-    servers_found: &HashSet<LanguageId>,
+    readiness: &LanguageServerReadinessMap,
 ) -> ReferenceEnrichment {
     languages
         .iter()
-        .map(|language| reference_enrichment_for(*language, servers_found))
+        .map(|language| reference_enrichment_for(*language, readiness))
         .min_by_key(|state| match state {
             // Weakest first: an unproducible class outranks an unproduced one,
             // which outranks an unread one, which outranks a working server.
             ReferenceEnrichment::Unsupported => 0,
             ReferenceEnrichment::NoLanguageServer => 1,
-            ReferenceEnrichment::Unknown => 2,
-            ReferenceEnrichment::Available => 3,
+            // A server that is present and cannot start produces exactly as
+            // many edges as one that is absent, so it ranks beside it and well
+            // below "nobody looked".
+            ReferenceEnrichment::LanguageServerUnusable => 2,
+            ReferenceEnrichment::Unknown => 3,
+            ReferenceEnrichment::Available => 4,
         })
         .unwrap_or(ReferenceEnrichment::Unknown)
 }
@@ -625,7 +627,7 @@ fn weakest_reference_enrichment(
 /// the same fact the enrichment path acted on. Unpublished reads as unknown, and
 /// unknown establishes nothing, which is the conservative reading this module
 /// takes everywhere else.
-fn published_language_servers() -> Option<HashSet<LanguageId>> {
+fn published_language_servers() -> Option<LanguageServerReadinessMap> {
     #[cfg(test)]
     if let Some(servers) = test_support::server_override() {
         return Some(servers);
@@ -636,18 +638,34 @@ fn published_language_servers() -> Option<HashSet<LanguageId>> {
         .and_then(|servers| servers.clone())
 }
 
-static PUBLISHED_SERVERS: std::sync::RwLock<Option<HashSet<LanguageId>>> =
+static PUBLISHED_SERVERS: std::sync::RwLock<Option<LanguageServerReadinessMap>> =
     std::sync::RwLock::new(None);
 
-/// Publish which languages have an enrichment server on this host.
+/// Publish what each language's enrichment server can actually do on this host.
 ///
-/// Called by the daemon at startup, beside the discovery that decides whether
-/// enrichment runs. Until it is called, every observation reports its languages'
-/// enrichment as unknown and the absence-trust gate stays silent about it, which
-/// is the behaviour a process that never looked should have.
-pub fn publish_installed_language_servers(servers: HashSet<LanguageId>) {
+/// Published by the process that probed, because deciding this needs a server
+/// started and a query path must not spawn subprocesses. Until it is called,
+/// every observation reports its languages' enrichment as unknown and the
+/// absence-trust gate stays silent about it, which is the behaviour a process
+/// that never looked should have, and is also the honest state while a probe is
+/// still in flight.
+///
+/// Readiness rather than a set of installed binaries: a binary on `PATH` is not
+/// a working language server, and publishing presence as though it were is how
+/// an absence came to be certified on evidence the host could not gather.
+/// The readiness a process with the right to spawn already established, or
+/// `None` when nobody has published yet.
+///
+/// Exposed so a query path can READ the verdict instead of probing the host
+/// itself. `None` is not an empty host: it means nothing looked, and a caller
+/// must leave its rows unknown rather than reporting servers missing.
+pub fn published_language_server_readiness() -> Option<LanguageServerReadinessMap> {
+    published_language_servers()
+}
+
+pub fn publish_language_server_readiness(readiness: LanguageServerReadinessMap) {
     if let Ok(mut slot) = PUBLISHED_SERVERS.write() {
-        *slot = Some(servers);
+        *slot = Some(readiness);
     }
 }
 
@@ -661,20 +679,21 @@ pub fn publish_installed_language_servers(servers: HashSet<LanguageId>) {
 /// process per test under nextest.
 #[cfg(test)]
 pub(crate) mod test_support {
-    use super::{HashSet, LanguageId};
+    use super::{LanguageId, LanguageServerReadinessMap};
+    use kin_core::reference_coverage::LanguageServerReadiness;
     use std::cell::RefCell;
 
     thread_local! {
-        static SERVERS: RefCell<Option<HashSet<LanguageId>>> = const { RefCell::new(None) };
+        static SERVERS: RefCell<Option<LanguageServerReadinessMap>> = const { RefCell::new(None) };
     }
 
-    pub(crate) fn server_override() -> Option<HashSet<LanguageId>> {
+    pub(crate) fn server_override() -> Option<LanguageServerReadinessMap> {
         SERVERS.with(|servers| servers.borrow().clone())
     }
 
     /// Restores the previous host on drop, including on unwind, so one test's
     /// environment never leaks into the next on a reused thread.
-    pub(crate) struct HostGuard(Option<HashSet<LanguageId>>);
+    pub(crate) struct HostGuard(Option<LanguageServerReadinessMap>);
 
     impl Drop for HostGuard {
         fn drop(&mut self) {
@@ -683,10 +702,32 @@ pub(crate) mod test_support {
     }
 
     /// Declare, for the rest of this scope, that the host carries exactly
-    /// `servers`. Bind the guard: dropping it immediately restores the host.
+    /// `servers`, all of them usable. Bind the guard: dropping it immediately
+    /// restores the host.
     #[must_use = "binding the guard is what keeps the declared host in force"]
     pub(crate) fn scoped_language_servers(servers: &[LanguageId]) -> HostGuard {
-        HostGuard(SERVERS.with(|slot| slot.borrow_mut().replace(servers.iter().copied().collect())))
+        scoped_language_server_readiness(
+            &servers
+                .iter()
+                .map(|language| (*language, LanguageServerReadiness::Usable))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Declare a host in the three-state vocabulary, so a test can state that a
+    /// server is PRESENT AND UNUSABLE rather than only present or absent.
+    ///
+    /// That case is the one this whole area exists for and the one a
+    /// presence-only override could not express, which meant no test could fail
+    /// when a broken server was reported as serving.
+    #[must_use = "binding the guard is what keeps the declared host in force"]
+    pub(crate) fn scoped_language_server_readiness(
+        readiness: &[(LanguageId, LanguageServerReadiness)],
+    ) -> HostGuard {
+        HostGuard(SERVERS.with(|slot| {
+            slot.borrow_mut()
+                .replace(readiness.iter().cloned().collect())
+        }))
     }
 
     /// Run `body` on a host carrying exactly `servers`.
@@ -1039,15 +1080,17 @@ mod tests {
     #[test]
     fn the_weakest_language_governs_a_batch() {
         use super::weakest_reference_enrichment;
-        let all: HashSet<LanguageId> = [
+        use kin_core::reference_coverage::{LanguageServerReadiness, LanguageServerReadinessMap};
+        let all: LanguageServerReadinessMap = [
             LanguageId::Rust,
             LanguageId::Python,
             LanguageId::TypeScript,
             LanguageId::JavaScript,
         ]
         .into_iter()
+        .map(|language| (language, LanguageServerReadiness::Usable))
         .collect();
-        let none: HashSet<LanguageId> = HashSet::new();
+        let none: LanguageServerReadinessMap = LanguageServerReadinessMap::new();
 
         assert_eq!(
             weakest_reference_enrichment(&[LanguageId::Python, LanguageId::Ruby], &all),
@@ -1061,6 +1104,29 @@ mod tests {
         assert_eq!(
             weakest_reference_enrichment(&[LanguageId::Python, LanguageId::JavaScript], &all),
             ReferenceEnrichment::Available
+        );
+
+        // The state a presence-only host could not express: JavaScript's server
+        // is installed and cannot start, so the batch is unproduced rather than
+        // available, and it is NOT reported as a missing install.
+        let javascript_broken: LanguageServerReadinessMap = [
+            (LanguageId::Python, LanguageServerReadiness::Usable),
+            (
+                LanguageId::JavaScript,
+                LanguageServerReadiness::Unusable {
+                    reason: "Could not find a valid TypeScript installation".to_string(),
+                },
+            ),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            weakest_reference_enrichment(
+                &[LanguageId::Python, LanguageId::JavaScript],
+                &javascript_broken
+            ),
+            ReferenceEnrichment::LanguageServerUnusable,
+            "a usable sibling must not lift a batch whose other server cannot start"
         );
         assert_eq!(
             weakest_reference_enrichment(&[], &all),

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.9"
+version = "0.7.10"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "859744dbb2855216be40ea258c0ff608888f00f19435d1bdf3714314176d93d3"
+checksum = "be211911c8cf30d0afd21673f4807f1fe4d7ac288b2324f7cf13c3f7667b4714"
 dependencies = [
  "chrono",
  "gix-hash",


### PR DESCRIPTION
## The defect that matters

Language-server readiness was answered with `which::which` in three places, and every surface that asked inherited the wrong answer. A binary on `PATH` is not a working language server: a host carrying `typescript-language-server` beside TypeScript 7 resolves fine and fails every start, because TypeScript 7 ships no `lib/tsserver.js`.

The surface that matters is not the operator's. `kin_core::reference_coverage::installed_language_servers` fed `publish_installed_language_servers`, which feeds kin-mcp's `edge_coverage`, which feeds `ReferenceEnrichment`, which is an input under the one verdict an agent reads when deciding whether an absence is real. So Kin certified absences to agents on reference evidence the host could not gather.

FIR-2463 collapsed a response's three disagreeing verdict blocks into one with the most pessimistic input winning. That fixed disagreement and could not make the inputs true. **A pessimistic-wins collapse made the verdicts consistently wrong rather than inconsistently wrong once an input carried a confident falsehood, and this was the false input underneath the verdict that collapse built.**

Not hypothetical. On 2026-08-20 this dev host ran the unpinned install at 18:48:57Z, landed TypeScript 7.0.2 beside the server, and sat in exactly that state until 18:59:33Z. Earlier the same day the same box produced the opposite failure, the binary gone entirely, and no Kin surface could name which one it was in.

## Three states, one probe, published once

`kin-core` carries `LanguageServerReadiness`: `Usable`, `Unusable { reason }`, `Absent`. `ReferenceEnrichment` gains `LanguageServerUnusable` beside `NoLanguageServer`, because a missing server and a broken one produce the same zero edges and need different repairs, and `is_actionable_gap` covers both since a broken install is something an operator can close.

The type lives in kin-core because of the dependency graph, not preference: kin-core and kin-mcp do not depend on kin-lsp, only kin-cli and kin-daemon do. kin-daemon is the one crate seeing both sides, so it translates kin-lsp's verdict at the publish boundary.

`kin-daemon` probes instead of looking up, in a background task so startup pays nothing, with the four languages probed concurrently so the worst case is one probe budget rather than four stacked. Until it publishes, the value stays `None`, which already means unknown and already keeps the absence-trust gate silent, so the interim is honest rather than a gap. A probe that does not finish is left OUT of the map rather than recorded as `Absent`, because recording it would be a claim the process did not earn.

`kin graph status` runs inside daemon request handling, so it READS the published verdict and, when nothing is published, skips the call entirely so rows stay `Unknown`. An empty map would read as every server missing, which is reporting a gap nothing looked for.

## The latch, and why the trigger is the sweep

Readiness taken once latches. That is FIR-2505's finding, and it bites hardest here: a user who follows Kin's own advice and installs the server it just named would leave a long-lived daemon reporting that language unavailable forever, with the stale answer sitting under an agent-facing verdict. A correct three-state answer that can silently fossilize is half a fix.

So the probe re-runs at the start of every sweep. That is the moment the daemon is about to want servers, it needs no new signal invented, and no caller can forget it. `kin setup` pokes the same existing `POST /lsp/sweep` route after installing, which re-probes and re-enriches in one motion, which is what someone actually wants after installing a server. That is why no dedicated route was added.

Note it uses `from_base_url_for_layout`, not `from_base_url`: the latter resolves the bearer token from the process working directory, which is the silent-wrong-target class that made `kin init`'s conversion phase 401 on runners.

## The operator surfaces

`kin doctor` is async and may spawn, so it probes directly, which also makes it immune to the latch by construction. Its row now separates the failures: an absent server gets the install command, an installed-but-dead one gets "installed but it did not start" plus the server's own reason.

`kin setup` refuses to count an install that landed a binary the server cannot run. That mirrors `InstallOutcome::RanButStillMissing` beside it, whose own comment says counting it as applied is how a closed-looking row keeps an open gap; this is its sibling, a zero exit that left something on `PATH` which cannot start. It withholds the restart advice too, rather than sending someone to restart into a broken server.

## Four presence probes deleted, not reconciled

The plan was a test asserting the duplicate binary-name tables agree. Once the consumers moved to readiness, the duplicates had no callers left, so they are gone instead: kin-core's `LANGUAGE_SERVER_BINARIES` with its PATH probe and its own test, and kin-cli's two `installed_language_servers`. Deleting a duplicate beats testing that a duplicate agrees.

The surviving statement of the binary-name fact is kin-lsp's, and kin-cli's install advice is now asserted against `ProviderRegistry::known_binaries` instead of restating it. Its old test hardcoded the names because, per its own comment, kin-cli could not see kin-lsp at compile time. It can.

## The pin ladder

Three pins move together because they must. kin-lsp 0.7.0 requires kin-model 0.7.10; kin-db `=0.7.36` requires kin-model `=0.7.9`, and kin-db 0.7.38 is the first version taking `=0.7.10`. Reading the index: 0.7.34 through 0.7.37 all require `=0.7.9`.

```
kin-db    =0.7.36 -> =0.7.38
kin-model =0.7.9  -> =0.7.10
kin-lsp   =0.6.16 -> =0.7.0
```

kin-db 0.7.37 is the credscan scanner narrowing and 0.7.38 is the dependency-wave pin refresh, both landed tonight under release captaincy.

kin-lsp 0.7.0 is kin-lsp#76: `probe_readiness` with the three-state answer, `ProviderGapReason::ServerUnusable`, FIR-2514's bounded stderr capture, and `known_binaries`.

## Falsification

Every new guard was broken and confirmed to fail with its own message, exit codes read raw and never through a pipe.

Reconciliation, by drifting `pyright-langserver` in the recipe table, exit 101:
```
python: the install advice and the runtime name different binaries
  left: ["pyright-langserver-drifted", "pylsp"]
 right: ["pyright-langserver", "pylsp"]
```

The doctor split and the batch verdict are asserted on the three-state input directly, including that a usable sibling must not lift a batch whose other server cannot start, and that a broken install is reported as broken rather than absent and still counts as actionable.

kin-lsp#76 carried its own five falsifications, including the one that matters most here: removing the stderr capture makes a dying server's failure read "server initialization failed: server shutdown unexpectedly", with no reason at all.

## Gate, registry-locked

The DEV-LOCAL gate cannot validate this PR: its cargo config path-patches the very crates this repins, so it would resolve by path and pass whatever version was written. So:

- `cargo nextest run --workspace --locked --no-fail-fast`: exit 0. `Summary [454.883s] 6607 tests run: 6607 passed (4 slow, 1 leaky), 12 skipped`. Zero `FAIL [` lines against a `PASS [` control in the thousands, and no cancellation line.
- `cargo test --doc --locked`: exit 0, 23 doctest targets ok.
- `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the `.github/clippy-allowed-lints.txt` allowlist, exactly as `ci.yml` runs it: exit 0.
- `cargo fmt --all -- --check`: exit 0.
- `scripts/verify-zero-file-search.py`: exit 0, 177 files scanned. It caught a `.canonicalize()` this PR had added to `daemon.rs`, over the allowlist's count of two. Rather than widen the allowlist, the call is gone: a readiness probe asks whether a server starts and never resolves a file through that path, so the filesystem round trip bought nothing.
- `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh`, `scripts/test-private-repo-coupling.py`: all exit 0.

Lock entries keep their registry source and checksum, verified with a fabricated crate name as the control proving the check can still say no:

```
kin-lsp   0.7.0    sparse+https://kinlab.ai/regis... checksum de810847...
kin-model 0.7.10   sparse+https://kinlab.ai/regis... checksum be211911...
kin-db    0.7.38   sparse+https://kinlab.ai/regis... checksum 9a914601...
```

`git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`.

## Not claiming

No end-to-end run against a repository with a broken server was performed under this change. What is proven is the unit and integration behavior, the gate above, and kin-lsp#76's own fixtures. The one-time announced host confirmation named in FIR-2519, installing TypeScript 7 beside the server and requiring the surfaces to move and then return, has not been run.

Closes FIR-2519
