### PR TITLE
Say when kin impact cannot rule out dependents, in the MCP verdict's own words

### DIFF
--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -400,20 +400,35 @@ fn impact_absence_qualifier(
         .and_then(serde_json::Value::as_str)
         .unwrap_or("this language");
     let classes = observed.and_then(|coverage| coverage.get("classes"));
-    let in_state = |state: &str| -> Vec<&'static str> {
-        ["calls", "imports", "references"]
-            .into_iter()
-            .filter(|class| {
-                classes
-                    .and_then(|classes| classes.get(*class))
-                    .and_then(serde_json::Value::as_str)
-                    == Some(state)
-            })
-            .map(edge_class_noun)
-            .collect()
+    let state_of = |class: &str| -> Option<&str> {
+        classes
+            .and_then(|classes| classes.get(class))
+            .and_then(serde_json::Value::as_str)
     };
-    let missing = in_state("absent");
-    let present = in_state("present");
+    // Only the classes the gate actually rested on may be named. Listing every
+    // absent class would tell a reader their import edges were the problem on a
+    // store where imports never mattered: Kin's linker mints no entity-level
+    // `Imports` relation on any language, so that class reads absent on healthy
+    // graphs too, and naming it is a small fabrication of the same kind this
+    // change exists to stop.
+    let requested: Vec<String> = kin_mcp::handlers::review::IMPACT_REFERENCE_KINDS
+        .iter()
+        .map(|kind| format!("{kind:?}").to_lowercase())
+        .collect();
+    let deciding = kin_mcp::negative::deciding_classes(
+        &requested,
+        kin_mcp::negative::references_producible(&payload),
+    );
+    let missing: Vec<&'static str> = deciding
+        .iter()
+        .filter(|class| state_of(class) == Some("absent"))
+        .map(|class| edge_class_noun(class))
+        .collect();
+    let present: Vec<&'static str> = requested
+        .iter()
+        .filter(|class| state_of(class) == Some("present"))
+        .map(|class| edge_class_noun(class))
+        .collect();
 
     // Naming a missing class the observation did not report would be the same
     // fabrication this ticket family exists to end, so when nothing is absent
@@ -789,6 +804,115 @@ mod tests {
         build_impact_response, downstream_impact_by_hop, impact_not_found_guidance, ImpactRequest,
         ImpactResponse, ImpactWalkGraph,
     };
+
+    /// THE SPINE (FIR-2524, captain's rider). A degraded daemon must make the CLI
+    /// inherit the MCP verdict for that degradation.
+    ///
+    /// This is the test the cheap wiring could never pass, and it is why the
+    /// expensive wiring was chosen. The rejected option built a thin envelope in
+    /// the route from facts it had locally, `initialized` and `graph_loaded`,
+    /// which carries no degraded signal. Under it the CLI would print nothing
+    /// here while `impact_analysis` refused on the same daemon at the same
+    /// instant: the human surface MORE confident than the agent surface, which
+    /// is precisely the divergence this ticket exists to close, reintroduced by
+    /// its own fix. Every other test in this file runs against a healthy daemon
+    /// and would have passed regardless, so without this case the choice between
+    /// the two wirings was unfalsifiable.
+    ///
+    /// It asserts inheritance rather than wording: the same `negative_for` call
+    /// the daemon's MCP handler makes, on the same payload, must reach the same
+    /// `safe_to_conclude_absent`, and the rendered line must name the signal the
+    /// verdict disclosed rather than inventing a cause.
+    #[tokio::test]
+    async fn a_degraded_daemon_makes_the_cli_inherit_the_mcp_verdict() {
+        let graph = kin_db::InMemoryGraph::new();
+        let target = entity("orphan", "src/orphan.rs");
+        graph.upsert_entity(&target).unwrap();
+        // Coverage is HEALTHY on purpose, so the degraded signal is the only
+        // reason left to refuse. Without this the store is genuinely
+        // coverage-poor, the refusal is over-determined, and the test would pass
+        // while proving nothing about the envelope.
+        let caller = entity("caller", "src/a.rs");
+        let callee = entity("callee", "src/b.rs");
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_entity(&callee).unwrap();
+        calls(&graph, &caller, &callee);
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+
+        let degraded = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 1,
+            "graph_generation": 1,
+            "embed_worker_failed": true,
+        }));
+
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "orphan".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+            &degraded,
+        )
+        .await
+        .expect("impact response");
+        let rendered = response.lines.join("\n");
+
+        // What the MCP surface would say about this same daemon and this same
+        // empty answer. Not a re-implementation: the identical entry point.
+        let coverage = kin_mcp::edge_coverage::observe_cross_file_reference_coverage_for_languages(
+            &graph,
+            &[target.language],
+            &kin_mcp::handlers::review::IMPACT_REFERENCE_KINDS,
+        );
+        let payload = serde_json::json!({
+            "entity_impacts": [],
+            kin_mcp::EDGE_COVERAGE_KEY: coverage,
+        });
+        let mcp = kin_mcp::negative::negative_for("impact_analysis", &payload, &degraded, &[])
+            .expect("impact_analysis always qualifies");
+        assert_eq!(
+            mcp["safe_to_conclude_absent"],
+            serde_json::json!(false),
+            "the MCP verdict must refuse on a degraded daemon, or this test asserts nothing: {mcp}"
+        );
+
+        assert!(
+            rendered.contains("Kin cannot rule out dependents"),
+            "the CLI must inherit the refusal the MCP surface reached: {rendered}"
+        );
+        assert!(
+            rendered.contains("embed_worker_failed"),
+            "the line names the signal the verdict disclosed rather than inventing a cause: \
+             {rendered}"
+        );
+        // And it must not fabricate a missing edge class. Nothing here observed
+        // one, and naming one anyway is the fabrication this family exists to end.
+        assert!(
+            !rendered.contains("holds no cross-file"),
+            "no absent class was observed, so none may be claimed: {rendered}"
+        );
+    }
+
+    /// A daemon whose substrate is sound, so the absence gate answers on
+    /// coverage rather than on the envelope. The tests that predate FIR-2524
+    /// assert impact CONTENT, and a synthetic envelope reading uninitialised
+    /// would make every one of them inconclusive for a reason they are not about.
+    fn healthy_test_envelope() -> kin_mcp::Envelope {
+        kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 2,
+            "graph_generation": 1,
+        }))
+    }
     use kin_model::{
         Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
         FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, Relation, RelationId, RelationKind,
@@ -870,6 +994,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -897,6 +1022,7 @@ mod tests {
                 signature: None,
                 require_unique: true,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -942,6 +1068,7 @@ mod tests {
                 signature: Some("fn changed()".to_string()),
                 require_unique: true,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -975,6 +1102,7 @@ mod tests {
                 signature: None,
                 require_unique: true,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1006,6 +1134,7 @@ mod tests {
                 signature: Some("fn   handle(value: String)".to_string()),
                 require_unique: true,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1063,6 +1192,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1120,6 +1250,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1166,6 +1297,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1205,6 +1337,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1242,6 +1375,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1293,6 +1427,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1316,6 +1451,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1361,6 +1497,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();
@@ -1609,6 +1746,7 @@ mod tests {
                 signature: None,
                 require_unique: false,
             },
+            &healthy_test_envelope(),
         )
         .await
         .unwrap();

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -411,23 +411,24 @@ fn impact_absence_qualifier(
     // `Imports` relation on any language, so that class reads absent on healthy
     // graphs too, and naming it is a small fabrication of the same kind this
     // change exists to stop.
-    let requested: Vec<String> = kin_mcp::handlers::review::IMPACT_REFERENCE_KINDS
-        .iter()
-        .map(|kind| format!("{kind:?}").to_lowercase())
-        .collect();
-    let deciding = kin_mcp::negative::deciding_classes(
-        &requested,
-        kin_mcp::negative::references_producible(&payload),
-    );
+    //
+    // Which classes those are is READ from the record the verdict publishes
+    // rather than recomputed from the function that produced it. FIR-2505 made
+    // the completeness block publish `decided_by` for exactly this reason, so
+    // consuming it here is identical to the decision by construction, and needs
+    // nothing from `kin_mcp::negative` that is not already public. Importing the
+    // deciding-set helper instead would have been reading the pieces, which is
+    // the habit this ticket family exists to break.
+    let deciding = completeness_decided_by(&payload, envelope);
     let missing: Vec<&'static str> = deciding
         .iter()
         .filter(|class| state_of(class) == Some("absent"))
         .map(|class| edge_class_noun(class))
         .collect();
-    let present: Vec<&'static str> = requested
-        .iter()
+    let present: Vec<&'static str> = ["calls", "imports", "references"]
+        .into_iter()
         .filter(|class| state_of(class) == Some("present"))
-        .map(|class| edge_class_noun(class))
+        .map(edge_class_noun)
         .collect();
 
     // Naming a missing class the observation did not report would be the same
@@ -470,6 +471,51 @@ fn impact_absence_qualifier(
         ));
     }
     said
+}
+
+/// The classes the verdict says it rested on, read off the published
+/// completeness block rather than recomputed.
+///
+/// `_kin.completeness.decided_by` is the verdict's own record of what it
+/// weighed (FIR-2505), so a renderer that reads it cannot name a class the
+/// decision did not use. Going through the same `finalize_with_envelope` the MCP
+/// surface goes through is the point: one producer, one record, two readers.
+///
+/// An empty answer here names no class, which is the conservative direction: the
+/// caller then falls back to the disclosed signals rather than inventing an edge
+/// class nobody observed.
+fn completeness_decided_by(
+    payload: &serde_json::Value,
+    envelope: &kin_mcp::Envelope,
+) -> Vec<String> {
+    let annotated = kin_mcp::finalize_with_envelope(
+        kin_mcp::ToolCallResult::text(payload.to_string()),
+        envelope.clone(),
+        "impact_analysis",
+    );
+    annotated
+        .content
+        .iter()
+        .find_map(|block| match block {
+            kin_mcp::ContentBlock::Text { text } => {
+                serde_json::from_str::<serde_json::Value>(text).ok()
+            }
+        })
+        .and_then(|value| {
+            value
+                .get(kin_mcp::ENVELOPE_KEY)
+                .and_then(|envelope| envelope.get("completeness"))
+                .and_then(|completeness| completeness.get("decided_by"))
+                .and_then(serde_json::Value::as_array)
+                .map(|classes| {
+                    classes
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .map(str::to_string)
+                        .collect()
+                })
+        })
+        .unwrap_or_default()
 }
 
 /// The edge class in the noun a sentence wants, since the observation keys are

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -133,6 +133,7 @@ pub async fn build_impact_response(
     _layout: &kin_core::KinLayout,
     graph: &kin_db::InMemoryGraph,
     request: &ImpactRequest,
+    envelope: &kin_mcp::Envelope,
 ) -> Result<ImpactResponse> {
     let ResolvedEntities {
         mut matches,
@@ -256,6 +257,7 @@ pub async fn build_impact_response(
     let local_impacted = downstream_impact_by_hop(graph, &target.id, request.depth)?;
     if local_impacted.is_empty() {
         lines.push("  No local downstream impact found.".to_string());
+        lines.extend(impact_absence_qualifier(graph, target, envelope));
         lines.extend(empty_impact_context(graph, target)?);
     } else {
         lines.push(format!(
@@ -343,6 +345,127 @@ const IMPACT_MEMBER_RELATION_KINDS: &[kin_model::RelationKind] = &[
     kin_model::RelationKind::Imports,
     kin_model::RelationKind::References,
 ];
+
+/// Say, in a human sentence, that this empty answer is not evidence of absence.
+///
+/// The VERDICT is not computed here. [`kin_mcp::negative::negative_for`] is the
+/// one gate, called with the same tool name and the same `edge_coverage`
+/// observation `impact_analysis` publishes over the same
+/// [`kin_mcp::handlers::review::IMPACT_REFERENCE_KINDS`], so this surface cannot
+/// reach a different conclusion from the MCP one about the same store. Only the
+/// RENDERING is local, because a person reading a terminal is not parsing an
+/// envelope (FIR-2524, captain's ruling 2026-08-20).
+///
+/// Silence is the certified case. A graph whose enrichment delivered says
+/// nothing extra, which is the control that stops this degrading into stamping
+/// every empty result uncertain, the FIR-2404 failure wearing its opposite
+/// costume.
+///
+/// The line promises no remedy, and that is decided rather than inherited. On a
+/// store whose sweep produced nothing the honest answer to "what should I do"
+/// does not exist yet; it is FIR-2519's to create. A promised remedy that may be
+/// false is the `absence_consequence` failure `kin_mcp::negative` already
+/// refuses on the MCP side, and `kin init` ships one today that misattributes a
+/// disabled sweep to a missing server (FIR-2531). One of those is enough.
+fn impact_absence_qualifier(
+    graph: &kin_db::InMemoryGraph,
+    target: &kin_model::Entity,
+    envelope: &kin_mcp::Envelope,
+) -> Vec<String> {
+    let coverage = kin_mcp::edge_coverage::observe_cross_file_reference_coverage_for_languages(
+        graph,
+        &[target.language],
+        &kin_mcp::handlers::review::IMPACT_REFERENCE_KINDS,
+    );
+    let payload = serde_json::json!({
+        "entity_impacts": [],
+        kin_mcp::EDGE_COVERAGE_KEY: coverage,
+    });
+    let Some(negative) =
+        kin_mcp::negative::negative_for("impact_analysis", &payload, envelope, &[])
+    else {
+        return Vec::new();
+    };
+    if negative
+        .get("safe_to_conclude_absent")
+        .and_then(serde_json::Value::as_bool)
+        != Some(false)
+    {
+        return Vec::new();
+    }
+
+    let observed = payload.get(kin_mcp::EDGE_COVERAGE_KEY);
+    let language = observed
+        .and_then(|coverage| coverage.get("language"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("this language");
+    let classes = observed.and_then(|coverage| coverage.get("classes"));
+    let in_state = |state: &str| -> Vec<&'static str> {
+        ["calls", "imports", "references"]
+            .into_iter()
+            .filter(|class| {
+                classes
+                    .and_then(|classes| classes.get(*class))
+                    .and_then(serde_json::Value::as_str)
+                    == Some(state)
+            })
+            .map(edge_class_noun)
+            .collect()
+    };
+    let missing = in_state("absent");
+    let present = in_state("present");
+
+    // Naming a missing class the observation did not report would be the same
+    // fabrication this ticket family exists to end, so when nothing is absent
+    // the reason is whatever the verdict actually disclosed.
+    if missing.is_empty() {
+        let disclosed = negative
+            .get("degraded_signals")
+            .and_then(serde_json::Value::as_array)
+            .map(|signals| {
+                signals
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .filter(|disclosed| !disclosed.is_empty());
+        return vec![match disclosed {
+            Some(disclosed) => format!(
+                "  Kin cannot rule out dependents: this answer carries [{disclosed}], so it may \
+                 not reflect current truth."
+            ),
+            None => {
+                "  Kin cannot rule out dependents: this answer's coverage could not be established."
+                    .to_string()
+            }
+        }];
+    }
+
+    let mut said = vec![format!(
+        "  Kin cannot rule out dependents: this graph holds no cross-file {} edges for \
+         {language}, so a use reaching this entity from another file could not have been found.",
+        missing.join(" or ")
+    )];
+    if !present.is_empty() {
+        said.push(format!(
+            "  Cross-file {} edges exist but do not stand in for {} edges.",
+            present.join(" and "),
+            missing.join(" or ")
+        ));
+    }
+    said
+}
+
+/// The edge class in the noun a sentence wants, since the observation keys are
+/// plural and the prose is not.
+fn edge_class_noun(class: &str) -> &'static str {
+    match class {
+        "calls" => "call",
+        "imports" => "import",
+        _ => "reference",
+    }
+}
 
 /// What the graph still says about a target with no downstream impact of its
 /// own.

--- a/crates/kin-cli/tests/declaration_resolution_e2e.rs
+++ b/crates/kin-cli/tests/declaration_resolution_e2e.rs
@@ -142,6 +142,14 @@ async fn impact_lines(graph: &InMemoryGraph, entity: &str, file: Option<&str>) -
             signature: None,
             require_unique: false,
         },
+        // Substrate sound, so the FIR-2524 absence qualifier answers on coverage
+        // rather than on the envelope. These cases assert impact CONTENT.
+        &kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 2,
+            "graph_generation": 1,
+        })),
     )
     .await
     .expect("impact response")

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -12412,6 +12412,89 @@ fn bind_std_listener(
 
 #[cfg(test)]
 mod tests {
+    /// THE WIRING SPINE (FIR-2524, captain's rider). The envelope the impact
+    /// route hands the CLI must carry the daemon's degraded signals.
+    ///
+    /// This is the assertion the rejected wiring could not pass, and the reason
+    /// it lives HERE rather than beside the CLI's rendering test: the rejected
+    /// option's defect is in what this route BUILDS, and a unit test that
+    /// constructs its own envelope and passes it to `build_impact_response`
+    /// cannot see it. That test asserts the renderer inherits a degraded verdict
+    /// and passes under both wirings; only this one distinguishes them.
+    ///
+    /// A thinner snapshot carrying just `initialized` and `graph_loaded` reads
+    /// perfectly healthy, so the CLI would stay silent on a daemon whose
+    /// embedding worker has failed while `impact_analysis` refuses on the same
+    /// instant. Human surface more confident than agent surface is the exact
+    /// divergence this ticket closes.
+    #[test]
+    fn the_impact_envelope_carries_the_daemons_degraded_signals() {
+        let health = serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 3,
+            "graph_generation": 7,
+            "embed_worker_failed": true,
+            "mass_deletion_blocked": false,
+        });
+        let envelope = kin_mcp::Envelope::daemon().with_health(&health);
+
+        // The verdict the CLI will render is the one this envelope produces, so
+        // assert the envelope actually carries the degradation into it rather
+        // than asserting on the JSON we just wrote.
+        // Coverage healthy, so the degraded flag is the ONLY variable. Without
+        // this the gate refuses both arms for `edge_coverage_unreported`, which
+        // is the gate working correctly and a test proving nothing.
+        let payload = serde_json::json!({
+            "entity_impacts": [],
+            kin_mcp::EDGE_COVERAGE_KEY: {
+                "scope": "language",
+                "language": "Rust",
+                "requested_classes": ["calls", "imports", "references"],
+                "classes": { "calls": "present", "imports": "absent", "references": "present" },
+                "cross_file_classes": ["calls", "references"],
+                "reference_enrichment": "available",
+                "budget_exhausted": false,
+                "entities_examined": 3,
+            }
+        });
+        let negative =
+            kin_mcp::negative::negative_for("impact_analysis", &payload, &envelope, &[])
+                .expect("impact_analysis always qualifies");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            serde_json::json!(false),
+            "a degraded daemon must not certify: {negative}"
+        );
+        assert!(
+            negative["degraded_signals"]
+                .as_array()
+                .is_some_and(|signals| signals
+                    .iter()
+                    .any(|signal| signal.as_str() == Some("embed_worker_failed"))),
+            "the signal must reach the verdict the CLI renders: {negative}"
+        );
+
+        // The control that makes the assertion above mean something: the same
+        // shape with the flag cleared must certify, so this is not a test that
+        // passes on any envelope at all.
+        let healthy = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 3,
+            "graph_generation": 7,
+            "embed_worker_failed": false,
+        }));
+        let negative =
+            kin_mcp::negative::negative_for("impact_analysis", &payload, &healthy, &[])
+                .expect("impact_analysis always qualifies");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            serde_json::json!(true),
+            "an undegraded daemon must still certify: {negative}"
+        );
+    }
+
     use super::*;
     use axum::body::Body;
     use axum::http::Request;
@@ -24541,6 +24624,88 @@ mod tests {
         assert!(
             !joined.contains("def handler"),
             "file body must not be served from disk: {joined}"
+        );
+    }
+
+    /// THE SPINE (FIR-2524, captain's rider). Drives the ROUTE, because that is
+    /// the only place the rejected wiring differs.
+    ///
+    /// The rendering test beside the CLI constructs its own degraded envelope
+    /// and passes it to `build_impact_response`, so it passes under BOTH
+    /// wirings; falsifying it against the thin-envelope option proved exactly
+    /// that, and proved the rendering test alone could not justify the choice.
+    /// The rejected option's defect lives in what this route BUILDS, so only a
+    /// test that lets the route build it can see the difference.
+    ///
+    /// Break `daemon_health_snapshot` down to `initialized` + `graph_loaded` and
+    /// this test fails: the CLI goes silent on a daemon whose embedding worker
+    /// has failed, while `impact_analysis` refuses on the same daemon at the
+    /// same instant. Human surface more confident than agent surface is the
+    /// divergence this ticket closes.
+    #[tokio::test]
+    async fn a_degraded_daemon_reaches_the_impact_cli_through_the_route() {
+        let state = test_state();
+        // Coverage healthy on purpose, so the degradation is the only reason
+        // left to refuse and the assertion cannot pass for the wrong cause.
+        let caller = test_entity("caller", "src/a.py");
+        let callee = test_entity("callee", "src/b.py");
+        let orphan = test_entity("orphan", "src/orphan.py");
+        for entity in [&caller, &callee, &orphan] {
+            state.graph.upsert_entity(entity).unwrap();
+        }
+        state
+            .graph
+            .upsert_relation(&kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind: kin_model::RelationKind::Calls,
+                src: kin_model::GraphNodeId::Entity(caller.id),
+                dst: kin_model::GraphNodeId::Entity(callee.id),
+                confidence: 1.0,
+                origin: kin_model::RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state
+            .embed_worker_failed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/impact")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "entity": "orphan", "depth": 3 }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let result: kin_cli::commands::impact::ImpactResponse =
+            serde_json::from_slice(&body).unwrap();
+        let rendered = result.lines.join("\n");
+
+        assert!(
+            rendered.contains("No local downstream impact found."),
+            "the orphan must still report no impact: {rendered}"
+        );
+        assert!(
+            rendered.contains("Kin cannot rule out dependents"),
+            "the route's envelope must carry the degradation into the rendered verdict; a \
+             thinner snapshot leaves this line out entirely: {rendered}"
+        );
+        assert!(
+            rendered.contains("embed_worker_failed"),
+            "the line names the signal the verdict disclosed rather than inventing a cause: \
+             {rendered}"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6012,6 +6012,37 @@ async fn trace(
     Ok(Json(result))
 }
 
+/// The substrate reading an absence verdict rests on, in the shape
+/// [`kin_mcp::Envelope::with_health`] consumes.
+///
+/// Read from the same `DaemonState` fields `/health` reads, deliberately, so the
+/// CLI's rendered verdict and the MCP one cannot disagree about the same daemon
+/// at the same instant. A second, thinner source of these facts is how two
+/// surfaces come to answer differently, which is the defect FIR-2524 exists to
+/// close; building one here would have closed it while opening it.
+///
+/// `graph_loaded` is derived from a nonzero entity count exactly as `/health`
+/// derives it, rather than asserted.
+fn daemon_health_snapshot(state: &Arc<DaemonState>) -> serde_json::Value {
+    let entity_count = state.graph.entity_count();
+    serde_json::json!({
+        "initialized": state
+            .is_initialized
+            .load(std::sync::atomic::Ordering::Relaxed),
+        "graph_loaded": entity_count > 0,
+        "graph_entity_count": entity_count as u64,
+        "graph_generation": state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::Relaxed),
+        "embed_worker_failed": state
+            .embed_worker_failed
+            .load(std::sync::atomic::Ordering::Relaxed),
+        "mass_deletion_blocked": state
+            .mass_deletion_blocked
+            .load(std::sync::atomic::Ordering::Relaxed),
+    })
+}
+
 /// POST /impact — compute downstream impact against daemon-owned graph state.
 async fn impact(
     headers: axum::http::HeaderMap,
@@ -6030,10 +6061,25 @@ async fn impact(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let result =
-        kin_cli::commands::impact::build_impact_response(&state.layout, graph.as_ref(), &req)
-            .await
-            .map_err(internal_error)?;
+    // The CLI's absence qualifier is the MCP verdict rendered as prose, so it
+    // needs the same substrate reading the MCP path gets (FIR-2524). Built here
+    // because only the daemon holds it: `build_impact_response` sees a graph and
+    // a layout and could not observe a degraded worker if it wanted to.
+    //
+    // Passing a thinner envelope was the tempting shortcut and is the defect
+    // this ticket closes, wearing the fix's clothes: an envelope carrying no
+    // degraded signal makes the CLI MORE confident than MCP on exactly the
+    // degraded daemon nobody exercises, and every test written against a healthy
+    // one would pass.
+    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state));
+    let result = kin_cli::commands::impact::build_impact_response(
+        &state.layout,
+        graph.as_ref(),
+        &req,
+        &envelope,
+    )
+    .await
+    .map_err(internal_error)?;
     Ok(Json(result))
 }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -12458,9 +12458,8 @@ mod tests {
                 "entities_examined": 3,
             }
         });
-        let negative =
-            kin_mcp::negative::negative_for("impact_analysis", &payload, &envelope, &[])
-                .expect("impact_analysis always qualifies");
+        let negative = kin_mcp::negative::negative_for("impact_analysis", &payload, &envelope, &[])
+            .expect("impact_analysis always qualifies");
         assert_eq!(
             negative["safe_to_conclude_absent"],
             serde_json::json!(false),
@@ -12485,9 +12484,8 @@ mod tests {
             "graph_generation": 7,
             "embed_worker_failed": false,
         }));
-        let negative =
-            kin_mcp::negative::negative_for("impact_analysis", &payload, &healthy, &[])
-                .expect("impact_analysis always qualifies");
+        let negative = kin_mcp::negative::negative_for("impact_analysis", &payload, &healthy, &[])
+            .expect("impact_analysis always qualifies");
         assert_eq!(
             negative["safe_to_conclude_absent"],
             serde_json::json!(true),

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -213,7 +213,12 @@ pub async fn handle_impact_analysis<G: GraphStore>(
 /// [`crate::negative::absence_cross_file_classes`] declares `impact_analysis`
 /// depends on. Declaring one set and observing another is how a gate comes to
 /// judge a class the answer never measured.
-const IMPACT_REFERENCE_KINDS: [kin_model::relation::RelationKind; 3] = [
+///
+/// Public because the CLI's `kin impact` renders the same verdict over the same
+/// classes (FIR-2524). Two consumers reading one declaration is the whole point;
+/// a second copy in `kin-cli` would be the drift this comment already warns
+/// about, arriving by the door it does not watch.
+pub const IMPACT_REFERENCE_KINDS: [kin_model::relation::RelationKind; 3] = [
     kin_model::relation::RelationKind::Calls,
     kin_model::relation::RelationKind::Imports,
     kin_model::relation::RelationKind::References,

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -366,7 +366,7 @@ pub(crate) fn load_bearing_classes(requested: &[String]) -> Vec<String> {
 /// have existed, and [`absence_coverage_gap`] already refuses both by name.
 /// `unknown` is an unread host, and unmeasured is not a finding anywhere else in
 /// this module either.
-pub(crate) fn references_producible(payload: &Value) -> bool {
+pub fn references_producible(payload: &Value) -> bool {
     payload
         .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
         .and_then(|coverage| coverage.get("reference_enrichment"))
@@ -376,6 +376,13 @@ pub(crate) fn references_producible(payload: &Value) -> bool {
 
 /// The classes this answer's verdict actually rests on: [`load_bearing_classes`]
 /// plus `references` wherever this host could have produced it.
+///
+/// Public for RENDERING, not for deciding. `kin impact` prints which classes the
+/// gate rested on, and naming a class the gate never weighed is its own small
+/// fabrication: `imports` is absent on every healthy graph, so a renderer that
+/// listed every absent class would tell a user their import edges were the
+/// problem on a store where they never mattered (FIR-2524). The DECISION stays
+/// [`negative_for`]'s alone.
 ///
 /// One definition, because three consumers ask the same question and a fourth
 /// answer would only be somewhere for them to drift. [`absence_coverage_gap`]
@@ -393,7 +400,7 @@ pub(crate) fn references_producible(payload: &Value) -> bool {
 /// that changes the answer: on a host that CAN produce reference edges, their
 /// absence is a finding rather than the ordinary silence of a language server
 /// that never ran.
-pub(crate) fn deciding_classes(requested: &[String], references_producible: bool) -> Vec<String> {
+pub fn deciding_classes(requested: &[String], references_producible: bool) -> Vec<String> {
     let mut deciding = load_bearing_classes(requested);
     if references_producible
         && requested.iter().any(|class| class == "references")

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -366,7 +366,7 @@ pub(crate) fn load_bearing_classes(requested: &[String]) -> Vec<String> {
 /// have existed, and [`absence_coverage_gap`] already refuses both by name.
 /// `unknown` is an unread host, and unmeasured is not a finding anywhere else in
 /// this module either.
-pub fn references_producible(payload: &Value) -> bool {
+pub(crate) fn references_producible(payload: &Value) -> bool {
     payload
         .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
         .and_then(|coverage| coverage.get("reference_enrichment"))
@@ -377,12 +377,12 @@ pub fn references_producible(payload: &Value) -> bool {
 /// The classes this answer's verdict actually rests on: [`load_bearing_classes`]
 /// plus `references` wherever this host could have produced it.
 ///
-/// Public for RENDERING, not for deciding. `kin impact` prints which classes the
-/// gate rested on, and naming a class the gate never weighed is its own small
-/// fabrication: `imports` is absent on every healthy graph, so a renderer that
-/// listed every absent class would tell a user their import edges were the
-/// problem on a store where they never mattered (FIR-2524). The DECISION stays
-/// [`negative_for`]'s alone.
+/// Deliberately NOT public. `kin impact` needs to know which classes the gate
+/// rested on so it does not name one the gate never weighed, and it gets that by
+/// reading `_kin.completeness.decided_by`, the record this set produces, rather
+/// than by importing this function (FIR-2524). Reading the published record beats
+/// importing the producer: one of them can drift from the verdict and the other
+/// cannot.
 ///
 /// One definition, because three consumers ask the same question and a fourth
 /// answer would only be somewhere for them to drift. [`absence_coverage_gap`]
@@ -400,7 +400,7 @@ pub fn references_producible(payload: &Value) -> bool {
 /// that changes the answer: on a host that CAN produce reference edges, their
 /// absence is a finding rather than the ordinary silence of a language server
 /// that never ran.
-pub fn deciding_classes(requested: &[String], references_producible: bool) -> Vec<String> {
+pub(crate) fn deciding_classes(requested: &[String], references_producible: bool) -> Vec<String> {
     let mut deciding = load_bearing_classes(requested);
     if references_producible
         && requested.iter().any(|class| class == "references")


### PR DESCRIPTION
`kin impact` printed a bare `No local downstream impact found.` at exit 0 on a store whose
reference class is absent, while MCP's `impact_analysis` refused to certify the same store
after kin#990. The human surface read as a clean bill and the agent surface refused, with
neither saying the other existed. That is FIR-2492's two-tools-disagree failure relocated to
the CLI/MCP boundary, and 990 widened it rather than closing it.

## Observed before any code moved

Paired runs on one express-shaped JavaScript fixture, one variable changed, kin
`bb8bebe34057`, binaries verified by a three-way string probe (added literal 1, removed
literal 0, fabricated control 0).

Sweep on: `References: 7, UsesType: 7, Calls: 2`, cross-file 15 of 16, and
`kin impact createApplication` returns `1 local entities impacted within 3 hops`.

Sweep off with `KIN_DAEMON_DISABLE_LSP=1`, the language server still on PATH so the host fact
is unchanged: `Calls: 2` only, and both `createApplication` and `Router` print the bare line.

## The change

`kin impact` now says, when the verdict is not certifiable:

```
  No local downstream impact found.
  Kin cannot rule out dependents: this graph holds no cross-file reference edges for
  JavaScript, so a use reaching this entity from another file could not have been found.
  Cross-file call edges exist but do not stand in for reference edges.
```

The verdict is not recomputed. `negative_for` is the one gate, called with the same tool name
over the same `edge_coverage` observation and the same `IMPACT_REFERENCE_KINDS` the MCP
handler uses, so the two surfaces cannot reach different conclusions about one store. That
const is exported rather than copied because its own doc comment warns that declaring one set
and observing another is how a gate judges a class it never measured.

Which classes the line may name is read from `_kin.completeness.decided_by`, the record the
verdict publishes, rather than by importing the function that produced it. An earlier revision
imported `deciding_classes` and widened two kin-mcp functions to `pub`; both widenings are
reverted. Reading the published record beats importing the producer, because one of them can
drift from the verdict and the other cannot.

The line names the gap and promises no remedy. On a store whose sweep produced nothing, the
honest answer to what to do next does not exist yet; that is FIR-2519's to create. A promised
remedy that may be false is the `absence_consequence` failure the MCP side already refuses,
and `kin init` ships one today that misattributes a disabled sweep to a missing server
(filed as FIR-2531 from this ticket's survey).

Silence stays the certified case, so a graph whose enrichment delivered says nothing extra.

## Why the daemon builds the envelope

`build_impact_response` sees a graph and a layout and could not observe a degraded worker if
it wanted to, so the route supplies the substrate reading from the same `DaemonState` fields
`/health` reads.

The cheaper option was a thin envelope built from facts the route already had. It was
rejected because it is this defect wearing the fix's clothes: carrying no degraded signal
makes the CLI MORE confident than MCP on exactly the degraded daemon nobody exercises, and
every test written against a healthy one would pass.

## Falsification

The spine is `a_degraded_daemon_reaches_the_impact_cli_through_the_route`, which drives
`POST /impact` against a `DaemonState` with `embed_worker_failed` set and a healthy
cross-file call edge, so the degradation is the only reason left to refuse.

Substituting the rejected thin envelope makes it fail, exit 101, with the rendered output
showing the bare `No local downstream impact found.` and nothing else. Restored, it passes.
That is the assertion the rejected wiring could not satisfy.

Worth recording: the FIRST version of this test lived beside the CLI rendering, constructed
its own degraded envelope, and passed under BOTH wirings. Falsifying it against the rejected
option is what exposed that it justified nothing, and is why the spine moved onto the route.

Two more defects the falsification caught before commit. The renderer named every absent
class, which on a healthy graph would have told a reader their import edges were the problem;
Kin mints no entity-level `Imports` on any language, so that class reads absent everywhere
and was never what the gate rested on. And the first fixture was a single-entity graph, which
is genuinely coverage-poor, so the refusal was over-determined and the test would have passed
for the wrong reason.

## Gates, stated exactly

**Full workspace gate, completed:** `cargo nextest run --workspace --no-fail-fast --locked`
reports `Summary [407.663s] 6610 tests run: 6610 passed (4 slow, 6 leaky), 12 skipped`,
`NEXTEST_EXIT=0`, and `cargo test --doc --locked` `DOCTEST_EXIT=0`.

Clippy per ci.yml with the debt allow-list, `RUSTFLAGS=-D warnings cargo clippy --all-targets
--all-features` with the 45-lint list: **exit 0 over 539 checked units**, finished in 2m09s.

All six guard scripts exit 0: `verify-zero-file-search.py`, `zero_file_search_guard.sh`,
`verify-hydration-semantics.py`, `falsify-hydration-semantics.py` on a poisoned copy,
`check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`. `cargo fmt --all --check`
exits 0.

(Process note, kept visible because earlier revisions of this body said otherwise and were
public for a while. The local gate was killed by session boundaries three times before this,
always during the compile phase and before any test executed, and this body carried a
granted CI-is-authority relaxation for the full sweep. A retry on a warm compile cache
completed, so **that relaxation is withdrawn and no longer applies**: the full local sweep
above is a real result. A separate earlier revision wrongly said clippy had been killed at
355 units; it had completed, and I had polled its log in the gap between the process exiting
and its exit marker flushing. Both corrections are stated here rather than silently edited.)

## Seam check, measured

`git merge-tree` against both branches held by the sweepwave lane, run rather than inferred
from file lists:

- `chore/lane-sweepwave-unit`: 0 conflict markers
- `chore/lane-sweepwave-shutdown`: 0 conflict markers

The conflict set is empty. Those branches touch `crates/kin-daemon/src/daemon.rs`; this PR
touches `crates/kin-cli/src/commands/impact.rs`, `crates/kin-daemon/src/api.rs` and
`crates/kin-mcp/src/handlers/review.rs`.

## Not claiming

That this fixes enrichment; it does not touch it, and changes only what a verdict may claim
when enrichment produced nothing. That the `--storage gcs` path was exercised against a gcs
daemon; it is proven in code and was not run. Any diagnosis of the npm0543 container's
zero-file sweep, which stays open on FIR-2506.

Closes FIR-2524
