### PR TITLE
Decompress the conversion closure once, and stop hashing a bootstrap transaction nothing reads

### DIFF
--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -307,9 +307,6 @@ impl PreparedRepositoryInit {
         transaction: RepositoryTransaction,
     ) -> Result<&RepositoryBootstrap> {
         verify_metadata_seal(&self.layout, &self.metadata_seal)?;
-        let transaction_hash = transaction
-            .transaction_hash()
-            .map_err(|error| KinError::Other(error.to_string()))?;
         let operation_id = transaction.operation_id;
         let repository_id = &self.repository_id;
         let workspace_id = self.workspace_id;
@@ -320,6 +317,17 @@ impl PreparedRepositoryInit {
         })?;
         match &mut self.bootstrap {
             Some(bootstrap) => {
+                // Hashed here rather than before the match, because only this arm
+                // reads it. `transaction_hash` canonicalizes by cloning the whole
+                // transaction, which carries every reachable external object and
+                // every change in history, so on a real repository it is the
+                // largest single allocation in the commit and it retains nothing.
+                // The first-commit arm below never used the value and paid for it
+                // on every init, and it also validated twice, once here and once
+                // in `validate_bootstrap_transaction`.
+                let transaction_hash = transaction
+                    .transaction_hash()
+                    .map_err(|error| KinError::Other(error.to_string()))?;
                 if bootstrap.receipt.transaction_hash != transaction_hash
                     || bootstrap.receipt.operation_id != operation_id
                 {

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -48,9 +48,9 @@ pub use error::{
 };
 pub use global_config::empty_global_git_config;
 pub use lossless::{
-    capture_lossless_git_repository, rehydrate_lossless_git_repository,
-    sync_git_repository_for_authority_handoff, GitObjectFormat, GitRehydrationResult,
-    LosslessGitRepository,
+    capture_lossless_git_repository, closure_reconstruction_count,
+    rehydrate_lossless_git_repository, sync_git_repository_for_authority_handoff, GitObjectFormat,
+    GitRehydrationResult, LosslessGitRepository,
 };
 pub use preflight::{
     kin_store_is_git_ignored, preflight_git_migration, preflight_git_migration_after_publication,

--- a/crates/kin-git/src/lossless.rs
+++ b/crates/kin-git/src/lossless.rs
@@ -59,7 +59,7 @@ std::thread_local! {
     // asks for it repeatedly, so one slot captures every repeat ask while
     // bounding what is held: the flask corpus's closure is 162.5 MiB, and a
     // cache that grew would trade the wall for a memory wall.
-    static CLOSURE_CACHE: std::cell::RefCell<Option<(ClosureKey, Rc<ClosureBodies>)>> =
+    static CLOSURE_CACHE: std::cell::RefCell<Option<(ClosureKey, SharedObjectClosure)>> =
         const { std::cell::RefCell::new(None) };
 }
 
@@ -88,6 +88,45 @@ struct ClosureKey {
 }
 
 type ClosureBodies = BTreeMap<ExternalObjectId, Vec<u8>>;
+
+/// A decompressed object closure this process built and is still holding.
+///
+/// The skip this enables rests on one claim: these bytes were read from the
+/// CAS and checked against their descriptors BY THIS PROCESS, and have been
+/// held immutable since. A closure that outlived the process, or reached a
+/// thread that did not verify it, would be a different claim needing
+/// re-verification on load, and nothing here would notice the difference.
+///
+/// So the type refuses to become one. The field is private and the only
+/// constructor is [`decompressed_closure`]. The handle is [`Rc`], which is
+/// `!Send`, so it cannot cross a thread boundary. The cache holding it is a
+/// `thread_local`, so it cannot outlive the thread. Neither this type nor the
+/// cache entry carries a serialization impl.
+pub(crate) struct SharedObjectClosure(Rc<ClosureBodies>);
+
+const _: () = {
+    // Holds the handle to `Rc` at compile time. Swapping it for `Arc` would
+    // make the closure `Send`, and a verified-here closure that can be moved
+    // to a thread that did not verify it is no longer evidence of anything.
+    #[allow(dead_code)]
+    fn the_handle_stays_thread_bound(closure: &SharedObjectClosure) -> &Rc<ClosureBodies> {
+        &closure.0
+    }
+};
+
+impl Clone for SharedObjectClosure {
+    fn clone(&self) -> Self {
+        Self(Rc::clone(&self.0))
+    }
+}
+
+impl std::ops::Deref for SharedObjectClosure {
+    type Target = ClosureBodies;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// Whether a caller may be handed a closure this thread already decompressed.
 ///
@@ -742,7 +781,7 @@ fn gix_object_id(oid: GitObjectId) -> Result<gix::ObjectId> {
 pub(crate) fn validate_snapshot(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
-) -> Result<Rc<ClosureBodies>> {
+) -> Result<SharedObjectClosure> {
     validate_snapshot_with(snapshot, blob_store, ClosureSharing::Shared)
 }
 
@@ -752,7 +791,7 @@ fn validate_snapshot_with(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
     sharing: ClosureSharing,
-) -> Result<Rc<ClosureBodies>> {
+) -> Result<SharedObjectClosure> {
     snapshot.refs.validate()?;
     for repository_ref in &snapshot.refs.refs {
         if repository_ref.repository_id != snapshot.repository_id {
@@ -794,7 +833,7 @@ fn decompressed_closure(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
     sharing: ClosureSharing,
-) -> Result<Rc<ClosureBodies>> {
+) -> Result<SharedObjectClosure> {
     let key = closure_key(snapshot);
     if sharing == ClosureSharing::Shared {
         if let Some(shared) = CLOSURE_CACHE.with(|cache| {
@@ -802,7 +841,7 @@ fn decompressed_closure(
                 .borrow()
                 .as_ref()
                 .filter(|(cached, _)| *cached == key)
-                .map(|(_, bodies)| Rc::clone(bodies))
+                .map(|(_, bodies)| bodies.clone())
         }) {
             return Ok(shared);
         }
@@ -846,9 +885,9 @@ fn decompressed_closure(
 
     // Published only after every body passed, so a rejected object set leaves
     // nothing behind for the next caller to hit.
-    let shared = Rc::new(bodies);
+    let shared = SharedObjectClosure(Rc::new(bodies));
     CLOSURE_CACHE.with(|cache| {
-        *cache.borrow_mut() = Some((key, Rc::clone(&shared)));
+        *cache.borrow_mut() = Some((key, shared.clone()));
     });
     Ok(shared)
 }
@@ -2323,6 +2362,35 @@ mod tests {
             Err(GitError::Blob(_))
         ));
         assert!(!cas_output.exists());
+    }
+
+    #[test]
+    fn a_shared_closure_is_byte_identical_to_a_rebuild() {
+        let fixture = Fixture::simple();
+        let snapshot = capture_lossless_git_repository(
+            &fixture.repo,
+            RepositoryId::new("byte-identical").unwrap(),
+            &fixture.blob_store,
+        )
+        .unwrap();
+
+        let shared = validate_snapshot(&snapshot, &fixture.blob_store).unwrap();
+
+        let before = closure_reconstruction_count();
+        let fresh =
+            validate_snapshot_with(&snapshot, &fixture.blob_store, ClosureSharing::Fresh).unwrap();
+        // Without this the test could compare a cached closure against itself
+        // and pass no matter how stale the cache had become.
+        assert_eq!(
+            closure_reconstruction_count(),
+            before + 1,
+            "the control arm must actually re-read the CAS, or it controls nothing",
+        );
+
+        assert_eq!(
+            *shared, *fresh,
+            "a shared closure must be byte-identical to one rebuilt from the CAS",
+        );
     }
 
     #[test]

--- a/crates/kin-git/src/lossless.rs
+++ b/crates/kin-git/src/lossless.rs
@@ -89,6 +89,30 @@ struct ClosureKey {
 
 type ClosureBodies = BTreeMap<ExternalObjectId, Vec<u8>>;
 
+/// Whether a caller may be handed a closure this thread already decompressed.
+///
+/// The cache key covers the object DESCRIPTORS, not the state of the CAS they
+/// point at, so a hit asserts something the key cannot see: that the bodies are
+/// still there and still those bytes. Inside one conversion that holds, because
+/// nothing mutates the CAS underneath a pipeline that is only reading it.
+///
+/// It does not hold for every caller, and the difference is not a detail.
+/// `rehydrate_lossless_git_repository` documents that it preflights all CAS
+/// bodies before mutating the filesystem, so its contract INCLUDES proving the
+/// CAS can supply them right now. A shared closure would let it write an export
+/// from bytes it never re-read, and a deleted body would stop failing closed.
+/// It reads fresh.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ClosureSharing {
+    /// Re-use this thread's closure when the object set is identical.
+    Shared,
+    /// Read every body from the CAS, whatever is cached.
+    ///
+    /// For callers whose contract is that the CAS holds these bodies NOW, which
+    /// only a read can establish.
+    Fresh,
+}
+
 fn closure_key(snapshot: &LosslessGitRepository) -> ClosureKey {
     ClosureKey {
         object_format: snapshot.object_format,
@@ -303,7 +327,12 @@ pub fn rehydrate_lossless_git_repository(
         ));
     }
     reject_existing_destination(output_path)?;
-    let bodies = validate_snapshot(snapshot, blob_store)?;
+    // Fresh, never shared. This function's contract is that every CAS body is
+    // preflighted before the filesystem is touched, and only a read establishes
+    // that the CAS still holds them. Handing it a closure decompressed earlier
+    // in this process would let an export be written from bytes nobody re-read,
+    // and a body deleted since would stop failing closed.
+    let bodies = validate_snapshot_with(snapshot, blob_store, ClosureSharing::Fresh)?;
 
     let parent = output_path.parent().ok_or_else(|| {
         GitError::InvalidSnapshot(format!(
@@ -714,6 +743,16 @@ pub(crate) fn validate_snapshot(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
 ) -> Result<Rc<ClosureBodies>> {
+    validate_snapshot_with(snapshot, blob_store, ClosureSharing::Shared)
+}
+
+/// [`validate_snapshot`], with the caller stating whether a shared closure is
+/// sound for what it is about to do.
+fn validate_snapshot_with(
+    snapshot: &LosslessGitRepository,
+    blob_store: &BlobStore,
+    sharing: ClosureSharing,
+) -> Result<Rc<ClosureBodies>> {
     snapshot.refs.validate()?;
     for repository_ref in &snapshot.refs.refs {
         if repository_ref.repository_id != snapshot.repository_id {
@@ -725,7 +764,7 @@ pub(crate) fn validate_snapshot(
     }
     validate_head_and_default(snapshot)?;
 
-    let bodies = decompressed_closure(snapshot, blob_store)?;
+    let bodies = decompressed_closure(snapshot, blob_store, sharing)?;
 
     // Outside the shared closure on purpose. Reachability is a function of the
     // refs and HEAD as well as the objects, and those are NOT part of the cache
@@ -754,16 +793,19 @@ pub(crate) fn validate_snapshot(
 fn decompressed_closure(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
+    sharing: ClosureSharing,
 ) -> Result<Rc<ClosureBodies>> {
     let key = closure_key(snapshot);
-    if let Some(shared) = CLOSURE_CACHE.with(|cache| {
-        cache
-            .borrow()
-            .as_ref()
-            .filter(|(cached, _)| *cached == key)
-            .map(|(_, bodies)| Rc::clone(bodies))
-    }) {
-        return Ok(shared);
+    if sharing == ClosureSharing::Shared {
+        if let Some(shared) = CLOSURE_CACHE.with(|cache| {
+            cache
+                .borrow()
+                .as_ref()
+                .filter(|(cached, _)| *cached == key)
+                .map(|(_, bodies)| Rc::clone(bodies))
+        }) {
+            return Ok(shared);
+        }
     }
 
     // Counted here rather than at the function entry, because a hit above costs
@@ -2281,6 +2323,52 @@ mod tests {
             Err(GitError::Blob(_))
         ));
         assert!(!cas_output.exists());
+    }
+
+    #[test]
+    fn a_warm_shared_closure_never_satisfies_rehydrations_cas_proof() {
+        let fixture = Fixture::simple();
+        let snapshot = capture_lossless_git_repository(
+            &fixture.repo,
+            RepositoryId::new("warm-closure").unwrap(),
+            &fixture.blob_store,
+        )
+        .unwrap();
+
+        // Assert the cache is warm rather than assume it. A body deleted while
+        // the cache is cold gets re-read by any implementation, so that test
+        // passes whatever rehydration does and would stop guarding this
+        // boundary without ever failing.
+        let before = closure_reconstruction_count();
+        validate_snapshot(&snapshot, &fixture.blob_store).unwrap();
+        assert_eq!(
+            closure_reconstruction_count(),
+            before,
+            "a second shared validation of one object set must hit the cache",
+        );
+
+        fixture
+            .blob_store
+            .delete(&snapshot.objects[0].body_hash)
+            .unwrap();
+
+        // The shared closure is now stale in the only way it can be: the
+        // descriptors are untouched, so the key still matches, and it still
+        // hands out a body the CAS can no longer supply.
+        let served = validate_snapshot(&snapshot, &fixture.blob_store).unwrap();
+        assert!(
+            served.contains_key(&snapshot.objects[0].object),
+            "the shared closure must still hold the deleted body for this to prove anything",
+        );
+
+        // Rehydration reads fresh, so it fails closed on the CAS rather than
+        // exporting from bytes nobody re-read.
+        let output = fixture._root.path().join("warm-closure.git");
+        assert!(matches!(
+            rehydrate_lossless_git_repository(&snapshot, &fixture.blob_store, &output),
+            Err(GitError::Blob(kin_blobs::BlobError::NotFound { .. }))
+        ));
+        assert!(!output.exists());
     }
 
     #[test]

--- a/crates/kin-git/src/lossless.rs
+++ b/crates/kin-git/src/lossless.rs
@@ -14,7 +14,9 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::rc::Rc;
+#[cfg(unix)]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use gix::bstr::ByteSlice;
 use gix::objs::tree::EntryKind;
@@ -30,25 +32,76 @@ use crate::error::{GitError, Result};
 #[cfg(unix)]
 static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
-/// How many times this process has decompressed a snapshot's whole object
-/// closure.
-///
-/// Counted because the cost is invisible from any one call site. Every caller
-/// that wants the closure asks [`validate_snapshot`] for it, and that call
-/// reads and verifies EVERY object body in the repository, so a conversion that
-/// asks eleven times pays eleven whole-repository decompressions for one
-/// import. On a 1,200-commit flask corpus that is 162.5 MiB decompressed
-/// against 13 MB packed, per rebuild, and it was the dominant repeated wall
-/// clock cost of `kin init` before anyone counted it.
-///
-/// This is a measurement rather than a guard, so it is `Relaxed`: nothing
-/// branches on it, and a test that reads it does so after the work it is
-/// measuring has finished on the same thread.
-static CLOSURE_RECONSTRUCTIONS: AtomicUsize = AtomicUsize::new(0);
+// How many times this process has decompressed a snapshot's whole object
+// closure.
+//
+// Counted because the cost is invisible from any one call site. Every caller
+// that wants the closure asks [`validate_snapshot`] for it, and that call
+// reads and verifies EVERY object body in the repository, so a conversion that
+// asked once per caller paid a whole-repository decompression per caller. On a 1,200-commit flask corpus that is 162.5 MiB decompressed
+// against 13 MB packed, per rebuild, and it was the dominant repeated wall
+// clock cost of `kin init` before anyone counted it.
+//
+// Per-thread rather than global, and that is what makes it usable as a test
+// assertion. A conversion is a sequential pipeline on one thread, so a
+// thread-local counts exactly the rebuilds its own caller provoked; a process
+// global would be polluted by any test running beside it, and `cargo test`
+// runs tests as threads in one process. Reading a delta around a call is
+// therefore exact here without serializing the suite or adding a dependency
+// to force it.
+std::thread_local! {
+    static CLOSURE_RECONSTRUCTIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 
-/// How many whole-closure decompressions this process has performed.
+    // The most recently decompressed closure, and the exact object set it was
+    // decompressed from.
+    //
+    // Capacity one on purpose. A conversion works one object set at a time and
+    // asks for it repeatedly, so one slot captures every repeat ask while
+    // bounding what is held: the flask corpus's closure is 162.5 MiB, and a
+    // cache that grew would trade the wall for a memory wall.
+    static CLOSURE_CACHE: std::cell::RefCell<Option<(ClosureKey, Rc<ClosureBodies>)>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// What a decompressed closure is a function of.
+///
+/// The object records themselves, which carry every object's identity, kind and
+/// CAS body hash. That is the entire input to the decompression below, which is
+/// what makes it sound as a cache key: two snapshots with equal records read
+/// the same bodies out of the same CAS and verify the same descriptors against
+/// them, so a hit cannot hand a caller a closure built from different objects.
+///
+/// Compared rather than hashed, so the match is exact rather than
+/// collision-resistant. Kin's import proofs are load-bearing and a closure that
+/// satisfied a proof by hash collision would be exactly the failure this key
+/// exists to make impossible. The comparison walks records without touching
+/// bodies, so it costs a pointer walk against the whole-repository read it
+/// avoids.
+///
+/// Keying on something coarser, the tree root for instance, would not have this
+/// property: two object sets can share a root and differ elsewhere, and a hit
+/// would then satisfy a proof with a closure the proof never covered.
+#[derive(PartialEq)]
+struct ClosureKey {
+    object_format: GitObjectFormat,
+    objects: Vec<ExternalObjectRecord>,
+}
+
+type ClosureBodies = BTreeMap<ExternalObjectId, Vec<u8>>;
+
+fn closure_key(snapshot: &LosslessGitRepository) -> ClosureKey {
+    ClosureKey {
+        object_format: snapshot.object_format,
+        objects: snapshot.objects.clone(),
+    }
+}
+
+/// How many whole-closure decompressions this thread has performed.
+///
+/// Read it either side of a conversion and subtract. The number that matters is
+/// the delta, not the total.
 pub fn closure_reconstruction_count() -> usize {
-    CLOSURE_RECONSTRUCTIONS.load(Ordering::Relaxed)
+    CLOSURE_RECONSTRUCTIONS.with(std::cell::Cell::get)
 }
 
 #[cfg(all(unix, test))]
@@ -651,10 +704,16 @@ fn gix_object_id(oid: GitObjectId) -> Result<gix::ObjectId> {
         .map_err(|error| GitError::InvalidSnapshot(format!("invalid Git object ID: {error}")))
 }
 
+/// Validate a snapshot and hand back its decompressed object closure.
+///
+/// The closure is returned SHARED rather than owned, because a conversion asks
+/// several times over the same objects and a per-caller copy of it is the same
+/// whole-repository cost this sharing exists to remove: on the flask corpus the
+/// map is 162.5 MiB. Callers read it; nobody mutates it.
 pub(crate) fn validate_snapshot(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
-) -> Result<BTreeMap<ExternalObjectId, Vec<u8>>> {
+) -> Result<Rc<ClosureBodies>> {
     snapshot.refs.validate()?;
     for repository_ref in &snapshot.refs.refs {
         if repository_ref.repository_id != snapshot.repository_id {
@@ -666,10 +725,52 @@ pub(crate) fn validate_snapshot(
     }
     validate_head_and_default(snapshot)?;
 
-    // Counted here rather than at the entry, because everything above this
-    // point is cheap ref arithmetic. The loop below is the whole-repository
-    // decompression this counter exists to make visible.
-    CLOSURE_RECONSTRUCTIONS.fetch_add(1, Ordering::Relaxed);
+    let bodies = decompressed_closure(snapshot, blob_store)?;
+
+    // Outside the shared closure on purpose. Reachability is a function of the
+    // refs and HEAD as well as the objects, and those are NOT part of the cache
+    // key, so two snapshots that share an object set can still disagree about
+    // what is reachable from it. Re-walking is cheap next to decompressing, and
+    // a proof that only ran on a cache miss would be a proof that stopped
+    // running.
+    validate_reachable_closure(snapshot, &bodies)?;
+    Ok(bodies)
+}
+
+/// The snapshot's object bodies, decompressed once per distinct object set.
+///
+/// A conversion asks for the same closure at every step, and each ask used to
+/// re-read and re-verify every object body in the repository. This returns the
+/// previous answer when the object set is byte-for-byte the one it was built
+/// from, and rebuilds otherwise.
+///
+/// What is shared is the DECOMPRESSION, never a verdict. The per-object
+/// descriptor check below runs on every body the first time that object set is
+/// seen, and a hit is only possible when the key covering every object ID, kind
+/// and CAS body hash matches, so a hit re-uses bodies that were verified
+/// against these exact descriptors and no others. Everything a proof actually
+/// asserts, the derived plan and the reachable closure, is recomputed by the
+/// caller either way.
+fn decompressed_closure(
+    snapshot: &LosslessGitRepository,
+    blob_store: &BlobStore,
+) -> Result<Rc<ClosureBodies>> {
+    let key = closure_key(snapshot);
+    if let Some(shared) = CLOSURE_CACHE.with(|cache| {
+        cache
+            .borrow()
+            .as_ref()
+            .filter(|(cached, _)| *cached == key)
+            .map(|(_, bodies)| Rc::clone(bodies))
+    }) {
+        return Ok(shared);
+    }
+
+    // Counted here rather than at the function entry, because a hit above costs
+    // nothing and everything before it is cheap ref arithmetic. The loop below
+    // is the whole-repository decompression this counter exists to make
+    // visible.
+    CLOSURE_RECONSTRUCTIONS.with(|count| count.set(count.get() + 1));
 
     let mut bodies = BTreeMap::new();
     let mut object_ids = BTreeSet::new();
@@ -701,8 +802,13 @@ pub(crate) fn validate_snapshot(
         }
     }
 
-    validate_reachable_closure(snapshot, &bodies)?;
-    Ok(bodies)
+    // Published only after every body passed, so a rejected object set leaves
+    // nothing behind for the next caller to hit.
+    let shared = Rc::new(bodies);
+    CLOSURE_CACHE.with(|cache| {
+        *cache.borrow_mut() = Some((key, Rc::clone(&shared)));
+    });
+    Ok(shared)
 }
 
 fn validate_head_and_default(snapshot: &LosslessGitRepository) -> Result<()> {

--- a/crates/kin-git/src/lossless.rs
+++ b/crates/kin-git/src/lossless.rs
@@ -14,8 +14,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
-#[cfg(unix)]
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use gix::bstr::ByteSlice;
 use gix::objs::tree::EntryKind;
@@ -30,6 +29,27 @@ use crate::error::{GitError, Result};
 
 #[cfg(unix)]
 static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// How many times this process has decompressed a snapshot's whole object
+/// closure.
+///
+/// Counted because the cost is invisible from any one call site. Every caller
+/// that wants the closure asks [`validate_snapshot`] for it, and that call
+/// reads and verifies EVERY object body in the repository, so a conversion that
+/// asks eleven times pays eleven whole-repository decompressions for one
+/// import. On a 1,200-commit flask corpus that is 162.5 MiB decompressed
+/// against 13 MB packed, per rebuild, and it was the dominant repeated wall
+/// clock cost of `kin init` before anyone counted it.
+///
+/// This is a measurement rather than a guard, so it is `Relaxed`: nothing
+/// branches on it, and a test that reads it does so after the work it is
+/// measuring has finished on the same thread.
+static CLOSURE_RECONSTRUCTIONS: AtomicUsize = AtomicUsize::new(0);
+
+/// How many whole-closure decompressions this process has performed.
+pub fn closure_reconstruction_count() -> usize {
+    CLOSURE_RECONSTRUCTIONS.load(Ordering::Relaxed)
+}
 
 #[cfg(all(unix, test))]
 std::thread_local! {
@@ -645,6 +665,11 @@ pub(crate) fn validate_snapshot(
         }
     }
     validate_head_and_default(snapshot)?;
+
+    // Counted here rather than at the entry, because everything above this
+    // point is cheap ref arithmetic. The loop below is the whole-repository
+    // decompression this counter exists to make visible.
+    CLOSURE_RECONSTRUCTIONS.fetch_add(1, Ordering::Relaxed);
 
     let mut bodies = BTreeMap::new();
     let mut object_ids = BTreeSet::new();

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -1772,6 +1772,55 @@ mod tests {
         admitted.validate(&blob_store).unwrap();
     }
 
+    /// What one conversion costs in whole-repository decompressions.
+    ///
+    /// The number is the point. Every step below asks for the same object
+    /// closure over the same unchanged objects, and before the closure was
+    /// shared each ask rebuilt it from the CAS: reading and verifying every
+    /// object body in the repository. On this fixture the repository is three
+    /// objects, so the rebuilds are free and only the COUNT is visible. On the
+    /// 1,200-commit flask corpus each one is 162.5 MiB decompressed against
+    /// 13 MB packed, which is what made this the conversion wall.
+    ///
+    /// Deliberately not a threshold. A test that asserted "fewer than before"
+    /// would keep passing as the count crept back up, so this pins the exact
+    /// number and fails in both directions.
+    #[test]
+    fn one_conversion_rebuilds_the_object_closure_once() {
+        let root = tempdir().unwrap();
+        let repo = root.path().join("source");
+        fs::create_dir(&repo).unwrap();
+        git_ok(&repo, ["init", "--initial-branch=main"]);
+        configure_git(&repo);
+        write(&repo, "lib.rs", b"pub fn f() -> u32 { 1 }\n");
+        git_ok(&repo, ["add", "--all"]);
+        git_ok(&repo, ["commit", "-m", "initial"]);
+        let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+
+        let before = crate::lossless::closure_reconstruction_count();
+        let snapshot = capture_lossless_git_repository(
+            &repo,
+            RepositoryId::new("closure-count").unwrap(),
+            &blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+        // The two proofs a conversion runs over the same objects: the plan
+        // re-derived from raw objects, and the enriched fold checked against
+        // that derivation.
+        plan.validate(&blob_store).unwrap();
+        let admitted = admit_semantic_git_import(&plan, &blob_store).unwrap();
+        admitted.validate(&blob_store).unwrap();
+        let rebuilds = crate::lossless::closure_reconstruction_count() - before;
+
+        assert_eq!(
+            rebuilds, 1,
+            "one conversion over one unchanged object set must decompress that set ONCE; \
+             {rebuilds} rebuilds means the closure is being rebuilt per caller again, which is \
+             the conversion wall this sharing removed"
+        );
+    }
+
     #[test]
     fn missing_tampered_cas_and_mutated_plan_fail_closed() {
         let root = tempdir().unwrap();


### PR DESCRIPTION
Refs FIR-2522

Two independent cuts at the same wall, the repeated work an init pays for and
throws away. They touch different crates, `kin-git` and `kin-core`, and were
composed into one landing rather than queued separately.

Each half is priced exactly as its own evidence supports, and no further.

## The object closure is decompressed once per conversion, not six times

`validate_snapshot` rebuilt the decompressed object closure for every caller,
re-reading and decompressing every Git object each time. One conversion over
one unchanged object set now decompresses that set once.

Before: 6. After: 1.

Six is this sequence's floor, not the whole-init number. Eleven was measured
across a full init; six is what one conversion pipeline does end to end, which
is the largest unit that can be driven deterministically. Every redundant
rebuild inside the pipeline is gone. Nothing here claims the init-level count.

The counter is `kin_git::closure_reconstruction_count()`, and the test asserts
a delta of exactly 1. An equality rather than a threshold, so it fails in both
directions, and a delta rather than an absolute, so test-thread reuse cannot
skew it.

## Sharing broke a load-bearing proof, and the proof won

This is the part worth reading. Sharing broke
`missing_cas_body_and_existing_destination_fail_closed`. Not a flake, and not a
test that needed updating.

The cache key covers the object DESCRIPTORS. Deleting a body from the CAS
changes none of them, so the key kept matching and the closure went stale in
the only way it can: `rehydrate_lossless_git_repository` was handed bytes the
CAS could no longer supply, and a missing body stopped failing closed.

The test was not touched. Rehydration now reads fresh, always. Its documented
contract is that every CAS body is preflighted before the filesystem is
mutated, and only a read establishes that the CAS still holds them, so a shared
closure was never sound there. Inside one conversion the assumption does hold,
because nothing mutates the CAS underneath a pipeline that is only reading it.

Sharing is now a NAMED mode at each call site, `Shared` or `Fresh`, rather than
an invisible default. That is what keeps the next caller from inheriting the
bug by writing nothing.

Reachability validation stays outside the cache, because a proof that only ran
on a cache miss would be a proof that stopped running. It depends on refs and
HEAD, which are not in the key, and it is re-walked on every call.

The old test only guarded this boundary because `capture` happens to warm the
cache first. Nothing in it said so, and a reorder would have left it passing
for the wrong reason. `a_warm_shared_closure_never_satisfies_rehydrations_cas_proof`
states it instead: it asserts the cache is warm, then asserts the shared
closure STILL hands out the deleted body, then asserts rehydration fails closed
anyway. The staleness is proven real and the boundary is proven to hold despite
it, so the protection can never again depend on a lucky ordering.

## Why the key is an exact comparison and not a digest

The key compares the object records themselves. Where a load-bearing import
proof rides on the answer, probabilistic soundness is the wrong currency. The
pointer walk also costs less than hashing the same records would, and it adds
no dependency for a cache key.

## The closure cannot outlive its own verification

The skip rests on one claim: these bytes were read from the CAS and checked
against their descriptors by THIS process, and have been held immutable since.
A closure that outlived the process, or reached a thread that did not verify
it, would be a different claim needing re-verification on load, and nothing
would notice the substitution.

So the handle refuses to become one. Private field, crate-private name, no
serialization impl, an `Rc` so it is not `Send`, and a `thread_local` cache so
it cannot outlive the thread. A compile-time assertion holds the handle to
`Rc`, because swapping in `Arc` would quietly make a verified-here closure
shareable with a thread that never verified it.

The limit, stated rather than glossed: this forecloses every ordinary path and
makes the name unreachable outside `kin-git`. Code inside `kin-git` could still
deref the map and write the bytes itself. No type can prevent that while
consumers need the bytes to build the plan. Nothing persists it today.

The closure is published to the cache only after every body has passed
verification, so a failed run leaves nothing behind for the next caller.

## Retention

The cache holds one entry, replaced when the key changes, freed when the thread
ends. Peak memory does not rise, since the closure was already live during the
conversion; only the tail changes.

That tail is bounded by process exit on the only production path. The single
production consumer outside `kin-git` is `kin_core::init_from_git`, reached from
`kin-cli`'s `init` and `clone`. Neither `kin-daemon` nor `kin-runtime` reaches
it. If a long-lived process ever takes up conversion, this needs an explicit
release. It does not today, and adding caller-discipline API for a caller that
does not exist would be the wrong trade.

## Falsification

Both arms were run, from a committed state.

Cache forced to always miss: the counter test fails with left=6 right=1, and
the warm-cache guard fails too, at "a second shared validation of one object
set must hit the cache", rather than passing vacuously on a cache it cannot
see. Restored, working tree verified clean, suite green.

The byte-equality control compares a shared closure against one rebuilt from
the CAS, and asserts its own fresh arm actually re-read (`before + 1`
reconstructions) before comparing. Without that it could compare a cached
closure against itself and pass however stale the cache had become.

## The bootstrap transaction is no longer hashed on the path that never reads it

From `chore/lane-fir2166-validate-churn`, one commit in
`crates/kin-core/src/init.rs`.

`commit_repository_bootstrap` computed `transaction_hash` before deciding which
arm it was in, but only the already-staged arm compares it. Every real init
takes the other arm, so every real init paid for a hash it discarded.

The cost is not incidental. `transaction_hash` canonicalizes by cloning the
whole transaction, which carries every reachable external object and every
change in history, so on a repository with real history it is one of the
largest allocations in the commit and it retains none of it. It also validates,
which the first-commit arm then does again inside
`validate_bootstrap_transaction`, so that path validated twice.

It is now computed in the arm that reads it. Measured on the 32-commit
admission fixture, that removes a 109.7 MiB transient allocation and one
redundant whole-transaction validation from the first-commit path.

Priced as its own commit message prices it, and no higher: this does NOT lower
init's peak. The peak on that fixture is unchanged at 330.1 MiB, because the
graph commit beside it independently allocates to the same high-water mark, and
removing a smaller transient does not move a peak set by a larger one. Waste
removed, not a ceiling lowered. It makes no wall-clock claim, and neither does
this body.


## Proof

Composition: base `origin/main` at `bb8bebe34057d9a6397db0b2ca49a7d096996800`,
plus `chore/lane-closureshare-kin` at `9f6beb8b` and
`chore/lane-fir2166-validate-churn` at `22bae136`, merged through
`bin/kin-lane compose kin closureshare` with rerere disabled. No conflicts.

Check after every merge: `cargo check --workspace --all-targets`, clean at the
baseline and clean after the fir2166 merge, so a failure would have named the
branch that introduced it.

Local gate on the composition whole, at `4362355e`, run through
`bin/kin-lane run closureshare kin -- bin/kin-dev local-test kin`, unpiped:
`Summary [ 423.892s ] 6610 tests run: 6610 passed (4 slow), 12 skipped`, with
kin-dev's closing line reporting no tracked lock contamination.

`cargo fmt --all -- --check` exits 0, and all five ci.yml guard scripts pass on
the composition: zero-file-search, its answer-modules pass, hydration
semantics, runtime boundaries, private repo coupling.

Tracked `.cargo/` and `Cargo.lock` at HEAD: compose reported its `.cargo/`
assertion clean, and that was re-checked independently afterward, because a
gate killed before kin-dev's restore step leaves the lock path-patched and
`.cargo/config.toml` moved aside while the run still reads ordinary. At HEAD
the working tree is clean, `.cargo/config.toml` is restored, `Cargo.lock` has
zero `source = "path` entries against eight `sparse+` entries as the positive
control, and neither file differs from `origin/main`.
