### PR TITLE
Report the enrichment cause kin init observed, not one derived from a boolean

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -282,6 +282,70 @@ async fn enrich_after_init(kin_root: &Path) {
     stop_conversion_daemon(borrowed_existing, kin_root).await;
 }
 
+/// The sentence `kin init` prints when a run produced no cross-file edges.
+///
+/// One argument per thing the daemon reported, and nothing read from this host,
+/// so what a user sees is decided entirely by what the daemon observed. This
+/// used to be one hardcoded sentence asserting "no language server is
+/// installed", which was false on a daemon with enrichment switched off and
+/// false again on a host that installed a server after the daemon started, and
+/// it prescribed an install that would have changed nothing in either case.
+///
+/// The repair travels with the cause rather than beside it. The old note was
+/// accidentally right about the cure, since its second step restarted the
+/// daemon, and that is the worst shape for a reader: following it works and
+/// believing it leaves them wrong about their own system.
+///
+/// An unrecognised reason keeps its own row instead of falling back to the
+/// missing-install sentence. A daemon older or newer than this CLI is exactly
+/// the case where guessing would reintroduce the defect.
+fn enrichment_unavailable_note(reason: &str, detail: Option<&str>) -> String {
+    // Both rows where the daemon looked at startup and found nothing share this
+    // repair, and they share it because the daemon cannot tell them apart: it
+    // read its own PATH once, at its own start, so whether this host has a
+    // server NOW is the reader's fact rather than the daemon's. Naming one
+    // repair would assert the state these rows exist to leave open, which is
+    // how the sentence this replaced came to send a user with a server
+    // installed off to install another.
+    const REPAIR: &str = "Run `kin doctor --fix --install-language-servers` if this host has \
+                          none, or `kin daemon stop` if one was installed after this daemon \
+                          started; the next command re-enriches this repository.";
+
+    match (reason, detail) {
+        ("no_language_server", Some(detail)) => format!(
+            "note: {detail}. Cross-file reference and override edges were not produced by this \
+             run. {REPAIR}"
+        ),
+        ("discovery_stale", Some(detail)) => format!(
+            "note: {detail}. Cross-file reference and override edges were not produced by this \
+             run. Run `kin daemon stop`; the next command re-enriches this repository."
+        ),
+        ("language_server_unusable", Some(detail)) => format!(
+            "note: {detail}. Cross-file reference and override edges were not produced. Repair \
+             the language server, then run `kin daemon stop`; the next command re-enriches this \
+             repository."
+        ),
+        ("enrichment_disabled", Some(detail)) => format!(
+            "note: {detail}. Cross-file reference and override edges were not produced by this \
+             run."
+        ),
+        // Startup discovery found nothing and the readiness probe has not
+        // landed either, so this row knows strictly less than
+        // `no_language_server` and says so in its detail. The repair is the
+        // same because the reader's question is the same.
+        ("discovery_found_none", Some(detail)) => format!(
+            "note: {detail}. Cross-file reference and override edges were not produced by this \
+             run. {REPAIR}"
+        ),
+        (_, detail) => format!(
+            "note: cross-file reference and override edges were not produced by this run, and \
+             this daemon did not report why ({}). Run `kin doctor` to see what its language \
+             servers can do.",
+            detail.unwrap_or("cause not established")
+        ),
+    }
+}
+
 async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
     let url = match crate::daemon_client::ensure_daemon_running(kin_root).await {
         Ok(url) => url,
@@ -319,11 +383,21 @@ async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
     // command that fixes it, beats waiting fifteen minutes for an event that
     // cannot happen.
     if queued.get("enrichment_available").and_then(|v| v.as_bool()) == Some(false) {
-        note!(
-            "note: no language server is installed, so cross-file reference and override edges \
-             were not produced. Run `kin doctor --fix --install-language-servers` to install one, \
-             then `kin daemon stop`; the next command re-enriches this repository."
-        );
+        // Report the cause the daemon OBSERVED, never a cause derived from the
+        // boolean. That boolean collapses several states, and this note used to
+        // assert the one it could not know, telling users with a language server
+        // installed that none was, and prescribing an install that would change
+        // nothing. The remedy is chosen by the same observed cause, so a reader
+        // who follows it is also right about why.
+        let observed = queued.get("enrichment_unavailable");
+        let reason = observed
+            .and_then(|value| value.get("reason"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("unknown");
+        let detail = observed
+            .and_then(|value| value.get("detail"))
+            .and_then(|value| value.as_str());
+        note!("{}", enrichment_unavailable_note(reason, detail));
         return;
     }
     let baseline = queued
@@ -971,6 +1045,211 @@ fn initialized_raw_git_head(result: &kin_core::InitResult) -> Option<&kin_model:
 mod tests {
     use super::*;
     use crate::commands::status::SemanticEnrichmentView;
+
+    /// What `kin init` actually prints when a run produced no cross-file edges.
+    ///
+    /// The daemon-side rows are tested where they are decided. These test the
+    /// other half, the sentence a user reads, because the defect this replaced
+    /// lived in the sentence: the daemon computed the truth, logged the truth
+    /// to itself, and handed the reader a fabrication.
+    mod enrichment_unavailable_notes {
+        use super::super::enrichment_unavailable_note;
+
+        /// The claim the old note made unconditionally, and the one claim no
+        /// row may make.
+        ///
+        /// Not because absence is unmentionable: the absent row below says
+        /// plainly that this daemon found no server. It is that "is installed"
+        /// speaks for the host, and nothing in this process ever read the host.
+        /// Discovery and the readiness probe each ran once, on this process's
+        /// PATH, at this process's start, and the ticket's own machine is what
+        /// the difference costs: a server sat at /opt/homebrew/bin while the
+        /// daemon that started before it reported none.
+        const FABRICATION: &str = "no language server is installed";
+
+        /// Every row the daemon can send, so the rule below is checked against
+        /// all of them rather than the ones a reader thought of.
+        fn every_row() -> Vec<(&'static str, Option<&'static str>)> {
+            vec![
+                (
+                    "no_language_server",
+                    Some(
+                        "this daemon found no language server for any language it enriches, and \
+                         it looks only at startup",
+                    ),
+                ),
+                (
+                    "discovery_found_none",
+                    Some(
+                        "this daemon found no language server when it started, and it looks only \
+                         at startup; the check of what this host can run has not finished",
+                    ),
+                ),
+                (
+                    "discovery_stale",
+                    Some(
+                        "a language server is usable now, but this daemon found none when it \
+                         started and it looks only at startup",
+                    ),
+                ),
+                (
+                    "language_server_unusable",
+                    Some(
+                        "a language server is installed but did not start (javascript: Could not \
+                         find a valid TypeScript installation), so it enriches nothing until \
+                         that is repaired",
+                    ),
+                ),
+                (
+                    "enrichment_disabled",
+                    Some(
+                        "cross-file reference enrichment is switched off for this daemon, so no \
+                         language server was consulted",
+                    ),
+                ),
+                ("something_this_cli_predates", None),
+            ]
+        }
+
+        #[test]
+        fn no_row_tells_a_user_that_no_language_server_is_installed() {
+            for (reason, detail) in every_row() {
+                let note = enrichment_unavailable_note(reason, detail);
+                assert!(
+                    !note.contains(FABRICATION),
+                    "row `{reason}` asserts a fact about the host that no daemon reads. Report \
+                     what this daemon found, at its own start, and let the reader decide which \
+                     repair applies: {note}"
+                );
+            }
+        }
+
+        #[test]
+        fn a_host_with_no_server_still_says_so_and_still_offers_the_install() {
+            let note = enrichment_unavailable_note(
+                "no_language_server",
+                Some(
+                    "this daemon found no language server for any language it enriches, and it \
+                     looks only at startup",
+                ),
+            );
+            assert!(
+                note.contains("found no language server"),
+                "the row the old note was right about must keep reporting the absence: {note}"
+            );
+            assert!(
+                note.contains("kin doctor --fix --install-language-servers"),
+                "and must keep offering the command that closes it: {note}"
+            );
+        }
+
+        #[test]
+        fn a_stale_discovery_names_a_restart_and_never_an_absent_install() {
+            let note = enrichment_unavailable_note(
+                "discovery_stale",
+                Some(
+                    "a language server is usable now, but this daemon found none when it \
+                     started and it looks only at startup",
+                ),
+            );
+            assert!(
+                !note.contains(FABRICATION),
+                "a host with a usable server must never be told it has none: {note}"
+            );
+            assert!(
+                note.contains("kin daemon stop"),
+                "the repair for a stale discovery is a restart: {note}"
+            );
+            assert!(
+                !note.contains("--install-language-servers"),
+                "and it is not an install, so that command must not appear: {note}"
+            );
+        }
+
+        /// Reached by `--storage gcs` or `KIN_DAEMON_DISABLE_LSP`. Telling this
+        /// operator to install a server sends them to buy a tool they own for a
+        /// job nothing will run.
+        #[test]
+        fn a_disabled_daemon_prescribes_nothing_about_language_servers() {
+            let note = enrichment_unavailable_note(
+                "enrichment_disabled",
+                Some(
+                    "cross-file reference enrichment is switched off for this daemon, so no \
+                     language server was consulted",
+                ),
+            );
+            assert!(
+                !note.contains(FABRICATION),
+                "a switched-off daemon is not a bare host: {note}"
+            );
+            assert!(
+                !note.contains("kin doctor --fix --install-language-servers")
+                    && !note.contains("kin daemon stop"),
+                "neither an install nor a restart changes a daemon told not to enrich: {note}"
+            );
+        }
+
+        /// Both rows that end in "this daemon found nothing at startup" name
+        /// both repairs, because the daemon cannot tell a bare host from one
+        /// that gained a server after it started, and naming one repair would
+        /// assert exactly the state it cannot see. This is the row the ticket's
+        /// own host lands on.
+        #[test]
+        fn a_startup_miss_offers_both_repairs_and_asserts_neither_cause() {
+            for reason in ["no_language_server", "discovery_found_none"] {
+                let (_, detail) = every_row()
+                    .into_iter()
+                    .find(|(row, _)| *row == reason)
+                    .expect("the row table covers every reason this CLI reads");
+                let note = enrichment_unavailable_note(reason, detail);
+                assert!(
+                    note.contains("kin doctor --fix --install-language-servers")
+                        && note.contains("kin daemon stop"),
+                    "row `{reason}` must name both repairs: {note}"
+                );
+                assert!(
+                    note.contains("if this host has none"),
+                    "row `{reason}` must offer the install on a condition rather than assert \
+                     it: {note}"
+                );
+            }
+        }
+
+        #[test]
+        fn an_installed_server_that_cannot_start_asks_for_a_repair() {
+            let note = enrichment_unavailable_note(
+                "language_server_unusable",
+                Some(
+                    "a language server is installed but did not start (javascript: Could not \
+                     find a valid TypeScript installation), so it enriches nothing until that \
+                     is repaired",
+                ),
+            );
+            assert!(
+                !note.contains(FABRICATION),
+                "a broken install is not an absent one: {note}"
+            );
+            assert!(
+                note.contains("Could not find a valid TypeScript installation"),
+                "the server's own message is the only text that names the repair: {note}"
+            );
+        }
+
+        /// A daemon older or newer than this CLI is exactly the case where
+        /// guessing would put the fabrication back.
+        #[test]
+        fn an_unrecognised_reason_reports_the_gap_rather_than_guessing() {
+            let note = enrichment_unavailable_note("something_this_cli_predates", None);
+            assert!(
+                !note.contains(FABRICATION),
+                "an unreadable cause must not become a missing install: {note}"
+            );
+            assert!(
+                note.contains("did not report why"),
+                "it must say the cause did not arrive: {note}"
+            );
+        }
+    }
 
     fn enrichment(
         presence: SemanticEnrichmentPresence,

--- a/crates/kin-cli/tests/init_non_tty_output.rs
+++ b/crates/kin-cli/tests/init_non_tty_output.rs
@@ -207,3 +207,68 @@ fn the_conversion_phase_leaves_no_daemon_behind_when_it_exits_early() {
         }
     }
 }
+
+/// The daemon reports a cause and the CLI prints that cause, across a real
+/// process boundary.
+///
+/// Both sides carry unit tests and they share no code, so a daemon that stopped
+/// sending `enrichment_unavailable`, or renamed a row, would leave every one of
+/// them green while a user read the CLI's fallback sentence instead of a cause.
+/// This is the check that fails on that, which is why the fallback text is an
+/// assertion below rather than a comment.
+///
+/// `KIN_DAEMON_DISABLE_LSP` is the row driven here because it is the one this
+/// suite can reach on any host: it switches enrichment off in the daemon, so
+/// the channel is closed no matter what the machine running the test has
+/// installed. Restricting `PATH` instead was the first attempt and it does not
+/// hold, since the daemon reached a server anyway and swept.
+///
+/// `--storage gcs` reaches the same row through
+/// `storage_backend_graph_authority`, and it is the more common way to land
+/// here in production. The two share this code path entirely, so the operator
+/// who never touched an env variable gets what is asserted below.
+#[test]
+fn the_enrichment_note_carries_a_cause_the_daemon_reported() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("enrichment-off");
+    seed_linkable_git_repo(&repo);
+
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let output = runtime
+        .process_command_for_test(env!("CARGO_BIN_EXE_kin"))
+        .arg("init")
+        .arg(&repo)
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .output()
+        .expect("run kin init");
+    assert!(
+        output.status.success(),
+        "init must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    // The positive control. Without it every assertion below would pass on a
+    // run that printed no note at all, which is the same result a broken seam
+    // produces.
+    assert!(
+        stderr.contains("switched off for this daemon"),
+        "a daemon told not to enrich must say so in the note it causes: {stderr}"
+    );
+    assert!(
+        !stderr.contains("did not report why"),
+        "the daemon must send a cause this CLI recognises, so the fallback row must not \
+         appear: {stderr}"
+    );
+    assert!(
+        !stderr.contains("no language server is installed"),
+        "no row may assert what is installed on the reader's host, and this row least of all: \
+         nothing here looked at a language server: {stderr}"
+    );
+    assert!(
+        !stderr.contains("--install-language-servers"),
+        "installing a server changes nothing while enrichment is switched off, so the note \
+         must not prescribe it: {stderr}"
+    );
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -11201,7 +11201,127 @@ async fn lsp_sweep(
         "status": if queued { "sweep_queued" } else { "sweep_already_running" },
         "sweeps_completed": queued_after,
         "enrichment_available": state.lsp_enrichment_tx.is_some(),
+        "enrichment_unavailable": enrichment_unavailable(&state),
     })))
+}
+
+/// Why enrichment is unavailable, when it is, and `None` when it is available.
+///
+/// `lsp_enrichment_tx.is_some()` collapses several different causes into one
+/// boolean, and every caller that read it alone had to invent a cause to
+/// explain it. `kin init` invented "no language server is installed", which is
+/// false on a deliberately disabled daemon and false again on a host that
+/// installed a server after this daemon started.
+///
+/// The distinctions matter because the repairs differ: installing a server,
+/// changing a config, restarting a daemon, or fixing a broken install are four
+/// different actions. When the readiness probe has not finished, this says so
+/// rather than guessing, because an unfinished check is not evidence of a
+/// missing server.
+fn enrichment_unavailable(state: &DaemonState) -> Option<serde_json::Value> {
+    let readiness = kin_mcp::edge_coverage::published_language_server_readiness();
+    enrichment_unavailable_reason(
+        state.lsp_enrichment_tx.is_some(),
+        state.lsp_enrichment_enabled,
+        readiness.as_ref(),
+    )
+    .map(|(reason, detail)| json!({ "reason": reason, "detail": detail }))
+}
+
+/// The decision behind [`enrichment_unavailable`], as a pure rule.
+///
+/// Split out so every row can be exercised without standing up a daemon. The
+/// rows are the point: they are the states one boolean used to hide.
+///
+/// One observation is available on every row below and is what they are built
+/// on: a closed channel on an enabled daemon means `discover_servers` returned
+/// nothing when this daemon started, because that is the only way
+/// `enrichment_channel_opens` refuses. The readiness probe then sharpens the
+/// cause when it has published, and until it does the startup observation
+/// stands on its own rather than waiting. That ordering matters because the
+/// probe is asynchronous: a rule that could only speak once it landed would
+/// leave a genuinely bare host with no install advice whenever `kin init` asked
+/// first.
+fn enrichment_unavailable_reason(
+    channel_open: bool,
+    enrichment_enabled: bool,
+    readiness: Option<&kin_core::reference_coverage::LanguageServerReadinessMap>,
+) -> Option<(&'static str, String)> {
+    use kin_core::reference_coverage::LanguageServerReadiness;
+
+    if channel_open {
+        return None;
+    }
+
+    if !enrichment_enabled {
+        return Some((
+            "enrichment_disabled",
+            "cross-file reference enrichment is switched off for this daemon, so no language \
+             server was consulted"
+                .to_string(),
+        ));
+    }
+
+    let Some(readiness) = readiness else {
+        return Some((
+            "discovery_found_none",
+            "this daemon found no language server when it started, and it looks only at startup; \
+             the check of what this host can run has not finished"
+                .to_string(),
+        ));
+    };
+
+    // Discovery runs once, at startup. A server that is usable now cannot open
+    // a channel this daemon already declined to open, which is the state a
+    // restart repairs and the state the old note called a missing install.
+    // Stated as the two facts this process holds, never as when the server was
+    // installed, which nothing here watched.
+    if readiness
+        .values()
+        .any(|state| matches!(state, LanguageServerReadiness::Usable))
+    {
+        return Some((
+            "discovery_stale",
+            "a language server is usable now, but this daemon found none when it started and it \
+             looks only at startup"
+                .to_string(),
+        ));
+    }
+
+    let mut unusable: Vec<String> = readiness
+        .iter()
+        .filter_map(|(language, state)| match state {
+            LanguageServerReadiness::Unusable { reason } => Some(format!("{language}: {reason}")),
+            _ => None,
+        })
+        .collect();
+    // The readiness map is a hash map, so two broken servers would otherwise
+    // reorder between runs and hand the same host a different sentence each
+    // time. One broken TypeScript install marks both JavaScript and TypeScript,
+    // so that is the ordinary case rather than a corner of one.
+    unusable.sort();
+    if unusable.is_empty() {
+        // What this daemon holds is its own startup reading: discovery found
+        // nothing and the probe that followed resolved no binary either. Both
+        // used this process's PATH at this process's start, so neither can
+        // speak for the host now, and a sentence that did would be the same
+        // fabrication with a probe behind it. The repair is decided by the
+        // reader, who does know.
+        return Some((
+            "no_language_server",
+            "this daemon found no language server for any language it enriches, and it looks \
+             only at startup"
+                .to_string(),
+        ));
+    }
+    Some((
+        "language_server_unusable",
+        format!(
+            "a language server is installed but did not start ({}), so it enriches nothing until \
+             that is repaired",
+            unusable.join("; ")
+        ),
+    ))
 }
 
 /// GET /lsp/sweep/status, reporting how far the cold sweep has got.
@@ -11229,6 +11349,7 @@ async fn lsp_sweep_status(State(state): State<Arc<DaemonState>>) -> impl IntoRes
         // for one would otherwise wait out its whole budget for an event that
         // cannot happen.
         "enrichment_available": state.lsp_enrichment_tx.is_some(),
+        "enrichment_unavailable": enrichment_unavailable(&state),
     }))
 }
 
@@ -12491,6 +12612,189 @@ mod tests {
             serde_json::json!(true),
             "an undegraded daemon must still certify: {negative}"
         );
+    }
+
+    /// `kin init` used to assert "no language server is installed" from a
+    /// boolean that meant several different things. These are those things.
+    mod enrichment_unavailable_rows {
+        use super::super::enrichment_unavailable_reason;
+        use kin_core::reference_coverage::{LanguageServerReadiness, LanguageServerReadinessMap};
+        use kin_model::LanguageId;
+
+        fn readiness(rows: &[(LanguageId, LanguageServerReadiness)]) -> LanguageServerReadinessMap {
+            rows.iter().cloned().collect()
+        }
+
+        /// The positive control. A healthy daemon reports no cause at all,
+        /// because there is nothing to explain, and `kin init` prints no note.
+        #[test]
+        fn a_working_daemon_reports_no_cause() {
+            assert!(
+                enrichment_unavailable_reason(true, true, None).is_none(),
+                "an open channel means enrichment works, so there is no cause to report"
+            );
+        }
+
+        /// The row the old note was right about, which a fix must not lose.
+        ///
+        /// Stated as this daemon's own startup reading rather than as a fact
+        /// about the host. Discovery and the probe both ran once, on this
+        /// process's PATH, so neither establishes what is installed now, and
+        /// the ticket's own host is the case: a server sat on PATH while the
+        /// daemon that had started before it reported none.
+        #[test]
+        fn a_host_with_no_server_still_reports_a_missing_server() {
+            let (reason, detail) =
+                enrichment_unavailable_reason(false, true, Some(&readiness(&[])))
+                    .expect("no server is a cause");
+            assert_eq!(reason, "no_language_server");
+            assert!(
+                detail.contains("found no language server"),
+                "the row must still report the absence it measured: {detail}"
+            );
+            assert!(
+                !detail.contains("no language server is installed"),
+                "but not as a claim about the host, which this daemon never read: {detail}"
+            );
+        }
+
+        /// The row reached by the ordinary first-run sequence with no knob:
+        /// install Kin, run a command which starts a daemon, then install a
+        /// language server. The old note called this a missing install.
+        #[test]
+        fn a_server_installed_after_the_daemon_started_is_not_a_missing_install() {
+            let (reason, detail) = enrichment_unavailable_reason(
+                false,
+                true,
+                Some(&readiness(&[(
+                    LanguageId::TypeScript,
+                    LanguageServerReadiness::Usable,
+                )])),
+            )
+            .expect("a stale discovery is a cause");
+            assert_eq!(
+                reason, "discovery_stale",
+                "a usable server plus a closed channel is stale discovery, not an absent install"
+            );
+            assert!(
+                !detail.contains("no language server is installed"),
+                "this row must never claim the server is missing: {detail}"
+            );
+            // Both halves of what this process observed, and only those. When
+            // the server was installed is not one of them, so the sentence must
+            // not turn the pair into a timeline it never watched.
+            assert!(
+                detail.contains("usable now") && detail.contains("found none when it started"),
+                "the row must name both observations rather than infer a history: {detail}"
+            );
+        }
+
+        /// A deliberately disabled daemon, reached by `--storage gcs` or
+        /// `KIN_DAEMON_DISABLE_LSP`. Telling this operator to install a server
+        /// sends them to buy a tool they already own for a job nothing will run.
+        #[test]
+        fn a_disabled_daemon_does_not_blame_a_missing_server() {
+            let (reason, detail) = enrichment_unavailable_reason(false, false, None)
+                .expect("a disabled daemon is a cause");
+            assert_eq!(reason, "enrichment_disabled");
+            assert!(
+                !detail.contains("no language server is installed"),
+                "a disabled daemon must not be reported as a missing install: {detail}"
+            );
+        }
+
+        /// The probe is asynchronous, so a row has to hold before it lands.
+        ///
+        /// What this daemon observed is that startup discovery found nothing,
+        /// which is true whether the host is bare or gained a server since. So
+        /// the row reports that and says the check is unfinished, rather than
+        /// asserting an absent install, which would be the same fabrication in
+        /// a new place, or reporting nothing, which would leave a genuinely
+        /// bare host with no advice whenever `kin init` asked first.
+        #[test]
+        fn an_unfinished_probe_reports_the_startup_discovery_it_did_observe() {
+            let (reason, detail) = enrichment_unavailable_reason(false, true, None)
+                .expect("not yet established is itself a reportable state");
+            assert_eq!(reason, "discovery_found_none");
+            assert!(
+                detail.contains("found no language server when it started"),
+                "the row must name the observation this daemon actually holds: {detail}"
+            );
+            assert!(
+                !detail.contains("no language server is installed"),
+                "an unfinished check must not be reported as an absent server: {detail}"
+            );
+        }
+
+        /// Installed and unusable is its own row, because its repair is neither
+        /// an install nor a restart.
+        #[test]
+        fn an_installed_server_that_cannot_start_is_named_with_its_own_reason() {
+            let (reason, detail) = enrichment_unavailable_reason(
+                false,
+                true,
+                Some(&readiness(&[(
+                    LanguageId::JavaScript,
+                    LanguageServerReadiness::Unusable {
+                        reason: "Could not find a valid TypeScript installation".to_string(),
+                    },
+                )])),
+            )
+            .expect("an unusable server is a cause");
+            assert_eq!(reason, "language_server_unusable");
+            assert!(
+                detail.contains("Could not find a valid TypeScript installation"),
+                "the row must carry the server's own reason: {detail}"
+            );
+            assert!(
+                !detail.contains("no language server is installed"),
+                "a broken install must not be reported as an absent one: {detail}"
+            );
+        }
+
+        /// Two broken servers must read the same way every time.
+        ///
+        /// The readiness map is a hash map, and one broken TypeScript install
+        /// marks both JavaScript and TypeScript, so this is the ordinary shape
+        /// of the row above rather than a corner of it. Without the sort the
+        /// same host gets a differently ordered sentence between runs, which is
+        /// a message that varies while the world does not.
+        #[test]
+        fn two_unusable_servers_are_reported_in_a_stable_order() {
+            // A fresh map per round, because a hash map seeds itself once and
+            // then iterates the same way for its whole life. Reading one map
+            // repeatedly would agree with itself under any implementation at
+            // all, which is a check that cannot fail.
+            for round in 0..32 {
+                let rows = readiness(&[
+                    (
+                        LanguageId::TypeScript,
+                        LanguageServerReadiness::Unusable {
+                            reason: "ts is broken".to_string(),
+                        },
+                    ),
+                    (
+                        LanguageId::JavaScript,
+                        LanguageServerReadiness::Unusable {
+                            reason: "js is broken".to_string(),
+                        },
+                    ),
+                ]);
+                let (_, detail) = enrichment_unavailable_reason(false, true, Some(&rows))
+                    .expect("two unusable servers are a cause");
+                let js = detail
+                    .find("javascript: js is broken")
+                    .unwrap_or_else(|| panic!("round {round} lost the javascript row: {detail}"));
+                let ts = detail
+                    .find("typescript: ts is broken")
+                    .unwrap_or_else(|| panic!("round {round} lost the typescript row: {detail}"));
+                assert!(
+                    js < ts,
+                    "round {round} reported the same host in a different order, so this \
+                     sentence varies while the world does not: {detail}"
+                );
+            }
+        }
     }
 
     use super::*;

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1949,6 +1949,10 @@ pub async fn run_with_authority_on(
     // Set up LSP enrichment channel before wrapping state in Arc.
     let enrichment_enabled =
         should_enable_lsp_enrichment(config.lsp_enabled, state.filesystem_reconcile_disabled());
+    // Recorded so a caller can tell a deliberately disabled daemon from one that
+    // simply found no server. Those need opposite answers and the channel alone
+    // cannot separate them.
+    state.lsp_enrichment_enabled = enrichment_enabled;
     let lsp_rx = if enrichment_enabled {
         let discovered = kin_lsp::discovery::discover_servers();
         if enrichment_channel_opens(enrichment_enabled, discovered.len()) {

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1292,6 +1292,15 @@ pub struct DaemonState {
     /// Channel for LSP enrichment messages (incremental or sweep).
     /// None if LSP enrichment is disabled (no servers found).
     pub lsp_enrichment_tx: Option<tokio::sync::mpsc::Sender<LspEnrichmentMessage>>,
+    /// Whether enrichment was switched ON for this daemon at all, apart from
+    /// whether any server was then found.
+    ///
+    /// Kept because the channel being closed collapses three different causes
+    /// into one boolean, and a caller that reads only the channel cannot tell a
+    /// deliberately disabled daemon from a host with no server. `kin init` used
+    /// to assert the second whenever it saw the boolean, which was false on
+    /// every gcs-backed or KIN_DAEMON_DISABLE_LSP daemon.
+    pub lsp_enrichment_enabled: bool,
     /// How far the running cold sweep has got, and how many have finished.
     ///
     /// A sweep is asynchronous and takes minutes on a real repository, and until
@@ -2398,6 +2407,7 @@ impl DaemonState {
             idle_timeout_ms: AtomicU64::new(0),
             active_requests: AtomicU64::new(0),
             lsp_enrichment_tx: None,
+            lsp_enrichment_enabled: false,
             lsp_sweep_files_done: AtomicU64::new(0),
             lsp_sweep_files_total: AtomicU64::new(0),
             lsp_sweep_files_blocked: AtomicU64::new(0),
@@ -2627,6 +2637,7 @@ impl DaemonState {
             idle_timeout_ms: AtomicU64::new(0),
             active_requests: AtomicU64::new(0),
             lsp_enrichment_tx: None,
+            lsp_enrichment_enabled: false,
             lsp_sweep_files_done: AtomicU64::new(0),
             lsp_sweep_files_total: AtomicU64::new(0),
             lsp_sweep_files_blocked: AtomicU64::new(0),


### PR DESCRIPTION
`kin init` printed "note: no language server is installed, so cross-file reference and override edges were not produced" whenever the daemon answered `enrichment_available: false`. That field is `state.lsp_enrichment_tx.is_some()` (`crates/kin-daemon/src/api.rs:11203`, `:11351`), and the channel opens only when `enrichment_channel_opens(enrichment_enabled, servers_discovered)` is true (`crates/kin-daemon/src/daemon.rs:73`), so a daemon told not to enrich and a daemon that discovered nothing produce the identical boolean. The note asserted one of those causes and prescribed an install for all of them. The host in the ticket had `typescript-language-server` at `/opt/homebrew/bin` and was told it had none.

## The fix

The daemon now publishes the cause it holds, as `enrichment_unavailable: {reason, detail}` beside the boolean on both sweep routes. The decision is a pure rule, `enrichment_unavailable_reason` in `api.rs`. It reads whether the channel is open, whether enrichment was enabled at all, and the language-server readiness that FIR-2519 publishes. Enablement is recorded on `DaemonState` (`crates/kin-daemon/src/state.rs`, set at startup in `daemon.rs`) because the channel alone cannot separate a switched-off daemon from a bare host, and those two need opposite answers.

Every row states what the process observed. A closed channel on an enabled daemon means startup discovery found nothing, so both rows that end there say exactly that and name both repairs: install if this host has none, restart if one was installed since. No row claims what is installed on the reader's machine, because discovery and the readiness probe each ran once, on the daemon's own PATH, at its own start.

That distinction decides behavior rather than wording. `spawn_language_server_readiness_probe` is spawned rather than awaited (`daemon.rs:1947`) and re-probes only on a `Sweep` message (`daemon.rs:3206`), which needs the channel open. So on the daemon this note exists for, the startup reading is the only reading there will ever be, and a rule that waited for the probe would leave a bare host with no install advice whenever `kin init` asked first.

`kin init` chooses its sentence in a pure function, `enrichment_unavailable_note` (`crates/kin-cli/src/commands/init.rs`), so what a user reads is falsifiable without a daemon. A reason this CLI does not recognise reports the gap instead of guessing, which is the case where a version skew would otherwise put the fabrication back. Nothing changed at `init.rs:264`, `:354` and `:370`, where the notes already named the errors they hit. `git diff origin/main` matches none of their text, and a control on a string the diff does contain returns 11 hits.

## Falsification

Each surface got two sabotage passes. A pass removes one property and predicts both which tests fail with which message and which must still pass. Every sabotage was confirmed applied by a diff naming the inserted line before the run, and every result was read from full output with the exit status taken raw.

Daemon rule, cause model removed: four failures and two passes were predicted and observed, each failure reading `left: "no_language_server"` against its own row. Daemon rule, true-absence branch removed: the prediction named one failure, in `a_host_with_no_server_still_reports_a_missing_server`. The run gave 5 passed and 1 failed on `left: "language_server_unusable"`. CLI note, row dispatch removed and the old sentence restored: the prediction of five failures and one pass held. Every failure message quotes the defect this replaces, such as `a host with a usable server must never be told it has none: note: no language server is installed, ...`. CLI note, true-absence arm removed: the predicted failure was the install command going missing rather than the absence claim, and the run gave `and must keep offering the command that closes it`. Both files were restored from pre-sabotage copies and confirmed byte-identical with `cmp` between passes.

A third daemon-side pass covers an ordering fix. The unusable-server list joins a hash map, so a host with two broken servers read differently between runs, and one broken TypeScript install marks both JavaScript and TypeScript. Removing the sort fails `two_unusable_servers_are_reported_in_a_stable_order` at round 1 of 32 with the reversed sentence. That test builds a fresh map each round, because reading one map repeatedly agrees with itself however the map is built and could not fail.

The disabled row was staged live rather than argued. A real `kin init` under `KIN_DAEMON_DISABLE_LSP=1`, isolated `KIN_HOME`, on an 8-file Git fixture, printed `note: cross-file reference enrichment is switched off for this daemon, so no language server was consulted. Cross-file reference and override edges were not produced by this run.` with no missing-server claim and no install command. `--storage gcs` reaches the same row through `storage_backend_graph_authority` and shares this code path entirely. The healthy positive control was staged in the same pass: a real `kin init` with nothing disabled printed no such note at all, only `cross-file enrichment complete (8/8 files)`.

`the_enrichment_note_carries_a_cause_the_daemon_reported` covers the seam between the two surfaces, which neither unit suite can see. It drives a real `kin init` against a real daemon with enrichment switched off and asserts the daemon's own cause reaches the CLI. Its first form restricted `PATH` instead and failed, because the daemon reached a server anyway and swept. The test's own positive control is what surfaced that.

## Gates

`cargo fmt --all -- --check` clean. Clippy exactly as `ci.yml` runs it, `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the `.github/clippy-allowed-lints.txt` allow list, clean. Every guard script `ci.yml` names passes: `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`.

The gate ran green: `Summary [431.098s] 6640 tests run: 6640 passed (4 slow), 12 skipped`, with `cargo test --doc` beside it and the exit status read raw. The full count matters because nextest cancels on the first failure, and this run reached the end rather than stopping early. The gate's own line names the tree it gated: `.kin-coord/worktrees/fir2531-kin @ 75911af9 (chore/lane-fir2531-kin)`. kin-dev restored the tracked `Cargo.lock` after the pass, and its sha256 matches the snapshot taken before the run.

The commit carries no `Cargo.lock` or `.cargo/` change, and `.cargo/config.toml` is the only tracked `.cargo` path.

Not proven here: the stale-discovery row rests on tests rather than a staged run. With `PATH=/usr/bin:/bin` the daemon on this host still discovered a language server and swept, so the bare-host and stale rows were unreachable live, and the sequence the ticket asked someone to stage still has not been.

Closes FIR-2531
