### PR TITLE
Say when kin trace and kin search cannot rule out what they did not see

### DIFF
--- a/crates/kin-cli/src/commands/absence_qualifier.rs
+++ b/crates/kin-cli/src/commands/absence_qualifier.rs
@@ -222,8 +222,9 @@ fn absence_subject(tool: &str) -> &'static str {
 /// stop, one clause later.
 fn absence_direction(tool: &str) -> &'static str {
     match tool {
-        "trace_data_flow" => "so a dependency this entity reaches in another file could not have \
-                              been found",
+        "trace_data_flow" => {
+            "so a dependency this entity reaches in another file could not have been found"
+        }
         _ => "so a use reaching this entity from another file could not have been found",
     }
 }

--- a/crates/kin-cli/src/commands/absence_qualifier.rs
+++ b/crates/kin-cli/src/commands/absence_qualifier.rs
@@ -1,0 +1,186 @@
+//! Say, in a human sentence, that an empty answer is not evidence of absence.
+//!
+//! One implementation for every CLI surface that answers an absence question,
+//! because the defect this module exists to close is two surfaces answering the
+//! same question differently (FIR-2492, FIR-2524). A second copy per command
+//! would be that defect arriving by the door the fix left open.
+//!
+//! The VERDICT is never computed here. [`kin_mcp::negative::negative_for`] is
+//! the one gate, called with the tool name whose declaration matches what the
+//! command actually reads, so a CLI surface cannot reach a different conclusion
+//! from its MCP counterpart about one store. Only the RENDERING is local,
+//! because a person reading a terminal is not parsing an envelope (captain's
+//! ruling, 2026-08-20).
+//!
+//! The tool name is load-bearing rather than decorative. `kin trace` builds a
+//! context pack, so it declares `get_context_pack` and NOT `trace_data_flow`,
+//! which describes a different walk; `kin search` declares `semantic_search`,
+//! which reads no edge class at all and is gated on the language scope instead.
+//! Naming the wrong one gates a command on a declaration describing evidence it
+//! never gathered, which is the failure `IMPACT_REFERENCE_KINDS` already warns
+//! about one level down.
+//!
+//! Silence is the certified case. A graph whose enrichment delivered says
+//! nothing extra, which is the control that stops this degrading into stamping
+//! every empty result uncertain, the FIR-2404 failure wearing its opposite
+//! costume.
+//!
+//! The line promises no remedy, and that is decided rather than inherited. On a
+//! store whose sweep produced nothing the honest answer to "what should I do"
+//! does not exist yet; it is FIR-2519's to create. A promised remedy that may be
+//! false is the `absence_consequence` failure `kin_mcp::negative` already
+//! refuses on the MCP side, and `kin init` ships one today that misattributes a
+//! disabled sweep to a missing server (FIR-2531). One of those is enough.
+
+/// Render the qualifier for `tool`'s empty answer, or nothing when the verdict
+/// certifies.
+///
+/// `payload` must carry the observation that tool's gate reads, which differs by
+/// tool: the cross-file `edge_coverage` for the reference readers, the absence
+/// scope for the language-scoped ones. Handing over a payload without one is not
+/// a smaller call, it is a claim the gate refuses by construction, and the gate
+/// says so rather than certifying on no evidence.
+pub fn qualify(
+    tool: &str,
+    payload: &serde_json::Value,
+    envelope: &kin_mcp::Envelope,
+    indent: &str,
+) -> Vec<String> {
+    let Some(negative) = kin_mcp::negative::negative_for(tool, payload, envelope, &[]) else {
+        return Vec::new();
+    };
+    if negative
+        .get("safe_to_conclude_absent")
+        .and_then(serde_json::Value::as_bool)
+        != Some(false)
+    {
+        return Vec::new();
+    }
+
+    let observed = payload.get(kin_mcp::EDGE_COVERAGE_KEY);
+    let language = observed
+        .and_then(|coverage| coverage.get("language"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("this language");
+    let classes = observed.and_then(|coverage| coverage.get("classes"));
+    let state_of = |class: &str| -> Option<&str> {
+        classes
+            .and_then(|classes| classes.get(class))
+            .and_then(serde_json::Value::as_str)
+    };
+
+    // Only the classes the gate rested on may be named, read off the record the
+    // verdict publishes rather than recomputed. Listing every absent class would
+    // tell a reader their import edges were the problem on a store where imports
+    // never mattered: Kin's linker mints no entity-level `Imports` relation on
+    // any language, so that class reads absent on healthy graphs too.
+    let missing: Vec<&'static str> = decided_by(tool, payload, envelope)
+        .iter()
+        .filter(|class| state_of(class) == Some("absent"))
+        .map(|class| edge_class_noun(class))
+        .collect();
+    let present: Vec<&'static str> = ["calls", "imports", "references"]
+        .into_iter()
+        .filter(|class| state_of(class) == Some("present"))
+        .map(edge_class_noun)
+        .collect();
+
+    // Naming a missing class the observation did not report would be the same
+    // fabrication this module exists to end, so when nothing is absent the reason
+    // is whatever the verdict actually disclosed. This is also the whole of the
+    // language-scoped path: `semantic_search` reads no edge class, so its
+    // qualifier always renders from the disclosed signals.
+    if missing.is_empty() {
+        let disclosed = negative
+            .get("degraded_signals")
+            .and_then(serde_json::Value::as_array)
+            .map(|signals| {
+                signals
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .filter(|disclosed| !disclosed.is_empty());
+        return vec![match disclosed {
+            Some(disclosed) => format!(
+                "{indent}Kin cannot rule out matches it did not see: this answer carries \
+                 [{disclosed}], so it may not reflect current truth."
+            ),
+            None => format!(
+                "{indent}Kin cannot rule out matches it did not see: this answer's coverage \
+                 could not be established."
+            ),
+        }];
+    }
+
+    let mut said = vec![format!(
+        "{indent}Kin cannot rule out dependents: this graph holds no cross-file {} edges for \
+         {language}, so a use reaching this entity from another file could not have been found.",
+        missing.join(" or ")
+    )];
+    if !present.is_empty() {
+        said.push(format!(
+            "{indent}Cross-file {} edges exist but do not stand in for {} edges.",
+            present.join(" and "),
+            missing.join(" or ")
+        ));
+    }
+    said
+}
+
+/// The classes the verdict says it rested on, read off the published
+/// completeness block rather than recomputed.
+///
+/// `_kin.completeness.decided_by` is the verdict's own record of what it weighed
+/// (FIR-2505), so a renderer that reads it cannot name a class the decision did
+/// not use. Going through the same `finalize_with_envelope` the MCP surface goes
+/// through is the point: one producer, one record, two readers.
+///
+/// An empty answer here names no class, which is the conservative direction: the
+/// caller then falls back to the disclosed signals rather than inventing an edge
+/// class nobody observed.
+fn decided_by(
+    tool: &str,
+    payload: &serde_json::Value,
+    envelope: &kin_mcp::Envelope,
+) -> Vec<String> {
+    let annotated = kin_mcp::finalize_with_envelope(
+        kin_mcp::ToolCallResult::text(payload.to_string()),
+        envelope.clone(),
+        tool,
+    );
+    annotated
+        .content
+        .iter()
+        .find_map(|block| match block {
+            kin_mcp::ContentBlock::Text { text } => {
+                serde_json::from_str::<serde_json::Value>(text).ok()
+            }
+        })
+        .and_then(|value| {
+            value
+                .get(kin_mcp::ENVELOPE_KEY)
+                .and_then(|envelope| envelope.get("completeness"))
+                .and_then(|completeness| completeness.get("decided_by"))
+                .and_then(serde_json::Value::as_array)
+                .map(|classes| {
+                    classes
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .map(str::to_string)
+                        .collect()
+                })
+        })
+        .unwrap_or_default()
+}
+
+/// The edge class in the noun a sentence wants, since the observation keys are
+/// plural and the prose is not.
+fn edge_class_noun(class: &str) -> &'static str {
+    match class {
+        "calls" => "call",
+        "imports" => "import",
+        _ => "reference",
+    }
+}

--- a/crates/kin-cli/src/commands/absence_qualifier.rs
+++ b/crates/kin-cli/src/commands/absence_qualifier.rs
@@ -12,13 +12,22 @@
 //! because a person reading a terminal is not parsing an envelope (captain's
 //! ruling, 2026-08-20).
 //!
-//! The tool name is load-bearing rather than decorative. `kin trace` builds a
-//! context pack, so it declares `get_context_pack` and NOT `trace_data_flow`,
-//! which describes a different walk; `kin search` declares `semantic_search`,
-//! which reads no edge class at all and is gated on the language scope instead.
-//! Naming the wrong one gates a command on a declaration describing evidence it
-//! never gathered, which is the failure `IMPACT_REFERENCE_KINDS` already warns
-//! about one level down.
+//! The tool name is load-bearing rather than decorative, and it is chosen to
+//! match the CLAIM the command makes rather than the code that built the answer.
+//! `kin impact` declares `impact_analysis`, whose absence is inbound. `kin trace`
+//! declares `trace_data_flow`, because every group a context pack carries runs
+//! OUTWARD from the focal; declaring `get_context_pack` instead would reach a
+//! gate whose field is `dependents`, a direction a `ContextPack` holds no group
+//! for at all. `kin search` declares `semantic_search`, which reads no edge class
+//! and is gated on the language scope instead. Naming the wrong one gates a
+//! command on a declaration describing evidence it never gathered, which is the
+//! failure `IMPACT_REFERENCE_KINDS` already warns about one level down.
+//!
+//! Two things then vary by tool and nothing else does: the noun the absence is
+//! OF ([`absence_subject`]) and the direction an absent edge class hides
+//! ([`absence_direction`]). Sharing one sentence across surfaces is how a shared
+//! renderer drifts, since the verdict stays right while the claim in front of
+//! the reader turns into a different one.
 //!
 //! Silence is the certified case. A graph whose enrichment delivered says
 //! nothing extra, which is the control that stops this degrading into stamping
@@ -91,6 +100,7 @@ pub fn qualify(
     // language-scoped path: `semantic_search` reads no edge class, so its
     // qualifier always renders from the disclosed signals.
     if missing.is_empty() {
+        let subject = absence_subject(tool);
         let disclosed = negative
             .get("degraded_signals")
             .and_then(serde_json::Value::as_array)
@@ -104,20 +114,22 @@ pub fn qualify(
             .filter(|disclosed| !disclosed.is_empty());
         return vec![match disclosed {
             Some(disclosed) => format!(
-                "{indent}Kin cannot rule out matches it did not see: this answer carries \
-                 [{disclosed}], so it may not reflect current truth."
+                "{indent}Kin cannot rule out {subject}: this answer carries [{disclosed}], so it \
+                 may not reflect current truth."
             ),
             None => format!(
-                "{indent}Kin cannot rule out matches it did not see: this answer's coverage \
-                 could not be established."
+                "{indent}Kin cannot rule out {subject}: this answer's coverage could not be \
+                 established."
             ),
         }];
     }
 
     let mut said = vec![format!(
-        "{indent}Kin cannot rule out dependents: this graph holds no cross-file {} edges for \
-         {language}, so a use reaching this entity from another file could not have been found.",
-        missing.join(" or ")
+        "{indent}Kin cannot rule out {}: this graph holds no cross-file {} edges for {language}, \
+         {}.",
+        absence_subject(tool),
+        missing.join(" or "),
+        absence_direction(tool)
     )];
     if !present.is_empty() {
         said.push(format!(
@@ -173,6 +185,47 @@ fn decided_by(
                 })
         })
         .unwrap_or_default()
+}
+
+/// What this tool's empty answer is an absence OF, in the reader's own terms.
+///
+/// Load-bearing rather than cosmetic, and it is the one thing sharing an
+/// implementation across surfaces gets wrong by default. `kin impact` and
+/// `kin trace` ask which code reaches an entity, so their absence is an absence
+/// of DEPENDENTS, which is the same noun the substrate's own retrieval spec uses
+/// for both (`no_dependents`, "nothing was found depending on the focal
+/// entity"). `kin search` asks whether the index admitted a declaration at all,
+/// so its absence is an absence of MATCHES.
+///
+/// One shared sentence would tell an impact reader about matches. The verdict
+/// behind it would still be right and the claim in front of them would not, and
+/// a surface that renders the wrong noun has drifted from its counterpart in the
+/// only place a person actually reads.
+fn absence_subject(tool: &str) -> &'static str {
+    match tool {
+        // Reads no edge class and is language-scoped instead, so what it could
+        // not rule out is an index match rather than a dependent.
+        "semantic_search" => "matches it did not see",
+        // Walks OUTWARD from the focal, so its empty answer is an absence of
+        // things this entity reaches rather than of things that reach it.
+        "trace_data_flow" => "dependencies it did not see",
+        _ => "dependents",
+    }
+}
+
+/// Why an absent cross-file class hides this tool's answer, in the direction
+/// that tool walked.
+///
+/// The inbound readers lose a use that reaches the focal; the outbound one loses
+/// a dependency the focal reaches. One sentence for both would state the wrong
+/// direction on one of them, which is the same drift `absence_subject` exists to
+/// stop, one clause later.
+fn absence_direction(tool: &str) -> &'static str {
+    match tool {
+        "trace_data_flow" => "so a dependency this entity reaches in another file could not have \
+                              been found",
+        _ => "so a use reaching this entity from another file could not have been found",
+    }
 }
 
 /// The edge class in the noun a sentence wants, since the observation keys are

--- a/crates/kin-cli/src/commands/dead_code.rs
+++ b/crates/kin-cli/src/commands/dead_code.rs
@@ -548,7 +548,14 @@ pub fn build_dead_code_seeded_response(
         show_body: false,
         body_limit: None,
     };
-    let search_response = collect_daemon_search_response(graph, &search_request)?;
+    // `dead_code` consumes this response programmatically rather than printing
+    // it, so it wants no absence qualifier and asserts no substrate reading. An
+    // envelope with no health is exactly that claim: `negative_for` refuses to
+    // certify on it, the qualifier stays unrendered here, and nothing about
+    // dead-code's own output changes. Rung three gives this command its own
+    // verdict on its own terms (FIR-2524 rollout).
+    let search_response =
+        collect_daemon_search_response(graph, &search_request, &kin_mcp::Envelope::daemon())?;
 
     let reference_kinds = [
         RelationKind::Calls,

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -346,27 +346,12 @@ const IMPACT_MEMBER_RELATION_KINDS: &[kin_model::RelationKind] = &[
     kin_model::RelationKind::References,
 ];
 
-/// Say, in a human sentence, that this empty answer is not evidence of absence.
+/// The absence qualifier for an empty impact answer.
 ///
-/// The VERDICT is not computed here. [`kin_mcp::negative::negative_for`] is the
-/// one gate, called with the same tool name and the same `edge_coverage`
-/// observation `impact_analysis` publishes over the same
-/// [`kin_mcp::handlers::review::IMPACT_REFERENCE_KINDS`], so this surface cannot
-/// reach a different conclusion from the MCP one about the same store. Only the
-/// RENDERING is local, because a person reading a terminal is not parsing an
-/// envelope (FIR-2524, captain's ruling 2026-08-20).
-///
-/// Silence is the certified case. A graph whose enrichment delivered says
-/// nothing extra, which is the control that stops this degrading into stamping
-/// every empty result uncertain, the FIR-2404 failure wearing its opposite
-/// costume.
-///
-/// The line promises no remedy, and that is decided rather than inherited. On a
-/// store whose sweep produced nothing the honest answer to "what should I do"
-/// does not exist yet; it is FIR-2519's to create. A promised remedy that may be
-/// false is the `absence_consequence` failure `kin_mcp::negative` already
-/// refuses on the MCP side, and `kin init` ships one today that misattributes a
-/// disabled sweep to a missing server (FIR-2531). One of those is enough.
+/// Thin on purpose: the observation is impact-specific (the cross-file classes
+/// `impact_analysis` declares) and the rendering is shared, because three CLI
+/// surfaces answering absence questions differently is the defect, not the
+/// implementation detail. See [`crate::commands::absence_qualifier`].
 fn impact_absence_qualifier(
     graph: &kin_db::InMemoryGraph,
     target: &kin_model::Entity,
@@ -381,151 +366,7 @@ fn impact_absence_qualifier(
         "entity_impacts": [],
         kin_mcp::EDGE_COVERAGE_KEY: coverage,
     });
-    let Some(negative) =
-        kin_mcp::negative::negative_for("impact_analysis", &payload, envelope, &[])
-    else {
-        return Vec::new();
-    };
-    if negative
-        .get("safe_to_conclude_absent")
-        .and_then(serde_json::Value::as_bool)
-        != Some(false)
-    {
-        return Vec::new();
-    }
-
-    let observed = payload.get(kin_mcp::EDGE_COVERAGE_KEY);
-    let language = observed
-        .and_then(|coverage| coverage.get("language"))
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("this language");
-    let classes = observed.and_then(|coverage| coverage.get("classes"));
-    let state_of = |class: &str| -> Option<&str> {
-        classes
-            .and_then(|classes| classes.get(class))
-            .and_then(serde_json::Value::as_str)
-    };
-    // Only the classes the gate actually rested on may be named. Listing every
-    // absent class would tell a reader their import edges were the problem on a
-    // store where imports never mattered: Kin's linker mints no entity-level
-    // `Imports` relation on any language, so that class reads absent on healthy
-    // graphs too, and naming it is a small fabrication of the same kind this
-    // change exists to stop.
-    //
-    // Which classes those are is READ from the record the verdict publishes
-    // rather than recomputed from the function that produced it. FIR-2505 made
-    // the completeness block publish `decided_by` for exactly this reason, so
-    // consuming it here is identical to the decision by construction, and needs
-    // nothing from `kin_mcp::negative` that is not already public. Importing the
-    // deciding-set helper instead would have been reading the pieces, which is
-    // the habit this ticket family exists to break.
-    let deciding = completeness_decided_by(&payload, envelope);
-    let missing: Vec<&'static str> = deciding
-        .iter()
-        .filter(|class| state_of(class) == Some("absent"))
-        .map(|class| edge_class_noun(class))
-        .collect();
-    let present: Vec<&'static str> = ["calls", "imports", "references"]
-        .into_iter()
-        .filter(|class| state_of(class) == Some("present"))
-        .map(edge_class_noun)
-        .collect();
-
-    // Naming a missing class the observation did not report would be the same
-    // fabrication this ticket family exists to end, so when nothing is absent
-    // the reason is whatever the verdict actually disclosed.
-    if missing.is_empty() {
-        let disclosed = negative
-            .get("degraded_signals")
-            .and_then(serde_json::Value::as_array)
-            .map(|signals| {
-                signals
-                    .iter()
-                    .filter_map(serde_json::Value::as_str)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            })
-            .filter(|disclosed| !disclosed.is_empty());
-        return vec![match disclosed {
-            Some(disclosed) => format!(
-                "  Kin cannot rule out dependents: this answer carries [{disclosed}], so it may \
-                 not reflect current truth."
-            ),
-            None => {
-                "  Kin cannot rule out dependents: this answer's coverage could not be established."
-                    .to_string()
-            }
-        }];
-    }
-
-    let mut said = vec![format!(
-        "  Kin cannot rule out dependents: this graph holds no cross-file {} edges for \
-         {language}, so a use reaching this entity from another file could not have been found.",
-        missing.join(" or ")
-    )];
-    if !present.is_empty() {
-        said.push(format!(
-            "  Cross-file {} edges exist but do not stand in for {} edges.",
-            present.join(" and "),
-            missing.join(" or ")
-        ));
-    }
-    said
-}
-
-/// The classes the verdict says it rested on, read off the published
-/// completeness block rather than recomputed.
-///
-/// `_kin.completeness.decided_by` is the verdict's own record of what it
-/// weighed (FIR-2505), so a renderer that reads it cannot name a class the
-/// decision did not use. Going through the same `finalize_with_envelope` the MCP
-/// surface goes through is the point: one producer, one record, two readers.
-///
-/// An empty answer here names no class, which is the conservative direction: the
-/// caller then falls back to the disclosed signals rather than inventing an edge
-/// class nobody observed.
-fn completeness_decided_by(
-    payload: &serde_json::Value,
-    envelope: &kin_mcp::Envelope,
-) -> Vec<String> {
-    let annotated = kin_mcp::finalize_with_envelope(
-        kin_mcp::ToolCallResult::text(payload.to_string()),
-        envelope.clone(),
-        "impact_analysis",
-    );
-    annotated
-        .content
-        .iter()
-        .find_map(|block| match block {
-            kin_mcp::ContentBlock::Text { text } => {
-                serde_json::from_str::<serde_json::Value>(text).ok()
-            }
-        })
-        .and_then(|value| {
-            value
-                .get(kin_mcp::ENVELOPE_KEY)
-                .and_then(|envelope| envelope.get("completeness"))
-                .and_then(|completeness| completeness.get("decided_by"))
-                .and_then(serde_json::Value::as_array)
-                .map(|classes| {
-                    classes
-                        .iter()
-                        .filter_map(serde_json::Value::as_str)
-                        .map(str::to_string)
-                        .collect()
-                })
-        })
-        .unwrap_or_default()
-}
-
-/// The edge class in the noun a sentence wants, since the observation keys are
-/// plural and the prose is not.
-fn edge_class_noun(class: &str) -> &'static str {
-    match class {
-        "calls" => "call",
-        "imports" => "import",
-        _ => "reference",
-    }
+    crate::commands::absence_qualifier::qualify("impact_analysis", &payload, envelope, "  ")
 }
 
 /// What the graph still says about a target with no downstream impact of its

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+pub mod absence_qualifier;
 pub mod admit;
 pub mod agent;
 pub mod approvals;

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -563,9 +563,11 @@ pub fn collect_daemon_search_response(
 fn collect_daemon_semantic_search_response(
     graph: &kin_db::InMemoryGraph,
     request: &DaemonSearchRequest,
+    envelope: &kin_mcp::Envelope,
 ) -> Result<DaemonSearchResponse> {
     let _ = graph;
     let _ = request;
+    let _ = envelope;
     anyhow::bail!("semantic search requires vector-enabled Kin embeddings")
 }
 

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -222,6 +222,15 @@ pub struct DaemonSearchResponse {
     /// searches.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_coverage: Option<crate::commands::locate::SemanticCoverage>,
+    /// Why an empty result is not evidence the repository holds no such
+    /// declaration, or empty when the verdict certifies (FIR-2524).
+    ///
+    /// Carried as data rather than rendered at the source because this response
+    /// is structured and printed client-side, so the verdict is computed where
+    /// the graph and the daemon's substrate reading are and spoken where the
+    /// reader is.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub absence_qualifier: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -474,12 +483,49 @@ async fn run_daemon_search(
     client.search(request).await.context("daemon search failed")
 }
 
+/// The absence qualifier for a search that matched nothing.
+///
+/// `semantic_search` declares NO edge class and is language-scoped instead, so
+/// its gate reads the scope the extractor populated rather than cross-file
+/// coverage, and its honest sentence is about what the index admitted rather
+/// than about missing edges. Handing it the reference-coverage observation would
+/// gate it on evidence it never gathers.
+fn search_absence_qualifier(
+    graph: &kin_db::InMemoryGraph,
+    query: &str,
+    envelope: &kin_mcp::Envelope,
+) -> Vec<String> {
+    let scoped = match graph.query_entities(&kin_model::graph::EntityFilter::default()) {
+        Ok(scoped) => scoped,
+        // An unreadable scope is not an empty one. Saying nothing here is the
+        // conservative direction: the gate refuses on an unreported observation
+        // anyway, and inventing a scope count would be the fabrication this
+        // change exists to stop.
+        Err(_) => return Vec::new(),
+    };
+    let payload = serde_json::json!({
+        "results": [],
+        "total_matches": 0,
+        kin_mcp::EDGE_COVERAGE_KEY: kin_mcp::edge_coverage::observe_absence_scope(
+            &kin_mcp::edge_coverage::languages_of(&scoped),
+            Some(scoped.len()),
+        ),
+    });
+    let _ = query;
+    crate::commands::absence_qualifier::qualify("semantic_search", &payload, envelope, "")
+}
+
 pub fn collect_daemon_search_response(
     graph: &kin_db::InMemoryGraph,
     request: &DaemonSearchRequest,
+    envelope: &kin_mcp::Envelope,
 ) -> Result<DaemonSearchResponse> {
     if request.semantic {
-        return collect_daemon_semantic_search_response(graph, request);
+        let mut response = collect_daemon_semantic_search_response(graph, request, envelope)?;
+        if response.records.is_empty() {
+            response.absence_qualifier = search_absence_qualifier(graph, &request.query, envelope);
+        }
+        return Ok(response);
     }
 
     let results = collect_search_results(
@@ -499,6 +545,11 @@ pub fn collect_daemon_search_response(
         .iter()
         .map(|matched| record_to_daemon_record(&matched.record, matched.match_kind, matched.score))
         .collect::<Vec<_>>();
+    let absence_qualifier = if records.is_empty() {
+        search_absence_qualifier(graph, &request.query, envelope)
+    } else {
+        Vec::new()
+    };
     Ok(DaemonSearchResponse {
         query: request.query.clone(),
         semantic: false,
@@ -506,6 +557,7 @@ pub fn collect_daemon_search_response(
         total_matches: records.len(),
         records,
         semantic_coverage: None,
+        absence_qualifier,
     })
 }
 
@@ -523,6 +575,7 @@ fn collect_daemon_semantic_search_response(
 fn collect_daemon_semantic_search_response(
     graph: &kin_db::InMemoryGraph,
     request: &DaemonSearchRequest,
+    envelope: &kin_mcp::Envelope,
 ) -> Result<DaemonSearchResponse> {
     let coverage = evaluate_semantic_coverage(graph)?;
     let limit = request.limit.unwrap_or(10);
@@ -537,6 +590,7 @@ fn collect_daemon_semantic_search_response(
                 body_limit: None,
                 ..request.clone()
             },
+            envelope,
         )?;
         response.semantic = true;
         response.text_fallback = true;
@@ -644,6 +698,11 @@ fn collect_daemon_semantic_search_response(
         }
     }
 
+    let absence_qualifier = if records.is_empty() {
+        search_absence_qualifier(graph, &request.query, envelope)
+    } else {
+        Vec::new()
+    };
     Ok(DaemonSearchResponse {
         query: request.query.clone(),
         semantic: true,
@@ -651,6 +710,7 @@ fn collect_daemon_semantic_search_response(
         total_matches: records.len(),
         records,
         semantic_coverage: Some(coverage),
+        absence_qualifier,
     })
 }
 
@@ -1231,6 +1291,11 @@ fn render_daemon_search_response(
         } else {
             println!("No results matching '{}'", response.query);
         }
+        // The banner alone says a query matched nothing, never whether this index
+        // could have matched it (FIR-2524).
+        for line in &response.absence_qualifier {
+            println!("{line}");
+        }
         return Ok(());
     }
 
@@ -1501,6 +1566,17 @@ fn parse_language(s: &str) -> Option<LanguageId> {
 // rendering; graph-assigned IDs are path-derived for these in-test records, so
 // the deprecated path constructor is the correct fixture tool here.
 mod tests {
+    /// A daemon whose substrate is sound, so the FIR-2524 absence qualifier
+    /// answers on the scope observation rather than on the envelope.
+    fn healthy_search_envelope() -> kin_mcp::Envelope {
+        kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 2,
+            "graph_generation": 1,
+        }))
+    }
+
     use super::{
         enforce_precise_search_mode, looks_precise_name, parse_kinds, record_display_context,
         record_preview, SearchRecord,
@@ -1734,6 +1810,7 @@ mod tests {
                     show_body: false,
                     body_limit: None,
                 },
+                &healthy_search_envelope(),
             )
             .expect("search")
         };
@@ -1863,6 +1940,7 @@ mod tests {
         };
 
         let response = DaemonSearchResponse {
+            absence_qualifier: Vec::new(),
             query: "zzz_this_symbol_does_not_exist_anywhere_9f3a".into(),
             semantic: false,
             text_fallback: true,

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -492,7 +492,6 @@ async fn run_daemon_search(
 /// gate it on evidence it never gathers.
 fn search_absence_qualifier(
     graph: &kin_db::InMemoryGraph,
-    query: &str,
     envelope: &kin_mcp::Envelope,
 ) -> Vec<String> {
     let scoped = match graph.query_entities(&kin_model::graph::EntityFilter::default()) {
@@ -511,7 +510,6 @@ fn search_absence_qualifier(
             Some(scoped.len()),
         ),
     });
-    let _ = query;
     crate::commands::absence_qualifier::qualify("semantic_search", &payload, envelope, "")
 }
 
@@ -523,7 +521,7 @@ pub fn collect_daemon_search_response(
     if request.semantic {
         let mut response = collect_daemon_semantic_search_response(graph, request, envelope)?;
         if response.records.is_empty() {
-            response.absence_qualifier = search_absence_qualifier(graph, &request.query, envelope);
+            response.absence_qualifier = search_absence_qualifier(graph, envelope);
         }
         return Ok(response);
     }
@@ -546,7 +544,7 @@ pub fn collect_daemon_search_response(
         .map(|matched| record_to_daemon_record(&matched.record, matched.match_kind, matched.score))
         .collect::<Vec<_>>();
     let absence_qualifier = if records.is_empty() {
-        search_absence_qualifier(graph, &request.query, envelope)
+        search_absence_qualifier(graph, envelope)
     } else {
         Vec::new()
     };
@@ -699,7 +697,7 @@ fn collect_daemon_semantic_search_response(
     }
 
     let absence_qualifier = if records.is_empty() {
-        search_absence_qualifier(graph, &request.query, envelope)
+        search_absence_qualifier(graph, envelope)
     } else {
         Vec::new()
     };

--- a/crates/kin-cli/src/commands/trace.rs
+++ b/crates/kin-cli/src/commands/trace.rs
@@ -129,6 +129,7 @@ pub fn build_trace_response(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &impl GraphStore,
     request: &TraceRequest,
+    envelope: &kin_mcp::Envelope,
 ) -> Result<TraceResponse> {
     if request.json {
         return build_trace_json_response(layout, graph, &request.entity);
@@ -146,9 +147,34 @@ pub fn build_trace_response(
             request.max_lines,
             request.nearby_limit,
             request.transitive_limit,
+            envelope,
         )?,
         entities: Vec::new(),
     })
+}
+
+/// The absence qualifier for a context pack with no dependencies.
+///
+/// Declares `get_context_pack`, which is what `kin trace` actually builds
+/// (`kin_context::build_context_pack` above), and deliberately NOT
+/// `trace_data_flow`: that tool describes a different walk, and gating this
+/// command on its declaration would be judging a class this answer never
+/// measured, the failure `IMPACT_REFERENCE_KINDS` warns about one level down.
+fn trace_absence_qualifier(
+    graph: &impl GraphStore,
+    target: &Entity,
+    envelope: &kin_mcp::Envelope,
+) -> Vec<String> {
+    let coverage = kin_mcp::edge_coverage::observe_cross_file_reference_coverage_for_languages(
+        graph,
+        &[target.language],
+        &kin_mcp::handlers::review::IMPACT_REFERENCE_KINDS,
+    );
+    let payload = serde_json::json!({
+        "dependents": [],
+        kin_mcp::EDGE_COVERAGE_KEY: coverage,
+    });
+    crate::commands::absence_qualifier::qualify("get_context_pack", &payload, envelope, "")
 }
 
 pub fn build_trace_json_response(
@@ -207,6 +233,7 @@ fn build_trace_lines(
     max_lines: usize,
     nearby_limit: usize,
     transitive_limit: usize,
+    envelope: &kin_mcp::Envelope,
 ) -> Result<Vec<String>> {
     // Agents sometimes pass file paths instead of entity names; resolve those to
     // the graph-owned entities declared in that file rather than a raw file read.
@@ -225,6 +252,7 @@ fn build_trace_lines(
         max_lines,
         nearby_limit,
         transitive_limit,
+        envelope,
     )
 }
 
@@ -269,6 +297,7 @@ fn build_trace_lines_with_graph(
     max_lines: usize,
     nearby_limit: usize,
     transitive_limit: usize,
+    envelope: &kin_mcp::Envelope,
 ) -> Result<Vec<String>> {
     let token_budget = parse_budget(budget)?;
     let focal_max_lines = if compact {
@@ -381,6 +410,14 @@ fn build_trace_lines_with_graph(
             .chain(pack.transitive_deps.iter())
             .map(|e| &e.entity_id)
             .collect();
+        if all_dep_ids.is_empty() {
+            // Where the silence was. An empty dependency set printed NOTHING at
+            // all, which is quieter than impact's bare line and says even less:
+            // a reader saw a pack with no Deps section and had no way to tell a
+            // focal nothing depends on from one whose dependency edges this
+            // graph could never have held (FIR-2524).
+            lines.extend(trace_absence_qualifier(graph, target, envelope));
+        }
         if !all_dep_ids.is_empty() {
             lines.push("\n--- Deps ---".to_string());
             let mut printed = 0usize;
@@ -804,6 +841,18 @@ fn trace_not_found_guidance(entity: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    /// A daemon whose substrate is sound, so the FIR-2524 absence qualifier
+    /// answers on coverage rather than on the envelope. These cases assert trace
+    /// CONTENT and must not start failing for a reason they are not about.
+    fn healthy_trace_envelope() -> kin_mcp::Envelope {
+        kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 2,
+            "graph_generation": 1,
+        }))
+    }
+
     use super::{
         entity_mentions_qualifier, fallback_leaf_trace_matches, query_trace_matches,
         select_best_match, trace_not_found_guidance,
@@ -1045,6 +1094,7 @@ issues.map((iss) => util.finalizeItem(iss, ctx, core.config()));
                 nearby_limit: 3,
                 transitive_limit: 0,
             },
+            &healthy_trace_envelope(),
         )
         .unwrap();
         let joined = response.lines.join("\n");

--- a/crates/kin-cli/src/commands/trace.rs
+++ b/crates/kin-cli/src/commands/trace.rs
@@ -153,13 +153,27 @@ pub fn build_trace_response(
     })
 }
 
-/// The absence qualifier for a context pack with no dependencies.
+/// The absence qualifier for a pack whose dependency walk came back empty.
 ///
-/// Declares `get_context_pack`, which is what `kin trace` actually builds
-/// (`kin_context::build_context_pack` above), and deliberately NOT
-/// `trace_data_flow`: that tool describes a different walk, and gating this
-/// command on its declaration would be judging a class this answer never
-/// measured, the failure `IMPACT_REFERENCE_KINDS` warns about one level down.
+/// Declares `trace_data_flow`, whose spec is `field: "chain"`, `kind: "no_flow"`
+/// and subject "no data-flow chain was found from the focal entity". That is the
+/// direction this command walked: every group a pack carries
+/// (`dependency_signatures`, `transitive_deps`) runs OUTWARD from the focal.
+///
+/// Deliberately NOT `get_context_pack`, even though `kin_context::build_context_pack`
+/// above is what builds the pack. That tool's spec field is `dependents`, the
+/// INBOUND direction, and `kin_mcp::negative` chose it over `dependencies` on
+/// purpose. A `ContextPack` holds no dependents group at all, so handing that
+/// gate a synthetic `"dependents": []` would run a leaf's outbound fact through
+/// a gate built for the opposite claim and print a sentence about a set this
+/// command never walked. Matching the gate to the BUILDER rather than to the
+/// CLAIM is the same mistake as naming the wrong edge class, which is what
+/// `IMPACT_REFERENCE_KINDS` warns about one level down.
+///
+/// The coverage observation is shared with the inbound readers because it is
+/// direction-agnostic: it reports whether this graph holds cross-file edges of
+/// these classes at all, and a graph holding none can no more show what a focal
+/// reaches than what reaches it.
 fn trace_absence_qualifier(
     graph: &impl GraphStore,
     target: &Entity,
@@ -171,10 +185,10 @@ fn trace_absence_qualifier(
         &kin_mcp::handlers::review::IMPACT_REFERENCE_KINDS,
     );
     let payload = serde_json::json!({
-        "dependents": [],
+        "chain": [],
         kin_mcp::EDGE_COVERAGE_KEY: coverage,
     });
-    crate::commands::absence_qualifier::qualify("get_context_pack", &payload, envelope, "")
+    crate::commands::absence_qualifier::qualify("trace_data_flow", &payload, envelope, "")
 }
 
 pub fn build_trace_json_response(
@@ -401,6 +415,19 @@ fn build_trace_lines_with_graph(
         }
     }
 
+    // Where the silence was. An empty dependency walk printed NOTHING at all,
+    // which is quieter than impact's bare line and says even less: a reader saw
+    // a pack with no dependency section and had no way to tell a focal that
+    // reaches nothing from one whose outbound edges this graph could never have
+    // held (FIR-2524).
+    //
+    // Hoisted above the compact split on purpose. Both renderings key on the
+    // same two groups, and leaving this inside the compact arm left the DEFAULT
+    // invocation, the one a person types, as the only surface still silent.
+    if pack.dependency_signatures.is_empty() && pack.transitive_deps.is_empty() {
+        lines.extend(trace_absence_qualifier(graph, target, envelope));
+    }
+
     if compact {
         // Compact deps: one-liner per dependency with file path so agents can Read
         // directly instead of tracing each dependency serially (anti-spiral).
@@ -410,14 +437,6 @@ fn build_trace_lines_with_graph(
             .chain(pack.transitive_deps.iter())
             .map(|e| &e.entity_id)
             .collect();
-        if all_dep_ids.is_empty() {
-            // Where the silence was. An empty dependency set printed NOTHING at
-            // all, which is quieter than impact's bare line and says even less:
-            // a reader saw a pack with no Deps section and had no way to tell a
-            // focal nothing depends on from one whose dependency edges this
-            // graph could never have held (FIR-2524).
-            lines.extend(trace_absence_qualifier(graph, target, envelope));
-        }
         if !all_dep_ids.is_empty() {
             lines.push("\n--- Deps ---".to_string());
             let mut printed = 0usize;

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -24736,6 +24736,190 @@ mod tests {
         );
     }
 
+    /// The same spine for `kin trace`, whose silence was TOTAL rather than bare.
+    ///
+    /// `kin impact` printed a wrong sentence; `kin trace` printed no dependency
+    /// section at all, so a reader could not tell a focal that reaches nothing
+    /// from one whose outbound edges this graph could never have held.
+    ///
+    /// Drives the DEFAULT (non-compact) invocation on purpose. The qualifier
+    /// first landed inside the compact arm, which left the mode a person
+    /// actually types as the only surface still silent, and every other trace
+    /// test in this file runs against a healthy daemon and would have passed
+    /// either way.
+    #[tokio::test]
+    async fn a_degraded_daemon_reaches_the_trace_cli_through_the_route() {
+        let state = test_state();
+        // Coverage healthy on purpose, so the degradation is the only reason
+        // left to refuse and the assertion cannot pass for the wrong cause.
+        let mut caller = test_entity("caller", "src/a.py");
+        let mut callee = test_entity("callee", "src/b.py");
+        let mut orphan = test_entity("orphan", "src/orphan.py");
+        for entity in [&mut caller, &mut callee, &mut orphan] {
+            install_trace_fixture_file(&state, entity);
+            state.graph.upsert_entity(entity).unwrap();
+        }
+        state
+            .graph
+            .upsert_relation(&kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind: kin_model::RelationKind::Calls,
+                src: kin_model::GraphNodeId::Entity(caller.id),
+                dst: kin_model::GraphNodeId::Entity(callee.id),
+                confidence: 1.0,
+                origin: kin_model::RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state
+            .embed_worker_failed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let rendered = trace_lines_through_route(&state, "orphan").await;
+
+        assert!(
+            rendered.contains("Kin cannot rule out dependencies it did not see"),
+            "the route's envelope must carry the degradation into a section that printed \
+             nothing at all before: {rendered}"
+        );
+        assert!(
+            rendered.contains("embed_worker_failed"),
+            "the line names the signal the verdict disclosed rather than inventing a cause: \
+             {rendered}"
+        );
+        // The direction is the whole point. A context pack carries no dependents
+        // group, so a trace that claimed them would be asserting a verdict about
+        // a set this command never walked.
+        assert!(
+            !rendered.contains("dependents"),
+            "trace walks outward and must not claim the inbound direction: {rendered}"
+        );
+        // And it must not fabricate a missing edge class: nothing here observed
+        // one, and naming one anyway is the fabrication this family exists to end.
+        assert!(
+            !rendered.contains("holds no cross-file"),
+            "no absent class was observed, so none may be claimed: {rendered}"
+        );
+    }
+
+    /// The control that keeps the trace qualifier from becoming noise: a focal
+    /// that DOES reach something says nothing extra, on the same degraded daemon.
+    ///
+    /// Without it the fix could stamp every trace with a caveat and still pass
+    /// the case above, which is the FIR-2404 failure wearing its opposite
+    /// costume.
+    #[tokio::test]
+    async fn a_trace_that_finds_dependencies_stays_unqualified_even_when_degraded() {
+        let state = test_state();
+        let mut caller = test_entity("caller", "src/a.py");
+        let mut callee = test_entity("callee", "src/b.py");
+        for entity in [&mut caller, &mut callee] {
+            install_trace_fixture_file(&state, entity);
+            state.graph.upsert_entity(entity).unwrap();
+        }
+        state
+            .graph
+            .upsert_relation(&kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind: kin_model::RelationKind::Calls,
+                src: kin_model::GraphNodeId::Entity(caller.id),
+                dst: kin_model::GraphNodeId::Entity(callee.id),
+                confidence: 1.0,
+                origin: kin_model::RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state
+            .embed_worker_failed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let rendered = trace_lines_through_route(&state, "caller").await;
+
+        // The control only means something if this focal really did reach
+        // something; otherwise it is the case above wearing a passing costume.
+        assert!(
+            rendered.contains("callee"),
+            "the focal must actually reach a dependency, or this control asserts nothing: \
+             {rendered}"
+        );
+        assert!(
+            !rendered.contains("Kin cannot rule out"),
+            "a walk that found dependencies asserts no absence and must carry no qualifier: \
+             {rendered}"
+        );
+    }
+
+    /// Put an entity's file into repository authority and the working copy.
+    ///
+    /// `/trace` resolves a repository authority binding before it renders, so a
+    /// graph-only fixture answers 500 and the assertions below never run.
+    fn install_trace_fixture_file(state: &Arc<DaemonState>, entity: &mut Entity) {
+        let path = entity
+            .file_origin
+            .as_ref()
+            .expect("trace fixture entities carry a file")
+            .0
+            .clone();
+        let source = format!("def {}():\n    return 1\n", entity.name);
+        install_repository_file(state, &path, source.as_bytes());
+        let working = state.layout.working_dir().join(&path);
+        std::fs::create_dir_all(working.parent().unwrap()).unwrap();
+        std::fs::write(&working, source.as_bytes()).unwrap();
+        // `test_entity` spans 0..0, which the route rejects against a file that
+        // has bytes. Left unfixed the route answers 500 and every assertion
+        // below never runs.
+        let span = entity.span.as_mut().expect("trace fixture entities carry a span");
+        span.end_byte = source.len();
+        span.end_line = 2;
+    }
+
+    /// Drive `/trace` in its DEFAULT rendering and return the lines it printed.
+    async fn trace_lines_through_route(state: &Arc<DaemonState>, entity: &str) -> String {
+        let response = router(Arc::clone(state))
+            .oneshot(
+                Request::post("/trace")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "entity": entity,
+                            "json": false,
+                            "compact": false,
+                            "budget": "8k",
+                            "max_lines": 20,
+                            "nearby_limit": 2,
+                            "transitive_limit": 1,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the route must answer, or every assertion below is vacuous: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let result: kin_cli::commands::trace::TraceResponse =
+            serde_json::from_slice(&body).unwrap();
+        result.lines.join("\n")
+    }
+
     /// THE SPINE (FIR-2524, captain's rider). Drives the ROUTE, because that is
     /// the only place the rejected wiring differs.
     ///

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -24646,7 +24646,10 @@ mod tests {
     #[tokio::test]
     async fn a_degraded_daemon_reaches_the_search_cli_through_the_route() {
         let state = test_state();
-        state.graph.upsert_entity(&test_entity("present", "src/a.py")).unwrap();
+        state
+            .graph
+            .upsert_entity(&test_entity("present", "src/a.py"))
+            .unwrap();
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
@@ -24701,7 +24704,10 @@ mod tests {
     #[tokio::test]
     async fn a_search_that_matches_stays_unqualified_even_when_degraded() {
         let state = test_state();
-        state.graph.upsert_entity(&test_entity("findable", "src/a.py")).unwrap();
+        state
+            .graph
+            .upsert_entity(&test_entity("findable", "src/a.py"))
+            .unwrap();
         state.graph.flush_text_index().ok();
         state
             .is_initialized
@@ -24728,7 +24734,10 @@ mod tests {
         let result: kin_cli::commands::search::DaemonSearchResponse =
             serde_json::from_slice(&body).unwrap();
 
-        assert!(!result.records.is_empty(), "the query must match: {result:?}");
+        assert!(
+            !result.records.is_empty(),
+            "the query must match: {result:?}"
+        );
         assert!(
             result.absence_qualifier.is_empty(),
             "a populated answer asserts no absence and must carry no qualifier: {:?}",
@@ -24878,7 +24887,10 @@ mod tests {
         // `test_entity` spans 0..0, which the route rejects against a file that
         // has bytes. Left unfixed the route answers 500 and every assertion
         // below never runs.
-        let span = entity.span.as_mut().expect("trace fixture entities carry a span");
+        let span = entity
+            .span
+            .as_mut()
+            .expect("trace fixture entities carry a span");
         span.end_byte = source.len();
         span.end_line = 2;
     }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -24636,6 +24636,106 @@ mod tests {
         );
     }
 
+    /// The same spine for `kin search`, whose gate is NOT impact's.
+    ///
+    /// `semantic_search` declares no edge class and is language-scoped, so this
+    /// asserts the degradation reaches a surface gated on scope rather than on
+    /// cross-file coverage. A fix proven only on the reference readers would
+    /// leave this one silent, which is why the rollout falsifies one command per
+    /// gate shape rather than one per rung.
+    #[tokio::test]
+    async fn a_degraded_daemon_reaches_the_search_cli_through_the_route() {
+        let state = test_state();
+        state.graph.upsert_entity(&test_entity("present", "src/a.py")).unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state
+            .embed_worker_failed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/search")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "query": "definitelyNoSuchSymbol" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let result: kin_cli::commands::search::DaemonSearchResponse =
+            serde_json::from_slice(&body).unwrap();
+
+        assert!(result.records.is_empty(), "the query must match nothing");
+        let qualifier = result.absence_qualifier.join(" ");
+        assert!(
+            qualifier.contains("Kin cannot rule out"),
+            "the route's envelope must carry the degradation into the rendered verdict; a \
+             thinner snapshot leaves this empty: {qualifier:?}"
+        );
+        assert!(
+            qualifier.contains("embed_worker_failed"),
+            "the line names the signal the verdict disclosed rather than inventing a cause: \
+             {qualifier:?}"
+        );
+        // And it must not fabricate a missing edge class: semantic_search reads
+        // none, so naming one would be gating on evidence it never gathers.
+        assert!(
+            !qualifier.contains("cross-file"),
+            "a scope-gated surface must not claim an edge class: {qualifier:?}"
+        );
+    }
+
+    /// The control that keeps the search qualifier from becoming noise: a query
+    /// that MATCHES says nothing extra, on the same degraded daemon.
+    ///
+    /// Without this the fix could stamp every search with a caveat and still
+    /// pass the case above, which is the FIR-2404 failure wearing its opposite
+    /// costume.
+    #[tokio::test]
+    async fn a_search_that_matches_stays_unqualified_even_when_degraded() {
+        let state = test_state();
+        state.graph.upsert_entity(&test_entity("findable", "src/a.py")).unwrap();
+        state.graph.flush_text_index().ok();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state
+            .embed_worker_failed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/search")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "query": "findable" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let result: kin_cli::commands::search::DaemonSearchResponse =
+            serde_json::from_slice(&body).unwrap();
+
+        assert!(!result.records.is_empty(), "the query must match: {result:?}");
+        assert!(
+            result.absence_qualifier.is_empty(),
+            "a populated answer asserts no absence and must carry no qualifier: {:?}",
+            result.absence_qualifier
+        );
+    }
+
     /// THE SPINE (FIR-2524, captain's rider). Drives the ROUTE, because that is
     /// the only place the rejected wiring differs.
     ///

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -5949,9 +5949,15 @@ async fn search(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let mut result =
-        kin_cli::commands::search::collect_daemon_search_response(graph.as_ref(), &req)
-            .map_err(internal_error)?;
+    let mut result = kin_cli::commands::search::collect_daemon_search_response(
+        graph.as_ref(),
+        &req,
+        // Same substrate reading the impact and trace routes supply, from the
+        // same helper, so no CLI surface can be more confident than its MCP
+        // counterpart about one daemon at one instant (FIR-2524).
+        &kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state)),
+    )
+    .map_err(internal_error)?;
     if req.show_body {
         attach_search_bodies(&state, &mut result, req.body_limit.unwrap_or(10));
     }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6002,11 +6002,16 @@ async fn trace(
     let repository_authority = state
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
+    // Same substrate reading the impact route supplies, from the same helper, so
+    // `kin trace` and `get_context_pack` cannot disagree about one daemon at one
+    // instant (FIR-2524).
+    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state));
     let result = kin_cli::commands::trace::build_trace_response(
         &state.layout,
         &repository_authority,
         graph.as_ref(),
         &req,
+        &envelope,
     )
     .map_err(internal_error)?;
     Ok(Json(result))


### PR DESCRIPTION
Rung two of FIR-2524 gives `kin trace` and `kin search` the absence verdict `kin impact` got in kin#999, so a person reading a terminal is told when an empty answer is not evidence of absence. The verdict is never recomputed CLI-side. `kin_mcp::negative::negative_for` stays the one gate, and only the sentence is local, which is the captain's ruling of 2026-08-20.

## Mechanism

`crates/kin-cli/src/commands/absence_qualifier.rs:52` is the shared renderer. It calls the same gate the MCP surface calls, with the tool name whose declaration matches what the command actually read, and returns nothing when the verdict certifies. Silence is the certified case, which is what stops this from stamping every empty result uncertain.

`kin trace` (`crates/kin-cli/src/commands/trace.rs:177`) declares `trace_data_flow`. Its retrieval spec is `field: "chain"`, `kind: "no_flow"`, subject "no data-flow chain was found from the focal entity", and that is the walk this command made: both groups a `ContextPack` carries, `dependency_signatures` and `transitive_deps`, run outward from the focal. The check sits at `trace.rs:427`, above the compact split, so the default invocation renders it too.

`kin search` (`crates/kin-cli/src/commands/search.rs:493`) declares `semantic_search`, which reads no edge class and is language-scoped, so it observes the scope the extractor populated rather than cross-file coverage. Its qualifier rides on the response as data (`search.rs:233`) because that response is structured at the daemon and printed client-side.

All three daemon routes build the envelope from the same `daemon_health_snapshot` helper (`crates/kin-daemon/src/api.rs:5958`, `:6014`, `:6085`), so no CLI surface can be more confident than its MCP counterpart about one daemon at one instant.

## What each surface now says, and when it stays silent

On a degraded daemon whose coverage is healthy, `kin trace` prints "Kin cannot rule out dependencies it did not see: this answer carries [embed_worker_failed, ...], so it may not reflect current truth." and `kin search` prints the same shape with "matches it did not see". Where a deciding edge class is absent, the line names that class and the direction it hid, and adds which present classes do not stand in for it. On a healthy graph every one of them prints nothing at all.

## Three defects found in the parked rung-two work

The branch was parked before it was gated, and it was red. Everything below was found by running it, not by reading it.

**The extraction moved impact's wording, not only its code.** The disclosed-signals branch went from "Kin cannot rule out dependents" to "Kin cannot rule out matches it did not see", so `kin impact` described an absence of search matches. Two rung-one tests failed on the parked tip, `a_degraded_daemon_makes_the_cli_inherit_the_mcp_verdict` and `a_degraded_daemon_reaches_the_impact_cli_through_the_route`, while the commit that caused it said behaviour for `kin impact` was unchanged. The two things that genuinely vary by surface now vary explicitly and nothing else does: `absence_subject` at `absence_qualifier.rs:204` names what the absence is of, and `absence_direction` at `:223` names which way an absent class hides it.

**`kin trace` claimed the direction it never walked.** It declared `get_context_pack`, whose spec field is `dependents`, the inbound direction, then fired on an empty dependency walk and handed that gate a synthetic `"dependents": []`. A `ContextPack` holds no dependents group at all. `kin_mcp::negative` chose `dependents` over `dependencies` for that tool deliberately, on the ground that an empty dependency set is an ordinary fact about a leaf, so routing a leaf through it inverted the gate's stated purpose and printed a verdict about a set the command never computed. That is this ticket family's own defect arriving through its fix.

**`kin trace` was silent in the mode people type.** The qualifier sat inside the `compact` arm, so the default invocation stayed the only surface with nothing to say. Both renderings key on the same two groups, so the check is hoisted and runs once.

Rung two also shipped with no test for the trace surface at all, which is why both trace defects survived. It now has a route spine and a paired control (`api.rs:24760`, `api.rs:24826`), matching the shape search already had.

## Falsification

Two-pass form per surface, each pass removing one property and predicting which tests must fail and which must still pass. Every pass ran all six tests, exit codes read raw and never through a pipe, and each run was checked for a "tests run:" line so a pass that compiled nothing could not read as a verdict. Restores were verified byte-identical with `git status`.

| pass | property removed | failed | passed |
| -- | -- | -- | -- |
| T1 | trace qualifier computed but not rendered | trace spine, on "must carry the degradation into a section that printed nothing at all before" | 5, including the trace control |
| T2 | trace qualifier rendered unconditionally | trace control, on "a walk that found dependencies asserts no absence and must carry no qualifier" | 5, including the trace spine |
| T3 | trace declares `get_context_pack` with `"dependents": []` again | trace spine, rendering "Kin cannot rule out dependents: this answer carries [embed_worker_failed, edge_coverage:imports_absent, edge_coverage:references_absent]" | 5 |
| S1 | search qualifier never produced | search spine, on "must carry the degradation into the rendered verdict", observed value `""` | 5, including the search control |
| S2 | search qualifier produced unconditionally | search control, on "a populated answer asserts no absence and must carry no qualifier" | 5, including the search spine |
| I1 | one shared noun for every tool, as parked | both impact tests and the trace spine | both search tests |

T1 and T2 are the two directions for trace, S1 and S2 for search. T3 is what proves the direction change is load-bearing rather than cosmetic: with the old declaration the line renders and says "dependents". I1 reproduces the parked branch's failure exactly and shows the per-tool noun carries three surfaces at once.

The degraded cases use a real degraded payload, a daemon with `embed_worker_failed` set and coverage deliberately healthy so the degradation is the only reason left to refuse. The certified cases use a real populated answer on that same degraded daemon, and each control asserts it really did find something before asserting no qualifier attached, so a control that stopped resolving anything fails instead of passing quietly.

One limit, stated rather than left implied. The trace spine's third assertion, that the line must not contain "dependents", is defence in depth against a future inbound section. Under T3 the first assertion panics before it is reached, so it has not itself been shown to fail.

## Gates

Run through `bin/kin-lane run fir2524b kin`, never piped, exit codes read raw.

The full local gate printed its own tree line, `local-test: kin /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/fir2524b-kin @ d1a1051c (chore/lane-fir2524b-kin)`, and reported `Summary [541.354s] 6627 tests run: 6627 passed (4 slow, 1 leaky), 12 skipped`. The run reached 6627 of 6627, so nextest did not cancel early and hide anything past a first failure. Doctests ran beside it.

`cargo fmt --all -- --check` exits 0. It was RED on the parked branch, and two of the four hunks were in the parked search-route tests, which would have failed CI's own formatting job on a branch whose local test runs were green.

Clippy exactly as `.github/workflows/ci.yml` runs it, `RUSTFLAGS=-D warnings cargo clippy --all-targets --all-features` with the 45-lint debt allow-list read from `.github/clippy-allowed-lints.txt`, exits 0.

All six guard scripts `ci.yml` names exit 0: `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `verify-hydration-semantics.py`, `falsify-hydration-semantics.py` against a poisoned copy, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`.

`git ls-tree -r HEAD --name-only` matched on `.cargo/` prints only `.cargo/config.toml`, with a fabricated path as the control returning nothing. `git diff origin/main --stat -- Cargo.lock .cargo/` is empty and `Cargo.lock` carries zero `source = "path` entries, at the same sha256 it had before the gate.

The full gate ran at `d1a1051c`, before the final rebase onto `79979a37`. After that rebase the formatting check and all six qualifier tests were re-run green; the rest of the suite at the new base is CI's to confirm.

Refs FIR-2524
