### PR TITLE
Retry a refused vector checkpoint instead of abandoning its vectors

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -619,6 +619,23 @@ fn build_graph_status_response(
             embeddings_line.push_str(&clause);
         }
     }
+    // Outside the pending gate on purpose, and the only clause here that is.
+    //
+    // Every clause above explains a shortfall the counters are already showing.
+    // This one explains a shortfall they are not: the daemon holds embedded
+    // vectors the sidecar does not, so the count beside it is true about this
+    // process and would not survive its exit. A drained queue reports zero
+    // pending in exactly that state, which is how the regression reached a
+    // reader as a complete store one minute and ordinary pending work the next.
+    // The clause says what is undurable, and does not promise a number: nothing
+    // on this path counts the vectors embedded since the refusal.
+    if let Some(reason) = embedding_runtime.deferred_vector_checkpoint.as_ref() {
+        embeddings_line.push_str(&format!(
+            "; the last vector checkpoint was refused ({reason}), so vectors embedded since then \
+             are in this daemon's memory rather than on disk and a restart re-derives them; the \
+             daemon retries the checkpoint until it lands"
+        ));
+    }
     lines.push(embeddings_line);
     // A census, not a queue, and the label has to say so.
     //
@@ -2277,6 +2294,108 @@ mod tests {
                 .any(|line| line == "Embeddings: 0/0 indexed (0 pending)"),
             "a store with nothing pending renders the plain measured line: {:?}",
             recovered.lines
+        );
+    }
+
+    /// A refused vector checkpoint has to reach the reader, and it has to reach
+    /// a reader whose counters look complete.
+    ///
+    /// Every other clause on this line explains a shortfall the counters are
+    /// already showing, so every other clause sits behind `pending > 0`. This
+    /// one explains a shortfall they are not showing: the daemon holds vectors
+    /// the sidecar does not, and a drained queue reports zero pending in
+    /// exactly that state. That is how the regression reached a reader as a
+    /// complete store at one reading and a store that had lost 342 vectors at
+    /// the next. Drive both counter shapes, because a clause that only fires
+    /// when something is already pending would miss the case it exists for.
+    #[cfg(feature = "vector")]
+    #[test]
+    fn a_refused_vector_checkpoint_is_named_even_when_nothing_is_pending() {
+        const REFUSAL: &str = "refusing vector checkpoint at repository generation 1: live exact \
+                               tree does not match workspace authority";
+
+        // A store whose counters read complete: nothing pending, nothing to
+        // explain, and the plain line is what the existing tests pin here.
+        let (_drained_temp, drained_binding, drained_graph) = graph_validation_fixture();
+        let drained_control = build_graph_status_response(
+            &pinned(&drained_binding),
+            &drained_graph,
+            &Default::default(),
+            &crate::commands::resources::EmbedRuntimeState::default(),
+        )
+        .unwrap();
+        assert!(
+            drained_control
+                .lines
+                .iter()
+                .any(|line| line == "Embeddings: 0/0 indexed (0 pending)"),
+            "the control must be the clean-counter case this clause has to survive: {:?}",
+            drained_control.lines
+        );
+
+        let drained = build_graph_status_response(
+            &pinned(&drained_binding),
+            &drained_graph,
+            &Default::default(),
+            &crate::commands::resources::EmbedRuntimeState {
+                deferred_vector_checkpoint: Some(REFUSAL.to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let drained_line = drained
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            drained_line.contains("the last vector checkpoint was refused"),
+            "a store reporting nothing pending must still disclose undurable coverage: \
+             {drained_line}"
+        );
+        assert!(
+            drained_line.contains(REFUSAL),
+            "the refusal's own cause is what tells a reader this is not ordinary pending work: \
+             {drained_line}"
+        );
+        assert!(
+            drained_line.contains("a restart re-derives them"),
+            "the consequence a reader acts on is what a restart costs: {drained_line}"
+        );
+
+        // And on a store that IS filling, the clause is appended to the existing
+        // chain rather than replacing it, so a reader keeps both facts.
+        let (_filling_temp, filling_binding, filling_graph) = graph_validation_fixture();
+        filling_graph
+            .upsert_entity(&test_entity("alpha_transform"))
+            .unwrap();
+        let filling_status = filling_graph.embedding_status();
+        assert!(
+            filling_status.pending > 0,
+            "the second fixture must actually have a backlog to explain"
+        );
+        let filling = build_graph_status_response(
+            &pinned(&filling_binding),
+            &filling_graph,
+            &Default::default(),
+            &crate::commands::resources::EmbedRuntimeState {
+                deferred_vector_checkpoint: Some(REFUSAL.to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let filling_line = filling
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            filling_line.contains("the live graph carries no vector index"),
+            "the existing pending-gated chain must still run: {filling_line}"
+        );
+        assert!(
+            filling_line.contains("the last vector checkpoint was refused"),
+            "and the refusal must be appended beside it, not instead of it: {filling_line}"
         );
     }
 

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -2397,6 +2397,46 @@ mod tests {
             filling_line.contains("the last vector checkpoint was refused"),
             "and the refusal must be appended beside it, not instead of it: {filling_line}"
         );
+
+        // The no-noise control, and the reason it is an assertion rather than a
+        // reading of the code. A clause outside the pending gate runs on every
+        // render, including every store that has nothing wrong with it, so the
+        // only thing standing between this fix and a permanent new line on
+        // every `kin graph status` is that the field is `None`. Pin both lines
+        // byte for byte against the same fixture rendered with no refusal.
+        let filling_quiet = build_graph_status_response(
+            &pinned(&filling_binding),
+            &filling_graph,
+            &Default::default(),
+            &crate::commands::resources::EmbedRuntimeState::default(),
+        )
+        .unwrap();
+        let filling_quiet_line = filling_quiet
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            !filling_quiet_line.contains("vector checkpoint"),
+            "a store with nothing refused must render exactly today's line: {filling_quiet_line}"
+        );
+        assert_eq!(
+            filling_quiet_line.as_str(),
+            filling_line
+                .split("; the last vector checkpoint was refused")
+                .next()
+                .expect("the refusal clause must be an append, so the prefix is today's line"),
+            "the clause must be a pure append: everything before it has to be byte-identical to \
+             what a store with nothing refused renders"
+        );
+        assert_eq!(
+            drained_control
+                .lines
+                .iter()
+                .find(|line| line.starts_with("Embeddings:")),
+            Some(&"Embeddings: 0/0 indexed (0 pending)".to_string()),
+            "and the drained control's line is today's, unchanged, to the byte"
+        );
     }
 
     /// A first fill that is waiting on the model download says so beside the

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -35,6 +35,15 @@ pub struct EmbedRuntimeState {
     /// distinguish that from a first run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vector_index_discarded: Option<String>,
+    /// Why the last vector checkpoint was refused, while that refusal stands.
+    ///
+    /// The counterpart to `vector_index_discarded` at the other end of a
+    /// daemon's life. That one says coverage on disk was not loaded; this one
+    /// says coverage in memory was not written. Both produce the same shortfall
+    /// on the next open, and without this the second arrives with no cause
+    /// attached and reads as ordinary pending work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferred_vector_checkpoint: Option<String>,
     /// Whether this store's embedding coverage has ever been whole, as recorded
     /// by the daemon where the embedding queue drained. Partial coverage means
     /// something different before this has ever been true than after it.

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3343,6 +3343,7 @@ async fn command_resources(
         hybrid_metrics: hybrid_metrics_runtime(),
         metal_profile: metal_profile_runtime(),
         vector_index_discarded: state.vector_index_discarded().map(str::to_string),
+        deferred_vector_checkpoint: state.deferred_vector_checkpoint(),
         embedding_coverage_ever_complete: state.embedding_coverage_ever_complete(),
         embed_persistence_unavailable: !state.can_persist_embed_progress_locally(),
         model_fetch: kin_cli::embed_model::EmbedModelFetch::probe(embed_pass_is_working(&state)),
@@ -3445,6 +3446,7 @@ fn graph_status_embedding_runtime(
     }
     kin_cli::commands::resources::EmbedRuntimeState {
         vector_index_discarded: state.vector_index_discarded().map(str::to_string),
+        deferred_vector_checkpoint: state.deferred_vector_checkpoint(),
         embedding_coverage_ever_complete: state.embedding_coverage_ever_complete(),
         embed_persistence_unavailable: !state.can_persist_embed_progress_locally(),
         model_fetch: kin_cli::embed_model::EmbedModelFetch::probe(embed_pass_is_working(state)),

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -635,6 +635,73 @@ async fn drain_embed_flush(
     }
 }
 
+/// Ceiling on the wait between retries of a refused vector checkpoint.
+const DEFERRED_CHECKPOINT_RETRY_MAX: Duration = Duration::from_secs(300);
+
+/// Re-attempt a vector checkpoint the daemon had to refuse, so the vectors it
+/// left in memory reach the sidecar instead of dying with the process.
+///
+/// A refusal means the live exact tree had moved away from committed workspace
+/// authority, which is what a commit in flight does to it, and it closes when
+/// that commit settles. The work therefore needs nothing but somewhere to be
+/// retried from. There was nowhere: the only caller of the checkpoint is the
+/// flush the worker runs after a batch embeds something, so a refusal on the
+/// last batch of a draining queue was the end of it, and everything embedded
+/// since the previous successful checkpoint was gone on the next open. This
+/// worker's wake tick is the one clock that keeps running with no batch to
+/// embed, which is exactly the case that was losing the work.
+///
+/// The backoff is not politeness. Proving the tree against authority costs a
+/// full reopen, linear in store size rather than in the batch, so a mismatch
+/// that does not close would otherwise reopen authority on every tick for as
+/// long as it lasts.
+async fn retry_deferred_vector_checkpoint(
+    state: &Arc<DaemonState>,
+    backoff: &mut Option<Duration>,
+    due: &mut Option<Instant>,
+    base: Duration,
+) {
+    if state.deferred_vector_checkpoint().is_none() {
+        *backoff = None;
+        *due = None;
+        return;
+    }
+    if due.is_some_and(|at| Instant::now() < at) {
+        return;
+    }
+    let retry_state = Arc::clone(state);
+    match tokio::task::spawn_blocking(move || retry_state.retry_deferred_vector_checkpoint()).await
+    {
+        Ok(Some(Ok(pending))) => {
+            *backoff = None;
+            *due = None;
+            info!(
+                pending,
+                "checkpointed the vector progress a refused checkpoint had left in memory"
+            );
+        }
+        Ok(Some(Err(error))) => {
+            let next = next_embed_error_backoff(*backoff, base, DEFERRED_CHECKPOINT_RETRY_MAX);
+            *backoff = Some(next);
+            *due = Some(Instant::now() + next);
+            warn!(
+                error = %error,
+                next_retry_s = next.as_secs(),
+                "vector checkpoint still refused; embedded vectors stay in memory until it lands"
+            );
+        }
+        // The record cleared under us, which is the ordinary outcome when the
+        // worker's own flush landed between the read above and this call.
+        Ok(None) => {
+            *backoff = None;
+            *due = None;
+        }
+        Err(error) => {
+            error!(error = %error, "deferred vector checkpoint retry task panicked");
+        }
+    }
+}
+
 // Shutdown-latency bound — how long the daemon may take to actually disappear.
 // Callers that budget for daemon cleanup (the merge-trust harness attests
 // against a 45s window) depend on this being bounded rather than generous, so
@@ -2528,6 +2595,11 @@ pub async fn run_with_authority_on(
         // batch that embeds something, since progress makes the next gap a new
         // question.
         let mut backfilled_gap: Option<usize> = None;
+        // A refused vector checkpoint outlives the batch that hit it, so its
+        // retry schedule lives out here with the wake loop rather than inside
+        // the drain that produced the refusal.
+        let mut deferred_checkpoint_backoff: Option<Duration> = None;
+        let mut deferred_checkpoint_due: Option<Instant> = None;
         'wake: loop {
             // Between wakes this worker is genuinely doing nothing, so the
             // working stretch ends here. A wedged drain never reaches this
@@ -2550,6 +2622,19 @@ pub async fn run_with_authority_on(
             if embed_pass.halted() {
                 break;
             }
+
+            // Before anything this tick might embed, land what the last tick
+            // already embedded and could not checkpoint. A drained queue never
+            // reaches the flush below, so this is the only path that closes a
+            // refusal once there is nothing left to embed, which is the state
+            // the regression was found in.
+            retry_deferred_vector_checkpoint(
+                &embed_state,
+                &mut deferred_checkpoint_backoff,
+                &mut deferred_checkpoint_due,
+                embed_interval,
+            )
+            .await;
 
             // Drain the pending backlog continuously within this wake rather than
             // one batch per `embed_interval`. A fresh central-graph embed (or an

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -638,6 +638,98 @@ async fn drain_embed_flush(
 /// Ceiling on the wait between retries of a refused vector checkpoint.
 const DEFERRED_CHECKPOINT_RETRY_MAX: Duration = Duration::from_secs(300);
 
+/// Everything the persistence task does on its way out.
+///
+/// A named function rather than the body of a `select!` arm, because both
+/// halves are durability decisions that have to be drivable by a test. The
+/// graph half was already load-bearing; the vector half below is the case the
+/// coverage regression was actually found in, and a wiring nothing exercises is
+/// how the first half of this fix would have shipped covering only a daemon
+/// nobody stops.
+///
+/// Runs under the persistence task's own shutdown budget
+/// (`KIN_DAEMON_SHUTDOWN_FLUSH_SECS`, five minutes by default), which exists
+/// because the graph flush here can need minutes on a real store.
+async fn run_shutdown_persistence(state: &Arc<DaemonState>) {
+    if state.is_dirty() {
+        if state.shutdown_flush_would_wipe_graph() {
+            // The in-memory graph collapsed to a small fraction of the last
+            // persisted entity count, almost certainly a transient wipe (e.g. an
+            // empty/bare checkout reconciled as all-deleted) rather than a real
+            // edit. Skip the final flush so the larger good snapshot survives;
+            // the daemon reloads it and re-reconciles against the filesystem on
+            // restart. (Graph-keyed, not embed-keyed: a stale vector index
+            // self-heals on load and never blocks this flush.)
+            warn!(
+                persisted = state
+                    .persisted_entity_count
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                current = state.graph.entity_count(),
+                "skipping final graph flush on shutdown — in-memory entity count collapsed vs on-disk snapshot; preserving the larger snapshot"
+            );
+        } else {
+            info!("final persistence flush on shutdown");
+            if let Err(e) = save_snapshot_blocking(Arc::clone(state)).await {
+                error!(error = %e, "shutdown save failed");
+            } else {
+                state.mark_clean();
+            }
+        }
+    }
+    retry_deferred_vector_checkpoint_at_shutdown(state).await;
+}
+
+/// Give a standing vector-checkpoint refusal its one attempt before the process
+/// ends.
+///
+/// The wake-tick retry covers a daemon that keeps running. This covers the case
+/// the regression was found in, where the process ENDED with a refusal standing
+/// and every vector embedded since the previous successful checkpoint went with
+/// it. Nothing else would have written them: the sidecar is not part of the
+/// graph flush above, so a clean shutdown published graph truth and left the
+/// vectors behind.
+///
+/// Unconditional and with no backoff, unlike the wake-tick retry, because
+/// shutdown has no next tick to defer to: the choice here is one attempt or
+/// lose the work. It costs one authority reopen, charged against the same
+/// budget the flush above already spends minutes of on a real store, and it
+/// costs an ordinary daemon nothing at all, because the first check returns at
+/// once when no refusal stands.
+///
+/// After the graph flush rather than before it, deliberately. Publishing
+/// advances the authority generation, which is exactly what closes the
+/// divergence a refusal is about, so this is the moment in shutdown when the
+/// checkpoint is most likely to be provable.
+async fn retry_deferred_vector_checkpoint_at_shutdown(state: &Arc<DaemonState>) {
+    if state.deferred_vector_checkpoint().is_none() {
+        return;
+    }
+    info!("retrying a refused vector checkpoint before shutdown");
+    let retry_state = Arc::clone(state);
+    match tokio::task::spawn_blocking(move || retry_state.retry_deferred_vector_checkpoint()).await
+    {
+        Ok(Some(Ok(pending))) => {
+            info!(
+                pending,
+                "checkpointed before shutdown the vector progress a refused checkpoint had left in memory"
+            );
+        }
+        Ok(Some(Err(error))) => {
+            // Loud, and named as loss rather than as a slow exit. This is the
+            // one path left where the vectors genuinely do not survive, and a
+            // reader has to be able to tell it from an untidy shutdown.
+            warn!(
+                error = %error,
+                "the vector checkpoint was still refused at shutdown; vectors embedded since the refusal are NOT durable and the next open re-derives them"
+            );
+        }
+        Ok(None) => {}
+        Err(error) => {
+            error!(error = %error, "shutdown vector checkpoint retry task panicked");
+        }
+    }
+}
+
 /// Re-attempt a vector checkpoint the daemon had to refuse, so the vectors it
 /// left in memory reach the sidecar instead of dying with the process.
 ///
@@ -2446,31 +2538,7 @@ pub async fn run_with_authority_on(
             tokio::select! {
                 _ = tokio::time::sleep(current_interval) => {}
                 _ = persist_cancel.changed() => {
-                    if persist_state.is_dirty() {
-                        if persist_state.shutdown_flush_would_wipe_graph() {
-                            // The in-memory graph collapsed to a small fraction of
-                            // the last persisted entity count — almost certainly a
-                            // transient wipe (e.g. an empty/bare checkout
-                            // reconciled as all-deleted), not a real edit. Skip the
-                            // final flush so the larger good snapshot survives; the
-                            // daemon reloads it and re-reconciles against the
-                            // filesystem on restart. (Graph-keyed, not embed-keyed:
-                            // a stale vector index self-heals on load and never
-                            // blocks this flush.)
-                            warn!(
-                                persisted = persist_state.persisted_entity_count.load(std::sync::atomic::Ordering::SeqCst),
-                                current = persist_state.graph.entity_count(),
-                                "skipping final graph flush on shutdown — in-memory entity count collapsed vs on-disk snapshot; preserving the larger snapshot"
-                            );
-                        } else {
-                            info!("final persistence flush on shutdown");
-                            if let Err(e) = save_snapshot_blocking(Arc::clone(&persist_state)).await {
-                                error!(error = %e, "shutdown save failed");
-                            } else {
-                                persist_state.mark_clean();
-                            }
-                        }
-                    }
+                    run_shutdown_persistence(&persist_state).await;
                     break;
                 }
             }
@@ -5941,5 +6009,242 @@ mod sweep_tally_tests {
     fn a_sweep_over_no_files_is_not_blocked() {
         assert_eq!(SweepTally::default().blocked_reason(0), None);
         assert_eq!(SweepTally::default().unaccounted(0), 0);
+    }
+}
+
+/// The shutdown half of FIR-2497.
+///
+/// The wake-tick retry proves durability for a daemon that keeps running. The
+/// coverage regression was found on a daemon that STOPPED with a refusal
+/// standing, and nothing in the graph flush writes the vector sidecar, so a
+/// clean shutdown published graph truth and left the vectors in a process that
+/// was about to end. These tests drive the real shutdown arm rather than the
+/// helper beside it, because what has to hold is the wiring: a retry that
+/// exists and is never called from shutdown is the bug it was written to fix.
+#[cfg(all(test, feature = "embeddings"))]
+mod shutdown_vector_checkpoint_tests {
+    use super::{run_shutdown_persistence, DaemonState};
+    use kin_db::EntityStore;
+    use kin_model::{
+        ArtifactId, Entity, EntityKind, EntityMetadata, FilePathId, FingerprintAlgorithm, Hash256,
+        LanguageId, LocatedEntry, RepoPath, SemanticFingerprint, TreeDelta, TreeEntry, Visibility,
+    };
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    const STAGED_VECTORS: usize = 3;
+
+    fn test_entity(name: &str) -> Entity {
+        Entity {
+            id: kin_model::EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([1; 32]),
+                signature_hash: Hash256::from_bytes([2; 32]),
+                behavior_hash: Hash256::from_bytes([3; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new("src/lib.rs")),
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: Visibility::Public,
+            role: kin_model::EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    /// Open a store, stage coverage the product's own counter can see, leave
+    /// nothing durable behind it, and force one authority-mismatch refusal by
+    /// moving the live tree inside the checkpoint's reopen window.
+    ///
+    /// Returns the state with a refusal standing and the divergence still open.
+    fn state_with_a_standing_refusal(
+        repo_dir: &std::path::Path,
+    ) -> (Arc<DaemonState>, ArtifactId, LocatedEntry) {
+        let init = kin_core::init(repo_dir).unwrap();
+        let vector_path = init.layout.kindb_vector_index_path();
+        let state = Arc::new(DaemonState::open(init.layout).expect("fixture store must open"));
+
+        let descriptor = kin_db::vector::IndexDescriptor {
+            model_id: Some("fixture-embedder-v1".to_string()),
+            graph_root: Some("fixture-root".to_string()),
+        };
+        let vectors = kin_db::VectorIndex::new(4).unwrap();
+        vectors.set_descriptor(descriptor.clone());
+        for slot in 0..STAGED_VECTORS {
+            let entity = test_entity(&format!("embedded_{slot}"));
+            state.graph.upsert_entity(&entity).unwrap();
+            let mut embedding = [0.0f32; 4];
+            embedding[slot] = 1.0;
+            vectors
+                .upsert_retrievable(kin_db::RetrievalKey::Entity(entity.id), &embedding)
+                .expect("the fixture index must accept a staged vector");
+        }
+        vectors.save(&vector_path).unwrap();
+        assert!(matches!(
+            state
+                .graph
+                .load_vector_index_compatible(&vector_path, &descriptor),
+            kin_db::vector::VectorIndexLoad::Loaded(STAGED_VECTORS)
+        ));
+        std::fs::remove_file(&vector_path).unwrap();
+        assert_eq!(
+            state.graph.embedding_status().indexed,
+            STAGED_VECTORS,
+            "the fixture must stage coverage the counter can see"
+        );
+
+        let arriving = ArtifactId::new();
+        let arrived = LocatedEntry::new(
+            RepoPath::from_utf8("src/arrived_during_reopen.rs").unwrap(),
+            TreeEntry::blob(Hash256::from_bytes([9u8; 32]), false),
+        );
+        let moving_graph = Arc::clone(&state.graph);
+        let moved = Arc::new(AtomicBool::new(false));
+        let arrived_seam = arrived.clone();
+        state.set_vector_checkpoint_reopen_test_hook(Some(Arc::new(move || {
+            // Once only: a seam that moved the tree on every reopen would model
+            // a repository nobody can ever checkpoint, not a commit that lands.
+            if moved.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            moving_graph
+                .apply_transaction_delta(&kin_model::TransactionDelta {
+                    tree_deltas: vec![TreeDelta::Added {
+                        artifact_id: arriving,
+                        new: arrived_seam.clone(),
+                    }],
+                    ..Default::default()
+                })
+                .expect("the live graph must accept the concurrent mutation under test");
+        })));
+        state
+            .flush_embed_progress()
+            .expect_err("a live tree that moved away from authority must be refused");
+        assert!(
+            state.deferred_vector_checkpoint().is_some(),
+            "the fixture must leave a refusal standing"
+        );
+        assert!(
+            !vector_path.exists(),
+            "the fixture must leave nothing durable behind the refusal"
+        );
+
+        (state, arriving, arrived)
+    }
+
+    /// Refusal standing, daemon shuts down cleanly, restart, count equals N.
+    ///
+    /// This is the arm the regression's own evidence asks for. Before the
+    /// shutdown retry, the sequence ended with the sidecar still holding its
+    /// older content and the process gone, which is why a store read
+    /// 2112/2112 on one daemon and 1770/2112 on the next.
+    ///
+    /// The restart is modelled by dropping the live index and re-reading the
+    /// sidecar through `load_vector_index_into_graph_if_valid`, the exact call
+    /// `DaemonState::load_validated_vector_index` makes at open. The drop is
+    /// load-bearing: without it the final count would come from the memory the
+    /// shutdown was supposed to be rescuing the vectors out of, and the test
+    /// could not fail.
+    #[tokio::test]
+    async fn a_refusal_standing_at_shutdown_is_checkpointed_and_survives_the_restart() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let (state, arriving, arrived) = state_with_a_standing_refusal(repo_dir.path());
+        let vector_path = state.layout.kindb_vector_index_path();
+
+        // The divergence closes, the way it closes in a real store once the
+        // commit that opened it has settled.
+        state
+            .graph
+            .apply_transaction_delta(&kin_model::TransactionDelta {
+                tree_deltas: vec![TreeDelta::Removed {
+                    artifact_id: arriving,
+                    old: arrived,
+                }],
+                ..Default::default()
+            })
+            .expect("the live graph must accept the settling transition");
+
+        run_shutdown_persistence(&state).await;
+
+        assert!(
+            vector_path.exists(),
+            "shutdown must land a standing refusal rather than end with the vectors in memory"
+        );
+        assert!(
+            state.deferred_vector_checkpoint().is_none(),
+            "a checkpoint that landed must retire the record it closed"
+        );
+
+        state.graph.reset_vector_index();
+        assert_eq!(
+            state.graph.embedding_status().indexed,
+            0,
+            "the control: with the live index dropped the count must come from disk alone"
+        );
+        assert!(
+            kin_db::SnapshotManager::load_vector_index_into_graph_if_valid(
+                state.graph.as_ref(),
+                &state.layout.kindb_snapshot_path(),
+                None,
+            )
+            .expect("the checkpointed sidecar must be readable"),
+            "the checkpointed sidecar must install through the daemon's own open-time path"
+        );
+        assert_eq!(
+            state.graph.embedding_status().indexed,
+            STAGED_VECTORS,
+            "a restart after a clean shutdown must read back every staged vector"
+        );
+    }
+
+    /// The budget kin#994 gave this arm is a ceiling, not an amount, and this
+    /// change must not turn it into one.
+    ///
+    /// An ordinary daemon has no refusal standing, so the shutdown retry has to
+    /// cost it nothing: no authority reopen, no sidecar write, no delay. A
+    /// version that retried unconditionally would pay a full reopen on every
+    /// clean exit, which is the overcorrection this must not become.
+    #[tokio::test]
+    async fn a_shutdown_with_no_refusal_standing_writes_no_sidecar() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let vector_path = init.layout.kindb_vector_index_path();
+        let state = Arc::new(DaemonState::open(init.layout).expect("fixture store must open"));
+        state
+            .graph
+            .upsert_entity(&test_entity("untouched"))
+            .unwrap();
+        assert!(
+            state.deferred_vector_checkpoint().is_none(),
+            "the control fixture must carry no refusal"
+        );
+        let before = vector_path.exists();
+
+        let started = std::time::Instant::now();
+        run_shutdown_persistence(&state).await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            vector_path.exists(),
+            before,
+            "a shutdown with nothing refused must not checkpoint the vector sidecar at all"
+        );
+        assert!(
+            state.deferred_vector_checkpoint().is_none(),
+            "and must not invent a refusal"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(30),
+            "a shutdown with nothing refused must not pay for an authority reopen; took {elapsed:?}"
+        );
     }
 }

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -6213,29 +6213,61 @@ mod shutdown_vector_checkpoint_tests {
     /// cost it nothing: no authority reopen, no sidecar write, no delay. A
     /// version that retried unconditionally would pay a full reopen on every
     /// clean exit, which is the overcorrection this must not become.
+    ///
+    /// The fixture stages a real attached index and then removes the sidecar,
+    /// which is what gives this test the ability to fail at all. An earlier
+    /// version opened a bare store with no index, so "no sidecar was written"
+    /// held whatever the code did, and the unconditional-retry sabotage passed
+    /// it cleanly. A control whose subject cannot act is not a control.
     #[tokio::test]
     async fn a_shutdown_with_no_refusal_standing_writes_no_sidecar() {
         let repo_dir = tempfile::tempdir().unwrap();
         let init = kin_core::init(repo_dir.path()).unwrap();
         let vector_path = init.layout.kindb_vector_index_path();
         let state = Arc::new(DaemonState::open(init.layout).expect("fixture store must open"));
-        state
-            .graph
-            .upsert_entity(&test_entity("untouched"))
-            .unwrap();
+
+        let descriptor = kin_db::vector::IndexDescriptor {
+            model_id: Some("fixture-embedder-v1".to_string()),
+            graph_root: Some("fixture-root".to_string()),
+        };
+        let vectors = kin_db::VectorIndex::new(4).unwrap();
+        vectors.set_descriptor(descriptor.clone());
+        for slot in 0..STAGED_VECTORS {
+            let entity = test_entity(&format!("embedded_{slot}"));
+            state.graph.upsert_entity(&entity).unwrap();
+            let mut embedding = [0.0f32; 4];
+            embedding[slot] = 1.0;
+            vectors
+                .upsert_retrievable(kin_db::RetrievalKey::Entity(entity.id), &embedding)
+                .expect("the fixture index must accept a staged vector");
+        }
+        vectors.save(&vector_path).unwrap();
+        assert!(matches!(
+            state
+                .graph
+                .load_vector_index_compatible(&vector_path, &descriptor),
+            kin_db::vector::VectorIndexLoad::Loaded(STAGED_VECTORS)
+        ));
+        // Removed so a write during shutdown is visible. The index stays
+        // attached, so there is real content a stray checkpoint would write,
+        // and an unconditional retry recreates this file.
+        std::fs::remove_file(&vector_path).unwrap();
+        assert!(
+            state.graph.embedding_status().indexed > 0,
+            "the fixture must hold coverage a stray checkpoint could write, or this control \
+             cannot fail"
+        );
         assert!(
             state.deferred_vector_checkpoint().is_none(),
             "the control fixture must carry no refusal"
         );
-        let before = vector_path.exists();
 
         let started = std::time::Instant::now();
         run_shutdown_persistence(&state).await;
         let elapsed = started.elapsed();
 
-        assert_eq!(
-            vector_path.exists(),
-            before,
+        assert!(
+            !vector_path.exists(),
             "a shutdown with nothing refused must not checkpoint the vector sidecar at all"
         );
         assert!(

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1254,6 +1254,30 @@ pub struct DaemonState {
     /// workspace authority for a vector checkpoint. Read under `persist_lock`.
     #[cfg(feature = "embeddings")]
     vector_checkpoint_authority_match: VectorCheckpointAuthorityMatch,
+    /// Why the last vector checkpoint was refused, held until a later
+    /// checkpoint lands.
+    ///
+    /// A refusal is transient by construction. It says the live exact tree had
+    /// moved away from committed workspace authority, which is exactly what a
+    /// commit in flight does to it, and the divergence closes when that commit
+    /// settles. The vectors are unharmed either way: they stay in the live
+    /// index, so the coverage a reader sees is true about this process.
+    ///
+    /// What was not true is that the coverage was durable. The refusal used to
+    /// be logged once at ERROR and abandoned. Nothing else in the daemon writes
+    /// the vector sidecar (`checkpoint_vector_index_for_graph` has exactly one
+    /// caller, `flush_embed_progress`), and the embed worker only reaches that
+    /// caller after a batch embeds something, so a refusal on the last batch of
+    /// a draining queue had nothing left to retry it. Every vector embedded
+    /// since the previous successful checkpoint then died with the process, and
+    /// the next open reported the shortfall as ordinary pending work. That is
+    /// the coverage regression a user reads as embedding going backwards after
+    /// a commit.
+    ///
+    /// Recording the refusal is what gives the retry something to fire on and
+    /// gives every embedding surface a cause to name while the gap is open.
+    #[cfg(feature = "embeddings")]
+    deferred_vector_checkpoint: std::sync::Mutex<Option<String>>,
     /// When the last successful background save completed.
     pub last_save: std::sync::Mutex<Instant>,
     /// When the graph was last mutated (`mark_dirty`). The background
@@ -2390,6 +2414,8 @@ impl DaemonState {
             persist_lock: Mutex::new(()),
             #[cfg(feature = "embeddings")]
             vector_checkpoint_authority_match: VectorCheckpointAuthorityMatch::default(),
+            #[cfg(feature = "embeddings")]
+            deferred_vector_checkpoint: std::sync::Mutex::new(None),
             last_save: std::sync::Mutex::new(Instant::now()),
             last_mutation: std::sync::Mutex::new(Instant::now()),
             active_embed_passes: AtomicU32::new(0),
@@ -2619,6 +2645,8 @@ impl DaemonState {
             persist_lock: Mutex::new(()),
             #[cfg(feature = "embeddings")]
             vector_checkpoint_authority_match: VectorCheckpointAuthorityMatch::default(),
+            #[cfg(feature = "embeddings")]
+            deferred_vector_checkpoint: std::sync::Mutex::new(None),
             last_save: std::sync::Mutex::new(Instant::now()),
             last_mutation: std::sync::Mutex::new(Instant::now()),
             active_embed_passes: AtomicU32::new(0),
@@ -4744,10 +4772,16 @@ impl DaemonState {
             self.run_vector_checkpoint_reopen_hook();
             let live_tree = self.graph.resolved_tree();
             if live_tree != authority_graph.resolved_tree() {
+                let refusal = format!(
+                    "refusing vector checkpoint at repository generation {generation}: live exact tree does not match workspace authority"
+                );
+                // Record before returning. The caller logs this error and moves
+                // on, and nothing downstream of that log would remember the
+                // vectors were left undurable; the retry and every embedding
+                // surface both read the record instead.
+                self.record_deferred_vector_checkpoint(refusal.clone());
                 return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
-                    format!(
-                        "refusing vector checkpoint at repository generation {generation}: live exact tree does not match workspace authority"
-                    ),
+                    refusal,
                 )));
             }
             self.vector_checkpoint_authority_match
@@ -4763,10 +4797,78 @@ impl DaemonState {
             None,
         )
         .map_err(DaemonError::from)?;
+        // Cleared only after the sidecar write returns. Clearing on entry, or
+        // beside the authority proof above, would retire the record while the
+        // work it describes was still undurable, which is the state the record
+        // exists to keep visible.
+        self.clear_deferred_vector_checkpoint();
         if self.post_commit_finalization_pending.load(Ordering::SeqCst) {
             self.finalize_committed_generation(generation)?;
         }
         Ok(self.graph.embedding_status().pending)
+    }
+
+    /// Remember that a vector checkpoint was refused, so the work it left in
+    /// memory can be retried and named rather than silently abandoned.
+    #[cfg(feature = "embeddings")]
+    fn record_deferred_vector_checkpoint(&self, reason: String) {
+        if let Ok(mut deferred) = self.deferred_vector_checkpoint.lock() {
+            *deferred = Some(reason);
+        }
+    }
+
+    /// Retire the record once a checkpoint has actually written the sidecar.
+    #[cfg(feature = "embeddings")]
+    fn clear_deferred_vector_checkpoint(&self) {
+        if let Ok(mut deferred) = self.deferred_vector_checkpoint.lock() {
+            *deferred = None;
+        }
+    }
+
+    /// Why the last vector checkpoint was refused, while that refusal still
+    /// stands.
+    ///
+    /// `Some` means this daemon holds embedded vectors the sidecar does not,
+    /// so the coverage every counter reports is real for this process and would
+    /// not survive its exit. Embedding surfaces read this to say so instead of
+    /// rendering the shortfall as ordinary pending work on the next open. A
+    /// poisoned lock answers `None`: an unreadable record is not evidence of a
+    /// deferral, and the retry below is what closes the gap either way.
+    #[cfg(feature = "embeddings")]
+    pub fn deferred_vector_checkpoint(&self) -> Option<String> {
+        self.deferred_vector_checkpoint
+            .lock()
+            .ok()
+            .and_then(|deferred| deferred.clone())
+    }
+
+    #[cfg(not(feature = "embeddings"))]
+    pub fn deferred_vector_checkpoint(&self) -> Option<String> {
+        None
+    }
+
+    /// Re-attempt a checkpoint that was refused, and report what happened.
+    ///
+    /// `None` means nothing was deferred and no work was done, which is the
+    /// answer on every tick of an ordinary daemon. `Some(Ok(pending))` means
+    /// the sidecar was written and the vectors held since the refusal are now
+    /// durable. `Some(Err(_))` means the tree still disagrees with authority
+    /// and the record still stands, so a caller can back off rather than
+    /// reopening authority every tick.
+    ///
+    /// Deliberately a retry of the same call rather than a weaker second path:
+    /// the authority proof is the whole reason the first attempt refused, so a
+    /// retry that skipped it would checkpoint exactly the state the refusal was
+    /// protecting against.
+    #[cfg(feature = "embeddings")]
+    pub fn retry_deferred_vector_checkpoint(&self) -> Option<Result<usize>> {
+        self.deferred_vector_checkpoint()?;
+        Some(self.flush_embed_progress())
+    }
+
+    #[cfg(not(feature = "embeddings"))]
+    pub fn retry_deferred_vector_checkpoint(&self) -> Option<Result<usize>> {
+        None
     }
 
     #[cfg(not(feature = "embeddings"))]
@@ -5976,6 +6078,166 @@ mod tests {
                 .vector_checkpoint_authority_match
                 .holds(generation, &tree_after),
             "a refused flush must retain nothing"
+        );
+    }
+
+    /// The whole lifecycle the coverage regression was found in, driven end to
+    /// end: vectors are embedded, a change moves the live tree while the
+    /// checkpoint is being proved, the checkpoint is refused, and the
+    /// divergence then closes.
+    ///
+    /// The test above proves the refusal is correct and retains nothing. It
+    /// proves nothing about what happens to the vectors afterwards, and that is
+    /// where the work was going. `checkpoint_vector_index_for_graph` has one
+    /// caller in this daemon, and the embed worker only reaches it after a
+    /// batch embeds something, so a refusal on the last batch of a draining
+    /// queue had nothing left to retry it: the vectors stayed in memory, the
+    /// sidecar kept its older content, and the next open reported the shortfall
+    /// as ordinary pending work. On the rc0545c brown arm that read as a store
+    /// at 2112/2112 with zero pending, then 1770/2112 with 342 pending three
+    /// minutes later.
+    ///
+    /// So the assertions here are about durability rather than about the
+    /// refusal: the sidecar must be absent while the refusal stands, the
+    /// refusal must be recorded with its cause, and the retry must land the
+    /// vectors once the divergence closes, with the count intact on both sides.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn a_refused_vector_checkpoint_is_retried_and_its_vectors_survive() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+
+        // Stage completed work: a real index carrying vectors, attached to the
+        // live graph, with nothing durable behind it. Removing the file is what
+        // makes "did this checkpoint land" answerable by existence rather than
+        // by reading bytes the daemon has no API to compare.
+        const STAGED_VECTORS: usize = 3;
+        let vector_path = state.layout.kindb_vector_index_path();
+        let descriptor = kin_db::vector::IndexDescriptor {
+            model_id: Some("fixture-embedder-v1".to_string()),
+            graph_root: Some("fixture-root".to_string()),
+        };
+        let vectors = kin_db::VectorIndex::new(4).unwrap();
+        vectors.set_descriptor(descriptor.clone());
+        for slot in 0..STAGED_VECTORS {
+            let mut embedding = [0.0f32; 4];
+            embedding[slot] = 1.0;
+            vectors
+                .upsert(kin_model::EntityId::new(), &embedding)
+                .expect("the fixture index must accept a staged vector");
+        }
+        vectors.save(&vector_path).unwrap();
+        assert!(matches!(
+            state
+                .graph
+                .load_vector_index_compatible(&vector_path, &descriptor),
+            kin_db::vector::VectorIndexLoad::Loaded(STAGED_VECTORS)
+        ));
+        std::fs::remove_file(&vector_path).unwrap();
+        assert_eq!(
+            state.graph.vector_index_stats(),
+            Some((4, STAGED_VECTORS)),
+            "the live index must carry the staged vectors before anything is refused"
+        );
+        assert!(
+            state.deferred_vector_checkpoint().is_none(),
+            "nothing is deferred before the first refusal"
+        );
+
+        // A change lands while the checkpoint is proving the tree, which is what
+        // a commit in flight does to it.
+        let arriving = ArtifactId::new();
+        let arrived = LocatedEntry::new(
+            RepoPath::from_utf8("src/arrived_during_reopen.rs").unwrap(),
+            TreeEntry::blob(Hash256::from_bytes([9u8; 32]), false),
+        );
+        let moving_graph = Arc::clone(&state.graph);
+        let moved = Arc::new(AtomicBool::new(false));
+        let moved_seam = Arc::clone(&moved);
+        let arrived_seam = arrived.clone();
+        state.set_vector_checkpoint_reopen_test_hook(Some(Arc::new(move || {
+            // Once only. A seam that moved the tree on every reopen would model
+            // a repository nobody can ever checkpoint, not a commit that lands.
+            if moved_seam.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            moving_graph
+                .apply_transaction_delta(&kin_model::TransactionDelta {
+                    tree_deltas: vec![TreeDelta::Added {
+                        artifact_id: arriving,
+                        new: arrived_seam.clone(),
+                    }],
+                    ..Default::default()
+                })
+                .expect("the live graph must accept the concurrent mutation under test");
+        })));
+
+        let error = state
+            .flush_embed_progress()
+            .expect_err("a live tree that moved away from authority must be refused");
+        assert!(
+            moved.load(Ordering::SeqCst),
+            "the seam must actually have fired, or the refusal under test never happened"
+        );
+        assert!(
+            !vector_path.exists(),
+            "a refused checkpoint must write nothing, which is why the work needs retrying"
+        );
+        let deferred = state
+            .deferred_vector_checkpoint()
+            .expect("a refused checkpoint must be recorded, not logged once and abandoned");
+        assert!(
+            error.to_string().ends_with(&deferred),
+            "the record must carry the refusal's own cause, so every surface names why; \
+             recorded {deferred:?} against error {error}"
+        );
+        assert!(
+            deferred.contains("live exact tree does not match workspace authority"),
+            "expected the authority-mismatch refusal, got: {deferred}"
+        );
+        assert_eq!(
+            state.graph.vector_index_stats(),
+            Some((4, STAGED_VECTORS)),
+            "the refusal must not cost the vectors it declined to write"
+        );
+
+        // The divergence closes, the way it closes in a real store once the
+        // commit that opened it has settled.
+        state
+            .graph
+            .apply_transaction_delta(&kin_model::TransactionDelta {
+                tree_deltas: vec![TreeDelta::Removed {
+                    artifact_id: arriving,
+                    old: arrived,
+                }],
+                ..Default::default()
+            })
+            .expect("the live graph must accept the settling transition");
+
+        let pending = state
+            .retry_deferred_vector_checkpoint()
+            .expect("a standing refusal must give the retry something to do")
+            .expect("a settled tree must checkpoint");
+        assert!(
+            vector_path.exists(),
+            "the retry is the whole fix: the vectors must reach the sidecar (pending {pending})"
+        );
+        assert!(
+            state.deferred_vector_checkpoint().is_none(),
+            "a checkpoint that landed must retire the record it closed"
+        );
+        assert_eq!(
+            state.graph.vector_index_stats(),
+            Some((4, STAGED_VECTORS)),
+            "the staged vectors must still be indexed and counted after the whole lifecycle"
+        );
+
+        // And with nothing outstanding, the retry is a no-op rather than a
+        // standing authority reopen on every tick of the worker that calls it.
+        assert!(
+            state.retry_deferred_vector_checkpoint().is_none(),
+            "an unrefused daemon must not pay for a retry it does not need"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -6108,10 +6108,11 @@ mod tests {
         let init = kin_core::init(repo_dir.path()).unwrap();
         let state = test_state(init.layout, repo_dir.path());
 
-        // Stage completed work: a real index carrying vectors, attached to the
-        // live graph, with nothing durable behind it. Removing the file is what
-        // makes "did this checkpoint land" answerable by existence rather than
-        // by reading bytes the daemon has no API to compare.
+        // Stage completed work the product's own counter can see: vectors keyed
+        // to entities that are in graph truth, so `embedding_status().indexed`
+        // counts them rather than a raw index length that means nothing to a
+        // reader. Removing the sidecar afterwards is what makes "did this
+        // checkpoint land" answerable by existence.
         const STAGED_VECTORS: usize = 3;
         let vector_path = state.layout.kindb_vector_index_path();
         let descriptor = kin_db::vector::IndexDescriptor {
@@ -6121,10 +6122,12 @@ mod tests {
         let vectors = kin_db::VectorIndex::new(4).unwrap();
         vectors.set_descriptor(descriptor.clone());
         for slot in 0..STAGED_VECTORS {
+            let entity = test_entity(&format!("embedded_{slot}"), "src/lib.rs");
+            state.graph.upsert_entity(&entity).unwrap();
             let mut embedding = [0.0f32; 4];
             embedding[slot] = 1.0;
             vectors
-                .upsert(kin_model::EntityId::new(), &embedding)
+                .upsert_retrievable(kin_db::RetrievalKey::Entity(entity.id), &embedding)
                 .expect("the fixture index must accept a staged vector");
         }
         vectors.save(&vector_path).unwrap();
@@ -6135,10 +6138,11 @@ mod tests {
             kin_db::vector::VectorIndexLoad::Loaded(STAGED_VECTORS)
         ));
         std::fs::remove_file(&vector_path).unwrap();
+        let staged = state.graph.embedding_status();
         assert_eq!(
-            state.graph.vector_index_stats(),
-            Some((4, STAGED_VECTORS)),
-            "the live index must carry the staged vectors before anything is refused"
+            staged.indexed, STAGED_VECTORS,
+            "the counter every surface reads must see the staged coverage before anything is \
+             refused, or this test is about a number nobody renders"
         );
         assert!(
             state.deferred_vector_checkpoint().is_none(),
@@ -6197,8 +6201,8 @@ mod tests {
             "expected the authority-mismatch refusal, got: {deferred}"
         );
         assert_eq!(
-            state.graph.vector_index_stats(),
-            Some((4, STAGED_VECTORS)),
+            state.graph.embedding_status().indexed,
+            STAGED_VECTORS,
             "the refusal must not cost the vectors it declined to write"
         );
 
@@ -6228,9 +6232,35 @@ mod tests {
             "a checkpoint that landed must retire the record it closed"
         );
         assert_eq!(
-            state.graph.vector_index_stats(),
-            Some((4, STAGED_VECTORS)),
+            state.graph.embedding_status().indexed,
+            STAGED_VECTORS,
             "the staged vectors must still be indexed and counted after the whole lifecycle"
+        );
+
+        // And they are on disk rather than merely still in memory. Dropping the
+        // live index and re-reading the sidecar through the exact call
+        // `load_validated_vector_index` makes at open is what a restart does to
+        // this count, so the assertion after it is about bytes that survived
+        // rather than about a process that has not ended yet.
+        state.graph.reset_vector_index();
+        assert_eq!(
+            state.graph.embedding_status().indexed,
+            0,
+            "the control: with the live index dropped the count must come from disk alone"
+        );
+        assert!(
+            kin_db::SnapshotManager::load_vector_index_into_graph_if_valid(
+                state.graph.as_ref(),
+                &state.layout.kindb_snapshot_path(),
+                None,
+            )
+            .expect("the checkpointed sidecar must be readable"),
+            "the checkpointed sidecar must install through the daemon's own open-time path"
+        );
+        assert_eq!(
+            state.graph.embedding_status().indexed,
+            STAGED_VECTORS,
+            "a restart must read back every vector the retry checkpointed"
         );
 
         // And with nothing outstanding, the retry is a no-op rather than a


### PR DESCRIPTION
## What a refused checkpoint actually costs

A commit never discards completed vectors and never orphans them under the old generation. It leaves them undurable, which produces the same coverage regression one daemon later and reads exactly like loss.

The refusal in FIR-2497 is raised in kin, not kin-db: `crates/kin-daemon/src/state.rs:4749`, inside `flush_embed_progress`. When it fires the already-indexed vectors stay whole in the live in-memory vector index, which is why `kin graph status` kept counting all 2112 of them truthfully for the running daemon. They are simply never written to the sidecar.

Nothing else in the daemon writes it. `kin_db::SnapshotManager::checkpoint_vector_index_for_graph` has exactly one caller in kin (`state.rs:4760`), and the embedding worker only reaches that caller after a batch embeds something (`crates/kin-daemon/src/daemon.rs:2720`). So a refusal on the last batch of a draining queue had nothing left to retry it: the error was logged once at `daemon.rs:609` and every vector embedded since the previous successful checkpoint died with the process. `save_snapshot` cannot stand in for it either, because its local publication arm publishes enrichment and flushes the text index and carries no vector write.

That is the whole distance between the two readings on the rc0545c brown arm. The store read 2112/2112 with 0 pending at 00:35:16Z on the daemon that embedded them, and 1770/2112 with 342 pending at 00:38:19Z on the next one, which read a sidecar that never received the last window. The right word is undurable rather than lost in place, and that distinction is what kept the defect invisible: every counter was correct at the moment it was read.

## The fix

`DaemonState` records why the last checkpoint was refused and clears the record only after a sidecar write returns, never on entry and never beside the authority proof, because clearing early would retire the record while the work it describes was still in memory only.

**The live arm.** The embedding worker retries a standing refusal at the top of each wake tick. That tick is the one clock in the daemon that keeps running when there is no batch left to embed, which is precisely the state the work was being lost in. The retry is the same call rather than a weaker second path: the authority proof is the entire reason the first attempt refused, so a retry that skipped it would checkpoint exactly the state the refusal was protecting against. It backs off from the embed interval to a five minute ceiling, because proving the tree costs a full authority reopen that is linear in store size rather than in the batch, so an unbounded per-tick retry would be a worse bug than the one being fixed.

**The shutdown arm.** The live retry covers a daemon that keeps running. The regression was found on a daemon that STOPPED with a refusal standing, and nothing in the graph flush writes the vector sidecar, so a clean shutdown published graph truth and left the vectors in a process that was about to end. kin#994 landed tonight as `79979a37` and gave the final persistence flush its own budget (`KIN_DAEMON_SHUTDOWN_FLUSH_SECS`, five minutes), which removes the latency argument for leaving shutdown alone. The persistence task's shutdown arm is now a named function, `run_shutdown_persistence`, and it gives a standing refusal one unconditional attempt after the graph flush. After rather than before, because publishing advances the authority generation, which is exactly what closes the divergence a refusal is about.

That arm is a function rather than the body of a `select!` arm on purpose. A retry that exists and is never called from shutdown is the bug it was written to fix, and no test of the helper alone can tell those two apart. Making the wiring a named function is what puts it under test, and Pass D below is that test earning its place.

**The status line.** `kin graph status` names a standing refusal on the embeddings line. That clause is the only one there outside the `pending > 0` gate, and deliberately: every other clause explains a shortfall the counters are already showing, this one explains a shortfall they are not, and a drained queue reports zero pending in exactly that state. The clause says what is undurable and promises no number, because nothing on that path counts the vectors embedded since the refusal.

## Falsification

Six passes, each removing one property, each verified by reading the sabotaged source back before running, and each restored to a byte-identical tree afterwards.

**Pass A, carry-forward removed.** The lifecycle test failed at `state.rs:6220`, "a standing refusal must give the retry something to do". Both authority-match algebra tests passed, and a separate run of the three `flush_embed_progress` tests came back `3 passed; 0 failed`.

That last number is the finding worth keeping: with the fix removed the entire pre-existing suite is green, including the test proving the refusal itself is correct. Every existing guard asks whether the refusal is right and none asks what happens to the work afterwards.

**Pass B, deferral recording removed.** Failure at `state.rs:6188`, "a refused checkpoint must be recorded, not logged once and abandoned", with `2 passed; 1 failed`.

**Pass C, render clause removed.** Failure at `graph.rs:2344`, "a store reporting nothing pending must still disclose undurable coverage: Embeddings: 0/0 indexed (0 pending)". The message carries the line that actually rendered, which is the clean-counter case the clause exists for.

**Pass D, shutdown wiring removed.** The call deleted from `run_shutdown_persistence`, leaving the helper in place and unreachable, which is the exact shape a fix that covers only a running daemon takes. Failure at `daemon.rs:6177`, "shutdown must land a standing refusal rather than end with the vectors in memory", `2 passed; 1 failed`.

**Pass E, shutdown retry made unconditional, and the pass that failed to fail.** Removing the early return makes every clean exit pay an authority reopen and a sidecar write, the overcorrection kin#994's ceiling-not-an-amount property forbids. The control **passed it**. The fixture had opened a bare store with no vector index attached, so there was nothing a stray checkpoint could write and "no sidecar was written" held whatever the code did. The fixture now stages an attached index and removes the sidecar so a write is visible; the same sabotage then fails at `daemon.rs:6266`, "a shutdown with nothing refused must not checkpoint the vector sidecar at all", with the shutdown-lands test still green. Both directions hold now: removing the wiring loses the work, making it unconditional taxes every clean exit.

**Pass F, render clause made unconditional.** Failure on the clean-counter control, carrying the noise it prevents, rendered on a healthy store:

```
Embeddings: 0/0 indexed (0 pending); the last vector checkpoint was refused (), so vectors
embedded since then are in this daemon's memory rather than on disk and a restart re-derives
them; the daemon retries the checkpoint until it lands
```

One assertion failed on its first honest run and was corrected rather than loosened: `DaemonError::Graph` prefixes its display, so the recorded cause is a suffix of the error rather than equal to it.

## Gates

Run through `bin/kin-lane run vecregress kin`, worktree `.kin-coord/worktrees/vecregress-kin`, every exit status read raw rather than through a pipe.

- `cargo test -p kin-daemon --lib` over the three lifecycle tests: exit 0, `3 passed; 0 failed`
- `cargo test -p kin-cli --lib commands::graph::tests`: exit 0, `49 passed; 0 failed`
- `cargo fmt --all -- --check`: exit 0
- `scripts/verify-zero-file-search.py`: exit 0, 177 source files
- `scripts/zero_file_search_guard.sh`: exit 0
- `scripts/check_runtime_boundaries.sh`: exit 0
- `scripts/check_private_repo_coupling.sh`: exit 0
- `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`; `git diff origin/main --stat -- Cargo.lock .cargo/` is empty

`cargo clippy --all-targets --all-features` with the 45 lint debt allow-list from `.github/clippy-allowed-lints.txt` under `RUSTFLAGS=-D warnings`, exactly as ci.yml runs it: exit 0.

**Local full gate not run under tonight's slot saturation; hosted CI (37 checks, all concluded, 0 failures) is the gate of record for this PR.** Two local `bin/kin-dev local-test kin` runs were interrupted by SIGTERM at 1960 and 2374 of 6629 tests with zero failures before the signal, and neither counts as a pass. The kill arrives at the lane session's turn boundary rather than from the gate, and each one costs a build slot other lanes are waiting on.

Hosted CI on head `ae40b99d`, every check by name:

```
SKIPPED  Check & Test
SKIPPED  Code Coverage
SKIPPED  Feature permutation tests
SKIPPED  Windows installer + vector release build
SUCCESS  Analyze (actions)
SUCCESS  Analyze (c-cpp)
SUCCESS  Analyze (csharp)
SUCCESS  Analyze (go)
SUCCESS  Analyze (javascript-typescript)
SUCCESS  Analyze (python)
SUCCESS  Analyze (ruby)
SUCCESS  Analyze (rust)
SUCCESS  Capability Contract Canary
SUCCESS  cargo-deny
SUCCESS  Check & Test (macos-latest)
SUCCESS  Check & Test (ubuntu-latest)
SUCCESS  Check & Test macOS shard (1)
SUCCESS  Check & Test macOS shard (2)
SUCCESS  Classify diff scope
SUCCESS  Classify diff scope
SUCCESS  CodeQL
SUCCESS  DCO sign-off
SUCCESS  DCO Sign-off
SUCCESS  Docker Image Build (no push)
SUCCESS  Falsify guards
SUCCESS  Feature permutation tests (macos-latest)
SUCCESS  Feature permutation tests (ubuntu-latest)
SUCCESS  gitleaks (full history)
SUCCESS  Install Proof (PR) / ubuntu-latest
SUCCESS  Install Proof (PR) Build
SUCCESS  Install Proof (PR) Gate
SUCCESS  Linux Daemon Smoke + MCP Headless
SUCCESS  npm launcher tests
SUCCESS  PR text hygiene
SUCCESS  Windows authority CLI tests
SUCCESS  Windows authority runtime tests
SUCCESS  Windows authority tests
```

33 SUCCESS, 4 SKIPPED, 0 failures. `Check & Test (ubuntu-latest)`, `Check & Test (macos-latest)` and both macOS shards are the hosted equivalents of the local gate, and `Falsify guards` is the leg that drives the Zero File-Search guards in both directions.

## What this does not close

`Refs` rather than `Closes`. Ask 1 on the ticket is closer to true because the work now reaches disk instead of waiting for a batch that never comes, but the `kin embed` wording itself was not touched. Ask 3 is met for `kin graph status` and the `/commands/resources` payload; `kin health` renders its vector clause through a different function and was not extended.

The residual window, stated plainly so this squash message says exactly what is and is not durable: a daemon killed outright (SIGKILL, an OOM, a power loss) still loses every vector embedded since its last successful checkpoint, because no shutdown arm runs on that path; the two retries cover a daemon that lives past the first retry interval and a daemon that exits cleanly. The per-batch checkpoint also stays throttled while a queue drains, so the window a hard kill costs is the last throttle interval rather than zero, and nothing here makes that window smaller.

The other half of the 342 is filed as **FIR-2562**. At daemon open, kin-db's stamp-drift salvage already computes `retained`, `evicted_orphans`, `retired_artifact_vectors` and `retired_stale_entity_heads` and logs them, but `load_vector_index_into_graph_if_valid` returns a bare `bool`, so `DaemonState::load_validated_vector_index` sees `Ok(true)`, records nothing, and the resulting shortfall renders as ordinary pending work. Closing that needs a kin-db API change and a registry publish train.

Refs FIR-2497
