### PR TITLE
Compare the relation census to the one this store last recorded

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1780,10 +1780,10 @@ mod tests {
         );
         assert!(
             unchanged
-                .lines
-                .iter()
-                .any(|line| line.contains("No issues detected")),
-            "the control reaches the all-clear, so its absence below means something: {}",
+                .relation_census
+                .as_ref()
+                .is_some_and(|census| !census.reports_loss()),
+            "the control withholds nothing, so the second arm's warning means something: {}",
             unchanged.lines.join("\n")
         );
 
@@ -1809,9 +1809,17 @@ mod tests {
         )
         .unwrap();
         let rendered = lost.lines.join("\n");
+        // The marker prefix is the assertion that matters. A `⚠` line exists
+        // only when the warnings vector is non-empty, and the all-clear prints
+        // only when that vector is empty, so this proves the loss reached the
+        // branch that suppresses "No issues detected". Asserting the absence of
+        // the all-clear string directly cannot prove it here: this fixture
+        // raises unrelated warnings of its own (pending embeddings, uniform
+        // roles), so that line is unreachable in both arms and the assertion
+        // would pass whether or not the census did anything.
         assert!(
-            !rendered.contains("No issues detected"),
-            "a store that lost a whole relation kind is not issue-free: {rendered}"
+            rendered.contains("⚠ relation kind UsesType lost every edge it held"),
+            "the loss is raised as a warning, which is what withholds the all-clear: {rendered}"
         );
         assert!(
             rendered.contains("UsesType went 1 to 0"),
@@ -1856,8 +1864,15 @@ mod tests {
             "the row states what it cannot do: {rendered}"
         );
         assert!(
-            rendered.contains("No issues detected"),
-            "an unrecorded census is not an issue: {rendered}"
+            !rendered.contains("⚠ relation kind"),
+            "an unrecorded census raises no warning of its own: {rendered}"
+        );
+        assert!(
+            response
+                .relation_census
+                .as_ref()
+                .is_some_and(|census| !census.reports_loss()),
+            "and reports no loss to doctor either"
         );
     }
 

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -2761,6 +2761,7 @@ mod tests {
             &drained_graph,
             &Default::default(),
             &crate::commands::resources::EmbedRuntimeState::default(),
+            &Default::default(),
         )
         .unwrap();
         assert!(
@@ -2780,6 +2781,7 @@ mod tests {
                 deferred_vector_checkpoint: Some(REFUSAL.to_string()),
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         let drained_line = drained
@@ -2821,6 +2823,7 @@ mod tests {
                 deferred_vector_checkpoint: Some(REFUSAL.to_string()),
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         let filling_line = filling
@@ -2848,6 +2851,7 @@ mod tests {
             &filling_graph,
             &Default::default(),
             &crate::commands::resources::EmbedRuntimeState::default(),
+            &Default::default(),
         )
         .unwrap();
         let filling_quiet_line = filling_quiet

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anyhow::{Context, Result};
 use kin_mcp::handlers::common::presentation_span_lines;
@@ -38,6 +38,15 @@ pub struct GraphCommandResponse {
     /// an older daemon sends none at all.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reference_edge_coverage: Option<kin_core::reference_coverage::ReferenceEdgeCoverage>,
+    /// The relation-kind census set beside the one this store last recorded.
+    ///
+    /// Carried structurally as well as in `lines` so `kin doctor` reads the
+    /// comparison rather than parsing prose out of a terminal rendering, which
+    /// is how the reference-edge coverage beside it reaches the same surface.
+    /// Optional because a subcommand that compares nothing has none to report
+    /// and an older daemon sends none at all.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relation_census: Option<kin_core::relation_census::RelationCensusComparison>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -247,10 +256,11 @@ pub fn execute_graph_command(
     request: &GraphCommandRequest,
     reconcile: &crate::commands::resources::ReconcileHealth,
     embedding_runtime: &crate::commands::resources::EmbedRuntimeState,
+    census: &kin_core::relation_census::CensusContext,
 ) -> Result<GraphCommandResponse> {
     match request {
         GraphCommandRequest::Status => {
-            build_graph_status_response(authority, graph, reconcile, embedding_runtime)
+            build_graph_status_response(authority, graph, reconcile, embedding_runtime, census)
         }
         GraphCommandRequest::Validate => build_graph_validate_response(authority, graph),
         GraphCommandRequest::Inspect { name } => build_graph_inspect_response(graph, name),
@@ -310,6 +320,45 @@ fn graph_relation_totals(
     }
 }
 
+/// The relation-kind census, in the one form the durable record and the status
+/// row both read.
+///
+/// Formatting lives here rather than at each call site because the recorded
+/// census and the compared census have to key on the same strings. A record
+/// written as `UsesType` and read as `uses_type` would report every kind as
+/// vanished and every kind as new on the same screen.
+fn kind_census(counts: &HashMap<RelationKind, usize>) -> BTreeMap<String, u64> {
+    counts
+        .iter()
+        .map(|(kind, count)| (format!("{kind:?}"), *count as u64))
+        .collect()
+}
+
+/// Take the entity-rooted relation-kind census of `graph`.
+///
+/// Entity-rooted, and de-duplicated by relation id, because that is exactly
+/// what the `Entity-to-entity relation kinds` line reports: an edge reachable
+/// from both endpoints is one edge. A census taken any other way would compare
+/// a different measurement against the printed one and report movement that
+/// never happened.
+///
+/// Deliberately not `graph_stats()`, which counts the whole relation table and
+/// probes the text and vector indexes once per entity on the way. Those probes
+/// are the cost `kin graph status` is already known for, and the writers of this
+/// record are a sweep and a commit, neither of which should pay it.
+pub fn measure_relation_census(graph: &kin_db::InMemoryGraph) -> Result<BTreeMap<String, u64>> {
+    let mut counts: HashMap<RelationKind, usize> = HashMap::new();
+    let mut seen = HashSet::new();
+    for entity in graph.list_all_entities()? {
+        for relation in graph.get_all_relations_for_entity(&entity.id)? {
+            if seen.insert(relation.id) {
+                *counts.entry(relation.kind).or_insert(0) += 1;
+            }
+        }
+    }
+    Ok(kind_census(&counts))
+}
+
 /// The one line that answers "how much of this repository can I query".
 ///
 /// Pure so both arms are testable without a store. A repository with nothing
@@ -333,6 +382,7 @@ fn build_graph_status_response(
     graph: &kin_db::InMemoryGraph,
     reconcile: &crate::commands::resources::ReconcileHealth,
     embedding_runtime: &crate::commands::resources::EmbedRuntimeState,
+    census: &kin_core::relation_census::CensusContext,
 ) -> Result<GraphCommandResponse> {
     // One sample for every embedding line in this response. The counter below
     // and the health warning used to sample coverage independently, and an
@@ -547,6 +597,20 @@ fn build_graph_status_response(
         "Entity-to-entity relation kinds: {}",
         rel_parts.join(", ")
     ));
+    // The line above is a census, and until this one existed it was compared to
+    // nothing. A store that lost an entire relation kind printed the histogram
+    // that proved it and then printed the all-clear: on the rc0545c run
+    // `UsesType` went 94 to 0 in 36 minutes under `✓ No issues detected.` This
+    // row sits directly beneath the histogram because it is the histogram's
+    // own reading, and it renders in every state, including the two where
+    // nothing can be compared. A row that fell silent when it had no previous
+    // census would be indistinguishable from one reporting a healthy store.
+    let census_comparison = kin_core::relation_census::RelationCensusComparison::build(
+        &census.previous,
+        &kind_census(&relation_counts),
+        census.causes.clone(),
+    );
+    lines.push(census_comparison.summary_line());
 
     // Kind distribution
     let mut kind_pairs: Vec<_> = kind_counts.iter().collect();
@@ -755,6 +819,13 @@ fn build_graph_status_response(
     for reason in reconcile.degraded_reasons() {
         warnings.push(format!("reconcile loop degraded — {reason}"));
     }
+    // Warnings rather than criticals, for the reason stated directly above:
+    // criticals set the response error and would turn `kin graph status`
+    // nonzero for every caller scripting it. A lost relation kind is a real
+    // defect in graph truth and it must withhold the all-clear, which a warning
+    // does; changing an exit code is a separate decision from killing a false
+    // all-clear, and only the second is what this closes.
+    warnings.extend(census_comparison.loss_lines());
     if warnings.is_empty() && criticals.is_empty() {
         lines.push(String::new());
         lines.push("✓ No issues detected.".to_string());
@@ -786,6 +857,7 @@ fn build_graph_status_response(
             .then(|| format!("{} critical graph health issue(s) found", criticals.len())),
         source: None,
         reference_edge_coverage: Some(health.reference_edge_coverage.clone()),
+        relation_census: Some(census_comparison),
     })
 }
 
@@ -978,6 +1050,7 @@ fn build_graph_validate_response(
         error: (!issues.is_empty()).then(|| format!("{} issue(s) found", issues.len())),
         source: None,
         reference_edge_coverage: Some(health.reference_edge_coverage.clone()),
+        relation_census: None,
     })
 }
 
@@ -1001,6 +1074,7 @@ fn build_graph_inspect_response(
             error: Some(format!("no entity found matching '{}'", name)),
             source: None,
             reference_edge_coverage: None,
+            relation_census: None,
         });
     }
 
@@ -1048,6 +1122,7 @@ fn build_graph_inspect_response(
         error: None,
         source: None,
         reference_edge_coverage: None,
+        relation_census: None,
     })
 }
 
@@ -1213,6 +1288,7 @@ pub fn build_graph_source_response(
                 error: None,
                 source: Some(record),
                 reference_edge_coverage: None,
+                relation_census: None,
             })
         }
         EntitySourceOutcome::NotFound(message) => Ok(GraphCommandResponse {
@@ -1220,6 +1296,7 @@ pub fn build_graph_source_response(
             error: Some(message),
             source: None,
             reference_edge_coverage: None,
+            relation_census: None,
         }),
         // A valid entity with no retrievable source is an error for the text/`?`
         // command paths (the CLI `kin graph source` and `trace_data_flow`, which
@@ -1631,6 +1708,159 @@ mod tests {
         (temp, binding, kin_db::InMemoryGraph::new())
     }
 
+    /// The rc0545c case, driven end to end through the record this store
+    /// actually carries.
+    ///
+    /// A census is taken and written for the store, the graph then loses a
+    /// whole relation kind, and status is asked again against the same layout.
+    /// The two arms share one fixture and differ only in whether `UsesType`
+    /// still has an edge, so a pass in the first arm is the control that makes
+    /// the second arm's failure mean something: without it, a build that never
+    /// printed the all-clear at all would read as a pass.
+    #[test]
+    fn a_relation_kind_that_vanished_since_the_recorded_census_refuses_no_issues() {
+        let temp = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(temp.path()).unwrap();
+        let layout = initialized.layout.clone();
+        let binding =
+            kin_core::LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+
+        let enriched = kin_db::InMemoryGraph::new();
+        let caller = test_entity("run_task");
+        let callee = test_entity("finalize");
+        let typed = test_entity("Payload");
+        for entity in [&caller, &callee, &typed] {
+            enriched.upsert_entity(entity).unwrap();
+        }
+        enriched
+            .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
+            .unwrap();
+        enriched
+            .upsert_relation(&test_relation(RelationKind::UsesType, caller.id, typed.id))
+            .unwrap();
+
+        // What a completed sweep records. Taken through the same measurement
+        // the status row compares against, which is the point of the shared
+        // function: a record written by one walk and read by another would
+        // report movement no graph ever made.
+        let recorded = kin_core::relation_census::RelationCensus::new(
+            chrono::Utc::now(),
+            kin_core::relation_census::CensusSource::Sweep,
+            measure_relation_census(&enriched).unwrap(),
+            Vec::new(),
+        );
+        assert_eq!(
+            recorded.kinds.get("UsesType"),
+            Some(&1),
+            "the recorded census holds the kind that is about to be lost: {:?}",
+            recorded.kinds
+        );
+        kin_core::relation_census::write(&layout, &recorded).unwrap();
+
+        // The control. Nothing has been lost yet, so the census row withholds
+        // nothing and the all-clear is reachable.
+        let unchanged = build_graph_status_response(
+            &pinned(&binding),
+            &enriched,
+            &Default::default(),
+            &Default::default(),
+            &kin_core::relation_census::CensusContext::for_layout(
+                &layout,
+                Vec::<(String, String)>::new(),
+            ),
+        )
+        .unwrap();
+        assert!(
+            !unchanged
+                .lines
+                .iter()
+                .any(|line| line.contains("relation kind UsesType")),
+            "an unchanged census reports no loss: {}",
+            unchanged.lines.join("\n")
+        );
+        assert!(
+            unchanged
+                .lines
+                .iter()
+                .any(|line| line.contains("No issues detected")),
+            "the control reaches the all-clear, so its absence below means something: {}",
+            unchanged.lines.join("\n")
+        );
+
+        // The kind is disabled. This is what `KIN_DAEMON_DISABLE_LSP=1` did to
+        // the stranger's store: the edges were re-derived without it.
+        let stripped = kin_db::InMemoryGraph::new();
+        for entity in [&caller, &callee, &typed] {
+            stripped.upsert_entity(entity).unwrap();
+        }
+        stripped
+            .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
+            .unwrap();
+
+        let lost = build_graph_status_response(
+            &pinned(&binding),
+            &stripped,
+            &Default::default(),
+            &Default::default(),
+            &kin_core::relation_census::CensusContext::for_layout(
+                &layout,
+                vec![("KIN_DAEMON_DISABLE_LSP".to_string(), "1".to_string())],
+            ),
+        )
+        .unwrap();
+        let rendered = lost.lines.join("\n");
+        assert!(
+            !rendered.contains("No issues detected"),
+            "a store that lost a whole relation kind is not issue-free: {rendered}"
+        );
+        assert!(
+            rendered.contains("UsesType went 1 to 0"),
+            "the loss is named with both counts: {rendered}"
+        );
+        assert!(
+            rendered.contains("KIN_DAEMON_DISABLE_LSP"),
+            "the recorded cause is named beside the loss: {rendered}"
+        );
+        assert!(
+            lost.relation_census
+                .as_ref()
+                .is_some_and(|census| census.reports_loss()),
+            "doctor reads the same verdict structurally rather than by parsing prose"
+        );
+    }
+
+    /// The absent arm, so the row above cannot be trivially true. A store with
+    /// no recorded census says it cannot compare, and says nothing about health.
+    #[test]
+    fn a_store_with_no_recorded_census_says_so_and_still_reaches_the_all_clear() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        let caller = test_entity("run_task");
+        let callee = test_entity("finalize");
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_entity(&callee).unwrap();
+        graph
+            .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
+            .unwrap();
+
+        let response = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
+        let rendered = response.lines.join("\n");
+        assert!(
+            rendered.contains("no previous relation census is recorded"),
+            "the row states what it cannot do: {rendered}"
+        );
+        assert!(
+            rendered.contains("No issues detected"),
+            "an unrecorded census is not an issue: {rendered}"
+        );
+    }
+
     /// The exact reported failure. `kin graph status` on the umbrella store
     /// printed "No issues detected" while the daemon had failed every
     /// whole-tree admission since Aug 6, because every check this command runs
@@ -1657,6 +1887,7 @@ mod tests {
             &graph,
             &Default::default(),
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
         assert!(
@@ -1678,6 +1909,7 @@ mod tests {
                 last_admission_success_age_seconds: Some(172_800),
                 ..Default::default()
             },
+            &Default::default(),
             &Default::default(),
         )
         .unwrap();
@@ -1727,6 +1959,7 @@ mod tests {
                 ..Default::default()
             },
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
         assert!(
@@ -1768,6 +2001,7 @@ mod tests {
                 last_error_age_seconds: Some(90),
                 ..Default::default()
             },
+            &Default::default(),
             &Default::default(),
         )
         .unwrap();
@@ -1846,6 +2080,7 @@ mod tests {
             &graph,
             &Default::default(),
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
 
@@ -1904,6 +2139,7 @@ mod tests {
         let response = build_graph_status_response(
             &pinned(&binding),
             &graph,
+            &Default::default(),
             &Default::default(),
             &Default::default(),
         )
@@ -1966,6 +2202,7 @@ mod tests {
             &graph,
             &Default::default(),
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
 
@@ -2020,6 +2257,7 @@ mod tests {
             &graph,
             &Default::default(),
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
 
@@ -2059,6 +2297,7 @@ mod tests {
         let response = build_graph_status_response(
             &pinned(&binding),
             &graph,
+            &Default::default(),
             &Default::default(),
             &Default::default(),
         )
@@ -2271,6 +2510,7 @@ mod tests {
                 embedding_coverage_ever_complete: true,
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         let embeddings_line = no_sidecar
@@ -2321,6 +2561,7 @@ mod tests {
             &graph,
             &Default::default(),
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
         let first_fill_line = first_fill
@@ -2364,6 +2605,7 @@ mod tests {
                 embed_persistence_unavailable: true,
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         let embeddings_line = remote
@@ -2411,6 +2653,7 @@ mod tests {
                 embedding_coverage_ever_complete: true,
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         let embeddings_line = discarded
@@ -2457,6 +2700,7 @@ mod tests {
                 embedding_coverage_ever_complete: true,
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         assert!(
@@ -2639,6 +2883,7 @@ mod tests {
                 model_fetch: kin_cli_model_fetch(137 * 1024 * 1024, true),
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         let embeddings_line = downloading
@@ -2665,6 +2910,7 @@ mod tests {
                 model_fetch: kin_cli_model_fetch(0, false),
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         let cached_line = cached
@@ -2714,6 +2960,7 @@ mod tests {
             &graph,
             &Default::default(),
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
 
@@ -2751,6 +2998,7 @@ mod tests {
         let response = build_graph_status_response(
             &pinned(&binding),
             &graph,
+            &Default::default(),
             &Default::default(),
             &Default::default(),
         )
@@ -3732,6 +3980,7 @@ mod tests {
         let status = build_graph_status_response(
             &pinned(&binding),
             &graph,
+            &Default::default(),
             &Default::default(),
             &Default::default(),
         )

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -2432,6 +2432,7 @@ mod tests {
                 embedding_coverage_ever_complete: true,
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         let ever_complete_line = ever_complete
@@ -2463,6 +2464,7 @@ mod tests {
         let first_fill = build_graph_status_response(
             &pinned(&binding),
             &graph,
+            &Default::default(),
             &Default::default(),
             &Default::default(),
         )

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -192,6 +192,7 @@ pub async fn run_health_checks() -> HealthReport {
     // operator is most likely to be running doctor because something is wrong.
     let graph_status = RunGraphStatus::for_run();
     checks.push(check_reference_edge_coverage(&graph_status).await);
+    checks.push(check_relation_census(&graph_status).await);
     checks.push(check_background_work().await);
     checks.push(check_embedding_model().await);
     checks.push(check_commit_memory_headroom());
@@ -2797,6 +2798,122 @@ async fn fetch_graph_status() -> GraphStatusForRun {
     }
 }
 
+/// Report whether this store has lost relation coverage it once held.
+///
+/// The relation-kind histogram `kin graph status` prints is a census, and until
+/// this row existed nothing compared it to anything. On the rc0545c stranger
+/// run a store went from 1985 entity-to-entity relations to 1807 and lost the
+/// `UsesType` kind entirely, from 94 edges to none, and the health line
+/// underneath the numbers that proved it read `✓ No issues detected.` Every
+/// counter needed to notice was on the screen. Nothing on the screen noticed.
+///
+/// The comparison is read structurally off the graph command rather than parsed
+/// out of its rendered lines, exactly as the reference-edge coverage above it
+/// is, so a wording change on one surface cannot silently break the other.
+async fn check_relation_census(graph_status: &RunGraphStatus) -> HealthCheck {
+    let response = match relation_census_row_for_unread_graph(graph_status.get().await) {
+        Ok(response) => response,
+        Err(row) => return row,
+    };
+    let Some(comparison) = response.relation_census.as_ref() else {
+        return HealthCheck::new(
+            "relation_census",
+            "Relation census",
+            HealthStatus::Stale,
+            "the daemon serving this repository does not report a relation census; it predates \
+             the measurement",
+        )
+        .with_manual_fix("restart the daemon with `kin daemon restart` to pick up this build");
+    };
+    relation_census_health(comparison)
+}
+
+/// This row's words for a graph status the run could not read, or the response
+/// when it could.
+fn relation_census_row_for_unread_graph(
+    status: &GraphStatusForRun,
+) -> Result<&crate::commands::graph::GraphCommandResponse, HealthCheck> {
+    const ID: &str = "relation_census";
+    const LABEL: &str = "Relation census";
+
+    match status {
+        GraphStatusForRun::Answered(response) => Ok(response),
+        GraphStatusForRun::NotInRepository => Err(HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Unsupported,
+            "n/a — not in a Kin repository",
+        )),
+        GraphStatusForRun::NoDaemon => Err(HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Unsupported,
+            "n/a — no daemon running for this repository, so the relation census cannot be \
+             read; a daemon starts on first use",
+        )
+        .with_manual_fix("run any `kin` command in the repo to auto-start the daemon")),
+        GraphStatusForRun::DaemonUrlInvalid { daemon_url, error } => Err(HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Stale,
+            format!("daemon reachable ({daemon_url}), but its URL is invalid: {error}"),
+        )
+        .with_manual_fix("check the daemon URL recorded for this repository")),
+        GraphStatusForRun::Unavailable { daemon_url, error } => Err(HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Stale,
+            format!(
+                "daemon reachable ({daemon_url}), but the relation census is unavailable: \
+                 {error}"
+            ),
+        )
+        .with_manual_fix("run `kin graph status` and resolve the reported daemon error")),
+    }
+}
+
+/// Turn the comparison into a verdict, split from its fetch so the rule is
+/// testable without a daemon.
+///
+/// A lost kind reads `Stale` rather than `Missing`: the store held those edges
+/// and no longer does, which is drift rather than a broken install, and a row
+/// that blocked readiness on it would refuse every repository whose enrichment
+/// is legitimately narrower than its last pass. It still counts as attention,
+/// so the doctor summary can no longer report a whole-kind loss as a pass.
+pub(crate) fn relation_census_health(
+    comparison: &kin_core::relation_census::RelationCensusComparison,
+) -> HealthCheck {
+    const ID: &str = "relation_census";
+    const LABEL: &str = "Relation census";
+
+    if let Some(unavailable) = &comparison.unavailable {
+        // Pending, not healthy. A store with no baseline is not a store that
+        // kept its coverage; it is one nothing can answer the question about
+        // yet, and those must not render the same.
+        return HealthCheck::new(ID, LABEL, HealthStatus::Pending, unavailable.clone())
+            .with_manual_fix(
+                "run `kin commit`, or let the enrichment sweep finish, to record the first census",
+            );
+    }
+    let losses = comparison.loss_lines();
+    if losses.is_empty() {
+        return HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Healthy,
+            format!(
+                "no relation kind has lost ground since the last recorded census ({} kind(s) \
+                 compared)",
+                comparison.changes.len()
+            ),
+        );
+    }
+    HealthCheck::new(ID, LABEL, HealthStatus::Stale, losses.join("; ")).with_manual_fix(
+        "compare `kin graph status` against the named cause, then re-run enrichment with it \
+         cleared",
+    )
+}
+
 /// The row for every state where the graph itself could not be read.
 ///
 /// It still reports the host probe, because that needed no daemon. Reporting
@@ -3923,6 +4040,96 @@ mod tests {
             check.detail
         );
         assert!(check.manual_fix.is_some());
+    }
+
+    fn census_pair(
+        previous: &[(&str, u64)],
+        current: &[(&str, u64)],
+        causes: Vec<String>,
+    ) -> kin_core::relation_census::RelationCensusComparison {
+        let recorded = kin_core::relation_census::RelationCensus::new(
+            chrono::Utc::now(),
+            kin_core::relation_census::CensusSource::Sweep,
+            previous
+                .iter()
+                .map(|(kind, count)| ((*kind).to_string(), *count))
+                .collect(),
+            Vec::new(),
+        );
+        kin_core::relation_census::RelationCensusComparison::build(
+            &kin_core::relation_census::RelationCensusRead::Recorded(recorded),
+            &current
+                .iter()
+                .map(|(kind, count)| ((*kind).to_string(), *count))
+                .collect(),
+            causes,
+        )
+    }
+
+    /// The rc0545c shape, at the doctor row. A store that lost a whole relation
+    /// kind must not be tallied as a pass.
+    #[test]
+    fn doctor_reports_a_relation_kind_that_vanished_since_the_recorded_census() {
+        let check = relation_census_health(&census_pair(
+            &[("Calls", 951), ("UsesType", 94)],
+            &[("Calls", 940)],
+            vec!["KIN_DAEMON_DISABLE_LSP set to non-default value \"1\"".to_string()],
+        ));
+        assert!(
+            matches!(check.status, HealthStatus::Stale),
+            "a lost kind needs attention: {:?}",
+            check.status
+        );
+        assert!(
+            check.detail.contains("UsesType went 94 to 0"),
+            "{}",
+            check.detail
+        );
+        assert!(
+            check.detail.contains("KIN_DAEMON_DISABLE_LSP"),
+            "the row carries the cause: {}",
+            check.detail
+        );
+    }
+
+    /// The counterpart, so the row above cannot be an unconditional warning.
+    #[test]
+    fn doctor_stays_green_when_no_relation_kind_lost_ground() {
+        let check = relation_census_health(&census_pair(
+            &[("Calls", 940), ("UsesType", 94)],
+            &[("Calls", 951), ("UsesType", 94)],
+            Vec::new(),
+        ));
+        assert!(
+            matches!(check.status, HealthStatus::Healthy),
+            "growth is not a loss: {:?} {}",
+            check.status,
+            check.detail
+        );
+    }
+
+    /// A store with no baseline cannot answer the question, and must not read
+    /// the same as one that kept its coverage.
+    #[test]
+    fn doctor_separates_a_store_with_no_recorded_census_from_a_healthy_one() {
+        let check =
+            relation_census_health(&kin_core::relation_census::RelationCensusComparison::build(
+                &kin_core::relation_census::RelationCensusRead::Absent,
+                &std::collections::BTreeMap::from([("Calls".to_string(), 940)]),
+                Vec::new(),
+            ));
+        assert!(
+            matches!(check.status, HealthStatus::Pending),
+            "an unrecorded census is pending, never healthy: {:?}",
+            check.status
+        );
+        assert!(
+            check
+                .detail
+                .contains("no previous relation census is recorded"),
+            "{}",
+            check.detail
+        );
     }
 
     /// The counterpart, so the row above cannot be an unconditional warning:

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -4232,6 +4232,7 @@ mod tests {
             reference_edge_coverage: Some(
                 kin_core::reference_coverage::ReferenceEdgeCoverage::default(),
             ),
+            relation_census: Some(census_pair(&[], &[], Vec::new())),
         }))
     }
 
@@ -4242,7 +4243,7 @@ mod tests {
     /// psf/requests store against 0.091 s on express, so a second fetch does not
     /// cost a little more, it roughly doubles the wall time of a doctor run on
     /// exactly the stores where an operator is most likely to be running doctor.
-    /// Three consumers here rather than the one the tree holds today, because the
+    /// Three consumers here rather than the two the tree holds today, because the
     /// cost this pins is the one a fourth row would add.
     #[tokio::test]
     async fn one_doctor_run_fetches_graph_status_once_however_many_rows_read_it() {
@@ -4319,18 +4320,22 @@ mod tests {
             ),
         ];
         for (status, expected) in unreadable {
-            let row = coverage_row_for_unread_graph(&status, &no_servers)
+            let coverage_row = coverage_row_for_unread_graph(&status, &no_servers)
                 .expect_err("an unread graph must produce a row rather than a response");
-            assert!(
-                !matches!(row.status, HealthStatus::Healthy),
-                "an unread graph must never render as healthy: {status:?} gave {:?}",
-                row.status
-            );
-            assert!(
-                row.detail.contains(expected),
-                "the row must name what happened: {status:?} gave {}",
-                row.detail
-            );
+            let census_row = relation_census_row_for_unread_graph(&status)
+                .expect_err("an unread graph must reach the census row too");
+            for row in [coverage_row, census_row] {
+                assert!(
+                    !matches!(row.status, HealthStatus::Healthy),
+                    "an unread graph must never render as healthy: {status:?} gave {:?}",
+                    row.status
+                );
+                assert!(
+                    row.detail.contains(expected),
+                    "the row must name what happened: {status:?} gave {}",
+                    row.detail
+                );
+            }
         }
 
         // And the readable case still yields the response, or the four arms
@@ -4338,7 +4343,11 @@ mod tests {
         // measurement.
         assert!(
             coverage_row_for_unread_graph(&answered_graph_status(), &no_servers).is_ok(),
-            "a graph the run did read must hand its response to the row"
+            "a graph the run did read must hand its response to the coverage row"
+        );
+        assert!(
+            relation_census_row_for_unread_graph(&answered_graph_status()).is_ok(),
+            "a graph the run did read must hand its response to the census row"
         );
     }
 

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -211,6 +211,7 @@ fn graph_status(
         &GraphCommandRequest::Status,
         &Default::default(),
         &Default::default(),
+        &Default::default(),
     )
     .expect("run graph status")
 }
@@ -263,6 +264,59 @@ fn graph_status_passes_on_a_healthy_freshly_admitted_repository() {
     );
 }
 
+/// The recorded census and the printed histogram must be the same measurement.
+///
+/// Two walks produce them: the status renderer counts relations while it also
+/// resolves cross-file endpoints, and `measure_relation_census` counts them on
+/// its own for the sweep and commit writers. If those ever disagree, every
+/// comparison this feature makes is against a number no surface displays, and
+/// the disagreement would present as movement rather than as a bug. This drives
+/// both over a real admitted repository rather than a fixture, so the agreement
+/// is asserted on relations an adapter actually produced.
+#[test]
+fn the_recorded_census_matches_the_histogram_status_prints() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    let admitted = admit(&repo);
+    let graph = workspace_query_graph(&admitted.binding);
+
+    let measured =
+        kin_cli::commands::graph::measure_relation_census(&graph).expect("measure the census");
+    let response = graph_status(&admitted.binding, &graph);
+    let printed = response
+        .lines
+        .iter()
+        .find(|line| line.starts_with("Entity-to-entity relation kinds: "))
+        .expect("status prints the relation-kind histogram")
+        .trim_start_matches("Entity-to-entity relation kinds: ")
+        .to_string();
+
+    // Rendered as `Kind: N, Kind: N`, so the census is checked term by term
+    // rather than by reassembling the string in the same order.
+    let mut rendered: Vec<String> = printed
+        .split(", ")
+        .filter(|term| !term.is_empty())
+        .map(|term| term.to_string())
+        .collect();
+    rendered.sort();
+    let mut from_census: Vec<String> = measured
+        .iter()
+        .filter(|(_, count)| **count > 0)
+        .map(|(kind, count)| format!("{kind}: {count}"))
+        .collect();
+    from_census.sort();
+    assert_eq!(
+        rendered, from_census,
+        "the census the sweep and commit record is the histogram status prints"
+    );
+    assert!(
+        !from_census.is_empty(),
+        "an empty census would make this agreement trivially true: {}",
+        response.lines.join("\n")
+    );
+}
+
 fn graph_validate(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
@@ -273,6 +327,7 @@ fn graph_validate(
         ),
         graph,
         &GraphCommandRequest::Validate,
+        &Default::default(),
         &Default::default(),
         &Default::default(),
     )

--- a/crates/kin-core/src/layout.rs
+++ b/crates/kin-core/src/layout.rs
@@ -146,6 +146,21 @@ impl KinLayout {
         self.kindb_dir().join("last-admission")
     }
 
+    /// `.kin/kindb/relation-census` — the relation-kind histogram as it stood
+    /// when the graph's relations were last settled.
+    ///
+    /// Durable rather than in-process for the same reason the last-admission
+    /// marker beside it is: a census is only interpretable against the census
+    /// before it, and an in-memory one dies with the daemon that took it. It is
+    /// written where relations actually change, at the end of a completed
+    /// enrichment sweep and at the end of a commit, and never on a read path.
+    /// Stamping it from `graph status` would make every reading compare against
+    /// the reading before it, so a store that lost a whole relation kind would
+    /// announce the loss once and then report itself clean forever.
+    pub fn kindb_relation_census_path(&self) -> PathBuf {
+        self.kindb_dir().join("relation-census")
+    }
+
     /// `.kin/kindb/graph.kvec` — persisted vector index aligned with the snapshot.
     pub fn kindb_vector_index_path(&self) -> PathBuf {
         self.kindb_snapshot_path().with_extension("kvec")

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod ranking;
 pub mod ref_view;
 pub mod reference_coverage;
 pub mod registry;
+pub mod relation_census;
 pub mod repository_authority;
 pub mod resolver;
 pub mod shims;

--- a/crates/kin-core/src/relation_census.rs
+++ b/crates/kin-core/src/relation_census.rs
@@ -1,0 +1,918 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Durable record of the relation-kind census, and the rule that compares one
+//! census to the one before it.
+//!
+//! `kin graph status` prints the full relation-kind histogram immediately above
+//! its health line and compares it to nothing, so a store that lost an entire
+//! relation kind reads as healthy. On the rc0545c stranger run a psf/requests
+//! store went from 1985 entity-to-entity relations to 1807 in 36 minutes, and
+//! `UsesType` went from 94 to zero, under `✓ No issues detected.` Every number
+//! needed to notice was on the screen, and nothing on the screen noticed.
+//!
+//! A census on its own cannot say whether a count is low or falling. Only a
+//! previous census can, so one is recorded where the graph's relations were last
+//! settled: at the end of a completed enrichment sweep and at the end of a
+//! commit. Both are points where the relation set just changed and the process
+//! doing the changing knows it finished.
+//!
+//! Reads are three-way for the same reason [`crate::last_admission`] reads are.
+//! Absent and unreadable are different answers and neither may present as
+//! "nothing changed": a surface that turns a missing record into a clean bill
+//! reintroduces the defect this record exists to close.
+
+use crate::layout::KinLayout;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Schema token carried in the record so a future format change is legible
+/// rather than silently misparsed.
+pub const RELATION_CENSUS_SCHEMA: &str = "kin.relation-census.v1";
+
+/// How far a kind must fall before the drop is reported as a warning rather
+/// than as ordinary movement.
+///
+/// Stated as a constant and named in the rendered line, because a threshold a
+/// reader cannot see is a threshold they cannot calibrate against. A quarter of
+/// a kind is far more than re-parsing noise and far less than the whole-kind
+/// loss that is reported unconditionally.
+pub const SHARP_DROP_FRACTION: f64 = 0.25;
+
+/// What was recorded, and where the recording happened.
+///
+/// The source is kept because the two writers answer different questions. A
+/// census recorded by a sweep describes a graph whose enrichment just finished;
+/// one recorded by a commit describes a graph that just took a change. A drop
+/// between a sweep census and a commit census is a different event from a drop
+/// between two sweep censuses, and a reader who cannot tell them apart cannot
+/// act on either.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CensusSource {
+    /// The end of a completed language-server enrichment sweep.
+    Sweep,
+    /// The end of a commit that installed its change in the live graph.
+    Commit,
+}
+
+impl CensusSource {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Sweep => "enrichment sweep",
+            Self::Commit => "commit",
+        }
+    }
+}
+
+/// The relation-kind census of one store at one moment.
+///
+/// `kinds` is entity-rooted, matching the `Entity-to-entity relation kinds` line
+/// `kin graph status` prints, so the recorded census and the compared census are
+/// the same measurement rather than two that merely resemble each other.
+///
+/// `causes` carries the correctness-relevant environment overrides active in the
+/// process that recorded it. Those are the conditions the graph was built under,
+/// and they are what turns "UsesType went 94 to 0" into an answer instead of a
+/// question.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RelationCensus {
+    pub schema: String,
+    pub at: DateTime<Utc>,
+    pub source: CensusSource,
+    pub kinds: BTreeMap<String, u64>,
+    pub total: u64,
+    #[serde(default)]
+    pub causes: Vec<String>,
+}
+
+impl RelationCensus {
+    pub fn new(
+        at: DateTime<Utc>,
+        source: CensusSource,
+        kinds: BTreeMap<String, u64>,
+        causes: Vec<String>,
+    ) -> Self {
+        let total = kinds.values().copied().sum();
+        Self {
+            schema: RELATION_CENSUS_SCHEMA.to_string(),
+            at,
+            source,
+            kinds,
+            total,
+            causes,
+        }
+    }
+}
+
+/// The outcome of consulting the record.
+///
+/// Three variants rather than an `Option`, for the reason
+/// [`crate::last_admission::LastAdmissionRead`] has three: a store with no
+/// record has nothing to compare against, and a record that will not parse is a
+/// louder fact than a missing one. Neither may render as "unchanged".
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum RelationCensusRead {
+    Recorded(RelationCensus),
+    #[default]
+    Absent,
+    Unreadable(String),
+}
+
+impl RelationCensusRead {
+    pub fn recorded(&self) -> Option<&RelationCensus> {
+        match self {
+            Self::Recorded(recorded) => Some(recorded),
+            Self::Absent | Self::Unreadable(_) => None,
+        }
+    }
+}
+
+/// What one relation kind did between two censuses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CensusMovement {
+    /// The kind held edges and now holds none. Reported unconditionally: a
+    /// whole kind disappearing is not a matter of degree.
+    Vanished,
+    /// The kind fell by at least [`SHARP_DROP_FRACTION`] without reaching zero.
+    Fell,
+    /// The kind fell by less than [`SHARP_DROP_FRACTION`]. Carried so a reader
+    /// asking for the whole comparison gets it, and never on its own a warning.
+    Slipped,
+    /// The kind grew.
+    Grew,
+    /// The kind is present now and was absent from the previous census.
+    Appeared,
+    /// The count is identical.
+    Unchanged,
+}
+
+impl CensusMovement {
+    /// Whether this movement withholds the all-clear.
+    ///
+    /// A vanished kind and a sharp fall both do. Growth, a new kind, an
+    /// identical count and ordinary slippage do not: reporting those as issues
+    /// would make every re-parse of a live repository print a warning, and a
+    /// surface that always warns is one nobody reads.
+    pub fn is_loss(self) -> bool {
+        matches!(self, Self::Vanished | Self::Fell)
+    }
+}
+
+/// One kind's before and after, with the verdict.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CensusChange {
+    pub kind: String,
+    pub previous: u64,
+    pub current: u64,
+    pub movement: CensusMovement,
+}
+
+impl CensusChange {
+    /// The fraction of the previous count that is gone, in `0.0..=1.0`.
+    ///
+    /// Zero when the kind did not fall, and zero when there was nothing to fall
+    /// from: a kind that appears from an absent previous count has no
+    /// denominator, and inventing one would report a new kind as a loss.
+    pub fn lost_fraction(&self) -> f64 {
+        if self.previous == 0 || self.current >= self.previous {
+            return 0.0;
+        }
+        (self.previous - self.current) as f64 / self.previous as f64
+    }
+
+    /// One sentence naming what this kind did, for a status or doctor line.
+    pub fn describe(&self) -> String {
+        match self.movement {
+            CensusMovement::Vanished => format!("{} went {} to 0", self.kind, self.previous),
+            CensusMovement::Fell => format!(
+                "{} fell {} to {} ({:.0}% of its edges)",
+                self.kind,
+                self.previous,
+                self.current,
+                self.lost_fraction() * 100.0
+            ),
+            CensusMovement::Slipped => format!(
+                "{} slipped {} to {}",
+                self.kind, self.previous, self.current
+            ),
+            CensusMovement::Grew => {
+                format!("{} grew {} to {}", self.kind, self.previous, self.current)
+            }
+            CensusMovement::Appeared => format!("{} is new at {}", self.kind, self.current),
+            CensusMovement::Unchanged => format!("{} held at {}", self.kind, self.current),
+        }
+    }
+}
+
+/// Classify every kind in either census.
+///
+/// Pure, and over the union of both key sets, so a kind that vanished is
+/// classified from the previous census alone. A comparison that iterated only
+/// the current census would be structurally unable to see the case this whole
+/// record exists for: the vanished kind is precisely the one that is no longer
+/// there to iterate.
+pub fn compare(
+    previous: &BTreeMap<String, u64>,
+    current: &BTreeMap<String, u64>,
+) -> Vec<CensusChange> {
+    let mut kinds: Vec<&String> = previous.keys().chain(current.keys()).collect();
+    kinds.sort_unstable();
+    kinds.dedup();
+
+    kinds
+        .into_iter()
+        .map(|kind| {
+            let before = previous.get(kind).copied().unwrap_or(0);
+            let after = current.get(kind).copied().unwrap_or(0);
+            let mut change = CensusChange {
+                kind: kind.clone(),
+                previous: before,
+                current: after,
+                movement: CensusMovement::Unchanged,
+            };
+            change.movement = if before == 0 && after > 0 {
+                CensusMovement::Appeared
+            } else if after > before {
+                CensusMovement::Grew
+            } else if after == before {
+                CensusMovement::Unchanged
+            } else if after == 0 {
+                CensusMovement::Vanished
+            } else if change.lost_fraction() >= SHARP_DROP_FRACTION {
+                CensusMovement::Fell
+            } else {
+                CensusMovement::Slipped
+            };
+            change
+        })
+        .collect()
+}
+
+/// A current census set beside the recorded one, and what the pair says.
+///
+/// Built even when there is no previous record, because every state has a line
+/// to print. A comparison that rendered nothing when it had nothing to compare
+/// would be indistinguishable from one reporting a healthy store, which is the
+/// exact failure mode being closed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RelationCensusComparison {
+    /// When the previous census was recorded, and by which writer. Absent when
+    /// no previous census could be read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_source: Option<CensusSource>,
+    /// Why nothing could be compared, when nothing could be.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unavailable: Option<String>,
+    #[serde(default)]
+    pub changes: Vec<CensusChange>,
+    /// Conditions known to reduce relation coverage, active now.
+    #[serde(default)]
+    pub causes: Vec<String>,
+}
+
+impl RelationCensusComparison {
+    /// Compare `current` against whatever the store recorded.
+    pub fn build(
+        previous: &RelationCensusRead,
+        current: &BTreeMap<String, u64>,
+        causes: Vec<String>,
+    ) -> Self {
+        match previous {
+            RelationCensusRead::Recorded(recorded) => Self {
+                previous_at: Some(recorded.at),
+                previous_source: Some(recorded.source),
+                unavailable: None,
+                changes: compare(&recorded.kinds, current),
+                causes,
+            },
+            RelationCensusRead::Absent => Self {
+                previous_at: None,
+                previous_source: None,
+                unavailable: Some(
+                    "no previous relation census is recorded for this store, so a lost relation \
+                     kind cannot be detected yet; one is recorded at the next completed \
+                     enrichment sweep or commit"
+                        .to_string(),
+                ),
+                changes: Vec::new(),
+                causes,
+            },
+            RelationCensusRead::Unreadable(reason) => Self {
+                previous_at: None,
+                previous_source: None,
+                unavailable: Some(format!(
+                    "the recorded relation census could not be read ({reason}), so a lost \
+                     relation kind cannot be detected; the next completed enrichment sweep or \
+                     commit rewrites it"
+                )),
+                changes: Vec::new(),
+                causes,
+            },
+        }
+    }
+
+    /// The kinds that disappeared entirely.
+    pub fn vanished(&self) -> Vec<&CensusChange> {
+        self.changes
+            .iter()
+            .filter(|change| change.movement == CensusMovement::Vanished)
+            .collect()
+    }
+
+    /// The kinds that fell beyond [`SHARP_DROP_FRACTION`] without vanishing.
+    pub fn sharp_drops(&self) -> Vec<&CensusChange> {
+        self.changes
+            .iter()
+            .filter(|change| change.movement == CensusMovement::Fell)
+            .collect()
+    }
+
+    /// Whether the pair withholds the all-clear.
+    pub fn reports_loss(&self) -> bool {
+        self.changes.iter().any(|change| change.movement.is_loss())
+    }
+
+    /// The clause naming why coverage fell, when the cause is known.
+    ///
+    /// Empty when nothing on this host is known to reduce coverage. Silence is
+    /// correct there: naming a cause that was not measured would send an
+    /// operator after a knob nobody set.
+    fn cause_clause(&self) -> String {
+        if self.causes.is_empty() {
+            return String::new();
+        }
+        format!("; recorded cause: {}", self.causes.join("; "))
+    }
+
+    /// The issue sentences a status surface adds to its warnings, most severe
+    /// first.
+    ///
+    /// One per losing kind rather than one summary, because the operator's next
+    /// action depends on which kind went: a lost `UsesType` points at type
+    /// resolution and a lost `Calls` points at the parser.
+    pub fn loss_lines(&self) -> Vec<String> {
+        let recorded = match (self.previous_at, self.previous_source) {
+            (Some(at), Some(source)) => {
+                format!(
+                    " since the census recorded at {} ({})",
+                    at.to_rfc3339(),
+                    source.label()
+                )
+            }
+            _ => String::new(),
+        };
+        let cause = self.cause_clause();
+        self.vanished()
+            .into_iter()
+            .map(|change| {
+                format!(
+                    "relation kind {} lost every edge it held: {}{recorded}{cause}",
+                    change.kind,
+                    change.describe()
+                )
+            })
+            .chain(self.sharp_drops().into_iter().map(|change| {
+                format!(
+                    "relation kind {} fell beyond {:.0}% of its edges: {}{recorded}{cause}",
+                    change.kind,
+                    SHARP_DROP_FRACTION * 100.0,
+                    change.describe()
+                )
+            }))
+            .collect()
+    }
+
+    /// Previous and current totals across every kind in the comparison.
+    pub fn totals(&self) -> (u64, u64) {
+        self.changes
+            .iter()
+            .fold((0, 0), |(previous, current), change| {
+                (previous + change.previous, current + change.current)
+            })
+    }
+
+    /// The clause naming an aggregate fall, when the total fell.
+    ///
+    /// Carried because a store can lose real ground with no single kind
+    /// crossing the warning threshold. On the run this record comes from,
+    /// `References` fell 412 to 340, comfortably inside tolerance, while the
+    /// total moved 1985 to 1807. A row reporting only per-kind losses would
+    /// have named the vanished kind and stayed silent about the rest.
+    fn total_clause(&self) -> String {
+        let (previous, current) = self.totals();
+        if current >= previous {
+            return String::new();
+        }
+        format!("the total fell {previous} to {current}")
+    }
+
+    /// The one row a status surface always prints, whatever the verdict.
+    pub fn summary_line(&self) -> String {
+        if let Some(unavailable) = &self.unavailable {
+            return format!("Relation census: {unavailable}");
+        }
+        let recorded = match (self.previous_at, self.previous_source) {
+            (Some(at), Some(source)) => format!("{} ({})", at.to_rfc3339(), source.label()),
+            _ => "an unrecorded moment".to_string(),
+        };
+        let total = self.total_clause();
+        let losses = self.loss_summary();
+        if losses.is_empty() {
+            if total.is_empty() {
+                return format!(
+                    "Relation census: no relation kind has lost ground since {recorded}, which \
+                     is what this row compares the histogram above against"
+                );
+            }
+            return format!(
+                "Relation census: no relation kind lost enough to warn about since {recorded}, \
+                 though {total}{}",
+                self.cause_clause()
+            );
+        }
+        let total = if total.is_empty() {
+            String::new()
+        } else {
+            format!(", and {total}")
+        };
+        format!(
+            "Relation census: {losses}{total} since {recorded}{}",
+            self.cause_clause()
+        )
+    }
+
+    fn loss_summary(&self) -> String {
+        let losses: Vec<String> = self
+            .changes
+            .iter()
+            .filter(|change| change.movement.is_loss())
+            .map(|change| change.describe())
+            .collect();
+        losses.join(", ")
+    }
+}
+
+/// What a status surface needs to compare its own census against the store's.
+///
+/// Bundled and passed in rather than read inside the renderer, so the rule is
+/// driven by real inputs in tests instead of by whatever the test process
+/// happens to have on disk and in its environment. `Default` is the honest
+/// no-store case: no previous census and no known cause.
+#[derive(Debug, Clone, Default)]
+pub struct CensusContext {
+    pub previous: RelationCensusRead,
+    pub causes: Vec<String>,
+}
+
+impl CensusContext {
+    /// Read the record for `layout` and audit `vars` for conditions known to
+    /// reduce relation coverage.
+    pub fn for_layout<I>(layout: &KinLayout, vars: I) -> Self
+    where
+        I: IntoIterator<Item = (String, String)>,
+    {
+        Self {
+            previous: read(layout),
+            causes: known_causes(vars),
+        }
+    }
+}
+
+/// Read the durable record for `layout`.
+///
+/// Never fails. A missing record is [`RelationCensusRead::Absent`] and anything
+/// unparseable is [`RelationCensusRead::Unreadable`]; a read error must not be
+/// able to present as "nothing changed".
+pub fn read(layout: &KinLayout) -> RelationCensusRead {
+    let path = layout.kindb_relation_census_path();
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return RelationCensusRead::Absent
+        }
+        Err(error) => return RelationCensusRead::Unreadable(error.to_string()),
+    };
+    match serde_json::from_str::<RelationCensus>(&raw) {
+        Ok(recorded) if recorded.schema == RELATION_CENSUS_SCHEMA => {
+            RelationCensusRead::Recorded(recorded)
+        }
+        Ok(recorded) => RelationCensusRead::Unreadable(format!(
+            "schema {} is not {RELATION_CENSUS_SCHEMA}",
+            recorded.schema
+        )),
+        Err(error) => RelationCensusRead::Unreadable(error.to_string()),
+    }
+}
+
+/// Write the durable record for `layout`, atomically.
+///
+/// Staged beside the target and renamed into place after an fsync, then the
+/// directory metadata is synced, so a crash mid-write leaves either the previous
+/// census or the new one and never a truncated file that would read as
+/// unreadable forever. This is the same publication the last-admission marker
+/// beside it uses.
+pub fn write(layout: &KinLayout, recorded: &RelationCensus) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let path = layout.kindb_relation_census_path();
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("relation-census path has no parent directory"))?;
+    std::fs::create_dir_all(parent)?;
+    let staged = path.with_extension(format!("tmp-{}", std::process::id()));
+    let body = serde_json::to_vec(recorded).map_err(std::io::Error::other)?;
+    {
+        let mut file = std::fs::File::create(&staged)?;
+        file.write_all(&body)?;
+        file.sync_all()?;
+    }
+    if let Err(error) = std::fs::rename(&staged, &path) {
+        let _ = std::fs::remove_file(&staged);
+        return Err(error);
+    }
+    sync_directory_metadata(parent)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory_metadata(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::File::open(path).and_then(|directory| directory.sync_all())
+}
+
+/// Non-unix platforms expose no portable directory handle to sync, so the
+/// rename's own ordering guarantees are all there is.
+#[cfg(not(unix))]
+fn sync_directory_metadata(_path: &std::path::Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// The conditions in an environment that are known to reduce relation coverage.
+///
+/// Derived from the same audit that emits `correctness-relevant override
+/// active` at startup, so the cause a status row names is the cause the log
+/// already warned about, word for word. On the run that produced this record's
+/// ticket the warning fired unprompted at commit time and the health line
+/// contradicted it three minutes later.
+///
+/// Pure over an iterator rather than reading the process environment, so the
+/// rule is testable and so a daemon reports the environment IT runs under
+/// rather than the one a reader's shell happens to carry.
+pub fn known_causes<I>(vars: I) -> Vec<String>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    crate::env_registry::audit_env(vars, false)
+        .non_default
+        .into_iter()
+        .map(|finding| format!("{} {}", finding.var, finding.message))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn layout_in(dir: &std::path::Path) -> KinLayout {
+        let kin_dir = dir.join(".kin");
+        std::fs::create_dir_all(kin_dir.join("kindb")).unwrap();
+        KinLayout::new(kin_dir)
+    }
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
+
+    fn census(pairs: &[(&str, u64)]) -> BTreeMap<String, u64> {
+        pairs
+            .iter()
+            .map(|(kind, count)| ((*kind).to_string(), *count))
+            .collect()
+    }
+
+    fn movement_of(changes: &[CensusChange], kind: &str) -> CensusMovement {
+        changes
+            .iter()
+            .find(|change| change.kind == kind)
+            .unwrap_or_else(|| panic!("no change recorded for {kind}: {changes:?}"))
+            .movement
+    }
+
+    /// The rc0545c case. `UsesType` held 94 edges and then held none, and no
+    /// surface said so.
+    #[test]
+    fn a_kind_that_vanished_is_reported_as_vanished() {
+        let previous = census(&[("Calls", 951), ("UsesType", 94)]);
+        let current = census(&[("Calls", 940)]);
+        let changes = compare(&previous, &current);
+        assert_eq!(movement_of(&changes, "UsesType"), CensusMovement::Vanished);
+        let vanished = changes
+            .iter()
+            .find(|change| change.kind == "UsesType")
+            .unwrap();
+        assert_eq!(vanished.previous, 94);
+        assert_eq!(vanished.current, 0);
+        assert_eq!(vanished.describe(), "UsesType went 94 to 0");
+    }
+
+    /// Forty percent is past the stated threshold, so it is a loss rather than
+    /// movement.
+    #[test]
+    fn a_kind_that_dropped_forty_percent_is_reported_as_a_sharp_fall() {
+        let previous = census(&[("References", 500)]);
+        let current = census(&[("References", 300)]);
+        let changes = compare(&previous, &current);
+        assert_eq!(movement_of(&changes, "References"), CensusMovement::Fell);
+        let fell = changes
+            .iter()
+            .find(|change| change.kind == "References")
+            .unwrap();
+        assert!(
+            (fell.lost_fraction() - 0.4).abs() < 1e-9,
+            "40% of 500 is 200: {}",
+            fell.lost_fraction()
+        );
+        assert!(
+            fell.describe().contains("References fell 500 to 300"),
+            "{}",
+            fell.describe()
+        );
+    }
+
+    /// Just under the threshold. Reported in the comparison, never as a
+    /// warning, because a surface that warns on every re-parse is one nobody
+    /// reads.
+    #[test]
+    fn a_kind_that_slipped_within_tolerance_is_not_a_loss() {
+        let previous = census(&[("Calls", 100)]);
+        let current = census(&[("Calls", 80)]);
+        let changes = compare(&previous, &current);
+        assert_eq!(movement_of(&changes, "Calls"), CensusMovement::Slipped);
+        assert!(!CensusMovement::Slipped.is_loss());
+    }
+
+    #[test]
+    fn a_kind_that_grew_is_not_a_loss() {
+        let previous = census(&[("Calls", 940)]);
+        let current = census(&[("Calls", 951)]);
+        let changes = compare(&previous, &current);
+        assert_eq!(movement_of(&changes, "Calls"), CensusMovement::Grew);
+        assert!(!CensusMovement::Grew.is_loss());
+    }
+
+    #[test]
+    fn a_kind_absent_from_the_previous_census_is_new_rather_than_a_loss() {
+        let previous = census(&[("Calls", 940)]);
+        let current = census(&[("Calls", 940), ("UsesType", 94)]);
+        let changes = compare(&previous, &current);
+        assert_eq!(movement_of(&changes, "UsesType"), CensusMovement::Appeared);
+        let appeared = changes
+            .iter()
+            .find(|change| change.kind == "UsesType")
+            .unwrap();
+        assert_eq!(appeared.previous, 0);
+        assert_eq!(
+            appeared.lost_fraction(),
+            0.0,
+            "a new kind has no denominator to lose against"
+        );
+    }
+
+    #[test]
+    fn an_identical_census_reports_every_kind_unchanged_and_no_loss() {
+        let both = census(&[("Calls", 940), ("Contains", 483), ("Overrides", 10)]);
+        let changes = compare(&both, &both);
+        assert_eq!(changes.len(), 3);
+        assert!(
+            changes
+                .iter()
+                .all(|change| change.movement == CensusMovement::Unchanged),
+            "{changes:?}"
+        );
+        assert!(!changes.iter().any(|change| change.movement.is_loss()));
+    }
+
+    /// The structural property. A kind that vanished is absent from the current
+    /// census, so a comparison that walked only the current one could never see
+    /// it, whatever its thresholds were.
+    #[test]
+    fn the_comparison_walks_kinds_the_current_census_no_longer_holds() {
+        let previous = census(&[("UsesType", 94)]);
+        let current = census(&[]);
+        let changes = compare(&previous, &current);
+        assert_eq!(changes.len(), 1, "{changes:?}");
+        assert_eq!(changes[0].kind, "UsesType");
+        assert_eq!(changes[0].movement, CensusMovement::Vanished);
+    }
+
+    #[test]
+    fn a_comparison_against_a_recorded_census_names_the_loss_and_its_cause() {
+        let recorded = RelationCensus::new(
+            at(1_000_000),
+            CensusSource::Sweep,
+            census(&[("Calls", 951), ("UsesType", 94)]),
+            Vec::new(),
+        );
+        let comparison = RelationCensusComparison::build(
+            &RelationCensusRead::Recorded(recorded),
+            &census(&[("Calls", 940)]),
+            vec!["KIN_DAEMON_DISABLE_LSP set to non-default value \"1\"".to_string()],
+        );
+        assert!(comparison.reports_loss());
+        let lines = comparison.loss_lines();
+        assert_eq!(lines.len(), 1, "{lines:?}");
+        assert!(
+            lines[0].contains("UsesType went 94 to 0"),
+            "the loss is named: {}",
+            lines[0]
+        );
+        assert!(
+            lines[0].contains("KIN_DAEMON_DISABLE_LSP"),
+            "the cause is named: {}",
+            lines[0]
+        );
+        assert!(
+            comparison.summary_line().contains("UsesType went 94 to 0"),
+            "{}",
+            comparison.summary_line()
+        );
+    }
+
+    /// Absent is not "unchanged". The row says what it cannot do.
+    #[test]
+    fn no_recorded_census_reports_that_nothing_could_be_compared() {
+        let comparison = RelationCensusComparison::build(
+            &RelationCensusRead::Absent,
+            &census(&[("Calls", 940)]),
+            Vec::new(),
+        );
+        assert!(!comparison.reports_loss());
+        assert!(comparison.loss_lines().is_empty());
+        assert!(
+            comparison
+                .summary_line()
+                .contains("no previous relation census is recorded"),
+            "{}",
+            comparison.summary_line()
+        );
+    }
+
+    #[test]
+    fn an_unreadable_census_reports_the_reason_rather_than_silence() {
+        let comparison = RelationCensusComparison::build(
+            &RelationCensusRead::Unreadable("expected value at line 1 column 1".to_string()),
+            &census(&[("Calls", 940)]),
+            Vec::new(),
+        );
+        assert!(!comparison.reports_loss());
+        assert!(
+            comparison
+                .summary_line()
+                .contains("expected value at line 1 column 1"),
+            "{}",
+            comparison.summary_line()
+        );
+    }
+
+    /// The gap a per-kind threshold leaves. Nothing crosses 25%, so nothing
+    /// warns, and the row still has to say the store holds fewer edges than it
+    /// did or the aggregate move is invisible.
+    #[test]
+    fn a_total_that_fell_is_named_even_when_no_single_kind_crossed_the_threshold() {
+        let recorded = RelationCensus::new(
+            at(1_000_000),
+            CensusSource::Sweep,
+            census(&[("Calls", 951), ("References", 412)]),
+            Vec::new(),
+        );
+        let comparison = RelationCensusComparison::build(
+            &RelationCensusRead::Recorded(recorded),
+            &census(&[("Calls", 940), ("References", 340)]),
+            Vec::new(),
+        );
+        assert!(
+            !comparison.reports_loss(),
+            "17% is inside tolerance, so nothing warns: {:?}",
+            comparison.changes
+        );
+        assert_eq!(comparison.totals(), (1363, 1280));
+        assert!(
+            comparison
+                .summary_line()
+                .contains("the total fell 1363 to 1280"),
+            "{}",
+            comparison.summary_line()
+        );
+    }
+
+    #[test]
+    fn a_total_that_grew_adds_no_clause() {
+        let recorded = RelationCensus::new(
+            at(1),
+            CensusSource::Commit,
+            census(&[("Calls", 100)]),
+            Vec::new(),
+        );
+        let comparison = RelationCensusComparison::build(
+            &RelationCensusRead::Recorded(recorded),
+            &census(&[("Calls", 120)]),
+            Vec::new(),
+        );
+        assert!(
+            !comparison.summary_line().contains("the total fell"),
+            "{}",
+            comparison.summary_line()
+        );
+    }
+
+    #[test]
+    fn a_written_census_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        let recorded = RelationCensus::new(
+            at(1_000_000),
+            CensusSource::Commit,
+            census(&[("Calls", 940), ("Contains", 483)]),
+            vec!["KIN_DAEMON_DISABLE_LSP set to non-default value \"1\"".to_string()],
+        );
+        write(&layout, &recorded).unwrap();
+        assert_eq!(read(&layout), RelationCensusRead::Recorded(recorded));
+    }
+
+    /// The durability property. A census survives being read by a process that
+    /// never wrote it, which is what a daemon restart looks like from the
+    /// reader's side.
+    #[test]
+    fn a_census_survives_a_reader_that_did_not_write_it() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let layout = layout_in(dir.path());
+            write(
+                &layout,
+                &RelationCensus::new(
+                    at(500),
+                    CensusSource::Sweep,
+                    census(&[("UsesType", 94)]),
+                    Vec::new(),
+                ),
+            )
+            .unwrap();
+        }
+        let reopened = layout_in(dir.path());
+        match read(&reopened) {
+            RelationCensusRead::Recorded(recorded) => {
+                assert_eq!(recorded.kinds.get("UsesType"), Some(&94));
+                assert_eq!(recorded.total, 94);
+            }
+            other => panic!("expected a recorded census, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_record_written_by_a_future_schema_reads_as_unreadable_rather_than_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        let mut recorded = RelationCensus::new(
+            at(1),
+            CensusSource::Sweep,
+            census(&[("Calls", 1)]),
+            Vec::new(),
+        );
+        recorded.schema = "kin.relation-census.v9".to_string();
+        std::fs::write(
+            layout.kindb_relation_census_path(),
+            serde_json::to_vec(&recorded).unwrap(),
+        )
+        .unwrap();
+        match read(&layout) {
+            RelationCensusRead::Unreadable(reason) => {
+                assert!(reason.contains("kin.relation-census.v9"), "{reason}")
+            }
+            other => panic!("expected unreadable, got {other:?}"),
+        }
+    }
+
+    /// The cause a status row names is the cause the startup log already
+    /// warned about, from the same audit.
+    #[test]
+    fn the_knob_that_disables_lsp_enrichment_is_reported_as_a_known_cause() {
+        let causes = known_causes([("KIN_DAEMON_DISABLE_LSP".to_string(), "1".to_string())]);
+        assert_eq!(causes.len(), 1, "{causes:?}");
+        assert!(
+            causes[0].starts_with("KIN_DAEMON_DISABLE_LSP"),
+            "{}",
+            causes[0]
+        );
+    }
+
+    #[test]
+    fn an_environment_with_no_overrides_names_no_cause() {
+        assert!(known_causes([("PATH".to_string(), "/usr/bin".to_string())]).is_empty());
+    }
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3510,6 +3510,14 @@ async fn command_graph(
             }),
         );
     let embedding_runtime = graph_status_embedding_runtime(&state, &graph);
+    // Read here rather than inside the renderer, for the reason the freshness
+    // marker is read in the CLI: the record is a property of the store on disk,
+    // and the environment worth auditing is the DAEMON's, because the daemon is
+    // the process that built the graph being reported. Auditing the caller's
+    // environment would name a knob the reader's shell carries and the graph
+    // never saw.
+    let census =
+        kin_core::relation_census::CensusContext::for_layout(&state.layout, std::env::vars());
     let response = kin_cli::commands::graph::execute_graph_command(
         &repository_authority,
         graph.as_ref(),
@@ -3518,6 +3526,7 @@ async fn command_graph(
             .background_work
             .reconcile_report(std::time::Instant::now()),
         &embedding_runtime,
+        &census,
     )
     .map_err(internal_error)?;
     Ok(Json(response))
@@ -4940,6 +4949,16 @@ fn command_commit_after_admission(
     // live graph rather than from the plan, because a plan's `entity_count` is
     // the size of its delta and this is the size of the whole.
     state.record_durable_entity_count(graph.entity_count() as u64);
+    // The relation set just moved and the change is installed, so this is the
+    // baseline the next `kin graph status` compares against. Recorded after the
+    // install rather than from the plan, for the reason the entity count above
+    // is: a plan carries the size of its delta and this is a census of the
+    // whole graph.
+    crate::background_work::record_relation_census(
+        &state.layout,
+        graph,
+        kin_core::relation_census::CensusSource::Commit,
+    );
     state.bump_version();
     state.emit_event(DaemonEvent::GraphRootChanged {
         old_root_hash: None,
@@ -14384,6 +14403,7 @@ mod tests {
             &kin_cli::commands::graph::GraphCommandRequest::Status,
             &Default::default(),
             &runtime,
+            &Default::default(),
         )
         .unwrap();
 

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -665,6 +665,59 @@ pub fn record_durable_admission(layout: &kin_core::KinLayout, tracked_artifacts:
     kin_core::last_admission::record(layout, tracked_artifacts);
 }
 
+/// Persist the relation-kind census of `graph` for this store.
+///
+/// Called where the relation set was just settled: at the end of a completed
+/// enrichment sweep, and at the end of a commit that installed its change in
+/// the live graph. Those are the moments a process both changed the relations
+/// and knows it finished, which is what makes the record interpretable as a
+/// baseline rather than as a sample taken mid-flight.
+///
+/// Never called from a read path. `kin graph status` reads this record and does
+/// not write it: a census stamped on every reading would compare each reading
+/// against the one before it, so a store that lost a whole relation kind would
+/// announce the loss once and then report itself clean forever, which is a
+/// quieter version of the defect this record closes.
+///
+/// The causes recorded beside the counts are the correctness-relevant
+/// environment overrides active in THIS process, because this is the process
+/// that built the graph. Reading them at status time instead would report the
+/// environment of whoever happened to ask.
+///
+/// A measurement or write failure is logged and swallowed, and the direction of
+/// that failure is the safe one: an unwritten census leaves the previous,
+/// older one in place, so the next comparison spans a longer window and reports
+/// more movement rather than less. Turning it into a sweep or commit failure
+/// would fail work that actually succeeded.
+pub fn record_relation_census(
+    layout: &kin_core::KinLayout,
+    graph: &kin_db::InMemoryGraph,
+    source: kin_core::relation_census::CensusSource,
+) {
+    let kinds = match kin_cli::commands::graph::measure_relation_census(graph) {
+        Ok(kinds) => kinds,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "could not measure the relation census; the previous census stays in place and                  the next comparison spans a longer window"
+            );
+            return;
+        }
+    };
+    let recorded = kin_core::relation_census::RelationCensus::new(
+        chrono::Utc::now(),
+        source,
+        kinds,
+        kin_core::relation_census::known_causes(std::env::vars()),
+    );
+    if let Err(error) = kin_core::relation_census::write(layout, &recorded) {
+        tracing::warn!(
+            error = %error,
+            "could not persist the relation census; graph status will compare against the              previous one until a later pass rewrites it"
+        );
+    }
+}
+
 /// What the filesystem reconciliation loop has actually managed to admit.
 ///
 /// The loop already knew every fact here. It logged an admission failure at

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -3987,6 +3987,18 @@ pub async fn run_with_authority_on(
                         // durable what it actually completed, and the crash
                         // window narrows to a hard kill, which the resume marker
                         // already recovers by re-sweeping.
+                        // Taken before the publication below rather than
+                        // after it, so the census this store carries describes
+                        // the graph the snapshot is about to publish. The
+                        // sweep's relations are all in the live graph by here;
+                        // what remains is making them durable, and a census
+                        // recorded after that would be a second reading of the
+                        // same graph taken later for no gain.
+                        crate::background_work::record_relation_census(
+                            &lsp_state.layout,
+                            lsp_state.graph.as_ref(),
+                            kin_core::relation_census::CensusSource::Sweep,
+                        );
                         let published = if total_relations > 0 {
                             match save_snapshot_blocking(Arc::clone(&lsp_state)).await {
                                 Ok(()) => {

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -3959,6 +3959,25 @@ pub async fn run_with_authority_on(
                             lsp_state.mark_dirty();
                         }
 
+                        // Record the relation census this sweep produced,
+                        // before the publication below makes it durable.
+                        //
+                        // The sweep's relations are all in the live graph by
+                        // here; what remains is writing them to disk. Taking
+                        // the census now means the record describes the graph
+                        // the snapshot is about to publish, and a census taken
+                        // afterwards would be a second reading of the same
+                        // graph for no gain. `kin graph status` compares its
+                        // own census against this record, which is what lets it
+                        // notice a relation kind that went to zero instead of
+                        // printing the histogram that proves the loss and then
+                        // an all-clear over it.
+                        crate::background_work::record_relation_census(
+                            &lsp_state.layout,
+                            lsp_state.graph.as_ref(),
+                            kin_core::relation_census::CensusSource::Sweep,
+                        );
+
                         // Publish this sweep's enrichment ONCE, here, and wait
                         // for it.
                         //
@@ -3987,18 +4006,6 @@ pub async fn run_with_authority_on(
                         // durable what it actually completed, and the crash
                         // window narrows to a hard kill, which the resume marker
                         // already recovers by re-sweeping.
-                        // Taken before the publication below rather than
-                        // after it, so the census this store carries describes
-                        // the graph the snapshot is about to publish. The
-                        // sweep's relations are all in the live graph by here;
-                        // what remains is making them durable, and a census
-                        // recorded after that would be a second reading of the
-                        // same graph taken later for no gain.
-                        crate::background_work::record_relation_census(
-                            &lsp_state.layout,
-                            lsp_state.graph.as_ref(),
-                            kin_core::relation_census::CensusSource::Sweep,
-                        );
                         let published = if total_relations > 0 {
                             match save_snapshot_blocking(Arc::clone(&lsp_state)).await {
                                 Ok(()) => {

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -2219,6 +2219,15 @@ fn finalize_committed_transaction(
             &carried_pending_files,
         )
     })?;
+    // The second commit path, recorded for the same reason the first one is.
+    // An agent that only ever writes through MCP would otherwise leave the
+    // store's census frozen at whatever the last CLI commit or sweep left, and
+    // every comparison after that would span a window nobody can date.
+    crate::background_work::record_relation_census(
+        &state.layout,
+        state.graph.as_ref(),
+        kin_core::relation_census::CensusSource::Commit,
+    );
 
     let observed_generation = state.snapshot_generation.load(Ordering::SeqCst);
     if observed_generation < committed.receipt.generation {

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -2223,6 +2223,16 @@ fn finalize_committed_transaction(
     // An agent that only ever writes through MCP would otherwise leave the
     // store's census frozen at whatever the last CLI commit or sweep left, and
     // every comparison after that would span a window nobody can date.
+    //
+    // Taken from the LIVE graph, unlike the durable entity count above, and the
+    // difference is deliberate. That count describes what authority carries, so
+    // reading it live would record entities an ambient admission added and this
+    // commit never published. A census is the baseline `kin graph status`
+    // compares against, and status answers from the live graph, so a census
+    // taken from authority would make every ambient admission read as movement
+    // this commit caused. `semantic_workspace_matches` ran just above, so the
+    // two views are level here either way; the live read is what keeps them
+    // level on every later path too.
     crate::background_work::record_relation_census(
         &state.layout,
         state.graph.as_ref(),

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -396,6 +396,20 @@
       ]
     },
     {
+      "file": "crates/kin-core/src/relation_census.rs",
+      "reason": "Durable bookkeeping marker published beside the last-admission marker, not an answer authority. The excused bodies read and write .kin/kindb/relation-census, which records the relation-kind histogram as it stood when the graph's relations were last settled, so `kin graph status` can compare its own census to the previous one instead of printing an all-clear over a store that lost a whole relation kind. It is written only at the end of a completed enrichment sweep and at the end of a commit, never on a read path, and read only by the status and doctor surfaces. The record names no entity, carries no repository content, and cannot change what any query returns: a reader that lied in either direction would change only the wording of a health row, never a locate, search, context, trace, review, or xref answer. Publication is a temp-and-rename with an fsync of the staged file and then of the containing directory, the same shape last_admission.rs beside it and write_generation_marker in crates/kin-daemon/src/state.rs use for the authority head marker. Routing through a shared boundary helper instead was not available: kin-core exposes no public atomic-write path, and config.rs, registry.rs, last_admission.rs, and the daemon's state.rs each open-code their own. Function-scoped rather than whole-file so the rest of the module stays scanned, including the comparison rule, the movement classification, and the cause lookup, and so any newly added filesystem primitive here fails the guard until it is justified.",
+      "owner": "kin-core",
+      "expiration": "2026-12-31",
+      "allow_fn": [
+        "read",
+        "write",
+        {
+          "fn": "sync_directory_metadata",
+          "count": 2
+        }
+      ]
+    },
+    {
       "file": "crates/kin-daemon/src/loop_runner.rs",
       "reason": "Host event ingestion boundary. The excused bodies are the file watcher's admission path: reading a host file or symlink target and its mode so the change can be admitted into the graph as exact tree state, and comparing a host entry against what the graph already holds so an unchanged file is not re-admitted. Reading the working tree is the entire job of an ingestion boundary, and the result is written into graph truth rather than returned as an answer. The remaining two are repository binding, which precedes any graph consult: recognizing a bare git layout, and resolving a path relative to the bound root. The helper that canonicalized a host parent while preserving its leaf moved to kin-index, which is a declared ingestion boundary, so the watcher and this runner decide repository containment by one rule instead of two. The cfg-gated executable-bit helper is the pair that carries a count of two. Function-scoped so the rest of the runner stays scanned.",
       "owner": "kin-daemon",


### PR DESCRIPTION
## The mechanism

`kin graph status` composes the relation-kind histogram at `crates/kin-cli/src/commands/graph.rs:547` and prints its verdict, `✓ No issues detected.`, at `graph.rs:712`. Nothing between those two lines read a previous state, because no previous state existed: the census was computed per request and discarded. So a store that lost an entire relation kind printed the numbers proving the loss, then printed the all-clear over them.

On the rc0545c stranger run, arm brown, a psf/requests store went from 1985 entity-to-entity relations at 23:59:21Z to 1807 at 00:35:16Z, and `UsesType` went from 94 edges to none, under `✓ No issues detected.` The capture is `.kin-coord/handoffs/stranger-rc0545c/brown/out/graph-status-requests.txt`. The loss itself was operator-induced, and Kin warned about the cause unprompted at commit time with `correctness-relevant override active: KIN_DAEMON_DISABLE_LSP set to non-default value "1"`. What Kin could not do was compare its own census to the one before it.

## The fix

A new `crates/kin-core/src/relation_census.rs` holds the record, the comparison rule, and the cause lookup. It follows `crates/kin-core/src/last_admission.rs` closely and on purpose. The record has a schema token in it. Publication is a staged temp file renamed into place after an fsync of the file and then of the containing directory. Reads are three-way, so `Absent` and `Unreadable` stay separate answers that may never render as "unchanged".

Writers, all through `record_relation_census` in `crates/kin-daemon/src/background_work.rs`:

- the end of a completed enrichment sweep in `crates/kin-daemon/src/daemon.rs`, taken just before the sweep publishes its snapshot so the recorded census describes the graph that publication is about to make durable;
- the end of a native commit in `crates/kin-daemon/src/api.rs`, after `graph.create_change` installs the change in the live graph;
- the end of an MCP transaction commit in `crates/kin-daemon/src/mcp_commit.rs`, beside `record_commit_provenance`, because an agent that only ever writes through MCP would otherwise leave the census frozen.

No read path writes. A census stamped on every status reading would compare each reading against the one before it. A store that lost a kind would then announce the loss once and report itself clean ever after, which is the same defect one level quieter.

Reader: `command_graph` in `api.rs` builds a `CensusContext` from the store's record and the daemon's own environment. `build_graph_status_response` compares its own census against that record. It adds one row directly under the histogram, then extends the warnings vector with one sentence per losing kind. The comparison also rides on `GraphCommandResponse` as `relation_census`, which is how `kin doctor` reads the verdict structurally instead of parsing prose, exactly as the reference-edge coverage beside it already does.

Doctor gets one new row, `Relation census`, in `check_relation_census`, with the verdict split into the pure `relation_census_health`. That mirrors `check_reference_edge_coverage` and `reference_edge_coverage_health`.

## The rule

A kind that went from more than zero to zero is a loss, reported unconditionally. A kind that fell by at least `SHARP_DROP_FRACTION` (0.25, named in the rendered line) without reaching zero is a loss. Slippage under that threshold, growth, a new kind and an identical count all appear in the comparison, and none of them withholds the all-clear. An aggregate fall is named even when no single kind crossed the threshold, because on the evidence run `References` fell 412 to 340, comfortably inside tolerance, while the total moved 1985 to 1807.

Losses are pushed as warnings rather than criticals. `graph.rs` already states why for the degraded-reconcile case directly above: criticals set the response error and would turn `kin graph status` nonzero for every caller scripting it. Killing the false all-clear is the requirement here. Changing an exit code is a separate decision.

The cause comes from `env_registry::audit_env`, so a row that names a knob names it in the words the startup warning already used.

## Why a store marker rather than an audit event

The record lives at `.kin/kindb/relation-census`, beside `last-admission`, `head-generation` and `embedding-coverage-complete`, which are the three existing per-store records of exactly this class. This was a deliberate choice over the graph's own provenance surface, and the reasoning is recorded here so it is not reopened.

`kin_model::GraphStore` comes from pinned external crates (kin-model `=0.7.10`, kin-db `=0.7.38`), carries no key/value or metadata surface, and its `GraphSnapshot` is `deny_unknown_fields` and MessagePack-positional, so a new field needs a kin-db release. The one free-form slot is `ProvenanceStore::record_audit_event`, whose `details` field already carries structured JSON on the MCP commit path. It was rejected for two reasons. `query_audit_events` filters only by actor and limit while commit attribution writes one event per changed entity, so on a busy store the census scrolls out of any bounded read and the reader reports "no previous census" while one exists. That is this same silent false negative reintroduced one level down. Separately, `kin-review` resolves attribution and its unreviewed-agent-change signal entirely from audit events and the actor they name, so census events written under a synthetic daemon actor would contaminate review output.

The marker is bookkeeping rather than an answer authority. It names no entity and carries no repository content, and a reader that lied in either direction would change only the wording of a health row. Its zero-file-search allowlist entry is function-scoped for that reason, so any newly added filesystem primitive in the module still fails the guard.

## Falsification

Clean baseline first, because a sabotage run proves nothing without one: `kin-core` 17 passed 0 failed on `relation_census`, `kin-cli` 7 passed 0 failed on the census and doctor filters.

Two passes, each removing one property, each predicted before it ran, each with the edit confirmed applied by `git diff --numstat` reading `1 1 crates/kin-core/src/relation_census.rs` first.

**Pass A removes the comparison.** `compare()` walks only `current.keys()` instead of the union of both key sets, which is the defect this ticket describes. A comparison that iterates only the current census cannot see a kind that is no longer there to iterate.

- `kin-core` 14 passed, 3 failed: `a_kind_that_vanished_is_reported_as_vanished`, `the_comparison_walks_kinds_the_current_census_no_longer_holds`, `a_comparison_against_a_recorded_census_names_the_loss_and_its_cause`.
- `kin-cli` 5 passed, 2 failed: `a_relation_kind_that_vanished_since_the_recorded_census_refuses_no_issues`, `doctor_reports_a_relation_kind_that_vanished_since_the_recorded_census`.
- Still green, which is what makes the pass discriminate: the 40 percent fall, the slip inside tolerance, growth, new kind, identical census, both persistence round-trips, both aggregate-total cases, both cause cases, `doctor_stays_green_when_no_relation_kind_lost_ground`, `doctor_separates_a_store_with_no_recorded_census_from_a_healthy_one`, `a_store_with_no_recorded_census_says_so_and_still_reaches_the_all_clear`.

**Pass B removes the persistence.** `write()` publishes to `kindb_relation_census_path().with_extension("not-published")`, so a census is written and nothing lands where `read()` looks. Chosen over stubbing the body because it leaves no dead code and no warning to muddy the result.

- `kin-core` 15 passed, 2 failed: `a_written_census_round_trips` and `a_census_survives_a_reader_that_did_not_write_it`, exactly the durability pair.
- `kin-cli` 6 passed, 1 failed: only `a_relation_kind_that_vanished_since_the_recorded_census_refuses_no_issues`. Both doctor rows pass, because they build their comparison in memory and never touch the record.

The passes fail disjoint sets except the lifecycle test, which fails under both. That is correct: it is the only case exercising record and compare together. The tree restored byte-identical after each pass (`git diff HEAD --stat` empty).

**A test of mine that could not fail, caught mid-run.** The lifecycle test first asserted that the loss arm did not print `No issues detected` and the control arm did. Neither assertion could do work: `graph_validation_fixture` always raises `all entities are Source` and `N embeddings are still pending`, so the all-clear is unreachable in both arms. The control failed on a clean tree, which exposed it. Both arms now assert on the `⚠ relation kind UsesType lost every edge it held` marker, which exists only when the warnings vector is non-empty, while the all-clear prints only when that vector is empty.

**The guard refused the module first.** `python3 scripts/verify-zero-file-search.py` failed with seven violations across the new read and write bodies before the allowlist entry existed. That refusal is the entry's own falsification: the guard does see this module and does reject it unexcused. It passes now at 178 files scanned, 9 with function-scoped exemptions.

## Current rebase and repair, 2026-08-21

This branch is rebased onto `c6487105590c7ff689e7b5c535c08d412f348a70`, current main after #1042 and #1026. The pushed head is `60a83df4a589d5e0ad18ae20e2b1460529e3bc1e`. The force update used `--force-with-lease` only after `git ls-remote` confirmed the existing remote head was exactly `33be6b3854f668982d9f2c3340f681d883bf7b43`.

The four original pull request commits were replayed in order. The clean local-only repair `2fe584bb43df5edf420d549244362a4f27203566` was reused for the two #1030 call sites rather than recreated. Main's #1040 changed doctor to fetch graph status once per run, so the census row now consumes that same `RunGraphStatus`; it does not restore the old second round trip. The shared fixture carries a healthy census and checks readable and unreadable outcomes for both graph consumers.

Source-level fallback evidence: semantic MCP was daemon-unreachable. The pull request's call-site parser reads this branch as 29 calls, 28 multiline and one single-line, all taking five arguments. Run unchanged against `origin/main`, it reads 26 calls and all take four. A search for `args=4` in the branch parser output exits 1, while the same control against main counts 26 and exits 0.

Verification at base `c6487105` and head `60a83df4`, with exit statuses read directly:

- `cargo fmt --all -- --check` exits 0.
- CI-equivalent `cargo clippy --all-targets --all-features` exits 0 under `RUSTFLAGS=-D warnings` and the repository's 45-lint allow list. Its only warning is the existing future-incompatibility note for third-party `block v0.1.6`.
- `python3 scripts/verify-zero-file-search.py` passes at 179 source files, 9 with function-scoped exemptions and 4 exempt whole-file. `bash scripts/zero_file_search_guard.sh`, `bash scripts/check_runtime_boundaries.sh`, and `bash scripts/check_private_repo_coupling.sh` all pass.
- `cargo test -p kin-cli graph --locked` exits 0. The kin-cli library target reports 121 passed and 0 failed. `a_refused_vector_checkpoint_is_named_even_when_nothing_is_pending`, `a_relation_kind_that_vanished_since_the_recorded_census_refuses_no_issues`, `a_store_with_no_recorded_census_says_so_and_still_reaches_the_all_clear`, `one_doctor_run_fetches_graph_status_once_however_many_rows_read_it`, and `an_unreadable_graph_reaches_the_row_rather_than_being_reported_once` all pass by name. The `graph_status_after_admission` integration target reports 6 passed and 0 failed.
- `git status --short` is empty. `git ls-tree -r HEAD --name-only` prints only `.cargo/config.toml` below `.cargo/`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

## Not claiming

The new head's hosted checks were triggered by this push and are not claimed green here. The full `bin/kin-dev local-test kin` gate was not run; the targeted graph gate is the compile and behavior check for the E0061 failure class, and the lane preamble says targeted tests, formatting, and Clippy do not take a build slot. This verification is source-level fallback evidence, not semantic MCP proof. The pull request has not been submitted to the hosted merge queue and auto-merge has not been armed.

Closes FIR-2544

