### PR TITLE
Record the complete admission a commit performs

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4752,6 +4752,34 @@ async fn command_commit(
                 .background_work
                 .reconcile()
                 .clear_deferred_tree_wedge();
+            // The forced admission above is a complete exact-tree admission by
+            // every measure the freshness surfaces use, so it is recorded on the
+            // same probes and in the same durable marker the ambient reconcile
+            // tick and `kin admit` write. Leaving it out made a commit the one
+            // complete admission no surface could see.
+            //
+            // Recorded here rather than beside the admission because this is the
+            // point the admitted tree is durable. The admission defers its
+            // publication to this transaction, and a marker stamped before the
+            // transaction reached authority would claim a complete admission for
+            // a tree authority never accepted, on exactly the path where the
+            // commit fails and the deferred publication fails behind it.
+            //
+            // Without this the marker had two writers, the ambient tick and
+            // `kin admit`, and neither runs on a convert-then-commit session: the
+            // tick stands its own round down for a commit inside the daemon. So a
+            // store that had just been converted and committed to reported that
+            // no complete admission was recorded for it, minutes after one had
+            // completed, while a sibling store that happened to get an ambient
+            // tick milliseconds before its commit reported a healthy timestamp.
+            state
+                .background_work
+                .reconcile()
+                .record_admission_success(std::time::Instant::now());
+            crate::background_work::record_durable_admission(
+                &state.layout,
+                state.graph.resolved_tree().len() as u64,
+            );
             Ok(response)
         }
         Err(error) => {
@@ -20324,6 +20352,165 @@ mod tests {
                 "the commit path must not name the {phase} phase; captured {:?}",
                 captured.phases
             );
+        }
+    }
+
+    /// A commit performs a complete exact-tree admission, so it must leave the
+    /// durable record of one behind.
+    ///
+    /// The marker had two writers before this, the ambient reconcile tick and
+    /// `kin admit`, and a convert-then-commit session runs neither: the tick
+    /// stands its own round down for a commit already inside the daemon. So two
+    /// stores converted and committed by one binary ended in opposite freshness
+    /// states, one carrying a timestamp because an ambient tick happened to land
+    /// milliseconds before its commit took the coordination gate, and the other
+    /// reporting that no complete admission had ever been recorded for it.
+    ///
+    /// The absent read before the commit is the control. `test_state` opens a
+    /// store with no ambient loop and no marker, so a marker afterwards can only
+    /// have been written by the commit under test, and an assertion that passed
+    /// on a store that was already stamped would prove nothing.
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_commit_records_the_complete_admission_it_performed() {
+        use kin_core::last_admission::LastAdmissionRead;
+
+        let state = test_state();
+        assert!(
+            matches!(
+                kin_core::last_admission::read(&state.layout),
+                LastAdmissionRead::Absent
+            ),
+            "the fixture store must carry no marker, or a marker afterwards proves nothing"
+        );
+
+        let root = state.layout.working_dir();
+        std::fs::write(root.join("admitted.rs"), b"pub fn admitted() {}\n").unwrap();
+        let app = router(Arc::clone(&state));
+        let response = app
+            .oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
+                            "message": "record the admission this commit performed"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+        let recorded = match kin_core::last_admission::read(&state.layout) {
+            LastAdmissionRead::Recorded(recorded) => recorded,
+            other => panic!(
+                "a successful commit must record the complete admission it performed, read {other:?}"
+            ),
+        };
+        assert_eq!(
+            recorded.tracked_artifacts,
+            state.graph.resolved_tree().len() as u64,
+            "the record must cover the tree the commit left behind, not a different count"
+        );
+        assert!(
+            recorded.age_seconds(chrono::Utc::now()) < 300,
+            "the record must be stamped by this commit rather than carried in from elsewhere"
+        );
+
+        // The in-memory probes carry the same fact, so `/health`, `kin doctor`
+        // and `kin admit` name a commit's admission instead of reporting that
+        // none has succeeded in this daemon's life.
+        assert!(
+            state
+                .background_work
+                .reconcile_report(std::time::Instant::now())
+                .last_admission_success_age_seconds
+                .is_some(),
+            "a commit's admission must reach the reconcile probes as a success"
+        );
+    }
+
+    /// A commit that never reached authority must not restamp the marker.
+    ///
+    /// The forced admission still runs on this path and still succeeds, but its
+    /// tree is deferred to a transaction that was refused, so recording a
+    /// complete admission here would claim freshness for a tree repository
+    /// authority never accepted. The failure direction is the safe one: an
+    /// unrefreshed marker reads as staler than the store is and never as
+    /// fresher.
+    ///
+    /// A second commit on an unchanged tree is the refusal with no mocking in
+    /// it. `refuse_a_successor_that_records_nothing` answers it 409 after the
+    /// admission has already run, which is exactly the ordering under test. An
+    /// empty workspace is not that case and was the first guess: the first
+    /// commit of a freshly initialized store is accepted, so a test written on
+    /// it asserts nothing about a refusal.
+    ///
+    /// The first commit's timestamp is the control. Asserting only that some
+    /// marker exists afterwards would pass on a build that restamped on every
+    /// request, which is the defect this guards.
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_commit_that_reaches_no_authority_records_no_admission() {
+        use kin_core::last_admission::LastAdmissionRead;
+
+        let state = test_state();
+        let root = state.layout.working_dir();
+        std::fs::write(root.join("committed.rs"), b"pub fn committed() {}\n").unwrap();
+
+        let commit = |body: &'static str| {
+            let app = router(Arc::clone(&state));
+            app.oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
+                            "message": body
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+        };
+
+        let accepted = commit("record the first admission").await.unwrap();
+        assert_eq!(
+            accepted.status(),
+            StatusCode::OK,
+            "the first commit must be accepted, or there is no marker to leave alone"
+        );
+        let stamped = match kin_core::last_admission::read(&state.layout) {
+            LastAdmissionRead::Recorded(recorded) => recorded,
+            other => panic!("the accepted commit must record its admission, read {other:?}"),
+        };
+
+        let refused = commit("commit the same tree again").await.unwrap();
+        assert_eq!(
+            refused.status(),
+            StatusCode::CONFLICT,
+            "a second commit on an unchanged tree must be refused, or this test is not \
+             exercising a failed commit"
+        );
+
+        match kin_core::last_admission::read(&state.layout) {
+            LastAdmissionRead::Recorded(after) => assert_eq!(
+                after, stamped,
+                "a commit that reached no authority must leave the freshness record exactly as \
+                 the last complete admission left it"
+            ),
+            other => panic!("the refused commit must not have removed the record, read {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Mechanism

A commit performs a complete exact-tree admission and never recorded that it had.

The durable last-admission marker had exactly two writers: `crates/kin-daemon/src/loop_runner.rs:2186`, in the ambient reconcile tick after `exact_tree_admission` returns `Ok`, and `crates/kin-daemon/src/repository_admit.rs:222`, in the `kin admit` pass. The commit endpoint runs its own complete exact-tree admission at `crates/kin-daemon/src/api.rs:4740`, through `sync_filesystem_with_graph_deferring_tree_publication` and timed as the `forced_filesystem_admission` phase, and recorded neither the probe success nor the durable marker.

A convert-then-commit session runs neither writer. `kin init` does not stamp one, and the ambient tick deliberately stands its own round down whenever a commit is already inside the daemon (`crates/kin-daemon/src/loop_runner.rs:2080`, `wait_out_imminent_commit`), which is exactly the cadence of writing a file and committing it. So `kin graph status` answered "no complete admission is recorded for this store" minutes after a successful conversion and a successful commit.

Two repositories converted by one binary in the rc0545c stranger run ended in opposite freshness states, and the daemon logs measure why rather than leaving it inferred. Express logged `publish_workspace_admission`, the standalone admission's own tree publication that the commit path deliberately does not spend, finishing at `2026-08-21T00:33:57.470740Z`; its marker reads `2026-08-21T00:33:57.473295250+00:00`, 2.5 ms later. Its commit then reached the coordination gate at 00:33:57.506. An ambient tick beat that commit to the gate by 33 ms and stamped the marker on its way past. The requests log contains `publish_workspace_admission` zero times across 1602 lines, against two occurrences of `forced_filesystem_admission`, so no standalone admission ever published in that store and nothing ever stamped it.

The requests path did not have an incomplete admission. Its `forced_filesystem_admission` completed in 7365 ms with no error and the commit that followed reached authority, so the fix is the missing write rather than a new message.

The ticket also reports two disjoint phase vocabularies for one subcommand. That is a logging threshold, not a second code path. `timed_commit_phase` (`crates/kin-daemon/src/mcp_commit.rs:2102`) and `timed_commit_phase_async` (`:2125`) emit at `info` only past `SLOW_FINALIZE_STEP` and at `debug` below it, so a user sees whichever phases happened to be slow on that machine. Four phase names are common to the two daemon logs. There is one `/commands/commit` handler and every repository takes it. No change here; the CLI progress surface is another lane's.

## The fix

On the arm of `command_commit` where `command_commit_after_admission` returned `Ok`, the handler now records the admission on the same reconcile probes the ambient tick records to, and stamps the same durable marker.

That arm and not beside the admission, on purpose. The commit's admission defers its tree publication to the commit's own transaction, so the admitted tree is durable only once that transaction reaches authority. A marker stamped earlier would claim a complete admission for a tree authority never accepted, on exactly the path where the commit fails and the deferred publication fails behind it, which is the false freshness the marker exists to prevent.

## Tests

Two, both driving a real commit through the router, both joined to the existing `commit_phase_capture` serial group because a test that emits commit phase events cannot run beside the test that captures them.

`a_commit_records_the_complete_admission_it_performed` reads the marker as `Absent` first as its control, then asserts it is `Recorded` after the commit with `tracked_artifacts` equal to the tree the commit left behind, and that the probes carry the success.

`a_commit_that_reaches_no_authority_records_no_admission` commits once, captures the record, then commits the unchanged tree again and asserts the 409 refusal leaves the record byte-identical. The first draft used an empty workspace on the assumption it would be refused; it is not, the first commit of a freshly initialized store is accepted with 200, and the assertion caught that rather than passing on a case it was not about.

## Falsification

Three passes, each removing one property, each asserting its sabotage applied before running and restoring byte-identical after.

Pass 1, delete the `record_durable_admission` call. Predicted both new tests fail and the phase test passes. Result `1 passed; 2 failed`: "a successful commit must record the complete admission it performed, read Absent" and "the accepted commit must record its admission, read Absent".

Pass 2, delete the `record_admission_success` probe call only. Predicted only the probe assertion fails. Result `2 passed; 1 failed`: "a commit's admission must reach the reconcile probes as a success", with the marker half of the same test still passing.

Pass 3, hoist both calls above the match so the commit stamps unconditionally. Predicted the recording test passes and the refusal test fails on the timestamp. Result `2 passed; 1 failed`: "a commit that reached no authority must leave the freshness record exactly as the last complete admission left it", `at: 2026-08-21T05:22:16.982751Z` against `at: 2026-08-21T05:22:15.873017Z`.

## Gates

`cargo fmt --all -- --check` exit 0. Clippy exactly as `ci.yml` runs it, `--all-targets --all-features` under `RUSTFLAGS=-D warnings` with the `.github/clippy-allowed-lints.txt` allowlist, exit 0.

The five guard scripts `ci.yml` names all pass locally: `scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh`, `scripts/verify-hydration-semantics.py`.

Full local gate under a build slot. Its own resolution line reads `kin-dev: local-test: kin /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/admission-kin @ 1c512ef9 (chore/lane-admission-kin)`, so the tree under test is this branch rather than the primary. Result `Summary [ 670.054s] 6625 tests run: 6625 passed (8 slow, 1 leaky), 12 skipped`, exit 0, doctests beside it.

`git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

## Scope left open

`/commands/stash` (`crates/kin-daemon/src/api.rs:4118`) runs the same complete admission through `sync_filesystem_with_graph_under_coordination` and records nothing. The `kin init` conversion path records nothing either, and stamping there honestly needs an empty `workspace_divergence` check, since init admits the committed Git tree while the worktree may still diverge from it. Both are the same defect on other callers and are filed as FIR-2558 and FIR-2559 rather than carried as riders here.

Refs FIR-2545
