### PR TITLE
Add list_file_entities, a graph-backed file entity enumeration with certifiable completeness

### DIFF
--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -253,6 +253,20 @@ fn shape_for(tool: &str) -> Option<ResponseShape> {
             bulk_keys: &[],
             narrow_param: "limit",
         },
+        // The enumeration surface. `narrow_param` is `page_size` rather than a
+        // limit, because this tool's answer to "too large" is a smaller page
+        // plus a cursor to the rest, never a smaller answer. Nothing is listed
+        // under `body_keys`: the rows carry a signature and a span and no source
+        // body at all, so there is no body layer to shed before rows are.
+        FILE_ENTITIES_TOOL => ResponseShape {
+            collections: &["entities"],
+            body_keys: &["doc_summary"],
+            explain_keys: &[],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            bulk_keys: &[],
+            narrow_param: "page_size",
+        },
         "semantic_search" => ResponseShape {
             collections: &["results"],
             body_keys: &["doc_summary"],
@@ -352,6 +366,10 @@ fn shape_for(tool: &str) -> Option<ResponseShape> {
 }
 
 /// Whether this tool's response is governed by the budget.
+/// The file-enumeration tool, named from the handler that defines it so this
+/// table cannot come to describe a tool under a name the registry stopped using.
+const FILE_ENTITIES_TOOL: &str = crate::handlers::file_entities::TOOL_NAME;
+
 pub fn is_budgeted(tool: &str) -> bool {
     shape_for(tool).is_some()
 }

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -501,11 +501,26 @@ impl Completeness {
             }
         };
 
-        let (classes, decided_by, mut limits) = match substrate {
+        let (mut classes, mut decided_by, mut limits) = match substrate {
             CoverageSubstrate::Edges => edge_class_states(tool, payload, &edge_classes),
             CoverageSubstrate::Embeddings => embedding_class_states(envelope),
             CoverageSubstrate::Graph => graph_class_states(envelope),
         };
+
+        // A file enumeration is decided by that file's own parse state, which
+        // no store-level class can see. A completely loaded, fully embedded,
+        // undegraded graph holds no entities for a file no adapter parsed, so
+        // the `graph` class above reads `present` while the answer is empty for
+        // a reason that has nothing to do with the code.
+        if tool == crate::handlers::file_entities::TOOL_NAME {
+            merge_file_coverage_classes(
+                payload,
+                envelope,
+                &mut classes,
+                &mut decided_by,
+                &mut limits,
+            );
+        }
 
         // A walk that refused a type-annotation hop withheld something the
         // caller could have asked for, so it is named here. It is disclosure
@@ -711,6 +726,109 @@ fn graph_class_states(envelope: &Envelope) -> (Map<String, Value>, Vec<String>, 
     (classes, vec!["graph".to_string()], limits)
 }
 
+/// The file's own coverage classes, folded in beside the store's.
+///
+/// `file_parsed` decides, and it is the only one that does. `file_enriched` and
+/// `embeddings` are disclosed because a reader asks about them, but neither can
+/// make an enumeration short: enrichment adds edges between entities and
+/// embeddings add ranking, while the entity set of a file is fixed by what the
+/// adapter extracted. Naming a class that cannot have limited the answer as one
+/// that did is how a correct answer comes to read as uncertain.
+///
+/// `embeddings` is the store-grain reading on purpose and says so in its own
+/// name rather than pretending to a per-file number nothing measures. A complete
+/// store is a sound superset claim about this file; an incomplete one says
+/// nothing about it, which is `unknown` rather than `absent`.
+fn merge_file_coverage_classes(
+    payload: &Value,
+    envelope: &Envelope,
+    classes: &mut Map<String, Value>,
+    decided_by: &mut Vec<String>,
+    limits: &mut Vec<String>,
+) {
+    let coverage = payload
+        .get(crate::handlers::file_entities::FILE_COVERAGE_KEY)
+        .and_then(Value::as_object);
+
+    let parsed = match coverage
+        .and_then(|coverage| coverage.get("parsed"))
+        .and_then(Value::as_str)
+    {
+        Some("full") => STATE_PRESENT,
+        Some("absent") | Some("partial") | Some("failed") => STATE_ABSENT,
+        _ => STATE_UNKNOWN,
+    };
+    classes.insert("file_parsed".to_string(), json!(parsed));
+    decided_by.push("file_parsed".to_string());
+    if parsed != STATE_PRESENT {
+        limits.push(format!("file_parsed_{parsed}"));
+    }
+
+    let enriched = match coverage
+        .and_then(|coverage| coverage.get("enriched"))
+        .and_then(Value::as_str)
+    {
+        Some("present") => STATE_PRESENT,
+        Some("absent") => STATE_ABSENT,
+        _ => STATE_UNKNOWN,
+    };
+    classes.insert("file_enriched".to_string(), json!(enriched));
+
+    let embedded = match &envelope.semantic_coverage {
+        Some(coverage) if coverage.complete => STATE_PRESENT,
+        _ => STATE_UNKNOWN,
+    };
+    classes.insert("embeddings_store_wide".to_string(), json!(embedded));
+}
+
+/// A file enumeration's accounting: how many entities the file holds, and
+/// whether this response holds all of them.
+///
+/// `reported` is the whole-file total rather than the page length, because that
+/// is the number a caller asks the tool for. `exact` is false the moment the
+/// response is one page of several, so the total can be read as the file's count
+/// without the page being read as the file.
+fn file_entities_counted(payload: &Value) -> Option<Value> {
+    let reported = payload.get("total_in_file").and_then(Value::as_u64)?;
+    let coverage = payload
+        .get(crate::handlers::file_entities::FILE_COVERAGE_KEY)
+        .and_then(Value::as_object);
+    let certified = coverage
+        .and_then(|coverage| coverage.get("certifies_enumeration"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let whole_file = coverage
+        .and_then(|coverage| coverage.get("whole_file_in_response"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let shifted = payload
+        .get("enumeration_shifted")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let parsed = coverage
+        .and_then(|coverage| coverage.get("parsed"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+
+    let mut counted = json!({
+        "unit": "entities_in_file",
+        "reported": reported,
+        "returned": payload.get("returned").and_then(Value::as_u64).unwrap_or(0),
+        "exact": certified,
+    });
+    // Named in the order a reader acts on. A file the adapter never parsed is
+    // the limiting factor whatever the paging did, because following every
+    // cursor to the end still assembles a set the extractor never produced.
+    if parsed != "full" {
+        counted["floor_reason"] = json!(format!("file_parsed_{parsed}"));
+    } else if shifted {
+        counted["floor_reason"] = json!("enumeration_shifted");
+    } else if !whole_file {
+        counted["floor_reason"] = json!("page_bounded");
+    }
+    Some(counted)
+}
+
 /// What this answer counted and whether the count is the whole set, lifted from
 /// the payload's own accounting.
 ///
@@ -719,6 +837,9 @@ fn graph_class_states(envelope: &Envelope) -> (Map<String, Value>, Vec<String>, 
 /// says whether the finer number is whole), and recomputing it in the envelope
 /// is how two counters come to disagree about one answer.
 fn counted_for(tool: &str, payload: &Value) -> Option<Value> {
+    if tool == crate::handlers::file_entities::TOOL_NAME {
+        return file_entities_counted(payload);
+    }
     let (unit, reported) = match tool {
         "find_references" => (
             payload

--- a/crates/kin-mcp/src/handlers/file_entities.rs
+++ b/crates/kin-mcp/src/handlers/file_entities.rs
@@ -534,6 +534,152 @@ pub fn handle_list_file_entities<G: GraphStore>(
 mod tests {
     use super::*;
 
+    use kin_db::InMemoryGraph;
+    use kin_model::graph::EntityStore;
+    use kin_model::layout::{FileLayout, ImportSection, SourceRegion};
+    use kin_model::{ArtifactId, LocatedEntry, RepoPath, TransactionDelta, TreeDelta, TreeEntry};
+    use kin_model::{
+        EntityId, EntityMetadata, FingerprintAlgorithm, Hash256, SemanticFingerprint, SourceSpan,
+    };
+
+    const FILE: &str = "lib/express.js";
+
+    fn entity_at(name: &str, file: &str, start_byte: usize) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::JavaScript,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file)),
+            span: Some(SourceSpan {
+                file: FilePathId::new(file),
+                start_byte,
+                end_byte: start_byte + 40,
+                start_line: start_byte as u32 / 10,
+                start_col: 0,
+                end_line: start_byte as u32 / 10 + 2,
+                end_col: 0,
+            }),
+            signature: format!("function {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn layout_for(file: &str, completeness: ParseCompleteness, regions: usize) -> FileLayout {
+        FileLayout {
+            file_id: FilePathId::new(file),
+            parse_completeness: completeness,
+            imports: ImportSection {
+                byte_range: 0..0,
+                items: Vec::new(),
+            },
+            regions: (0..regions)
+                .map(|index| SourceRegion::EntityRef {
+                    entity_id: EntityId::new(),
+                    byte_range: index..index + 1,
+                })
+                .collect(),
+        }
+    }
+
+    /// Admit one path into the graph's repository tree through the real tree
+    /// transaction, which is what a layout or artifact facet requires.
+    fn admit(store: &InMemoryGraph, path: &str) -> ArtifactId {
+        let repo_path = RepoPath::from_utf8(path.to_string()).expect("valid test path");
+        if let Some(artifact_id) = store.artifact_id_at_path(&repo_path) {
+            return artifact_id;
+        }
+        let artifact_id = ArtifactId::new();
+        store
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: Vec::new(),
+                relation_deltas: Vec::new(),
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id,
+                    new: LocatedEntry::new(
+                        repo_path,
+                        TreeEntry::blob(Hash256::from_bytes([7; 32]), false),
+                    ),
+                }],
+                admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
+            })
+            .expect("test admission goes through the repository tree transaction");
+        artifact_id
+    }
+
+    /// A store holding `count` entities in [`FILE`], plus one entity in another
+    /// file so every "not in the list" assertion has a live control: the graph
+    /// can see that entity, and this tool still must not report it.
+    fn store_with(count: usize, parse: Option<ParseCompleteness>) -> InMemoryGraph {
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        admit(&store, "lib/router.js");
+        for index in 0..count {
+            store
+                .upsert_entity(&entity_at(&format!("export{index}"), FILE, index * 100))
+                .unwrap();
+        }
+        store
+            .upsert_entity(&entity_at("elsewhere", "lib/router.js", 0))
+            .unwrap();
+        if let Some(parse) = parse {
+            store
+                .upsert_file_layout(&layout_for(FILE, parse, count))
+                .unwrap();
+        }
+        store
+    }
+
+    fn call(
+        store: &InMemoryGraph,
+        args: &[(&str, serde_json::Value)],
+    ) -> Result<serde_json::Value> {
+        let args: HashMap<String, serde_json::Value> = args
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.clone()))
+            .collect();
+        let result = handle_list_file_entities(&args, store)?;
+        let crate::types::ContentBlock::Text { text } = &result.content[0];
+        Ok(serde_json::from_str(text).expect("payload is JSON"))
+    }
+
+    fn names(payload: &serde_json::Value) -> Vec<String> {
+        payload["entities"]
+            .as_array()
+            .expect("entities array")
+            .iter()
+            .map(|row| row["name"].as_str().expect("name").to_string())
+            .collect()
+    }
+
+    /// A daemon envelope whose STRUCTURAL substrate is clean: the only state in
+    /// which this tool's absence could be certified at all, so a refusal under
+    /// it is a refusal this tool's own gate produced rather than one it
+    /// inherited.
+    fn structural_authoritative_envelope() -> crate::envelope::Envelope {
+        let mut envelope = crate::envelope::Envelope::daemon();
+        envelope.graph_state.initialized = Some(true);
+        envelope.graph_state.loaded = Some(true);
+        envelope.graph_state.entity_count = Some(42);
+        envelope.graph_as_of = Some(serde_json::json!("change:deadbeef"));
+        envelope
+    }
+
     #[test]
     fn normalize_path_drops_dot_slash_and_swaps_separators() {
         assert_eq!(normalize_path("lib/express.js"), "lib/express.js");
@@ -562,5 +708,372 @@ mod tests {
         assert!(!ParsedState::Partial.certifies_enumeration());
         assert!(!ParsedState::Failed.certifies_enumeration());
         assert!(!ParsedState::Absent.certifies_enumeration());
+    }
+
+    /// The ticket's own case: a file with N entities enumerates exactly N, and a
+    /// name that is not in it is absent.
+    ///
+    /// The control is `elsewhere`, a real entity this store holds in another
+    /// file. Without it, "absent" would be satisfied by a tool that returns
+    /// nothing at all, and the fabricated name would prove only that the graph
+    /// does not invent rows.
+    #[test]
+    fn enumerates_exactly_the_file_and_nothing_else() {
+        let store = store_with(5, Some(ParseCompleteness::Full));
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+
+        assert_eq!(payload["total_in_file"], serde_json::json!(5));
+        assert_eq!(payload["returned"], serde_json::json!(5));
+        let names = names(&payload);
+        for index in 0..5 {
+            assert!(
+                names.contains(&format!("export{index}")),
+                "export{index} missing from {names:?}"
+            );
+        }
+        assert!(
+            !names.contains(&"elsewhere".to_string()),
+            "an entity in another file leaked into {names:?}"
+        );
+        assert!(
+            !names.contains(&"neverDefinedAnywhere".to_string()),
+            "a fabricated name appeared in {names:?}"
+        );
+        assert_eq!(
+            payload[FILE_COVERAGE_KEY]["certifies_enumeration"],
+            serde_json::json!(true)
+        );
+        assert_eq!(payload["next_cursor"], serde_json::Value::Null);
+    }
+
+    /// A leading `./` is the one path spelling a caller reliably types that the
+    /// graph never stores, so it must resolve rather than read as a miss.
+    #[test]
+    fn a_dot_slash_path_resolves_to_the_same_file() {
+        let store = store_with(3, Some(ParseCompleteness::Full));
+        let payload = call(&store, &[("path", serde_json::json!("./lib/express.js"))]).unwrap();
+        assert_eq!(payload["total_in_file"], serde_json::json!(3));
+        assert_eq!(payload["path"], serde_json::json!(FILE));
+    }
+
+    /// The refusal the ticket asks for. A path this graph has never seen must
+    /// not come back as `entities: []`, because that response says "this file
+    /// holds no entities" about a file Kin cannot see.
+    #[test]
+    fn an_unknown_path_refuses_rather_than_returning_an_empty_list() {
+        let store = InMemoryGraph::new();
+        let error = call(&store, &[("path", serde_json::json!("lib/nonexistent.js"))])
+            .expect_err("an untracked path must refuse");
+        let message = error.to_string();
+        assert!(
+            message.contains("graph gap"),
+            "refusal must name the gap; got {message}"
+        );
+        assert!(
+            message.contains("not a claim that the file has no entities"),
+            "refusal must deny the absence reading; got {message}"
+        );
+
+        // Control: the identical call on a store that holds the file answers,
+        // so the refusal is about this path rather than about the tool.
+        let seeded = store_with(2, Some(ParseCompleteness::Full));
+        let payload = call(&seeded, &[("path", serde_json::json!(FILE))]).unwrap();
+        assert_eq!(payload["total_in_file"], serde_json::json!(2));
+    }
+
+    /// A path with no admitted identity that DOES carry a layout is a tracked
+    /// file, so it answers rather than refusing. This is what stops the refusal
+    /// above from firing on every legitimately empty source file.
+    #[test]
+    fn a_parsed_but_empty_file_answers_empty_instead_of_refusing() {
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 0))
+            .unwrap();
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        assert_eq!(payload["total_in_file"], serde_json::json!(0));
+        assert_eq!(
+            payload[FILE_COVERAGE_KEY]["parsed"],
+            serde_json::json!("full")
+        );
+        assert_eq!(
+            payload[FILE_COVERAGE_KEY]["tier"],
+            serde_json::json!("entity_source")
+        );
+    }
+
+    /// Parse state decides certification, and each state is distinguishable.
+    /// A file the extractor never parsed and a file it parsed completely both
+    /// return rows; only one of them may be read as the file's whole surface.
+    #[test]
+    fn parse_state_decides_whether_the_enumeration_is_certified() {
+        for (parse, expected, certified) in [
+            (Some(ParseCompleteness::Full), "full", true),
+            (
+                Some(ParseCompleteness::Partial("2 parse error range(s)".into())),
+                "partial",
+                false,
+            ),
+            (
+                Some(ParseCompleteness::Failed("last known good".into())),
+                "failed",
+                false,
+            ),
+            (None, "absent", false),
+        ] {
+            let store = store_with(4, parse);
+            let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+            assert_eq!(
+                payload[FILE_COVERAGE_KEY]["parsed"],
+                serde_json::json!(expected)
+            );
+            assert_eq!(
+                payload[FILE_COVERAGE_KEY]["certifies_enumeration"],
+                serde_json::json!(certified),
+                "parse state {expected} certified the wrong way"
+            );
+            // Rows are served either way. Withholding real graph truth because
+            // it cannot be certified teaches an agent nothing and costs it the
+            // answer it can still act on.
+            assert_eq!(payload["total_in_file"], serde_json::json!(4));
+        }
+    }
+
+    /// Pagination walks the whole set with no duplicates and no silent cap.
+    #[test]
+    fn pagination_covers_the_whole_set_without_duplicates() {
+        let store = store_with(7, Some(ParseCompleteness::Full));
+        let mut seen: Vec<String> = Vec::new();
+        let mut pages = 0;
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let mut args = vec![("page_size", serde_json::json!(3))];
+            match &cursor {
+                Some(token) => args.push(("cursor", serde_json::json!(token))),
+                None => args.push(("path", serde_json::json!(FILE))),
+            }
+            let payload = call(&store, &args).unwrap();
+            pages += 1;
+            assert_eq!(
+                payload["total_in_file"],
+                serde_json::json!(7),
+                "every page must report the whole-file count"
+            );
+            seen.extend(names(&payload));
+            match payload["next_cursor"].as_str() {
+                Some(token) => cursor = Some(token.to_string()),
+                None => break,
+            }
+            assert!(pages < 10, "cursor walk did not terminate");
+        }
+
+        assert_eq!(pages, 3, "7 entities at page_size 3 is three pages");
+        assert_eq!(seen.len(), 7, "walk returned {} rows, want 7", seen.len());
+        let unique: std::collections::BTreeSet<&String> = seen.iter().collect();
+        assert_eq!(unique.len(), 7, "walk repeated a row: {seen:?}");
+        for index in 0..7 {
+            assert!(
+                seen.contains(&format!("export{index}")),
+                "export{index} was never returned across {pages} pages"
+            );
+        }
+    }
+
+    /// A page is not a file. The first page of three carries every entity it
+    /// returned and still may not be read as the whole set.
+    #[test]
+    fn a_partial_page_is_not_certified() {
+        let store = store_with(7, Some(ParseCompleteness::Full));
+        let payload = call(
+            &store,
+            &[
+                ("path", serde_json::json!(FILE)),
+                ("page_size", serde_json::json!(3)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(payload["returned"], serde_json::json!(3));
+        assert_eq!(payload["total_in_file"], serde_json::json!(7));
+        assert_eq!(payload["truncated"], serde_json::json!(true));
+        assert_eq!(
+            payload[FILE_COVERAGE_KEY]["whole_file_in_response"],
+            serde_json::json!(false)
+        );
+        assert_eq!(
+            payload[FILE_COVERAGE_KEY]["certifies_enumeration"],
+            serde_json::json!(false),
+            "a page of a file must not certify the file"
+        );
+    }
+
+    /// A cursor minted before the file changed is served, and the shift is named
+    /// rather than paged over in silence.
+    #[test]
+    fn a_cursor_from_a_changed_file_reports_the_shift() {
+        let store = store_with(7, Some(ParseCompleteness::Full));
+        let stale = PageCursor {
+            path: FILE.to_string(),
+            offset: 3,
+            total: 99,
+        }
+        .encode();
+        let payload = call(&store, &[("cursor", serde_json::json!(stale))]).unwrap();
+        assert_eq!(payload["enumeration_shifted"], serde_json::json!(true));
+        assert_eq!(
+            payload[FILE_COVERAGE_KEY]["certifies_enumeration"],
+            serde_json::json!(false)
+        );
+
+        // Control: the matching cursor pages cleanly and claims no shift.
+        let fresh = PageCursor {
+            path: FILE.to_string(),
+            offset: 3,
+            total: 7,
+        }
+        .encode();
+        let clean = call(&store, &[("cursor", serde_json::json!(fresh))]).unwrap();
+        assert_eq!(clean["enumeration_shifted"], serde_json::json!(false));
+    }
+
+    /// A cursor names its file, so paging one file with another's cursor is a
+    /// refusal rather than a window into a list nobody asked for.
+    #[test]
+    fn a_cursor_for_another_file_is_refused() {
+        let store = store_with(7, Some(ParseCompleteness::Full));
+        let token = PageCursor {
+            path: "lib/router.js".to_string(),
+            offset: 0,
+            total: 1,
+        }
+        .encode();
+        let error = call(
+            &store,
+            &[
+                ("path", serde_json::json!(FILE)),
+                ("cursor", serde_json::json!(token)),
+            ],
+        )
+        .expect_err("mismatched cursor must refuse");
+        assert!(
+            error.to_string().contains("page one file at a time"),
+            "got {error}"
+        );
+    }
+
+    /// An absolute path or a `..` escape is refused by name. Without this it
+    /// becomes an exact-match miss, which reads as "this file has no entities".
+    #[test]
+    fn an_inadmissible_path_is_refused_by_name() {
+        let store = store_with(3, Some(ParseCompleteness::Full));
+        for bad in ["/etc/passwd", "../outside.js", ""] {
+            let error = call(&store, &[("path", serde_json::json!(bad))])
+                .expect_err("an inadmissible path must refuse");
+            let message = error.to_string();
+            assert!(
+                message.contains("invalid parameter"),
+                "{bad:?} refused without naming the parameter: {message}"
+            );
+        }
+        // Control: the admissible path still answers, so the guard rejects bad
+        // paths rather than every path.
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        assert_eq!(payload["total_in_file"], serde_json::json!(3));
+    }
+
+    /// The verdict an agent reads. An empty enumeration on a fully parsed file
+    /// is a certifiable absence; the same empty enumeration on a file no adapter
+    /// parsed is not, and the reason names the parse rather than store health.
+    #[test]
+    fn absence_is_certified_only_when_the_file_was_parsed() {
+        let envelope = structural_authoritative_envelope();
+
+        let parsed = InMemoryGraph::new();
+        admit(&parsed, FILE);
+        parsed
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 0))
+            .unwrap();
+        let payload = call(&parsed, &[("path", serde_json::json!(FILE))]).unwrap();
+        let negative = crate::negative::negative_for(TOOL_NAME, &payload, &envelope, &[])
+            .expect("an empty enumeration must carry a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            serde_json::json!(true),
+            "a fully parsed empty file is a certifiable absence: {negative}"
+        );
+        assert_eq!(negative["kind"], serde_json::json!("no_file_entities"));
+
+        let unparsed = InMemoryGraph::new();
+        admit(&unparsed, FILE);
+        unparsed
+            .upsert_opaque_artifact(&kin_model::layout::OpaqueArtifact {
+                file_id: FilePathId::new(FILE),
+                content_hash: Hash256::from_bytes([0; 32]),
+                mime_type: None,
+                text_preview: None,
+            })
+            .unwrap();
+        let payload = call(&unparsed, &[("path", serde_json::json!(FILE))]).unwrap();
+        let negative = crate::negative::negative_for(TOOL_NAME, &payload, &envelope, &[])
+            .expect("an empty enumeration must carry a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            serde_json::json!(false),
+            "an unparsed file must never certify an absence: {negative}"
+        );
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("file_not_parsed"),
+            "the reason must name the parse, not store health: {negative}"
+        );
+    }
+
+    /// The completeness signal a caller reads instead of the row count. A page
+    /// of a file reports its counts as a floor and names why.
+    #[test]
+    fn completeness_reports_a_page_as_a_floor() {
+        let envelope = structural_authoritative_envelope();
+        let store = store_with(7, Some(ParseCompleteness::Full));
+
+        let whole = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let annotated = crate::envelope::finalize(
+            ToolCallResult::text(serde_json::to_string(&whole).unwrap()),
+            envelope.clone(),
+            TOOL_NAME,
+        );
+        let crate::types::ContentBlock::Text { text } = &annotated.content[0];
+        let value: serde_json::Value = serde_json::from_str(text).unwrap();
+        let counted = &value["_kin"]["completeness"]["counted"];
+        assert_eq!(counted["unit"], serde_json::json!("entities_in_file"));
+        assert_eq!(counted["reported"], serde_json::json!(7));
+        assert_eq!(counted["exact"], serde_json::json!(true));
+        assert_eq!(
+            value["_kin"]["completeness"]["classes"]["file_parsed"],
+            serde_json::json!("present")
+        );
+
+        let page = call(
+            &store,
+            &[
+                ("path", serde_json::json!(FILE)),
+                ("page_size", serde_json::json!(3)),
+            ],
+        )
+        .unwrap();
+        let annotated = crate::envelope::finalize(
+            ToolCallResult::text(serde_json::to_string(&page).unwrap()),
+            envelope.clone(),
+            TOOL_NAME,
+        );
+        let crate::types::ContentBlock::Text { text } = &annotated.content[0];
+        let value: serde_json::Value = serde_json::from_str(text).unwrap();
+        let counted = &value["_kin"]["completeness"]["counted"];
+        assert_eq!(counted["reported"], serde_json::json!(7));
+        assert_eq!(counted["returned"], serde_json::json!(3));
+        assert_eq!(counted["exact"], serde_json::json!(false));
+        assert_eq!(counted["floor_reason"], serde_json::json!("page_bounded"));
     }
 }

--- a/crates/kin-mcp/src/handlers/file_entities.rs
+++ b/crates/kin-mcp/src/handlers/file_entities.rs
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! File-scoped entity enumeration (FIR-2546).
+//!
+//! "What is in this file" is the cheapest question the graph can answer and it
+//! was the one no tool on the `agent-default` profile asked. An agent that
+//! needed it had to read ids out of a `semantic_locate` response and hope the
+//! ranking had returned them all, which it cannot promise: locate is a bounded
+//! ranking, so a short list and a full list are the same response.
+//!
+//! This tool answers the enumeration directly from graph truth and certifies
+//! what it left out. Three facts decide that certification and each is read
+//! from the store rather than inferred:
+//!
+//! - the entities whose `file_origin` is this path ([`kin_model::EntityFilter`]),
+//! - whether a language adapter parsed the file, and how completely
+//!   ([`kin_model::layout::FileLayout::parse_completeness`]),
+//! - whether the repository tree admits the path at all
+//!   ([`kin_model::graph::EntityStore::artifact_id_at_path`]).
+//!
+//! Nothing here reads the filesystem. A path the graph does not track is a
+//! refusal that names the gap, never an empty list: those two answers look
+//! identical to a caller and only one of them means the file has no entities.
+//!
+//! ## Why the page is bounded by a cursor rather than a cap
+//!
+//! A silent cap is the defect this tool exists to remove wearing a different
+//! costume. `take(40)` returns forty entities from a file holding two hundred
+//! and says nothing, so the caller reads a complete-looking list. Every page
+//! here carries `total_in_file`, and a page that does not hold the whole file
+//! carries a `next_cursor` and reports `exact: false` through
+//! [`crate::envelope::Completeness`], so a partial answer can never be read as
+//! a whole one.
+
+use std::collections::HashMap;
+
+use base64::Engine as _;
+use kin_model::graph::{EntityFilter, GraphStore};
+use kin_model::layout::ParseCompleteness;
+use kin_model::{entity::Entity, EntityKind, EntityRole, FilePathId, LanguageId, Visibility};
+use serde::Serialize;
+
+use crate::error::{McpError, Result};
+use crate::handlers::common::{entity_presentation_end_line, entity_presentation_start_line};
+use crate::types::ToolCallResult;
+
+/// The tool's registered name, spelled once so the registry, the dispatcher,
+/// the budget table and the negative registry cannot drift from each other.
+pub const TOOL_NAME: &str = "list_file_entities";
+
+/// Key under which this tool publishes what the graph knows about the file
+/// itself, beside the entities it enumerated.
+///
+/// Read back by [`crate::envelope::Completeness`] and [`crate::negative`], which
+/// project it into the response's one verdict. Publishing the raw observation
+/// here and the verdict there is the same split `edge_coverage` already uses: a
+/// reader who disagrees with the verdict can audit the evidence it was built
+/// from.
+pub const FILE_COVERAGE_KEY: &str = "file_coverage";
+
+/// Entities returned per page when the caller names no `page_size`.
+const DEFAULT_PAGE_SIZE: u64 = 200;
+
+/// Ceiling on `page_size`. Above this a single response stops being something
+/// an agent can read and becomes something the response budget has to cut,
+/// which reintroduces the silent truncation this tool exists to remove.
+const MAX_PAGE_SIZE: u64 = 1_000;
+
+pub const LIST_FILE_ENTITIES_DESC: &str = "\
+Enumerate every entity the graph holds for one repository-relative file, with a completeness \
+you can act on. This is the enumeration surface: unlike `semantic_locate`, which ranks and \
+therefore cannot say what it left out, this returns the whole set the graph owns for the path \
+and reports whether that set is whole. Give it `path`, such as \"lib/express.js\". Each row \
+carries the `id` every other tool here takes (`get_entity_source`, `get_context_pack`, \
+`find_references`, `graph_neighborhood`), plus `name`, `kind`, `language`, `role`, \
+`visibility`, `signature`, and the defining span as both lines and bytes. \
+`file_coverage` says what the graph knows about the file itself: `parsed` is `full` when a \
+language adapter parsed it completely, `partial` or `failed` when it did not, and `absent` \
+when no adapter parsed it at all. Only a `full` parse licenses reading this list as the file's \
+whole surface, and `_kin.completeness` and `negative.safe_to_conclude_absent` are computed \
+from that fact rather than from store-wide health. A path the graph does not track is refused \
+by name instead of answered with an empty list, because those two answers are \
+indistinguishable and only one of them means the file holds no entities. Large files page: \
+`total_in_file` is the whole-file count on every page, and a page that does not hold all of \
+them carries `next_cursor`, which you pass back as `cursor` for the next page.";
+
+/// One entity as this tool serves it.
+///
+/// The byte span rides beside the line span rather than replacing it. Lines are
+/// what an agent quotes to a human; bytes are what a splice or an exact
+/// comparison needs, and recomputing them from lines requires the file, which is
+/// the read this whole surface exists to avoid.
+#[derive(Debug, Serialize)]
+pub struct FileEntityRow {
+    pub id: kin_model::EntityId,
+    pub name: String,
+    pub kind: EntityKind,
+    pub language: LanguageId,
+    pub role: EntityRole,
+    pub visibility: Visibility,
+    pub signature: String,
+    pub start_line: Option<u32>,
+    pub end_line: Option<u32>,
+    pub start_byte: Option<usize>,
+    pub end_byte: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc_summary: Option<String>,
+}
+
+impl From<Entity> for FileEntityRow {
+    fn from(entity: Entity) -> Self {
+        let start_line = entity_presentation_start_line(&entity);
+        let end_line = entity_presentation_end_line(&entity);
+        let (start_byte, end_byte) = entity
+            .span
+            .as_ref()
+            .map(|span| (Some(span.start_byte), Some(span.end_byte)))
+            .unwrap_or((None, None));
+        Self {
+            id: entity.id,
+            name: entity.name,
+            kind: entity.kind,
+            language: entity.language,
+            role: entity.role,
+            visibility: entity.visibility,
+            signature: entity.signature,
+            start_line,
+            end_line,
+            start_byte,
+            end_byte,
+            doc_summary: entity.doc_summary,
+        }
+    }
+}
+
+/// How completely a language adapter parsed this file, in the one word the
+/// verdict is computed from.
+///
+/// `Absent` is not `Failed`. A file nothing ever tried to parse and a file whose
+/// parse failed both hold no entities, and only the second one is evidence about
+/// the code; collapsing them is how "no entities" comes to read as "no exports".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParsedState {
+    Full,
+    Partial,
+    Failed,
+    Absent,
+}
+
+impl ParsedState {
+    /// The wire word, matching [`ParseCompleteness::bucket`] for the three
+    /// states that have a layout to read it from.
+    pub fn wire(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Partial => "partial",
+            Self::Failed => "failed",
+            Self::Absent => "absent",
+        }
+    }
+
+    /// Whether this state licenses reading the enumeration as the file's whole
+    /// entity surface. Only a complete parse does.
+    pub fn certifies_enumeration(self) -> bool {
+        matches!(self, Self::Full)
+    }
+}
+
+/// Entities scanned before the language-server reading gives up and reports
+/// `unknown`.
+///
+/// The reading costs one relation read per entity and it decides nothing, so a
+/// file large enough to make it expensive gets an honest `unknown` rather than a
+/// query nobody asked for. `unknown` is a real answer here; the parse state is
+/// what the verdict rests on.
+const ENRICHMENT_SCAN_CAP: usize = 500;
+
+/// Which tier of tracking the graph holds this file at.
+///
+/// Kin classifies every tracked file into exactly one of these
+/// ([`kin_model::layout::TrackedFile`]), and the tier is what tells a caller
+/// whether an empty enumeration is a defect or the ordinary answer. A lockfile
+/// tracked as an opaque artifact holds no entities by design.
+///
+/// The four facets are mutually exclusive per file and the daemon enforces that
+/// (`clear_incompatible_facets_in`), so the first hit in this order is the
+/// file's tier rather than one of several.
+fn tracking_tier<G: GraphStore>(store: &G, file_id: &FilePathId) -> Result<&'static str> {
+    if store
+        .get_file_layout(file_id)
+        .map_err(McpError::graph)?
+        .is_some()
+    {
+        return Ok("entity_source");
+    }
+    if store
+        .get_shallow_file(file_id)
+        .map_err(McpError::graph)?
+        .is_some()
+    {
+        return Ok("shallow_syntax");
+    }
+    if store
+        .get_structured_artifact(file_id)
+        .map_err(McpError::graph)?
+        .is_some()
+    {
+        return Ok("structured_artifact");
+    }
+    if store
+        .get_opaque_artifact(file_id)
+        .map_err(McpError::graph)?
+        .is_some()
+    {
+        return Ok("opaque_artifact");
+    }
+    Ok("none")
+}
+
+/// Whether the graph holds language-server-derived edges for this file's
+/// entities: the graph-truth reading of "enriched".
+///
+/// The daemon's own `lsp_enriched_files` marker is operational state its module
+/// documents as something nothing answers a query from, so it is not read here.
+/// [`kin_model::RelationOrigin::Lsp`] on an edge incident to one of the file's
+/// entities is the durable fact, and it is the same test the daemon applies to
+/// decide whether its own marker can be trusted.
+///
+/// Disclosure only. Enrichment adds edges between entities; it does not add
+/// entities to a file, so it can never be the reason an enumeration is short.
+fn language_server_edges<G: GraphStore>(store: &G, entities: &[Entity]) -> Result<&'static str> {
+    if entities.is_empty() || entities.len() > ENRICHMENT_SCAN_CAP {
+        return Ok("unknown");
+    }
+    for entity in entities {
+        let relations = store
+            .get_all_relations_for_entity(&entity.id)
+            .map_err(McpError::graph)?;
+        if relations
+            .iter()
+            .any(|relation| relation.origin == kin_model::RelationOrigin::Lsp)
+        {
+            return Ok("present");
+        }
+    }
+    Ok("absent")
+}
+
+/// Where a page starts, and what the enumeration looked like when the cursor
+/// that names it was minted.
+///
+/// `total` rides in the cursor so a later page can tell that the file changed
+/// under the walk. Without it the second page of a file that gained or lost an
+/// entity is served silently against a different list, and the caller assembles
+/// pages that never described one state of the repository.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageCursor {
+    pub path: String,
+    pub offset: usize,
+    pub total: usize,
+}
+
+impl PageCursor {
+    /// Encode as one opaque URL-safe token. Opaque on purpose: a caller that
+    /// parses and edits a cursor is constructing a page the graph never served.
+    pub fn encode(&self) -> String {
+        let raw = serde_json::json!({
+            "p": self.path,
+            "o": self.offset,
+            "t": self.total,
+        })
+        .to_string();
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw)
+    }
+
+    /// Decode a token, or `None` for anything this function did not mint.
+    pub fn decode(token: &str) -> Option<Self> {
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(token.trim())
+            .ok()?;
+        let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+        Some(Self {
+            path: value.get("p")?.as_str()?.to_string(),
+            offset: value.get("o")?.as_u64()? as usize,
+            total: value.get("t")?.as_u64()? as usize,
+        })
+    }
+}
+
+/// Normalize a caller's path to the spelling the graph stores.
+///
+/// Only the two rewrites that cannot change which file is meant: a `./` prefix
+/// is dropped and backslashes become forward slashes, because a Windows client
+/// spells the same tracked path with the other separator. No suffix matching and
+/// no fuzzy fallback: a path that resolves by suffix resolves to whichever file
+/// happened to end that way, and answering confidently about a file the caller
+/// did not name is worse than refusing.
+fn normalize_path(raw: &str) -> String {
+    let swapped = raw.replace('\\', "/");
+    let trimmed = swapped.trim();
+    let mut path = trimmed;
+    while let Some(rest) = path.strip_prefix("./") {
+        path = rest;
+    }
+    path.to_string()
+}
+
+/// Sort key giving the enumeration one deterministic order.
+///
+/// Determinism is what makes offset paging correct: two pages of one stable
+/// graph must partition the set, and a query whose order varies between calls
+/// can repeat an entity on page two and drop another entirely. Byte position
+/// first so the list reads down the file; name and id break ties for entities
+/// the projection never placed, which sort last rather than at byte zero.
+fn sort_key(entity: &Entity) -> (usize, String, String) {
+    (
+        entity
+            .span
+            .as_ref()
+            .map(|span| span.start_byte)
+            .unwrap_or(usize::MAX),
+        entity.name.clone(),
+        entity.id.0.to_string(),
+    )
+}
+
+/// Enumerate the entities the graph holds for one file.
+pub fn handle_list_file_entities<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<ToolCallResult> {
+    let cursor = match args.get("cursor").and_then(serde_json::Value::as_str) {
+        Some(token) if !token.trim().is_empty() => {
+            Some(PageCursor::decode(token).ok_or_else(|| {
+                McpError::InvalidParams(
+                    "invalid cursor: pass back a `next_cursor` this tool returned, unedited, or \
+                     omit `cursor` to start a fresh enumeration"
+                        .to_string(),
+                )
+            })?)
+        }
+        _ => None,
+    };
+
+    // The cursor carries the path it was minted for, so a caller that pages one
+    // file with another file's cursor is refused rather than served a window
+    // into a list it never asked for.
+    let raw_path = match (
+        args.get("path").and_then(serde_json::Value::as_str),
+        cursor.as_ref(),
+    ) {
+        (Some(path), Some(cursor)) if normalize_path(path) != cursor.path => {
+            return Err(McpError::InvalidParams(format!(
+                "cursor was minted for {:?} but `path` names {:?}; page one file at a time",
+                cursor.path,
+                normalize_path(path)
+            )));
+        }
+        (Some(path), _) => path.to_string(),
+        (None, Some(cursor)) => cursor.path.clone(),
+        (None, None) => {
+            return Err(McpError::InvalidParams(
+                "missing required parameter: path (a repository-relative path such as \
+                 \"lib/express.js\")"
+                    .to_string(),
+            ))
+        }
+    };
+
+    let path = normalize_path(&raw_path);
+    if path.is_empty() {
+        return Err(McpError::InvalidParams(
+            "invalid parameter: path must not be empty; name a repository-relative path such as \
+             \"lib/express.js\""
+                .to_string(),
+        ));
+    }
+    // The same rule the projection and the transaction stage path apply, so a
+    // path this tool accepts is a path the rest of Kin accepts. An absolute
+    // path, a `..` escape, or a Kin/Git control component is refused by name
+    // here rather than turned into an exact-match miss that reads as "this file
+    // has no entities".
+    let repo_path = kin_model::RepoPath::from_utf8(path.clone()).map_err(|error| {
+        McpError::InvalidParams(format!(
+            "invalid parameter: path {path:?} is not a usable repository path: {error}"
+        ))
+    })?;
+    kin_core::validate_source_paths([&repo_path]).map_err(|error| {
+        McpError::InvalidParams(format!(
+            "invalid parameter: path {path:?} is not an admissible repository source path: \
+             {error}. Name a repository-relative path such as \"lib/express.js\", with no leading \
+             slash, no \"..\", and no Kin or Git control component"
+        ))
+    })?;
+
+    let page_size = args
+        .get("page_size")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+        .clamp(1, MAX_PAGE_SIZE) as usize;
+
+    let file_id = FilePathId::new(path.clone());
+    let mut entities = store
+        .query_entities(&EntityFilter {
+            file_path: Some(file_id.clone()),
+            ..Default::default()
+        })
+        .map_err(McpError::graph)?;
+    entities.sort_by_key(sort_key);
+    let total_in_file = entities.len();
+
+    let layout = store.get_file_layout(&file_id).map_err(McpError::graph)?;
+    let parsed = match layout.as_ref().map(|layout| &layout.parse_completeness) {
+        Some(ParseCompleteness::Full) => ParsedState::Full,
+        Some(ParseCompleteness::Partial(_)) => ParsedState::Partial,
+        Some(ParseCompleteness::Failed(_)) => ParsedState::Failed,
+        None => ParsedState::Absent,
+    };
+    let parse_detail = match layout.as_ref().map(|layout| &layout.parse_completeness) {
+        Some(ParseCompleteness::Partial(reason)) | Some(ParseCompleteness::Failed(reason)) => {
+            Some(reason.clone())
+        }
+        _ => None,
+    };
+    // The layout's own entity-region count, published beside the enumeration
+    // rather than folded into it. Two independent readings of one file: if the
+    // CST recorded regions for entities the entity index does not return, the
+    // enumeration is short and this is the number that says so.
+    let layout_entity_regions = layout.as_ref().map(|layout| {
+        layout
+            .regions
+            .iter()
+            .filter(|region| matches!(region, kin_model::layout::SourceRegion::EntityRef { .. }))
+            .count()
+    });
+
+    let tier = tracking_tier(store, &file_id)?;
+    // Admission identity, resolved through the repository tree rather than
+    // through a path-keyed facet. This is the ordering `kin-context` documents:
+    // a path the tree does not admit is a graph gap, and answering it from
+    // whatever enrichment still carries that path is how a stale facet comes to
+    // stand in for a file the repository no longer has.
+    let tracked_in_graph = store.artifact_id_at_path(&repo_path).is_some();
+
+    // A path with no admitted identity, no facet at any tier, and no entities is
+    // a path this graph has never seen. Answering it with an empty array
+    // publishes "this file has no entities" about a file Kin cannot see, which
+    // is the exact confusion this tool was filed to end, so it fails loudly and
+    // names the gap instead.
+    if !tracked_in_graph && tier == "none" && total_in_file == 0 {
+        return Err(McpError::Context(format!(
+            "graph gap: {path:?} is not tracked by this graph at any tier, so Kin cannot say what \
+             entities it holds. This is not a claim that the file has no entities. Check the path \
+             spelling against `kin_artifact_list`, or run a reconcile if the file is new."
+        )));
+    }
+
+    let enriched = language_server_edges(store, &entities)?;
+
+    let offset = cursor.as_ref().map(|cursor| cursor.offset).unwrap_or(0);
+    // A cursor minted against a different-sized enumeration is describing a file
+    // that changed under the walk. The rows are still served, because withholding
+    // real graph truth teaches nothing, but the shift is named so the assembled
+    // pages are never read as one consistent snapshot.
+    let enumeration_shifted = cursor
+        .as_ref()
+        .is_some_and(|cursor| cursor.total != total_in_file);
+    let window: Vec<FileEntityRow> = entities
+        .into_iter()
+        .skip(offset)
+        .take(page_size)
+        .map(FileEntityRow::from)
+        .collect();
+    let returned = window.len();
+    let reached = offset.saturating_add(returned);
+    let next_cursor = (reached < total_in_file).then(|| {
+        PageCursor {
+            path: path.clone(),
+            offset: reached,
+            total: total_in_file,
+        }
+        .encode()
+    });
+    // Whether THIS response holds the file's whole entity set. A last page is
+    // not a whole answer: it holds the tail, and a caller reading `exact` off it
+    // would be reading a claim about the pages it does not have.
+    let whole_file_in_response = offset == 0 && next_cursor.is_none();
+
+    let payload = serde_json::json!({
+        "path": path,
+        "entities": window,
+        "returned": returned,
+        "total_in_file": total_in_file,
+        "page_size": page_size,
+        "offset": offset,
+        "next_cursor": next_cursor,
+        // The same flag `kin_artifact_list` and `semantic_search` publish, in
+        // the same sense: this response does not hold everything it counted.
+        "truncated": next_cursor.is_some() || offset > 0,
+        "enumeration_shifted": enumeration_shifted,
+        FILE_COVERAGE_KEY: {
+            "path": path,
+            "tracked_in_graph": tracked_in_graph,
+            "tier": tier,
+            "parsed": parsed.wire(),
+            "parse_detail": parse_detail,
+            "layout_entity_regions": layout_entity_regions,
+            // Whether the graph holds language-server-derived edges for this
+            // file's entities. Disclosure: enrichment adds edges between
+            // entities and never adds entities to a file, so it cannot be the
+            // reason an enumeration is short.
+            "enriched": enriched,
+            // Deliberately not a per-file number, and named so a reader cannot
+            // mistake it for one. No store API reports whether one file's
+            // entities are embedded, and this enumeration reads the entity
+            // index rather than the vector index, so embedding coverage is
+            // disclosure here and never a decider. `_kin.completeness` carries
+            // the store-grain reading beside it, labelled as store-grain.
+            "embedded": "not_measured_per_file",
+            "whole_file_in_response": whole_file_in_response,
+            "certifies_enumeration": parsed.certifies_enumeration()
+                && whole_file_in_response
+                && !enumeration_shifted,
+        },
+    });
+
+    Ok(ToolCallResult::text(
+        serde_json::to_string_pretty(&payload).map_err(McpError::Json)?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_path_drops_dot_slash_and_swaps_separators() {
+        assert_eq!(normalize_path("lib/express.js"), "lib/express.js");
+        assert_eq!(normalize_path("./lib/express.js"), "lib/express.js");
+        assert_eq!(normalize_path(".././lib/express.js"), ".././lib/express.js");
+        assert_eq!(normalize_path("lib\\express.js"), "lib/express.js");
+        assert_eq!(normalize_path("  lib/express.js  "), "lib/express.js");
+    }
+
+    #[test]
+    fn cursor_round_trips_and_rejects_foreign_tokens() {
+        let cursor = PageCursor {
+            path: "lib/express.js".to_string(),
+            offset: 200,
+            total: 431,
+        };
+        let token = cursor.encode();
+        assert_eq!(PageCursor::decode(&token), Some(cursor));
+        assert_eq!(PageCursor::decode("not-a-cursor"), None);
+        assert_eq!(PageCursor::decode(""), None);
+    }
+
+    #[test]
+    fn only_a_full_parse_certifies_an_enumeration() {
+        assert!(ParsedState::Full.certifies_enumeration());
+        assert!(!ParsedState::Partial.certifies_enumeration());
+        assert!(!ParsedState::Failed.certifies_enumeration());
+        assert!(!ParsedState::Absent.certifies_enumeration());
+    }
+}

--- a/crates/kin-mcp/src/handlers/file_entities.rs
+++ b/crates/kin-mcp/src/handlers/file_entities.rs
@@ -1031,6 +1031,56 @@ mod tests {
         );
     }
 
+    /// The negative registry keys this tool's spec on a `const` used as a match
+    /// pattern, and a `const` pattern that ever degrades to a fresh binding
+    /// matches EVERY tool from that arm onward and hands them all this spec.
+    ///
+    /// The assertions below are chosen so they CAN fail. A tool whose arm sits
+    /// earlier in the match is shadowed by its own arm and would keep its spec
+    /// under the bug, so proving anything with one is proving nothing: the two
+    /// probes here are a tool whose arm comes AFTER this one, and a tool with no
+    /// spec at all, which is the case a catch-all binding turns from `None` into
+    /// a confident file-enumeration negative about a response that has no file
+    /// in it.
+    #[test]
+    fn the_file_spec_does_not_swallow_other_tools() {
+        let envelope = structural_authoritative_envelope();
+
+        let empty_flow = serde_json::json!({ "chain": [], "total_steps": 0 });
+        let negative =
+            crate::negative::negative_for("trace_data_flow", &empty_flow, &envelope, &[])
+                .expect("trace_data_flow keeps its own negative");
+        assert_eq!(
+            negative["kind"],
+            serde_json::json!("no_flow"),
+            "the file-enumeration spec captured a tool declared after it: {negative}"
+        );
+
+        assert!(
+            crate::negative::negative_for(
+                "kin_work_create",
+                &serde_json::json!({ "entities": [] }),
+                &envelope,
+                &[],
+            )
+            .is_none(),
+            "a tool with no negative spec must synthesize no negative"
+        );
+
+        // Positive control: this tool still gets its own kind, so the two
+        // assertions above are about scoping rather than about a spec that
+        // never matches anything.
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 0))
+            .unwrap();
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let mine = crate::negative::negative_for(TOOL_NAME, &payload, &envelope, &[])
+            .expect("the file enumeration carries its own negative");
+        assert_eq!(mine["kind"], serde_json::json!("no_file_entities"));
+    }
+
     /// The completeness signal a caller reads instead of the row count. A page
     /// of a file reports its counts as a floor and names why.
     #[test]

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod common;
 // two from drifting apart.
 pub mod bench;
 pub mod entities;
+pub mod file_entities;
 pub mod provenance;
 pub(crate) mod repository_authority;
 pub mod review;
@@ -74,6 +75,7 @@ pub async fn handle_tool_call<G: GraphStore>(
         "dead_code" => entities::handle_dead_code(arguments, store),
         "find_dead_code_seeded" => entities::handle_find_dead_code_seeded(arguments, store),
         "graph_neighborhood" => entities::handle_graph_neighborhood(arguments, store),
+        "list_file_entities" => file_entities::handle_list_file_entities(arguments, store),
         // Review
         "semantic_diff" => review::handle_semantic_diff(arguments, store),
         "impact_analysis" => review::handle_impact_analysis(arguments, store, sessions).await,

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -60,6 +60,99 @@ use crate::envelope::{Envelope, NegativeClass};
 /// Distinctive enough not to collide with any tool payload's own fields.
 pub const NEGATIVE_KEY: &str = "negative";
 
+/// The file-enumeration tool, named once here so the spec, the gate and the
+/// dependency declaration below cannot drift from the registry that serves it.
+const FILE_ENTITIES_TOOL: &str = crate::handlers::file_entities::TOOL_NAME;
+
+/// Why a file enumeration cannot be certified as the file's whole entity set,
+/// or `None` when nothing stops it.
+///
+/// Read from the tool's own `file_coverage` observation rather than from the
+/// envelope, because the question is about one file and every envelope signal is
+/// about the store. A completely embedded, fully loaded, undegraded graph
+/// carries no entities at all for a file no language adapter parsed, and every
+/// store-level gate reads healthy while it says so.
+///
+/// Four things can stop the certification and each is named separately, because
+/// the remediation differs: a file nothing parsed needs an adapter, a partial
+/// parse needs the syntax fixed, a page needs its cursor followed, and a shifted
+/// enumeration needs re-walking from the start.
+fn file_enumeration_gap(payload: &Value) -> Option<String> {
+    let Some(coverage) = payload
+        .get(crate::handlers::file_entities::FILE_COVERAGE_KEY)
+        .and_then(Value::as_object)
+    else {
+        return Some(
+            "file_coverage_unreported: this answer did not report whether a language adapter \
+             parsed the file, so an empty enumeration cannot be distinguished from a file \
+             nothing ever extracted entities from"
+                .to_string(),
+        );
+    };
+
+    let parsed = coverage
+        .get("parsed")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let detail = coverage
+        .get("parse_detail")
+        .and_then(Value::as_str)
+        .map(|detail| format!(" ({detail})"))
+        .unwrap_or_default();
+    match parsed {
+        "full" => {}
+        "absent" => {
+            return Some(
+                "file_not_parsed: no language adapter produced a layout for this file, so the \
+                 graph holds no entity set for it to be missing from. An empty enumeration here \
+                 is a fact about Kin's extraction coverage, not about the file's contents"
+                    .to_string(),
+            )
+        }
+        "partial" => {
+            return Some(format!(
+                "file_parsed_partially: the adapter hit parse errors in this file{detail}, so the \
+                 entities it produced are a floor and the enumeration may be short"
+            ))
+        }
+        "failed" => {
+            return Some(format!(
+                "file_parse_failed: the adapter could not parse this file{detail}, so whatever \
+                 entities the graph still carries for it describe an earlier state"
+            ))
+        }
+        other => {
+            return Some(format!(
+                "file_parse_state_unknown: this answer reported the parse state as {other:?}, \
+                 which is not a state that licenses reading the enumeration as whole"
+            ))
+        }
+    }
+
+    if coverage.get("enumeration_shifted").and_then(Value::as_bool) == Some(true) {
+        return Some(
+            "enumeration_shifted: the file gained or lost entities between the page that minted \
+             this cursor and the page it served, so these pages do not assemble into one state of \
+             the repository. Re-walk from the start"
+                .to_string(),
+        );
+    }
+
+    if coverage
+        .get("whole_file_in_response")
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return Some(
+            "page_bounded: this response holds one page of the file rather than all of it, so its \
+             rows are a floor. Follow `next_cursor` to the end before reading the set as whole"
+                .to_string(),
+        );
+    }
+
+    None
+}
+
 /// How one tool's payload expresses "no result", and how to frame the resulting
 /// negative. One row per negative-capable tool — the single source of truth.
 struct RetrievalSpec {
@@ -144,6 +237,20 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
             field: "relations",
             kind: "no_neighbors",
             subject: "the entity has no graph neighbors at the requested depth",
+            always: false,
+            class: NegativeClass::Structural,
+        },
+        // The enumeration surface. Its absence claim is the sharpest one any
+        // retrieval tool here makes -- "this file holds no entities" -- and it
+        // is also the one with a decisive per-file fact behind it, so it is
+        // gated on that fact rather than on store-wide health. `Structural`
+        // because it reads the entity index; no embedding is consulted, and
+        // gating it on embedding coverage would report a complete answer as
+        // uncertain for a substrate it never touched.
+        FILE_ENTITIES_TOOL => RetrievalSpec {
+            field: "entities",
+            kind: "no_file_entities",
+            subject: "the graph holds no entities for this file",
             always: false,
             class: NegativeClass::Structural,
         },
@@ -719,7 +826,9 @@ fn qualifies_populated_answers(tool: &str) -> bool {
 /// extracted graph has nothing for this gate to say, and silence is not
 /// agreement.
 pub(crate) fn declares_absence_dependency(tool: &str, payload: &Value) -> bool {
-    !absence_cross_file_classes(tool, payload).is_empty() || absence_is_language_scoped(tool)
+    !absence_cross_file_classes(tool, payload).is_empty()
+        || absence_is_language_scoped(tool)
+        || tool == FILE_ENTITIES_TOOL
 }
 
 /// One class's observed state, defaulting to `unknown` for a class the
@@ -1742,6 +1851,17 @@ pub fn negative_for(
     // resolves a name.
     if tool == "find_references" {
         if let Some(gap) = focal_resolution_gap(payload, "this reference list") {
+            push_gap(&mut trustworthy, &mut trust_reason, gap);
+        }
+    }
+
+    // The enumeration's own gate, and the only one that can certify it. Every
+    // other signal here describes the store; this describes the file, and a
+    // file no adapter parsed holds no entities in a graph of any health at all.
+    // Reading store health as licence for that absence is exactly the
+    // substitution FIR-2430 made on the language axis.
+    if tool == FILE_ENTITIES_TOOL {
+        if let Some(gap) = file_enumeration_gap(payload) {
             push_gap(&mut trustworthy, &mut trust_reason, gap);
         }
     }

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -685,6 +685,19 @@ fn registered_tools() -> ToolsListResult {
                 }),
             },
             ToolDefinition {
+                name: crate::handlers::file_entities::TOOL_NAME.into(),
+                description: crate::handlers::file_entities::LIST_FILE_ENTITIES_DESC.into(),
+                annotations: read_only("List file entities"),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string", "description": "Repository-relative path of the file to enumerate, such as \"lib/express.js\". No leading slash, no \"..\", and no Kin or Git control component. A leading \"./\" is dropped and backslashes are read as separators; nothing else is rewritten, because a path resolved by suffix resolves to whichever file happened to end that way. Optional only when `cursor` is given, which already names the file." },
+                        "page_size": { "type": "integer", "description": "Entities per page (default 200, clamped 1..1000). `total_in_file` is the whole-file count on every page, so a page smaller than it is a page, never the file.", "default": 200, "minimum": 1, "maximum": 1000 },
+                        "cursor": { "type": "string", "description": "Opaque token from a prior result's `next_cursor`, returning the next page of the same enumeration. Pass it back unedited; it carries the path and the count the page was cut from, so a file that changed under the walk is reported as `enumeration_shifted` rather than paged silently against a different list." }
+                    }
+                }),
+            },
+            ToolDefinition {
                 name: "benchmark".into(),
                 description: crate::handlers::bench::BENCHMARK_DESC.into(),
                 annotations: read_only("Benchmark metrics"),
@@ -1357,6 +1370,13 @@ pub fn agent_default_tool_names() -> &'static [&'static str] {
         "trace_data_flow",
         "find_references",
         "graph_neighborhood",
+        // The enumeration half of discovery. Every other retrieval tool in this
+        // profile ranks, filters, or walks, and none of them can say what it
+        // left out, so "what is in this file" -- the cheapest question the graph
+        // answers and the first one a file-first user asks -- had to be answered
+        // by scavenging ids out of a locate ranking and hoping it was whole
+        // (FIR-2546).
+        crate::handlers::file_entities::TOOL_NAME,
         "kin_session_start",
         "kin_session_heartbeat",
         "kin_session_end",

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -1790,8 +1790,9 @@ mod tests {
     fn expected_tool_count() {
         let list = tool_definitions();
         // 54 + 5 transaction tools + 1 semantic_locate + 1 shadow_gate_report
-        // + 1 get_entity_sources + 2 exact artifact tools = 64
-        assert_eq!(list.tools.len(), 64);
+        // + 1 get_entity_sources + 2 exact artifact tools
+        // + 1 list_file_entities = 65
+        assert_eq!(list.tools.len(), 65);
     }
 
     /// The reference lists each category's members on a line opening with this
@@ -2020,7 +2021,7 @@ The Kin MCP server exposes 2 semantic tools to AI assistants.
         let profile = agent_default_tool_names();
 
         assert!(
-            profile.len() >= 10 && profile.len() <= 19,
+            profile.len() >= 10 && profile.len() <= 20,
             "agent-default should be small but cover the wedge; got {}",
             profile.len()
         );

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # Model Context Protocol (MCP) Tool Surface Reference
 
-The Kin MCP server exposes 64 semantic tools to AI assistants (Claude, Cursor, Gemini,
+The Kin MCP server exposes 65 semantic tools to AI assistants (Claude, Cursor, Gemini,
 Codex, etc.). These tools bridge the gap between traditional file-first navigation and
 Kin's graph-first semantic substrate: instead of issuing raw shell commands or reading raw
 files, an assistant interacts with the codebase through entity-level primitives.
@@ -121,10 +121,11 @@ boundary you can rely on.
 ---
 
 ## 1. Retrieval & Codebase Exploration
-*Tools:* `semantic_search`, `semantic_locate`, `get_entity`, `get_entity_source`, `get_entity_body`, `get_entity_sources`, `get_context_pack`, `explore_codebase`, `graph_neighborhood`
+*Tools:* `semantic_search`, `semantic_locate`, `list_file_entities`, `get_entity`, `get_entity_source`, `get_entity_body`, `get_entity_sources`, `get_context_pack`, `explore_codebase`, `graph_neighborhood`
 
 - **`semantic_search`**: Find declarations by **name, kind, or language** (functions, classes, structs, traits, enums, interfaces, types, constants). This matches real parsed declarations rather than raw string occurrences like grep, and returns each match's file path, line range, signature, and stable entity ID. Note: despite the name, this is a metadata matcher; it does **not** rank by vector similarity. Use it as your first step to find "the thing called X."
 - **`semantic_locate`**: Rank the code most relevant to a **natural-language** query using Kin's vector index, the same embedding-backed retrieval that powers `kin locate`. Use it when you only have a description of the behavior, not an exact symbol name. Supports `granularity` of `entity` (default) or `file`, reports `semantic_coverage` as the counter object, and requires the running daemon. Each hit carries its inline source once: on `body` for the fused pipeline (the default, `routing: "fused-v1"`) and on `snippet` for the cosine pipeline. Multi-query fan-out echoes the variants once under `queries`, and a hit names the ones that surfaced it by position in `matched_variant_indexes`.
+- **`list_file_entities`**: Enumerate every entity the graph holds for one repository-relative file. This is the enumeration surface, and it is the one to reach for when the question is "what is in this file" rather than "what is most relevant to this query". `semantic_search` and `semantic_locate` both return a bounded set they cannot certify, so a short answer and a whole one read identically; this one reports `total_in_file` on every page and says whether the set is complete. Completeness rests on the file's own parse record rather than on store-wide health: `file_coverage.parsed` is `full` only when a language adapter parsed the file completely, and `_kin.completeness` and `negative.safe_to_conclude_absent` follow that fact. A path the graph does not track is refused by name instead of answered with an empty list, because a caller cannot tell those two answers apart and only one of them means the file holds no entities. Large files page through `next_cursor`.
 - **`get_entity`**: Fetch metadata about a specific entity (kind, language, path, line range, signature) without its source body.
 - **`get_entity_source` / `get_entity_body`**: Retrieve the implementation source of an entity, served from the graph.
 - **`get_entity_sources`**: The batch form of `get_entity_source`. Hand it up to 50 entity IDs in priority order and it returns each entity's metadata plus its body in one budgeted call, which replaces the N separate round-trips and N response envelopes those reads would otherwise cost. Bodies fill in the order you list the IDs until the shared `token_budget` is reached, and entities past that point come back signature-only with `omitted=true`.

--- a/llms.txt
+++ b/llms.txt
@@ -26,7 +26,8 @@ Native Windows x86_64 support is early. Repository admission works: `kin init` i
 Kin ships an MCP server exposing semantic tools that answer from graph-owned truth, not raw file search — prefer them:
 
 - `semantic_locate` — find symbols, functions, and types by meaning.
-- `get_context_pack` — a structured context bundle for a file or symbol.
+- `list_file_entities` lists every entity in one file, with a completeness flag saying whether the list is whole.
+- `get_context_pack` — a structured context bundle around one entity, by id.
 - `trace_data_flow` — cross-file data lineage and dependencies.
 
 `kin setup` auto-configures the MCP server for supported agents.


### PR DESCRIPTION
## Mechanism

No tool on the `agent-default` profile listed the entities in a file, so an enumeration question had to be answered from a ranking that cannot certify what it left out. The stranger run rc0545c hit this on expressjs/express: enumerating the exports of `lib/express.js` meant pulling ids out of an earlier `semantic_locate` response and hoping the ranking had returned them all. `semantic_locate` is a bounded ranking, so a short list and a whole list are the same response, and the caller has no field to read the difference from. The eleven-export answer the stranger produced was correct and was verified with `rg` rather than with Kin.

The facts to answer it properly were already in the graph and nothing assembled them. `query_entities` with `file_path` set is an exact index lookup (`kin-db` `engine/index.rs:114`). `FileLayout::parse_completeness` is `Full`, `Partial(reason)` or `Failed(reason)` per file. `artifact_id_at_path` resolves admission identity through the repository tree. Each read answered on its own and nothing put them together into a verdict a caller could act on.

## The fix

`list_file_entities`, a new tool on the `agent-default` profile, implemented in a new module `crates/kin-mcp/src/handlers/file_entities.rs`. It takes a repository-relative `path`, optional `page_size` (default 200, clamped 1 to 1000) and optional `cursor`, and returns every entity the graph holds for that path with the `id` every other Kin tool takes, plus `name`, `kind`, `language`, `role`, `visibility`, `signature`, and the defining span as both lines and bytes.

Completeness is certified from the file's own parse record rather than from store-wide health. `file_coverage.parsed` is `full`, `partial`, `failed` or `absent`, and only `full` licenses reading the list as the file's whole surface. `negative.safe_to_conclude_absent` (`crates/kin-mcp/src/negative.rs`, new `file_enumeration_gap`) is true only when the enumeration is empty, the file parsed fully, this response holds the whole file, and no cursor shift was detected. `_kin.completeness.classes` gains `file_parsed` as the deciding class, with `file_enriched` and `embeddings_store_wide` disclosed beside it and deciding nothing, because enrichment adds edges between entities and embeddings add ranking, while a file's entity set is fixed by what the adapter extracted.

Paging is a cursor, never a silent cap. `total_in_file` is the whole-file count on every page, a page that does not hold all of them carries `next_cursor`, and `_kin.completeness.counted` reports `exact: false` with `floor_reason: page_bounded` for such a page. The cursor carries the path it was minted for and the count it was cut from, so paging one file with another file's cursor is refused and a file that changed under the walk is reported as `enumeration_shifted` rather than paged silently against a different list.

A path the graph does not track is refused by name, never answered with `entities: []`. Those two responses are indistinguishable to a caller and only one of them means the file holds no entities.

Nothing reads the filesystem. The handler is generic over `GraphStore`, so the daemon's generic fall-through at `crates/kin-daemon/src/api.rs:8922` and the offline path in `crates/kin-mcp/src/handlers/mod.rs` serve it from the same code, and no daemon route or delegate arm was needed.

### Why a new tool rather than a file mode on an existing one

`get_context_pack` requires `entity_id` and nothing else (`crates/kin-mcp/src/tools.rs:429`), despite prose in the server blurb and `crates/kin-cli/src/commands/setup.rs:2032` describing it as taking "a file or symbol". More decisively, `negative::spec_for` holds exactly one `RetrievalSpec` per tool name and `envelope::counted_for` is per-tool the same way, so a tool with two disjoint answer shapes cannot express two negatives and a file mode would either be mis-qualified by its own registry row or go unqualified. `agent_default_tool_names()` is a flat name list, so a new tool is the natural registry move and profile membership stays explicit.

### What is not measured

Per-file embedding coverage does not exist in this codebase: `contains_retrievable` lives in kin-db's vector index, `InMemoryGraph::vector_index` is private, and the method has zero call sites under `crates/`. `file_coverage.embedded` is the literal string `not_measured_per_file`, and the store-grain reading rides in the envelope under `embeddings_store_wide`, named so it cannot be mistaken for a per-file number.

`file_coverage.enriched` is derived from `RelationOrigin::Lsp` on edges incident to the file's entities, which is the same test the daemon applies to decide whether its own `lsp_enriched_files` marker can be trusted. The marker itself is not read: its module documents it as operational state that nothing answers a query from. The scan is capped at 500 entities and reports `unknown` above that, because it decides nothing.

## Falsification

Two passes, each removing one property, each predicted before running, each restored to a byte-identical tree afterwards (empty `git status --porcelain`).

**Pass A, remove the completeness check.** `certifies_enumeration` forced true and `file_enumeration_gap` forced to return `None`. I predicted five failures and got these four:

```
absence_is_certified_only_when_the_file_was_parsed
  assertion `left == right` failed: an unparsed file must never certify an absence:
  {"safe_to_conclude_absent":true,"trust":"authoritative","kind":"no_file_entities", ...}
  left: Bool(true)  right: Bool(false)
parse_state_decides_whether_the_enumeration_is_certified
  assertion `left == right` failed: parse state partial certified the wrong way
a_partial_page_is_not_certified
a_cursor_from_a_changed_file_reports_the_shift
test result: FAILED. 11 passed; 4 failed
```

The fifth prediction was wrong, and usefully. `completeness_reports_a_page_as_a_floor` survived because `counted.floor_reason` is computed from `whole_file_in_response` rather than from `certifies_enumeration`, and the envelope's truncation veto then forces `exact: false`. That is a second, independent guard on the same fact.

**Pass B, remove the pagination.** Offset pinned to 0 and `next_cursor` pinned to `None`, which is the silent-cap defect this tool exists to remove. I predicted four failures and got these three:

```
pagination_covers_the_whole_set_without_duplicates
  assertion `left == right` failed: 7 entities at page_size 3 is three pages
  left: 1  right: 3
a_partial_page_is_not_certified
completeness_reports_a_page_as_a_floor
test result: FAILED. 12 passed; 3 failed
```

`a_cursor_from_a_changed_file_reports_the_shift` survived, because the shift is detected by comparing the cursor's recorded total against the observed total, independently of the offset arithmetic that was broken.

**A third pass caught a test of mine that could not fail.** The guard against the negative registry's `const` match pattern degrading into a catch-all binding first probed `semantic_search`, whose arm sits earlier in the match and is shadowed by its own arm. It passed under the sabotage and proved nothing. Rewritten to probe `trace_data_flow`, whose arm comes after this one, and `kin_work_create`, which has no spec at all, it now fails under the same sabotage with `trace_data_flow keeps its own negative`, and carries a positive control on this tool's own kind.

## Gates

The full local gate under build slot `gate-slot-3`, resolving this lane's tree:

```
kin-dev: local-test: kin  .kin-coord/worktrees/fileentities-kin @ 980d5b45 (chore/lane-fileentities-kin)
     Summary [ 798.974s] 6641 tests run: 6641 passed (10 slow), 12 skipped
GATE_RAW_STATUS=0
```

The doctest pass that runs beside nextest was green too, and afterwards `git status --porcelain` was empty, `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` printed only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` was empty.

That gate ran at 980d5b45. One commit landed after it, 17484449, which is a two-line edit to `llms.txt` and touches no Rust. Rather than leave the tip ungated I re-ran at 17484449 everything that can read that file or that the edit could plausibly break: `cargo test -p kin-mcp --lib` (585 of 585), `python3 scripts/test-release-workflow-authority.py` (0, and it is the only test in the tree that reads `llms.txt`), `cargo fmt -- --check` (0), and all four guard scripts (0). The 6641-test figure belongs to 980d5b45 and I am not claiming it for the tip.

Run directly on this branch: `cargo fmt -- --check` (0), `python3 scripts/verify-zero-file-search.py` (passed, 178 source files scanned), `bash scripts/zero_file_search_guard.sh` (passed, answer paths graph-clean), `bash scripts/check_runtime_boundaries.sh` (passed), `bash scripts/check_private_repo_coupling.sh` (passed), `cargo clippy -p kin-mcp --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the 90-word `.github/clippy-allowed-lints.txt` allowlist (0), and `npm test --prefix ./packages/kin-mcp` (21 of 21).

The registry guards that went red on the new tool were updated rather than relaxed. `expected_tool_count` moves 64 to 65, the `agent-default` size bound moves 19 to 20, and `mcp_doc_enumerates_exactly_the_registered_tools` required `docs/mcp-tools.md` to gain the tool in its retrieval roster with a description and to move its headline count.

Closes FIR-2546
