### PR TITLE
Let the release train own a region of its PR body, not the whole message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
             ./scripts/write-release-archive-docs.test.mjs \
             ./scripts/release-order.test.mjs \
             ./scripts/release-hold-alarm.test.mjs \
+            ./scripts/release-train-body.test.mjs \
             ./scripts/advisory-sweep.test.mjs \
             ./scripts/verify-capability-proof.test.mjs \
             ./scripts/verify-npm-attestation.test.mjs
@@ -121,6 +122,7 @@ jobs:
           node --check ./scripts/prepare-release.mjs
           node --check ./scripts/release-order.mjs
           node --check ./scripts/release-hold-alarm.mjs
+          node --check ./scripts/release-train-body.mjs
           node --check ./scripts/advisory-sweep.mjs
           node --check ./scripts/verify-capability-proof.mjs
           node --check ./scripts/verify-npm-attestation.mjs
@@ -1000,6 +1002,7 @@ jobs:
             scripts/check-kin-vfs-compat.test.mjs \
             scripts/check-rc-build-drift.test.mjs \
             scripts/check-release-proof-artifacts.test.mjs \
+            scripts/release-train-body.test.mjs \
             scripts/check-release-version.test.mjs \
             scripts/extract-release-notes.test.mjs \
             scripts/prepare-release.test.mjs \

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -545,14 +545,43 @@ jobs:
               .[0].number // ""
             end
           ' <<< "$pr_data")"
+          # The body is not a description of this release, it is the
+          # release's permanent commit message: this repository squashes
+          # with the pull-request body, and the merge queue mints that
+          # message when the entry is admitted. So the train owns one
+          # delimited region of it and rewrites nothing else. It used to
+          # rewrite the whole body to the line below on every cycle, which
+          # discarded the disclosures the release doctrine requires an
+          # operator to add, and a cycle landing between that edit and
+          # queue admission would have shipped a release whose permanent
+          # message carried none of them.
+          #
+          # The merge is read from protected main for the same reason the
+          # proof gate below is: the branch under judgement must not be
+          # able to change how its own commit message is assembled.
+          merge_body="$RUNNER_TEMP/release-train-body.mjs"
+          git show \
+            "refs/remotes/origin/main:scripts/release-train-body.mjs" \
+            > "$merge_body"
+          test -s "$merge_body"
+          region="$RUNNER_TEMP/release-train-region.md"
+          cat > "$region" <<'RELEASE_TRAIN_REGION'
+          Automated, coalescing Kin release PR. It carries the lockstep Cargo/npm version, exact internal path pin, workspace-only lockfile movement, and generated notes for every reviewed first-parent change since the prior stable tag.
+          RELEASE_TRAIN_REGION
+
           created=false
           if [ -z "$pr" ]; then
+            initial_body="$RUNNER_TEMP/release-train-initial-body.md"
+            node "$merge_body" \
+              --region "$region" \
+              --out "$initial_body" \
+              >/dev/null
             gh pr create \
               --repo "$GITHUB_REPOSITORY" \
               --base main \
               --head "$BRANCH" \
               --title "Release Kin ${TAG}" \
-              --body "Automated, coalescing Kin release PR. It carries the lockstep Cargo/npm version, exact internal path pin, workspace-only lockfile movement, and generated notes for every reviewed first-parent change since the prior stable tag." \
+              --body-file "$initial_body" \
               >/dev/null
             pr_data="$(gh pr list \
               --repo "$GITHUB_REPOSITORY" \
@@ -576,10 +605,47 @@ jobs:
             test -n "$pr"
             created=true
           fi
+          # The title is generated every cycle and carries nothing an
+          # operator writes, so it stays a plain overwrite.
           gh pr edit "$pr" \
             --repo "$GITHUB_REPOSITORY" \
-            --title "Release Kin ${TAG}" \
-            --body "Automated, coalescing Kin release PR. It carries the lockstep Cargo/npm version, exact internal path pin, workspace-only lockfile movement, and generated notes for every reviewed first-parent change since the prior stable tag."
+            --title "Release Kin ${TAG}"
+          # Read the body as JSON rather than as text, so no shell or jq
+          # step can add, strip, or re-encode a byte an operator wrote.
+          current_body="$RUNNER_TEMP/release-train-current-body.json"
+          gh pr view "$pr" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json body \
+            > "$current_body"
+          next_body="$RUNNER_TEMP/release-train-next-body.md"
+          merge_result="$(node "$merge_body" \
+            --region "$region" \
+            --current-json "$current_body" \
+            --out "$next_body")"
+          merge_status="$(jq -er .status <<< "$merge_result")"
+          merge_detail="$(jq -er .detail <<< "$merge_result")"
+          # Read the flag as text, never as a jq truth value: `jq -e` exits
+          # 1 on a false result, so a no-op cycle would abort this step
+          # under set -e, and no-op is the common case. Requiring the field
+          # to be a boolean keeps the absent-field failure loud.
+          merge_changed="$(jq -er '
+            if (.changed | type) == "boolean" then
+              .changed | tostring
+            else
+              error("release PR body merge reported no changed flag")
+            end
+          ' <<< "$merge_result")"
+          if [ "$merge_status" = "unmergeable" ]; then
+            # Leave the body exactly as it stands. Refusing costs the
+            # train its own line; guessing at which region it owns costs
+            # the release the disclosures this preservation exists for.
+            echo "::error::release PR body left untouched: ${merge_detail}"
+          elif [ "$merge_changed" = "true" ]; then
+            gh pr edit "$pr" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file "$next_body"
+            echo "::notice::release PR body reconciled: ${merge_detail}"
+          fi
           jq -n \
             --arg automated "release:automated" \
             --arg bump "release:${BUMP}" \

--- a/scripts/release-train-body.mjs
+++ b/scripts/release-train-body.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+/**
+ * Merge the release train's own text into a release pull-request body without
+ * disturbing what an operator wrote around it.
+ *
+ * This repository squashes with the pull-request body as the commit message,
+ * and the merge queue mints that message when the entry is admitted. So the
+ * release body is not a description of the release, it is the release's
+ * permanent commit message, and every disclosure the release doctrine requires
+ * lives in it. The train reconciles on a four-times-an-hour schedule and used
+ * to rewrite the whole body to its own generic line on every cycle, which
+ * discards anything a human added and, if a cycle lands between the edit and
+ * queue admission, ships a release whose message carries none of it.
+ *
+ * The train therefore owns one delimited region and nothing else. Text above
+ * or below the markers survives byte for byte, including its line endings. A
+ * body with no region gets one at the top; a body whose markers are missing a
+ * partner or repeat is refused rather than guessed at, because a wrong guess
+ * here destroys the operator text this exists to protect.
+ */
+
+import fs from 'node:fs';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const BEGIN_MARKER = '<!-- kin-release-train:begin -->';
+export const END_MARKER = '<!-- kin-release-train:end -->';
+
+/** Wrap the train's text in its markers. */
+export function renderRegion(region) {
+  const text = String(region).replace(/^\n+/, '').replace(/\s+$/, '');
+  return `${BEGIN_MARKER}\n${text}\n${END_MARKER}`;
+}
+
+function countOccurrences(haystack, needle) {
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index >= 0) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+/**
+ * Merge `region` into `current`, returning what happened and the body to write.
+ *
+ * `changed` is the caller's whole decision: false means do not touch the body
+ * at all, which covers both an already-current region and a body this function
+ * refuses to rewrite.
+ */
+export function mergeBody({ current = '', region }) {
+  if (typeof region !== 'string' || region.trim() === '') {
+    throw new Error('release train body region must be non-empty text');
+  }
+  const body = typeof current === 'string' ? current : '';
+  const rendered = renderRegion(region);
+  const begins = countOccurrences(body, BEGIN_MARKER);
+  const ends = countOccurrences(body, END_MARKER);
+
+  if (begins === 0 && ends === 0) {
+    // A body the train has never marked. The legacy shape is the train's own
+    // generic line at the top followed by whatever an operator appended, and
+    // absorbing that exact line into the region is not a loss of anyone's
+    // text: the train wrote it. Anything that merely resembles it is operator
+    // text and stays where it is.
+    const legacy = String(region).trim();
+    let rest = body;
+    let status = 'region-added';
+    if (rest.startsWith(legacy)) {
+      rest = rest.slice(legacy.length).replace(/^[\r\n]+/, '');
+      status = 'legacy-region-adopted';
+    }
+    const merged = rest.trim() === '' ? rendered : `${rendered}\n\n${rest}`;
+    return {
+      changed: merged !== body,
+      status,
+      body: merged,
+      detail:
+        status === 'legacy-region-adopted'
+          ? 'the train-authored opening line became the delimited region'
+          : 'the delimited region was added above the existing body',
+    };
+  }
+
+  if (begins !== 1 || ends !== 1) {
+    return {
+      changed: false,
+      status: 'unmergeable',
+      body: null,
+      detail: `body carries ${begins} begin and ${ends} end release-train markers, so the region the train owns is ambiguous`,
+    };
+  }
+
+  const begin = body.indexOf(BEGIN_MARKER);
+  const end = body.indexOf(END_MARKER);
+  if (end < begin) {
+    return {
+      changed: false,
+      status: 'unmergeable',
+      body: null,
+      detail: 'body carries the release-train end marker before its begin marker',
+    };
+  }
+
+  const merged = body.slice(0, begin) + rendered + body.slice(end + END_MARKER.length);
+  return {
+    changed: merged !== body,
+    status: 'region-replaced',
+    body: merged,
+    detail:
+      merged === body
+        ? 'the delimited region already carries this text'
+        : 'the delimited region was replaced and nothing outside it moved',
+  };
+}
+
+function readOption(argv, name) {
+  const index = argv.indexOf(name);
+  if (index < 0) {
+    return null;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`${name} needs a file path`);
+  }
+  return value;
+}
+
+function main(argv) {
+  const regionPath = readOption(argv, '--region');
+  const currentJsonPath = readOption(argv, '--current-json');
+  const outPath = readOption(argv, '--out');
+  if (!regionPath || !outPath) {
+    throw new Error(
+      'usage: release-train-body.mjs --region <file> --out <file> [--current-json <file>]',
+    );
+  }
+
+  let current = '';
+  if (currentJsonPath) {
+    // The body arrives as JSON rather than as raw text so no shell or jq step
+    // can add, strip, or re-encode a byte of what the operator wrote.
+    const parsed = JSON.parse(fs.readFileSync(currentJsonPath, 'utf8'));
+    if (typeof parsed.body !== 'string') {
+      throw new Error('pull-request JSON carries no body string, so the current body was never read');
+    }
+    current = parsed.body;
+  }
+
+  const result = mergeBody({
+    current,
+    region: fs.readFileSync(regionPath, 'utf8'),
+  });
+  if (result.body !== null) {
+    fs.writeFileSync(outPath, result.body);
+  }
+  process.stdout.write(
+    `${JSON.stringify({
+      changed: result.changed,
+      status: result.status,
+      detail: result.detail,
+    })}\n`,
+  );
+}
+
+/**
+ * Whether this file is the program being run rather than an imported module.
+ *
+ * Compare resolved paths, not the URL against a raw argv string: a runner that
+ * copies this script under a symlinked directory (every macOS $TMPDIR is one)
+ * makes those two spellings differ, and the mismatch is silent. The script
+ * would read its arguments, write nothing, and exit 0, which the caller then
+ * reads as an empty merge result.
+ */
+function invokedDirectly() {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  try {
+    return fs.realpathSync(entry) === fs.realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedDirectly()) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`::error::${error.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/release-train-body.test.mjs
+++ b/scripts/release-train-body.test.mjs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  BEGIN_MARKER,
+  END_MARKER,
+  mergeBody,
+  renderRegion,
+} from './release-train-body.mjs';
+
+const SCRIPT = fileURLToPath(new URL('./release-train-body.mjs', import.meta.url));
+
+// The exact sentence the train writes, so a fixture cannot drift into proving
+// something about a sentence the workflow never sends.
+const GENERIC =
+  'Automated, coalescing Kin release PR. It carries the lockstep Cargo/npm version, exact internal path pin, workspace-only lockfile movement, and generated notes for every reviewed first-parent change since the prior stable tag.';
+
+// The two sections tonight's release doctrine requires, shortened but shaped
+// like the ones a captain wrote on kin#1001.
+const ABOVE = '## What this release carries\n\nSeven reviewed changes landed on main since v0.5.45.';
+const BELOW =
+  '## What this release did not test\n\nThe stranger ran the greenfield arm only on these bytes.\n\n## Known limitation\n\nReceiver recall over two hops is incomplete at history depth.';
+
+function region(text = GENERIC) {
+  return `${BEGIN_MARKER}\n${text}\n${END_MARKER}`;
+}
+
+test('a body with no region gets one at the top and keeps every operator byte', () => {
+  const current = `${ABOVE}\n\n${BELOW}`;
+  const result = mergeBody({ current, region: GENERIC });
+  assert.equal(result.changed, true);
+  assert.equal(result.status, 'region-added');
+  assert.equal(result.body, `${region()}\n\n${ABOVE}\n\n${BELOW}`);
+  assert.ok(result.body.endsWith(`${ABOVE}\n\n${BELOW}`));
+});
+
+test('operator text above and below the region survives byte for byte', () => {
+  const current = `${ABOVE}\n\n${region('stale generated text')}\n\n${BELOW}`;
+  const result = mergeBody({ current, region: GENERIC });
+  assert.equal(result.changed, true);
+  assert.equal(result.status, 'region-replaced');
+  assert.equal(result.body, `${ABOVE}\n\n${region()}\n\n${BELOW}`);
+  // The claim is about bytes, so state it about bytes: everything outside the
+  // region is unchanged, not merely present.
+  const [beforeOld, afterOld] = [
+    current.slice(0, current.indexOf(BEGIN_MARKER)),
+    current.slice(current.indexOf(END_MARKER) + END_MARKER.length),
+  ];
+  const [beforeNew, afterNew] = [
+    result.body.slice(0, result.body.indexOf(BEGIN_MARKER)),
+    result.body.slice(result.body.indexOf(END_MARKER) + END_MARKER.length),
+  ];
+  assert.equal(beforeNew, beforeOld);
+  assert.equal(afterNew, afterOld);
+});
+
+test('a body that is only the region and already current is left alone', () => {
+  const current = region();
+  const result = mergeBody({ current, region: GENERIC });
+  assert.equal(result.changed, false);
+  assert.equal(result.status, 'region-replaced');
+  assert.equal(result.body, current);
+});
+
+test('a region-only body still updates when the generated text drifts', () => {
+  const current = region('older generated text');
+  const result = mergeBody({ current, region: GENERIC });
+  assert.equal(result.changed, true);
+  assert.equal(result.body, region());
+});
+
+test('the train-authored opening line is adopted as the region rather than duplicated', () => {
+  const current = `${GENERIC}\n\n${ABOVE}`;
+  const result = mergeBody({ current, region: GENERIC });
+  assert.equal(result.status, 'legacy-region-adopted');
+  assert.equal(result.body, `${region()}\n\n${ABOVE}`);
+  assert.equal(result.body.split(GENERIC).length - 1, 1);
+});
+
+test('an opening line that only resembles the train sentence is operator text and stays put', () => {
+  const nearMiss = `${GENERIC.slice(0, -1)}!`;
+  const current = `${nearMiss}\n\n${ABOVE}`;
+  const result = mergeBody({ current, region: GENERIC });
+  assert.equal(result.status, 'region-added');
+  assert.equal(result.body, `${region()}\n\n${nearMiss}\n\n${ABOVE}`);
+  assert.ok(result.body.includes(nearMiss));
+});
+
+test('an empty body becomes the region alone, which is the create path', () => {
+  const result = mergeBody({ current: '', region: GENERIC });
+  assert.equal(result.changed, true);
+  assert.equal(result.body, region());
+});
+
+test('a second pass over a merged body changes nothing', () => {
+  const once = mergeBody({ current: `${ABOVE}\n\n${BELOW}`, region: GENERIC });
+  const twice = mergeBody({ current: once.body, region: GENERIC });
+  assert.equal(twice.changed, false);
+  assert.equal(twice.body, once.body);
+});
+
+test('web-edited CRLF operator text keeps its line endings', () => {
+  const current = `## Known limitation\r\n\r\nReceiver recall is incomplete.\r\n`;
+  const result = mergeBody({ current, region: GENERIC });
+  assert.ok(result.body.endsWith(current));
+  assert.equal(result.body.includes('\r\n'), true);
+});
+
+test('a half-marked body is refused rather than guessed at', () => {
+  for (const [label, current] of [
+    ['begin with no end', `${BEGIN_MARKER}\n${GENERIC}\n\n${ABOVE}`],
+    ['end with no begin', `${GENERIC}\n${END_MARKER}\n\n${ABOVE}`],
+    ['markers in the wrong order', `${END_MARKER}\n${GENERIC}\n${BEGIN_MARKER}`],
+    ['a repeated region', `${region()}\n\n${ABOVE}\n\n${region()}`],
+  ]) {
+    const result = mergeBody({ current, region: GENERIC });
+    assert.equal(result.status, 'unmergeable', label);
+    assert.equal(result.changed, false, label);
+    assert.equal(result.body, null, label);
+    assert.match(result.detail, /marker/, label);
+  }
+});
+
+test('an empty region is refused, because a body cannot be reconciled against nothing', () => {
+  assert.throws(() => mergeBody({ current: ABOVE, region: '   \n' }), /non-empty/);
+});
+
+test('renderRegion trims its own whitespace and never nests markers', () => {
+  assert.equal(renderRegion(`\n\n${GENERIC}\n\n`), region());
+});
+
+test('the command line writes the merged body and reports what it did', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-train-body-'));
+  const regionPath = path.join(dir, 'region.md');
+  const currentPath = path.join(dir, 'current.json');
+  const outPath = path.join(dir, 'next.md');
+  const current = `${ABOVE}\n\n${region('older generated text')}\n\n${BELOW}`;
+  fs.writeFileSync(regionPath, `${GENERIC}\n`);
+  fs.writeFileSync(currentPath, JSON.stringify({ body: current }));
+
+  const stdout = execFileSync(process.execPath, [
+    SCRIPT,
+    '--region',
+    regionPath,
+    '--current-json',
+    currentPath,
+    '--out',
+    outPath,
+  ]);
+  const result = JSON.parse(stdout.toString());
+  assert.equal(result.changed, true);
+  assert.equal(result.status, 'region-replaced');
+  assert.equal(fs.readFileSync(outPath, 'utf8'), `${ABOVE}\n\n${region()}\n\n${BELOW}`);
+
+  // No --current-json is the create path, and it must produce the region alone.
+  const createOut = path.join(dir, 'create.md');
+  const created = JSON.parse(
+    execFileSync(process.execPath, [SCRIPT, '--region', regionPath, '--out', createOut]).toString(),
+  );
+  assert.equal(created.changed, true);
+  assert.equal(fs.readFileSync(createOut, 'utf8'), region());
+});
+
+test('the script still runs when its path reaches node through a symlink', () => {
+  // Every macOS $TMPDIR is a symlink, and the release train copies this file
+  // into $RUNNER_TEMP before running it. Comparing import.meta.url against a
+  // raw argv path made the program body never execute: no output, exit 0, and
+  // a caller reading an empty merge result as a failed jq parse.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-train-body-link-'));
+  const linked = path.join(dir, 'release-train-body.mjs');
+  fs.symlinkSync(SCRIPT, linked);
+  const regionPath = path.join(dir, 'region.md');
+  const outPath = path.join(dir, 'next.md');
+  fs.writeFileSync(regionPath, GENERIC);
+  const stdout = execFileSync(process.execPath, [
+    linked,
+    '--region',
+    regionPath,
+    '--out',
+    outPath,
+  ]).toString();
+  assert.notEqual(stdout.trim(), '');
+  assert.equal(JSON.parse(stdout).changed, true);
+  assert.equal(fs.readFileSync(outPath, 'utf8'), region());
+});
+
+test('a pull-request payload with no body string fails loud rather than blanking the body', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-train-body-'));
+  const regionPath = path.join(dir, 'region.md');
+  const currentPath = path.join(dir, 'current.json');
+  fs.writeFileSync(regionPath, GENERIC);
+  fs.writeFileSync(currentPath, JSON.stringify({}));
+  assert.throws(
+    () =>
+      execFileSync(process.execPath, [
+        SCRIPT,
+        '--region',
+        regionPath,
+        '--current-json',
+        currentPath,
+        '--out',
+        path.join(dir, 'next.md'),
+      ]),
+    /carries no body string/,
+  );
+});

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -67,6 +67,10 @@ TAG_SELECTOR = ROOT / "scripts" / "select-admissible-release-tag.py"
 ABANDONED_TAGS_POLICY = "scripts/abandoned-release-tags.json"
 TAG_SELECTOR_POLICY = "scripts/select-admissible-release-tag.py"
 ASSERTION_REACHABILITY = ROOT / "scripts" / "test-assertion-reachability.py"
+RELEASE_TRAIN_BODY = ROOT / "scripts" / "release-train-body.mjs"
+RELEASE_TRAIN_BODY_POLICY = "scripts/release-train-body.mjs"
+RELEASE_TRAIN_BODY_BEGIN = "<!-- kin-release-train:begin -->"
+RELEASE_TRAIN_BODY_END = "<!-- kin-release-train:end -->"
 ASSERTION_REACHABILITY_POLICY = "scripts/test-assertion-reachability.py"
 GLIBC_FLOOR_GUARD = ROOT / "scripts" / "check-glibc-floor.mjs"
 GLIBC_FLOOR_GUARD_POLICY = "scripts/check-glibc-floor.mjs"
@@ -5183,6 +5187,56 @@ def assert_release_pr_author_identity(release_train: str) -> None:
         )
 
 
+def assert_release_pr_body_preserves_operator_text(
+    release_train: str, merge_script: str
+) -> None:
+    """The train may own a delimited region of the release body, nothing more.
+
+    This repository squashes with the pull-request body as the commit message,
+    and the merge queue mints that message when the entry is admitted, so the
+    release body is the release's permanent commit message rather than a
+    description of it. The train used to overwrite the whole body with its own
+    generic line on every reconcile cycle, which erased the disclosures the
+    release doctrine requires an operator to add, and a cycle landing between
+    that edit and queue admission would have shipped a release carrying none of
+    them. A captain-side polling guard covered the window once; a guard that
+    lives in a session can always be retired, so the preservation lives here.
+
+    Reading the merge from protected main is load bearing for the same reason
+    the proof gate's read is: a release branch that could carry its own body
+    merge could decide what its own commit message says.
+    """
+
+    step = workflow_step_source(
+        "release train", release_train, RELEASE_PR_STEP_ANCHOR
+    )
+    if '--body "' in step:
+        raise AssertionError(
+            "the release PR body must never be written from an inline literal: "
+            "that overwrite is what discarded the operator-authored release "
+            "disclosures the squash message has to carry"
+        )
+    for policy in (
+        f"{TRUSTED_POLICY_PREFIX}{RELEASE_TRAIN_BODY_POLICY}",
+        '--body-file "$initial_body"',
+        '--body-file "$next_body"',
+        '--json body',
+    ):
+        require(step, policy, "operator-preserving release PR body")
+    index = step.find(RELEASE_TRAIN_BODY_POLICY)
+    while index >= 0:
+        prefix = step[max(0, index - len(TRUSTED_POLICY_PREFIX)) : index]
+        if prefix != TRUSTED_POLICY_PREFIX:
+            raise AssertionError(
+                "the release PR body merge must be read from protected main. A "
+                "branch that carries its own body merge decides what its own "
+                "squash message says"
+            )
+        index = step.find(RELEASE_TRAIN_BODY_POLICY, index + 1)
+    for marker in (RELEASE_TRAIN_BODY_BEGIN, RELEASE_TRAIN_BODY_END):
+        require(merge_script, marker, "release PR body merge")
+
+
 def release_branch_allowlist(release_train: str) -> str:
     """Return the regex the train uses to admit its own generated branch."""
 
@@ -8298,6 +8352,64 @@ def main() -> None:
         "protected release PR opener is missing required policy: gh pr create",
         lambda: assert_release_pr_author_identity(
             release_train.replace("gh pr create \\", "gh pr view \\", 1)
+        ),
+    )
+    release_train_body = RELEASE_TRAIN_BODY.read_text(encoding="utf-8")
+    assert_release_pr_body_preserves_operator_text(release_train, release_train_body)
+    # The reverts this preservation has to survive, in the order they are
+    # reachable: the generic line going back to an inline overwrite, the merge
+    # moving off protected main and onto the branch under judgement, and the
+    # created body losing its file.
+    expect_assertion(
+        "the release PR body returns to an inline literal overwrite",
+        "must never be written from an inline literal",
+        lambda: assert_release_pr_body_preserves_operator_text(
+            release_train.replace(
+                '--body-file "$next_body"',
+                '--body "Automated, coalescing Kin release PR."',
+                1,
+            ),
+            release_train_body,
+        ),
+    )
+    expect_assertion(
+        "the release PR body merge stops being read from protected main",
+        f"is missing required policy: {TRUSTED_POLICY_PREFIX}"
+        f"{RELEASE_TRAIN_BODY_POLICY}",
+        lambda: assert_release_pr_body_preserves_operator_text(
+            release_train.replace(
+                f"{TRUSTED_POLICY_PREFIX}{RELEASE_TRAIN_BODY_POLICY}",
+                RELEASE_TRAIN_BODY_POLICY,
+                1,
+            ),
+            release_train_body,
+        ),
+    )
+    expect_assertion(
+        "a second body merge runs from the branch beside the trusted read",
+        "must be read from protected main",
+        lambda: assert_release_pr_body_preserves_operator_text(
+            release_train.replace(
+                'node "$merge_body"',
+                f"node {RELEASE_TRAIN_BODY_POLICY}",
+                1,
+            ),
+            release_train_body,
+        ),
+    )
+    expect_assertion(
+        "the created release PR body stops coming from the merged file",
+        'is missing required policy: --body-file "$initial_body"',
+        lambda: assert_release_pr_body_preserves_operator_text(
+            release_train.replace('--body-file "$initial_body"', "--body-file -", 1),
+            release_train_body,
+        ),
+    )
+    expect_assertion(
+        "the body merge loses the markers that delimit what the train owns",
+        f"is missing required policy: {RELEASE_TRAIN_BODY_BEGIN}",
+        lambda: assert_release_pr_body_preserves_operator_text(
+            release_train, release_train_body.replace(RELEASE_TRAIN_BODY_BEGIN, "")
         ),
     )
     assert_release_branch_allowlist_covers_generator(release_train)


### PR DESCRIPTION
`release-train.yml` reconciles the open release pull request four times an hour, and until now every cycle ran `gh pr edit "$pr" --title ... --body "<generic literal>"` with the same sentence it writes at create time (`.github/workflows/release-train.yml:555` and `:582` at origin/main 79979a37). This repository squashes with the pull-request body as the commit message and the merge queue mints that message at admission, so the release body is not a description of the release, it is the release's permanent commit message. On 2026-08-21 the captain wrote the two disclosure sections the release doctrine requires into kin#1001 at 06:02Z, the 06:19:30Z cycle rewrote the body back to the generic line, and a 15 second polling guard re-applied it at 06:20:24Z. A cycle landing between an operator's edit and queue entry would have shipped v0.5.46 with a commit message carrying none of it.

## What changed

The train now owns one delimited region of the body and rewrites nothing else. `scripts/release-train-body.mjs` merges its text between `<!-- kin-release-train:begin -->` and `<!-- kin-release-train:end -->` and leaves every byte outside those markers alone, including CRLF line endings a web edit introduces. A body with no region gets one at the top. A body that opens with text byte identical to the train's own sentence has that opening adopted as the region rather than duplicated, which is the only case where the merge touches anything outside the markers, and it touches only text the train itself wrote. A body whose markers are unpaired or repeated is refused: the train's line is skipped, an `::error::` annotation names the reason, and the body is left exactly as it stands, because guessing which region it owns is what would cost the release its disclosures.

The workflow reads the current body as JSON rather than as text so no shell or `jq` step can add, strip or re-encode a byte an operator wrote, reads the merge from `refs/remotes/origin/main` for the same reason the proof gate does, and skips the edit call entirely when nothing changed. Title updates stay a plain overwrite, since the title is generated and carries nothing an operator writes. The hold-comment logic and the proof step from #993 are untouched, as are `release.yml` and `release-tag.yml`.

`scripts/test-release-workflow-authority.py` gains `assert_release_pr_body_preserves_operator_text`, which refuses any inline `--body "` literal in the release PR step, requires both `--body-file` writes and the protected-main read, and pins the markers in the merge script. Four falsifications run beside it, covering the revert to an inline literal, the protected-main read disappearing, a second merge running from the branch under judgement, and the created body losing its file.

## Fixtures

`node --test ./scripts/release-train-body.test.mjs` is 15 tests, 15 pass, 0 fail. The three the ticket asked for, with their exact outputs:

- No region: body `## What this release carries...\n\n## What this release did not test...` becomes the region followed by both sections, and everything after the end marker is byte identical to the input.
- Region with operator text above and below: the region is replaced and `body.slice(0, begin)` and `body.slice(end + END.length)` are asserted equal before and after, so the claim is about bytes rather than about presence.
- Region only and already current: `changed` is false and the body is returned unmodified, so no API write happens at all.

The workflow's own shell was extracted from the YAML block scalar, dedented and run against stubbed `gh` and `git` with a body shaped like kin#1001. Cycle 1 emitted `::notice::release PR body reconciled: the train-authored opening line became the delimited region` and cycles 2 and 3 wrote nothing but the title. A section appended after the region survived two further cycles byte identical, with the generic sentence appearing exactly once. The same fixture run against origin/main's step reduced the body to the generic line in one cycle, with both disclosure sections gone, which is the behaviour this PR removes. A malformed body carrying a begin marker and no end left the body untouched and printed `::error::release PR body left untouched: body carries 1 begin and 0 end release-train markers, so the region the train owns is ambiguous`.

That simulation earned its keep twice. It caught a direct-invocation guard comparing `import.meta.url` against a raw `process.argv[1]`, which never matched under a symlinked `$RUNNER_TEMP` and made the script exit 0 having written nothing; the guard now compares resolved paths and a test runs the script through a symlink. It also caught `jq -er .changed` exiting 1 on a `false` result, which would have aborted the step under `set -e` on every no-op cycle, and no-op is the common case; the flag is now read as text with the absent-field failure kept loud.

## Falsification

Three passes, each removing one property, each restored byte identical afterwards:

- Region replacement replaced by a whole-body overwrite: tests 2, 8 and 13 fail, and 1, 5, 6 and 9 still pass because those drive the no-region branch the sabotage did not touch.
- The no-region branch dropping the operator text: tests 1, 5, 6 and 9 fail, and 2, 8 and 13 pass.
- The unpaired-marker refusal accepting the body instead: test 10 fails alone.

## Gates

`actionlint .github/workflows/release-train.yml .github/workflows/ci.yml` exits 0, with a positive control confirming actionlint fails this file when an undefined matrix property is introduced. `python3 scripts/test-release-workflow-authority.py` exits 0 on the final tree. `python3 scripts/test-assertion-reachability.py` reports 3 gate suites run on pull requests and define no check that nothing calls. `bash scripts/test-release-policy-gate.sh` exits 0. The exact `node --test` list ci.yml runs, with the new suite registered, is 153 tests, 153 pass, 0 fail. `node --check ./scripts/release-train-body.mjs` passes.

This change touches no Rust, so the full `bin/kin-dev local-test kin` gate exercises nothing it can move and no build slot was taken; `git diff origin/main --stat -- Cargo.lock .cargo/` is empty and `git ls-tree -r HEAD --name-only` shows only `.cargo/config.toml`. Hosted CI is the gate of record for this PR: 37 checks, all concluded, 32 passing and 5 skipping, 0 failures, including `Check & Test (ubuntu-latest)`, `Check & Test (macos-latest)`, both macOS shards, `Falsify guards`, all three Windows authority legs, `Install Proof (PR) Gate`, `cargo-deny` and `gitleaks (full history)`.

Closes FIR-2568
