### PR TITLE
Read a member that exited mid-classification as contained, and scale the settle by load

### DIFF
--- a/crates/kin-cli/tests/live_graph_durability_disclosure.rs
+++ b/crates/kin-cli/tests/live_graph_durability_disclosure.rs
@@ -65,11 +65,59 @@ const WATCHER_RECORD: &str = "started file watcher";
 /// into repository authority (`crates/kin-daemon/src/loop_runner.rs`).
 const ADMISSION_RECORD: &str = "admitted exact workspace tree into repository authority";
 
+/// The settle budget a quiet host needs, and the floor every busier host starts
+/// from.
+///
+/// Generous against the few hundred milliseconds this repository's four vectors
+/// take, so expiry on an idle box means the lock is never being yielded rather
+/// than that embedding was merely busy.
+const RETRY_BOUND_FLOOR: Duration = Duration::from_secs(30);
+
+/// The most the settle may stretch to, so a daemon that never yields the lock
+/// still fails inside a bounded pass.
+///
+/// The same 120 seconds [`ADMISSION_BOUND`] allows itself, for the same reason:
+/// the wait is event driven, so a passing run never spends it, and this is only
+/// how long a run that is going to fail spends proving it.
+const RETRY_BOUND_CEILING: Duration = Duration::from_secs(120);
+
 /// How long the fixture will keep repeating a session while `kin_graph_status`
-/// refuses to sample its counts. Generous against the few hundred milliseconds
-/// this repository's four vectors take, so expiry means the lock is never being
-/// yielded rather than that embedding was merely busy.
-const RETRY_BOUND: Duration = Duration::from_secs(30);
+/// refuses to sample its counts, scaled by how oversubscribed this host is.
+///
+/// A single fixed number was calibrated for an idle box and had no margin left
+/// on a busy one. Three solo runs of this case on an idle eighteen core
+/// workstation took 25.9, 29.0 and 27.7 seconds end to end against a settle
+/// bound of 30, so the case was already finishing inside a budget it had nearly
+/// spent. Under fleet co-load the same case ran 70.3 seconds and the settle
+/// burned all thirty of them without the daemon ever answering wrongly: it was
+/// asking to be retried while the embedding-work lock moved, which is its
+/// documented answer. The host read load average 136 on those eighteen cores at
+/// the time, on a pass whose slowest routine test took 413 seconds.
+///
+/// What the settle waits on is the daemon finishing embedding work, and that is
+/// CPU time competing with everything else on the host, so the budget tracks
+/// the competition. The floor stays what a quiet box needs, which keeps the
+/// discrimination this bound exists for: on an unloaded machine a daemon that
+/// never yields still fails in thirty seconds, exactly as before.
+fn retry_bound() -> Duration {
+    let cores = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
+    scaled_retry_bound(sysinfo::System::load_average().one, cores)
+}
+
+/// [`RETRY_BOUND_FLOOR`] stretched by run-queue depth per core.
+///
+/// Split from the reading above so the arithmetic can be driven with observed
+/// numbers rather than with whatever the box running the tests happens to
+/// report at that instant.
+fn scaled_retry_bound(run_queue_depth: f64, cores: usize) -> Duration {
+    let widest = RETRY_BOUND_CEILING.as_secs_f64() / RETRY_BOUND_FLOOR.as_secs_f64();
+    let stretch = run_queue_depth / cores.max(1) as f64;
+    // Platforms that do not publish a load average report zero, and a garbled
+    // reading is not a reason to change the budget, so anything that is not a
+    // finite number falls back to the floor rather than propagating.
+    let stretch = if stretch.is_finite() { stretch } else { 1.0 };
+    RETRY_BOUND_FLOOR.mul_f64(stretch.clamp(1.0, widest))
+}
 
 struct IsolatedDaemon {
     child: Option<common::RuntimeOwnedChild>,
@@ -492,7 +540,7 @@ fn asks_for_retry(payload: &serde_json::Value) -> bool {
 /// mask: a daemon that never yields the lock still fails, naming how many times
 /// it refused.
 fn settled_mcp_session(repo: &Path, home: &Path, port: u16) -> Vec<(u64, serde_json::Value)> {
-    let deadline = Instant::now() + RETRY_BOUND;
+    let deadline = Instant::now() + retry_bound();
     let mut refusals = 0_u32;
     loop {
         let session = run_mcp_session(repo, home, port);
@@ -660,4 +708,68 @@ fn mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit
     );
 
     daemon.stop();
+}
+
+#[test]
+fn a_quiet_host_keeps_the_settle_budget_the_fixed_bound_gave_it() {
+    // The property the stretch must not cost: on a box that is not fighting
+    // anyone, a daemon that never yields the lock still fails in thirty
+    // seconds. The stretch is for contention, so a host at or under its own
+    // core count gets nothing extra.
+    assert_eq!(
+        scaled_retry_bound(1.2, 18),
+        RETRY_BOUND_FLOOR,
+        "an idle host must keep paying exactly the old price"
+    );
+    assert_eq!(
+        scaled_retry_bound(18.0, 18),
+        RETRY_BOUND_FLOOR,
+        "a host busy up to its core count is not oversubscribed"
+    );
+}
+
+#[test]
+fn the_load_that_produced_the_failure_buys_a_budget_that_covers_it() {
+    // The reading taken when this case failed: load average 136.33 on eighteen
+    // cores, in a pass where the case itself ran 70.265 seconds and the settle
+    // spent all thirty of its seconds inside that.
+    let bound = scaled_retry_bound(136.33, 18);
+    assert_eq!(
+        bound, RETRY_BOUND_CEILING,
+        "seven times oversubscribed is past the widest stretch, so the ceiling applies"
+    );
+    assert!(
+        bound >= Duration::from_secs_f64(70.265),
+        "the budget has to cover what that run actually spent, and {bound:?} does not"
+    );
+}
+
+#[test]
+fn the_stretch_is_proportional_and_survives_a_host_that_reports_nothing() {
+    assert_eq!(
+        scaled_retry_bound(36.0, 18),
+        Duration::from_secs(60),
+        "twice oversubscribed buys twice the floor, not the ceiling"
+    );
+    assert_eq!(
+        scaled_retry_bound(0.0, 18),
+        RETRY_BOUND_FLOOR,
+        "a platform that publishes no load average must not shrink the budget"
+    );
+    assert_eq!(
+        scaled_retry_bound(f64::NAN, 18),
+        RETRY_BOUND_FLOOR,
+        "a garbled reading is not a reason to change the budget"
+    );
+    assert_eq!(
+        scaled_retry_bound(f64::INFINITY, 18),
+        RETRY_BOUND_FLOOR,
+        "an unbounded reading is garbled rather than evidence of load, and must not \
+         stretch anything"
+    );
+    assert_eq!(
+        scaled_retry_bound(4.0, 0),
+        RETRY_BOUND_CEILING,
+        "a host reporting no cores at all must not divide by zero"
+    );
 }

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -2492,28 +2492,64 @@ fn process_group_containment(process_group: libc::pid_t) -> ProcessGroupContainm
         return ProcessGroupContainment::Empty;
     }
     match process_group_members(process_group) {
-        Ok(members) if members.is_empty() => {
-            // The group emptied between the two calls. Nothing remains to run.
-            ProcessGroupContainment::Empty
-        }
-        Ok(members) => {
-            for pid in members {
-                match process_has_exited(pid) {
-                    Ok(true) => {}
-                    Ok(false) => return ProcessGroupContainment::LiveMember { pid },
-                    Err(error) => {
-                        return ProcessGroupContainment::Indeterminate {
-                            detail: format!("classify member {pid}: {error}"),
-                        };
-                    }
-                }
-            }
-            ProcessGroupContainment::OnlyExited
-        }
+        Ok(members) => classify_process_group_members(&members),
         Err(error) => ProcessGroupContainment::Indeterminate {
             detail: format!("enumerate group members: {error}"),
         },
     }
+}
+
+/// Classify a member list that enumeration has already produced.
+///
+/// Split from the enumeration above so the gap between the two steps can be
+/// driven directly rather than only hoped for. The gap is real work: a member
+/// enumeration named can run to completion, and be collected, before
+/// classification reaches it, and what the classifier reads then is a pid with
+/// nothing behind it.
+#[cfg(unix)]
+fn classify_process_group_members(members: &[libc::pid_t]) -> ProcessGroupContainment {
+    if members.is_empty() {
+        // The group emptied between the two calls. Nothing remains to run.
+        return ProcessGroupContainment::Empty;
+    }
+    for &pid in members {
+        match process_has_exited(pid) {
+            Ok(true) => {}
+            Ok(false) => return ProcessGroupContainment::LiveMember { pid },
+            Err(error) => {
+                return ProcessGroupContainment::Indeterminate {
+                    detail: format!("classify member {pid}: {error}"),
+                };
+            }
+        }
+    }
+    ProcessGroupContainment::OnlyExited
+}
+
+/// Whether a failed member probe means the member is gone rather than
+/// unreadable.
+///
+/// A member can leave the process table between enumeration and
+/// classification, and the errno that reports it depends on which step of the
+/// probe the disappearance lands in. An entry that is already gone answers the
+/// open with ENOENT. An entry whose task is collected after the open answers
+/// the read with ESRCH, because Linux resolves `/proc/<pid>/stat` through
+/// `proc_single_show`, which looks the task up at read time; the same errno is
+/// what `kill(pid, 0)` reports for a pid with nothing behind it at all.
+///
+/// Both answers say the same thing, and it is the strongest form of the state
+/// containment exists to reach: no task remains behind that pid, so it holds no
+/// address space, executes no instructions, and cannot fork. Reporting it as
+/// unclassifiable failed a correct cleanup for reaching its goal a moment
+/// early.
+///
+/// Every other failure stays a failure. EPERM, EACCES and an unparseable entry
+/// mean the member could not be read, and an unreadable member is not a
+/// contained one; treating those as gone would be the silent pass this whole
+/// path exists to prevent.
+#[cfg(unix)]
+fn member_probe_failure_means_gone(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::NotFound || error.raw_os_error() == Some(libc::ESRCH)
 }
 
 /// `proc_listpids` selector for "processes in this process group".
@@ -2635,11 +2671,11 @@ fn process_has_exited(pid: libc::pid_t) -> std::io::Result<bool> {
         return Ok(true);
     }
     let signal_error = std::io::Error::last_os_error();
-    match signal_error.raw_os_error() {
-        // Gone from the table entirely.
-        Some(libc::ESRCH) => Ok(true),
-        _ => Err(signal_error),
+    // Gone from the table entirely, which is more than exited.
+    if member_probe_failure_means_gone(&signal_error) {
+        return Ok(true);
     }
+    Err(signal_error)
 }
 
 /// PIDs currently reported as members of a process group.
@@ -2677,8 +2713,10 @@ fn process_has_exited(pid: libc::pid_t) -> std::io::Result<bool> {
         Ok(stat) => parse_proc_stat_state(&stat)
             .map(|state| state == 'Z')
             .ok_or_else(|| std::io::Error::other(format!("unparseable /proc/{pid}/stat"))),
-        // Gone entirely, which is more than exited.
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        // Gone entirely, which is more than exited. ENOENT is the open
+        // failing and ESRCH is the read failing, and this file can answer
+        // either way depending on when in the probe the member disappeared.
+        Err(error) if member_probe_failure_means_gone(&error) => Ok(true),
         Err(error) => Err(error),
     }
 }
@@ -4120,6 +4158,128 @@ mod tests {
         assert_eq!(
             process_group_containment(pgid),
             ProcessGroupContainment::Empty
+        );
+    }
+
+    #[cfg(all(unix, any(target_os = "macos", target_os = "linux")))]
+    #[test]
+    fn a_member_that_exits_between_enumeration_and_classification_is_contained() {
+        // The hosted-runner failure, reproduced at the seam it happened on:
+        // enumeration named a live member, the member exited and was collected
+        // before classification reached it, and the classifier reported the
+        // group unreadable rather than contained.
+        let mut child = spawn_in_own_group("sleep", &["30"]);
+        let pgid = libc::pid_t::try_from(child.id()).expect("child pid fits pid_t");
+
+        let members = process_group_members(pgid).expect("enumerate the group");
+        assert!(
+            members.contains(&pgid),
+            "enumeration must see the live member, or this test races nothing: {members:?}"
+        );
+
+        // The whole gap, taken at once: the member stops running and its slot
+        // is collected, all before a single pid is classified.
+        child.kill().expect("stop the member");
+        child.wait().expect("collect the member");
+
+        assert_eq!(
+            classify_process_group_members(&members),
+            ProcessGroupContainment::OnlyExited,
+            "a member that vanished between the two steps is gone, which is contained"
+        );
+    }
+
+    #[cfg(all(unix, any(target_os = "macos", target_os = "linux")))]
+    #[test]
+    fn a_member_that_outlives_the_classification_is_still_reported_live() {
+        // The control the case above needs. If treating a vanished member as
+        // contained degenerated into treating any hard-to-read member as
+        // contained, this is the assertion that would stop being true.
+        let mut child = spawn_in_own_group("sleep", &["30"]);
+        let pgid = libc::pid_t::try_from(child.id()).expect("child pid fits pid_t");
+
+        let members = process_group_members(pgid).expect("enumerate the group");
+        assert!(
+            members.contains(&pgid),
+            "enumeration must see the live member: {members:?}"
+        );
+
+        // Outlive a deadline of the settle's own order, then classify the same
+        // list. Nothing collected this member, so nothing may excuse it.
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            classify_process_group_members(&members),
+            ProcessGroupContainment::LiveMember { pid: pgid },
+            "a member that is still running must be reported, and named"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn only_a_gone_member_excuses_a_failed_probe() {
+        // The decision rule on its own, in both directions, because the two
+        // errnos that mean gone arrive from different steps of the probe and
+        // everything else has to keep failing.
+        assert!(
+            member_probe_failure_means_gone(&std::io::Error::from_raw_os_error(libc::ESRCH)),
+            "ESRCH is a pid with no task behind it"
+        );
+        assert!(
+            member_probe_failure_means_gone(&std::io::Error::from_raw_os_error(libc::ENOENT)),
+            "ENOENT is the entry already gone when the probe opened it"
+        );
+        assert!(
+            !member_probe_failure_means_gone(&std::io::Error::from_raw_os_error(libc::EPERM)),
+            "EPERM is a member this process may not read, which is not a contained one"
+        );
+        assert!(
+            !member_probe_failure_means_gone(&std::io::Error::from_raw_os_error(libc::EACCES)),
+            "EACCES is a member this process may not read, which is not a contained one"
+        );
+        assert!(
+            !member_probe_failure_means_gone(&std::io::Error::other("unparseable /proc/7/stat")),
+            "an entry that read but would not parse is unclassified, not gone"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_stat_entry_read_after_its_task_is_collected_answers_esrch_and_reads_as_gone() {
+        // Why the ENOENT arm alone was not enough, proven against the kernel
+        // rather than argued. procfs resolves this file at READ time, so an
+        // open taken while the member lives and a read taken after the member
+        // is collected is the exact ordering the classifier hits, and it
+        // answers ESRCH while the directory it lives in is still there.
+        use std::io::Read as _;
+
+        let mut child = spawn_in_own_group("sleep", &["30"]);
+        let pid = libc::pid_t::try_from(child.id()).expect("child pid fits pid_t");
+        let mut entry = std::fs::File::open(format!("/proc/{pid}/stat"))
+            .expect("open the member's stat entry while it is live");
+
+        child.kill().expect("stop the member");
+        child.wait().expect("collect the member");
+
+        let mut buffer = String::new();
+        let error = entry
+            .read_to_string(&mut buffer)
+            .expect_err("a collected task cannot answer its own stat entry");
+        assert_eq!(
+            error.raw_os_error(),
+            Some(libc::ESRCH),
+            "procfs reports a collected task as ESRCH: {error}"
+        );
+        assert_ne!(
+            error.kind(),
+            std::io::ErrorKind::NotFound,
+            "this errno is not the ENOENT a not-found arm catches: {error}"
+        );
+        assert!(
+            member_probe_failure_means_gone(&error),
+            "the read-time errno has to read as gone, or the classifier fails a reaped member"
         );
     }
 


### PR DESCRIPTION
Two test-harness defects that fail correct runs, one on a race and one on load. Both fixes are falsified in two passes each, and both leave the property they guard able to fail.

## FIR-2564: a member that exits mid-classification read as unreadable

The containment check enumerates a process group and then classifies each member, and a member can finish and be collected in the gap. On Linux the classifier read that as a failure. procfs resolves `/proc/<pid>/stat` through `proc_single_show`, which looks the task up at read time rather than at open time, so a member collected after the open answers the read with ESRCH while its directory is still present. The not-found arm at `crates/kin-daemon-spawn/src/lib.rs:2711` caught ENOENT only, so ESRCH fell through to the error arm at 2721 and `finalize_owned_process_group` reported `containment could not be established after sentinel reap: classify member 82989: No such process (os error 3)`, which the fixture's teardown at `crates/kin-cli/tests/common/mod.rs:1342` turns into a panic. That is what held kin#1001 out of the queue.

Both platform probes now route a failed read through one decision rule, `member_probe_failure_means_gone` at `crates/kin-daemon-spawn/src/lib.rs:2551`. It accepts ENOENT and ESRCH, which both mean no task remains behind the pid, and keeps every other failure a failure, because EPERM, EACCES and an unparseable entry all mean the member could not be read and an unreadable member is not a contained one. The macOS path is unchanged in behaviour: `kill(2)` cannot report ENOENT and its ESRCH arm already returned `Ok(true)`. Classification is split out of enumeration as `classify_process_group_members` at 2510 so the gap between the two steps can be driven directly rather than only hoped for.

The kernel behaviour the fix rests on was measured rather than argued. In a Linux 6.12 container, opening a live child's stat entry, collecting the child, then reading gives `read-after-collect errno: 3 No such process`, while opening after collection gives `open-after-collect errno: 2 No such file or directory`, and a live member reads fine as the positive control. Those are two different errnos, and the old arm could only ever catch the second.

## FIR-2563: a settle bound with no margin under co-load

`settled_mcp_session` at `crates/kin-cli/tests/live_graph_durability_disclosure.rs:543` repeats its session while `kin_graph_status` asks to be retried, which the daemon does while the embedding-work lock is held. The bound was a fixed thirty seconds calibrated on an idle box. Three solo runs of the case took 25.9, 29.0 and 27.7 seconds end to end, and under fleet co-load the same case ran 70.3 seconds with the settle burning all thirty of its own, at load average 136 on eighteen cores, in a pass whose slowest routine test took 413 seconds. The daemon never answered wrongly. Because the local gate runs nextest without `--no-fail-fast`, that one failure cancelled 4,538 remaining tests.

What the settle waits on is the daemon finishing embedding work, and that is CPU time competing with everything else on the host, so the budget now tracks the competition. `RETRY_BOUND_FLOOR` stays thirty seconds at line 74 and `scaled_retry_bound` at line 112 stretches it by one minute run-queue depth over core count, clamped at one below and at `RETRY_BOUND_CEILING` divided by the floor above. The ceiling is the 120 seconds `ADMISSION_BOUND` already allows itself, for the reason `ADMISSION_BOUND` gives: the wait is event driven, so a passing run never spends it, and it is only how long a run that is going to fail spends proving it.

The discrimination is unchanged where it matters. On an unloaded machine a daemon that never yields the lock still fails in thirty seconds, and a reading that is not a finite number falls back to the floor rather than stretching anything.

## Falsification

FIR-2564, pass one removed the ESRCH half of the decision rule, leaving the pre-fix not-found arm. Predicted and observed, on macOS:

```
test tests::only_a_gone_member_excuses_a_failed_probe ... FAILED
test tests::a_member_that_exits_between_enumeration_and_classification_is_contained ... FAILED
test tests::a_member_that_is_still_running_is_not_contained ... ok
test tests::a_group_whose_members_are_all_collected_is_empty ... ok
test tests::a_member_that_exited_without_being_waited_is_contained ... ok
test tests::a_member_that_outlives_the_classification_is_still_reported_live ... ok
  left: Indeterminate { detail: "classify member 57915: No such process (os error 3)" }
 right: OnlyExited
```

That left-hand side is the hosted failure's own message, reproduced locally by removing the fix.

Pass two made the rule accept every failure, so an unreadable member would read as contained. One test fails and it is the right one:

```
test tests::only_a_gone_member_excuses_a_failed_probe ... FAILED
  EPERM is a member this process may not read, which is not a contained one
test tests::a_member_that_exits_between_enumeration_and_classification_is_contained ... ok
test tests::a_member_that_outlives_the_classification_is_still_reported_live ... ok
```

FIR-2563, pass one removed the stretch, restoring the fixed thirty seconds:

```
test a_quiet_host_keeps_the_settle_budget_the_fixed_bound_gave_it ... ok
test the_load_that_produced_the_failure_buys_a_budget_that_covers_it ... FAILED
  left: 30s   right: 120s
test the_stretch_is_proportional_and_survives_a_host_that_reports_nothing ... FAILED
  left: 30s   right: 60s
```

Pass two removed the lower clamp, letting a quiet host shrink its own budget:

```
test a_quiet_host_keeps_the_settle_budget_the_fixed_bound_gave_it ... FAILED
  an idle host must keep paying exactly the old price
  left: 2s   right: 30s
test the_stretch_is_proportional_and_survives_a_host_that_reports_nothing ... FAILED
  a platform that publishes no load average must not shrink the budget
  left: 0ns   right: 30s
test the_load_that_produced_the_failure_buys_a_budget_that_covers_it ... ok
```

Both files were restored byte-identical after each pass, verified by sha256 against a copy taken before the first sabotage.

One expectation of mine was wrong and the test caught it before review did. The first version asserted that an infinite load reading should reach the ceiling; the code falls back to the floor, because a garbled reading is not evidence of load. The assertion was corrected to match the code rather than the other way round.

## Scope

The FIR-2564 fix lands in `crates/kin-daemon-spawn/src/lib.rs` rather than in `tests/`, because that is where the classifier is. The ticket's fix shape is followed exactly; only its guess at the file was off. The change is behaviour-preserving on macOS and a strict correctness improvement on Linux, and the same false failure would have been possible outside tests, since product binaries run the same guardian.

## Gates

`cargo fmt --all -- --check` exit 0. `cargo clippy --all-targets --all-features` with the 45 lint debt allow-list under `RUSTFLAGS=-D warnings` exit 0, run in the lane worktree. `python3 scripts/verify-zero-file-search.py`, `bash scripts/zero_file_search_guard.sh`, `python3 scripts/verify-hydration-semantics.py`, `bash scripts/check_runtime_boundaries.sh`, `bash scripts/check_private_repo_coupling.sh` and `python3 scripts/test-private-repo-coupling.py` all exit 0.

Targeted binaries, run through `bin/kin-lane run esrch kin` in the lane worktree at `.kin-coord/worktrees/esrch-kin`: `cargo test -p kin-cli --test repository_branches` gave `25 passed; 0 failed` in 302.31s, including `branch_switch_carries_an_admitted_edit_to_a_member_both_branches_hold_identically`, the case FIR-2564 fired on. `cargo test -p kin-cli --test live_graph_durability_disclosure` gave `13 passed; 0 failed` in 20.80s at load average 85.98 falling to 36.44, including `mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit_records_them`, the case FIR-2563 is about. `cargo test -p kin-daemon-spawn --lib` gave `6 passed; 0 failed` over the containment set.

The full local gate ran under `gate-slot-2` with `--no-fail-fast`, so nothing was cancelled and every test reported: `Summary [ 694.958s] 6631 tests run: 6630 passed (10 slow, 4 leaky), 1 failed, 12 skipped`, load average 26.01 at start and 30.79 at end. Its own resolution line reads `worktree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/esrch-kin`, which is this branch. Doctests are clean.

The one failure is `kin-cli commands::setup::tests::hook_liveness_guard_starts_on_stale_sockets_and_keeps_the_shim_unconditional`, and it is not this diff. That test asserts on a `start.log` line written by a process the zsh hook detaches with `&!` at `crates/kin-cli/src/commands/setup.rs:178`, and reads it at `setup.rs:15563` immediately after `Command::output()` returns, which waits only for the probe shell and never for the disowned grandchild. It passed in 3.187s, 3.161s, 3.108s and 3.570s in four earlier lane gate logs and took 10.231s here. Three independent things point away from this change: the kin-daemon-spawn hunk is a provable no-op on macOS, since the only behavioural line is `Some(libc::ESRCH) => Ok(true), _ => Err(signal_error)` becoming "ESRCH or ENOENT is gone, else Err" and `kill(2)` cannot report ENOENT; the other file is a separate integration test binary that cannot reach a kin-cli unit test; and both hosted macOS shards are green at this commit, which together run exactly the unpartitioned set. Filed as FIR-2573 with the mechanism.

Tree checks after the gate: `git status --porcelain` is empty, `ls .cargo/` holds only `config.toml`, and `git diff $(git merge-base HEAD origin/main) --stat -- Cargo.lock .cargo/` is empty. The bare `git diff origin/main` form reports 48 changed lines in `Cargo.lock` and that is the v0.5.46 release landing on main under this branch, not anything from here: `git diff 79979a37 HEAD -- Cargo.lock` is empty, so this branch never touched the lock.

Hosted CI concluded at this commit with 33 SUCCESS, 4 SKIPPED and zero failures across 37 checks, read by name after every check had a conclusion. `Check & Test (ubuntu-latest)` is the leg that matters most here, and it ran `Summary [ 729.495s] 6590 tests run: 6590 passed (4 slow), 12 skipped`. All seven new tests appear in that log by name, with a fabricated name as the control at zero:

```
PASS kin-daemon-spawn tests::a_stat_entry_read_after_its_task_is_collected_answers_esrch_and_reads_as_gone
PASS kin-daemon-spawn tests::only_a_gone_member_excuses_a_failed_probe
PASS kin-daemon-spawn tests::a_member_that_exits_between_enumeration_and_classification_is_contained
PASS kin-daemon-spawn tests::a_member_that_outlives_the_classification_is_still_reported_live
PASS kin-cli::live_graph_durability_disclosure a_quiet_host_keeps_the_settle_budget_the_fixed_bound_gave_it
PASS kin-cli::live_graph_durability_disclosure the_load_that_produced_the_failure_buys_a_budget_that_covers_it
PASS kin-cli::live_graph_durability_disclosure the_stretch_is_proportional_and_survives_a_host_that_reports_nothing
```

The first of those is the Linux-only case, so the read-time ESRCH this fix turns on was asserted against a real Linux kernel on the platform FIR-2564 fired on, not only against a container measurement.

Closes FIR-2564
Closes FIR-2563
