### PR TITLE
Make kin doctor --fix honest about the repairs it could not make

### DIFF
--- a/crates/kin-cli/src/commands/language_servers.rs
+++ b/crates/kin-cli/src/commands/language_servers.rs
@@ -23,7 +23,9 @@
 //! download into a shared global prefix, and Kin does not spend a user's
 //! bandwidth or mutate their toolchain on a probe's say-so.
 
-use std::process::Command;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use kin_model::LanguageId;
 
@@ -391,23 +393,254 @@ pub(crate) fn provision(
     reports
 }
 
-/// Run a recipe's install command, inheriting stdio so the operator sees the
-/// package manager's own progress rather than a spinner hiding it.
+/// Where a global npm install would land on this host, and whether this user
+/// can write there.
+///
+/// npm's own answer rather than a guess: `npm config get prefix` resolves the
+/// value the install will actually use, including one set by `npm config set
+/// prefix`, by `NPM_CONFIG_PREFIX`, or by a version manager.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NpmGlobalPrefix {
+    pub(crate) prefix: PathBuf,
+    pub(crate) install_dir: PathBuf,
+    pub(crate) writable: bool,
+}
+
+/// Where npm unpacks a global package under `prefix`.
+fn npm_global_install_dir(prefix: &Path) -> PathBuf {
+    if cfg!(windows) {
+        prefix.join("node_modules")
+    } else {
+        prefix.join("lib").join("node_modules")
+    }
+}
+
+/// Whether this process can create an entry in `dir`, or in the nearest
+/// existing ancestor npm would have to create it under.
+///
+/// Asked by trying, because the permission bits do not answer it: a directory
+/// can be group-writable through a group this user is not in, and an ACL or a
+/// read-only mount refuses a directory whose mode says yes.
+fn directory_is_writable(dir: &Path) -> bool {
+    let mut candidate = dir;
+    while !candidate.exists() {
+        match candidate.parent() {
+            Some(parent) => candidate = parent,
+            None => return false,
+        }
+    }
+    let probe = candidate.join(format!(".kin-install-probe-{}", std::process::id()));
+    match std::fs::create_dir(&probe) {
+        Ok(()) => {
+            let _ = std::fs::remove_dir(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Ask npm where its global prefix is, and whether this user owns it.
+fn npm_global_prefix() -> Option<NpmGlobalPrefix> {
+    let output = Command::new("npm")
+        .args(["config", "get", "prefix"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let answer = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if answer.is_empty() || answer == "undefined" || answer == "null" {
+        return None;
+    }
+    let prefix = PathBuf::from(answer);
+    let install_dir = npm_global_install_dir(&prefix);
+    let writable = directory_is_writable(&install_dir);
+    Some(NpmGlobalPrefix {
+        prefix,
+        install_dir,
+        writable,
+    })
+}
+
+/// The reason a global npm install cannot succeed, stated before it is tried.
+pub(crate) fn npm_prefix_blocker(prefix: &NpmGlobalPrefix) -> Option<String> {
+    if prefix.writable {
+        return None;
+    }
+    Some(format!(
+        "the global npm prefix {} is not writable by this user, so `npm install -g` cannot \
+         create {}",
+        prefix.prefix.display(),
+        prefix.install_dir.display()
+    ))
+}
+
+/// Why this install cannot succeed, known before it is attempted.
+///
+/// Only the npm recipes have one today, and it is the one a container hits:
+/// the Node base images set the global prefix to `/usr/local`, whose
+/// `lib/node_modules` is owned by root, and a Kin running as an unprivileged
+/// user cannot write there. Attempting it anyway spends the download and ends
+/// in npm's own EACCES trace, which reads as a Kin defect and names no remedy.
+fn install_blocker(recipe: &LanguageServerRecipe) -> Option<String> {
+    if recipe.program != "npm" {
+        return None;
+    }
+    npm_prefix_blocker(&npm_global_prefix()?)
+}
+
+/// How many of an installer's stderr lines are kept for the failure report.
+const MAX_RETAINED_INSTALLER_LINES: usize = 200;
+
+/// How many of an installer's own error lines a failure reason repeats.
+const MAX_REPORTED_INSTALLER_LINES: usize = 4;
+
+/// Whether a failure is the install location refusing this user.
+///
+/// Matched against the installer's own words as well as Kin's preflight
+/// sentence, because the two describe the same wall from opposite sides.
+pub(crate) fn is_permission_failure(reason: &str) -> bool {
+    const SIGNATURES: [&str; 6] = [
+        "eacces",
+        "eperm",
+        "permission denied",
+        "operation not permitted",
+        "not writable",
+        "access is denied",
+    ];
+    let lowered = reason.to_lowercase();
+    SIGNATURES.iter().any(|signature| lowered.contains(signature))
+}
+
+/// The installer's own account of the failure, reduced to the lines naming it.
+///
+/// npm leads with the code, the syscall and the path, which is exactly the
+/// triple an operator needs and exactly what an exit code alone destroys. When
+/// nothing announces itself as an error the last lines stand in, because a
+/// reason that carries no words at all sends someone back to scroll a terminal.
+pub(crate) fn installer_error_summary(lines: &[String]) -> Option<String> {
+    let said: Vec<&str> = lines
+        .iter()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .collect();
+    let mut named: Vec<&str> = said
+        .iter()
+        .copied()
+        .filter(|line| line.to_lowercase().contains("error"))
+        .take(MAX_REPORTED_INSTALLER_LINES)
+        .collect();
+    if named.is_empty() {
+        named = said.iter().copied().rev().take(2).collect();
+        named.reverse();
+    }
+    if named.is_empty() {
+        return None;
+    }
+    Some(named.join("; "))
+}
+
+/// The failure reason for an installer that ran and exited non-zero.
+pub(crate) fn installer_failure_reason(
+    command: &str,
+    code: Option<i32>,
+    stderr_lines: &[String],
+) -> String {
+    let exit = code
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "a signal".to_string());
+    match installer_error_summary(stderr_lines) {
+        Some(said) => format!("`{command}` exited with {exit}: {said}"),
+        None => format!("`{command}` exited with {exit}"),
+    }
+}
+
+/// What to tell an operator whose install failed, chosen by the cause.
+///
+/// A permission failure has two real remedies and Kin can run neither: moving
+/// the prefix somewhere the user owns, or running the same command with the
+/// privileges the current prefix needs. Naming both is the whole value, because
+/// the container this was found in has no `sudo` at all and the first is the
+/// only one available there.
+pub(crate) fn install_failure_remediation(
+    recipe: &LanguageServerRecipe,
+    reason: &str,
+) -> Vec<String> {
+    let command = recipe.command_line();
+    if !is_permission_failure(reason) {
+        return vec![format!(
+            "run `{command}` yourself to see the installer's own error"
+        )];
+    }
+    if recipe.program != "npm" {
+        return vec![format!(
+            "the directory `{command}` writes to refuses this user; fix its permissions, then \
+             run the command again"
+        )];
+    }
+    vec![
+        "point npm at a prefix you own, then install again:".to_string(),
+        "    npm config set prefix \"$HOME/.npm-global\"".to_string(),
+        "    export PATH=\"$HOME/.npm-global/bin:$PATH\"".to_string(),
+        format!("    {command}"),
+        format!("or install into the current prefix with the privileges it requires: sudo {command}"),
+    ]
+}
+
+/// What to tell an operator whose install succeeded somewhere nothing reads.
+pub(crate) fn unreachable_after_install_remediation(recipe: &LanguageServerRecipe) -> Vec<String> {
+    let command = recipe.command_line();
+    if recipe.program == "npm" {
+        return vec![
+            format!("`{command}` reported success, so the package landed outside this shell's PATH"),
+            "`npm prefix -g` prints the prefix; add its `bin` subdirectory to PATH".to_string(),
+        ];
+    }
+    vec![format!(
+        "`{command}` reported success, so the binary landed outside this shell's PATH; add the \
+         directory {} installs into to PATH",
+        recipe.program
+    )]
+}
+
+/// Run a recipe's install command, streaming the installer's own output.
+///
+/// Two things happen here that a bare `status()` cannot do. The prefix is
+/// checked before the command runs, because `npm install -g` against a prefix
+/// this user cannot write ends in an EACCES trace that is npm's diagnostic
+/// rather than Kin's, and Kin can know the answer without spending the attempt.
+/// And stderr is teed rather than inherited, so the operator still reads the
+/// installer live while a failure keeps the installer's own words for the
+/// report at the end: a reason that says only "exited with 243" sends someone
+/// back to scroll a terminal for the cause (FIR-2547).
 pub(crate) fn run_install(recipe: &LanguageServerRecipe) -> Result<(), String> {
-    let status = Command::new(recipe.program)
+    if let Some(blocker) = install_blocker(recipe) {
+        return Err(blocker);
+    }
+    let mut child = Command::new(recipe.program)
         .args(recipe.args)
-        .status()
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|error| format!("could not run `{}`: {error}", recipe.command_line()))?;
+    let mut stderr_lines: Vec<String> = Vec::new();
+    if let Some(stderr) = child.stderr.take() {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            eprintln!("{line}");
+            if stderr_lines.len() < MAX_RETAINED_INSTALLER_LINES {
+                stderr_lines.push(line);
+            }
+        }
+    }
+    let status = child
+        .wait()
+        .map_err(|error| format!("could not wait for `{}`: {error}", recipe.command_line()))?;
     if status.success() {
         Ok(())
     } else {
-        Err(format!(
-            "`{}` exited with {}",
-            recipe.command_line(),
-            status
-                .code()
-                .map(|code| code.to_string())
-                .unwrap_or_else(|| "a signal".to_string())
+        Err(installer_failure_reason(
+            &recipe.command_line(),
+            status.code(),
+            &stderr_lines,
         ))
     }
 }
@@ -535,6 +768,130 @@ mod tests {
                  TypeScript installation\" and exits."
             );
         }
+    }
+
+    /// The pin has to survive every line that quotes the command back.
+    ///
+    /// The remediation for a permission failure hands the operator the same
+    /// install to run under `sudo` or under a prefix they own, and a copy that
+    /// dropped the pin would walk them into TypeScript 7 by hand. It is
+    /// composed from the recipe rather than restated, and this is what holds
+    /// that composition to it.
+    #[test]
+    fn the_remediation_quotes_the_install_with_its_pin_intact() {
+        for language in [LanguageId::TypeScript, LanguageId::JavaScript] {
+            let recipe = recipe_for(language).expect("language must have a recipe");
+            let lines = install_failure_remediation(
+                recipe,
+                "npm error code EACCES: permission denied, mkdir '/usr/local/lib/node_modules'",
+            );
+            let quoting: Vec<&String> = lines
+                .iter()
+                .filter(|line| line.contains("npm install -g"))
+                .collect();
+            assert!(
+                !quoting.is_empty(),
+                "{language}: the permission remedy must hand back the install command"
+            );
+            for line in quoting {
+                assert!(
+                    line.contains("typescript@^5"),
+                    "{language}: a remedy quoting the install dropped the 5.x pin, which walks \
+                     the operator into the TypeScript 7 that ships no lib/tsserver.js: {line}"
+                );
+            }
+        }
+    }
+
+    /// An unwritable global prefix is Kin's finding, not npm's stack trace.
+    #[test]
+    fn an_unwritable_npm_prefix_is_named_before_the_install_runs() {
+        let refused = NpmGlobalPrefix {
+            prefix: PathBuf::from("/usr/local"),
+            install_dir: PathBuf::from("/usr/local/lib/node_modules"),
+            writable: false,
+        };
+        let blocker = npm_prefix_blocker(&refused)
+            .expect("a prefix this user cannot write must block the install");
+        assert!(blocker.contains("/usr/local"), "{blocker}");
+        assert!(blocker.contains("/usr/local/lib/node_modules"), "{blocker}");
+        assert!(is_permission_failure(&blocker), "{blocker}");
+
+        // Positive control: the same probe on a prefix the user owns must let
+        // the install proceed, or this check would refuse every host.
+        let owned = NpmGlobalPrefix {
+            prefix: PathBuf::from("/home/dev/.npm-global"),
+            install_dir: PathBuf::from("/home/dev/.npm-global/lib/node_modules"),
+            writable: true,
+        };
+        assert_eq!(npm_prefix_blocker(&owned), None);
+    }
+
+    /// A permission failure gets the two remedies that exist, and Kin can run
+    /// neither: a prefix the user owns, or the privileged command.
+    #[test]
+    fn a_permission_failure_names_a_prefix_the_user_owns_and_the_privileged_command() {
+        let recipe = recipe_for(LanguageId::Python).expect("python must have a recipe");
+        let lines = install_failure_remediation(
+            recipe,
+            "`npm install -g pyright` exited with 243: npm error code EACCES; npm error Error: \
+             EACCES: permission denied, mkdir '/usr/local/lib/node_modules/pyright'",
+        );
+        let joined = lines.join("\n");
+        assert!(
+            joined.contains("npm config set prefix"),
+            "the container that found this has no sudo at all, so the prefix move is the only \
+             remedy available there: {joined}"
+        );
+        assert!(joined.contains("sudo npm install -g pyright"), "{joined}");
+    }
+
+    /// A failure that is not about permissions must not be handed a permission
+    /// remedy, or the advice sends an operator to change a prefix that was
+    /// never the problem.
+    #[test]
+    fn a_failure_that_is_not_about_permissions_gets_no_permission_remedy() {
+        let recipe = recipe_for(LanguageId::Python).expect("python must have a recipe");
+        let lines = install_failure_remediation(
+            recipe,
+            "`npm install -g pyright` exited with 1: npm error code E404; npm error 404 Not Found",
+        );
+        let joined = lines.join("\n");
+        assert!(!joined.contains("npm config set prefix"), "{joined}");
+        assert!(!joined.contains("sudo"), "{joined}");
+        assert!(joined.contains("npm install -g pyright"), "{joined}");
+    }
+
+    /// The failure reason has to carry the installer's own words.
+    ///
+    /// An exit code alone is what sent the reader of the run this came from
+    /// back to scroll a terminal: 243 names nothing, while the code, the
+    /// syscall and the path name the whole cause.
+    #[test]
+    fn an_installer_failure_reason_carries_the_installers_own_words() {
+        let stderr: Vec<String> = [
+            "npm error code EACCES",
+            "npm error syscall mkdir",
+            "npm error path /usr/local/lib/node_modules/pyright",
+            "npm error errno -13",
+        ]
+        .iter()
+        .map(|line| (*line).to_string())
+        .collect();
+        let reason = installer_failure_reason("npm install -g pyright", Some(243), &stderr);
+        assert!(reason.contains("243"), "{reason}");
+        assert!(reason.contains("EACCES"), "{reason}");
+        assert!(
+            reason.contains("/usr/local/lib/node_modules/pyright"),
+            "{reason}"
+        );
+        assert!(is_permission_failure(&reason), "{reason}");
+
+        // An installer that said nothing recognisable still reports its exit,
+        // and must not invent an error it never printed.
+        let quiet = installer_failure_reason("npm install -g pyright", Some(1), &[]);
+        assert_eq!(quiet, "`npm install -g pyright` exited with 1");
+        assert!(!is_permission_failure(&quiet), "{quiet}");
     }
 
     /// One npm package serves both JavaScript and TypeScript, so the advice is

--- a/crates/kin-cli/src/commands/language_servers.rs
+++ b/crates/kin-cli/src/commands/language_servers.rs
@@ -23,7 +23,7 @@
 //! download into a shared global prefix, and Kin does not spend a user's
 //! bandwidth or mutate their toolchain on a probe's say-so.
 
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -509,7 +509,9 @@ pub(crate) fn is_permission_failure(reason: &str) -> bool {
         "access is denied",
     ];
     let lowered = reason.to_lowercase();
-    SIGNATURES.iter().any(|signature| lowered.contains(signature))
+    SIGNATURES
+        .iter()
+        .any(|signature| lowered.contains(signature))
 }
 
 /// The installer's own account of the failure, reduced to the lines naming it.
@@ -583,7 +585,9 @@ pub(crate) fn install_failure_remediation(
         "    npm config set prefix \"$HOME/.npm-global\"".to_string(),
         "    export PATH=\"$HOME/.npm-global/bin:$PATH\"".to_string(),
         format!("    {command}"),
-        format!("or install into the current prefix with the privileges it requires: sudo {command}"),
+        format!(
+            "or install into the current prefix with the privileges it requires: sudo {command}"
+        ),
     ]
 }
 
@@ -592,7 +596,9 @@ pub(crate) fn unreachable_after_install_remediation(recipe: &LanguageServerRecip
     let command = recipe.command_line();
     if recipe.program == "npm" {
         return vec![
-            format!("`{command}` reported success, so the package landed outside this shell's PATH"),
+            format!(
+                "`{command}` reported success, so the package landed outside this shell's PATH"
+            ),
             "`npm prefix -g` prints the prefix; add its `bin` subdirectory to PATH".to_string(),
         ];
     }
@@ -625,7 +631,14 @@ pub(crate) fn run_install(recipe: &LanguageServerRecipe) -> Result<(), String> {
     let mut stderr_lines: Vec<String> = Vec::new();
     if let Some(stderr) = child.stderr.take() {
         for line in BufReader::new(stderr).lines().map_while(Result::ok) {
-            eprintln!("{line}");
+            // Written rather than `eprintln!`, and the error dropped on
+            // purpose. Rust ignores SIGPIPE, so `eprintln!` panics when the
+            // reader has gone away, and the process exits 101. A caller who
+            // piped this run into `head` would then get a panic exit out of an
+            // install that completed, which is the same lie as the exit 0 this
+            // ticket is about, told in the other direction. An echoed progress
+            // line is not worth an exit code.
+            let _ = writeln!(std::io::stderr(), "{line}");
             if stderr_lines.len() < MAX_RETAINED_INSTALLER_LINES {
                 stderr_lines.push(line);
             }

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -12724,7 +12724,12 @@ fn readiness_line(report: &crate::commands::health::HealthReport) -> ReadinessLi
     let waiting: Vec<&crate::commands::health::HealthCheck> = report
         .checks
         .iter()
-        .filter(|check| !matches!(check.status, HealthStatus::Healthy | HealthStatus::Unsupported))
+        .filter(|check| {
+            !matches!(
+                check.status,
+                HealthStatus::Healthy | HealthStatus::Unsupported
+            )
+        })
         .collect();
     if report.healthy && summary.attention == 0 && waiting.is_empty() {
         return ReadinessLine {
@@ -12799,12 +12804,7 @@ fn print_unfinished_repairs(unfinished: &[UnfinishedRepair]) {
     println!();
     println!("Repairs that did not complete:");
     for repair in unfinished {
-        println!(
-            "  {} {}: {}",
-            style("✗").red(),
-            repair.what,
-            repair.reason
-        );
+        println!("  {} {}: {}", style("✗").red(), repair.what, repair.reason);
         for line in &repair.remediation {
             println!("      {line}");
         }
@@ -12997,7 +12997,9 @@ async fn apply_language_server_provisioning(
                 let remediation = recipe
                     .map(|recipe| language_servers::install_failure_remediation(recipe, &reason))
                     .unwrap_or_else(|| {
-                        vec![format!("run `{command}` yourself to see the installer's own error")]
+                        vec![format!(
+                            "run `{command}` yourself to see the installer's own error"
+                        )]
                     });
                 unfinished.push(UnfinishedRepair {
                     what: format!("install the {} language server", report.language),
@@ -13157,7 +13159,10 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
             }
             Err(e) => {
                 let reason = e.to_string();
-                println!("  {} shell hook reinstall failed: {reason}", style("✗").red());
+                println!(
+                    "  {} shell hook reinstall failed: {reason}",
+                    style("✗").red()
+                );
                 unfinished.push(UnfinishedRepair {
                     what: "reinstall the shell hook".to_string(),
                     reason,
@@ -13225,11 +13230,9 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
                         unfinished.push(UnfinishedRepair {
                             what: "restore the VFS shim".to_string(),
                             reason,
-                            remediation: vec![
-                                "reinstall kin to restore it: curl -fsSL \
+                            remediation: vec!["reinstall kin to restore it: curl -fsSL \
                                  https://get.kinlab.dev/install | sh"
-                                    .to_string(),
-                            ],
+                                .to_string()],
                             requested: false,
                         });
                     }
@@ -13352,7 +13355,20 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
     }
 
     if applied.is_empty() {
-        println!("  Nothing to repair automatically.");
+        // "Nothing to repair automatically" belongs to a run that found nothing
+        // to do. A run that attempted four repairs and failed all four printed
+        // it directly under its own four failure lines (FIR-2512), which is the
+        // same defect as the closing line that could not read its rows.
+        if unfinished.is_empty() {
+            println!("  Nothing to repair automatically.");
+        } else {
+            println!(
+                "  {} nothing was repaired; {} repair{} did not complete, listed below.",
+                style("✗").red(),
+                unfinished.len(),
+                if unfinished.len() == 1 { "" } else { "s" }
+            );
+        }
     } else {
         for line in &applied {
             println!("  {} {line}", style("✓").green());
@@ -14851,7 +14867,11 @@ mod tests {
             healthy: true,
         };
         let line = readiness_line(&report);
-        assert!(!line.ready, "{}", line.sentence);
+        assert!(
+            !line.ready,
+            "a report holding a row that needs attention must not claim readiness, got: {}",
+            line.sentence
+        );
         assert!(
             !line.sentence.contains("First-run ready"),
             "a row that knows no language server was found must not close under a claim that \
@@ -14878,13 +14898,21 @@ mod tests {
             platform: "linux".to_string(),
             checks: vec![
                 check("kin_binary", "Kin binary", HealthStatus::Healthy),
-                check("vfs_projection", "VFS projection", HealthStatus::Unsupported),
+                check(
+                    "vfs_projection",
+                    "VFS projection",
+                    HealthStatus::Unsupported,
+                ),
             ],
             healthy: true,
         };
         let line = readiness_line(&report);
         assert!(line.ready, "{}", line.sentence);
-        assert!(line.sentence.contains("First-run ready"), "{}", line.sentence);
+        assert!(
+            line.sentence.contains("First-run ready"),
+            "{}",
+            line.sentence
+        );
     }
 
     /// A real failure keeps the red mark and the repair route.
@@ -14894,7 +14922,10 @@ mod tests {
         missing.fixable = true;
         let report = HealthReport {
             platform: "linux".to_string(),
-            checks: vec![check("kin_binary", "Kin binary", HealthStatus::Healthy), missing],
+            checks: vec![
+                check("kin_binary", "Kin binary", HealthStatus::Healthy),
+                missing,
+            ],
             healthy: false,
         };
         let line = readiness_line(&report);
@@ -14921,7 +14952,10 @@ mod tests {
         let error = fix_verdict(std::slice::from_ref(&requested))
             .expect_err("a requested repair that did not happen must not exit 0");
         let text = error.to_string();
-        assert!(text.contains("install the python language server"), "{text}");
+        assert!(
+            text.contains("install the python language server"),
+            "{text}"
+        );
 
         // Two controls. Nothing unfinished is a clean run, and a best-effort
         // convergence repair reports itself without failing the run, because

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -11895,9 +11895,11 @@ async fn provision_language_servers_in_wizard(opts: &WizardOptions, interactive:
         opts.install_language_servers,
         interactive && !opts.install_language_servers,
     );
-    for line in apply_language_server_provisioning(&missing, consent).await {
+    let outcome = apply_language_server_provisioning(&missing, consent).await;
+    for line in &outcome.applied {
         println!("  {} {line}", style("✓").green());
     }
+    outcome.print_unfinished();
 }
 
 /// Get the notification identity working, and say so when it cannot be.
@@ -12680,17 +12682,159 @@ fn print_human_report(report: &crate::commands::health::HealthReport) {
         },
         style(summary.skipped).dim(),
     );
-    if report.healthy {
-        println!(
-            "{} First-run ready — no component is missing or misconfigured.",
-            style("✓").green()
-        );
+    let readiness = readiness_line(report);
+    let mark = if readiness.ready {
+        style("✓").green()
+    } else if readiness.severe {
+        style("✗").red()
     } else {
-        println!(
-            "{} Some checks need attention. Run `kin doctor --fix` to apply safe repairs.",
-            style("✗").red()
-        );
+        style("!").yellow()
+    };
+    println!("{mark} {}", readiness.sentence);
+}
+
+/// The closing readiness line, and how loudly to print it.
+struct ReadinessLine {
+    /// Whether the run may claim readiness at all.
+    ready: bool,
+    /// Whether the rows needing attention include a real failure rather than
+    /// expected first-run work. Only the mark depends on it.
+    severe: bool,
+    sentence: String,
+}
+
+/// Compose the closing line from the rows the table just printed.
+///
+/// It used to be read off `report.healthy` alone, which asks a narrower
+/// question than the table answers: `healthy` gates on Missing and
+/// Misconfigured, so a container run whose `Reference edge coverage` row read
+/// PENDING for want of a language server closed with "First-run ready" one line
+/// under its own "4 need attention" tally, and the repair that would have
+/// closed that row had failed in the same output (FIR-2547). The row knew; the
+/// summary did not read it. A reader who trusts the last line is entitled to
+/// have it agree with the rows above it, so claiming readiness now requires
+/// that nothing at all needs attention, and the line names what does.
+fn readiness_line(report: &crate::commands::health::HealthReport) -> ReadinessLine {
+    use crate::commands::health::HealthStatus;
+
+    /// How many rows the line names before it counts the rest.
+    const NAMED: usize = 4;
+
+    let summary = report.summary();
+    let waiting: Vec<&crate::commands::health::HealthCheck> = report
+        .checks
+        .iter()
+        .filter(|check| !matches!(check.status, HealthStatus::Healthy | HealthStatus::Unsupported))
+        .collect();
+    if report.healthy && summary.attention == 0 && waiting.is_empty() {
+        return ReadinessLine {
+            ready: true,
+            severe: false,
+            sentence: "First-run ready — no component is missing or misconfigured.".to_string(),
+        };
     }
+    let severe = !report.healthy
+        || waiting.iter().any(|check| {
+            matches!(
+                check.status,
+                HealthStatus::Missing | HealthStatus::Misconfigured | HealthStatus::Degraded
+            )
+        });
+    let mut labels: Vec<String> = waiting
+        .iter()
+        .take(NAMED)
+        .map(|check| check.label.clone())
+        .collect();
+    if waiting.len() > NAMED {
+        labels.push(format!("and {} more", waiting.len() - NAMED));
+    }
+    let advice = if waiting.iter().any(|check| check.fixable) {
+        "Run `kin doctor --fix` to apply safe repairs."
+    } else {
+        "Each row above carries the fix it needs."
+    };
+    let sentence = if waiting.len() == 1 {
+        format!("1 check needs attention: {}. {advice}", labels.join(", "))
+    } else {
+        format!(
+            "{} checks need attention: {}. {advice}",
+            waiting.len(),
+            labels.join(", ")
+        )
+    };
+    ReadinessLine {
+        ready: false,
+        severe,
+        sentence,
+    }
+}
+
+/// A repair `kin doctor --fix` attempted and could not complete.
+struct UnfinishedRepair {
+    /// What Kin was trying to do, in the operator's terms.
+    what: String,
+    /// Why it did not happen, in the failing tool's own words where there were
+    /// any to keep.
+    reason: String,
+    /// The commands that close it by hand.
+    remediation: Vec<String>,
+    /// Whether the operator asked for this repair by name.
+    ///
+    /// Only these set the exit code. `--fix` also runs a set of best-effort
+    /// convergence repairs nobody asked for individually, and `kin update` runs
+    /// `kin setup doctor --fix` unattended as the last step of its chain
+    /// (`update::ChainStep::RepairConfigs`), where a VFS shim that could not be
+    /// re-downloaded on an offline host must not report an installed release as
+    /// a failed update. A requested repair is the opposite case: the operator
+    /// typed `--install-language-servers` or answered the prompt, and silence
+    /// about its failure is the defect FIR-2547 records.
+    requested: bool,
+}
+
+/// Print what could not be repaired, with the commands that close it.
+fn print_unfinished_repairs(unfinished: &[UnfinishedRepair]) {
+    if unfinished.is_empty() {
+        return;
+    }
+    println!();
+    println!("Repairs that did not complete:");
+    for repair in unfinished {
+        println!(
+            "  {} {}: {}",
+            style("✗").red(),
+            repair.what,
+            repair.reason
+        );
+        for line in &repair.remediation {
+            println!("      {line}");
+        }
+    }
+}
+
+/// The exit verdict for a `--fix` run.
+///
+/// Non-zero when a repair the operator asked for did not happen. The run has
+/// already printed what failed and what closes it; this is the half a script
+/// can read, and the half whose absence let a run that installed nothing close
+/// under a green tick.
+fn fix_verdict(unfinished: &[UnfinishedRepair]) -> Result<()> {
+    let requested: Vec<&UnfinishedRepair> = unfinished
+        .iter()
+        .filter(|repair| repair.requested)
+        .collect();
+    if requested.is_empty() {
+        return Ok(());
+    }
+    let names = requested
+        .iter()
+        .map(|repair| repair.what.clone())
+        .collect::<Vec<_>>()
+        .join(", ");
+    anyhow::bail!(
+        "{} requested repair{} did not complete: {names}",
+        requested.len(),
+        if requested.len() == 1 { "" } else { "s" }
+    )
 }
 
 /// Provision the language servers behind Kin's cross-file reference edges, and
@@ -12737,14 +12881,33 @@ async fn refresh_running_daemon_after_install(cwd: &std::path::Path) -> bool {
     }
 }
 
+/// What one provisioning pass applied, and what it could not.
+#[derive(Default)]
+struct ProvisioningOutcome {
+    applied: Vec<String>,
+    unfinished: Vec<UnfinishedRepair>,
+}
+
+impl ProvisioningOutcome {
+    /// Print the remedies for what did not happen, for surfaces with no
+    /// closing block of their own.
+    fn print_unfinished(&self) {
+        for repair in &self.unfinished {
+            for line in &repair.remediation {
+                println!("      {line}");
+            }
+        }
+    }
+}
+
 async fn apply_language_server_provisioning(
     missing: &[kin_model::LanguageId],
     consent: language_servers::InstallConsent,
-) -> Vec<String> {
+) -> ProvisioningOutcome {
     use language_servers::{InstallConsent, InstallOutcome};
 
     if missing.is_empty() {
-        return Vec::new();
+        return ProvisioningOutcome::default();
     }
 
     if consent == InstallConsent::Withheld {
@@ -12768,7 +12931,7 @@ async fn apply_language_server_provisioning(
             "      or re-run with --install-language-servers to have Kin run {}",
             if missing.len() == 1 { "it" } else { "them" }
         );
-        return Vec::new();
+        return ProvisioningOutcome::default();
     }
 
     let reports = language_servers::provision(
@@ -12791,8 +12954,10 @@ async fn apply_language_server_provisioning(
     );
 
     let mut applied = Vec::new();
+    let mut unfinished: Vec<UnfinishedRepair> = Vec::new();
     let mut installed_any = false;
     for report in reports {
+        let recipe = language_servers::recipe_for(report.language);
         match report.outcome {
             InstallOutcome::AlreadyPresent => {}
             InstallOutcome::Installed { command } => {
@@ -12805,28 +12970,63 @@ async fn apply_language_server_provisioning(
             // A zero exit that left the binary unreachable is reported as the
             // gap it still is. Counting it as applied is how a closed-looking
             // row keeps an open gap.
-            InstallOutcome::RanButStillMissing { command } => println!(
-                "  {} `{command}` succeeded but no {} server is on PATH; check that your npm \
-                 global prefix is on PATH",
-                style("✗").red(),
-                report.language
-            ),
-            InstallOutcome::Failed { command, reason } => println!(
-                "  {} could not install the {} language server: {reason} (`{command}`)",
-                style("✗").red(),
-                report.language
-            ),
+            InstallOutcome::RanButStillMissing { command } => {
+                println!(
+                    "  {} `{command}` succeeded but no {} server is on PATH",
+                    style("✗").red(),
+                    report.language
+                );
+                unfinished.push(UnfinishedRepair {
+                    what: format!("install the {} language server", report.language),
+                    reason: format!(
+                        "`{command}` reported success and no {} server is on PATH",
+                        report.language
+                    ),
+                    remediation: recipe
+                        .map(language_servers::unreachable_after_install_remediation)
+                        .unwrap_or_default(),
+                    requested: true,
+                });
+            }
+            InstallOutcome::Failed { command, reason } => {
+                println!(
+                    "  {} could not install the {} language server: {reason}",
+                    style("✗").red(),
+                    report.language
+                );
+                let remediation = recipe
+                    .map(|recipe| language_servers::install_failure_remediation(recipe, &reason))
+                    .unwrap_or_else(|| {
+                        vec![format!("run `{command}` yourself to see the installer's own error")]
+                    });
+                unfinished.push(UnfinishedRepair {
+                    what: format!("install the {} language server", report.language),
+                    reason,
+                    remediation,
+                    requested: true,
+                });
+            }
             InstallOutcome::Declined { command } => println!(
                 "  {} skipped the {} language server; run `{command}` to install it later",
                 style("-").dim(),
                 report.language
             ),
-            InstallOutcome::NoInstaller { program, command } => println!(
-                "  {} `{program}` is not installed, so Kin cannot run `{command}` to provision \
-                 the {} language server",
-                style("✗").red(),
-                report.language
-            ),
+            InstallOutcome::NoInstaller { program, command } => {
+                println!(
+                    "  {} `{program}` is not installed, so Kin cannot run `{command}` to \
+                     provision the {} language server",
+                    style("✗").red(),
+                    report.language
+                );
+                unfinished.push(UnfinishedRepair {
+                    what: format!("install the {} language server", report.language),
+                    reason: format!("`{program}` is not installed on this host"),
+                    remediation: vec![format!("install `{program}`, then run `{command}`")],
+                    // Consent was never asked for here, so only the flag makes
+                    // this a repair the operator requested.
+                    requested: consent == InstallConsent::Granted,
+                });
+            }
         }
     }
 
@@ -12852,6 +13052,15 @@ async fn apply_language_server_provisioning(
                     "  {} the {language} language server installed but did not start: {reason}",
                     style("✗").red(),
                 );
+                unfinished.push(UnfinishedRepair {
+                    what: format!("install a working {language} language server"),
+                    reason: format!("the server installed and refused to start: {reason}"),
+                    remediation: vec![format!(
+                        "the binary is on PATH and cannot serve {language}; the server's own \
+                         message above names what it could not find"
+                    )],
+                    requested: true,
+                });
             }
         }
         if !unusable {
@@ -12870,7 +13079,10 @@ async fn apply_language_server_provisioning(
             }
         }
     }
-    applied
+    ProvisioningOutcome {
+        applied,
+        unfinished,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -12893,6 +13105,10 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
     println!("Applying safe repairs...");
     println!();
     let mut applied: Vec<String> = Vec::new();
+    // Every repair below that fails records itself here, so the run closes
+    // with what it could not do and the commands that close it, rather than
+    // with a summary that never read its own attempts (FIR-2547).
+    let mut unfinished: Vec<UnfinishedRepair> = Vec::new();
 
     let registry_needs_fix = report.checks.iter().any(|c| {
         c.id == "registry_authority"
@@ -12909,10 +13125,23 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
                     ));
                 }
             }
-            Err(e) => println!(
-                "  {} registry permission repair refused: {e}",
-                style("✗").red()
-            ),
+            Err(e) => {
+                let reason = e.to_string();
+                println!(
+                    "  {} registry permission repair refused: {reason}",
+                    style("✗").red()
+                );
+                unfinished.push(UnfinishedRepair {
+                    what: "repair the registry authority permissions".to_string(),
+                    reason,
+                    remediation: vec![
+                        "fix the owner and mode of the path named above, then run `kin doctor \
+                         --fix` again"
+                            .to_string(),
+                    ],
+                    requested: false,
+                });
+            }
         }
     }
 
@@ -12926,7 +13155,20 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
             Ok(path) => {
                 applied.push(format!("reinstalled shell hook ({})", path.display()));
             }
-            Err(e) => println!("  {} shell hook reinstall failed: {e}", style("✗").red()),
+            Err(e) => {
+                let reason = e.to_string();
+                println!("  {} shell hook reinstall failed: {reason}", style("✗").red());
+                unfinished.push(UnfinishedRepair {
+                    what: "reinstall the shell hook".to_string(),
+                    reason,
+                    remediation: vec![
+                        "run `kin setup` to write the shell hook, or add Kin's bin directory to \
+                         PATH by hand"
+                            .to_string(),
+                    ],
+                    requested: false,
+                });
+            }
         }
     }
 
@@ -12971,18 +13213,42 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
                         dest.display()
                     )),
                     Err(e) => {
+                        let reason = e.to_string();
                         println!(
-                            "  {} could not restore the VFS shim automatically: {e}",
+                            "  {} could not restore the VFS shim automatically: {reason}",
                             style("✗").red()
                         );
                         println!(
                             "      reinstall kin to restore it: \
                              curl -fsSL https://get.kinlab.dev/install | sh"
                         );
+                        unfinished.push(UnfinishedRepair {
+                            what: "restore the VFS shim".to_string(),
+                            reason,
+                            remediation: vec![
+                                "reinstall kin to restore it: curl -fsSL \
+                                 https://get.kinlab.dev/install | sh"
+                                    .to_string(),
+                            ],
+                            requested: false,
+                        });
                     }
                 }
             }
-            Err(e) => println!("  {} VFS shim reinstall failed: {e}", style("✗").red()),
+            Err(e) => {
+                let reason = e.to_string();
+                println!("  {} VFS shim reinstall failed: {reason}", style("✗").red());
+                unfinished.push(UnfinishedRepair {
+                    what: "reinstall the VFS shim".to_string(),
+                    reason,
+                    remediation: vec![
+                        "reinstall kin to restore it: curl -fsSL https://get.kinlab.dev/install \
+                         | sh"
+                            .to_string(),
+                    ],
+                    requested: false,
+                });
+            }
         }
     }
 
@@ -12996,7 +13262,19 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
         match start_repo_daemon().await {
             Ok(Some(url)) => applied.push(format!("started kin-daemon ({url})")),
             Ok(None) => {}
-            Err(e) => println!("  {} kin-daemon start failed: {e}", style("✗").red()),
+            Err(e) => {
+                let reason = e.to_string();
+                println!("  {} kin-daemon start failed: {reason}", style("✗").red());
+                unfinished.push(UnfinishedRepair {
+                    what: "start the repository daemon".to_string(),
+                    reason,
+                    remediation: vec![
+                        "run `kin status` in the repository to see the daemon's own error"
+                            .to_string(),
+                    ],
+                    requested: false,
+                });
+            }
         }
     }
 
@@ -13034,9 +13312,9 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
                 install_language_servers,
                 !install_language_servers && is_tty(),
             );
-            for line in apply_language_server_provisioning(&missing, consent).await {
-                applied.push(line);
-            }
+            let outcome = apply_language_server_provisioning(&missing, consent).await;
+            applied.extend(outcome.applied);
+            unfinished.extend(outcome.unfinished);
         }
     }
 
@@ -13054,10 +13332,23 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
             applied.push(format!("cleaned {cleaned} stale daemon(s)"));
         }
         Ok(_) => {}
-        Err(e) => println!(
-            "  {} stale-daemon cleanup refused registry authority: {e}",
-            style("✗").red()
-        ),
+        Err(e) => {
+            let reason = e.to_string();
+            println!(
+                "  {} stale-daemon cleanup refused registry authority: {reason}",
+                style("✗").red()
+            );
+            unfinished.push(UnfinishedRepair {
+                what: "clean stale daemon records".to_string(),
+                reason,
+                remediation: vec![
+                    "run `kin registry authority --fix` to repair the registry, then run `kin \
+                     doctor --fix` again"
+                        .to_string(),
+                ],
+                requested: false,
+            });
+        }
     }
 
     if applied.is_empty() {
@@ -13073,7 +13364,10 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
     let after = crate::commands::health::run_health_checks().await;
     if json {
         println!("{}", serde_json::to_string_pretty(&after)?);
-        return Ok(());
+        // The verdict still applies: a JSON caller reads the exit code, and a
+        // repair that did not happen is exactly what it would otherwise have to
+        // infer from a report that cannot see the attempt.
+        return fix_verdict(&unfinished);
     }
     println!("Re-running checks...");
     println!();
@@ -13097,7 +13391,9 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
         }
     }
 
-    Ok(())
+    print_unfinished_repairs(&unfinished);
+
+    fix_verdict(&unfinished)
 }
 
 /// Start the daemon for the repo containing the current directory, if any.
@@ -14520,6 +14816,127 @@ pub async fn uninstall(all: bool, dry_run: bool, force: bool, json: bool) -> Res
 #[cfg(test)]
 mod tests {
     use super::projection_mode_to_record;
+    use super::{fix_verdict, readiness_line, UnfinishedRepair};
+    use crate::commands::health::{HealthCheck, HealthReport, HealthStatus};
+
+    fn check(id: &str, label: &str, status: HealthStatus) -> HealthCheck {
+        HealthCheck {
+            id: id.to_string(),
+            label: label.to_string(),
+            status,
+            detail: String::new(),
+            platform_note: None,
+            fixable: false,
+            manual_fix: None,
+        }
+    }
+
+    /// The state the container run was actually in: `healthy` true, because
+    /// nothing was Missing or Misconfigured, while the coverage row read
+    /// PENDING because no language server was found and the repair meant to
+    /// install one had just failed. The closing line said "First-run ready"
+    /// under its own "4 need attention" tally (FIR-2547).
+    #[test]
+    fn a_pending_row_keeps_the_summary_from_claiming_first_run_ready() {
+        let report = HealthReport {
+            platform: "linux".to_string(),
+            checks: vec![
+                check("kin_binary", "Kin binary", HealthStatus::Healthy),
+                check(
+                    "reference_edge_coverage",
+                    "Reference edge coverage",
+                    HealthStatus::Pending,
+                ),
+            ],
+            healthy: true,
+        };
+        let line = readiness_line(&report);
+        assert!(!line.ready, "{}", line.sentence);
+        assert!(
+            !line.sentence.contains("First-run ready"),
+            "a row that knows no language server was found must not close under a claim that \
+             nothing is missing: {}",
+            line.sentence
+        );
+        assert!(
+            line.sentence.contains("Reference edge coverage"),
+            "the line has to name the row it is refusing on: {}",
+            line.sentence
+        );
+        assert!(
+            !line.severe,
+            "pending work is not a failure, so the mark stays short of red: {}",
+            line.sentence
+        );
+    }
+
+    /// Positive control: a report with nothing needing attention still reads
+    /// ready, or the line would refuse every correct install.
+    #[test]
+    fn a_report_with_nothing_waiting_still_reads_first_run_ready() {
+        let report = HealthReport {
+            platform: "linux".to_string(),
+            checks: vec![
+                check("kin_binary", "Kin binary", HealthStatus::Healthy),
+                check("vfs_projection", "VFS projection", HealthStatus::Unsupported),
+            ],
+            healthy: true,
+        };
+        let line = readiness_line(&report);
+        assert!(line.ready, "{}", line.sentence);
+        assert!(line.sentence.contains("First-run ready"), "{}", line.sentence);
+    }
+
+    /// A real failure keeps the red mark and the repair route.
+    #[test]
+    fn a_missing_row_reads_as_severe_and_names_the_repair() {
+        let mut missing = check("shell_path", "Shell PATH", HealthStatus::Missing);
+        missing.fixable = true;
+        let report = HealthReport {
+            platform: "linux".to_string(),
+            checks: vec![check("kin_binary", "Kin binary", HealthStatus::Healthy), missing],
+            healthy: false,
+        };
+        let line = readiness_line(&report);
+        assert!(!line.ready, "{}", line.sentence);
+        assert!(line.severe, "{}", line.sentence);
+        assert!(line.sentence.contains("Shell PATH"), "{}", line.sentence);
+        assert!(
+            line.sentence.contains("kin doctor --fix"),
+            "{}",
+            line.sentence
+        );
+    }
+
+    /// A repair the operator asked for and Kin could not make ends the run
+    /// non-zero. The run this comes from installed nothing and exited 0.
+    #[test]
+    fn a_requested_repair_that_did_not_complete_fails_the_run() {
+        let requested = UnfinishedRepair {
+            what: "install the python language server".to_string(),
+            reason: "`npm install -g pyright` exited with 243: npm error code EACCES".to_string(),
+            remediation: vec!["npm config set prefix \"$HOME/.npm-global\"".to_string()],
+            requested: true,
+        };
+        let error = fix_verdict(std::slice::from_ref(&requested))
+            .expect_err("a requested repair that did not happen must not exit 0");
+        let text = error.to_string();
+        assert!(text.contains("install the python language server"), "{text}");
+
+        // Two controls. Nothing unfinished is a clean run, and a best-effort
+        // convergence repair reports itself without failing the run, because
+        // `kin update` runs `kin setup doctor --fix` unattended as its last
+        // step and an offline shim fetch must not report the release as a
+        // failed update.
+        assert!(fix_verdict(&[]).is_ok());
+        let unrequested = UnfinishedRepair {
+            what: "restore the VFS shim".to_string(),
+            reason: "the release asset could not be fetched".to_string(),
+            remediation: Vec::new(),
+            requested: false,
+        };
+        assert!(fix_verdict(std::slice::from_ref(&unrequested)).is_ok());
+    }
 
     /// Setup must never record a mount mode it did not engage. The v0.5.41
     /// release install proof failed on all three non-Linux legs because a


### PR DESCRIPTION
`kin doctor --fix --install-language-servers` ran npm against a prefix it could not write,
installed nothing, and closed with a green tick and exit 0. This makes the run honest about
what it did and makes the closing line read the rows above it.

## Mechanism

Two independent halves, in different files, sharing no code.

The summary half is `crates/kin-cli/src/commands/setup.rs:12685`. `print_human_report` chose
its closing line from `report.healthy`, which `assemble_health_report`
(`crates/kin-cli/src/commands/health.rs:119`) computes through `blocks_readiness`, and that
gates on `Missing` and `Misconfigured` only. `Pending` sits outside the gate deliberately, so
a run whose `Reference edge coverage` row read PENDING because no language server was found
still had `healthy == true` and printed "First-run ready, no component is missing or
misconfigured" one line under its own "14 passed, 4 need attention" tally. The row held the
fact. The line never read it.

The exit half is `doctor()` in the same file, which returned `Ok(())` on every path, and
`run_install` in `crates/kin-cli/src/commands/language_servers.rs:396`, which used
`Command::status()` with inherited stdio. npm's EACCES text reached the terminal and never
reached Kin: the recorded reason was "`npm install -g pyright` exited with 243", which names
no cause, and nothing carried the failure into an exit code.

## The fix

`readiness_line` composes the closing line from the rows: readiness is claimed only when no
row needs attention, and otherwise the line counts and names the rows that do. The ready
sentence itself is byte-identical to the one that shipped.

`run_install` asks npm where its global prefix is and whether this user can write there
before spending the install, so the container case is refused with Kin's own sentence naming
the prefix rather than with npm's stack trace. When an install does run, its stderr is teed
rather than inherited: the operator still reads npm live, and a failure keeps npm's own words
for the report.

Each repair that did not complete is recorded with what was attempted, why it failed in the
failing tool's words, and a remedy chosen by the cause. A permission failure gets both
remedies that exist, `npm config set prefix` for a prefix the user owns and the privileged
command, because the container this was found in has no `sudo` at all. Kin names the prefix
move rather than performing it: rewriting a user's npm config unasked is not a repair Kin
should make on its own.

`--fix` now exits non-zero when a repair the operator asked for did not happen. That scope is
deliberate. `kin update` runs `kin setup doctor --fix` unattended as
`update::ChainStep::RepairConfigs` and `run_chain_step` bails on a non-zero exit, so failing
the run for every best-effort convergence repair would report an installed release as a failed
update on any host where, say, the VFS shim could not be re-fetched. Those failures print in
the same block and leave the exit code alone.

The `typescript@^5` pin is untouched, and the test that guards it now also guards the new
remediation surface, which quotes the install command back at the operator.

Two things ride along, both inside functions this PR already changes. `--fix` printed "Nothing
to repair automatically." directly under its own failure lines, which is FIR-2512 item 1; that
line now distinguishes a run that found nothing to do from a run whose repairs all failed. And
`run_install`'s new tee writes through `writeln!` with the error dropped rather than
`eprintln!`, because Rust ignores SIGPIPE and `eprintln!` panics on a closed pipe, which would
let an echoed npm progress line turn a completed install into exit 101.

## What this changes for a healthy install

A run with a genuinely pending row now closes with "1 check needs attention: Background work."
rather than "First-run ready", which is the intended consequence and the whole point of reading
the rows. The mark still separates the two cases: red when a row is Missing, Misconfigured or
Degraded, yellow when only expected first-run work is outstanding, so a correct install that is
still embedding does not read as broken. A report with nothing waiting prints the ready sentence
unchanged, byte for byte.

## Evidence

Three arms run the real binary built from this branch, each with a different fake npm first on
PATH, an isolated HOME and KIN_HOME, and a repository that is a `.kin` directory and nothing
else, so no daemon, no store and no GPU are involved. Every fake npm appends to one shared
marker file when its `install` verb runs and the runner clears that marker first, so the marker
discriminates in both directions.

| arm | fake npm | install spent | exit | closing line | requested failure |
|---|---|---|---|---|---|
| preflight | prefix mode 500 | no, marker absent | 1 | 4 checks need attention | yes, prefix remedy |
| eacces | install exits 243 with npm's EACCES text | yes, marker present | 1 | 4 checks need attention | yes, npm's own words |
| ok | install succeeds, server answers `initialize` | yes, marker present | 0 | 4 checks need attention | none |

The preflight arm refused with "the global npm prefix /tmp/doctorfix-fal/prefix-ro is not
writable by this user, so `npm install -g` cannot create
/tmp/doctorfix-fal/prefix-ro/lib/node_modules" and never spent the install. The eacces arm
recorded "`npm install -g pyright` exited with 243: npm error code EACCES; npm error syscall
mkdir; npm error path /usr/local/lib/node_modules/pyright; npm error errno -13". The ok arm is
the stronger positive control, because two repairs failed in it, the VFS shim fetch and the
daemon start, both are listed under "Repairs that did not complete", and the run still exited 0
because neither was requested.

The readiness probe was exercised rather than skipped: the post-fix coverage row names "python
(pyright-langserver or pylsp)" as missing in the preflight and eacces arms and does not name
python in the ok arm, and no "installed but did not start" line appears there. A fabricated
language phrase returns zero in all three arms.

What the arms do not prove: none of them reaches an all-healthy report, so the branch that still
claims readiness is covered by `a_report_with_nothing_waiting_still_reads_first_run_ready` and by
nothing else here.

## On the shipped0545 G3 finding

G3 reports that `kin setup --install-language-servers` "exits 101 while printing success" and
concludes the nonzero status belongs to the run that performed the npm installs. The raw
transcript does not support it. Of the three runs in that session, the one piped into `head -50`
exited 101, and the two that exited 0 were piped into `tail -45` and redirected to a file. The
head-50 run's kin output is exactly fifty lines and stops at "=== Health checklist ==="; it never
printed a Summary line or "First-run ready" at all, so G3's quoted block is a splice of two runs.
`head` closes the pipe, Rust ignores SIGPIPE, and `println!` panics on the write, which is 101
exactly. The exit code belongs to the reader, not to the installs. This PR hardens the one EPIPE
surface it introduces and deliberately does not attempt a CLI-wide broken-pipe policy.

## Falsification

Four passes, each removing exactly one property, each predicting both which tests must fail and
which must still pass, each restoring the file byte-identical (verified by sha256).

1. The closing line stops reading its rows (`readiness_line` returns ready whenever
   `report.healthy`). Predicted and observed: 1 failed, 173 passed, and the failure is
   `a_pending_row_keeps_the_summary_from_claiming_first_run_ready`. The other three readiness and
   verdict tests still pass, which is what scopes the property to this one rule.
2. A failed repair stops setting the exit code (`fix_verdict` returns Ok early). Predicted and
   observed: 1 failed, 173 passed, `a_requested_repair_that_did_not_complete_fails_the_run`,
   message "a requested repair that did not happen must not exit 0".
3. The typescript pin is removed (`TYPESCRIPT_PACKAGE = "typescript"`). Predicted and observed: 4
   failed, 170 passed. Both pin guards fire, the pre-existing
   `the_typescript_package_is_pinned_away_from_the_version_without_tsserver` and the new
   `the_remediation_quotes_the_install_with_its_pin_intact`, along with the two command-shape
   tests. The new one reports "a remedy quoting the install dropped the 5.x pin, which walks the
   operator into the TypeScript 7 that ships no lib/tsserver.js: npm install -g
   typescript-language-server typescript".
4. The installer's own words are dropped from the failure reason. Predicted and observed: 1
   failed, 173 passed, `an_installer_failure_reason_carries_the_installers_own_words`, whose
   message shows the reason collapsing to "`npm install -g pyright` exited with 243".

## Gate

`cargo fmt --all -- --check` exit 0, clippy exactly as ci.yml runs it (allow list word-split in
bash, not zsh) exit 0, `scripts/verify-zero-file-search.py` exit 0,
`scripts/zero_file_search_guard.sh` exit 0, `scripts/check_runtime_boundaries.sh` exit 0,
`scripts/check_private_repo_coupling.sh` exit 0, and `scripts/test-windows-authority-legs.sh`
exit 0.

The full local gate ran twice on this branch, both times against the tree line
`/Users/.../.kin-coord/worktrees/doctorfix-kin @ 5907d88b (chore/lane-doctorfix-kin)`. The first
pass stopped at 2098 of 6634 because nextest cancels on the first failure, so the second ran with
`--no-fail-fast` and reports the whole workspace:

```
Summary [ 938.248s] 6634 tests run: 6633 passed (50 slow, 2 leaky), 1 failed, 12 skipped
```

The one failure is `kin-cli::live_graph_durability_disclosure
mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit_records_them`, on
the 30 second `RETRY_BOUND` at `live_graph_durability_disclosure.rs:504`, with "kin_graph_status
refused 36 times without ever sampling its counts". It is not this change, on four legs rather
than on the fact that it looks unrelated. Nothing outside `setup.rs`, `health.rs` and
`language_servers.rs` calls `language_servers::`, and the failing test file names none of them, so
the MCP and daemon paths cannot reach the edited code. Two other lanes hit the identical assertion
tonight, at 10 refusals under load 136.33 and 9 under load 104, and the same test failed kin#996
on two jobs. Run alone on this branch it passes, "PASS [ 451.304s] (1/1)", at load average 153.46.
And the second gate ran the 4,536 tests the first one skipped, all of which passed.

One honest note about one of those guards: `verify-zero-file-search.py` passes on this branch and
also passes on a copy of this tree with `std::fs::read_to_string("/etc/hosts")` inserted into
`language_servers.rs`, because `is_test_file` skips every file under `crates/kin-cli/src/commands/`
that is not in `QUERY_COMMANDS`. So its green is not evidence about these two files. The change
adds no repository-content read anywhere; its only new filesystem calls create and remove a probe
directory under npm's own global prefix.

Closes FIR-2547
Refs FIR-2512
