### PR TITLE
Document a registration and an install a stranger can actually run

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,24 @@ The npm entry point resolves the same public release channel:
 npm install -g @kinlab/kin@latest
 ```
 
+A global install needs a writable npm prefix. Where the prefix is root-owned and you are
+not root, npm refuses with `EACCES: permission denied, mkdir
+'/usr/local/lib/node_modules/@kinlab'` before Kin runs at all, which is the usual case
+inside a container whose default user is not root. Either use the zero-install path,
+`npx -y @kinlab/kin setup --intent agent --no-interactive`, or move the prefix somewhere
+you own and put it on your `PATH`:
+
+```sh
+npm config set prefix ~/.npm-global
+export PATH="$HOME/.npm-global/bin:$PATH"   # add this to your shell profile too
+npm install -g @kinlab/kin@latest
+```
+
+A user prefix is on your interactive shell's `PATH` and nowhere else. Scripts, CI steps,
+`docker exec`, and agent clients do not inherit it, so give those the absolute path to the
+binary rather than a bare `kin`. See
+[Works with your agent](#works-with-your-agent) for the registration shape.
+
 A Homebrew tap tracks the same release channel:
 
 ```sh

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2878,6 +2878,11 @@ const MODEL_HOST_PROBE_BUDGET: std::time::Duration = std::time::Duration::from_s
 /// egress with no surface naming the download, the size, the destination, or
 /// the host it needs to reach, and an air-gapped host produced exactly the same
 /// output as a healthy one that was simply still working.
+///
+/// The detail names `kin init` as what starts that pass. It is the command a
+/// reader has usually just run when they reach doctor, and the earlier wording
+/// pointed at a later `kin embed` that was never going to be the one paying
+/// (FIR-2555).
 async fn check_embedding_model() -> HealthCheck {
     // `false`: this is a one-shot CLI process with no embed pass of its own, so
     // the download-in-flight phase is not a state doctor can be in. Doctor
@@ -2948,16 +2953,16 @@ fn embedding_model_check_from(
             HealthStatus::Missing,
             format!(
                 "{model} is not in the cache{location} and this host did not reach {host}:443 \
-                 within {}s; the first embed pass fetches {download} from {host}, and until \
-                 that lands nothing embeds",
+                 within {}s; `kin init` starts the first embed pass, which fetches {download} \
+                 from {host}, and until that lands nothing embeds",
                 MODEL_HOST_PROBE_BUDGET.as_secs()
             ),
         ),
         (None, false, _) => (
             HealthStatus::Pending,
             format!(
-                "{model} is not in the cache{location}; the first embed pass fetches {download} \
-                 from {host} before it records anything"
+                "{model} is not in the cache{location}; `kin init` starts the first embed pass, \
+                 which fetches {download} from {host} before it records anything"
             ),
         ),
     };
@@ -6911,6 +6916,20 @@ mod tests {
         assert!(
             check.detail.contains("about 523 MB") && check.detail.contains("huggingface.co"),
             "the size and the source are both named: {}",
+            check.detail
+        );
+        // FIR-2555: the command that starts the pass, not a later one the
+        // reader has no reason to run.
+        assert!(
+            check
+                .detail
+                .contains("`kin init` starts the first embed pass"),
+            "the detail names what starts the fetch: {}",
+            check.detail
+        );
+        assert!(
+            !check.detail.contains("a later embed pass fetches"),
+            "the check must be able to fail: {}",
             check.detail
         );
         assert!(

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -82,9 +82,11 @@ struct InitResultPayload<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     uncommitted_worktree: Option<UncommittedWorktreePayload>,
     /// The embedding model the first embed pass will need, and whether this
-    /// machine already has it. Additive to this schema version: a consumer that
-    /// does not read it is unaffected, and one that does can tell a fresh
-    /// machine's pending download from a warm cache before it schedules work.
+    /// machine already has it. This command starts that pass, so on a fresh
+    /// machine the download is work `kin init` does rather than work it defers.
+    /// Additive to this schema version: a consumer that does not read it is
+    /// unaffected, and one that does can tell a fresh machine's pending
+    /// download from a warm cache before it schedules work.
     embedding_model: crate::embed_model::EmbedModelFetch,
 }
 
@@ -807,10 +809,20 @@ fn render_human_result(
 ///
 /// No install ships the weights, so a converted repository that has never
 /// embedded is one large download away from its first vector, and admission
-/// finishes long before that download starts. Said here because this is the
-/// last thing a fresh install reads before the daemon begins the fetch, and
-/// because every counter published during it reports a pass that is working
-/// and recording nothing.
+/// finishes long before that download starts.
+///
+/// Who pays for it is the part this line used to get wrong. It said "the first
+/// embed pass fetches", which reads as a later command's cost, and the stranger
+/// pass on shipped 0.5.45 measured otherwise: 2.576s to init an empty
+/// repository against 67.1s to init a one-file TypeScript one, the difference
+/// being the fetch (FIR-2555). The enrichment phase at `enrich_after_init`
+/// starts a daemon, that daemon's background embed worker starts as soon as its
+/// first reconcile lands (`kin-daemon/src/daemon.rs`, "embedding worker
+/// started"), and it queues everything the index is missing unless an operator
+/// opted out. So on a repository with parseable content the download is work
+/// `kin init` does, during `kin init`, and this notice prints after it rather
+/// than before. Saying so costs a clause and saves a reader the wrong mental
+/// model of when their machine is busy.
 fn embedding_model_notice(fetch: &crate::embed_model::EmbedModelFetch) -> String {
     if let Some(reason) = fetch.no_fetch_reason.as_deref() {
         return format!("Embedding model: {} ({reason})", fetch.model_id);
@@ -821,14 +833,14 @@ fn embedding_model_notice(fetch: &crate::embed_model::EmbedModelFetch) -> String
     };
     if fetch.present {
         return format!(
-            "Embedding model: {} is already cached{location}, so the first embed pass downloads \
-             nothing",
+            "Embedding model: {} is already cached{location}, so nothing is downloaded",
             fetch.model_id
         );
     }
     format!(
-        "Embedding model: {} is not on this machine yet; the first embed pass fetches {} \
-         from {}{}, which needs egress and runs before any vector exists",
+        "Embedding model: {} is not on this machine yet; `kin init` starts the first embed \
+         pass, which fetches {} from {}{} and needs egress. On a repository with parseable \
+         content that download happens during this command, before any vector exists",
         fetch.model_id,
         fetch.expected_download(),
         crate::embed_model::endpoint_host(),
@@ -1438,6 +1450,26 @@ mod tests {
                 && notice.contains("huggingface.co")
                 && notice.contains("/home/dev/.cache/huggingface/hub/models--x"),
             "the model, the size, the source and the destination are all named: {notice}"
+        );
+
+        // FIR-2555. The size and the host were already here; who pays was not.
+        // This line used to read "the first embed pass fetches", which put the
+        // cost on a command the reader had not run, while the enrichment phase
+        // of this very `kin init` was starting the daemon whose embed worker
+        // does the fetching. A stranger measured 2.576s to init an empty
+        // repository against 67.1s to init a one-file TypeScript one on shipped
+        // 0.5.45, and the difference was this download.
+        assert!(
+            notice.contains("`kin init` starts the first embed pass"),
+            "the notice must name the command that pays for the download: {notice}"
+        );
+        assert!(
+            notice.contains("during this command"),
+            "the notice must say the download happens now rather than later: {notice}"
+        );
+        assert!(
+            !notice.contains("after this command finishes"),
+            "the check must be able to fail: {notice}"
         );
 
         let cached = crate::embed_model::EmbedModelFetch {

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -51,8 +51,10 @@ pub struct EmbedRuntimeState {
     ///
     /// The weights are not shipped, so the first embed pass on a fresh machine
     /// spends several hundred megabytes of egress before it can record a single
-    /// unit. Without this the pass reports working with zero progress for the
-    /// whole download, which is indistinguishable from a wedged pass.
+    /// unit. `kin init` is what starts that pass on a repository with parseable
+    /// content, so the egress is usually paid there rather than on a later
+    /// `kin embed`. Without this the pass reports working with zero progress for
+    /// the whole download, which is indistinguishable from a wedged pass.
     #[serde(default)]
     pub model_fetch: crate::embed_model::EmbedModelFetch,
 }

--- a/crates/kin-cli/src/embed_model.rs
+++ b/crates/kin-cli/src/embed_model.rs
@@ -7,10 +7,16 @@
 //! No install ships the weights. The first local embed pass resolves
 //! `nomic-ai/nomic-embed-text-v1.5` through `hf-hub`, which downloads it into
 //! the Hugging Face hub cache before a single vector is computed. On a fresh
-//! machine that is several hundred megabytes of egress standing between a
-//! finished `kin init` and the first embedding, and every counter the product
-//! published during it read as an embed pass that was working and recording
-//! nothing.
+//! machine that is several hundred megabytes of egress, and every counter the
+//! product published during it read as an embed pass that was working and
+//! recording nothing.
+//!
+//! `kin init` is what usually pays it. The command's enrichment phase starts a
+//! daemon, and that daemon's background embed worker queues everything the
+//! index is missing as soon as its first reconcile lands, so on a repository
+//! with parseable content the fetch happens inside `kin init` rather than
+//! between it and a later `kin embed`. Wording on every surface says so, since
+//! the earlier phrasing put the cost on a command the user had not run yet.
 //!
 //! This module is the one place that knows where those bytes land, how many of
 //! them have landed, and what to say about it. Its probes are local filesystem
@@ -171,7 +177,7 @@ impl EmbedModelFetch {
             format!("Embed model: {} cached{location}", self.model_id)
         } else {
             format!(
-                "Embed model: {} not in the cache{location}; the first embed pass fetches {} from {EMBED_MODEL_HOST}",
+                "Embed model: {} not in the cache{location}; `kin init` starts the first embed pass, which fetches {} from {EMBED_MODEL_HOST}",
                 self.model_id,
                 self.expected_download(),
             )
@@ -524,6 +530,17 @@ mod tests {
                 && line.contains("about 523 MB")
                 && line.contains("huggingface.co"),
             "an absent model states its cost and its source: {line}"
+        );
+        // FIR-2555: which command pays. `kin init` starts the daemon whose
+        // background embed worker does the fetching, so a reader told to expect
+        // it from a later `kin embed` is told the wrong thing.
+        assert!(
+            line.contains("`kin init` starts the first embed pass"),
+            "an absent model names the command that fetches it: {line}"
+        );
+        assert!(
+            !line.contains("a later embed pass fetches"),
+            "the check must be able to fail: {line}"
         );
     }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1865,12 +1865,29 @@ enum McpAction {
     /// A server that bound a repository of its own keeps serving it and ignores
     /// client workspace roots it cannot resolve to a Kin repository. That is
     /// what makes a container or remote registration work: with
-    /// `docker exec -i -w /work/repo <container> kin mcp start`, the client
-    /// announces host paths that do not exist inside the container, and treating
-    /// them as a workspace change would refuse every call. Roots that do name a
-    /// Kin repository this server can see, and does not serve, are still a real
-    /// disagreement and are refused rather than answered from the wrong
-    /// repository.
+    /// `docker exec -i -w /work/repo <container> /absolute/path/to/kin mcp start`,
+    /// the client announces host paths that do not exist inside the container,
+    /// and treating them as a workspace change would refuse every call. Roots
+    /// that do name a Kin repository this server can see, and does not serve,
+    /// are still a real disagreement and are refused rather than answered from
+    /// the wrong repository.
+    ///
+    /// Register the absolute path to the binary, never a bare `kin`.
+    /// `docker exec` resolves a bare command against the image's own PATH,
+    /// which carries neither `~/.kin/bin` nor an npm user prefix, so a bare
+    /// registration dies with `exec: "kin": executable file not found in
+    /// $PATH` and blames Docker for a Kin configuration gap. After
+    /// `kin setup`, the managed binary is at `~/.kin/bin/kin`; after
+    /// `npm install -g @kinlab/kin`, it is at `$(npm prefix -g)/bin/kin`. To
+    /// keep the bare command instead, hand `docker exec` the environment it
+    /// needs: `docker exec -e PATH=/home/<user>/.kin/bin:$PATH -i -w
+    /// /work/repo <container> kin mcp start`.
+    ///
+    /// Reinstalling as root is not a shortcut past this on an image that gives
+    /// every user the same HOME. Root's npm reads that HOME's `.npmrc` and
+    /// reinstalls into the user prefix while reporting success, so nothing new
+    /// lands on the default PATH. Name the prefix outright when that is what
+    /// you want: `npm install -g --prefix /usr/local @kinlab/kin`.
     Start {
         /// Run in global mode, serving all registered repos from ~/.kin/registry.toml
         #[arg(long)]
@@ -4771,6 +4788,72 @@ mod tests {
             // assertions above green.
             assert!(
                 !flattened.contains("ignores client workspace roots entirely"),
+                "the check must be able to fail: {flattened}"
+            );
+        });
+    }
+
+    /// The registration this help documents has to be one an operator can paste
+    /// into a stock image.
+    ///
+    /// It was not. `docker exec` with a bare command resolves it against the
+    /// image's own `ENV PATH`, which carries neither `~/.kin/bin` nor an npm
+    /// user prefix, so the documented shape died with `exec: "kin": executable
+    /// file not found in $PATH` on npm-served 0.5.45 in a Debian 12 container
+    /// (FIR-2553). The error names Docker, so a reader has no way back to the
+    /// cause from the failure. Documenting a command that cannot run is worse
+    /// than documenting none, which is why the absolute-path form is asserted
+    /// here rather than left to review.
+    #[test]
+    fn mcp_start_help_registers_an_absolute_binary_path_for_docker_exec() {
+        on_cli_test_stack(|| {
+            let command = Cli::command();
+            let start = command
+                .get_subcommands()
+                .find(|subcommand| subcommand.get_name() == "mcp")
+                .expect("kin mcp must exist")
+                .get_subcommands()
+                .find(|subcommand| subcommand.get_name() == "start")
+                .expect("kin mcp start must exist")
+                .clone();
+            let help = start
+                .get_long_about()
+                .or_else(|| start.get_about())
+                .expect("kin mcp start must carry help text")
+                .to_string();
+            let flattened = help.split_whitespace().collect::<Vec<_>>().join(" ");
+
+            assert!(
+                flattened
+                    .contains("docker exec -i -w /work/repo <container> /absolute/path/to/kin"),
+                "help must register an absolute path to the binary, since a bare `kin` is not on \
+                 the PATH docker exec uses: {flattened}"
+            );
+            assert!(
+                flattened.contains("executable file not found in $PATH"),
+                "help must quote the failure a bare registration produces, so a reader who hits \
+                 it can find their way back: {flattened}"
+            );
+            assert!(
+                flattened.contains("~/.kin/bin/kin"),
+                "help must say where the managed binary is, or the absolute path it asks for is \
+                 one the reader still has to hunt for: {flattened}"
+            );
+
+            // The npm reinstall that looks like the obvious fix and is not: an
+            // image with one shared HOME sends root's install back into the
+            // user prefix while reporting success.
+            assert!(
+                flattened.contains("npm install -g --prefix /usr/local @kinlab/kin"),
+                "help must name the prefix-explicit install, since the plain root reinstall \
+                 reports success and lands nothing on the default PATH: {flattened}"
+            );
+
+            // Falsification: a phrase that was never written must be absent, so
+            // a `contains` that matches anything cannot be what made the
+            // assertions above green.
+            assert!(
+                !flattened.contains("docker exec resolves the managed binary automatically"),
                 "the check must be able to fail: {flattened}"
             );
         });

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -85,12 +85,43 @@ confident answer about the codebase you just left is worse than an error.
 
 A server that bound a repository of its own keeps serving it and ignores client workspace
 roots it cannot resolve to a Kin repository. That is what makes a container or remote
-registration work. Registered as `docker exec -i -w /work/repo <container> kin mcp start`,
-the server serves a container path while the client announces host paths that do not exist
-inside the container, and reading those as a workspace change would refuse every call for
-the life of the process. Roots that do name a Kin repository the server can see, and does
-not serve, are a real disagreement: those calls are refused, and the refusal carries
+registration work. Registered as
+`docker exec -i -w /work/repo <container> /absolute/path/to/kin mcp start`, the server
+serves a container path while the client announces host paths that do not exist inside the
+container, and reading those as a workspace change would refuse every call for the life of
+the process. Roots that do name a Kin repository the server can see, and does not serve,
+are a real disagreement: those calls are refused, and the refusal carries
 `degraded.workspace_mismatch` with both paths named.
+
+### Reaching `kin` from `docker exec`
+
+Give `docker exec` the absolute path to the binary. A bare `kin` is resolved against the
+image's own `ENV PATH`, which on a stock image carries neither `~/.kin/bin` nor an npm user
+prefix, so the registration fails before Kin runs at all:
+
+```
+$ docker exec -i -w /work/repo <container> kin mcp start
+OCI runtime exec failed: exec failed: unable to start container process:
+exec: "kin": executable file not found in $PATH
+```
+
+That message names Docker, not Kin, which is why it is worth recognizing. After
+`kin setup`, the managed binary is at `~/.kin/bin/kin`. After `npm install -g @kinlab/kin`,
+it is under `$(npm prefix -g)/bin/kin`. Either absolute path works as the registration
+command. To keep the bare command instead, pass the environment the exec needs:
+
+```sh
+docker exec -e PATH=/home/<user>/.kin/bin:$PATH -i -w /work/repo <container> kin mcp start
+```
+
+Reinstalling as root is not a shortcut past this on an image that gives every user the same
+`HOME`. Root's npm reads that `HOME`'s `.npmrc`, reinstalls into the user prefix, and
+reports `changed 1 package` while nothing new lands on the default `PATH`. Name the prefix
+outright when a system-wide binary is what you want:
+
+```sh
+docker exec -u root <container> npm install -g --prefix /usr/local @kinlab/kin
+```
 
 ### Tool profiles
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,6 +59,26 @@ The launcher provisions the same managed native `kin` + `kin-daemon` release und
 `~/.kin/bin`; `kin setup` writes MCP configs with an absolute path to that binary and
 adds the managed bin directory to your shell profile for new sessions.
 
+A global install needs a writable npm prefix. Where the prefix is root-owned and you are
+not root, npm refuses with `EACCES: permission denied, mkdir
+'/usr/local/lib/node_modules/@kinlab'` and installs nothing, which is the usual case inside
+a container whose default user is not root. The zero-install line above needs no writable
+prefix. Otherwise move the prefix somewhere you own and put it on your `PATH`:
+
+```sh
+npm config set prefix ~/.npm-global
+export PATH="$HOME/.npm-global/bin:$PATH"   # add this to your shell profile too
+npm install -g @kinlab/kin
+```
+
+A user prefix is read by your interactive shell and by nothing else. Scripts, CI steps,
+`docker exec`, and agent clients do not inherit it, so register `kin` with those by its
+absolute path (`$(npm prefix -g)/bin/kin`, or `~/.kin/bin/kin` once `kin setup` has run)
+rather than by name. Installing as root does not fix that on an image where every user
+shares one `HOME`: root's npm reads the same `.npmrc`, reinstalls into the user prefix, and
+reports success. Use `npm install -g --prefix /usr/local @kinlab/kin` when the system prefix
+is what you want.
+
 ### Windows
 
 On native Windows, use PowerShell:

--- a/llms-install.md
+++ b/llms-install.md
@@ -45,6 +45,17 @@ From npm:
 npm install -g @kinlab/kin
 ```
 
+That line needs a writable global npm prefix. If it fails with `EACCES: permission denied,
+mkdir '/usr/local/lib/node_modules/@kinlab'`, you are not root and the prefix is. Either
+run everything below through `npx -y @kinlab/kin`, which needs no writable prefix, or move
+the prefix somewhere you own first:
+
+```sh
+npm config set prefix ~/.npm-global
+export PATH="$HOME/.npm-global/bin:$PATH"
+npm install -g @kinlab/kin
+```
+
 From Homebrew:
 
 ```sh

--- a/packages/kin/README.md
+++ b/packages/kin/README.md
@@ -21,6 +21,36 @@ No native Windows ARM64 archive is published. An x64 Node process under Windows
 emulation can provision the x86_64 archive; use WSL2 for the repository workflow
 documented below.
 
+## If the global install is refused
+
+On a machine whose global npm prefix is root-owned, and where you are not root and have no
+`sudo`, that first line fails before Kin runs:
+
+```
+npm error code EACCES
+npm error syscall mkdir
+npm error path /usr/local/lib/node_modules/@kinlab
+npm error Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules/@kinlab'
+```
+
+Containers whose default user is not root are the common case. Two ways out. The
+zero-install path above needs no writable prefix and is the shorter one. Or move the prefix
+somewhere you own, and put it on your `PATH`:
+
+```sh
+npm config set prefix ~/.npm-global
+export PATH="$HOME/.npm-global/bin:$PATH"   # add this to your shell profile too
+npm install -g @kinlab/kin
+```
+
+A user prefix is read by your interactive shell and by nothing else. Scripts, CI steps,
+`docker exec`, and agent clients do not inherit it, so register `kin` with those by its
+absolute path (`$(npm prefix -g)/bin/kin`, or `~/.kin/bin/kin` after `kin setup`) rather
+than by name. Installing as root does not fix that on an image where every user shares one
+`HOME`: root's npm reads the same `.npmrc`, reinstalls into the user prefix, and reports
+success. Pass `npm install -g --prefix /usr/local @kinlab/kin` when you want the system
+prefix.
+
 ## What it does
 
 `@kinlab/kin` ships two thin launchers, not a JavaScript reimplementation:


### PR DESCRIPTION
Three defects the shipped-bytes stranger pass `npm0545` hit on npm-served v0.5.45, all of them in text rather than in behavior. Debian 12 bookworm aarch64, default exec user `dev` (uid 1001), no `sudo`, `HOME=/home/dev` for every user including root, image `ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.

## FIR-2553: the documented `docker exec` registration could not run

`crates/kin-cli/src/main.rs:1864` documented `docker exec -i -w /work/repo <container> kin mcp start`, and `docs/mcp-tools.md:88` documented the same shape. `docker exec` with a bare command resolves it against the image's own `ENV PATH`, which carries neither `~/.kin/bin` nor an npm user prefix, so the stranger got `OCI runtime exec failed: exec failed: unable to start container process: exec: "kin": executable file not found in $PATH`. That message names Docker, so a reader has no route back to the cause. Kin's own proof harness hit the same thing in the brown arm's capture step (`bash: line 1: kin: command not found`).

The help and the docs page now register an absolute path, quote the failure a bare registration produces, name where the managed binary lands on each install path (`~/.kin/bin/kin` after `kin setup`, `$(npm prefix -g)/bin/kin` after npm), offer `docker exec -e PATH=...` for anyone who wants to keep the bare command, and name the root-HOME trap: on an image that shares one `HOME`, `npm install -g` as root reads the same `.npmrc`, reinstalls into the user prefix, and reports `changed 1 package` while nothing lands on the default `PATH`. `npm install -g --prefix /usr/local @kinlab/kin` is the working form.

Ask 2 of the ticket is not delivered here. Making `kin setup` detect that `kin` is unresolvable from a non-interactive shell and say so is a code change in `setup.rs`, and it shares its fix locus with FIR-2236 symptom 4. Hence `Refs`, not `Closes`.

## FIR-2557: the npm install line does not run for a non-root user

`npm install -g @kinlab/kin` exits 243 with `EACCES: permission denied, mkdir '/usr/local/lib/node_modules/@kinlab'` on any image whose global prefix is root-owned and whose default user is not root. The stranger's own fix, `npm config set prefix ~/.npm-global`, is what then produced FIR-2553, so this is the first domino rather than an isolated papercut.

`README.md`, `docs/quickstart.md`, `llms-install.md` and `packages/kin/README.md` now name the symptom so a reader recognizes it, point at the zero-install `npx -y @kinlab/kin` path the docs already carried, and give the `npm config set prefix` plus `PATH` form inline. Each also says a user prefix is on the interactive shell's `PATH` and nowhere else, so scripts, CI steps, `docker exec` and agent clients need the absolute path. The original `npm install -g @kinlab/kin@latest` line in `README.md` is untouched, so `scripts/test-release-workflow-authority.py`'s moving-latest-release requirement still holds and the root or writable-prefix case reads exactly as it did.

Ask 3, having the launcher detect the EACCES and print the prefix fix, is a change in `packages/kin/lib/`. Not taken here. Hence `Refs`.

## FIR-2555: seven strings put the 523 MB download on the wrong command

The attribution was traced rather than taken from the stranger's report. `crates/kin-cli/src/commands/init.rs:185` runs `enrich_after_init` before the result is printed; `enrich_phase` at `init.rs:293` calls `ensure_daemon_running`; `crates/kin-daemon/src/daemon.rs:2506` spawns the background embedding worker once the first reconcile lands and logs `embedding worker started`; `daemon.rs:790` `start_or_defer_background_embed` queues everything the index is missing unless `KIN_AUTO_EMBED` opts out. So on a repository with parseable content the fetch happens inside `kin init`, and the notice that mentions it prints after the fetch rather than before. That matches the stranger's measurement of 2.576s to init an empty repository against 67.1s to init a one-file TypeScript one.

Six sites that made a claim about which command pays now name `kin init`: `init.rs:84` and `:830`, `health.rs:2956` and `:2964`, `resources.rs:52`, `embed_model.rs:180`, plus the module doc at `embed_model.rs:7` and the check doc at `health.rs:2877`. `init.rs:836`'s cached arm dropped the phrase entirely, since nothing fetches on that arm. `health.rs:2980` keeps "for the first embed pass" on purpose: it is the manual fix about egress, and the egress genuinely is for the pass. That site is the positive control the ticket's wording sweep asks for.

Sweep after the edit, with its control:

```
$ git grep -n "the first embed pass" -- .
crates/kin-cli/src/commands/health.rs:2956:  ...`kin init` starts the first embed pass, which fetches {download} \
crates/kin-cli/src/commands/health.rs:2964:  ...`kin init` starts the first embed pass, \
crates/kin-cli/src/commands/health.rs:2980:  "allow egress to {host} for the first embed pass, or pre-seed the model by copying an \
crates/kin-cli/src/commands/init.rs:84:     /// The embedding model the first embed pass will need, and whether this
crates/kin-cli/src/commands/resources.rs:52: /// The weights are not shipped, so the first embed pass on a fresh machine
crates/kin-cli/src/embed_model.rs:180:       ...`kin init` starts the first embed pass, which fetches {} from {EMBED_MODEL_HOST}
rc=0
```

Every remaining hit either names `kin init` in the same sentence or is a doc comment whose next sentence does. `init.rs:830`, the user-facing line, does not appear because the source wraps the phrase across two lines; its rendered form is asserted by the test below.

Ask 2, giving `kin init`'s progress output its own download phase, is NOT delivered. That line is `note!("Enriching cross-file references (language server)...")` at `init.rs:334`, inside `enrich_phase`, and lane `fir2531` is editing that same function tonight (`origin/chore/lane-fir2531-kin` hunk `@@ -319,11 +383,21 @@ async fn enrich_phase`). It is also more than a string change, since naming the fetch needs a probe inside the wait loop. Left to whoever owns that function. Hence `Refs`.

## Overlap with sibling lanes

- `fir2531` touches `crates/kin-cli/src/commands/init.rs` at `enrich_after_init` (`@@ -282,6`), `enrich_phase` (`@@ -319,11`) and the test module (`@@ -972,6`). This PR touches `InitResultPayload`'s doc comment (line 84), `embedding_model_notice` (around line 815) and one existing test. No shared hunk; expect a clean rebase.
- `censusdiff` touches `crates/kin-cli/src/commands/health.rs` at `@@ -184,6`, `@@ -2503,6` and `@@ -3626,6`. This PR touches `check_embedding_model`'s doc comment and `embedding_model_check_from` around 2877 to 2980, plus one test at 6923. No shared hunk. Its 125-line insertion at 2503 shifts my line numbers, nothing more.
- `doctorfix` and `memhonest` had no branch on origin when this was written, checked with `git rev-parse --verify origin/chore/lane-<lane>-kin`.

## Tests and falsification

One new test, `mcp_start_help_registers_an_absolute_binary_path_for_docker_exec` in `crates/kin-cli/src/main.rs`, and attribution assertions added to three existing tests. Every guard was falsified by breaking the behavior it covers, with the sabotage asserted applied before the run and the file restored byte-identical after (`shasum -a 256 -c`, rc=0, all four files OK).

Pass 1, revert the absolute-path form in the help. Predicted: the new test fails, the existing roots test passes.

```
test tests::mcp_start_help_documents_that_a_bound_server_holds_unresolvable_client_roots ... ok
test tests::mcp_start_help_registers_an_absolute_binary_path_for_docker_exec ... FAILED
panicked at crates/kin-cli/src/main.rs:4826:13:
help must register an absolute path to the binary, since a bare `kin` is not on the PATH docker exec uses: ...
test result: FAILED. 1 passed; 1 failed
```

Pass 2, revert `init.rs`'s absent-arm wording only. Predicted: the init test fails, the health and embed_model tests pass.

```
test embed_model::tests::an_absent_model_states_the_download_before_anything_starts ... ok
test commands::init::tests::init_states_the_model_download_a_fresh_machine_still_owes ... FAILED
test commands::health::tests::a_missing_embedding_model_states_the_fetch_it_will_do ... ok
panicked at crates/kin-cli/src/commands/init.rs:1461:9:
the notice must name the command that pays for the download: Embedding model: nomic-ai/nomic-embed-text-v1.5 is not on this machine yet; the first embed pass fetches about 523 MB from huggingface.co into /home/dev/.cache/huggingface/hub/models--x, which needs egress and runs before any vector exists
test result: FAILED. 2 passed; 1 failed
```

Pass 3, revert `health.rs` and `embed_model.rs` together. Predicted: those two fail, the init test passes.

```
test embed_model::tests::an_absent_model_states_the_download_before_anything_starts ... FAILED
test commands::health::tests::a_missing_embedding_model_states_the_fetch_it_will_do ... FAILED
test commands::init::tests::init_states_the_model_download_a_fresh_machine_still_owes ... ok
panicked at crates/kin-cli/src/embed_model.rs:537:9:
an absent model names the command that fetches it: ...
panicked at crates/kin-cli/src/commands/health.rs:6923:9:
the detail names what starts the fetch: ...
test result: FAILED. 1 passed; 2 failed
```

Every prediction held in all three passes, so each guard fails only when its own behavior is removed.

Green after restore:

```
test embed_model::tests::an_absent_model_states_the_download_before_anything_starts ... ok
test commands::init::tests::init_states_the_model_download_a_fresh_machine_still_owes ... ok
test commands::health::tests::a_missing_embedding_model_states_the_fetch_it_will_do ... ok
test result: ok. 3 passed; 0 failed; 1630 filtered out

test tests::mcp_start_help_registers_an_absolute_binary_path_for_docker_exec ... ok
test tests::mcp_start_help_documents_that_a_bound_server_holds_unresolvable_client_roots ... ok
test result: ok. 2 passed; 0 failed; 25 filtered out
```

## Gates

Run through `bin/kin-lane run strangerdocs kin --`, worktree `/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/strangerdocs-kin`, branch `chore/lane-strangerdocs-kin`, base sha `79979a374ad39db260b1cfa03f6e2dd77eab47fa`.

- `cargo fmt --all -- --check`, rc=0
- `cargo clippy --all-targets --all-features -- $allows` under `RUSTFLAGS=-D warnings` with the `.github/clippy-allowed-lints.txt` allow list, rc=0
- `python3 scripts/verify-zero-file-search.py`, rc=0, 177 source files scanned
- `bash scripts/zero_file_search_guard.sh`, rc=0
- `bash scripts/check_runtime_boundaries.sh`, rc=0
- `bash scripts/check_private_repo_coupling.sh`, rc=0
- `python3 scripts/test-release-workflow-authority.py`, rc=0
- `npm test --prefix ./packages/kin`, rc=0, 44 pass 0 fail; `npm run lint --prefix ./packages/kin`, rc=0
- README language count step replayed, derived 14, unchanged by this PR

This PR's own diff is `git diff HEAD~1..HEAD --numstat`, ten files, 296 insertions and 33 deletions. No new external URL is added to any link-checked file; the one new link is the internal anchor `#works-with-your-agent`, which resolves to `README.md:302`. No em dash anywhere in the diff, verified with a detector that scores 1 on a control string.

### The full local gate, and why hosted CI is the gate of record here

`bin/kin-dev local-test kin` ran under `gate-slot-3` and stopped at `2091/6626 tests run: 2090 passed, 1 failed`. nextest cancels on the first failure, so that total is not a pass. The one failure is `kin-cli::live_graph_durability_disclosure mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit_records_them`, which panicked with `kin_graph_status refused 21 times without ever sampling its counts` after exhausting the fixture's 30 second `RETRY_BOUND` at `crates/kin-cli/tests/live_graph_durability_disclosure.rs:72`.

It is not this PR's failure, on three independent grounds:

1. The same test failed the same way for lane `truncwalk`, on a different branch and a different worktree, in that lane's own gate log (`FAIL [ 73.011s] (2115/6636)`), which is a tree this PR's commit is not in.
2. Re-run alone on this branch it passes: `test result: ok. 1 passed; 0 failed; 9 filtered out; finished in 261.27s`. The environment was captured on both runs, since a failure that stops reproducing is not automatically flaky. The failing run was one of 2091 concurrently scheduled tests beside other lanes' gates at load 46 to 56; the passing run was that test alone, starting at load 28. What changed is contention, not code.
3. `Check & Test (ubuntu-latest)` runs `cargo nextest run --locked` over the whole workspace, including that test, and is SUCCESS on this PR's head.

So hosted CI is the gate of record for this PR: 39 checks, all concluded, 0 failures (35 SUCCESS, 4 SKIPPED, the skips being the documentation-fast-path and coverage jobs that are skipped by design on a diff of this shape). Every check was read by name. `Check & Test (ubuntu-latest)`, `Check & Test (macos-latest)`, both macOS shards, `Falsify guards`, `Install Proof (PR) Gate`, `npm launcher tests`, `Check public documentation links`, `PR text hygiene`, `Windows authority tests`, `Windows authority CLI tests`, `Windows authority runtime tests` and `CodeQL` are all SUCCESS.

The retry bound this exposed is worth a look independently of this PR. Nothing here changes it and nothing here is affected by it.

After the gate the tree is clean: `git status --porcelain` empty, `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, `.cargo/config.toml` carries no `[patch.kin]`, and `git diff HEAD~1..HEAD --stat -- Cargo.lock .cargo/` is empty. `HEAD~1..HEAD` rather than `origin/main`, because `main` gained the v0.5.46 release commit (#1001) while this branch was in flight and a bare `origin/main` diff would count that commit's files as this PR's.

Refs FIR-2553
Refs FIR-2555
Refs FIR-2557
