### PR TITLE
Give the sensitive-artifact refusal a command that performs the approval it names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.38"
+version = "0.7.40"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "9a91460113b99ffac03b62f011d76ce7eb4570b9affde59ede4c24688f061382"
+checksum = "581287b29e2c3937b31dc441da46c88f69593bd535746c7e6d6a55f2d5328241"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.38", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.40", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.7", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/commands/allow.rs
+++ b/crates/kin-cli/src/commands/allow.rs
@@ -17,10 +17,8 @@
 //! reviewer sees, bound to a digest, so editing the artifact blocks it again.
 
 use anyhow::{bail, Context, Result};
-use kin_model::{
-    parse_sensitive_allowances, RepoPath, SensitiveArtifactAllowance, SensitiveArtifactKind,
-    SENSITIVE_ALLOWANCE_SOURCE_PATH,
-};
+use kin_model::admission::{parse_sensitive_allowances, SENSITIVE_ALLOWANCE_SOURCE_PATH};
+use kin_model::{RepoPath, SensitiveArtifactAllowance, SensitiveArtifactKind};
 use sha2::{Digest, Sha256};
 use std::path::Path;
 

--- a/crates/kin-cli/src/commands/allow.rs
+++ b/crates/kin-cli/src/commands/allow.rs
@@ -42,8 +42,8 @@ pub async fn run(path: String, reason: String) -> Result<()> {
             .context("approval paths must be valid UTF-8 to be written to the allowance file")?,
     );
 
-    let metadata = std::fs::symlink_metadata(&target)
-        .with_context(|| format!("read {}", target.display()))?;
+    let metadata =
+        std::fs::symlink_metadata(&target).with_context(|| format!("read {}", target.display()))?;
     if metadata.is_dir() {
         bail!(
             "{} is a directory; approve the exact file that admission named",
@@ -104,10 +104,7 @@ pub async fn run(path: String, reason: String) -> Result<()> {
         repo_path
     );
     println!("  digest  {content_hash}");
-    println!(
-        "  kind    {}",
-        if executable { "blob+x" } else { "blob" }
-    );
+    println!("  kind    {}", if executable { "blob+x" } else { "blob" });
     println!("  reason  {reason}");
     println!();
     println!(
@@ -133,11 +130,7 @@ fn render(allowances: &[SensitiveArtifactAllowance]) -> Vec<u8> {
         };
         out.push_str(&format!(
             "{}\t{}\t{}\t{}\t{}\n",
-            allowance.path,
-            allowance.content_hash,
-            kind,
-            allowance.approved_by,
-            allowance.reason
+            allowance.path, allowance.content_hash, kind, allowance.approved_by, allowance.reason
         ));
     }
     out.into_bytes()

--- a/crates/kin-cli/src/commands/allow.rs
+++ b/crates/kin-cli/src/commands/allow.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 pub async fn run(path: String, reason: String) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let approved_by = crate::commands::require_commit_author_for(&layout)?;
-    let root = layout.root().to_path_buf();
+    let root = repo_root_of(&layout);
 
     if reason.trim().is_empty() {
         bail!("an approval needs a reason: it is what a reviewer reads to judge the exemption");
@@ -70,7 +70,7 @@ pub async fn run(path: String, reason: String) -> Result<()> {
     };
     allowance.validate()?;
 
-    let allowance_file = root.join(SENSITIVE_ALLOWANCE_SOURCE_PATH);
+    let allowance_file = allowance_file_path(&layout);
     let mut existing = match std::fs::read(&allowance_file) {
         Ok(body) => parse_sensitive_allowances(&body).with_context(|| {
             format!("{SENSITIVE_ALLOWANCE_SOURCE_PATH} is present but could not be read")
@@ -143,6 +143,21 @@ fn render(allowances: &[SensitiveArtifactAllowance]) -> Vec<u8> {
     out.into_bytes()
 }
 
+/// The repository working directory.
+///
+/// `working_dir()`, never `root()`: `root()` is the `.kin/` directory itself, so
+/// resolving against it reports every repository path as outside the repository
+/// and writes the approval where no derivation reads it. One accessor for both
+/// callers, so the two cannot disagree.
+fn repo_root_of(layout: &kin_core::KinLayout) -> std::path::PathBuf {
+    layout.working_dir().to_path_buf()
+}
+
+/// Where the approval file lives: beside `.kin/`, not inside it.
+fn allowance_file_path(layout: &kin_core::KinLayout) -> std::path::PathBuf {
+    repo_root_of(layout).join(SENSITIVE_ALLOWANCE_SOURCE_PATH)
+}
+
 fn repo_relative(root: &Path, given: &str) -> Result<RepoPath> {
     let candidate = Path::new(given);
     let absolute = if candidate.is_absolute() {
@@ -213,6 +228,29 @@ mod tests {
             approved_by: AuthorId::new("troy@firelock.ai"),
             reason: "reviewed in the pull request that adds this line".to_string(),
         }
+    }
+
+    /// `root()` is the `.kin/` directory and `working_dir()` is the repository.
+    /// Reaching for the wrong one reports every repository path as outside the
+    /// repository and writes the approval inside `.kin/`, where no derivation
+    /// reads it. A live acceptance run caught exactly that; this pins it.
+    #[test]
+    fn paths_resolve_against_the_repository_not_against_dot_kin() {
+        let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/tmp/repo/.kin"));
+        assert_eq!(
+            repo_root_of(&layout),
+            std::path::PathBuf::from("/tmp/repo"),
+            "paths resolve against the repository, not against .kin/"
+        );
+        let path = allowance_file_path(&layout);
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/tmp/repo").join(SENSITIVE_ALLOWANCE_SOURCE_PATH)
+        );
+        assert!(
+            !path.starts_with("/tmp/repo/.kin/"),
+            "an approval inside .kin/ is invisible to policy derivation: {path:?}"
+        );
     }
 
     /// The writer and the reader live in different crates, so nothing but a

--- a/crates/kin-cli/src/commands/allow.rs
+++ b/crates/kin-cli/src/commands/allow.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin allow` — record an explicit approval for one blocked sensitive artifact.
+//!
+//! Admission refuses to publish untracked content that looks like a leaked
+//! credential, and names the path, digest and entry kind that an approval has to
+//! carry. This writes exactly that triple into the tracked `.kin-allowances`
+//! file at the repository root, which is where policy derivation reads
+//! approvals from.
+//!
+//! The approval rides the tree rather than daemon state on purpose. Policy state
+//! dies at the repository boundary, so a teammate who cloned the repository and
+//! ran `kin init` would hit the wall a colleague had already cleared. A tracked
+//! file survives clone and convert, derives on init, and reaches review as an
+//! ordinary diff, which is also its security story: an approval is something a
+//! reviewer sees, bound to a digest, so editing the artifact blocks it again.
+
+use anyhow::{bail, Context, Result};
+use kin_model::{
+    parse_sensitive_allowances, RepoPath, SensitiveArtifactAllowance, SensitiveArtifactKind,
+    SENSITIVE_ALLOWANCE_SOURCE_PATH,
+};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+/// `kin allow <path> --reason <why>`
+pub async fn run(path: String, reason: String) -> Result<()> {
+    let layout = crate::commands::require_repository_layout()?;
+    let approved_by = crate::commands::require_commit_author_for(&layout)?;
+    let root = layout.root().to_path_buf();
+
+    if reason.trim().is_empty() {
+        bail!("an approval needs a reason: it is what a reviewer reads to judge the exemption");
+    }
+    if reason.contains('\t') || reason.contains('\n') {
+        bail!("a reason is one line and cannot contain a tab, which separates the fields");
+    }
+
+    let repo_path = repo_relative(&root, &path)?;
+    let target = root.join(
+        repo_path
+            .as_utf8()
+            .context("approval paths must be valid UTF-8 to be written to the allowance file")?,
+    );
+
+    let metadata = std::fs::symlink_metadata(&target)
+        .with_context(|| format!("read {}", target.display()))?;
+    if metadata.is_dir() {
+        bail!(
+            "{} is a directory; approve the exact file that admission named",
+            repo_path
+        );
+    }
+    if metadata.file_type().is_symlink() {
+        bail!(
+            "{repo_path} is a symlink, and a symlink's digest is the hash of its target rather \
+             than of any file body; approving one is not supported yet, so approve the file it \
+             points at or exclude the link"
+        );
+    }
+    let body = std::fs::read(&target).with_context(|| format!("read {}", target.display()))?;
+    let content_hash = sha256(&body);
+    let executable = is_executable(&metadata);
+
+    let allowance = SensitiveArtifactAllowance {
+        path: repo_path.clone(),
+        content_hash,
+        kind: SensitiveArtifactKind::Blob { executable },
+        approved_by,
+        reason: reason.clone(),
+    };
+    allowance.validate()?;
+
+    let allowance_file = root.join(SENSITIVE_ALLOWANCE_SOURCE_PATH);
+    let mut existing = match std::fs::read(&allowance_file) {
+        Ok(body) => parse_sensitive_allowances(&body).with_context(|| {
+            format!("{SENSITIVE_ALLOWANCE_SOURCE_PATH} is present but could not be read")
+        })?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => {
+            return Err(error).with_context(|| format!("read {}", allowance_file.display()))
+        }
+    };
+
+    // One approval per path, which is what the policy's own validation enforces.
+    // A moved digest replaces the line rather than adding a second, so the file
+    // never says two contradictory things about one artifact.
+    let replaced = existing.iter().position(|entry| entry.path == repo_path);
+    match replaced {
+        Some(index) => existing[index] = allowance.clone(),
+        None => existing.push(allowance.clone()),
+    }
+    existing.sort_by(|left, right| left.path.as_bytes().cmp(right.path.as_bytes()));
+
+    std::fs::write(&allowance_file, render(&existing))
+        .with_context(|| format!("write {}", allowance_file.display()))?;
+
+    println!(
+        "{} {} in {SENSITIVE_ALLOWANCE_SOURCE_PATH}",
+        if replaced.is_some() {
+            "Updated the approval for"
+        } else {
+            "Approved"
+        },
+        repo_path
+    );
+    println!("  digest  {content_hash}");
+    println!(
+        "  kind    {}",
+        if executable { "blob+x" } else { "blob" }
+    );
+    println!("  reason  {reason}");
+    println!();
+    println!(
+        "Commit {SENSITIVE_ALLOWANCE_SOURCE_PATH} for the approval to take effect. It is tracked \
+         on purpose, so it travels with the repository and a reviewer sees it. Editing {repo_path} \
+         changes its digest and blocks it again."
+    );
+    Ok(())
+}
+
+/// The canonical rendering of an approval set, matching what kin-model parses.
+fn render(allowances: &[SensitiveArtifactAllowance]) -> Vec<u8> {
+    let mut out = String::new();
+    out.push_str("# Sensitive artifacts approved for publication, one per line.\n");
+    out.push_str("# Fields: path, sha256, kind, approver, reason. Tab separated.\n");
+    out.push_str("# Deleting a line revokes that approval. Editing the artifact re-blocks it.\n");
+    out.push_str("kin-allowances 1\n");
+    for allowance in allowances {
+        let kind = match allowance.kind {
+            SensitiveArtifactKind::Blob { executable: false } => "blob",
+            SensitiveArtifactKind::Blob { executable: true } => "blob+x",
+            SensitiveArtifactKind::Symlink => "symlink",
+        };
+        out.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\n",
+            allowance.path,
+            allowance.content_hash,
+            kind,
+            allowance.approved_by,
+            allowance.reason
+        ));
+    }
+    out.into_bytes()
+}
+
+fn repo_relative(root: &Path, given: &str) -> Result<RepoPath> {
+    let candidate = Path::new(given);
+    let absolute = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("resolve the current directory")?
+            .join(candidate)
+    };
+    let absolute = normalize(&absolute);
+    let root = normalize(root);
+    let relative = absolute.strip_prefix(&root).map_err(|_| {
+        anyhow::anyhow!(
+            "{} is outside this repository at {}",
+            absolute.display(),
+            root.display()
+        )
+    })?;
+    let text = relative
+        .to_str()
+        .context("repository paths must be valid UTF-8")?
+        .replace(std::path::MAIN_SEPARATOR, "/");
+    RepoPath::from_utf8(text).map_err(|error| anyhow::anyhow!("invalid repository path: {error}"))
+}
+
+fn normalize(path: &Path) -> std::path::PathBuf {
+    let mut out = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+fn sha256(bytes: &[u8]) -> kin_model::Hash256 {
+    let digest = Sha256::digest(bytes);
+    let mut hash = [0_u8; 32];
+    hash.copy_from_slice(&digest);
+    kin_model::Hash256::from_bytes(hash)
+}
+
+#[cfg(unix)]
+fn is_executable(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::{AuthorId, Hash256};
+
+    fn allowance(path: &str, byte: u8, kind: SensitiveArtifactKind) -> SensitiveArtifactAllowance {
+        SensitiveArtifactAllowance {
+            path: RepoPath::from_utf8(path).unwrap(),
+            content_hash: Hash256::from_bytes([byte; 32]),
+            kind,
+            approved_by: AuthorId::new("troy@firelock.ai"),
+            reason: "reviewed in the pull request that adds this line".to_string(),
+        }
+    }
+
+    /// The writer and the reader live in different crates, so nothing but a
+    /// round trip stops them drifting. If this file's format ever stops being
+    /// the format policy derivation reads, approvals silently stop applying.
+    #[test]
+    fn what_this_writes_is_what_kin_model_parses() {
+        let written = vec![
+            allowance(
+                "notekeeper/client.py",
+                0x51,
+                SensitiveArtifactKind::Blob { executable: false },
+            ),
+            allowance(
+                "scripts/deploy.sh",
+                0x52,
+                SensitiveArtifactKind::Blob { executable: true },
+            ),
+            allowance("config/link", 0x53, SensitiveArtifactKind::Symlink),
+        ];
+        let rendered = render(&written);
+        let parsed = parse_sensitive_allowances(&rendered)
+            .expect("what kin allow writes must parse as an approval set");
+        assert_eq!(parsed.len(), written.len());
+        for expected in &written {
+            assert!(
+                parsed.iter().any(|entry| entry == expected),
+                "the round trip lost or altered {}: {parsed:?}",
+                expected.path
+            );
+        }
+    }
+
+    /// An empty approval set is still a readable file rather than a truncated
+    /// one, which is what makes revoking the last approval safe.
+    #[test]
+    fn an_empty_approval_set_still_parses() {
+        assert_eq!(
+            parse_sensitive_allowances(&render(&[])).expect("an empty set is valid"),
+            Vec::new()
+        );
+    }
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -2,8 +2,8 @@
 // Copyright 2026 Firelock, LLC
 
 pub mod admit;
-pub mod allow;
 pub mod agent;
+pub mod allow;
 pub mod approvals;
 pub mod assistant;
 pub mod assistant_adapter;

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 pub mod admit;
+pub mod allow;
 pub mod agent;
 pub mod approvals;
 pub mod assistant;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -974,6 +974,20 @@ enum Command {
     /// a graph that fell behind its working tree and is waiting for churn that
     /// is not coming.
     Admit,
+    /// Approve one blocked sensitive artifact for publication
+    ///
+    /// Admission refuses untracked content that looks like a leaked credential
+    /// and names the path, digest, and entry kind an approval must carry. This
+    /// records exactly that triple in the tracked .kin-allowances file, so the
+    /// approval travels with the repository and a reviewer sees it in the diff.
+    /// Editing the artifact changes its digest and blocks it again.
+    Allow {
+        /// Path to the artifact admission blocked
+        path: String,
+        /// Why this artifact is safe to publish, read by whoever reviews it
+        #[arg(long)]
+        reason: String,
+    },
     /// Admit one exact disposable-session observation into repository-v6 authority
     Reconcile {
         /// Session ID (defaults to most recent session)
@@ -3522,6 +3536,7 @@ fn main() -> Result<()> {
                     commands::capabilities::require_ready("admit")?;
                     commands::admit::run().await
                 }
+                Command::Allow { path, reason } => commands::allow::run(path, reason).await,
                 Command::Reconcile {
                     session,
                     confirm_mass_deletion,

--- a/crates/kin-core/dependency_env_allowlist.txt
+++ b/crates/kin-core/dependency_env_allowlist.txt
@@ -67,3 +67,10 @@ KIN_SEARCH_SOAK_SECS
 KIN_VECTOR_BENCH_DIM
 KIN_VECTOR_BENCH_VECTORS
 KIN_VECTOR_BENCH_ITERS
+
+# kin-db storage/repository.rs: the two inputs to its FIR-2334 attribution
+# harness, a `#[cfg(test)] mod fir2334_attribution` whose only test is
+# `#[ignore]`d because it opens a multi-gigabyte on-disk store by hand. Nothing
+# in a kin process reads either name.
+KIN_FIR2334_STORE
+KIN_FIR2334_REPO

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -229,7 +229,7 @@ pub(crate) fn plan_session_workspace_admission(
 
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
     let mut source_lengths = std::collections::BTreeMap::new();
-    let (shared_policy, _) = SharedAdmissionPolicy::derive_from_tree(
+    let (shared_policy, _) = SharedAdmissionPolicy::derive_from_tree_with_allowances(
         Some(&base.source_workspace.shared_admission_policy),
         desired_tree,
         |hash| {
@@ -249,6 +249,15 @@ pub(crate) fn plan_session_workspace_admission(
             source_lengths.insert(hash, length);
             Ok(length)
         },
+    |hash| {
+    read_publishable_source(blobs, &authority, hash)
+        .map(|source| source.body().to_vec())
+        .map_err(|error| {
+            ModelError::InvalidOperation(format!(
+                "{error}, while reading the approvals the exact session policy derives"
+            ))
+        })
+},
     )?;
     let tree_hash = compute_resolved_tree_hash(desired_tree)?;
     let new_generation = base
@@ -491,7 +500,7 @@ pub(crate) fn publish_workspace_tree(
 
     let tree_deltas = kin_core::exact_tree_correction(&workspace.tree, desired_tree)?;
     let mut source_lengths = std::collections::BTreeMap::new();
-    let (shared_policy, _) = SharedAdmissionPolicy::derive_from_tree(
+    let (shared_policy, _) = SharedAdmissionPolicy::derive_from_tree_with_allowances(
         Some(&workspace.shared_admission_policy),
         desired_tree,
         |hash| {
@@ -514,6 +523,15 @@ pub(crate) fn publish_workspace_tree(
             source_lengths.insert(hash, length);
             Ok(length)
         },
+    |hash| {
+    read_publishable_source(blobs, &authority, hash)
+        .map(|source| source.body().to_vec())
+        .map_err(|error| {
+            ModelError::InvalidOperation(format!(
+                "{error}, while reading the approvals the admitted workspace policy derives"
+            ))
+        })
+},
     )?;
     let tree_hash = compute_resolved_tree_hash(desired_tree)?;
     let new_generation = workspace.generation.checked_add(1).ok_or_else(|| {
@@ -814,7 +832,7 @@ fn plan_native_commit_inner(
     let mut source_lengths = std::collections::BTreeMap::new();
     let (shared_policy, admission_policy_delta) =
         crate::mcp_commit::timed_commit_phase("plan_derive_admission_policy", || {
-            SharedAdmissionPolicy::derive_from_tree(
+            SharedAdmissionPolicy::derive_from_tree_with_allowances(
                 parent_policy.as_ref(),
                 &deltas.expected_tree,
                 |hash| {
@@ -835,6 +853,15 @@ fn plan_native_commit_inner(
                     source_lengths.insert(hash, length);
                     Ok(length)
                 },
+            |hash| {
+    read_publishable_source(blobs, &authority, hash)
+        .map(|source| source.body().to_vec())
+        .map_err(|error| {
+            ModelError::InvalidOperation(format!(
+                "{error}, while reading the approvals the graph-owned policy derives"
+            ))
+        })
+},
             )
         })?;
 

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -249,15 +249,15 @@ pub(crate) fn plan_session_workspace_admission(
             source_lengths.insert(hash, length);
             Ok(length)
         },
-    |hash| {
-    read_publishable_source(blobs, &authority, hash)
-        .map(|source| source.body().to_vec())
-        .map_err(|error| {
-            ModelError::InvalidOperation(format!(
-                "{error}, while reading the approvals the exact session policy derives"
-            ))
-        })
-},
+        |hash| {
+            read_publishable_source(blobs, &authority, hash)
+                .map(|source| source.body().to_vec())
+                .map_err(|error| {
+                    ModelError::InvalidOperation(format!(
+                        "{error}, while reading the approvals the exact session policy derives"
+                    ))
+                })
+        },
     )?;
     let tree_hash = compute_resolved_tree_hash(desired_tree)?;
     let new_generation = base
@@ -523,15 +523,15 @@ pub(crate) fn publish_workspace_tree(
             source_lengths.insert(hash, length);
             Ok(length)
         },
-    |hash| {
-    read_publishable_source(blobs, &authority, hash)
-        .map(|source| source.body().to_vec())
-        .map_err(|error| {
-            ModelError::InvalidOperation(format!(
+        |hash| {
+            read_publishable_source(blobs, &authority, hash)
+                .map(|source| source.body().to_vec())
+                .map_err(|error| {
+                    ModelError::InvalidOperation(format!(
                 "{error}, while reading the approvals the admitted workspace policy derives"
             ))
-        })
-},
+                })
+        },
     )?;
     let tree_hash = compute_resolved_tree_hash(desired_tree)?;
     let new_generation = workspace.generation.checked_add(1).ok_or_else(|| {
@@ -853,15 +853,15 @@ fn plan_native_commit_inner(
                     source_lengths.insert(hash, length);
                     Ok(length)
                 },
-            |hash| {
-    read_publishable_source(blobs, &authority, hash)
-        .map(|source| source.body().to_vec())
-        .map_err(|error| {
-            ModelError::InvalidOperation(format!(
+                |hash| {
+                    read_publishable_source(blobs, &authority, hash)
+                        .map(|source| source.body().to_vec())
+                        .map_err(|error| {
+                            ModelError::InvalidOperation(format!(
                 "{error}, while reading the approvals the graph-owned policy derives"
             ))
-        })
-},
+                        })
+                },
             )
         })?;
 

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -1494,21 +1494,36 @@ fn derive_policy(
     Option<kin_model::AdmissionPolicyDelta>,
 )> {
     let mut lengths: BTreeMap<Hash256, u64> = BTreeMap::new();
-    SharedAdmissionPolicy::derive_from_tree(Some(parent), tree, |hash| {
-        if let Some(length) = lengths.get(&hash) {
-            return Ok(*length);
-        }
-        let source = read_publishable_source(blobs, authority, hash).map_err(|error| {
-            ModelError::InvalidOperation(format!(
-                "{error}, while deriving the merged tree's admission policy"
-            ))
-        })?;
-        let length = u64::try_from(source.body().len()).map_err(|_| {
-            ModelError::InvalidOperation(format!("graph-owned admission source {hash} exceeds u64"))
-        })?;
-        lengths.insert(hash, length);
-        Ok(length)
-    })
+    SharedAdmissionPolicy::derive_from_tree_with_allowances(
+        Some(parent),
+        tree,
+        |hash| {
+            if let Some(length) = lengths.get(&hash) {
+                return Ok(*length);
+            }
+            let source = read_publishable_source(blobs, authority, hash).map_err(|error| {
+                ModelError::InvalidOperation(format!(
+                    "{error}, while deriving the merged tree's admission policy"
+                ))
+            })?;
+            let length = u64::try_from(source.body().len()).map_err(|_| {
+                ModelError::InvalidOperation(format!(
+                    "graph-owned admission source {hash} exceeds u64"
+                ))
+            })?;
+            lengths.insert(hash, length);
+            Ok(length)
+        },
+        |hash| {
+            read_publishable_source(blobs, authority, hash)
+                .map(|source| source.body().to_vec())
+                .map_err(|error| {
+                    ModelError::InvalidOperation(format!(
+                        "{error}, while reading the approvals the merged tree's policy derives"
+                    ))
+                })
+        },
+    )
     .context("derive exact admission policy for the merged tree")
 }
 

--- a/crates/kin-daemon/src/repository_rollback.rs
+++ b/crates/kin-daemon/src/repository_rollback.rs
@@ -296,9 +296,12 @@ fn plan_and_commit(
     // change was published from it. Reading lengths back through authority
     // proves that, and fails closed if any source is missing.
     let (shared_policy, admission_policy_delta) =
-        SharedAdmissionPolicy::derive_from_tree(Some(&previous_policy), &target_tree, |hash| {
-            source_body_len(authority, hash)
-        })
+        SharedAdmissionPolicy::derive_from_tree_with_allowances(
+            Some(&previous_policy),
+            &target_tree,
+            |hash| source_body_len(authority, hash),
+            |hash| source_body(authority, hash),
+        )
         .context("derive the restored shared admission policy")?;
 
     let mut change = SemanticChange {
@@ -740,6 +743,25 @@ fn relation_transition(
     }
     deltas.sort_by_key(RelationDelta::target_id);
     deltas
+}
+
+fn source_body(
+    authority: &ActiveLocalRepositoryAuthority,
+    hash: Hash256,
+) -> std::result::Result<Vec<u8>, kin_model::ModelError> {
+    authority
+        .manager
+        .load_source_blob(hash)
+        .map_err(|error| {
+            kin_model::ModelError::InvalidOperation(format!(
+                "read restored admission source {hash}: {error}"
+            ))
+        })?
+        .ok_or_else(|| {
+            kin_model::ModelError::InvalidOperation(format!(
+                "repository source CAS is missing restored admission source {hash}"
+            ))
+        })
 }
 
 fn source_body_len(

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -356,10 +356,11 @@ fn push(
         &daemon_relations,
     )
     .context("plan the exact sealed workspace semantic transition")?;
-    let (sealed_policy, admission_policy_delta) = SharedAdmissionPolicy::derive_from_tree(
+    let (sealed_policy, admission_policy_delta) = SharedAdmissionPolicy::derive_from_tree_with_allowances(
         parent_policy.as_ref(),
         &sealed.expected_tree,
         |hash| repository_source_length(&authority.manager, hash),
+    |hash| repository_source_body(&authority.manager, hash),
     )
     .context("derive the exact admission policy for the sealed workspace tree")?;
     let sealed_tree = sealed.expected_tree;
@@ -1045,6 +1046,24 @@ fn require_sealed_sources_in_repository_cas(
         }
     }
     Ok(())
+}
+
+fn repository_source_body(
+    manager: &kin_db::RepositoryAuthorityManager<kin_db::LocalFileBackend>,
+    hash: Hash256,
+) -> std::result::Result<Vec<u8>, kin_model::ModelError> {
+    manager
+        .load_source_blob(hash)
+        .map_err(|error| {
+            kin_model::ModelError::InvalidOperation(format!(
+                "read graph-owned admission source {hash}: {error}"
+            ))
+        })?
+        .ok_or_else(|| {
+            kin_model::ModelError::InvalidOperation(format!(
+                "repository source CAS is missing exact admission source {hash}"
+            ))
+        })
 }
 
 fn repository_source_length(

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -356,13 +356,14 @@ fn push(
         &daemon_relations,
     )
     .context("plan the exact sealed workspace semantic transition")?;
-    let (sealed_policy, admission_policy_delta) = SharedAdmissionPolicy::derive_from_tree_with_allowances(
-        parent_policy.as_ref(),
-        &sealed.expected_tree,
-        |hash| repository_source_length(&authority.manager, hash),
-    |hash| repository_source_body(&authority.manager, hash),
-    )
-    .context("derive the exact admission policy for the sealed workspace tree")?;
+    let (sealed_policy, admission_policy_delta) =
+        SharedAdmissionPolicy::derive_from_tree_with_allowances(
+            parent_policy.as_ref(),
+            &sealed.expected_tree,
+            |hash| repository_source_length(&authority.manager, hash),
+            |hash| repository_source_body(&authority.manager, hash),
+        )
+        .context("derive the exact admission policy for the sealed workspace tree")?;
     let sealed_tree = sealed.expected_tree;
     let sealed_tree_hash =
         compute_resolved_tree_hash(&sealed_tree).context("hash the exact sealed workspace tree")?;


### PR DESCRIPTION
Admission refuses to publish untracked content that looks like a leaked
credential and tells the author to "approve this exact path, digest, and entry
kind explicitly". Nothing performed that approval, so the only escape was
`.kinignore` amputation. This is the kin half of the fix, and it is atomic by
construction: `kin allow` writes the tracked `.kin-allowances` file, and the
daemon's six production derivation sites read it. Shipping either half alone
would break the repository it was meant to unblock, because kin-model's
compatibility entry point refuses by name when a tree carries approvals the
consumer cannot read, so a command that wrote the file without the adoption
would fail the very next commit.

## Mechanism

`SharedAdmissionPolicy::derive_from_tree` in kin-model never derived
`sensitive_allowances` from the tree. It started them empty with no parent and
otherwise carried the parent's forward verbatim, and `shared_rule_source_path`
recognised exactly two tracked filenames as policy sources. kin-model 0.7.10 adds
`derive_from_tree_with_allowances`, which reads the approval set from a tracked
root-level `.kin-allowances` in the tree being derived, and kin-db 0.7.38 points
the refusal at the command. Both are published and both are what kin main already
pins, so this pull request moves no pin.

Six production call sites now derive through the allowance-aware entry point:
`crates/kin-daemon/src/repository_commit.rs` at 232, 503 and 835,
`crates/kin-daemon/src/repository_merge.rs` at 1497,
`crates/kin-daemon/src/repository_rollback.rs` at 299, and
`crates/kin-daemon/src/repository_stash.rs` at 360. Each already loaded the
source body to measure its length, so reading approvals from the same CAS costs
no extra read; rollback and stash gained body-returning siblings of the length
helpers they already had. One site stays on the older entry point on purpose,
`repository_merge.rs:2328` inside `#[cfg(test)]`, which derives from an empty
tree and keeps the compatibility path exercised.

`kin allow <path> --reason <why>` writes the path, sha256 digest and entry kind
into `.kin-allowances` at the repository root. It replaces rather than appends
when a path is already approved, since the policy permits one approval per path
and a moved digest must not leave the file saying two contradictory things about
one artifact. It refuses a directory, and refuses a symlink by name rather than
writing a wrong digest. Paths resolve against `KinLayout::working_dir()`, never
`root()`, which is the `.kin/` directory: one accessor serves both callers so
they cannot disagree.

## The pin move, and why it is not cosmetic

kin main pinned kin-db `=0.7.38`, and 0.7.38 does not carry the refusal text that
names this command. `kin allow` appears zero times in the published 0.7.38 and
zero times in 0.7.39, and twice in 0.7.40, read out of the crates the registry
serves rather than out of the branches that wrote them. kin-db PR 208 merged
carrying that text and a bump to 0.7.38, but 0.7.38 had already been published by
the dependency-wave automation, so the bump was dropped on rebase as "patch
contents already upstream" and the text first reached a published crate at
0.7.40. Without this move the command would have shipped beside a refusal that
still promised nothing, which is the exact defect the ticket is about.

The pin therefore moves to `=0.7.40`, the lowest published kin-db carrying the
text whose kin-model requirement is still `=0.7.10`, which is what this workspace
pins. 0.7.41 requires `=0.7.11` and would move a second pin with it. The move
also brings in the kin-db work published as 0.7.39 and 0.7.40 beyond the error
text, in `engine/graph.rs`, `storage/change_validation.rs`, `storage/format.rs`
and `storage/repository.rs`; the workspace suite below is what gates that.

## Proven live, not at the decision point

An acceptance run against a throwaway repository, isolated `KIN_HOME`,
`KIN_DAEMON_AUTO_EMBED=false` so nothing starts on the GPU, under the fleet
daemon lock: 21 assertions, 0 failures. The fixture commits only harmless files,
runs `kin init`, and writes the offending content untracked afterwards, which is
what a real author hits; a fixture that commits the secret first takes the import
path, the artifact is tracked, `enforce_sensitive_admission` returns `Ok`
immediately, and the phase passes while proving nothing.

* `kin admit` refuses `notekeeper/client.py`, and the refusal names `kin allow`,
  `.kin-allowances` and the digest `dc89be5f6d25...`.
* `notekeeper/util.py`, whose only assignment is `token = term.strip()`, is not
  what blocks, which keeps kin-db PR 205's fix honest.
* `kin allow` exits 0 and writes `.kin-allowances` at the repository root, not
  inside `.kin/`, carrying the artifact's real digest.
* Negative control: one field of that file changed to a wrong digest and the same
  admission still refuses, naming the path and the bad digest. The run asserts
  separately that it refused on the digest rather than on an unreadable file.
* The same `kin admit` then exits 0, and no derivation site reports
  "cannot read .kin-allowances".
* `kin graph status` and `kin locate` both answer for the approved module, so it
  is admitted rather than excluded.
* An approval is scoped to its path: a second untracked secret still blocks while
  the first is approved.
* Editing an approved but still-untracked artifact changes its digest and blocks
  it again; re-approving replaces the line rather than adding a second, and then
  it admits.

## Falsification

Two passes, each removing one property, each predicting what fails and what does
not, each restored byte-identical and re-run.

**The accessor.** Changing `repo_root_of` from `layout.working_dir()` to
`layout.root()` fails `paths_resolve_against_the_repository_not_against_dot_kin`
at exit 101 with its own message, left `/tmp/repo/.kin` against right
`/tmp/repo`, while `what_this_writes_is_what_kin_model_parses` and
`an_empty_approval_set_still_parses` still pass, because neither touches a
layout. Restored by sha256 and all three pass. That accessor is not cosmetic: a
live acceptance run caught `kin allow` reporting every path as outside the
repository, and the version that would have written the approval into `.kin/`
where no derivation reads it.

**The adoption.** Restoring `origin/main`'s `crates/kin-daemon/` removes all six
sites, which the run asserts by counting them at zero before it builds anything.
The prediction was recorded before the run: the block and `kin allow` still work,
and every phase that admits a tree carrying `.kin-allowances` fails with
kin-model's "this build cannot read .kin-allowances". That is exactly what
happened. The acceptance went from 21 passing assertions and 0 failures to 15 and
6. Phase 1 still blocks and still names the command, phase 2 still writes the
approval at the repository root with the real digest, and every phase from 3 on
fails, including the assertion written for this case, "a derivation site still
uses the entry point that cannot read approvals". Six of the harness's logs carry:

```
Complete exact-tree admission failed: Core error: model error: invalid operation:
this build cannot read .kin-allowances: upgrade to a consumer that derives
sensitive-artifact allowances, or remove the file
```

That refusal is why the two halves are one change. A `kin allow` shipped without
the adoption would write the file and then fail the very next commit, breaking
the repository it was meant to unblock. Restored to six sites, working tree
clean, binaries rebuilt, and `kin allow --help` exits 0 on the rebuilt binary.

## The gate

Registry resolution, no patches, on gate-slot-2 in an isolated worktree and
target directory:

* `cargo fmt --all -- --check` exit 0.
* `cargo clippy --all-targets --all-features --locked` under `RUSTFLAGS=-D warnings`
  with the ci.yml allow-list of 45 lints, exit 0.
* `cargo nextest run --workspace --locked --no-fail-fast`: 6628 tests run, 6627
  passed, 1 failed, 12 skipped.
* `cargo test --doc --locked` exit 0.
* `cargo build --locked --bin kin --bin kin-daemon` exit 0.
* `verify-zero-file-search.py` exit 0 over 177 source files,
  `zero_file_search_guard.sh` exit 0, `check_runtime_boundaries.sh` exit 0,
  `check_private_repo_coupling.sh` exit 0 with its four guard tests passing,
  `check-rc-build-drift.mjs` exit 0, `check-kin-vfs-compat.mjs` exit 0.

The one failure is `kin-cli::symlinked_repository_root_admission
a_repository_bound_through_a_symlinked_root_admits_a_host_write`, and it is a
load-sensitive race in that test rather than anything here. It asserts
`kin graph status` exits 0 with no settling wait, and graph status exits 1 while
the per-file facet write is still catching up with authority, which its own
output explains on the same run. Three whole-file repeats on this branch pass at
204.88s under load average 147, 5.99s under 17 and 9.68s under 30; a filtered run
passes on this branch, on main's source with this pin, and on plain
`origin/main`. Filed as FIR-2566 with the full load record.

`bin/kin-dev local-test` was deliberately not the gate. It path-patches the crate
this change pins: the umbrella kin-db sibling is at 0.7.37, which cannot satisfy
`=0.7.40`, so cargo would drop that patch silently and resolve from the registry,
while the kin-model patch would apply and swap the published 0.7.10 for a local
checkout. That is a weaker resolution than the one shipped here, so the `--locked`
runs above are the gate.

Both lock files were checked after the pin move. The root lock carries kin-db
0.7.40 with checksum `581287b29e2c...`, matching the registry index exactly, and
keeps its `sparse+https://kinlab.ai/registry/cargo/` source; `fuzz/Cargo.lock`
names kin-db nowhere and needed no change, with `cargo metadata --locked
--manifest-path fuzz/Cargo.toml` returning 0 and leaving it byte-identical.
Neither lock carries a `source = "path` entry. `git grep -F '0.7.38'` returns
nothing tree-wide afterwards and `git grep -F '0.7.40'` returns both homes.

## Not claiming

No test in this repository covers the daemon adoption. `.kin-allowances`,
`SensitiveArtifactAllowance` and `derive_from_tree_with_allowances` appear in zero
files under any `tests/` directory, against a positive control that finds all four
source files, so the live acceptance run above is the only thing that exercises
those six sites. The falsification measured that directly: with all six reverted,
the workspace builds and the suite passes. Filed as FIR-2575.

The refusal's closing promise, that a later edit changes the digest and blocks
again, holds only while an artifact is still untracked.
`enforce_sensitive_admission` returns `Ok` for tracked content at
`admission.rs:526` before it looks at anything else, so an artifact that has
already been admitted is not re-scanned when it changes. That is a deliberate
design in kin-db, the gate being on entry to authority rather than a standing
content policy, and the sentence promises slightly more than it delivers. It is
not changed here; filed against kin-db as FIR-2576.

The pin move also brings in the kin-db work published as 0.7.39 and 0.7.40 beyond
the error text, in `engine/graph.rs`, `storage/change_validation.rs`,
`storage/format.rs` and `storage/repository.rs`. The workspace suite is what
gates that, and it is green apart from the flake above. All 39 hosted checks on
this pull request concluded, 35 SUCCESS and 4 SKIPPED, with zero failures.

Closes FIR-2518
