### PR TITLE
Say why a trace walk stopped, per hop, and stop reporting coverage as unreported on complete walks

### DIFF
--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -1241,7 +1241,15 @@ fn record_terminal_steps(response: &mut TraceDataFlowResponse) {
     response.terminal_bound_steps = count(TraceTerminal::BoundReached);
     response.terminal_coverage_gap_steps = count(TraceTerminal::CoverageGap);
 
-    // The flag follows the hops, and one rule decides which hops move it.
+    // The flag follows the hops, and ONE rule decides which hops move it.
+    //
+    // Deliberately read back off each terminal through
+    // [`TraceTerminal::truncates`] rather than off the counts above, even
+    // though the counts are right there. Two derivations of one fact is how
+    // they come to disagree: an earlier draft summed the counts here and
+    // consulted the shared rule only for the focal, so deleting the rule left
+    // every chain-side shortfall still reporting itself correctly and the
+    // guard could not fail.
     //
     // A bound the caller can raise and a graph that could not have held the
     // next hop are both cases where the chain may be shorter than the code, and
@@ -1249,14 +1257,16 @@ fn record_terminal_steps(response: &mut TraceDataFlowResponse) {
     // real walks on `psf/requests` stopped one caller short and reported
     // themselves complete. Never cleared here, because the walk's own ceilings
     // set it first and this pass must not overturn them.
-    let shortfall = response.terminal_bound_steps > 0
-        || response.terminal_coverage_gap_steps > 0
+    let shortfall = |name: Option<&str>| {
+        name.and_then(trace_terminal_named)
+            .is_some_and(TraceTerminal::truncates)
+    };
+    if shortfall(response.focal_terminal.as_deref())
         || response
-            .focal_terminal
-            .as_deref()
-            .and_then(trace_terminal_named)
-            .is_some_and(TraceTerminal::truncates);
-    if shortfall {
+            .chain
+            .iter()
+            .any(|step| shortfall(step.terminal.as_deref()))
+    {
         response.truncated = true;
     }
 }
@@ -2958,9 +2968,22 @@ mod tests {
             vec!["WikiLink".to_string(), "normalize_target".to_string()],
             "a field typed with a repo class flows into it, so the hop continues"
         );
-        assert!(response.chain.iter().all(|step| step.terminal.is_none()));
+        assert_eq!(
+            response.chain[0].terminal, None,
+            "the annotation gate opened, so the type is an ordinary step"
+        );
         assert_eq!(response.terminal_annotation_steps, 0);
         assert!(response.include_type_edges);
+        // The fixture's only call edge sits inside one file, so the walk cannot
+        // certify the hop past `normalize_target` as absent. Asserted rather
+        // than ignored: this is the FIR-2353 graph shape, and a walk that
+        // reported a leaf here would be making exactly the claim FIR-2542 is
+        // about.
+        assert_eq!(
+            response.chain[1].terminal.as_deref(),
+            Some("coverage_gap"),
+            "no cross-file call edge exists in this fixture, so an empty read proves nothing"
+        );
     }
 
     /// The CLI parses this payload from whatever daemon is already running, and

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -18,7 +18,9 @@
 use anyhow::{Context, Result};
 use kin_index::RelationResolution;
 use kin_model::{Entity, EntityId, EntityStore, GraphNodeId, RelationKind};
-use kin_ranking::entity_ranking::TraceTerminal;
+use kin_ranking::entity_ranking::{
+    trace_terminal_named, trace_walk_terminal, TraceExpansion, TraceTerminal,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
@@ -537,6 +539,45 @@ pub struct TraceDataFlowResponse {
     pub terminal_external_steps: usize,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub terminal_annotation_steps: usize,
+    /// Steps whose relations were read and held no admissible edge, split by
+    /// whether the graph could have held one.
+    ///
+    /// `terminal_leaf_steps` is the only count in this response that asserts a
+    /// branch ended because the code ends. `terminal_coverage_gap_steps` is the
+    /// same empty read on a language whose deciding coverage classes were not
+    /// observed present, so the walk cannot tell an absent hop from a graph
+    /// that never held one. `terminal_bound_steps` counts nodes whose relations
+    /// were never read at all, because the requested depth or a work budget
+    /// stopped the walk first.
+    ///
+    /// Kept apart rather than summed, and counted rather than left to a scan of
+    /// `chain`, because a caller acts differently on each: raise `depth` for a
+    /// bound, repair enrichment for a gap, and believe a leaf.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub terminal_leaf_steps: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub terminal_bound_steps: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub terminal_coverage_gap_steps: usize,
+    /// Why the walk stopped at the FOCAL itself, in the same vocabulary each
+    /// step's `terminal` uses, or null when the focal was expanded and had
+    /// neighbors.
+    ///
+    /// The focal is not a member of `chain`, so an empty chain otherwise
+    /// carries no statement at all about why it is empty, and an empty chain is
+    /// precisely the answer whose trust depends on that statement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub focal_terminal: Option<String>,
+    /// This walk's own cross-file edge-class observation for the focal's
+    /// language, in the shape every reference tool publishes it in.
+    ///
+    /// Published on every walk rather than only on an empty one. A chain built
+    /// over a graph holding no cross-file calls has stayed inside one file, and
+    /// a response that reported nothing about coverage made the envelope say
+    /// `edge_coverage_unreported` on complete walks and short ones alike, which
+    /// is a limit that distinguishes nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edge_coverage: Option<serde_json::Value>,
     /// The ceiling this response was measured against, echoed so a caller that
     /// wants more (or less) knows the name and the number to send.
     ///
@@ -737,6 +778,20 @@ pub fn build_trace_data_flow_response_within(
     let mut clipped_steps: Vec<TraceFanoutClip> = Vec::new();
     let mut truncated = false;
     let mut stop = TraceStop::Exhausted;
+    // What each node's expansion produced, keyed by step index (`0` is the
+    // focal). Recorded here because none of it survives into the chain: a step
+    // with no children looks the same whether its relations were read and held
+    // nothing or were never read at all, which is the whole defect.
+    //
+    // Only expanded nodes are inserted. Everything else is read as "never
+    // expanded" below, which covers both ways that happens: a step at the
+    // requested depth is never pushed onto the frontier, and a walk that hits a
+    // work ceiling abandons the frontier it had.
+    let mut expansion: HashMap<usize, TraceExpansion> = HashMap::new();
+    // Each step's language, so a coverage verdict is read for the node it is
+    // about rather than borrowed from the focal. A chain that crosses a
+    // language boundary crosses an extraction boundary with it.
+    let mut step_language: HashMap<usize, kin_model::ids::LanguageId> = HashMap::new();
 
     let mut frontier: Vec<FrontierNode> = vec![FrontierNode::rooted(&focal_entity)];
     let mut next_frontier: Vec<FrontierNode>;
@@ -779,6 +834,13 @@ pub fn build_trace_data_flow_response_within(
             // file and were in the graph the whole time.
             let mut candidates: Vec<FanoutCandidate> = Vec::new();
             let mut candidate_index: HashMap<(EntityId, &'static str), usize> = HashMap::new();
+            // Counted before the visited filter, and before the per-step cap.
+            // The question a terminal answers is whether the GRAPH held a next
+            // hop for this node, not whether this response admitted one: a node
+            // whose only neighbors are already in the chain has neighbors, and
+            // calling it a leaf would claim the code ends where the walk merely
+            // stopped repeating itself.
+            let mut admissible_neighbors = 0usize;
             for rel in &relations {
                 if let Some(reason) = meter.charge_edge() {
                     stop = reason;
@@ -809,6 +871,8 @@ pub fn build_trace_data_flow_response_within(
                 } else {
                     continue;
                 };
+
+                admissible_neighbors += 1;
 
                 // Already in the chain by another edge. Not a candidate, and not
                 // a drop either: the caller has the node, so counting it as
@@ -853,6 +917,17 @@ pub fn build_trace_data_flow_response_within(
                     }
                 }
             }
+
+            // This node's relations were read to the end, so what the graph
+            // held for it is now a fact rather than a guess.
+            expansion.insert(
+                node.step,
+                if admissible_neighbors > 0 {
+                    TraceExpansion::HadEdges
+                } else {
+                    TraceExpansion::NoEdges
+                },
+            );
 
             // Independent budgets per direction so `direction=both` doesn't
             // starve callers when callees are listed first (or vice versa).
@@ -935,6 +1010,10 @@ pub fn build_trace_data_flow_response_within(
                         .map(|terminal| terminal.as_str().to_string());
                         let promoted_terminal = promoted.terminal.is_some();
                         let promoted_depth = promoted.depth;
+                        // The record that replaced the placeholder brings its
+                        // own language, and the coverage verdict this step is
+                        // read against has to follow it.
+                        step_language.insert(existing, candidate.entity.language);
                         visited.insert(candidate.entity.id);
                         external_identities_merged += 1;
                         // The placeholder had no edges to walk; the record that
@@ -982,6 +1061,7 @@ pub fn build_trace_data_flow_response_within(
                     fanout_dropped: 0,
                     terminal: terminal.map(|terminal| terminal.as_str().to_string()),
                 });
+                step_language.insert(step_index, candidate.entity.language);
 
                 if terminal.is_none() && next_depth < depth {
                     next_frontier.push(FrontierNode::at(step_index, next_depth, &candidate.entity));
@@ -1032,13 +1112,110 @@ pub fn build_trace_data_flow_response_within(
         external_identities_merged,
         terminal_external_steps: 0,
         terminal_annotation_steps: 0,
+        terminal_leaf_steps: 0,
+        terminal_bound_steps: 0,
+        terminal_coverage_gap_steps: 0,
+        focal_terminal: None,
+        edge_coverage: None,
         max_response_chars: request.budget_chars(),
         degradations,
     };
+    // Before the budget, because it reads facts the walk recorded per node and
+    // the budget only ever removes steps. Counting them is what happens after.
+    classify_walk_terminals(
+        graph,
+        &focal_entity,
+        &reference_kinds,
+        &expansion,
+        &step_language,
+        &mut response,
+    );
     enforce_response_budget(&mut response);
     record_unproven_steps(&mut response);
     record_terminal_steps(&mut response);
     Ok(response)
+}
+
+/// Give every node the walk did not continue through a reason, and publish the
+/// coverage observation those reasons rest on.
+///
+/// Runs once, after the walk and before the response budget. The three states
+/// it decides between are the ticket this exists for: a walk that stopped
+/// because the code ends, one that stopped at a bound the caller can raise, and
+/// one that stopped on a graph that could not have held the next hop. Before
+/// this, all three arrived as a step with no children and `truncated: false`.
+fn classify_walk_terminals<S: EntityStore>(
+    store: &S,
+    focal: &Entity,
+    reference_kinds: &[RelationKind],
+    expansion: &HashMap<usize, TraceExpansion>,
+    step_language: &HashMap<usize, kin_model::ids::LanguageId>,
+    response: &mut TraceDataFlowResponse,
+) {
+    // The focal's own observation is the one the response publishes, matching
+    // what `find_references` publishes and what the envelope's absence gate
+    // reads. Per-step verdicts below may consult another language's, but the
+    // published object stays the focal's so one payload carries one scope.
+    let focal_observation =
+        kin_mcp::edge_coverage::observe_cross_file_reference_coverage(store, focal, reference_kinds);
+    let mut certain: HashMap<kin_model::ids::LanguageId, bool> = HashMap::new();
+    certain.insert(
+        focal.language,
+        kin_mcp::edge_coverage::deciding_classes_observed_present(&focal_observation),
+    );
+    response.edge_coverage = Some(focal_observation);
+
+    // A walk whose focal was never expanded, or was expanded and held nothing,
+    // is the answer whose trust depends most on saying which. The chain carries
+    // no row for the focal, so the statement has nowhere else to go.
+    let focal_expansion = expansion
+        .get(&0)
+        .copied()
+        .unwrap_or(TraceExpansion::BoundStopped);
+    let focal_certain = certain.get(&focal.language).copied().unwrap_or(false);
+    response.focal_terminal = trace_walk_terminal(focal_expansion, focal_certain)
+        .map(|terminal| terminal.as_str().to_string());
+
+    for index in 0..response.chain.len() {
+        // An external or annotation boundary was decided at the edge that
+        // reached the node and is a stronger statement than anything the
+        // expansion can add: there is nothing on the other side to walk.
+        if response.chain[index].terminal.is_some() {
+            continue;
+        }
+        let step_number = response.chain[index].step;
+        let outcome = expansion
+            .get(&step_number)
+            .copied()
+            .unwrap_or(TraceExpansion::BoundStopped);
+        // Only an empty read consults coverage, so a healthy chain pays one
+        // language scan for the focal and none for its steps.
+        let coverage_certain = if matches!(outcome, TraceExpansion::NoEdges) {
+            let language = step_language
+                .get(&step_number)
+                .copied()
+                .unwrap_or(focal.language);
+            match certain.get(&language) {
+                Some(&known) => known,
+                None => {
+                    let observation =
+                        kin_mcp::edge_coverage::observe_cross_file_reference_coverage_for_languages(
+                            store,
+                            &[language],
+                            reference_kinds,
+                        );
+                    let known =
+                        kin_mcp::edge_coverage::deciding_classes_observed_present(&observation);
+                    certain.insert(language, known);
+                    known
+                }
+            }
+        } else {
+            false
+        };
+        response.chain[index].terminal = trace_walk_terminal(outcome, coverage_certain)
+            .map(|terminal| terminal.as_str().to_string());
+    }
 }
 
 /// Count the leaves this walk refused to expand, from the chain the caller
@@ -1050,18 +1227,38 @@ pub fn build_trace_data_flow_response_within(
 /// describing steps the payload no longer carries. A placeholder promoted to a
 /// located record mid-walk has the same effect from the other direction.
 fn record_terminal_steps(response: &mut TraceDataFlowResponse) {
-    let external = TraceTerminal::ExternalReference.as_str();
-    let annotation = TraceTerminal::TypeAnnotation.as_str();
-    response.terminal_external_steps = response
-        .chain
-        .iter()
-        .filter(|step| step.terminal.as_deref() == Some(external))
-        .count();
-    response.terminal_annotation_steps = response
-        .chain
-        .iter()
-        .filter(|step| step.terminal.as_deref() == Some(annotation))
-        .count();
+    let count = |terminal: TraceTerminal| {
+        let name = terminal.as_str();
+        response
+            .chain
+            .iter()
+            .filter(|step| step.terminal.as_deref() == Some(name))
+            .count()
+    };
+    response.terminal_external_steps = count(TraceTerminal::ExternalReference);
+    response.terminal_annotation_steps = count(TraceTerminal::TypeAnnotation);
+    response.terminal_leaf_steps = count(TraceTerminal::Leaf);
+    response.terminal_bound_steps = count(TraceTerminal::BoundReached);
+    response.terminal_coverage_gap_steps = count(TraceTerminal::CoverageGap);
+
+    // The flag follows the hops, and one rule decides which hops move it.
+    //
+    // A bound the caller can raise and a graph that could not have held the
+    // next hop are both cases where the chain may be shorter than the code, and
+    // both used to arrive as `truncated: false`. That is the whole defect: two
+    // real walks on `psf/requests` stopped one caller short and reported
+    // themselves complete. Never cleared here, because the walk's own ceilings
+    // set it first and this pass must not overturn them.
+    let shortfall = response.terminal_bound_steps > 0
+        || response.terminal_coverage_gap_steps > 0
+        || response
+            .focal_terminal
+            .as_deref()
+            .and_then(trace_terminal_named)
+            .is_some_and(TraceTerminal::truncates);
+    if shortfall {
+        response.truncated = true;
+    }
 }
 
 /// Count the hops this response rests on that were matched by name alone, and
@@ -2266,6 +2463,11 @@ mod tests {
             external_identities_merged: 0,
             terminal_external_steps: 0,
             terminal_annotation_steps: 0,
+            terminal_leaf_steps: 0,
+            terminal_bound_steps: 0,
+            terminal_coverage_gap_steps: 0,
+            focal_terminal: None,
+            edge_coverage: None,
             max_response_chars: DEFAULT_MAX_RESPONSE_CHARS,
             degradations: Vec::new(),
         }
@@ -2790,44 +2992,247 @@ mod tests {
         );
     }
 
-    /// An ordinary chain must be untouched by both gates, or the fix would have
-    /// bought correctness with coverage.
+    /// An ordinary chain must be untouched by the external and annotation
+    /// gates, or the fix would have bought correctness with coverage.
     #[test]
-    fn an_ordinary_call_chain_reports_no_terminal_at_all() {
-        let graph = InMemoryGraph::new();
-        let focal = make_entity("send", "src/sessions.rs");
-        let focal_id = focal.id;
-        let inner = make_entity("resolve_redirects", "src/sessions.rs");
-        let inner_id = inner.id;
-        let leaf = make_entity("rebuild_method", "src/sessions.rs");
-        graph.upsert_entity(&focal).unwrap();
-        graph.upsert_entity(&inner).unwrap();
-        graph.upsert_entity(&leaf).unwrap();
-        graph
-            .upsert_relation(&make_relation(focal_id, inner_id, RelationKind::Calls))
-            .unwrap();
-        graph
-            .upsert_relation(&make_relation(inner_id, leaf.id, RelationKind::Calls))
-            .unwrap();
+    fn an_ordinary_call_chain_reports_no_boundary_terminal_at_all() {
+        let (graph, focal_id) = call_chain(&[
+            ("send", "src/sessions.rs"),
+            ("resolve_redirects", "src/adapters.rs"),
+            ("rebuild_method", "src/models.rs"),
+        ]);
 
         let mut request = trace_request(&focal_id, 3, TraceDirection::Calls, 8);
         request.include_body = Some(false);
         let response = traced(&graph, &request);
 
         assert_eq!(response.total_steps, 2);
-        assert!(response.chain.iter().all(|step| step.terminal.is_none()));
         assert_eq!(response.terminal_external_steps, 0);
         assert_eq!(response.terminal_annotation_steps, 0);
-        // Present as an explicit null on every step, never omitted: one array
+        // Present as an explicit key on every step, never omitted: one array
         // holding two key sets is the shape `every_step_carries_the_same_keys`
         // exists to bar.
         let json = serde_json::to_value(&response).unwrap();
         for step in json["chain"].as_array().unwrap() {
-            assert_eq!(
-                step["terminal"],
-                serde_json::Value::Null,
-                "an ordinary step reports a null terminal: {step}"
+            assert!(
+                step.as_object().unwrap().contains_key("terminal"),
+                "every step carries the key whatever its value: {step}"
             );
         }
+        // The middle of a chain is an ordinary step and says nothing.
+        assert_eq!(response.chain[0].terminal, None);
+    }
+
+    /// Three entities in the given files, each calling the next, and the id of
+    /// the first. The files decide whether the graph holds cross-file call
+    /// edges, which is the fact a leaf terminal rests on.
+    fn call_chain(nodes: &[(&str, &str)]) -> (InMemoryGraph, EntityId) {
+        let graph = InMemoryGraph::new();
+        let entities: Vec<Entity> = nodes
+            .iter()
+            .map(|(name, file)| make_entity(name, file))
+            .collect();
+        for entity in &entities {
+            graph.upsert_entity(entity).unwrap();
+        }
+        for pair in entities.windows(2) {
+            graph
+                .upsert_relation(&make_relation(pair[0].id, pair[1].id, RelationKind::Calls))
+                .unwrap();
+        }
+        (graph, entities[0].id)
+    }
+
+    fn terminals(response: &TraceDataFlowResponse) -> Vec<Option<&str>> {
+        response
+            .chain
+            .iter()
+            .map(|step| step.terminal.as_deref())
+            .collect()
+    }
+
+    /// The positive control for the whole ticket. A chain that ran out of code
+    /// on a graph that links calls across files says so, and says it without
+    /// claiming a shortfall.
+    #[test]
+    fn a_chain_that_ran_out_of_code_reports_a_leaf_and_no_shortfall() {
+        let (graph, focal_id) = call_chain(&[
+            ("cert_verify", "src/adapters.py"),
+            ("send", "src/sessions.py"),
+            ("request", "src/api.py"),
+        ]);
+        let mut request = trace_request(&focal_id, 5, TraceDirection::Calls, 15);
+        request.include_body = Some(false);
+        let response = traced(&graph, &request);
+
+        assert_eq!(response.total_steps, 2, "the fixture must produce a chain");
+        assert_eq!(
+            terminals(&response),
+            vec![None, Some("leaf")],
+            "only the last hop ended, and it ended because the code ends"
+        );
+        assert_eq!(response.terminal_leaf_steps, 1);
+        assert_eq!(response.terminal_bound_steps, 0);
+        assert_eq!(response.terminal_coverage_gap_steps, 0);
+        assert!(
+            !response.truncated,
+            "a walk that reached the end of the code received the whole chain"
+        );
+        assert_eq!(
+            response.focal_terminal, None,
+            "the focal had a neighbor, so it is not an end of any kind"
+        );
+        // The observation the leaf rests on travels with the answer, so the
+        // envelope's absence gate reads a measured class instead of reporting
+        // that nothing was measured.
+        let coverage = response
+            .edge_coverage
+            .as_ref()
+            .expect("a walk must publish the coverage its terminals rest on");
+        assert_eq!(
+            coverage["classes"]["calls"],
+            serde_json::json!("present"),
+            "the fixture links calls across files: {coverage}"
+        );
+    }
+
+    /// The defect's own shape, in the smallest graph that has it: every call
+    /// edge sits inside one file, so an empty read cannot be told apart from a
+    /// graph that could never have held the next hop.
+    #[test]
+    fn a_chain_that_stopped_on_an_unlinked_graph_reports_a_coverage_gap() {
+        let (graph, focal_id) = call_chain(&[
+            ("cert_verify", "src/one.py"),
+            ("send", "src/one.py"),
+            ("request", "src/one.py"),
+        ]);
+        let mut request = trace_request(&focal_id, 5, TraceDirection::Calls, 15);
+        request.include_body = Some(false);
+        let response = traced(&graph, &request);
+
+        assert_eq!(response.total_steps, 2, "the fixture must produce a chain");
+        assert_eq!(
+            terminals(&response),
+            vec![None, Some("coverage_gap")],
+            "the walk cannot know whether this hop was the last one"
+        );
+        assert_eq!(response.terminal_coverage_gap_steps, 1);
+        assert_eq!(response.terminal_leaf_steps, 0);
+        assert!(
+            response.truncated,
+            "an answer the graph could not have completed is not a complete answer"
+        );
+        let coverage = response.edge_coverage.as_ref().expect("published");
+        assert_eq!(
+            coverage["classes"]["calls"],
+            serde_json::json!("absent"),
+            "the fixture holds no cross-file call edge: {coverage}"
+        );
+    }
+
+    /// The third state. A node whose relations were never read is not a leaf on
+    /// any graph, however well linked, and the caller has a number to raise.
+    #[test]
+    fn a_chain_cut_by_the_depth_bound_reports_a_bound_and_not_a_leaf() {
+        let (graph, focal_id) = call_chain(&[
+            ("cert_verify", "src/adapters.py"),
+            ("send", "src/sessions.py"),
+            ("request", "src/api.py"),
+        ]);
+        let mut request = trace_request(&focal_id, 2, TraceDirection::Calls, 15);
+        request.include_body = Some(false);
+        let response = traced(&graph, &request);
+
+        assert_eq!(response.total_steps, 2, "the fixture must produce a chain");
+        assert_eq!(
+            terminals(&response),
+            vec![None, Some("bound_reached")],
+            "the last hop sits at the requested depth and was never expanded"
+        );
+        assert_eq!(response.terminal_bound_steps, 1);
+        assert_eq!(response.terminal_leaf_steps, 0);
+        assert_eq!(response.terminal_coverage_gap_steps, 0);
+        assert!(
+            response.truncated,
+            "a chain the caller can lengthen by raising depth is truncated"
+        );
+        // Same graph, same focal, one more level of depth: the identical last
+        // entity now reads as an end rather than as a cut. Without this the
+        // bound arm could be passing because the fixture has no third hop.
+        let mut deeper = trace_request(&focal_id, 5, TraceDirection::Calls, 15);
+        deeper.include_body = Some(false);
+        let opened = traced(&graph, &deeper);
+        assert_eq!(terminals(&opened), vec![None, Some("leaf")]);
+        assert!(!opened.truncated);
+    }
+
+    /// An empty chain is the answer whose trust depends most on why it is
+    /// empty, and the focal has no row in `chain` to say so on.
+    #[test]
+    fn an_empty_chain_says_why_it_is_empty() {
+        // A lone entity on a graph that links nothing: nothing was found, and
+        // nothing could have been.
+        let (unlinked, alone) = call_chain(&[("cert_verify", "src/one.py")]);
+        let mut request = trace_request(&alone, 3, TraceDirection::Calls, 15);
+        request.include_body = Some(false);
+        let blind = traced(&unlinked, &request);
+        assert_eq!(blind.total_steps, 0);
+        assert_eq!(blind.focal_terminal.as_deref(), Some("coverage_gap"));
+        assert!(
+            blind.truncated,
+            "an empty chain on a graph holding no cross-file calls is not a proven absence"
+        );
+
+        // The same empty answer on a graph that demonstrably links calls across
+        // files. Now the emptiness is a fact about the code.
+        let (linked, _) = call_chain(&[("send", "src/a.py"), ("request", "src/b.py")]);
+        let lone = make_entity("cert_verify", "src/c.py");
+        linked.upsert_entity(&lone).unwrap();
+        let mut request = trace_request(&lone.id, 3, TraceDirection::Calls, 15);
+        request.include_body = Some(false);
+        let certain = traced(&linked, &request);
+        assert_eq!(certain.total_steps, 0);
+        assert_eq!(
+            certain.focal_terminal.as_deref(),
+            Some("leaf"),
+            "the same empty chain, on a graph that can tell empty from blind"
+        );
+        assert!(!certain.truncated);
+    }
+
+    /// A node whose only neighbors are already in the chain has neighbors. A
+    /// counter placed after the visited filter would call it a leaf and claim
+    /// the code ends where the walk merely stopped repeating itself.
+    #[test]
+    fn a_cycle_back_into_the_chain_is_not_a_leaf() {
+        let (graph, focal_id) = call_chain(&[
+            ("send", "src/sessions.py"),
+            ("resolve_redirects", "src/adapters.py"),
+        ]);
+        graph
+            .upsert_relation(&make_relation(
+                graph
+                    .query_entities(&kin_model::graph::EntityFilter::default())
+                    .unwrap()
+                    .iter()
+                    .find(|entity| entity.name == "resolve_redirects")
+                    .unwrap()
+                    .id,
+                focal_id,
+                RelationKind::Calls,
+            ))
+            .unwrap();
+
+        let mut request = trace_request(&focal_id, 5, TraceDirection::Calls, 15);
+        request.include_body = Some(false);
+        let response = traced(&graph, &request);
+
+        assert_eq!(response.total_steps, 1);
+        assert_eq!(
+            terminals(&response),
+            vec![None],
+            "its one neighbor is the focal, which the response already carries"
+        );
+        assert!(!response.truncated);
     }
 }

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -1156,8 +1156,11 @@ fn classify_walk_terminals<S: EntityStore>(
     // what `find_references` publishes and what the envelope's absence gate
     // reads. Per-step verdicts below may consult another language's, but the
     // published object stays the focal's so one payload carries one scope.
-    let focal_observation =
-        kin_mcp::edge_coverage::observe_cross_file_reference_coverage(store, focal, reference_kinds);
+    let focal_observation = kin_mcp::edge_coverage::observe_cross_file_reference_coverage(
+        store,
+        focal,
+        reference_kinds,
+    );
     let mut certain: HashMap<kin_model::ids::LanguageId, bool> = HashMap::new();
     certain.insert(
         focal.language,

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -1179,14 +1179,14 @@ fn classify_walk_terminals<S: EntityStore>(
     response.focal_terminal = trace_walk_terminal(focal_expansion, focal_certain)
         .map(|terminal| terminal.as_str().to_string());
 
-    for index in 0..response.chain.len() {
+    for step in response.chain.iter_mut() {
         // An external or annotation boundary was decided at the edge that
         // reached the node and is a stronger statement than anything the
         // expansion can add: there is nothing on the other side to walk.
-        if response.chain[index].terminal.is_some() {
+        if step.terminal.is_some() {
             continue;
         }
-        let step_number = response.chain[index].step;
+        let step_number = step.step;
         let outcome = expansion
             .get(&step_number)
             .copied()
@@ -1216,7 +1216,7 @@ fn classify_walk_terminals<S: EntityStore>(
         } else {
             false
         };
-        response.chain[index].terminal = trace_walk_terminal(outcome, coverage_certain)
+        step.terminal = trace_walk_terminal(outcome, coverage_certain)
             .map(|terminal| terminal.as_str().to_string());
     }
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -30203,10 +30203,32 @@ mod tests {
         );
         assert_eq!(cut["bodies_included"], json!(false));
         assert!(cut["bodies_omitted"].as_u64().unwrap_or(0) > 0);
+        // Compared against the UNBOUNDED run rather than against a literal
+        // `false`. This fixture walks six hops at `depth: 5`, so its last hop
+        // sits at the requested depth and was never expanded, which the walk
+        // now reports as `terminal: "bound_reached"` and counts in
+        // `truncated`. Asserting `false` here would assert that a depth bound
+        // goes unreported, which is the FIR-2542 defect wearing this test's
+        // name. What this test is about is narrower and still holds: dropping
+        // bodies must not move the flag in either direction.
         assert_eq!(
-            cut["truncated"],
-            json!(false),
-            "a chain that lost only bodies is not a truncated chain"
+            full["terminal_bound_steps"],
+            json!(1),
+            "the fixture must end at its depth bound, or the comparisons below hold for the \
+             uninteresting reason that both runs report nothing"
+        );
+        assert_eq!(
+            cut["truncated"], full["truncated"],
+            "a chain that lost only bodies is truncated exactly as much as it was before"
+        );
+        assert_eq!(
+            cut["steps_omitted"].as_u64().unwrap_or(0),
+            0,
+            "no edge was dropped, so nothing about the chain's own length changed"
+        );
+        assert_eq!(
+            cut["terminal_bound_steps"], full["terminal_bound_steps"],
+            "the depth bound is what this chain's truncation reports, and the budget did not touch it"
         );
         let disclosure = cut["degradations"]
             .as_array()

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -1325,7 +1325,11 @@ mod tests {
         let linked = observe_cross_file_reference_coverage(
             &store,
             &caller,
-            &[RelationKind::Calls, RelationKind::Imports, RelationKind::References],
+            &[
+                RelationKind::Calls,
+                RelationKind::Imports,
+                RelationKind::References,
+            ],
         );
         assert_eq!(linked["classes"]["calls"], json!("present"));
         assert_eq!(
@@ -1344,7 +1348,11 @@ mod tests {
         let empty = observe_cross_file_reference_coverage(
             &unlinked,
             &lone,
-            &[RelationKind::Calls, RelationKind::Imports, RelationKind::References],
+            &[
+                RelationKind::Calls,
+                RelationKind::Imports,
+                RelationKind::References,
+            ],
         );
         assert_eq!(empty["classes"]["calls"], json!("absent"));
         assert!(

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -430,6 +430,51 @@ pub fn languages_of(entities: &[Entity]) -> Vec<LanguageId> {
 /// of its own: Kin mints no entity-level `Imports` edge, so a rule that waited
 /// for every requested class would never skip a scan and would report every
 /// answer on every healthy graph as short of coverage.
+/// [`deciding_classes_all_present`], asked of a PUBLISHED observation.
+///
+/// The private form above reads the scan's own working state and decides
+/// whether a scan is still needed. This form reads the object that scan
+/// published, so a producer that has to state a per-hop fact ("is this empty
+/// read a leaf, or a graph that could not have held the hop") reaches the same
+/// verdict [`crate::negative::absence_coverage_gap`] will reach over the same
+/// payload. Two rules for one question is exactly how a chain came to say
+/// `truncated: false` beside an envelope saying coverage was never reported.
+///
+/// A missing or malformed observation is `false`: unmeasured coverage is the
+/// unknown case, not the healthy one, which is the reading the whole module
+/// already takes.
+pub fn deciding_classes_observed_present(observation: &Value) -> bool {
+    let Some(observation) = observation.as_object() else {
+        return false;
+    };
+    let requested: Vec<String> = observation
+        .get("requested_classes")
+        .and_then(Value::as_array)
+        .map(|classes| {
+            classes
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let references_producible = observation
+        .get("reference_enrichment")
+        .and_then(Value::as_str)
+        == Some("available");
+    let deciding = crate::negative::deciding_classes(&requested, references_producible);
+    if deciding.is_empty() {
+        return false;
+    }
+    let states = observation.get("classes").and_then(Value::as_object);
+    deciding.iter().all(|class| {
+        states
+            .and_then(|states| states.get(class.as_str()))
+            .and_then(Value::as_str)
+            == Some("present")
+    })
+}
+
 fn deciding_classes_all_present(
     merged: &[(RelationKind, ClassState)],
     references_producible: bool,
@@ -1261,5 +1306,74 @@ mod tests {
         let coverage =
             observe_cross_file_reference_coverage(&store, &first, &[RelationKind::Calls]);
         assert_eq!(coverage["classes"]["calls"], json!("absent"));
+    }
+
+    /// The published form and the private form must reach the same verdict over
+    /// the same store, or a per-hop terminal and the response-level gate can
+    /// disagree inside one payload.
+    #[test]
+    fn the_published_verdict_matches_the_scan_that_produced_it() {
+        let store = InMemoryGraph::new();
+        let caller = entity("outer", "nk/a.py", LanguageId::Python);
+        let callee = entity("inner", "nk/b.py", LanguageId::Python);
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&callee).unwrap();
+        store
+            .upsert_relation(&relation(caller.id, callee.id, RelationKind::Calls))
+            .unwrap();
+
+        let linked = observe_cross_file_reference_coverage(
+            &store,
+            &caller,
+            &[RelationKind::Calls, RelationKind::Imports, RelationKind::References],
+        );
+        assert_eq!(linked["classes"]["calls"], json!("present"));
+        assert_eq!(
+            linked["classes"]["imports"],
+            json!("absent"),
+            "the fixture holds no import edge, and the deciding rule must not need one"
+        );
+        assert!(
+            deciding_classes_observed_present(&linked),
+            "cross-file calls decide a trace absence: {linked}"
+        );
+
+        let unlinked = InMemoryGraph::new();
+        let lone = entity("outer", "nk/a.py", LanguageId::Python);
+        unlinked.upsert_entity(&lone).unwrap();
+        let empty = observe_cross_file_reference_coverage(
+            &unlinked,
+            &lone,
+            &[RelationKind::Calls, RelationKind::Imports, RelationKind::References],
+        );
+        assert_eq!(empty["classes"]["calls"], json!("absent"));
+        assert!(
+            !deciding_classes_observed_present(&empty),
+            "a graph with no cross-file calls cannot certify that a hop is absent: {empty}"
+        );
+    }
+
+    /// An unmeasured observation is the unknown case. A producer that read a
+    /// missing object as healthy would publish exactly the confident terminal
+    /// this gate exists to withhold.
+    #[test]
+    fn an_unreported_observation_never_certifies() {
+        assert!(!deciding_classes_observed_present(&Value::Null));
+        assert!(!deciding_classes_observed_present(&json!({})));
+        assert!(!deciding_classes_observed_present(&json!({
+            "requested_classes": ["calls"],
+        })));
+        assert!(!deciding_classes_observed_present(&json!({
+            "requested_classes": [],
+            "classes": {},
+        })));
+        assert!(!deciding_classes_observed_present(&json!({
+            "requested_classes": ["calls"],
+            "classes": {"calls": "unknown"},
+        })));
+        assert!(deciding_classes_observed_present(&json!({
+            "requested_classes": ["calls"],
+            "classes": {"calls": "present"},
+        })));
     }
 }

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -399,7 +399,7 @@ pub fn is_trace_function(entity: &Entity) -> bool {
 
 pub use kin_ranking::entity_ranking::{
     trace_callee_score, trace_entity_is_external, trace_fanout_score, trace_relation_rank,
-    trace_step_terminal, TraceTerminal,
+    trace_step_terminal, trace_terminal_named, trace_walk_terminal, TraceExpansion, TraceTerminal,
 };
 
 /// Serialized characters one trace response may occupy before the tool cuts its

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3847,14 +3847,14 @@ pub fn handle_trace_data_flow<G: GraphStore>(
             .copied()
             .unwrap_or(false),
     );
-    for index in 0..chain.len() {
+    for step in chain.iter_mut() {
         // An external or annotation boundary was decided at the edge that
         // reached the node and is the stronger statement: there is nothing on
         // the other side to walk.
-        if chain[index]["terminal"].as_str().is_some() {
+        if step["terminal"].as_str().is_some() {
             continue;
         }
-        let step_number = chain[index]["step"].as_u64().unwrap_or(0) as usize;
+        let step_number = step["step"].as_u64().unwrap_or(0) as usize;
         let outcome = expansion
             .get(&step_number)
             .copied()
@@ -3884,7 +3884,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
         } else {
             false
         };
-        chain[index]["terminal"] = match trace_walk_terminal(outcome, coverage_certain) {
+        step["terminal"] = match trace_walk_terminal(outcome, coverage_certain) {
             Some(terminal) => serde_json::Value::from(terminal.as_str()),
             None => serde_json::Value::Null,
         };

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3556,6 +3556,15 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     let mut external_identities_merged = 0usize;
     let mut clipped_steps: Vec<serde_json::Value> = Vec::new();
     let mut truncated = false;
+    // What each node's expansion produced, keyed by step index (`0` is the
+    // focal), and each step's language. Neither survives into the chain: a step
+    // with no children looks the same whether its relations were read and held
+    // nothing or were never read at all, and a coverage verdict borrowed from
+    // the focal would cross an extraction boundary the chain crossed.
+    let mut expansion: std::collections::HashMap<usize, TraceExpansion> =
+        std::collections::HashMap::new();
+    let mut step_language: std::collections::HashMap<usize, kin_model::ids::LanguageId> =
+        std::collections::HashMap::new();
 
     // Frontier: (step, entity, depth, file, dir) — the expanded node's own
     // location travels with it, because relevance is scored against the node
@@ -3579,6 +3588,10 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                 (kin_model::ids::EntityId, &'static str),
                 usize,
             > = std::collections::HashMap::new();
+            // Counted before the visited filter and before the per-step cap: a
+            // terminal answers whether the GRAPH held a next hop, not whether
+            // this response admitted one.
+            let mut admissible_neighbors = 0usize;
             for rel in &relations {
                 if !allowed.contains(&rel.kind) {
                     continue;
@@ -3603,6 +3616,8 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                 } else {
                     continue;
                 };
+
+                admissible_neighbors += 1;
 
                 // Already in the chain by another edge: not a candidate, and not
                 // a drop either.
@@ -3639,6 +3654,17 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                     }
                 }
             }
+
+            // This node's relations were read to the end, so what the graph held
+            // for it is now a fact rather than a guess.
+            expansion.insert(
+                node.step,
+                if admissible_neighbors > 0 {
+                    TraceExpansion::HadEdges
+                } else {
+                    TraceExpansion::NoEdges
+                },
+            );
 
             // Independent per-direction budgets so `direction=both` doesn't
             // starve one side when relations are emitted in either order.
@@ -3720,6 +3746,10 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                             promoted_terminal,
                         );
                         chain[existing - 1] = promoted;
+                        // The record that replaced the placeholder brings its
+                        // own language, and the coverage verdict this step is
+                        // read against has to follow it.
+                        step_language.insert(existing, candidate.entity.language);
                         visited.insert(candidate.entity.id);
                         external_identities_merged += 1;
                         if promoted_terminal.is_none() && promoted_depth < depth {
@@ -3757,6 +3787,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                     &candidate.entity,
                     terminal,
                 ));
+                step_language.insert(step_index, candidate.entity.language);
                 if terminal.is_none() && next_depth < depth {
                     next_frontier.push(TraceFrontierNode::at(
                         step_index,
@@ -3794,6 +3825,85 @@ pub fn handle_trace_data_flow<G: GraphStore>(
         &focal_entity,
         &reference_kinds,
     );
+
+    // Give every node the walk did not continue through a reason, in the same
+    // vocabulary and by the same rule the daemon arm uses. A step with no
+    // children arrived here indistinguishable from three different endings: the
+    // code ends, a bound stopped the walk, or the graph could not have held the
+    // next hop. Only the first is a complete answer.
+    let mut certain: std::collections::HashMap<kin_model::ids::LanguageId, bool> =
+        std::collections::HashMap::new();
+    certain.insert(
+        focal_entity.language,
+        crate::edge_coverage::deciding_classes_observed_present(&edge_coverage),
+    );
+    let focal_terminal = trace_walk_terminal(
+        expansion
+            .get(&0)
+            .copied()
+            .unwrap_or(TraceExpansion::BoundStopped),
+        certain
+            .get(&focal_entity.language)
+            .copied()
+            .unwrap_or(false),
+    );
+    for index in 0..chain.len() {
+        // An external or annotation boundary was decided at the edge that
+        // reached the node and is the stronger statement: there is nothing on
+        // the other side to walk.
+        if chain[index]["terminal"].as_str().is_some() {
+            continue;
+        }
+        let step_number = chain[index]["step"].as_u64().unwrap_or(0) as usize;
+        let outcome = expansion
+            .get(&step_number)
+            .copied()
+            .unwrap_or(TraceExpansion::BoundStopped);
+        // Only an empty read consults coverage, so a healthy chain pays one
+        // language scan for the focal and none for its steps.
+        let coverage_certain = if matches!(outcome, TraceExpansion::NoEdges) {
+            let language = step_language
+                .get(&step_number)
+                .copied()
+                .unwrap_or(focal_entity.language);
+            match certain.get(&language) {
+                Some(&known) => known,
+                None => {
+                    let observation =
+                        crate::edge_coverage::observe_cross_file_reference_coverage_for_languages(
+                            store,
+                            &[language],
+                            &reference_kinds,
+                        );
+                    let known =
+                        crate::edge_coverage::deciding_classes_observed_present(&observation);
+                    certain.insert(language, known);
+                    known
+                }
+            }
+        } else {
+            false
+        };
+        chain[index]["terminal"] = match trace_walk_terminal(outcome, coverage_certain) {
+            Some(terminal) => serde_json::Value::from(terminal.as_str()),
+            None => serde_json::Value::Null,
+        };
+    }
+    // A bound the caller can raise and a graph that could not have held the next
+    // hop both mean the chain may be shorter than the code, which is what this
+    // flag has always meant. Never cleared here: the walk's own ceilings set it
+    // first and this pass must not overturn them.
+    if focal_terminal.is_some_and(TraceTerminal::truncates)
+        || chain.iter().any(|step| {
+            step["terminal"]
+                .as_str()
+                .and_then(trace_terminal_named)
+                .is_some_and(TraceTerminal::truncates)
+        })
+    {
+        truncated = true;
+    }
+
     let mut result = serde_json::json!({
         "focal_id": focal_entity.id.to_string(),
         "focal_name": focal_entity.name.clone(),
@@ -3852,13 +3962,32 @@ pub fn handle_trace_data_flow<G: GraphStore>(
             })
             .unwrap_or(0)
     };
-    let terminal_external_steps = terminal_count(TraceTerminal::ExternalReference);
-    let terminal_annotation_steps = terminal_count(TraceTerminal::TypeAnnotation);
-    if terminal_external_steps > 0 {
-        result["terminal_external_steps"] = serde_json::Value::from(terminal_external_steps);
+    // Every count is taken before the first write, because the counter reads
+    // `result` and a write would end its borrow of it.
+    //
+    // The three walk terminals are counted the same way and kept apart for the
+    // same reason the two boundary ones are: a caller raises `depth` for a
+    // bound, repairs enrichment for a gap, and believes a leaf.
+    let counted: Vec<(&str, usize)> = [
+        ("terminal_external_steps", TraceTerminal::ExternalReference),
+        ("terminal_annotation_steps", TraceTerminal::TypeAnnotation),
+        ("terminal_leaf_steps", TraceTerminal::Leaf),
+        ("terminal_bound_steps", TraceTerminal::BoundReached),
+        ("terminal_coverage_gap_steps", TraceTerminal::CoverageGap),
+    ]
+    .into_iter()
+    .map(|(key, class)| (key, terminal_count(class)))
+    .collect();
+    for (key, total) in counted {
+        if total > 0 {
+            result[key] = serde_json::Value::from(total);
+        }
     }
-    if terminal_annotation_steps > 0 {
-        result["terminal_annotation_steps"] = serde_json::Value::from(terminal_annotation_steps);
+    // The chain carries no row for the focal, so an empty chain has nowhere
+    // else to say why it is empty, and an empty chain is the answer whose trust
+    // depends on that most.
+    if let Some(focal_terminal) = focal_terminal {
+        result["focal_terminal"] = serde_json::Value::from(focal_terminal.as_str());
     }
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3233,7 +3233,21 @@ with the same class share no data; pass include_type_edges=true to walk through 
 the type is one this repository defines, which is a real flow for a field or a return. \
 `terminal_external_steps` and `terminal_annotation_steps` count them, kept apart because only \
 the second is recoverable by a parameter. Neither sets `truncated`: a boundary means the chain \
-ends there, not that you received less of one that exists.";
+ends there, not that you received less of one that exists. \
+Every other node the walk did not continue through also says why, in the same field. \
+`terminal: \"leaf\"` means the walk read that node's relations, the graph held no further \
+edge of the walked classes, and the coverage classes the answer rests on were observed \
+present, so the chain ends there. `terminal: \"bound_reached\"` means the node's relations \
+were never read, because the requested depth or a work budget stopped the walk first; raise \
+`depth` to open it. `terminal: \"coverage_gap\"` means the read was empty on a language whose \
+deciding coverage classes were absent or unmeasured, so the walk cannot tell a missing hop \
+from a graph that never held one; `edge_coverage` on the response names the classes and \
+`_kin.completeness` carries the same reading. The last two DO set `truncated`, and \
+`terminal_leaf_steps`, `terminal_bound_steps` and `terminal_coverage_gap_steps` count them. \
+`focal_terminal` says the same thing about the focal, which has no row in `chain`, so an \
+empty chain still states why it is empty. Read `truncated: false` as a claim only when no \
+step carries one of those two: it now means the walk received every hop the graph could \
+offer, rather than only that no cap fired.";
 
 /// One node of a trace walk, carrying the file and directory its fan-out is
 /// scored against.

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -5229,4 +5229,59 @@ mod tests {
         assert!(!query_names_a_symbol("graph-native repo substrate"));
         assert!(!query_names_a_symbol(""));
     }
+
+    /// FIR-2542's second half. `edge_coverage_unreported` reached every
+    /// `trace_data_flow` response, complete ones included, because the daemon
+    /// route published no observation at all. A limit that is always set
+    /// distinguishes nothing, so the fix is the walk publishing what it
+    /// measured; this asserts the gate reacts to that and still refuses when
+    /// the measurement says the graph could not have answered.
+    #[test]
+    fn a_trace_that_publishes_its_coverage_stops_reporting_it_as_unreported() {
+        let chain = json!({
+            "chain": [{"step": 1, "terminal": "leaf"}],
+            "total_steps": 1,
+            "truncated": false,
+        });
+
+        // Before: no observation, so every walk carried the same limit.
+        let unreported =
+            absence_coverage_gap("trace_data_flow", &chain).expect("an unmeasured walk is unknown");
+        assert!(
+            unreported.starts_with("edge_coverage_unreported"),
+            "{unreported}"
+        );
+        assert!(edge_coverage_degradation_labels("trace_data_flow", &chain)
+            .contains(&"edge_coverage:unreported".to_string()));
+
+        // After: the walk publishes what it measured, and a graph that links
+        // calls across files leaves the gate with nothing to say.
+        let mut measured = chain.clone();
+        measured["edge_coverage"] = json!({
+            "scope": "language",
+            "language": "Python",
+            "requested_classes": ["calls", "imports", "references"],
+            "classes": {"calls": "present", "imports": "absent", "references": "absent"},
+            "reference_enrichment": "unknown",
+            "budget_exhausted": false,
+        });
+        assert_eq!(
+            absence_coverage_gap("trace_data_flow", &measured),
+            None,
+            "a complete walk over a linked graph must carry no coverage limit"
+        );
+        let labels = edge_coverage_degradation_labels("trace_data_flow", &measured);
+        assert!(
+            !labels.contains(&"edge_coverage:unreported".to_string()),
+            "the limit that distinguished nothing must be gone: {labels:?}"
+        );
+
+        // And the gate still fires on the graph shape it exists for, so the fix
+        // is not simply a way of never reporting a gap.
+        let mut unlinked = measured.clone();
+        unlinked["edge_coverage"]["classes"]["calls"] = json!("absent");
+        let gap = absence_coverage_gap("trace_data_flow", &unlinked)
+            .expect("a graph holding no cross-file calls cannot complete a call chain");
+        assert!(gap.starts_with("cross_file_edges_absent"), "{gap}");
+    }
 }

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -275,9 +275,12 @@ pub fn trace_relation_is_annotation(kind: RelationKind) -> bool {
 
 /// Why a trace walk reported a node as a leaf instead of expanding it.
 ///
-/// A terminal is not a truncation. Both of these are boundaries of what a
-/// data-flow answer means, so neither says the caller received less of the
-/// chain than exists; they say the chain ends there.
+/// Three of these are boundaries of what a data-flow answer means and say the
+/// chain ends there. Two are shortfalls and say the walk stopped before the
+/// chain did. [`TraceTerminal::truncates`] is the one place that distinction is
+/// decided, because a response reporting the same flag for both is the defect
+/// this enum grew to fix: a walk that stopped for lack of an edge read as a
+/// walk that ran out of code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TraceTerminal {
     /// The repository defines nothing for this symbol, so there is no next hop
@@ -291,6 +294,21 @@ pub enum TraceTerminal {
     /// class share nothing, so traversing the annotation makes every widely
     /// used type name a hub joining everything to everything.
     TypeAnnotation,
+    /// The walk read this node's relations and the graph held no admissible
+    /// edge of the walked classes, on a language whose deciding classes are
+    /// observed present. This is the only terminal that asserts the chain ends
+    /// here, and it earns that by resting on a coverage observation rather than
+    /// on the empty read alone.
+    Leaf,
+    /// The walk never read this node's relations, because the requested depth
+    /// or a work budget stopped it first. Whatever edges the node holds were
+    /// not examined, so the branch below it is unknown rather than absent.
+    BoundReached,
+    /// The walk read this node's relations and found no admissible edge, on a
+    /// language whose deciding coverage classes are absent or unmeasured. An
+    /// empty read on such a graph cannot be told apart from a graph that could
+    /// not have held the next hop in the first place.
+    CoverageGap,
 }
 
 impl TraceTerminal {
@@ -298,7 +316,88 @@ impl TraceTerminal {
         match self {
             TraceTerminal::ExternalReference => "external_reference",
             TraceTerminal::TypeAnnotation => "type_annotation",
+            TraceTerminal::Leaf => "leaf",
+            TraceTerminal::BoundReached => "bound_reached",
+            TraceTerminal::CoverageGap => "coverage_gap",
         }
+    }
+
+    /// Whether a response carrying this terminal received less chain than
+    /// exists, or may have.
+    ///
+    /// The two boundary terminals are complete answers: a symbol this
+    /// repository does not define has no next hop, and an annotation edge the
+    /// caller declined to walk is a hop they asked not to take. `Leaf` is
+    /// complete for the same reason and says so on evidence. The other two are
+    /// not: one stopped at a bound the caller can raise, and one stopped on a
+    /// graph that could not have answered. Reporting either as complete is what
+    /// let two short chains read as whole ones.
+    pub fn truncates(self) -> bool {
+        match self {
+            TraceTerminal::ExternalReference | TraceTerminal::TypeAnnotation | TraceTerminal::Leaf => {
+                false
+            }
+            TraceTerminal::BoundReached | TraceTerminal::CoverageGap => true,
+        }
+    }
+}
+
+/// The terminal a published wire name stands for, or `None` for a name this
+/// build does not know.
+///
+/// Two payload builders read terminals back off a serialized chain, and a name
+/// neither of them recognizes must not be guessed at: a response written by a
+/// build this one has never seen is not evidence of a shortfall.
+pub fn trace_terminal_named(name: &str) -> Option<TraceTerminal> {
+    [
+        TraceTerminal::ExternalReference,
+        TraceTerminal::TypeAnnotation,
+        TraceTerminal::Leaf,
+        TraceTerminal::BoundReached,
+        TraceTerminal::CoverageGap,
+    ]
+    .into_iter()
+    .find(|terminal| terminal.as_str() == name)
+}
+
+/// What a walk's attempt to expand one node actually produced.
+///
+/// Recorded by the walk at the node, because none of it is recoverable from the
+/// finished chain: a node with no children in the payload looks identical
+/// whether its relations were read and held nothing, or were never read at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceExpansion {
+    /// The node's relations were never read: the requested depth was already
+    /// reached, or a work budget ended the walk before this node's turn.
+    BoundStopped,
+    /// The node's relations were read and held no admissible edge of the walked
+    /// classes in the walked direction.
+    NoEdges,
+    /// The node's relations were read and held at least one admissible edge,
+    /// whether or not the per-step cap kept it.
+    HadEdges,
+}
+
+/// Classify a node the walk did not continue through.
+///
+/// `coverage_certain` is the answer's own edge-coverage observation for THIS
+/// node's language, reduced to the one question a terminal rests on: were the
+/// classes the verdict decides on observed present. It is passed in rather than
+/// derived here so one observation governs both the per-hop terminal and the
+/// response-level gate, which is the pairing that stopped agreeing when the
+/// walk published no observation at all.
+///
+/// `None` means the node was expanded and has neighbors, so it is an ordinary
+/// step rather than an end of any kind.
+pub fn trace_walk_terminal(
+    expansion: TraceExpansion,
+    coverage_certain: bool,
+) -> Option<TraceTerminal> {
+    match expansion {
+        TraceExpansion::BoundStopped => Some(TraceTerminal::BoundReached),
+        TraceExpansion::NoEdges if coverage_certain => Some(TraceTerminal::Leaf),
+        TraceExpansion::NoEdges => Some(TraceTerminal::CoverageGap),
+        TraceExpansion::HadEdges => None,
     }
 }
 
@@ -572,6 +671,80 @@ mod tests {
             None,
             "an ordinary call is untouched by either boundary"
         );
+    }
+
+    #[test]
+    fn an_unread_node_and_an_empty_read_are_different_terminals() {
+        // The whole point: the same finished chain, three different reasons for
+        // ending, and the classifier must not collapse them.
+        assert_eq!(
+            trace_walk_terminal(TraceExpansion::BoundStopped, true),
+            Some(TraceTerminal::BoundReached),
+            "a node whose relations were never read cannot be reported as a leaf"
+        );
+        assert_eq!(
+            trace_walk_terminal(TraceExpansion::BoundStopped, false),
+            Some(TraceTerminal::BoundReached),
+            "coverage says nothing about a node the walk never examined"
+        );
+        assert_eq!(
+            trace_walk_terminal(TraceExpansion::NoEdges, true),
+            Some(TraceTerminal::Leaf)
+        );
+        assert_eq!(
+            trace_walk_terminal(TraceExpansion::NoEdges, false),
+            Some(TraceTerminal::CoverageGap),
+            "an empty read on a graph that could not hold the hop is not a leaf"
+        );
+        for certain in [false, true] {
+            assert_eq!(
+                trace_walk_terminal(TraceExpansion::HadEdges, certain),
+                None,
+                "a node with neighbors is an ordinary step, not an end"
+            );
+        }
+    }
+
+    #[test]
+    fn only_the_two_shortfall_terminals_truncate() {
+        assert!(TraceTerminal::BoundReached.truncates());
+        assert!(TraceTerminal::CoverageGap.truncates());
+        for complete in [
+            TraceTerminal::ExternalReference,
+            TraceTerminal::TypeAnnotation,
+            TraceTerminal::Leaf,
+        ] {
+            assert!(
+                !complete.truncates(),
+                "{} ends the chain and must not report a shortfall",
+                complete.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn every_terminal_has_its_own_wire_name() {
+        let names: Vec<&str> = [
+            TraceTerminal::ExternalReference,
+            TraceTerminal::TypeAnnotation,
+            TraceTerminal::Leaf,
+            TraceTerminal::BoundReached,
+            TraceTerminal::CoverageGap,
+        ]
+        .iter()
+        .map(|terminal| terminal.as_str())
+        .collect();
+        let mut unique = names.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            names.len(),
+            "two terminals sharing a wire name would be indistinguishable to a client: {names:?}"
+        );
+        assert!(names.contains(&"leaf"));
+        assert!(names.contains(&"bound_reached"));
+        assert!(names.contains(&"coverage_gap"));
     }
 
     fn relation(kind: RelationKind, src: EntityId, dst: EntityId) -> Relation {

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -334,9 +334,9 @@ impl TraceTerminal {
     /// let two short chains read as whole ones.
     pub fn truncates(self) -> bool {
         match self {
-            TraceTerminal::ExternalReference | TraceTerminal::TypeAnnotation | TraceTerminal::Leaf => {
-                false
-            }
+            TraceTerminal::ExternalReference
+            | TraceTerminal::TypeAnnotation
+            | TraceTerminal::Leaf => false,
             TraceTerminal::BoundReached | TraceTerminal::CoverageGap => true,
         }
     }


### PR DESCRIPTION
A `trace_data_flow` walk that stopped for lack of an edge now says so, per hop, and the `edge_coverage_unreported` limit stops firing on complete walks.

## The mechanism

`truncated` was decided by caps alone. In `crates/kin-cli/src/commands/trace_data_flow.rs` it is set when the per-step fan-out cap drops a neighbor, when `MAX_TOTAL_STEPS` is reached, when a time or edge budget ends the walk, and when the response budget drops steps. Nothing set it for a node the walk never expanded, because a step whose `next_depth` equals the requested depth is simply not pushed onto the frontier, and nothing set it for a node whose relations were read and held no admissible edge. Both arrive as a step with no children and `truncated: false`, which is byte for byte what a walk that ran out of code produces. The stranger read two `psf/requests` walks as complete on that basis and was wrong both times.

The second half is separate. The daemon route serializes `TraceDataFlowResponse` directly at `crates/kin-daemon/src/api.rs:8600`, and that struct carried no `edge_coverage` field, so the payload reaching `kin_mcp::negative::absence_coverage_gap` never had the observation object. That function returns `edge_coverage_unreported` for any trace payload missing it (`crates/kin-mcp/src/negative.rs:473`), and `edge_coverage_degradation_labels` adds the matching `edge_coverage:unreported` label (`crates/kin-mcp/src/negative.rs:768`). Both fired on every response, complete ones included, so the limit distinguished nothing. The offline kin-mcp arm already published the observation, so only the daemon arm was blind.

## The fix

`crates/kin-ranking/src/entity_ranking.rs` holds the single rule. `TraceTerminal` gains `Leaf`, `BoundReached` and `CoverageGap` beside the existing `ExternalReference` and `TypeAnnotation`; `TraceTerminal::truncates` decides which of the five mean the walk stopped before the chain did; `TraceExpansion` records what a node's expansion produced; `trace_walk_terminal` maps an expansion plus one coverage bit onto a terminal; and `trace_terminal_named` reads a published wire name back, answering `None` for a name this build does not know so a payload from an unknown build is never read as a shortfall.

Both walk arms, the daemon one in kin-cli and the offline one in `crates/kin-mcp/src/handlers/entities.rs`, now record the two facts they were throwing away: whether a node's relations were read at all, and whether that read found any admissible neighbor. The neighbor count is taken before the visited filter and before the per-step cap on purpose. A node whose only neighbor is already in the chain has a neighbor, and calling it a leaf would claim the code ends where the walk merely stopped repeating itself.

Coverage is consulted only for an empty read, so a healthy chain pays one language scan for the focal and none for its steps. A step whose language differs from the focal's gets its own observation, cached per language, because extraction gaps are per language and a Rust chain must not lend its coverage to a Python hop. `kin_mcp::edge_coverage::deciding_classes_observed_present` applies `negative::deciding_classes` to a published observation, which is the same rule `absence_coverage_gap` applies to the same payload, so a per-hop terminal and the response-level gate cannot disagree inside one response.

New payload fields, all additive, all omitted when zero or absent, and no existing field renamed: `terminal_leaf_steps`, `terminal_bound_steps`, `terminal_coverage_gap_steps`, `focal_terminal`, `edge_coverage`. `focal_terminal` exists because the chain carries no row for the focal, so an empty chain otherwise says nothing about why it is empty, and an empty chain is the answer whose trust depends on that most.

`TRACE_DATA_FLOW_DESC` names the three new terminals and says that the last two set `truncated`, because an agent reads the tool description rather than the struct. That description already documented the two boundary terminals, so leaving it alone would have left `truncated` changing meaning with nothing to say so.

## Falsification

Four passes, each predicted before it ran, each verified to have applied, each restored byte identical afterwards with a matching `shasum -a 256` and an empty `git status --porcelain`.

Pass A removed the coverage check so `NoEdges` mapped to `Leaf` unconditionally. `cargo test --no-fail-fast -p kin-ranking -p kin-cli --lib` returned rc=101 with four failures and no others:

```
a_chain_that_stopped_on_an_unlinked_graph_reports_a_coverage_gap
  assertion `left == right` failed: the walk cannot know whether this hop was the last one
    left: [None, Some("leaf")]
an_empty_chain_says_why_it_is_empty                        left: Some("leaf")
a_repo_defined_annotation_target_is_walkable_on_request    left: Some("leaf")
entity_ranking::tests::an_unread_node_and_an_empty_read_are_different_terminals
  assertion failed: an empty read on a graph that could not hold the hop is not a leaf
```

kin-cli 1635 passed, 3 failed; kin-ranking 118 passed, 1 failed. The leaf test and the depth-bound test both passed, which is what makes the passes independent.

Pass B removed the bound check so `BoundStopped` mapped to `Leaf`. Same command, rc=101, and exactly the other two failed:

```
a_chain_cut_by_the_depth_bound_reports_a_bound_and_not_a_leaf
  assertion failed: the last hop sits at the requested depth and was never expanded
    left: [None, Some("leaf")]
entity_ranking::tests::an_unread_node_and_an_empty_read_are_different_terminals
  assertion failed: a node whose relations were never read cannot be reported as a leaf
```

kin-cli 1637 passed, 1 failed; kin-ranking 118 passed, 1 failed. The coverage-gap test and the leaf test both passed.

Pass C made `truncates` return false for both shortfall terminals, and it found a defect in the first draft of this change. Only the kin-ranking rule test and the focal half of `an_empty_chain_says_why_it_is_empty` failed, while the depth-bound and coverage-gap chain tests stayed green, because the chain side was summing the per-terminal counts rather than consulting the shared rule. Deleting the rule left every chain-side shortfall still reporting itself correctly, which is a check that could not fail. The derivation was rewritten to read each terminal back through `TraceTerminal::truncates`, and on re-run all three failed:

```
a_chain_cut_by_the_depth_bound_reports_a_bound_and_not_a_leaf ... FAILED
an_empty_chain_says_why_it_is_empty ... FAILED
a_chain_that_stopped_on_an_unlinked_graph_reports_a_coverage_gap ... FAILED
test result: FAILED. 32 passed; 3 failed
```

Pass D removed the coverage publication. `cargo test --no-fail-fast -p kin-cli --lib commands::trace_data_flow` returned rc=101, 33 passed, 2 failed, at `a walk must publish the coverage its terminals rest on` and at `published`. Restored, the same command read `test result: ok. 35 passed; 0 failed`.

The fixtures differ in exactly one property each. The positive control is `cert_verify` in `src/adapters.py` calling `send` in `src/sessions.py` calling `request` in `src/api.py` at depth 5, whose last hop reads `terminal: "leaf"`, `truncated: false` and `edge_coverage.classes.calls: "present"`. The coverage-gap fixture is the same three entities in one file, so the graph holds no cross-file call edge, and its last hop reads `terminal: "coverage_gap"`, `truncated: true` and `edge_coverage.classes.calls: "absent"`. The bound fixture is the cross-file chain at depth 2, whose last hop reads `bound_reached` with `truncated: true` and which, at depth 5 on the same graph, reads `leaf` with `truncated: false`, so the bound arm cannot be passing merely because the fixture has no third hop.

The gate itself is asserted in both directions by `a_trace_that_publishes_its_coverage_stops_reporting_it_as_unreported` in `crates/kin-mcp/src/negative.rs`. A payload with no observation still reads `edge_coverage_unreported`. A payload whose measured `calls` class is present leaves `absence_coverage_gap` returning `None`, with the `edge_coverage:unreported` label gone. A payload whose measured `calls` class is absent still refuses, with `cross_file_edges_absent`.

## The one existing test this had to move

`kin-daemon api::tests::a_trace_over_its_budget_drops_bodies_and_keeps_every_edge` asserted `truncated == false` after a response-budget cut that dropped bodies and no edges. Its fixture walks six hops at `depth: 5`, so the last hop sits at the requested depth and was never expanded, which the walk now reports as `terminal: "bound_reached"`. Asserting a literal `false` there is asserting that a depth bound goes unreported, which is this ticket's defect wearing that test's name. The narrower claim the test exists for still holds and is now stated directly: `truncated` and `terminal_bound_steps` are compared against the same walk's unbounded run rather than against a literal, `steps_omitted` is asserted zero, and the fixture is checked to reach its bound so the comparison cannot pass because both runs report nothing. The other three trace tests in that module passed unchanged.

## Gates

`cargo fmt --all -- --check` rc=0. Clippy exactly as `.github/workflows/ci.yml` runs it, `RUSTFLAGS=-D warnings` with `cargo clippy --all-targets --all-features` and the debt allow-list from `.github/clippy-allowed-lints.txt`, rc=0 after fixing one real finding (`clippy::needless_range_loop` on the kin-mcp classification loop). `python3 scripts/verify-zero-file-search.py` rc=0 over 177 source files, `bash scripts/zero_file_search_guard.sh` rc=0, `bash scripts/check_runtime_boundaries.sh` rc=0, `bash scripts/check_private_repo_coupling.sh` rc=0.

The full local gate ran as `bin/kin-lane run truncwalk kin -- bin/kin-dev local-test kin -- --no-fail-fast` and returned rc=0. Its own tree line reads `kin-dev: local-test: kin /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/truncwalk-kin @ 267dd21f (chore/lane-truncwalk-kin)`, so it gated this branch rather than the primary checkout, and the summary reads `6636 tests run: 6636 passed (4 slow), 12 skipped` in 526s. Afterwards `git status --porcelain` was empty, `git diff origin/main --stat -- Cargo.lock .cargo/` was empty, and `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` printed only `.cargo/config.toml`.

An earlier attempt of the same gate read 6634 of 6636 with two failures. One was the daemon assertion described above and is fixed here. The other, `kin-cli::live_graph_durability_disclosure mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit_records_them`, panicked with "kin_graph_status refused 26 times without ever sampling its counts: selected-graph embedding coverage is changing" after 73 seconds, with the box at load average 70 and three lanes compiling. It passed in 11.3 seconds on the green run, and this change touches no embedding, coverage-sampling or graph-status path.

## Residual gaps

FIR-2486 and FIR-2500 still own the missing edges the stranger actually hit, which are untouched here. The coverage bit a terminal rests on is language scoped rather than site scoped, so on a graph that does link calls across files a hop missing for a per-site reason reads as `leaf` rather than as `coverage_gap`. The ticket's second listed detection, a stopping node whose own outgoing edges include an unresolved or `name_only` receiver, is not implemented here and is worth a follow-up ticket; what is implemented is the completeness signal the ticket's severity rests on, which is that a walk stopping next to such a gap can no longer report itself complete when the graph's coverage cannot support the claim.

Closes FIR-2542
