### PR TITLE
Decide the embedding class from the coverage counters, not from a conjunction

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -126,6 +126,95 @@ pub struct RetrievalDegradation {
     pub remediation: String,
 }
 
+/// What the embedding substrate itself was observed to be for one query.
+///
+/// This is the one embedding verdict in the system. It is decided from the
+/// counters beside it and from whether an index was attached to take them, and
+/// from nothing else, so no surface has to re-derive a verdict from
+/// [`SemanticCoverage::complete`]. That flag is a CONJUNCTION over the substrate
+/// AND the population a query ranked over, and deriving an embedding verdict
+/// from it is how a `semantic_locate` envelope came to carry `indexed 2112,
+/// pending 0` beside `classes.embeddings: absent` in one response (FIR-2543):
+/// fifteen test-role paths had been withheld from ranking, which clears
+/// `complete` and says nothing at all about embeddings.
+///
+/// `Unknown` is a state, not a shade of `Absent`. `embedding_status` answers
+/// `indexed = 0` for every retrievable object when no vector index is attached,
+/// which is exactly the reading a never-embedded repository produces, so a
+/// verdict taken from the counters alone cannot tell a fully embedded store
+/// whose index was not loaded from one that was never embedded. The two have
+/// different remediations and only one of them is a real gap.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingState {
+    /// Every eligible entity is indexed and nothing is queued, measured against
+    /// an index that was actually attached.
+    Present,
+    /// Some eligible entities are indexed and some are not.
+    Partial,
+    /// An attached index holds no embedding for any eligible entity.
+    Absent,
+    /// Nobody could say: no vector backend in this build, or no index attached
+    /// to take a reading from.
+    Unknown,
+}
+
+impl EmbeddingState {
+    /// The wire word, so a caller matching on the payload and a caller matching
+    /// on the type read the same vocabulary.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Present => "present",
+            Self::Partial => "partial",
+            Self::Absent => "absent",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Decide the state from an observation, at the one place that holds every
+    /// input it needs.
+    ///
+    /// Order matters and is deliberate. Both "nobody could say" checks run
+    /// before any counter is read, because a counter taken with no index behind
+    /// it is not a small number, it is not a number. That includes the
+    /// zero-eligible case: a graph with nothing retrievable and no index
+    /// attached is the shape that let a store report complete semantic coverage
+    /// over an empty graph (FIR-2215), and it is unknowable here rather than
+    /// whole.
+    pub fn observe(
+        supported: bool,
+        index_attached: bool,
+        indexed: usize,
+        total: usize,
+        pending: usize,
+    ) -> Self {
+        if !supported || !index_attached {
+            return Self::Unknown;
+        }
+        if total == 0 || (indexed >= total && pending == 0) {
+            return Self::Present;
+        }
+        if indexed == 0 {
+            return Self::Absent;
+        }
+        Self::Partial
+    }
+}
+
+/// Machine-stable reason [`SemanticCoverage::complete`] is false because this
+/// build ships no vector backend.
+pub const COVERAGE_LIMIT_VECTOR_SUPPORT_DISABLED: &str = "vector_support_disabled";
+/// Machine-stable reason `complete` is false because no index was attached.
+pub const COVERAGE_LIMIT_VECTOR_INDEX_ABSENT: &str = "vector_index_absent";
+/// Machine-stable reason `complete` is false because the index is unfinished.
+pub const COVERAGE_LIMIT_EMBEDDINGS_INCOMPLETE: &str = "embeddings_incomplete";
+/// Machine-stable reason `complete` is false because the role filter narrowed
+/// the population the counters were taken over.
+pub const COVERAGE_LIMIT_GRAPH_ROLE_FILTER: &str = "graph_role_filter";
+/// Machine-stable reason `complete` is false because graph-owned source bodies
+/// are missing for some paths.
+pub const COVERAGE_LIMIT_GRAPH_BODY_GAP: &str = "graph_body_gap";
+
 /// Honest, in-band report of how complete the embedding (semantic) signal was
 /// for a locate query. This is the trust-contract "per-signal degradation"
 /// property: a partial semantic index is surfaced, not hidden behind an opaque
@@ -159,6 +248,41 @@ pub struct SemanticCoverage {
     /// that cannot observe bodies as degraded. Read `graph_bodies.observed` to
     /// tell "no gap" from "not looked at"; they are different answers.
     pub complete: bool,
+    /// What the embedding substrate itself was observed to be, decided by
+    /// [`EmbeddingState::observe`] at the moment the counters above were taken.
+    ///
+    /// This is the field a surface reporting on EMBEDDINGS reads.
+    /// [`Self::complete`] answers a wider question and cannot be narrowed back
+    /// to this one, which is the defect FIR-2543 reported: an envelope carried
+    /// `indexed 2112, pending 0` and `classes.embeddings: absent` because a
+    /// consumer derived an embedding verdict from a flag a role filter had
+    /// already cleared.
+    ///
+    /// Older payloads predate the field. Absent deserializes to `Unknown`,
+    /// because a reader that cannot see the observation has not observed
+    /// anything, and guessing `Present` from the counters is the structural zero
+    /// wearing the opposite costume.
+    #[serde(default = "semantic_embedding_state_default")]
+    pub embedding_state: EmbeddingState,
+    /// Every machine-stable reason [`Self::complete`] is false, in the order
+    /// they were observed. Empty when coverage is complete.
+    ///
+    /// `complete` is one bit over several independent causes with different
+    /// remediations: an absent index, an unfinished index, a narrowed
+    /// population, missing source bodies. A caller told only that it is false
+    /// cannot tell which of them to act on, and every consumer that guessed
+    /// guessed "run `kin embed`".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub limited_by: Vec<String>,
+    /// When these counters were sampled, RFC 3339 in UTC.
+    ///
+    /// Two surfaces reporting different embedding counts in the same minute is
+    /// the normal state of a store with a backfill running, and it is
+    /// indistinguishable from a store where one of them is wrong unless each
+    /// reading says when it was taken. Absent on payloads minted before the
+    /// field existed; never fabricated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_at: Option<String>,
     /// Human-readable note describing the degraded state, present only when the
     /// semantic signal was partial. Lexical + graph signals still ran.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -272,6 +396,24 @@ impl GraphBodyCoverage {
 
 fn semantic_signal_supported_default() -> bool {
     true
+}
+
+/// A payload minted before [`SemanticCoverage::embedding_state`] existed carries
+/// no observation of the embedding substrate, so it deserializes to one that
+/// says so.
+fn semantic_embedding_state_default() -> EmbeddingState {
+    EmbeddingState::Unknown
+}
+
+/// The instant a coverage observation was taken, RFC 3339 in UTC with second
+/// resolution. Second resolution is enough for the question the field answers,
+/// which is whether two surfaces read the same store minutes apart.
+pub(crate) fn coverage_read_at_now() -> Option<String> {
+    Some(
+        chrono::Utc::now()
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+            .to_string(),
+    )
 }
 
 impl LocateResult {
@@ -1520,7 +1662,7 @@ fn cross_encoder_load_target(model_id: &str, snapshot: Option<&std::path::Path>)
 /// `vector_index_stats()` is the call that separates them, and reading it is a
 /// lock and an `Option` map rather than a walk of graph truth.
 #[cfg(feature = "vector")]
-fn vector_index_attached(graph: &kin_db::InMemoryGraph) -> bool {
+pub(crate) fn vector_index_attached(graph: &kin_db::InMemoryGraph) -> bool {
     graph.vector_index_stats().is_some()
 }
 
@@ -1528,7 +1670,7 @@ fn vector_index_attached(graph: &kin_db::InMemoryGraph) -> bool {
 /// arm of the coverage report is what callers read in this build; this exists
 /// so the two arms share one call shape.
 #[cfg(not(feature = "vector"))]
-fn vector_index_attached(_graph: &kin_db::InMemoryGraph) -> bool {
+pub(crate) fn vector_index_attached(_graph: &kin_db::InMemoryGraph) -> bool {
     false
 }
 
@@ -1622,6 +1764,15 @@ fn coverage_from_status(
             total: status.total,
             pending: status.pending,
             complete: false,
+            embedding_state: EmbeddingState::observe(
+                false,
+                false,
+                status.indexed,
+                status.total,
+                status.pending,
+            ),
+            limited_by: vec![COVERAGE_LIMIT_VECTOR_SUPPORT_DISABLED.to_string()],
+            read_at: coverage_read_at_now(),
             note: Some(
                 "semantic vector ranking is unsupported in this build; lexical and graph signals remain available"
                     .to_string(),
@@ -1652,12 +1803,27 @@ fn coverage_from_status(
             embedding_status_summary(status)
         ))
         };
+        let mut limited_by = Vec::new();
+        if !index_attached {
+            limited_by.push(COVERAGE_LIMIT_VECTOR_INDEX_ABSENT.to_string());
+        } else if !embedding_status_complete(status) {
+            limited_by.push(COVERAGE_LIMIT_EMBEDDINGS_INCOMPLETE.to_string());
+        }
         SemanticCoverage {
             supported: true,
             indexed: status.indexed,
             total: status.total,
             pending: status.pending,
             complete,
+            embedding_state: EmbeddingState::observe(
+                true,
+                index_attached,
+                status.indexed,
+                status.total,
+                status.pending,
+            ),
+            limited_by,
+            read_at: coverage_read_at_now(),
             note,
             graph_bodies: None,
         }
@@ -1674,8 +1840,18 @@ impl SemanticCoverage {
     /// carries, and an already-present embedding note is kept rather than
     /// overwritten, since both causes can hold at once and the caller needs to
     /// know which remediation applies.
+    ///
+    /// [`Self::embedding_state`] is deliberately untouched here. Neither cause
+    /// below is an observation about embeddings: a withheld test path was never
+    /// ranked and a body-less path cannot be ranked, and both hold on stores
+    /// whose every eligible entity carries a vector. Each is recorded in
+    /// [`Self::limited_by`] instead, which is what lets a consumer say why
+    /// `complete` is false without inventing an embedding shortfall to explain
+    /// it (FIR-2543).
     pub fn with_graph_bodies(mut self, bodies: GraphBodyCoverage) -> Self {
         if bodies.withholds_tests() {
+            self.limited_by
+                .push(COVERAGE_LIMIT_GRAPH_ROLE_FILTER.to_string());
             // Completeness is a claim about the population the caller asked
             // about, and this one was narrowed before the counters were taken.
             // Saying `complete: true` over it is the defect: the caller cannot
@@ -1695,6 +1871,8 @@ impl SemanticCoverage {
         }
         if bodies.has_gap() {
             self.complete = false;
+            self.limited_by
+                .push(COVERAGE_LIMIT_GRAPH_BODY_GAP.to_string());
             let gap_note = format!(
                 "graph body gap: {} of {} graph-owned source paths carry no body, so entity \
                  ranking over them falls back to text matching; graph_bodies.sample names them.",
@@ -28143,6 +28321,9 @@ mod tests {
             total: 10,
             pending: 0,
             complete: true,
+            embedding_state: EmbeddingState::Present,
+            limited_by: Vec::new(),
+            read_at: None,
             note: None,
             graph_bodies: None,
         };
@@ -28157,6 +28338,9 @@ mod tests {
             total: 10,
             pending: 6,
             complete: false,
+            embedding_state: EmbeddingState::Partial,
+            limited_by: vec![COVERAGE_LIMIT_EMBEDDINGS_INCOMPLETE.to_string()],
+            read_at: None,
             note: Some("custom degradation note".to_string()),
             graph_bodies: None,
         };
@@ -28172,6 +28356,9 @@ mod tests {
             total: 10,
             pending: 6,
             complete: false,
+            embedding_state: EmbeddingState::Partial,
+            limited_by: vec![COVERAGE_LIMIT_EMBEDDINGS_INCOMPLETE.to_string()],
+            read_at: None,
             note: None,
             graph_bodies: None,
         };
@@ -28193,6 +28380,9 @@ mod tests {
             total: 1644,
             pending: 0,
             complete: true,
+            embedding_state: EmbeddingState::Present,
+            limited_by: Vec::new(),
+            read_at: None,
             note: None,
             graph_bodies: None,
         }
@@ -28324,6 +28514,9 @@ mod tests {
             total: 10,
             pending: 6,
             complete: false,
+            embedding_state: EmbeddingState::Partial,
+            limited_by: vec![COVERAGE_LIMIT_EMBEDDINGS_INCOMPLETE.to_string()],
+            read_at: None,
             note: Some("semantic signal partial: 4/10 embedded.".to_string()),
             graph_bodies: None,
         };

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -90,6 +90,7 @@ fn evaluate_semantic_coverage(
     graph: &kin_db::InMemoryGraph,
 ) -> Result<crate::commands::locate::SemanticCoverage> {
     let status = graph.embedding_status();
+    let index_attached = crate::commands::locate::vector_index_attached(graph);
     let complete = embedding_status_complete(&status);
 
     if !complete && embedding_strict_mode() {
@@ -117,6 +118,26 @@ fn evaluate_semantic_coverage(
         total: status.total,
         pending: status.pending,
         complete,
+        // Search reads the same counters locate does and owes the same verdict.
+        // The index has to be proven attached before the counters mean
+        // anything: `embedding_status` answers zero indexed for every
+        // retrievable object on a graph with no index, and search was reporting
+        // that as a measured shortfall.
+        embedding_state: crate::commands::locate::EmbeddingState::observe(
+            true,
+            index_attached,
+            status.indexed,
+            status.total,
+            status.pending,
+        ),
+        limited_by: if !index_attached {
+            vec![crate::commands::locate::COVERAGE_LIMIT_VECTOR_INDEX_ABSENT.to_string()]
+        } else if complete {
+            Vec::new()
+        } else {
+            vec![crate::commands::locate::COVERAGE_LIMIT_EMBEDDINGS_INCOMPLETE.to_string()]
+        },
+        read_at: crate::commands::locate::coverage_read_at_now(),
         note,
         // Search does not run locate's source-text phase, so it observes no
         // bodies. Absent means unobserved, never "no gap".

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13439,6 +13439,9 @@ mod tests {
             total: 10,
             pending: 0,
             complete: true,
+            embedding_state: kin_cli::commands::locate::EmbeddingState::Present,
+            limited_by: Vec::new(),
+            read_at: None,
             note: None,
             graph_bodies: None,
         };

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -45,6 +45,20 @@ pub const ENVELOPE_VERSION: u32 = 1;
 /// namespaced so it never collides with a tool payload's own fields.
 pub const ENVELOPE_KEY: &str = "_kin";
 
+/// The `semantic_coverage.limited_by` label a producing surface records when the
+/// role filter narrowed the population its counters were taken over.
+///
+/// Spelled here as a literal rather than imported: this crate mirrors the
+/// coverage shape kin-cli publishes and does not depend on it. The producer is
+/// `kin_cli::commands::locate::COVERAGE_LIMIT_GRAPH_ROLE_FILTER`, and the two
+/// have to stay spelled the same.
+const SCOPE_LIMIT_ROLE_FILTER: &str = "graph_role_filter";
+
+/// The `semantic_coverage.limited_by` label for missing graph-owned source
+/// bodies. Producer:
+/// `kin_cli::commands::locate::COVERAGE_LIMIT_GRAPH_BODY_GAP`.
+const SCOPE_LIMIT_BODY_GAP: &str = "graph_body_gap";
+
 /// Which runtime produced a tool response.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -72,7 +86,41 @@ pub struct SemanticCoverage {
     pub pending: u64,
     /// True when the semantic signal was complete (`total == 0`, or every entity
     /// indexed with nothing pending).
+    ///
+    /// A CONJUNCTION over several independent causes, so it cannot be read as a
+    /// statement about embeddings. Read [`Self::embedding_state`] for that, and
+    /// [`Self::limited_by`] for which cause cleared this flag.
     pub complete: bool,
+    /// What the embedding substrate itself was observed to be, as the producing
+    /// surface decided it: `present`, `partial`, `absent` or `unknown`.
+    ///
+    /// This is the one embedding verdict, computed once where the counters were
+    /// taken and carried on the wire rather than re-derived here. Deriving one
+    /// from [`Self::complete`] is the FIR-2543 defect: a `semantic_locate`
+    /// envelope carried `indexed 2112, pending 0` beside
+    /// `completeness.classes.embeddings: absent`, because fifteen test-role
+    /// paths withheld from ranking had cleared `complete` and a consumer read
+    /// that as an embedding shortfall.
+    ///
+    /// Absent on payloads minted before the field existed.
+    /// [`Self::embedding_state`] narrows those from the counters and answers
+    /// `unknown` wherever the counters alone cannot tell a detached index from
+    /// an unembedded store.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_state_reported: Option<String>,
+    /// Every machine-stable reason [`Self::complete`] is false, as the producing
+    /// surface recorded them. Empty or absent when nothing was recorded.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub limited_by: Vec<String>,
+    /// When the counters above were sampled, RFC 3339 in UTC, when the payload
+    /// carried it.
+    ///
+    /// Two surfaces reporting different counts for one store in the same minute
+    /// is the ordinary state of a store with a backfill running. Without a read
+    /// time it is indistinguishable from one of them being wrong, which is half
+    /// of what FIR-2543 reported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_at: Option<String>,
     /// Human-readable note describing the degraded state, present only when the
     /// semantic signal was partial.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -87,7 +135,111 @@ pub struct SemanticCoverage {
     pub graph_body_gap_paths: Option<u64>,
 }
 
+/// What the embedding substrate was observed to be, as every consumer in this
+/// crate reads it.
+///
+/// Deliberately four states where [`Completeness::classes`] carries three. The
+/// class vocabulary answers "was the substrate whole", so `Partial` and `Absent`
+/// both render there as `absent`; the finer reading is kept here and named in
+/// `limits`, because "some of it is indexed" and "none of it is" have different
+/// remediations and only one of them is what a first query on a fresh
+/// conversion sees.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddingState {
+    /// Every eligible entity is indexed and nothing is queued.
+    Present,
+    /// Some eligible entities are indexed and some are not.
+    Partial,
+    /// An attached index holds no embedding for any eligible entity.
+    Absent,
+    /// Nobody could say.
+    Unknown,
+}
+
+impl EmbeddingState {
+    /// The class word this state contributes to [`Completeness::classes`].
+    fn class_state(self) -> &'static str {
+        match self {
+            Self::Present => STATE_PRESENT,
+            Self::Partial | Self::Absent => STATE_ABSENT,
+            Self::Unknown => STATE_UNKNOWN,
+        }
+    }
+
+    /// The machine-stable label this state contributes to
+    /// [`Completeness::limits`], or `None` when there is no shortfall to name.
+    fn limit_label(self) -> Option<&'static str> {
+        match self {
+            Self::Present => None,
+            Self::Partial => Some("embeddings_partial"),
+            Self::Absent => Some("embeddings_absent"),
+            Self::Unknown => Some("embeddings_unknown"),
+        }
+    }
+}
+
 impl SemanticCoverage {
+    /// The one embedding verdict every surface in this crate reads.
+    ///
+    /// Prefers the observation the producing surface published, because that is
+    /// the only reader that knew whether a vector index was attached when the
+    /// counters were taken. Falls back to the counters for a payload minted
+    /// before the field existed, and that fallback answers `Unknown` for every
+    /// reading the counters cannot decide on their own:
+    /// `kin_db::InMemoryGraph::embedding_status` reports zero indexed for every
+    /// retrievable object when no index is attached, so `indexed: 0` is a
+    /// fully embedded store whose index did not load and an unembedded store at
+    /// the same time. A count nobody can read is unknown, never zero and never
+    /// absent.
+    pub fn embedding_state(&self) -> EmbeddingState {
+        match self.embedding_state_reported.as_deref() {
+            Some("present") => return EmbeddingState::Present,
+            Some("partial") => return EmbeddingState::Partial,
+            Some("absent") => return EmbeddingState::Absent,
+            Some("unknown") => return EmbeddingState::Unknown,
+            // An unrecognized word is a producer this build does not understand.
+            // Reading it as healthy would let a future state certify answers
+            // nobody has decided are certifiable.
+            Some(_) => return EmbeddingState::Unknown,
+            None => {}
+        }
+        if self.total > 0 && self.indexed >= self.total && self.pending == 0 {
+            EmbeddingState::Present
+        } else if self.total == 0 || self.indexed == 0 {
+            EmbeddingState::Unknown
+        } else {
+            EmbeddingState::Partial
+        }
+    }
+
+    /// Every reason `complete` is false that is NOT a statement about
+    /// embeddings, as machine-stable labels.
+    ///
+    /// These are disclosure. A withheld test path was never ranked and a
+    /// body-less path cannot be ranked, and both hold on stores whose every
+    /// eligible entity carries a vector, so neither may decide the embedding
+    /// class. They still narrow what an empty answer proves, which is why
+    /// [`Envelope::negative_trust`] reads them.
+    pub fn scope_limits(&self) -> Vec<String> {
+        let mut limits = Vec::new();
+        if self
+            .limited_by
+            .iter()
+            .any(|limit| limit == SCOPE_LIMIT_ROLE_FILTER)
+        {
+            limits.push("graph_role_filter_withheld".to_string());
+        }
+        if self.graph_body_gap_paths.is_some_and(|gaps| gaps > 0)
+            || self
+                .limited_by
+                .iter()
+                .any(|limit| limit == SCOPE_LIMIT_BODY_GAP)
+        {
+            limits.push("graph_body_gap".to_string());
+        }
+        limits
+    }
+
     /// Lift a `semantic_coverage` object out of a tool payload, validating the
     /// shape. Returns `None` when the payload has no such field or it is not the
     /// expected object — we surface `unknown` rather than guessing.
@@ -98,6 +250,42 @@ impl SemanticCoverage {
             total: obj.get("total").and_then(Value::as_u64)?,
             pending: obj.get("pending").and_then(Value::as_u64)?,
             complete: obj.get("complete").and_then(Value::as_bool)?,
+            embedding_state_reported: obj
+                .get("embedding_state")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            limited_by: {
+                let mut limited_by: Vec<String> = obj
+                    .get("limited_by")
+                    .and_then(Value::as_array)
+                    .map(|limits| {
+                        limits
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(str::to_string)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                // A payload that carries the body-coverage object but not the
+                // reason list still stated the role filter, in the one field
+                // that has always disclosed it. Reading it here is what keeps a
+                // producer one version behind from having its narrowed
+                // population read as an embedding shortfall.
+                let withheld = obj
+                    .get("graph_bodies")
+                    .and_then(Value::as_object)
+                    .and_then(|bodies| bodies.get("withheld_test_paths"))
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                if withheld > 0 && !limited_by.iter().any(|it| it == SCOPE_LIMIT_ROLE_FILTER) {
+                    limited_by.push(SCOPE_LIMIT_ROLE_FILTER.to_string());
+                }
+                limited_by
+            },
+            read_at: obj
+                .get("read_at")
+                .and_then(Value::as_str)
+                .map(str::to_string),
             note: obj.get("note").and_then(Value::as_str).map(str::to_string),
             // Optional: payloads from surfaces that ran no retrieval, and every
             // payload minted before graph-body coverage existed, carry no such
@@ -681,23 +869,32 @@ fn edge_class_states(
     (classes, decided_by, limits)
 }
 
-/// The embedding class state, from the coverage the envelope already lifted.
+/// The embedding class state, from the one embedding verdict the coverage
+/// object carries.
+///
+/// Reads [`SemanticCoverage::embedding_state`] and never
+/// [`SemanticCoverage::complete`]. That flag is a conjunction over the substrate
+/// AND the population a query ranked over, so deriving the embedding class from
+/// it published `classes.embeddings: absent` beside `indexed 2112, pending 0` in
+/// one shipped `semantic_locate` envelope: the role filter had withheld fifteen
+/// test-role paths, which clears `complete` and says nothing about embeddings
+/// (FIR-2543).
+///
+/// Every other reason `complete` is false is still reported, in `limits`, where
+/// it is disclosure rather than a verdict about a substrate it never measured.
 fn embedding_class_states(envelope: &Envelope) -> (Map<String, Value>, Vec<String>, Vec<String>) {
     let mut limits = Vec::new();
     let state = match &envelope.semantic_coverage {
-        None => STATE_UNKNOWN,
-        Some(coverage) if coverage.complete => STATE_PRESENT,
+        None => EmbeddingState::Unknown,
         Some(coverage) => {
-            if coverage.graph_body_gap_paths.is_some_and(|gaps| gaps > 0) {
-                limits.push("graph_body_gap".to_string());
-            }
-            STATE_ABSENT
+            limits.extend(coverage.scope_limits());
+            coverage.embedding_state()
         }
     };
     let mut classes = Map::new();
-    classes.insert("embeddings".to_string(), json!(state));
-    if state != STATE_PRESENT {
-        limits.push(format!("embeddings_{state}"));
+    classes.insert("embeddings".to_string(), json!(state.class_state()));
+    if let Some(label) = state.limit_label() {
+        limits.push(label.to_string());
     }
     (classes, vec!["embeddings".to_string()], limits)
 }
@@ -1081,6 +1278,14 @@ impl Envelope {
             total: embeddings_total,
             pending: embeddings_pending,
             complete,
+            // Graph status hands over counters and no index observation, so the
+            // verdict is left to the one fallback in
+            // [`SemanticCoverage::embedding_state`] rather than decided a second
+            // way here. Naming a state this path cannot observe is how a second
+            // authority for one fact gets created.
+            embedding_state_reported: None,
+            limited_by: Vec::new(),
+            read_at: None,
             note: (!complete).then(|| {
                 "Selected-graph embedding coverage is incomplete at this point-in-time observation."
                     .to_string()
@@ -1270,33 +1475,57 @@ impl Envelope {
             );
         }
         match class {
+            // Every reason this gate refuses is read off the same object the
+            // completeness class reads, and each one names the cause it actually
+            // observed. Three causes clear `coverage.complete` and they have
+            // three different remediations, so a gate that reported all of them
+            // as "the semantic index is incomplete" sent a caller to `kin embed`
+            // on a store whose embeddings were already whole (FIR-2543).
             NegativeClass::Semantic => match &self.semantic_coverage {
                 None => (
                     false,
                     "coverage_unknown: embedding coverage was not reported, so an empty result may mean 'not indexed' rather than 'not present'",
                 ),
-                // A body gap and an embedding shortfall both clear `complete`,
-                // and they are different problems with different remediations.
-                // Reporting a body gap as "the semantic index is incomplete"
-                // sends a caller to `kin embed` on a store whose embeddings are
-                // already whole, so the limiting factor is named.
-                Some(coverage)
-                    if !coverage.complete
-                        && coverage.graph_body_gap_paths.is_some_and(|gaps| gaps > 0) =>
-                {
-                    (
+                Some(coverage) => match coverage.embedding_state() {
+                    EmbeddingState::Unknown => (
                         false,
-                        "coverage_graph_body_gap: graph-owned source bodies are missing for some paths, so entities in them rank on text fallback and an empty result may mean 'no body to rank' rather than 'not present'",
-                    )
-                }
-                Some(coverage) if !coverage.complete => (
-                    false,
-                    "coverage_partial: the semantic index is incomplete, so an empty result may mean 'not indexed' rather than 'not present'",
-                ),
-                Some(_) => (
-                    true,
-                    "semantic_authoritative: daemon-owned truth with complete embedding coverage",
-                ),
+                        "coverage_unknown: no vector index was attached to read coverage from, so an empty result may mean 'not indexed' rather than 'not present'",
+                    ),
+                    EmbeddingState::Absent => (
+                        false,
+                        "coverage_absent: no entity in this store carries an embedding, so an empty result means 'nothing was ranked' rather than 'not present'",
+                    ),
+                    EmbeddingState::Partial => (
+                        false,
+                        "coverage_partial: the semantic index is incomplete, so an empty result may mean 'not indexed' rather than 'not present'",
+                    ),
+                    // Embeddings are whole. What is left can only narrow the
+                    // POPULATION that was ranked, and an absence over a narrowed
+                    // population is not an absence over the repository, so the
+                    // gate still refuses and says which narrowing it saw.
+                    EmbeddingState::Present => {
+                        let scope = coverage.scope_limits();
+                        if scope.iter().any(|limit| limit == "graph_body_gap") {
+                            (
+                                false,
+                                "coverage_graph_body_gap: graph-owned source bodies are missing for some paths, so entities in them rank on text fallback and an empty result may mean 'no body to rank' rather than 'not present'",
+                            )
+                        } else if scope
+                            .iter()
+                            .any(|limit| limit == "graph_role_filter_withheld")
+                        {
+                            (
+                                false,
+                                "coverage_role_filter_withheld: test-role source paths were withheld from ranking, so an empty result may mean 'not ranked' rather than 'not present'; pass include_tests to rank them",
+                            )
+                        } else {
+                            (
+                                true,
+                                "semantic_authoritative: daemon-owned truth with complete embedding coverage",
+                            )
+                        }
+                    }
+                },
             },
             NegativeClass::Structural => {
                 if self.graph_state.initialized != Some(true) {
@@ -2194,6 +2423,255 @@ mod tests {
         assert_eq!(completeness["classes"]["embeddings"], "absent");
         assert_eq!(completeness["status"], "partial", "{completeness}");
         assert_eq!(completeness["bound"], "at_least");
+    }
+
+    /// Build one `semantic_locate` response over a store with the given
+    /// coverage, exactly as the serving path assembles it.
+    fn locate_response_with_coverage(coverage: Value) -> Value {
+        let payload = ToolCallResult::text(
+            json!({
+                "results": [{"name": "normalize_title"}],
+                "semantic_coverage": coverage,
+            })
+            .to_string(),
+        );
+        envelope_of(&finalize(
+            payload,
+            ready_daemon_envelope(),
+            "semantic_locate",
+        ))
+    }
+
+    /// The counters and the class verdict in one envelope are one fact, so a
+    /// reader acting on either reaches the same decision.
+    ///
+    /// FIR-2543 is the case this drives with. A shipped v0.5.45 `semantic_locate`
+    /// envelope carried `semantic_coverage: {indexed: 2112, total: 2112,
+    /// pending: 0}` and `completeness.classes.embeddings: "absent"` in one
+    /// response, because fifteen test-role paths withheld from ranking had
+    /// cleared `complete` and the class was derived from that flag. An agent
+    /// reading the counters proceeded and an agent reading the class backed off,
+    /// both from the same object.
+    ///
+    /// Every case below carries real counters. There is no empty-input arm,
+    /// because a store with no eligible entity makes the agreement trivially
+    /// true and could not fail if the rule were removed.
+    #[test]
+    fn the_coverage_counters_and_the_embedding_class_never_disagree() {
+        // (case name, coverage payload, expected class, expected limit label)
+        let cases: Vec<(&str, Value, &str, Option<&str>)> = vec![
+            (
+                "n_of_n_with_a_role_filter_withholding_paths",
+                json!({
+                    "indexed": 2112, "total": 2112, "pending": 0,
+                    "complete": false,
+                    "embedding_state": "present",
+                    "limited_by": ["graph_role_filter"],
+                    "graph_bodies": {
+                        "source_paths": 275, "with_body": 275, "gap_paths": 0,
+                        "withheld_test_paths": 15,
+                    },
+                }),
+                "present",
+                None,
+            ),
+            (
+                "n_of_n_with_nothing_pending",
+                json!({
+                    "indexed": 2112, "total": 2112, "pending": 0,
+                    "complete": true,
+                    "embedding_state": "present",
+                }),
+                "present",
+                None,
+            ),
+            (
+                "zero_of_n_against_an_attached_index",
+                json!({
+                    "indexed": 0, "total": 2112, "pending": 2112,
+                    "complete": false,
+                    "embedding_state": "absent",
+                    "limited_by": ["embeddings_incomplete"],
+                }),
+                "absent",
+                Some("embeddings_absent"),
+            ),
+            (
+                "some_indexed_with_work_still_pending",
+                json!({
+                    "indexed": 1536, "total": 2112, "pending": 576,
+                    "complete": false,
+                    "embedding_state": "partial",
+                    "limited_by": ["embeddings_incomplete"],
+                }),
+                "absent",
+                Some("embeddings_partial"),
+            ),
+            (
+                "counters_taken_with_no_index_attached_to_read_them",
+                json!({
+                    "indexed": 0, "total": 2112, "pending": 2112,
+                    "complete": false,
+                    "embedding_state": "unknown",
+                    "limited_by": ["vector_index_absent"],
+                }),
+                "unknown",
+                Some("embeddings_unknown"),
+            ),
+        ];
+
+        for (case, coverage, expected_class, expected_limit) in cases {
+            let envelope = locate_response_with_coverage(coverage);
+            let completeness = &envelope["completeness"];
+            let counters = &envelope["semantic_coverage"];
+            assert_eq!(
+                completeness["classes"]["embeddings"],
+                json!(expected_class),
+                "case {case}: the class must follow the counters beside it: {envelope}"
+            );
+            // The counters have to survive intact, because the whole defect was
+            // two readings of one store in one object.
+            assert_eq!(
+                counters["indexed"], envelope["semantic_coverage"]["indexed"],
+                "case {case}: counters are republished verbatim"
+            );
+            let limits = completeness["limits"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+            match expected_limit {
+                Some(label) => assert!(
+                    limits.contains(&json!(label)),
+                    "case {case}: the finer reading must be named in limits: {completeness}"
+                ),
+                None => assert!(
+                    !limits.iter().any(|limit| limit
+                        .as_str()
+                        .is_some_and(|limit| limit.starts_with("embeddings_"))),
+                    "case {case}: a whole index names no embedding shortfall: {completeness}"
+                ),
+            }
+        }
+    }
+
+    /// The FIR-2543 envelope, asserted as the one thing a reader cannot be asked
+    /// to reconcile: `pending: 0` over a full index beside a class saying the
+    /// embeddings are gone.
+    ///
+    /// The role filter is still disclosed, because it narrowed the population
+    /// that was ranked. It is disclosed as what it is.
+    #[test]
+    fn a_role_filter_is_disclosed_without_being_reported_as_a_missing_index() {
+        let envelope = locate_response_with_coverage(json!({
+            "indexed": 2112, "total": 2112, "pending": 0,
+            "complete": false,
+            "embedding_state": "present",
+            "limited_by": ["graph_role_filter"],
+            "graph_bodies": {
+                "source_paths": 275, "with_body": 275, "gap_paths": 0,
+                "withheld_test_paths": 15,
+            },
+        }));
+        let completeness = &envelope["completeness"];
+        assert_eq!(
+            completeness["classes"]["embeddings"],
+            json!("present"),
+            "2112 of 2112 indexed with nothing pending is a present index: {completeness}"
+        );
+        let limits = completeness["limits"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            limits.contains(&json!("graph_role_filter_withheld")),
+            "the narrowed population is still disclosed: {completeness}"
+        );
+        assert!(
+            !limits.contains(&json!("embeddings_absent")),
+            "a whole index is never an absent one: {completeness}"
+        );
+    }
+
+    /// A producer one version behind carries the body-coverage object and no
+    /// reason list, and its role filter still must not be read as an embedding
+    /// shortfall.
+    #[test]
+    fn a_role_filter_declared_only_by_the_body_coverage_object_is_still_read() {
+        let envelope = locate_response_with_coverage(json!({
+            "indexed": 800, "total": 800, "pending": 0,
+            "complete": false,
+            "embedding_state": "present",
+            "graph_bodies": {
+                "source_paths": 40, "with_body": 40, "gap_paths": 0,
+                "withheld_test_paths": 6,
+            },
+        }));
+        let limits = envelope["completeness"]["limits"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            limits.contains(&json!("graph_role_filter_withheld")),
+            "the filter is disclosed from the only field that carried it: {}",
+            envelope["completeness"]
+        );
+    }
+
+    /// A payload minted before the verdict existed gets the honest reading of
+    /// its own counters, and `indexed: 0` is not one of the readings the
+    /// counters can decide.
+    ///
+    /// `embedding_status` reports zero indexed for every retrievable object when
+    /// no vector index is attached, so a bare `0 of 2112` is a fully embedded
+    /// store whose index did not load and a store nobody embedded, at once.
+    #[test]
+    fn a_legacy_payload_reporting_zero_indexed_is_unknown_rather_than_absent() {
+        let envelope = locate_response_with_coverage(json!({
+            "indexed": 0, "total": 2112, "pending": 2112,
+            "complete": false,
+        }));
+        let completeness = &envelope["completeness"];
+        assert_eq!(
+            completeness["classes"]["embeddings"],
+            json!("unknown"),
+            "a count nobody could read is unknown, never zero: {completeness}"
+        );
+        assert_eq!(
+            completeness["status"],
+            json!("unknown"),
+            "and the status it decides follows it: {completeness}"
+        );
+
+        // The control that makes the arm above capable of failing: the same
+        // legacy shape with counters that DO decide reads partial, not unknown.
+        let decidable = locate_response_with_coverage(json!({
+            "indexed": 1536, "total": 2112, "pending": 576,
+            "complete": false,
+        }));
+        assert_eq!(
+            decidable["completeness"]["classes"]["embeddings"],
+            json!("absent"),
+            "counters that decide are still read: {}",
+            decidable["completeness"]
+        );
+    }
+
+    /// A wire word this build does not know is not a healthy one. A future
+    /// producer must not be able to certify an answer by naming a state nobody
+    /// here has agreed is certifiable.
+    #[test]
+    fn an_unrecognized_embedding_state_reads_as_unknown() {
+        let envelope = locate_response_with_coverage(json!({
+            "indexed": 2112, "total": 2112, "pending": 0,
+            "complete": true,
+            "embedding_state": "mostly_fine",
+        }));
+        assert_eq!(
+            envelope["completeness"]["classes"]["embeddings"],
+            json!("unknown"),
+            "{}",
+            envelope["completeness"]
+        );
     }
 
     /// A mutation is not retrieval and carries no completeness object, so the

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1082,6 +1082,18 @@ fn locate_ranking_names_nothing(payload: &Value) -> bool {
         })
 }
 
+/// The wire word for the one embedding verdict, so the absence object and the
+/// completeness block publish the same vocabulary for the same fact.
+fn embedding_state_word(coverage: &crate::envelope::SemanticCoverage) -> &'static str {
+    use crate::envelope::EmbeddingState;
+    match coverage.embedding_state() {
+        EmbeddingState::Present => "present",
+        EmbeddingState::Partial => "partial",
+        EmbeddingState::Absent => "absent",
+        EmbeddingState::Unknown => "unknown",
+    }
+}
+
 /// Render the envelope's embedding coverage as a compact, agent-readable object
 /// (with a rounded percentage), or `Value::Null` when coverage is unknown.
 fn coverage_value(envelope: &Envelope) -> Value {
@@ -1092,13 +1104,24 @@ fn coverage_value(envelope: &Envelope) -> Value {
             } else {
                 (coverage.indexed as f64 / coverage.total as f64) * 100.0
             };
-            json!({
+            let mut rendered = json!({
                 "indexed": coverage.indexed,
                 "total": coverage.total,
                 "pending": coverage.pending,
                 "complete": coverage.complete,
+                // The one embedding verdict, beside the counters a reader would
+                // otherwise have to derive one from. `complete` is a
+                // conjunction and a reader deriving an embedding state from it
+                // gets `absent` on a fully embedded store (FIR-2543).
+                "embedding_state": embedding_state_word(coverage),
                 "percent": (percent * 10.0).round() / 10.0,
-            })
+            });
+            // Never fabricated: absent stays absent, so a reader can tell a
+            // producer that did not report a read time from one that did.
+            if let Some(read_at) = coverage.read_at.as_ref() {
+                rendered["read_at"] = json!(read_at);
+            }
+            rendered
         }
         None => Value::Null,
     }
@@ -1367,7 +1390,18 @@ fn coverage_basis(class: NegativeClass) -> &'static str {
 /// checked, which is exactly as much as that verdict knows.
 fn coverage_clause(class: NegativeClass, payload: &Value, envelope: &Envelope) -> String {
     match class {
+        // A percentage recited off counters nobody could read is the structural
+        // zero in prose: with no vector index attached, `embedding_status`
+        // answers zero indexed for every retrievable object, and this clause
+        // used to recite that as "semantic coverage 0.0%", which is a
+        // measurement of a store nothing measured. The unknown state says so
+        // instead (FIR-2543).
         NegativeClass::Semantic => match &envelope.semantic_coverage {
+            Some(coverage)
+                if coverage.embedding_state() == crate::envelope::EmbeddingState::Unknown =>
+            {
+                "semantic coverage unknown".to_string()
+            }
             Some(coverage) if coverage.total > 0 => {
                 let percent = (coverage.indexed as f64 / coverage.total as f64) * 100.0;
                 format!("semantic coverage {percent:.1}%")
@@ -2306,6 +2340,9 @@ mod tests {
             total: 100,
             pending: 0,
             complete: true,
+            embedding_state_reported: Some("present".to_string()),
+            limited_by: Vec::new(),
+            read_at: None,
             note: None,
             graph_body_gap_paths: None,
         });
@@ -2598,6 +2635,9 @@ mod tests {
             total: 100,
             pending: 60,
             complete: false,
+            embedding_state_reported: Some("partial".to_string()),
+            limited_by: vec!["embeddings_incomplete".to_string()],
+            read_at: None,
             note: Some("indexing".to_string()),
             graph_body_gap_paths: None,
         });
@@ -2626,6 +2666,9 @@ mod tests {
             total: 1644,
             pending: 0,
             complete: false,
+            embedding_state_reported: Some("present".to_string()),
+            limited_by: vec!["graph_body_gap".to_string()],
+            read_at: None,
             note: Some("graph body gap: 111 of 777 …".to_string()),
             graph_body_gap_paths: Some(111),
         });


### PR DESCRIPTION
A `semantic_locate` response carried `semantic_coverage: {indexed: 2112, total: 2112, pending: 0}` and `completeness.classes.embeddings: "absent"` in the same envelope. An agent reading the counters proceeds and an agent reading the class backs off, both from one object. This fixes that, which is the part of FIR-2543 with a single mechanism behind it, and gives the cross-surface half the read time it needs.

## Mechanism

The literal envelope is at `.kin-coord/handoffs/stranger-rc0545c/brown/out/phase2-work.jsonl` line 361. Its `graph_body_gap_paths` reads 0, so the body gap was not the cause, and its coverage note names the real one, "role filter: 15 test-role source path(s) were withheld from ranking and from the counters beside this note".

`SemanticCoverage.complete` is a conjunction. A detached vector index clears it. So does an unfinished index. So does a graph body gap, and so does the test-role filter. `SemanticCoverage::with_graph_bodies` at `crates/kin-cli/src/commands/locate.rs:1851` sets `self.complete = false` whenever `bodies.withholds_tests()` holds, which is a true statement about the population a query ranked over and no statement at all about embeddings.

`embedding_class_states` in `crates/kin-mcp/src/envelope.rs` derived the embedding class from that one flag, mapping `complete == false` to `absent`. The absence gate at `crates/kin-mcp/src/envelope.rs:1363` read the same flag and answered `coverage_partial: the semantic index is incomplete` over a whole index. One flag produced two false readings of one store inside one response, with the store's own counters sitting beside them saying otherwise. Only two of those four causes are about embeddings, and only those two share the `kin embed` remediation every consumer was implying.

## The fix

One embedding verdict, computed where the counters are taken and read by every surface.

`EmbeddingState::observe` at `crates/kin-cli/src/commands/locate.rs:184` decides `present`, `partial`, `absent` or `unknown` from `indexed`, `total`, `pending`, whether this build carries a vector backend, and whether an index was attached to take the reading. Both "nobody could say" checks run before any counter is read, because a counter taken with no index behind it is not a small number. `SemanticCoverage` gained `embedding_state` carrying that verdict, `limited_by` naming every reason `complete` is false, and `read_at` recording when the counters were sampled. `with_graph_bodies` records `graph_role_filter` and `graph_body_gap` in `limited_by` and deliberately leaves `embedding_state` alone.

`SemanticCoverage::embedding_state()` at `crates/kin-mcp/src/envelope.rs:194` is the one accessor. It prefers the verdict the producing surface published, because that is the only reader that knew whether an index was attached, and falls back to the counters for older payloads. That fallback answers `unknown` for every reading the counters cannot decide alone. `embedding_status` reports zero indexed for every retrievable object when no index is attached, so a bare `indexed: 0` is both a fully embedded store whose index did not load and a store nobody embedded. An unrecognized wire word also reads `unknown`, so a future producer cannot certify an answer by naming a state this build has not agreed is certifiable.

`scope_limits()` at `crates/kin-mcp/src/envelope.rs:223` carries the role filter and the body gap into `completeness.limits` as disclosure rather than as a verdict about a substrate neither one measured. `embedding_class_states` and the absence gate both consume the accessor, and the gate now names the cause it actually observed. That includes a new `coverage_role_filter_withheld` reason. With embeddings whole, an absence over a narrowed population is still not an absence over the repository, so the gate keeps refusing, for the true reason instead of a false one.

One consequence is worth stating rather than leaving for a reviewer to find. With the class now
`present` on a role-filtered store, `completeness.status` reads `complete` for that response where
it used to read `partial`. The safety that reading used to provide has not gone anywhere, and it
comes from two places that are both more accurate than the old flag. The absence gate refuses with
`coverage_role_filter_withheld`, because an absence over a narrowed population is not an absence
over the repository. And the role filter always emits a `graph_role_filter:tests_withheld`
degradation, which makes `_kin.verdict` inconclusive, and `Verdict::project_onto_completeness` caps
`bound` back to `at_least` and rewrites the note. The recorded envelope shows both, carrying that
degradation and `verdict.state: inconclusive`. The unit fixtures omit the degradations array on
purpose, so they isolate the class rule from the projection that sits on top of it.

`crates/kin-mcp/src/negative.rs` publishes `embedding_state` and `read_at` beside the counters, and `coverage_clause` says "semantic coverage unknown" when the state is unknown instead of reciting "semantic coverage 0.0%", which was the structural zero in prose.

`crates/kin-cli/src/commands/search.rs` had no index-attached gate at all, so `kin search` published a measured shortfall on a graph whose counters nothing measured. It now takes the same observation locate does.

This PR carried a second commit, an honesty fix for `kin embed` from the stranger run on the released v0.5.45 bytes. That commit is gone as of the 2026-08-21 rebase below, because kin#1030 landed the same fix first. See the rebase note at the end; nothing was lost.

## Falsification

Three passes, each removing one property, each predicted before it ran. Every sabotage was confirmed present in the file before its run and the file was restored to a matching sha256 afterwards. Every exit status was read raw and every failure message in full, never through a pipe.

Pass 1 put the class back on `coverage.complete`. Result `26 passed; 4 failed`, and the headline failure regenerates the defect in the released bytes exactly:

```
case n_of_n_with_a_role_filter_withholding_paths: the class must follow the counters beside it:
  "classes":{"embeddings":"absent"} ... "semantic_coverage":{"indexed":2112,"pending":0,"total":2112}
  left: String("absent")  right: String("present")
```

I predicted five failures and got four. `a_role_filter_declared_only_by_the_body_coverage_object_is_still_read` passed, because it guards the disclosure property in `scope_limits()`, which pass 1 did not remove. The prediction was wrong about which property that test guards. `a_ranked_answer_reports_the_embedding_substrate` passed as predicted, since 40 of 100 is partial under both rules.

Pass 2 kept the accessor and made the legacy fallback read `indexed == 0` as `absent`. It predicted exactly one failure and produced exactly one, `29 passed; 1 failed`:

```
a count nobody could read is unknown, never zero: "classes":{"embeddings":"absent"}
  left: String("absent")  right: String("unknown")
```

Every other new test passed under pass 2, which is what shows each guards a distinct property rather than all restating one.

Pass 3 belonged to the `kin embed` commit that the 2026-08-21 rebase dropped, so it no longer describes anything this PR carries. It is left recorded here rather than deleted, because the falsification it reports did happen; it simply now evidences code that landed under kin#1030 instead. Passes 1 and 2 above are this PR's own.

The main table test drives cases with real counters, one per row and each named on its own: `n_of_n_with_a_role_filter_withholding_paths`, `n_of_n_with_nothing_pending`, `zero_of_n_against_an_attached_index`, `some_indexed_with_work_still_pending`, and `counters_taken_with_no_index_attached_to_read_them`. There is no empty-input arm, because a store with no eligible entity makes the agreement trivially true and could not fail if the rule were removed.

## Gates

The full local gate `bin/kin-dev local-test kin -- --no-fail-fast` returned 0 with
`Summary [ 491.811s] 6632 tests run: 6632 passed (7 slow, 3 leaky), 12 skipped`, over the tree its
own line names, `.kin-coord/worktrees/embedcount-kin @ bd195030 (chore/lane-embedcount-kin)`. It
was re-run after the rebase onto 674af63a for fmt and the four guard scripts; the test total above
is from bd195030, which carries the same six files.

An earlier gate run on the same tree went red on one test,
`kin-cli::live_graph_durability_disclosure mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit_records_them`,
and that is worth reporting rather than burying. It fails when the daemon's `try_lock` on
`state.embedding_work` at `crates/kin-daemon/src/api.rs:2057` is refused for the fixture's whole
flat 30-second budget, which happens when an embedding batch holds that lock at
`crates/kin-daemon/src/daemon.rs:232`. Across eight runs the result tracked box load rather than
the diff: `origin/main` passed at load 17, 91 and 38, this branch failed at load 98 and 96 and
passed at load 40, and two partial-revert variants failed at load 112 and 22. The code rules
this change out on mechanism twice over. Its only kin-daemon edit sits inside `#[cfg(test)] mod tests`, which
starts at line 12414, so it is not in the daemon binary the fixture spawns. And the one hunk adding
a graph call, `vector_index_attached` in `search.rs`, is off that test's path entirely: the fixture
calls `kin_graph_status` and `semantic_locate` and nothing else, and the daemon serves
`semantic_locate` from `local_semantic_coverage` at `api.rs:7528`. A bisect had pointed at that
hunk and the call graph disproved it. Filed on FIR-2563 with the run table.

`cargo fmt --all -- --check` exits 0. Clippy exactly as `.github/workflows/ci.yml` runs it, `RUSTFLAGS=-D warnings` with the `.github/clippy-allowed-lints.txt` allow list over `--all-targets --all-features`, exits 0 with zero error lines. `python3 scripts/verify-zero-file-search.py` exits 0 over 177 source files, `bash scripts/zero_file_search_guard.sh` exits 0, `bash scripts/check_runtime_boundaries.sh` exits 0 and `bash scripts/check_private_repo_coupling.sh` exits 0. `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

## Left undone

This does not close the ticket. Ask 1, that `kin graph status` and `kin status` derive from one authoritative store counter rather than computing their own, is a larger change than one lane should make during a release freeze. Those two surfaces still sample their own graphs. They do now have `read_at` on the coverage payload. That answers the half of the disagreement that is about time rather than truth. The four-state verdict is there for them to adopt whenever someone unifies them.

Nothing here was reproduced against a live daemon. Every result is from unit tests over payload fixtures plus the envelope the stranger run recorded.

One seam is worth naming. kin-mcp does not depend on kin-cli, so its mirror spells the two scope labels as literals (`SCOPE_LIMIT_ROLE_FILTER`, `SCOPE_LIMIT_BODY_GAP`) with doc comments naming the kin-cli constants they mirror. Nothing in the build enforces that those stay spelled the same, and a rename on either side would silently stop the role filter being disclosed.

## Rebase note, 2026-08-21 12:5xZ

This PR was ejected from the merge queue at 12:13:48Z with reason `merge_conflict` against kin#1030, which was queued behind it and landed first at 12:13:12Z as squash `3c21f868`. Rebased onto `origin/main` by the salvage lane, which holds both sides of the conflict.

What changed, and why nothing was lost. The branch's second commit, `f3674888` "Separate what a kin embed run embedded from what the store holds", touched `crates/kin-cli/src/commands/embed.rs` and nothing else, and its whole content was superseded by what kin#1030 landed: both fix the same stranger finding on the same line. Resolving the conflict to the landed side made that commit empty and the rebase dropped it. `crates/kin-cli/src/commands/embed.rs` on this branch is now byte-identical to `origin/main`, and the branch carries one commit against five files, all of it the FIR-2543 embedding-class work this PR is titled for.

One behaviour did not survive, deliberately. `full_coverage_line`'s zero arm said the daemon's background worker had already covered the store. The landed version does not, because a store already whole when a pass starts may equally have been filled by `kin init` or by an earlier explicit `kin embed`, and nothing at the completion line distinguishes them. The landed line says the work predates the pass, which is what the process can establish. The two tests that asserted the attribution went with it; every other property they guarded is covered on main by `a_pass_that_inherited_a_covered_store_says_the_work_predated_it` and `a_pass_that_embedded_reports_its_own_work_and_the_span_it_moved`.

One difference is named rather than smuggled in. `full_coverage_line` reported the store as entity and artifact totals separately; the landed line reports the coverage span over retrieval keys (`3/53` to `53/53 indexed`). Both are useful and neither is wrong. Adding the entity and artifact split to the landed sentence would need its own test and falsification, so it is a follow-up rather than something a rebase quietly introduces.

Gates re-run on the rebased branch through `bin/kin-lane run embedcount kin`, every exit status read raw and every total taken from its run's own `test result:` summary line rather than an rc file:

- `cargo test -p kin-mcp --lib`: exit 0, `593 passed; 0 failed`
- `cargo test -p kin-cli --lib commands::`: exit 0, `1461 passed; 0 failed`
- `cargo fmt --all -- --check`: exit 0
- clippy exactly as ci.yml runs it, `--all-targets --all-features` under `RUSTFLAGS=-D warnings`: exit 0, no unused or never-used warnings
- `python3 scripts/verify-zero-file-search.py`: exit 0, 178 source files
- `bash scripts/zero_file_search_guard.sh`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`: all exit 0

`git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml` and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty. Pushed with `--force-with-lease` pinned to the pre-rebase head `f3674888`, and the PR head was confirmed equal to the branch head afterwards rather than inferred from a green check.

Refs FIR-2543

