### PR TITLE
Give the auth credential test a per-process store instead of the host one

### DIFF
--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -48,7 +48,47 @@ fn project_dirs() -> Result<ProjectDirs> {
         .ok_or_else(|| anyhow::anyhow!("failed to resolve Kin config directory"))
 }
 
+#[cfg(test)]
+thread_local! {
+    /// Where a test has redirected the fallback credential root, if anywhere.
+    ///
+    /// The real root is host-global, shared by every process on the machine,
+    /// so a test that writes into it is racing every other process that does
+    /// the same, including another checkout's copy of this same test binary.
+    /// `#[serial]` cannot help there: it orders tests inside ONE binary and the
+    /// contended resource is one path on the host.
+    ///
+    /// Thread-local rather than a static, so a threaded `cargo test` run cannot
+    /// leak one test's redirect into another, and taken through an RAII guard
+    /// so a panicking test still puts it back.
+    static TEST_CREDENTIAL_ROOT: std::cell::RefCell<Option<PathBuf>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Redirect [`fallback_credential_root`] for the life of the guard.
+#[cfg(test)]
+struct TestCredentialRoot;
+
+#[cfg(test)]
+impl TestCredentialRoot {
+    fn set(root: &std::path::Path) -> Self {
+        TEST_CREDENTIAL_ROOT.with(|slot| *slot.borrow_mut() = Some(root.to_path_buf()));
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestCredentialRoot {
+    fn drop(&mut self) {
+        TEST_CREDENTIAL_ROOT.with(|slot| *slot.borrow_mut() = None);
+    }
+}
+
 fn fallback_credential_root() -> Result<PathBuf> {
+    #[cfg(test)]
+    if let Some(root) = TEST_CREDENTIAL_ROOT.with(|slot| slot.borrow().clone()) {
+        return Ok(root);
+    }
     Ok(project_dirs()?.data_local_dir().join("auth"))
 }
 
@@ -587,10 +627,20 @@ mod tests {
     #[serial]
     fn default_cli_actor_id_prefers_saved_credential_email() {
         let base_url = "https://kinlab.example.com";
-        let dirs = project_dirs().unwrap();
-        let root = dirs.data_local_dir().join("auth");
-        fs::create_dir_all(&root).unwrap();
-        let path = root.join(format!("{}.json.age", account_key(base_url)));
+        // Per-process root. The real one is host-global, so two lanes running
+        // this binary at once wrote and deleted one file and whichever lost
+        // panicked in its own teardown.
+        let store = tempfile::tempdir().expect("a private credential store");
+        let _root = TestCredentialRoot::set(&store.path().join("auth"));
+
+        // Resolved through the locator the product itself reads, so a test
+        // that wrote somewhere the product never looks would fail rather than
+        // quietly assert on the ambient machine's credential.
+        let path = fallback_credential_path(base_url).unwrap();
+        assert!(
+            path.starts_with(store.path()),
+            "the credential path must resolve inside this test's own store, not {path:?}"
+        );
         let payload = serde_json::to_vec(&StoredCredential {
             base_url: base_url.to_string(),
             token: "token".to_string(),
@@ -608,7 +658,36 @@ mod tests {
         let actor_id = default_cli_actor_id(base_url);
         assert_eq!(actor_id, "cli:troy@firelock.ai:workstation");
 
-        fs::remove_file(path).unwrap();
+        // No teardown to race: the tempdir takes the whole store with it.
+    }
+
+    /// The redirect is what keeps the test off the host, so it gets its own
+    /// case in both directions rather than being trusted.
+    #[test]
+    #[serial]
+    fn the_credential_root_redirect_applies_and_then_stops_applying() {
+        let host_root = fallback_credential_root().unwrap();
+        let store = tempfile::tempdir().expect("a private credential store");
+        let redirected = store.path().join("auth");
+
+        {
+            let _root = TestCredentialRoot::set(&redirected);
+            assert_eq!(
+                fallback_credential_root().unwrap(),
+                redirected,
+                "the guard must redirect the root the product reads"
+            );
+        }
+
+        assert_eq!(
+            fallback_credential_root().unwrap(),
+            host_root,
+            "the guard must put the host root back when it drops"
+        );
+        assert!(
+            !host_root.starts_with(store.path()),
+            "the host root and the redirect must be different places, or this proves nothing"
+        );
     }
 
     /// A probe that never read the keyring has not learned that the machine is


### PR DESCRIPTION
A unit test that wrote to a host-global path, so any two lanes running the full gate at once could fail each other on one file.

## Mechanism

`kin-cli commands::auth::tests::default_cli_actor_id_prefers_saved_credential_email` built its path from `project_dirs().unwrap().data_local_dir().join("auth")` at `crates/kin-cli/src/commands/auth.rs:589-593`, wrote `<account_key>.json.age` into it, and ended with `fs::remove_file(path).unwrap()` at line 611. That directory is host-global and shared by every process on the machine, and the account key is derived from a fixed base URL, so every copy of this binary anywhere on the host writes and deletes the exact same file.

`#[serial]` cannot help. It orders tests inside one test binary, and the contended resource is one path on the host, so two lanes running `bin/kin-dev local-test kin` concurrently raced and whichever lost panicked in its own teardown with `Os { code: 2, kind: NotFound }`. The build-slot throttle cannot help either, since it bounds CPU rather than host paths.

## The fix

`fallback_credential_root` at `crates/kin-cli/src/commands/auth.rs:86` now consults a `#[cfg(test)]` thread-local redirect before the host root, so a test can point the locator the product itself reads at its own tempdir. Thread-local rather than a static, so a threaded `cargo test` run cannot leak one test's redirect into another, and taken through an RAII guard so a panicking test still puts it back. Outside `cfg(test)` the function is byte for byte what it was, so the product path is unchanged.

The test resolves its path through `fallback_credential_path` rather than rebuilding it, and asserts that path lands inside its own store. A redirect that failed to apply therefore fails the test, instead of quietly asserting against the ambient machine's credential. There is no teardown left to race: the tempdir takes the whole store with it.

A second case, `the_credential_root_redirect_applies_and_then_stops_applying`, drives the redirect in both directions, that it applies while the guard is held and that the host root comes back when it drops, with an assertion that the two are different places so the case cannot pass vacuously.

## Falsification

Run as the ticket asks: four copies of the `kin-cli` unit-test binary launched concurrently, each looping the auth test 25 times, so 100 runs per arm. Binary provenance checked first on a string only the fixed build carries, control 0 and fixed 1, because both arms build to the same path.

With the fix:

```
host auth dir before: []
FIXED: copies=4 rounds=25 failed_copies=0
host auth dir after: []
```

With `crates/kin-cli/src/commands/auth.rs` reverted to `origin/main` and rebuilt, everything else identical:

```
CONTROL: copies=4 rounds=25 failed_copies=3
thread 'commands::auth::tests::default_cli_actor_id_prefers_saved_credential_email'
panicked at crates/kin-cli/src/commands/auth.rs:611:31:
called `Result::unwrap()` on an `Err` value:
Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

Three of four copies failed, at the line and with the errno the ticket names. The host directory `~/Library/Application Support/ai.Firelock.kin/auth/` was empty before and after both arms, and the fixed arm never created anything in it, which is the separate assertion that the test has left the host alone rather than merely stopped racing. The file was restored byte-identical afterwards, sha256 verified against a copy taken before the revert.

## Sweep

Every `#[cfg(test)] mod tests` in `crates/kin-cli/src` was scanned for `project_dirs()`, `data_local_dir()`, `config_local_dir()` and `home_dir()`, across the 86 files that carry a test module. Four call sites came back besides this one. `retrieval_profile.rs:848` is a doc comment. `setup.rs:14737-14738` compares `home_dir()` against `BaseDirs` inside the env mutation domain, and `setup.rs:19068` reads the current home's ACL; all three read and none writes. The setup hook tests that do write already run with `HOME` set to their own tempdir. So this was the only test in the crate writing to a host-global path.

## Gates

`cargo fmt --all -- --check` exit 0. `cargo clippy --all-targets --all-features` with the 45 lint debt allow-list under `RUSTFLAGS=-D warnings` exit 0, run in the lane worktree. `python3 scripts/verify-zero-file-search.py`, `bash scripts/zero_file_search_guard.sh`, `python3 scripts/verify-hydration-semantics.py`, `bash scripts/check_runtime_boundaries.sh`, `bash scripts/check_private_repo_coupling.sh` and `python3 scripts/test-private-repo-coupling.py` all exit 0. `cargo test -p kin-cli --lib -- commands::auth::tests` gives 3 passed, 0 failed.

The full local gate is not run here: the box is carrying the post-tag drain and other lanes' gates, and this diff is one file inside one crate whose unit tests are green and whose concurrent-run behaviour is the thing under test. Hosted CI is the gate of record for this PR, and its per-check lines go in the lane report once every check has concluded.

Worth recording: the unused-doc-comment error that `cargo clippy --all-targets` caught here would have been a red CI check, and `cargo test -p kin-cli --lib` passed with it in place. A doc comment above a `thread_local!` invocation documents a macro call rather than the static it declares, and `-D warnings` rejects it only when the lib test target is built. Moving the prose inside the macro onto the static fixed it.

`Closes FIR-1747` as well: that is the same test, the same `remove_file` NotFound panic, and the same fix shape, filed on 2026-07-31 against the then line 515 and observed exactly once. It sat for three weeks and cost another lane a whole gate on 2026-08-21, which is the argument for treating a one-occurrence host-path race as a defect rather than as a flake.

Closes FIR-2571
Closes FIR-1747
