### PR TITLE
Report the store's coverage beside an embed pass's own count

### DIFF
--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -41,6 +41,31 @@ pub struct EmbedRequest {
     pub cap_batch_size: bool,
 }
 
+/// The store's own embedding coverage either side of one embed pass, sampled by
+/// the daemon that ran it.
+///
+/// A pass reports how much IT embedded. That number and the store's coverage
+/// are different facts, and a pass that arrives after the queue is already
+/// drained holds a zero for the first while the second reads whole. Printed
+/// under one heading the two are indistinguishable, which is the state a user
+/// runs `kin embed` to tell apart.
+///
+/// Both samples are taken inside `build_embed_response`, which runs holding
+/// `DaemonState::embedding_work`. That mutex serializes explicit `/embed`
+/// requests against the background embedding worker, so the worker cannot move
+/// coverage between the two reads: `indexed_before` is exactly the state this
+/// pass inherited and `indexed_after` is exactly the state it left.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PassCoverage {
+    /// Retrievable objects already in the vector index when the pass started,
+    /// before it propagated, queued or embedded anything.
+    pub indexed_before: usize,
+    /// Retrievable objects in the vector index when the pass returned.
+    pub indexed_after: usize,
+    /// Retrievable objects that require an embedding, as the pass last read it.
+    pub total: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbedResult {
     pub total_entities: usize,
@@ -51,6 +76,15 @@ pub struct EmbedResult {
     pub pending_artifacts: usize,
     pub time_limited: bool,
     pub vector_index_path: String,
+    /// The store's coverage either side of this pass, or `None` from a daemon
+    /// that does not report it.
+    ///
+    /// Optional rather than defaulted to zeros on purpose: a daemon that never
+    /// measured coverage and a store holding nothing both deserialize to the
+    /// same three zeros, and a summary line built from those would state a
+    /// measurement nobody took. `None` renders no coverage claim at all.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<PassCoverage>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,6 +92,89 @@ pub struct EmbedResponse {
     pub result: EmbedResult,
     #[serde(default)]
     pub lines: Vec<String>,
+}
+
+/// The completion line for a run that ended with nothing pending.
+///
+/// The line this replaces was `Done. Full coverage: {embedded} entities,
+/// {embedded} artifacts embedded ...`, which put the run's own pass counter
+/// under a heading about the store. On the shipped v0.5.45 bytes a stranger ran
+/// it on a store whose coverage went from 3 of 51 to 51 of 51 across the call
+/// and read `Done. Full coverage: 0 entities, 0 artifacts embedded`. Both
+/// numbers were true and the sentence was unreadable: a run that found an empty
+/// queue and a run that silently failed to embed produce the same zero, and
+/// those are the two states the command is run to tell apart.
+///
+/// So the run's own work and the store's coverage are named as two facts, and
+/// which sentence a zero gets is decided by `coverage`, which the daemon
+/// measured, rather than by an assumption about who filled the store. This
+/// process cannot observe that: a store already whole at entry may have been
+/// filled by the background worker, by `kin init`, or by an earlier explicit
+/// pass, and nothing reaching here distinguishes them. What it can say, and
+/// does, is that the work was finished before this pass started.
+///
+/// `None` coverage comes from a daemon that does not report it. That arm states
+/// the run's own work and makes no claim about the store, because a claim built
+/// from numbers nobody sampled is the defect this function exists to remove.
+fn embed_completion_line(
+    embedded_entities: usize,
+    embedded_artifacts: usize,
+    passes: usize,
+    rate: f64,
+    coverage: Option<PassCoverage>,
+) -> String {
+    let embedded = embedded_entities + embedded_artifacts;
+    let Some(coverage) = coverage else {
+        return format!(
+            "Done. This run embedded {embedded_entities} entities and {embedded_artifacts} \
+             artifacts across {passes} pass(es) at {rate:.2} ent/s, and the daemon reports \
+             nothing pending. This daemon does not report the store's coverage, so no claim \
+             about it is made here"
+        );
+    };
+    let PassCoverage {
+        indexed_before,
+        indexed_after,
+        total,
+    } = coverage;
+    if total == 0 {
+        return "Done. This repository has no retrievable graph objects that require an \
+                embedding, so there was nothing to embed"
+            .to_string();
+    }
+    if embedded > 0 {
+        return format!(
+            "Done. This run embedded {embedded_entities} entities and {embedded_artifacts} \
+             artifacts across {passes} pass(es) at {rate:.2} ent/s, taking this store from \
+             {indexed_before}/{total} to {indexed_after}/{total} indexed"
+        );
+    }
+    if indexed_before >= total {
+        return format!(
+            "Done. Nothing to embed: this store was already fully covered at {indexed_before}/\
+             {total} indexed when this pass started, so the work was finished before it ran"
+        );
+    }
+    if indexed_after > indexed_before {
+        // Coverage moved while the pass held the embedding lock and its queue
+        // embedded nothing, which is `propagate_revision_vectors` reusing
+        // vectors from fingerprint-identical revisions. That IS this pass's
+        // work; crediting it to an absent worker would be the same error the
+        // old line made, pointed the other way.
+        return format!(
+            "Done. This run embedded nothing through the queue and still took this store from \
+             {indexed_before}/{total} to {indexed_after}/{total} indexed, by reusing vectors \
+             from content-identical revisions"
+        );
+    }
+    // Nothing pending, nothing embedded, and coverage below total: the queue
+    // and the coverage counters disagree about what is left. Report both rather
+    // than picking one, since neither is established here.
+    format!(
+        "Done. This run embedded nothing and the daemon reports nothing pending, but this store \
+         reads {indexed_after}/{total} indexed. Run `kin health` to see why coverage and the \
+         queue disagree"
+    )
 }
 
 /// Decide whether the embed loop should enqueue missing retrievable objects.
@@ -391,6 +508,11 @@ pub async fn run(
     let mut embedded_entities = 0usize;
     let mut embedded_artifacts = 0usize;
     let mut budget_stopped = false;
+    // The run's coverage span is the FIRST pass's entry reading and the LAST
+    // pass's exit reading. Taking both from the final pass would report the
+    // span of one pass under a heading about the run, which is the same class
+    // of error as reporting a pass counter as the store's coverage.
+    let mut first_pass_indexed_before: Option<usize> = None;
     let final_result = loop {
         pass += 1;
         let response = run_daemon_embed(
@@ -410,6 +532,9 @@ pub async fn run(
         let result = response.result;
         embedded_entities += result.embedded_entities;
         embedded_artifacts += result.embedded_artifacts;
+        if first_pass_indexed_before.is_none() {
+            first_pass_indexed_before = result.coverage.map(|c| c.indexed_before);
+        }
         let made_progress = result.embedded_entities + result.embedded_artifacts > 0;
 
         let elapsed = embed_started.elapsed().as_secs_f64();
@@ -438,18 +563,36 @@ pub async fn run(
     let pending = final_result.pending_entities + final_result.pending_artifacts;
     let elapsed = embed_started.elapsed().as_secs_f64();
     let rate = throughput_per_sec(embedded_entities + embedded_artifacts, elapsed);
+    // The run's span: where the first pass found this store, where the last one
+    // left it. Both halves have to be present, so a daemon that reported
+    // coverage on only some passes yields no span rather than a mixed one.
+    let run_coverage = match (first_pass_indexed_before, final_result.coverage) {
+        (Some(indexed_before), Some(last)) => Some(PassCoverage {
+            indexed_before,
+            ..last
+        }),
+        _ => None,
+    };
     if json {
         let aggregate = EmbedResult {
             embedded_entities,
             embedded_artifacts,
             time_limited: pending > 0,
+            coverage: run_coverage,
             ..final_result
         };
         println!("{}", serde_json::to_string_pretty(&aggregate)?);
     } else if pending == 0 {
         println!(
-            "Done. Full coverage: {} entities, {} artifacts embedded across {pass} pass(es) at {:.2} ent/s, index saved to {}",
-            embedded_entities, embedded_artifacts, rate, final_result.vector_index_path
+            "{}, index saved to {}",
+            embed_completion_line(
+                embedded_entities,
+                embedded_artifacts,
+                pass,
+                rate,
+                run_coverage,
+            ),
+            final_result.vector_index_path
         );
     } else if budget_stopped {
         println!(
@@ -525,10 +668,25 @@ pub fn build_embed_response(
                 pending_artifacts: 0,
                 time_limited: false,
                 vector_index_path: String::new(),
+                coverage: Some(PassCoverage {
+                    indexed_before: 0,
+                    indexed_after: 0,
+                    total: 0,
+                }),
             },
             lines: vec!["No retrievable graph objects found. Run `kin init` first.".to_string()],
         });
     }
+
+    // Sampled here, before this pass propagates, queues or embeds anything, so
+    // it reports the store this pass INHERITED. The reading taken further down
+    // for the queue decision is already post-propagation, and reusing it would
+    // credit this pass's own propagation to whatever ran before it.
+    //
+    // Nothing else can move coverage between this line and the exit sample: the
+    // caller holds `DaemonState::embedding_work`, which serializes explicit
+    // passes against the background embedding worker.
+    let coverage_before = graph.embedding_status();
 
     // Propagate vectors from fingerprint-identical previous revisions before
     // queueing, so identical-content revisions skip GPU inference entirely.
@@ -621,6 +779,7 @@ pub fn build_embed_response(
     let vi_path = crate::backend::vector_index_path(layout);
     let pending_entities = graph.pending_embeddings();
     let pending_artifacts = graph.pending_artifact_embeddings();
+    let coverage_after = graph.embedding_status();
     let result = EmbedResult {
         total_entities,
         embedded_entities: total_embedded_entities,
@@ -630,6 +789,11 @@ pub fn build_embed_response(
         pending_artifacts,
         time_limited,
         vector_index_path: vi_path.to_string_lossy().to_string(),
+        coverage: Some(PassCoverage {
+            indexed_before: coverage_before.indexed,
+            indexed_after: coverage_after.indexed,
+            total: coverage_after.total,
+        }),
     };
     let mut lines = Vec::new();
     if time_limited {
@@ -659,11 +823,11 @@ pub fn build_embed_response(
 #[cfg(test)]
 mod tests {
     use super::{
-        constrained_memory_notice, effective_batch_size, embed_pass_should_continue,
-        embed_resource_exhaustion, eta_suffix, format_duration_secs, resolve_total_budget,
-        should_queue_missing_embedding_pass, throughput_per_sec, EmbedResult, DEFAULT_BATCH_SIZE,
-        DEFAULT_CONSTRAINED_TOTAL_SECONDS, EMBED_MODEL_DOWNLOAD, EMBED_MODEL_ID,
-        RECOMMENDED_EMBED_MEMORY_BYTES,
+        constrained_memory_notice, effective_batch_size, embed_completion_line,
+        embed_pass_should_continue, embed_resource_exhaustion, eta_suffix, format_duration_secs,
+        resolve_total_budget, should_queue_missing_embedding_pass, throughput_per_sec, EmbedResult,
+        PassCoverage, DEFAULT_BATCH_SIZE, DEFAULT_CONSTRAINED_TOTAL_SECONDS, EMBED_MODEL_DOWNLOAD,
+        EMBED_MODEL_ID, RECOMMENDED_EMBED_MEMORY_BYTES,
     };
 
     fn result_with(pending_entities: usize, pending_artifacts: usize) -> EmbedResult {
@@ -676,7 +840,270 @@ mod tests {
             pending_artifacts,
             time_limited: false,
             vector_index_path: String::new(),
+            coverage: None,
         }
+    }
+
+    fn coverage(indexed_before: usize, indexed_after: usize, total: usize) -> Option<PassCoverage> {
+        Some(PassCoverage {
+            indexed_before,
+            indexed_after,
+            total,
+        })
+    }
+
+    /// The defect, driven with the stranger's own numbers.
+    ///
+    /// On the shipped v0.5.45 bytes a store went from 3 of 51 to 51 of 51 across
+    /// one `kin embed`, and the command reported `Done. Full coverage: 0
+    /// entities, 0 artifacts embedded`. The pass that printed it inherited a
+    /// store already at 51 of 51, so its own zero was correct and its heading
+    /// was not. Two properties have to hold at once: the store's coverage is
+    /// stated, and the run's zero never renders as the store's.
+    #[test]
+    fn a_pass_that_inherited_a_covered_store_says_the_work_predated_it() {
+        let line = embed_completion_line(0, 0, 1, 0.0, coverage(51, 51, 51));
+        assert!(
+            line.contains("51/51 indexed"),
+            "the store's own coverage has to be stated: {line}"
+        );
+        assert!(
+            line.contains("already fully covered")
+                && line.contains("the work was finished before it ran"),
+            "a zero has to say which of the two states this is: {line}"
+        );
+        assert!(
+            !line.contains("Full coverage: 0"),
+            "the run's own zero must never render as the store's coverage: {line}"
+        );
+    }
+
+    /// The control that lets the arm above fail: a run that did the work reports
+    /// its own count and the span it moved the store across, which is a
+    /// different sentence and carries different numbers.
+    #[test]
+    fn a_pass_that_embedded_reports_its_own_work_and_the_span_it_moved() {
+        let line = embed_completion_line(48, 2, 2, 12.5, coverage(3, 53, 53));
+        assert!(
+            line.contains("embedded 48 entities and 2 artifacts"),
+            "this run's own work is named: {line}"
+        );
+        assert!(
+            line.contains("3/53") && line.contains("53/53"),
+            "the coverage span it moved is named beside it: {line}"
+        );
+        assert!(
+            !line.contains("already fully covered"),
+            "a run that did the work must not report the store as pre-covered: {line}"
+        );
+    }
+
+    /// Coverage that moved while the queue embedded nothing is this pass's own
+    /// propagation of vectors from content-identical revisions, so it is
+    /// credited here rather than to whatever ran before. Without this arm the
+    /// span would be reported under the pre-covered sentence, which is false.
+    #[test]
+    fn coverage_that_moved_without_the_queue_is_credited_to_this_run() {
+        let line = embed_completion_line(0, 0, 1, 0.0, coverage(10, 51, 51));
+        assert!(
+            line.contains("10/51") && line.contains("51/51"),
+            "both ends of the span are named: {line}"
+        );
+        assert!(
+            line.contains("content-identical revisions"),
+            "the reader learns where the coverage came from: {line}"
+        );
+        assert!(
+            !line.contains("already fully covered"),
+            "a store that was not covered at entry must not be reported as covered: {line}"
+        );
+    }
+
+    /// A daemon that reports no coverage gets no coverage sentence. Defaulting
+    /// the three counters to zero would make an unmeasured store and an empty
+    /// one render identically, which is the defect this change removes wearing
+    /// a different costume.
+    #[test]
+    fn an_unreported_coverage_states_the_runs_work_and_claims_nothing_else() {
+        let line = embed_completion_line(7, 0, 1, 3.5, None);
+        assert!(
+            line.contains("embedded 7 entities"),
+            "the run's own work still renders: {line}"
+        );
+        assert!(
+            line.contains("does not report the store's coverage"),
+            "the absence of a measurement is stated, not filled in: {line}"
+        );
+        assert!(
+            !line.contains("0/0"),
+            "an unmeasured store must never render as a counted one: {line}"
+        );
+    }
+
+    /// The wiring, not the helper: a real pass has to PUBLISH the coverage the
+    /// sentence is built from.
+    ///
+    /// Every arm above drives `embed_completion_line` directly, and a
+    /// `build_embed_response` that never filled `coverage` would satisfy all of
+    /// them while every real run rendered the no-measurement sentence. That is
+    /// the same defect wearing the fix's clothes, and only a test that runs a
+    /// pass can tell the two apart.
+    ///
+    /// The store here is the one FIR-2556 is about: an explicit pass arriving at
+    /// a store somebody else already finished. It needs no embedder, because
+    /// with coverage whole there is nothing for either queue loop to process,
+    /// which is exactly why this case reaches a user as a zero.
+    #[cfg(feature = "vector")]
+    #[test]
+    fn a_pass_publishes_the_store_coverage_its_summary_is_built_from() {
+        use super::EmbedRequest;
+        use kin_model::{
+            Entity, EntityMetadata, EntityStore, FingerprintAlgorithm, Hash256, LanguageId,
+            SemanticFingerprint, Visibility,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(temp.path()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        for name in ["alpha_transform", "beta_reduce"] {
+            graph
+                .upsert_entity(&Entity {
+                    id: kin_model::EntityId::new(),
+                    kind: kin_model::EntityKind::Function,
+                    name: name.to_string(),
+                    language: LanguageId::Rust,
+                    fingerprint: SemanticFingerprint {
+                        algorithm: FingerprintAlgorithm::V1TreeSitter,
+                        ast_hash: Hash256::from_bytes([1; 32]),
+                        signature_hash: Hash256::from_bytes([2; 32]),
+                        behavior_hash: Hash256::from_bytes([3; 32]),
+                        equivalence_hash: Hash256::from_bytes([0; 32]),
+                        stability_score: 1.0,
+                    },
+                    file_origin: None,
+                    span: None,
+                    signature: format!("fn {name}()"),
+                    visibility: Visibility::Public,
+                    role: kin_model::EntityRole::Source,
+                    doc_summary: None,
+                    metadata: EntityMetadata::default(),
+                    lineage_parent: None,
+                    created_in: None,
+                    superseded_by: None,
+                })
+                .unwrap();
+        }
+
+        // Cover every retrievable key, which is what "somebody else finished
+        // this store" leaves behind.
+        let index = kin_db::VectorIndex::new(2).unwrap();
+        let snapshot = graph.to_snapshot();
+        for id in snapshot.entities.keys() {
+            index
+                .upsert_retrievable(kin_model::RetrievalKey::Entity(*id), &[1.0, 0.0])
+                .unwrap();
+        }
+        for revision in snapshot
+            .entity_revisions
+            .values()
+            .flat_map(|revisions| revisions.iter())
+        {
+            index
+                .upsert_retrievable(
+                    kin_model::RetrievalKey::EntityRevision(revision.revision_id),
+                    &[1.0, 0.0],
+                )
+                .unwrap();
+        }
+        let descriptor = kin_db::IndexDescriptor {
+            model_id: Some("embed-wiring-fixture@v1".to_string()),
+            graph_root: Some(hex::encode(graph.compute_root_hash())),
+        };
+        index.set_descriptor(descriptor.clone());
+        let sidecar = temp.path().join("wiring.kvec");
+        index.save(&sidecar).unwrap();
+        assert!(matches!(
+            graph.load_vector_index_compatible(&sidecar, &descriptor),
+            kin_db::VectorIndexLoad::Loaded(_)
+        ));
+
+        // Rebuild the graph from its own snapshot and carry the index across.
+        // `upsert_entity` enqueues every entity it admits, and nothing short of
+        // a real embedder drains that queue, so a graph built by upserting
+        // reads as fully indexed AND fully queued at once. A store a worker
+        // actually finished has an empty queue, and reconstructing from the
+        // snapshot is how this fixture reaches that state without an embedder.
+        let covered = kin_db::InMemoryGraph::from_snapshot(graph.to_snapshot()).unwrap();
+        covered.share_vector_index_from(&graph);
+
+        let status = covered.embedding_status();
+        assert!(
+            status.total > 0 && status.indexed == status.total && status.pending == 0,
+            "the fixture must be the already-covered store this case is about: {status:?}"
+        );
+
+        let response = super::build_embed_response(
+            &initialized.layout,
+            &covered,
+            &EmbedRequest {
+                batch_size: DEFAULT_BATCH_SIZE,
+                json: false,
+                max_seconds: Some(30),
+                rebuild: false,
+                cap_batch_size: true,
+            },
+            || Ok(()),
+            || false,
+        )
+        .unwrap();
+
+        let published = response
+            .result
+            .coverage
+            .expect("a pass must publish the coverage it measured");
+        assert_eq!(
+            (
+                published.indexed_before,
+                published.indexed_after,
+                published.total
+            ),
+            (status.indexed, status.indexed, status.total),
+            "the published span must be the store's own counters, not a placeholder"
+        );
+        assert_eq!(
+            response.result.embedded_entities + response.result.embedded_artifacts,
+            0,
+            "this pass embedded nothing, which is the zero the old line printed alone"
+        );
+
+        // End to end: what a user of this pass would actually read.
+        let line = embed_completion_line(
+            response.result.embedded_entities,
+            response.result.embedded_artifacts,
+            1,
+            0.0,
+            response.result.coverage,
+        );
+        assert!(
+            line.contains("already fully covered")
+                && line.contains(&format!("{}/{} indexed", status.indexed, status.total)),
+            "a real pass on a covered store must render the covered sentence: {line}"
+        );
+    }
+
+    /// The empty repository stays a correct fast no-op and says so in its own
+    /// words, rather than borrowing a coverage claim over a population of zero.
+    #[test]
+    fn an_empty_repository_reports_having_nothing_to_embed() {
+        let line = embed_completion_line(0, 0, 1, 0.0, coverage(0, 0, 0));
+        assert!(
+            line.contains("no retrievable graph objects"),
+            "the empty repository names its own case: {line}"
+        );
+        assert!(
+            !line.contains("already fully covered"),
+            "nothing was covered, so nothing may be reported as covered: {line}"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -609,6 +609,37 @@ fn build_graph_status_response(
             if embedding_runtime.embedding_coverage_ever_complete {
                 embeddings_line.push_str(" and coverage has completed on this store before");
             }
+        } else if embedding_runtime.embedding_coverage_ever_complete {
+            // An index IS attached, coverage is short, and nothing above
+            // applies. Until this arm existed the line fell off the end of the
+            // chain and rendered bare, so a store that had lost ground read
+            // exactly like a store filling for the first time. The evidence is
+            // the rc0545c brown arm, which logged a per-key vector salvage at
+            // 00:35:35Z and then published `Embeddings: 1770/2112 indexed (342
+            // pending)` at 00:38:19Z with nothing beside it (FIR-2562).
+            //
+            // The arm above cannot cover this case: it is gated on no index
+            // being attached, and a salvage attaches one. The marker this reads
+            // is durable rather than latched in memory
+            // (`DaemonState::embedding_coverage_ever_complete`), so the daemon
+            // that opens after the drift still knows what an earlier daemon on
+            // this store finished, which is what makes the arm reachable in the
+            // very case it exists for.
+            //
+            // The claim stops where the evidence does. This says a fill
+            // finished here once and this shortfall is measured against it. It
+            // does NOT say what caused the shortfall, because a working copy
+            // that admitted new files and a sidecar that retired keys at open
+            // are indistinguishable from here. Naming the cause and its counts
+            // needs the salvage outcome kin-db already computes and discards at
+            // `kin-db crates/kin-db/src/storage/snapshot.rs:2117`, which
+            // `SnapshotManager::load_vector_index_into_graph_if_valid` collapses
+            // into a bare `Ok(true)`. That is the other half of FIR-2562 and it
+            // is a kin-db change, so no clause here may imply kin knows it.
+            embeddings_line.push_str(
+                "; coverage has completed on this store before, so this is a shortfall against a \
+                 fill that finished rather than a first fill",
+            );
         }
         // Appended after the chain rather than folded into it: every clause
         // above stays true while the model is arriving, and this names the one
@@ -2048,6 +2079,155 @@ mod tests {
                 .any(|line| line.contains("no relation in this graph crosses a file boundary")),
             "a graph that does cross files must not be told it cannot: {:?}",
             response.lines
+        );
+    }
+
+    /// Attach a vector index covering `covered` of this graph's retrievable
+    /// keys, so the store reads as measured and short at the same time.
+    ///
+    /// That pair is what a per-key salvage leaves behind and what no other
+    /// fixture here produces: the daemon installed an index, so coverage IS
+    /// measured, and it retired the keys current truth could not prove, so
+    /// coverage is short. A fixture with no index attached cannot reach the arm
+    /// under test, because the arm above it is gated on exactly that.
+    #[cfg(feature = "vector")]
+    fn attach_partial_vector_index(
+        graph: &kin_db::InMemoryGraph,
+        dir: &std::path::Path,
+        covered: usize,
+    ) {
+        let index = kin_db::VectorIndex::new(2).unwrap();
+        let snapshot = graph.to_snapshot();
+        let keys: Vec<kin_model::RetrievalKey> = snapshot
+            .entities
+            .keys()
+            .map(|id| kin_model::RetrievalKey::Entity(*id))
+            .chain(
+                snapshot
+                    .entity_revisions
+                    .values()
+                    .flat_map(|revisions| revisions.iter())
+                    .map(|revision| kin_model::RetrievalKey::EntityRevision(revision.revision_id)),
+            )
+            .collect();
+        assert!(
+            keys.len() > covered,
+            "the fixture must leave keys uncovered so the store reads short: {} keys, {covered} \
+             covered",
+            keys.len()
+        );
+        for key in keys.iter().take(covered) {
+            index.upsert_retrievable(*key, &[1.0, 0.0]).unwrap();
+        }
+        let descriptor = kin_db::IndexDescriptor {
+            model_id: Some("salvage-partial-coverage-fixture@v1".to_string()),
+            graph_root: Some(hex::encode(graph.compute_root_hash())),
+        };
+        index.set_descriptor(descriptor.clone());
+        let path = dir.join("partial.kvec");
+        index.save(&path).unwrap();
+        assert!(matches!(
+            graph.load_vector_index_compatible(&path, &descriptor),
+            kin_db::VectorIndexLoad::Loaded(_)
+        ));
+    }
+
+    /// A store whose coverage was whole once and is short now says so, and the
+    /// clause has to survive an index being attached.
+    ///
+    /// This is the rendering half of FIR-2562. A per-key vector salvage retires
+    /// what current graph truth cannot prove and installs the rest, so the
+    /// daemon records no discard and the graph carries a measured, partial
+    /// index. Every clause on this line was gated either on a recorded discard
+    /// or on NO index being attached, so a salvaged store fell off the end of
+    /// the chain and rendered bare: the rc0545c brown arm logged its salvage at
+    /// 00:35:35Z and published `Embeddings: 1770/2112 indexed (342 pending)` at
+    /// 00:38:19Z with nothing beside it, which is byte-for-byte the shape a
+    /// store filling for the first time prints.
+    ///
+    /// Both directions are driven, because the clause is only worth anything if
+    /// it separates the two stores it exists to separate. The store that never
+    /// finished a fill must render the same counters and no clause.
+    #[cfg(feature = "vector")]
+    #[test]
+    fn a_measured_store_short_of_a_fill_it_once_finished_says_so() {
+        let (temp, binding, graph) = graph_validation_fixture();
+        for name in ["alpha_transform", "beta_reduce", "gamma_emit", "delta_fold"] {
+            graph.upsert_entity(&test_entity(name)).unwrap();
+        }
+        attach_partial_vector_index(&graph, temp.path(), 2);
+
+        // The fixture has to hold both properties at once or the arm under test
+        // is unreachable and every assertion below passes on the arm above it.
+        let status = graph.embedding_status();
+        assert!(
+            graph.vector_index_stats().is_some(),
+            "the fixture must carry an ATTACHED index, which is what a salvage leaves"
+        );
+        assert!(
+            status.pending > 0 && status.indexed > 0,
+            "the fixture must read measured and short: {status:?}"
+        );
+
+        let ever_complete = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &crate::commands::resources::EmbedRuntimeState {
+                vector_index_discarded: None,
+                embedding_coverage_ever_complete: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let ever_complete_line = ever_complete
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            ever_complete_line.contains(
+                "a shortfall against a fill that finished rather than a \
+                 first fill"
+            ),
+            "a store that lost ground must not render as a first fill: {ever_complete_line}"
+        );
+        assert!(
+            !ever_complete_line.contains("the live graph carries no vector index"),
+            "an attached index must not be described as absent: {ever_complete_line}"
+        );
+        // The cause and its counts live in kin-db and are not plumbed yet, so
+        // nothing here may imply this line knows which of them applies.
+        for forbidden in ["salvage", "retired", "evicted", "vectors were dropped"] {
+            assert!(
+                !ever_complete_line.contains(forbidden),
+                "this line cannot name a cause kin does not receive ({forbidden}): \
+                 {ever_complete_line}"
+            );
+        }
+
+        let first_fill = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
+        let first_fill_line = first_fill
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            first_fill_line.contains(&format!(
+                "{}/{} indexed ({} pending)",
+                status.indexed, status.total, status.pending
+            )),
+            "the counters stay disclosed on both stores: {first_fill_line}"
+        );
+        assert!(
+            !first_fill_line.contains("a fill that finished"),
+            "a store that never finished a fill must not claim one: {first_fill_line}"
         );
     }
 


### PR DESCRIPTION
`kin embed` and `kin graph status` each printed a sentence that two different stores share. This makes each one say which store it is looking at, from numbers the daemon measured.

## kin embed: the run's own count under a heading about the store

The completion line was `Done. Full coverage: {embedded} entities, {embedded} artifacts embedded across {n} pass(es)` at `crates/kin-cli/src/commands/embed.rs:451`. `embedded` is what THIS run's passes embedded. Full coverage is a property of the store. A pass that arrives after the queue is already drained holds a zero for the first while the second reads whole, and prints both under one heading.

The stranger run on the shipped v0.5.45 bytes hit exactly that. `/work/notekeeper` read `Embeddings: 3/51 indexed (48 pending)` before the call and `51/51 indexed (0 pending)` after it, and the command in the middle reported `Done. Full coverage: 0 entities, 0 artifacts embedded`. Every number was true and the sentence was unreadable: a run that found nothing to do and a run that failed to embed what it should have print the same zero, and those are the two states a user runs `kin embed` to tell apart.

`EmbedResult` now carries `PassCoverage`, the store's indexed count either side of the pass. Both samples are taken inside `build_embed_response`: the first before it propagates, queues or embeds anything, the second when it returns. The caller holds `DaemonState::embedding_work`, which serializes explicit passes against the background embedding worker, so nothing can move coverage between the two reads. `indexed_before` is the store this pass inherited and `indexed_after` is the store it left.

`embed_completion_line` decides the sentence from those numbers rather than from an assumption about who filled the store:

- already whole at entry: `Done. Nothing to embed: this store was already fully covered at 51/51 indexed when this pass started, so the work was finished before it ran`
- a span the queue did not move: credited to this pass's own `propagate_revision_vectors`, which reuses vectors from content-identical revisions
- a run that embedded: its own count beside the span it moved, `taking this store from 3/53 to 53/53 indexed`
- nothing pending, nothing embedded, coverage short: both facts reported and neither resolved, since neither is established here

Nothing names WHO filled the store. This process cannot observe that: a covered store may have been filled by the background worker, by `kin init`, or by an earlier explicit pass, and nothing reaching the completion line distinguishes them. What it can establish, and says, is that the work predates this pass.

The field is `Option` rather than three defaulted zeros. A daemon that never measured coverage and a store holding nothing deserialize identically under `#[serde(default)]`, so a sentence built from those would state a measurement nobody took. `None` renders no coverage claim at all. Falsification pass 4 below is that property earning its place.

## kin graph status: a salvaged store falls off the end of the clause chain

The embeddings line appends a cause when the daemon knows one, and every arm was gated either on a recorded discard or on NO vector index being attached (`crates/kin-cli/src/commands/graph.rs:597`). A per-key vector salvage installs an index and records no discard, so a salvaged store matched no arm and rendered bare.

That is the shape in the rc0545c brown arm. Its daemon log carries `vector sidecar stamp drifted from graph authority; salvaged the index per key instead of rebuilding` at 00:35:35Z, and `graph-status-requests.txt` from the same store at 00:38:19Z reads `Embeddings: 1770/2112 indexed (342 pending)` with nothing beside it, which is byte-identical to what a store filling for the first time prints.

The clause that becomes reachable is named exactly, because "made a clause reachable" is not a reviewable statement on its own. It is the `embedding_coverage_ever_complete` clause, which before this change existed only as a suffix inside the no-index arm, appended as `" and coverage has completed on this store before"` after `"; the live graph carries no vector index, so nothing in it is indexed yet"`. Reaching that suffix required `!coverage_is_measured`, and `coverage_is_measured` is `graph.vector_index_stats().is_some() || embed_status.total == 0`. A salvage makes `vector_index_stats()` return `Some`, so the condition was false and the suffix was unreachable in the one state it describes best. It is now also a standalone arm at the end of the chain, on the same marker, phrased for a store whose index IS attached: `"; coverage has completed on this store before, so this is a shortfall against a fill that finished rather than a first fill"`. The two other arms are untouched, and the ordering is unchanged: `embed_persistence_unavailable` still outranks everything, then `vector_index_discarded`, then the no-index arm, then this.

That marker is durable rather than latched in memory (`DaemonState::embedding_coverage_ever_complete` at `crates/kin-daemon/src/state.rs:1754` stats an on-disk file), so the daemon that opens after the drift still knows what an earlier daemon on this store finished. It would have fired on the rc0545c store, whose prior daemon read 2112/2112 and therefore wrote the marker.

The claim stops where the evidence does. It says a fill finished here once and this shortfall is measured against it. It does NOT name a cause and it does NOT name a count, because a working copy that admitted new files and a sidecar that retired keys at open are indistinguishable from here, and the per-key numbers never reach kin at all.

**The count and the cause arrive with the pin move, not with this PR.** kin-db already computes exactly what moved (`retained`, `evicted_orphans`, `retired_artifact_vectors`, `retired_stale_entity_heads`) and logs it at `kin-db crates/kin-db/src/storage/snapshot.rs:2117`, then `SnapshotManager::load_vector_index_into_graph_if_valid` collapses all of it into a bare `Ok(true)` at `snapshot.rs:2170`, which is what `DaemonState::load_validated_vector_index` reads at `crates/kin-daemon/src/state.rs:1688`. Lane salvagedb is changing that return type on kin-db for 0.7.47. Once it publishes and kin's pin moves off `kin-db = "=0.7.38"` (`Cargo.toml:158`), a follow-up records the salvage outcome the way `vector_index_discarded` is recorded and renders its counts on this same line and in `/health`. That is FIR-2562's first ask, and it is why this PR says `Refs FIR-2562` rather than `Closes`.

Until then the wording is fenced by a test: the line must contain none of "salvage", "retired", "evicted" or "vectors were dropped", so it cannot drift into a claim kin has not received.

## Falsification

Five passes, each removing one property, each predicting which tests must fail and which must still pass. Every sabotage was verified applied before its run (the target string asserted unique, then confirmed absent from the production path), every exit status read raw, every failure message read in full rather than through a pipe, and every file restored to a matching sha256 before the next pass.

**Pass 1, the graph status arm's body removed.** Predicted one failure. Got `48 passed; 1 failed`:

```
a store that lost ground must not render as a first fill: Embeddings: 2/4 indexed (4 pending)
```

That message carries the regenerated defect verbatim: the bare line, with nothing beside it. `a_graph_with_no_attached_index_is_not_told_its_embeddings_are_intact` stayed green, which is the scoping evidence, since the arm above it was untouched.

**Pass 2, the arm made unconditional.** The other direction. Predicted one failure on the first-fill control. Got `48 passed; 1 failed`:

```
a store that never finished a fill must not claim one: Embeddings: 2/4 indexed (4 pending); coverage
has completed on this store before, so this is a shortfall against a fill that finished rather than a first fill
```

**Pass 3, the already-covered arm removed from `embed_completion_line`.** Predicted exactly one failure, with the other four helper arms still green. Got `28 passed; 1 failed`:

```
a zero has to say which of the two states this is: Done. This run embedded nothing and the daemon
reports nothing pending, but this store reads 51/51 indexed. Run `kin health` to see why coverage
and the queue disagree
```

**Pass 4, `None` coverage defaulted to zeros instead of stating the absence.** Predicted one failure. Got `28 passed; 1 failed`, and the failure is worth quoting because it is the defect this design prevents, wearing the fix's clothes:

```
the run's own work still renders: Done. This repository has no retrievable graph objects that
require an embedding, so there was nothing to embed
```

A run that embedded 7 entities, on a store the daemon never measured, reported as an empty repository.

**Pass 5, the wiring cut.** `build_embed_response` set `coverage: None` instead of publishing what it sampled, leaving `embed_completion_line` intact. `29 passed; 1 failed`:

```
a pass must publish the coverage it measured
```

The five helper tests all stayed green under that sabotage, which is why the wiring test exists: a `build_embed_response` that never filled `coverage` would satisfy every helper test while every real run rendered the no-measurement sentence. Its fixture runs a real pass on a genuinely already-covered store, rebuilt from its own snapshot so the embedding queue is empty, because `upsert_entity` enqueues every entity it admits and nothing short of a real embedder drains that queue. It needs no embedder and takes no GPU.

## Gates

Run through `bin/kin-lane run salvage kin`, worktree `.kin-coord/worktrees/salvage-kin`, every exit status read raw rather than through a pipe.

- `cargo test -p kin-cli --lib commands::embed::tests`: exit 0, `30 passed; 0 failed`
- `cargo test -p kin-cli --lib commands::graph::tests`: exit 0, `49 passed; 0 failed`
- `cargo fmt --all -- --check`: exit 0
- clippy exactly as ci.yml runs it, `--all-targets --all-features` under `RUSTFLAGS=-D warnings` with the 45-lint debt allow-list: exit 0
- `python3 scripts/verify-zero-file-search.py`: exit 0, 177 source files
- `bash scripts/zero_file_search_guard.sh`: exit 0
- `bash scripts/check_runtime_boundaries.sh`: exit 0
- `bash scripts/check_private_repo_coupling.sh`: exit 0

`git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

The local full gate was not run under tonight's slot saturation; hosted CI (38 checks, all concluded, 0 failures) is the gate of record for this PR. Every total quoted above was read from its run's own `test result:` summary line in the log, never from an rc file, and this lane wrote no rc file at any point (preamble amendment 11:21Z). A log carrying no summary line was used as the control and correctly reported none. All three build slots were held for the whole window and box load reached 128. The hosted run covers the same gate on three platforms rather than one: `Check & Test (ubuntu-latest)`, `Check & Test (macos-latest)`, both macOS shards, `Feature permutation tests` on both platforms, `Falsify guards`, `Windows authority tests`, `Windows authority CLI tests`, `Windows authority runtime tests`, `Linux Daemon Smoke + MCP Headless`, `Install Proof (PR) Gate`, `CodeQL`, `cargo-deny` and `Capability Contract Canary` all read SUCCESS. The four SKIPPED entries are the matrix parents `Check & Test`, `Feature permutation tests`, `Code Coverage` and `Windows installer + vector release build`.

## Overlap with branches in flight

kin#1026 (embedcount) carries a second commit adding `full_coverage_line` at `crates/kin-cli/src/commands/embed.rs:79`, which addresses the same stranger finding from the other side: it names the background worker as the cause. This PR replaces that attribution with the daemon's own before and after readings, because a store already covered at entry may have been filled by `kin init` or by an earlier explicit pass, and the process cannot tell. kin#1026 was still OPEN when this body was last written, so no rebase has happened yet. Whichever lands first, the other rebases onto it, and the two tests 1026 adds are kept either way.

kin#1006 (vecregress) adds a clause to the same embeddings line, after the pending gate rather than inside the chain, so the collision there is adjacent lines rather than shared logic.

## Why FIR-2556 is Refs and not Closes, ask by ask

Ask 1, report the store's coverage before and after the pass rather than only the pass's own delta: **met.** Both numbers are on `PassCoverage` and both appear in every sentence that has them.

Ask 3, reserve "Full coverage" for a claim the command can support: **met.** The phrase is gone. What replaces it is the store's own counters as the daemon sampled them, which is a reading this command took rather than a state read elsewhere.

Ask 2, say who did the work when the queue was drained by someone else: **not met as written, and the ticket's premise here does not hold.** It asks for `the background worker completed N entities while this pass was starting`, on the ground that "the daemon knows which one is true". It does not. A store already whole when a pass starts may have been filled by the background worker, by `kin init`, or by an earlier explicit `kin embed`, and nothing distinguishes them at the completion line. There is no durable record to fall back on either: the only one is the coverage marker, and `write_embedding_coverage_marker` writes the literal text `complete` once and returns early when the file already exists, so its mtime dates the first completion on a store rather than the last. No timestamp was invented for this. What the pass can establish, and now says, is that the work predates it.

The ticket's own falsification list is satisfied. Four outcomes are now distinguishable in the output: a store already covered at entry, a run that genuinely embedded, a run on an empty repository, and a pass that should have embedded and could not. The fourth is the pre-existing `Stopped with N entities + M artifacts still pending after P pass(es), the daemon made no progress on the last pass` branch, which this change leaves alone; it is named here because the ticket asks for that case to differ from the other two, and it does.

Refs FIR-2556
Refs FIR-2562
