### PR TITLE
Scope a review to the entities that changed, and pair same-name declarations by their own signature

### DIFF
--- a/crates/kin-cli/tests/review_scope_after_edit.rs
+++ b/crates/kin-cli/tests/review_scope_after_edit.rs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What a review says about a one-line edit, end to end from the parser.
+//!
+//! The storage delta for an edit covers every declaration in the touched file:
+//! the reconciler stamps that file's blob hash onto all of them, and any added
+//! or removed byte shifts the span of every declaration below the edit. Both are
+//! real provenance and the published change has to carry them, or the workspace
+//! overlay keeps the difference and reports dirty forever.
+//!
+//! A review is a different question. It asks what a reviewer must look at, and
+//! the answer for a one-line edit is the entity that was edited, plus the file's
+//! own module entity, whose body is the file and whose fingerprint therefore did
+//! move. The module is kept deliberately: suppressing it would hide a content
+//! change that really happened. Every other declaration in the file must be
+//! absent. These tests drive the real Python parser and the real reconciler,
+//! then read the review surfaces, so they fail if either half of that separation
+//! breaks.
+
+use std::path::PathBuf;
+
+use kin_blobs::BlobStore;
+use kin_db::InMemoryGraph;
+use kin_index::FileEvent;
+use kin_model::{
+    ArtifactId, AuthorId, EntityStore, Hash256, LocatedEntry, RepoPath, SemanticChange,
+    SemanticChangeId, Timestamp, TransactionDelta, TreeDelta, TreeEntry,
+};
+use kin_reconcile::Reconciler;
+use tempfile::TempDir;
+
+struct LiveRepo {
+    dir: TempDir,
+    graph: InMemoryGraph,
+    blobs: BlobStore,
+    reconciler: Reconciler,
+}
+
+impl LiveRepo {
+    fn new() -> Self {
+        let dir = TempDir::new().expect("temp repo");
+        let blobs = BlobStore::new(dir.path().join("blobs")).expect("blob store");
+        let graph = InMemoryGraph::new();
+        let mut reconciler = Reconciler::new(dir.path().to_path_buf());
+        reconciler.seed_cross_file_linker_from_graph(&graph);
+        Self {
+            dir,
+            graph,
+            blobs,
+            reconciler,
+        }
+    }
+
+    fn abs(&self, rel: &str) -> PathBuf {
+        self.dir.path().join(rel)
+    }
+
+    fn commit(&mut self, rel: &str, source: &str) -> TransactionDelta {
+        let path = self.abs(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(&path, source).expect("write source");
+
+        let blob_hash = self.blobs.write(source.as_bytes()).expect("store blob");
+        let repo_path = RepoPath::from_utf8(rel.to_string()).expect("repo path");
+        let entry = TreeEntry::blob(Hash256::from_bytes(blob_hash.0), false);
+        let tree_delta = match self.graph.artifact_id_at_path(&repo_path) {
+            Some(artifact_id) => {
+                let old_entry = self
+                    .graph
+                    .get_tree_entry(&kin_model::FilePathId::new(rel))
+                    .ok()
+                    .flatten();
+                match old_entry {
+                    Some(old) if old == entry => None,
+                    Some(old) => Some(TreeDelta::Updated {
+                        artifact_id,
+                        old: LocatedEntry::new(repo_path.clone(), old),
+                        new: LocatedEntry::new(repo_path, entry),
+                    }),
+                    None => Some(TreeDelta::Added {
+                        artifact_id,
+                        new: LocatedEntry::new(repo_path, entry),
+                    }),
+                }
+            }
+            None => Some(TreeDelta::Added {
+                artifact_id: ArtifactId::new(),
+                new: LocatedEntry::new(repo_path, entry),
+            }),
+        };
+        if let Some(tree_delta) = tree_delta {
+            self.graph
+                .apply_transaction_delta(&TransactionDelta {
+                    tree_deltas: vec![tree_delta],
+                    ..TransactionDelta::default()
+                })
+                .expect("admit artifact");
+        }
+
+        let result = self
+            .reconciler
+            .reconcile_file_change(&FileEvent::Changed(path), &self.blobs, &self.graph)
+            .expect("reconcile succeeds");
+        let (_, delta) = result.into_parts();
+        self.graph
+            .apply_transaction_delta(&delta)
+            .expect("apply reconciled delta");
+        delta
+    }
+}
+
+/// The change a commit of this delta would publish.
+fn change_from(delta: &TransactionDelta) -> SemanticChange {
+    SemanticChange {
+        id: SemanticChangeId::from_hash(Hash256::from_bytes([2; 32])),
+        origin: kin_model::ChangeOrigin::Native,
+        parents: vec![SemanticChangeId::from_hash(Hash256::from_bytes([1; 32]))],
+        timestamp: Timestamp::now(),
+        author: AuthorId::new("test"),
+        message: "edit one line".to_string(),
+        entity_deltas: delta.entity_deltas.clone(),
+        relation_deltas: delta.relation_deltas.clone(),
+        tree_deltas: vec![],
+        admission_policy_delta: None,
+        projected_files: vec![],
+        spec_link: None,
+        evidence: vec![],
+        risk_summary: None,
+        external_reference_deltas: Vec::new(),
+    }
+}
+
+/// A file with one constant, an `@overload` group, a caller, and a class, so a
+/// one-line edit has plenty of untouched company. `ABOVE_THE_EDIT` is declared
+/// before `LIMIT`, so its text and its position are both provably untouched by
+/// an edit to `LIMIT`: it is this fixture's `REDIRECT_STATI`.
+const BASE: &str = r#"from typing import Literal, overload
+
+ABOVE_THE_EDIT: int = 1
+REDIRECT_LIMIT: int = 30
+BELOW_THE_EDIT: int = 2
+
+
+@overload
+def render(value: str, raw: Literal[True]) -> bytes: ...
+
+
+@overload
+def render(value: str, raw: Literal[False] = False) -> str: ...
+
+
+def render(value, raw=False):
+    return value.encode() if raw else value
+
+
+def dispatch(value, raw=False):
+    return render(value, raw)
+
+
+class Client:
+    def __init__(self):
+        self.limit = REDIRECT_LIMIT
+
+    def send(self, value):
+        return dispatch(value)
+"#;
+
+fn modified_names(diff: &kin_review::SemanticDiff) -> Vec<String> {
+    let mut names: Vec<String> = diff
+        .modified_entities()
+        .into_iter()
+        .map(|(_, new)| new.name.clone())
+        .collect();
+    names.sort();
+    names
+}
+
+/// FIR-2479's headline falsification. One byte changes, the review names the
+/// entity that changed and the file it lives in, and the count of records the
+/// storage layer re-emitted is published rather than hidden.
+#[test]
+fn a_one_line_value_edit_reviews_as_the_edited_entity_and_its_module() {
+    let mut repo = LiveRepo::new();
+    let first = repo.commit("mod.py", BASE);
+    assert!(
+        first.entity_deltas.len() >= 8,
+        "the fixture must produce a file with several entities, got {}",
+        first.entity_deltas.len()
+    );
+
+    // The whole edit. One byte shorter, so no line moves and every declaration
+    // above it is untouched in text and in position.
+    let edited = BASE.replace("REDIRECT_LIMIT: int = 30", "REDIRECT_LIMIT: int = 5");
+    assert_ne!(edited, BASE, "the fixture edit must apply");
+    assert_eq!(
+        edited.lines().count(),
+        BASE.lines().count(),
+        "this edit must not move a line"
+    );
+
+    let delta = repo.commit("mod.py", &edited);
+    let stored = delta.entity_deltas.len();
+    assert!(
+        stored >= 8,
+        "the storage delta is expected to carry the whole file; got {stored}"
+    );
+
+    let change = change_from(&delta);
+    let diff = kin_review::diff_from_change(&change);
+
+    // The edited constant, and the module entity whose body is the file. Nothing
+    // else: not the declaration above the edit, not the ones below it, and not
+    // one member of the `render` group.
+    assert_eq!(
+        modified_names(&diff),
+        vec!["REDIRECT_LIMIT".to_string(), "mod".to_string()],
+        "a one-line value edit must review as the edited entity and its file's module"
+    );
+    for untouched in [
+        "ABOVE_THE_EDIT",
+        "BELOW_THE_EDIT",
+        "render",
+        "dispatch",
+        "Client",
+        "Client.send",
+    ] {
+        assert!(
+            !modified_names(&diff).contains(&untouched.to_string()),
+            "`{untouched}` was not edited and must not be reported as modified"
+        );
+    }
+    assert_eq!(
+        diff.provenance_only_entity_changes,
+        stored - 2,
+        "every record the review set aside must be counted"
+    );
+}
+
+/// The other half: the review must not report a declaration against a different
+/// declaration of the same name, and it must never publish two findings about
+/// one name that contradict each other.
+///
+/// The edit here inserts a block BETWEEN two members of the `render` group, so
+/// every later member moves further than the spacing between them. That shape is
+/// deliberate: a one-line shift is small enough that pairing by nearest position
+/// alone still lands correctly, so a test built on one could not fail when the
+/// pairing rule is wrong.
+#[test]
+fn a_wide_insertion_produces_no_contradictory_breaking_changes() {
+    let mut repo = LiveRepo::new();
+    repo.commit("mod.py", BASE);
+
+    let filler: String = (0..4)
+        .map(|index| format!("\n\ndef filler_{index}(value):\n    return value\n"))
+        .collect();
+    let edited = BASE.replace(
+        "def render(value: str, raw: Literal[True]) -> bytes: ...\n",
+        &format!("def render(value: str, raw: Literal[True]) -> bytes: ...\n{filler}"),
+    );
+    assert_ne!(edited, BASE, "the fixture edit must apply");
+    assert!(
+        edited.lines().count() >= BASE.lines().count() + 12,
+        "the insertion must be wider than the spacing between group members"
+    );
+
+    let delta = repo.commit("mod.py", &edited);
+    let change = change_from(&delta);
+    let diff = kin_review::diff_from_change(&change);
+    let impact = kin_review::analyze_impact(&repo.graph, &diff).expect("impact");
+    let risk = kin_review::assess_risk(&diff, &impact);
+
+    let render_findings: Vec<&String> = risk
+        .breaking_changes
+        .iter()
+        .filter(|finding| finding.contains("render"))
+        .collect();
+    assert!(
+        render_findings.is_empty(),
+        "nothing about `render` was edited, so no breaking change may name it: {render_findings:#?}"
+    );
+    assert!(
+        !modified_names(&diff).contains(&"render".to_string()),
+        "no member of the `render` group was edited, so none may be reported as modified: {:#?}",
+        modified_names(&diff)
+    );
+
+    // The cheap invariant a reader can apply by eye: for a signature finding
+    // `X: A -> B` there must be no sibling `X: B -> A`.
+    let transitions: Vec<(String, String)> = diff
+        .modified_entities()
+        .into_iter()
+        .map(|(old, new)| (old.signature.clone(), new.signature.clone()))
+        .collect();
+    for (left_old, left_new) in &transitions {
+        for (right_old, right_new) in &transitions {
+            assert!(
+                !(left_old == right_new && left_new == right_old && left_old != left_new),
+                "contradictory transitions reported: `{left_old}` -> `{left_new}` alongside \
+                 `{right_old}` -> `{right_new}`"
+            );
+        }
+    }
+}
+
+/// The positive control. A real signature change on a function with a graph-known
+/// caller must survive every rule above, be reported on that function, and reach
+/// the breaking-changes list. `dispatch` is used rather than `render` because
+/// `render` has three declarations sharing one name, and which of them a call
+/// binds to is a separate question that must not decide this test.
+#[test]
+fn a_real_signature_change_with_a_caller_still_reports_as_breaking() {
+    let mut repo = LiveRepo::new();
+    repo.commit("mod.py", BASE);
+
+    let edited = BASE.replace(
+        "def dispatch(value, raw=False):",
+        "def dispatch(value, raw=False, *, trace_id):",
+    );
+    assert_ne!(edited, BASE, "the fixture edit must apply");
+    let delta = repo.commit("mod.py", &edited);
+
+    let change = change_from(&delta);
+    let diff = kin_review::diff_from_change(&change);
+
+    assert_eq!(
+        modified_names(&diff),
+        vec!["dispatch".to_string(), "mod".to_string()],
+        "the edited implementation and its file's module are the only entities reported"
+    );
+
+    let impact = kin_review::analyze_impact(&repo.graph, &diff).expect("impact");
+    let risk = kin_review::assess_risk(&diff, &impact);
+    let signature_findings: Vec<&String> = risk
+        .breaking_changes
+        .iter()
+        .filter(|finding| finding.starts_with("Signature change on `dispatch`"))
+        .collect();
+    assert_eq!(
+        signature_findings.len(),
+        1,
+        "the real signature change must reach the breaking-changes list exactly once, got {:#?}",
+        risk.breaking_changes
+    );
+    assert!(
+        signature_findings[0].contains("def dispatch(value, raw=False)")
+            && signature_findings[0].contains("trace_id"),
+        "the finding must carry the real transition, got {}",
+        signature_findings[0]
+    );
+}

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -652,13 +652,25 @@ impl Reconciler {
             // ordinary filesystem reconciliation continues to match by name
             // and kind as before.
             //
-            // Both passes skip an entity another parsed declaration already
+            // Every pass skips an entity another parsed declaration already
             // claimed, so the match is one-to-one. Identity is derived from the
             // declaration's start line, so an edit above a declaration retires
-            // the id the graph holds for it and drops it to the name-and-kind
-            // pass. A file that declares one name twice, which a cfg-gated pair
-            // does routinely, would otherwise collapse both halves onto
-            // whichever half the graph returned first.
+            // the id the graph holds for it and drops it to the passes below.
+            // A file that declares one name twice, which a cfg-gated pair and a
+            // Python `@overload` group both do routinely, would otherwise
+            // collapse both halves onto whichever half the graph returned
+            // first.
+            //
+            // Name and kind alone cannot tell one member of such a group from
+            // another, and `get_file_entities` returns graph-query order rather
+            // than declaration order, so a line-shifting edit anywhere above the
+            // group rotated its members onto each other: three declarations came
+            // back as three modifications reporting signature transitions none
+            // of them underwent, in mutually contradictory directions. The
+            // declaration's own signature is what distinguishes group members,
+            // so it is consulted before falling back to name and kind, and the
+            // fallback pairs by nearest declaration position rather than by
+            // whatever order the graph happened to return.
             let existing_match = existing
                 .iter()
                 .find(|entity| {
@@ -667,12 +679,11 @@ impl Reconciler {
                         && !claimed.contains(&entity.id)
                 })
                 .or_else(|| {
-                    existing.iter().find(|entity| {
-                        entity.name == new_entity.name
-                            && entity.kind == new_entity.kind
-                            && !claimed.contains(&entity.id)
+                    nearest_unclaimed(&existing, new_entity, &claimed, |candidate, parsed| {
+                        candidate.signature == parsed.signature
                     })
-                });
+                })
+                .or_else(|| nearest_unclaimed(&existing, new_entity, &claimed, |_, _| true));
 
             match existing_match {
                 Some(old) => {
@@ -1810,6 +1821,46 @@ fn validate_entity(entity: &Entity) -> Option<String> {
         return Some(format!("entity '{}' has an empty signature", entity.name));
     }
     None
+}
+
+/// Carry-forward candidate for one re-parsed declaration: the unclaimed
+/// existing entity of the same name and kind that `accept` admits and whose
+/// declaration sits nearest the parsed one.
+///
+/// Position breaks the tie rather than deciding the match, and it is the last
+/// word rather than the first. Graph query order is not declaration order, so
+/// the previous "first unclaimed candidate the graph returned" rule paired a
+/// same-name group's members arbitrarily; distance in the file is at least a
+/// property of the declarations themselves and orders them the way an author
+/// reading the diff would. An entity with no span sorts last and is compared
+/// by id, so the choice stays deterministic when nothing has a position.
+fn nearest_unclaimed<'a>(
+    existing: &'a [Entity],
+    parsed: &Entity,
+    claimed: &HashSet<EntityId>,
+    accept: impl Fn(&Entity, &Entity) -> bool,
+) -> Option<&'a Entity> {
+    let parsed_line = parsed.span.as_ref().map(|span| span.start_line);
+    existing
+        .iter()
+        .filter(|candidate| {
+            candidate.name == parsed.name
+                && candidate.kind == parsed.kind
+                && !claimed.contains(&candidate.id)
+                && accept(candidate, parsed)
+        })
+        .min_by_key(|candidate| {
+            let distance = match (candidate.span.as_ref().map(|span| span.start_line), parsed_line) {
+                (Some(candidate_line), Some(parsed_line)) => {
+                    Some(candidate_line.abs_diff(parsed_line))
+                }
+                _ => None,
+            };
+            // `None` sorts after every `Some`, which is what puts a spanless
+            // candidate last without a sentinel distance that a real span could
+            // reach.
+            (distance.is_none(), distance, candidate.id)
+        })
 }
 
 /// Collect all unique file origins from both entity sets.

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -1850,7 +1850,10 @@ fn nearest_unclaimed<'a>(
                 && accept(candidate, parsed)
         })
         .min_by_key(|candidate| {
-            let distance = match (candidate.span.as_ref().map(|span| span.start_line), parsed_line) {
+            let distance = match (
+                candidate.span.as_ref().map(|span| span.start_line),
+                parsed_line,
+            ) {
                 (Some(candidate_line), Some(parsed_line)) => {
                     Some(candidate_line.abs_diff(parsed_line))
                 }

--- a/crates/kin-reconcile/tests/same_name_group_pairing.rs
+++ b/crates/kin-reconcile/tests/same_name_group_pairing.rs
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Carrying a re-parsed declaration forward onto the right existing entity when
+//! several declarations in one file share a name.
+//!
+//! Entity identity is `(file, kind, name, start_line)`, so any edit that adds or
+//! removes a line retires the id of every declaration below it and drops them to
+//! the name-based carry-forward passes. Name and kind alone cannot tell one
+//! member of a Python `@overload` group from another, and the graph returns a
+//! file's entities in query order rather than declaration order, so the group's
+//! members were paired arbitrarily: three untouched declarations came back as
+//! three modifications reporting signature transitions in mutually
+//! contradictory directions. A reviewer reading two findings that say
+//! `A -> B` and `B -> A` about the same function stops believing the tool.
+
+use std::path::PathBuf;
+
+use kin_blobs::BlobStore;
+use kin_db::InMemoryGraph;
+use kin_index::FileEvent;
+use kin_model::{
+    ArtifactId, Entity, EntityDelta, EntityStore, Hash256, LocatedEntry, RepoPath,
+    TransactionDelta, TreeDelta, TreeEntry,
+};
+use kin_reconcile::Reconciler;
+use tempfile::TempDir;
+
+/// A repository built the way a user builds one: write the file, admit its
+/// artifact, reconcile, apply.
+struct LiveRepo {
+    dir: TempDir,
+    graph: InMemoryGraph,
+    blobs: BlobStore,
+    reconciler: Reconciler,
+}
+
+impl LiveRepo {
+    fn new() -> Self {
+        let dir = TempDir::new().expect("temp repo");
+        let blobs = BlobStore::new(dir.path().join("blobs")).expect("blob store");
+        let graph = InMemoryGraph::new();
+        let mut reconciler = Reconciler::new(dir.path().to_path_buf());
+        reconciler.seed_cross_file_linker_from_graph(&graph);
+        Self {
+            dir,
+            graph,
+            blobs,
+            reconciler,
+        }
+    }
+
+    fn abs(&self, rel: &str) -> PathBuf {
+        self.dir.path().join(rel)
+    }
+
+    fn commit(&mut self, rel: &str, source: &str) -> TransactionDelta {
+        let path = self.abs(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(&path, source).expect("write source");
+
+        let blob_hash = self.blobs.write(source.as_bytes()).expect("store blob");
+        let repo_path = RepoPath::from_utf8(rel.to_string()).expect("repo path");
+        let entry = TreeEntry::blob(Hash256::from_bytes(blob_hash.0), false);
+        let tree_delta = match self.graph.artifact_id_at_path(&repo_path) {
+            Some(artifact_id) => {
+                let old_entry = self
+                    .graph
+                    .get_tree_entry(&kin_model::FilePathId::new(rel))
+                    .ok()
+                    .flatten();
+                match old_entry {
+                    Some(old) if old == entry => None,
+                    Some(old) => Some(TreeDelta::Updated {
+                        artifact_id,
+                        old: LocatedEntry::new(repo_path.clone(), old),
+                        new: LocatedEntry::new(repo_path, entry),
+                    }),
+                    None => Some(TreeDelta::Added {
+                        artifact_id,
+                        new: LocatedEntry::new(repo_path, entry),
+                    }),
+                }
+            }
+            None => Some(TreeDelta::Added {
+                artifact_id: ArtifactId::new(),
+                new: LocatedEntry::new(repo_path, entry),
+            }),
+        };
+        if let Some(tree_delta) = tree_delta {
+            self.graph
+                .apply_transaction_delta(&TransactionDelta {
+                    tree_deltas: vec![tree_delta],
+                    ..TransactionDelta::default()
+                })
+                .expect("admit artifact");
+        }
+
+        let result = self
+            .reconciler
+            .reconcile_file_change(&FileEvent::Changed(path), &self.blobs, &self.graph)
+            .expect("reconcile succeeds");
+        let (_, delta) = result.into_parts();
+        self.graph
+            .apply_transaction_delta(&delta)
+            .expect("apply reconciled delta");
+        delta
+    }
+}
+
+/// Three declarations of `render`: two `@overload` stubs and the implementation.
+/// `leading` sits above all of them so an edit there shifts every line below.
+const BASE: &str = r#"from typing import Literal, overload
+
+LIMIT: int = 30
+
+
+def leading(value):
+    return value
+
+
+@overload
+def render(value: str, raw: Literal[True]) -> bytes: ...
+
+
+@overload
+def render(value: str, raw: Literal[False] = False) -> str: ...
+
+
+def render(value, raw=False):
+    return value.encode() if raw else value
+
+
+def trailing(value):
+    return render(value)
+"#;
+
+/// Every `(old signature, new signature)` a modification on `name` reported.
+fn signature_transitions<'a>(
+    delta: &'a TransactionDelta,
+    name: &str,
+) -> Vec<(&'a str, &'a str)> {
+    delta
+        .entity_deltas
+        .iter()
+        .filter_map(|entity_delta| match entity_delta {
+            EntityDelta::Modified { old, new } if new.name == name => {
+                Some((old.signature.as_str(), new.signature.as_str()))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn modified_pairs(delta: &TransactionDelta) -> Vec<(&Entity, &Entity)> {
+    delta
+        .entity_deltas
+        .iter()
+        .filter_map(|entity_delta| match entity_delta {
+            EntityDelta::Modified { old, new } => Some((old, new)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The defect exactly as FIR-2479 reports it: an edit that touches no member of
+/// a same-name group still rotates the group's members onto each other, and the
+/// rotation surfaces as breaking-change findings that contradict one another.
+#[test]
+fn a_line_shift_above_a_same_name_group_does_not_rotate_its_members() {
+    let mut repo = LiveRepo::new();
+    repo.commit("mod.py", BASE);
+
+    // One line added inside `leading`. Nothing in the `render` group is touched,
+    // and every declaration below `leading` shifts down by exactly one line.
+    let edited = BASE.replace(
+        "def leading(value):\n    return value",
+        "def leading(value):\n    value = value\n    return value",
+    );
+    assert_ne!(edited, BASE, "the fixture edit must apply");
+    assert_eq!(
+        edited.lines().count(),
+        BASE.lines().count() + 1,
+        "the fixture edit must shift the lines below it"
+    );
+
+    let delta = repo.commit("mod.py", &edited);
+
+    let transitions = signature_transitions(&delta, "render");
+    assert_eq!(
+        transitions.len(),
+        3,
+        "all three declarations of `render` should still be carried forward, got {transitions:#?}"
+    );
+    for (old_signature, new_signature) in &transitions {
+        assert_eq!(
+            old_signature, new_signature,
+            "a declaration nobody edited was paired with a different declaration of the same \
+             name: `{old_signature}` was reported as becoming `{new_signature}`"
+        );
+    }
+
+    // The cheap invariant the ticket names: no two findings about one name may
+    // describe inverse transitions. It is what makes the fabrication obvious to
+    // a reader, so it is asserted directly rather than inferred from the above.
+    for (left_old, left_new) in &transitions {
+        for (right_old, right_new) in &transitions {
+            assert!(
+                !(left_old == right_new && left_new == right_old && left_old != left_new),
+                "contradictory pair reported on `render`: `{left_old}` -> `{left_new}` \
+                 alongside `{right_old}` -> `{right_new}`"
+            );
+        }
+    }
+}
+
+/// The positive control. Editing one member of the group must still be reported,
+/// on that member, with its real transition, and must not disturb the others.
+#[test]
+fn editing_one_member_of_a_same_name_group_reports_exactly_that_member() {
+    let mut repo = LiveRepo::new();
+    repo.commit("mod.py", BASE);
+
+    let edited = BASE.replace(
+        "def render(value, raw=False):",
+        "def render(value, raw=False, encoding=\"utf-8\"):",
+    );
+    assert_ne!(edited, BASE, "the fixture edit must apply");
+    assert_eq!(
+        edited.lines().count(),
+        BASE.lines().count(),
+        "this fixture must not move any line, so only the edited declaration can differ"
+    );
+
+    let delta = repo.commit("mod.py", &edited);
+
+    let changed: Vec<(&str, &str)> = signature_transitions(&delta, "render")
+        .into_iter()
+        .filter(|(old_signature, new_signature)| old_signature != new_signature)
+        .collect();
+    assert_eq!(
+        changed,
+        vec![(
+            "def render(value, raw=False)",
+            "def render(value, raw=False, encoding=\"utf-8\")",
+        )],
+        "the implementation's own signature change is the only one that may be reported"
+    );
+}
+
+/// Position alone is not enough, so the signature tier is load-bearing rather
+/// than belt-and-braces. Inserting a block BETWEEN two members of the group
+/// moves the later members further than the spacing between them, so pairing on
+/// nearest declaration position cross-pairs the stub with the implementation.
+/// Only the declaration's own signature gets this right.
+#[test]
+fn a_wide_insertion_inside_a_same_name_group_pairs_by_signature_not_position() {
+    let mut repo = LiveRepo::new();
+    repo.commit("mod.py", BASE);
+
+    // Twelve lines land between the first stub and the second. The group's
+    // members sit four lines apart, so every later member is now nearer to the
+    // slot its neighbour used to occupy than to its own.
+    let filler: String = (0..4)
+        .map(|index| format!("\n\ndef filler_{index}(value):\n    return value\n"))
+        .collect();
+    let edited = BASE.replace(
+        "def render(value: str, raw: Literal[True]) -> bytes: ...\n",
+        &format!("def render(value: str, raw: Literal[True]) -> bytes: ...\n{filler}"),
+    );
+    assert_ne!(edited, BASE, "the fixture edit must apply");
+    assert!(
+        edited.lines().count() >= BASE.lines().count() + 12,
+        "the insertion must be wider than the spacing between group members, got {} vs {}",
+        edited.lines().count(),
+        BASE.lines().count()
+    );
+
+    let delta = repo.commit("mod.py", &edited);
+
+    let transitions = signature_transitions(&delta, "render");
+    assert_eq!(
+        transitions.len(),
+        3,
+        "all three declarations of `render` should still be carried forward, got {transitions:#?}"
+    );
+    for (old_signature, new_signature) in &transitions {
+        assert_eq!(
+            old_signature, new_signature,
+            "a declaration nobody edited was paired with a different declaration of the same \
+             name: `{old_signature}` was reported as becoming `{new_signature}`"
+        );
+    }
+}
+
+/// The other direction: when a member's own signature changed, the signature
+/// tier cannot match it, and the fallback decides. Two members change here, so
+/// the fallback has two candidates for two declarations and its ordering rule is
+/// what picks. Nearest declaration position pairs each with the one it actually
+/// descends from; the graph's query order is not declaration order and has no
+/// reason to.
+#[test]
+fn when_signatures_moved_the_fallback_pairs_by_nearest_declaration() {
+    let mut repo = LiveRepo::new();
+    repo.commit("mod.py", BASE);
+
+    let edited = BASE
+        .replace("LIMIT: int = 30", "LIMIT: int = 30\nEXTRA: int = 1")
+        .replace(
+            "def render(value: str, raw: Literal[True]) -> bytes: ...",
+            "def render(value: str, raw: Literal[True], *, strict: bool) -> bytes: ...",
+        )
+        .replace(
+            "def render(value: str, raw: Literal[False] = False) -> str: ...",
+            "def render(value: str, raw: Literal[False] = False, *, strict: bool) -> str: ...",
+        );
+    assert_ne!(edited, BASE, "the fixture edit must apply");
+
+    let delta = repo.commit("mod.py", &edited);
+
+    let mut transitions = signature_transitions(&delta, "render")
+        .into_iter()
+        .filter(|(old_signature, new_signature)| old_signature != new_signature)
+        .collect::<Vec<_>>();
+    transitions.sort_unstable();
+    assert_eq!(
+        transitions,
+        vec![
+            (
+                "@overload def render(value: str, raw: Literal[False] = False) -> str",
+                "@overload def render(value: str, raw: Literal[False] = False, *, strict: bool) \
+                 -> str",
+            ),
+            (
+                "@overload def render(value: str, raw: Literal[True]) -> bytes",
+                "@overload def render(value: str, raw: Literal[True], *, strict: bool) -> bytes",
+            ),
+        ],
+        "each stub must be reported against the stub it descends from, not against the other"
+    );
+}
+
+/// Identity is never invented: whatever an entity is paired with, the id the
+/// graph already holds is the id the modification carries. This is the rule
+/// FIR-1656 protects, asserted here so a future pairing change cannot quietly
+/// mint a new persisted identity for an existing declaration.
+#[test]
+fn carry_forward_never_mints_a_new_identity_for_an_existing_declaration() {
+    let mut repo = LiveRepo::new();
+    repo.commit("mod.py", BASE);
+
+    let edited = BASE.replace(
+        "def leading(value):\n    return value",
+        "def leading(value):\n    value = value\n    return value",
+    );
+    assert_ne!(edited, BASE, "the fixture edit must apply");
+    let delta = repo.commit("mod.py", &edited);
+
+    let pairs = modified_pairs(&delta);
+    assert!(
+        !pairs.is_empty(),
+        "the fixture must produce modifications for this assertion to mean anything"
+    );
+    for (old, new) in pairs {
+        assert_eq!(
+            old.id, new.id,
+            "a carried-forward declaration must keep the id the graph already holds"
+        );
+    }
+}

--- a/crates/kin-reconcile/tests/same_name_group_pairing.rs
+++ b/crates/kin-reconcile/tests/same_name_group_pairing.rs
@@ -138,10 +138,7 @@ def trailing(value):
 "#;
 
 /// Every `(old signature, new signature)` a modification on `name` reported.
-fn signature_transitions<'a>(
-    delta: &'a TransactionDelta,
-    name: &str,
-) -> Vec<(&'a str, &'a str)> {
+fn signature_transitions<'a>(delta: &'a TransactionDelta, name: &str) -> Vec<(&'a str, &'a str)> {
     delta
         .entity_deltas
         .iter()

--- a/crates/kin-review/src/diff.rs
+++ b/crates/kin-review/src/diff.rs
@@ -159,11 +159,6 @@ impl SemanticDiff {
     }
 }
 
-/// Stable ordering key for a relation change. Relation deltas are accumulated
-/// through HashMaps whose iteration order is not stable, so emitted diffs sort
-/// on this key to stay byte-identical across repeated runs. A relation id is
-/// unique to a single add-or-remove within one diff, so the id alone totally
-/// orders the set.
 /// Drop the modifications that only advanced provenance, returning how many
 /// were dropped so the caller can publish the count.
 fn split_provenance_only(changes: Vec<EntityChange>) -> (Vec<EntityChange>, usize) {
@@ -221,6 +216,11 @@ fn fold_modified(
     }
 }
 
+/// Stable ordering key for a relation change. Relation deltas are accumulated
+/// through HashMaps whose iteration order is not stable, so emitted diffs sort
+/// on this key to stay byte-identical across repeated runs. A relation id is
+/// unique to a single add-or-remove within one diff, so the id alone totally
+/// orders the set.
 fn relation_change_key(change: &RelationChange) -> String {
     match &change.kind {
         RelationChangeKind::Added(rel) => rel.id.to_string(),
@@ -658,7 +658,7 @@ mod tests {
     use kin_model::change::{EntityDelta, RelationDelta};
     use kin_model::entity::{
         Entity, EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
-        Visibility,
+        SourceSpan, Visibility,
     };
     use kin_model::ids::*;
     use kin_model::relation::{Relation, RelationKind, RelationOrigin};
@@ -1184,5 +1184,214 @@ mod tests {
 
         let diff = diff_from_changes(&[c1, c2]);
         assert!(diff.entity_changes.is_empty());
+    }
+    /// Build the change a re-emitted file produces: one entity really edited,
+    /// the rest carrying nothing but the file's new blob hash and a shifted
+    /// span.
+    fn reemitted_file_change(edited: usize, untouched: usize) -> SemanticChange {
+        let mut entity_deltas = Vec::new();
+
+        for index in 0..edited {
+            let old = test_entity(&format!("edited_{index}"));
+            let mut new = old.clone();
+            new.signature = format!("fn edited_{index}(extra: u32)");
+            new.fingerprint.signature_hash = Hash256::from_bytes([9; 32]);
+            entity_deltas.push(EntityDelta::Modified { old, new });
+        }
+
+        for index in 0..untouched {
+            let old = test_entity(&format!("untouched_{index}"));
+            let mut new = old.clone();
+            // Exactly what the reconciler stamps on every declaration in a
+            // touched file, and exactly what an added or removed byte above a
+            // declaration does to its span.
+            new.metadata.extra.insert(
+                "blob_hash".into(),
+                serde_json::Value::String("advanced-source-blob".into()),
+            );
+            new.span = Some(SourceSpan {
+                file: FilePathId::new("src/lib.rs"),
+                start_byte: 40,
+                end_byte: 80,
+                start_line: 4,
+                start_col: 0,
+                end_line: 6,
+                end_col: 1,
+            });
+            assert_ne!(old, new, "the fixture must move the payload");
+            assert_eq!(
+                old.fingerprint, new.fingerprint,
+                "the fixture must not move the semantic fingerprint"
+            );
+            entity_deltas.push(EntityDelta::Modified { old, new });
+        }
+
+        SemanticChange {
+            id: test_change_id(7),
+            parents: vec![test_change_id(6)],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("test"),
+            message: "edit one line".into(),
+            entity_deltas,
+            relation_deltas: vec![],
+            tree_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            origin: kin_model::ChangeOrigin::Native,
+            admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
+        }
+    }
+
+    /// The headline of FIR-2479, at the layer that decides what a review says.
+    /// A one-line edit records a modification for every declaration in the
+    /// touched file, because the reconciler stamps that file's blob hash on all
+    /// of them and the storage delta must carry the whole payload. The review
+    /// must name the one entity that changed, and say how many records it set
+    /// aside rather than dropping them silently.
+    #[test]
+    fn a_reemitted_file_reports_only_the_entity_that_changed() {
+        let change = reemitted_file_change(1, 60);
+
+        let diff = diff_from_change(&change);
+
+        assert_eq!(
+            diff.entity_changes.len(),
+            1,
+            "only the edited entity may be reported, got {:#?}",
+            diff.entity_changes
+                .iter()
+                .map(|change| match &change.kind {
+                    EntityChangeKind::Modified { new, .. } => new.name.clone(),
+                    EntityChangeKind::Added(entity) => entity.name.clone(),
+                    EntityChangeKind::Removed { .. } => "<removed>".to_string(),
+                })
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            diff.provenance_only_entity_changes, 60,
+            "every suppressed record must be counted, not dropped"
+        );
+        let modified = diff.modified_entities();
+        assert_eq!(modified.len(), 1);
+        assert_eq!(modified[0].1.name, "edited_0");
+    }
+
+    /// The positive control, stated separately so the rule above cannot pass by
+    /// suppressing everything. Nothing but provenance moved, so nothing is
+    /// reported, and the count still says the file was re-emitted.
+    #[test]
+    fn a_file_whose_entities_only_moved_reports_no_modification_and_says_so() {
+        let change = reemitted_file_change(0, 3);
+
+        let diff = diff_from_change(&change);
+
+        assert!(
+            diff.entity_changes.is_empty(),
+            "a provenance-only change has nothing for a reviewer to act on"
+        );
+        assert_eq!(diff.provenance_only_entity_changes, 3);
+    }
+
+    /// A real edit followed by a later re-emission of the same file must survive
+    /// the range walk. The accumulated base-side payload has to stay the FIRST
+    /// one the range recorded: comparing against the latest delta's base would
+    /// compare the edited entity with itself and report no change at all.
+    #[test]
+    fn a_later_reemission_does_not_erase_an_earlier_edit_in_the_same_range() {
+        let old = test_entity("moved");
+        let mut edited = old.clone();
+        edited.signature = "fn moved(extra: u32)".into();
+        edited.fingerprint.signature_hash = Hash256::from_bytes([9; 32]);
+
+        let mut reemitted = edited.clone();
+        reemitted.metadata.extra.insert(
+            "blob_hash".into(),
+            serde_json::Value::String("advanced-source-blob".into()),
+        );
+        assert_ne!(edited, reemitted, "the fixture must move the payload");
+
+        let first = SemanticChange {
+            entity_deltas: vec![EntityDelta::Modified {
+                old: old.clone(),
+                new: edited.clone(),
+            }],
+            ..reemitted_file_change(0, 0)
+        };
+        let second = SemanticChange {
+            id: test_change_id(8),
+            parents: vec![test_change_id(7)],
+            entity_deltas: vec![EntityDelta::Modified {
+                old: edited,
+                new: reemitted.clone(),
+            }],
+            ..reemitted_file_change(0, 0)
+        };
+
+        let diff = diff_from_changes(&[first, second]);
+
+        let modified = diff.modified_entities();
+        assert_eq!(
+            modified.len(),
+            1,
+            "the range still changed this entity, so the range must report it"
+        );
+        assert_eq!(
+            modified[0].0.signature, "fn moved()",
+            "the reported base must be the range's base, not the last delta's"
+        );
+        assert_eq!(modified[0].1.signature, "fn moved(extra: u32)");
+        assert_eq!(diff.provenance_only_entity_changes, 0);
+    }
+
+    /// The classifier itself, driven in both directions on real fields rather
+    /// than inferred from the two rules above.
+    #[test]
+    fn semantic_modification_reads_content_and_ignores_placement() {
+        let base = test_entity("subject");
+
+        let mut moved = base.clone();
+        moved.span = Some(SourceSpan {
+            file: FilePathId::new("src/lib.rs"),
+            start_byte: 1,
+            end_byte: 2,
+            start_line: 9,
+            start_col: 0,
+            end_line: 9,
+            end_col: 1,
+        });
+        assert!(!is_semantic_modification(&base, &moved));
+
+        let mut reprovenanced = base.clone();
+        reprovenanced
+            .metadata
+            .extra
+            .insert("blob_hash".into(), serde_json::Value::String("x".into()));
+        assert!(!is_semantic_modification(&base, &reprovenanced));
+
+        let mut resigned = base.clone();
+        resigned.signature = "fn subject(flag: bool)".into();
+        assert!(is_semantic_modification(&base, &resigned));
+
+        let mut refingerprinted = base.clone();
+        refingerprinted.fingerprint.behavior_hash = Hash256::from_bytes([3; 32]);
+        assert!(is_semantic_modification(&base, &refingerprinted));
+
+        let mut renamed = base.clone();
+        renamed.name = "renamed".into();
+        assert!(is_semantic_modification(&base, &renamed));
+
+        let mut hidden = base.clone();
+        hidden.visibility = Visibility::Private;
+        assert!(is_semantic_modification(&base, &hidden));
+
+        let mut relocated = base.clone();
+        relocated.file_origin = Some(FilePathId::new("src/elsewhere.rs"));
+        assert!(
+            is_semantic_modification(&base, &relocated),
+            "a declaration that changed file is a move a reviewer must see"
+        );
     }
 }

--- a/crates/kin-review/src/diff.rs
+++ b/crates/kin-review/src/diff.rs
@@ -560,6 +560,12 @@ pub fn diff_from_changes(changes: &[SemanticChange]) -> SemanticDiff {
 /// This is the primary mechanism for "review from arbitrary user-specified
 /// change sets" — callers can hand-pick any set of entities and get a full
 /// review with impact analysis and risk scoring.
+///
+/// This constructor and [`diff_from_files`] are deliberately NOT filtered for
+/// provenance-only modifications, unlike the three range constructors above. A
+/// caller here named the entities or the files it wants described, so answering
+/// with silence about one of them would be dropping something that was asked for
+/// rather than declining to invent a finding.
 pub fn diff_from_entity_ids<G: GraphStore>(
     store: &G,
     entity_ids: &[EntityId],

--- a/crates/kin-review/src/diff.rs
+++ b/crates/kin-review/src/diff.rs
@@ -66,6 +66,42 @@ pub struct SemanticDiff {
     pub head: Option<SemanticChangeId>,
     pub entity_changes: Vec<EntityChange>,
     pub relation_changes: Vec<RelationChange>,
+    /// How many recorded modifications this range carried whose entity did not
+    /// change: same name, kind, signature, visibility, role, and fingerprint,
+    /// with only the span and the source-blob provenance advanced.
+    ///
+    /// They are excluded from `entity_changes` because a review that names them
+    /// is naming work nobody did, but the count is published rather than
+    /// dropped. It is the honest measure of how much of a stored change is
+    /// re-emission, and a reader who sees "Modified (1)" beside 60 suppressed
+    /// entries knows the storage layer touched the whole file while the review
+    /// found one edit.
+    #[serde(default)]
+    pub provenance_only_entity_changes: usize,
+}
+
+/// Whether a recorded modification changed what the entity IS, rather than only
+/// where it sits or which blob it was last read out of.
+///
+/// The reconciler stamps the touched file's blob hash onto every declaration in
+/// that file (`kin-reconcile/src/reconciler.rs`), and an edit that adds or
+/// removes bytes shifts the span of every declaration below it. Both are true
+/// provenance and the storage delta must carry them, because the workspace
+/// overlay is derived by whole-value difference and a payload held back there
+/// strands the workspace dirty forever. Neither is a change a reviewer can act
+/// on, so this is where the two meanings of "modified" separate.
+///
+/// The comparison normalizes the provenance fields onto the base value and then
+/// compares the whole entity, rather than listing the fields that count. A field
+/// added to `Entity` later is therefore treated as semantic until someone
+/// decides otherwise, which fails toward reporting a change rather than hiding
+/// one.
+pub fn is_semantic_modification(old: &Entity, new: &Entity) -> bool {
+    let mut normalized = new.clone();
+    normalized.span.clone_from(&old.span);
+    normalized.metadata.clone_from(&old.metadata);
+    normalized.created_in = old.created_in;
+    normalized != *old
 }
 
 impl SemanticDiff {
@@ -128,6 +164,63 @@ impl SemanticDiff {
 /// on this key to stay byte-identical across repeated runs. A relation id is
 /// unique to a single add-or-remove within one diff, so the id alone totally
 /// orders the set.
+/// Drop the modifications that only advanced provenance, returning how many
+/// were dropped so the caller can publish the count.
+fn split_provenance_only(changes: Vec<EntityChange>) -> (Vec<EntityChange>, usize) {
+    let before = changes.len();
+    let kept: Vec<EntityChange> = changes
+        .into_iter()
+        .filter(|change| match &change.kind {
+            EntityChangeKind::Modified { old, new } => is_semantic_modification(old, new),
+            EntityChangeKind::Added(_) | EntityChangeKind::Removed { .. } => true,
+        })
+        .collect();
+    let suppressed = before - kept.len();
+    (kept, suppressed)
+}
+
+/// Fold one `Modified` delta into the accumulated state for its entity.
+///
+/// The accumulated `old` stays the FIRST base-side payload the range recorded,
+/// never the latest delta's. Overwriting it collapsed `base..head` into
+/// `last_change..head`: an entity whose signature moved in the first change and
+/// whose blob provenance advanced in a later one would be compared against a
+/// base that already carried the new signature, and the range would report no
+/// change at all.
+fn fold_modified(
+    entity_states: &mut HashMap<EntityId, EntityChangeKind>,
+    old: &Entity,
+    new: &Entity,
+) {
+    let id = new.id;
+    match entity_states.get(&id) {
+        // Added in this range and then edited: still an addition from the
+        // range's point of view.
+        Some(EntityChangeKind::Added(_)) => {
+            entity_states.insert(id, EntityChangeKind::Added(new.clone()));
+        }
+        Some(EntityChangeKind::Modified { old: first, .. }) => {
+            let first = first.clone();
+            entity_states.insert(
+                id,
+                EntityChangeKind::Modified {
+                    old: first,
+                    new: new.clone(),
+                },
+            );
+        }
+        _ => {
+            entity_states.insert(
+                id,
+                EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            );
+        }
+    }
+}
+
 fn relation_change_key(change: &RelationChange) -> String {
     match &change.kind {
         RelationChangeKind::Added(rel) => rel.id.to_string(),
@@ -201,23 +294,7 @@ pub fn compute_diff_scoped<G: GraphStore>(
                     }
                 }
                 EntityDelta::Modified { old, new } => {
-                    let id = new.id;
-                    match entity_states.get(&id) {
-                        Some(EntityChangeKind::Added(_)) => {
-                            // Was added in this range, now modified — still "added"
-                            // from the perspective of the overall diff
-                            entity_states.insert(id, EntityChangeKind::Added(new.clone()));
-                        }
-                        _ => {
-                            entity_states.insert(
-                                id,
-                                EntityChangeKind::Modified {
-                                    old: old.clone(),
-                                    new: new.clone(),
-                                },
-                            );
-                        }
-                    }
+                    fold_modified(&mut entity_states, old, new);
                 }
                 EntityDelta::Removed { old } => {
                     let id = old.id;
@@ -249,7 +326,9 @@ pub fn compute_diff_scoped<G: GraphStore>(
         .map(|(entity_id, kind)| EntityChange { entity_id, kind })
         .collect();
     entity_changes.sort_by_key(|change| change.entity_id);
+    let (entity_changes, provenance_only) = split_provenance_only(entity_changes);
     diff.entity_changes = entity_changes;
+    diff.provenance_only_entity_changes = provenance_only;
 
     // Accumulate relation deltas
     let mut relation_added: HashMap<RelationId, Relation> = HashMap::new();
@@ -317,6 +396,7 @@ pub fn diff_from_change(change: &SemanticChange) -> SemanticDiff {
         ..Default::default()
     };
 
+    let mut entity_changes = Vec::new();
     for delta in &change.entity_deltas {
         let (entity_id, kind) = match delta {
             EntityDelta::Added { new: e } => (e.id, EntityChangeKind::Added(e.clone())),
@@ -334,8 +414,11 @@ pub fn diff_from_change(change: &SemanticChange) -> SemanticDiff {
                 },
             ),
         };
-        diff.entity_changes.push(EntityChange { entity_id, kind });
+        entity_changes.push(EntityChange { entity_id, kind });
     }
+    let (entity_changes, provenance_only) = split_provenance_only(entity_changes);
+    diff.entity_changes = entity_changes;
+    diff.provenance_only_entity_changes = provenance_only;
 
     for delta in &change.relation_deltas {
         let kind = match delta {
@@ -379,22 +462,7 @@ pub fn diff_from_changes(changes: &[SemanticChange]) -> SemanticDiff {
                     entity_states.insert(id, EntityChangeKind::Added(entity.clone()));
                 }
                 EntityDelta::Modified { old, new } => {
-                    let id = new.id;
-                    match entity_states.get(&id) {
-                        Some(EntityChangeKind::Added(_)) => {
-                            // Was added earlier in this set — still "added"
-                            entity_states.insert(id, EntityChangeKind::Added(new.clone()));
-                        }
-                        _ => {
-                            entity_states.insert(
-                                id,
-                                EntityChangeKind::Modified {
-                                    old: old.clone(),
-                                    new: new.clone(),
-                                },
-                            );
-                        }
-                    }
+                    fold_modified(&mut entity_states, old, new);
                 }
                 EntityDelta::Removed { old } => match entity_states.get(&old.id) {
                     Some(EntityChangeKind::Added(_)) => {
@@ -420,7 +488,9 @@ pub fn diff_from_changes(changes: &[SemanticChange]) -> SemanticDiff {
         .map(|(entity_id, kind)| EntityChange { entity_id, kind })
         .collect();
     entity_changes.sort_by_key(|change| change.entity_id);
+    let (entity_changes, provenance_only) = split_provenance_only(entity_changes);
     diff.entity_changes = entity_changes;
+    diff.provenance_only_entity_changes = provenance_only;
 
     // Accumulate relation deltas
     let mut relation_added: HashMap<RelationId, Relation> = HashMap::new();

--- a/crates/kin-review/src/format.rs
+++ b/crates/kin-review/src/format.rs
@@ -69,8 +69,25 @@ fn entity_location(entity: &kin_model::entity::Entity) -> Option<String> {
 pub fn format_diff(diff: &SemanticDiff) -> String {
     let mut out = String::new();
 
+    // The provenance note comes before the empty check on purpose. A change
+    // that re-emitted a whole file and edited nothing in it is exactly the case
+    // where a bare "No entity changes." would look like the review had read
+    // nothing, so the line that explains the discrepancy has to survive it.
+    let provenance_note = if diff.provenance_only_entity_changes > 0 {
+        Some(format!(
+            "{} entity record(s) in the touched file(s) advanced only their span or source-blob \
+             provenance and are not listed as modified.",
+            diff.provenance_only_entity_changes,
+        ))
+    } else {
+        None
+    };
+
     if diff.is_empty() {
         writeln!(out, "No entity changes.").unwrap();
+        if let Some(note) = provenance_note {
+            writeln!(out, "{note}").unwrap();
+        }
         return out;
     }
 
@@ -93,6 +110,10 @@ pub fn format_diff(diff: &SemanticDiff) -> String {
                 writeln!(out, "    file: {}", file).unwrap();
             }
         }
+    }
+
+    if let Some(note) = provenance_note {
+        writeln!(out, "\n{note}").unwrap();
     }
 
     if !modified.is_empty() {

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -22,7 +22,7 @@ pub use change_shape::{
 };
 pub use diff::{
     compute_diff, diff_from_change, diff_from_changes, diff_from_entity_ids, diff_from_files,
-    EntityChange, EntityChangeKind, SemanticDiff,
+    is_semantic_modification, EntityChange, EntityChangeKind, SemanticDiff,
 };
 pub use error::ReviewError;
 pub use format::{

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -2570,6 +2570,7 @@ mod tests {
                     head: None,
                     entity_changes,
                     relation_changes: vec![],
+                    ..SemanticDiff::default()
                 },
                 // One graph-known consumer per removed entity makes the
                 // per-entity contract-surface rule fire for each candidate.
@@ -3649,6 +3650,7 @@ mod tests {
                     },
                 ],
                 relation_changes: vec![],
+                ..SemanticDiff::default()
             },
             impact: ImpactReport {
                 entity_impacts: vec![EntityImpact {
@@ -3749,6 +3751,7 @@ mod tests {
                     },
                 }],
                 relation_changes: vec![],
+                ..SemanticDiff::default()
             },
             impact: ImpactReport {
                 entity_impacts: vec![EntityImpact {
@@ -4364,6 +4367,7 @@ mod tests {
                     kind: EntityChangeKind::Removed { old: None },
                 }],
                 relation_changes: vec![],
+                ..SemanticDiff::default()
             },
             impact: ImpactReport {
                 entity_impacts: vec![EntityImpact {
@@ -4469,6 +4473,7 @@ mod tests {
                     },
                 }],
                 relation_changes: vec![],
+                ..SemanticDiff::default()
             },
             impact: ImpactReport {
                 entity_impacts: vec![EntityImpact {


### PR DESCRIPTION
Any edit to a file made `kin review` report every declaration in that file as Modified, which manufactured roughly ten phantom coverage findings per review and, worse, cross-paired same-name declaration groups into breaking changes that contradicted each other. On a one-line constant edit the reviewprobe lane saw nine breaking changes of which one was real, and the eight fabrications came in inverse pairs (`A -> B` beside `B -> A` on the same function). That is the failure mode most likely to make a reviewer stop believing the tool, so this fixes both halves.

## Mechanism

There are two independent causes, and both were reproduced on a fixture built for this PR that drives the real Python parser and the real reconciler.

**Re-emission.** `crates/kin-reconcile/src/reconciler.rs:699` stamps the touched file's blob hash into every re-parsed declaration's metadata, and the payload comparison at `crates/kin-reconcile/src/reconciler.rs:705` is a whole-value comparison, so it is true for every entity in the file. An added or removed byte also shifts the span of every declaration below the edit. Neither of those may be dropped from the stored delta: `crates/kin-daemon/src/commit_deltas.rs:463` compares the complete payload on purpose, because the workspace overlay is derived by whole-value difference and a payload held back there leaves the workspace dirty forever. The test at `crates/kin-daemon/src/commit_deltas.rs:2232` asserts exactly that. So the storage layer is right and the review layer was reading a storage answer as if it were a semantic one.

**Cross-pairing.** Entity identity is `(file, kind, name, start_line)` (`kin-model` `EntityId::from_content`, used at `crates/kin-parser/src/extract.rs:77`), so any edit that adds or removes a line retires the id of every declaration below it. Those declarations dropped to a carry-forward pass that matched on name and kind alone, taking the first unclaimed candidate in graph query order, which is not declaration order. A Python `@overload` group's three declarations share a name and kind, so they were paired arbitrarily and each reported a signature transition it never underwent. Measured on the fixture: a one-line insertion rotated the group three ways, reporting the implementation as having become a stub and each stub as having become the other.

## The fix

`crates/kin-reconcile/src/reconciler.rs` adds a signature-matching tier between the id pass and the name-and-kind fallback, and makes the fallback pair by nearest declaration position instead of by graph query order. No persisted identity format changes: `EntityId` derivation is untouched, and a carried-forward declaration still keeps the id the graph already holds, which is asserted by a test. FIR-1656's constraint is therefore not reached.

`crates/kin-review/src/diff.rs` adds `is_semantic_modification`, which normalizes span, metadata, and `created_in` from the base value onto the head value and then compares the whole entity. Comparing whole values rather than listing the fields that count means a field added to `Entity` later is treated as semantic until someone decides otherwise, which fails toward reporting a change rather than hiding one. The three diff constructors filter provenance-only modifications out of `entity_changes` and publish the count as `SemanticDiff::provenance_only_entity_changes`, and `crates/kin-review/src/format.rs` prints it, so the suppression is auditable rather than silent.

`crates/kin-review/src/diff.rs` also fixes the range accumulation, which had been overwriting the base-side payload with each later delta's. That collapsed `base..head` into `last_change..head`, and with the new filter on top it would have hidden a real edit whenever a later change re-emitted the same file. Falsification pass B below shows that exact case reporting zero changes.

## What the fixture measures

A Python file with three `@overload`-group declarations of one name, a constant above the edit, a constant below it, a class, and a caller. Before this change a one-line value edit produced eleven Modified records covering the whole file. After it the review names two: the edited constant and the file's own module entity, whose body is the file and whose fingerprint really did move. The module is kept deliberately; suppressing it would hide a content change that happened.

## Falsification

Four passes, each removing one property, each predicting which tests fail and which still pass, each restored byte-identical afterwards and verified by sha256.

Pass 1, signature tier removed from the reconciler: `a_wide_insertion_inside_a_same_name_group_pairs_by_signature_not_position` failed with "a declaration nobody edited was paired with a different declaration of the same name: `def render(value, raw=False)` was reported as becoming `@overload def render(value: str, raw: Literal[False] = False) -> str`". The other four reconcile tests passed, which is the scoping the second pass then breaks.

Pass 2, nearest-position fallback replaced by graph query order: `when_signatures_moved_the_fallback_pairs_by_nearest_declaration` failed, and its output is the three-way rotation itself, the implementation reported as becoming a stub. The other four passed.

Pass A, provenance normalization removed from `is_semantic_modification`: the two suppression tests and the classifier test failed, and `a_later_reemission_does_not_erase_an_earlier_edit_in_the_same_range` passed, which is what shows the two rules are separately scoped.

Pass B, earliest-base preservation removed from the accumulation: `a_later_reemission_does_not_erase_an_earlier_edit_in_the_same_range` failed reporting 0 modified entities where 1 was expected. The other three passed.

The end-to-end suite was falsified in both directions too. With the classifier removed, all three tests failed listing all eleven entity names. With the reconciler's signature tier removed, only `a_wide_insertion_produces_no_contradictory_breaking_changes` failed, naming the two rotated `render` records. The contradictions test was rewritten mid-work for this reason: its first version used an edit that moved no lines, which made it structurally unable to fail from the pairing defect it is named for.

## Gates

`cargo fmt --all -- --check` exits 0. Clippy exactly as `.github/workflows/ci.yml` runs it, `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the 45-lint allowlist from `.github/clippy-allowed-lints.txt`, exits 0 across the whole workspace. `scripts/verify-zero-file-search.py` passed over 177 source files, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh` and `scripts/verify-hydration-semantics.py` all passed. Targeted suites: 914 tests across kin-review, kin-reconcile and kin-mcp, 0 failures, run with `--no-fail-fast`.

`git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty. The lock keeps 8 `sparse+` sources and 0 path sources.

The local full gate was launched under a build slot and did not complete: the agent harness culled it at 2m46s while it was still compiling `kin-cli`, with zero tests run. Its restore trap then wrote a rc of 0, which is a false pass rather than a result, because the trap reads `$?` and kin-dev returns 0 after reporting its child's termination. The worktree was verified clean afterwards, with `Cargo.lock` back to 8 `sparse+` sources and 0 path sources, `.cargo/config.toml` restored, no stray `.bak`, and no orphaned cargo or nextest process. Under the 05:52Z amendment hosted CI is therefore the gate of record for this PR: 36 checks, all concluded, 32 pass, 4 skipped, 0 failures, read at head `4390f4b6` after verifying that head equals this branch's. Both `Check & Test` legs, both macOS shards, `Falsify guards`, the three Windows authority legs and the Linux daemon smoke are among the passes, which covers more than the local gate would have.

## A verdict consequence, stated rather than left to be found

`derive_decision` at `crates/kin-review/src/gate.rs:39` blocks when `blocking_count > 0` OR when
`approvals_required > 1 && attention_count > 2`. Phantom coverage gaps were attention signals, and
the reviewprobe run counted ten of them against one real blocking finding. So on a repository
requiring more than one approval, a review that blocked purely on phantom attention signals can now
read NeedsAttention instead. That is the intended outcome, since those signals were fabricated, but
it is a change in what the gate returns and not only in what it prints. Blocking findings themselves
are unaffected: nothing here suppresses an Added, a Removed, or a modification whose content moved.

## What this does not fix

The ticket's Consequence 3 is untouched: shadow repair context is still file-scoped rather than entity-scoped, so a finding is still handed the module's tests and consumers. With one finding instead of eleven the report is no longer dominated by it, but the scoping defect itself remains. A constant's value edit is also still framed as a "Signature change", which is the wrong frame even though the finding is real.

One separate defect was found while building the fixture and is not fixed here: `looks_like_py_constant_name` at `crates/kin-parser/src/languages/python.rs:1091` requires a constant's name to contain both an uppercase letter and an underscore, so a single-word Python constant such as `LIMIT`, `TIMEOUT` or `DEBUG` is not extracted as an entity at all. It is invisible to locate, impact and review, and the absence reads as a clean answer. That deserves its own ticket.

Refs FIR-2479
