### PR TITLE
Wait on the observable in six load-flaky tests instead of on a fixed budget

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -4536,12 +4536,175 @@ mod tests {
         );
     }
 
-    /// Write an executable stand-in for the projection driver.
+    /// How long a fixture waits for a file it just wrote to become executable.
+    ///
+    /// Generous against a loaded runner and far short of any real failure: the
+    /// only handle that can still be open is a copy this process forked, and
+    /// that copy is closed by the child's own exec microseconds later. A bound
+    /// this wide expiring means something holds the file open indefinitely,
+    /// which no fixture here does.
+    #[cfg(unix)]
+    const EXEC_READY_BOUND: std::time::Duration = std::time::Duration::from_secs(10);
+
+    /// Write an executable stand-in for the projection driver, and do not
+    /// return until the host will actually run it.
+    ///
+    /// `write_file` closes its own handle before this returns, and that is not
+    /// enough. A fork raised by another test thread between the open and the
+    /// close inherits a copy of the write descriptor, and the kernel refuses to
+    /// exec a file any process still holds open for writing: ETXTBSY, spelled
+    /// "Text file busy". The inherited copy dies at that child's own exec, so
+    /// the window is short and belongs entirely to the fixture, but it is wide
+    /// enough under load to have ejected two green pull requests from the merge
+    /// queue (FIR-2488, FIR-2457).
+    ///
+    /// Waiting for one successful exec is what closes the window rather than
+    /// widening a sleep. Nothing else writes these files, so once the kernel
+    /// has let the file run, no writer can appear again.
     #[cfg(unix)]
     fn write_driver(path: &Path, script: &str) {
         use std::os::unix::fs::PermissionsExt;
         write_file(path, script.as_bytes());
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        wait_until_executable(path);
+    }
+
+    /// Block until the host executes `path`, or fail naming what still refuses.
+    ///
+    /// Only ETXTBSY is waited out. Every other spawn error, and every exit
+    /// status, means the file ran or is broken for a reason no wait repairs,
+    /// so both return immediately.
+    #[cfg(unix)]
+    fn wait_until_executable(path: &Path) {
+        wait_until_executable_within(path, EXEC_READY_BOUND);
+    }
+
+    /// [`wait_until_executable`] with the bound named, so the guard below can
+    /// prove the wait expires without spending the real one.
+    #[cfg(unix)]
+    fn wait_until_executable_within(path: &Path, bound: std::time::Duration) {
+        let deadline = std::time::Instant::now() + bound;
+        let mut attempts = 0_u32;
+        loop {
+            let error = match std::process::Command::new(path)
+                .arg("--kin-fixture-exec-probe")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+            {
+                Ok(_) => return,
+                Err(error) => error,
+            };
+            assert_eq!(
+                error.kind(),
+                std::io::ErrorKind::ExecutableFileBusy,
+                "{} could not be executed: {error}",
+                path.display()
+            );
+            attempts += 1;
+            assert!(
+                std::time::Instant::now() < deadline,
+                "{} stayed text-busy across {attempts} exec attempts in {bound:?}",
+                path.display()
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    /// The exec-readiness wait has to be able to see the condition it waits
+    /// for, or it is a sleep that always returns.
+    ///
+    /// The condition is a file some process still holds open for writing, which
+    /// is what a fork raised mid-write leaves behind. Linux refuses to exec such
+    /// a file with ETXTBSY and macOS does not refuse at all, measured on both:
+    /// `ubuntu:24.04` answers "Text file busy" and exit 126 while a descriptor
+    /// is held and exit 0 once it closes, and this workstation runs the file in
+    /// both states. So the refusing half of this guard asserts only where the
+    /// kernel produces the refusal, decided by asking rather than by target
+    /// name, and the returning half is asserted everywhere. That platform split
+    /// is also why the flake this wait removes never reproduced on a local
+    /// macOS gate and only ever ejected pull requests from Linux runs
+    /// (FIR-2488, FIR-2457).
+    #[test]
+    #[cfg(unix)]
+    fn the_exec_readiness_wait_sees_a_busy_file_and_stops_waiting_when_it_clears() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("stand-in");
+        write_file(&script, b"#!/bin/sh\nexit 0\n");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let handle = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&script)
+            .unwrap();
+        let refused_while_held = std::process::Command::new(&script)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .err()
+            .is_some_and(|error| error.kind() == std::io::ErrorKind::ExecutableFileBusy);
+
+        if refused_while_held {
+            let previous = std::panic::take_hook();
+            std::panic::set_hook(Box::new(|_| {}));
+            let expired = std::panic::catch_unwind(|| {
+                wait_until_executable_within(&script, std::time::Duration::from_millis(200));
+            });
+            std::panic::set_hook(previous);
+            let payload = expired
+                .expect_err("a file this kernel refuses to exec must make the bounded wait expire");
+            let message = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .unwrap_or_default();
+            assert!(
+                message.contains("stayed text-busy"),
+                "the expiry must name what it was waiting on, got {message:?}"
+            );
+        }
+
+        // Text-busy is the only failure worth waiting out. A wait that sat out
+        // its bound on every error would turn a fixture typo into a timeout
+        // instead of naming the missing file, so the discrimination is asserted
+        // rather than assumed.
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let started = std::time::Instant::now();
+        let missing = std::panic::catch_unwind(|| {
+            wait_until_executable_within(
+                &dir.path().join("no-such-stand-in"),
+                std::time::Duration::from_secs(30),
+            );
+        });
+        std::panic::set_hook(previous);
+        let payload = missing.expect_err("a path that is not there cannot become executable");
+        assert!(
+            payload
+                .downcast_ref::<String>()
+                .is_some_and(|message| message.contains("could not be executed")),
+            "an absent file must be reported, not waited out: {payload:?}"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "an error that is not text-busy must fail at once, took {:?}",
+            started.elapsed()
+        );
+
+        drop(handle);
+        // Both worlds: with no writer left the wait returns rather than
+        // spending its bound, which is the half that keeps every fixture in
+        // this module cheap.
+        let cleared = std::time::Instant::now();
+        wait_until_executable_within(&script, EXEC_READY_BOUND);
+        assert!(
+            cleared.elapsed() < std::time::Duration::from_secs(5),
+            "a file nothing holds open must be executable at once, took {:?}",
+            cleared.elapsed()
+        );
     }
 
     /// A driver the loader refuses is not an absent driver. The linux-aarch64

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -15850,6 +15850,50 @@ fi
     /// authority must surface as EIO from the shim, never as silent raw-disk
     /// reads, so the shell only ever decides whether to START a daemon and
     /// never whether the preload applies.
+    /// How long a scenario waits for a start the hook launched detached.
+    ///
+    /// Only how long a run that is going to fail spends proving it: the wait
+    /// below returns the instant the line lands, so a passing scenario never
+    /// spends this. Sized against a runner where the whole probe shell took ten
+    /// seconds rather than the three a quiet box takes.
+    #[cfg(unix)]
+    const DETACHED_START_BOUND: Duration = Duration::from_secs(30);
+
+    /// Start lines the stub has recorded so far.
+    #[cfg(unix)]
+    fn recorded_starts(start_log: &Path) -> usize {
+        fs::read_to_string(start_log)
+            .map(|log| log.lines().count())
+            .unwrap_or(0)
+    }
+
+    /// Wait for the starts a scenario expects, and return what the log holds.
+    ///
+    /// Every hook launches `kin-vfs start` detached, zsh with `&!` and the
+    /// others with a plain `&`, and none of them waits for it. `Command::output`
+    /// waits for the probe shell alone, so reading the log the moment it returns
+    /// reads a side effect of a process nothing synchronised with: on a loaded
+    /// host the shell's ten bounded retries expire and it exits before the
+    /// disowned grandchild has appended its line (FIR-2573).
+    ///
+    /// So wait on the observable rather than on the shell. This returns as soon
+    /// as the expected count is there and hands the count back either way, so
+    /// the caller's assertion still names the scenario and prints the call log.
+    /// A scenario expecting no start has nothing to wait for and is read
+    /// directly: a start that has not landed yet cannot fail that assertion, so
+    /// it has never been the flaky direction.
+    #[cfg(unix)]
+    fn starts_recorded_within_bound(start_log: &Path, expected: usize) -> usize {
+        let deadline = std::time::Instant::now() + DETACHED_START_BOUND;
+        loop {
+            let starts = recorded_starts(start_log);
+            if starts >= expected || std::time::Instant::now() >= deadline {
+                return starts;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn hook_liveness_guard_starts_on_stale_sockets_and_keeps_the_shim_unconditional() {
@@ -16010,10 +16054,12 @@ printf 'LD=[%s]\n' "$LD_PRELOAD"
                     "{hook_name}/{mode}: probe shell failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
                 );
 
+                let starts = if expected_starts == 0 {
+                    recorded_starts(&start_log)
+                } else {
+                    starts_recorded_within_bound(&start_log, expected_starts)
+                };
                 let calls_text = fs::read_to_string(&calls).unwrap_or_default();
-                let starts = fs::read_to_string(&start_log)
-                    .map(|s| s.lines().count())
-                    .unwrap_or(0);
                 assert_eq!(
                     starts, expected_starts,
                     "{hook_name}/{mode}: {why}\ncalls:\n{calls_text}\nstdout:\n{stdout}"

--- a/crates/kin-cli/src/daemon_client/probe_process.rs
+++ b/crates/kin-cli/src/daemon_client/probe_process.rs
@@ -1322,6 +1322,40 @@ mod tests {
         );
     }
 
+    /// How long the `delayed-ready` worker withholds its PID marker.
+    ///
+    /// The whole point of the case below is that a runtime budget shorter than
+    /// this one must not expire while the worker is still silent, so this has
+    /// to stay comfortably above [`DELAYED_READY_RUNTIME_BUDGET`]. A sleep only
+    /// ever overshoots, so a loaded runner widens this gap rather than closing
+    /// it: the falsification direction cannot be lost to load.
+    const DELAYED_READY_SILENCE: Duration = Duration::from_secs(3);
+
+    /// What the `delayed-ready` worker still has to do once its PID is
+    /// readable.
+    ///
+    /// Load bearing rather than padding. With no work left after the marker,
+    /// the worker could exit before the parent's first post-readiness poll, and
+    /// a budget of zero would pass the case just as well as a correct one.
+    const DELAYED_READY_WORK_AFTER_READY: Duration = Duration::from_millis(250);
+
+    /// The runtime budget the case gives the worker once its PID is readable.
+    ///
+    /// Sized from what the worker actually does after publishing rather than
+    /// from a round number: eight times [`DELAYED_READY_WORK_AFTER_READY`], so
+    /// a runner that stretches a quarter-second sleep several fold still fits.
+    /// The predecessor was 400ms against 250ms of work, and that 150ms of
+    /// margin ejected kin#983 from the merge queue when the child finished at
+    /// 1.12s (FIR-2491).
+    const DELAYED_READY_RUNTIME_BUDGET: Duration = Duration::from_secs(2);
+
+    /// How long the case waits for the worker's PID to become readable.
+    ///
+    /// Only how long a run that is going to fail spends proving it, so it is
+    /// deliberately far above [`DELAYED_READY_SILENCE`] rather than tuned to
+    /// it.
+    const DELAYED_READY_READINESS_BOUND: Duration = Duration::from_secs(60);
+
     #[test]
     fn probe_worker() {
         let Ok(mode) = std::env::var(PROBE_WORKER_ENV) else {
@@ -1343,9 +1377,9 @@ mod tests {
         } else if mode == "delayed-ready" {
             let marker =
                 std::path::PathBuf::from(std::env::var_os(PROBE_DESCENDANT_MARKER_ENV).unwrap());
-            std::thread::sleep(Duration::from_millis(500));
+            std::thread::sleep(DELAYED_READY_SILENCE);
             publish_pid_marker(&marker).unwrap();
-            std::thread::sleep(Duration::from_millis(250));
+            std::thread::sleep(DELAYED_READY_WORK_AFTER_READY);
         } else if mode == "parent-owner" {
             let marker = std::env::var_os(PROBE_DESCENDANT_MARKER_ENV).unwrap();
             let mut nested_probe = Command::new(std::env::current_exe().unwrap());
@@ -1447,12 +1481,22 @@ mod tests {
             .env(PROBE_WORKER_ENV, "delayed-ready")
             .env(PROBE_DESCENDANT_MARKER_ENV, &marker);
 
+        // The property: the runtime budget is shorter than the worker's whole
+        // life and longer than the part of it that follows readiness, so a
+        // deadline anchored at spawn expires and one anchored at readiness does
+        // not. Both margins are multiples rather than the tens of milliseconds
+        // the fixed pair left (FIR-2491).
+        assert!(
+            DELAYED_READY_WORK_AFTER_READY < DELAYED_READY_RUNTIME_BUDGET
+                && DELAYED_READY_RUNTIME_BUDGET < DELAYED_READY_SILENCE,
+            "the case only discriminates while work < budget < silence"
+        );
         let output = output_finalized_with_timeout_and_limit_after_parseable_pid_ready(
             command,
             "delayed-ready daemon probe fixture",
             &marker,
-            Duration::from_secs(2),
-            Duration::from_millis(400),
+            DELAYED_READY_READINESS_BOUND,
+            DELAYED_READY_RUNTIME_BUDGET,
             MAX_CAPTURE_BYTES_PER_STREAM,
         )
         .unwrap();

--- a/crates/kin-cli/tests/live_graph_durability_disclosure.rs
+++ b/crates/kin-cli/tests/live_graph_durability_disclosure.rs
@@ -109,6 +109,20 @@ fn retry_bound() -> Duration {
 /// Split from the reading above so the arithmetic can be driven with observed
 /// numbers rather than with whatever the box running the tests happens to
 /// report at that instant.
+/// The deadline a settle already under way should hold.
+///
+/// A load average is a one minute mean, so a host that saturates as a settle
+/// begins still reads quiet for the first samples of it, and a budget taken
+/// once at the start is the budget an idle box would have got. This takes the
+/// widest the host justifies while the settle runs. It only ever widens, so a
+/// reading that falls back cannot cut short a settle already in progress, and
+/// every candidate is measured from `started` against a bound already clamped
+/// to [`RETRY_BOUND_CEILING`], so no sequence of readings pushes the pass past
+/// the two minutes it was always bounded by.
+fn widened_settle_deadline(current: Instant, started: Instant, bound: Duration) -> Instant {
+    current.max(started + bound)
+}
+
 fn scaled_retry_bound(run_queue_depth: f64, cores: usize) -> Duration {
     let widest = RETRY_BOUND_CEILING.as_secs_f64() / RETRY_BOUND_FLOOR.as_secs_f64();
     let stretch = run_queue_depth / cores.max(1) as f64;
@@ -440,11 +454,21 @@ fn payload(session: &[(u64, serde_json::Value)], id: u64, what: &str) -> serde_j
 
 /// The live entity count the daemon reports, read through `kin graph status`
 /// so the poll below does not have to spawn a whole MCP session per tick.
-fn live_entity_count(repo: &Path, home: &Path, port: u16) -> u64 {
-    let text = stdout_of(
-        &kin_against_daemon(repo, home, port, &["graph", "status"]),
-        "kin graph status",
-    );
+///
+/// `None` while the command exits non-zero. It does that on a critical graph
+/// health issue, and one of those is transient by construction: authority
+/// admission binds the entity layer and facets are written per file after it,
+/// so a read taken between the two halves sees a derived tree that trails
+/// authority (`crates/kin-cli/src/commands/graph_health.rs:481`). That is the
+/// gap the poll below exists to cross, so a reading taken inside it is "not
+/// yet" rather than a failure. Its text still reaches the caller, which is what
+/// reports it when the bound expires.
+fn live_entity_count(repo: &Path, home: &Path, port: u16) -> (Option<u64>, std::process::Output) {
+    let output = kin_against_daemon(repo, home, port, &["graph", "status"]);
+    if !output.status.success() {
+        return (None, output);
+    }
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
     let line = text
         .lines()
         .find(|line| line.contains("Entities:"))
@@ -453,13 +477,14 @@ fn live_entity_count(repo: &Path, home: &Path, port: u16) -> u64 {
         .split("Entities:")
         .nth(1)
         .expect("the entity line carries a count");
-    after
+    let count = after
         .trim_start()
         .chars()
         .take_while(char::is_ascii_digit)
         .collect::<String>()
         .parse()
-        .unwrap_or_else(|_| panic!("could not read an entity count from {line:?}"))
+        .unwrap_or_else(|_| panic!("could not read an entity count from {line:?}"));
+    (Some(count), output)
 }
 
 /// Wait until ambient admission has taken the host write into the live graph.
@@ -499,18 +524,21 @@ fn wait_for_live_growth(
     // to hide a missing admission is the bug this test kept reporting.
     let deadline = Instant::now() + COUNT_SETTLE_BOUND;
     loop {
-        let live = live_entity_count(repo, home, port);
-        if live > above {
-            return live;
+        let (live, status) = live_entity_count(repo, home, port);
+        if live.is_some_and(|live| live > above) {
+            return live.expect("the reading above carried a count");
         }
+        // Printing the reading this loop actually took, rather than running the
+        // command again to explain itself: a second run answers about a later
+        // instant, and the helper that asserts on its exit status would panic
+        // there instead of reporting here.
         assert!(
             Instant::now() < deadline,
             "the daemon recorded admitting the host write, but the live entity count stayed at \
-             {live} against above={above}; graph status said:\n{}",
-            stdout_of(
-                &kin_against_daemon(repo, home, port, &["graph", "status"]),
-                "kin graph status"
-            )
+             {live:?} against above={above}; graph status exited {} and said:\n{}\n{}",
+            status.status,
+            String::from_utf8_lossy(&status.stdout),
+            String::from_utf8_lossy(&status.stderr)
         );
         thread::sleep(Duration::from_millis(100));
     }
@@ -540,7 +568,8 @@ fn asks_for_retry(payload: &serde_json::Value) -> bool {
 /// mask: a daemon that never yields the lock still fails, naming how many times
 /// it refused.
 fn settled_mcp_session(repo: &Path, home: &Path, port: u16) -> Vec<(u64, serde_json::Value)> {
-    let deadline = Instant::now() + retry_bound();
+    let started = Instant::now();
+    let mut deadline = started + retry_bound();
     let mut refusals = 0_u32;
     loop {
         let session = run_mcp_session(repo, home, port);
@@ -549,6 +578,14 @@ fn settled_mcp_session(repo: &Path, home: &Path, port: u16) -> Vec<(u64, serde_j
             return session;
         }
         refusals += 1;
+        // A load average is a one minute mean, so a host that saturates as this
+        // settle begins still reads quiet for the first samples of it and the
+        // budget taken at the start is the one an idle box would have got. Take
+        // the widest the host justifies while the settle runs instead. It only
+        // ever widens, and every candidate is already clamped to
+        // RETRY_BOUND_CEILING measured from `started`, so the pass stays
+        // bounded by the same two minutes it was before.
+        deadline = widened_settle_deadline(deadline, started, retry_bound());
         assert!(
             Instant::now() < deadline,
             "kin_graph_status refused {refusals} times without ever sampling its counts: {status}"
@@ -771,5 +808,44 @@ fn the_stretch_is_proportional_and_survives_a_host_that_reports_nothing() {
         scaled_retry_bound(4.0, 0),
         RETRY_BOUND_CEILING,
         "a host reporting no cores at all must not divide by zero"
+    );
+}
+
+#[test]
+fn a_settle_that_begins_quiet_and_turns_busy_gets_the_busy_budget() {
+    // Why the settle re-reads the host instead of budgeting once: a load
+    // average is a one minute mean, so a box that goes from idle to saturated
+    // at the instant this case starts reports an idle number for the first
+    // samples of the settle, and a budget taken once is the idle one for the
+    // whole run. The rule is to hold the widest budget the host justifies while
+    // the settle runs.
+    let started = Instant::now();
+    let quiet = widened_settle_deadline(started, started, scaled_retry_bound(1.0, 18));
+    assert_eq!(
+        quiet,
+        started + RETRY_BOUND_FLOOR,
+        "the first reading of an idle host is the floor"
+    );
+
+    let busy = widened_settle_deadline(quiet, started, scaled_retry_bound(136.33, 18));
+    assert_eq!(
+        busy,
+        started + RETRY_BOUND_CEILING,
+        "a saturation the first reading could not see still buys its budget"
+    );
+
+    // And only ever widens: a reading that falls back must not cut short a
+    // settle already under way, or the lag works in the other direction.
+    assert_eq!(
+        widened_settle_deadline(busy, started, scaled_retry_bound(1.0, 18)),
+        busy,
+        "a later quiet reading must not shorten a settle that already widened"
+    );
+
+    // Still bounded by the same ceiling the fixed pass had, measured from the
+    // instant the settle began.
+    assert!(
+        busy <= started + RETRY_BOUND_CEILING,
+        "no sequence of readings may push the settle past its ceiling"
     );
 }

--- a/crates/kin-cli/tests/symlinked_repository_root_admission.rs
+++ b/crates/kin-cli/tests/symlinked_repository_root_admission.rs
@@ -126,32 +126,65 @@ fn seed_repository(repo: &Path) {
     run_git(repo, &["commit", "-m", "seed"]);
 }
 
-/// Entities the live query graph reports, read through the production route.
-fn live_entity_count(repo: &Path, home: &Path, port: u16) -> u64 {
-    let output = Command::new(env!("CARGO_BIN_EXE_kin"))
+/// How long a reading waits for the daemon's two-phase admission to settle.
+///
+/// Only how long a reading that is going to fail spends proving it: the wait
+/// returns on the first healthy answer, so a quiet host never spends this.
+const STATUS_SETTLE_BOUND: Duration = Duration::from_secs(60);
+
+/// One `kin graph status`, run through the production route.
+fn graph_status(repo: &Path, home: &Path, port: u16) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kin"))
         .args(["graph", "status"])
         .env("HOME", home)
         .env("USERPROFILE", home)
         .env("KIN_DAEMON_URL", format!("http://127.0.0.1:{port}"))
         .current_dir(repo)
         .output()
-        .expect("run production kin graph status route");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        output.status.success(),
-        "graph status stdout={stdout} stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    stdout
-        .lines()
-        .find(|line| line.starts_with("Entities: "))
-        .and_then(|line| {
-            line.trim_start_matches("Entities: ")
-                .split_whitespace()
-                .next()
-        })
-        .and_then(|count| count.parse::<u64>().ok())
-        .unwrap_or_else(|| panic!("graph status names an entity count: {stdout}"))
+        .expect("run production kin graph status route")
+}
+
+/// Entities the live query graph reports, once it can report them.
+///
+/// `kin graph status` exits non-zero on a critical graph health issue, and one
+/// of those issues is transient by construction: "derived graph tree has N
+/// artifacts but repository authority has M"
+/// (`crates/kin-cli/src/commands/graph_health.rs:481`), which the same output
+/// explains on the same run as authority admission binding the entity layer
+/// while facets are written per file after it. A single point-in-time read
+/// therefore samples a two-phase process and fails on the gap between its
+/// halves. That is not a product fault and no assertion here is about it, but
+/// it failed this case at 15.6 seconds on a host at load 100 while the same
+/// file passed in 5.99 seconds at load 17.87 (FIR-2566).
+///
+/// So wait for a reading rather than take the first one. A graph that is
+/// genuinely unhealthy still fails, at the bound, printing the last thing the
+/// command said.
+fn live_entity_count(repo: &Path, home: &Path, port: u16) -> u64 {
+    let deadline = Instant::now() + STATUS_SETTLE_BOUND;
+    loop {
+        let output = graph_status(repo, home, port);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if output.status.success() {
+            return stdout
+                .lines()
+                .find(|line| line.starts_with("Entities: "))
+                .and_then(|line| {
+                    line.trim_start_matches("Entities: ")
+                        .split_whitespace()
+                        .next()
+                })
+                .and_then(|count| count.parse::<u64>().ok())
+                .unwrap_or_else(|| panic!("graph status names an entity count: {stdout}"));
+        }
+        assert!(
+            Instant::now() < deadline,
+            "graph status never reported a healthy graph in {}s: stdout={stdout} stderr={}",
+            STATUS_SETTLE_BOUND.as_secs(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        thread::sleep(Duration::from_millis(250));
+    }
 }
 
 /// FIR-2442. A repository reached through a symbolic link admits host writes


### PR DESCRIPTION
Six tests in kin-cli decided on a fixed budget, an unsynchronised side effect, or a single point-in-time sample, and lost that decision on a loaded runner. Each one that lands in a merge group ejects the whole train car without marking the pull request, so the cost falls on other lanes rather than on the test's owner. Every fix here waits on the thing the test actually depends on, or sizes a bound from what the fixture actually does. None widens a sleep and none retries an assertion.

## The exec-after-write race, FIR-2488 and FIR-2457

`write_driver` at `crates/kin-cli/src/commands/health.rs:4565` chmods a script and hands the path straight to `resolve_vfs_driver`, which execs it at `health.rs:892`. `write_file` closes its own handle, and that is not enough: a fork raised by another test thread between the write's open and close inherits a copy of the descriptor, and the kernel refuses to exec a file any process still holds open for writing. `probe_vfs_driver` maps that spawn error into `Unloadable { message }` at `health.rs:846`, which is how the panic read "the loader's own words must reach the report: Text file busy (os error 26)".

`write_driver` now waits until the host actually runs the file, retrying only ETXTBSY and reporting every other error at once, so the fixture cannot return a path that is still text-busy. Once one exec succeeds the window is closed for good, because nothing else writes these files.

The platform split is worth recording, because it is why this never reproduced locally. Measured directly: `ubuntu:24.04` answers "Text file busy" and exit 126 while a descriptor is held on the file and exit 0 once it closes, while this macOS host runs the file in both states. The failures in both tickets were Linux runs.

The sweep both tickets asked for found 22 sites minting a 0o755 file across 12 files. The ones that later exec what they wrote are `crates/kin-cli/src/commands/setup.rs:15908`, `crates/kin-cli/tests/mcp_stdio_contract.rs:337`, `crates/kin-cli/tests/projection_modes.rs:131` and `:332`, `crates/kin-daemon/src/api.rs:23277`, and `crates/kin-notify/src/lib.rs:997`. None is changed here: in each of them the write and the exec are separated by further setup and by a process spawn, where the health fixture's two steps are adjacent statements on one thread, and three of those files are being edited by open pull requests today.

## The readiness budget, FIR-2491

`bounded_probe_runtime_timeout_starts_after_parseable_pid_readiness` proves the runtime budget starts when the child's PID becomes readable rather than at spawn. It gave the child 400ms of runtime after readiness against 250ms of work it still had to do, so kin#983 was ejected from the merge queue when the child finished at 1.12s.

The fixture's shape is now three named constants at `crates/kin-cli/src/daemon_client/probe_process.rs:1332`, with the invariant the case needs asserted in the test itself: work of 250ms, a budget of 2s, and 3s of silence before the PID appears. The budget is eight times the work rather than one and a half times it, and the falsifying direction cannot be lost to load, because a sleep only ever overshoots.

## The detached start, FIR-2573

Every shell hook launches `kin-vfs start` detached, zsh with `&!` at `crates/kin-cli/src/commands/setup.rs:180` and bash and fish with a plain `&`, and none waits for it. The test read `start.log` the instant `Command::output` returned, which waits for the probe shell alone, so it asserted on a side effect of a process nothing synchronised with.

`starts_recorded_within_bound` at `setup.rs:15886` now waits for the expected count under a bounded deadline and hands the count back either way, so the assertion still names its scenario and prints the call log. The scenario expecting no start reads directly, since a start that has not landed yet cannot fail that assertion.

## The two-phase admission gap, FIR-2566

`live_entity_count` at `crates/kin-cli/tests/symlinked_repository_root_admission.rs:163` asserted on one `kin graph status` exit status. That command exits non-zero on a critical graph health issue, and one of them is transient by construction: "derived graph tree has N artifacts but repository authority has M", raised at `crates/kin-cli/src/commands/graph_health.rs:481` and explained on the same run as authority admission binding the entity layer while facets are written per file after it. A single sample of a two-phase process lands in the gap between its halves.

The reader now polls past that gap and fails at a 60 second bound printing the last output, so a genuinely unhealthy graph still fails and says why.

## The settle budget, FIR-2529

kin#1012 already scaled this settle by host load, which is the substantive fix the ticket asked for. What is left is that a load average is a one minute mean, so a host that saturates as the settle begins reads quiet for its first samples and the budget taken once at the start is the one an idle box would have got. `widened_settle_deadline` at `crates/kin-cli/tests/live_graph_durability_disclosure.rs:122` now holds the widest budget the host justifies while the settle runs. It only ever widens, and every candidate stays clamped to the same `RETRY_BOUND_CEILING` measured from the settle's start, so the pass is bounded by the same two minutes it always was. The same file's live entity reader gained the two-phase tolerance described above, since it reads `kin graph status` immediately after the daemon records an admission.

## Falsification

Each pass removed one property, predicted which tests fail and which still pass, asserted the sabotage applied by diff, and restored the file byte identical by sha256.

Anchoring the probe deadline at spawn instead of readiness: `bounded_probe_runtime_timeout_starts_after_parseable_pid_readiness` FAILED with `Custom { kind: TimedOut, error: "delayed-ready daemon probe fixture timed out after 2s; cleanup=ok; capture=ok" }`, and the four sibling bounded-probe cases passed.

Removing the ETXTBSY discrimination from the exec wait: `the_exec_readiness_wait_sees_a_busy_file_and_stops_waiting_when_it_clears` FAILED after 30.07s with "an absent file must be reported, not waited out". Forcing the refusing arm to run on a kernel that does not refuse: the same test FAILED with "a file this kernel refuses to exec must make the bounded wait expire". Both arms of that guard are therefore live.

Delaying the stub's detached start by two seconds and removing the wait: the hook test FAILED with "kin-vfs.bash/follow_start: a stale socket must trigger exactly one daemon start", left 0, right 1, which is the shape FIR-2573 recorded. With the wait present and the same delay it passed in 8.97s.

Pointing the symlinked-root reader at a port nothing listens on with a two second bound: the test FAILED with "graph status never reported a healthy graph in 2s" and the connection-refused text, so the new bound cannot hide a broken graph.

Removing the widening from `widened_settle_deadline`: `a_settle_that_begins_quiet_and_turns_busy_gets_the_busy_budget` FAILED on "the first reading of an idle host is the floor", and the three sibling bound tests passed.

## Under load

Run with `bin/kin-lane load --cores 56`, load average read at each run. The symlinked-root admission case passed in 22.22s at load 33.75 rising to 65.63, and in 25.12s at load 58.24 rising to 82.72. The live-graph disclosure case passed three times at load 72.58, 98.02 and 93.79, in 14.47s, 14.15s and 18.09s. The hook liveness case passed three times at load 76.93, 81.58 and 85.53, in 2.81s, 2.91s and 2.88s. The probe readiness case passed six times at load 80.87 to 86.59, each in 3.33s against 0.82s before, which is the 2.5 seconds of extra silence the new shape buys.

Synthetic co-load did not reproduce either original failure on this eighteen core host: the pre-fix probe constants passed six of six at load 88 and again at nice 0, and the pre-fix symlinked reader passed four of four at load 76 to 100. So the case for both rests on the mechanism and on the runs the tickets recorded, not on a reproduction produced here.

## Gates

`cargo fmt --all -- --check` clean. Clippy exactly as ci.yml runs it, `RUSTFLAGS=-D warnings cargo clippy --all-targets --all-features` with the 45 entry debt allow-list, finished in 3m 19s with zero warnings. `scripts/verify-zero-file-search.py` passed over 177 source files, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh` and `scripts/verify-hydration-semantics.py` all passed. The full local gate `bin/kin-dev local-test kin` passed, 6701 tests run and 6701 passed in 549.086s with 12 skipped and zero failures, resolved against `/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/flakytests-kin @ 85cb52af (chore/lane-flakytests-kin)`, which is this branch head, and kin-dev restored its lock snapshot afterwards. `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty with the lock holding 8 sparse+ sources and 0 path sources.

Closes FIR-2491
Closes FIR-2488
Closes FIR-2457
Closes FIR-2573
Closes FIR-2566
Refs FIR-2529
