### PR TITLE
Move the kin registry pin to kin-vfs-core 0.4.13 and advance the kin-vfs release input

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -191,7 +191,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
+          ref: e01e2e09793019c3157285cc780e5735914e37a9
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -665,7 +665,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
+          EXPECTED_VFS_COMMIT: e01e2e09793019c3157285cc780e5735914e37a9
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,7 +528,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
+          ref: e01e2e09793019c3157285cc780e5735914e37a9
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -1154,7 +1154,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
+          EXPECTED_VFS_COMMIT: e01e2e09793019c3157285cc780e5735914e37a9
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1442,7 +1442,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
+          ref: e01e2e09793019c3157285cc780e5735914e37a9
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1510,7 +1510,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
+          EXPECTED_VFS_COMMIT: e01e2e09793019c3157285cc780e5735914e37a9
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1872,7 +1872,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a
+      expected_vfs_commit: e01e2e09793019c3157285cc780e5735914e37a9
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.4.7"
+version = "0.4.13"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "710f3abce2a31d8408509fc8c4dac9b3d4c56ea4d29e3d138ae0ea5b7637dd58"
+checksum = "557bc44b4a226d001883015d0945c4e0e26a290f8bbac99a5aeb1f57d0757a9a"
 dependencies = [
  "lru",
  "parking_lot",
@@ -6645,7 +6645,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "=0.7.40", registry = "kin", default-features = false }
-kin-vfs-core = { version = "=0.4.7", registry = "kin" }
+kin-vfs-core = { version = "=0.4.13", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -13332,7 +13332,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: 3ad20e675b58d227e3100ef0012ce048dbc1fc5a",
+        "expected_vfs_commit: e01e2e09793019c3157285cc780e5735914e37a9",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
kin-vfs #120 (admit a projection root only when it is a Kin repository) and #123
(decide the shim's Kin-family stand-down from the executable image) landed on
kin-vfs main this morning as 737bbbdf and e01e2e09. They are the kin-vfs halves
of FIR-2552 and FIR-2236, and a kin release cannot ship either while kin pins
kin-vfs-core =0.4.7. This is that pin move.

## What moved

`Cargo.toml:159` goes from `=0.4.7` to `=0.4.13`, and the immutable kin-vfs
commit every release input records goes to
`e01e2e09793019c3157285cc780e5735914e37a9`, the kin-vfs main commit whose
Registry Publish run (`32476161998`) shipped kin-vfs-core 0.4.13 at 11:15:59Z.

That commit has eight homes here, not the five `release.yml` carries:

| File | Sites |
|---|---|
| `.github/workflows/release.yml` | 5 (build-matrix checkout ref, per-artifact provenance manifest, publish job provenance-source checkout, aggregate provenance check, install-proof workflow input) |
| `.github/workflows/rc-build.yml` | 2 (checkout ref, expected-commit value) |
| `scripts/test-release-workflow-authority.py` | 1 (literal assertion) |

`rc-build.yml` mirrors release.yml's build job, and
`scripts/check-rc-build-drift.mjs` refuses a change that moves one and not the
other, so the candidate build and the release build cannot disagree about which
kin-vfs they carry.

After the move, `git grep` for the old sha returns nothing and exit 1, and the
new sha returns those eight lines across those three files.

## API adaptations

None were needed. kin-vfs-core's only source change between `v0.4.7` and
`e01e2e09` is `crates/kin-vfs-core/src/pathmap.rs`, nineteen insertions and no
deletions, adding one public constant, `REPOSITORY_IDENTITY_MARKER`. Nothing
existing changed shape, and the workspace compiles against 0.4.13 unchanged.

## The lock entry

```
name = "kin-vfs-core"
version = "0.4.13"
source = "sparse+https://kinlab.ai/registry/cargo/"
checksum = "557bc44b4a226d001883015d0945c4e0e26a290f8bbac99a5aeb1f57d0757a9a"
```

The `sparse+` source survived the re-lock and the checksum is the published one.
`Cargo.lock` carries zero `source = "path` entries and eight `sparse+` entries.
Both tracked locks (`Cargo.lock` and `fuzz/Cargo.lock`) resolve under
`cargo metadata --locked`; `fuzz/Cargo.lock` names no kin-vfs-core and needed no
change.

The re-lock also wrote one incidental hunk, `winapi-util 0.1.11`'s dependency
edge moving from `windows-sys 0.48.0` to `windows-sys 0.61.2`. Cargo produced it
while re-resolving and it is kept rather than hand-reverted, since a lock cargo
did not write would be worse than an honest extra hunk.

## Gate

This change cannot be gated by `bin/kin-dev local-test`, which path-patches
kin-vfs-core and would therefore pass whatever version the manifest names,
including one the registry does not serve. It was gated against the registry
resolution it actually changes.

The local full gate (`cargo nextest run --workspace --locked --no-fail-fast` plus `cargo test --doc --locked`) is running under build slot gate-slot-3 and its totals are pending. They will be written into this body before the PR is enqueued.

Guards run locally on the branch, all exit 0: `check-kin-vfs-compat.mjs`
("Verified Kin/kin-vfs compatibility at kin-vfs-core 0.4.13 (pinned kin-vfs
e01e2e09793019c3157285cc780e5735914e37a9)"), `check-rc-build-drift.mjs`,
`test-release-workflow-authority.py`, `cargo fmt --all -- --check`,
`verify-zero-file-search.py`, `zero_file_search_guard.sh`,
`check_runtime_boundaries.sh` and `check_private_repo_coupling.sh`.

The compat guard was falsified three ways, each restored and re-verified green.
Reverting one release.yml site produced "release.yml records disagreeing
firelock-ai/kin-vfs pins ... the release would build one commit and prove
another". Reverting all five produced "Kin resolves kin-vfs-core 0.4.13, but the
pinned kin-vfs checkout builds 0.4.7". Leaving rc-build.yml behind produced the
drift guard's refusal naming both ref lines.

## Supersedes kin#1022

Dependabot kin#1022 bumps the same pin and changes only `Cargo.lock` and
`Cargo.toml`. It moves no release input, which is the second falsification case
above, and it fails for that reason today: run `32476539397`, job "Check & Test
(ubuntu-latest)", failed step "Verify Kin/kin-vfs compatibility at the pinned
release input". Close it in favour of this PR.

Refs FIR-2552
Refs FIR-2236
