### PR TITLE
Cover three of the daemon allowance derivation sites with fixtures

### DIFF
--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -2531,4 +2531,222 @@ mod tests {
         );
         assert_eq!(reopen(&init).read_authority().roots().generation, 1);
     }
+
+    /// A body the credential scanner blocks.
+    ///
+    /// Every test using it proves that claim on its own refusal arm rather than
+    /// assuming it. A fixture whose secret the scanner never flagged would let
+    /// the approval arm pass with the derivation site reverted and approvals
+    /// ignored, which is the shape of a check that cannot fail.
+    const BLOCKED_SECRET: &[u8] = b"API_TOKEN = \"sk-proj-abcd1234efgh5678ijkl\"\n";
+
+    /// The path the scanner names when it refuses [`BLOCKED_SECRET`].
+    const BLOCKED_PATH: &[u8] = b"notekeeper/client.py";
+
+    /// The bytes of a tracked approval set, in the format kin-model parses.
+    ///
+    /// Written out here rather than produced by the writer that ships in the
+    /// CLI, because a fixture generating the file with the code under test
+    /// could agree with itself while both drifted from the format the published
+    /// kin-model actually reads.
+    fn approval_file(path: &str, digest: Hash256, approver: &str) -> Vec<u8> {
+        format!(
+            "# approvals for this fixture\n\
+             kin-allowances 1\n\
+             {path}\t{digest}\tblob\t{approver}\tpinned by the test covering this derivation site\n"
+        )
+        .into_bytes()
+    }
+
+    fn blob_hash(artifact: &ResolvedArtifact) -> Hash256 {
+        match artifact.entry {
+            TreeEntry::Blob { hash, .. } => hash,
+            other => panic!("fixture artifact must be a blob, found {other:?}"),
+        }
+    }
+
+    /// The approvals a planned transition carries into authority.
+    fn planned_approvals(
+        transaction: &RepositoryTransaction,
+    ) -> Vec<kin_model::SensitiveArtifactAllowance> {
+        transaction
+            .workspace_mutation
+            .as_ref()
+            .expect("a workspace transition carries a workspace mutation")
+            .new_shared_admission_policy
+            .sensitive_allowances
+            .clone()
+    }
+
+    /// The graph-owned policy a native commit derives has to be derived through
+    /// the entry point that reads a tracked `.kin-allowances`, or an approval a
+    /// reviewer can see in the diff never reaches admission.
+    ///
+    /// Reverting `plan_native_commit_inner`'s derivation to `derive_from_tree`
+    /// fails the approved arm below, because the compatibility entry point
+    /// refuses by name the moment the tree carries approvals it cannot read.
+    /// The refused arm is what makes that meaningful: it proves this fixture's
+    /// body really is blocked, so the approved arm is passing because the
+    /// approval was read rather than because nothing was ever in the way.
+    #[test]
+    fn a_native_commit_derives_the_approvals_its_tree_carries() {
+        let refused = tempfile::tempdir().unwrap();
+        let init = kin_core::init(refused.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        add_artifact(&graph, &blobs, BLOCKED_PATH, BLOCKED_SECRET, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("credscan"),
+            "publish a secret with no approval".to_string(),
+        )
+        .unwrap();
+        let error = commit_native_plan(&init.layout, &blobs, plan).unwrap_err();
+        assert!(
+            error.to_string().contains("notekeeper/client.py"),
+            "this fixture's body must be one the scanner actually blocks, or the approved \
+             arm below proves nothing: {error}"
+        );
+
+        let approved = tempfile::tempdir().unwrap();
+        let init = kin_core::init(approved.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let secret = add_artifact(&graph, &blobs, BLOCKED_PATH, BLOCKED_SECRET, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let approvals = approval_file(
+            "notekeeper/client.py",
+            blob_hash(&secret),
+            "credscan@firelock.ai",
+        );
+        add_artifact(&graph, &blobs, b".kin-allowances", &approvals, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("credscan"),
+            "publish the secret beside the approval that clears it".to_string(),
+        )
+        .unwrap_or_else(|error| {
+            panic!(
+                "planning a native commit whose tree carries .kin-allowances must derive its \
+                 approvals rather than refusing: {error}"
+            )
+        });
+        let approvals = planned_approvals(&plan.transaction);
+        assert_eq!(
+            approvals.len(),
+            1,
+            "the planned policy must carry the one approval the tree declares: {approvals:?}"
+        );
+        assert_eq!(approvals[0].path.as_utf8().unwrap(), "notekeeper/client.py");
+        assert_eq!(approvals[0].content_hash, blob_hash(&secret));
+
+        commit_native_plan(&init.layout, &blobs, plan).unwrap_or_else(|error| {
+            panic!("the approved secret must publish rather than being refused: {error}")
+        });
+
+        let authority = reopen(&init);
+        let lease = authority.read_authority();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == init.workspace_id)
+            .unwrap();
+        assert_eq!(
+            workspace.shared_admission_policy.sensitive_allowances.len(),
+            1,
+            "the approval has to reach durable authority, not just the plan"
+        );
+    }
+
+    /// The same property for the workspace-admission derivation, which is the
+    /// site a dirty working tree reaches rather than a commit.
+    ///
+    /// Reverting `publish_workspace_tree`'s derivation fails the approved arm
+    /// here and leaves the commit test above untouched, which is what makes
+    /// these two separate tests rather than one.
+    #[test]
+    fn admitting_a_workspace_tree_derives_the_approvals_it_carries() {
+        let refused = tempfile::tempdir().unwrap();
+        let init = kin_core::init(refused.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let secret = add_artifact(&graph, &blobs, BLOCKED_PATH, BLOCKED_SECRET, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let error = publish_workspace_tree(
+            &init.layout,
+            &blobs,
+            &ResolvedTree::from_artifacts([secret.clone()]).unwrap(),
+            OperationId::new(),
+            AuthorId::new("credscan"),
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("notekeeper/client.py"),
+            "this fixture's body must be one the scanner actually blocks, or the approved \
+             arm below proves nothing: {error}"
+        );
+
+        let approved = tempfile::tempdir().unwrap();
+        let init = kin_core::init(approved.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let secret = add_artifact(&graph, &blobs, BLOCKED_PATH, BLOCKED_SECRET, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let approvals = approval_file(
+            "notekeeper/client.py",
+            blob_hash(&secret),
+            "credscan@firelock.ai",
+        );
+        let allowance = add_artifact(&graph, &blobs, b".kin-allowances", &approvals, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+
+        publish_workspace_tree(
+            &init.layout,
+            &blobs,
+            &ResolvedTree::from_artifacts([secret.clone(), allowance]).unwrap(),
+            OperationId::new(),
+            AuthorId::new("credscan"),
+        )
+        .unwrap_or_else(|error| {
+            panic!(
+                "admitting a workspace tree carrying .kin-allowances must derive its approvals \
+                 rather than refusing: {error}"
+            )
+        })
+        .expect("the transition must advance authority");
+
+        let authority = reopen(&init);
+        let lease = authority.read_authority();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == init.workspace_id)
+            .unwrap();
+        let carried = &workspace.shared_admission_policy.sensitive_allowances;
+        assert_eq!(
+            carried.len(),
+            1,
+            "the admitted workspace policy must carry the tree's one approval: {carried:?}"
+        );
+        assert_eq!(carried[0].content_hash, blob_hash(&secret));
+    }
 }

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -2388,4 +2388,73 @@ mod tests {
             "the refusal names both stores it consulted: {error:#}"
         );
     }
+
+    /// The merged tree's policy has to be derived through the entry point that
+    /// reads a tracked `.kin-allowances`, or an approval a reviewer accepted on
+    /// one side of a merge is dropped by the merge itself.
+    ///
+    /// Reverting this file's derivation to `derive_from_tree` fails here,
+    /// because the compatibility entry point refuses by name the moment the
+    /// tree carries approvals it cannot read. The two structural assertions
+    /// below are what stop this passing for the wrong reason: the approval must
+    /// land in `sensitive_allowances` and must NOT land in `sources`, because
+    /// the allowance file is an approval set rather than an exclusion rule, and
+    /// a derivation that treated it as an ordinary rule source would satisfy a
+    /// bare "the policy changed" check while approving nothing.
+    #[test]
+    fn a_merged_tree_derives_the_approvals_it_carries() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let authority = authority(&init);
+
+        let secret = b"API_TOKEN = \"sk-proj-abcd1234efgh5678ijkl\"\n";
+        let secret_hash = Hash256::from_bytes(blobs.write(secret).unwrap().0);
+        let approvals = format!(
+            "# approvals for this fixture\n\
+             kin-allowances 1\n\
+             notekeeper/client.py\t{secret_hash}\tblob\tcredscan@firelock.ai\tpinned by the \
+             test covering this derivation site\n"
+        );
+        let approvals_hash = Hash256::from_bytes(blobs.write(approvals.as_bytes()).unwrap().0);
+
+        let tree = ResolvedTree::from_artifacts([
+            ResolvedArtifact::new(
+                ArtifactId::new(),
+                RepoPath::from_utf8("notekeeper/client.py").unwrap(),
+                TreeEntry::blob(secret_hash, false),
+            ),
+            ResolvedArtifact::new(
+                ArtifactId::new(),
+                RepoPath::from_utf8(".kin-allowances").unwrap(),
+                TreeEntry::blob(approvals_hash, false),
+            ),
+        ])
+        .unwrap();
+
+        let (policy, delta) = derive_policy(&blobs, &authority, &empty_policy(), &tree)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "a merged tree carrying .kin-allowances must derive its approvals rather \
+                     than refusing: {error:#}"
+                )
+            });
+
+        assert_eq!(
+            policy.sensitive_allowances.len(),
+            1,
+            "the merged policy must carry the tree's one approval: {:?}",
+            policy.sensitive_allowances
+        );
+        assert_eq!(policy.sensitive_allowances[0].content_hash, secret_hash);
+        assert!(
+            policy.sources.is_empty(),
+            "an approval set is not an exclusion rule source: {:?}",
+            policy.sources
+        );
+        assert!(
+            delta.is_some(),
+            "a tree that introduces approvals moves the policy, so the merge records a delta"
+        );
+    }
 }


### PR DESCRIPTION
Six production sites in kin-daemon derive the shared admission policy through
`SharedAdmissionPolicy::derive_from_tree_with_allowances`, which is what makes a
tracked `.kin-allowances` reach admission at all. Nothing in this repository
exercised any of them. Reverting all six compiles and leaves the whole workspace
suite green, so the only thing that catches a regression today is a live run.

This covers three of the six with fixture-level tests, each falsified against its
own site. It carries `Refs FIR-2575` rather than `Closes`, because the other
three are named below with what each one needs.

## What the tests assert

Reverting a site turns its call back into `derive_from_tree`, and kin-model's
compatibility entry point refuses by name the moment the tree carries approvals
it cannot read:

```
this build cannot read .kin-allowances: upgrade to a consumer that derives
sensitive-artifact allowances, or remove the file
```

So a test that drives the enclosing function with a tree containing a
`.kin-allowances` blob and asserts success fails loudly on a revert, with a
message naming what was lost.

* `a_native_commit_derives_the_approvals_its_tree_carries` drives
  `plan_native_commit` into `plan_native_commit_inner`, asserts the planned
  policy carries the approval with the artifact's own digest, commits, and then
  reads the workspace back out of authority to prove the approval reached
  durable state rather than only the plan.
* `admitting_a_workspace_tree_derives_the_approvals_it_carries` does the same
  through `publish_workspace_tree`, which is the site a dirty working tree
  reaches rather than a commit.
* `a_merged_tree_derives_the_approvals_it_carries` drives `derive_policy`
  directly and asserts the approval lands in `sensitive_allowances` and does NOT
  land in `sources`. Without that second assertion a derivation that read the
  allowance file as an ordinary exclusion rule would satisfy a bare
  "the policy changed" check while approving nothing.

Each commit-path test runs its refusal arm first, on a repository with no
approval, and asserts the scanner really does block the fixture body. That arm is
not decoration. Without it a fixture whose secret the scanner never flagged would
pass the approval arm with the site reverted and approvals ignored, which is a
check that cannot fail.

The approval file is written out in the test rather than produced by the writer
that ships in the CLI, because a fixture generating the file with the code under
test could agree with itself while both drifted from the format the published
kin-model reads.

## Falsification, per site

Three arms, each reverting exactly one site to `derive_from_tree` and deleting
its allowance closure, each predicting which single test fails, each restored
byte-identical by sha256 and confirmed clean:

| site reverted | predicted to fail | failed | others |
|---|---|---|---|
| `publish_workspace_tree` | `admitting_a_workspace_tree_…` | exactly that | both green |
| `plan_native_commit_inner` | `a_native_commit_…` | exactly that | both green |
| `derive_policy` | `a_merged_tree_…` | exactly that | both green |

Every arm compiled cleanly, so each failure is the behaviour changing rather than
the crate failing to build. The baseline before any sabotage is 3 passed, 0
failed.

## The trap this falsification hit first, and what it cost

The first run of these three arms reported a confident, wrong answer: reverting
`publish_workspace_tree` failed the native-commit test, and reverting
`plan_native_commit_inner` failed the merge test. Both readings were internally
consistent, both named a real test, and neither matched the call graph, which has
no path from `plan_native_commit` to `publish_workspace_tree` and none at all
from the merge test into `repository_commit.rs`.

The cause was cargo's mtime-based fingerprinting. Each arm edited a file, built,
ran, and restored with `git checkout` inside a second or two, so an arm could be
handed the previous arm's binary while its own source sat on disk unbuilt. The
run reports success, the test names are real, and the attribution is off by one
arm.

Advancing the mtime past filesystem granularity before each build, with a short
sleep and an explicit `utime`, makes every arm land on its own site. That was
isolated rather than assumed: a control arm run touched but with default parallel
test threads also held, so parallel execution was not the cause and the
timestamps were.

## Not covered here, and why

* **`plan_session_workspace_admission`**, `repository_commit.rs:232`. Its only
  parameter that matters is a `SessionReconcileObservation`, which kin-cli seals
  deliberately: every field is private and a `compile_fail` doctest at
  `crates/kin-cli/src/commands/reconcile.rs:130` exists to keep it unbuildable by
  hand. It also carries a `RetainedSession` capability that
  `revalidate_retained_capability` re-proves against a real on-disk session. A
  fixture would mean either breaking that seal or minting a real retained
  session, and breaking the seal to test something else is the wrong trade.
* **`plan_and_commit`**, `repository_rollback.rs:299`. The file has no test
  module at all, and the derivation sits behind fourteen guards: a clean
  workspace on a symbolic head whose base equals its branch, a daemon graph in
  generation lockstep, two committed changes where the older one carries
  `.kin-allowances`, a resolved policy record for the current change, and zero
  projection drift against the real working directory. `RollbackOutcome` exposes
  no policy either, so the assertion has to read back through
  `authority.manager.read_authority().metadata()`.
* **`push`**, `repository_stash.rs:360`. Also no test module. Needs a real
  `DaemonState`, an `ActiveLocalRepositoryAuthority`, and a workspace that is
  dirty, with the allowance body in **repository** CAS rather than ingest CAS,
  because stash reads through `manager.load_source_blob` alone. Its return value
  does carry the derived policy at
  `plan.sealed_workspace.shared_admission_policy`, so it is the cheapest of the
  three to assert on once the fixture exists.

That last detail is the one most likely to waste someone's afternoon: commit and
merge read through `read_publishable_source`, which consults ingest CAS first and
repository CAS second, so `blobs.write` alone is enough. Rollback and stash
consult repository CAS only, so a fixture that only writes to the blob store
fails with "repository source CAS is missing …", a refusal that looks nothing
like the one the test is trying to provoke.

## Gate

Test-only change, so the suite is the whole question, and it is green.

* `cargo nextest run --workspace --locked --no-fail-fast`: **6631 tests run,
  6631 passed, 0 failed, 12 skipped**. The count is 6628 plus the three added
  here.
* `cargo fmt --all -- --check` exit 0.
* `cargo clippy --all-targets --all-features --locked` under
  `RUSTFLAGS=-D warnings` with the ci.yml allow-list, exit 0.
* `cargo test --doc --locked` exit 0.
* `verify-zero-file-search.py`, `zero_file_search_guard.sh`,
  `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`,
  `test-private-repo-coupling.py`, `check-rc-build-drift.mjs` and
  `check-kin-vfs-compat.mjs` all exit 0.

This branch was developed on kin#1016's head, because the six derivation sites
only existed there. 1016 merged as a squash at 11:14:36Z, and the branch was
replayed with `git rebase --onto origin/main a40dea67`, which is exact rather
than relying on patch ids matching against a squash. Before that replay the diff
against main read 52 files and 9152 deletions; after it, the two files above.
The three tests were re-run on the new base and pass in 6.77s.

Refs FIR-2575
