### PR TITLE
Bind a Python method call through its receiver's declared type, and keep a module off its function's call edges

### DIFF
--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -590,7 +590,13 @@ fn build_link_context<'a>(
             };
             known_files.insert(file_path);
             *entity_count_by_file.entry(file_path).or_insert(0) += 1;
-            entity_by_file_name.insert((file_path, &entity.name), entity.id);
+            let slot_free = entity_by_file_name
+                .get(&(file_path, entity.name.as_str()))
+                .and_then(|occupant| entity_kind_by_id.get(occupant))
+                .is_none_or(|occupant| file_name_slot_admits(entity.kind, *occupant));
+            if slot_free {
+                entity_by_file_name.insert((file_path, &entity.name), entity.id);
+            }
             entity_by_name
                 .entry(&*entity.name)
                 .or_default()
@@ -947,6 +953,34 @@ fn resolve_one_file(
                         continue;
                     }
                     dst_lookup = method;
+                } else if rel.receiver.is_some() {
+                    // (a2b) The owner half came from the receiver's DECLARED
+                    // type rather than from a path the caller wrote, so the
+                    // class it names is one the file imports or the repository
+                    // holds exactly one of, not necessarily one defined here.
+                    // `adapter.send(request)` under `adapter: HTTPAdapter`
+                    // binds to `HTTPAdapter.send`, which is the call
+                    // `find_references` counted as zero while the annotation
+                    // proving it sat in the graph.
+                    if let Some((owner_file, owner_class)) =
+                        locate_base_class(&file.file_path, owner, ctx)
+                    {
+                        if let Some(dst_id) =
+                            resolve_inherited_method(&owner_file, &owner_class, method, ctx)
+                        {
+                            accumulate_relation(
+                                &mut resolved,
+                                &mut relation_indices,
+                                make_relation(rel, src_id, dst_id, RECEIVER_TYPE_CONFIDENCE),
+                            );
+                            continue;
+                        }
+                    }
+                    // The declared type names nothing this repository defines,
+                    // or defines no such method. The call keeps the bare leaf
+                    // it arrived with before the type was consulted, so the
+                    // disclaimed same-name path below runs exactly as it did.
+                    dst_lookup = method;
                 }
             }
         }
@@ -1021,6 +1055,8 @@ fn resolve_one_file(
             .filter(|(fp, _)| *fp != file.file_path.as_str())
             .map(|&(fp, id)| (fp, id))
             .collect();
+        let other_file_candidates =
+            drop_module_call_targets(rel.kind, other_file_candidates, &ctx.entity_kind_by_id);
 
         // (b3) Parser-pinned import resolution: the relation carries the module
         // its callee was imported from. A pinned callee must resolve inside
@@ -1845,6 +1881,15 @@ const QUALIFIED_SUFFIX_CONFIDENCE: f32 = 0.6;
 /// and well above the review-side strong-consumer floor, below an
 /// import-verified edge (0.95) because the base-class link itself may have been
 /// name-resolved.
+/// Confidence for a call bound through the receiver's declared type.
+///
+/// The type is written in the source the call sits in, the owner resolved to a
+/// class entity, and the method was selected inside that class or an ancestor
+/// of it, so nothing here is inferred from a name matching a name. It sits
+/// above the inherited-method walk, which infers the dispatch class, and below
+/// the same-file parser-certain edge.
+const RECEIVER_TYPE_CONFIDENCE: f32 = 0.95;
+
 const INHERITED_METHOD_CONFIDENCE: f32 = 0.85;
 
 /// Split a dotted `Owner.method` dst_name into its owner and method parts at
@@ -2374,6 +2419,23 @@ fn resolve_qualified_suffix_incremental(
 }
 
 /// Whether an entity id names a type that can anchor an inheritance walk.
+/// Whether an entity may take the `(file, name)` slot another entity holds.
+///
+/// A Python file's Module entity is named for the file stem, so `nk/search.py`
+/// containing `def search(...)` puts a Module and a Function on one
+/// `(file, name)` key. Inside a module that name binds to the function: Python
+/// binds no name for the module itself in the module's own namespace. Letting
+/// the Module take the slot parked every caller of `search` on the module node,
+/// left the function holding zero incoming edges, and made `kin dead-code`
+/// print the program's primary function as unreferenced.
+///
+/// So a Module never displaces a non-Module here, and a non-Module always
+/// displaces a Module. Two entities of any other kinds keep the prior
+/// last-one-wins behaviour.
+fn file_name_slot_admits(candidate: EntityKind, occupant: EntityKind) -> bool {
+    candidate != EntityKind::Module || occupant == EntityKind::Module
+}
+
 fn is_class_like(kind: Option<&EntityKind>) -> bool {
     matches!(
         kind,
@@ -3193,6 +3255,32 @@ fn rust_bare_call_may_reach_owned(
 ///
 /// Non-method candidates are left to the builtin and import tiers above; this
 /// filter only answers the receiver question.
+/// Drop the module entities a call can never reach.
+///
+/// A module is not callable in any language this indexes, and its Python entity
+/// is named for the file stem, so `nk/search.py` puts a Module named `search`
+/// in the same-name bucket as the function `def search(...)`. Leaving it there
+/// made the bucket hold two ids for one callable name, which the exact-name
+/// tier reads as an unresolvable ambiguity and the package-directory fallback
+/// reads as two candidates, so a caller writing `from nk.search import search`
+/// got no edge at all rather than the wrong one.
+///
+/// A `References` edge is left alone: `import nk.search` then passing
+/// `nk.search` as a value genuinely names the module.
+fn drop_module_call_targets<'a>(
+    kind: RelationKind,
+    candidates: Vec<(&'a str, EntityId)>,
+    kinds: &HashMap<EntityId, EntityKind>,
+) -> Vec<(&'a str, EntityId)> {
+    if kind != RelationKind::Calls {
+        return candidates;
+    }
+    candidates
+        .into_iter()
+        .filter(|(_, id)| kinds.get(id) != Some(&EntityKind::Module))
+        .collect()
+}
+
 fn drop_method_candidates<'a>(
     candidates: Vec<(&'a str, EntityId)>,
     kinds: &HashMap<EntityId, EntityKind>,
@@ -5085,8 +5173,14 @@ impl IncrementalLinker {
         let mut file_entities_list = Vec::new();
 
         for entity in entities {
-            file_entities_map.insert(entity.name.clone(), entity.id);
             self.entity_kind_by_id.insert(entity.id, entity.kind);
+            let slot_free = file_entities_map
+                .get(&entity.name)
+                .and_then(|occupant| self.entity_kind_by_id.get(occupant))
+                .is_none_or(|occupant| file_name_slot_admits(entity.kind, *occupant));
+            if slot_free {
+                file_entities_map.insert(entity.name.clone(), entity.id);
+            }
             self.entity_language_by_id
                 .insert(entity.id, entity.language);
             self.entity_role_by_id.insert(entity.id, entity.role);
@@ -5532,6 +5626,31 @@ fn resolve_one_file_incremental(
                         continue;
                     }
                     dst_lookup = method;
+                } else if rel.receiver.is_some() {
+                    // (a2b) mirrors the batch linker: an owner half that came
+                    // from the receiver's declared type resolves through the
+                    // class that type names, wherever the repository defines
+                    // it, and falls back to the bare leaf when it names none.
+                    if let Some((owner_file, owner_class)) =
+                        locate_base_class_incremental(&file.file_path, owner, linker, import_map)
+                    {
+                        if let Some(dst_id) = resolve_inherited_method_incremental(
+                            &owner_file,
+                            &owner_class,
+                            method,
+                            linker,
+                            import_map,
+                            class_bases,
+                        ) {
+                            accumulate_relation(
+                                &mut resolved,
+                                &mut relation_indices,
+                                make_relation(rel, src_id, dst_id, RECEIVER_TYPE_CONFIDENCE),
+                            );
+                            continue;
+                        }
+                    }
+                    dst_lookup = method;
                 }
             }
         }
@@ -5603,6 +5722,8 @@ fn resolve_one_file_incremental(
                     .collect()
             })
             .unwrap_or_default();
+        let other_file_candidates =
+            drop_module_call_targets(rel.kind, other_file_candidates, &linker.entity_kind_by_id);
 
         // (b3) Parser-pinned import resolution — mirrors the batch linker:
         // a callee pinned to a module must resolve inside that module (or

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -966,7 +966,7 @@ fn resolve_one_file(
                         locate_base_class(&file.file_path, owner, ctx)
                     {
                         if let Some(dst_id) =
-                            resolve_inherited_method(&owner_file, &owner_class, method, ctx)
+                            resolve_declared_method(&owner_file, &owner_class, method, ctx)
                         {
                             accumulate_relation(
                                 &mut resolved,
@@ -2564,6 +2564,54 @@ fn locate_base_class(
 /// cycle-guarded, and ends any branch whose base cannot be located
 /// ([`locate_base_class`]) — it never guesses. Kept in exact resolution parity
 /// with [`resolve_inherited_method_incremental`].
+/// The method `owner_class` itself declares, before any ancestor is consulted.
+///
+/// [`resolve_inherited_method`] deliberately starts at the class's bases: its
+/// caller has already given a same-file own method its win. A call bound
+/// through the receiver's declared type has had no such tier, because the owner
+/// is usually defined in another file, so it asks for the class's own method
+/// first and walks the hierarchy only when the class does not declare it.
+fn resolve_declared_method(owner_file: &str, owner_class: &str, method: &str, ctx: &LinkContext<'_>) -> Option<EntityId> {
+    receiver_method_keys(owner_class, method)
+        .iter()
+        .find_map(|key| {
+            ctx.entity_by_file_name
+                .get(&(owner_file, key.as_str()))
+                .copied()
+        })
+        .or_else(|| resolve_inherited_method(owner_file, owner_class, method, ctx))
+}
+
+/// The incremental mirror of [`resolve_declared_method`].
+fn resolve_declared_method_incremental(
+    owner_file: &str,
+    owner_class: &str,
+    method: &str,
+    linker: &IncrementalLinker,
+    import_map: &HashMap<&str, HashMap<&str, (&str, &str)>>,
+    class_bases: &HashMap<String, Vec<(String, Vec<String>)>>,
+) -> Option<EntityId> {
+    receiver_method_keys(owner_class, method)
+        .iter()
+        .find_map(|key| {
+            linker
+                .entity_by_file_name
+                .get(owner_file)
+                .and_then(|by_name| by_name.get(key.as_str()))
+                .copied()
+        })
+        .or_else(|| {
+            resolve_inherited_method_incremental(
+                owner_file,
+                owner_class,
+                method,
+                linker,
+                import_map,
+                class_bases,
+            )
+        })
+}
+
 fn resolve_inherited_method(
     src_file: &str,
     owner: &str,
@@ -5634,7 +5682,7 @@ fn resolve_one_file_incremental(
                     if let Some((owner_file, owner_class)) =
                         locate_base_class_incremental(&file.file_path, owner, linker, import_map)
                     {
-                        if let Some(dst_id) = resolve_inherited_method_incremental(
+                        if let Some(dst_id) = resolve_declared_method_incremental(
                             &owner_file,
                             &owner_class,
                             method,

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -2571,7 +2571,12 @@ fn locate_base_class(
 /// through the receiver's declared type has had no such tier, because the owner
 /// is usually defined in another file, so it asks for the class's own method
 /// first and walks the hierarchy only when the class does not declare it.
-fn resolve_declared_method(owner_file: &str, owner_class: &str, method: &str, ctx: &LinkContext<'_>) -> Option<EntityId> {
+fn resolve_declared_method(
+    owner_file: &str,
+    owner_class: &str,
+    method: &str,
+    ctx: &LinkContext<'_>,
+) -> Option<EntityId> {
     receiver_method_keys(owner_class, method)
         .iter()
         .find_map(|key| {

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -11263,6 +11263,11 @@ void f();
             (1.0_f32, RelationResolution::TypeResolved, "same-file"),
             (0.95, RelationResolution::TypeResolved, "import-declared"),
             (
+                RECEIVER_TYPE_CONFIDENCE,
+                RelationResolution::TypeResolved,
+                "declared receiver type",
+            ),
+            (
                 INHERITED_METHOD_CONFIDENCE,
                 RelationResolution::TypeResolved,
                 "inherited dispatch",

--- a/crates/kin-index/tests/python_receiver_type_resolution.rs
+++ b/crates/kin-index/tests/python_receiver_type_resolution.rs
@@ -63,7 +63,8 @@ fn link_incremental(files: &[FileParseData]) -> Vec<kin_model::Relation> {
     for file in files {
         linker.add_file(&file.file_path, ArtifactId::new(), &file.entities);
     }
-    link_cross_file_incremental(files, &linker).expect("the incremental index holds every fixture file")
+    link_cross_file_incremental(files, &linker)
+        .expect("the incremental index holds every fixture file")
 }
 
 /// The id of the entity of `kind` named `name` in `file`.
@@ -162,7 +163,12 @@ fn requests_shaped_package() -> Vec<FileParseData> {
 #[test]
 fn a_method_call_binds_through_the_receivers_annotated_parameter_type() {
     let files = requests_shaped_package();
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
 
     let relations = link_cross_file(&files);
@@ -178,7 +184,12 @@ fn a_method_call_binds_through_the_receivers_annotated_parameter_type() {
 #[test]
 fn a_method_call_binds_through_a_class_declared_attribute_type() {
     let files = requests_shaped_package();
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let caller = entity_id(
         &files,
         "auth.py",
@@ -199,7 +210,12 @@ fn a_method_call_binds_through_a_class_declared_attribute_type() {
 #[test]
 fn both_declared_receiver_callers_reach_the_method_and_nothing_else_does() {
     let files = requests_shaped_package();
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let session_send = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
     let handle_401 = entity_id(
         &files,
@@ -223,7 +239,12 @@ fn both_declared_receiver_callers_reach_the_method_and_nothing_else_does() {
 #[test]
 fn the_incremental_linker_binds_the_same_declared_receiver_types() {
     let files = requests_shaped_package();
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let session_send = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
     let handle_401 = entity_id(
         &files,
@@ -268,7 +289,12 @@ class HTTPDigestAuth:
 "#,
         ),
     ];
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let caller = entity_id(
         &files,
         "auth.py",
@@ -309,7 +335,12 @@ class Session:
 "#,
         ),
     ];
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
 
     let relations = link_cross_file(&files);
@@ -343,7 +374,12 @@ class Session:
 "#,
         ),
     ];
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
 
     let relations = link_cross_file(&files);
@@ -372,7 +408,12 @@ class Session:
 "#,
         ),
     ];
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
 
     let relations = link_incremental(&files);
@@ -439,7 +480,12 @@ class Session:
 "#,
         ),
     ];
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
 
     let relations = link_cross_file(&files);
@@ -472,7 +518,12 @@ class Session:
 "#,
         ),
     ];
-    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
     let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
 
     let relations = link_cross_file(&files);

--- a/crates/kin-index/tests/python_receiver_type_resolution.rs
+++ b/crates/kin-index/tests/python_receiver_type_resolution.rs
@@ -521,6 +521,48 @@ fn module_name_collision_package() -> Vec<FileParseData> {
 }
 
 #[test]
+fn a_package_re_export_reaches_the_function_past_its_module_twin() {
+    // `nk/__init__.py` re-exports `search`, so a caller writing
+    // `from nk import search` pins its callee to the package rather than to the
+    // module file. The package's own file does not declare the symbol, so the
+    // linker falls back to the one same-named entity in that directory — and
+    // the module entity named for `search.py` sits there too, making it two.
+    // Two is not one, so the pinned call was refused outright and the caller
+    // got no edge at all, which is a stricter loss than parking the edge on the
+    // wrong node.
+    let files = vec![
+        parse_py("nk/__init__.py", "from nk.search import search\n"),
+        parse_py("nk/search.py", SEARCH_PY),
+        parse_py(
+            "app.py",
+            r#"
+from nk import search
+
+
+def run(store, terms):
+    return search(store, terms)
+"#,
+        ),
+    ];
+    let function = entity_id(&files, "nk/search.py", "search", EntityKind::Function);
+    let module = entity_id(&files, "nk/search.py", "search", EntityKind::Module);
+    let run = entity_id(&files, "app.py", "run", EntityKind::Function);
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, run, function),
+        "a call pinned to a package must reach the function that package \
+         re-exports; the module entity sharing its name is not a second \
+         candidate, because a module is not callable"
+    );
+    assert!(
+        callers_of(&relations, module).is_empty(),
+        "and the module must still hold no call edges of its own"
+    );
+}
+
+#[test]
 fn a_module_does_not_take_the_call_edges_of_its_same_named_function() {
     let files = module_name_collision_package();
     let function = entity_id(&files, "nk/search.py", "search", EntityKind::Function);

--- a/crates/kin-index/tests/python_receiver_type_resolution.rs
+++ b/crates/kin-index/tests/python_receiver_type_resolution.rs
@@ -21,7 +21,7 @@
 
 use kin_index::{
     link_cross_file as link_cross_file_with_identities, link_cross_file_incremental, FileParseData,
-    IncrementalLinker,
+    IncrementalLinker, RelationResolution,
 };
 use kin_model::{ArtifactId, Entity, EntityId, EntityKind, FilePathId, RelationKind};
 use kin_parser::{LanguageAdapter, PythonAdapter};
@@ -308,6 +308,57 @@ class HTTPDigestAuth:
         has_call(&relations, caller, target),
         "an attribute whose declared type is an aliased import must bind to the \
          class the alias names; nothing else in the linker can reach it"
+    );
+}
+
+#[test]
+fn a_declared_receiver_edge_publishes_itself_as_type_resolved() {
+    // The marker is the half a reader acts on. An edge the linker bound by
+    // matching a leaf name publishes `name_only`, and every count that may
+    // only use proven edges drops it. This edge was proven from a type the
+    // source declares, so it must publish `type_resolved` and be usable as
+    // evidence that the method is called.
+    let files = vec![
+        parse_py("adapters.py", ADAPTERS_PY),
+        parse_py(
+            "sessions.py",
+            r#"
+from adapters import HTTPAdapter as Transport
+
+
+class Session:
+    def send(self, request, adapter: Transport):
+        return adapter.send(request)
+"#,
+        ),
+    ];
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "HTTPAdapter.send",
+        EntityKind::Method,
+    );
+    let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
+
+    let relations = link_cross_file(&files);
+    let edge = relations
+        .iter()
+        .find(|r| {
+            r.kind == RelationKind::Calls
+                && r.src.as_entity() == Some(caller)
+                && r.dst.as_entity() == Some(target)
+        })
+        .expect("the declared receiver type binds this call");
+
+    assert_eq!(
+        RelationResolution::of(edge).as_str(),
+        "type_resolved",
+        "an edge bound through a declared type must say so; published as \
+         name_only it is withheld from the very counts the ticket is about"
+    );
+    assert!(
+        RelationResolution::of(edge).is_proven(),
+        "and it must be countable as proof the method is used"
     );
 }
 

--- a/crates/kin-index/tests/python_receiver_type_resolution.rs
+++ b/crates/kin-index/tests/python_receiver_type_resolution.rs
@@ -1,0 +1,586 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Two Python relation defects, driven through the real parser and the real
+//! linker so the fixtures state what a repository actually looks like.
+//!
+//! FIR-2500: a method call arrived at the linker as its bare leaf, so the
+//! receiver's declared type was never consulted. `find_references` on
+//! `HTTPAdapter.send` in a requests-shaped package counted zero callers and
+//! held the one it did see as an unproven same-name candidate, while the
+//! annotation naming the receiver's type sat in the same graph.
+//!
+//! FIR-2508: a Python module entity is named for the file stem, so a module and
+//! a same-named function land on the linker's one `(file, name)` slot. The
+//! module took it, every caller of the function parked on the module node, and
+//! `kin dead-code` printed the program's primary function as unreferenced.
+//!
+//! The fixtures below are the two shapes those tickets were found on: a package
+//! shaped like `requests`' adapters, and a module whose name matches its
+//! primary function.
+
+use kin_index::{
+    link_cross_file as link_cross_file_with_identities, link_cross_file_incremental, FileParseData,
+    IncrementalLinker,
+};
+use kin_model::{ArtifactId, Entity, EntityId, EntityKind, FilePathId, RelationKind};
+use kin_parser::{LanguageAdapter, PythonAdapter};
+
+fn parse_py(file_path: &str, source: &str) -> FileParseData {
+    let adapter = PythonAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn link_cross_file(files: &[FileParseData]) -> Vec<kin_model::Relation> {
+    let artifact_ids = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    link_cross_file_with_identities(files, &artifact_ids)
+        .expect("every fixture file has an explicitly assigned artifact identity")
+}
+
+/// Link the same fixture through the live-edit path, so a rule proven on the
+/// batch linker is proven on the one a running daemon uses too.
+fn link_incremental(files: &[FileParseData]) -> Vec<kin_model::Relation> {
+    let mut linker = IncrementalLinker::new();
+    for file in files {
+        linker.add_file(&file.file_path, ArtifactId::new(), &file.entities);
+    }
+    link_cross_file_incremental(files, &linker).expect("the incremental index holds every fixture file")
+}
+
+/// The id of the entity of `kind` named `name` in `file`.
+///
+/// The kind is part of the query on purpose: this suite is about two entities
+/// that share a file and a name, so a lookup keyed on the name alone would pick
+/// one of them by accident and the assertion built on it would prove nothing.
+fn entity_id(files: &[FileParseData], file: &str, name: &str, kind: EntityKind) -> EntityId {
+    let matches: Vec<&Entity> = files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .filter(|e| {
+            e.name == name
+                && e.kind == kind
+                && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file)
+        })
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one {kind:?} named `{name}` in `{file}`, found {}",
+        matches.len()
+    );
+    matches[0].id
+}
+
+fn callers_of(relations: &[kin_model::Relation], dst: EntityId) -> Vec<EntityId> {
+    let mut callers: Vec<EntityId> = relations
+        .iter()
+        .filter(|r| r.kind == RelationKind::Calls && r.dst.as_entity() == Some(dst))
+        .filter_map(|r| r.src.as_entity())
+        .collect();
+    callers.sort();
+    callers.dedup();
+    callers
+}
+
+fn has_call(relations: &[kin_model::Relation], src: EntityId, dst: EntityId) -> bool {
+    relations.iter().any(|r| {
+        r.kind == RelationKind::Calls
+            && r.src.as_entity() == Some(src)
+            && r.dst.as_entity() == Some(dst)
+    })
+}
+
+// ── FIR-2500: the receiver's declared type ──────────────────────────────────
+
+const ADAPTERS_PY: &str = r#"
+class BaseAdapter:
+    def close(self):
+        pass
+
+
+class HTTPAdapter(BaseAdapter):
+    def send(self, request, stream=False):
+        return build_response(request)
+
+
+def build_response(request):
+    return request
+"#;
+
+/// A caller that annotates the receiver in its signature, which is the
+/// `Session.send` shape: the adapter is handed in and its type is written down.
+const SESSIONS_PY: &str = r#"
+from adapters import HTTPAdapter
+
+
+class Session:
+    def send(self, request, adapter: HTTPAdapter):
+        return adapter.send(request)
+"#;
+
+/// A caller that annotates the receiver as a field of its own class, which is
+/// the `HTTPDigestAuth.handle_401` shape: the adapter is reached through an
+/// attribute whose type the class declares.
+const AUTH_PY: &str = r#"
+from adapters import HTTPAdapter
+
+
+class HTTPDigestAuth:
+    connection: HTTPAdapter
+
+    def handle_401(self, prep):
+        return self.connection.send(prep)
+"#;
+
+fn requests_shaped_package() -> Vec<FileParseData> {
+    vec![
+        parse_py("adapters.py", ADAPTERS_PY),
+        parse_py("sessions.py", SESSIONS_PY),
+        parse_py("auth.py", AUTH_PY),
+    ]
+}
+
+#[test]
+fn a_method_call_binds_through_the_receivers_annotated_parameter_type() {
+    let files = requests_shaped_package();
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, caller, target),
+        "`adapter.send(request)` under `adapter: HTTPAdapter` must bind to \
+         HTTPAdapter.send; binding by bare name instead is what made \
+         find_references count this caller as an unproven candidate"
+    );
+}
+
+#[test]
+fn a_method_call_binds_through_a_class_declared_attribute_type() {
+    let files = requests_shaped_package();
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let caller = entity_id(
+        &files,
+        "auth.py",
+        "HTTPDigestAuth.handle_401",
+        EntityKind::Method,
+    );
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, caller, target),
+        "`self.connection.send(prep)` under `connection: HTTPAdapter` must bind \
+         to HTTPAdapter.send; this is the call site find_references missed \
+         entirely while the annotation proving it was in the graph"
+    );
+}
+
+#[test]
+fn both_declared_receiver_callers_reach_the_method_and_nothing_else_does() {
+    let files = requests_shaped_package();
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let session_send = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
+    let handle_401 = entity_id(
+        &files,
+        "auth.py",
+        "HTTPDigestAuth.handle_401",
+        EntityKind::Method,
+    );
+
+    let relations = link_cross_file(&files);
+    let mut expected = vec![session_send, handle_401];
+    expected.sort();
+
+    assert_eq!(
+        callers_of(&relations, target),
+        expected,
+        "find_references on HTTPAdapter.send must return both callers and no \
+         third: the count the ticket recorded was zero"
+    );
+}
+
+#[test]
+fn the_incremental_linker_binds_the_same_declared_receiver_types() {
+    let files = requests_shaped_package();
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let session_send = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
+    let handle_401 = entity_id(
+        &files,
+        "auth.py",
+        "HTTPDigestAuth.handle_401",
+        EntityKind::Method,
+    );
+
+    let relations = link_incremental(&files);
+    let mut expected = vec![session_send, handle_401];
+    expected.sort();
+
+    assert_eq!(
+        callers_of(&relations, target),
+        expected,
+        "a live edit must resolve the receiver's declared type exactly as the \
+         full index does; a rule proven only on the batch path leaves the \
+         running daemon on the old behaviour"
+    );
+}
+
+#[test]
+fn an_aliased_class_attribute_type_binds_where_the_bare_name_rule_cannot() {
+    // The attribute half of the discriminating pair. `self.connection.send` is
+    // the `HTTPDigestAuth.handle_401` shape, and under an aliased import the
+    // owner key the bare-name rule builds is `Transport.send`, which matches
+    // nothing. Only the class body's declaration says what type that attribute
+    // holds.
+    let files = vec![
+        parse_py("adapters.py", ADAPTERS_PY),
+        parse_py(
+            "auth.py",
+            r#"
+from adapters import HTTPAdapter as Transport
+
+
+class HTTPDigestAuth:
+    connection: Transport
+
+    def handle_401(self, prep):
+        return self.connection.send(prep)
+"#,
+        ),
+    ];
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let caller = entity_id(
+        &files,
+        "auth.py",
+        "HTTPDigestAuth.handle_401",
+        EntityKind::Method,
+    );
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, caller, target),
+        "an attribute whose declared type is an aliased import must bind to the \
+         class the alias names; nothing else in the linker can reach it"
+    );
+}
+
+#[test]
+fn an_aliased_declared_type_binds_where_the_bare_name_rule_cannot() {
+    // The discriminating case, and the one that says the declared-type tier is
+    // what does the work here. The bare-name rule settles a receiver call
+    // against the owners the calling file's import bindings name, and it builds
+    // those owner keys from the LOCAL name: `Transport.send` matches no entity,
+    // because the method is stored as `HTTPAdapter.send`. So the pre-fix linker
+    // reaches no owner at all and leaves the call unlinked, which is the "0
+    // counted, candidate withheld" answer the ticket recorded. The annotation
+    // says which type it is, and the import says what that name resolves to.
+    let files = vec![
+        parse_py("adapters.py", ADAPTERS_PY),
+        parse_py(
+            "sessions.py",
+            r#"
+from adapters import HTTPAdapter as Transport
+
+
+class Session:
+    def send(self, request, adapter: Transport):
+        return adapter.send(request)
+"#,
+        ),
+    ];
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, caller, target),
+        "a receiver declared under an aliased import must bind to the class the \
+         alias names; the bare-name rule cannot reach it, so this edge exists \
+         only if the declared type was consulted"
+    );
+}
+
+#[test]
+fn an_undeclared_aliased_receiver_still_reaches_no_owner() {
+    // Pass two of the pair above. Same file, same alias, same call, and the one
+    // annotation removed. Nothing else can bind it, so the edge must be absent:
+    // that is what makes the test above evidence rather than a coincidence of
+    // the fixture.
+    let files = vec![
+        parse_py("adapters.py", ADAPTERS_PY),
+        parse_py(
+            "sessions.py",
+            r#"
+from adapters import HTTPAdapter as Transport
+
+
+class Session:
+    def send(self, request):
+        adapter = self.get_adapter(request)
+        return adapter.send(request)
+"#,
+        ),
+    ];
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        !has_call(&relations, caller, target),
+        "with no annotation the linker has no proof of the receiver's type, and \
+         a bare-name match through an alias is not one; binding here would mean \
+         the declared-type tier is not what bound the aliased case"
+    );
+}
+
+#[test]
+fn the_incremental_linker_binds_an_aliased_declared_type_too() {
+    let files = vec![
+        parse_py("adapters.py", ADAPTERS_PY),
+        parse_py(
+            "sessions.py",
+            r#"
+from adapters import HTTPAdapter as Transport
+
+
+class Session:
+    def send(self, request, adapter: Transport):
+        return adapter.send(request)
+"#,
+        ),
+    ];
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
+
+    let relations = link_incremental(&files);
+
+    assert!(
+        has_call(&relations, caller, target),
+        "the live-edit path must bind the aliased declared type as well"
+    );
+}
+
+#[test]
+fn an_inherited_method_binds_through_the_declared_subclass() {
+    // `close` is declared on BaseAdapter and reached through a receiver
+    // annotated with the subclass, so the type must be walked to its ancestor
+    // rather than matched against the leaf `close`.
+    let files = vec![
+        parse_py("adapters.py", ADAPTERS_PY),
+        parse_py(
+            "pool.py",
+            r#"
+from adapters import HTTPAdapter
+
+
+class Pool:
+    def release(self, adapter: HTTPAdapter):
+        adapter.close()
+"#,
+        ),
+    ];
+    let target = entity_id(
+        &files,
+        "adapters.py",
+        "BaseAdapter.close",
+        EntityKind::Method,
+    );
+    let caller = entity_id(&files, "pool.py", "Pool.release", EntityKind::Method);
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, caller, target),
+        "a declared receiver type that does not define the method must reach \
+         the ancestor that does"
+    );
+}
+
+#[test]
+fn an_undeclared_receiver_still_binds_by_the_disclaimed_bare_name_rule() {
+    // The scoping half. Nothing annotates `adapter` here, so the call must
+    // reach HTTPAdapter.send exactly as it did before the declared-type tier
+    // existed: through the file's import naming the one owner it can see.
+    let files = vec![
+        parse_py("adapters.py", ADAPTERS_PY),
+        parse_py(
+            "sessions.py",
+            r#"
+from adapters import HTTPAdapter
+
+
+class Session:
+    def send(self, request):
+        adapter = self.get_adapter(request)
+        return adapter.send(request)
+"#,
+        ),
+    ];
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, caller, target),
+        "an unannotated receiver must keep the bare-name path it had; the \
+         declared-type tier may add recall and must never remove it"
+    );
+}
+
+#[test]
+fn a_declared_type_the_repository_does_not_define_falls_back_to_the_bare_leaf() {
+    // The fail-open half. `ThirdPartyAdapter` is not an entity anywhere, so the
+    // owner-qualified name resolves to nothing. The call must not vanish: it
+    // returns to the leaf `send` and settles by the rule that governed it
+    // before, which here is the one owner the file's imports name.
+    let files = vec![
+        parse_py("adapters.py", ADAPTERS_PY),
+        parse_py(
+            "sessions.py",
+            r#"
+from adapters import HTTPAdapter
+from vendor import ThirdPartyAdapter
+
+
+class Session:
+    def send(self, request, adapter: ThirdPartyAdapter):
+        return adapter.send(request)
+"#,
+        ),
+    ];
+    let target = entity_id(&files, "adapters.py", "HTTPAdapter.send", EntityKind::Method);
+    let caller = entity_id(&files, "sessions.py", "Session.send", EntityKind::Method);
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, caller, target),
+        "a declared type this repository does not hold must fall back to the \
+         disclaimed bare-name match, not to no edge at all"
+    );
+}
+
+// ── FIR-2508: a module and a same-named function ────────────────────────────
+
+const SEARCH_PY: &str = r#"
+class Hit:
+    def __init__(self, path):
+        self.path = path
+
+
+def search(store, terms, limit=20):
+    return [Hit(term) for term in terms]
+"#;
+
+const CLI_PY: &str = r#"
+from nk.search import search
+
+
+def cmd_search(store, terms):
+    return search(store, terms)
+"#;
+
+const TEST_SEARCH_PY: &str = r#"
+from nk.search import search
+
+
+def test_search_returns_hits():
+    return search(None, ["a"])
+"#;
+
+fn module_name_collision_package() -> Vec<FileParseData> {
+    vec![
+        parse_py("nk/search.py", SEARCH_PY),
+        parse_py("nk/cli.py", CLI_PY),
+        parse_py("tests/test_search.py", TEST_SEARCH_PY),
+    ]
+}
+
+#[test]
+fn a_module_does_not_take_the_call_edges_of_its_same_named_function() {
+    let files = module_name_collision_package();
+    let function = entity_id(&files, "nk/search.py", "search", EntityKind::Function);
+    let module = entity_id(&files, "nk/search.py", "search", EntityKind::Module);
+    let cmd_search = entity_id(&files, "nk/cli.py", "cmd_search", EntityKind::Function);
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, cmd_search, function),
+        "a caller of `search` must reach the function; parking that edge on the \
+         module named for the file is what made kin dead-code print the \
+         program's primary function as unreferenced"
+    );
+    assert!(
+        callers_of(&relations, module).is_empty(),
+        "a module is not callable, so no Calls edge may land on it"
+    );
+}
+
+#[test]
+fn every_caller_of_a_module_named_function_reaches_it() {
+    let files = module_name_collision_package();
+    let function = entity_id(&files, "nk/search.py", "search", EntityKind::Function);
+    let cmd_search = entity_id(&files, "nk/cli.py", "cmd_search", EntityKind::Function);
+    let test_search = entity_id(
+        &files,
+        "tests/test_search.py",
+        "test_search_returns_hits",
+        EntityKind::Function,
+    );
+
+    let relations = link_cross_file(&files);
+    let mut expected = vec![cmd_search, test_search];
+    expected.sort();
+
+    assert_eq!(
+        callers_of(&relations, function),
+        expected,
+        "the module twin in the same-name bucket must not read as an \
+         ambiguity that drops every caller's edge"
+    );
+}
+
+#[test]
+fn the_incremental_linker_keeps_the_module_off_the_functions_call_edges() {
+    let files = module_name_collision_package();
+    let function = entity_id(&files, "nk/search.py", "search", EntityKind::Function);
+    let module = entity_id(&files, "nk/search.py", "search", EntityKind::Module);
+    let cmd_search = entity_id(&files, "nk/cli.py", "cmd_search", EntityKind::Function);
+
+    let relations = link_incremental(&files);
+
+    assert!(
+        has_call(&relations, cmd_search, function),
+        "the live-edit path is the one the ticket was found on: its per-file \
+         index took the module last, so the module won the slot outright"
+    );
+    assert!(
+        callers_of(&relations, module).is_empty(),
+        "a module is not callable on the live path either"
+    );
+}

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -1351,15 +1351,13 @@ fn python_receiver_types(node: &tree_sitter::Node, source: &[u8]) -> PythonRecei
         let mut cursor = params.walk();
         for param in params.named_children(&mut cursor) {
             let (Some(name), Some(annotation)) = (
-                param
-                    .child_by_field_name("name")
-                    .and_then(|n| n.utf8_text(source).ok()),
+                python_parameter_name(&param, source),
                 param.child_by_field_name("type"),
             ) else {
                 continue;
             };
             if let Some(declared) = python_annotation_type_name(&annotation, source) {
-                types.insert(name.to_string(), declared);
+                types.insert(name, declared);
             }
         }
     }
@@ -1374,6 +1372,28 @@ fn python_receiver_types(node: &tree_sitter::Node, source: &[u8]) -> PythonRecei
         }
     }
     types
+}
+
+/// The name one parameter binds, for the two annotated shapes a receiver can
+/// arrive as.
+///
+/// `typed_default_parameter` carries a `name` field; `typed_parameter` does
+/// not, and holds its identifier as its first named child beside the `type`
+/// field. A splat parameter (`*args: T`) binds a tuple rather than a value of
+/// `T`, so its name is deliberately not returned.
+fn python_parameter_name(param: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    if let Some(name) = param.child_by_field_name("name") {
+        return name.utf8_text(source).ok().map(str::to_string);
+    }
+    let first = param.named_child(0)?;
+    if first.kind() != "identifier" {
+        return None;
+    }
+    first
+        .utf8_text(source)
+        .ok()
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
 }
 
 /// The `class_definition` a method is written inside, if any.

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -389,7 +389,16 @@ fn extract_py_node(
                     span: span_from_node(node, file_id),
                 });
                 // Extract calls within function/method body
-                extract_calls_from_context(node, source, &name, class_ctx, relations, call_audit);
+                let receiver_types = python_receiver_types(node, source);
+                extract_calls_from_context(
+                    node,
+                    source,
+                    &name,
+                    class_ctx,
+                    &receiver_types,
+                    relations,
+                    call_audit,
+                );
                 extract_value_refs_from_definition(node, source, &name, value_refs);
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
@@ -1251,6 +1260,7 @@ fn extract_named_callee(
     function: &tree_sitter::Node,
     source: &[u8],
     class_ctx: Option<&str>,
+    receiver_types: &PythonReceiverTypes,
 ) -> Option<PythonNamedCallee> {
     let callee = match function.kind() {
         "parenthesized_expression" => {
@@ -1260,7 +1270,7 @@ fn extract_named_callee(
             if named.next().is_some() {
                 return None;
             }
-            return extract_named_callee(&inner, source, class_ctx);
+            return extract_named_callee(&inner, source, class_ctx, receiver_types);
         }
         "attribute" => {
             let attr = function
@@ -1276,11 +1286,26 @@ fn extract_named_callee(
                 .filter(|obj| obj.kind() == "identifier")
                 .and_then(|obj| obj.utf8_text(source).ok())
                 .is_some_and(|text| text == "self" || text == "cls");
-            match class_ctx {
-                Some(cls) if self_or_cls_receiver => PythonNamedCallee {
+            let declared_owner = receiver_text
+                .as_deref()
+                .and_then(|receiver| receiver_types.get(receiver));
+            match (class_ctx, declared_owner) {
+                (Some(cls), _) if self_or_cls_receiver => PythonNamedCallee {
                     name: format!("{cls}.{attr}"),
                     resolution_proven: true,
                     receiver: None,
+                },
+                // The receiver's type is declared here, so the call names one
+                // owner and arrives owner-qualified exactly as a `self.m()`
+                // call does. The receiver is still carried: it is what tells
+                // the linker this owner came from a declaration rather than
+                // from a written path, so a type the repository does not
+                // define falls back to the bare leaf instead of resolving to
+                // nothing.
+                (_, Some(owner)) => PythonNamedCallee {
+                    name: format!("{owner}.{attr}"),
+                    resolution_proven: true,
+                    receiver: receiver_text,
                 },
                 _ => PythonNamedCallee {
                     name: attr.to_string(),
@@ -1299,12 +1324,203 @@ fn extract_named_callee(
     is_valid_callee_name(&callee.name).then_some(callee)
 }
 
+/// The declared type of every receiver expression a call in this scope can be
+/// written through, keyed by the receiver exactly as source spells it.
+///
+/// Two spellings reach it. A plain name the enclosing definition annotates
+/// (`def send(self, adapter: HTTPAdapter)`, `adapter: HTTPAdapter = ...`) keys
+/// on that name, and an attribute of the enclosing class the class body
+/// annotates (`connection: HTTPAdapter`) keys on `self.connection` and
+/// `cls.connection`, which is how such an attribute is read.
+///
+/// Only a declaration populates this. Nothing is inferred from an assignment's
+/// right-hand side, so a name the file never annotates has no entry and its
+/// calls keep the bare-leaf behaviour they had before.
+type PythonReceiverTypes = std::collections::HashMap<String, String>;
+
+/// Collect the receiver types one `function_definition` can dispatch through.
+///
+/// Without this, `adapter.send(request)` reached the linker as the bare leaf
+/// `send`, so `find_references(HTTPAdapter.send)` on a requests-shaped package
+/// counted zero callers and held the real one as an unproven same-name
+/// candidate, while the annotation naming the receiver's type sat in the graph
+/// one lookup away.
+fn python_receiver_types(node: &tree_sitter::Node, source: &[u8]) -> PythonReceiverTypes {
+    let mut types = PythonReceiverTypes::new();
+    if let Some(params) = node.child_by_field_name("parameters") {
+        let mut cursor = params.walk();
+        for param in params.named_children(&mut cursor) {
+            let (Some(name), Some(annotation)) = (
+                param
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok()),
+                param.child_by_field_name("type"),
+            ) else {
+                continue;
+            };
+            if let Some(declared) = python_annotation_type_name(&annotation, source) {
+                types.insert(name.to_string(), declared);
+            }
+        }
+    }
+    if let Some(body) = node.child_by_field_name("body") {
+        collect_python_annotated_bindings(&body, source, "", &mut types);
+    }
+    if let Some(class) = python_enclosing_class(node) {
+        if let Some(body) = class.child_by_field_name("body") {
+            for prefix in ["self.", "cls."] {
+                collect_python_annotated_bindings(&body, source, prefix, &mut types);
+            }
+        }
+    }
+    types
+}
+
+/// The `class_definition` a method is written inside, if any.
+///
+/// A method's parent is its class body; a decorated method sits one
+/// `decorated_definition` further out, which is why the walk is a short climb
+/// rather than a single `parent()` call. A nested function inside a method
+/// still reaches the class, which is correct: `self` means the same thing there.
+fn python_enclosing_class<'tree>(
+    node: &tree_sitter::Node<'tree>,
+) -> Option<tree_sitter::Node<'tree>> {
+    let mut current = node.parent();
+    for _ in 0..PYTHON_CLASS_ANCESTOR_DEPTH {
+        let ancestor = current?;
+        if ancestor.kind() == "class_definition" {
+            return Some(ancestor);
+        }
+        current = ancestor.parent();
+    }
+    None
+}
+
+/// How far above a definition its class may sit. A method's body, its own
+/// definition node and one decorator wrapper are the three steps a class
+/// member can be nested behind; the cap keeps the climb off unrelated
+/// enclosing classes when a definition is nested deeper than that.
+const PYTHON_CLASS_ANCESTOR_DEPTH: usize = 4;
+
+/// Record every `name: Type` binding written directly in `body`, under
+/// `prefix`.
+///
+/// Only statements at this level are read. A binding written inside a nested
+/// `if` or `for` is skipped rather than hoisted, because the annotation there
+/// is conditional and a receiver type has to be the one the reader can see.
+fn collect_python_annotated_bindings(
+    body: &tree_sitter::Node,
+    source: &[u8],
+    prefix: &str,
+    types: &mut PythonReceiverTypes,
+) {
+    let mut cursor = body.walk();
+    for statement in body.named_children(&mut cursor) {
+        let assignment = match statement.kind() {
+            "assignment" => Some(statement),
+            "expression_statement" => statement
+                .named_child(0)
+                .filter(|child| child.kind() == "assignment"),
+            _ => None,
+        };
+        let Some(assignment) = assignment else {
+            continue;
+        };
+        let (Some(left), Some(annotation)) = (
+            assignment.child_by_field_name("left"),
+            assignment.child_by_field_name("type"),
+        ) else {
+            continue;
+        };
+        let bound = match left.kind() {
+            "identifier" => left.utf8_text(source).ok().map(str::to_string),
+            // `self.connection: HTTPAdapter` inside a method declares the same
+            // attribute a class-body `connection: HTTPAdapter` does.
+            "attribute" => python_self_attribute_path(&left, source),
+            _ => None,
+        };
+        let (Some(bound), Some(declared)) =
+            (bound, python_annotation_type_name(&annotation, source))
+        else {
+            continue;
+        };
+        if bound.contains('.') {
+            types.insert(bound, declared);
+        } else {
+            types.insert(format!("{prefix}{bound}"), declared);
+        }
+    }
+}
+
+/// `self.connection` for a `self.connection` attribute node, `None` for any
+/// other receiver. Only `self` and `cls` name the enclosing instance, so an
+/// annotation on anything else declares a field of some other object and says
+/// nothing about a call written here.
+fn python_self_attribute_path(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    let object = node.child_by_field_name("object")?;
+    if object.kind() != "identifier" {
+        return None;
+    }
+    let root = object.utf8_text(source).ok()?;
+    if root != "self" && root != "cls" {
+        return None;
+    }
+    let leaf = node
+        .child_by_field_name("attribute")?
+        .utf8_text(source)
+        .ok()?;
+    (!leaf.is_empty()).then(|| format!("{root}.{leaf}"))
+}
+
+/// The class name one type annotation declares, or `None` when the annotation
+/// names no single class.
+///
+/// A bare `HTTPAdapter` and a module-qualified `adapters.HTTPAdapter` both name
+/// one type, and `Optional[HTTPAdapter]` names the same type with `None` added,
+/// which does not change what a call through it dispatches to. Everything else
+/// stays out: a union, a container and a string forward reference each leave
+/// the receiver's type undecided, and a receiver whose type is undecided must
+/// keep the bare-name behaviour rather than pick one arm of it.
+fn python_annotation_type_name(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    let inner = if node.kind() == "type" {
+        node.named_child(0)?
+    } else {
+        *node
+    };
+    match inner.kind() {
+        "identifier" => inner
+            .utf8_text(source)
+            .ok()
+            .filter(|name| !name.is_empty())
+            .map(str::to_string),
+        "attribute" => {
+            let text = inner.utf8_text(source).ok()?;
+            (!text.is_empty() && text.split('.').all(|seg| !seg.is_empty())).then(|| text.to_string())
+        }
+        "subscript" => {
+            let value = inner.child_by_field_name("value")?;
+            let wrapper = value.utf8_text(source).ok()?;
+            if !matches!(wrapper, "Optional" | "typing.Optional") {
+                return None;
+            }
+            let mut cursor = inner.walk();
+            let mut arguments = inner
+                .children_by_field_name("subscript", &mut cursor)
+                .collect::<Vec<_>>();
+            let argument = arguments.pop().filter(|_| arguments.is_empty())?;
+            python_annotation_type_name(&argument, source)
+        }
+        _ => None,
+    }
+}
+
 /// Extract all function/method calls within a function/method body.
 fn extract_calls_from_context(
     node: &tree_sitter::Node,
     source: &[u8],
     context_name: &str,
     class_ctx: Option<&str>,
+    receiver_types: &PythonReceiverTypes,
     relations: &mut Vec<ExtractedRelation>,
     call_audit: &mut PythonCallExtractionAudit,
 ) {
@@ -1316,7 +1532,9 @@ fn extract_calls_from_context(
                 .insert((child.start_byte(), child.end_byte()));
             let callee = child
                 .child_by_field_name("function")
-                .and_then(|function| extract_named_callee(&function, source, class_ctx));
+                .and_then(|function| {
+                    extract_named_callee(&function, source, class_ctx, receiver_types)
+                });
             if let Some(callee) = callee {
                 relations.push(ExtractedRelation {
                     // The call expression itself, so a reference row can report the
@@ -1343,6 +1561,7 @@ fn extract_calls_from_context(
             source,
             context_name,
             class_ctx,
+            receiver_types,
             relations,
             call_audit,
         );

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -1515,7 +1515,8 @@ fn python_annotation_type_name(node: &tree_sitter::Node, source: &[u8]) -> Optio
             .map(str::to_string),
         "attribute" => {
             let text = inner.utf8_text(source).ok()?;
-            (!text.is_empty() && text.split('.').all(|seg| !seg.is_empty())).then(|| text.to_string())
+            (!text.is_empty() && text.split('.').all(|seg| !seg.is_empty()))
+                .then(|| text.to_string())
         }
         "subscript" => {
             let value = inner.child_by_field_name("value")?;
@@ -1550,11 +1551,9 @@ fn extract_calls_from_context(
             call_audit
                 .seen_calls
                 .insert((child.start_byte(), child.end_byte()));
-            let callee = child
-                .child_by_field_name("function")
-                .and_then(|function| {
-                    extract_named_callee(&function, source, class_ctx, receiver_types)
-                });
+            let callee = child.child_by_field_name("function").and_then(|function| {
+                extract_named_callee(&function, source, class_ctx, receiver_types)
+            });
             if let Some(callee) = callee {
                 relations.push(ExtractedRelation {
                     // The call expression itself, so a reference row can report the


### PR DESCRIPTION
Two Python relation defects, one in the linker's receiver handling and one in
its `(file, name)` index. Both were found by stranger runs on shipped bytes,
and both make a correct absence answer out of a graph that already holds the
proof.

## FIR-2500: a method reference was a bare-name matcher

The Python adapter folds a `self.m()` receiver into the callee name and hands
the linker `EnclosingClass.m`. Every other attribute call lost its receiver's
type at `crates/kin-parser/src/languages/python.rs:1462`, where the non-`self`
arm of `extract_named_callee` returned the bare leaf `send` with
`resolution_proven: false`. The linker then had nothing but a name. Its
receiver tier at `crates/kin-index/src/linker.rs:1214` settles such a call
against the owners the calling file's import bindings name, so a file that
names no single owner binds nothing and the call is withheld as an unproven
candidate. That is the answer the ticket recorded on `HTTPAdapter.send`: zero
counted, one candidate held back, absence not authoritative, while the
annotation naming the receiver's type sat in the same graph.

The fix reads the declaration. `python_receiver_types` collects the types the
enclosing definition writes down, from parameter annotations, annotated
assignments in the body, and the class body's own attribute annotations, keyed
by the receiver exactly as source spells it, so both `adapter` and
`self.connection` resolve. When a call's receiver has a declared type, the
callee arrives owner-qualified exactly as a `self.m()` call does. A new linker
tier (a2b) resolves that owner through `locate_base_class`, which handles a
class defined here, one an import names under any alias, and one the repository
holds exactly one of, then selects the method on that class or the ancestor
that declares it. The edge is stamped `RECEIVER_TYPE_CONFIDENCE`, which the
resolution ladder maps to `type_resolved`, so it counts as proof the method is
used rather than being withheld.

Nothing is inferred. A receiver the file never annotates has no entry, and a
declared type this repository does not define falls back to the bare leaf, so
the disclaimed same-name path runs exactly as before and recall never drops.

## FIR-2508: a module took its function's call edges

A Python module entity is named for the file stem
(`crates/kin-parser/src/languages/python.rs:298`), so `nk/search.py` holding
`def search(...)` puts a Module and a Function on the linker's one
`(file, name)` slot at `crates/kin-index/src/linker.rs:593` and, on the
live-edit path, `crates/kin-index/src/linker.rs:5087`. Both were bare inserts,
so the last entity in iteration order took the slot. The two linkers disagreed
about who that was: the batch path sorts by start line and the module sits at
line zero, so the function displaced it, while the incremental path iterates
parse order and the adapter pushes the module last, so the module won. That is
the path a running daemon uses, and it is where the ticket's 23 call edges
parked.

The two entities are distinct nodes, not one: `EntityId::from_content` keys on
file, kind, name and start line, so no identity format changes here and
FIR-1656 is not engaged. The fix is a preference at the index, not a rename.
`file_name_slot_admits` says a Module never displaces a non-Module and a
non-Module always displaces a Module, which is what Python itself does: inside
a module, that name binds to the function, because a module binds no name for
itself in its own namespace.

A second site needed the same fact. The pinned-import fallback counts the
same-named entities in a package directory and resolves only when there is
exactly one, so a package re-export (`from nk import search`) saw the module
and the function, called it two, and refused the call outright. A module is not
callable, so `drop_module_call_targets` keeps Module entities out of a `Calls`
relation's candidate set. `References` edges are left alone, because passing a
module as a value genuinely names it.

## Falsification

Three passes, each removing one property, each predicting which tests fail and
which still pass, each sabotage confirmed applied by a non-empty diff naming
the target lines, each restored byte-identical.

Pass 1 reverted the parser's declared-type fold to the bare leaf. Predicted and
observed: 4 failed, 10 passed. The four are exactly the declared-type-only
cases, `an_aliased_declared_type_binds_where_the_bare_name_rule_cannot`,
`an_aliased_class_attribute_type_binds_where_the_bare_name_rule_cannot`,
`the_incremental_linker_binds_an_aliased_declared_type_too` and
`an_inherited_method_binds_through_the_declared_subclass`. The module tests and
both scoping tests passed, which is the evidence that the new tier is scoped to
declared receivers.

Pass 2 reverted both `(file, name)` inserts to bare inserts. Predicted and
observed: 1 failed, 13 passed, the failure being
`the_incremental_linker_keeps_the_module_off_the_functions_call_edges`. That is
the honest result and it is worth stating plainly: the batch assertion passes
either way today, because the batch sort order already preferred the function.
The batch guard makes that correctness explicit rather than an accident of the
sort key, and only the incremental path can fail on it now.

Pass 3 neutered `drop_module_call_targets`. The first run of this pass passed
all 14 tests, which meant the filter was shipping unproven, so a fixture was
built for the shape it actually protects: a package re-export. Re-running the
same sabotage then failed exactly
`a_package_re_export_reaches_the_function_past_its_module_twin` with its named
message, "a call pinned to a package must reach the function that package
re-exports; the module entity sharing its name is not a second candidate,
because a module is not callable".

## Gates

`cargo fmt --all -- --check` exits 0. Clippy exactly as ci.yml runs it
(`cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with
the 90-entry debt allow-list) exits 0. All four guard scripts ci.yml names pass:
`verify-zero-file-search.py` ("Verification PASSED", 178 source files scanned),
`zero_file_search_guard.sh` ("answer paths are graph-clean"),
`check_runtime_boundaries.sh` and `check_private_repo_coupling.sh`.
`cargo test -p kin-index -p kin-parser --no-fail-fast` runs 909 tests across 28
binaries with zero failures. `git diff origin/main --numstat` lists three files,
all mine, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

The local full gate ran on this branch under `gate-slot-3`, against the lane
worktree the pass printed for itself
(`worktree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/pymethod-kin`).
Its own summary line reads `Summary [454.875s] 6757 tests run: 6757 passed (4
slow), 12 skipped`, and the doctest pass beside it reports zero failures. An
ANSI-stripped sweep of the gate log finds 0 FAIL lines against 6757 PASS lines
as the positive control. Afterwards `git status -s` is empty, `Cargo.lock` keeps
8 `sparse+` sources with 0 `source = "path` entries, and no stray
`config.toml.bak` remains.

## What is left

Both tickets keep residuals, so neither closes here.

FIR-2500's second call site in `requests` is `r.connection.send(prep)` where
`r` carries no annotation at all, and its type lives on `Response.connection`
in another file. Binding that needs a repository-wide table of declared
attribute types, which is a second carrier this change does not add. The rule
shipped here is the ticket's own Ask, one hop from a declaration the calling
file writes.

FIR-2508 also reports that attribute access on a `@property` is not a call, so
no edge exists and every property in an idiomatic Python codebase reads as
dead. Five of that ticket's six rows were properties. That mechanism is
untouched here.

Refs FIR-2500
Refs FIR-2508
