### PR TITLE
Admit single-word uppercase and call-bound Python module constants

### DIFF
--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -1076,31 +1076,110 @@ fn emit_python_value_references(
     }
 }
 
+/// Name a module-level assignment binds, when the graph should own the value.
+///
+/// Two independent rules admit a binding, because they answer to different
+/// evidence and either one alone leaves a real constant invisible.
+///
+/// The first is the name's spelling, and it is decided by
+/// [`looks_like_py_constant_name`].
+///
+/// The second is the value's shape: a name bound to a CALL is a module
+/// singleton other files import and read, whatever case it is written in.
+/// `codes = LookupDict(name="status_codes")` in requests is the case that named
+/// the rule; three files import that name and the redirect path is built
+/// entirely out of it, and with no entity behind it `kin impact codes` retargeted
+/// to the enclosing module and answered "No local downstream impact found". The
+/// same rule is already what JavaScript applies to a module-level binding: a
+/// value containing a call expression is not data-only there and is admitted as
+/// a `Constant` regardless of the name (`is_data_only_js_value` in
+/// javascript.rs), which is how `React.forwardRef`, `styled` and `memo` bindings
+/// become entities. Python's import is a statement rather than a call, so the
+/// dependency-line flood that forced JavaScript to exclude `require(...)`
+/// bindings has no equivalent here.
+///
+/// Only a bare identifier target qualifies for the call rule. `a, b = make()`
+/// and `obj.attr = make()` reach here as `pattern_list` and `attribute`, and
+/// their text is a destructuring or an attribute write rather than a name the
+/// graph can carry.
+///
+/// Both rules run only where the caller already stands at module scope: the
+/// `assignment` arm of `extract_py_node` is guarded by `class_ctx.is_none()`, so
+/// class attributes never reach it, and the module-root walk never descends into
+/// a function body, so locals never reach it either.
 fn extract_py_constant_name(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
     let target = node
         .child_by_field_name("left")
         .or_else(|| node.named_child(0))?;
     let name = target.utf8_text(source).ok()?.trim().to_string();
     if looks_like_py_constant_name(&name) {
-        Some(name)
-    } else {
-        None
+        return Some(name);
+    }
+    if target.kind() == "identifier"
+        && node
+            .child_by_field_name("right")
+            .is_some_and(|value| py_value_is_call(&value))
+    {
+        return Some(name);
+    }
+    None
+}
+
+/// Whether an assignment's right-hand side is a call.
+///
+/// `await make()` and `(make())` bind the same singleton the bare call does, so
+/// both unwrap to the call underneath rather than reading as some other shape.
+fn py_value_is_call(node: &tree_sitter::Node) -> bool {
+    match node.kind() {
+        "call" => true,
+        "await" | "parenthesized_expression" => node
+            .named_child(0)
+            .is_some_and(|inner| py_value_is_call(&inner)),
+        _ => false,
     }
 }
 
+/// Whether a module-level assignment target is SPELLED as a constant.
+///
+/// PEP 8 writes constants in upper case "with underscores separating words", so
+/// the underscore is a word separator rather than part of the convention.
+/// Requiring one dropped every single-word constant while admitting its
+/// multi-word siblings in the same file: on the store behind FIR-2509, five of
+/// six module-level constants in one package were entities and `SCHEMA` at
+/// `nk/storage.py:22` was not, so `semantic_search("SCHEMA")` certified
+/// `safe_to_conclude_absent: true` over a constant that is plainly there. The
+/// graph was self-consistently missing it, which is what made the certification
+/// dangerous rather than merely wrong.
+///
+/// Two spellings are accepted. An all-uppercase name of two characters or more
+/// is the PEP 8 constant with or without a separator (`SCHEMA`, `TAG_RE`,
+/// `HTTP2`). A mixed-case name carrying an underscore is the looser shape this
+/// predicate already admitted, kept so that no name which is an entity today
+/// stops being one.
+///
+/// A single character stays out. At module level `T = TypeVar("T")` and a bare
+/// `E` read as type parameters and scratch names far more often than as
+/// constants, and the ones genuinely built by a call are admitted by the call
+/// rule in [`extract_py_constant_name`] instead.
 fn looks_like_py_constant_name(name: &str) -> bool {
     let mut has_upper = false;
+    let mut has_lower = false;
     let mut has_underscore = false;
     for ch in name.chars() {
         if ch == '_' {
             has_underscore = true;
         } else if ch.is_ascii_uppercase() {
             has_upper = true;
-        } else if !ch.is_ascii_alphanumeric() {
+        } else if ch.is_ascii_lowercase() {
+            has_lower = true;
+        } else if !ch.is_ascii_digit() {
             return false;
         }
     }
-    !name.is_empty() && has_upper && has_underscore
+    if name.is_empty() || !has_upper {
+        return false;
+    }
+    (!has_lower && name.len() >= 2) || has_underscore
 }
 
 /// Extract decorator names from a `decorated_definition` node.
@@ -1673,6 +1752,230 @@ mod tests {
             constants
         );
         assert_eq!(constants[0].name, "PROBE_SECRET_abcd1234");
+    }
+
+    /// FIR-2509: a single-word module-level constant was never an entity while
+    /// its multi-word siblings in the same package were, so `semantic_search`
+    /// certified `safe_to_conclude_absent: true` over a constant plainly in the
+    /// file. The multi-word names are asserted beside the single-word ones so a
+    /// fix in one direction cannot quietly cost the other.
+    #[test]
+    fn parse_python_single_word_uppercase_constants_are_entities() {
+        let adapter = PythonAdapter;
+        let source = br##"SCHEMA = """
+CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT);
+"""
+LIMIT = 50
+TIMEOUT = 30
+DEBUG = False
+PORT = 8080
+VERSION = "1.0"
+HTTP2 = True
+TAG_RE = "#(\w+)"
+DEFAULT_REDIRECT_LIMIT = 30
+"##;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("storage.py");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let mut names: Vec<&str> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Constant)
+            .map(|e| e.name.as_str())
+            .collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec![
+                "DEBUG",
+                "DEFAULT_REDIRECT_LIMIT",
+                "HTTP2",
+                "LIMIT",
+                "PORT",
+                "SCHEMA",
+                "TAG_RE",
+                "TIMEOUT",
+                "VERSION",
+            ],
+            "every all-uppercase module-level assignment is a constant, with or \
+             without a word separator; got {names:?}"
+        );
+        let schema = output
+            .entities
+            .iter()
+            .find(|e| e.name == "SCHEMA")
+            .expect("SCHEMA is the single-word triple-quoted constant FIR-2509 named");
+        assert_eq!(schema.kind, EntityKind::Constant);
+        assert_eq!(
+            schema.span.start_line, 0,
+            "SCHEMA's span must name its own assignment (tree-sitter rows are 0-based, \
+             so source line 1) rather than the module's"
+        );
+    }
+
+    /// FIR-2481: `codes = LookupDict(name="status_codes")` in requests produced
+    /// no entity, so `kin impact codes` retargeted to the enclosing module and
+    /// answered "No local downstream impact found" for a name three files
+    /// import. The uppercase sibling in the same file is asserted beside it
+    /// because the case is the only thing that distinguished them.
+    #[test]
+    fn parse_python_module_level_call_binding_is_an_entity() {
+        let adapter = PythonAdapter;
+        let source = br#"class LookupDict(dict):
+    pass
+
+
+codes = LookupDict(name="status_codes")
+session = build_session()
+awaited = await make_client()
+wrapped = (make_wrapped())
+annotated: LookupDict = LookupDict(name="annotated")
+DEFAULT_REDIRECT_LIMIT = 30
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("status_codes.py");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let mut names: Vec<&str> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Constant)
+            .map(|e| e.name.as_str())
+            .collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec![
+                "DEFAULT_REDIRECT_LIMIT",
+                "annotated",
+                "awaited",
+                "codes",
+                "session",
+                "wrapped",
+            ],
+            "a module-level name bound to a call is an entity whatever its case, \
+             including through `await` and parentheses; got {names:?}"
+        );
+        let codes = output
+            .entities
+            .iter()
+            .find(|e| e.name == "codes")
+            .expect("codes is the lowercase call-bound constant FIR-2481 named");
+        assert_eq!(codes.kind, EntityKind::Constant);
+        assert_eq!(
+            codes.span.start_line, 4,
+            "codes' span must name its own assignment (tree-sitter rows are 0-based, \
+             so source line 5) rather than the module's"
+        );
+    }
+
+    /// The other direction of both rules. A lowercase module-level name with no
+    /// call behind it, a single uppercase character, a destructuring target and
+    /// an attribute write all stay out, so neither rule is a licence to promote
+    /// every assignment in the file.
+    #[test]
+    fn parse_python_module_level_non_constants_stay_out() {
+        let adapter = PythonAdapter;
+        let source = br#"schema = "notes"
+total = 0
+_cache = {}
+T = 1
+E = "x"
+first, second = make_pair()
+holder.attr = make_attr()
+holder["key"] = make_item()
+__all__ = ["schema"]
+KEPT = make_kept()
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("scope.py");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let mut names: Vec<&str> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Constant)
+            .map(|e| e.name.as_str())
+            .collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["KEPT"],
+            "only the uppercase call-bound name qualifies; a lowercase literal \
+             binding, a single character, a destructuring and an attribute write \
+             must not become constants; got {names:?}"
+        );
+    }
+
+    /// Scope, in both places the rules must not reach. A class attribute and a
+    /// function-local carry exactly the spellings the two new rules admit at
+    /// module level, and neither may produce a constant.
+    #[test]
+    fn parse_python_constant_rules_do_not_reach_class_or_function_scope() {
+        let adapter = PythonAdapter;
+        let source = br#"class Store:
+    SCHEMA = "create table"
+    codes = LookupDict(name="attr")
+
+    def build(self):
+        LIMIT = 50
+        rows = fetch_rows()
+        return LIMIT, rows
+
+
+def helper():
+    TIMEOUT = 30
+    client = make_client()
+    return TIMEOUT, client
+
+
+MODULE_LIMIT = 50
+module_client = make_client()
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("scope.py");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let mut names: Vec<&str> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Constant)
+            .map(|e| e.name.as_str())
+            .collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["MODULE_LIMIT", "module_client"],
+            "only the two module-level bindings are constants; the class \
+             attributes SCHEMA and codes and the locals LIMIT, rows, TIMEOUT and \
+             client must stay out; got {names:?}"
+        );
+    }
+
+    /// The reference edge the impact answer is built from. Once `codes` is an
+    /// entity, a consumer that imports it and reads a member off it references
+    /// the name rather than nothing, which is what `kin impact codes` walks.
+    #[test]
+    fn parse_python_call_bound_constant_receives_reference_edges() {
+        let adapter = PythonAdapter;
+        let source = br#"from .status_codes import codes
+
+
+class Response:
+    def is_redirect(self):
+        return codes.moved
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("models.py");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let refs: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::References)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert!(
+            refs.contains(&("Response.is_redirect", "codes")),
+            "the consumer must reference `codes` by name so the impact walk can \
+             reach it; got {refs:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two rules in the Python extractor made real module-level constants invisible. This fixes both.

## Mechanism

`looks_like_py_constant_name` at `crates/kin-parser/src/languages/python.rs:1091` returned `!name.is_empty() && has_upper && has_underscore`. PEP 8 writes constants in upper case "with underscores separating words", so the underscore is a word separator rather than part of the convention, and requiring one dropped every single-word constant while admitting its multi-word siblings in the same file. That is why FIR-2509 found five of six module constants in one package were entities and `SCHEMA` at `nk/storage.py:22` was not, and why `semantic_search` could certify `safe_to_conclude_absent: true` over it. The graph was self-consistently missing it, which is what made the certification dangerous rather than merely wrong.

`extract_py_constant_name` at the same file's line 1079 consulted only that predicate, so the value's shape was never asked about. A module-level name bound to a call produced no entity whatever its case, which is FIR-2481: `codes = LookupDict(name="status_codes")` had no entity, so `kin impact codes` retargeted to the enclosing module and answered "No local downstream impact found" for a name three files import.

## The fix, and where the second rule comes from

An all-uppercase module-level target of two characters or more is now a constant, with or without a word separator. The previous mixed-case-with-underscore shape is kept beside it, so the predicate is strictly additive and no name that is an entity today stops being one. A single character stays out, because `T = TypeVar("T")` at module level reads as a type parameter.

A module-level assignment to a bare identifier whose right-hand side is a call is now a constant, whatever case the name is written in, with `await make()` and `(make())` unwrapping to the call underneath. This is the rule JavaScript already applies: `is_data_only_js_value` at `crates/kin-parser/src/languages/javascript.rs:794` returns false for a `call_expression` subtree and its caller at line 653 emits a `Constant` regardless of the name, which is how `React.forwardRef`, `styled` and `memo` bindings become entities. The one shape JavaScript excludes is a `require(...)` binding, because those are dependency lines already carried as imports; Python's import is a statement rather than a call and never reaches this arm, so that flood has no equivalent here. Downstream is the other half of the reason: `kin impact` walks entity-to-entity edges, so a name with no entity has nothing to walk from.

Destructuring and attribute-write targets are excluded by requiring the target node to be an `identifier`. Both rules run only inside the module-scope arm, so class attributes and function locals are unchanged.

Identity is untouched. `EntityId::from_content` in kin-model 0.7.11 at `src/ids.rs:28` is a UUIDv5 over `{file_path}\u{1f}{kind}\u{1f}{name}\u{1f}{start_line}`, and this change alters no input to an entity that already exists. Every new id is a fresh point in that namespace, so no persisted coordinate is reinterpreted, which is what FIR-1656 asks for.

## Falsification, six passes

Every pass removed one property, predicted the outcome, asserted the edit applied before running, and restored byte-identical afterwards.

- All-uppercase arm removed: `parse_python_single_word_uppercase_constants_are_entities` FAILED with `got ["DEFAULT_REDIRECT_LIMIT", "TAG_RE"]`; the other four passed.
- Call rule removed: `parse_python_module_level_call_binding_is_an_entity` FAILED with `got ["DEFAULT_REDIRECT_LIMIT"]` and the scope test FAILED with `got ["MODULE_LIMIT"]`; the uppercase test passed.
- Both class-scope guards removed together: the scope test FAILED with `got ["MODULE_LIMIT", "SCHEMA", "codes", "module_client"]`. Removing either guard alone left it green, because a class-body assignment arrives as an `expression_statement` wrapping an `assignment` and each arm rejects it independently.
- Recursion added into function bodies: the scope test FAILED with `got ["LIMIT", "MODULE_LIMIT", "TIMEOUT", "client", "module_client", "rows"]`, which is the direction proving a lowercase single-word local is not promoted.
- Identifier target check removed: the non-constants test FAILED with `got ["KEPT", "first, second", "holder.attr", "holder[\"key\"]"]`.
- Two-character minimum removed: the non-constants test FAILED with `got ["E", "KEPT", "T"]`.

## Product effect, base binary against fixed binary

Two `kin` and `kin-daemon` pairs were built from this worktree, one with the change and one with `origin/main`'s `python.rs` checked out over it, then the tree was restored and verified byte-identical. The pairs differ by sha256 and by version stamp. They ran against one fixture reproducing both tickets' shapes at their own paths, each arm with its own `HOME`, its own `KIN_HOME`, a repository directory built fresh rather than copied, `KIN_DAEMON_AUTO_EMBED=0` and `KIN_DAEMON_DISABLE_LSP=1`.

`kin graph status` over the same eight files moves from 34 entities, 19 relations, 9 constants, 5 References and 1 cross-file relation to 41 entities, 27 relations, 16 constants, 13 References and 5 cross-file relations. The seven new constants are `SCHEMA`, `LIMIT`, `TIMEOUT`, `DEBUG`, `PORT`, `VERSION` and `codes`.

`kin impact codes --depth 3` on the base binary prints "Impact analysis for 'status_codes' (Module) @ src/requests/status_codes.py:1: No local downstream impact found." On the fixed binary it prints "Impact analysis for 'codes' (Constant) @ src/requests/status_codes.py:19: 7 local entities impacted within 3 hops", naming `Session.resolve_redirects` and `Session.rebuild_method` in sessions.py and `Response.is_permanent_redirect` and the `models` module in models.py. The `--json` form moves off `"resolution": "not_found"`.

`semantic_search("SCHEMA")` was driven over the MCP stdio server, since the `negative` envelope is applied by the MCP path and absent on the raw daemon route. The base arm returns `total_matches: 0` with `"kind": "no_entity_match"`, `"trust": "authoritative"` and `"safe_to_conclude_absent": true`, which is FIR-2509's headline reproduced. The fixed arm returns `total_matches: 1` with `results[0] = {"name": "SCHEMA", "kind": "constant", "language": "Python"}` and the negative flips to `"kind": "qualified_answer"` with `"safe_to_conclude_absent": false`.

Controls: `DEFAULT_REDIRECT_LIMIT` stays a `Constant` at models.py with identical output on both arms, and the fabricated names `codez` and `SCHEMAZZ` still report not found and `no_entity_match` / `authoritative` on both arms, so every check can still say no.

Over the Python 3.13.12 standard library (699 files, 3157 module-level functions, 2657 classes) the previous rule admitted 1003 module-level constants; the uppercase rule adds 533 and the call rule a further 535, for 2071 constants against 5814 functions and classes.

## Gates

The full local gate ran on this lane's worktree, and its own tree line reads `kin-dev: local-test: kin  /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/pyconst-kin @ c35ddca5 (chore/lane-pyconst-kin)`, which is this branch's content before the rebase onto `4c6161de`. The verdict is the log's own summary line rather than an exit code: `Summary [ 420.508s] 6719 tests run: 6719 passed (4 slow, 1 leaky), 12 skipped`, with the doctest pass beside it producing 23 `test result: ok` lines and 0 failures.

After the gate, `git status -s` was empty, `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` printed only `.cargo/config.toml`, `git diff origin/main --stat -- Cargo.lock .cargo/` was empty, and `Cargo.lock` held 8 `source = "sparse+` entries and 0 `source = "path` entries.

Re-run after the rebase onto `4c6161de`: `cargo fmt --all -- --check` rc 0; `cargo clippy --all-targets --all-features` with the 45-lint debt allow-list under `RUSTFLAGS=-D warnings` rc 0; `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh` and `scripts/check_private_repo_coupling.sh` all rc 0 with their own pass lines; `cargo test -p kin-parser` 463 tests, 0 failed; and `cargo test -p kin-cli --test python_impact_walk_agreement`, the Python impact test main gained in #1032, 4 passed and 0 failed.

## What is left

FIR-2509 names two separable fixes and this is the first. Certification is unchanged, so a filter whose extractor coverage is unreported can still certify an absence over some other shape the extractor misses. FIR-2481's module-`Imports`-edge half, which that ticket flagged as possibly sharing a cause with FIR-2478, is also untouched.

Refs FIR-2509
Closes FIR-2481
