### PR TITLE
Record the complete admission init conversion and stash perform, and fetch doctor's graph status once per run

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -8,7 +8,9 @@
 //! truth behind `kin setup status [--json]` and `kin doctor [--fix]`.
 
 use std::env;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 
 use serde_json::Value;
 
@@ -183,7 +185,13 @@ pub async fn run_health_checks() -> HealthReport {
     checks.push(check_editor());
     checks.push(check_kinlab_connect());
     checks.push(check_semantic_query_readiness().await);
-    checks.push(check_reference_edge_coverage().await);
+    // One `graph status` for the whole run, handed to every row that reads graph
+    // truth. `kin graph status` is the slowest surface Kin has on a real store,
+    // and it was fetched per row, so each row answering from graph truth added a
+    // whole one to the wall time of a doctor run on exactly the stores where an
+    // operator is most likely to be running doctor because something is wrong.
+    let graph_status = RunGraphStatus::for_run();
+    checks.push(check_reference_edge_coverage(&graph_status).await);
     checks.push(check_background_work().await);
     checks.push(check_embedding_model().await);
     checks.push(check_commit_memory_headroom());
@@ -2428,10 +2436,7 @@ async fn check_background_work() -> HealthCheck {
 /// on a graph missing 16 imports and roughly 40 cross-file call edges, and
 /// `kin languages` listed the language as fully extracted, so every readiness
 /// signal pointed away from the gap.
-async fn check_reference_edge_coverage() -> HealthCheck {
-    const ID: &str = "reference_edge_coverage";
-    const LABEL: &str = "Reference edge coverage";
-
+async fn check_reference_edge_coverage(graph_status: &RunGraphStatus) -> HealthCheck {
     // Probed first, because it needs no daemon. Every branch below that cannot
     // read the graph still reports this half, so a repository whose daemon is
     // down does not silently lose the language-server signal that used to have
@@ -2442,56 +2447,15 @@ async fn check_reference_edge_coverage() -> HealthCheck {
     // looking for a problem somewhere else entirely.
     let readiness = crate::commands::language_servers::probe_language_server_readiness(&cwd).await;
     let missing_servers = missing_language_servers(&readiness);
-    let Some(layout) = kin_core::KinLayout::discover(&cwd) else {
-        return HealthCheck::new(
-            ID,
-            LABEL,
-            HealthStatus::Unsupported,
-            "n/a — not in a Kin repository",
-        );
-    };
-    let Some(daemon_url) = crate::daemon_client::resolve_daemon_url_if_running_async(&layout).await
-    else {
-        return coverage_unreadable(
-            HealthStatus::Unsupported,
-            "no daemon running for this repository, so relation-graph completeness cannot be \
-             read; a daemon starts on first use",
-            "run any `kin` command in the repo to auto-start the daemon",
-            &missing_servers,
-        );
-    };
-    let client = match crate::daemon_client::DaemonClient::from_base_url_for_layout(
-        daemon_url.clone(),
-        &layout,
-    ) {
-        Ok(client) => client,
-        Err(error) => {
-            return coverage_unreadable(
-                HealthStatus::Stale,
-                format!("daemon reachable ({daemon_url}), but its URL is invalid: {error}"),
-                "check the daemon URL recorded for this repository",
-                &missing_servers,
-            );
-        }
-    };
-    let response = match client
-        .graph_command(&crate::commands::graph::GraphCommandRequest::Status)
-        .await
-    {
+    // The run's one fetch. Every unreadable state is phrased by this row in its
+    // own words rather than reported once by the fetch, because a row that reads
+    // graph truth must never render the same whether the graph was healthy or
+    // unreadable.
+    let response = match coverage_row_for_unread_graph(graph_status.get().await, &missing_servers) {
         Ok(response) => response,
-        Err(error) => {
-            return coverage_unreadable(
-                HealthStatus::Stale,
-                format!(
-                    "daemon reachable ({daemon_url}), but relation-graph completeness is \
-                     unavailable: {error}"
-                ),
-                "run `kin graph status` and resolve the reported daemon error",
-                &missing_servers,
-            );
-        }
+        Err(row) => return row,
     };
-    let Some(coverage) = response.reference_edge_coverage else {
+    let Some(coverage) = response.reference_edge_coverage.as_ref() else {
         return coverage_unreadable(
             HealthStatus::Stale,
             "the daemon serving this repository does not report relation-graph completeness; it \
@@ -2500,7 +2464,154 @@ async fn check_reference_edge_coverage() -> HealthCheck {
             &missing_servers,
         );
     };
-    reference_edge_coverage_health(&coverage)
+    reference_edge_coverage_health(coverage)
+}
+
+/// This row's words for a graph status the run could not read, or the response
+/// when it could.
+///
+/// Split from the fetch and from the verdict so every cause has a rendering that
+/// is testable without a daemon, and so the property FIR-2560 must not lose stays
+/// checkable: a shared fetch carries its failure to each consumer rather than
+/// reporting it once, and no unreadable state renders as a healthy graph.
+fn coverage_row_for_unread_graph<'a>(
+    status: &'a GraphStatusForRun,
+    missing_servers: &[String],
+) -> Result<&'a crate::commands::graph::GraphCommandResponse, HealthCheck> {
+    const ID: &str = "reference_edge_coverage";
+    const LABEL: &str = "Reference edge coverage";
+
+    match status {
+        GraphStatusForRun::Answered(response) => Ok(response),
+        GraphStatusForRun::NotInRepository => Err(HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Unsupported,
+            "n/a — not in a Kin repository",
+        )),
+        GraphStatusForRun::NoDaemon => Err(coverage_unreadable(
+            HealthStatus::Unsupported,
+            "no daemon running for this repository, so relation-graph completeness cannot be \
+             read; a daemon starts on first use",
+            "run any `kin` command in the repo to auto-start the daemon",
+            missing_servers,
+        )),
+        GraphStatusForRun::DaemonUrlInvalid { daemon_url, error } => Err(coverage_unreadable(
+            HealthStatus::Stale,
+            format!("daemon reachable ({daemon_url}), but its URL is invalid: {error}"),
+            "check the daemon URL recorded for this repository",
+            missing_servers,
+        )),
+        GraphStatusForRun::Unavailable { daemon_url, error } => Err(coverage_unreadable(
+            HealthStatus::Stale,
+            format!(
+                "daemon reachable ({daemon_url}), but relation-graph completeness is unavailable: \
+                 {error}"
+            ),
+            "run `kin graph status` and resolve the reported daemon error",
+            missing_servers,
+        )),
+    }
+}
+
+/// What a doctor run's single `graph status` fetch produced.
+///
+/// The failure arms carry the cause rather than a rendered row. A shared fetch
+/// that reported its own failure once would leave every other row silent about a
+/// graph it could not read, and a row that goes quiet when the graph is
+/// unreadable is indistinguishable from one reporting a healthy graph. So each
+/// consumer phrases the same cause in the words its own row needs.
+#[derive(Debug)]
+pub(crate) enum GraphStatusForRun {
+    /// The daemon answered.
+    Answered(Box<crate::commands::graph::GraphCommandResponse>),
+    /// This process is not standing in a Kin repository, so nothing was fetched.
+    NotInRepository,
+    /// No daemon is running for this repository, so nothing was fetched.
+    NoDaemon,
+    /// A daemon is running and the URL recorded for it will not parse.
+    DaemonUrlInvalid { daemon_url: String, error: String },
+    /// The daemon was asked and did not answer.
+    Unavailable { daemon_url: String, error: String },
+}
+
+/// A future producing the run's graph status, boxed so the fetch can be
+/// substituted in tests.
+type GraphStatusFuture = Pin<Box<dyn Future<Output = GraphStatusForRun> + Send>>;
+
+/// The `graph status` a doctor run reads, fetched at most once however many rows
+/// consult it.
+///
+/// FIR-2416 measured `kin graph status` at 31.812 s on the rc0545c psf/requests
+/// store against 0.091 s on express. A second fetch therefore does not cost a
+/// little more, it roughly doubles the wall time of a doctor run, and the shape
+/// did not stop at two: every future row answering from graph truth added
+/// another whole fetch. Holding the answer here makes a new consumer free.
+///
+/// Lazy rather than eager so a run whose rows all short-circuit before reading
+/// graph truth still pays nothing, and so the fetch keeps its position in the
+/// run relative to the probes a row takes first.
+pub(crate) struct RunGraphStatus {
+    fetch: Box<dyn Fn() -> GraphStatusFuture + Send + Sync>,
+    once: tokio::sync::OnceCell<GraphStatusForRun>,
+}
+
+impl RunGraphStatus {
+    /// The real fetch, against the daemon serving the current directory.
+    pub(crate) fn for_run() -> Self {
+        Self::with_fetch(|| Box::pin(fetch_graph_status()))
+    }
+
+    fn with_fetch(fetch: impl Fn() -> GraphStatusFuture + Send + Sync + 'static) -> Self {
+        Self {
+            fetch: Box::new(fetch),
+            once: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    /// The run's graph status, fetching it on the first call and returning that
+    /// same answer to every later one.
+    pub(crate) async fn get(&self) -> &GraphStatusForRun {
+        self.once.get_or_init(|| (self.fetch)()).await
+    }
+}
+
+/// Take the run's one `graph status` round trip.
+///
+/// Every way this can fail to produce a response is a named variant rather than
+/// a message, so a consumer renders the cause in its own row's terms and no
+/// caller has to parse prose to tell "no daemon" from "the daemon refused".
+async fn fetch_graph_status() -> GraphStatusForRun {
+    let cwd = env::current_dir().unwrap_or_default();
+    let Some(layout) = kin_core::KinLayout::discover(&cwd) else {
+        return GraphStatusForRun::NotInRepository;
+    };
+    let Some(daemon_url) = crate::daemon_client::resolve_daemon_url_if_running_async(&layout).await
+    else {
+        return GraphStatusForRun::NoDaemon;
+    };
+    let client = match crate::daemon_client::DaemonClient::from_base_url_for_layout(
+        daemon_url.clone(),
+        &layout,
+    ) {
+        Ok(client) => client,
+        Err(error) => {
+            return GraphStatusForRun::DaemonUrlInvalid {
+                daemon_url,
+                error: error.to_string(),
+            };
+        }
+    };
+    match client
+        .graph_command(&crate::commands::graph::GraphCommandRequest::Status)
+        .await
+    {
+        Ok(response) => GraphStatusForRun::Answered(Box::new(response)),
+        Err(error) => GraphStatusForRun::Unavailable {
+            daemon_url,
+            error: error.to_string(),
+        },
+    }
 }
 
 /// The row for every state where the graph itself could not be read.
@@ -3720,6 +3831,125 @@ mod tests {
         let report = assemble_health_report("test".to_string(), vec![check]);
         assert!(report.healthy);
         assert_eq!(report.summary().attention, 1);
+    }
+
+    /// A healthy response for the fetch tests to hand back.
+    fn answered_graph_status() -> GraphStatusForRun {
+        GraphStatusForRun::Answered(Box::new(crate::commands::graph::GraphCommandResponse {
+            lines: vec!["graph status".to_string()],
+            error: None,
+            source: None,
+            reference_edge_coverage: Some(
+                kin_core::reference_coverage::ReferenceEdgeCoverage::default(),
+            ),
+        }))
+    }
+
+    /// FIR-2560. One `graph status` per doctor run, however many rows read it.
+    ///
+    /// `kin graph status` is the slowest surface Kin has on a real store, and it
+    /// was fetched per row: FIR-2416 measured 31.812 s on the rc0545c
+    /// psf/requests store against 0.091 s on express, so a second fetch does not
+    /// cost a little more, it roughly doubles the wall time of a doctor run on
+    /// exactly the stores where an operator is most likely to be running doctor.
+    /// Three consumers here rather than the one the tree holds today, because the
+    /// cost this pins is the one a fourth row would add.
+    #[tokio::test]
+    async fn one_doctor_run_fetches_graph_status_once_however_many_rows_read_it() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let counted = Arc::clone(&fetches);
+        let status = RunGraphStatus::with_fetch(move || {
+            let counted = Arc::clone(&counted);
+            Box::pin(async move {
+                counted.fetch_add(1, Ordering::SeqCst);
+                answered_graph_status()
+            })
+        });
+
+        assert_eq!(
+            fetches.load(Ordering::SeqCst),
+            0,
+            "the fetch is lazy, so a run whose rows never read graph truth pays nothing"
+        );
+
+        let mut seen = Vec::new();
+        for _ in 0..3 {
+            seen.push(format!("{:?}", status.get().await));
+        }
+
+        assert_eq!(
+            fetches.load(Ordering::SeqCst),
+            1,
+            "three rows reading graph status must cost one daemon round trip, not three"
+        );
+        assert_eq!(
+            seen.iter().collect::<std::collections::BTreeSet<_>>().len(),
+            1,
+            "and every row must see the same answer: {seen:?}"
+        );
+    }
+
+    /// The property the shared fetch must not cost. A graph the run could not
+    /// read reaches the row as its own unreadable state, rather than being
+    /// reported once by the fetch and leaving the row silent.
+    ///
+    /// A row that goes quiet when the graph is unreadable is indistinguishable
+    /// from one reporting a healthy graph, which is the failure the row exists to
+    /// end. So each cause is checked for a status that is not healthy and for
+    /// words naming what happened.
+    #[test]
+    fn an_unreadable_graph_reaches_the_row_rather_than_being_reported_once() {
+        let no_servers: Vec<String> = Vec::new();
+
+        let unreadable = [
+            (
+                GraphStatusForRun::NotInRepository,
+                "not in a Kin repository",
+            ),
+            (
+                GraphStatusForRun::NoDaemon,
+                "no daemon running for this repository",
+            ),
+            (
+                GraphStatusForRun::DaemonUrlInvalid {
+                    daemon_url: "http://127.0.0.1:0".to_string(),
+                    error: "invalid port".to_string(),
+                },
+                "its URL is invalid",
+            ),
+            (
+                GraphStatusForRun::Unavailable {
+                    daemon_url: "http://127.0.0.1:4242".to_string(),
+                    error: "connection refused".to_string(),
+                },
+                "unavailable",
+            ),
+        ];
+        for (status, expected) in unreadable {
+            let row = coverage_row_for_unread_graph(&status, &no_servers)
+                .expect_err("an unread graph must produce a row rather than a response");
+            assert!(
+                !matches!(row.status, HealthStatus::Healthy),
+                "an unread graph must never render as healthy: {status:?} gave {:?}",
+                row.status
+            );
+            assert!(
+                row.detail.contains(expected),
+                "the row must name what happened: {status:?} gave {}",
+                row.detail
+            );
+        }
+
+        // And the readable case still yields the response, or the four arms
+        // above would be the only outcome and the row could never report a
+        // measurement.
+        assert!(
+            coverage_row_for_unread_graph(&answered_graph_status(), &no_servers).is_ok(),
+            "a graph the run did read must hand its response to the row"
+        );
     }
 
     /// FIR-2370. Two rows about one graph teach an operator to skip both, so the

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -725,3 +725,97 @@ fn init_status_and_graph_status_use_their_real_durable_and_live_routes() {
         "{graph_stdout}"
     );
 }
+
+/// FIR-2559 end to end, through the shipped binaries. A store the product has
+/// just converted reports the admission that conversion performed, rather than
+/// telling its owner that how far graph truth has fallen behind is unknown.
+///
+/// `--no-enrich` is load-bearing rather than a speed-up: it is what keeps the
+/// conversion the only thing that could have written the marker. The enrichment
+/// phase starts a daemon, whose ambient reconcile tick is one of the two writers
+/// that existed before this, so a marker read after it would be evidence about
+/// the tick instead. The read below therefore happens with no daemon in this
+/// fixture's life at all.
+///
+/// The rendered line is asserted afterwards, once a daemon is serving, because
+/// that is the sentence a user actually reads.
+#[test]
+fn a_converted_store_reports_its_admission_rather_than_unknown_freshness() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&repo).expect("create repo");
+    seed_repository(&repo);
+
+    let init = Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(["init", ".", "--json", "--no-enrich"])
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env_remove("KIN_DAEMON_URL")
+        .current_dir(&repo)
+        .output()
+        .expect("run production kin init route");
+    assert!(
+        init.status.success(),
+        "init stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    assert!(
+        !repo.join(".kin/daemon.port").exists(),
+        "no daemon ran for this store, so the marker below can only be the conversion's"
+    );
+
+    let layout = kin_core::KinLayout::discover(&repo).expect("the conversion published a store");
+    let freshness = kin_core::last_admission::read(&layout);
+    let recorded = match &freshness {
+        kin_core::last_admission::LastAdmissionRead::Recorded(recorded) => recorded,
+        other => panic!("a converted store must record its complete admission, read {other:?}"),
+    };
+    assert_eq!(
+        recorded.tracked_artifacts, 3,
+        "the record must cover the three files this repository commits"
+    );
+
+    let line = freshness.describe(chrono::Utc::now());
+    assert!(
+        line.contains("last complete admission"),
+        "the freshness surface must name the admission: {line}"
+    );
+    assert!(
+        !line.contains("unknown"),
+        "and must not report unknown freshness on a store converted a moment ago: {line}"
+    );
+
+    // The same fact through the shipped `kin graph status` route, which is where
+    // a user meets it.
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let mut daemon = IsolatedDaemon::spawn(&repo, &runtime);
+    let port = daemon.wait_until_serving(&repo.join(".kin"));
+    let graph_status = Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(["graph", "status"])
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("KIN_DAEMON_URL", format!("http://127.0.0.1:{port}"))
+        .current_dir(&repo)
+        .output()
+        .expect("run production kin graph status route");
+    daemon.stop();
+
+    assert!(
+        graph_status.status.success(),
+        "graph status stdout={} stderr={}",
+        String::from_utf8_lossy(&graph_status.stdout),
+        String::from_utf8_lossy(&graph_status.stderr)
+    );
+    let graph_stdout = String::from_utf8_lossy(&graph_status.stdout);
+    assert!(
+        graph_stdout.contains("graph truth: last complete admission"),
+        "{graph_stdout}"
+    );
+    assert!(
+        !graph_stdout.contains("no complete admission is recorded"),
+        "{graph_stdout}"
+    );
+}

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -328,6 +328,12 @@ fn init_from_git_with_hooks(
     };
 
     let workspace_seed = admitted.workspace_seed.clone();
+    // Counted here because the seed is consumed by the bootstrap transaction
+    // below. This is the committed tree the publication admits, and it is the
+    // count the durable freshness marker is stamped with at the tail of this
+    // function, so the marker's coverage is the publication's own rather than a
+    // number read back off a reopened store.
+    let admitted_tracked_artifacts = workspace_seed.base_tree.len() as u64;
     let workspace_policy = admitted.workspace_policy().clone();
     let workspace_base_change_id = admitted.workspace_base_change_id();
 
@@ -469,6 +475,24 @@ fn init_from_git_with_hooks(
     result
         .workspace_divergence
         .clone_from(&source_proof.workspace_divergence);
+
+    // A conversion is a complete exact-tree admission, so it records one, through
+    // the same writer the ambient reconcile tick, `kin admit`, a commit and a
+    // stash write. Without this a freshly converted store answered `kin graph
+    // status` with "no complete admission is recorded for this store", which told
+    // a user to run `kin admit` to redo the work the conversion had just done.
+    //
+    // Only when the source held nothing the committed state does not. Init admits
+    // the committed Git tree, and the divergence above is exactly what the
+    // worktree carries beyond it; the daemon admits that as workspace state on its
+    // first run. Stamping unconditionally would claim a complete admission of a
+    // working copy that was never admitted, which is the false freshness this
+    // marker exists to prevent, reached through the one door where the admitted
+    // tree is legitimately not the tree the repository holds. A dirty conversion
+    // has no complete admission of its working copy yet and keeps saying so.
+    if result.workspace_divergence.is_empty() {
+        crate::last_admission::record(&result.layout, admitted_tracked_artifacts);
+    }
 
     info!(
         path = %source.display(),
@@ -1227,6 +1251,101 @@ mod tests {
         );
         assert!(source.join("init.log").exists());
         assert_no_staging_directories(root.path());
+    }
+
+    /// A conversion admits the complete exact reachable Git repository, so it
+    /// must leave the durable record of one behind.
+    ///
+    /// Without this the marker had two writers, the ambient reconcile tick and
+    /// `kin admit`, and a store that had just been converted answered `kin graph
+    /// status` with "no complete admission is recorded for this store", telling a
+    /// user to run `kin admit` to redo the work the conversion had just done.
+    ///
+    /// The absent read before the conversion is the control. A published `.kin`
+    /// is what the marker lives inside, so before the conversion there is no
+    /// store to read at all, and the count is what makes the assertion say more
+    /// than "some file appeared": it has to be the tree the publication admitted.
+    #[test]
+    fn a_clean_conversion_records_the_complete_admission_it_performed() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        std::fs::write(source.join("README.md"), b"exact source\n").unwrap();
+        std::fs::write(source.join("kept.txt"), b"committed\n").unwrap();
+        git(&source, ["add", "--all"]);
+        git(&source, ["commit", "-m", "initial"]);
+
+        assert!(
+            !source.join(".kin").exists(),
+            "the marker lives inside the published store, so there must be none before the \
+             conversion or a marker afterwards proves nothing"
+        );
+
+        let result = init_from_git(&source).unwrap();
+        assert!(
+            result.workspace_divergence.is_empty(),
+            "this fixture is the clean case: {:?}",
+            result.workspace_divergence
+        );
+
+        let recorded = match crate::last_admission::read(&result.layout) {
+            crate::last_admission::LastAdmissionRead::Recorded(recorded) => recorded,
+            other => panic!(
+                "a clean conversion must record the complete admission it performed, read \
+                 {other:?}"
+            ),
+        };
+        assert_eq!(
+            recorded.tracked_artifacts, 2,
+            "the record must cover the two files the publication admitted"
+        );
+        assert!(
+            recorded.age_seconds(chrono::Utc::now()) < 300,
+            "the record must be stamped by this conversion rather than carried in from elsewhere"
+        );
+    }
+
+    /// A conversion of a worked-in checkout must NOT record one.
+    ///
+    /// Init admits the committed Git tree while the worktree keeps everything
+    /// the commit does not carry, and the daemon admits that as workspace state
+    /// on its first run. So the admitted tree is genuinely not the tree the
+    /// repository holds, and a marker here would claim a complete admission of a
+    /// working copy nothing had admitted, which is the false freshness the marker
+    /// exists to prevent. Unknown is the honest answer until something admits the
+    /// working copy.
+    #[test]
+    fn a_conversion_with_an_uncommitted_change_records_no_admission() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        std::fs::write(source.join("README.md"), b"exact source\n").unwrap();
+        std::fs::write(source.join("kept.txt"), b"committed\n").unwrap();
+        git(&source, ["add", "--all"]);
+        git(&source, ["commit", "-m", "initial"]);
+        // One modification to a tracked file, which is the smallest thing that
+        // makes the admitted committed tree differ from the working copy.
+        std::fs::write(source.join("README.md"), b"edited after the commit\n").unwrap();
+
+        let result = init_from_git(&source).unwrap();
+        assert!(
+            !result.workspace_divergence.is_empty(),
+            "this fixture is the dirty case, or the assertion below is about nothing"
+        );
+
+        let read_back = crate::last_admission::read(&result.layout);
+        assert!(
+            matches!(read_back, crate::last_admission::LastAdmissionRead::Absent),
+            "a conversion whose working copy diverges from the tree it admitted must record no \
+             complete admission, read {read_back:?}"
+        );
+        assert!(
+            read_back.describe(chrono::Utc::now()).contains("unknown"),
+            "and the surface must say so rather than going quiet: {}",
+            read_back.describe(chrono::Utc::now())
+        );
     }
 
     /// An init killed mid-capture leaves neither `.kin` nor a capture directory.

--- a/crates/kin-core/src/last_admission.rs
+++ b/crates/kin-core/src/last_admission.rs
@@ -170,6 +170,34 @@ pub fn read(layout: &KinLayout) -> LastAdmissionRead {
     }
 }
 
+/// Stamp the marker now, for a complete exact-tree admission that has already
+/// completed and is durable.
+///
+/// The one writer every complete-admission path goes through, so freshness reads
+/// the same way whichever path admitted. Before this existed each caller decided
+/// for itself and most decided not to: the ambient reconcile tick and `kin admit`
+/// wrote the marker, while the commit endpoint, the stash endpoint and the Git
+/// conversion that creates the store all performed a complete admission and
+/// recorded none. That is how a store answered "no complete admission is
+/// recorded for this store" minutes after being converted and committed to.
+///
+/// A write failure is logged and swallowed. An admission that succeeded did
+/// succeed, and turning a marker-write failure into an admission failure would
+/// report an admitted tree as unadmitted, which is a worse lie than the one this
+/// marker fixes. The failure direction is also the safe one: an unwritten marker
+/// leaves the previous, older timestamp in place, so the store reads as staler
+/// than it is and never as fresher.
+pub fn record(layout: &KinLayout, tracked_artifacts: u64) {
+    let recorded = LastAdmission::new(Utc::now(), tracked_artifacts);
+    if let Err(error) = write(layout, &recorded) {
+        tracing::warn!(
+            error = %error,
+            "could not persist the last-admission marker; freshness surfaces will report the \
+             previous admission until the next pass rewrites it"
+        );
+    }
+}
+
 /// Write the durable marker for `layout`, atomically.
 ///
 /// Staged beside the target and renamed into place after an fsync, then the

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4120,6 +4120,26 @@ async fn command_stash(
     crate::loop_runner::sync_filesystem_with_graph_under_coordination(&state)
         .await
         .map_err(internal_error)?;
+    // That sync is a complete exact-tree admission publishing its tree standalone,
+    // so the admission is durable the moment it returns and is recorded here, on
+    // the same probes and in the same durable marker the ambient reconcile tick,
+    // `kin admit` and a commit write. Without it a user who sealed or restored a
+    // stash had just had their whole working copy admitted and `kin graph status`
+    // still answered that no complete admission was recorded for the store.
+    //
+    // Before the stash executes rather than after, and counted here, because this
+    // is the tree the admission published. The seal that follows returns the
+    // workspace to its base and writes that move as its own authority, which is
+    // the stash operating rather than a second admission; counting after it would
+    // record a tree no admission had passed over.
+    state
+        .background_work
+        .reconcile()
+        .record_admission_success(std::time::Instant::now());
+    crate::background_work::record_durable_admission(
+        &state.layout,
+        state.graph.resolved_tree().len() as u64,
+    );
     let response = crate::repository_stash::execute(&state, &request)?;
     Ok(Json(response))
 }
@@ -18706,6 +18726,160 @@ mod tests {
             stash_entries(Arc::clone(&state)).await.len(),
             1,
             "the refused restore left the sealed state intact"
+        );
+    }
+
+    /// A stash performs a complete exact-tree admission, so it must leave the
+    /// durable record of one behind.
+    ///
+    /// Seal and restore both decide against the exact workspace the host holds,
+    /// so the endpoint runs a complete-scan admission first and publishes its
+    /// tree standalone. Nothing recorded it, and the marker's two writers, the
+    /// ambient reconcile tick and `kin admit`, need not run on a store whose tick
+    /// is quiet. So a user who had just had their whole working copy admitted was
+    /// told that how far graph truth had fallen behind the repository was
+    /// unknown.
+    ///
+    /// The absent read before the request is the control, and the read-only
+    /// `list` beside it is the second one: `list` returns before the admission,
+    /// so a marker appearing there would mean the recording had attached to the
+    /// endpoint rather than to the admission.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_stash_records_the_complete_admission_it_performed() {
+        use kin_core::last_admission::LastAdmissionRead;
+
+        let (state, _layout, repository, _main, _feature) =
+            universal_branch_test_state("stash-records-admission");
+
+        // The fixture converts a Git repository, and a clean conversion now
+        // records its own complete admission, so the control is the conversion's
+        // timestamp rather than an absent marker: whatever this stash writes has
+        // to be strictly later than what the store was born with.
+        let born_with = match kin_core::last_admission::read(&state.layout) {
+            LastAdmissionRead::Recorded(recorded) => recorded,
+            other => {
+                panic!("the conversion that built this fixture records a marker, read {other:?}")
+            }
+        };
+        assert!(
+            stash_entries(Arc::clone(&state)).await.is_empty(),
+            "the fixture starts with nothing sealed"
+        );
+        assert_eq!(
+            kin_core::last_admission::read(&state.layout),
+            LastAdmissionRead::Recorded(born_with.clone()),
+            "a read-only stash list returns before the admission, so it must record nothing"
+        );
+
+        // A modification to a tracked file, so the admitted tree holds the same
+        // paths the base does and the count is stable across the seal that
+        // follows.
+        std::fs::write(
+            repository.join("selected/compose.yaml"),
+            b"services:\n  api:\n    image: sealed\n",
+        )
+        .unwrap();
+        let tracked_before = state.graph.resolved_tree().len() as u64;
+
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_push()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+        let recorded = match kin_core::last_admission::read(&state.layout) {
+            LastAdmissionRead::Recorded(recorded) => recorded,
+            other => {
+                panic!("a stash must record the complete admission it performed, read {other:?}")
+            }
+        };
+        assert_eq!(
+            recorded.tracked_artifacts, tracked_before,
+            "the record must cover the tree the admission passed over"
+        );
+        assert_eq!(
+            recorded.tracked_artifacts,
+            state.graph.resolved_tree().len() as u64,
+            "and the seal returned the workspace to a base holding the same paths"
+        );
+        assert!(
+            recorded.at > born_with.at,
+            "the record must be stamped by this stash rather than left as the conversion wrote \
+             it: {} against {}",
+            recorded.at.to_rfc3339(),
+            born_with.at.to_rfc3339()
+        );
+
+        // The in-memory probes carry the same fact, so `/health`, `kin doctor`
+        // and `kin admit` name the stash's admission instead of reporting that
+        // none has succeeded in this daemon's life.
+        assert!(
+            state
+                .background_work
+                .reconcile_report(std::time::Instant::now())
+                .last_admission_success_age_seconds
+                .is_some(),
+            "a stash's admission must reach the reconcile probes as a success"
+        );
+    }
+
+    /// A stash the seal itself refuses still records the admission that ran
+    /// before the refusal.
+    ///
+    /// This is where the stash path differs from the commit path and why the
+    /// recording sits where it does. A commit defers its admitted tree to its own
+    /// transaction, so nothing is durable until that transaction reaches
+    /// authority and a marker stamped earlier would claim a complete admission
+    /// for a tree authority never accepted. A stash publishes its tree standalone
+    /// before the seal is even attempted, so the admission is complete and
+    /// durable whatever the seal then answers, and withholding the marker would
+    /// report a store as staler than the daemon had just made it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_refused_stash_still_records_the_admission_that_ran_before_it() {
+        use kin_core::last_admission::LastAdmissionRead;
+
+        let (state, _layout, _repository, _main, _feature) =
+            universal_branch_test_state("stash-refused-records-admission");
+
+        let born_with = match kin_core::last_admission::read(&state.layout) {
+            LastAdmissionRead::Recorded(recorded) => recorded,
+            other => {
+                panic!("the conversion that built this fixture records a marker, read {other:?}")
+            }
+        };
+
+        // A clean workspace has nothing to seal, so the endpoint admits the exact
+        // tree and then refuses.
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_push()).await;
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "{}",
+            String::from_utf8_lossy(&body)
+        );
+        assert!(
+            String::from_utf8_lossy(&body).contains("no graph-owned changes to seal"),
+            "{}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let recorded = match kin_core::last_admission::read(&state.layout) {
+            LastAdmissionRead::Recorded(recorded) => recorded,
+            other => panic!(
+                "the admission published its tree standalone before the refusal, so it must be \
+                 recorded, read {other:?}"
+            ),
+        };
+        assert!(
+            recorded.at > born_with.at,
+            "the refused stash still admitted, so the marker must have moved past the one the \
+             conversion wrote: {} against {}",
+            recorded.at.to_rfc3339(),
+            born_with.at.to_rfc3339()
+        );
+        assert_eq!(
+            recorded.tracked_artifacts,
+            state.graph.resolved_tree().len() as u64,
+            "the record must cover the tree the admission passed over"
         );
     }
 

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -656,22 +656,13 @@ impl RecordedFault {
 /// waits behind. And the probes deliberately know nothing about the store's
 /// layout, which keeps them a pure in-memory disclosure.
 ///
-/// A write failure is logged and swallowed. An admission that succeeded did
-/// succeed, and turning a marker-write failure into an admission failure would
-/// report an admitted tree as unadmitted, which is a worse lie than the one this
-/// marker fixes. The failure direction is also the safe one: an unwritten marker
-/// leaves the previous, older timestamp in place, so the store reads as staler
-/// than it is and never as fresher.
+/// The write itself is `kin_core::last_admission::record`, which every complete
+/// admission in the product goes through, daemon and conversion alike. This
+/// remains as the daemon's own entry point so the three call sites here keep
+/// naming the probes and the marker together, and so the reason for the split
+/// above stays beside them.
 pub fn record_durable_admission(layout: &kin_core::KinLayout, tracked_artifacts: u64) {
-    let recorded =
-        kin_core::last_admission::LastAdmission::new(chrono::Utc::now(), tracked_artifacts);
-    if let Err(error) = kin_core::last_admission::write(layout, &recorded) {
-        tracing::warn!(
-            error = %error,
-            "could not persist the last-admission marker; freshness surfaces will report the \
-             previous admission until the next pass rewrites it"
-        );
-    }
+    kin_core::last_admission::record(layout, tracked_artifacts);
 }
 
 /// What the filesystem reconciliation loop has actually managed to admit.


### PR DESCRIPTION
## Mechanism

Three paths perform a complete exact-tree admission. Until kin#1008 only two of
them recorded that they had, and after it, two still do not.

The durable last-admission marker had two writers before #1008,
`crates/kin-daemon/src/loop_runner.rs:2212` in the ambient reconcile tick and
`crates/kin-daemon/src/repository_admit.rs:222` in the `kin admit` pass. #1008
added the third, on the arm of `command_commit` where the commit reached
authority. The two callers it named as out of scope are the ones here.

`kin_core::init_from_git` (`crates/kin-core/src/git_init.rs:178`) admits the
complete exact reachable Git repository as graph-owned authority and publishes
it, so the store is born with its whole committed tree admitted, and it wrote no
marker. A conversion with no commit after it therefore left `kin graph status`
answering "no complete admission is recorded for this store, so how far graph
truth has fallen behind the repository is unknown; run `kin admit` to admit the
complete exact tree and record one", which tells a user to redo the work the
conversion had just done.

`POST /commands/stash` (`crates/kin-daemon/src/api.rs:4119`) runs its own
complete admission through
`crate::loop_runner::sync_filesystem_with_graph_under_coordination`, which
publishes with `TreePublication::Standalone`
(`crates/kin-daemon/src/loop_runner.rs:6188`), so the admitted tree is durable
the moment that call returns. Neither `record_admission_success` nor
`record_durable_admission` ran on that path. A user who sealed or restored a
stash had just had their whole working copy admitted and was still told the
freshness of the store was unknown.

Separately, `kin doctor` fetched `GraphCommandRequest::Status` once per row that
needs graph truth rather than once per run. FIR-2416 measured `kin graph status`
at 31.812 s on the rc0545c psf/requests store against 0.091 s on express, so a
second fetch does not cost a little more, it roughly doubles the wall time of a
doctor run on exactly the stores where an operator is most likely to be running
doctor because something is wrong, and the shape did not stop at two.

## The fix

One writer underneath every complete admission. `kin_core::last_admission::record`
is new, and `crate::background_work::record_durable_admission` now delegates to
it, so the ambient tick, `kin admit`, a commit, a stash and the Git conversion
all stamp the same marker the same way and freshness reads the same whichever
path admitted.

The conversion stamps at the tail of `init_from_git_with_hooks`, and only when
`result.workspace_divergence.is_empty()`. Init admits the committed Git tree
while the worktree keeps everything the commit does not carry, so on a dirty
checkout the admitted tree is genuinely not the tree the repository holds.
Stamping unconditionally would claim a complete admission of a working copy
nothing had admitted, which is the false freshness the marker exists to prevent.
A dirty conversion keeps saying unknown until something admits its working copy.

The stash records after the sync returns `Ok` and before
`repository_stash::execute`, because that is the point the admitted tree is
published and it is the tree the admission passed over. The seal that follows
returns the workspace to its base and writes that move as its own authority,
which is the stash operating rather than a second admission.

For doctor, `RunGraphStatus` holds the run's single fetch behind a
`tokio::sync::OnceCell` and hands the answer to every row that reads graph truth.
It is lazy, so a run whose rows all short-circuit pays nothing and the fetch
keeps its position relative to the probes a row takes first.
`coverage_row_for_unread_graph` carries each unreadable cause to its consumer as
a named variant rather than reporting it once, so an unreadable graph and a
healthy one never render the same row. `check_reference_edge_coverage` keeps
every string it had.

## Tests

Six. Two in `kin-core` over the conversion, three in `kin-daemon` over the stash
route, two in `kin-cli` over the shared fetch, and one integration test driving
the shipped binaries.

`a_clean_conversion_records_the_complete_admission_it_performed` asserts no
`.kin` exists before the conversion, then that the marker is `Recorded` with
`tracked_artifacts` equal to the two files the fixture commits.
`a_conversion_with_an_uncommitted_change_records_no_admission` is the other
direction: one modification to a tracked file, and the marker must stay `Absent`
and the surface must still say unknown.

`a_stash_records_the_complete_admission_it_performed` reads the conversion's own
marker as its control, checks a read-only `stash list` leaves it untouched, then
asserts a push moved it strictly later with `tracked_artifacts` matching the tree
and the probes carrying the success.
`a_refused_stash_still_records_the_admission_that_ran_before_it` pins the
placement: a clean workspace admits and then refuses with 409, and the admission
that published standalone before the refusal is still recorded.

`one_doctor_run_fetches_graph_status_once_however_many_rows_read_it` counts
fetches through an injected fetcher across three consumers and asserts one, plus
zero before any row reads.
`an_unreadable_graph_reaches_the_row_rather_than_being_reported_once` drives all
four unread causes and asserts none renders healthy and each names what happened,
with the readable case still yielding its response.

`a_converted_store_reports_its_admission_rather_than_unknown_freshness` runs the
shipped `kin init . --json --no-enrich` under an isolated `HOME`, asserts no
`.kin/daemon.port` exists so the conversion is the only thing that could have
written the marker, reads it, then spawns an isolated daemon and asserts the
shipped `kin graph status` prints "graph truth: last complete admission" and not
"no complete admission is recorded".

## Falsification

Six passes, each removing one property, each asserting its sabotage applied by
diff before running and restored byte-identical after.

Conversion pass 1, delete the marker write. Predicted the clean test fails and
the dirty one passes. Result `1 passed; 1 failed`: "a clean conversion must
record the complete admission it performed, read Absent". The stash fixture
control fails with it, as predicted, on "the conversion that built this fixture
records a marker, read Absent".

Conversion pass 2, stamp unconditionally by removing the divergence guard.
Predicted the dirty test fails and the clean one passes. Result `1 passed; 1
failed`: "a conversion whose working copy diverges from the tree it admitted must
record no complete admission, read Recorded(LastAdmission { ... tracked_artifacts:
2 })".

Stash pass 1, delete both recording calls. Predicted both new stash tests fail
and the four existing stash tests pass. Result `4 passed; 2 failed`: "the record
must be stamped by this stash rather than left as the conversion wrote it" and
"the refused stash still admitted, so the marker must have moved past the one the
conversion wrote", both quoting the same timestamp on each side.

Stash pass 2, move the recording after `repository_stash::execute`. Predicted
only the refusal test fails. Result `5 passed; 1 failed`, the refusal test alone.

Stash pass 3, delete only the `record_admission_success` probe call. Predicted
only the probe assertion fails. Result `5 passed; 1 failed`: "a stash's admission
must reach the reconcile probes as a success", with the marker half of the same
test still passing.

Doctor pass 1, fetch on every `get` instead of once. Predicted only the count
test fails. Result `117 passed; 1 failed`: "three rows reading graph status must
cost one daemon round trip, not three", left 3 right 1.

Doctor pass 2, render the no-daemon cause as `HealthStatus::Healthy`. Predicted
only the rendering test fails. Result `117 passed; 1 failed`: "an unread graph
must never render as healthy: NoDaemon gave Healthy".

## Gates

`cargo fmt --all -- --check` exit 0. Clippy exactly as `.github/workflows/ci.yml`
runs it, `--all-targets --all-features` under `RUSTFLAGS=-D warnings` with the
`.github/clippy-allowed-lints.txt` allowlist, exit 0.

The five guard scripts `ci.yml` names all pass locally:
`scripts/verify-zero-file-search.py` (178 files scanned),
`scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`,
`scripts/check_private_repo_coupling.sh`,
`scripts/verify-hydration-semantics.py` (13 guarded functions at
HYDRATION_SEMANTICS_VERSION=9).

Full local gate under build slot gate-slot-2. Its own resolution line reads
`kin-dev: local-test: kin
/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/freshness-kin @
dc32ce80 (chore/lane-freshness-kin)`, so the tree under test is this branch and
not the primary. Result `Summary [ 346.307s] 6759 tests run: 6759 passed (3
slow), 12 skipped`, zero FAIL lines in the log, kin-dev exit 0, doctests beside
it.

An earlier run of the same gate on the same commit stopped at 2700/6759 on
`kin-cli::symlinked_repository_root_admission
a_repository_bound_through_a_symlinked_root_admits_a_host_write`, which this
change does not touch. It failed at 8.192s asserting `kin graph status` exited
zero, with the daemon reporting "derived graph tree has 1 artifacts but
repository authority has 2", an admission race in that fixture. The environment
was measured on both runs rather than assumed: the failing run was on a box at
load 42 with the gate compiling beside other lanes, the same test passes solo
here in 197.86s, and it passed on both hosted operating systems. The clean 6759
run above is on the identical commit.

Every hosted check has concluded: 34 pass, 4 skipping matrix parents, 0 failing,
0 pending, including Check & Test on ubuntu-latest and macos-latest, both macOS
shards, Falsify guards, the three Windows authority legs, Install Proof and
Docker Image Build.

`git ls-tree -r HEAD --name-only | command grep -F '.cargo/'` prints only
`.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is
empty.

Closes FIR-2559
Closes FIR-2558
Closes FIR-2560
Refs FIR-2545
