### PR TITLE
Refuse to certify an absence over a coverage map that measured nothing

### DIFF
--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -77,6 +77,15 @@ pub const REFERENCE_RESOLUTION_KEY: &str = "reference_resolution";
 /// [`crate::negative`].
 pub const NAME_FILTER_KEY: &str = "name_filter";
 
+/// What the `language` field reads when the answer resolved no entity to take a
+/// language from, so the observation names the absence rather than guessing one.
+///
+/// Shared with [`crate::negative`], which has to be able to tell an observation
+/// about a real language from one about none: a gap sentence naming a language's
+/// extractor coverage answers a question nobody asked when no language was
+/// named, and displaces the reason the reader actually needs.
+pub const NO_RESOLVED_LANGUAGE: &str = "no resolved language";
+
 /// How many entities may have their relations read while looking for a witness.
 ///
 /// A healthy graph answers in single digits, so this bound is only reached on a
@@ -291,7 +300,7 @@ pub fn observe_cross_file_reference_coverage_for_languages_witnessed<S: EntitySt
     // and an empty string would read as one. Naming the absence keeps the reason
     // it produces readable.
     let language = if observed_languages.is_empty() {
-        "no resolved language".to_string()
+        NO_RESOLVED_LANGUAGE.to_string()
     } else {
         observed_languages
             .iter()
@@ -356,7 +365,7 @@ pub fn observe_absence_scope(languages: &[LanguageId], scope_entities: Option<us
         }
     }
     let language = if observed.is_empty() {
-        "no resolved language".to_string()
+        NO_RESOLVED_LANGUAGE.to_string()
     } else {
         observed
             .iter()

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -38,11 +38,13 @@ or merely \"not indexed yet\" — check it before treating \"none found\" as gro
 truth. This filter reads the entity index rather than the vector index, so its \
 absence is gated on the graph being complete, not on embedding coverage. An empty \
 answer also carries `edge_coverage`, naming the languages the filter's own scope \
-spans and how many entities it holds with the name pattern removed, and the absence \
-is NOT certified when that scope is empty or when its language is one this build \
-wires no language-server adapter for: nothing then resolves the program behind the \
-declarations, so a miss cannot separate a symbol the repository lacks from one the \
-extractor never admitted as an entity of that kind.";
+spans and how many entities it holds with the name pattern removed. Nothing measures \
+a coverage class for those languages yet, so an empty answer is never certified: a \
+miss cannot separate a declaration the repository lacks from one the extractor never \
+admitted as an entity, and a file the graph has not admitted reads the same way. \
+Where a sharper reason applies it leads instead, naming a scope the index never \
+populated, a language this build wires no adapter for, or the narrowing filter that \
+removed every candidate the name did match.";
 
 pub fn handle_semantic_search<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
@@ -3055,10 +3057,11 @@ candidate and exhaust your round-trips on a large repo. Use dead_code instead wh
 want a whole-repo or file-scoped sweep rather than a concept-seeded one, and \
 bulk_check_references when you already hold the exact set of entity IDs to classify. \
 When the seed matches nothing the response carries an additive `negative` object beside \
-an `edge_coverage` naming the languages the graph holds, and that absence is not \
-certified on a language this build wires no language-server adapter for, because a seed \
-that matched no declaration cannot then separate a symbol the repository lacks from one \
-the extractor never admitted.";
+an `edge_coverage` naming the languages the graph holds. Nothing measures a coverage \
+class for them yet, so that absence is never certified: a seed that matched no \
+declaration cannot separate a symbol the repository lacks from one the extractor never \
+admitted. A language this build wires no language-server adapter for is named as the \
+sharper reason where it applies.";
 
 /// Seeded find-dead-code primitive: `semantic_search(query)` + per-candidate
 /// reference counting + dead-filter, returned as one structured response, so
@@ -4118,8 +4121,10 @@ When no neighbors come back, the additive `negative` object's `safe_to_conclude_
 flag says whether that absence is authoritative or merely \"not indexed yet\", and its \
 `subject` scopes the absence to the side that was walked, so an empty 'in' result is never \
 read as \"no dependencies\". A walk that expanded no edge also carries `edge_coverage` \
-naming the focal's language, and the absence is not certified when this build wires no \
-language-server adapter for it. A focal that is not in the graph is reported as that gap \
+naming the focal's language. Nothing measures a coverage class for it yet, so an empty \
+walk is never certified as isolation: an entity nothing reaches and one whose incoming \
+edges were never linked read the same here. A build that wires no language-server \
+adapter for that language is named as the sharper reason where it applies. A focal that is not in the graph is reported as that gap \
 rather than as an isolated entity. Every edge also carries `resolution` \
 (`type_resolved`, `import_scoped`, `name_only`) saying how strongly its destination was \
 proven; a `name_only` edge was matched by bare name and is a candidate, not structure you \
@@ -5089,7 +5094,8 @@ mod tests {
     /// absence on the same repository because this build wires no
     /// language-server adapter for JavaScript.
     #[test]
-    fn a_javascript_search_absence_is_inconclusive_while_a_python_one_still_certifies() {
+    fn a_javascript_search_absence_names_an_unresolved_program_and_a_python_one_names_unmeasured_coverage(
+    ) {
         // A Python developer's machine: pyright installed, no JavaScript server.
         // Stated rather than inherited, because the whole contrast below is
         // between a language something resolved and one nothing did, and a test
@@ -5157,10 +5163,14 @@ mod tests {
             "{negative}"
         );
 
-        // The other direction on the same code path. Python is a language this
-        // build wires an adapter for, so a name nothing carries is still a
-        // certifiable absence and the fix has not degraded into marking
-        // everything uncertain.
+        // The other direction on the same code path, and what makes it a test
+        // rather than a tautology: both arms refuse this zero and they refuse it
+        // for different reasons, which is the discrimination the gate exists to
+        // make. JavaScript's program is unresolved, so nothing could have linked
+        // it; Python's resolves, and what stops the certification there is the
+        // coverage class nothing measured (FIR-2496). Read the reasons, not the
+        // flags: if the enrichment gate were removed, this arm's reason would
+        // appear on the arm above.
         let python = InMemoryGraph::new();
         python
             .upsert_entity(&module_entity(LanguageId::Python, "utils", "app/utils.py"))
@@ -5198,13 +5208,23 @@ mod tests {
             &[],
         )
         .expect("an empty search carries a negative");
-        // The Python half certifies, and FIR-2464 is what earns it: the host
-        // probe found a server for this language, so the observation reports
-        // `available` rather than leaving the question open. What stops a
-        // narrowed name filter certifying a false zero is FIR-2452's own gate on
-        // the name's side, not this one.
-        assert_eq!(negative["safe_to_conclude_absent"], true);
-        assert_eq!(negative["trust"], "authoritative");
+        // The Python half clears the enrichment gate, and FIR-2464 is what earns
+        // it: the host probe found a server for this language, so the
+        // observation reports `available` rather than leaving the question open.
+        // It still does not certify, because `observe_absence_scope` measures no
+        // coverage class and the shipped v0.5.43 answer that did certify on this
+        // exact shape was wrong twice in one session.
+        assert_eq!(negative["safe_to_conclude_absent"], false);
+        assert_eq!(negative["trust"], "inconclusive");
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("absence_coverage_unmeasured"),
+            "a resolved program with no measured coverage names that: {negative}"
+        );
+        assert!(
+            !reason.contains("entity_index_unresolved"),
+            "the JavaScript reason must not appear on a language this host resolves: {negative}"
+        );
     }
 
     /// The reported call from the v0.5.41 stranger run, end to end (FIR-2452).
@@ -5281,11 +5301,16 @@ mod tests {
             "{negative}"
         );
 
-        // Positive control on the same store and the same kind filter: a name
-        // nothing carries matches nothing on its own, so no filter removed
-        // anything and the absence is still certifiable. Without this the fix
-        // would be indistinguishable from marking every kind-filtered answer
-        // uncertain.
+        // Control on the same store and the same kind filter: a name nothing
+        // carries matches nothing on its own, so no filter removed anything and
+        // this gate stays quiet. Without it the fix would be indistinguishable
+        // from firing the name-filter reason on every kind-filtered answer.
+        //
+        // The zero is not certifiable either, since FIR-2496: this store's
+        // observation measures no coverage class, so nothing separates a
+        // declaration the repository lacks from one the extractor never
+        // admitted. What separates the two cases is which reason leads, and that
+        // is what this control now reads.
         let absent = parsed_response(
             &handle_semantic_search(&search_args("zzz_not_a_symbol", Some("method")), &store)
                 .unwrap(),
@@ -5304,8 +5329,18 @@ mod tests {
         )
         .expect("an empty search carries a negative");
         assert_eq!(
-            negative["safe_to_conclude_absent"], true,
-            "a name that matches nothing at all is still a certifiable absence: {negative}"
+            negative["safe_to_conclude_absent"], false,
+            "an unmeasured coverage class stops this zero too: {negative}"
+        );
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with("absence_coverage_unmeasured"),
+            "a name that matched nothing is limited by the coverage nobody measured, not by a \
+             filter that removed nothing: {negative}"
+        );
+        assert!(
+            !reason.contains("name_filter_narrowed_to_zero"),
+            "no candidate was removed here, so that gate must stay quiet: {negative}"
         );
 
         // And a query that applied no narrowing filter publishes no name-filter
@@ -7630,7 +7665,20 @@ mod tests {
         );
         let response = parsed_response(&annotated);
         assert_eq!(response["negative"]["kind"], "no_neighbors");
-        assert_eq!(response["negative"]["safe_to_conclude_absent"], true);
+        // The promise is that the object arrives and says how far the walk can
+        // be trusted. Since FIR-2496 the answer on this store is that it cannot
+        // certify: the walk publishes an observation that measured no coverage
+        // class, so "isolated" and "never linked" are the same reading of the
+        // same zero, and the flag says so rather than picking one.
+        assert_eq!(response["negative"]["safe_to_conclude_absent"], false);
+        assert!(
+            response["negative"]["trust_reason"]
+                .as_str()
+                .expect("the negative must carry a trust reason")
+                .contains("absence_coverage_unmeasured"),
+            "the reason names the measurement nothing took: {}",
+            response["negative"]
+        );
         assert!(
             response["negative"]["subject"]
                 .as_str()

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -575,22 +575,36 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
         return None;
     }
     let named = requested.join(", ");
+    let claims_absence = answer_claims_absence(tool, payload);
 
     let Some(coverage) = payload
         .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
         .and_then(Value::as_object)
     else {
-        return Some(if requested.is_empty() {
-            "absence_coverage_unreported: this answer did not report which languages the absence \
-             claim spans or whether this build can resolve their programs, so an empty result \
-             cannot be distinguished from a scope the extractor never populated"
-                .to_string()
-        } else {
+        return Some(if !requested.is_empty() {
             format!(
                 "edge_coverage_unreported: this answer did not report whether the graph holds \
                  cross-file {named} edges, so an empty result cannot be distinguished from a graph \
                  that could not have found a reference in the first place"
             )
+        } else if claims_absence {
+            "absence_coverage_unreported: this answer did not report which languages the absence \
+             claim spans or whether this build can resolve their programs, so an empty result \
+             cannot be distinguished from a scope the extractor never populated"
+                .to_string()
+        } else {
+            // FIR-2496. The same missing observation, read against the claim the
+            // answer actually made. A response holding rows asserts no absence,
+            // and handing it the sentence above put the one caveat about
+            // absences on the one call that was not making one: on the v0.5.43
+            // stranger run three empty searches certified byte-identically while
+            // `notes_with_tag`, which returned a row, was the response that read
+            // `limiting_factor: absence_coverage_unreported`. The limit is real
+            // either way, and what it limits is different, so it says so.
+            "answer_coverage_unreported: this answer did not report which languages its rows \
+             span or whether this build can resolve their programs, so the rows here are a floor \
+             and a declaration the extractor never admitted could not be among them"
+                .to_string()
         });
     };
     let language = coverage
@@ -787,7 +801,104 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
         });
     }
 
+    // FIR-2496, and the gate every other one in this function was standing in
+    // for. An observation that measured no coverage class states nothing about
+    // what the extractor admitted, and nothing observed is not the same fact as
+    // every input agreeing. Until FIR-2496 an empty class map read as the
+    // second: on the v0.5.43 stranger run `semantic_search("SCHEMA")` and
+    // `semantic_search("build_match_query")` both returned zero over
+    // `"classes": {}` and both certified `safe_to_conclude_absent: true`,
+    // `trust: "authoritative"`, `limiting_factor: null`. `SCHEMA` was a
+    // module-level constant at `storage.py:24` that the Python extractor skips
+    // because it is a triple-quoted string, sitting between two one-line
+    // constants the same file's parse admitted (FIR-2509), and
+    // `build_match_query` was a function in a file the graph had not admitted at
+    // all. Neither was absent from the repository. Both were absent from the
+    // index, which is the one thing an unmeasured class map cannot tell apart.
+    //
+    // It reads the observation rather than the tool name, so it is not a
+    // blocklist: a producer that measures a class for this scope lifts the
+    // refusal by publishing the measurement, and no producer does today. The
+    // requested-class tools are excluded because the block above already reports
+    // their unmeasured classes by name, and one fact stated twice in one reason
+    // is not stated better.
+    //
+    // Last in the list on purpose. Every gap above is a positive finding about a
+    // measured thing, and a sharper reason has to lead a composed one; this is
+    // the reason that applies when nothing sharper was observed.
+    //
+    // Fires only on a real language, for the reason the enrichment gate above
+    // fires only on a positive finding: an answer that resolved no language has
+    // no language's extractor coverage to be missing, and a sentence about one
+    // would displace the reason such an answer actually carries, which is that
+    // its focal is not in the graph or that its filter selected an empty region.
+    // Both of those are reported by name, so nothing here is left ungated.
+    if coverage_classes_unmeasured(coverage, &requested) {
+        gaps.push(if claims_absence {
+            format!(
+                "absence_coverage_unmeasured: no coverage class was measured for {language}, so \
+                 nothing established what the extractor admitted for it, and an empty result \
+                 cannot be separated from a declaration the extractor never admitted as an entity \
+                 or from a file the graph does not hold yet"
+            )
+        } else {
+            format!(
+                "answer_coverage_unmeasured: no coverage class was measured for {language}, so \
+                 the rows here are a floor and a declaration the extractor never admitted could \
+                 not be among them"
+            )
+        });
+    }
+
     (!gaps.is_empty()).then(|| gaps.join("; "))
+}
+
+/// Whether this response asserts that something is NOT there, as opposed to
+/// returning rows and leaving the question of how complete they are.
+///
+/// One definition, read by [`absence_coverage_gap`] so a coverage limit is
+/// stated against the claim the answer actually made, and by [`negative_for`] so
+/// the two cannot drift. Before FIR-2496 the gate had no idea which it was
+/// looking at, so an answer with rows was handed a sentence about what an empty
+/// result cannot be distinguished from, and three empty answers beside it were
+/// handed nothing at all.
+///
+/// The reading is the spec's: a tool whose spec `always` qualifies is making a
+/// per-row verdict claim (`bulk_check_references`, `impact_analysis`), a locate
+/// page whose ranking names nothing is claiming the name is not there, and every
+/// other tool claims an absence exactly when its answer group came back empty. A
+/// tool with no spec claims nothing, because this module does not qualify it.
+///
+/// An answer group the payload does not carry reads as an absence claim, which
+/// is [`negative_for`]'s own reading of the same shape: an omitted group makes
+/// the same claim as an empty one and is the more dangerous of the two, since a
+/// missing key reads as a question the tool does not answer. Only a group that
+/// is present and populated makes this false, so the rows phrasing is reached
+/// from evidence of rows rather than from the absence of evidence.
+fn answer_claims_absence(tool: &str, payload: &Value) -> bool {
+    let Some(spec) = spec_for(tool) else {
+        return false;
+    };
+    // A walk that expanded edges is reporting what it found, whatever its
+    // entity collection reads: `graph_neighborhood` returns the focal itself in
+    // that collection, so the count alone cannot tell a populated walk from an
+    // isolated focal. `relation_count` can.
+    if tool == "graph_neighborhood"
+        && payload
+            .get("relation_count")
+            .and_then(Value::as_u64)
+            .is_some_and(|total| total > 0)
+    {
+        return false;
+    }
+    if spec.always {
+        return true;
+    }
+    if tool == "semantic_locate" {
+        return locate_result_count(payload).is_none_or(|count| count == 0)
+            || locate_ranking_names_nothing(payload);
+    }
+    collection_len(payload, spec.field).is_none_or(|count| count == 0)
 }
 
 /// Whether a POPULATED answer from `tool` carries the response's verdict too,
@@ -829,6 +940,42 @@ pub(crate) fn declares_absence_dependency(tool: &str, payload: &Value) -> bool {
     !absence_cross_file_classes(tool, payload).is_empty()
         || absence_is_language_scoped(tool)
         || tool == FILE_ENTITIES_TOOL
+}
+
+/// Whether this observation measured no coverage class at all for a language it
+/// named, which is the state FIR-2496 found certifying absences.
+///
+/// Three readers ask the same question and one answer serves them:
+/// [`absence_coverage_gap`] refuses the certification,
+/// [`edge_coverage_degradation_labels`] discloses the shortfall beside it, and
+/// [`crate::verdict`] records the coverage input's own reading. A reason with no
+/// signal beside it, or a signal with no reason, is the drift this module keeps
+/// catching, so the three read one function rather than three copies of a
+/// condition.
+///
+/// Scoped to an observation that named a language and declared no edge class.
+/// The class-declaring tools report their unmeasured classes by name one gate
+/// above, and an answer that resolved no language has no language's extractor
+/// coverage to be missing.
+pub(crate) fn coverage_classes_unmeasured(
+    coverage: &Map<String, Value>,
+    requested: &[String],
+) -> bool {
+    if !requested.is_empty() {
+        return false;
+    }
+    let named = coverage
+        .get("language")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|language| {
+            !language.is_empty() && language != crate::edge_coverage::NO_RESOLVED_LANGUAGE
+        });
+    named
+        && coverage
+            .get("classes")
+            .and_then(Value::as_object)
+            .is_none_or(Map::is_empty)
 }
 
 /// One class's observed state, defaulting to `unknown` for a class the
@@ -891,6 +1038,9 @@ pub(crate) fn edge_coverage_degradation_labels(tool: &str, payload: &Value) -> V
             state => Some(format!("edge_coverage:{class}_{state}")),
         })
         .collect();
+    if coverage_classes_unmeasured(coverage, &requested) {
+        labels.push("absence_coverage:classes_unmeasured".to_string());
+    }
     if coverage.get("scope_entities").and_then(Value::as_u64) == Some(0) {
         labels.push("absence_coverage:scope_empty".to_string());
     }
@@ -1797,7 +1947,12 @@ pub fn negative_for(
     // rows asserts nothing of the kind, and still gets qualified: the gates
     // below decide how far its rows can be trusted as the whole set, which is
     // the question `graph_neighborhood` used to leave unanswered.
-    let mut claims_absence = count == 0 || spec.always || ranking_names_nothing;
+    //
+    // Read from [`answer_claims_absence`] rather than recomputed, because
+    // [`absence_coverage_gap`] states its limit against the same claim and two
+    // readings of one question are how a caveat about absences came to ride on
+    // an answer with rows (FIR-2496).
+    let claims_absence = answer_claims_absence(tool, payload);
     if !claims_absence && !qualifies_populated_answers(tool) {
         return None;
     }
@@ -1952,7 +2107,9 @@ pub fn negative_for(
         // The emitted edge array is capped by the caller's `limit`, and a
         // `limit` of zero empties it while the walk still found neighbors. The
         // pre-truncation total is what decides whether anything was there, so a
-        // truncated answer is never dressed up as an absence.
+        // truncated answer is never dressed up as an absence. That reading lives
+        // in [`answer_claims_absence`] since FIR-2496, so the gate reads the same
+        // one rather than a second copy of it.
         //
         // It stops the ABSENCE framing and no longer stops the qualifier. This
         // returned `None` until FIR-2463, which is why a neighborhood that walked
@@ -1960,13 +2117,6 @@ pub fn negative_for(
         // claim at all, in the same session where `find_references` refused to
         // certify the same entity over the same edges. Whichever tool you reached
         // for first decided what you believed.
-        if payload
-            .get("relation_count")
-            .and_then(Value::as_u64)
-            .is_some_and(|total| total > 0)
-        {
-            claims_absence = false;
-        }
         let neighborhood_gap = if payload.get("entity_count").and_then(Value::as_u64) == Some(0) {
             kind = "focal_not_in_graph";
             subject = "the focal entity is not in the graph, so no neighborhood was walked";
@@ -2397,6 +2547,30 @@ mod tests {
         observation
     }
 
+    /// The same scope observation with one coverage class actually measured for
+    /// the language, which is the shape that lifts the FIR-2496 refusal.
+    ///
+    /// It exists because the refusal reads the observation and not the tool
+    /// name, and every case below that asserts a certification has to be able to
+    /// prove that. A rule that refused these tools by name would pass every test
+    /// that only ever shows it an unmeasured map, and would go on refusing after
+    /// the measurement arrived. It is also what keeps those cases falsifiable:
+    /// with no payload that can certify, a control asserting "the gate can still
+    /// pass" is a check that cannot pass, which is no more evidence than one
+    /// that cannot fail.
+    ///
+    /// No producer emits this today. `observe_absence_scope` measures no class
+    /// on purpose, so every `semantic_search`, `find_dead_code_seeded` and
+    /// `graph_neighborhood` absence this build produces is inconclusive, and
+    /// FIR-2509's extractor-coverage measurement is the work that would change
+    /// that.
+    fn scope_with_a_measured_class(scope_entities: Option<usize>) -> Value {
+        let mut observation = resolvable_language_scope(scope_entities);
+        observation["classes"] = json!({ "calls": "present" });
+        observation["cross_file_classes"] = json!(["calls"]);
+        observation
+    }
+
     /// The same observation over a language nothing resolved: the express
     /// shape, where `imports` and `references` were never produced.
     ///
@@ -2670,8 +2844,10 @@ mod tests {
         // embeddings were complete. It answers to the graph gate instead, which
         // is the substrate it actually reads. Since FIR-2430 that substrate has
         // to be OBSERVED rather than assumed, so the page carries the scope its
-        // filter selected; embedding coverage is still not what decides.
-        let payload = empty_search_page(resolvable_language_scope(Some(12)));
+        // filter selected, and since FIR-2496 that observation has to have
+        // measured something; embedding coverage is still not what decides
+        // either way.
+        let payload = empty_search_page(scope_with_a_measured_class(Some(12)));
         let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
             .expect("empty results yields a negative");
         assert_eq!(negative["safe_to_conclude_absent"], json!(true));
@@ -2737,12 +2913,18 @@ mod tests {
     }
 
     #[test]
-    fn a_resolvable_language_still_certifies_a_genuinely_absent_declaration() {
+    fn a_measured_scope_still_certifies_a_genuinely_absent_declaration() {
         // The other direction, and the regression bar FIR-2404 set: the fix must
         // not degrade into marking everything inconclusive. Python is a language
-        // this build wires an adapter for, so an empty name filter over a
-        // populated region is still a certifiable absence.
-        let payload = empty_search_page(resolvable_language_scope(Some(29)));
+        // this build wires an adapter for, and this answer's observation measured
+        // a class over it, so an empty name filter over a populated region is
+        // still a certifiable absence.
+        //
+        // The measurement is what carries it since FIR-2496, and the pair below
+        // is the whole rule in two readings: the same payload with the same
+        // language, the same populated region and the same healthy envelope
+        // certifies when a class was measured and refuses when none was.
+        let payload = empty_search_page(scope_with_a_measured_class(Some(29)));
         let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
             .expect("empty results yields a negative");
         assert_eq!(negative["safe_to_conclude_absent"], json!(true));
@@ -2751,6 +2933,148 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("structural_authoritative"));
+
+        let unmeasured = empty_search_page(resolvable_language_scope(Some(29)));
+        let negative = negative_for("semantic_search", &unmeasured, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "an unmeasured class map is the FIR-2496 shape and cannot certify: {negative}"
+        );
+    }
+
+    /// FIR-2496, the reported shape. Three empty searches in one session on a
+    /// green store certified byte-identical verdicts over `"classes": {}`, and
+    /// two of them were wrong: `SCHEMA` is a module-level constant at
+    /// `storage.py:24` that the Python extractor skips because it is
+    /// triple-quoted, sitting between two one-line constants the same parse
+    /// admitted, and `build_match_query` is a function in a file the graph had
+    /// not admitted at all. Neither was absent from the repository. Both were
+    /// absent from the index, and an unmeasured class map is exactly the
+    /// observation that cannot tell those apart.
+    #[test]
+    fn an_unmeasured_class_map_cannot_certify_an_absence() {
+        let payload = empty_search_page(resolvable_language_scope(Some(51)));
+        let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "nothing observed is not every input agreeing: {negative}"
+        );
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with("absence_coverage_unmeasured"),
+            "the limiting factor names the measurement nothing took: {reason}"
+        );
+        assert!(
+            reason.contains("for Python"),
+            "it names the language whose coverage went unmeasured: {reason}"
+        );
+        assert!(
+            reason.contains("never admitted"),
+            "and what that leaves indistinguishable from a true absence: {reason}"
+        );
+        let advice = negative["advice"].as_str().unwrap();
+        assert!(
+            !advice.contains("Absence is authoritative"),
+            "the advice a reader acts on follows the verdict: {advice}"
+        );
+        assert!(
+            negative["degraded_signals"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("absence_coverage:classes_unmeasured")),
+            "the shortfall the verdict rests on is disclosed beside it, so a reader never has \
+             to parse the reason sentence to find it: {negative}"
+        );
+
+        // Every other gate reads healthy on this payload, which is why it
+        // certified for four releases: the region holds 51 entities, the
+        // language resolves on this host, and no narrowing filter removed a
+        // candidate. Asserted so a later change cannot make this case pass for
+        // one of those reasons instead.
+        assert!(
+            !reason.contains("absence_scope_empty") && !reason.contains("entity_index_unresolved"),
+            "no other gate fired here, so this one is doing the work: {reason}"
+        );
+    }
+
+    /// The other half of FIR-2496, and the one the stranger noticed first: the
+    /// caveat about absences was riding the one call that asserted none. Of four
+    /// searches in that session, `notes_with_tag` returned a row and was the
+    /// response that read `limiting_factor: absence_coverage_unreported`, while
+    /// the three empty ones carried nothing. A limit stated against a claim the
+    /// answer never made teaches a reader to skip the limit.
+    #[test]
+    fn a_search_that_returned_rows_is_not_qualified_by_a_caveat_about_absences() {
+        let populated = json!({
+            "query": "notes_with_tag",
+            "limit": 10,
+            "total_matches": 1,
+            "truncated": false,
+            "results": [{ "name": "notes_with_tag", "kind": "Function" }],
+        });
+        let negative = negative_for("semantic_search", &populated, &structural_ready_envelope())
+            .expect("every retrieval answer carries the response verdict");
+        assert_eq!(negative["interpretation"], json!("qualified_answer"));
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            !reason.contains("absence_coverage_unreported"),
+            "an answer with rows asserts no absence and must not be limited by one: {negative}"
+        );
+        assert!(
+            reason.starts_with("answer_coverage_unreported"),
+            "the same missing observation, stated against the claim this answer made: {reason}"
+        );
+        assert!(
+            reason.contains("rows here are a floor"),
+            "which is that its rows may be short, not that an absence is unsafe: {reason}"
+        );
+
+        // The empty answer from the same tool keeps the absence wording, so the
+        // split is between the two claims rather than a rename of one of them.
+        let empty = json!({
+            "query": "notes_with_tag",
+            "limit": 10,
+            "total_matches": 0,
+            "truncated": false,
+            "results": [],
+        });
+        let negative = negative_for("semantic_search", &empty, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("absence_coverage_unreported"),
+            "{negative}"
+        );
+    }
+
+    /// The regression bar in the other direction, on the surface that measures
+    /// what it reads. A tool whose observation carries a class map is judged on
+    /// that map, so a fully enriched store still certifies a true absence and
+    /// FIR-2496 has not degraded into marking every answer uncertain.
+    #[test]
+    fn a_healthy_enriched_store_still_certifies_a_true_absence() {
+        let payload = authoritative_empty_references("function");
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("an empty reference list carries a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "a measured class map certifies exactly as it did before: {negative}"
+        );
+        assert_eq!(negative["trust"], json!("authoritative"));
+        assert_eq!(
+            payload[crate::edge_coverage::EDGE_COVERAGE_KEY]["classes"]["calls"],
+            json!("present"),
+            "and the measurement it rests on is in the payload: {payload}"
+        );
     }
 
     /// A narrowing filter that removed every candidate the name DID match
@@ -2803,8 +3127,10 @@ mod tests {
 
         // Positive control on the same payload shape: the name matched nothing
         // on its own, so the narrowing filter removed nothing and the absence is
-        // the name's, not the filter's. The gate reads the count.
-        let mut matched_nothing = resolvable_language_scope(Some(256));
+        // the name's, not the filter's. The gate reads the count. It carries a
+        // measured class since FIR-2496, or the control could not pass whatever
+        // this gate did.
+        let mut matched_nothing = scope_with_a_measured_class(Some(256));
         matched_nothing["name_filter"] = json!({ "narrowed_by": ["kind"], "candidates": 0 });
         let negative = negative_for(
             "semantic_search",
@@ -2824,7 +3150,7 @@ mod tests {
     /// sentence supplied the word anyway.
     #[test]
     fn a_certified_search_absence_states_no_verdict_about_use() {
-        let payload = empty_search_page(resolvable_language_scope(Some(29)));
+        let payload = empty_search_page(scope_with_a_measured_class(Some(29)));
         let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
             .expect("empty results yields a negative");
         assert_eq!(
@@ -2943,8 +3269,10 @@ mod tests {
             .unwrap()
             .contains(&json!("absence_coverage:scope_empty")));
         // Positive control on the same payload shape: one entity in the region
-        // and the same absence certifies, so the gate reads the count.
-        let populated = empty_search_page(resolvable_language_scope(Some(1)));
+        // and the same absence certifies, so the gate reads the count. It carries
+        // a measured class since FIR-2496, which is the other input a
+        // certification needs.
+        let populated = empty_search_page(scope_with_a_measured_class(Some(1)));
         let negative = negative_for("semantic_search", &populated, &structural_ready_envelope())
             .expect("empty results yields a negative");
         assert_eq!(negative["safe_to_conclude_absent"], json!(true));
@@ -2958,7 +3286,7 @@ mod tests {
         // was never what backed a structural claim. A negative names the basis
         // its verdict rests on and recites THAT, so an unknown coverage can no
         // longer sit beside a certification it did not back.
-        let payload = empty_search_page(resolvable_language_scope(Some(29)));
+        let payload = empty_search_page(scope_with_a_measured_class(Some(29)));
         let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
             .expect("empty results yields a negative");
         assert_eq!(negative["trust"], json!("authoritative"));
@@ -3029,10 +3357,10 @@ mod tests {
             .unwrap()
             .starts_with("entity_index_unresolved"));
 
-        // Positive control for both: a resolvable language certifies, so
-        // neither gate is one that always fires.
+        // Positive control for both: a resolvable language whose observation
+        // measured a class certifies, so neither gate is one that always fires.
         let mut neighborhood = neighborhood_payload("in", 0);
-        neighborhood["edge_coverage"] = resolvable_language_scope(None);
+        neighborhood["edge_coverage"] = scope_with_a_measured_class(None);
         assert_eq!(
             negative_for(
                 "graph_neighborhood",
@@ -3046,7 +3374,7 @@ mod tests {
             "query": "utils",
             "total_searched": 0,
             "candidates": [],
-            "edge_coverage": resolvable_language_scope(Some(29)),
+            "edge_coverage": scope_with_a_measured_class(Some(29)),
         });
         assert_eq!(
             negative_for(
@@ -3225,7 +3553,7 @@ mod tests {
             "initialized": true,
             "graph_entity_count": 0,
         }));
-        let payload = empty_search_page(resolvable_language_scope(Some(12)));
+        let payload = empty_search_page(scope_with_a_measured_class(Some(12)));
         let negative = negative_for("semantic_search", &payload, &empty_graph)
             .expect("empty results yields a negative");
         assert_eq!(negative["safe_to_conclude_absent"], json!(false));
@@ -3940,7 +4268,7 @@ mod tests {
     /// so, so the repair adds a fact rather than removing one.
     #[test]
     fn a_verdict_with_no_signals_still_says_it_has_none() {
-        let payload = empty_search_page(resolvable_language_scope(Some(12)));
+        let payload = empty_search_page(scope_with_a_measured_class(Some(12)));
         let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
             .expect("empty results yields a negative");
         assert_eq!(negative["degraded_signals"], json!([]));
@@ -4398,7 +4726,7 @@ mod tests {
 
     /// The neighborhood always returns the focal itself, so keying its absence
     /// on the entity list meant the qualifier the tool's own description
-    /// promises never fired for an entity that is in the graph — the only case
+    /// promises never fired for an entity that is in the graph, the only case
     /// an agent asks "is this really isolated?" about.
     #[test]
     fn neighborhood_with_no_neighbors_is_qualified() {
@@ -4407,7 +4735,21 @@ mod tests {
             .expect("an indexed focal with no neighbors must carry a negative");
         assert_eq!(negative["kind"], json!("no_neighbors"));
         assert_eq!(negative["result_count"], json!(0));
-        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+        // The qualifier arriving is what this case is about, and since FIR-2496
+        // what it says is that the walk cannot certify isolation: the handler's
+        // observation measures no coverage class, so an entity nothing reaches
+        // and an entity whose incoming edges were never linked read the same
+        // here. The same payload with a class measured certifies, which is the
+        // control in
+        // `the_neighborhood_and_the_seeded_scan_answer_to_the_same_gate`.
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .contains("absence_coverage_unmeasured"),
+            "the reason names the measurement nothing took: {negative}"
+        );
     }
 
     /// One neighbor is not an absence, whichever side it sits on.

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -366,10 +366,29 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
     }
 
     let requested = crate::negative::absence_cross_file_classes(tool, payload);
+    let states = coverage.get("classes").and_then(Value::as_object);
     if requested.is_empty() {
+        // FIR-2496. This input used to answer `certified` for any observation
+        // that named no class to check, which is every observation a tool
+        // traversing no edge publishes. That is agreement inferred from silence:
+        // the shipped verdict block read `"inputs": {"edge_coverage":
+        // "certified"}` over `"classes": {}` on the two searches that were wrong
+        // and on the one that was right, with nothing separating them. An
+        // observation that measured nothing licenses nothing, and the absence
+        // gate leads with the sharper wording when both refuse.
+        //
+        // On a real language only, matching the gate: an answer that resolved
+        // none has no language's coverage to be missing, and it carries its own
+        // sharper reason. Read from the gate's own function so the input's
+        // reading and the refusal can never disagree about one observation.
+        if crate::negative::coverage_classes_unmeasured(coverage, &requested) {
+            return Reading::Inconclusive(format!(
+                "absence_coverage_unmeasured: this answer measured no coverage class for \
+                 {language}, so nothing established what the extractor admitted for it"
+            ));
+        }
         return Reading::Certified;
     }
-    let states = coverage.get("classes").and_then(Value::as_object);
     let deciding = crate::negative::load_bearing_classes(&requested);
     let unhealthy: Vec<&str> = deciding
         .iter()
@@ -877,6 +896,90 @@ mod tests {
             verdict.to_value()["state"],
             json!(CERTIFIED),
             "{}",
+            verdict.to_value()
+        );
+    }
+
+    /// FIR-2496. The `edge_coverage` input used to answer `certified` for an
+    /// observation that named no class to check, which is every observation a
+    /// tool traversing no edge publishes. The shipped v0.5.43 verdict block read
+    /// `"inputs": {"edge_coverage": "certified"}` over `"classes": {}` on three
+    /// searches, two of which were wrong: `SCHEMA` was a module constant the
+    /// Python extractor skips and `build_match_query` sat in a file the graph
+    /// had not admitted. Agreement inferred from silence is not agreement.
+    #[test]
+    fn an_unmeasured_class_map_is_not_an_agreeing_input() {
+        let payload = json!({
+            "results": [],
+            "total_matches": 0,
+            "edge_coverage": {
+                "scope": "absence_scope",
+                "language": "Python",
+                "requested_classes": [],
+                "classes": {},
+                "reference_enrichment": "available",
+                "scope_entities": 51,
+            },
+        });
+        let verdict = Verdict::compute("semantic_search", &payload, &Envelope::daemon(), None)
+            .expect("a retrieval payload carries a verdict");
+        let value = verdict.to_value();
+        assert_eq!(value["state"], json!(INCONCLUSIVE), "{value}");
+        assert_eq!(
+            value["inputs"]["edge_coverage"],
+            json!(INCONCLUSIVE),
+            "{value}"
+        );
+        assert!(
+            value["limiting_factor"]
+                .as_str()
+                .expect("an inconclusive verdict names its limiting factor")
+                .contains("absence_coverage_unmeasured"),
+            "{value}"
+        );
+
+        // The control that makes it a reading of the observation rather than of
+        // the tool name: one measured class over the same language, same filter,
+        // same store, and the same answer certifies.
+        let mut measured = payload.clone();
+        measured["edge_coverage"]["classes"] = json!({"calls": "present"});
+        let verdict = Verdict::compute("semantic_search", &measured, &Envelope::daemon(), None)
+            .expect("a retrieval payload carries a verdict");
+        assert_eq!(
+            verdict.to_value()["inputs"]["edge_coverage"],
+            json!(CERTIFIED),
+            "{}",
+            verdict.to_value()
+        );
+    }
+
+    /// The other half of the same rule. An answer that resolved no language has
+    /// no language's extractor coverage to be missing, and this input must not
+    /// invent one: the tools that produce that observation carry their own
+    /// sharper reason (an unresolved focal, an empty filtered region), and a
+    /// correct refusal beside an unrelated reason is what this module exists to
+    /// prevent.
+    #[test]
+    fn an_observation_that_resolved_no_language_is_not_refused_for_one() {
+        let payload = json!({
+            "entities": [],
+            "relations": [],
+            "relation_count": 0,
+            "entity_count": 0,
+            "edge_coverage": {
+                "scope": "absence_scope",
+                "language": crate::edge_coverage::NO_RESOLVED_LANGUAGE,
+                "requested_classes": [],
+                "classes": {},
+                "reference_enrichment": "unknown",
+            },
+        });
+        let verdict = Verdict::compute("graph_neighborhood", &payload, &Envelope::daemon(), None)
+            .expect("a retrieval payload carries a verdict");
+        assert_eq!(
+            verdict.to_value()["inputs"]["edge_coverage"],
+            json!(CERTIFIED),
+            "the coverage input says nothing about an answer with no language: {}",
             verdict.to_value()
         );
     }


### PR DESCRIPTION
`semantic_search`, `find_dead_code_seeded` and `graph_neighborhood` traverse no edge, so their absence scope is published by `observe_absence_scope` at `crates/kin-mcp/src/edge_coverage.rs:360`, which reports `"classes": {}` on purpose. The gate read that empty map as agreement. With no class to check, `absence_coverage_gap` at `crates/kin-mcp/src/negative.rs:571` skipped its class block and returned `None`, `absence_gate_reading` at `crates/kin-mcp/src/verdict.rs:302` read that as certified, and `edge_coverage_reading` at `crates/kin-mcp/src/verdict.rs:316` certified from its own `requested.is_empty()` early return. Nothing was observed, so nothing could disagree, so every input agreed.

That is the v0.5.43 answer FIR-2496 recorded. On one green store `semantic_search("SCHEMA")` and `semantic_search("build_match_query")` each returned zero and each certified `safe_to_conclude_absent: true`, `trust: "authoritative"`, `limiting_factor: null`, and neither name was absent from the repository. `SCHEMA` was a module-level constant the Python extractor skips because it is triple-quoted, sitting between two one-line constants the same parse admitted. `build_match_query` was a function in a file the graph had not admitted at all.

The same gate stated its limit against a claim the answer never made. `handle_semantic_search` at `crates/kin-mcp/src/handlers/entities.rs:99` attaches the observation only when `total_matches == 0`, so an answer holding rows reached the no-observation branch at `crates/kin-mcp/src/negative.rs:580` and took the `absence_coverage_unreported` sentence about what an empty result cannot be distinguished from. In that session it rode on `notes_with_tag`, the one call of four that returned a row.

## The fix

`coverage_classes_unmeasured` is one condition with three readers. The absence gate refuses the certification with `absence_coverage_unmeasured`, `edge_coverage_degradation_labels` discloses `absence_coverage:classes_unmeasured` beside the verdict, and the verdict's coverage input records the same reading. A reason with no signal, or a signal with no reason, is the drift this module keeps catching, so the three read one function rather than three copies of a condition.

It reads the observation and not the tool name, so a producer that measures a class for this scope lifts the refusal by publishing the measurement. No producer emits that today, and this PR states it rather than implying it: on this build every `semantic_search`, `find_dead_code_seeded` and `graph_neighborhood` absence now reads inconclusive, with the limiting factor naming the coverage class nothing measured and naming what that leaves indistinguishable from a true absence, which is a declaration the extractor never admitted or a file the graph does not hold yet. `find_references` and the other class-measuring tools are untouched and still certify.

It fires only on an observation that named a language. An answer that resolved none has no language's extractor coverage to be missing, and a sentence about one would displace the reason such an answer already carries, which is a focal that is not in the graph or a filter that selected an empty region. `NO_RESOLVED_LANGUAGE` is now a shared constant so the producer and the gate cannot spell that sentinel differently.

`answer_claims_absence` is one reading of whether a response asserts that something is not there, shared with `negative_for` so the two cannot drift. A populated answer takes `answer_coverage_unreported`, whose consequence clause says its rows are a floor. An answer group the payload does not carry still reads as an absence claim, which is `negative_for`'s own reading of that shape, so the rows wording is reached from evidence of rows rather than from the absence of evidence.

The envelope keeps its shape, with the same keys and fields carrying new values. The published contract text for the three tools now says what this build certifies. An empty `kin search` gains one qualifier line, rendered by the existing `crates/kin-cli/src/commands/absence_qualifier.rs` from the one gate's decision.

## Falsification

Each pass removed one property and predicted both directions before it ran. Every sabotage was confirmed applied by reading the `git diff` line it produced, and both files were restored and checked byte-identical by sha256 afterwards. Every exit status was read raw and every failure message in full, never through a pipe.

Pass 1 disabled the unmeasured-coverage refusal in both readers. It predicted seven failures and produced exactly those seven, `586 passed; 7 failed`. The headline one regenerates the defect the release carried:

```
an_unmeasured_class_map_cannot_certify_an_absence
  nothing observed is not every input agreeing:
  "safe_to_conclude_absent":true,"trust":"authoritative",
  "advice":"... Absence is authoritative for this filter: no declaration in the index
  carries this name under it. ..."
```

and the verdict case shows `"inputs":{"edge_coverage":"certified"}` over an empty class map, the line the ticket quoted. `a_search_that_returned_rows_is_not_qualified_by_a_caveat_about_absences` and `a_healthy_enriched_store_still_certifies_a_true_absence` both passed under pass 1 as predicted, which is what shows they guard different properties.

Pass 2 removed the claim split. It predicted one failure and produced one, `592 passed; 1 failed`:

```
a_search_that_returned_rows_is_not_qualified_by_a_caveat_about_absences
  an answer with rows asserts no absence and must not be limited by one:
  "result_count":1, "interpretation":"qualified_answer",
  "trust_reason":"absence_coverage_unreported: ... so an empty result cannot be
  distinguished from a scope the extractor never populated"
```

Pass 3 let the refusal fire whatever language the observation named. It predicted two failures and produced exactly those two, `591 passed; 2 failed`: `an_empty_neighborhood_publishes_the_scope_it_walked`, whose reason then led with unmeasured coverage for "no resolved language" ahead of the focal miss, and `an_observation_that_resolved_no_language_is_not_refused_for_one`.

## Tests

`an_unmeasured_class_map_cannot_certify_an_absence` is the reported shape, and it asserts that no other gate fired on that payload, so the refusal can only have come from this one. `a_search_that_returned_rows_is_not_qualified_by_a_caveat_about_absences` covers the rows half in both directions on one tool. `a_healthy_enriched_store_still_certifies_a_true_absence` is the regression bar in the other direction, on the surface that measures what it reads. `a_measured_scope_still_certifies_a_genuinely_absent_declaration` states the whole rule in one place, holding the language, the populated region and the envelope fixed while the measured class is what decides. Two more in `verdict.rs` guard the coverage input's own reading and the language restriction.

Of the eleven existing cases that changed, nine carried a positive control shaped "the same absence certifies, so this gate is one that can pass". Those now use a fixture whose observation measured a class, because with no payload that can certify they would have become checks that cannot pass. The other two run through the handler over a real store, where no fixture can change what the producer measures, so they assert the discrimination that survives. The JavaScript arm's reason names an unresolved program and the Python arm's names unmeasured coverage, and each asserts the other's reason is absent.

## Gates

The full local gate `bin/kin-lane run absentclass kin -- bin/kin-dev local-test kin` exited 0 over the tree its own line names, `/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/absentclass-kin @ cdbadcec (chore/lane-absentclass-kin)`. The verdict is read from the log rather than from an exit code: `Summary [ 464.228s] 6719 tests run: 6719 passed (4 slow), 12 skipped`, followed by the doctest pass with no failing result line, and kin-dev's own closing line "All repos green under 'cargo nextest run --workspace (+ cargo test --doc)', no tracked lock contamination". That total is from cdbadcec. The branch was then rebased onto origin/main at 199edead, and `cargo test -p kin-mcp --lib` on the rebased tree returned `593 passed; 0 failed`.

`cargo fmt --all -- --check` exits 0. Clippy exactly as `.github/workflows/ci.yml` runs it, under `RUSTFLAGS=-D warnings` with the `.github/clippy-allowed-lints.txt` allow list over `--all-targets --all-features`, exits 0 with zero error lines. `python3 scripts/verify-zero-file-search.py` exits 0 over 178 source files, `bash scripts/zero_file_search_guard.sh` exits 0, `bash scripts/check_runtime_boundaries.sh` exits 0 and `bash scripts/check_private_repo_coupling.sh` exits 0. `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

## Left undone

This does not close the ticket. Ask 3, admitting a triple-quoted Python module constant as an entity, is FIR-2509 and another lane's work, and ask 4's durability half is FIR-2499. Nothing here was reproduced against a live daemon; every result is from unit and handler tests over payload fixtures and in-memory graphs, plus the envelopes the stranger runs recorded.

Refs FIR-2496

## Follow-up producer

FIR-2581 tracks the High-priority graph-owned producer that must populate `EdgeCoverageObservation.classes` for `semantic_search`, `find_dead_code_seeded`, and `graph_neighborhood`. This PR intentionally ships the safe inconclusive verdict until that measured producer exists. The follow-up requires live-daemon acceptance before claiming certification restored.
