### PR TITLE
Arm the reconcile watch before publishing the endpoint, and stop certifying absence over a store the working copy has outrun

### DIFF
--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -633,8 +633,42 @@ pub fn run(base: Option<String>, head: Option<String>, json: bool) -> Result<()>
         for line in render_lines(&report) {
             println!("{line}");
         }
+        println!("{}", admitted_scope_line(&layout));
     }
     Ok(())
+}
+
+/// What this diff does not cover, and when the graph last caught up.
+///
+/// Both endpoints are admitted authority, so a file the working copy holds and
+/// no admission has taken contributes nothing to either side and the summary
+/// reads `+0 ~0 -0`. That answer is exactly right about authority and reads as
+/// "nothing changed" to anyone who just wrote a file, which is how a session
+/// concluded the graph could not see its own new module (FIR-2499). Naming the
+/// scope beside the counts is what tells those two apart.
+///
+/// The clock comes from the durable last-admission marker rather than from a
+/// daemon, because this command talks to none. That bounds what it can say: it
+/// reports WHEN the graph last caught up, never HOW MANY host paths are
+/// outstanding, which needs the daemon's own reconcile reading.
+fn admitted_scope_line(layout: &kin_core::KinLayout) -> String {
+    let scope = "Admitted scope: both endpoints are admitted repository authority, so host \
+                 content no admission has taken appears on neither side";
+    match kin_core::last_admission::read(layout) {
+        kin_core::last_admission::LastAdmissionRead::Recorded(recorded) => format!(
+            "{scope}; graph truth was last admitted at {} over {} artifact(s).",
+            recorded.at.to_rfc3339(),
+            recorded.tracked_artifacts
+        ),
+        kin_core::last_admission::LastAdmissionRead::Absent => format!(
+            "{scope}; this store records no complete admission, so how far it is behind is \
+             unknown. `kin admit` takes what the working copy holds."
+        ),
+        kin_core::last_admission::LastAdmissionRead::Unreadable(reason) => format!(
+            "{scope}; the last-admission marker will not parse ({reason}), so how far this store \
+             is behind is unknown. `kin admit` takes what the working copy holds."
+        ),
+    }
 }
 
 pub fn build_diff_response(

--- a/crates/kin-cli/tests/live_graph_durability_disclosure.rs
+++ b/crates/kin-cli/tests/live_graph_durability_disclosure.rs
@@ -960,13 +960,30 @@ fn a_file_written_while_no_daemon_watched_is_admitted_by_the_next_one() {
     let before_write = first.log_offset();
     fs::write(repo.join(UNCOMMITTED_PATH), UNCOMMITTED_SOURCE)
         .expect("write the watched source");
-    let watched = wait_for_live_growth(
+    wait_for_live_growth(
         &first,
         &repo,
         &home,
         first_port,
         durable_at_init,
         before_write,
+    );
+    // Committed before the restart, and the reason is the confound this fixture
+    // would otherwise measure instead. A daemon rebuilds the entity layer for
+    // uncommitted content from zero on the next open (FIR-2421), so a count
+    // taken across a restart mixes what the catch-up added with what the
+    // restart dropped. On the first run of this case those two happened to be
+    // three entities each and the count came back unchanged over a catch-up
+    // that had plainly worked.
+    stdout_of(
+        &kin_against_daemon(&repo, &home, first_port, &["commit", "-m", "link graph"]),
+        "kin commit",
+    );
+    let watched = live_entity_count(&repo, &home, first_port);
+    assert!(
+        watched > durable_at_init,
+        "the fixture needs the watched write recorded before the restart, got {watched} against \
+         {durable_at_init} at init"
     );
     first.stop();
 
@@ -987,12 +1004,41 @@ fn a_file_written_while_no_daemon_watched_is_admitted_by_the_next_one() {
         WATCHER_BOUND,
         "plan a startup catch-up over what changed while it was down",
     );
-    let caught_up = wait_for_live_growth(&second, &repo, &home, second_port, watched, 0);
-    assert!(
-        caught_up > watched,
-        "the graph has to carry the file written while nothing watched: {caught_up} against \
-         {watched} before it"
+    second.wait_for_record(
+        ADMISSION_RECORD,
+        0,
+        ADMISSION_BOUND,
+        "admit what the catch-up planned",
     );
+    // The reconciler's own record for that exact path: direct evidence that the
+    // entity layer took the file, separate from the count below, so a failure
+    // says which half broke.
+    second.wait_for_record(
+        "src/catch_up.rs",
+        0,
+        ADMISSION_BOUND,
+        "reconcile the file written while it was down",
+    );
+    // Read with the daemon's own log in the failure, because the two ways this
+    // can fail need different fixes: a catch-up that planned nothing is an
+    // ingestion defect, and one that planned the path and never derived its
+    // entities is an enrichment defect.
+    let deadline = Instant::now() + COUNT_SETTLE_BOUND;
+    let caught_up = loop {
+        let live = live_entity_count(&repo, &home, second_port);
+        if live > watched {
+            break live;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the graph has to carry the file written while nothing watched, but the live \
+             entity count stayed at {live} against {watched} before the restart. The second \
+             daemon's log:\n{}",
+            second.log_text()
+        );
+        thread::sleep(Duration::from_millis(200));
+    };
+    assert!(caught_up > watched);
 
     second.stop();
 }

--- a/crates/kin-cli/tests/live_graph_durability_disclosure.rs
+++ b/crates/kin-cli/tests/live_graph_durability_disclosure.rs
@@ -65,6 +65,16 @@ const WATCHER_RECORD: &str = "started file watcher";
 /// into repository authority (`crates/kin-daemon/src/loop_runner.rs`).
 const ADMISSION_RECORD: &str = "admitted exact workspace tree into repository authority";
 
+/// What the daemon logs immediately after it writes `.kin/daemon.port`
+/// (`crates/kin-daemon/src/daemon.rs`, the line after
+/// `publish_daemon_endpoint`).
+const ENDPOINT_RECORD: &str = "published the daemon endpoint";
+
+/// What the reconciliation loop logs when its startup catch-up finds host paths
+/// the working copy changed while nothing was watching
+/// (`crates/kin-daemon/src/loop_runner.rs`).
+const CATCH_UP_RECORD: &str = "admitting host paths modified since the last complete admission";
+
 /// The settle budget a quiet host needs, and the floor every busier host starts
 /// from.
 ///
@@ -195,6 +205,11 @@ impl IsolatedDaemon {
     /// written after this point and cannot match an older line.
     fn log_offset(&self) -> u64 {
         fs::metadata(&self.log).map(|meta| meta.len()).unwrap_or(0)
+    }
+
+    /// Everything this daemon has recorded so far.
+    fn log_text(&self) -> String {
+        fs::read_to_string(&self.log).unwrap_or_default()
     }
 
     /// Poll the daemon's log for `record`, considering only bytes at or after
@@ -848,4 +863,136 @@ fn a_settle_that_begins_quiet_and_turns_busy_gets_the_busy_budget() {
         busy <= started + RETRY_BOUND_CEILING,
         "no sequence of readings may push the settle past its ceiling"
     );
+}
+
+/// FIR-2466. The endpoint a client finds is a daemon that is already watching.
+///
+/// `.kin/daemon.port` is the readiness signal real clients key on, and the
+/// daemon used to publish it and spawn the reconciliation loop afterwards. The
+/// loop is what calls `FileWatcher::new`, and startup replays nothing, so a
+/// write landing between those two points raised no event and never reached the
+/// graph at all. The gap measured a few milliseconds on this host and the
+/// fixture that depended on losing that race lost it repeatedly.
+///
+/// Asserted on the ordering of the daemon's own records rather than on a write
+/// that has to win a race, so restoring the old order fails this outright
+/// instead of failing it sometimes.
+#[test]
+fn the_reconciliation_watch_is_armed_before_the_endpoint_is_published() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&repo).expect("create repo");
+    let repo = repo.canonicalize().expect("resolve the repository path");
+    let home = home.canonicalize().expect("resolve the home path");
+    seed_repository(&repo);
+    stdout_of(&kin(&repo, &home, &["init", "."]), "kin init");
+
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let daemon_log = root.path().join("kin-daemon.log");
+    let mut daemon = IsolatedDaemon::spawn(&repo, &daemon_log, &runtime);
+    daemon.wait_until_serving(&repo.join(".kin"));
+    // Both records have to be present before their positions mean anything.
+    // The port file appears a moment before the line that reports it, so the
+    // wait above proves the publication happened and this proves it was logged.
+    daemon.wait_for_record(ENDPOINT_RECORD, 0, WATCHER_BOUND, "publish its endpoint");
+    daemon.wait_for_record(WATCHER_RECORD, 0, WATCHER_BOUND, "register its file watcher");
+
+    let log = daemon.log_text();
+    let watch_at = log
+        .find(WATCHER_RECORD)
+        .unwrap_or_else(|| panic!("the daemon logged no watcher record:\n{log}"));
+    let publish_at = log
+        .find(ENDPOINT_RECORD)
+        .unwrap_or_else(|| panic!("the daemon logged no endpoint record:\n{log}"));
+    assert!(
+        watch_at < publish_at,
+        "the watch must exist before the endpoint advertises this daemon, but the watcher \
+         record is at byte {watch_at} and the publication record at {publish_at}; a client \
+         writing the instant the port appears would have that write observed by nobody. \
+         The log:\n{log}"
+    );
+
+    daemon.stop();
+}
+
+/// FIR-2499. A file written while no daemon was running reaches the graph
+/// without a commit.
+///
+/// The stranger's finding was that the graph is always one commit behind the
+/// work, and the mechanism is this: a watcher reports only edits it was alive
+/// for. An idle timeout ends a daemon mid-session, the next command starts a
+/// fresh one, and everything written in between was seen by nobody. Startup
+/// admitted nothing, so nothing ever replayed it and the file stayed invisible
+/// until a commit swept it in.
+///
+/// Written between two daemons deliberately: it is the only construction in
+/// which no watcher can have seen the write, so a pass here cannot be the
+/// watcher quietly doing the work.
+#[test]
+fn a_file_written_while_no_daemon_watched_is_admitted_by_the_next_one() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&repo).expect("create repo");
+    let repo = repo.canonicalize().expect("resolve the repository path");
+    let home = home.canonicalize().expect("resolve the home path");
+    seed_repository(&repo);
+    let init = kin(&repo, &home, &["init", ".", "--json"]);
+    let init_payload: serde_json::Value =
+        serde_json::from_slice(&stdout_of(&init, "kin init").into_bytes())
+            .expect("init emits JSON");
+    let durable_at_init = init_payload["semantic_enrichment"]["entity_count"]
+        .as_u64()
+        .expect("init reports a durable entity count");
+
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let first_log = root.path().join("kin-daemon-first.log");
+    let mut first = IsolatedDaemon::spawn(&repo, &first_log, &runtime);
+    let first_port = first.wait_until_serving(&repo.join(".kin"));
+    first.wait_until_watching();
+
+    // One ordinary watched write, so this store records a complete admission
+    // and the catch-up below has a window to open at. Without a marker there is
+    // no lower bound and the pass correctly declines to run at all.
+    let before_write = first.log_offset();
+    fs::write(repo.join(UNCOMMITTED_PATH), UNCOMMITTED_SOURCE)
+        .expect("write the watched source");
+    let watched = wait_for_live_growth(
+        &first,
+        &repo,
+        &home,
+        first_port,
+        durable_at_init,
+        before_write,
+    );
+    first.stop();
+
+    // The write nothing could see. No daemon is running, so no watcher exists
+    // to raise an event for it and nothing will replay one.
+    fs::write(
+        repo.join("src/catch_up.rs"),
+        b"pub fn build_catch_up() -> u32 {\n    5\n}\n\npub fn walk_catch_up() -> u32 {\n    build_catch_up() + 1\n}\n\npub fn render_catch_up() -> u32 {\n    walk_catch_up() + 1\n}\n",
+    )
+    .expect("write the unwatched source");
+
+    let second_log = root.path().join("kin-daemon-second.log");
+    let mut second = IsolatedDaemon::spawn(&repo, &second_log, &runtime);
+    let second_port = second.wait_until_serving(&repo.join(".kin"));
+    second.wait_for_record(
+        CATCH_UP_RECORD,
+        0,
+        WATCHER_BOUND,
+        "plan a startup catch-up over what changed while it was down",
+    );
+    let caught_up = wait_for_live_growth(&second, &repo, &home, second_port, watched, 0);
+    assert!(
+        caught_up > watched,
+        "the graph has to carry the file written while nothing watched: {caught_up} against \
+         {watched} before it"
+    );
+
+    second.stop();
 }

--- a/crates/kin-cli/tests/live_graph_durability_disclosure.rs
+++ b/crates/kin-cli/tests/live_graph_durability_disclosure.rs
@@ -897,7 +897,12 @@ fn the_reconciliation_watch_is_armed_before_the_endpoint_is_published() {
     // The port file appears a moment before the line that reports it, so the
     // wait above proves the publication happened and this proves it was logged.
     daemon.wait_for_record(ENDPOINT_RECORD, 0, WATCHER_BOUND, "publish its endpoint");
-    daemon.wait_for_record(WATCHER_RECORD, 0, WATCHER_BOUND, "register its file watcher");
+    daemon.wait_for_record(
+        WATCHER_RECORD,
+        0,
+        WATCHER_BOUND,
+        "register its file watcher",
+    );
 
     let log = daemon.log_text();
     let watch_at = log
@@ -958,8 +963,7 @@ fn a_file_written_while_no_daemon_watched_is_admitted_by_the_next_one() {
     // and the catch-up below has a window to open at. Without a marker there is
     // no lower bound and the pass correctly declines to run at all.
     let before_write = first.log_offset();
-    fs::write(repo.join(UNCOMMITTED_PATH), UNCOMMITTED_SOURCE)
-        .expect("write the watched source");
+    fs::write(repo.join(UNCOMMITTED_PATH), UNCOMMITTED_SOURCE).expect("write the watched source");
     wait_for_live_growth(
         &first,
         &repo,

--- a/crates/kin-cli/tests/live_graph_durability_disclosure.rs
+++ b/crates/kin-cli/tests/live_graph_durability_disclosure.rs
@@ -559,6 +559,32 @@ fn wait_for_live_growth(
     }
 }
 
+/// The live entity count, waited out rather than sampled once.
+///
+/// `kin graph status` exits non-zero on a critical graph health issue, and one
+/// of those is transient by construction: authority admission binds the entity
+/// layer and facets are written per file after it, so a read taken between the
+/// two halves sees a derived tree that trails authority. A caller that wants a
+/// number rather than an event waits for one, and reports the command's own
+/// output when the bound expires instead of a bare `None`.
+fn settled_entity_count(repo: &Path, home: &Path, port: u16) -> u64 {
+    let deadline = Instant::now() + COUNT_SETTLE_BOUND;
+    loop {
+        let (live, status) = live_entity_count(repo, home, port);
+        if let Some(live) = live {
+            return live;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "graph status never reported an entity count: it exited {} and said:\n{}\n{}",
+            status.status,
+            String::from_utf8_lossy(&status.stdout),
+            String::from_utf8_lossy(&status.stderr)
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
 /// Whether `kin_graph_status` refused this call and asked to be repeated.
 ///
 /// `crates/kin-daemon/src/api.rs:2084` fails the call outright when the
@@ -616,6 +642,37 @@ fn durability(payload: &serde_json::Value) -> serde_json::Value {
         .get("durability")
         .unwrap_or_else(|| panic!("envelope carries no durability object: {payload}"))
         .clone()
+}
+
+/// The envelope's report of how far graph truth is behind the working copy.
+///
+/// Absent when the runtime reported nothing unadmitted, which is a different
+/// answer from a zero and is why this returns an option rather than a count.
+fn behind(payload: &serde_json::Value) -> Option<serde_json::Value> {
+    payload.get("_kin")?.get("behind").cloned()
+}
+
+/// Set a host entry's modification time outright.
+///
+/// Both stamps are written because setting only one is refused on some hosts,
+/// and the access time is not what any assertion here reads.
+fn stamp_modified(path: &Path, at: std::time::SystemTime) {
+    let handle = fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("open the file to stamp it");
+    handle
+        .set_times(fs::FileTimes::new().set_accessed(at).set_modified(at))
+        .expect("stamp the modification time");
+    assert_eq!(
+        fs::symlink_metadata(path)
+            .expect("read back the stamped entry")
+            .modified()
+            .expect("the host publishes modification times"),
+        at,
+        "the stamp has to have applied, or every assertion resting on it is about the file's \
+         real age instead"
+    );
 }
 
 #[test]
@@ -983,7 +1040,7 @@ fn a_file_written_while_no_daemon_watched_is_admitted_by_the_next_one() {
         &kin_against_daemon(&repo, &home, first_port, &["commit", "-m", "link graph"]),
         "kin commit",
     );
-    let watched = live_entity_count(&repo, &home, first_port);
+    let watched = settled_entity_count(&repo, &home, first_port);
     assert!(
         watched > durable_at_init,
         "the fixture needs the watched write recorded before the restart, got {watched} against \
@@ -998,6 +1055,20 @@ fn a_file_written_while_no_daemon_watched_is_admitted_by_the_next_one() {
         b"pub fn build_catch_up() -> u32 {\n    5\n}\n\npub fn walk_catch_up() -> u32 {\n    build_catch_up() + 1\n}\n\npub fn render_catch_up() -> u32 {\n    walk_catch_up() + 1\n}\n",
     )
     .expect("write the unwatched source");
+
+    // And one the catch-up must NOT take: its modification time predates every
+    // admission this store has recorded, so the window does not cover it and
+    // nothing observed it arriving. The bound matters as much as the reach. A
+    // catch-up with no lower bound would sweep the whole working copy, which is
+    // exactly what startup must never do, so this file is both the control on
+    // that bound and the store's remaining behind-ness for the disclosure
+    // assertions below.
+    let stale = repo.join("src/stale_drift.rs");
+    fs::write(&stale, b"pub fn drifted() -> u32 {\n    9\n}\n").expect("write the stale source");
+    stamp_modified(
+        &stale,
+        std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000),
+    );
 
     let second_log = root.path().join("kin-daemon-second.log");
     let mut second = IsolatedDaemon::spawn(&repo, &second_log, &runtime);
@@ -1029,20 +1100,49 @@ fn a_file_written_while_no_daemon_watched_is_admitted_by_the_next_one() {
     // entities is an enrichment defect.
     let deadline = Instant::now() + COUNT_SETTLE_BOUND;
     let caught_up = loop {
-        let live = live_entity_count(&repo, &home, second_port);
-        if live > watched {
-            break live;
+        let (live, status) = live_entity_count(&repo, &home, second_port);
+        if live.is_some_and(|live| live > watched) {
+            break live.expect("the reading above carried a count");
         }
         assert!(
             Instant::now() < deadline,
             "the graph has to carry the file written while nothing watched, but the live \
-             entity count stayed at {live} against {watched} before the restart. The second \
-             daemon's log:\n{}",
+             entity count stayed at {live:?} against {watched} before the restart; graph \
+             status exited {} and said:\n{}\nThe second daemon's log:\n{}",
+            status.status,
+            String::from_utf8_lossy(&status.stdout),
             second.log_text()
         );
         thread::sleep(Duration::from_millis(200));
     };
     assert!(caught_up > watched);
+
+    // FIR-2499's other half, read off the real MCP surface rather than a
+    // hand-built health body. The store still holds one path no admission has
+    // taken, so every envelope has to say so and none may certify over it.
+    let session = settled_mcp_session(&repo, &home, second_port);
+    let locate = payload(&session, 3, "semantic_locate");
+    let behind = behind(&locate)
+        .unwrap_or_else(|| panic!("a store holding an unadmitted path must disclose it: {locate}"));
+    assert_eq!(
+        behind["unadmitted_paths"],
+        serde_json::json!(1),
+        "exactly the stale file is outstanding; the catch-up took the other one: {behind}"
+    );
+    assert!(
+        behind["note"]
+            .as_str()
+            .is_some_and(|note| note.contains("Answers here cover admitted content only")),
+        "the disclosure has to say what it means for an answer: {behind}"
+    );
+    let durability = durability(&locate);
+    assert!(
+        !durability["note"]
+            .as_str()
+            .is_some_and(|note| note.contains("records everything answering here")),
+        "durability may not report an all-clear over a repository holding an unadmitted \
+         module: {durability}"
+    );
 
     second.stop();
 }

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -4645,16 +4645,69 @@ async fn select_with_signals(
 #[cfg(all(test, unix))]
 mod tests {
     use super::{
-        coverage_drain_verdict, drain_pending_flush, embed_work_outstanding,
+        await_watch_armed, coverage_drain_verdict, drain_pending_flush, embed_work_outstanding,
         format_singleton_contention, next_embed_error_backoff, parse_duration_secs,
         parse_owner_watch_pid, should_enable_lsp_enrichment, should_flush_now, shutdown_signalled,
         watched_process_is_alive, ControlPlane, CoverageDrainVerdict, DaemonConfig, DaemonState,
-        FlushSuppression, DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
-        RECON_IDLE,
+        FlushSuppression, WatchArming, DEFAULT_RUNTIME_SHUTDOWN_GRACE,
+        DEFAULT_SHUTDOWN_ESCALATION_GRACE, RECON_IDLE,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+
+    /// FIR-2466. The healthy path: the loop reports its watcher and publication
+    /// proceeds.
+    ///
+    /// The arming is deliberately delayed rather than already sent. A future
+    /// that is ready on its first poll returns before any deadline applies, so a
+    /// version of this test with an instantly-ready signal stays green at a
+    /// one-nanosecond bound and can never tell waiting from not waiting.
+    #[tokio::test]
+    async fn a_reported_watch_releases_publication() {
+        let (armed_tx, armed_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(120)).await;
+            let _ = armed_tx.send(());
+        });
+
+        assert_eq!(
+            await_watch_armed(armed_rx, Duration::from_secs(10)).await,
+            WatchArming::Armed,
+            "a watch reported inside the bound is what lets the endpoint be published"
+        );
+    }
+
+    /// A loop that ends before building a watcher releases publication too.
+    ///
+    /// Filesystem reconcile switched off, a bare checkout, or a watcher the host
+    /// refused all reach this. There is no watch coming, so waiting the bound
+    /// out would hold the endpoint back for nothing.
+    #[tokio::test]
+    async fn a_loop_that_ends_without_a_watch_releases_publication_at_once() {
+        let (armed_tx, armed_rx) = tokio::sync::oneshot::channel::<()>();
+        drop(armed_tx);
+
+        assert_eq!(
+            await_watch_armed(armed_rx, Duration::from_secs(10)).await,
+            WatchArming::LoopGone
+        );
+    }
+
+    /// The bound is a ceiling on a wedged loop, not on a healthy one. An
+    /// endpoint that never appears is a daemon no client can reach, so the wait
+    /// expires into publication with the reason recorded.
+    #[tokio::test]
+    async fn a_loop_that_never_reports_stops_holding_publication_at_its_bound() {
+        // Held rather than dropped: dropping it is the LoopGone arm above, and
+        // this arm is the one where nothing happens at all.
+        let (_armed_tx, armed_rx) = tokio::sync::oneshot::channel::<()>();
+
+        assert_eq!(
+            await_watch_armed(armed_rx, Duration::from_millis(80)).await,
+            WatchArming::TimedOut
+        );
+    }
 
     #[test]
     fn default_embed_batch_is_backlog_friendly() {

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1164,6 +1164,66 @@ async fn save_snapshot_blocking(state: Arc<DaemonState>) -> Result<()> {
 /// How often the owner-death watchdog checks whether the owning process is
 /// still alive. A `kill(pid, 0)` every couple of seconds is a single cheap
 /// syscall, so this is set for detection latency rather than to save work.
+/// How long endpoint publication waits for the reconcile loop's file watcher.
+///
+/// A ceiling, not an amount of waiting: the healthy path returns the instant the
+/// loop reports, and this only decides how long a wedged loop may hold the
+/// endpoint back. Registering a recursive watch is fast on the backends Kin
+/// uses, so reaching this bound means something is wrong rather than large.
+const WATCH_ARMING_BOUND: Duration = Duration::from_secs(30);
+
+/// How the wait for the reconcile loop's watch ended.
+///
+/// Three outcomes rather than a bool because they mean different things to an
+/// operator reading the log. Only `Armed` promises that a write landing after
+/// the endpoint appears will be observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WatchArming {
+    /// The loop reported its watcher. Publication is safe to proceed.
+    Armed,
+    /// The loop ended before reporting one, which is what a disabled
+    /// reconciler, a bare checkout or a refused watcher looks like from here.
+    /// There is no watch to wait for, so waiting longer buys nothing.
+    LoopGone,
+    /// The bound expired with the loop neither arming nor ending.
+    TimedOut,
+}
+
+/// Wait for the reconcile loop to report its file watcher, but never forever.
+///
+/// Publishing late beats not publishing: an endpoint that never appears is a
+/// daemon no client can reach, so the bound expires into publication with the
+/// reason recorded rather than into a refusal.
+pub(crate) async fn await_watch_armed(
+    armed: tokio::sync::oneshot::Receiver<()>,
+    bound: Duration,
+) -> WatchArming {
+    match tokio::time::timeout(bound, armed).await {
+        Ok(Ok(())) => WatchArming::Armed,
+        Ok(Err(_)) => WatchArming::LoopGone,
+        Err(_) => WatchArming::TimedOut,
+    }
+}
+
+/// Say what the wait produced, at the level each outcome deserves.
+fn announce_watch_arming(arming: WatchArming, bound: Duration) {
+    match arming {
+        WatchArming::Armed => {
+            debug!("the reconciliation watch is armed; publishing the daemon endpoint")
+        }
+        WatchArming::LoopGone => info!(
+            "the reconciliation loop ended before arming a watch, so this daemon observes no \
+             working-copy edits; publishing the endpoint so it stays reachable"
+        ),
+        WatchArming::TimedOut => warn!(
+            bound_s = bound.as_secs(),
+            "the reconciliation loop did not report a file watcher within its bound; publishing \
+             the endpoint anyway, so a host write landing now may go unobserved until an \
+             explicit admission seam takes it"
+        ),
+    }
+}
+
 const OWNER_WATCH_CHECK_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Validate a raw `KIN_DAEMON_WATCH_PID` value into an owner PID this daemon may
@@ -2415,6 +2475,39 @@ pub async fn run_with_authority_on(
         }
     };
 
+    // Shutdown signal: when set to true, all loops exit.
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+
+    // Spawn the reconciliation loop BEFORE the endpoint is published, and wait
+    // for it to report its file watcher.
+    //
+    // Serving is not watching. The endpoint file is the readiness signal real
+    // clients key on, so a client that connects the moment it appears and
+    // writes immediately used to land in a window where the watcher did not yet
+    // exist: the write raised no event, startup replayed nothing, and the file
+    // stayed absent from the graph until some unrelated later touch of the same
+    // path (FIR-2466). Publishing after the watch closes that window by
+    // construction rather than by racing it.
+    //
+    // The wait is bounded and the signal fires on the loop's drop as well as on
+    // arming, so no early return, disabled loop, bare checkout, or refused
+    // watcher can leave this daemon unpublished.
+    let (armed_tx, armed_rx) = tokio::sync::oneshot::channel();
+    let loop_state = Arc::clone(&state);
+    let loop_config = config.loop_config.clone();
+    let loop_cancel = cancel_rx.clone();
+    let loop_handle = tokio::spawn(async move {
+        loop_runner::run_loop_armed(
+            loop_state,
+            loop_config,
+            loop_cancel,
+            Some(loop_runner::WatchArmed::new(armed_tx)),
+        )
+        .await
+    });
+    let arming = await_watch_armed(armed_rx, WATCH_ARMING_BOUND).await;
+    announce_watch_arming(arming, WATCH_ARMING_BOUND);
+
     // Publish PID and the actual bound port as one lifecycle-authorized
     // operation. Endpoint retirement takes the same authority, so no client can
     // delete a successor publication using a verdict about its predecessor.
@@ -2427,6 +2520,10 @@ pub async fn run_with_authority_on(
     // costs nothing here because it advertises nothing; only publication does.
     crate::lifecycle::publish_daemon_endpoint(state.layout.root(), bound_port)
         .map_err(DaemonError::Io)?;
+    // Recorded so the ordering above is readable off the daemon's own log
+    // rather than inferred from timings. A watcher record that does not precede
+    // this one is the regression.
+    info!(port = bound_port, "published the daemon endpoint");
 
     // Retire the readiness surface: the full API serves this socket from here.
     // Both handles accept from one listen queue, so there is no instant at which
@@ -2435,9 +2532,6 @@ pub async fn run_with_authority_on(
     if let Some(ready_tx) = warming_retired {
         let _ = ready_tx.send(true);
     }
-
-    // Shutdown signal: when set to true, all loops exit.
-    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
 
     info!(port = bound_port, "starting kin daemon");
 
@@ -2521,15 +2615,6 @@ pub async fn run_with_authority_on(
             warn!(error = %error, "failed to spawn owner-death watchdog");
         }
     }
-
-    // Spawn the reconciliation loop.
-    let loop_state = Arc::clone(&state);
-    let loop_config = config.loop_config.clone();
-    let loop_cancel = cancel_rx.clone();
-    let loop_handle =
-        tokio::spawn(
-            async move { loop_runner::run_loop(loop_state, loop_config, loop_cancel).await },
-        );
 
     // Spawn the API server on the pre-bound listener.
     let api_state = Arc::clone(&state);

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -6664,11 +6664,17 @@ mod tests {
 
         let before = repo.path().join("settled.rs");
         std::fs::write(&before, b"pub fn settled() -> u32 { 1 }\n").unwrap();
-        stamp_modified(&before, SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000));
+        stamp_modified(
+            &before,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000),
+        );
 
         let after = repo.path().join("written_while_nothing_watched.rs");
         std::fs::write(&after, b"pub fn written() -> u32 { 2 }\n").unwrap();
-        stamp_modified(&after, SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000));
+        stamp_modified(
+            &after,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000),
+        );
 
         let window = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
         let planned = plan_catch_up_events(&state, window).unwrap();
@@ -6717,10 +6723,16 @@ mod tests {
 
         let ignored = repo.path().join("secrets.rs");
         std::fs::write(&ignored, b"pub fn secret() -> u32 { 3 }\n").unwrap();
-        stamp_modified(&ignored, SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000));
+        stamp_modified(
+            &ignored,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000),
+        );
         let visible = repo.path().join("visible.rs");
         std::fs::write(&visible, b"pub fn visible() -> u32 { 4 }\n").unwrap();
-        stamp_modified(&visible, SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000));
+        stamp_modified(
+            &visible,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000),
+        );
 
         let window = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
         let named = event_paths(&plan_catch_up_events(&state, window).unwrap())
@@ -6766,7 +6778,6 @@ mod tests {
              file's real age instead"
         );
     }
-
 }
 
 /// Decide whether a filesystem-sync tick's bulk deletions should be WITHHELD as

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use kin_index::{
     FileClassification, FileClassifier, FileEvent, FileWatcher, IndexPipeline, IndexedAny,
@@ -1812,11 +1812,161 @@ async fn park_reconcile_loop(
 /// 4. Projects overlay mutations back to files (overlay -> file)
 ///
 /// The loop runs on a tokio task and shares state through `DaemonState`.
+/// The reconcile loop's one-shot promise that its file watcher exists.
+///
+/// Fired on arming, and fired again on drop if the loop never got that far.
+/// Drop-firing is the whole safety argument for making endpoint publication
+/// wait on it. A loop can end before it ever builds a watcher — filesystem
+/// reconcile switched off, a bare checkout, a watcher the host refused — and a
+/// daemon that waited on a signal none of those paths sends would never publish
+/// its endpoint at all, which is a worse failure than the unobserved window
+/// this exists to close.
+#[derive(Debug)]
+pub struct WatchArmed(Option<tokio::sync::oneshot::Sender<()>>);
+
+impl WatchArmed {
+    pub fn new(signal: tokio::sync::oneshot::Sender<()>) -> Self {
+        Self(Some(signal))
+    }
+
+    /// Report the watch, once. Later calls and the drop below do nothing.
+    fn arm(&mut self) {
+        if let Some(signal) = self.0.take() {
+            let _ = signal.send(());
+        }
+    }
+}
+
+impl Drop for WatchArmed {
+    fn drop(&mut self) {
+        self.arm();
+    }
+}
+
+/// When a startup catch-up should begin, or `None` when no window can be named.
+///
+/// The window opens at the last complete admission this store recorded, because
+/// that is the last moment anything is known to have observed the working copy.
+/// A file watcher only ever reports edits it was alive for, so everything the
+/// host did between one daemon's last admission and the next daemon's watch was
+/// seen by nobody, and nothing replays it. That stretch is the whole of the
+/// "graph is one commit behind the work" complaint, and it is not only a
+/// startup artifact: an idle timeout ends a daemon mid-session and the next
+/// command starts a fresh one.
+///
+/// A store with no marker gets no catch-up. Absent means either never admitted
+/// or admitted by a build older than the marker, and neither supplies a window;
+/// with no lower bound the pass would propose the entire working copy, which is
+/// exactly the sweep startup must not perform. An unreadable marker is the same
+/// answer said louder, so it is logged rather than silently treated as absent.
+fn startup_catch_up_window(state: &DaemonState) -> Option<SystemTime> {
+    match kin_core::last_admission::read(&state.layout) {
+        kin_core::last_admission::LastAdmissionRead::Recorded(recorded) => {
+            let since = unix_instant(recorded.at);
+            info!(
+                since = %recorded.at.to_rfc3339(),
+                "planning a startup catch-up over host paths modified since the last complete \
+                 admission"
+            );
+            Some(since)
+        }
+        kin_core::last_admission::LastAdmissionRead::Absent => {
+            debug!(
+                "no last-admission marker, so no catch-up window can be named; working-copy \
+                 divergence stays projection drift until an explicit seam admits it"
+            );
+            None
+        }
+        kin_core::last_admission::LastAdmissionRead::Unreadable(reason) => {
+            warn!(
+                reason = %reason,
+                "the last-admission marker will not parse, so no catch-up window can be named; \
+                 `kin admit` takes whatever the host changed while nothing was watching"
+            );
+            None
+        }
+    }
+}
+
+/// A UTC instant as a [`SystemTime`], for comparison against host modification
+/// times.
+///
+/// A marker stamped before the epoch clamps to the epoch rather than wrapping.
+/// No real store carries one, and a wrap would silently move the window to the
+/// far future, which is the direction that loses every file.
+fn unix_instant(at: chrono::DateTime<chrono::Utc>) -> SystemTime {
+    let seconds = at.timestamp();
+    if seconds < 0 {
+        return SystemTime::UNIX_EPOCH;
+    }
+    SystemTime::UNIX_EPOCH + Duration::new(seconds as u64, at.timestamp_subsec_nanos())
+}
+
+/// Host events for every path the working copy changed at or after `since`.
+///
+/// Stat-only: the walk that produces this opens nothing and hashes nothing, so
+/// a store whose host did not move since its last admission pays one traversal
+/// and returns an empty list. The events it does return go through the ordinary
+/// tick, so a catch-up path is admitted by the same bounded observation, the
+/// same policy filter and the same compare-and-swap as one the watcher saw.
+/// This plans no transition of its own and publishes nothing.
+///
+/// The bound is inclusive because filesystem modification times are coarse. A
+/// file written in the same second the marker was stamped is re-observed, and
+/// re-observing an unchanged path costs one admission that plans nothing.
+fn plan_catch_up_events(state: &DaemonState, since: SystemTime) -> Result<Vec<FileEvent>> {
+    let working_dir = state.layout.working_dir();
+    let (_, policy) = current_authority_admission(state)?;
+    let previous = state.graph.resolved_tree();
+    let tracked_paths = previous
+        .artifacts_by_path()
+        .map(|artifact| artifact.path.clone())
+        .collect::<Vec<_>>();
+    let graph_only_paths = crate::graph_only_members::members_of(&previous)?;
+    let ignore =
+        kin_index::RepositoryIgnore::load(working_dir).map_err(kin_index::IndexError::from)?;
+    let modified = kin_index::scan_repository_modified_since(
+        working_dir,
+        &ignore,
+        policy.as_ref(),
+        tracked_paths.iter(),
+        graph_only_paths.iter(),
+        since,
+    )
+    .map_err(kin_index::IndexError::from)?;
+    Ok(modified
+        .iter()
+        .filter_map(|path| kin_index::host_path_from_repo_path(working_dir, path).ok())
+        .map(FileEvent::Changed)
+        .collect())
+}
+
 pub async fn run_loop(
     state: Arc<DaemonState>,
     config: LoopConfig,
     cancel: tokio::sync::watch::Receiver<bool>,
 ) -> Result<()> {
+    run_loop_armed(state, config, cancel, None).await
+}
+
+/// Run the loop and report the moment its file watcher exists.
+///
+/// The daemon publishes `.kin/daemon.port` only after this fires, so a client
+/// that finds the endpoint is finding a daemon that is already observing the
+/// working copy. Before this signal existed the endpoint was published first
+/// and the loop was spawned afterwards, so a write landing in between raised no
+/// event and nothing ever replayed it: the graph simply never learned about
+/// that file (FIR-2466).
+pub async fn run_loop_armed(
+    state: Arc<DaemonState>,
+    config: LoopConfig,
+    cancel: tokio::sync::watch::Receiver<bool>,
+    armed: Option<WatchArmed>,
+) -> Result<()> {
+    // Held for the whole body so every early return below still releases the
+    // daemon, through `WatchArmed`'s drop rather than through a call each of
+    // those paths would have to remember.
+    let mut armed = armed;
     if state.filesystem_reconcile_disabled() {
         info!(
             env = DISABLE_FILESYSTEM_RECONCILE_ENV,
@@ -1842,6 +1992,16 @@ pub async fn run_loop(
     }
 
     let watcher = FileWatcher::new(working_dir).map_err(DaemonError::from)?;
+    // Read while the watcher is already reporting and before the endpoint can
+    // be published, so the catch-up window and the watch meet rather than leave
+    // a seam between them. Planning the pass itself is deliberately left to the
+    // first round: the window is fixed here, the walk is not on the path to
+    // publication, and a client finding the port is never waiting on a
+    // traversal.
+    let mut catch_up_owed = startup_catch_up_window(&state);
+    if let Some(armed) = armed.as_mut() {
+        armed.arm();
+    }
     let enrichment_pipeline = IndexPipeline::new();
     // The watcher's running total of host events it could not place inside this
     // repository, as this loop last disclosed it. Held so a standing count is
@@ -1854,16 +2014,21 @@ pub async fn run_loop(
         "reconciliation loop started"
     );
 
-    // Startup deliberately admits nothing. Repository authority is already
-    // complete when the daemon opens it, and the working copy is a derived
-    // view of that authority. Sweeping the working copy here would publish
-    // whatever bytes happen to sit on disk into the repository-v6 workspace
-    // before any command runs, so a command that spawned this daemon would
-    // observe ambiently ingested content as graph-owned workspace state.
-    // Working-copy content crosses the compare-and-swap only through live
-    // watcher-observed edits below and through explicit admission seams such
-    // as `/commands/commit`. Divergence introduced while no daemon was
-    // running stays projection drift until one of those seams admits it.
+    // Startup sweeps nothing. Repository authority is already complete when the
+    // daemon opens it, and the working copy is a derived view of that
+    // authority. Admitting whatever bytes happen to sit on disk would publish
+    // them into the repository-v6 workspace before any command runs, so a
+    // command that spawned this daemon would observe ambiently ingested content
+    // as graph-owned workspace state.
+    //
+    // The one exception is bounded by a clock rather than by taste. A file
+    // watcher reports only the edits it was alive for, so the stretch between
+    // one daemon's last complete admission and the next daemon's watch was
+    // observed by nobody and nothing replays it. `catch_up_owed` above names
+    // that stretch, and the first round below re-observes exactly the paths the
+    // host modified inside it. Everything older is untouched: it predates the
+    // last admission, which already covered it, and divergence with no window
+    // to place it in stays projection drift until an explicit seam admits it.
 
     let interval = Duration::from_millis(config.poll_interval_ms);
     let mut cancel = cancel;
@@ -1955,6 +2120,36 @@ pub async fn run_loop(
         }
 
         sweep_expired_intents(&state).await;
+
+        // The catch-up, owed once and taken on the first round that gets this
+        // far. Enqueued as ordinary host events rather than admitted here, so
+        // every one of them crosses authority through the same bounded
+        // observation, the same policy filter and the same compare-and-swap a
+        // watcher-observed edit does. A pass that fails is logged and dropped:
+        // it is a repair, and retrying it forever would spend a traversal per
+        // round on a store that already has an explicit seam for this.
+        if let Some(since) = catch_up_owed.take() {
+            match plan_catch_up_events(&state, since) {
+                Ok(events) if events.is_empty() => {
+                    debug!("no host path changed since the last complete admission");
+                }
+                Ok(events) => {
+                    info!(
+                        count = events.len(),
+                        "admitting host paths modified since the last complete admission"
+                    );
+                    enqueue_file_events(&mut pending_events, events);
+                }
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        "could not plan the startup catch-up, so host content written while \
+                         nothing was watching stays unadmitted until `kin admit` or a commit \
+                         takes it"
+                    );
+                }
+            }
+        }
 
         // Collect retries first and real watcher notifications second. Dedup once per tick,
         // only when something new arrived; a real remove/recreate therefore supersedes a

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -6564,6 +6564,209 @@ mod tests {
             "no poll cadence may turn the grace into a stall"
         );
     }
+
+    /// FIR-2466. The daemon may not publish its endpoint on a promise the loop
+    /// never keeps, so the signal fires even when the loop never reaches its
+    /// watcher.
+    #[test]
+    fn a_watch_signal_fires_on_drop_when_the_loop_never_arms() {
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        {
+            let _armed = WatchArmed::new(tx);
+        }
+        assert_eq!(
+            rx.try_recv(),
+            Ok(()),
+            "a dropped WatchArmed must release the daemon; a loop that ends before building a \
+             watcher would otherwise hold the endpoint back forever"
+        );
+    }
+
+    /// Arming is once. A second call after an explicit arm must not panic and
+    /// must not send again, because the receiver is a one-shot.
+    #[test]
+    fn a_watch_signal_arms_once_and_the_later_drop_is_silent() {
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        let mut armed = WatchArmed::new(tx);
+        armed.arm();
+        armed.arm();
+        drop(armed);
+        assert_eq!(rx.try_recv(), Ok(()), "the arm reaches the daemon");
+    }
+
+    /// A store that records no complete admission names no window, so the loop
+    /// falls back to admitting nothing at startup rather than proposing the
+    /// whole working copy.
+    #[test]
+    fn a_store_with_no_admission_marker_opens_no_catch_up_window() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        assert!(
+            matches!(
+                kin_core::last_admission::read(&state.layout),
+                kin_core::last_admission::LastAdmissionRead::Absent
+            ),
+            "the control this assertion rests on: a fresh store carries no marker"
+        );
+        assert_eq!(
+            startup_catch_up_window(&state),
+            None,
+            "with no lower bound the pass would propose the entire working copy, which is the \
+             sweep startup must never perform"
+        );
+    }
+
+    /// A recorded marker opens the window at its own instant, which is what
+    /// bounds the catch-up to the stretch nothing was watching.
+    #[test]
+    fn a_recorded_admission_marker_opens_the_window_at_its_own_instant() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let at = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        kin_core::last_admission::write(
+            &state.layout,
+            &kin_core::last_admission::LastAdmission::new(at, 7),
+        )
+        .unwrap();
+
+        assert_eq!(
+            startup_catch_up_window(&state),
+            Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)),
+            "the window opens at the last complete admission, not at process start"
+        );
+    }
+
+    /// A marker stamped before the epoch clamps rather than wrapping. A wrap
+    /// would move the window to the far future, which loses every file.
+    #[test]
+    fn a_pre_epoch_marker_clamps_the_window_to_the_epoch() {
+        let before = chrono::DateTime::from_timestamp(-10, 0).unwrap();
+        assert_eq!(unix_instant(before), SystemTime::UNIX_EPOCH);
+        let after = chrono::DateTime::from_timestamp(5, 250_000_000).unwrap();
+        assert_eq!(
+            unix_instant(after),
+            SystemTime::UNIX_EPOCH + Duration::new(5, 250_000_000),
+            "the ordinary case is not clamped, which is the control for the arm above"
+        );
+    }
+
+    /// FIR-2499. The catch-up names what the host changed inside the window and
+    /// nothing older, and what it names is admissible by the ordinary ambient
+    /// path.
+    ///
+    /// Modification times are set outright rather than slept for, so the two
+    /// arms sit on either side of the window by construction instead of by
+    /// racing a filesystem's clock granularity.
+    #[test]
+    fn the_catch_up_names_host_paths_changed_inside_the_window_and_no_others() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+
+        let before = repo.path().join("settled.rs");
+        std::fs::write(&before, b"pub fn settled() -> u32 { 1 }\n").unwrap();
+        stamp_modified(&before, SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000));
+
+        let after = repo.path().join("written_while_nothing_watched.rs");
+        std::fs::write(&after, b"pub fn written() -> u32 { 2 }\n").unwrap();
+        stamp_modified(&after, SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000));
+
+        let window = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
+        let planned = plan_catch_up_events(&state, window).unwrap();
+        let named = event_paths(&planned);
+        // The plan speaks in the working directory the state is bound to, which
+        // the layout resolved; a tempdir path is the unresolved form of the
+        // same entry, so the two are compared by leaf.
+        let named = named
+            .iter()
+            .filter_map(|path| path.file_name())
+            .map(|leaf| leaf.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        let after_leaf = "written_while_nothing_watched.rs".to_string();
+        let before_leaf = "settled.rs".to_string();
+
+        assert!(
+            named.contains(&after_leaf),
+            "a file written after the last admission is exactly what nothing observed: {named:?}"
+        );
+        assert!(
+            !named.contains(&before_leaf),
+            "a file older than the window was already covered by that admission: {named:?}"
+        );
+
+        // What the catch-up plans has to be admissible by the path it feeds,
+        // or the plan is a list nothing acts on.
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(after)).unwrap();
+        assert!(
+            matches!(admitted, AdmittedFileEvent::Regular { .. }),
+            "the catch-up's own event must reach the tree: {admitted:?}"
+        );
+        assert!(
+            tree_entry(&state, "written_while_nothing_watched.rs").is_some(),
+            "the file the graph never met is what the catch-up exists to admit"
+        );
+    }
+
+    /// The rules the catch-up walk shares with the content walk. An ignored
+    /// path is excluded whatever its modification time says, so the catch-up
+    /// cannot admit what an ordinary tick would refuse.
+    #[test]
+    fn the_catch_up_skips_a_path_the_ignore_rules_exclude() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join(".kinignore"), b"secrets.rs\n").unwrap();
+        let state = open_test_state(&repo);
+
+        let ignored = repo.path().join("secrets.rs");
+        std::fs::write(&ignored, b"pub fn secret() -> u32 { 3 }\n").unwrap();
+        stamp_modified(&ignored, SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000));
+        let visible = repo.path().join("visible.rs");
+        std::fs::write(&visible, b"pub fn visible() -> u32 { 4 }\n").unwrap();
+        stamp_modified(&visible, SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000));
+
+        let window = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
+        let named = event_paths(&plan_catch_up_events(&state, window).unwrap())
+            .iter()
+            .filter_map(|path| path.file_name())
+            .map(|leaf| leaf.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(
+            named.contains(&"visible.rs".to_string()),
+            "the positive control: an ordinary path inside the window is named: {named:?}"
+        );
+        assert!(
+            !named.contains(&"secrets.rs".to_string()),
+            "the catch-up walks under the same rules a tick does: {named:?}"
+        );
+    }
+
+    /// The host paths a planned batch names.
+    fn event_paths(events: &[FileEvent]) -> Vec<PathBuf> {
+        events
+            .iter()
+            .map(|event| {
+                let (FileEvent::Changed(path) | FileEvent::Removed(path)) = event;
+                path.clone()
+            })
+            .collect()
+    }
+
+    /// Set a host entry's modification time outright.
+    ///
+    /// Both stamps are written because setting only one is refused on some
+    /// hosts, and the access time is not what any assertion here reads.
+    fn stamp_modified(path: &Path, at: SystemTime) {
+        let handle = std::fs::File::options().write(true).open(path).unwrap();
+        handle
+            .set_times(std::fs::FileTimes::new().set_accessed(at).set_modified(at))
+            .unwrap();
+        assert_eq!(
+            std::fs::symlink_metadata(path).unwrap().modified().unwrap(),
+            at,
+            "the stamp has to have applied, or every assertion resting on it is about the \
+             file's real age instead"
+        );
+    }
+
 }
 
 /// Decide whether a filesystem-sync tick's bulk deletions should be WITHHELD as

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -6751,6 +6751,114 @@ mod tests {
         );
     }
 
+    /// FIR-2499. A path graph truth already tracks is projection drift, not
+    /// catch-up work, however recently the host touched it.
+    ///
+    /// Repository authority holds bytes for a tracked path, so a host edit to
+    /// one is what `kin doctor --drift` reports and `kin doctor --heal`
+    /// repairs. A catch-up that took it would advance the workspace over
+    /// graph-owned content at daemon start and empty the report an operator is
+    /// about to read. The untracked file beside it is the positive control:
+    /// same directory, same window, and it is still named.
+    #[test]
+    fn the_catch_up_leaves_a_tracked_path_to_the_drift_report() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+
+        let tracked = repo.path().join("tracked.rs");
+        std::fs::write(&tracked, b"pub fn tracked() -> u32 { 1 }\n").unwrap();
+        admit_file_event_ambient(&state, &FileEvent::Changed(tracked.clone())).unwrap();
+        assert!(
+            tree_entry(&state, "tracked.rs").is_some(),
+            "the fixture needs this path tracked before the window is opened"
+        );
+        std::fs::write(&tracked, b"pub fn tracked() -> u32 { 2 }\n").unwrap();
+        stamp_modified(
+            &tracked,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000),
+        );
+
+        let untracked = repo.path().join("untracked.rs");
+        std::fs::write(&untracked, b"pub fn untracked() -> u32 { 3 }\n").unwrap();
+        stamp_modified(
+            &untracked,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000),
+        );
+
+        let window = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
+        let named = event_paths(&plan_catch_up_events(&state, window).unwrap())
+            .iter()
+            .filter_map(|path| path.file_name())
+            .map(|leaf| leaf.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(
+            named.contains(&"untracked.rs".to_string()),
+            "the positive control: content the graph has never met is still named: {named:?}"
+        );
+        assert!(
+            !named.contains(&"tracked.rs".to_string()),
+            "a tracked path edited off-watch is drift for `kin doctor`, not a silent catch-up \
+             admission: {named:?}"
+        );
+    }
+
+    /// FIR-2499. A directory graph truth has never met is disclosed, not swept
+    /// in.
+    ///
+    /// A directory arriving whole is a clone, a move, an unpacked archive or a
+    /// renamed control directory, and a move restamps every entry it carries,
+    /// so modification times cannot tell that content from authored work.
+    /// Admitting one at daemon start is the working-copy sweep startup must
+    /// never perform. The file beside the tracked one is the positive control:
+    /// it sits where the graph already looks, so the window still reaches it.
+    #[test]
+    fn the_catch_up_declines_a_directory_the_graph_has_never_met() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+
+        let known = repo.path().join("known.rs");
+        std::fs::write(&known, b"pub fn known() -> u32 { 1 }\n").unwrap();
+        admit_file_event_ambient(&state, &FileEvent::Changed(known)).unwrap();
+        assert!(
+            tree_entry(&state, "known.rs").is_some(),
+            "the fixture needs the repository root to hold tracked content"
+        );
+
+        let beside = repo.path().join("beside_known.rs");
+        std::fs::write(&beside, b"pub fn beside() -> u32 { 2 }\n").unwrap();
+        stamp_modified(
+            &beside,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000),
+        );
+
+        let arrived = repo.path().join("arrived_whole");
+        std::fs::create_dir_all(&arrived).unwrap();
+        let carried = arrived.join("carried.rs");
+        std::fs::write(&carried, b"pub fn carried() -> u32 { 3 }\n").unwrap();
+        stamp_modified(
+            &carried,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(3_000_000),
+        );
+
+        let window = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
+        let named = event_paths(&plan_catch_up_events(&state, window).unwrap())
+            .iter()
+            .filter_map(|path| path.file_name())
+            .map(|leaf| leaf.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(
+            named.contains(&"beside_known.rs".to_string()),
+            "the positive control: a new file where the graph already looks is named: {named:?}"
+        );
+        assert!(
+            !named.contains(&"carried.rs".to_string()),
+            "a directory the graph has never met is for the behind disclosure and `kin admit`, \
+             not for a startup sweep: {named:?}"
+        );
+    }
+
     /// The host paths a planned batch names.
     fn event_paths(events: &[FileEvent]) -> Vec<PathBuf> {
         events

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -75,7 +75,8 @@ pub use pipeline::{
 pub use repository::{
     canonicalize_host_parent_preserving_leaf, host_path_from_repo_path, is_repository_control_path,
     read_verified_scanned_entry, repo_path_from_host_relative, scan_repository,
-    scan_repository_preserving_graph_only, should_track_host_relative_path,
+    scan_repository_modified_since, scan_repository_preserving_graph_only,
+    should_track_host_relative_path,
     tracked_paths_covered_by_ignore, tracked_paths_retracted_by_ignore, CompleteRepositoryScan,
     CompleteScanToken, IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore,
     RepositoryScanDiagnostics, ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES,

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -76,11 +76,10 @@ pub use repository::{
     canonicalize_host_parent_preserving_leaf, host_path_from_repo_path, is_repository_control_path,
     read_verified_scanned_entry, repo_path_from_host_relative, scan_repository,
     scan_repository_modified_since, scan_repository_preserving_graph_only,
-    should_track_host_relative_path,
-    tracked_paths_covered_by_ignore, tracked_paths_retracted_by_ignore, CompleteRepositoryScan,
-    CompleteScanToken, IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore,
-    RepositoryScanDiagnostics, ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES,
-    PYTHON_VIRTUALENV_MARKER,
+    should_track_host_relative_path, tracked_paths_covered_by_ignore,
+    tracked_paths_retracted_by_ignore, CompleteRepositoryScan, CompleteScanToken,
+    IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore, RepositoryScanDiagnostics,
+    ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES, PYTHON_VIRTUALENV_MARKER,
 };
 pub use resolution::{RelationResolution, RESOLUTION_FIELD, RESOLUTION_TIER_LADDER};
 pub use support::{compute_coverage_report, CoverageReport};

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -2287,6 +2287,8 @@ mod tests {
             policy_excluded_sample: Vec::new(),
             entries: BTreeMap::new(),
             diagnostics: RepositoryScanDiagnostics::default(),
+            mode: ScanMode::Content,
+            modified: Vec::new(),
         };
 
         let error = scanner
@@ -2476,6 +2478,8 @@ mod tests {
             policy_excluded_sample: Vec::new(),
             entries: BTreeMap::new(),
             diagnostics: RepositoryScanDiagnostics::default(),
+            mode: ScanMode::Content,
+            modified: Vec::new(),
         };
 
         let error = scanner

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -1194,9 +1194,10 @@ impl Scanner<'_> {
             // own: a special entry is not admissible either way.
             if let ScanMode::ModifiedSince(since) = self.mode {
                 if file_type.is_file() || file_type.is_symlink() {
-                    let modified = host_entry_modified_since(&host_path, since).map_err(|error| {
-                        self.fail(&host_path, "read entry modification time", error)
-                    })?;
+                    let modified =
+                        host_entry_modified_since(&host_path, since).map_err(|error| {
+                            self.fail(&host_path, "read entry modification time", error)
+                        })?;
                     if modified == Some(true) {
                         self.modified.push(repo_path);
                     }

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -43,6 +43,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
+use std::time::SystemTime;
 
 use kin_model::RepoPath;
 use sha2::{Digest, Sha256};
@@ -860,6 +861,45 @@ pub fn scan_repository_preserving_graph_only<'a>(
     tracked_paths: impl IntoIterator<Item = &'a RepoPath>,
     graph_only_paths: impl IntoIterator<Item = &'a RepoPath>,
 ) -> Result<CompleteRepositoryScan, IncompleteRepositoryScan> {
+    let mut scanner = prepare_scanner(
+        root,
+        ignore,
+        policy,
+        tracked_paths,
+        graph_only_paths,
+        ScanMode::Content,
+    )?;
+    scanner.walk(root, false)?;
+    scanner.diagnostics.admitted_entries = scanner.entries.len();
+    scanner.diagnostics.graph_only_entries_preserved = scanner.graph_only_paths.len();
+    scanner.diagnostics.ignored_tracked_entries_unverified = scanner.unverified_ignored_paths.len();
+    Ok(CompleteRepositoryScan {
+        entries: scanner.entries,
+        graph_only_paths: scanner.graph_only_paths,
+        unverified_ignored_paths: scanner.unverified_ignored_paths,
+        policy_excluded_sample: scanner.policy_excluded_sample,
+        diagnostics: scanner.diagnostics,
+        completion: CompleteScanToken { _private: () },
+    })
+}
+
+/// How many policy-excluded paths one walk names outright. See
+/// [`CompleteRepositoryScan::policy_excluded_paths_sample`].
+const POLICY_EXCLUDED_SAMPLE_LIMIT: usize = 8;
+
+/// Validate the scan baseline and build the walker both modes share.
+///
+/// Extracted so a stat-only pass cannot acquire its own idea of which paths are
+/// tracked, which are graph-only, and which the rules already excluded before
+/// the walk begins.
+fn prepare_scanner<'a, 'b>(
+    root: &'b Path,
+    ignore: &'b RepositoryIgnore,
+    policy: Option<&'b ResolvedAdmissionMatcher>,
+    tracked_paths: impl IntoIterator<Item = &'a RepoPath>,
+    graph_only_paths: impl IntoIterator<Item = &'a RepoPath>,
+    mode: ScanMode,
+) -> Result<Scanner<'b>, IncompleteRepositoryScan> {
     let tracked_paths = tracked_paths.into_iter().cloned().collect::<BTreeSet<_>>();
     let graph_only_paths = graph_only_paths
         .into_iter()
@@ -882,7 +922,7 @@ pub fn scan_repository_preserving_graph_only<'a>(
     let (unverified_ignored_paths, tracked_paths): (BTreeSet<_>, BTreeSet<_>) = tracked_paths
         .into_iter()
         .partition(|path| ignore.matches(path) && !graph_only_paths.contains(path));
-    let mut scanner = Scanner {
+    Ok(Scanner {
         root,
         ignore,
         policy,
@@ -892,24 +932,79 @@ pub fn scan_repository_preserving_graph_only<'a>(
         policy_excluded_sample: Vec::new(),
         entries: BTreeMap::new(),
         diagnostics: RepositoryScanDiagnostics::default(),
-    };
-    scanner.walk(root, false)?;
-    scanner.diagnostics.admitted_entries = scanner.entries.len();
-    scanner.diagnostics.graph_only_entries_preserved = scanner.graph_only_paths.len();
-    scanner.diagnostics.ignored_tracked_entries_unverified = scanner.unverified_ignored_paths.len();
-    Ok(CompleteRepositoryScan {
-        entries: scanner.entries,
-        graph_only_paths: scanner.graph_only_paths,
-        unverified_ignored_paths: scanner.unverified_ignored_paths,
-        policy_excluded_sample: scanner.policy_excluded_sample,
-        diagnostics: scanner.diagnostics,
-        completion: CompleteScanToken { _private: () },
+        mode,
+        modified: Vec::new(),
     })
 }
 
-/// How many policy-excluded paths one walk names outright. See
-/// [`CompleteRepositoryScan::policy_excluded_paths_sample`].
-const POLICY_EXCLUDED_SAMPLE_LIMIT: usize = 8;
+/// What a repository walk does when it reaches a leaf it may admit.
+///
+/// The two modes share every exclusion rule and differ only in what they do
+/// once a leaf survives them. Sharing the walk is the point: a second traversal
+/// written beside this one would decide membership by its own rules, and the
+/// two would drift the first time an exclusion changed.
+#[derive(Debug, Clone, Copy)]
+enum ScanMode {
+    /// Read and hash every admissible leaf, producing byte-exact entries and a
+    /// completion proof.
+    Content,
+    /// Stat every admissible leaf and keep only the paths whose directory entry
+    /// was last modified at or after this instant. Opens nothing, hashes
+    /// nothing, and produces no completion proof, because it observed no
+    /// content and must never be mistaken for a walk that did.
+    ModifiedSince(SystemTime),
+}
+
+/// Repository paths whose host entry was last modified at or after `since`.
+///
+/// This is the cheap half of catching a graph up after a stretch with nobody
+/// watching. A daemon that starts holds authority that is complete as of its
+/// last admission and no evidence at all about what the host did afterwards,
+/// and the file watcher can only report edits it was alive for. Walking with
+/// the same rules the content scan uses, and stopping at the directory entry's
+/// modification time, names exactly the paths worth re-observing without
+/// reading a byte of the ones that did not move.
+///
+/// A leaf whose modification time will not read counts as modified. The window
+/// exists to find work the graph missed, so losing a file is the worse error;
+/// re-observing an unchanged path costs one admission that plans nothing.
+///
+/// A leaf that vanished between the directory read and the stat is left out. It
+/// is not there to admit, and if it comes back the watcher that is already
+/// armed reports its arrival.
+pub fn scan_repository_modified_since<'a>(
+    root: &Path,
+    ignore: &RepositoryIgnore,
+    policy: Option<&ResolvedAdmissionMatcher>,
+    tracked_paths: impl IntoIterator<Item = &'a RepoPath>,
+    graph_only_paths: impl IntoIterator<Item = &'a RepoPath>,
+    since: SystemTime,
+) -> Result<Vec<RepoPath>, IncompleteRepositoryScan> {
+    let mut scanner = prepare_scanner(
+        root,
+        ignore,
+        policy,
+        tracked_paths,
+        graph_only_paths,
+        ScanMode::ModifiedSince(since),
+    )?;
+    scanner.walk(root, false)?;
+    Ok(scanner.modified)
+}
+
+/// Was this directory entry last modified at or after `since`?
+///
+/// `None` means the entry is no longer there. An unreadable modification time
+/// reads as modified, which is the direction that cannot lose a file.
+fn host_entry_modified_since(path: &Path, since: SystemTime) -> io::Result<Option<bool>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(
+            metadata.modified().map(|at| at >= since).unwrap_or(true),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
 
 struct Scanner<'a> {
     root: &'a Path,
@@ -921,6 +1016,9 @@ struct Scanner<'a> {
     policy_excluded_sample: Vec<RepoPath>,
     entries: BTreeMap<RepoPath, ScannedRepositoryEntry>,
     diagnostics: RepositoryScanDiagnostics,
+    mode: ScanMode,
+    /// Paths [`ScanMode::ModifiedSince`] kept. Empty in every other mode.
+    modified: Vec<RepoPath>,
 }
 
 impl Scanner<'_> {
@@ -1086,6 +1184,23 @@ impl Scanner<'_> {
             if !self.tracked_paths.contains(&repo_path)
                 && self.policy_excludes_untracked(&repo_path, false)
             {
+                continue;
+            }
+
+            // A stat-only pass stops here. Every exclusion above has already
+            // run, so what it keeps is exactly what a content walk would have
+            // admitted, minus the reads. Restricted to the two leaf kinds the
+            // content walk admits so this mode invents no membership of its
+            // own: a special entry is not admissible either way.
+            if let ScanMode::ModifiedSince(since) = self.mode {
+                if file_type.is_file() || file_type.is_symlink() {
+                    let modified = host_entry_modified_since(&host_path, since).map_err(|error| {
+                        self.fail(&host_path, "read entry modification time", error)
+                    })?;
+                    if modified == Some(true) {
+                        self.modified.push(repo_path);
+                    }
+                }
                 continue;
             }
 

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -869,7 +869,7 @@ pub fn scan_repository_preserving_graph_only<'a>(
         graph_only_paths,
         ScanMode::Content,
     )?;
-    scanner.walk(root, false)?;
+    scanner.walk(root, false, true)?;
     scanner.diagnostics.admitted_entries = scanner.entries.len();
     scanner.diagnostics.graph_only_entries_preserved = scanner.graph_only_paths.len();
     scanner.diagnostics.ignored_tracked_entries_unverified = scanner.unverified_ignored_paths.len();
@@ -951,7 +951,9 @@ enum ScanMode {
     /// Stat every admissible leaf and keep only the paths whose directory entry
     /// was last modified at or after this instant. Opens nothing, hashes
     /// nothing, and produces no completion proof, because it observed no
-    /// content and must never be mistaken for a walk that did.
+    /// content and must never be mistaken for a walk that did. Narrower than
+    /// [`ScanMode::Content`] by two rules: a tracked path is never kept, and
+    /// neither is a leaf inside a directory graph truth has never met.
     ModifiedSince(SystemTime),
 }
 
@@ -968,6 +970,15 @@ enum ScanMode {
 /// A leaf whose modification time will not read counts as modified. The window
 /// exists to find work the graph missed, so losing a file is the worse error;
 /// re-observing an unchanged path costs one admission that plans nothing.
+///
+/// What this names is bounded on both sides. Below, by `since`, so the pass is
+/// never a whole-working-copy sweep. Across, by two rules the content walk does
+/// not apply: a path graph truth already tracks stays projection drift for
+/// `kin doctor` to report and repair rather than being admitted from under it,
+/// and a leaf inside a directory graph truth has never met is left to the
+/// behind disclosure and to `kin admit`, because a directory arriving whole is
+/// a move or a clone and its entries carry fresh modification times whatever
+/// their content's age.
 ///
 /// A leaf that vanished between the directory read and the stat is left out. It
 /// is not there to admit, and if it comes back the watcher that is already
@@ -988,7 +999,7 @@ pub fn scan_repository_modified_since<'a>(
         graph_only_paths,
         ScanMode::ModifiedSince(since),
     )?;
-    scanner.walk(root, false)?;
+    scanner.walk(root, false, true)?;
     Ok(scanner.modified)
 }
 
@@ -1085,6 +1096,7 @@ impl Scanner<'_> {
         &mut self,
         directory: &Path,
         within_excluded_environment: bool,
+        directory_known_to_graph: bool,
     ) -> Result<(), IncompleteRepositoryScan> {
         self.diagnostics.directories_visited += 1;
         let entries = fs::read_dir(directory)
@@ -1148,6 +1160,7 @@ impl Scanner<'_> {
                 self.walk(
                     &host_path,
                     within_excluded_environment || excluded_environment,
+                    holds_tracked,
                 )?;
                 continue;
             }
@@ -1193,6 +1206,38 @@ impl Scanner<'_> {
             // content walk admits so this mode invents no membership of its
             // own: a special entry is not admissible either way.
             if let ScanMode::ModifiedSince(since) = self.mode {
+                // Two narrowings this mode applies and the content walk does
+                // not, because the two modes answer different questions. A
+                // content walk states what the working copy holds. This mode
+                // proposes what a daemon should re-observe after a stretch
+                // nobody watched, and a proposal is admitted with no operator
+                // in the loop, so it may only reach the population where
+                // admitting is the safe direction.
+                //
+                // A path graph truth already tracks is never proposed.
+                // Repository authority holds bytes for it, so a host edit to it
+                // is projection drift: `kin doctor --drift` reports it, `kin
+                // doctor --heal` restores it from authority and `kin admit`
+                // takes it, and each of those is a seam somebody chose.
+                // Proposing it here would instead advance the workspace over
+                // graph-owned content at daemon start, behind the back of the
+                // report an operator is about to read.
+                //
+                // A leaf inside a directory graph truth has never met is not
+                // proposed either. One file appearing beside files the graph
+                // already tracks is an edit to a part of the tree the graph
+                // knows; a directory nobody has ever admitted, arriving whole,
+                // is a clone, a move, an unpacked archive or a renamed control
+                // directory, and modification times cannot tell those from
+                // authored work because a move restamps every entry it carries.
+                // Admitting one silently at startup is the working-copy sweep
+                // startup must never perform. Nothing is lost by declining:
+                // that content is exactly what the behind disclosure counts and
+                // names, so it is announced rather than hidden, and `kin admit`
+                // is the seam that takes it.
+                if self.tracked_paths.contains(&repo_path) || !directory_known_to_graph {
+                    continue;
+                }
                 if file_type.is_file() || file_type.is_symlink() {
                     let modified =
                         host_entry_modified_since(&host_path, since).map_err(|error| {

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -2106,6 +2106,87 @@ mod tests {
             .is_none());
     }
 
+    /// FIR-2499. The pair that was wrong together: a store holding an
+    /// unadmitted module reported "0 uncommitted; durable repository authority
+    /// records everything answering here".
+    #[test]
+    fn a_store_holding_unadmitted_host_paths_never_reports_an_all_clear() {
+        let env = Envelope::daemon().with_health(&serde_json::json!({
+            "graph_entity_count": 51,
+            "durable_entity_count": 51,
+            "reconcile": {
+                "untracked_path_count": 1,
+                "untracked_paths_sample": ["notekeeper/search.py"],
+                "last_admission_success_at": "2026-08-20T13:00:00Z",
+            },
+        }));
+
+        let behind = env
+            .behind
+            .as_ref()
+            .expect("a reported untracked path is the store being behind");
+        assert_eq!(behind.unadmitted_paths, 1);
+        assert_eq!(behind.since.as_deref(), Some("2026-08-20T13:00:00Z"));
+        assert_eq!(behind.sample, vec!["notekeeper/search.py".to_string()]);
+
+        let durability = env.durability.expect("the counts still answer");
+        assert_eq!(
+            durability.live_entities,
+            Some(51),
+            "the counts were never the wrong part and are left exactly as observed"
+        );
+        assert!(
+            !durability.note.contains("records everything answering here"),
+            "the all-clear this reading cannot make: {}",
+            durability.note
+        );
+        assert!(
+            durability.note.contains("host path(s) on disk that no admission has taken"),
+            "the note has to name what it does not cover: {}",
+            durability.note
+        );
+    }
+
+    /// The control for the case above, and the one that keeps this from
+    /// qualifying every answer: a store with nothing unadmitted says so exactly
+    /// as before.
+    #[test]
+    fn a_store_with_nothing_unadmitted_keeps_its_recorded_reading() {
+        let env = Envelope::daemon().with_health(&serde_json::json!({
+            "graph_entity_count": 51,
+            "durable_entity_count": 51,
+            "reconcile": { "untracked_path_count": 0 },
+        }));
+
+        assert!(env.behind.is_none(), "nothing unadmitted is nothing to say");
+        let durability = env.durability.expect("the counts still answer");
+        assert_eq!(durability.state, "recorded");
+        assert!(
+            durability.note.contains("records everything answering here"),
+            "{}",
+            durability.note
+        );
+    }
+
+    /// A body carrying no reconcile reading at all says nothing here. Silence
+    /// is the absence of a reading, never a zero this envelope did not verify.
+    #[test]
+    fn a_health_body_with_no_reconcile_reading_makes_no_behind_claim() {
+        let env = Envelope::daemon().with_health(&serde_json::json!({
+            "graph_entity_count": 51,
+            "durable_entity_count": 51,
+        }));
+        assert!(env.behind.is_none());
+
+        // And a reconcile block that omits the count is the same answer, which
+        // is the arm that would otherwise read as zero.
+        let partial = Envelope::daemon().with_health(&serde_json::json!({
+            "graph_entity_count": 51,
+            "reconcile": { "skipped_events": 3 },
+        }));
+        assert!(partial.behind.is_none());
+    }
+
     #[test]
     fn with_health_missing_fields_stay_unknown() {
         // An empty/partial health body must not fabricate `false`/`0` values.

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -530,8 +530,9 @@ impl GraphBehind {
     fn describe(unadmitted_paths: u64, since: Option<&str>) -> String {
         let clock = match since {
             Some(since) => format!("the last complete admission was at {since}"),
-            None => "this daemon has not reported when a complete admission last succeeded"
-                .to_string(),
+            None => {
+                "this daemon has not reported when a complete admission last succeeded".to_string()
+            }
         };
         format!(
             "{unadmitted_paths} host path(s) are on disk that graph truth does not carry, and \
@@ -2136,12 +2137,16 @@ mod tests {
             "the counts were never the wrong part and are left exactly as observed"
         );
         assert!(
-            !durability.note.contains("records everything answering here"),
+            !durability
+                .note
+                .contains("records everything answering here"),
             "the all-clear this reading cannot make: {}",
             durability.note
         );
         assert!(
-            durability.note.contains("host path(s) on disk that no admission has taken"),
+            durability
+                .note
+                .contains("host path(s) on disk that no admission has taken"),
             "the note has to name what it does not cover: {}",
             durability.note
         );
@@ -2162,7 +2167,9 @@ mod tests {
         let durability = env.durability.expect("the counts still answer");
         assert_eq!(durability.state, "recorded");
         assert!(
-            durability.note.contains("records everything answering here"),
+            durability
+                .note
+                .contains("records everything answering here"),
             "{}",
             durability.note
         );

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -461,6 +461,106 @@ pub struct Durability {
     pub note: String,
 }
 
+/// How far graph truth is behind the working copy this daemon watches.
+///
+/// Two facts a reader has to have together. `unadmitted_paths` is how many host
+/// paths the daemon's most recent complete walk observed that repository
+/// authority does not carry and no observation covered; `since` is when a
+/// complete admission last succeeded. Either alone misleads. A count with no
+/// clock cannot say whether the store fell behind a second ago or a month ago,
+/// and a clock with no count cannot say whether anything is actually missing.
+///
+/// Present only when the store IS behind. An absent object is not a claim that
+/// it is current: a runtime that reported no reconcile reading has nothing to
+/// say here, and reporting a zero it never verified is the shape of wrong
+/// answer this object exists to stop.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GraphBehind {
+    /// Host paths on disk that no admission has taken.
+    pub unadmitted_paths: u64,
+    /// When a complete admission last succeeded, as the daemon reported it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since: Option<String>,
+    /// A bounded sample of the unadmitted paths, enough to recognize the file
+    /// you just wrote.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sample: Vec<String>,
+    /// One line an agent can act on without reading the counts.
+    pub note: String,
+}
+
+impl GraphBehind {
+    /// Read the two halves out of a daemon `/health` body.
+    ///
+    /// `None` when the body carries no reconcile reading at all, and `None`
+    /// again when it reports nothing unadmitted. The two are different facts and
+    /// both are correctly silent here: this object speaks only when the store is
+    /// behind, and the gates that consume it treat its silence as no reading
+    /// rather than as an all-clear.
+    pub fn from_health(health: &Value) -> Option<Self> {
+        let reconcile = health.get("reconcile")?;
+        let unadmitted_paths = reconcile.get("untracked_path_count")?.as_u64()?;
+        if unadmitted_paths == 0 {
+            return None;
+        }
+        let since = reconcile
+            .get("last_admission_success_at")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let sample = reconcile
+            .get("untracked_paths_sample")
+            .and_then(Value::as_array)
+            .map(|paths| {
+                paths
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let note = Self::describe(unadmitted_paths, since.as_deref());
+        Some(Self {
+            unadmitted_paths,
+            since,
+            sample,
+            note,
+        })
+    }
+
+    fn describe(unadmitted_paths: u64, since: Option<&str>) -> String {
+        let clock = match since {
+            Some(since) => format!("the last complete admission was at {since}"),
+            None => "this daemon has not reported when a complete admission last succeeded"
+                .to_string(),
+        };
+        format!(
+            "{unadmitted_paths} host path(s) are on disk that graph truth does not carry, and \
+             {clock}. Answers here cover admitted content only. `kin admit` takes those paths \
+             now, and a commit takes them anyway."
+        )
+    }
+
+    /// The machine-stable reason an absence claim cannot be certified over this
+    /// store.
+    ///
+    /// A symbol defined only inside an unadmitted path is absent from every
+    /// index the query reads, so the answer is right about the graph and wrong
+    /// about the repository. That is the difference between "not there" and "not
+    /// admitted yet", and it is the whole of what this factor names.
+    pub fn limiting_factor(&self) -> String {
+        let clock = match self.since.as_deref() {
+            Some(since) => format!("the last complete admission was at {since}"),
+            None => "no complete admission has been reported".to_string(),
+        };
+        format!(
+            "graph_behind_working_tree: {} host path(s) on disk have never been admitted and \
+             {clock}, so an absence here cannot be told apart from content the graph has not \
+             taken yet",
+            self.unadmitted_paths
+        )
+    }
+}
+
 impl Durability {
     /// Derive the durability state from the two counts the daemon observed.
     ///
@@ -525,6 +625,31 @@ impl Durability {
                 }
             ),
         }
+    }
+
+    /// Restate this reading over a store the working copy has outrun.
+    ///
+    /// [`Self::observe`] compares two ENTITY counts, so it answers a question
+    /// about what a commit carries and is structurally unable to see a file no
+    /// admission has taken. A store holding unadmitted host paths therefore
+    /// reached `recorded` and said "durable repository authority records
+    /// everything answering here" over a repository holding a 140-line module
+    /// the graph had never met (FIR-2499). The counts are left exactly as
+    /// observed, because they were never the wrong part; what changes is the
+    /// claim made from them.
+    pub fn qualified_by(mut self, behind: &GraphBehind) -> Self {
+        let counts = match (self.live_entities, self.live_only_entities) {
+            (Some(live), Some(live_only)) => format!("{live} entities, {live_only} uncommitted"),
+            (Some(live), None) => format!("{live} entities"),
+            _ => "this graph".to_string(),
+        };
+        self.note = format!(
+            "{counts}, and {} host path(s) on disk that no admission has taken; this reading \
+             covers admitted content only. `kin admit` takes those paths now, and a commit takes \
+             them anyway.",
+            behind.unadmitted_paths
+        );
+        self
     }
 
     /// True when durable authority does not carry everything the answer read.
@@ -1182,6 +1307,18 @@ pub struct Envelope {
     /// saying `unknown` for a runtime that has no durable layer to compare to.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub durability: Option<Durability>,
+    /// How far graph truth is behind the working copy, when the runtime
+    /// reported that it is behind at all.
+    ///
+    /// Beside `durability` rather than inside it because the two count
+    /// different things and can disagree. `durability` compares entity counts
+    /// and answers "is what answered here recorded"; this compares the graph to
+    /// the host and answers "is there content that never reached the graph at
+    /// all". A store can be perfectly durable and still be missing the file you
+    /// wrote a minute ago, which is exactly the pair FIR-2499 caught reporting
+    /// an all-clear.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub behind: Option<GraphBehind>,
     /// Honest graph freshness context; omitted entirely when nothing is known.
     #[serde(default, skip_serializing_if = "GraphState::is_empty")]
     pub graph_state: GraphState,
@@ -1222,6 +1359,7 @@ impl Envelope {
             semantic_coverage: None,
             graph_as_of: None,
             durability: None,
+            behind: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 offline_fallback: Some(true),
@@ -1243,6 +1381,7 @@ impl Envelope {
             semantic_coverage: None,
             graph_as_of: None,
             durability: None,
+            behind: None,
             graph_state: GraphState::default(),
             degraded: Degraded::default(),
             completeness: None,
@@ -1295,7 +1434,15 @@ impl Envelope {
             graph_body_gap_paths: None,
         });
         self.graph_as_of = None;
-        self.durability = Some(Durability::observe(entity_count, durable_entity_count));
+        let durability = Durability::observe(entity_count, durable_entity_count);
+        // Requalified rather than replaced. This runs on the graph-status path,
+        // which may set durability after `with_health` has already read the
+        // reconcile block, and a plain assignment there would restore the
+        // all-clear note that block exists to withdraw.
+        self.durability = Some(match self.behind.as_ref() {
+            Some(behind) => durability.qualified_by(behind),
+            None => durability,
+        });
         self.graph_state = GraphState {
             entity_count: Some(entity_count),
             ..GraphState::default()
@@ -1313,6 +1460,7 @@ impl Envelope {
             semantic_coverage: None,
             graph_as_of: None,
             durability: None,
+            behind: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 daemon_unreachable: Some(true),
@@ -1339,6 +1487,7 @@ impl Envelope {
             semantic_coverage: None,
             graph_as_of: None,
             durability: None,
+            behind: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 workspace_mismatch: Some(true),
@@ -1385,6 +1534,17 @@ impl Envelope {
                 live,
                 health.get("durable_entity_count").and_then(Value::as_u64),
             ));
+        }
+        // Read after the counts, and applied to them. The reconcile block is
+        // the only place a response can learn that the host holds content the
+        // graph never met, and without it every surface built from the counts
+        // above states an all-clear it did not verify.
+        self.behind = GraphBehind::from_health(health);
+        if let Some(behind) = self.behind.as_ref() {
+            self.durability = self
+                .durability
+                .take()
+                .map(|durability| durability.qualified_by(behind));
         }
         // The daemon `/health` `graph_generation` marker (monotonic snapshot
         // generation, bumped per committed snapshot) is a precise freshness

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -2152,6 +2152,45 @@ mod tests {
         );
     }
 
+    /// FIR-2499. The graph-status path sets durability after `with_health` has
+    /// already read the reconcile block, so it has to requalify rather than
+    /// assign.
+    ///
+    /// This is the sibling of the case above and it needed its own: a plain
+    /// assignment here restores the all-clear the reconcile block exists to
+    /// withdraw, and every assertion on the `with_health` path stays green
+    /// while it does, because that path is not the one this call rewrites.
+    #[test]
+    fn a_graph_status_reading_over_a_behind_store_does_not_restore_the_all_clear() {
+        let env = Envelope::daemon()
+            .with_health(&serde_json::json!({
+                "graph_entity_count": 51,
+                "durable_entity_count": 51,
+                "reconcile": {
+                    "untracked_path_count": 2,
+                    "untracked_paths_sample": ["notekeeper/search.py"],
+                    "last_admission_success_at": "2026-08-20T13:00:00Z",
+                },
+            }))
+            .with_selected_graph_observation(51, 51, 0, 51, Some(51));
+
+        let durability = env.durability.expect("graph status reports the counts");
+        assert!(
+            !durability
+                .note
+                .contains("records everything answering here"),
+            "the graph-status reading restored an all-clear over a behind store: {}",
+            durability.note
+        );
+        assert!(
+            durability
+                .note
+                .contains("host path(s) on disk that no admission has taken"),
+            "the note has to keep naming what it does not cover: {}",
+            durability.note
+        );
+    }
+
     /// The control for the case above, and the one that keeps this from
     /// qualifying every answer: a store with nothing unadmitted says so exactly
     /// as before.

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -3351,6 +3351,81 @@ mod tests {
         assert_eq!(negative["safe_to_conclude_absent"], json!(true));
     }
 
+    /// FIR-2499. An absence over a store the working copy has outrun is
+    /// unknown, not absent.
+    ///
+    /// The reported case: `semantic_search("build_match_query")` returned zero
+    /// rows with `safe_to_conclude_absent: true` while the function sat in a
+    /// 140-line module on disk that no admission had taken. The graph answered
+    /// correctly and the claim made from it was wrong, because the module was in
+    /// no index the query reads.
+    #[test]
+    fn an_absence_over_unadmitted_host_content_certifies_nothing() {
+        let payload = empty_search_page(resolvable_language_scope(Some(29)));
+
+        // The positive control first, so a failure below cannot be the payload
+        // simply never certifying.
+        let certified = negative_for("semantic_search", &payload, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(
+            certified["safe_to_conclude_absent"],
+            json!(true),
+            "the control this test rests on: the same payload certifies when the store is level"
+        );
+
+        let negative = negative_for("semantic_search", &payload, &behind_envelope(1))
+            .expect("empty results yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("graph_behind_working_tree"),
+            "the factor names the store being behind: {reason}"
+        );
+        assert!(
+            reason.contains("host path(s) on disk have never been admitted"),
+            "and says what that means for the claim: {reason}"
+        );
+    }
+
+    /// The scope of the gate. A populated answer asserts no absence, so a store
+    /// being behind is not a limit on it; applying it there would put a floor
+    /// under every answer on every working copy holding one untracked file.
+    #[test]
+    fn a_populated_answer_is_not_qualified_by_unadmitted_host_content() {
+        let mut payload = empty_search_page(resolvable_language_scope(Some(29)));
+        payload["results"] = json!([{ "entity_id": "e1", "name": "build_match_query" }]);
+        payload["total_matches"] = json!(1);
+
+        let level = negative_for("semantic_search", &payload, &structural_ready_envelope());
+        let behind = negative_for("semantic_search", &payload, &behind_envelope(1));
+        let reason_of = |value: &Option<Value>| {
+            value
+                .as_ref()
+                .and_then(|negative| negative["trust_reason"].as_str().map(str::to_string))
+        };
+        assert_eq!(
+            reason_of(&behind),
+            reason_of(&level),
+            "a populated answer reads the same either way; this gate speaks only about absences"
+        );
+    }
+
+    /// A daemon envelope that is otherwise authoritative over a store holding
+    /// host paths no admission has taken.
+    fn behind_envelope(unadmitted_paths: u64) -> Envelope {
+        Envelope::daemon().with_health(&json!({
+            "graph_loaded": true,
+            "initialized": true,
+            "graph_generation": 12,
+            "reconcile": {
+                "untracked_path_count": unadmitted_paths,
+                "untracked_paths_sample": ["notekeeper/search.py"],
+                "last_admission_success_at": "2026-08-20T13:00:00Z",
+            },
+        }))
+    }
+
     #[test]
     fn an_authoritative_absence_never_recites_a_coverage_it_did_not_rest_on() {
         // FIR-2430 contract item 3. The express envelope certified an absence in

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -3361,7 +3361,12 @@ mod tests {
     /// no index the query reads.
     #[test]
     fn an_absence_over_unadmitted_host_content_certifies_nothing() {
-        let payload = empty_search_page(resolvable_language_scope(Some(29)));
+        // The scope carries a measured coverage class, which is what lets this
+        // payload certify at all. Without it the FIR-2496 refusal answers first
+        // and the control below asserts a certification no payload of this shape
+        // can make, which would leave this case unable to tell a working gate
+        // from a broken one.
+        let payload = empty_search_page(scope_with_a_measured_class(Some(29)));
 
         // The positive control first, so a failure below cannot be the payload
         // simply never certifying.

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1075,6 +1075,25 @@ pub(crate) fn edge_coverage_degradation_labels(tool: &str, payload: &Value) -> V
 /// `trust_reason` directly. Direct assignment is how a cross-repo topology note
 /// came to overwrite the reason an absence was actually limited by, leaving a
 /// correct verdict beside an unrelated explanation.
+/// Host content on disk that no admission has taken, which no absence claim can
+/// see past.
+///
+/// The store answered from graph truth, and graph truth does not carry these
+/// paths at all. A symbol defined only inside one of them is missing from every
+/// index the query reads, so the answer is right about the graph and wrong about
+/// the repository. That is how `semantic_search` returned
+/// `safe_to_conclude_absent: true` for a function sitting in a 140-line module
+/// on disk, with `durability` in the same payload reading "0 uncommitted"
+/// (FIR-2499).
+///
+/// Silence here is the absence of a reading, never an all-clear: the envelope
+/// carries this object only when the runtime reported that the store is behind,
+/// and a runtime that reported no reconcile block at all is already refused by
+/// the runtime gates above.
+fn unadmitted_host_content_gap(envelope: &Envelope) -> Option<String> {
+    Some(envelope.behind.as_ref()?.limiting_factor())
+}
+
 fn push_gap(trustworthy: &mut bool, trust_reason: &mut String, gap: String) {
     *trust_reason = if *trustworthy {
         gap
@@ -2003,6 +2022,17 @@ pub fn negative_for(
     // if it were.
     if let Some(gap) = absence_coverage_gap(tool, payload) {
         push_gap(&mut trustworthy, &mut trust_reason, gap);
+    }
+
+    // Scoped to answers that actually claim an absence, for the same reason the
+    // cross-repo gate below is. A store being behind bounds what "nothing is
+    // there" can mean; it says nothing about whether the rows a populated answer
+    // did return are real, and applying it there would put a floor under every
+    // answer on every working copy holding one untracked file.
+    if claims_absence {
+        if let Some(gap) = unadmitted_host_content_gap(envelope) {
+            push_gap(&mut trustworthy, &mut trust_reason, gap);
+        }
     }
 
     // Gaps the response carries that this function cannot observe from the


### PR DESCRIPTION
The daemon no longer advertises itself before it is watching, a file written while nothing was watching now reaches the graph on the next daemon's first round instead of waiting for a commit, and a store the working copy has outrun says so on the surfaces that were quietly certifying an all-clear over it.

## What was wrong

**FIR-2466.** `crates/kin-daemon/src/daemon.rs` published `.kin/daemon.port` and then spawned the reconciliation loop, and that loop is what calls `FileWatcher::new` (`crates/kin-daemon/src/loop_runner.rs`). The port file is the readiness signal real clients key on, so a client that connected the moment it appeared and wrote immediately landed in a window where no watcher existed. The write raised no event, and `run_loop`'s startup deliberately admitted nothing, so nothing replayed it. The ticket measured that window at 5 to 113 ms on this host.

**FIR-2499.** The ingestion half is one mechanism rather than two. kin#739 already admits an observed new file into the workspace as it is written, so a create is admitted within a tick provided the watcher saw it. What no watcher can see is a write that lands while no watcher exists, and that is not only a startup artifact: an idle timeout ends a daemon mid-session and the next command starts a fresh one, so the window recurs for as long as an agent keeps working.

The disclosure half was real and separate. `Durability::observe` (`crates/kin-mcp/src/envelope.rs`) compares two entity counts, so it answers "is what answered here recorded" and is structurally unable to see a file no admission has taken. It reached `recorded` and said "durable repository authority records everything answering here" over a repository holding a 140-line module the graph had never met.

## What changed

`crates/kin-index/src/repository.rs`, `crates/kin-index/src/lib.rs`: a `ScanMode` on the existing `Scanner`, plus `scan_repository_modified_since`. It walks under every exclusion rule the content scan uses, stats each admissible leaf, and keeps the paths modified at or after a given instant. It opens nothing and hashes nothing. `prepare_scanner` was extracted so the two modes cannot acquire different ideas of which paths are tracked.

The stat-only mode is narrower than the content walk by two rules, and both exist because its output is admitted with no operator in the loop. A path repository authority already tracks is never proposed, because a host edit to one is projection drift that `kin doctor --drift` reports and `kin doctor --heal` repairs; proposing it here advances the workspace over graph-owned content behind the back of the report an operator is about to read. A leaf inside a directory graph truth has never met is not proposed either, because a move restamps every entry it carries, so modification times cannot tell a clone, an unpacked archive or a renamed control directory from authored work, and admitting one at daemon start is the working-copy sweep startup must never perform. Nothing is lost by declining the second: that content is exactly what the behind disclosure counts and names, and `kin admit` is the seam that takes it.

`crates/kin-daemon/src/loop_runner.rs`: `WatchArmed`, a one-shot the loop fires on arming and again on drop, and `run_loop_armed` beside the unchanged `run_loop`. Drop-firing is the safety argument: a disabled reconciler, a bare checkout and a refused watcher all end the loop before it ever builds a watcher, and a daemon waiting on a signal none of those paths sends would never publish its endpoint at all. `startup_catch_up_window` reads the durable last-admission marker and returns the window, or `None` when no marker names one. `plan_catch_up_events` turns that window into ordinary `FileEvent::Changed` events, and the first round enqueues them, so every catch-up path crosses authority through the same bounded observation, the same policy filter and the same compare-and-swap a watcher-observed edit does. A store with no marker gets no catch-up rather than a working-copy sweep.

`crates/kin-daemon/src/daemon.rs`: the reconciliation loop is spawned before `publish_daemon_endpoint`, and publication waits on the arming signal under a 30 second ceiling (`WATCH_ARMING_BOUND`). `await_watch_armed` returns `Armed`, `LoopGone` or `TimedOut`, and `announce_watch_arming` says which. Publishing late beats not publishing, so the bound expires into publication with the reason logged. A new `info!` record, "published the daemon endpoint", makes the ordering readable off the daemon's own log instead of inferred from timings.

`crates/kin-mcp/src/envelope.rs`: `GraphBehind`, carried on the envelope as `_kin.behind`, holding how many host paths are unadmitted, when a complete admission last succeeded, and a bounded sample. Read from the daemon's own reconcile block in `with_health`. Present only when the store IS behind, so its absence is the absence of a reading and never a zero the envelope did not verify. `Durability::qualified_by` restates the note over such a store and leaves the counts exactly as observed, because the counts were never the wrong part.

`crates/kin-mcp/src/negative.rs`: `unadmitted_host_content_gap`, one function, pushed through the existing `push_gap` accumulator and scoped to answers that actually claim an absence. A populated answer asserts no absence, and applying it there would put a floor under every answer on every working copy holding one untracked file. It composes with the coverage gate #1043 landed rather than colliding with it, because both reach the verdict through that one accumulator.

`crates/kin-cli/src/commands/diff.rs`: `admitted_scope_line`, which names the scope both endpoints cover and when the graph last caught up.

`crates/kin-cli/tests/live_graph_durability_disclosure.rs`: two live cases against a real daemon. The second carries the disclosure proof end to end. It writes two files while no daemon is running: one with an ordinary modification time, which the catch-up takes, and one stamped before every admission this store has recorded, which the catch-up must not take. That second file is the control on the window's lower bound and it is also what leaves the store behind by exactly one path, so a real MCP session over the real daemon then has to report `unadmitted_paths: 1` and a durability note that no longer says it records everything answering here.

## Why the previous head was red, and what it turned out to be

The previous head failed `Check & Test` on ubuntu, both macOS shards and the featureless permutation, on two tests this branch does not touch: `branch_switch_preserves_graph_only_gitlinks_without_traversing_nested_checkout` and `heal_restores_diverged_tracked_members_from_graph_truth`. Neither was a load flake and neither was a collision with main; sibling PR #1046 ran all four of those contexts green on the same base. Both were this branch's own defect, and disabling only the catch-up wiring turned the gitlink case green three times running, which is what named the half at fault. The drift case was the tracked-path rule: with a daemon stopped and two tracked members diverged, `kin doctor --drift` read `drift_count 2`, the daemon logged `admitting host paths modified since the last complete admission count=1`, and the next drift read 1, so heal saw fewer divergences than drift had reported. The gitlink case was the directory rule, and the failure message pointed at the wrong thing: the admitted path was `git-authority-disabled/info/exclude`, the `.git` directory the fixture renames, not gitlink content at all. Once that path stopped being proposed the case passed with no change to the fixture.

## Falsification

Every sabotage was confirmed applied by reading the diff before the run, and every file was restored and verified byte-identical against HEAD afterwards. Each daemon-driven pass rebuilt `kin-daemon` explicitly first, because `cargo test -p kin-cli` does not rebuild the binary the fixture spawns and an earlier run of this repair read a stale one.

Restoring the old startup order (publish, then spawn) failed `the_reconciliation_watch_is_armed_before_the_endpoint_is_published` with "the watch must exist before the endpoint advertises this daemon, but the watcher record is at byte 2482 and the publication record at 2338", and left the catch-up case passing: `1 passed; 1 failed`.

Forcing `catch_up_owed` to `None` failed `a_file_written_while_no_daemon_watched_is_admitted_by_the_next_one` with "the daemon did not plan a startup catch-up over what changed while it was down within 90s", left the ordering case passing, and left all six catch-up unit tests passing, because they drive `startup_catch_up_window` and `plan_catch_up_events` directly.

Removing the absence gate call left `safe_to_conclude_absent` at `Bool(true)` over a behind store while the populated-answer control still passed.

Removing the `with_health` durability requalification failed `a_store_holding_unadmitted_host_paths_never_reports_an_all_clear` with the reported sentence quoted back: "51 entities, 0 uncommitted; durable repository authority records everything answering here."

Removing only the tracked-path rule failed `the_catch_up_leaves_a_tracked_path_to_the_drift_report` with "a tracked path edited off-watch is drift for `kin doctor`, not a silent catch-up admission" and left the directory case passing. Removing only the directory rule failed `the_catch_up_declines_a_directory_the_graph_has_never_met` with "a directory the graph has never met is for the behind disclosure and `kin admit`, not for a startup sweep" and left the tracked case passing.

Two test-quality repairs came out of this. Sabotaging the graph-status arm of the behind requalification left every envelope test green, so that arm had no coverage at all; it now has a case that fails there with the restored sentence quoted back. And the behind-store absence case rested on a control asserting that the same payload certifies when the store is level, which stopped holding once #1043's coverage refusal landed, so the control was moved onto the measured-class scope built for exactly that. With the control valid again, removing the behind gate fails the behind assertion rather than the control.

## Gates

`cargo fmt --all -- --check` rc 0. Clippy exactly as `.github/workflows/ci.yml` runs it, `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the 45-lint debt allow-list, rc 0 with zero errors. All five guard scripts the workflow names, run from the repository root: `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh` and `verify-hydration-semantics.py`, each rc 0. The new filesystem work is in `crates/kin-index/`, which the zero-file-search verifier excludes wholesale as a declared ingestion boundary, so no allowlist entry was added and nothing new was excused.

The full local gate ran under one build slot against this branch's own worktree, which `kin-lane run` named as `worktree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/portwatch-kin`, and read `Summary [ 489.017s] 6859 tests run: 6859 passed (4 slow), 12 skipped`, taken from the run log rather than an exit code. `kin-dev` reported all repos green and no tracked lock contamination.

`git diff origin/main --stat -- Cargo.lock .cargo/` is empty and `git ls-tree -r HEAD --name-only` lists `.cargo/config.toml` and nothing else under `.cargo/`.

## What this does not claim

The container half of FIR-2499 is not closed, which is why it is referenced rather than closed here. The stranger ran inside Docker on macOS and suspected the bind mount. Nothing was reproduced in a container; what is proven is that a create is admitted within a tick on this host when the watcher sees it, and that the write nothing watched is now replayed. If in-container events are being dropped by the mount, this does not fix that.

`kin diff` is not claimed to report "behind by N paths". It talks to no daemon, so it can name when the graph last caught up from the durable marker and cannot name how many paths are outstanding without a daemon round trip. The full pair is on the MCP envelope, where the reconcile reading is already available.

The catch-up is not claimed to cover divergence older than the last recorded admission, nor a file modified during a running admission's own walk, nor content the two narrowing rules decline. Those last are disclosed by `_kin.behind` and taken by `kin admit`, which is the trade the rules make on purpose.

Closes FIR-2466
Refs FIR-2499
