### PR TITLE
Cover the sealed-tree and restored-tree allowance derivation sites with fixtures

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -18884,6 +18884,8 @@ mod tests {
             state.graph.resolved_tree().len() as u64,
             "the record must cover the tree the admission passed over"
         );
+    }
+
     /// The body the approval under test names.
     ///
     /// Deliberately harmless. This test asks one question, whether the sealed

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -18884,6 +18884,104 @@ mod tests {
             state.graph.resolved_tree().len() as u64,
             "the record must cover the tree the admission passed over"
         );
+    /// The body the approval under test names.
+    ///
+    /// Deliberately harmless. This test asks one question, whether the sealed
+    /// tree's derivation reads a tracked approval at all, and answering it does
+    /// not require the approval to be clearing a live refusal. Approving a real
+    /// secret would drag in authority's separate rule that an approved body must
+    /// already be in repository CAS before the transition that approves it, and
+    /// this test would then fail for a reason that has nothing to do with the
+    /// derivation site.
+    #[cfg(unix)]
+    const STASH_APPROVED_BODY: &[u8] = b"def normalize(term):\n    return term.strip()\n";
+
+    /// Sealing a workspace derives the policy for the sealed tree, and it has to
+    /// derive it through the entry point that reads a tracked `.kin-allowances`.
+    ///
+    /// Reverting `repository_stash::push`'s derivation to `derive_from_tree`
+    /// fails here, because the compatibility entry point refuses by name the
+    /// moment the sealed tree carries approvals it cannot read.
+    ///
+    /// Three details in this fixture are load-bearing and none is obvious.
+    /// The approval file is committed rather than left dirty, because stash
+    /// reads allowance bodies through `manager.load_source_blob`, which consults
+    /// repository CAS alone; a dirty approval file lives only in ingest CAS and
+    /// fails with "repository source CAS is missing", a refusal that looks
+    /// nothing like the one this test exists to provoke. The workspace has to be
+    /// dirty, because `push` refuses a clean one before it reaches the
+    /// derivation at all. And the request goes through the route rather than
+    /// straight into `execute`, because the route runs the complete-scan
+    /// admission first, which is what turns a working-copy write into workspace
+    /// dirtiness that authority can see.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sealing_a_workspace_derives_the_approvals_its_tree_carries() {
+        let state = committed_test_state();
+
+        // The approved artifact is committed first, so authority owns its body
+        // before any approval names its digest.
+        let approved_digest =
+            Hash256::from_bytes(state.blobs.write(STASH_APPROVED_BODY).unwrap().0);
+        install_repository_file(&state, "notekeeper/client.py", STASH_APPROVED_BODY);
+        install_working_copy_file(&state, "notekeeper/client.py", STASH_APPROVED_BODY, false);
+
+        let approvals = format!(
+            "# approvals for this fixture\n\
+             kin-allowances 1\n\
+             notekeeper/client.py\t{approved_digest}\tblob\tcredscan@firelock.ai\tpinned by \
+             the test covering the sealed-tree derivation site\n"
+        );
+        install_repository_file(&state, ".kin-allowances", approvals.as_bytes());
+        install_working_copy_file(&state, ".kin-allowances", approvals.as_bytes(), false);
+
+        // Dirty the workspace through the host, which is what the route's scan
+        // admits and what makes the workspace sealable.
+        std::fs::write(
+            state.layout.working_dir().join("scratch.txt"),
+            b"sealed while dirty\n",
+        )
+        .unwrap();
+
+        let request = kin_cli::commands::stash::StashRequest::Push {
+            message: Some("seal a workspace whose tree carries approvals".to_string()),
+            operation_id: kin_model::OperationId::new(),
+            timestamp: Timestamp::now(),
+            actor: AuthorId::new("credscan"),
+        };
+        let (status, body) = post_stash_request(Arc::clone(&state), &request).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "sealing a workspace whose tree carries .kin-allowances must derive its approvals \
+             rather than refusing: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let response: kin_cli::commands::stash::StashResponse =
+            serde_json::from_slice(&body).unwrap();
+        let sealed = response
+            .entry
+            .expect("a push reports the entry it sealed")
+            .change_id;
+
+        let authority = ActiveApiRepositoryAuthority::open(&state).unwrap();
+        let lease = authority.manager.read_authority();
+        let policy = lease
+            .metadata()
+            .admission_policies
+            .iter()
+            .find(|resolved| resolved.change_id == sealed)
+            .expect("the sealed change carries an admission-policy record")
+            .policy
+            .clone()
+            .expect("the sealed change's policy is resolved");
+        assert_eq!(
+            policy.sensitive_allowances.len(),
+            1,
+            "the sealed policy must carry the tree's one approval: {:?}",
+            policy.sensitive_allowances
+        );
+        assert_eq!(policy.sensitive_allowances[0].content_hash, approved_digest);
     }
 
     #[cfg(unix)]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -22036,8 +22036,11 @@ mod tests {
         )
         .await;
 
-        std::fs::write(root.join("notekeeper/client.py"), b"def normalize(term):\n    return term\n")
-            .unwrap();
+        std::fs::write(
+            root.join("notekeeper/client.py"),
+            b"def normalize(term):\n    return term\n",
+        )
+        .unwrap();
         let regression =
             commit_through_api(&app, kin_model::OperationId::new(), "publish a regression").await;
         assert_eq!(branch_change(&state), regression);

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -21995,6 +21995,93 @@ mod tests {
         lease.resolve_target_change_id(&target).unwrap()
     }
 
+    /// A rollback derives the policy for the tree it restores, and it has to
+    /// derive it through the entry point that reads a tracked `.kin-allowances`.
+    ///
+    /// Reverting `repository_rollback::plan_and_commit`'s derivation to
+    /// `derive_from_tree` fails here, because the compatibility entry point
+    /// refuses by name the moment the restored tree carries approvals it cannot
+    /// read. That is the shape this covers: an approval a reviewer accepted,
+    /// silently dropped by rolling back to the very change that carried it.
+    ///
+    /// The approval rides the FIRST change, because rollback derives from the
+    /// target tree rather than from the tree it is leaving. The approved body is
+    /// harmless for the same reason it is in the sealed-tree test: this asks
+    /// whether the derivation reads the approval, and approving a real secret
+    /// would pull in authority's separate rule about repository CAS ordering.
+    #[tokio::test]
+    async fn rolling_back_derives_the_approvals_the_restored_tree_carries() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let root = state.layout.working_dir().to_path_buf();
+        let app = router(Arc::clone(&state));
+
+        let approved_body = b"def normalize(term):\n    return term.strip()\n";
+        let approved_digest = Hash256::from_bytes(state.blobs.write(approved_body).unwrap().0);
+        std::fs::create_dir_all(root.join("notekeeper")).unwrap();
+        std::fs::write(root.join("notekeeper/client.py"), approved_body).unwrap();
+        let approvals = format!(
+            "# approvals for this fixture\n\
+             kin-allowances 1\n\
+             notekeeper/client.py\t{approved_digest}\tblob\tcredscan@firelock.ai\tpinned by \
+             the test covering the restored-tree derivation site\n"
+        );
+        std::fs::write(root.join(".kin-allowances"), approvals.as_bytes()).unwrap();
+        let restored = commit_through_api(
+            &app,
+            kin_model::OperationId::new(),
+            "publish a tree carrying an approval",
+        )
+        .await;
+
+        std::fs::write(root.join("notekeeper/client.py"), b"def normalize(term):\n    return term\n")
+            .unwrap();
+        let regression =
+            commit_through_api(&app, kin_model::OperationId::new(), "publish a regression").await;
+        assert_eq!(branch_change(&state), regression);
+
+        let (status, body) =
+            rollback_through_api(&app, kin_model::OperationId::new(), restored).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "rolling back to a tree carrying .kin-allowances must derive its approvals rather \
+             than refusing: {body}"
+        );
+        // A rollback publishes a NEW change that restores the old tree rather
+        // than moving the branch back onto the old id, so the branch must have
+        // left the regression without landing on `restored` itself.
+        let after = branch_change(&state);
+        assert_ne!(
+            after, regression,
+            "the rollback must move the branch off the regression"
+        );
+        assert_ne!(
+            after, restored,
+            "a rollback publishes a restoring change rather than re-pointing at the old one"
+        );
+
+        let authority = ActiveApiRepositoryAuthority::open(&state).unwrap();
+        let lease = authority.manager.read_authority();
+        let carried = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == authority.workspace_id)
+            .expect("the bound workspace survives the rollback")
+            .shared_admission_policy
+            .sensitive_allowances
+            .clone();
+        assert_eq!(
+            carried.len(),
+            1,
+            "the restored policy must carry the tree's one approval: {carried:?}"
+        );
+        assert_eq!(carried[0].content_hash, approved_digest);
+    }
+
     /// An operation id is matched before any history validation runs, and an
     /// ordinary commit publishes the same receipt shape a rollback does. Only
     /// the restored content separates them, so reusing a commit's operation id


### PR DESCRIPTION
Two more of the six daemon derivation sites now have fixture-level tests:
`repository_stash::push`, which derives the policy for the workspace it seals,
and `repository_rollback::plan_and_commit`, which derives the policy for the tree
it restores. Neither was exercised by anything. With kin#1036 that makes five of
six covered; the sixth is named at the bottom with what it would take.

## What these cover

Reverting a site turns its call back into `derive_from_tree`, and kin-model's
compatibility entry point refuses by name the moment the tree carries approvals
it cannot read. So each test drives its site with a tree carrying a tracked
`.kin-allowances` and asserts the derived policy carries the approval.

* `sealing_a_workspace_derives_the_approvals_its_tree_carries` seals a dirty
  workspace and reads the sealed change's policy back out of
  `metadata().admission_policies`.
* `rolling_back_derives_the_approvals_the_restored_tree_carries` publishes an
  approving change, publishes a regression over it, rolls back, and reads the
  restored workspace policy back out of authority. The shape it covers is an
  approval a reviewer accepted being silently dropped by rolling back to the very
  change that carried it.

## Three fixture facts that cost real attempts

None of these is visible from the source, and each was found by a run failing
for a reason that looked nothing like the property under test.

**Stash reads allowance bodies from repository CAS alone.** Commit and merge go
through `read_publishable_source`, which consults ingest CAS first, so
`blobs.write` is enough there. Stash goes through `manager.load_source_blob`. A
dirty approval file lives only in ingest CAS and fails with "repository source
CAS is missing", which reads like a broken fixture rather than the refusal the
test wants. The approval file is therefore committed, not left dirty.

**Stash refuses a clean workspace before it derives anything.** The guard is
"workspace holds no graph-owned changes to seal", so the fixture has to dirty the
workspace, and it has to dirty it through the host rather than by staging a graph
delta: the route runs the complete-scan admission before `execute`, and that scan
is what turns a working-copy write into dirtiness authority can see. Calling
`execute` directly skips it and the seal is refused.

**Rollback derives from the target tree, not the one it is leaving.** The
approval has to ride the first change, the one being restored.

There is also a fourth, in the test rather than the product: a rollback publishes
a **new** change that restores the old tree rather than re-pointing the branch at
the old id. The first version of this test asserted the latter and failed on it,
which is now what the branch assertions say explicitly.

## Why the approved bodies are harmless

Both tests approve an ordinary function rather than a real secret. These ask one
question, whether the derivation reads a tracked approval at all. Approving a
real secret pulls in authority's separate rule that an approved body must already
be in repository CAS before the transition that approves it, and both tests then
fail on ordering rather than on the derivation. The refusal-and-approval behaviour
is covered where it belongs, in the commit-path tests on kin#1036 and in the live
acceptance run on kin#1016.

## Falsification, per site

Two arms, each reverting exactly one site and predicting one failure, run
single-threaded with the mtime advanced past filesystem granularity before each
build:

| site reverted | predicted to fail | failed | other |
|---|---|---|---|
| `repository_stash::push` | `sealing_a_workspace_…` | exactly that | rollback test green |
| `repository_rollback::plan_and_commit` | `rolling_back_…` | exactly that | stash test green |

Both compiled cleanly, so each failure is behaviour changing rather than the
crate failing to build, and both files restored byte-identical by sha256 with a
clean worktree afterwards.

The mtime step is not decoration. On kin#1036 a falsification loop that edited,
built and restored inside a second was handed the previous arm's binary and
reported a confident, cross-wired attribution: two arms each blaming a test that
no call path connects to the site they reverted. Advancing the mtime is what
makes an arm land on its own site.

## Gate

Current head `6030c690f` is rebased onto main `c6487105`.

* `cargo test -p kin-daemon approvals -- --nocapture --test-threads=1`: **5 passed, 0 failed**. This covers all five derivation fixtures together after the rebase.
* `cargo fmt --all -- --check` and `git diff --check origin/main...HEAD`: exit 0.
* Hosted CI is rerunning the full PR gate on the current head.

Supporting evidence from the pre-rebase head:

* `cargo nextest run --workspace --locked --no-fail-fast`: **6754 tests run, 6754 passed, 0 failed, 12 skipped**.
* `cargo clippy --all-targets --all-features --locked` under `RUSTFLAGS=-D warnings` with the ci.yml allow-list and `cargo test --doc --locked`: exit 0.
* `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`, `test-private-repo-coupling.py`, `check-rc-build-drift.mjs`, and `check-kin-vfs-compat.mjs`: exit 0.

## What `Closes` would still need

One site, `plan_session_workspace_admission` at `repository_commit.rs:232`. Its
input is a `SessionReconcileObservation`, which kin-cli seals on purpose: every
field is private and a `compile_fail` doctest at
`crates/kin-cli/src/commands/reconcile.rs:130` exists to keep it unbuildable by
hand, and it carries a `RetainedSession` capability that
`revalidate_retained_capability` re-proves against a real on-disk session.

Covering it means one of two things, and both are decisions rather than work:
add a `#[cfg(test)]` constructor to kin-cli, which weakens a seal built
deliberately to stop exactly that; or mint a real retained session in the
fixture, which is the honest route and is its own piece of work. Breaking the
seal to test something else is the wrong trade, so this stays open until someone
picks the second.

Refs FIR-2575
