### PR TITLE
Name a vector salvage as lost coverage instead of pending work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.40"
+version = "0.7.49"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "581287b29e2c3937b31dc441da46c88f69593bd535746c7e6d6a55f2d5328241"
+checksum = "22708c9f01b9bdb79c23eb6292e1da4fd7b6de1eed2d46bcacf88f5e2d004d24"
 dependencies = [
  "bincode",
  "bstr",
@@ -3502,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.10"
+version = "0.7.13"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "be211911c8cf30d0afd21673f4807f1fe4d7ac288b2324f7cf13c3f7667b4714"
+checksum = "cd309d7ab7dd74066a146fdc9749e65328d82a0698c27f1f5b484f6ed676812d"
 dependencies = [
  "chrono",
  "gix-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.10", registry = "kin" }
+kin-model = { version = "=0.7.13", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.40", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.49", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.13", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -254,15 +254,19 @@ fn load_vector_index_if_exists(snap: &kin_db::SnapshotManager, layout: &kin_core
         &snapshot_path,
         None,
     ) {
-        Ok(true) => {
+        Ok(outcome) if outcome.attached => {
             tracing::debug!(
                 path = %vector_index_path(layout).display(),
+                kept = outcome.vectors_loaded,
+                dropped = outcome.vectors_dropped,
+                disposition = ?outcome.disposition,
                 "loaded validated vector index from disk"
             );
         }
-        Ok(false) => {
+        Ok(outcome) => {
             tracing::debug!(
                 path = %vector_index_path(layout).display(),
+                disposition = ?outcome.disposition,
                 "no compatible vector index available"
             );
         }

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -658,6 +658,25 @@ fn build_graph_status_response(
                 "; the persisted vector index was not loaded when this daemon opened ({reason}); \
                  the daemon restores coverage in the background"
             ));
+        } else if let Some(salvage) = embedding_runtime.vector_index_salvage {
+            // The state FIR-2562 was filed for, and the reason the clause below
+            // it could never reach it: a per-key salvage INSTALLS an index, so
+            // no discard is recorded and `coverage_is_measured` holds. Before
+            // the counts existed on this side of the boundary the line could
+            // say only that a fill had finished here once. Now it can name the
+            // loss and its size.
+            //
+            // The cause is stated as what was observed, a sidecar whose stamp
+            // no longer matched graph authority, and nothing further is
+            // asserted. An ordinary commit between flush and reopen drifts the
+            // same stamp with nothing wrong, so naming a fault here would be an
+            // exemption doubling as a proof of its own cause.
+            embeddings_line.push_str(&format!(
+                "; when this daemon opened, the persisted vector index no longer matched this \
+                 repository's graph authority, so it was salvaged per key: {} vectors were kept \
+                 and {} were retired, and only the retired keys re-embed",
+                salvage.kept, salvage.dropped
+            ));
         } else if !coverage_is_measured {
             // No index is attached and the daemon recorded no discard at open,
             // so these zeros are structural rather than a measurement of a
@@ -692,14 +711,13 @@ fn build_graph_status_response(
             //
             // The claim stops where the evidence does. This says a fill
             // finished here once and this shortfall is measured against it. It
-            // does NOT say what caused the shortfall, because a working copy
-            // that admitted new files and a sidecar that retired keys at open
-            // are indistinguishable from here. Naming the cause and its counts
-            // needs the salvage outcome kin-db already computes and discards at
-            // `kin-db crates/kin-db/src/storage/snapshot.rs:2117`, which
-            // `SnapshotManager::load_vector_index_into_graph_if_valid` collapses
-            // into a bare `Ok(true)`. That is the other half of FIR-2562 and it
-            // is a kin-db change, so no clause here may imply kin knows it.
+            // does NOT say what caused the shortfall, and it still cannot: a
+            // working copy that admitted new files and a sidecar that retired
+            // keys at open both land here, and only the second is a loss. The
+            // arm above is where a loss gets named, and it is reached only when
+            // the daemon actually recorded a salvage. So this remains the
+            // honest wording for everything else, and no clause here may imply
+            // kin knows a cause it was not told.
             embeddings_line.push_str(
                 "; coverage has completed on this store before, so this is a shortfall against a \
                  fill that finished rather than a first fill",
@@ -2384,6 +2402,123 @@ mod tests {
             graph.load_vector_index_compatible(&path, &descriptor),
             kin_db::VectorIndexLoad::Loaded(_)
         ));
+    }
+
+    /// A store that had coverage retired at open says so, with both counts.
+    ///
+    /// This is FIR-2562's first ask, and it could not be answered from kin at
+    /// all until kin-db 0.7.47: the counts were computed on the salvage path
+    /// and thrown away when `load_vector_index_into_graph_if_valid` collapsed
+    /// its outcome into a bare `bool`. With `VectorSidecarLoadOutcome` carrying
+    /// them, a coverage LOSS renders as a loss with its size and its cause,
+    /// distinct from work not yet done.
+    ///
+    /// Three arms, because the clause is only worth anything if it separates
+    /// the stores it exists to separate: a salvaged store, the same store with
+    /// no salvage recorded, and a store that never finished a fill.
+    #[cfg(feature = "vector")]
+    #[test]
+    fn a_store_whose_coverage_was_retired_at_open_names_the_loss_and_its_size() {
+        let (temp, binding, graph) = graph_validation_fixture();
+        for name in ["alpha_transform", "beta_reduce", "gamma_emit", "delta_fold"] {
+            graph.upsert_entity(&test_entity(name)).unwrap();
+        }
+        attach_partial_vector_index(&graph, temp.path(), 2);
+        let status = graph.embedding_status();
+        assert!(
+            graph.vector_index_stats().is_some() && status.pending > 0,
+            "the fixture must read measured and short, which is what a salvage leaves: {status:?}"
+        );
+
+        let salvaged = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &crate::commands::resources::EmbedRuntimeState {
+                vector_index_salvage: Some(crate::commands::resources::VectorSalvage {
+                    kept: 1770,
+                    dropped: 342,
+                }),
+                embedding_coverage_ever_complete: true,
+                ..Default::default()
+            },
+            &Default::default(),
+        )
+        .unwrap();
+        let salvaged_line = salvaged
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            salvaged_line.contains("1770 vectors were kept")
+                && salvaged_line.contains("342 were retired"),
+            "both counts have to reach the reader: {salvaged_line}"
+        );
+        assert!(
+            salvaged_line.contains("salvaged per key"),
+            "the cause has to be named, not left to be inferred: {salvaged_line}"
+        );
+        assert!(
+            !salvaged_line.contains("shortfall against a fill that finished"),
+            "the cause-bearing clause must outrank the one that only knows a fill \
+             finished once: {salvaged_line}"
+        );
+
+        // Control one: the same store, same marker, no salvage recorded. The
+        // counts must vanish rather than persist from somewhere.
+        let no_salvage = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &crate::commands::resources::EmbedRuntimeState {
+                vector_index_salvage: None,
+                embedding_coverage_ever_complete: true,
+                ..Default::default()
+            },
+            &Default::default(),
+        )
+        .unwrap();
+        let no_salvage_line = no_salvage
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            !no_salvage_line.contains("salvaged per key") && !no_salvage_line.contains("retired"),
+            "a store with no salvage recorded must claim none: {no_salvage_line}"
+        );
+        assert!(
+            no_salvage_line.contains("shortfall against a fill that finished"),
+            "and it falls back to what it does know: {no_salvage_line}"
+        );
+
+        // Control two: a store that never finished a fill gets neither clause.
+        let first_fill = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
+        let first_fill_line = first_fill
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            !first_fill_line.contains("salvaged per key")
+                && !first_fill_line.contains("a fill that finished"),
+            "a first fill claims neither a salvage nor a completed fill: {first_fill_line}"
+        );
+        assert!(
+            first_fill_line.contains(&format!(
+                "{}/{} indexed ({} pending)",
+                status.indexed, status.total, status.pending
+            )),
+            "the counters stay disclosed on all three: {first_fill_line}"
+        );
     }
 
     /// A store whose coverage was whole once and is short now says so, and the

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -3107,6 +3107,31 @@ fn semantic_query_health_from_runtime(
     // repository whose finished index was thrown away at open. Only one of them
     // means work already paid for is being paid for again, so when the daemon
     // knows which it is, say so instead of leaving it to be inferred.
+    // Checked before the discard arm's `else`, because a salvage is the case
+    // neither arm below can describe. It attaches an index, so no discard is
+    // recorded and the first arm falls through; and it leaves a real shortfall
+    // against a fill that finished, so the "backlog is filling" arm would call
+    // a coverage loss healthy. Stale is the honest verdict: the surface is
+    // serving off less than it was.
+    if let Some(salvage) = runtime.vector_index_salvage {
+        return HealthCheck::new(
+            "semantic_query_readiness",
+            "Semantic query readiness",
+            HealthStatus::Stale,
+            format!(
+                "{detail}; the persisted vector index no longer matched this repository's graph \
+                 authority when the daemon opened, so it was salvaged per key: {} vectors were \
+                 kept and {} were retired. The daemon re-embeds the retired keys in the \
+                 background",
+                salvage.kept, salvage.dropped
+            ),
+        )
+        .with_manual_fix(
+            "allow daemon embedding to finish, or run `kin embed` to force it now; only the \
+             retired keys are re-derived",
+        );
+    }
+
     let Some(reason) = &runtime.vector_index_discarded else {
         // Nothing was discarded, so the remaining question is whether this
         // store has ever finished a fill. Before it has, partial coverage is a
@@ -6583,6 +6608,67 @@ mod tests {
         assert!(semantic.detail.contains("41/41 embeddings indexed"));
         assert!(!semantic.detail.contains("graph.kvec"));
         assert!(semantic.manual_fix.is_none());
+    }
+
+    /// A salvage is lost ground, and the arm that would otherwise catch it
+    /// calls the identical counters healthy.
+    ///
+    /// A per-key salvage attaches an index, so no discard is recorded, and it
+    /// happens on stores that HAVE finished a fill, so `ever_complete` holds.
+    /// Both of those steer the same counters to the Healthy top-up arm, which
+    /// is the correct verdict for a working copy admitting new files and the
+    /// wrong one for a store that just had coverage retired. The counts kin-db
+    /// now returns are what let this path tell them apart (FIR-2562).
+    #[cfg(feature = "vector")]
+    #[test]
+    fn semantic_query_readiness_calls_a_retired_coverage_stale_not_filling() {
+        // Identical to the top-up fixture below in every field that the
+        // healthy arm reads, so the verdict can only turn on the salvage.
+        let topping_up = crate::commands::resources::EmbedRuntimeState {
+            embeddings_indexed: 40,
+            embeddings_total: 41,
+            embeddings_pending: 1,
+            embedding_coverage_ever_complete: true,
+            ..Default::default()
+        };
+        let healthy = semantic_query_health_from_runtime("http://daemon", &topping_up);
+        assert!(
+            matches!(healthy.status, HealthStatus::Healthy),
+            "the control: these counters alone are a healthy top-up: {:?}",
+            healthy.status
+        );
+
+        let salvaged = crate::commands::resources::EmbedRuntimeState {
+            vector_index_salvage: Some(crate::commands::resources::VectorSalvage {
+                kept: 1770,
+                dropped: 342,
+            }),
+            ..topping_up.clone()
+        };
+        let stale = semantic_query_health_from_runtime("http://daemon", &salvaged);
+        assert!(
+            matches!(stale.status, HealthStatus::Stale),
+            "coverage retired at open is not a backlog filling: {:?}, {}",
+            stale.status,
+            stale.detail
+        );
+        assert!(
+            stale.detail.contains("1770") && stale.detail.contains("342"),
+            "both counts have to reach the reader: {}",
+            stale.detail
+        );
+        assert!(
+            !stale
+                .detail
+                .contains("coverage completed earlier and this backlog is filling"),
+            "the filling sentence must not survive beside a retirement: {}",
+            stale.detail
+        );
+        assert!(stale.manual_fix.is_some());
+        assert!(
+            !assemble_health_report("test".to_string(), vec![stale]).healthy,
+            "a retired coverage has to fail the aggregate, as a discard does"
+        );
     }
 
     #[cfg(feature = "vector")]

--- a/crates/kin-cli/src/commands/prepared_state.rs
+++ b/crates/kin-cli/src/commands/prepared_state.rs
@@ -328,7 +328,7 @@ fn require_complete_prepared_embeddings(kin_dir: &Path) -> Result<()> {
         None,
     )
     .with_context(|| format!("validate prepared vector index {}", vector_path.display()))?;
-    if !loaded {
+    if !loaded.attached {
         bail!(
             "prepared vector index {} is missing or incompatible with its graph/model metadata",
             vector_path.display()

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -44,6 +44,21 @@ pub struct EmbedRuntimeState {
     /// attached and reads as ordinary pending work.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deferred_vector_checkpoint: Option<String>,
+    /// What a per-key vector salvage retired when this daemon opened, when one
+    /// happened.
+    ///
+    /// This is the state `vector_index_discarded` cannot describe. A salvage
+    /// INSTALLS an index, so no discard is recorded and coverage reads as
+    /// measured, while keys current graph truth could not prove were retired.
+    /// The counters then show a shortfall that is indistinguishable from a
+    /// first fill, which is how a store that had just lost 342 vectors rendered
+    /// as ordinary pending work (FIR-2562).
+    ///
+    /// `None` means no salvage happened, or the daemon does not report one.
+    /// Optional rather than a zeroed pair, because a salvage that retired
+    /// nothing and a load nobody measured are different facts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vector_index_salvage: Option<VectorSalvage>,
     /// Whether this store's embedding coverage has ever been whole, as recorded
     /// by the daemon where the embedding queue drained. Partial coverage means
     /// something different before this has ever been true than after it.
@@ -66,6 +81,22 @@ pub struct EmbedRuntimeState {
     /// the whole download, which is indistinguishable from a wedged pass.
     #[serde(default)]
     pub model_fetch: crate::embed_model::EmbedModelFetch,
+}
+
+/// What a per-key vector salvage kept and retired at daemon open.
+///
+/// kin-db computes these while reconciling a sidecar whose graph-authority
+/// stamp drifted, and until kin-db 0.7.47 it logged them and returned a bare
+/// `bool`, so every count was thrown away at the boundary. They are carried
+/// here so a coverage LOSS can be named as a loss, with its size, rather than
+/// rendering as work not yet done.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VectorSalvage {
+    /// Vectors current graph truth could prove, which stayed in the index.
+    pub kept: usize,
+    /// Vectors current graph truth could not prove, which were retired and
+    /// which the daemon re-embeds.
+    pub dropped: usize,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/kin-cli/tests/background_embed_opt_out.rs
+++ b/crates/kin-cli/tests/background_embed_opt_out.rs
@@ -86,6 +86,9 @@ fn seed_repository(repo: &Path) {
 fn kin_command(runtime: &common::IsolatedDaemonRuntime) -> Command<'_> {
     let mut command = runtime.kin_command();
     command
+        // This test uses an info-level worker record as the positive control,
+        // so it must not inherit a developer or lane filter that hides info.
+        .env("RUST_LOG", "info")
         .env("KIN_DAEMON_DISABLE_LSP", "1")
         .env("KIN_DAEMON_BIN", runtime.daemon_bin())
         .env("KIN_DAEMON_READY_TIMEOUT_SECS", "60")

--- a/crates/kin-cli/tests/prepared_state_json.rs
+++ b/crates/kin-cli/tests/prepared_state_json.rs
@@ -182,7 +182,8 @@ fn seed_local_vectors(kin_dir: &Path) {
             &layout.kindb_snapshot_path(),
             None,
         )
-        .expect("validate seeded vector sidecar"),
+        .expect("validate seeded vector sidecar")
+        .attached,
         "seeded sidecar must validate against the repository graph it was built from"
     );
 }

--- a/crates/kin-core/dependency_env_allowlist.txt
+++ b/crates/kin-core/dependency_env_allowlist.txt
@@ -74,3 +74,13 @@ KIN_VECTOR_BENCH_ITERS
 # in a kin process reads either name.
 KIN_FIR2334_STORE
 KIN_FIR2334_REPO
+
+# kin-db storage/repository.rs: inputs to five ignored profiling fixtures that
+# measure history-replay and commit-preparation costs. They are read only from
+# the dependency's own `#[cfg(test)]` modules, so no Kin process can observe
+# them as operator controls.
+KIN_REPLAYWALL_COMMITS
+KIN_CLOCKHALF_COMMITS
+KIN_CLOCKHALF_FILES
+KIN_CLOCKHALF_FLAT
+KIN_CLOCKHALF_CHURN

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -724,6 +724,18 @@ pub struct HealthResponse {
     /// and goes quiet once coverage is whole.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vector_index_discarded: Option<String>,
+    /// What a per-key salvage retired when this daemon opened, when one
+    /// happened. A value drives `status: "attention"`, exactly as a discard
+    /// does, because both mean this store is serving off less coverage than it
+    /// had.
+    ///
+    /// The field above cannot carry this. A salvage INSTALLS an index, so
+    /// nothing is discarded and the counters read measured and short, which is
+    /// byte-identical to a store filling for the first time. That is what let a
+    /// store publish `1770/2112 indexed (342 pending)` three minutes after
+    /// retiring 342 vectors, with every surface reporting `ok` (FIR-2562).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vector_index_salvage: Option<kin_cli::commands::resources::VectorSalvage>,
     /// Effective filesystem-to-graph admission policy. This reports the frozen
     /// daemon state, including intrinsic storage-backend graph authority, not
     /// merely whether the opt-in environment variable was present.
@@ -2586,6 +2598,7 @@ async fn health(
         .load(std::sync::atomic::Ordering::Relaxed);
     let embed_persistence_unavailable = !state.can_persist_embed_progress_locally();
     let vector_index_discarded = state.vector_index_discarded().map(str::to_string);
+    let vector_index_salvage = state.vector_index_salvage();
     let coordination_event_persist_failures = state
         .coordination_event_persist_failures
         .load(std::sync::atomic::Ordering::Relaxed);
@@ -2599,10 +2612,17 @@ async fn health(
     // is withholding a suspected mass-deletion wipe OR the embedding worker has
     // permanently stopped (embed-degraded), OR the configured storage backend
     // cannot durably persist vector progress, OR the persisted vector index was
-    // discarded at open and is being re-derived, OR coordination evidence could
-    // not be persisted, OR a background pass was stopped for spending the
-    // machine without advancing, OR the reconcile loop is failing to admit what
-    // it observes. The graph itself stays intact and served in all cases.
+    // discarded at open and is being re-derived, OR the index attached only
+    // after a per-key salvage retired coverage this store had, OR coordination
+    // evidence could not be persisted, OR a background pass was stopped for
+    // spending the machine without advancing, OR the reconcile loop is failing
+    // to admit what it observes. The graph itself stays intact and served in
+    // all cases.
+    //
+    // The salvage term is the one a client could not see. It reaches this
+    // verdict on its own rather than through the discard above, because a
+    // salvage records no discard: an index DID attach, and only the counts say
+    // how much of it survived.
     //
     // The reconcile term is the one that was missing. `reconciliation_status`
     // below reports whether a pass is running this instant, which a loop failing
@@ -2613,6 +2633,7 @@ async fn health(
         || embed_worker_failed
         || embed_persistence_unavailable
         || vector_index_discarded.is_some()
+        || vector_index_salvage.is_some()
         || coordination_event_persist_failures > 0
         || background_pass_stopped
         || reconcile_degraded
@@ -2651,6 +2672,7 @@ async fn health(
         embed_worker_failed,
         embed_persistence_unavailable,
         vector_index_discarded,
+        vector_index_salvage,
         filesystem_reconcile_disabled: state.filesystem_reconcile_disabled(),
         background_embed_deferred: !crate::daemon::auto_embed_enabled(),
         graph_generation: DaemonState::read_generation_marker(&state.layout),
@@ -3343,6 +3365,7 @@ async fn command_resources(
         hybrid_metrics: hybrid_metrics_runtime(),
         metal_profile: metal_profile_runtime(),
         vector_index_discarded: state.vector_index_discarded().map(str::to_string),
+        vector_index_salvage: state.vector_index_salvage(),
         deferred_vector_checkpoint: state.deferred_vector_checkpoint(),
         embedding_coverage_ever_complete: state.embedding_coverage_ever_complete(),
         embed_persistence_unavailable: !state.can_persist_embed_progress_locally(),
@@ -3446,6 +3469,7 @@ fn graph_status_embedding_runtime(
     }
     kin_cli::commands::resources::EmbedRuntimeState {
         vector_index_discarded: state.vector_index_discarded().map(str::to_string),
+        vector_index_salvage: state.vector_index_salvage(),
         deferred_vector_checkpoint: state.deferred_vector_checkpoint(),
         embedding_coverage_ever_complete: state.embedding_coverage_ever_complete(),
         embed_persistence_unavailable: !state.can_persist_embed_progress_locally(),
@@ -20232,6 +20256,101 @@ mod tests {
             !json.embed_worker_failed,
             "a discarded index is not a worker crash"
         );
+    }
+
+    /// A salvage is the state the discard field cannot report, and it has to
+    /// reach `/health` on its own.
+    ///
+    /// The store here is the shape the rc0545c brown arm was in: a sidecar
+    /// stamped against graph truth that then moved, so kin-db installs it and
+    /// reconciles per key rather than refusing it whole. Nothing is discarded,
+    /// so the field beside this one stays empty and the counters read measured
+    /// and short, which is exactly what a first fill looks like. Without this
+    /// the endpoint answers `ok` for a store that just lost coverage.
+    #[tokio::test]
+    #[cfg(feature = "vector")]
+    async fn health_surfaces_a_salvaged_vector_index_as_attention() {
+        install_test_registry_override();
+        let dir = std::env::temp_dir().join(format!("kin-daemon-kvec-salvage-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let layout = kin_core::init(&dir).unwrap().layout;
+
+        let snapshot_path = layout.kindb_snapshot_path();
+        {
+            let manager = kin_db::SnapshotManager::new(&snapshot_path);
+            let graph = manager.graph();
+            let entity = test_entity("salvage_survivor", "src/lib.rs");
+            graph.upsert_entity(&entity).unwrap();
+
+            let descriptor = kin_db::IndexDescriptor {
+                model_id: Some("fixture-model".to_string()),
+                graph_root: Some("fixture-root".to_string()),
+            };
+            let index = kin_db::VectorIndex::new(4).unwrap();
+            index.upsert(entity.id, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+            index.set_descriptor(descriptor.clone());
+            index.save(&layout.kindb_vector_index_path()).unwrap();
+            assert!(
+                matches!(
+                    graph.load_vector_index_compatible(
+                        &layout.kindb_vector_index_path(),
+                        &descriptor
+                    ),
+                    kin_db::VectorIndexLoad::Loaded(_)
+                ),
+                "the fixture index must install before the sidecar is stamped"
+            );
+            manager.save().unwrap();
+            kin_db::SnapshotManager::save_vector_index_for_graph(
+                &snapshot_path,
+                graph.as_ref(),
+                None,
+            )
+            .unwrap();
+
+            // Graph truth moves after the stamp and the sidecar is left alone,
+            // which is the drift. Saving the snapshot again persists the newer
+            // truth beside the older stamp, so the next open sees both.
+            graph
+                .upsert_entity(&test_entity("admitted_after_the_stamp", "src/added.rs"))
+                .unwrap();
+            manager.save().unwrap();
+        }
+
+        let state = Arc::new(DaemonState::open(layout).unwrap());
+        let salvage = state
+            .vector_index_salvage()
+            .expect("the fixture must reach kin-db's salvage path, or it proves nothing");
+        assert!(
+            state.vector_index_discarded().is_none(),
+            "a salvage records no discard, which is the whole reason it needs its own field"
+        );
+
+        let response = router(state)
+            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: HealthResponse = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            json.vector_index_salvage,
+            Some(salvage),
+            "the route must publish the counts the daemon recorded at open"
+        );
+        assert!(
+            json.vector_index_discarded.is_none(),
+            "and it must not invent a discard to explain them: {:?}",
+            json.vector_index_discarded
+        );
+        assert_eq!(
+            json.status, "attention",
+            "a store serving off less coverage than it had is not an `ok` steady state"
+        );
+        assert!(!json.embed_worker_failed, "a salvage is not a worker crash");
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -6956,7 +6956,8 @@ mod shutdown_vector_checkpoint_tests {
                 &state.layout.kindb_snapshot_path(),
                 None,
             )
-            .expect("the checkpointed sidecar must be readable"),
+            .expect("the checkpointed sidecar must be readable")
+            .attached,
             "the checkpointed sidecar must install through the daemon's own open-time path"
         );
         assert_eq!(

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -151,6 +151,7 @@ pub use daemon::{
     DaemonConfig,
 };
 pub use error::{DaemonError, Result};
+pub use kin_cli::commands::resources::VectorSalvage;
 pub use lifecycle::{daemon_is_up, AutoStartError, MCP_IDLE_TIMEOUT_SECS};
 pub use loop_runner::LoopConfig;
 pub use session_registry::SessionCoordinator;

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1063,6 +1063,50 @@ pub fn resolve_idle_timeout_floor(
 
 /// Shared daemon state. All mutable state is behind RwLock for
 /// concurrent access from the reconciliation loop and API handlers.
+/// What opening a store's vector sidecar did, as the surfaces need to report it.
+///
+/// Two independent facts rather than one enum, because they answer different
+/// questions and a reader needs both: `discarded` says an index was on disk and
+/// is NOT attached, `salvage` says one IS attached after retiring keys. At most
+/// one is ever set, but folding them into a single field would invite a caller
+/// to treat "no discard" as "nothing was lost", which is precisely the reading
+/// that made a salvaged store render as a first fill (FIR-2562).
+#[derive(Debug, Clone, Default)]
+struct VectorSidecarOpen {
+    discarded: Option<String>,
+    salvage: Option<crate::VectorSalvage>,
+}
+
+/// Read kin-db's sidecar load outcome as the salvage fact the surfaces report,
+/// or `None` when nothing was retired at open.
+///
+/// Only a stamp-drift salvage produces a record. An exact load can still drop
+/// orphaned generations, and reporting that as lost coverage would fire on
+/// ordinary re-inits; the ticket's whole point is that "loaded whole" and
+/// "loaded partially" have to stay distinguishable (FIR-2562).
+///
+/// The kept count is a subtraction rather than a field, because
+/// `vectors_loaded` is what the sidecar held BEFORE reconciliation ran, not
+/// what survived it (kin-db 0.7.49
+/// `crates/kin-db/src/storage/snapshot.rs:1460`). Passing it through as "kept"
+/// would print the sidecar's whole size beside a retired count already inside
+/// it, so a store that kept 1770 of 2112 would read as keeping 2112 and
+/// retiring 342 at the same time.
+fn salvage_from_sidecar_outcome(
+    outcome: &kin_db::VectorSidecarLoadOutcome,
+) -> Option<crate::VectorSalvage> {
+    matches!(
+        outcome.disposition,
+        kin_db::VectorSidecarDisposition::SalvagedAfterStampDrift
+    )
+    .then(|| crate::VectorSalvage {
+        kept: outcome
+            .vectors_loaded
+            .saturating_sub(outcome.vectors_dropped),
+        dropped: outcome.vectors_dropped,
+    })
+}
+
 pub struct DaemonState {
     pub layout: KinLayout,
     pub graph: Arc<kin_db::InMemoryGraph>,
@@ -1107,6 +1151,10 @@ pub struct DaemonState {
     /// `None` means either that the index loaded or that there was none to
     /// load, which are the two states that need no explanation.
     vector_index_discarded: Option<String>,
+    /// What a per-key salvage retired at open, when one happened. Separate from
+    /// the discard reason above because a salvage ATTACHES an index: the two
+    /// describe different stores and only one of them can be true at a time.
+    vector_index_salvage: Option<crate::VectorSalvage>,
     pub reconciler: RwLock<Reconciler>,
     /// Cached FileLayouts for all tracked files.
     /// Populated on init, updated on commits.
@@ -1715,18 +1763,24 @@ impl DaemonState {
     /// the pipeline (kin-db's embedding pipeline epoch), which every persisted
     /// sidecar already carries and every load already checks.
     ///
-    /// Returns `Some(reason)` when an index was on disk and was not installed,
-    /// so the caller can record and announce what was discarded. `None` means
-    /// the index loaded, or there was none to load.
+    /// Returns what the sidecar did, in the two facts the surfaces report: a
+    /// discard reason when an index was on disk and was not installed, and a
+    /// salvage record when one WAS installed after retiring keys.
+    ///
+    /// Those two are not alternatives and neither implies the other. A discard
+    /// leaves nothing attached and the counters read structurally zero. A
+    /// salvage attaches an index and the counters read partial, with no discard
+    /// to record, which is exactly the state that used to render identically to
+    /// a first fill (FIR-2562).
     fn load_validated_vector_index(
         layout: &KinLayout,
         graph: &kin_db::InMemoryGraph,
-    ) -> Option<String> {
+    ) -> VectorSidecarOpen {
         let snapshot_path = layout.kindb_snapshot_path();
         let vector_path = layout.kindb_vector_index_path();
         // Sampled BEFORE the load so a discard can be told apart from a repo
-        // that simply has no index yet. kin-db reports both as `Ok(false)`, and
-        // announcing the second would fire this on every fresh repository.
+        // that simply has no index yet. kin-db reports both as not attached,
+        // and announcing the second would fire this on every fresh repository.
         let had_persisted_index = vector_path.exists();
         let outcome = kin_db::SnapshotManager::load_vector_index_into_graph_if_valid(
             graph,
@@ -1734,12 +1788,37 @@ impl DaemonState {
             None,
         );
         let discarded = match outcome {
-            Ok(true) => {
-                debug!(path = %snapshot_path.display(), "loaded validated persisted vector index");
-                return None;
+            Ok(outcome) if outcome.attached => {
+                // Attached, so nothing was discarded. What matters now is
+                // whether it attached WHOLE or after retiring keys, because
+                // only the second explains a shortfall the counters are about
+                // to show. The counts come from kin-db's own reconcile rather
+                // than being recomputed here.
+                let salvage = salvage_from_sidecar_outcome(&outcome);
+                if let Some(record) = salvage {
+                    // Loud, because this is coverage a user had and no longer
+                    // has. The cause is stated as what was observed, a stamp
+                    // that drifted from graph authority, and no further cause
+                    // is asserted: an ordinary commit between flush and reopen
+                    // drifts the same stamp with nothing wrong.
+                    warn!(
+                        path = %vector_path.display(),
+                        kept = record.kept,
+                        dropped = record.dropped,
+                        "the persisted vector index no longer matched this repository's graph \
+                         authority, so it was salvaged per key rather than rebuilt; the retired \
+                         keys re-embed in the background"
+                    );
+                } else {
+                    debug!(path = %snapshot_path.display(), "loaded validated persisted vector index");
+                }
+                return VectorSidecarOpen {
+                    discarded: None,
+                    salvage,
+                };
             }
-            Ok(false) if !had_persisted_index => return None,
-            Ok(false) => format!(
+            Ok(_) if !had_persisted_index => return VectorSidecarOpen::default(),
+            Ok(_) => format!(
                 "the persisted vector index at {} no longer matches this repository's graph or \
                  embedding model, so it was not loaded",
                 vector_path.display()
@@ -1762,7 +1841,20 @@ impl DaemonState {
              vectors where they still apply. Run `kin health` to watch coverage recover, or \
              `kin embed` to force a rebuild now."
         );
-        Some(discarded)
+        VectorSidecarOpen {
+            discarded: Some(discarded),
+            salvage: None,
+        }
+    }
+
+    /// Why the persisted vector index retired coverage at open, when it did.
+    ///
+    /// Reported beside `vector_index_discarded` rather than folded into it,
+    /// because the two describe different stores: a discard leaves nothing
+    /// attached, a salvage leaves a partial index attached with no discard to
+    /// record. Collapsing them is the defect FIR-2562 names.
+    pub fn vector_index_salvage(&self) -> Option<crate::VectorSalvage> {
+        self.vector_index_salvage
     }
 
     /// Why the persisted vector index was not installed at open, when it was
@@ -2325,7 +2417,7 @@ impl DaemonState {
         // `from_snapshot_with_text_index` restores the text index but not the
         // vector sidecar, so without this the reopened repository reports every
         // entity as unembedded and re-derives an index it already has on disk.
-        let vector_index_discarded = phases.record("vector_index", || {
+        let sidecar_open = phases.record("vector_index", || {
             Self::load_validated_vector_index(&layout, graph.as_ref())
         });
 
@@ -2368,7 +2460,8 @@ impl DaemonState {
             graph,
             blobs: Arc::new(blobs),
             ingest_cas_hydration_gap: None,
-            vector_index_discarded,
+            vector_index_discarded: sidecar_open.discarded,
+            vector_index_salvage: sidecar_open.salvage,
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
@@ -2576,7 +2669,7 @@ impl DaemonState {
         // The backend path builds the graph via `from_snapshot_with_text_index`,
         // which does NOT load the vector-index sidecar — do the validated load
         // here (no-ops if no/stale sidecar).
-        let vector_index_discarded = Self::load_validated_vector_index(&layout, graph.as_ref());
+        let sidecar_open = Self::load_validated_vector_index(&layout, graph.as_ref());
         let mut reconciler = Reconciler::new(layout.working_dir().to_path_buf());
         reconciler.seed_lkg_entities_from_graph(graph.as_ref());
         reconciler.seed_cross_file_linker_from_graph(graph.as_ref());
@@ -2600,7 +2693,8 @@ impl DaemonState {
             graph: Arc::clone(&graph),
             blobs: Arc::new(blobs),
             ingest_cas_hydration_gap,
-            vector_index_discarded,
+            vector_index_discarded: sidecar_open.discarded,
+            vector_index_salvage: sidecar_open.salvage,
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
@@ -6265,7 +6359,8 @@ mod tests {
                 &state.layout.kindb_snapshot_path(),
                 None,
             )
-            .expect("the checkpointed sidecar must be readable"),
+            .expect("the checkpointed sidecar must be readable")
+            .attached,
             "the checkpointed sidecar must install through the daemon's own open-time path"
         );
         assert_eq!(
@@ -9582,7 +9677,7 @@ mod tests {
         let discarded = DaemonState::load_validated_vector_index(&layout, graph.as_ref());
 
         assert_eq!(
-            discarded, None,
+            discarded.discarded, None,
             "an index from another build is not a discard: {discarded:?}"
         );
         assert_eq!(
@@ -9615,7 +9710,9 @@ mod tests {
 
         let discarded = DaemonState::load_validated_vector_index(&layout, graph.as_ref());
 
-        let reason = discarded.expect("a refused sidecar must be announced, not dropped silently");
+        let reason = discarded
+            .discarded
+            .expect("a refused sidecar must be announced, not dropped silently");
         assert!(
             reason.contains("graph.kvec") && reason.contains("could not be read"),
             "the announcement must name what was discarded and why: {reason}"
@@ -9633,6 +9730,12 @@ mod tests {
     /// The whole-index refusal this test used to pin was the FIR-2325 defect;
     /// kin-db 0.7.24 replaced it with per-key salvage, and the corrupted-format
     /// case above still proves a real refusal stays loud.
+    ///
+    /// It now also pins the half FIR-2562 was about. "Not discarded" was the
+    /// only thing this path could say about a salvage, and a caller reading it
+    /// learned that an index attached and nothing else. A salvage has to arrive
+    /// as its own fact, with the counts kin-db already computed, or the
+    /// shortfall it leaves renders as a first fill.
     #[test]
     #[cfg(feature = "vector")]
     fn an_index_bound_to_drifted_graph_truth_is_salvaged_per_key() {
@@ -9644,13 +9747,26 @@ mod tests {
             .upsert_entity(&test_entity("added_after_the_index", "src/added.rs"))
             .unwrap();
 
-        let discarded = DaemonState::load_validated_vector_index(&layout, graph.as_ref());
+        let opened = DaemonState::load_validated_vector_index(&layout, graph.as_ref());
 
         assert_eq!(
-            discarded, None,
+            opened.discarded, None,
             "a salvageable sidecar must be reused, not announced as discarded"
         );
+        let salvage = opened
+            .salvage
+            .expect("a per-key salvage must reach the caller as a salvage, not as silence");
+        assert!(
+            salvage.kept > 0,
+            "the salvage must report what it kept, which is what makes it a salvage \
+             rather than a discard: {salvage:?}"
+        );
         let status = graph.embedding_status();
+        assert_eq!(
+            salvage.kept, status.indexed,
+            "the reported kept count must be the coverage actually attached: {salvage:?} \
+             against {status:?}"
+        );
         assert_eq!(
             status.indexed, 1,
             "the persisted vector whose entity truth is unchanged must survive the reopen"
@@ -9658,6 +9774,98 @@ mod tests {
         assert!(
             status.total >= 2,
             "graph truth must still owe a vector for the entity added after the index"
+        );
+    }
+
+    /// The control that makes the arm above capable of failing: an exact load
+    /// reports NO salvage.
+    ///
+    /// Loaded whole and loaded partially are different facts, and a reader that
+    /// cannot tell them apart is back where FIR-2562 started. Without this arm
+    /// a `load_validated_vector_index` that reported a salvage on every attach
+    /// would satisfy the test above completely.
+    #[test]
+    #[cfg(feature = "vector")]
+    fn an_index_that_still_matches_its_graph_reports_no_salvage() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(repo_dir.path().join(".kin"));
+        let graph = store_with_persisted_vector_index(&layout, None);
+        as_reopened_by_the_daemon(graph.as_ref());
+        // No entity added, so graph truth has not moved and the stamp still
+        // matches. This is the same fixture as the salvage arm minus the one
+        // change that causes the drift.
+
+        let opened = DaemonState::load_validated_vector_index(&layout, graph.as_ref());
+
+        assert_eq!(
+            opened.discarded, None,
+            "an index that still matches its graph is not a discard"
+        );
+        assert_eq!(
+            opened.salvage, None,
+            "an exact load must not report a salvage: nothing was retired"
+        );
+        assert_eq!(
+            graph.embedding_status().indexed,
+            1,
+            "the control must actually have attached an index, or it proves nothing"
+        );
+    }
+
+    /// The kept count is what survived reconciliation, not what the sidecar
+    /// held before it ran.
+    ///
+    /// kin-db's `vectors_loaded` is sampled before the per-key reconcile
+    /// (`crates/kin-db/src/storage/snapshot.rs:1460` in 0.7.49), so the retired
+    /// count it reports beside it is already inside that number. Passing
+    /// `vectors_loaded` straight through as "kept" would have printed
+    /// `2112 vectors were kept and 342 were retired` for the store FIR-2562 was
+    /// filed on, which reads 1770/2112 indexed: two numbers that cannot both be
+    /// true, on the one line the ticket exists to make trustworthy.
+    ///
+    /// The store fixtures cannot catch this on their own. They install a single
+    /// vector and retire nothing, so kept and loaded are the same number there
+    /// and the subtraction is invisible. This drives the mapping directly with
+    /// a drop that is bigger than zero.
+    #[test]
+    fn a_salvage_reports_what_survived_reconciliation_not_what_the_sidecar_held() {
+        let salvaged = kin_db::VectorSidecarLoadOutcome {
+            attached: true,
+            vectors_loaded: 2112,
+            vectors_dropped: 342,
+            disposition: kin_db::VectorSidecarDisposition::SalvagedAfterStampDrift,
+            durable_coverage_before_load: true,
+        };
+
+        let record = salvage_from_sidecar_outcome(&salvaged)
+            .expect("a stamp-drift salvage is the case this record exists for");
+        assert_eq!(
+            record,
+            crate::VectorSalvage {
+                kept: 1770,
+                dropped: 342,
+            },
+            "kept must be the survivors, and kept plus retired must be the sidecar: {record:?}"
+        );
+
+        // An exact load reports no salvage even when it evicted orphaned
+        // generations, because a re-init dropping stale keys is not a store
+        // losing ground and rendering it as one would fire on ordinary work.
+        assert_eq!(
+            salvage_from_sidecar_outcome(&kin_db::VectorSidecarLoadOutcome {
+                attached: true,
+                vectors_loaded: 2112,
+                vectors_dropped: 7,
+                disposition: kin_db::VectorSidecarDisposition::LoadedExact,
+                durable_coverage_before_load: true,
+            }),
+            None,
+            "an exact load is not a salvage, whatever it pruned"
+        );
+        assert_eq!(
+            salvage_from_sidecar_outcome(&kin_db::VectorSidecarLoadOutcome::default()),
+            None,
+            "a store with no sidecar has retired nothing"
         );
     }
 
@@ -9673,10 +9881,14 @@ mod tests {
         std::fs::create_dir_all(layout.kindb_dir()).unwrap();
         let graph = kin_db::InMemoryGraph::new();
 
+        let opened = DaemonState::load_validated_vector_index(&layout, &graph);
         assert_eq!(
-            DaemonState::load_validated_vector_index(&layout, &graph),
-            None,
+            opened.discarded, None,
             "a repository that never had an index has had nothing discarded"
+        );
+        assert_eq!(
+            opened.salvage, None,
+            "and nothing was salvaged either, since there was nothing to salvage"
         );
     }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.10"
+version = "0.7.13"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "be211911c8cf30d0afd21673f4807f1fe4d7ac288b2324f7cf13c3f7667b4714"
+checksum = "cd309d7ab7dd74066a146fdc9749e65328d82a0698c27f1f5b484f6ed676812d"
 dependencies = [
  "chrono",
  "gix-hash",


### PR DESCRIPTION
A store that had coverage retired when the daemon opened now says so, with both counts, instead of printing the same sentence a store filling for the first time prints. That was FIR-2562's second ask, and it needed the first one to land in kin-db before kin could answer it at all.

## What was wrong

When a vector sidecar's graph-authority stamp has drifted, kin-db does not rebuild. It salvages per key, keeps what current truth can prove, retires what it cannot, and counts both. Until kin-db 0.7.47 those counts were logged and thrown away: `load_vector_index_into_graph_if_valid` returned a bare `bool`.

kin read that bool at `crates/kin-daemon/src/state.rs:1751`. An index HAD attached, so no discard was recorded, `vector_index_discarded()` stayed empty, and every surface downstream fell through to a wording that knows nothing. The rc0545c brown arm is the live shape: its daemon log carries the per-key salvage at 00:35:35Z and `graph-status-requests.txt` from the same store at 00:38:19Z reads `Embeddings: 1770/2112 indexed (342 pending)` with nothing beside it, which is byte-identical to a first fill.

## What changed

kin takes kin-db 0.7.49 and kin-model 0.7.13, and reads the `VectorSidecarLoadOutcome` kin-db now returns. `DaemonState::load_validated_vector_index` returns two facts rather than one: the discard reason as before, and a salvage record beside it. They are separate because at most one can ever be true and folding them invites a caller to read "no discard" as "nothing was lost", which is the defect.

The kept count is a subtraction, not a field. kin-db samples `vectors_loaded` before reconciliation runs (`crates/kin-db/src/storage/snapshot.rs:1460` in 0.7.49), so the retired count sits inside it. Passing it straight through would have printed `2112 vectors were kept and 342 were retired` for a sidecar of 2112, two numbers that cannot both be true on the one line this ticket exists to make trustworthy. `salvage_from_sidecar_outcome` at `crates/kin-daemon/src/state.rs:1092` does the subtraction and gates on the disposition, so an exact load reports no salvage whatever it pruned.

## What the surfaces print

`kin graph status`, salvage case, at `crates/kin-cli/src/commands/graph.rs:661`:

```
Embeddings: 1770/2112 indexed (342 pending); when this daemon opened, the persisted vector index no longer matched this repository's graph authority, so it was salvaged per key: 1770 vectors were kept and 342 were retired, and only the retired keys re-embed
```

Same counters, no salvage recorded, coverage finished here before:

```
Embeddings: 1770/2112 indexed (342 pending); coverage has completed on this store before, so this is a shortfall against a fill that finished rather than a first fill
```

First fill, neither clause:

```
Embeddings: 2/4 indexed (4 pending)
```

`kin health` returns `Stale` with `the persisted vector index no longer matched this repository's graph authority when the daemon opened, so it was salvaged per key: 1770 vectors were kept and 342 were retired. The daemon re-embeds the retired keys in the background`, and a manual fix naming that only the retired keys are re-derived (`crates/kin-cli/src/commands/health.rs:3116`). The identical counters with no salvage recorded return `Healthy` with `coverage completed earlier and this backlog is filling`, which is the right verdict for a working copy admitting new files and the wrong one for a store that just lost ground.

The daemon's `/health` route publishes `vector_index_salvage` and reads `attention` rather than `ok`, the way a discard already does (`crates/kin-daemon/src/api.rs:2637`). Without that term a client polling the route sees `ok` for a store serving off less coverage than it had.

## Falsification

Six passes, each removing one property, each verified applied before its run, each exit status read raw and each failure message read in full. Every file restored to a matching sha256 afterwards.

1. Salvage clause in `graph.rs` made unreachable. Exit 101, and the message is the regenerated defect: `both counts have to reach the reader: Embeddings: 2/4 indexed (4 pending); coverage has completed on this store before, so this is a shortfall against a fill that finished rather than a first fill`.
2. `health.rs` salvage arm made unreachable. Exit 101: `coverage retired at open is not a backlog filling: Healthy, daemon graph at http://daemon reports 40/41 embeddings indexed, 1 pending; coverage completed earlier and this backlog is filling`.
3. Kept count reverted to `vectors_loaded`. Exit 101, `left: VectorSalvage { kept: 2112, dropped: 342 }` against `right: VectorSalvage { kept: 1770, dropped: 342 }`. Both store fixtures stayed green under this sabotage, which is why the unit arm exists at all: they install one vector and retire nothing, so the subtraction is invisible to them.
4. Disposition gate dropped so every attach reports a salvage. Exit 101, two failures, both predicted: the exact-load control read `Some(VectorSalvage { kept: 1, dropped: 0 })` and the unit arm's exact case read `Some(VectorSalvage { kept: 2105, dropped: 7 })`. The drift case stayed green.
5. Wiring cut, mapping computed and discarded. Exit 101, `a per-key salvage must reach the caller as a salvage, not as silence`, with the two pure arms green, which is what makes the wiring test necessary.
6. `|| vector_index_salvage.is_some()` removed from the `/health` verdict. Exit 101, `left: "ok"` against `right: "attention"`.

One process note: pass 5's first attempt wrote an untyped `None` and failed to compile, exit 101 with `error[E0282]`. A compile error is not a falsification, so it was rewritten with an explicit type and rerun.

## The pin, proved

The registry serves kin-db 0.7.49 as its newest, not yanked. `curl -sS 'https://kinlab.ai/registry/cargo/ki/n-/kin-db'` returns 105 entries ending `0.7.43, 0.7.44, 0.7.46, 0.7.47, 0.7.48, 0.7.49`, all `yanked: false`, and 0.7.49 requires `kin-model =0.7.13`, which is also that crate's newest.

`VectorSidecarLoadOutcome` first shipped in 0.7.47, not 0.7.48: the published crate for 0.7.47 carries 14 occurrences of the name and 0.7.46 carries zero. Two comments naming 0.7.48 were corrected to 0.7.47 on that evidence.

The lock was rebuilt from main's, with only the two entries replaced. `git diff origin/main -- Cargo.lock` is four changed lines, both entries keeping `source = "sparse+https://kinlab.ai/registry/cargo/"` and a checksum. `grep -c 'source = "path' Cargo.lock` returns 0 against a positive control of 8 `sparse+` sources, and `cargo metadata --locked` exits 0 on it.

`git grep '0\.7\.40'` over the tracked tree returns nothing, with `0\.7\.999` as the control that must also return nothing and `0\.7\.49` returning the pin site. The `fuzz/Cargo.lock` hunk is required rather than incidental: the Fuzz workflow enforces its lock with `cargo metadata --locked`, kin-parser inherits the root's kin-model pin, and reverting that hunk makes `cargo metadata --locked` in `fuzz/` exit 1 while the bumped one exits 0.

`crates/kin-core/dependency_env_allowlist.txt` gains the five profiling-fixture variables kin-db 0.7.49 reads from its own `#[cfg(test)]` modules, which no kin process can observe as operator controls.

## Gates

A registry pin move cannot be gated by `bin/kin-dev local-test`, which path-patches the crate under test and never consults the registry, so this branch was gated with `--locked` runs instead. Every command went through `bin/kin-lane run salvage2 kin`, worktree `/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/salvage2-kin`, and the build resolved `kin-db v0.7.49 (registry \`kin\`)`, which is the line that proves the pin was consulted.

- `cargo nextest run --workspace --locked --no-fail-fast`: exit 0, and the run's own summary line reads `Summary [ 323.109s] 6831 tests run: 6831 passed (3 slow, 2 leaky), 12 skipped`. `--no-fail-fast` because this change touches shared test modules in `state.rs` and `api.rs`, and nextest otherwise cancels on the first failure and reports a partial total that reads like a pass.
- `cargo test --doc --locked`: exit 0 across 23 doctest suites, 1 passed, 0 failed, 2 ignored.

- `cargo clippy --all-targets --all-features --locked` with the 45-lint debt allow-list under `RUSTFLAGS=-D warnings`: exit 0, zero errors.
- `cargo fmt --all -- --check`: exit 0.
- `python3 scripts/verify-zero-file-search.py`: exit 0, 179 source files scanned.
- `bash scripts/zero_file_search_guard.sh`: exit 0.
- `bash scripts/check_runtime_boundaries.sh`: exit 0.
- `bash scripts/check_private_repo_coupling.sh`: exit 0.

`git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- .cargo/` is empty.

## Not claiming

No test here drives a real embedder and no GPU or daemon lock was taken. The `/health` fixture builds a drifted store on disk and opens a daemon state against it in-process; it starts no daemon.

The clause names what was observed, a sidecar whose stamp no longer matched graph authority, and asserts no cause. An ordinary commit between flush and reopen drifts the same stamp with nothing wrong, so a refused checkpoint and a routine commit are indistinguishable from here and neither is named.

Closes FIR-2562
