### PR TITLE
Bind a Python declared receiver to its class's own method when that class is in the calling file

### DIFF
--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -942,6 +942,32 @@ fn resolve_one_file(
                     .map(|id| is_class_like(ctx.entity_kind_by_id.get(id)))
                     .unwrap_or(false);
                 if owner_is_class {
+                    // (a2a) The owner half came from the receiver's DECLARED
+                    // type and that type names a class right here, so the
+                    // method the class declares is the destination the source
+                    // wrote down. The inheritance walk below starts at the
+                    // bases on the documented assumption that an earlier tier
+                    // already gave a same-file own method its win, and for a
+                    // receiver-typed call none did: tier (a) passes over the
+                    // same-file entity precisely because the receiver is an
+                    // object. Without this tier the call reaches nothing able
+                    // to look inside its own file — (b), (c) and (c4) are
+                    // skipped for an object receiver and (c2) drops same-file
+                    // candidates — and `ingest_directory(database: Database)`
+                    // calling `database.upsert_note()` in the file that
+                    // declares `Database` produced no edge at all.
+                    if rel.receiver.is_some() {
+                        if let Some(dst_id) =
+                            resolve_own_method(&file.file_path, owner, method, ctx)
+                        {
+                            accumulate_relation(
+                                &mut resolved,
+                                &mut relation_indices,
+                                make_relation(rel, src_id, dst_id, RECEIVER_TYPE_CONFIDENCE),
+                            );
+                            continue;
+                        }
+                    }
                     if let Some(dst_id) =
                         resolve_inherited_method(&file.file_path, owner, method, ctx)
                     {
@@ -2568,10 +2594,29 @@ fn locate_base_class(
 ///
 /// [`resolve_inherited_method`] deliberately starts at the class's bases: its
 /// caller has already given a same-file own method its win. A call bound
-/// through the receiver's declared type has had no such tier, because the owner
-/// is usually defined in another file, so it asks for the class's own method
-/// first and walks the hierarchy only when the class does not declare it.
+/// through the receiver's declared type has had no such tier, because tier (a)
+/// passes over the same-file entity whenever the receiver is an object, so it
+/// asks for the class's own method first and walks the hierarchy only when the
+/// class does not declare it.
 fn resolve_declared_method(
+    owner_file: &str,
+    owner_class: &str,
+    method: &str,
+    ctx: &LinkContext<'_>,
+) -> Option<EntityId> {
+    resolve_own_method(owner_file, owner_class, method, ctx)
+        .or_else(|| resolve_inherited_method(owner_file, owner_class, method, ctx))
+}
+
+/// The method entity `owner_class` declares under its own name in
+/// `owner_file`, with no ancestor consulted.
+///
+/// The lookup is keyed on the class-qualified entity name (`Class.method` or
+/// `Class::method`), so a free function in the same file that happens to share
+/// the method's leaf name is not a candidate here. That is what lets a
+/// receiver-typed call ask a same-file class for its own method without
+/// reopening the decoy tier (a) refuses.
+fn resolve_own_method(
     owner_file: &str,
     owner_class: &str,
     method: &str,
@@ -2584,7 +2629,6 @@ fn resolve_declared_method(
                 .get(&(owner_file, key.as_str()))
                 .copied()
         })
-        .or_else(|| resolve_inherited_method(owner_file, owner_class, method, ctx))
 }
 
 /// The incremental mirror of [`resolve_declared_method`].
@@ -2596,6 +2640,25 @@ fn resolve_declared_method_incremental(
     import_map: &HashMap<&str, HashMap<&str, (&str, &str)>>,
     class_bases: &HashMap<String, Vec<(String, Vec<String>)>>,
 ) -> Option<EntityId> {
+    resolve_own_method_incremental(owner_file, owner_class, method, linker).or_else(|| {
+        resolve_inherited_method_incremental(
+            owner_file,
+            owner_class,
+            method,
+            linker,
+            import_map,
+            class_bases,
+        )
+    })
+}
+
+/// The incremental mirror of [`resolve_own_method`].
+fn resolve_own_method_incremental(
+    owner_file: &str,
+    owner_class: &str,
+    method: &str,
+    linker: &IncrementalLinker,
+) -> Option<EntityId> {
     receiver_method_keys(owner_class, method)
         .iter()
         .find_map(|key| {
@@ -2604,16 +2667,6 @@ fn resolve_declared_method_incremental(
                 .get(owner_file)
                 .and_then(|by_name| by_name.get(key.as_str()))
                 .copied()
-        })
-        .or_else(|| {
-            resolve_inherited_method_incremental(
-                owner_file,
-                owner_class,
-                method,
-                linker,
-                import_map,
-                class_bases,
-            )
         })
 }
 
@@ -5663,6 +5716,24 @@ fn resolve_one_file_incremental(
                     .map(|id| is_class_like(linker.entity_kind_by_id.get(id)))
                     .unwrap_or(false);
                 if owner_is_class {
+                    // (a2a) mirrors the batch linker: a receiver whose
+                    // declared type names a class in this very file binds to
+                    // that class's own method, which the bases-first walk
+                    // below never consults and no later tier can reach for an
+                    // object receiver. A live edit must resolve this call the
+                    // same way a cold index does.
+                    if rel.receiver.is_some() {
+                        if let Some(dst_id) =
+                            resolve_own_method_incremental(&file.file_path, owner, method, linker)
+                        {
+                            accumulate_relation(
+                                &mut resolved,
+                                &mut relation_indices,
+                                make_relation(rel, src_id, dst_id, RECEIVER_TYPE_CONFIDENCE),
+                            );
+                            continue;
+                        }
+                    }
                     if let Some(dst_id) = resolve_inherited_method_incremental(
                         &file.file_path,
                         owner,

--- a/crates/kin-index/tests/python_receiver_type_resolution.rs
+++ b/crates/kin-index/tests/python_receiver_type_resolution.rs
@@ -731,6 +731,159 @@ def ingest_directory(database: Database, root):
     );
 }
 
+#[test]
+fn the_incremental_linker_binds_the_same_file_declared_receiver() {
+    // The live-edit twin of the pair above. A daemon relinking a touched file
+    // runs its own copy of these tiers, so a rule proven on the batch linker
+    // says nothing about the path a running editor session actually uses.
+    let files = vec![
+        parse_py("storage.py", STORAGE_PY),
+        parse_py("cli.py", NOTEKEEPER_CLI_PY),
+    ];
+    let target = entity_id(
+        &files,
+        "storage.py",
+        "Database.upsert_note",
+        EntityKind::Method,
+    );
+    let caller = entity_id(
+        &files,
+        "storage.py",
+        "ingest_directory",
+        EntityKind::Function,
+    );
+    let main = entity_id(&files, "cli.py", "main", EntityKind::Function);
+
+    let relations = link_incremental(&files);
+
+    assert!(
+        has_call(&relations, main, caller),
+        "positive control: the incremental linker must bind this fixture's \
+         cross-file call, or the same-file assertion below is measuring a \
+         linker that never ran"
+    );
+
+    assert!(
+        has_call(&relations, caller, target),
+        "the incremental linker must bind `database.upsert_note(root, \"\")` \
+         under `database: Database` to Database.upsert_note when Database is \
+         declared in the same file, exactly as the batch linker does"
+    );
+
+    let edge = relations
+        .iter()
+        .find(|r| {
+            r.kind == RelationKind::Calls
+                && r.src.as_entity() == Some(caller)
+                && r.dst.as_entity() == Some(target)
+        })
+        .expect("the declared receiver type binds this call incrementally too");
+
+    assert_eq!(
+        RelationResolution::of(edge).as_str(),
+        "type_resolved",
+        "and it must publish the same declared-type marker on both paths, or a \
+         live edit would quietly downgrade an edge a full index proves"
+    );
+}
+
+/// The same shape with the decoy the same-file tier refuses. `upsert_note` is
+/// a module-level function here as well as a method on `Database`, and
+/// `ingest_untyped` calls the leaf through a receiver carrying no annotation.
+const DECOY_STORAGE_PY: &str = r#"
+class Database:
+    def upsert_note(self, path, body):
+        return path
+
+
+def upsert_note(path, body):
+    return path
+
+
+def ingest_directory(database: Database, root):
+    return database.upsert_note(root, "")
+
+
+def ingest_untyped(database, root):
+    return database.upsert_note(root, "")
+"#;
+
+/// The ids the decoy fixture's two assertions are written against.
+struct DecoyIds {
+    method: EntityId,
+    free_function: EntityId,
+    typed_caller: EntityId,
+    untyped_caller: EntityId,
+    main: EntityId,
+}
+
+fn decoy_fixture() -> (Vec<FileParseData>, DecoyIds) {
+    let files = vec![
+        parse_py("storage.py", DECOY_STORAGE_PY),
+        parse_py("cli.py", NOTEKEEPER_CLI_PY),
+    ];
+    let ids = DecoyIds {
+        method: entity_id(
+            &files,
+            "storage.py",
+            "Database.upsert_note",
+            EntityKind::Method,
+        ),
+        free_function: entity_id(&files, "storage.py", "upsert_note", EntityKind::Function),
+        typed_caller: entity_id(
+            &files,
+            "storage.py",
+            "ingest_directory",
+            EntityKind::Function,
+        ),
+        untyped_caller: entity_id(&files, "storage.py", "ingest_untyped", EntityKind::Function),
+        main: entity_id(&files, "cli.py", "main", EntityKind::Function),
+    };
+    (files, ids)
+}
+
+/// Assert the decoy stayed refused and the declared type still won, whichever
+/// linker produced `relations`.
+fn assert_decoy_refused(relations: &[kin_model::Relation], ids: &DecoyIds, path: &str) {
+    assert!(
+        has_call(relations, ids.main, ids.typed_caller),
+        "positive control on the {path} linker: this fixture's cross-file call \
+         must bind, or the assertions below are measuring a linker that never ran"
+    );
+
+    assert!(
+        has_call(relations, ids.typed_caller, ids.method),
+        "the {path} linker must still bind the annotated call to the class's \
+         own method; the decoy sharing the leaf name must not cost the edge"
+    );
+
+    assert!(
+        !has_call(relations, ids.typed_caller, ids.free_function),
+        "the {path} linker must not bind `database.upsert_note()` to the \
+         module-level `upsert_note`: the leaf is a member name read off a \
+         value, and a same-file free function sharing it is a decoy"
+    );
+
+    assert!(
+        !has_call(relations, ids.untyped_caller, ids.free_function),
+        "and with no annotation to name an owner, the {path} linker must \
+         refuse the decoy outright rather than fall back to it, which is the \
+         guard the same-file tier's receiver filter exists for"
+    );
+}
+
+#[test]
+fn a_same_file_free_function_sharing_the_method_name_still_loses_to_the_class() {
+    let (files, ids) = decoy_fixture();
+    assert_decoy_refused(&link_cross_file(&files), &ids, "batch");
+}
+
+#[test]
+fn the_incremental_linker_keeps_the_same_file_decoy_refused_too() {
+    let (files, ids) = decoy_fixture();
+    assert_decoy_refused(&link_incremental(&files), &ids, "incremental");
+}
+
 // ── FIR-2508: a module and a same-named function ────────────────────────────
 
 const SEARCH_PY: &str = r#"

--- a/crates/kin-index/tests/python_receiver_type_resolution.rs
+++ b/crates/kin-index/tests/python_receiver_type_resolution.rs
@@ -586,6 +586,151 @@ class Session:
     );
 }
 
+// ── The declared receiver whose class is in the calling file ────────────────
+//
+// Every fixture above splits the annotated receiver from its class across two
+// files, which is the shape FIR-2500 was filed on. The greenfield miss is the
+// other half: one module holds the class and the module-level function that
+// takes it as an annotated parameter, and the call between them is the one a
+// reader would expect to be easiest.
+
+/// One module, both halves. `Database` and the function annotating a parameter
+/// with it live in `storage.py`, so the owner half of the qualified callee
+/// names a class in the calling file.
+const STORAGE_PY: &str = r#"
+class Database:
+    def upsert_note(self, path, body):
+        return path
+
+
+def ingest_directory(database: Database, root):
+    return database.upsert_note(root, "")
+"#;
+
+/// A second file so the fixture universe is a real cross-file link rather than
+/// a single-file degenerate case, and so its own cross-file call can serve as
+/// the positive control that the linker ran at all.
+const NOTEKEEPER_CLI_PY: &str = r#"
+from storage import ingest_directory
+
+
+def main(database, root):
+    return ingest_directory(database, root)
+"#;
+
+#[test]
+fn a_declared_receiver_binds_when_its_class_is_in_the_calling_file() {
+    let files = vec![
+        parse_py("storage.py", STORAGE_PY),
+        parse_py("cli.py", NOTEKEEPER_CLI_PY),
+    ];
+    let target = entity_id(
+        &files,
+        "storage.py",
+        "Database.upsert_note",
+        EntityKind::Method,
+    );
+    let caller = entity_id(
+        &files,
+        "storage.py",
+        "ingest_directory",
+        EntityKind::Function,
+    );
+    let main = entity_id(&files, "cli.py", "main", EntityKind::Function);
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, main, caller),
+        "positive control: this fixture's cross-file call must bind, or the \
+         same-file assertion below is measuring a linker that never ran"
+    );
+
+    assert!(
+        has_call(&relations, caller, target),
+        "`database.upsert_note(root, \"\")` under `database: Database` must \
+         bind to Database.upsert_note when Database is declared in this very \
+         file; a declared type the caller can see without an import is the \
+         easiest case, not the hardest"
+    );
+
+    let edge = relations
+        .iter()
+        .find(|r| {
+            r.kind == RelationKind::Calls
+                && r.src.as_entity() == Some(caller)
+                && r.dst.as_entity() == Some(target)
+        })
+        .expect("the declared receiver type binds this call");
+
+    assert_eq!(
+        RelationResolution::of(edge).as_str(),
+        "type_resolved",
+        "and it must publish as proven from the declared type, exactly as the \
+         cross-file twin does; a disclaimed bare-name edge is withheld from \
+         the counts find_references reports"
+    );
+}
+
+#[test]
+fn the_same_declared_receiver_binds_with_its_class_moved_to_another_file() {
+    // The control, and a minimal pair with the test above: same annotation,
+    // same call text, same callee. The one difference is that `Database` now
+    // lives in its own file and an import brings the name back. This is the
+    // path the rest of this suite covers, so it must pass, which is what makes
+    // a failure above a statement about the class's file and nothing else.
+    let files = vec![
+        parse_py(
+            "db.py",
+            r#"
+class Database:
+    def upsert_note(self, path, body):
+        return path
+"#,
+        ),
+        parse_py(
+            "storage.py",
+            r#"
+from db import Database
+
+
+def ingest_directory(database: Database, root):
+    return database.upsert_note(root, "")
+"#,
+        ),
+        parse_py("cli.py", NOTEKEEPER_CLI_PY),
+    ];
+    let target = entity_id(&files, "db.py", "Database.upsert_note", EntityKind::Method);
+    let caller = entity_id(
+        &files,
+        "storage.py",
+        "ingest_directory",
+        EntityKind::Function,
+    );
+
+    let relations = link_cross_file(&files);
+
+    assert!(
+        has_call(&relations, caller, target),
+        "the cross-file half of the pair must bind through the declared type"
+    );
+
+    let edge = relations
+        .iter()
+        .find(|r| {
+            r.kind == RelationKind::Calls
+                && r.src.as_entity() == Some(caller)
+                && r.dst.as_entity() == Some(target)
+        })
+        .expect("the declared receiver type binds this call");
+
+    assert_eq!(
+        RelationResolution::of(edge).as_str(),
+        "type_resolved",
+        "the cross-file half publishes the declared-type marker"
+    );
+}
+
 // ── FIR-2508: a module and a same-named function ────────────────────────────
 
 const SEARCH_PY: &str = r#"


### PR DESCRIPTION
A Python method call through an annotated receiver produced no call edge at all when the receiver's class was declared in the same file. Move that class into its own file and the identical call binds at `type_resolved`, confidence 0.95. This makes the same-file case bind the same way, in both linker paths. Every line reference below is to `crates/kin-index/src/linker.rs` at origin/main 6e4503807, the sha the defect was proven on.

## The minimal pair

The first commit on this branch landed two fixtures that differ by one line of Python. Both write `def ingest_directory(database: Database, root)` and call `database.upsert_note(root, "")`. In one, `Database` is declared in the same `storage.py`. In the other it lives in `db.py` and an import brings the name back. On origin/main the first failed and the second passed: `cargo test -p kin-index --test python_receiver_type_resolution`, raw exit 101, `test result: FAILED. 17 passed; 1 failed`. The failing test carries an in-test positive control asserting the fixture's cross-file call from `cli.main` to `ingest_directory` binds, and that control passed, so the failure was not a linker that never ran.

The asymmetry is the product fact. An unannotated cross-file call still earns a `name_only` edge, so writing the type annotation down in the same file as the class was worse for recall than writing nothing.

## Mechanism

The parser was complete. Its relation for the one-file fixture reads `src=ingest_directory dst=Database.upsert_note kind=Calls receiver=Some("database")`, and `Database.upsert_note` exists as a `Method` entity in that file. The linker dropped it.

Tier (a) at `linker.rs:871` guards its same-file win with `dst_same_file.filter(|_| !receiver_is_object)`, and `database` classifies as `ReceiverScope::Object` at `linker.rs:843`, so the same-file entity is passed over even though the map holds exactly the right id. That filter is deliberate: a same-file free function sharing a member's leaf name is a decoy, not the destination.

Tier (a2) at `linker.rs:939` splits `Database.upsert_note` and looks the owner up in the calling file, so `owner_is_class` is true precisely because the class is local, and control takes (a2) rather than the (a2b) branch every cross-file fixture rides. (a2) called `resolve_inherited_method`, which at `linker.rs:2620` seeds its queue with the class and then reads `class_bases_by_file_class`, iterating bases only. The doc comment at `linker.rs:2569` states the assumption outright, that the walk starts at the bases because its caller already gave a same-file own method its win. For a receiver-typed call no such tier had run.

So a base-less `Database` returned nothing, `dst_lookup` fell back to the bare `upsert_note`, tier (b) at `linker.rs:988` and tier (c) at `linker.rs:1130` were skipped by the same `!receiver_is_object` filter, and tier (c2) at `linker.rs:1173` filters candidates with `fp != file.file_path.as_str()` at `linker.rs:1190`, which discards the only correct answer because it lives in the calling file. Nothing downstream could recover it.

## The fix

A new (a2a) sub-tier asks the class for the method it declares itself, before the bases walk, gated on the relation carrying a receiver. It emits `RECEIVER_TYPE_CONFIDENCE`, so the edge publishes as `type_resolved` exactly as its cross-file twin does. It lands in both paths: the batch linker's (a2), and the incremental linker's own copy of these tiers at `linker.rs:5651`, which is the path a running daemon takes on a live edit. The shared lookup is factored out as `resolve_own_method` and `resolve_own_method_incremental`, which `resolve_declared_method` and its incremental mirror now call, so the own-method half and the inherited half each stay one implementation.

The decoy stays refused by construction. The new lookup is keyed on the class-qualified entity name (`Class.method` or `Class::method`), and a same-file free function is keyed on its bare leaf, so it is not a candidate. Tier (a)'s receiver filter is untouched. The inherited walk keeps its own lower confidence, so a receiver-typed call to an inherited method still publishes at `INHERITED_METHOD_CONFIDENCE` rather than being promoted by this change.

## Tests

Three tests join the minimal pair. `the_incremental_linker_binds_the_same_file_declared_receiver` is the live-edit twin of the failing test. `a_same_file_free_function_sharing_the_method_name_still_loses_to_the_class` and `the_incremental_linker_keeps_the_same_file_decoy_refused_too` drive a fixture that declares `upsert_note` both as a method on `Database` and as a module-level function, and call that leaf twice, once through an annotated receiver and once through a bare one. They assert the annotated call still reaches the method, that neither call reaches the free function, and each carries the cross-file positive control.

## Falsification

Four passes, each removing one property and predicting which tests fail. Every sabotage was an exact-match replacement that asserted it matched exactly once, and every restore was `git checkout --` against the commit with `git diff --quiet` confirming byte-identical.

Removing the batch (a2a) tier gave `test result: FAILED. 19 passed; 2 failed`, exactly `a_declared_receiver_binds_when_its_class_is_in_the_calling_file` on "must bind to Database.upsert_note when Database is declared in this very file" and the batch decoy test on "the batch linker must still bind the annotated call to the class's own method". Both incremental tests stayed green.

Removing the incremental (a2a) tier gave `test result: FAILED. 19 passed; 2 failed`, exactly the two incremental tests, and both batch tests stayed green. The two paths are covered independently.

Removing tier (a)'s `!receiver_is_object` filter gave `test result: FAILED. 20 passed; 1 failed`, exactly the batch decoy test on "with no annotation to name an owner, the batch linker must refuse the decoy outright". No pre-existing test in this suite caught that removal, so the decoy guard is new coverage rather than a restatement of one.

Emitting 0.7 in place of `RECEIVER_TYPE_CONFIDENCE` in (a2a) gave `test result: FAILED. 20 passed; 1 failed` on the resolution assertion, `left: "name_only"` against `right: "type_resolved"`. The marker assertion does work the `has_call` assertion does not.

## Gates

`cargo fmt --all -- --check` exit 0. Clippy as ci.yml runs it, `RUSTFLAGS='-D warnings' cargo clippy -p kin-index --all-targets --all-features` with the 45-lint allow list from `.github/clippy-allowed-lints.txt`, exit 0. `python3 scripts/verify-zero-file-search.py` exit 0, `bash scripts/zero_file_search_guard.sh` exit 0, `bash scripts/check_runtime_boundaries.sh` exit 0, `bash scripts/check_private_repo_coupling.sh` exit 0, `python3 scripts/test-private-repo-coupling.py` exit 0. `cargo test -p kin-index` in full, 456 tests across its 15 binaries, 0 failed.

The full local gate ran on this branch under one build slot. Its tree line reads `kin-dev: local-test: kin /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/samefilerecv-kin @ 9a2b4bbe9 (chore/lane-samefilerecv-kin)` and its summary reads `Summary [ 372.112s] 6844 tests run: 6844 passed (3 slow), 12 skipped`, read from the gate log rather than from an exit code. The four test names above appear in that log. `git diff origin/main --stat -- Cargo.lock .cargo/` is empty, and the tracked `.cargo/` tree holds only `.cargo/config.toml`.

Closes FIR-2585
