### PR TITLE
Stage what kin agent writes, so a run lands a commit

### DIFF
--- a/crates/kin-agent/src/belt.rs
+++ b/crates/kin-agent/src/belt.rs
@@ -409,6 +409,13 @@ impl LocalOutcome {
 ///
 /// Session and transaction lifecycle is the harness's job, so exposing those tools would
 /// let the model open a second session or commit a transaction the harness is holding.
+///
+/// `kin_transaction_stage` and `kin_transaction_validate` belong on this list for a
+/// sharper reason than tidiness. Both require a transaction id, and `kin_transaction_begin`
+/// is the only way to get one honestly. A model holding stage without begin cannot obtain
+/// an id at all, so its only remaining move is to invent one, which is what an observed
+/// local-model run did before the harness staged on its own behalf. Hiding the whole set
+/// is what makes the harness the single writer.
 pub fn is_harness_owned(name: &str) -> bool {
     matches!(
         name,
@@ -416,6 +423,8 @@ pub fn is_harness_owned(name: &str) -> bool {
             | "kin_session_end"
             | "kin_session_heartbeat"
             | "kin_transaction_begin"
+            | "kin_transaction_stage"
+            | "kin_transaction_validate"
             | "kin_transaction_commit"
             | "kin_transaction_abort"
     )

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -35,10 +35,17 @@ When a Kin result is empty, read what Kin says about that emptiness. If it repor
 absence cannot be trusted, the honest answer is that you do not know, and you should say \
 what the gap is. Never turn an untrusted absence into a claim that something does not exist.
 
-To change code, use edit_file for a surgical change to an existing file and write_file for \
-a new one. Read the exact current text through Kin first so your edit matches byte for byte. \
-Your edits are recorded through Kin's transaction tools, so the change carries provenance \
-naming this agent.
+To change code, use edit_file for a surgical change to an existing file and write_file to \
+create a new one. Read the exact current text through Kin first so your edit matches byte \
+for byte. You never open, stage or commit a transaction yourself, and those tools are not \
+on your belt on purpose. The harness does it around every call you make: a file you create \
+with write_file is staged as Kin's create operation, carrying the repository-relative path \
+and the full body, and committed with provenance naming this agent. An edit to a file Kin \
+already tracks lands in the working tree and is recorded in this run's trace, and the \
+harness does not yet admit that edit to the graph in the same step.
+
+Your tools are the mcp__kin__ ones named above plus edit_file and write_file. You have no \
+others.
 
 Work in small steps. Call one or two tools, read what came back, then decide. When you have \
 the answer, say it in plain text without calling a tool.";
@@ -497,11 +504,17 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                 Ok(()) => {
                                     counters.local_calls += 1;
                                     let started_call = Instant::now();
-                                    let bracket = begin_transaction(
+                                    // The plan is made before the tool runs, because
+                                    // `write_file` is what makes a new path exist and
+                                    // afterwards nothing can tell a create from an
+                                    // overwrite.
+                                    let plan = plan_stage(&config.repo, tool, &call.arguments);
+                                    let mut bracket = begin_transaction(
                                         &mut mcp,
                                         kin_session.as_deref(),
                                         &server_tool_names,
                                         &call.arguments,
+                                        &plan,
                                         &mut writer,
                                     )?;
                                     let outcome = match tool {
@@ -512,10 +525,24 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                             belt::run_write(&config.repo, &call.arguments)
                                         }
                                     };
+                                    // Stage what the harness just did, inside the open
+                                    // bracket, so the commit below has something to
+                                    // publish. An empty transaction is refused by design.
+                                    let staged = if outcome.is_error {
+                                        false
+                                    } else {
+                                        stage_planned_operation(
+                                            &mut mcp,
+                                            &mut bracket,
+                                            kin_session.as_deref(),
+                                            &plan,
+                                            &mut writer,
+                                        )?
+                                    };
                                     let provenance = close_transaction(
                                         &mut mcp,
                                         bracket,
-                                        !outcome.is_error,
+                                        !outcome.is_error && staged,
                                         &mut writer,
                                     )?;
                                     if let Some(path) = outcome.changed.clone() {
@@ -767,10 +794,97 @@ fn end_kin_session(
     Ok(())
 }
 
+/// What the harness will stage inside the bracket for one local tool call.
+///
+/// `kin_transaction_stage` admits five disjoint shapes (`crates/kin-mcp/src/tools.rs`),
+/// and exactly one of them is keyed on a repository-relative path plus a body: the new
+/// source file, verb `create`. The in-place edit shape resolves its target against
+/// repository authority as an entity uuid or an exact entity name
+/// (`kin_mcp::handlers::sessions::resolve_target_entity`), which a text splice does not
+/// know, so the harness plans nothing for an edit rather than staging a shape the daemon
+/// would refuse at commit. A transaction with nothing in it is refused too, by design, so
+/// an unstageable call opens no transaction at all and the trace says why.
+enum StagePlan {
+    /// Admit the file at this repository-relative path with this body. Repository
+    /// authority refuses it by name if it already tracks the path.
+    Create { target: String, body: String },
+    /// Nothing the stage surface admits fits this call, and this is the reason.
+    Unstageable { reason: String },
+}
+
+/// Decide what to stage for one local tool call.
+///
+/// Whether the path is new is repository authority's question, not the filesystem's, and
+/// the two answers differ: a path can sit on disk untracked, or be tracked with nothing on
+/// disk yet. So the harness plans the create and lets the daemon refuse it by name if the
+/// graph already holds that path, which is the rule `create` documents. Probing the disk
+/// here would put a filesystem heuristic on the runtime path to answer a question the
+/// graph owns.
+fn plan_stage(repo: &Path, tool: LocalTool, arguments: &Value) -> StagePlan {
+    let raw_path = arguments.get("path").and_then(Value::as_str).unwrap_or("");
+    match tool {
+        LocalTool::Edit => StagePlan::Unstageable {
+            reason: "an in-place edit has no stage shape keyed on a path; the update \
+                     operation names an entity uuid or an exact entity name"
+                .into(),
+        },
+        LocalTool::Write => {
+            let content = arguments
+                .get("content")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if content.trim().is_empty() {
+                return StagePlan::Unstageable {
+                    reason: "the create operation requires a non-empty body".into(),
+                };
+            }
+            let path = match belt::resolve_in_repo(repo, raw_path) {
+                Ok(path) => path,
+                Err(problem) => return StagePlan::Unstageable { reason: problem },
+            };
+            match repository_relative(repo, &path) {
+                Some(target) => StagePlan::Create {
+                    target,
+                    body: content.to_string(),
+                },
+                None => StagePlan::Unstageable {
+                    reason: "the path did not reduce to a repository-relative target".into(),
+                },
+            }
+        }
+    }
+}
+
+/// The repository-relative form of a resolved path, with `/` separators on every platform
+/// because that is what repository authority stores.
+fn repository_relative(repo: &Path, resolved: &Path) -> Option<String> {
+    let relative = resolved.strip_prefix(repo).ok()?;
+    let parts: Vec<String> = relative
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect();
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
 /// An open provenance bracket around one local edit.
 struct Bracket {
     transaction_id: Option<String>,
     reason: Option<String>,
+    /// What the harness staged into this transaction, and whether the server took it.
+    staged: Option<Value>,
+}
+
+impl Bracket {
+    fn unopened(reason: impl Into<String>) -> Self {
+        Bracket {
+            transaction_id: None,
+            reason: Some(reason.into()),
+            staged: None,
+        }
+    }
 }
 
 fn begin_transaction(
@@ -778,22 +892,23 @@ fn begin_transaction(
     session: Option<&str>,
     server_tools: &[String],
     arguments: &Value,
+    plan: &StagePlan,
     writer: &mut TranscriptWriter,
 ) -> anyhow::Result<Bracket> {
+    // A transaction the harness cannot stage into can only end in the daemon's refusal of
+    // an empty commit, so it is not opened. The reason travels into the provenance record.
+    if let StagePlan::Unstageable { reason } = plan {
+        return Ok(Bracket::unopened(reason.clone()));
+    }
     let Some(session) = session else {
-        return Ok(Bracket {
-            transaction_id: None,
-            reason: Some("no Kin session was open".into()),
-        });
+        return Ok(Bracket::unopened("no Kin session was open"));
     };
-    if !server_tools
-        .iter()
-        .any(|name| name == "kin_transaction_begin")
-    {
-        return Ok(Bracket {
-            transaction_id: None,
-            reason: Some("the server does not expose kin_transaction_begin".into()),
-        });
+    for required in ["kin_transaction_begin", "kin_transaction_stage"] {
+        if !server_tools.iter().any(|name| name == required) {
+            return Ok(Bracket::unopened(format!(
+                "the server does not expose {required}"
+            )));
+        }
     }
     let scope = arguments
         .get("path")
@@ -821,6 +936,7 @@ fn begin_transaction(
                     .is_none()
                     .then(|| "the server returned no transaction id".to_string()),
                 transaction_id,
+                staged: None,
             })
         }
         Ok(outcome) => {
@@ -833,16 +949,67 @@ fn begin_transaction(
                 "is_error": true,
                 "detail": truncate(&outcome.text, 300),
             }))?;
-            Ok(Bracket {
-                transaction_id: None,
-                reason: Some(truncate(&outcome.text, 200)),
-            })
+            Ok(Bracket::unopened(truncate(&outcome.text, 200)))
         }
-        Err(err) => Ok(Bracket {
-            transaction_id: None,
-            reason: Some(err.to_string()),
-        }),
+        Err(err) => Ok(Bracket::unopened(err.to_string())),
     }
+}
+
+/// Stage the operation the harness just performed, inside the open bracket.
+///
+/// Returns whether the transaction now holds something committable. A bracket that was
+/// never opened, or a plan with nothing the stage surface admits, stages nothing and says
+/// so, which is what keeps the commit below from claiming a provenance it did not get.
+fn stage_planned_operation(
+    mcp: &mut McpClient,
+    bracket: &mut Bracket,
+    session: Option<&str>,
+    plan: &StagePlan,
+    writer: &mut TranscriptWriter,
+) -> anyhow::Result<bool> {
+    let (Some(transaction_id), StagePlan::Create { target, body }) =
+        (bracket.transaction_id.clone(), plan)
+    else {
+        return Ok(false);
+    };
+    let operation = json!({
+        "verb": "create",
+        "target": target,
+        "body": body,
+        "description": format!("kin agent created {target}"),
+    });
+    let mut arguments = json!({
+        "transaction_id": transaction_id,
+        "operations": [operation],
+    });
+    if let Some(session) = session {
+        arguments["session_id"] = Value::String(session.to_string());
+    }
+    let outcome = mcp.call_tool("kin_transaction_stage", &arguments);
+    let (is_error, detail) = match &outcome {
+        Ok(outcome) => (outcome.is_error, truncate(&outcome.text, 300)),
+        Err(err) => (true, err.to_string()),
+    };
+    writer.trace(json!({
+        "surface": "kin",
+        "tool": "kin_transaction_stage",
+        "policy": "allowed",
+        "event": "transaction_stage",
+        "transaction_id": transaction_id,
+        "verb": "create",
+        "target": target,
+        "body_bytes": body.len(),
+        "is_error": is_error,
+        "detail": detail,
+    }))?;
+    bracket.staged = Some(json!({
+        "verb": "create",
+        "target": target,
+        "body_bytes": body.len(),
+        "accepted": !is_error,
+        "detail": if is_error { Value::String(detail) } else { Value::Null },
+    }));
+    Ok(!is_error)
 }
 
 /// Close the bracket. The recorded provenance says what actually happened, including a
@@ -856,6 +1023,7 @@ fn close_transaction(
     let Some(transaction_id) = bracket.transaction_id else {
         return Ok(json!({
             "bracketed": false,
+            "staged": bracket.staged,
             "reason": bracket.reason,
         }));
     };
@@ -880,9 +1048,13 @@ fn close_transaction(
     }))?;
     Ok(json!({
         "bracketed": true,
+        "staged": bracket.staged,
         "transaction_id": transaction_id,
         "closed_with": tool,
         "closed_cleanly": !is_error,
+        // The server's own answer to the close, kept whether it accepted or refused, so a
+        // run's evidence is what the daemon said rather than the harness's summary of it.
+        "response": detail.clone(),
         "detail": if is_error { Value::String(detail) } else { Value::Null },
     }))
 }

--- a/crates/kin-agent/src/tests.rs
+++ b/crates/kin-agent/src/tests.rs
@@ -266,7 +266,13 @@ fn harness_owned_tools_never_reach_the_model() {
     for name in [
         "kin_session_start",
         "kin_session_end",
+        "kin_session_heartbeat",
         "kin_transaction_begin",
+        // Stage and validate both need a transaction id, and begin is the only honest
+        // source of one. Exposing either without begin leaves a model nothing to do but
+        // invent an id.
+        "kin_transaction_stage",
+        "kin_transaction_validate",
         "kin_transaction_commit",
         "kin_transaction_abort",
     ] {

--- a/crates/kin-agent/tests/loop_integration.rs
+++ b/crates/kin-agent/tests/loop_integration.rs
@@ -141,6 +141,8 @@ TOOLS = [
      "inputSchema": {"type": "object", "properties": {}}},
     {"name": "kin_transaction_begin", "description": "Begin a transaction.",
      "inputSchema": {"type": "object", "properties": {}}},
+    {"name": "kin_transaction_stage", "description": "Stage transaction operations.",
+     "inputSchema": {"type": "object", "properties": {}}},
     {"name": "kin_transaction_commit", "description": "Commit a transaction.",
      "inputSchema": {"type": "object", "properties": {}}},
     {"name": "kin_transaction_abort", "description": "Abort a transaction.",
@@ -174,6 +176,17 @@ def call(name, args):
         return payload({"ended": True, "_kin": ENVELOPE})
     if name == "kin_transaction_begin":
         return payload({"transaction_id": "txn-fixture-1", "_kin": ENVELOPE})
+    if name == "kin_transaction_stage":
+        # The daemon refuses a create whose path repository authority already tracks.
+        # TRACKED stands for the fixture graph's contents, so the refusal is the graph's
+        # answer rather than a look at the working tree.
+        TRACKED = ("src/greet.py", "README.md")
+        for op in args.get("operations", []):
+            if op.get("target") in TRACKED:
+                return payload({"error": "path " + op.get("target") + " is already tracked",
+                                "_kin": ENVELOPE}, is_error=True)
+        return payload({"staged": len(args.get("operations", [])),
+                        "transaction_id": "txn-fixture-1", "_kin": ENVELOPE})
     if name == "kin_transaction_commit":
         return payload({"committed": True, "transaction_id": "txn-fixture-1", "_kin": ENVELOPE})
     if name == "kin_transaction_abort":
@@ -338,7 +351,7 @@ fn mcp_log(path: &Path) -> Vec<Value> {
 }
 
 #[test]
-fn a_tool_call_reaches_kin_the_edit_is_bracketed_and_the_transcript_records_it() {
+fn a_tool_call_reaches_kin_and_an_in_place_edit_records_why_it_stages_nothing() {
     let dir = tempfile::tempdir().unwrap();
     let repo = fixture_repo(dir.path());
     let out = dir.path().join("out");
@@ -389,8 +402,9 @@ fn a_tool_call_reaches_kin_the_edit_is_bracketed_and_the_transcript_records_it()
         "the docstring must be in the file: {edited}"
     );
 
-    // The call reached the graph server, and the edit was bracketed by a transaction
-    // under a session, in that order.
+    // The call reached the graph server. The edit itself opens no transaction: the stage
+    // surface has no shape keyed on a path for an in-place edit, and a transaction with
+    // nothing staged in it can only end in the daemon's refusal of an empty commit.
     let calls = mcp_log(&log);
     let names: Vec<&str> = calls
         .iter()
@@ -398,14 +412,8 @@ fn a_tool_call_reaches_kin_the_edit_is_bracketed_and_the_transcript_records_it()
         .collect();
     assert_eq!(
         names,
-        vec![
-            "kin_session_start",
-            "semantic_locate",
-            "kin_transaction_begin",
-            "kin_transaction_commit",
-            "kin_session_end"
-        ],
-        "the edit must be bracketed by begin/commit under a session"
+        vec!["kin_session_start", "semantic_locate", "kin_session_end"],
+        "an unstageable edit must not open a transaction it cannot stage into"
     );
     assert_eq!(calls[1]["args"]["query"], "greet");
 
@@ -461,10 +469,13 @@ fn a_tool_call_reaches_kin_the_edit_is_bracketed_and_the_transcript_records_it()
         .iter()
         .find(|row| row["surface"] == "local" && row["tool"] == "edit_file")
         .expect("the local edit is traced");
-    assert_eq!(edit["provenance"]["bracketed"], true);
-    assert_eq!(edit["provenance"]["transaction_id"], "txn-fixture-1");
-    assert_eq!(edit["provenance"]["closed_with"], "kin_transaction_commit");
-    assert_eq!(edit["provenance"]["closed_cleanly"], true);
+    assert_eq!(edit["provenance"]["bracketed"], false);
+    assert_eq!(edit["provenance"]["staged"], Value::Null);
+    let reason = edit["provenance"]["reason"].as_str().unwrap();
+    assert!(
+        reason.contains("entity uuid or an exact entity name"),
+        "the provenance must name why the edit could not be staged: {reason}"
+    );
     // The whole written body stays out of the trace row; the transcript already has it.
     assert!(edit["args"]["replace"]
         .as_str()
@@ -487,6 +498,172 @@ fn a_tool_call_reaches_kin_the_edit_is_bracketed_and_the_transcript_records_it()
     assert_eq!(
         requests[1]["messages"].as_array().unwrap().last().unwrap()["role"],
         "tool"
+    );
+}
+
+/// The end-to-end shape FIR-2586 is about: a new file the model writes is staged as the
+/// `create` operation and committed, so the run lands something rather than opening a
+/// transaction it never fills.
+#[test]
+fn a_new_file_is_staged_as_a_create_and_then_committed() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+    let body = "def farewell(name):\n    return f\"bye {name}\"\n";
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Writing the new module.",
+            Some(tool_call(
+                "c1",
+                "write_file",
+                json!({ "path": "src/farewell.py", "content": body }),
+            )),
+        ),
+        completion("src/farewell.py now holds farewell.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+    assert_eq!(outcome.status, ExitStatus::Success);
+
+    // The file landed on disk.
+    assert_eq!(
+        std::fs::read_to_string(repo.join("src/farewell.py")).unwrap(),
+        body
+    );
+
+    // The write was bracketed, staged, and committed, in that order.
+    let calls = mcp_log(&log);
+    let names: Vec<&str> = calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "kin_session_start",
+            "kin_transaction_begin",
+            "kin_transaction_stage",
+            "kin_transaction_commit",
+            "kin_session_end"
+        ],
+        "a new file must be staged inside the bracket before the commit"
+    );
+
+    // The staged operation is the FIR-2417 create shape: a repository-relative target and
+    // the full body, carried in the call rather than read off disk by the daemon.
+    let stage = calls
+        .iter()
+        .find(|call| call["tool"] == "kin_transaction_stage")
+        .expect("the create is staged");
+    assert_eq!(stage["args"]["transaction_id"], "txn-fixture-1");
+    assert_eq!(stage["args"]["session_id"], "sess-fixture-1");
+    let operations = stage["args"]["operations"].as_array().unwrap();
+    assert_eq!(operations.len(), 1);
+    assert_eq!(operations[0]["verb"], "create");
+    assert_eq!(operations[0]["target"], "src/farewell.py");
+    assert_eq!(operations[0]["body"], body);
+    assert!(operations[0]["description"]
+        .as_str()
+        .unwrap()
+        .contains("src/farewell.py"));
+
+    // The commit carries the daemon's own accepted answer into the trace, so the evidence
+    // is what the server said rather than the harness's summary of it.
+    let trace = read_jsonl(&outcome.trace_path);
+    let write = trace
+        .iter()
+        .find(|row| row["surface"] == "local" && row["tool"] == "write_file")
+        .expect("the local write is traced");
+    assert_eq!(write["provenance"]["bracketed"], true);
+    assert_eq!(write["provenance"]["staged"]["verb"], "create");
+    assert_eq!(write["provenance"]["staged"]["target"], "src/farewell.py");
+    assert_eq!(write["provenance"]["staged"]["accepted"], true);
+    assert_eq!(write["provenance"]["closed_with"], "kin_transaction_commit");
+    assert_eq!(write["provenance"]["closed_cleanly"], true);
+    let response = write["provenance"]["response"].as_str().unwrap();
+    assert!(
+        response.contains("committed"),
+        "the commit response must be the daemon's own: {response}"
+    );
+
+    // The stage call is traced in its own right, joinable with the transaction.
+    let staged = trace
+        .iter()
+        .find(|row| row["tool"] == "kin_transaction_stage")
+        .expect("the stage call is traced");
+    assert_eq!(staged["event"], "transaction_stage");
+    assert_eq!(staged["transaction_id"], "txn-fixture-1");
+    assert_eq!(staged["is_error"], false);
+    assert_eq!(staged["body_bytes"], body.len());
+}
+
+/// A `write_file` over a path the graph already tracks is refused by repository authority
+/// rather than by the harness looking at the disk, and the refusal aborts the transaction.
+#[test]
+fn a_write_over_a_tracked_path_is_refused_by_the_graph_and_aborts() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Rewriting the readme.",
+            Some(tool_call(
+                "c1",
+                "write_file",
+                json!({ "path": "README.md", "content": "# rewritten\n" }),
+            )),
+        ),
+        completion("README.md rewritten.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+    assert_eq!(outcome.status, ExitStatus::Success);
+    assert_eq!(
+        std::fs::read_to_string(repo.join("README.md")).unwrap(),
+        "# rewritten\n"
+    );
+
+    // Repository authority refuses the create by name, so the transaction aborts rather
+    // than committing, and the harness never claims a provenance it did not get.
+    let calls = mcp_log(&log);
+    let names: Vec<&str> = calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "kin_session_start",
+            "kin_transaction_begin",
+            "kin_transaction_stage",
+            "kin_transaction_abort",
+            "kin_session_end"
+        ],
+        "a refused stage must abort rather than commit an empty transaction"
+    );
+
+    let trace = read_jsonl(&outcome.trace_path);
+    let write = trace
+        .iter()
+        .find(|row| row["surface"] == "local" && row["tool"] == "write_file")
+        .expect("the local write is traced");
+    assert_eq!(write["provenance"]["bracketed"], true);
+    assert_eq!(write["provenance"]["staged"]["accepted"], false);
+    assert_eq!(write["provenance"]["closed_with"], "kin_transaction_abort");
+    let detail = write["provenance"]["staged"]["detail"].as_str().unwrap();
+    assert!(
+        detail.contains("already tracked"),
+        "the graph's refusal must survive into the provenance: {detail}"
     );
 }
 


### PR DESCRIPTION
`kin agent` now lands what it writes. A new file the model creates is staged as Kin's `create` operation and committed, so a run produces a commit instead of a refused empty transaction.

## Mechanism

The harness bracketed every local `edit_file` and `write_file` in a transaction (`crates/kin-agent/src/run.rs:500-520`, helpers at `run.rs:777-880`) and staged nothing inside it. The close then asked the daemon to commit an empty transaction, which `crates/kin-daemon/src/mcp_commit.rs:318` refuses by design with "exact repository commits reject empty transactions". Every bracketed edit ended in that refusal, so every run landed zero commits for a harness reason rather than a model one.

`belt::is_harness_owned` (`crates/kin-agent/src/belt.rs:412-422`) also hid `kin_transaction_begin`, `commit` and `abort` from the model while leaving `kin_transaction_stage` and `kin_transaction_validate` on the belt. Both need a transaction id and `begin` is the only honest source of one, so a model holding stage without begin had nothing to do but invent an id, which is what the observed local-model run did.

## The fix

A successful `write_file` now stages the FIR-2417 `create` operation inside the bracket, carrying the repository-relative target and the full body, before the commit. That is the shape `kin_transaction_stage` documents for source the graph has never seen (`crates/kin-mcp/src/tools.rs:120-145`, `crates/kin-mcp/src/session.rs:82-115`).

An in-place edit has no admitted shape, and this PR says so rather than staging something the daemon would refuse. `kin_transaction_stage` admits five disjoint shapes and only `create` is keyed on a path plus a body. The edit shape resolves its target through `kin_mcp::handlers::sessions::resolve_target_entity` (`crates/kin-mcp/src/handlers/sessions.rs:528-580`), which takes an entity uuid or an exact entity name and splices into that entity's span. A text splice knows a path and a file body, not an entity, so an `edit_file` now opens no transaction at all and the trace records that reason. Staging a path-targeted `update` instead would be admitted at stage time and refused at commit, which is a worse record than an honest one. Deriving the containing entity and its new body from a byte span is real work with a data-loss failure mode, so it is named below rather than guessed at here.

Whether a path is new is repository authority's question, not the filesystem's, and the two answers differ: a path can sit on disk untracked, or be tracked with nothing on disk. So the harness plans the create and lets the daemon refuse a tracked path by name. An early version probed `path.exists()` and `scripts/verify-zero-file-search.py` refused it, correctly.

A refused stage aborts instead of committing, and the provenance now carries the daemon's own answer to both the stage and the close, so a run's evidence is what the server said rather than the harness's summary of it.

`kin_transaction_stage` and `kin_transaction_validate` join `is_harness_owned`, which makes the harness the single writer.

The system prompt (`crates/kin-agent/src/run.rs:38-48`) now says what the harness does around each call and names the tools the model actually has.

## Tests

Three integration tests in `crates/kin-agent/tests/loop_integration.rs`, driven by the existing scripted MCP server, plus the widened unit guard in `crates/kin-agent/src/tests.rs`. The fake server gained `kin_transaction_stage` and refuses a create on a path its fixture graph tracks, mirroring the daemon's rule.

`a_new_file_is_staged_as_a_create_and_then_committed` asserts the call sequence is begin, stage, commit under a session, that the staged operation is verb `create` with target `src/farewell.py` and the exact body, and that the commit's transcript record carries the daemon's accepted response. `a_write_over_a_tracked_path_is_refused_by_the_graph_and_aborts` asserts the refusal aborts and survives into the provenance. `a_tool_call_reaches_kin_and_an_in_place_edit_records_why_it_stages_nothing` asserts an edit opens no transaction and names the reason. That last one is the previous `a_tool_call_reaches_kin_the_edit_is_bracketed_and_the_transcript_records_it`, updated: it used to assert the bracket that this PR shows was always doomed.

### Falsification

Each guard was broken and the named failure confirmed, then restored byte-identical (`git diff HEAD --stat` empty after each pass).

Removing the stage call, exit 101:

```
test a_new_file_is_staged_as_a_create_and_then_committed ... FAILED
test a_write_over_a_tracked_path_is_refused_by_the_graph_and_aborts ... FAILED
assertion `left == right` failed: a new file must be staged inside the bracket before the commit
  left: ["kin_session_start", "kin_transaction_begin", "kin_transaction_abort", "kin_session_end"]
 right: ["kin_session_start", "kin_transaction_begin", "kin_transaction_stage", "kin_transaction_commit", "kin_session_end"]
test result: FAILED. 7 passed; 2 failed; 1 ignored
```

Planning a create for an edit too, exit 101:

```
test a_tool_call_reaches_kin_and_an_in_place_edit_records_why_it_stages_nothing ... FAILED
assertion `left == right` failed: an unstageable edit must not open a transaction it cannot stage into
  left: ["kin_session_start", "semantic_locate", "kin_transaction_begin", "kin_transaction_stage", "kin_transaction_abort", "kin_session_end"]
 right: ["kin_session_start", "semantic_locate", "kin_session_end"]
test result: FAILED. 8 passed; 1 failed; 1 ignored
```

Dropping stage and validate from `is_harness_owned`, exit 101:

```
test tests::harness_owned_tools_never_reach_the_model ... FAILED
test result: FAILED. 29 passed; 1 failed; 0 ignored
```

## Gates

`cargo test -p kin-agent` exit 0: 30 unit tests passed, 9 integration tests passed with 1 ignored, 0 doctests. `cargo test -p kin-cli agent` exit 0, 5 passed. `cargo fmt --all -- --check` exit 0. Clippy exit 0 with the ci.yml allowlist (45 lints) under `RUSTFLAGS=-D warnings` for `-p kin-agent -p kin-cli`. `python3 scripts/verify-zero-file-search.py` exit 0 over 179 source files, `bash scripts/zero_file_search_guard.sh` exit 0, `bash scripts/check_runtime_boundaries.sh` exit 0. `git diff origin/main --stat -- Cargo.lock .cargo/` is empty and `git ls-tree -r HEAD --name-only` shows only `.cargo/config.toml` under `.cargo/`.

The local full gate was not run under tonight's build-slot saturation. Hosted CI is the gate of record for this PR, per the 05:52Z lane amendment, and every check must conclude with zero failures before it is submitted.

## What is left on FIR-2586

Two of the ticket's items are not in this PR. `--mcp-command` is still a single `Option<String>` (`crates/kin-cli/src/main.rs:1829`, `:1862`), so a brownfield arm cannot attach two repositories; making it repeatable means one MCP client per server, a session and transaction per server, and routing each local edit to the server that owns its repository, which is more than this change should carry. The ticket's acceptance run, one `kin agent run` on a local model landing a commit that `kin log` shows, is a proof step this PR enables but does not perform.

Refs FIR-2586
