### PR TITLE
Order the LSP cold sweep behind the embedding backfill on first boot

### DIFF
--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1758,6 +1758,424 @@ fn sweep_marker_is_durable(total_relations: usize, published: bool) -> bool {
     total_relations == 0 || published
 }
 
+/// How long a cold sweep waits for the embedding backfill before starting
+/// anyway.
+///
+/// A ceiling on the ordering rather than an amount of waiting: a backfill that
+/// drains in ninety seconds holds the sweep for ninety seconds, and only one
+/// still working past this bound loses its exclusivity. Ten minutes because the
+/// backfill this was written for took about five on the store it was measured
+/// on, and a bound shorter than the work it orders would order nothing. The
+/// sweep starting late is a slower convergence; the two running together is a
+/// daemon that dies and loses both.
+const SWEEP_BACKFILL_WAIT_BOUND: Duration = Duration::from_secs(600);
+
+/// How long the backfill may hold the sweep back while making no progress.
+///
+/// The wait bound alone is not enough. A backfill wedged on a refused vector
+/// checkpoint neither drains nor errors, so without this the sweep would spend
+/// the whole ten minutes waiting on a count that was never going to move.
+/// Progress is a fall in the pending count, so a backfill that is landing
+/// batches resets this on every one of them and is never cut short by it.
+const SWEEP_BACKFILL_STALL_BOUND: Duration = Duration::from_secs(90);
+
+/// How often the gate re-reads the store's pending-embedding count.
+const SWEEP_BACKFILL_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Why the cold sweep was released to start, which is what the gate logs.
+///
+/// Five outcomes rather than a bool because an operator reading the daemon log
+/// needs to tell a sweep that waited its turn from one that gave up on a
+/// backfill going nowhere. The first two are the fast paths that keep an
+/// already-embedded store behaving exactly as it did before this gate existed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SweepStartReason {
+    /// The store had nothing left to embed, so there was nothing to wait for.
+    NothingPending,
+    /// No worker will drain a backlog on this boot, so waiting would never end.
+    BackfillNotRunning,
+    /// The backfill finished while the sweep waited.
+    BackfillDrained,
+    /// The backfill stopped making progress for the stall bound.
+    BackfillStalled,
+    /// The backfill was still working when the whole wait bound expired.
+    WaitBoundExpired,
+}
+
+impl SweepStartReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            SweepStartReason::NothingPending => "nothing-pending",
+            SweepStartReason::BackfillNotRunning => "backfill-not-running",
+            SweepStartReason::BackfillDrained => "backfill-drained",
+            SweepStartReason::BackfillStalled => "backfill-stalled",
+            SweepStartReason::WaitBoundExpired => "wait-bound-expired",
+        }
+    }
+}
+
+/// What the gate does on one look at the store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SweepGateStep {
+    /// Keep holding the sweep back.
+    Wait,
+    /// Release the sweep, for this reason.
+    Start(SweepStartReason),
+}
+
+/// One look at the embedding backfill, in the terms the gate decides on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BackfillLook {
+    /// Whether any worker will drain a backlog on this boot. False when an
+    /// operator opted out, and false when the graph authority has no durable
+    /// vector-sidecar contract to persist progress into.
+    running: bool,
+    /// Entities and artifacts the vector index still lacks vectors for.
+    pending: usize,
+    /// Whether the gate has already held the sweep back at least once. What
+    /// separates a store that arrived converged from one that drained while
+    /// the sweep waited, which read the same without it.
+    held: bool,
+    /// How long the gate has been holding the sweep back.
+    waited: Duration,
+    /// How long since the pending count last fell.
+    since_progress: Duration,
+}
+
+/// Whether the sweep may start yet, given what the backfill is doing.
+///
+/// Pure, and separate from the loop that calls it, because the rule is what
+/// this change is about and a rule embedded in an async loop with two clocks
+/// can only be tested by waiting out its bounds.
+fn sweep_gate_step(
+    look: BackfillLook,
+    wait_bound: Duration,
+    stall_bound: Duration,
+) -> SweepGateStep {
+    if look.pending == 0 {
+        return SweepGateStep::Start(if look.held {
+            SweepStartReason::BackfillDrained
+        } else {
+            SweepStartReason::NothingPending
+        });
+    }
+    if !look.running {
+        return SweepGateStep::Start(SweepStartReason::BackfillNotRunning);
+    }
+    if look.waited >= wait_bound {
+        return SweepGateStep::Start(SweepStartReason::WaitBoundExpired);
+    }
+    if look.since_progress >= stall_bound {
+        return SweepGateStep::Start(SweepStartReason::BackfillStalled);
+    }
+    SweepGateStep::Wait
+}
+
+/// Hold a cold sweep until the embedding backfill has had the process to
+/// itself, and report why it was released.
+///
+/// Both passes used to be peer spawns with nothing ordering them, and on a
+/// full-history store in a memory-capped container that is what killed the
+/// daemon: the sweep reopens repository authority and rebuilds the graph from
+/// snapshot while the backfill holds a batch of vectors, and neither is small.
+/// The backfill goes first because it checkpoints durably as it goes, so a kill
+/// costs it the batch in flight rather than the pass; everything the sweep
+/// makes durable happens after its last file, so a kill costs the sweep all of
+/// it.
+///
+/// The bounds are parameters so the loop itself can be tested rather than only
+/// the rule it applies; production passes the constants above.
+async fn await_backfill_before_sweep<F>(
+    running: bool,
+    mut pending: F,
+    wait_bound: Duration,
+    stall_bound: Duration,
+    poll: Duration,
+) -> SweepStartReason
+where
+    F: FnMut() -> usize,
+{
+    let started = Instant::now();
+    let mut last_progress = started;
+    let mut lowest = usize::MAX;
+    let mut held = false;
+    loop {
+        let current = pending();
+        if current < lowest {
+            lowest = current;
+            last_progress = Instant::now();
+        }
+        let now = Instant::now();
+        let look = BackfillLook {
+            running,
+            pending: current,
+            held,
+            waited: now.duration_since(started),
+            since_progress: now.duration_since(last_progress),
+        };
+        match sweep_gate_step(look, wait_bound, stall_bound) {
+            SweepGateStep::Start(reason) => return reason,
+            SweepGateStep::Wait => {
+                held = true;
+                tokio::time::sleep(poll).await;
+            }
+        }
+    }
+}
+
+/// The ordering between the cold sweep and the embedding backfill, which is
+/// what FIR-2493 is about.
+///
+/// Both used to be peer spawns, and the tally tests further down passed
+/// throughout while a first boot ran them together. Arithmetic was never the
+/// gap. These tests drive the gate's own loop with a synthetic pending count
+/// and small bounds, so the rule is exercised rather than the constants.
+#[cfg(test)]
+mod sweep_backfill_gate_tests {
+    use super::{
+        await_backfill_before_sweep, sweep_gate_step, BackfillLook, SweepGateStep,
+        SweepStartReason, SWEEP_BACKFILL_POLL_INTERVAL, SWEEP_BACKFILL_STALL_BOUND,
+        SWEEP_BACKFILL_WAIT_BOUND,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// The gate returns the reason the daemon then logs, so asserting on the
+    /// returned reason asserts on the log line's content: the `info!` at the
+    /// gate's call site takes `reason.as_str()` and nothing else decides it.
+    fn reason_is_logged(reason: SweepStartReason) -> &'static str {
+        reason.as_str()
+    }
+
+    /// A store with work left to embed holds the sweep, and the sweep starts
+    /// once the backfill has drained.
+    ///
+    /// The count starts above zero on purpose. A source that began at zero
+    /// would make "the sweep waited" trivially true of any code at all,
+    /// including code with the gate deleted, and the test could not fail.
+    #[tokio::test]
+    async fn pending_embeddings_hold_the_sweep_until_the_backfill_drains() {
+        let pending = Arc::new(AtomicUsize::new(3));
+        let looks = Arc::new(AtomicUsize::new(0));
+        let source = Arc::clone(&pending);
+        let counter = Arc::clone(&looks);
+
+        // One entity embedded per look, so the backfill is unmistakably working
+        // and the gate has to hold through three of them.
+        let reason = await_backfill_before_sweep(
+            true,
+            move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                let seen = source.load(Ordering::SeqCst);
+                source.store(seen.saturating_sub(1), Ordering::SeqCst);
+                seen
+            },
+            Duration::from_secs(30),
+            Duration::from_secs(30),
+            Duration::from_millis(1),
+        )
+        .await;
+
+        assert_eq!(
+            reason,
+            SweepStartReason::BackfillDrained,
+            "a sweep released after waiting must say so; `NothingPending` here would mean the \
+             gate let it start beside a backfill that still had work"
+        );
+        assert_eq!(
+            looks.load(Ordering::SeqCst),
+            4,
+            "three looks with work pending and a fourth that found the backfill drained"
+        );
+        assert_eq!(
+            pending.load(Ordering::SeqCst),
+            0,
+            "and the backfill really did drain, rather than the gate giving up on it"
+        );
+        assert_eq!(reason_is_logged(reason), "backfill-drained");
+    }
+
+    /// An opted-out backfill releases the sweep at once rather than making it
+    /// wait out a bound nothing will satisfy.
+    ///
+    /// Run against the production constants deliberately. If the rule were
+    /// wrong this test would sit for the stall bound and then fail, so the
+    /// assertion below is not the only thing that can catch a regression.
+    #[tokio::test]
+    async fn an_opted_out_backfill_releases_the_sweep_at_once() {
+        let looks = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&looks);
+
+        let reason = await_backfill_before_sweep(
+            false,
+            move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                4096
+            },
+            SWEEP_BACKFILL_WAIT_BOUND,
+            SWEEP_BACKFILL_STALL_BOUND,
+            SWEEP_BACKFILL_POLL_INTERVAL,
+        )
+        .await;
+
+        assert_eq!(
+            reason,
+            SweepStartReason::BackfillNotRunning,
+            "with no worker to drain it, a pending count is not a reason to wait"
+        );
+        assert_eq!(
+            looks.load(Ordering::SeqCst),
+            1,
+            "one look and no sleep: an opt-out is known before the first poll interval"
+        );
+        assert_eq!(reason_is_logged(reason), "backfill-not-running");
+    }
+
+    /// A backfill still working when the whole wait bound expires loses the
+    /// sweep, and the reason says which bound ended it.
+    ///
+    /// The count falls on every look, so the stall bound can never fire here
+    /// and only the total wait bound can end this wait. That is what makes the
+    /// assertion about the wait bound rather than about either bound.
+    #[tokio::test]
+    async fn the_wait_bound_releases_a_sweep_a_working_backfill_is_still_holding() {
+        let source = Arc::new(AtomicUsize::new(1_000_000));
+        let pending = Arc::clone(&source);
+
+        let reason = await_backfill_before_sweep(
+            true,
+            move || pending.fetch_sub(1, Ordering::SeqCst),
+            Duration::from_millis(50),
+            Duration::from_secs(30),
+            Duration::from_millis(1),
+        )
+        .await;
+
+        assert_eq!(
+            reason,
+            SweepStartReason::WaitBoundExpired,
+            "the ordering is a ceiling, not a promise: a backfill that outlasts the bound must \
+             not hold the sweep forever"
+        );
+        assert!(
+            source.load(Ordering::SeqCst) > 0,
+            "and it must have been released with work still pending, or this proved nothing"
+        );
+        assert_eq!(reason_is_logged(reason), "wait-bound-expired");
+    }
+
+    /// A backfill that stops moving releases the sweep on the stall bound
+    /// rather than holding it for the whole wait bound.
+    ///
+    /// The case the wait bound alone gets wrong: a backfill wedged on a refused
+    /// vector checkpoint neither drains nor errors, so its pending count simply
+    /// stops falling.
+    #[tokio::test]
+    async fn a_wedged_backfill_releases_the_sweep_on_the_stall_bound() {
+        let reason = await_backfill_before_sweep(
+            true,
+            || 512,
+            Duration::from_secs(30),
+            Duration::from_millis(20),
+            Duration::from_millis(1),
+        )
+        .await;
+
+        assert_eq!(
+            reason,
+            SweepStartReason::BackfillStalled,
+            "a count that never falls is a backfill going nowhere, and waiting out the full \
+             bound on it delays the sweep for nothing"
+        );
+        assert_eq!(reason_is_logged(reason), "backfill-stalled");
+    }
+
+    /// A store with nothing left to embed sweeps exactly as it did before this
+    /// gate existed: released on the first look, having waited for nothing.
+    #[tokio::test]
+    async fn a_converged_store_is_released_on_the_first_look() {
+        let looks = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&looks);
+
+        let reason = await_backfill_before_sweep(
+            true,
+            move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                0
+            },
+            SWEEP_BACKFILL_WAIT_BOUND,
+            SWEEP_BACKFILL_STALL_BOUND,
+            SWEEP_BACKFILL_POLL_INTERVAL,
+        )
+        .await;
+
+        assert_eq!(reason, SweepStartReason::NothingPending);
+        assert_eq!(
+            looks.load(Ordering::SeqCst),
+            1,
+            "one look: an already-embedded store must not pay a poll interval for this gate"
+        );
+    }
+
+    /// The rule itself, at the boundaries the loop can only reach by waiting.
+    #[test]
+    fn the_gate_holds_a_sweep_while_a_running_backfill_is_inside_both_bounds() {
+        let wait = Duration::from_secs(600);
+        let stall = Duration::from_secs(90);
+        let working = BackfillLook {
+            running: true,
+            pending: 576,
+            held: true,
+            waited: Duration::from_secs(300),
+            since_progress: Duration::from_secs(5),
+        };
+        assert_eq!(
+            sweep_gate_step(working, wait, stall),
+            SweepGateStep::Wait,
+            "a backfill halfway through its bound and landing batches keeps the sweep back"
+        );
+        assert_eq!(
+            sweep_gate_step(
+                BackfillLook {
+                    waited: wait,
+                    ..working
+                },
+                wait,
+                stall
+            ),
+            SweepGateStep::Start(SweepStartReason::WaitBoundExpired),
+            "and stops keeping it back the moment the bound is reached, not after it"
+        );
+        assert_eq!(
+            sweep_gate_step(
+                BackfillLook {
+                    since_progress: stall,
+                    ..working
+                },
+                wait,
+                stall
+            ),
+            SweepGateStep::Start(SweepStartReason::BackfillStalled),
+        );
+    }
+
+    /// A stall bound at or above the wait bound could never fire, so the wedged
+    /// backfill it exists for would hold the sweep for the full ten minutes.
+    #[test]
+    fn the_stall_bound_can_fire_before_the_wait_bound_it_sits_inside() {
+        assert!(
+            SWEEP_BACKFILL_STALL_BOUND < SWEEP_BACKFILL_WAIT_BOUND,
+            "the stall bound is the inner one; at or above the wait bound it is unreachable"
+        );
+        assert!(
+            SWEEP_BACKFILL_POLL_INTERVAL < SWEEP_BACKFILL_STALL_BOUND,
+            "and the gate has to look more than once inside the shorter bound, or it cannot \
+             tell a stalled backfill from a working one"
+        );
+    }
+}
+
 /// Whether the sweep has already finished this file.
 fn file_already_enriched(state: &DaemonState, file: &str) -> bool {
     state
@@ -2366,9 +2784,15 @@ pub async fn run_with_authority_on(
     // sweep skips files that already carry language-server evidence, so this is
     // cheap on a converged repository, resumable after a kill, and safe to queue
     // on every start.
+    // Decided here and acted on later. Settling the previous sweep has to happen
+    // at startup, because the in-flight record it takes is the only trace a
+    // killed sweep leaves and a second daemon would read it as its own. Queueing
+    // does not: the sweep is handed to the gate below, which starts it once the
+    // embedding backfill is out of the way.
+    let mut sweep_admitted = false;
     if enrichment_enabled && state.lsp_enrichment_tx.is_some() {
         // A store whose sweeps keep dying before enriching anything gets one
-        // fewer, not another. Queued on EVERY daemon start, this is the point
+        // fewer, not another. Decided on EVERY daemon start, this is the point
         // the marker-discard loop turns at: a sweep dies, the daemon restarts,
         // queues another, dies again. One stranger session logged 24 of them.
         match decide_sweep_on_start(&state) {
@@ -2383,8 +2807,7 @@ pub async fn run_with_authority_on(
                 );
             }
             SweepStartDecision::Queue => {
-                info!("queueing an LSP sweep so a graph with unenriched files converges");
-                state.queue_lsp_sweep();
+                sweep_admitted = true;
             }
         }
     }
@@ -3237,6 +3660,59 @@ pub async fn run_with_authority_on(
         }
         embed_pass.idle();
     });
+
+    // Order the cold sweep behind the embedding backfill.
+    //
+    // Until this gate the two were peer spawns in one process with nothing
+    // between them: the sweep was queued at startup (`decide_sweep_on_start`
+    // above) and the backfill started as soon as the daemon reported itself
+    // initialized, so on a first boot they ran together. On a full-history store
+    // inside a memory cap that is what killed the daemon, and the loss is not
+    // symmetric. The backfill checkpoints as it goes, so a kill costs it the
+    // batch in flight. Everything the sweep makes durable happens after its last
+    // file, so a kill costs the sweep the whole pass and the next daemon sweeps
+    // the same files again.
+    //
+    // So the one that checkpoints goes first. A store with nothing left to embed
+    // is released on the gate's first look and behaves exactly as it did before
+    // this existed.
+    if sweep_admitted {
+        let gate_state = Arc::clone(&state);
+        let pending_state = Arc::clone(&state);
+        let mut gate_cancel = cancel_rx.clone();
+        // Read once, here, rather than inside the loop: both halves are fixed
+        // for the life of the process, and a gate that re-read them could wait
+        // on a backfill that was never going to run.
+        let backfill_running =
+            auto_embed_enabled() && pending_state.can_persist_embed_progress_locally();
+        tokio::spawn(async move {
+            let gate = await_backfill_before_sweep(
+                backfill_running,
+                move || pending_state.graph.embedding_status().pending,
+                SWEEP_BACKFILL_WAIT_BOUND,
+                SWEEP_BACKFILL_STALL_BOUND,
+                SWEEP_BACKFILL_POLL_INTERVAL,
+            );
+            let reason = tokio::select! {
+                // Biased so a shutdown that arrives while the gate waits ends it
+                // rather than racing it. A daemon asked to stop must not queue a
+                // sweep on its way out.
+                biased;
+                _ = gate_cancel.changed() => {
+                    info!("daemon shutting down before the LSP sweep gate released; no sweep queued");
+                    return;
+                }
+                reason = gate => reason,
+            };
+            info!(
+                reason = reason.as_str(),
+                wait_bound_s = SWEEP_BACKFILL_WAIT_BOUND.as_secs(),
+                stall_bound_s = SWEEP_BACKFILL_STALL_BOUND.as_secs(),
+                "queueing an LSP sweep so a graph with unenriched files converges"
+            );
+            gate_state.queue_lsp_sweep();
+        });
+    }
 
     // Spawn the background-work supervisor.
     //


### PR DESCRIPTION
The daemon no longer runs the LSP cold sweep and the embedding backfill at the same time on a first boot. The one that checkpoints durably goes first, and the other waits for it.

## The mechanism

On `origin/main` at `6e450380` the two passes were peers with nothing between them. The sweep was queued at startup in `crates/kin-daemon/src/daemon.rs:2387`, inside the `SweepStartDecision::Queue` arm, before the API listener even bound. The embedding worker was spawned as an ordinary tokio task at `daemon.rs:2841`, and the LSP enrichment worker that drains the sweep queue was spawned at `daemon.rs:3277`. Nothing ordered any of it. On a store with unembedded entities, a first boot started both.

That pairing is what the brown stranger arms kept dying on. The sweep reopens repository authority and rebuilds the graph from snapshot, and pyright peaks near 2 GiB beside it as a separate process, while the backfill holds a batch of vectors in the same address space. The loss is not symmetric either. The backfill checkpoints as it goes, so a kill costs it the batch in flight. Everything a sweep makes durable happens after its last file, so a kill costs the sweep the whole pass, and the next daemon finds a marker whose relations are absent, discards it, and sweeps the same files again. The rc0545c requests log is that shape in one line: 20 `LSP cold sweep started`, zero `LSP cold sweep complete`. The same run showed the backfill finishing in about five minutes once `KIN_DAEMON_DISABLE_LSP=1` gave it the process to itself.

## The ordering rule and its bound

`decide_sweep_on_start` still runs at startup, unchanged, because the in-flight record it takes is the only trace a killed sweep leaves and a second daemon would otherwise read it as its own. The circuit tally from kin#1005 is untouched: its three lifecycle tests and eight tally tests still pass. What changed is that the `Queue` arm no longer queues. It admits the sweep to a gate (`daemon.rs:2792` sets the flag, `daemon.rs:3679` spawns the gate beside the embedding worker), and the gate decides when the sweep starts.

The rule is `sweep_gate_step` at `daemon.rs:1850`, kept pure and separate from the loop that applies it. In order: a store with nothing pending releases the sweep on the first look; a backfill that will not run at all releases it, because waiting on a queue no worker will drain never ends; the total wait bound releases it; a backfill that has stopped making progress releases it; otherwise the sweep waits. Every release carries the reason, and the daemon logs that reason with both bounds beside it.

Two bounds, both constants rather than knobs. `SWEEP_BACKFILL_WAIT_BOUND` is 600 seconds (`daemon.rs:1771`), a ceiling on the ordering rather than an amount of waiting: a backfill that drains in ninety seconds holds the sweep for ninety seconds. `SWEEP_BACKFILL_STALL_BOUND` is 90 seconds (`daemon.rs:1780`), and it exists because the wait bound alone gets one case wrong. A backfill wedged on a refused vector checkpoint neither drains nor errors, so its pending count simply stops falling, and without the stall bound the sweep would spend the full ten minutes waiting on a number that was never going to move. Progress is a fall in the pending count, so a backfill landing batches resets it on every one and is never cut short by it.

"Pending" is read from `state.graph.embedding_status().pending`, which is `queue_len.max(total - indexed)`. That is graph against index truth rather than queue length, so the gate needs no lifecycle landmark and reads correctly on a converted store the moment the daemon opens it. The gate also loses to shutdown: its select is biased on the cancel channel, so a daemon asked to stop does not queue a sweep on its way out.

The gate's own loop, `await_backfill_before_sweep` at `daemon.rs:1888`, takes its bounds as parameters and production passes the constants. That is what lets the tests drive the real loop rather than a copy of it.

## Tests

Seven new tests in `mod sweep_backfill_gate_tests` at `daemon.rs:1934`, at the level the existing sweep tests sit at. Five drive the async gate; two check the rule and the constants directly.

```
running 7 tests
test daemon::sweep_backfill_gate_tests::the_stall_bound_can_fire_before_the_wait_bound_it_sits_inside ... ok
test daemon::sweep_backfill_gate_tests::the_gate_holds_a_sweep_while_a_running_backfill_is_inside_both_bounds ... ok
test daemon::sweep_backfill_gate_tests::a_converged_store_is_released_on_the_first_look ... ok
test daemon::sweep_backfill_gate_tests::an_opted_out_backfill_releases_the_sweep_at_once ... ok
test daemon::sweep_backfill_gate_tests::pending_embeddings_hold_the_sweep_until_the_backfill_drains ... ok
test daemon::sweep_backfill_gate_tests::a_wedged_backfill_releases_the_sweep_on_the_stall_bound ... ok
test daemon::sweep_backfill_gate_tests::the_wait_bound_releases_a_sweep_a_working_backfill_is_still_holding ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 959 filtered out; finished in 0.05s
```

`cargo test -p kin-daemon sweep` reads `41 passed; 0 failed` and `cargo test -p kin-daemon embed` reads `23 passed; 0 failed`.

## Falsification

Four sabotages, each applied to a committed tree, run, then reverted with `git checkout` and confirmed byte-identical by sha256 (`0ee8c0c02eefbafe2179ed00990228323d46fd6cc3375200963ca08138114a98` before and after every one).

Remove the wait rule, so the gate never holds a sweep (`SweepGateStep::Wait` becomes `Start(NothingPending)`). Four fail, three pass, and the failure is the reason the daemon would have logged:

```
test result: FAILED. 3 passed; 4 failed
  left: NothingPending
 right: BackfillDrained
  left: NothingPending
 right: BackfillStalled
  left: NothingPending
 right: WaitBoundExpired
  left: Start(NothingPending)
 right: Wait
```

Invert the backfill-not-running rule (`if !look.running` becomes `if look.running`). Five fail, and the opt-out test is the one that matters: it ran for 90.10 seconds and then failed, which is also a direct reading of the production stall bound.

```
test daemon::sweep_backfill_gate_tests::an_opted_out_backfill_releases_the_sweep_at_once has been running for over 60 seconds
  left: BackfillStalled
 right: BackfillNotRunning
test result: FAILED. 2 passed; 5 failed; ... finished in 90.10s
```

Mislabel the wait bound's reason as `BackfillStalled`. Two fail on the reason alone, which is what proves the log tells an operator which bound ended the wait:

```
  left: BackfillStalled
 right: WaitBoundExpired
test result: FAILED. 5 passed; 2 failed
```

Drop the `held` flag, so a sweep that waited cannot be told from one that never needed to. Exactly one fails:

```
  left: NothingPending
 right: BackfillDrained
test result: FAILED. 6 passed; 1 failed
```

## Gates

`cargo fmt --all -- --check` exits 0. Clippy runs as `.github/workflows/ci.yml` runs it, under `RUSTFLAGS=-D warnings` with the 45-lint debt allow-list read from `.github/clippy-allowed-lints.txt`, and exits 0. All four guard scripts pass with their statuses read raw, not through a pipe: `verify-zero-file-search.py` (0), `zero_file_search_guard.sh` (0), `check_runtime_boundaries.sh` (0), `check_private_repo_coupling.sh` (0). `git diff origin/main --stat -- Cargo.lock .cargo/` is empty and `git ls-tree -r HEAD --name-only` lists only `.cargo/config.toml` under `.cargo/`. The local full gate was not run under tonight's slot saturation; hosted CI is the gate of record for this PR, and the per-check lines go into `.kin-coord/reports/sweeporder-20260821.md` once every check has concluded.

Refs FIR-2493. This is ask 1 read as "or bound it", and it bounds the concurrency rather than the sweep's own profile. The sweep's peak on the authority reopen and snapshot rebuild path is unchanged and still open, as are asks 3 and 4, the OOM diagnostic's attribution and making `KIN_DAEMON_DISABLE_LSP` discoverable.

Refs FIR-2539. This removes one of the two passes that shared a container's memory on a first boot, which is the in-process half. The mission-shape half is untouched: nothing here stops one store's daemon before the next repository converts, so two resident daemons can still meet in one cap.

One case this deliberately does not cover, named so nobody has to find it: a daemon that comes up while a repository is still being converted can see a pending count of zero because the entities do not exist yet, and start its sweep before the backfill has anything to report. The gate keys on durable graph against index truth rather than on a lifecycle landmark, so closing that window means ordering against initialization too, and that is a separate change.
