### PR TITLE
Rank a public entity above its private helpers on a description query

### DIFF
--- a/crates/kin-cli/src/capability.rs
+++ b/crates/kin-cli/src/capability.rs
@@ -27,6 +27,16 @@
 //! variable, set to `minimal`, `standard`, or `performance` (case-insensitive);
 //! any other value falls through to auto-detection.
 //!
+//! [`CapabilityDetection::detect`] reads that variable from the environment of
+//! the process it runs in, once per call, and the process that runs it is
+//! whichever one serves the query. `kin-daemon` serves `/locate` by calling
+//! straight into this crate, and a daemon captured its environment when it
+//! started, so exporting the variable in front of a CLI invocation reaches the
+//! client and never the daemon that ranks. The tier a result reports is the
+//! daemon's. Changing it means setting the variable where the daemon will start
+//! and restarting it, which is what the `capability_tier` degradation's
+//! remediation says rather than naming the variable alone.
+//!
 //! Detection that cannot read the host says so. A probe failure used to be
 //! swallowed and replaced with a plausible number, which scored a large machine
 //! as `Minimal` and then advised its operator to obtain the hardware they were

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2056,8 +2056,10 @@ fn record_small_corpus_degradation(entity_count: usize, sink: &mut Vec<Retrieval
                  low or miss it"
             ),
             remediation: "at this size ask by exact entity or file name, or by a literal \
-                 string you expect in the code; description queries earn their accuracy as the \
-                 graph grows"
+                 string you expect in the code; a description you cannot name a symbol for \
+                 ranks better at granularity: \"file\", where the path heuristics still \
+                 separate candidates; description queries at entity granularity earn their \
+                 accuracy as the graph grows"
                 .to_string(),
         },
     );
@@ -2097,7 +2099,10 @@ fn record_capability_tier_degradation(
                     describe_disabled_signals(profile),
                 ),
                 remediation: "this tier was not derived from a reading of this host; set \
-                     KIN_LOCATE_PROFILE=performance|standard|minimal to state it explicitly"
+                     KIN_LOCATE_PROFILE=performance|standard|minimal to state it explicitly, \
+                     in the environment of the process that serves the query: the value is \
+                     read once at process start, so against a running daemon it takes effect \
+                     only after `kin daemon stop` and the next command"
                     .to_string(),
             },
         );
@@ -2117,8 +2122,13 @@ fn record_capability_tier_degradation(
                 describe_disabled_signals(profile),
             ),
             remediation:
-                "set KIN_LOCATE_PROFILE=performance to widen the multihop budget on this host, \
-                 or run on a host with >=8 cores and >=16GB RAM"
+                "set KIN_LOCATE_PROFILE=performance in the environment of the process that \
+                 serves the query, or run on a host with >=8 cores and >=16GB RAM. The value \
+                 is read once at process start, not per request, so exporting it in front of \
+                 a command reaches the CLI client and not a daemon already serving: run `kin \
+                 daemon stop` and let the next command start one that reads it. It widens the \
+                 graph multihop budget (depth, frontier, timeout) and nothing else, so a \
+                 query whose weakness is ranking rather than reach will not change"
                     .to_string(),
         },
     );
@@ -17109,6 +17119,112 @@ fn artifact_locate_entity(file: &LocateFileEntry, query: &str) -> LocateEntity {
     }
 }
 
+/// The surface class of an entity's OWN name, or `None` when the name reads as
+/// ordinary public API.
+///
+/// The entity-granularity twin of the path-keyed impl penalties
+/// ([`is_deep_impl_path`], `KIN_LOCATE_CLI_IMPL_PENALTY`,
+/// `KIN_LOCATE_PUBLIC_API_IMPL_PENALTY`). Those key on the FILE a hit lives in,
+/// which is why a description query answered at `granularity: "file"` ranks the
+/// module a reader wanted while the same query at entity granularity ranked its
+/// private helpers: nothing at entity granularity looked at the name at all, so
+/// a public `to_dot` and a module-private `_dot_escape` competed as equals.
+///
+/// The rule is a naming convention, not a visibility lookup, because the graph
+/// carries names for every language and visibility for only some. A leading
+/// underscore means internal in Python, C, JavaScript and Rust alike, and the
+/// languages that spell it differently simply do not match here rather than
+/// matching wrongly.
+///
+/// Dunder names are deliberately exempt. `__init__` and `__repr__` begin with an
+/// underscore and are a language protocol rather than a private surface, so
+/// demoting them would answer "how is this constructed" with everything except
+/// the constructor.
+fn entity_surface_class(name: &str, kind: &str) -> Option<&'static str> {
+    let tail = qualified_name_tail(name);
+    if tail.is_empty() {
+        return None;
+    }
+    let lower = tail.to_ascii_lowercase();
+    if kind == "test"
+        || lower.starts_with("test_")
+        || lower.ends_with("_test")
+        || lower.ends_with("_tests")
+        || lower == "tests"
+    {
+        return Some("test_support");
+    }
+    if tail.starts_with('_') && !(tail.starts_with("__") && tail.ends_with("__")) {
+        return Some("private_name");
+    }
+    None
+}
+
+/// Demote private and test-support entities on a query that did not name one.
+///
+/// Multiplicative, in the same family as the path-keyed impl penalties and with
+/// the same shape of knob (`KIN_LOCATE_ENTITY_SURFACE_PENALTY`, default 0.3,
+/// matching `KIN_LOCATE_PUBLIC_API_IMPL_PENALTY`). It demotes rather than
+/// filters: a private helper really is the answer sometimes, and the only store
+/// where it is the ONLY candidate is one where nothing else is left to outrank
+/// it.
+///
+/// Exact-name hits are exempt, which is the whole gate on "description-shaped".
+/// [`locate_exact_name_tier`] is already the single definition of "the query
+/// literally named this symbol", so a caller asking for `_dot_escape` by name
+/// gets it unpenalized and above every fused score, and the tier rather than a
+/// second predicate decides that. A description query has no token that IS an
+/// entity name, so every one of its hits lands here.
+///
+/// A knob outside `[0, 1)` is a no-op rather than an amplifier: this function's
+/// job is to demote, and a value above one would silently promote every private
+/// name in the store.
+fn apply_entity_surface_penalty(ranked: &mut [(usize, LocateEntity)]) {
+    let penalty = locate_env_f32("KIN_LOCATE_ENTITY_SURFACE_PENALTY", 0.3);
+    if !(0.0..1.0).contains(&penalty) {
+        return;
+    }
+    for (_, entity) in ranked.iter_mut() {
+        if locate_exact_name_tier(entity) > 0 {
+            continue;
+        }
+        if entity_surface_class(&entity.name, &entity.kind).is_some() {
+            entity.score *= penalty;
+        }
+    }
+}
+
+/// The global entity ordering: definitions first, then the exact-name tier
+/// ([`locate_exact_name_tier`]: a hit the query literally named cannot be outbid
+/// by fallback scale), then composite score desc, then owner graph mass for the
+/// exact-name ties fixed scores produce (the canonical definition over test
+/// doubles and forwarding impls; 0 for every non-name row, so nothing else
+/// moves), then the file's own rank, then name/id for a total deterministic
+/// order.
+///
+/// Extracted from [`build_entity_view`] so the ordering a test asserts on is the
+/// ordering the product runs, rather than a second copy that can come to
+/// disagree with it.
+fn order_locate_entities(
+    ranked: &mut [(usize, LocateEntity)],
+    owner_mass_of: impl Fn(&LocateEntity) -> usize,
+) {
+    ranked.sort_by(|(a_rank, a), (b_rank, b)| {
+        b.definition
+            .cmp(&a.definition)
+            .then_with(|| locate_exact_name_tier(b).cmp(&locate_exact_name_tier(a)))
+            .then_with(|| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| owner_mass_of(b).cmp(&owner_mass_of(a)))
+            .then_with(|| a_rank.cmp(b_rank))
+            .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.identity_key().cmp(b.identity_key()))
+    });
+}
+
 pub fn build_entity_view(
     result: &mut LocateResult,
     held_authority: &kin_mcp::handlers::common::HeldSourceAuthority<'_, kin_db::InMemoryGraph>,
@@ -17232,33 +17348,16 @@ pub fn build_entity_view(
         }
     }
 
-    // Global rank: definitions first, then the exact-name tier
-    // ([`locate_exact_name_tier`]: a hit the query literally named cannot be
-    // outbid by fallback scale), then composite score desc, then owner graph
-    // mass for the exact-name ties fixed scores produce (the canonical
-    // definition over test doubles and forwarding impls; 0 for every non-name
-    // row, so nothing else moves), then the file's own rank, then name/id for
-    // a total deterministic order.
+    // Surface penalty before the ordering, because it moves the composite score
+    // the ordering then reads ([`apply_entity_surface_penalty`]).
+    apply_entity_surface_penalty(&mut ranked);
     let owner_mass_of = |entity: &LocateEntity| {
         name_owner_mass
             .get(entity.identity_key())
             .copied()
             .unwrap_or(0)
     };
-    ranked.sort_by(|(a_rank, a), (b_rank, b)| {
-        b.definition
-            .cmp(&a.definition)
-            .then_with(|| locate_exact_name_tier(b).cmp(&locate_exact_name_tier(a)))
-            .then_with(|| {
-                b.score
-                    .partial_cmp(&a.score)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
-            .then_with(|| owner_mass_of(b).cmp(&owner_mass_of(a)))
-            .then_with(|| a_rank.cmp(b_rank))
-            .then_with(|| a.name.cmp(&b.name))
-            .then_with(|| a.identity_key().cmp(b.identity_key()))
-    });
+    order_locate_entities(&mut ranked, owner_mass_of);
 
     result.entities = ranked.into_iter().map(|(_, entity)| entity).collect();
 
@@ -17866,6 +17965,15 @@ mod tests {
             "the remediation must name the form that does work at this size: {}",
             entry.remediation
         );
+        // FIR-2582: and the granularity that works, which the stranger found by
+        // accident after the run had already gone wrong. The path heuristics
+        // that separate candidates live at file granularity, so a caller with a
+        // description and no symbol to name has somewhere to go besides grep.
+        assert!(
+            entry.remediation.contains("granularity: \"file\""),
+            "the remediation must name the granularity that ranks under the constant: {}",
+            entry.remediation
+        );
 
         // The control that makes the threshold mean something: a graph at the
         // constant discloses nothing, so this cannot be an entry every store
@@ -17952,6 +18060,235 @@ mod tests {
             &mut sink,
         );
         assert!(sink.is_empty());
+    }
+
+    /// FIR-2583. The tier remediation named `KIN_LOCATE_PROFILE` and stopped
+    /// there, so a reader exported it in front of a CLI call and nothing
+    /// changed: `CapabilityDetection::detect` reads the environment of the
+    /// process it runs in, and on a repo with a daemon up that process is the
+    /// daemon, which captured its environment when it started. The advice was
+    /// unreachable from where the reader stood. It now says where the value is
+    /// read, how to make a serving process read a new one, and what the tier
+    /// actually gates, so nobody restarts a daemon expecting a description
+    /// query to rank differently.
+    #[test]
+    fn the_capability_remediation_says_where_the_override_is_read_and_what_it_gates() {
+        // The stranger's own container: 5 cores of quota and 12 GiB, scored
+        // Standard, which is a sub-Performance tier and so discloses.
+        let mut sink = Vec::new();
+        record_capability_tier_degradation(
+            &CapabilityDetection {
+                profile: LocateProfile::Standard,
+                forced_by_env: false,
+                cores: Some(5),
+                memory: Some(crate::capability::HostMemory::Detected(12.0)),
+            },
+            &mut sink,
+        );
+        let entry = capability_entry(&sink);
+        assert_eq!(entry.reason, "standard");
+        for required in [
+            "KIN_LOCATE_PROFILE=performance",
+            "read once at process start",
+            "kin daemon stop",
+            "multihop budget",
+        ] {
+            assert!(
+                entry.remediation.contains(required),
+                "the remediation must say {required:?}, got: {}",
+                entry.remediation
+            );
+        }
+
+        // The misread-host entry names the same variable, so it carries the
+        // same reachability clause. Its own rule still holds: a host that was
+        // never read is not told to become a bigger host.
+        let mut misread = Vec::new();
+        record_capability_tier_degradation(
+            &CapabilityDetection {
+                profile: LocateProfile::Minimal,
+                forced_by_env: false,
+                cores: Some(18),
+                memory: Some(crate::capability::HostMemory::Undetected(
+                    "sysctlbyname(hw.memsize) failed".to_string(),
+                )),
+            },
+            &mut misread,
+        );
+        let misread_entry = capability_entry(&misread);
+        assert!(
+            misread_entry.remediation.contains("kin daemon stop"),
+            "the misread entry names the same variable and must say the same thing about \
+             reaching it: {}",
+            misread_entry.remediation
+        );
+        assert!(
+            !misread_entry.remediation.contains("run on a host"),
+            "a host that was never read must not be told to become a bigger host: {}",
+            misread_entry.remediation
+        );
+
+        // The control that keeps the strings above meaningful: a host on the
+        // full tier records no entry at all, so this is not text every result
+        // carries.
+        let mut performance = Vec::new();
+        record_capability_tier_degradation(
+            &CapabilityDetection {
+                profile: LocateProfile::Performance,
+                forced_by_env: false,
+                cores: Some(18),
+                memory: Some(crate::capability::HostMemory::Detected(128.0)),
+            },
+            &mut performance,
+        );
+        assert!(
+            performance.is_empty(),
+            "the full tier narrows nothing and must stay silent, got {performance:?}"
+        );
+    }
+
+    /// A ranked entity carrying the query's own classification, so the test
+    /// drives [`classify_locate_match`] rather than asserting a hand-set kind.
+    fn surface_hit(name: &str, kind: &str, score: f32, query: &str) -> LocateEntity {
+        LocateEntity {
+            entity_id: format!("id-{name}"),
+            id_space: LocateIdSpace::Entity,
+            artifact_path: None,
+            kind: kind.to_string(),
+            name: name.to_string(),
+            signature: format!("def {name}(...)"),
+            score,
+            definition: true,
+            span: Some([1, 9]),
+            body: None,
+            match_kind: Some(classify_locate_match(query, name, "text")),
+            provenance: LocateProvenance {
+                file: Some("linkgraph.py".to_string()),
+                origin: "text".to_string(),
+                cosine: Some(0.8),
+            },
+            matched_queries: Vec::new(),
+        }
+    }
+
+    /// Rank a small entity set exactly as `build_entity_view` does: the surface
+    /// penalty, then the shared ordering. Owner mass is 0 for every row, which
+    /// is what it reads for every non-name hit in production too.
+    fn surface_ranked(query: &str, hits: &[(&str, &str, f32)]) -> Vec<LocateEntity> {
+        let mut ranked: Vec<(usize, LocateEntity)> = hits
+            .iter()
+            .enumerate()
+            .map(|(rank, (name, kind, score))| (rank, surface_hit(name, kind, *score, query)))
+            .collect();
+        apply_entity_surface_penalty(&mut ranked);
+        order_locate_entities(&mut ranked, |_| 0);
+        ranked.into_iter().map(|(_, entity)| entity).collect()
+    }
+
+    fn surface_ranked_names(query: &str, hits: &[(&str, &str, f32)]) -> Vec<String> {
+        surface_ranked(query, hits)
+            .into_iter()
+            .map(|entity| entity.name)
+            .collect()
+    }
+
+    /// FIR-2582, the stranger's exact failure. On a five-module project a
+    /// description of the dot-export code returned `_dot_escape`, `_blank` and
+    /// `_clean_snippet` while `to_dot` was absent at rank 30 of 83: the private
+    /// helpers carried more lexical mass than the exported function, and
+    /// nothing at entity granularity looked at a name to tell them apart. The
+    /// same query at file granularity put the module first, because the impl
+    /// penalties there key on the path.
+    #[test]
+    fn a_description_ranks_the_public_entity_above_the_private_helpers() {
+        let hits = [
+            ("_dot_escape", "function", 1.0f32),
+            ("_blank", "function", 0.9f32),
+            ("to_dot", "function", 0.6f32),
+        ];
+
+        assert_eq!(
+            surface_ranked_names("render the graph as dot output for graphviz", &hits),
+            vec!["to_dot", "_dot_escape", "_blank"],
+            "a description query must rank the exported function above the private helpers \
+             it calls, even when they score higher on lexical mass"
+        );
+
+        // And the other half of the contract: naming a private symbol asks for
+        // it, so the penalty must not touch it. The exact-name tier already
+        // owns this case; the penalty stays out of its way rather than fighting
+        // it, which is why the exemption reads the tier instead of a second
+        // predicate.
+        let by_name = surface_ranked("_dot_escape", &hits);
+        assert_eq!(
+            by_name
+                .iter()
+                .map(|entity| entity.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["_dot_escape", "to_dot", "_blank"],
+            "a query that names a private helper exactly must still rank it first"
+        );
+        // The tier would put it first whether or not it was penalized, so the
+        // exemption is only visible in the score the caller reads back. Assert
+        // it, or removing the exemption changes what the surface reports and no
+        // test says a word.
+        assert_eq!(
+            by_name[0].score, 1.0,
+            "an exact-name hit must be reported at its own score, unpenalized"
+        );
+        assert_eq!(
+            by_name[2].score,
+            0.9 * 0.3,
+            "while a private helper the query did not name still carries the penalty"
+        );
+    }
+
+    /// The naming rule on its own, including the case that makes it a rule
+    /// about surfaces rather than about underscores.
+    #[test]
+    fn a_dunder_is_language_protocol_and_a_leading_underscore_is_private() {
+        assert_eq!(
+            entity_surface_class("_dot_escape", "function"),
+            Some("private_name")
+        );
+        assert_eq!(
+            entity_surface_class("LinkGraph._blank", "method"),
+            Some("private_name"),
+            "the rule reads the entity's own name, not the owner it hangs off"
+        );
+        assert_eq!(
+            entity_surface_class("_LinkRow__mangled", "method"),
+            Some("private_name")
+        );
+
+        // `__init__` opens with an underscore and is the answer to "how is this
+        // constructed". Demoting it would answer that with everything except
+        // the constructor.
+        assert_eq!(entity_surface_class("__init__", "method"), None);
+        assert_eq!(entity_surface_class("LinkRow.__repr__", "method"), None);
+
+        assert_eq!(
+            entity_surface_class("test_to_dot", "function"),
+            Some("test_support")
+        );
+        assert_eq!(
+            entity_surface_class("roundtrip_test", "function"),
+            Some("test_support")
+        );
+        assert_eq!(
+            entity_surface_class("to_dot", "test"),
+            Some("test_support"),
+            "the graph's own Test kind says it too, whatever the name reads like"
+        );
+
+        // Controls: ordinary public API must not match, or the rule demotes
+        // every candidate and orders nothing.
+        assert_eq!(entity_surface_class("to_dot", "function"), None);
+        assert_eq!(
+            entity_surface_class("LinkGraph.ingest_directory", "method"),
+            None
+        );
+        assert_eq!(entity_surface_class("", "function"), None);
     }
 
     fn native_change(

--- a/crates/kin-core/src/env_registry_generated.rs
+++ b/crates/kin-core/src/env_registry_generated.rs
@@ -11,6 +11,9 @@ use super::{EnvVarSpec, Kind, Sensitivity};
 #[rustfmt::skip]
 pub const GENERATED_KNOBS: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_LOCATE_AMALGAM_PENALTY", kind: Kind::NonNegF32, default: "0.05", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: amalgam penalty" },
+    EnvVarSpec { name: "KIN_LOCATE_ARTIFACT_ADMIT_LIMIT", kind: Kind::Usize, default: "3", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: artifact admit limit" },
+    EnvVarSpec { name: "KIN_LOCATE_ARTIFACT_ADMIT_SHARE", kind: Kind::NonNegF32, default: "0.5", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: artifact admit share" },
+    EnvVarSpec { name: "KIN_LOCATE_ARTIFACT_FULL_PRIORITY", kind: Kind::NonNegF32, default: "72.0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: artifact full priority" },
     EnvVarSpec { name: "KIN_LOCATE_ARTIFACT_HUB_FANOUT_PENALTY", kind: Kind::NonNegF32, default: "0.45", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: artifact hub fanout penalty" },
     EnvVarSpec { name: "KIN_LOCATE_ARTIFACT_PATH_OVERLAP_BOOST", kind: Kind::NonNegF32, default: "1.85", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: artifact path overlap boost" },
     EnvVarSpec { name: "KIN_LOCATE_AUTO_FANOUT_CONFIDENCE_RATIO", kind: Kind::NonNegF32, default: "1.5", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: auto fanout confidence ratio" },
@@ -92,6 +95,7 @@ pub const GENERATED_KNOBS: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_LOCATE_ENTITY_DOMINANT_RESOLVE_WEIGHT", kind: Kind::NonNegF32, default: "8.0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity dominant resolve weight" },
     EnvVarSpec { name: "KIN_LOCATE_ENTITY_DOMINANT_RRF_THRESHOLD", kind: Kind::Usize, default: "3", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity dominant rrf threshold" },
     EnvVarSpec { name: "KIN_LOCATE_ENTITY_FUSION", kind: Kind::Bool, default: "context-dependent", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity fusion" },
+    EnvVarSpec { name: "KIN_LOCATE_ENTITY_SURFACE_PENALTY", kind: Kind::NonNegF32, default: "0.3", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity surface penalty" },
     EnvVarSpec { name: "KIN_LOCATE_EXPLAIN_DEF_FLOOR_PCT", kind: Kind::NonNegF32, default: "0.0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: explain def floor pct" },
     EnvVarSpec { name: "KIN_LOCATE_EXPLAIN_DEF_TOPK", kind: Kind::Usize, default: "0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: explain def topk" },
     EnvVarSpec { name: "KIN_LOCATE_EXPLICIT_PHASE_MISMATCH_PENALTY", kind: Kind::NonNegF32, default: "0.22", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: explicit phase mismatch penalty" },
@@ -146,6 +150,7 @@ pub const GENERATED_KNOBS: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_LOCATE_MULTIHOP_TEST_SEED_FILES", kind: Kind::Usize, default: "16", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: multihop test seed files" },
     EnvVarSpec { name: "KIN_LOCATE_MULTI_SIGNAL_FLOOR_MAX", kind: Kind::Usize, default: "3", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: multi signal floor max" },
     EnvVarSpec { name: "KIN_LOCATE_MULTI_SIGNAL_FLOOR_PCT", kind: Kind::NonNegF32, default: "0.2", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: multi signal floor pct" },
+    EnvVarSpec { name: "KIN_LOCATE_NAME_TIE_OWNER_MASS_LIMIT", kind: Kind::Usize, default: "16", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: name tie owner mass limit" },
     EnvVarSpec { name: "KIN_LOCATE_NEGATION_PENALTY", kind: Kind::NonNegF32, default: "0.01", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: negation penalty" },
     EnvVarSpec { name: "KIN_LOCATE_NOISE_TAIL_COMPRESS", kind: Kind::NonNegF32, default: "0.4", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: noise tail compress" },
     EnvVarSpec { name: "KIN_LOCATE_NOISY_COCHANGE_ONLY_PENALTY", kind: Kind::NonNegF32, default: "0.08", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: noisy cochange only penalty" },

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (483 total, 333 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (488 total, 338 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -280,6 +280,9 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | Variable | Kind | Default | Sensitivity | Description |
 | --- | --- | --- | --- | --- |
 | `KIN_LOCATE_AMALGAM_PENALTY` | float>=0 | 0.05 | correctness | locate tuning knob: amalgam penalty |
+| `KIN_LOCATE_ARTIFACT_ADMIT_LIMIT` | usize | 3 | correctness | locate tuning knob: artifact admit limit |
+| `KIN_LOCATE_ARTIFACT_ADMIT_SHARE` | float>=0 | 0.5 | correctness | locate tuning knob: artifact admit share |
+| `KIN_LOCATE_ARTIFACT_FULL_PRIORITY` | float>=0 | 72.0 | correctness | locate tuning knob: artifact full priority |
 | `KIN_LOCATE_ARTIFACT_HUB_FANOUT_PENALTY` | float>=0 | 0.45 | correctness | locate tuning knob: artifact hub fanout penalty |
 | `KIN_LOCATE_ARTIFACT_PATH_OVERLAP_BOOST` | float>=0 | 1.85 | correctness | locate tuning knob: artifact path overlap boost |
 | `KIN_LOCATE_AUTO_FANOUT_CONFIDENCE_RATIO` | float>=0 | 1.5 | correctness | locate tuning knob: auto fanout confidence ratio |
@@ -365,6 +368,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_LOCATE_ENTITY_DOMINANT_RESOLVE_WEIGHT` | float>=0 | 8.0 | correctness | locate tuning knob: entity dominant resolve weight |
 | `KIN_LOCATE_ENTITY_DOMINANT_RRF_THRESHOLD` | usize | 3 | correctness | locate tuning knob: entity dominant rrf threshold |
 | `KIN_LOCATE_ENTITY_FUSION` | bool | context-dependent | correctness | locate tuning knob: entity fusion |
+| `KIN_LOCATE_ENTITY_SURFACE_PENALTY` | float>=0 | 0.3 | correctness | locate tuning knob: entity surface penalty |
 | `KIN_LOCATE_EXPLAIN_DEF_FLOOR_PCT` | float>=0 | 0.0 | correctness | locate tuning knob: explain def floor pct |
 | `KIN_LOCATE_EXPLAIN_DEF_TOPK` | usize | 0 | correctness | locate tuning knob: explain def topk |
 | `KIN_LOCATE_EXPLICIT_PHASE_MISMATCH_PENALTY` | float>=0 | 0.22 | correctness | locate tuning knob: explicit phase mismatch penalty |
@@ -420,6 +424,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_LOCATE_MULTIHOP_TIMEOUT_MS` | ms bound (0=unbounded) | profile-dependent (200/500/1000 ms) | correctness | multihop BFS timeout; 0 disables the bound (still capped by depth/frontier) |
 | `KIN_LOCATE_MULTI_SIGNAL_FLOOR_MAX` | usize | 3 | correctness | locate tuning knob: multi signal floor max |
 | `KIN_LOCATE_MULTI_SIGNAL_FLOOR_PCT` | float>=0 | 0.2 | correctness | locate tuning knob: multi signal floor pct |
+| `KIN_LOCATE_NAME_TIE_OWNER_MASS_LIMIT` | usize | 16 | correctness | locate tuning knob: name tie owner mass limit |
 | `KIN_LOCATE_NEGATION_PENALTY` | float>=0 | 0.01 | correctness | locate tuning knob: negation penalty |
 | `KIN_LOCATE_NOISE_TAIL_COMPRESS` | float>=0 | 0.4 | correctness | locate tuning knob: noise tail compress |
 | `KIN_LOCATE_NOISY_COCHANGE_ONLY_PENALTY` | float>=0 | 0.08 | correctness | locate tuning knob: noisy cochange only penalty |


### PR DESCRIPTION
## What was wrong

`kin locate` carried no entity-level surface signal. The two impl penalties, `KIN_LOCATE_CLI_IMPL_PENALTY` and `KIN_LOCATE_PUBLIC_API_IMPL_PENALTY` at `crates/kin-cli/src/commands/locate.rs:14372-14373`, key on the file path through `is_deep_impl_path` at `locate.rs:14503`, so they separate candidates at `granularity: "file"` and do nothing at entity granularity. A public `to_dot` and a module-private `_dot_escape` therefore competed as equals.

That is what the greenfield stranger measured on the v0.5.46 candidate. Three times, the last with embeddings at 193/193 and five phrasings, `_dot_escape`, `_blank` and `_clean_snippet` ranked while `to_dot`, `build_graph` and `ingest_directory` were absent at rank 30 of 83. The same query at file granularity put `linkgraph.py` first, and the small-corpus remediation at `locate.rs:2058` never mentioned the granularity that worked.

Separately, the capability-tier remediation at `locate.rs:2120` told the reader to set `KIN_LOCATE_PROFILE` and stopped there. `CapabilityDetection::detect` reads that variable from the environment of the process it runs in (`crates/kin-cli/src/capability.rs:321`), and `kin-daemon` serves `/locate` by calling straight into that same kin-cli code, so a daemon that captured its environment when it started never sees a value exported in front of a CLI call. The advice was unreachable from where the reader stood.

## The fix

`entity_surface_class` is a naming rule over an entity's own name and kind: a leading underscore, a `test_` prefix or `_test` suffix, or the graph's own `Test` kind. `apply_entity_surface_penalty` demotes what it matches multiplicatively behind `KIN_LOCATE_ENTITY_SURFACE_PENALTY`, default 0.3 to match the public-API impl penalty it mirrors. It demotes rather than filters, because a private helper is sometimes the answer and on a store where it is the only candidate there is nothing left to outrank it.

Exact-name hits are exempt, and that exemption is the whole gate on "description-shaped". `locate_exact_name_tier` at `locate.rs:666` is already the single definition of "the query named this symbol", so a caller asking for `_dot_escape` by name gets it first and at its own unpenalized score, decided by the tier rather than by a second predicate that could drift from it. Dunder names are exempt too: `__init__` opens with an underscore and is a language protocol rather than a private surface, and demoting it would answer "how is this constructed" with everything except the constructor.

The global entity ordering moves out of `build_entity_view` into `order_locate_entities`, unchanged, so the ordering the new test asserts on is the ordering the product runs.

The small-corpus remediation now names `granularity: "file"` beside the exact-name advice it already gave. `record_small_corpus_degradation` keeps its threshold on `locate_rrf_k()` and its disclosure is otherwise untouched.

Both capability entries now say the value is read once at process start, name `kin daemon stop` as the way to make a serving process read a new one, and say the tier widens the graph multihop budget and nothing else, so nobody restarts a daemon expecting a description query to rank differently. The reachability fact is also stated in the `capability.rs` module docs. The per-request read was not taken: the override would have to cross the daemon request schema in `boundary-contracts` to reach `detect`, which is not a small change, and the honest string is the fix the ticket asks for otherwise.

Regenerating the env registry with `scripts/gen_env_registry.py` also picked up four knobs that were added without re-running it: `KIN_LOCATE_ARTIFACT_ADMIT_LIMIT`, `KIN_LOCATE_ARTIFACT_ADMIT_SHARE`, `KIN_LOCATE_ARTIFACT_FULL_PRIORITY` and `KIN_LOCATE_NAME_TIE_OWNER_MASS_LIMIT`. An unregistered knob is reported to the operator as a probable typo with no effect, so all four are now registered and documented.

## Falsification

Five passes, each breaking one property and predicting which test fails and which still pass. Every sabotage was asserted applied before the run, and `crates/kin-cli/src/commands/locate.rs` was restored to sha256 `d04d1cc16b4a97157b0ef283308d1006ad74055f5b4b4e44afdb3e275c536c85` after each.

1. The penalty stops demoting. `a_description_ranks_the_public_entity_above_the_private_helpers` failed with `left: ["_dot_escape", "_blank", "to_dot"] right: ["to_dot", "_dot_escape", "_blank"]`, which is the stranger's own order. 304 passed, 1 failed.
2. The dunder exemption goes away. `a_dunder_is_language_protocol_and_a_leading_underscore_is_private` failed with `left: Some("private_name") right: None` on `__init__`. 304 passed, 1 failed.
3. The exact-name exemption goes away. The tier would still rank a named private hit first, so ordering alone cannot catch this; the score assertion did, failing with `an exact-name hit must be reported at its own score, unpenalized  left: 0.3 right: 1.0`. 304 passed, 1 failed.
4. The small-corpus remediation reverts. `a_graph_under_the_fusion_constant_discloses_that_descriptions_rank_weakly` failed with `the remediation must name the granularity that ranks under the constant`. 304 passed, 1 failed.
5. The capability remediation reverts. `the_capability_remediation_says_where_the_override_is_read_and_what_it_gates` failed with `the remediation must say "read once at process start"`. 304 passed, 1 failed.

## Gates

`cargo fmt --all -- --check` exits 0. Clippy over `-p kin-cli -p kin-core --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the 45-lint `.github/clippy-allowed-lints.txt` allow-list exits 0. `scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh` and `scripts/check_private_repo_coupling.sh` all exit 0. `cargo test -p kin-cli -p kin-core -p kin-mcp --no-fail-fast` exits 0 with 3602 passed and 0 failed. `git diff origin/main --stat -- Cargo.lock .cargo/` is empty and `git ls-tree -r HEAD --name-only` carries only `.cargo/config.toml` under `.cargo/`.

The local full gate was not run under tonight's slot saturation; hosted CI is the gate of record for this PR.

## Tickets

FIR-2582 is not fully met. The penalty and the granularity advice are here, but the ticket also asks for a before-and-after measurement on the rc0546 green fixture and on the gauntlet, and for a decision on routing a description query to file granularity by default under the threshold. Neither is in this PR.

Refs FIR-2582
Closes FIR-2583
