### PR TITLE
Admit a path-keyed rewrite of a tracked file as a stage operation

### DIFF
--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -104,6 +104,7 @@ fn authored_files_from_staged(
                 // every file it published as carried when the original declared
                 // none of them.
                 if kin_mcp::session::is_new_source_file(operation)
+                    || kin_mcp::session::is_replaced_source_file(operation)
                     || kin_mcp::session::is_retired_source_file(operation)
                 {
                     authored.insert(RepoPath::from_utf8(operation.target.trim().to_string()).ok()?);
@@ -941,6 +942,7 @@ fn plan_exact_transaction(
         .map_err(|error| format!("create prospective exact graph: {error}"))?;
     let mut edits: BTreeMap<String, (FilePathId, Vec<(Entity, Vec<u8>)>)> = BTreeMap::new();
     let mut creations: BTreeMap<String, (FilePathId, Vec<u8>)> = BTreeMap::new();
+    let mut replacements: BTreeMap<String, (FilePathId, Vec<u8>)> = BTreeMap::new();
     let mut retirements: BTreeMap<String, FilePathId> = BTreeMap::new();
     let mut relocations: BTreeMap<String, (FilePathId, FilePathId)> = BTreeMap::new();
     let mut relation_operations = Vec::new();
@@ -958,6 +960,19 @@ fn plan_exact_transaction(
         // edit another and publish both or neither.
         if operation.payload.is_none() && kin_mcp::session::is_new_source_file(operation) {
             record_new_source_file(&mut creations, base, operation)?;
+            continue;
+        }
+        // A payload-less `replace` carrying a repository path and a body
+        // rewrites source the graph already holds. It is the create's sibling
+        // for a file that exists, and it is the only shape a caller holding a
+        // path and a whole file can use: an entity edit resolves its target
+        // against one entity and splices into that entity's span, so a rewrite
+        // that adds or drops declarations has no span to land in. Recorded here
+        // and planned below, beside the creations and the edits, so one
+        // transaction can rewrite one file and create another and publish both
+        // or neither.
+        if operation.payload.is_none() && kin_mcp::session::is_replaced_source_file(operation) {
+            record_replaced_source_file(&mut replacements, base, operation)?;
             continue;
         }
         // A payload-less `delete` carrying a repository path retires source the
@@ -1119,6 +1134,7 @@ fn plan_exact_transaction(
         .values()
         .map(|(file_id, _)| file_id)
         .chain(creations.values().map(|(file_id, _)| file_id))
+        .chain(replacements.values().map(|(file_id, _)| file_id))
         .chain(retirements.values())
         .chain(relocations.values().flat_map(|(from, to)| [from, to]))
         .map(|file_id| {
@@ -1130,7 +1146,13 @@ fn plan_exact_transaction(
     let mut layouts = Vec::new();
     let pipeline = kin_index::IndexPipeline::new();
 
-    refuse_overlapping_file_operations(&creations, &retirements, &relocations, &edits)?;
+    refuse_overlapping_file_operations(
+        &creations,
+        &replacements,
+        &retirements,
+        &relocations,
+        &edits,
+    )?;
     // Retirements and relocations run before the creations and the edits. A
     // transaction that retires one path and creates another has to see the
     // retirement first, or the create plans against a tree that still carries
@@ -1141,6 +1163,7 @@ fn plan_exact_transaction(
     plan_retired_source_files(&prospective, retirements)?;
     plan_renamed_source_files(&prospective, relocations, &mut layouts)?;
     plan_new_source_files(state, &prospective, &pipeline, creations, &mut layouts)?;
+    plan_replaced_source_files(state, &prospective, &pipeline, replacements, &mut layouts)?;
     for (_, (file_id, file_edits)) in edits {
         let path = RepoPath::from_utf8(file_id.0.clone())
             .map_err(|error| format!("invalid exact source path {file_id}: {error}"))?;
@@ -1428,8 +1451,9 @@ fn record_new_source_file(
     if base.tree.artifact_at_path(&path).is_some() {
         return Err(format!(
             "{target} is already tracked by repository authority, so it cannot be created; \
-             'create' admits only source the graph has never seen. Edit it with verb 'update' \
-             naming an entity inside it, or create a path that does not exist yet"
+             'create' admits only source the graph has never seen. Rewrite it with verb \
+             'replace' carrying its complete new text, edit one entity inside it with verb \
+             'update', or create a path that does not exist yet"
         ));
     }
     let body = operation
@@ -1444,6 +1468,65 @@ fn record_new_source_file(
         return Err(format!(
             "{target} is created more than once in one transaction; overlapping source authority \
              is ambiguous"
+        ));
+    }
+    Ok(())
+}
+
+/// Record one "rewrite this tracked source file" operation against repository
+/// authority, refusing every shape the planner could not honor later.
+///
+/// The mirror of [`record_new_source_file`]: that one refuses a path authority
+/// already tracks, this one refuses a path it does not, so between them a
+/// caller is always pointed at the verb that does what it asked for. A rewrite
+/// of a path nothing tracks is not a harmless creation, because the caller
+/// believes it is changing a file that exists.
+///
+/// An identical body is refused here as well as at stage time. Publishing it
+/// would mint a change whose tree delta moves no bytes, and the transaction's
+/// own no-semantic-change guard would then refuse the whole commit with a
+/// message about the transaction rather than about the operation that emptied
+/// it. The comparison is on content hashes, which is what the tracked entry
+/// carries, so nothing is read off disk and no source is loaded to answer it.
+fn record_replaced_source_file(
+    replacements: &mut BTreeMap<String, (FilePathId, Vec<u8>)>,
+    base: &NativeCommitBase,
+    operation: &kin_mcp::McpMutationOperation,
+) -> Result<(), String> {
+    let target = operation.target.trim();
+    let path = RepoPath::from_utf8(target.to_string())
+        .map_err(|error| format!("replaced source path {target:?} is unusable: {error}"))?;
+    kin_core::validate_source_paths([&path]).map_err(|error| {
+        format!("replaced source path {target:?} is not an admissible repository path: {error}")
+    })?;
+    let artifact = base.tree.artifact_at_path(&path).ok_or_else(|| {
+        format!(
+            "{target} is not tracked by repository authority, so there is nothing to replace; \
+             'replace' rewrites only source the graph already holds. Admit a path the graph has \
+             never seen with verb 'create' instead, carrying the same body"
+        )
+    })?;
+    let body = operation
+        .body
+        .as_ref()
+        .expect("a replaced source file operation always carries a body");
+    if let TreeEntry::Blob { hash, .. } = artifact.entry {
+        if hash == kin_blobs::digest(body.as_bytes()) {
+            return Err(format!(
+                "the body sent for {target} is byte-identical to the contents repository \
+                 authority already tracks, so this operation changes nothing; no repository \
+                 commit was created"
+            ));
+        }
+    }
+    let file_id = FilePathId::new(target.to_string());
+    if replacements
+        .insert(file_id.0.clone(), (file_id, body.as_bytes().to_vec()))
+        .is_some()
+    {
+        return Err(format!(
+            "{target} is replaced more than once in one transaction; overlapping source \
+             authority is ambiguous"
         ));
     }
     Ok(())
@@ -1467,6 +1550,7 @@ fn record_new_source_file(
 /// in" that both halves survive.
 fn refuse_overlapping_file_operations(
     creations: &BTreeMap<String, (FilePathId, Vec<u8>)>,
+    replacements: &BTreeMap<String, (FilePathId, Vec<u8>)>,
     retirements: &BTreeMap<String, FilePathId>,
     relocations: &BTreeMap<String, (FilePathId, FilePathId)>,
     edits: &BTreeMap<String, (FilePathId, Vec<(Entity, Vec<u8>)>)>,
@@ -1484,10 +1568,35 @@ fn refuse_overlapping_file_operations(
                  and admit the new file in the next, so each is reviewable on its own"
             ));
         }
+        if replacements.contains_key(path) {
+            return Err(format!(
+                "{path} is both retired and rewritten in one transaction; the rewrite would be \
+                 planned against a path this transaction has already taken out"
+            ));
+        }
         if edits.contains_key(path) {
             return Err(format!(
                 "{path} is retired and also carries an entity edit in one transaction; the edit \
                  would be planned against a path this transaction has already taken out"
+            ));
+        }
+    }
+    // A rewrite states the file's whole new text, so anything else that also
+    // writes the same path in the same transaction is a second authority over
+    // the same bytes. Whichever one ran last would win silently, and the
+    // caller would have no way to tell which it was.
+    for path in replacements.keys() {
+        if relocations.contains_key(path) {
+            return Err(format!(
+                "{path} is both rewritten and renamed away in one transaction; rewrite the file \
+                 where it lands, or move it in a separate transaction"
+            ));
+        }
+        if edits.contains_key(path) {
+            return Err(format!(
+                "{path} carries both a whole-file rewrite and an entity edit in one transaction; \
+                 the rewrite already states the file's complete new text, so the edit would be \
+                 spliced into bytes it replaces"
             ));
         }
     }
@@ -1882,6 +1991,113 @@ fn plan_new_source_files(
             .get_layout(&file_id)
             .cloned()
             .ok_or_else(|| format!("parsing produced no file layout for new source {file_id}"))?;
+        prospective
+            .upsert_file_layout(&layout)
+            .map_err(|error| format!("install prospective layout for {file_id}: {error}"))?;
+        layouts.push(layout);
+    }
+    Ok(())
+}
+
+/// Turn recorded rewrites into prospective graph truth: exact blob, tree
+/// transition, re-derived entities, re-derived relations, and a file layout.
+///
+/// Every step is the one [`plan_new_source_files`] runs, against a path that
+/// already exists rather than one that does not, so the artifact keeps its
+/// identity and the transition is an update rather than an admission. The
+/// bytes come from the call, never from the working copy, and the working file
+/// appears afterwards because the commit projects the tree it published.
+///
+/// The reconciler is what makes this a rewrite rather than a splice. It reads
+/// the entities the graph already holds for the file, matches them against the
+/// declarations the new text parses to, and derives the additions, the
+/// modifications and the removals from the difference. So an entity the new
+/// text drops leaves the graph, an entity it adds enters, and one it merely
+/// edits keeps its id and its incoming edges. That is exactly what an entity
+/// edit cannot do: it names one entity and one span, so a rewrite that changes
+/// how many declarations a file has has nowhere to land.
+///
+/// A rewritten file must still classify as entity source. The alternative is
+/// to admit the new bytes and leave the entities the old bytes derived standing
+/// with nothing under them, which is a graph that answers about source the
+/// repository no longer holds. Refusing says so instead.
+fn plan_replaced_source_files(
+    state: &DaemonState,
+    prospective: &kin_db::InMemoryGraph,
+    pipeline: &kin_index::IndexPipeline,
+    replacements: BTreeMap<String, (FilePathId, Vec<u8>)>,
+    layouts: &mut Vec<FileLayout>,
+) -> Result<(), String> {
+    if replacements.is_empty() {
+        return Ok(());
+    }
+    let mut reconciler = kin_reconcile::Reconciler::new(PathBuf::new());
+    reconciler.seed_cross_file_linker_from_graph(prospective);
+
+    for (_, (file_id, body)) in replacements {
+        let path = RepoPath::from_utf8(file_id.0.clone())
+            .map_err(|error| format!("invalid replaced source path {file_id}: {error}"))?;
+        let artifact = prospective
+            .resolved_tree()
+            .artifact_at_path(&path)
+            .cloned()
+            .ok_or_else(|| {
+                format!("replaced source artifact disappeared during planning: {file_id}")
+            })?;
+        let executable = match artifact.entry {
+            TreeEntry::Blob { executable, .. } => executable,
+            TreeEntry::Symlink { .. } => {
+                return Err(format!(
+                    "replaced source {file_id} resolves through a symlink"
+                ))
+            }
+            TreeEntry::Gitlink { .. } => {
+                return Err(format!(
+                    "replaced source {file_id} resolves through a gitlink"
+                ))
+            }
+        };
+
+        let digest = state
+            .blobs
+            .write(&body)
+            .map_err(|error| format!("store replaced source {file_id}: {error}"))?;
+        let hash = Hash256::from_bytes(digest.0);
+        prospective
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Updated {
+                    artifact_id: artifact.artifact_id,
+                    old: artifact.located_entry(),
+                    new: LocatedEntry::new(path, TreeEntry::blob(hash, executable)),
+                }],
+                ..TransactionDelta::default()
+            })
+            .map_err(|error| format!("install prospective exact tree for {file_id}: {error}"))?;
+
+        let indexed = pipeline
+            .index_any_content(&file_id, &body, digest)
+            .map_err(|error| format!("parse replaced source {file_id}: {error}"))?;
+        let kin_index::IndexedAny::EntitySource(indexed) = indexed else {
+            return Err(format!(
+                "the replacement body for {file_id} does not classify as supported entity \
+                 source, and the entities the tracked file derives would be left standing over \
+                 bytes the repository no longer holds; retire the file with verb 'delete' if \
+                 that is what you meant"
+            ));
+        };
+        let reconcile = reconciler
+            .reconcile_indexed_content(&indexed, state.blobs.as_ref(), prospective)
+            .map_err(|error| format!("derive semantics for replaced source {file_id}: {error}"))?;
+        prospective
+            .apply_transaction_delta(&reconcile.delta)
+            .map_err(|error| format!("apply derived semantics for {file_id}: {error}"))?;
+        let layout = reconciler
+            .projection()
+            .get_layout(&file_id)
+            .cloned()
+            .ok_or_else(|| {
+                format!("parsing produced no file layout for replaced source {file_id}")
+            })?;
         prospective
             .upsert_file_layout(&layout)
             .map_err(|error| format!("install prospective layout for {file_id}: {error}"))?;
@@ -2990,6 +3206,262 @@ mod tests {
         assert_eq!(
             std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
             b"pub fn value() -> u8 { 1 }\n"
+        );
+    }
+
+    /// Build the replace-file operation an agent stages to rewrite tracked
+    /// source from its complete new text.
+    fn replaced_source_file(path: &str, body: &str) -> kin_mcp::McpMutationOperation {
+        kin_mcp::McpMutationOperation {
+            verb: "replace".to_string(),
+            target: path.to_string(),
+            payload: None,
+            body: Some(body.to_string()),
+            destination: None,
+            description: format!("rewrite {path}"),
+        }
+    }
+
+    const TRACKED_RS: &str =
+        "pub fn value() -> u8 {\n    1\n}\n\npub fn doomed() -> u8 {\n    9\n}\n";
+    const REWRITTEN_RS: &str =
+        "pub fn value() -> u8 {\n    2\n}\n\npub fn added() -> u8 {\n    3\n}\n";
+
+    /// An agent holding a path and a file's complete new text lands the rewrite
+    /// as one change, and the graph re-derives the file's entities from the
+    /// bytes that were published.
+    ///
+    /// This is the half of the write surface FIR-2586 found missing. `create`
+    /// admits a path the graph has never seen, and an entity edit resolves a
+    /// target against one entity and splices into that entity's span, so a
+    /// caller holding a path and a whole file could reach neither. Every local
+    /// `edit_file` and `write_file` harness holds exactly that, which is why
+    /// kin#1049 opens no transaction for an in-place edit at all.
+    ///
+    /// The re-derivation is asserted rather than assumed, because it is what
+    /// separates a rewrite from an admission: the entity the new text keeps
+    /// holds its id, the entity it drops leaves the graph, and the entity it
+    /// adds enters. An entity edit refuses this case by name, since it may
+    /// only change the body of the one entity it resolved.
+    #[test]
+    fn replacing_a_tracked_file_over_mcp_republishes_it_and_re_derives_its_entities() {
+        let (_dir, state) = test_state();
+        let (before_entity, installed_change) =
+            install_exact_source(&state, "src/lib.rs", TRACKED_RS.as_bytes(), "value");
+        let doomed_before = state
+            .graph
+            .query_entities(&EntityFilter {
+                name_pattern: Some("doomed".to_string()),
+                file_path: Some(FilePathId::new("src/lib.rs")),
+                ..EntityFilter::default()
+            })
+            .unwrap();
+        assert_eq!(
+            doomed_before.len(),
+            1,
+            "the fixture must hold the entity the rewrite drops"
+        );
+
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        let operations = vec![replaced_source_file("src/lib.rs", REWRITTEN_RS)];
+        kin_mcp::session::validate_staged_operations(&operations)
+            .expect("staging must accept the whole-file rewrite form");
+        sessions
+            .stage_transaction(&transaction.transaction_id, operations)
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "rewriting tracked source over MCP failed: {}",
+            result_text(&result)
+        );
+
+        // The working file is a projection of what committed, written by the
+        // commit rather than by the agent. Byte-exact, so a body that arrived
+        // mangled cannot pass.
+        assert_eq!(
+            std::fs::read_to_string(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            REWRITTEN_RS
+        );
+
+        // One change, which is what `kin log` reports. A rewrite that published
+        // a retirement and an admission would read as two.
+        let reply: serde_json::Value = commit_reply(&result);
+        let committed = SemanticChangeId::from_hash(
+            Hash256::from_hex(
+                reply["change_id"]
+                    .as_str()
+                    .expect("a successful commit names its change"),
+            )
+            .expect("the change id is a content hash"),
+        );
+        let published = state
+            .graph
+            .get_changes_since(&installed_change, &committed)
+            .unwrap();
+        assert_eq!(
+            published.iter().map(|change| change.id).collect::<Vec<_>>(),
+            vec![committed],
+            "the rewrite must publish exactly one change on top of the fixture"
+        );
+
+        let after = load_native_commit_base(&state.layout).unwrap();
+        let named = |name: &str| {
+            after
+                .graph
+                .query_entities(&EntityFilter {
+                    name_pattern: Some(name.to_string()),
+                    file_path: Some(FilePathId::new("src/lib.rs")),
+                    ..EntityFilter::default()
+                })
+                .unwrap()
+                .into_iter()
+                .filter(|entity| entity.name == name)
+                .collect::<Vec<_>>()
+        };
+        let kept = named("value");
+        assert_eq!(kept.len(), 1, "the entity the new text keeps must survive");
+        assert_eq!(
+            kept[0].id, before_entity.id,
+            "a rewrite keeps entity identity; minting a new id would orphan every incoming edge"
+        );
+        assert_eq!(
+            named("added").len(),
+            1,
+            "an entity the new text adds must enter the graph"
+        );
+        assert!(
+            named("doomed").is_empty(),
+            "an entity the new text drops must leave the graph"
+        );
+    }
+
+    /// A rewrite of a path repository authority does not track is refused by
+    /// name, and told which verb admits one.
+    ///
+    /// The mirror of the create refusal, and it matters for the same reason:
+    /// admitting the file instead would report a rewrite of something that
+    /// existed while actually creating it, and the caller would have no way to
+    /// learn the file it meant to change was never there.
+    #[test]
+    fn replacing_a_path_the_graph_does_not_track_is_refused_by_name() {
+        let (_dir, state) = test_state();
+        install_exact_source(&state, "src/lib.rs", TRACKED_RS.as_bytes(), "value");
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/absent.rs")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![replaced_source_file("src/absent.rs", REWRITTEN_RS)],
+            )
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_eq!(result.is_error, Some(true));
+        let text = result_text(&result);
+        assert!(
+            text.contains("src/absent.rs is not tracked by repository authority"),
+            "refusal must name the untracked path: {text}"
+        );
+        assert!(
+            text.contains("verb 'create'"),
+            "refusal must name the verb that admits a new path: {text}"
+        );
+        assert!(
+            !state.layout.working_dir().join("src/absent.rs").exists(),
+            "a refused rewrite must not leave the file it named on disk"
+        );
+    }
+
+    /// A rewrite carrying the text authority already holds is refused as the
+    /// empty change it is.
+    ///
+    /// Publishing it would mint a change whose tree delta moves no bytes, and
+    /// the transaction's own no-semantic-change guard would then refuse the
+    /// commit with a message about the transaction rather than about the
+    /// operation that emptied it. The comparison is on content hashes, which is
+    /// what the tracked entry carries, so nothing is read off the working copy
+    /// to answer it.
+    #[test]
+    fn replacing_a_tracked_file_with_the_text_it_already_holds_is_refused_as_an_empty_change() {
+        let (_dir, state) = test_state();
+        install_exact_source(&state, "src/lib.rs", TRACKED_RS.as_bytes(), "value");
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![replaced_source_file("src/lib.rs", TRACKED_RS)],
+            )
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_eq!(result.is_error, Some(true));
+        let text = result_text(&result);
+        assert!(
+            text.contains("byte-identical to the contents repository authority already tracks"),
+            "refusal must say the operation changes nothing: {text}"
+        );
+
+        // The control: the same path, the same shape, different text, commits.
+        // Without it the refusal above would also be satisfied by a planner
+        // that refused every rewrite.
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![replaced_source_file("src/lib.rs", REWRITTEN_RS)],
+            )
+            .unwrap();
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "a rewrite carrying new text must still commit: {}",
+            result_text(&result)
         );
     }
 

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -3237,7 +3237,9 @@ mod tests {
             "`body` (string, optional)",
             "`payload` (object, optional)",
             "`destination` (string, optional)",
-            "create/add/upsert/insert, update/modify, delete/remove, or rename/move",
+            "a rewritten source file",
+            "create/add/upsert/insert, update/modify, replace/overwrite, delete/remove, or \
+             rename/move",
         ] {
             assert!(err.contains(expected), "refusal omits {expected:?}: {err}");
         }

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -5473,6 +5473,112 @@ mod tests {
         }
     }
 
+    /// A whole-file rewrite is admitted for a tracked path, and refused both
+    /// when the path is untracked and when the body is the text authority
+    /// already holds.
+    ///
+    /// This is the shape an agent holding a path and a file's new contents
+    /// stages, which is every local `edit_file` and `write_file` harness. Both
+    /// refusals are checked here rather than only at commit because a caller
+    /// that learns at commit has already staged whatever it built on top, and
+    /// because each one names the verb that does what it asked: `create` for a
+    /// path the graph has never seen, and nothing at all for a body that
+    /// changes nothing.
+    ///
+    /// The identical-body answer comes from the artifact's own content hash,
+    /// so it is a graph-authority read rather than a look at the working copy.
+    #[tokio::test]
+    async fn handle_transaction_stage_admits_a_rewrite_and_refuses_the_two_ways_it_can_be_empty() {
+        use crate::session::McpMutationOperation;
+
+        const TRACKED: &str = "def value():\n    return 1\n";
+        const REWRITTEN: &str = "def value():\n    return 2\n\n\ndef added():\n    return 3\n";
+
+        let store = InMemoryGraph::default();
+        let tracked_path = kin_model::RepoPath::from_utf8("src/tracked.py".to_string()).unwrap();
+        store
+            .apply_transaction_delta(&kin_model::TransactionDelta {
+                tree_deltas: vec![kin_model::TreeDelta::Added {
+                    artifact_id: kin_model::ArtifactId::new(),
+                    new: kin_model::LocatedEntry::new(
+                        tracked_path,
+                        kin_model::TreeEntry::blob(kin_blobs::digest(TRACKED.as_bytes()), false),
+                    ),
+                }],
+                ..kin_model::TransactionDelta::default()
+            })
+            .unwrap();
+        let sessions = SessionRegistry::new();
+        let session_authority = SessionAuthorityMode::OfflineFallback;
+
+        let rewrite = |target: &str, body: &str| {
+            let op = McpMutationOperation {
+                verb: "replace".into(),
+                target: target.into(),
+                payload: None,
+                body: Some(body.into()),
+                destination: None,
+                description: format!("rewrite {target}"),
+            };
+            let mut args = HashMap::new();
+            args.insert("transaction_id".into(), serde_json::json!("no-such-tx"));
+            args.insert("operations".into(), serde_json::json!(vec![op]));
+            args
+        };
+
+        let err = sessions::handle_transaction_stage(
+            &rewrite("src/never_tracked.py", REWRITTEN),
+            &store,
+            &sessions,
+            session_authority,
+        )
+        .await
+        .expect_err("a rewrite of an untracked path must be rejected at stage time");
+        assert!(matches!(err, McpError::InvalidParams(_)));
+        let message = err.to_string();
+        assert!(
+            message.contains("\"src/never_tracked.py\" is not tracked by repository authority"),
+            "the refusal must name the path it rejected, got: {message}"
+        );
+        assert!(
+            message.contains("verb 'create'"),
+            "the refusal must name the verb that admits a new path, got: {message}"
+        );
+
+        let err = sessions::handle_transaction_stage(
+            &rewrite("src/tracked.py", TRACKED),
+            &store,
+            &sessions,
+            session_authority,
+        )
+        .await
+        .expect_err("a rewrite carrying the tracked contents must be rejected at stage time");
+        assert!(matches!(err, McpError::InvalidParams(_)));
+        let message = err.to_string();
+        assert!(
+            message.contains("byte-identical to the contents repository authority already tracks"),
+            "the refusal must say the operation changes nothing, got: {message}"
+        );
+
+        // The control: the same shape, on the tracked path, carrying text that
+        // differs, gets past both checks and fails only on the bogus
+        // transaction id. Without it the two refusals above would also be
+        // satisfied by a stage call that refused every rewrite.
+        let result = sessions::handle_transaction_stage(
+            &rewrite("src/tracked.py", REWRITTEN),
+            &store,
+            &sessions,
+            session_authority,
+        )
+        .await
+        .expect("a rewrite of a tracked path with new text must reach transaction lookup");
+        let text = tool_result_text(&result);
+        assert!(
+            text.contains("Transaction not found"),
+            "expected the bogus transaction id to be what refuses, got: {text}"
+        );
+    }
+
     use std::sync::{Mutex, OnceLock};
     static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
 

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -692,6 +692,17 @@ tool does NOT put it in the graph; nothing ambient admits it, and only this oper
 Create several files in one transaction to have them reference each other, and edit an \
 existing file with 'update' in that same transaction if you need to. A path the graph \
 already tracks is refused by name rather than quietly overwritten. \
+Use verb 'replace' (or 'overwrite') to rewrite a file the graph already tracks from its \
+complete new text: {verb: \"replace\", target: \"<repository-relative path>\", \
+body: \"<the file's complete new source text>\", description: \"...\"}. This is the shape \
+for what a local edit or write leaves you holding, a path and the file's new contents, and \
+it needs no entity: Kin reparses the body with the same extractor the ingest path uses, so \
+entities the new text adds enter the graph, entities it drops leave it, and the commit \
+writes the new contents into the working file. Send the WHOLE file, never a fragment or a \
+diff. A path the graph does not track is refused by name ('create' is the verb for that \
+one), and a body byte-identical to the tracked contents is refused as an empty change. \
+Prefer 'update' when you are changing one function or class and you know which: it names \
+what you meant, and it cannot lose the rest of the file to a truncated body. \
 Use verb 'update' (or 'modify') to change an entity the graph already holds. That is a \
 payload-less entity source edit: {verb: \"update\", target: \"<entity name or id>\", \
 body: \"<the entity's full new source text>\", description: \"...\"}. Prefer the entity \
@@ -711,14 +722,15 @@ resolved fail-closed server-side and on \
 commit the graph-to-file projection writes the body into the entity's working-directory \
 file. Structured payloads (full entity, relation add/remove) are also accepted. Each \
 operation is validated at stage time: anything the commit path would silently drop (a \
-missing or unknown verb, a missing payload outside the two payload-less source forms, a \
-nameless entity, a relation update/modify, a blob payload, a new-file path that is \
-absolute, escapes the repository, or names Kin or Git control metadata, or a 'create' \
-naming a path repository authority already tracks) is rejected immediately with an \
-actionable error instead of vanishing at commit. The already-tracked check reads a \
-snapshot of the graph this call is authoritative over: it catches the ordinary case, but \
-a path another transaction creates between this stage call and your commit is still only \
-caught at commit, which stays the final authority. This rejection is identical in daemon \
+missing or unknown verb, a missing payload outside the payload-less source forms, a \
+nameless entity, a relation update/modify, a blob payload, a file path that is \
+absolute, escapes the repository, or names Kin or Git control metadata, a 'create' \
+naming a path repository authority already tracks, or a 'replace' naming one it does not \
+track or carrying the text it already holds) is rejected immediately with an \
+actionable error instead of vanishing at commit. The tracked-path checks read a \
+snapshot of the graph this call is authoritative over: they catch the ordinary case, but \
+a path another transaction creates or rewrites between this stage call and your commit is \
+still only caught at commit, which stays the final authority. This rejection is identical in daemon \
 and in-process modes. Accepted operations are queued and can be validated or committed \
 together.";
 
@@ -764,9 +776,50 @@ pub async fn handle_transaction_stage<G: GraphStore>(
                 return Err(crate::error::McpError::InvalidParams(format!(
                     "operation #{idx} ('create'): {target:?} is already tracked by repository \
                      authority, so it cannot be created; 'create' admits only source the graph \
-                     has never seen. Edit it with verb 'update' naming an entity inside it, or \
-                     create a path that does not exist yet"
+                     has never seen. Rewrite it with verb 'replace' carrying its complete new \
+                     text, edit one entity inside it with verb 'update', or create a path that \
+                     does not exist yet"
                 )));
+            }
+            continue;
+        }
+        // A rewrite is the create's mirror: it names a path the graph must
+        // already hold, and it is refused when the text it carries is the text
+        // authority already has. Both answers come from the same snapshot this
+        // call is authoritative over, and neither reads the working copy. The
+        // tracked contents are identified by the artifact's own content hash,
+        // so comparing it against the hash of the submitted body settles the
+        // empty-change question without loading a single byte of source.
+        if crate::session::is_replaced_source_file(operation) {
+            let verb = operation.verb.trim().to_lowercase();
+            let target = operation.target.trim();
+            let Ok(path) = kin_model::RepoPath::from_utf8(target.to_string()) else {
+                continue;
+            };
+            if store.artifact_id_at_path(&path).is_none() {
+                return Err(crate::error::McpError::InvalidParams(format!(
+                    "operation #{idx} ('{verb}'): {target:?} is not tracked by repository \
+                     authority, so there is nothing to replace; '{verb}' rewrites source the \
+                     graph already holds. Admit a path the graph has never seen with verb \
+                     'create' instead, carrying the same body"
+                )));
+            }
+            let body = operation
+                .body
+                .as_deref()
+                .expect("a replaced source file always carries a body");
+            let tracked = store
+                .get_tree_entry(&kin_model::FilePathId::new(target))
+                .ok()
+                .flatten();
+            if let Some(kin_model::TreeEntry::Blob { hash, .. }) = tracked {
+                if hash == kin_blobs::digest(body.as_bytes()) {
+                    return Err(crate::error::McpError::InvalidParams(format!(
+                        "operation #{idx} ('{verb}'): the body sent for {target:?} is byte-identical \
+                         to the contents repository authority already tracks, so this operation \
+                         changes nothing. Send the file's new text, or drop the operation"
+                    )));
+                }
             }
             continue;
         }
@@ -1024,6 +1077,9 @@ fn offline_only_uncommittable_operations(operations: &[McpMutationOperation]) ->
                 "a payload-less retirement (target naming a tracked path)"
             } else if crate::session::is_renamed_source_file(op) {
                 "a payload-less rename (target plus destination)"
+            } else if crate::session::is_replaced_source_file(op) {
+                "a payload-less rewrite (target naming a tracked path, plus the file's complete \
+                 new body)"
             } else if op.payload.is_some() {
                 "an entity payload plus a source body"
             } else {

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -111,6 +111,42 @@ pub fn is_new_source_file(op: &McpMutationOperation) -> bool {
             .is_some_and(|body| !body.trim().is_empty())
 }
 
+/// A payload-less operation that expresses "the complete new source of the
+/// tracked repository file at `target` is `body`": verb replace/overwrite,
+/// `target` naming a repository-relative path, and a non-empty `body`.
+///
+/// This is the sibling of [`is_new_source_file`] for source the graph already
+/// holds, and it exists because an agent that has just rewritten a file holds a
+/// path and the file's new text, never an entity. [`is_target_body_update`]
+/// resolves `target` against repository authority as an entity uuid or an exact
+/// entity name and splices the body into that entity's span, so a caller
+/// holding only a path cannot reach it, and a caller holding a whole file
+/// cannot describe a whole-file rewrite as one span edit. Every local harness
+/// that offers `edit_file` or `write_file` is in exactly that position.
+///
+/// The verb is its own, rather than a path reading of `update`, because the
+/// branches have to stay disjoint: an entity name and a repository path are
+/// both bare strings, so one verb covering both would make the meaning of an
+/// operation depend on which one the target happened to resolve as. Naming the
+/// rewrite `replace` keeps the shape decidable from the operation alone.
+///
+/// `upsert` is deliberately not one of the verbs, for the reason
+/// [`is_new_source_file`] gives: a rewrite that silently becomes an admission
+/// is the failure these two shapes exist to keep apart. A path the graph does
+/// not track is refused by name, and `create` is the verb for it.
+pub fn is_replaced_source_file(op: &McpMutationOperation) -> bool {
+    op.payload.is_none()
+        && matches!(
+            op.verb.trim().to_lowercase().as_str(),
+            "replace" | "overwrite"
+        )
+        && !op.target.trim().is_empty()
+        && op
+            .body
+            .as_deref()
+            .is_some_and(|body| !body.trim().is_empty())
+}
+
 /// A payload-less operation that expresses "the repository no longer holds the
 /// file at `target`": verb delete/remove, `target` naming a repository-relative
 /// path, and no body.
@@ -392,7 +428,7 @@ pub struct CoordinationWritePreflight {
 /// The mutation verbs the transaction commit path understands, listed for
 /// actionable error messages.
 const KNOWN_MUTATION_VERBS: &str =
-    "create/add/upsert/insert, update/modify, delete/remove, or rename/move";
+    "create/add/upsert/insert, update/modify, replace/overwrite, delete/remove, or rename/move";
 
 fn is_known_mutation_verb(verb: &str) -> bool {
     matches!(
@@ -403,6 +439,8 @@ fn is_known_mutation_verb(verb: &str) -> bool {
             | "insert"
             | "update"
             | "modify"
+            | "replace"
+            | "overwrite"
             | "delete"
             | "remove"
             | "rename"
@@ -447,6 +485,10 @@ pub fn validate_staged_operations(
                 validate_source_operation_path(idx, op, op.target.trim(), "target")?;
                 continue;
             }
+            if is_replaced_source_file(op) {
+                validate_source_operation_path(idx, op, op.target.trim(), "target")?;
+                continue;
+            }
             if is_retired_source_file(op) {
                 validate_source_operation_path(idx, op, op.target.trim(), "target")?;
                 continue;
@@ -473,10 +515,11 @@ pub fn validate_staged_operations(
                  payload, express an edit to an existing entity as verb 'update' with `target` \
                  (entity name or id) and `body` (the entity's full new source text), admit a \
                  source file the graph has never seen as verb 'create' with `target` (its \
-                 repository-relative path) and `body` (the file's complete text), retire a \
-                 tracked file as verb 'delete' with `target` (its repository-relative path) and \
-                 no body, or relocate one as verb 'rename' with `target` and `destination` (both \
-                 repository-relative paths)",
+                 repository-relative path) and `body` (the file's complete text), rewrite a \
+                 tracked file as verb 'replace' with `target` (its repository-relative path) and \
+                 `body` (the file's complete new text), retire a tracked file as verb 'delete' \
+                 with `target` (its repository-relative path) and no body, or relocate one as \
+                 verb 'rename' with `target` and `destination` (both repository-relative paths)",
                 op.verb
             ));
         };
@@ -566,6 +609,7 @@ pub fn uncommittable_reason(op: &McpMutationOperation) -> Option<String> {
     let Some(payload) = op.payload.as_ref() else {
         if is_target_body_update(op)
             || is_new_source_file(op)
+            || is_replaced_source_file(op)
             || is_retired_source_file(op)
             || is_renamed_source_file(op)
         {
@@ -589,12 +633,23 @@ pub fn uncommittable_reason(op: &McpMutationOperation) -> Option<String> {
                      repository-relative path, and `destination` set to its new one",
                     op.verb
                 ))
+            } else if matches!(verb.as_str(), "replace" | "overwrite") {
+                Some(format!(
+                    "verb '{}' is not committable for entity payloads; a replacement rewrites a \
+                     whole file, so stage it with no payload, `target` set to the file's \
+                     repository-relative path, and `body` set to its complete new text. To \
+                     change one entity in place, use verb 'update'",
+                    op.verb
+                ))
             } else {
                 None
             }
         }
         McpMutationPayload::Relation { .. } => {
-            if matches!(verb.as_str(), "update" | "modify" | "rename" | "move") {
+            if matches!(
+                verb.as_str(),
+                "update" | "modify" | "replace" | "overwrite" | "rename" | "move"
+            ) {
                 Some(format!(
                     "verb '{}' is not committable for relation payloads; relations support only \
                      create/add/upsert/insert or delete/remove",
@@ -629,6 +684,9 @@ pub const ACCEPTED_OPERATION_SHAPES: &str = "each element of `operations` is one
      \"description\": \"<why>\"}\n  \
      - a new source file: {\"verb\": \"create\", \"target\": \"<repository-relative path>\", \
      \"body\": \"<the file's complete source text>\", \"description\": \"<why>\"}\n  \
+     - a rewritten source file: {\"verb\": \"replace\", \"target\": \"<repository-relative path \
+     the graph already tracks>\", \"body\": \"<the file's complete new source text>\", \
+     \"description\": \"<why>\"}\n  \
      - a retired source file: {\"verb\": \"delete\", \"target\": \"<repository-relative path>\", \
      \"description\": \"<why>\"}\n  \
      - a renamed source file: {\"verb\": \"rename\", \"target\": \"<current path>\", \
@@ -637,11 +695,12 @@ pub const ACCEPTED_OPERATION_SHAPES: &str = "each element of `operations` is one
      source text.\n\
      Every field of an operation, and nothing else is accepted:\n  \
      - `verb` (string, REQUIRED): one of create/add/upsert/insert, update/modify, \
-     delete/remove, or rename/move. Compared case-insensitively after trimming.\n  \
+     replace/overwrite, delete/remove, or rename/move. Compared case-insensitively after \
+     trimming.\n  \
      - `target` (string, REQUIRED): the entity this operation acts on, as either its uuid or \
-     its exact name. A repository-relative path instead for the three file-level shapes \
-     (create, delete, rename). Empty string for relation payloads, which identify themselves \
-     by their endpoints and kind.\n  \
+     its exact name. A repository-relative path instead for the four file-level shapes \
+     (create, replace, delete, rename). Empty string for relation payloads, which identify \
+     themselves by their endpoints and kind.\n  \
      - `description` (string, REQUIRED): why this operation is being made.\n  \
      - `destination` (string, optional): where a rename puts the file, as a \
      repository-relative path. Required by rename/move and accepted by nothing else.\n  \
@@ -2819,6 +2878,82 @@ mod target_body_update_tests {
             "moved",
         )));
         assert!(uncommittable_reason(&entity_update).is_none());
+    }
+
+    /// The whole-file rewrite is its own shape, and the shapes it sits between
+    /// do not answer for it.
+    ///
+    /// The near misses carry the point. `replace` is a verb the stage path did
+    /// not know at all before this shape existed, so a payload-less `replace`
+    /// used to fail with "unknown verb" and now succeeds; everything that still
+    /// has to fail is listed here so the widening is bounded to what was
+    /// intended. The disjointness assertions matter most: an entity edit and a
+    /// rewrite both carry a bare target and a body, so the verb is the only
+    /// thing that separates "splice this into one entity's span" from "this is
+    /// the file's whole new text".
+    #[test]
+    fn the_rewrite_shape_is_recognized_and_its_near_misses_are_not() {
+        let rewrite = target_op("replace", "src/parser.py", Some("def parse():\n    pass\n"));
+        assert!(is_replaced_source_file(&rewrite));
+        assert!(!is_target_body_update(&rewrite));
+        assert!(!is_new_source_file(&rewrite));
+        assert!(!is_retired_source_file(&rewrite));
+        assert!(!is_renamed_source_file(&rewrite));
+        assert!(uncommittable_reason(&rewrite).is_none());
+        validate_staged_operations(std::slice::from_ref(&rewrite))
+            .expect("a payload-less replace naming a path and carrying a body must stage");
+
+        let overwrite = target_op("overwrite", "src/parser.py", Some("x = 1\n"));
+        assert!(is_replaced_source_file(&overwrite));
+        assert!(uncommittable_reason(&overwrite).is_none());
+        validate_staged_operations(std::slice::from_ref(&overwrite))
+            .expect("'overwrite' is the same shape under its other verb");
+
+        // A create and an entity edit keep their own verbs. If either matched
+        // the rewrite, an operation's meaning would depend on how its target
+        // happened to resolve rather than on what it said.
+        let create = target_op("create", "src/parser.py", Some("x = 1\n"));
+        assert!(!is_replaced_source_file(&create));
+        let edit = target_op("update", "parse", Some("def parse():\n    pass\n"));
+        assert!(!is_replaced_source_file(&edit));
+
+        // A rewrite states a whole file, so it is nothing without one.
+        let no_body = target_op("replace", "src/parser.py", None);
+        assert!(!is_replaced_source_file(&no_body));
+        assert!(validate_staged_operations(std::slice::from_ref(&no_body)).is_err());
+
+        let empty_body = target_op("replace", "src/parser.py", Some("   "));
+        assert!(!is_replaced_source_file(&empty_body));
+        assert!(validate_staged_operations(std::slice::from_ref(&empty_body)).is_err());
+
+        let no_target = target_op("replace", "", Some("x = 1\n"));
+        assert!(!is_replaced_source_file(&no_target));
+        assert!(validate_staged_operations(std::slice::from_ref(&no_target)).is_err());
+
+        // The path rule the projection applies runs here too, so a path the
+        // commit could never materialize is refused where it was typed.
+        let escaping = target_op("replace", "../outside.py", Some("x = 1\n"));
+        assert!(is_replaced_source_file(&escaping));
+        let error = validate_staged_operations(std::slice::from_ref(&escaping))
+            .expect_err("a path that escapes the repository must not stage");
+        assert!(
+            error.contains("../outside.py"),
+            "the refusal must quote the path it rejected: {error}"
+        );
+
+        // A payload turns it into a shape the commit path has no arm for, so
+        // stage time refuses it and names the payload-less form.
+        let mut with_entity = target_op("replace", "src/parser.py", Some("x = 1\n"));
+        with_entity.payload = Some(McpMutationPayload::Entity(super::tests::entity_named(
+            "parse",
+        )));
+        let reason = uncommittable_reason(&with_entity)
+            .expect("an entity payload must not be committable with a replace verb");
+        assert!(
+            reason.contains("is not committable for entity payloads"),
+            "{reason}"
+        );
+        assert!(validate_staged_operations(std::slice::from_ref(&with_entity)).is_err());
     }
 
     #[test]

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -55,15 +55,18 @@ fn destructive_idempotent(title: &str) -> ToolAnnotations {
 
 /// Honest JSON Schema for one transaction operation.
 ///
-/// The product daemon accepts five materially different shapes. A source-body
-/// edit, a new source file, a retirement, and a rename are all intentionally
-/// payload-less; structured entity/relation mutations require `payload`.
-/// Keeping these as disjoint `oneOf` branches prevents MCP clients from being
-/// told that the preferred source-edit form is invalid.
+/// The product daemon accepts six materially different shapes. A source-body
+/// edit, a new source file, a rewritten source file, a retirement, and a rename
+/// are all intentionally payload-less; structured entity/relation mutations
+/// require `payload`. Keeping these as disjoint `oneOf` branches prevents MCP
+/// clients from being told that the preferred source-edit form is invalid.
 ///
-/// No two branches can match one operation: the four payload-less branches
+/// No two branches can match one operation: the five payload-less branches
 /// carry disjoint verb enums, and the structured branch requires `payload`,
-/// which none of the others accepts.
+/// which none of the others accepts. The rewrite has a verb of its own rather
+/// than a path reading of `update` for that reason: an entity name and a
+/// repository path are both bare strings, so one verb covering both would make
+/// an operation's meaning depend on how its target happened to resolve.
 fn transaction_operation_schema() -> serde_json::Value {
     serde_json::json!({
         "oneOf": [
@@ -128,12 +131,39 @@ fn transaction_operation_schema() -> serde_json::Value {
                     "target": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Repository-relative path of the new file, such as \"src/parser.py\". No leading slash, no \"..\", and no Kin or Git control component. A path the graph already tracks is refused; edit that one with verb 'update' instead."
+                        "description": "Repository-relative path of the new file, such as \"src/parser.py\". No leading slash, no \"..\", and no Kin or Git control component. A path the graph already tracks is refused; rewrite that one with verb 'replace' instead."
                     },
                     "body": {
                         "type": "string",
                         "minLength": 1,
                         "description": "The file's complete UTF-8 source text. Kin parses it with the same extractor the ingest path uses, so every entity in it enters the graph, and writes the file into the working directory when the transaction commits. You do not need to write the file yourself first."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable explanation of this change."
+                    }
+                },
+                "required": ["verb", "target", "body", "description"],
+                "additionalProperties": false
+            },
+            {
+                "title": "Replaced source file",
+                "type": "object",
+                "properties": {
+                    "verb": {
+                        "type": "string",
+                        "enum": ["replace", "overwrite"],
+                        "description": "Rewrite a tracked file from its complete new text. This is the operation to use when you hold a path and the file's new contents, which is what a local edit or write leaves you holding."
+                    },
+                    "target": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Repository-relative path of the file to rewrite, such as \"src/parser.py\". It must be a path repository authority already tracks; a path the graph has never seen is refused, and 'create' is the verb for it."
+                    },
+                    "body": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The file's complete new UTF-8 source text, never a fragment or a diff. Kin reparses it with the same extractor the ingest path uses, so entities the new text adds enter the graph, entities it drops leave it, and the rest keep their identity. A body identical to the tracked contents is refused as an empty change."
                     },
                     "description": {
                         "type": "string",
@@ -1702,7 +1732,7 @@ mod tests {
             let variants = tool["inputSchema"]["properties"]["operations"]["items"]["oneOf"]
                 .as_array()
                 .expect("transaction operations must be disjoint oneOf variants");
-            assert_eq!(variants.len(), 5, "{tool_name}");
+            assert_eq!(variants.len(), 6, "{tool_name}");
 
             let retirement = variants
                 .iter()
@@ -1755,6 +1785,45 @@ mod tests {
                 new_source_file["properties"].get("payload").is_none(),
                 "payload-less new-source-file branch must reject payload"
             );
+
+            let replaced_source_file = variants
+                .iter()
+                .find(|variant| variant["title"] == "Replaced source file")
+                .expect("payload-less replaced-source-file branch");
+            assert_eq!(
+                required_set(replaced_source_file),
+                ["body", "description", "target", "verb"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            );
+            assert!(
+                replaced_source_file["properties"].get("payload").is_none(),
+                "payload-less replaced-source-file branch must reject payload"
+            );
+            // The rewrite is only decidable from the operation itself while its
+            // verbs belong to it alone among the payload-less branches. Sharing
+            // one with the entity edit would make the shape depend on how a
+            // bare target string happened to resolve. The structured branch is
+            // exempt because `payload` already separates it from all five.
+            let verbs = |variant: &serde_json::Value| {
+                variant["properties"]["verb"]["enum"]
+                    .as_array()
+                    .expect("every branch pins its verbs")
+                    .iter()
+                    .map(|verb| verb.as_str().expect("a verb is a string").to_string())
+                    .collect::<std::collections::BTreeSet<String>>()
+            };
+            for other in variants.iter().filter(|variant| {
+                variant["title"] != "Replaced source file"
+                    && variant["title"] != "Structured entity or relation mutation"
+            }) {
+                assert!(
+                    verbs(replaced_source_file).is_disjoint(&verbs(other)),
+                    "the rewrite branch shares a verb with {}",
+                    other["title"]
+                );
+            }
 
             let body_edit = variants
                 .iter()

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -208,7 +208,13 @@ reported rather than served as a confident answer.
 *Tools:* `kin_transaction_begin`, `kin_transaction_stage`, `kin_transaction_validate`, `kin_transaction_commit`, `kin_transaction_abort`
 
 - **`kin_transaction_begin`**: Start a transaction context.
-- **`kin_transaction_stage`**: Stage entity changes to the transaction.
+- **`kin_transaction_stage`**: Stage changes to the transaction. Each staged operation is one of six disjoint shapes, and the verb decides which:
+  - `create` (or `add`/`insert`) with `target` set to a repository-relative path and `body` set to the file's complete source text admits a file the graph has never seen. It is the only operation that introduces a new file, and it refuses a path repository authority already tracks.
+  - `replace` (or `overwrite`) with `target` set to a repository-relative path and `body` set to the file's complete new source text rewrites a file the graph already tracks. This is the shape for what a local edit or write leaves you holding, a path and the file's new contents, and it needs no entity: Kin reparses the body, so entities the new text adds enter the graph, entities it drops leave it, and the rest keep their ids and their incoming edges. It refuses a path repository authority does not track, and it refuses a body byte-identical to the contents already tracked.
+  - `update` (or `modify`) with `target` set to an entity uuid or an unambiguous exact entity name, and `body` set to that entity's complete new source text, edits one entity in place. Prefer it when you are changing one function or class and you know which.
+  - `delete` (or `remove`) with `target` set to a repository-relative path and no body retires a tracked file, along with every entity derived from it and every edge incident to those entities.
+  - `rename` (or `move`) with `target` and `destination` both repository-relative paths relocates a tracked file. Entity ids, history, and incoming references survive the move.
+  - A structured entity or relation mutation carries an explicit `payload`, for callers that already hold Kin's own entity and relation objects.
 - **`kin_transaction_validate`**: Run constraints and validation against staged changes.
 - **`kin_transaction_commit` / `kin_transaction_abort`**: Commit changes to the branch head or discard them.
 


### PR DESCRIPTION
An agent that holds a path and a file's new contents can now land that change through Kin's own write path. `kin_transaction_stage` gains verb `replace` (or `overwrite`) with `target` set to a repository-relative path and `body` set to the file's complete new text, which is the sibling of `create` for source the graph already tracks.

## The gap

`kin_transaction_stage` admitted five disjoint shapes and none of them fit a whole-file rewrite. The create shape is keyed on a path plus a body, but `is_new_source_file` is only reachable for a path repository authority has never seen, and `record_new_source_file` refuses a tracked one by name (`crates/kin-mcp/src/session.rs:101`, `crates/kin-daemon/src/mcp_commit.rs:1447`). The edit shape resolves its target through `resolve_target_entity` (`crates/kin-mcp/src/handlers/sessions.rs:528-580`) as an entity uuid or an unambiguous exact entity name, then splices the body into that one entity's span, and the planner refuses the result outright if reparsing added or removed an entity (`crates/kin-daemon/src/mcp_commit.rs:1230`). So a caller holding a path and a whole file could reach neither shape.

Every local `edit_file` and `write_file` harness is in exactly that position, which is why kin#1049 opens no transaction at all for an in-place edit and records the reason in the trace instead.

## The new shape

A payload-less operation with verb `replace` or `overwrite`, a repository-relative `target`, and the file's complete new `body`. It has its own verb rather than a path reading of `update` because the branches have to stay decidable from the operation alone: an entity name and a repository path are both bare strings, so one verb covering both would make an operation's meaning depend on how its target happened to resolve. The schema carries it as a sixth `oneOf` branch titled "Replaced source file", and a test asserts its verbs are disjoint from every other payload-less branch.

Validation runs at stage time against repository authority, alongside the checks `create`, `delete` and `rename` already make. Two refusals, verbatim:

- untracked path: `operation #0 ('replace'): "src/never_tracked.py" is not tracked by repository authority, so there is nothing to replace; 'replace' rewrites only source the graph already holds. Admit a path the graph has never seen with verb 'create' instead, carrying the same body`
- identical body: `operation #0 ('replace'): the body sent for "src/tracked.py" is byte-identical to the contents repository authority already tracks, so this operation changes nothing. Send the file's new text, or drop the operation`

Neither answer touches the working copy. Tracked-ness comes from `GraphStore::artifact_id_at_path`, and the empty-change answer compares the staged body's SHA-256 against the content hash the tracked artifact already carries, read through `GraphStore::get_tree_entry`. `python3 scripts/verify-zero-file-search.py` and `bash scripts/zero_file_search_guard.sh` both pass on this branch.

The daemon plans the rewrite beside `create` in `plan_replaced_source_files`. The body is written to the blob store, the artifact takes a `TreeDelta::Updated` so it keeps its identity, and the reconciler re-derives the file's entities from the bytes that were published. An entity the new text keeps holds its id and its incoming edges, one it drops leaves the graph, and one it adds enters. A rewrite whose new body no longer classifies as entity source is refused rather than admitted, because admitting it would leave the old entities standing over bytes the repository no longer holds. The commit path repeats both refusals against the base tree, since stage time is a snapshot and commit is the authority.

`refuse_overlapping_file_operations` also refuses a path this transaction both rewrites and retires, both rewrites and renames away, or rewrites while also carrying an entity edit. A rewrite states the file's whole new text, so anything else writing the same path is a second authority over the same bytes.

## Tests

Five new tests, all mirroring the shape of the `create` tests beside them.

`crates/kin-mcp/src/session.rs`: `the_rewrite_shape_is_recognized_and_its_near_misses_are_not` asserts the shape is recognized, that create and update do not match it, and that a missing body, an empty body, an empty target, an escaping path, and an entity payload all fail closed.

`crates/kin-mcp/src/handlers/mod.rs`: `handle_transaction_stage_admits_a_rewrite_and_refuses_the_two_ways_it_can_be_empty` drives the stage handler against a store holding one tracked artifact, asserts both refusals by message, and carries a positive control where the same shape on the tracked path with new text gets past both checks and fails only on the bogus transaction id.

`crates/kin-daemon/src/mcp_commit.rs`: `replacing_a_tracked_file_over_mcp_republishes_it_and_re_derives_its_entities` commits a rewrite and asserts the working file byte-exactly, that `get_changes_since` reports exactly one published change, that the kept entity holds its original id, that the added entity entered the graph, and that the dropped entity left it. `replacing_a_path_the_graph_does_not_track_is_refused_by_name` and `replacing_a_tracked_file_with_the_text_it_already_holds_is_refused_as_an_empty_change` assert the two refusals at commit, the second with a control that the same path and shape carrying different text still commits.

### Falsification

Seven passes, each removing one property, running the tests that guard it, and restoring the tree byte-identically (`git status --porcelain` empty after every pass, and no compile errors in any log).

Removing the `plan_replaced_source_files` call, exit 101, two of three daemon tests failing and the refusal test still passing:

```
assertion `left != right` failed: rewriting tracked source over MCP failed: exact MCP transaction produced no semantic, relation, or tree change
dropped: replace src/lib.rs
test result: FAILED. 1 passed; 2 failed
```

Removing the untracked refusal in `record_replaced_source_file`, exit 101:

```
refusal must name the untracked path: exact MCP transaction produced no semantic, relation, or tree change
dropped: replace src/absent.rs
test result: FAILED. 2 passed; 1 failed
```

Removing the identical-body refusal at commit, exit 101. The failure shows what the refusal exists to prevent, an internal error naming an artifact id rather than the operation the caller wrote:

```
refusal must say the operation changes nothing: install prospective exact tree for src/lib.rs: invalid operation: artifact ArtifactId(91e64c3c-fcb6-46ef-bff2-91f9ccda2108) update is a no-op
test result: FAILED. 2 passed; 1 failed
```

Removing the stage-time untracked refusal, exit 101:

```
a rewrite of an untracked path must be rejected at stage time: ToolCallResult { content: [Text { text: "Transaction not found: no-such-tx" }], is_error: Some(true) }
test result: FAILED. 0 passed; 1 failed
```

Removing the stage-time identical-body refusal, exit 101:

```
a rewrite carrying the tracked contents must be rejected at stage time: ToolCallResult { content: [Text { text: "Transaction not found: no-such-tx" }], is_error: Some(true) }
test result: FAILED. 0 passed; 1 failed
```

Dropping the shape from `validate_staged_operations`, exit 101:

```
a payload-less replace naming a path and carrying a body must stage: "operation #0 ('replace'): missing payload; provide an entity, relation, or blob payload, ..."
test result: FAILED. 0 passed; 1 failed
```

Removing the schema branch, exit 101:

```
panicked at crates/kin-mcp/src/tools.rs:1792:18: payload-less replaced-source-file branch
test result: FAILED. 17 passed; 1 failed
```

## Gates

`cargo test -p kin-mcp` exit 0, 600 passed and 0 failed, plus 0 doctests. `cargo test -p kin-daemon --lib mcp_commit` exit 0, 61 passed and 0 failed. `cargo fmt --all -- --check` exit 0. Clippy exit 0 with the ci.yml allowlist under `RUSTFLAGS=-D warnings` for `-p kin-mcp -p kin-daemon --all-targets --all-features`. `python3 scripts/verify-zero-file-search.py` exit 0 over 179 source files, `bash scripts/zero_file_search_guard.sh` exit 0, `bash scripts/check_runtime_boundaries.sh` exit 0, `bash scripts/check_private_repo_coupling.sh` exit 0, `python3 scripts/test-private-repo-coupling.py` exit 0, `bash scripts/test-windows-authority-legs.sh` exit 0, `bash scripts/test-release-policy-gate.sh` exit 0. Every run was against the lane worktree at `.kin-coord/worktrees/stageshape-kin`, rebased onto origin/main at 521aa35de and re-run there, which is what picked up the kin-db 0.7.49 and kin-model 0.7.13 pins that landed while this branch was in flight. `git diff origin/main --stat -- Cargo.lock .cargo/` is empty and `git ls-tree -r HEAD --name-only` shows only `.cargo/config.toml` under `.cargo/`.

The local full gate was not run under tonight's build-slot saturation. Hosted CI is the gate of record for this PR, per the 05:52Z lane amendment, and every check must conclude with zero failures before it is submitted.

## What is left

This PR gives the belt the shape; it does not change `kin agent` to use it. kin#1049 owns that harness and currently opens no transaction for an in-place edit, which stays true until it stages this operation. The acceptance run FIR-2586 asks for, one `kin agent run` on a local model landing a commit `kin log` shows, is a proof step this change enables and does not perform.

Refs FIR-2586
Refs FIR-2417
