### PR TITLE
Attach one graph server per repository to a kin agent run

### DIFF
--- a/crates/kin-agent/src/belt.rs
+++ b/crates/kin-agent/src/belt.rs
@@ -25,12 +25,80 @@ pub const KIN_TOOL_PREFIX: &str = "mcp__kin__";
 /// Where a routed call goes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Route {
-    /// A Kin tool, named without the transcript prefix.
-    Kin(String),
+    /// A Kin tool, named without the transcript prefix, on the server that serves it.
+    Kin { server: usize, tool: String },
     /// One of the two local tools.
     Local(LocalTool),
     /// Not in the belt. Carries the refusal the model is told.
     Refused(String),
+}
+
+/// One Kin tool on the belt, bound to the server that declared it.
+///
+/// A run can attach several graph servers, one per repository, and every one of them
+/// declares the same tool names. The binding has to travel with the tool or a call cannot
+/// be sent anywhere: the model's name is the only thing the router has to go on.
+#[derive(Debug, Clone)]
+pub struct KinTool {
+    /// Index into the run's server list.
+    pub server: usize,
+    /// The name the server itself declares.
+    pub bare: String,
+    /// The name the model calls, carrying the transcript prefix.
+    pub exposed: String,
+    pub description: String,
+    pub schema: Value,
+}
+
+/// The prefix one server's tools carry on the model's belt.
+///
+/// A single-server run keeps the historical `mcp__kin__`, so a one-repository transcript
+/// stays byte-identical to what the fleet's analyzers already read. Several servers each
+/// get `mcp__kin_<label>__`, which holds the `mcp__<server>__<tool>` shape those analyzers
+/// classify while naming the repository in every call the model makes.
+pub fn tool_prefix(label: Option<&str>) -> String {
+    match label {
+        None => KIN_TOOL_PREFIX.to_string(),
+        Some(label) => format!("mcp__kin_{label}__"),
+    }
+}
+
+/// A short, stable, unique label for one repository, for use in a tool prefix.
+///
+/// The directory name is what an operator recognizes, so it is the source. Anything a tool
+/// name cannot carry becomes `_`, and a collision takes a numeric suffix rather than
+/// silently sharing a namespace with another repository.
+pub fn server_label(repo: &Path, taken: &BTreeSet<String>) -> String {
+    let base: String = repo
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default()
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let base = base.trim_matches('_').to_string();
+    let base = if base.is_empty() {
+        "repo".to_string()
+    } else {
+        base
+    };
+    if !taken.contains(&base) {
+        return base;
+    }
+    let mut suffix = 2usize;
+    loop {
+        let candidate = format!("{base}_{suffix}");
+        if !taken.contains(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,17 +110,15 @@ pub enum LocalTool {
 /// The belt: every name the model may call this run.
 #[derive(Debug, Clone)]
 pub struct Belt {
-    kin_tools: Vec<(String, Value)>,
+    kin_tools: Vec<KinTool>,
     names: BTreeSet<String>,
 }
 
 impl Belt {
-    /// Build the belt from what the MCP server declared, plus the two local tools.
-    pub fn new(kin_tools: Vec<(String, Value)>) -> Self {
-        let mut names: BTreeSet<String> = kin_tools
-            .iter()
-            .map(|(name, _)| format!("{KIN_TOOL_PREFIX}{name}"))
-            .collect();
+    /// Build the belt from what the MCP servers declared, plus the two local tools.
+    pub fn new(kin_tools: Vec<KinTool>) -> Self {
+        let mut names: BTreeSet<String> =
+            kin_tools.iter().map(|tool| tool.exposed.clone()).collect();
         names.insert(EDIT_FILE.to_string());
         names.insert(WRITE_FILE.to_string());
         Belt { kin_tools, names }
@@ -65,12 +131,8 @@ impl Belt {
 
     /// The schema a named tool declares, for argument validation.
     pub fn schema_for(&self, name: &str) -> Option<Value> {
-        if let Some(bare) = name.strip_prefix(KIN_TOOL_PREFIX) {
-            return self
-                .kin_tools
-                .iter()
-                .find(|(tool, _)| tool == bare)
-                .map(|(_, schema)| schema.clone());
+        if let Some(tool) = self.kin_tools.iter().find(|tool| tool.exposed == name) {
+            return Some(tool.schema.clone());
         }
         match name {
             EDIT_FILE => Some(edit_file_schema()),
@@ -81,10 +143,11 @@ impl Belt {
 
     /// Route a name the model produced.
     pub fn route(&self, name: &str) -> Route {
-        if let Some(bare) = name.strip_prefix(KIN_TOOL_PREFIX) {
-            if self.kin_tools.iter().any(|(tool, _)| tool == bare) {
-                return Route::Kin(bare.to_string());
-            }
+        if let Some(tool) = self.kin_tools.iter().find(|tool| tool.exposed == name) {
+            return Route::Kin {
+                server: tool.server,
+                tool: tool.bare.clone(),
+            };
         }
         match name {
             EDIT_FILE => return Route::Local(LocalTool::Edit),
@@ -92,11 +155,20 @@ impl Belt {
             _ => {}
         }
         // A bare Kin tool name is a near miss worth naming precisely, because the model
-        // very likely meant the prefixed one and a generic refusal would not say so.
-        if self.kin_tools.iter().any(|(tool, _)| tool == name) {
+        // very likely meant a prefixed one and a generic refusal would not say so. With
+        // several repositories attached the same bare name exists on each, so the refusal
+        // names every prefixed form rather than picking one for the model.
+        let candidates: Vec<String> = self
+            .kin_tools
+            .iter()
+            .filter(|tool| tool.bare == name)
+            .map(|tool| format!("`{}`", tool.exposed))
+            .collect();
+        if !candidates.is_empty() {
             return Route::Refused(format!(
-                "There is no tool named `{name}`. The Kin tool is called `{KIN_TOOL_PREFIX}{name}`. \
-                 Call it by that exact name."
+                "There is no tool named `{name}`. The Kin tool is called {}. Call it by that \
+                 exact name.",
+                candidates.join(" or ")
             ));
         }
         Route::Refused(format!(
@@ -108,31 +180,35 @@ impl Belt {
     }
 
     /// The `tools` array sent to the chat endpoint.
-    pub fn to_specs(&self, descriptions: &[(String, String)]) -> Vec<Value> {
+    ///
+    /// `repo_note` is appended to the two local tool descriptions when a run attached more
+    /// than one repository, because the path rule genuinely changes: a relative path can no
+    /// longer mean only one tree.
+    pub fn to_specs(&self, repo_note: Option<&str>) -> Vec<Value> {
         let mut specs = Vec::new();
-        for (name, schema) in &self.kin_tools {
-            let description = descriptions
-                .iter()
-                .find(|(tool, _)| tool == name)
-                .map(|(_, text)| text.clone())
-                .unwrap_or_default();
+        for tool in &self.kin_tools {
             specs.push(json!({
                 "type": "function",
                 "function": {
-                    "name": format!("{KIN_TOOL_PREFIX}{name}"),
-                    "description": description,
-                    "parameters": schema,
+                    "name": tool.exposed,
+                    "description": tool.description,
+                    "parameters": tool.schema,
                 }
             }));
         }
+        let suffix = match repo_note {
+            Some(note) => format!(" {note}"),
+            None => String::new(),
+        };
         specs.push(json!({
             "type": "function",
             "function": {
                 "name": EDIT_FILE,
-                "description": "Replace one exact snippet of text in one file. The `find` text \
-                                must appear exactly once in the file unless `replace_all` is true. \
-                                Use this for a small, surgical change once Kin has told you where \
-                                the code is.",
+                "description": format!(
+                    "Replace one exact snippet of text in one file. The `find` text must appear \
+                     exactly once in the file unless `replace_all` is true. Use this for a small, \
+                     surgical change once Kin has told you where the code is.{suffix}"
+                ),
                 "parameters": edit_file_schema(),
             }
         }));
@@ -140,8 +216,10 @@ impl Belt {
             "type": "function",
             "function": {
                 "name": WRITE_FILE,
-                "description": "Write a file in full, creating it if it does not exist. Use this \
-                                for a new file; prefer edit_file for a change to an existing one.",
+                "description": format!(
+                    "Write a file in full, creating it if it does not exist. Use this for a new \
+                     file; prefer edit_file for a change to an existing one.{suffix}"
+                ),
                 "parameters": write_file_schema(),
             }
         }));
@@ -301,6 +379,49 @@ pub fn resolve_in_repo(repo: &Path, raw: &str) -> Result<PathBuf, String> {
     Ok(repo.join(resolved))
 }
 
+/// Resolve a model-supplied path to the repository that owns it, and to the file inside it.
+///
+/// One repository is the ordinary case and behaves exactly like [`resolve_in_repo`]. With
+/// several attached, an absolute path is matched against every root and the longest match
+/// wins, which is the containment rule and the only one that stays correct when one
+/// checkout sits inside another. A relative path resolves against the primary repository,
+/// because the alternative is asking the filesystem which tree the model meant, and a wrong
+/// guess writes into the wrong repository. The model is told this rule in the tool
+/// descriptions rather than left to discover it.
+pub fn resolve_across_repos(repos: &[PathBuf], raw: &str) -> Result<(usize, PathBuf), String> {
+    let Some(primary) = repos.first() else {
+        return Err("this run attached no repository".to_string());
+    };
+    if repos.len() == 1 || !Path::new(raw).is_absolute() {
+        return resolve_in_repo(primary, raw).map(|path| (0, path));
+    }
+    let mut best: Option<(usize, PathBuf, usize)> = None;
+    for (index, repo) in repos.iter().enumerate() {
+        let Ok(path) = resolve_in_repo(repo, raw) else {
+            continue;
+        };
+        let depth = repo.components().count();
+        let better = match &best {
+            None => true,
+            Some((_, _, chosen)) => depth > *chosen,
+        };
+        if better {
+            best = Some((index, path, depth));
+        }
+    }
+    match best {
+        Some((index, path, _)) => Ok((index, path)),
+        None => Err(format!(
+            "`{raw}` is outside every repository this run attached. The roots are: {}.",
+            repos
+                .iter()
+                .map(|repo| repo.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
 /// Run `edit_file`.
 pub fn run_edit(repo: &Path, arguments: &Value) -> LocalOutcome {
     let raw_path = arguments.get("path").and_then(Value::as_str).unwrap_or("");
@@ -396,7 +517,9 @@ pub fn run_write(repo: &Path, arguments: &Value) -> LocalOutcome {
 }
 
 impl LocalOutcome {
-    fn error(message: String) -> Self {
+    /// A refusal the model is handed instead of a run, in the shape a run would have
+    /// produced, so a routing failure reads to the caller exactly like a tool failure.
+    pub fn error(message: String) -> Self {
         LocalOutcome {
             text: message,
             is_error: true,

--- a/crates/kin-agent/src/lib.rs
+++ b/crates/kin-agent/src/lib.rs
@@ -67,19 +67,48 @@ impl ExitStatus {
     }
 }
 
+/// One graph server and the repository it serves.
+///
+/// A run attaches one of these per repository. The agent's own tools are named per server,
+/// and every write is routed to the server that owns the path, so a two-repository run
+/// cannot commit one repository's change into the other's graph.
+#[derive(Debug, Clone)]
+pub struct ServerSpec {
+    pub repo: PathBuf,
+    pub mcp_command: Vec<String>,
+}
+
 /// Everything one run needs.
 #[derive(Debug, Clone)]
 pub struct AgentConfig {
     pub task: String,
     pub system_prompt: Option<String>,
+    /// The primary repository: the process working directory, the default for a relative
+    /// path, and the repository the transcript names.
     pub repo: PathBuf,
     pub out_dir: PathBuf,
     pub provider: ProviderConfig,
+    /// The primary repository's server argv.
     pub mcp_command: Vec<String>,
+    /// Further repositories attached to the same run, each with its own server. Empty for
+    /// the ordinary single-repository run, whose behaviour is unchanged by this field.
+    pub extra_servers: Vec<ServerSpec>,
     pub mcp_timeout: Duration,
     pub max_tool_calls: u32,
     pub deadline: Duration,
     pub tool_profile: Option<String>,
+}
+
+impl AgentConfig {
+    /// Every server this run attaches, primary first.
+    pub fn servers(&self) -> Vec<ServerSpec> {
+        let mut servers = vec![ServerSpec {
+            repo: self.repo.clone(),
+            mcp_command: self.mcp_command.clone(),
+        }];
+        servers.extend(self.extra_servers.iter().cloned());
+        servers
+    }
 }
 
 /// What a finished run produced.

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -4,7 +4,7 @@
 //! The agent loop.
 
 use crate::belt::{self, Belt, LocalTool, Route};
-use crate::mcp::{McpClient, ToolOutcome};
+use crate::mcp::{McpClient, McpError, McpTool, ToolOutcome};
 use crate::parse::{self, Turn};
 use crate::provider::{Provider, ProviderError, Usage};
 use crate::transcript::{now_iso, TranscriptWriter};
@@ -49,6 +49,55 @@ others.
 
 Work in small steps. Call one or two tools, read what came back, then decide. When you have \
 the answer, say it in plain text without calling a tool.";
+
+/// One attached graph server and the repository it serves.
+///
+/// A run holds one of these per repository. Everything that has to reach a particular
+/// graph goes through the server that owns the path, which is what keeps a two-repository
+/// run from committing one repository's change into the other's graph.
+struct Server {
+    /// `None` for a single-server run, whose tools keep the historical `mcp__kin__`
+    /// prefix. `Some(label)` once several are attached and they must be told apart.
+    label: Option<String>,
+    repo: std::path::PathBuf,
+    client: McpClient,
+    declared: Vec<McpTool>,
+    session: Option<String>,
+}
+
+impl Server {
+    /// How this server is named in the trace.
+    fn name(&self) -> String {
+        match &self.label {
+            None => "kin".to_string(),
+            Some(label) => format!("kin_{label}"),
+        }
+    }
+
+    /// Whether this server declares a tool by that exact name.
+    fn declares(&self, tool: &str) -> bool {
+        self.declared.iter().any(|declared| declared.name == tool)
+    }
+}
+
+/// What the model is told about paths once a run attaches several repositories.
+fn repo_path_note(repos: &[std::path::PathBuf]) -> String {
+    let primary = repos
+        .first()
+        .map(|repo| repo.display().to_string())
+        .unwrap_or_default();
+    let others: Vec<String> = repos
+        .iter()
+        .skip(1)
+        .map(|repo| repo.display().to_string())
+        .collect();
+    format!(
+        "This run has {} repositories attached. A relative path is read inside the primary \
+         repository at {primary}. To change a file in {}, give its absolute path.",
+        repos.len(),
+        others.join(" or ")
+    )
+}
 
 struct Counters {
     tool_calls: u32,
@@ -139,72 +188,106 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
     });
 
     // Connect to Kin first. A run that could not attach must be loud, not quietly scored.
-    let mut mcp = match McpClient::start(&config.mcp_command, &config.repo, config.mcp_timeout) {
-        Ok(client) => client,
-        Err(err) => {
-            let message = err.to_string();
-            writer.init(
-                &config.provider.model,
-                &config.repo,
-                &[],
-                "failed",
-                std::slice::from_ref(&message),
-                agent_meta,
-            )?;
-            return finish(
-                writer,
-                &config,
-                ExitStatus::McpError,
-                "the MCP server did not start",
-                &message,
-                counters,
-                started,
-                None,
-            );
-        }
-    };
+    // One server per repository, primary first, each spawned in the tree it serves.
+    let wanted = config.servers();
+    let multi = wanted.len() > 1;
+    let mut servers: Vec<Server> = Vec::new();
+    let mut taken: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for spec in &wanted {
+        let attach = |err: McpError| {
+            if multi {
+                format!("{err} (serving {})", spec.repo.display())
+            } else {
+                err.to_string()
+            }
+        };
+        let mut client = match McpClient::start(&spec.mcp_command, &spec.repo, config.mcp_timeout) {
+            Ok(client) => client,
+            Err(err) => {
+                let message = attach(err);
+                writer.init(
+                    &config.provider.model,
+                    &config.repo,
+                    &[],
+                    "failed",
+                    std::slice::from_ref(&message),
+                    agent_meta,
+                )?;
+                return finish(
+                    writer,
+                    &config,
+                    ExitStatus::McpError,
+                    "the MCP server did not start",
+                    &message,
+                    counters,
+                    started,
+                    None,
+                );
+            }
+        };
+        let declared = match client.list_tools() {
+            Ok(tools) => tools,
+            Err(err) => {
+                let message = attach(err);
+                writer.init(
+                    &config.provider.model,
+                    &config.repo,
+                    &[],
+                    "failed",
+                    std::slice::from_ref(&message),
+                    agent_meta,
+                )?;
+                return finish(
+                    writer,
+                    &config,
+                    ExitStatus::McpError,
+                    "the MCP server did not list its tools",
+                    &message,
+                    counters,
+                    started,
+                    None,
+                );
+            }
+        };
+        // A single-server run carries no label, so its tools keep the historical
+        // `mcp__kin__` prefix and its transcript stays what the analyzers already read.
+        let label = if multi {
+            let label = belt::server_label(&spec.repo, &taken);
+            taken.insert(label.clone());
+            Some(label)
+        } else {
+            None
+        };
+        servers.push(Server {
+            label,
+            repo: spec.repo.clone(),
+            client,
+            declared,
+            session: None,
+        });
+    }
 
-    let declared = match mcp.list_tools() {
-        Ok(tools) => tools,
-        Err(err) => {
-            let message = err.to_string();
-            writer.init(
-                &config.provider.model,
-                &config.repo,
-                &[],
-                "failed",
-                std::slice::from_ref(&message),
-                agent_meta,
-            )?;
-            return finish(
-                writer,
-                &config,
-                ExitStatus::McpError,
-                "the MCP server did not list its tools",
-                &message,
-                counters,
-                started,
-                None,
-            );
+    let mut kin_tools: Vec<belt::KinTool> = Vec::new();
+    for (index, server) in servers.iter().enumerate() {
+        let prefix = belt::tool_prefix(server.label.as_deref());
+        for tool in &server.declared {
+            if belt::is_harness_owned(&tool.name) {
+                continue;
+            }
+            kin_tools.push(belt::KinTool {
+                server: index,
+                bare: tool.name.clone(),
+                exposed: format!("{prefix}{}", tool.name),
+                description: tool.description.clone(),
+                schema: tool.input_schema.clone(),
+            });
         }
-    };
-
-    let server_tool_names: Vec<String> = declared.iter().map(|tool| tool.name.clone()).collect();
-    let exposed: Vec<_> = declared
-        .iter()
-        .filter(|tool| !belt::is_harness_owned(&tool.name))
-        .collect();
-    let belt = Belt::new(
-        exposed
-            .iter()
-            .map(|tool| (tool.name.clone(), tool.input_schema.clone()))
-            .collect(),
-    );
-    let descriptions: Vec<(String, String)> = exposed
-        .iter()
-        .map(|tool| (tool.name.clone(), tool.description.clone()))
-        .collect();
-    let specs = belt.to_specs(&descriptions);
+    }
+    let belt = Belt::new(kin_tools);
+    let repo_roots: Vec<std::path::PathBuf> =
+        servers.iter().map(|server| server.repo.clone()).collect();
+    let repo_note = multi.then(|| repo_path_note(&repo_roots));
+    let specs = belt.to_specs(repo_note.as_deref());
     let tool_names: Vec<String> = belt.names().iter().cloned().collect();
 
     writer.init(
@@ -218,15 +301,33 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
 
     let provider = Provider::new(config.provider.clone())?;
 
-    // Open a Kin session so every mutation this run makes names this agent rather than an
-    // anonymous file write. A server without the tool is not an error; it just means the
-    // provenance bracket is unavailable and the trace says so.
-    let kin_session = start_kin_session(&mut mcp, &config, &server_tool_names, &mut writer)?;
+    // Open a Kin session per server, so every mutation this run makes names this agent
+    // rather than an anonymous file write. A server without the tool is not an error; it
+    // just means the provenance bracket is unavailable there and the trace says so.
+    for server in servers.iter_mut() {
+        let session = start_kin_session(server, &config, &mut writer)?;
+        server.session = session;
+    }
 
-    let system_prompt = config
+    let mut system_prompt = config
         .system_prompt
         .clone()
         .unwrap_or_else(|| DEFAULT_SYSTEM_PROMPT.to_string());
+    // The repository roots are a fact about this run that the model cannot infer, and
+    // without them it cannot address the second repository at all, so the note is appended
+    // to an operator-supplied prompt as well as to the built-in one.
+    if let Some(note) = repo_note.as_deref() {
+        let roots = repo_roots
+            .iter()
+            .map(|repo| repo.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        system_prompt.push_str(&format!(
+            "\n\nThe repositories attached to this run are: {roots}. Each has its own Kin \
+             graph, and its tools carry that repository's own prefix, so read the tool names \
+             you were given and call the one belonging to the repository you mean. {note}"
+        ));
+    }
     let mut messages = vec![
         json!({ "role": "system", "content": system_prompt }),
         json!({ "role": "user", "content": config.task }),
@@ -397,13 +498,18 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                             }))?;
                             (message, true)
                         }
-                        Route::Kin(name) => {
+                        Route::Kin {
+                            server: server_index,
+                            tool: name,
+                        } => {
+                            let server_name = servers[server_index].name();
                             match check_arguments(&belt, &call.name, &call.arguments) {
                                 Err(problem) => {
                                     counters.repairs += 1;
                                     writer.trace(json!({
                                         "tool_use_id": call.id,
                                         "surface": "kin",
+                                        "server": server_name,
                                         "tool": name,
                                         "args": call.arguments,
                                         "policy": "repaired",
@@ -421,7 +527,9 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                     )
                                 }
                                 Ok(()) => {
-                                    let outcome = mcp.call_tool(&name, &call.arguments);
+                                    let outcome = servers[server_index]
+                                        .client
+                                        .call_tool(&name, &call.arguments);
                                     match outcome {
                                         Err(err) => {
                                             // The server died or stopped answering. Nothing
@@ -429,6 +537,7 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                             writer.trace(json!({
                                                 "tool_use_id": call.id,
                                                 "surface": "kin",
+                                                "server": server_name,
                                                 "tool": name,
                                                 "args": call.arguments,
                                                 "policy": "allowed",
@@ -463,6 +572,7 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                             writer.trace(json!({
                                                 "tool_use_id": call.id,
                                                 "surface": "kin",
+                                                "server": server_name,
                                                 "tool": name,
                                                 "args": call.arguments,
                                                 "wall_ms": outcome.wall_ms as u64,
@@ -504,65 +614,105 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                 Ok(()) => {
                                     counters.local_calls += 1;
                                     let started_call = Instant::now();
-                                    // The plan is made before the tool runs, because
-                                    // `write_file` is what makes a new path exist and
-                                    // afterwards nothing can tell a create from an
-                                    // overwrite.
-                                    let plan = plan_stage(&config.repo, tool, &call.arguments);
-                                    let mut bracket = begin_transaction(
-                                        &mut mcp,
-                                        kin_session.as_deref(),
-                                        &server_tool_names,
-                                        &call.arguments,
-                                        &plan,
-                                        &mut writer,
-                                    )?;
-                                    let outcome = match tool {
-                                        LocalTool::Edit => {
-                                            belt::run_edit(&config.repo, &call.arguments)
+                                    // Which repository owns the path decides which graph
+                                    // the change is staged into, so it is resolved before
+                                    // anything is written. A path that belongs to no
+                                    // attached repository runs nothing at all.
+                                    let raw_path = call
+                                        .arguments
+                                        .get("path")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or("");
+                                    match belt::resolve_across_repos(&repo_roots, raw_path) {
+                                        Err(problem) => {
+                                            writer.trace(json!({
+                                                "tool_use_id": call.id,
+                                                "surface": "local",
+                                                "tool": call.name,
+                                                "args": redact_content(&call.arguments),
+                                                "policy": "allowed",
+                                                "call_shape": call.shape.as_str(),
+                                                "problem": problem,
+                                                "is_error": true,
+                                            }))?;
+                                            (problem, true)
                                         }
-                                        LocalTool::Write => {
-                                            belt::run_write(&config.repo, &call.arguments)
-                                        }
-                                    };
-                                    // Stage what the harness just did, inside the open
-                                    // bracket, so the commit below has something to
-                                    // publish. An empty transaction is refused by design.
-                                    let staged = if outcome.is_error {
-                                        false
-                                    } else {
-                                        stage_planned_operation(
-                                            &mut mcp,
-                                            &mut bracket,
-                                            kin_session.as_deref(),
-                                            &plan,
-                                            &mut writer,
-                                        )?
-                                    };
-                                    let provenance = close_transaction(
-                                        &mut mcp,
-                                        bracket,
-                                        !outcome.is_error && staged,
-                                        &mut writer,
-                                    )?;
-                                    if let Some(path) = outcome.changed.clone() {
-                                        if !counters.edits.contains(&path) {
-                                            counters.edits.push(path);
+                                        Ok((index, resolved)) => {
+                                            let repo = servers[index].repo.clone();
+                                            let session = servers[index].session.clone();
+                                            let server_name = servers[index].name();
+                                            // The plan is made before the tool runs,
+                                            // because `write_file` is what makes a new
+                                            // path exist and afterwards nothing can tell a
+                                            // create from an overwrite.
+                                            let plan = plan_stage(&repo, tool, &call.arguments);
+                                            let mut bracket = begin_transaction(
+                                                &mut servers[index],
+                                                session.as_deref(),
+                                                &call.arguments,
+                                                &plan,
+                                                &mut writer,
+                                            )?;
+                                            let outcome = match tool {
+                                                LocalTool::Edit => {
+                                                    belt::run_edit(&repo, &call.arguments)
+                                                }
+                                                LocalTool::Write => {
+                                                    belt::run_write(&repo, &call.arguments)
+                                                }
+                                            };
+                                            // Stage what the harness just did, inside the
+                                            // open bracket, so the commit below has
+                                            // something to publish. An empty transaction
+                                            // is refused by design.
+                                            let staged = if outcome.is_error {
+                                                false
+                                            } else {
+                                                stage_planned_operation(
+                                                    &mut servers[index],
+                                                    &mut bracket,
+                                                    session.as_deref(),
+                                                    &plan,
+                                                    &mut writer,
+                                                )?
+                                            };
+                                            let provenance = close_transaction(
+                                                &mut servers[index],
+                                                bracket,
+                                                !outcome.is_error && staged,
+                                                &mut writer,
+                                            )?;
+                                            if let Some(path) = outcome.changed.clone() {
+                                                // With several repositories attached the
+                                                // same relative path exists in more than
+                                                // one, so the record is absolute or it
+                                                // names nothing in particular.
+                                                let recorded = if multi {
+                                                    resolved.display().to_string()
+                                                } else {
+                                                    path
+                                                };
+                                                if !counters.edits.contains(&recorded) {
+                                                    counters.edits.push(recorded);
+                                                }
+                                            }
+                                            writer.trace(json!({
+                                                "tool_use_id": call.id,
+                                                "surface": "local",
+                                                "server": server_name,
+                                                "repo": repo.display().to_string(),
+                                                "tool": call.name,
+                                                "args": redact_content(&call.arguments),
+                                                "wall_ms": started_call.elapsed().as_millis() as u64,
+                                                "is_error": outcome.is_error,
+                                                "policy": "allowed",
+                                                "call_shape": call.shape.as_str(),
+                                                "changed": outcome.changed,
+                                                "provenance": provenance,
+                                            }))?;
+                                            (outcome.text, outcome.is_error)
                                         }
                                     }
-                                    writer.trace(json!({
-                                        "tool_use_id": call.id,
-                                        "surface": "local",
-                                        "tool": call.name,
-                                        "args": redact_content(&call.arguments),
-                                        "wall_ms": started_call.elapsed().as_millis() as u64,
-                                        "is_error": outcome.is_error,
-                                        "policy": "allowed",
-                                        "call_shape": call.shape.as_str(),
-                                        "changed": outcome.changed,
-                                        "provenance": provenance,
-                                    }))?;
-                                    (outcome.text, outcome.is_error)
                                 }
                             }
                         }
@@ -588,12 +738,9 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
         }
     }
 
-    end_kin_session(
-        &mut mcp,
-        kin_session.as_deref(),
-        &server_tool_names,
-        &mut writer,
-    )?;
+    for server in servers.iter_mut() {
+        end_kin_session(server, &mut writer)?;
+    }
     finish(
         writer,
         &config,
@@ -720,14 +867,15 @@ fn complete_with_retry(
 }
 
 fn start_kin_session(
-    mcp: &mut McpClient,
+    server: &mut Server,
     config: &AgentConfig,
-    server_tools: &[String],
     writer: &mut TranscriptWriter,
 ) -> anyhow::Result<Option<String>> {
-    if !server_tools.iter().any(|name| name == "kin_session_start") {
+    let server_name = server.name();
+    if !server.declares("kin_session_start") {
         writer.trace(json!({
             "surface": "policy",
+            "server": server_name,
             "policy": "allowed",
             "event": "session_unavailable",
             "detail": "the server does not expose kin_session_start; edits will carry no session provenance",
@@ -739,14 +887,15 @@ fn start_kin_session(
         "client_name": format!("kin-agent ({})", config.provider.model),
         "transport": "mcp",
         "pid": std::process::id(),
-        "cwd": config.repo.display().to_string(),
+        "cwd": server.repo.display().to_string(),
         "capabilities": { "can_read": true, "can_write": true, "can_commit": true },
     });
-    match mcp.call_tool("kin_session_start", &arguments) {
+    match server.client.call_tool("kin_session_start", &arguments) {
         Ok(outcome) => {
             let session = extract_id(&outcome, &["session_id", "id"]);
             writer.trace(json!({
                 "surface": "kin",
+                "server": server_name,
                 "tool": "kin_session_start",
                 "policy": "allowed",
                 "event": "session_start",
@@ -759,6 +908,7 @@ fn start_kin_session(
         Err(err) => {
             writer.trace(json!({
                 "surface": "kin",
+                "server": server_name,
                 "tool": "kin_session_start",
                 "policy": "allowed",
                 "event": "session_start",
@@ -770,21 +920,20 @@ fn start_kin_session(
     }
 }
 
-fn end_kin_session(
-    mcp: &mut McpClient,
-    session: Option<&str>,
-    server_tools: &[String],
-    writer: &mut TranscriptWriter,
-) -> anyhow::Result<()> {
-    let Some(session) = session else {
+fn end_kin_session(server: &mut Server, writer: &mut TranscriptWriter) -> anyhow::Result<()> {
+    let Some(session) = server.session.clone() else {
         return Ok(());
     };
-    if !server_tools.iter().any(|name| name == "kin_session_end") {
+    if !server.declares("kin_session_end") {
         return Ok(());
     }
-    let outcome = mcp.call_tool("kin_session_end", &json!({ "session_id": session }));
+    let server_name = server.name();
+    let outcome = server
+        .client
+        .call_tool("kin_session_end", &json!({ "session_id": session }));
     writer.trace(json!({
         "surface": "kin",
+        "server": server_name,
         "tool": "kin_session_end",
         "policy": "allowed",
         "event": "session_end",
@@ -888,9 +1037,8 @@ impl Bracket {
 }
 
 fn begin_transaction(
-    mcp: &mut McpClient,
+    server: &mut Server,
     session: Option<&str>,
-    server_tools: &[String],
     arguments: &Value,
     plan: &StagePlan,
     writer: &mut TranscriptWriter,
@@ -904,18 +1052,19 @@ fn begin_transaction(
         return Ok(Bracket::unopened("no Kin session was open"));
     };
     for required in ["kin_transaction_begin", "kin_transaction_stage"] {
-        if !server_tools.iter().any(|name| name == required) {
+        if !server.declares(required) {
             return Ok(Bracket::unopened(format!(
                 "the server does not expose {required}"
             )));
         }
     }
+    let server_name = server.name();
     let scope = arguments
         .get("path")
         .and_then(Value::as_str)
         .unwrap_or("repository")
         .to_string();
-    match mcp.call_tool(
+    match server.client.call_tool(
         "kin_transaction_begin",
         &json!({ "session_id": session, "scope": scope }),
     ) {
@@ -923,6 +1072,7 @@ fn begin_transaction(
             let transaction_id = extract_id(&outcome, &["transaction_id", "id"]);
             writer.trace(json!({
                 "surface": "kin",
+                "server": server_name,
                 "tool": "kin_transaction_begin",
                 "policy": "allowed",
                 "event": "transaction_begin",
@@ -942,6 +1092,7 @@ fn begin_transaction(
         Ok(outcome) => {
             writer.trace(json!({
                 "surface": "kin",
+                "server": server_name,
                 "tool": "kin_transaction_begin",
                 "policy": "allowed",
                 "event": "transaction_begin",
@@ -961,12 +1112,13 @@ fn begin_transaction(
 /// never opened, or a plan with nothing the stage surface admits, stages nothing and says
 /// so, which is what keeps the commit below from claiming a provenance it did not get.
 fn stage_planned_operation(
-    mcp: &mut McpClient,
+    server: &mut Server,
     bracket: &mut Bracket,
     session: Option<&str>,
     plan: &StagePlan,
     writer: &mut TranscriptWriter,
 ) -> anyhow::Result<bool> {
+    let server_name = server.name();
     let (Some(transaction_id), StagePlan::Create { target, body }) =
         (bracket.transaction_id.clone(), plan)
     else {
@@ -985,13 +1137,14 @@ fn stage_planned_operation(
     if let Some(session) = session {
         arguments["session_id"] = Value::String(session.to_string());
     }
-    let outcome = mcp.call_tool("kin_transaction_stage", &arguments);
+    let outcome = server.client.call_tool("kin_transaction_stage", &arguments);
     let (is_error, detail) = match &outcome {
         Ok(outcome) => (outcome.is_error, truncate(&outcome.text, 300)),
         Err(err) => (true, err.to_string()),
     };
     writer.trace(json!({
         "surface": "kin",
+        "server": server_name,
         "tool": "kin_transaction_stage",
         "policy": "allowed",
         "event": "transaction_stage",
@@ -1015,11 +1168,12 @@ fn stage_planned_operation(
 /// Close the bracket. The recorded provenance says what actually happened, including a
 /// refusal, so a run never claims a provenance it did not get.
 fn close_transaction(
-    mcp: &mut McpClient,
+    server: &mut Server,
     bracket: Bracket,
     succeeded: bool,
     writer: &mut TranscriptWriter,
 ) -> anyhow::Result<Value> {
+    let server_name = server.name();
     let Some(transaction_id) = bracket.transaction_id else {
         return Ok(json!({
             "bracketed": false,
@@ -1032,13 +1186,16 @@ fn close_transaction(
     } else {
         "kin_transaction_abort"
     };
-    let outcome = mcp.call_tool(tool, &json!({ "transaction_id": transaction_id }));
+    let outcome = server
+        .client
+        .call_tool(tool, &json!({ "transaction_id": transaction_id }));
     let (is_error, detail) = match &outcome {
         Ok(outcome) => (outcome.is_error, truncate(&outcome.text, 300)),
         Err(err) => (true, err.to_string()),
     };
     writer.trace(json!({
         "surface": "kin",
+        "server": server_name,
         "tool": tool,
         "policy": "allowed",
         "event": if succeeded { "transaction_commit" } else { "transaction_abort" },

--- a/crates/kin-agent/src/tests.rs
+++ b/crates/kin-agent/src/tests.rs
@@ -201,9 +201,18 @@ fn well_formed_arguments_are_not_reported_as_malformed() {
 }
 
 fn test_belt() -> Belt {
-    Belt::new(vec![(
-        "semantic_locate".to_string(),
-        json!({
+    Belt::new(vec![kin_tool(0, "semantic_locate", None)])
+}
+
+/// One belt entry as a run would build it: bare name from the server, exposed name from
+/// that server's prefix.
+fn kin_tool(server: usize, bare: &str, label: Option<&str>) -> belt::KinTool {
+    belt::KinTool {
+        server,
+        bare: bare.to_string(),
+        exposed: format!("{}{bare}", belt::tool_prefix(label)),
+        description: format!("test tool {bare}"),
+        schema: json!({
             "type": "object",
             "properties": {
                 "query": { "type": "string" },
@@ -211,7 +220,7 @@ fn test_belt() -> Belt {
             },
             "required": ["query"]
         }),
-    )])
+    }
 }
 
 #[test]
@@ -243,7 +252,10 @@ fn the_router_routes_what_is_on_the_belt() {
     let belt = test_belt();
     assert_eq!(
         belt.route("mcp__kin__semantic_locate"),
-        Route::Kin("semantic_locate".into())
+        Route::Kin {
+            server: 0,
+            tool: "semantic_locate".into()
+        }
     );
     assert_eq!(belt.route("edit_file"), Route::Local(LocalTool::Edit));
     assert_eq!(belt.route("write_file"), Route::Local(LocalTool::Write));
@@ -280,6 +292,87 @@ fn harness_owned_tools_never_reach_the_model() {
     }
     assert!(!belt::is_harness_owned("semantic_locate"));
     assert!(!belt::is_harness_owned("get_context_pack"));
+}
+
+#[test]
+fn a_second_repository_of_the_same_name_gets_its_own_label() {
+    use std::collections::BTreeSet;
+    let mut taken = BTreeSet::new();
+    let first = belt::server_label(std::path::Path::new("/tmp/one/kin"), &taken);
+    assert_eq!(first, "kin");
+    taken.insert(first);
+    // Two checkouts of the same repository is the ordinary brownfield case, and sharing a
+    // prefix would make the model's call ambiguous rather than merely ugly.
+    let second = belt::server_label(std::path::Path::new("/other/kin"), &taken);
+    assert_eq!(second, "kin_2");
+    // A name a tool prefix cannot carry is reduced, not passed through.
+    let odd = belt::server_label(std::path::Path::new("/tmp/my repo.v2"), &BTreeSet::new());
+    assert_eq!(odd, "my_repo_v2");
+}
+
+#[test]
+fn tool_prefixes_separate_two_servers_and_a_bare_name_names_both() {
+    let belt = Belt::new(vec![
+        kin_tool(0, "semantic_locate", Some("alpha")),
+        kin_tool(1, "semantic_locate", Some("beta")),
+    ]);
+    assert_eq!(
+        belt.route("mcp__kin_alpha__semantic_locate"),
+        Route::Kin {
+            server: 0,
+            tool: "semantic_locate".into()
+        }
+    );
+    assert_eq!(
+        belt.route("mcp__kin_beta__semantic_locate"),
+        Route::Kin {
+            server: 1,
+            tool: "semantic_locate".into()
+        }
+    );
+    // A bare name is ambiguous across servers, so the refusal names every form rather than
+    // choosing a repository on the model's behalf.
+    let Route::Refused(message) = belt.route("semantic_locate") else {
+        panic!("a bare name must be refused when two servers declare it");
+    };
+    assert!(
+        message.contains("mcp__kin_alpha__semantic_locate")
+            && message.contains("mcp__kin_beta__semantic_locate"),
+        "the refusal must name both prefixed forms: {message}"
+    );
+}
+
+#[test]
+fn a_relative_path_means_the_primary_and_an_absolute_path_finds_its_own_repository() {
+    let repos = vec![
+        std::path::PathBuf::from("/work/alpha"),
+        std::path::PathBuf::from("/work/beta"),
+    ];
+    let (index, path) = belt::resolve_across_repos(&repos, "src/main.rs").unwrap();
+    assert_eq!(index, 0);
+    assert_eq!(path, std::path::PathBuf::from("/work/alpha/src/main.rs"));
+
+    let (index, path) = belt::resolve_across_repos(&repos, "/work/beta/src/main.rs").unwrap();
+    assert_eq!(index, 1);
+    assert_eq!(path, std::path::PathBuf::from("/work/beta/src/main.rs"));
+
+    // A checkout inside another checkout resolves to the innermost one, which is the
+    // containment rule; the outer repository would otherwise swallow every path.
+    let nested = vec![
+        std::path::PathBuf::from("/work/alpha"),
+        std::path::PathBuf::from("/work/alpha/vendor/beta"),
+    ];
+    let (index, _) =
+        belt::resolve_across_repos(&nested, "/work/alpha/vendor/beta/src/main.rs").unwrap();
+    assert_eq!(index, 1);
+
+    let problem = belt::resolve_across_repos(&repos, "/elsewhere/main.rs").unwrap_err();
+    assert!(
+        problem.contains("outside every repository")
+            && problem.contains("/work/alpha")
+            && problem.contains("/work/beta"),
+        "the refusal must name every root: {problem}"
+    );
 }
 
 #[test]

--- a/crates/kin-agent/tests/loop_integration.rs
+++ b/crates/kin-agent/tests/loop_integration.rs
@@ -242,11 +242,26 @@ fn config(repo: &Path, out: &Path, base_url: &str, mcp_command: Vec<String>) -> 
             request_timeout: Duration::from_secs(20),
         },
         mcp_command,
+        extra_servers: Vec::new(),
         mcp_timeout: Duration::from_secs(60),
         max_tool_calls: 10,
         deadline: Duration::from_secs(120),
         tool_profile: None,
     }
+}
+
+/// A fixture repository at a named directory, so two attached repositories carry
+/// different labels and their tool prefixes are told apart by name rather than by index.
+fn fixture_repo_named(dir: &Path, name: &str) -> PathBuf {
+    let repo = dir.join(name);
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    std::fs::write(
+        repo.join("src/greet.py"),
+        "def greet(name):\n    return f\"hello {name}\"\n",
+    )
+    .unwrap();
+    std::fs::write(repo.join("README.md"), "# fixture\n").unwrap();
+    repo
 }
 
 fn read_jsonl(path: &Path) -> Vec<Value> {
@@ -664,6 +679,237 @@ fn a_write_over_a_tracked_path_is_refused_by_the_graph_and_aborts() {
     assert!(
         detail.contains("already tracked"),
         "the graph's refusal must survive into the provenance: {detail}"
+    );
+}
+
+/// Two repositories, two servers, two graphs. Each write is staged and committed into the
+/// graph of the repository that owns its path, and a Kin call reaches only the server whose
+/// prefix the model used.
+#[test]
+fn two_repositories_each_get_their_own_server_session_and_commits() {
+    let dir = tempfile::tempdir().unwrap();
+    let alpha = fixture_repo_named(dir.path(), "alpha");
+    let beta = fixture_repo_named(dir.path(), "beta");
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let alpha_log = dir.path().join("alpha-calls.jsonl");
+    let beta_log = dir.path().join("beta-calls.jsonl");
+    let beta_file = beta.join("src/new_b.py");
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Looking in beta.",
+            Some(tool_call(
+                "c1",
+                "mcp__kin_beta__semantic_locate",
+                json!({ "query": "greet" }),
+            )),
+        ),
+        completion(
+            "Writing into the primary.",
+            Some(tool_call(
+                "c2",
+                "write_file",
+                json!({ "path": "src/new_a.py", "content": "a = 1\n" }),
+            )),
+        ),
+        completion(
+            "Writing into beta.",
+            Some(tool_call(
+                "c3",
+                "write_file",
+                json!({ "path": beta_file.display().to_string(), "content": "b = 2\n" }),
+            )),
+        ),
+        completion("Both files are written.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let mut cfg = config(&alpha, &out, &base_url, mcp_command(&server, &alpha_log));
+    cfg.extra_servers = vec![kin_agent::ServerSpec {
+        repo: beta.clone(),
+        mcp_command: mcp_command(&server, &beta_log),
+    }];
+
+    let outcome = kin_agent::run(cfg).expect("the run completes");
+    assert_eq!(outcome.status, ExitStatus::Success);
+
+    // Both files landed, each in its own tree.
+    assert_eq!(
+        std::fs::read_to_string(alpha.join("src/new_a.py")).unwrap(),
+        "a = 1\n"
+    );
+    assert!(
+        beta_file.exists(),
+        "the absolute-path write must land in the second repository at {}",
+        beta_file.display()
+    );
+    assert_eq!(std::fs::read_to_string(&beta_file).unwrap(), "b = 2\n");
+
+    // The primary server saw its own session, its own transaction, and no beta work.
+    let alpha_names: Vec<String> = mcp_log(&alpha_log)
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        alpha_names,
+        vec![
+            "kin_session_start",
+            "kin_transaction_begin",
+            "kin_transaction_stage",
+            "kin_transaction_commit",
+            "kin_session_end"
+        ],
+        "the primary must carry only its own relative-path write"
+    );
+
+    // The second server saw the model's Kin call and its own absolute-path write.
+    let beta_calls = mcp_log(&beta_log);
+    let beta_names: Vec<String> = beta_calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        beta_names,
+        vec![
+            "kin_session_start",
+            "semantic_locate",
+            "kin_transaction_begin",
+            "kin_transaction_stage",
+            "kin_transaction_commit",
+            "kin_session_end"
+        ],
+        "the prefixed Kin call and the absolute-path write must both reach beta"
+    );
+
+    // Each staged create names the path relative to its OWN repository, never the other's.
+    let staged_target = |calls: &[Value]| -> String {
+        calls
+            .iter()
+            .find(|call| call["tool"] == "kin_transaction_stage")
+            .expect("a create is staged")["args"]["operations"][0]["target"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+    assert_eq!(staged_target(&mcp_log(&alpha_log)), "src/new_a.py");
+    assert_eq!(staged_target(&beta_calls), "src/new_b.py");
+
+    // The trace attributes every call to the server that served it.
+    let trace = read_jsonl(&outcome.trace_path);
+    let locate = trace
+        .iter()
+        .find(|row| row["tool"] == "semantic_locate")
+        .expect("the Kin call is traced");
+    assert_eq!(locate["server"], "kin_beta");
+    let writes: Vec<&Value> = trace
+        .iter()
+        .filter(|row| row["surface"] == "local" && row["tool"] == "write_file")
+        .collect();
+    assert_eq!(writes.len(), 2);
+    assert_eq!(writes[0]["server"], "kin_alpha");
+    assert_eq!(writes[0]["repo"], alpha.display().to_string());
+    assert_eq!(writes[1]["server"], "kin_beta");
+    assert_eq!(writes[1]["repo"], beta.display().to_string());
+    for write in &writes {
+        assert_eq!(write["provenance"]["staged"]["accepted"], true);
+        assert_eq!(write["provenance"]["closed_with"], "kin_transaction_commit");
+    }
+
+    // The belt the model was given namespaces each repository's tools, and carries no
+    // ambiguous bare Kin name.
+    let requests = endpoint.requests();
+    let sent: Vec<String> = requests[0]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|spec| spec["function"]["name"].as_str().unwrap().to_string())
+        .collect();
+    assert!(sent
+        .iter()
+        .any(|name| name == "mcp__kin_alpha__semantic_locate"));
+    assert!(sent
+        .iter()
+        .any(|name| name == "mcp__kin_beta__semantic_locate"));
+    assert!(
+        !sent.iter().any(|name| name == "mcp__kin__semantic_locate"),
+        "a multi-repository run must not expose an unqualified Kin tool: {sent:?}"
+    );
+
+    // Files changed are recorded absolutely, because the same relative path exists in both.
+    let changed: Vec<String> = outcome.result["kin_agent"]["files_changed"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|value| value.as_str().unwrap().to_string())
+        .collect();
+    assert!(changed
+        .iter()
+        .any(|path| path.ends_with("alpha/src/new_a.py")));
+    assert!(changed
+        .iter()
+        .any(|path| path.ends_with("beta/src/new_b.py")));
+}
+
+/// A path in no attached repository runs nothing at all, and the refusal names the roots.
+#[test]
+fn a_path_outside_every_attached_repository_writes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let alpha = fixture_repo_named(dir.path(), "alpha");
+    let beta = fixture_repo_named(dir.path(), "beta");
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let alpha_log = dir.path().join("alpha-calls.jsonl");
+    let beta_log = dir.path().join("beta-calls.jsonl");
+    let stray = dir.path().join("elsewhere/escaped.py");
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Writing outside.",
+            Some(tool_call(
+                "c1",
+                "write_file",
+                json!({ "path": stray.display().to_string(), "content": "x = 1\n" }),
+            )),
+        ),
+        completion("I could not write there.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let mut cfg = config(&alpha, &out, &base_url, mcp_command(&server, &alpha_log));
+    cfg.extra_servers = vec![kin_agent::ServerSpec {
+        repo: beta.clone(),
+        mcp_command: mcp_command(&server, &beta_log),
+    }];
+
+    let outcome = kin_agent::run(cfg).expect("the run completes");
+    assert_eq!(outcome.status, ExitStatus::Success);
+    assert!(
+        !stray.exists(),
+        "nothing may be written outside the repositories"
+    );
+
+    // Neither server opened a transaction for it.
+    for log in [&alpha_log, &beta_log] {
+        let names: Vec<String> = mcp_log(log)
+            .iter()
+            .map(|call| call["tool"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(names, vec!["kin_session_start", "kin_session_end"]);
+    }
+
+    let trace = read_jsonl(&outcome.trace_path);
+    let write = trace
+        .iter()
+        .find(|row| row["surface"] == "local" && row["tool"] == "write_file")
+        .expect("the refused write is traced");
+    assert_eq!(write["is_error"], true);
+    let problem = write["problem"].as_str().unwrap();
+    assert!(
+        problem.contains("outside every repository")
+            && problem.contains(&alpha.display().to_string())
+            && problem.contains(&beta.display().to_string()),
+        "the refusal must name every root: {problem}"
     );
 }
 

--- a/crates/kin-cli/src/commands/agent.rs
+++ b/crates/kin-cli/src/commands/agent.rs
@@ -5,8 +5,8 @@
 
 use anyhow::{Context, Result};
 use kin_agent::{
-    AgentConfig, ExitStatus, ProviderConfig, DEFAULT_DEADLINE_S, DEFAULT_MAX_TOOL_CALLS,
-    DEFAULT_MCP_TIMEOUT_S, DEFAULT_REQUEST_TIMEOUT_S,
+    AgentConfig, ExitStatus, ProviderConfig, ServerSpec, DEFAULT_DEADLINE_S,
+    DEFAULT_MAX_TOOL_CALLS, DEFAULT_MCP_TIMEOUT_S, DEFAULT_REQUEST_TIMEOUT_S,
 };
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -18,8 +18,8 @@ pub struct RunArgs {
     pub model: String,
     pub base_url: String,
     pub api_key_env: Option<String>,
-    pub repo: Option<PathBuf>,
-    pub mcp_command: Option<String>,
+    pub repo: Vec<PathBuf>,
+    pub mcp_command: Vec<String>,
     pub out: Option<PathBuf>,
     pub max_tool_calls: Option<u32>,
     pub deadline: Option<u64>,
@@ -30,13 +30,10 @@ pub struct RunArgs {
 
 /// Run one task. Returns the process exit code; the caller exits with it.
 pub fn run(args: RunArgs) -> Result<i32> {
-    let repo = match args.repo {
-        Some(path) => path,
-        None => std::env::current_dir().context("could not resolve the current directory")?,
-    };
-    let repo = repo
-        .canonicalize()
-        .with_context(|| format!("no such directory: {}", repo.display()))?;
+    let servers = resolve_servers(&args.repo, &args.mcp_command, args.tool_profile.as_deref())?;
+    // The first repository is the primary: the process working directory, the default for
+    // a relative path, and the tree the transcript names.
+    let repo = servers[0].repo.clone();
 
     // `--task` takes a file when the value names one, and the literal text otherwise, so a
     // short task needs no file and a long mission is not pasted onto a command line.
@@ -64,11 +61,8 @@ pub fn run(args: RunArgs) -> Result<i32> {
         request_timeout: Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_S),
     };
 
-    let mcp_command = resolve_mcp_command(
-        args.mcp_command.as_deref(),
-        &repo,
-        args.tool_profile.as_deref(),
-    );
+    let mut servers = servers;
+    let primary = servers.remove(0);
 
     let config = AgentConfig {
         task,
@@ -76,18 +70,25 @@ pub fn run(args: RunArgs) -> Result<i32> {
         repo: repo.clone(),
         out_dir: out.clone(),
         provider,
-        mcp_command,
+        mcp_command: primary.mcp_command,
+        extra_servers: servers,
         mcp_timeout: Duration::from_secs(DEFAULT_MCP_TIMEOUT_S),
         max_tool_calls: args.max_tool_calls.unwrap_or(DEFAULT_MAX_TOOL_CALLS),
         deadline: Duration::from_secs(args.deadline.unwrap_or(DEFAULT_DEADLINE_S)),
         tool_profile: args.tool_profile,
     };
 
+    let attached = config
+        .servers()
+        .iter()
+        .map(|server| server.repo.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
     eprintln!(
         "kin agent: model={} endpoint={} repo={} out={}",
         config.provider.model,
         config.provider.base_url,
-        config.repo.display(),
+        attached,
         out.display()
     );
 
@@ -115,18 +116,12 @@ pub fn run(args: RunArgs) -> Result<i32> {
 pub fn doctor(
     base_url: String,
     model: Option<String>,
-    repo: Option<PathBuf>,
-    mcp_command: Option<String>,
+    repo: Vec<PathBuf>,
+    mcp_command: Vec<String>,
     api_key_env: Option<String>,
     tool_profile: Option<String>,
 ) -> Result<i32> {
-    let repo = match repo {
-        Some(path) => path,
-        None => std::env::current_dir().context("could not resolve the current directory")?,
-    };
-    let repo = repo
-        .canonicalize()
-        .with_context(|| format!("no such directory: {}", repo.display()))?;
+    let servers = resolve_servers(&repo, &mcp_command, tool_profile.as_deref())?;
 
     let provider = ProviderConfig {
         base_url: ProviderConfig::normalize_base_url(&base_url),
@@ -159,30 +154,37 @@ pub fn doctor(
             }
         };
 
-    let command = resolve_mcp_command(mcp_command.as_deref(), &repo, tool_profile.as_deref());
-    println!("mcp: {}", command.join(" "));
-    let mcp_ok = match kin_agent::run::probe_mcp(
-        &command,
-        &repo,
-        Duration::from_secs(DEFAULT_MCP_TIMEOUT_S),
-    ) {
-        Ok(tools) => {
-            let exposed = tools
-                .iter()
-                .filter(|name| !kin_agent::belt::is_harness_owned(name))
-                .count();
-            println!(
-                "  initialize and tools/list answered: {} tool(s), {} exposed to the model",
-                tools.len(),
-                exposed
-            );
-            true
+    // Every attached repository is probed, because a run that cannot reach the second
+    // server fails just as completely as one that cannot reach the first.
+    let mut mcp_ok = true;
+    for server in &servers {
+        println!(
+            "mcp: {} (serving {})",
+            server.mcp_command.join(" "),
+            server.repo.display()
+        );
+        match kin_agent::run::probe_mcp(
+            &server.mcp_command,
+            &server.repo,
+            Duration::from_secs(DEFAULT_MCP_TIMEOUT_S),
+        ) {
+            Ok(tools) => {
+                let exposed = tools
+                    .iter()
+                    .filter(|name| !kin_agent::belt::is_harness_owned(name))
+                    .count();
+                println!(
+                    "  initialize and tools/list answered: {} tool(s), {} exposed to the model",
+                    tools.len(),
+                    exposed
+                );
+            }
+            Err(err) => {
+                println!("  FAILED: {err}");
+                mcp_ok = false;
+            }
         }
-        Err(err) => {
-            println!("  FAILED: {err}");
-            false
-        }
-    };
+    }
 
     if !provider_ok {
         return Ok(ExitStatus::EndpointError.code());
@@ -204,6 +206,45 @@ fn read_task(value: &str) -> Result<String> {
         anyhow::bail!("--task was empty");
     }
     Ok(value.to_string())
+}
+
+/// Every repository this invocation attaches, each paired with the server that serves it.
+///
+/// `--repo` and `--mcp-command` are both repeatable and pair by position, so the second
+/// `--mcp-command` overrides the server for the second `--repo`. Fewer commands than
+/// repositories is ordinary and the rest take the default. More commands than repositories
+/// is refused rather than ignored, because a command with no repository would silently
+/// never be started and the run would look like it had attached something it had not.
+fn resolve_servers(
+    repos: &[PathBuf],
+    commands: &[String],
+    tool_profile: Option<&str>,
+) -> Result<Vec<ServerSpec>> {
+    let mut roots: Vec<PathBuf> = repos.to_vec();
+    if roots.is_empty() {
+        roots.push(std::env::current_dir().context("could not resolve the current directory")?);
+    }
+    if commands.len() > roots.len() {
+        anyhow::bail!(
+            "{} --mcp-command value(s) were given for {} --repo value(s); each command needs a \
+             repository to serve",
+            commands.len(),
+            roots.len()
+        );
+    }
+    let mut servers = Vec::new();
+    for (index, root) in roots.iter().enumerate() {
+        let repo = root
+            .canonicalize()
+            .with_context(|| format!("no such directory: {}", root.display()))?;
+        let command =
+            resolve_mcp_command(commands.get(index).map(String::as_str), &repo, tool_profile);
+        servers.push(ServerSpec {
+            repo,
+            mcp_command: command,
+        });
+    }
+    Ok(servers)
 }
 
 /// The MCP command: an override split on whitespace, or this binary serving the repo.

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1821,12 +1821,14 @@ enum AgentAction {
         /// accepted on the command line, so it cannot land in a process listing.
         #[arg(long = "api-key-env", value_name = "NAME")]
         api_key_env: Option<String>,
-        /// Repository to work in (default: the current directory)
+        /// Repository to work in (default: the current directory). Repeat to attach a
+        /// second repository; the first given is the primary and a relative path means it.
         #[arg(long, value_name = "PATH")]
-        repo: Option<PathBuf>,
-        /// Override the MCP server command (default: this binary serving --repo)
+        repo: Vec<PathBuf>,
+        /// Override the MCP server command (default: this binary serving --repo). Repeat
+        /// to give one command per --repo, paired in the order both were written.
         #[arg(long = "mcp-command", value_name = "CMD")]
-        mcp_command: Option<String>,
+        mcp_command: Vec<String>,
         /// Directory for the transcript, the Kin trace and the result record
         #[arg(long, value_name = "DIR")]
         out: Option<PathBuf>,
@@ -1854,12 +1856,13 @@ enum AgentAction {
         /// Model id to look for in the endpoint's list
         #[arg(long, value_name = "ID")]
         model: Option<String>,
-        /// Repository to serve (default: the current directory)
+        /// Repository to serve (default: the current directory). Repeat to probe every
+        /// repository a run would attach.
         #[arg(long, value_name = "PATH")]
-        repo: Option<PathBuf>,
-        /// Override the MCP server command
+        repo: Vec<PathBuf>,
+        /// Override the MCP server command. Repeat to give one command per --repo.
         #[arg(long = "mcp-command", value_name = "CMD")]
-        mcp_command: Option<String>,
+        mcp_command: Vec<String>,
         /// Name of an environment variable holding the API key
         #[arg(long = "api-key-env", value_name = "NAME")]
         api_key_env: Option<String>,


### PR DESCRIPTION
One `kin agent` run can now attach more than one repository. Each gets its own graph server, its own Kin session, and its own transactions, and every edit is committed into the graph of the repository that owns its path.

This is the third ask on FIR-2586. It was built on kin#1049, which has since merged, and the branch is rebased onto main at 4909de162, so it now carries one commit and its diff is this change alone.

## Mechanism

`--repo` and `--mcp-command` were both single-valued (`crates/kin-cli/src/main.rs:1829`, `:1862`), and `AgentConfig.mcp_command` was one server's argv. A run reached one repository, so a brownfield task spanning two could not be expressed at all, which is the four-of-seven-tasks result the ticket records.

## The fix

Both flags are repeatable and pair by position, so the second `--mcp-command` serves the second `--repo`. Fewer commands than repositories is ordinary and the rest take the default server. More commands than repositories is refused rather than ignored, because a command with no repository would never be started and the run would look like it had attached something it had not.

Each repository gets its own `McpClient`, spawned in its own tree, its own session, and its own transactions. `crates/kin-agent/src/run.rs` now holds a `Server` per repository, and `begin_transaction`, `kin_transaction_stage` and the close all take the server that owns the path rather than a single client.

Routing happens before anything is written. An absolute path matches the longest repository root that contains it, which is the containment rule and the only one that stays correct when one checkout sits inside another. A relative path means the primary repository. A path in no attached repository writes nothing at all and the refusal names every root. The alternative was asking the filesystem which tree the model meant, and a wrong guess writes into the wrong repository, so `resolve_across_repos` in `crates/kin-agent/src/belt.rs` decides from the configured roots and never touches the disk.

Tools are namespaced per repository. A single-server run keeps the historical `mcp__kin__` prefix, so a one-repository transcript stays exactly what the fleet's analyzers already read and every existing test passes unchanged. Several servers each take `mcp__kin_<label>__`, derived from the repository directory name, reduced to what a tool name can carry, and deduplicated with a numeric suffix. That holds the `mcp__<server>__<tool>` shape `usage.py` classifies. A bare tool name is genuinely ambiguous once two servers declare it, so the refusal names every prefixed form rather than choosing a repository on the model's behalf.

The system prompt gains the attached roots and the path rule, which the model cannot infer. It is appended to an operator-supplied prompt as well as the built-in one, because without it the model cannot address the second repository.

Every trace row carries the server that served it, and `files_changed` is recorded absolutely in a multi-repository run, since the same relative path exists in more than one tree. `kin agent doctor` probes every attached repository, because a run that cannot reach the second server fails as completely as one that cannot reach the first.

## Tests

Two integration tests in `crates/kin-agent/tests/loop_integration.rs`, driven by two instances of the existing scripted MCP server with separate call logs, and three unit tests in `crates/kin-agent/src/tests.rs`.

`two_repositories_each_get_their_own_server_session_and_commits` drives a prefixed Kin call at the second repository, a relative-path write into the primary and an absolute-path write into the second. It asserts each server's exact call sequence, that each staged `create` names the path relative to its own repository, that the trace attributes every call to the right server, that the belt carries both prefixes and no unqualified Kin name, and that `files_changed` is absolute. `a_path_outside_every_attached_repository_writes_nothing` asserts nothing is written and neither server opens a transaction.

The unit tests cover label deduplication and reduction, the ambiguous bare-name refusal naming both forms, and path resolution including a checkout nested inside another and the outside-every-root refusal.

### Falsification

Each guard was broken and the named failure confirmed, then restored byte-identical (`git diff HEAD --stat` empty after each pass).

Pinning every local edit to the primary server, exit 101:

```
test two_repositories_each_get_their_own_server_session_and_commits ... FAILED
the absolute-path write must land in the second repository at /var/folders/.../beta/src/new_b.py
test result: FAILED. 10 passed; 1 failed; 1 ignored
```

Collapsing every server onto one namespace, exit 101:

```
test tests::tool_prefixes_separate_two_servers_and_a_bare_name_names_both ... FAILED
assertion `left == right` failed
  left: Refused("There is no tool named `mcp__kin_alpha__semantic_locate` and it will not be run. ... Available tools: edit_file, mcp__kin__semantic_locate, write_file.")
 right: Kin { server: 0, tool: "semantic_locate" }
test result: FAILED. 32 passed; 1 failed; 0 ignored
```

Letting a path outside every root fall back to the primary, exit 101:

```
test tests::a_relative_path_means_the_primary_and_an_absolute_path_finds_its_own_repository ... FAILED
the refusal must name every root: `/elsewhere/main.rs` is outside the repository at /work/alpha. Paths must be repository-relative.
test result: FAILED. 32 passed; 1 failed; 0 ignored
```

## Gates

`cargo test -p kin-agent` exit 0: 33 unit tests passed, 11 integration tests passed with 1 ignored, 0 doctests. `cargo test -p kin-cli agent` exit 0, 5 passed. `cargo fmt --all -- --check` exit 0. Clippy exit 0 with the ci.yml allowlist under `RUSTFLAGS=-D warnings` for `-p kin-agent -p kin-cli`. `python3 scripts/verify-zero-file-search.py` exit 0, `bash scripts/zero_file_search_guard.sh` exit 0, `bash scripts/check_runtime_boundaries.sh` exit 0. All of these were re-run after the rebase onto 4909de162, the main that already carries kin#1049. `git diff origin/main --stat -- Cargo.lock .cargo/` is empty and `git ls-tree -r HEAD --name-only` shows only `.cargo/config.toml` under `.cargo/`.

The local full gate was not run under tonight's build-slot saturation. Hosted CI is the gate of record for this PR, per the 05:52Z lane amendment, and every check must conclude with zero failures before it is submitted.

## What is left on FIR-2586

The ticket's acceptance run is still outstanding: one `kin agent run` on a local model landing a commit that `kin log` shows and `kin graph status` counts, on a container serving 0.5.41 or later. This PR and the merged kin#1049 together make that run possible and neither performs it.

In-place edit staging also remains open. `kin_transaction_stage` admits no path-plus-body shape for a file the graph already tracks, only entity-keyed edits, which is a product gap in kin-mcp rather than in the harness.

Refs FIR-2586
