### PR TITLE
Run the product acceptance suites on every pull request

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -275,4 +275,4 @@ jobs:
           python3 scripts/acceptance/gate.py \
             --report magic=acceptance/magic.json \
             --report brownfield=acceptance/brownfield.json \
-            --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk came back truncated=True with clipped_steps=None on a debug build of main, so an absent edge could not be told from a dropped one. This job now builds release, which is what decides it; the moment the check passes this allowance announces itself stale and can go.'
+            --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk comes back truncated=True with clipped_steps=None on ubuntu-latest, so an absent edge cannot be told from a dropped one. Build profile, product code from 0.5.44 through 0.5.46, and the pinned language-server versions are all ruled out; platform and code newer than 0.5.46 are still confounded. The moment the check passes this allowance announces itself stale and can go.'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -101,6 +101,23 @@ jobs:
       - name: Install language servers for the enrichment checks
         run: bash scripts/ci-install-language-servers.sh
 
+      # The magic suite's virtual-environment check builds a real venv, and
+      # Debian and Ubuntu ship `python3 -m venv` in a separate package. Probe by
+      # creating one rather than by importing the module, because the module
+      # imports fine on an image whose ensurepip was split out and only the
+      # creation fails. A missing venv would otherwise surface as UNREADABLE on
+      # that one check, which is a red job blamed on the diff under review.
+      - name: Ensure python3 can create a virtual environment
+        run: |
+          set -euo pipefail
+          probe="$(mktemp -d)"
+          if ! python3 -m venv "$probe/env" >/dev/null 2>&1; then
+            scripts/ci-apt-install.sh python3-venv
+            python3 -m venv "$probe/env"
+          fi
+          rm -rf "$probe"
+          echo "python3 -m venv works"
+
       # The two upstream trees the brownfield suite pins, cached as depth-1
       # fetches plus the express node_modules the language server needs to
       # resolve require() targets. The key is derived from the pinned commits in

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -67,6 +67,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Before the build, because this needs no binary and no corpus and a broken
+      # grader should be named in seconds rather than after three minutes of
+      # compiling. Every verdict the brownfield suite reports is decided by
+      # verdict_surfaces, name_matches, sweep_verdict and Result.status, and each
+      # self-test case is paired with its inverse, so a grader that cannot tell
+      # its own cases apart fails here instead of reporting a clean product on a
+      # broken one.
+      - name: Falsify the brownfield verdict graders
+        run: python3 scripts/acceptance/brownfield_repro.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -18,6 +18,13 @@
 # this repository (scripts/acceptance/), so the suite versions with the code it
 # tests rather than drifting against it in another checkout.
 #
+# The build is the RELEASE profile, unlike daemon-smoke.yml's debug one, and the
+# extra minutes are bought deliberately. Release is what ships, so it is what a
+# product acceptance answer should be about, and the first run of this job
+# turned up a walk that a debug build truncated and a release build did not
+# (FIR-2593). An acceptance suite whose result depends on a profile nobody
+# releases is answering a question nobody asked.
+#
 # This workflow publishes no required context yet. It becomes one on main after
 # it has been green on five consecutive pull requests, which is a separate,
 # deliberate step (FIR-2591).
@@ -62,7 +69,7 @@ jobs:
   acceptance:
     name: Product Acceptance
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -94,22 +101,29 @@ jobs:
           grep -q '^\[registries\.kin\]' .cargo/config.toml
           if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed. kin-* resolve from the Kin registry"; exit 1; fi
 
-      # Registry only, matching daemon-smoke.yml: the suites assert on freshly
-      # built binaries, so no target directory is carried across runs. Restore on
-      # every event, save only from main, because an entry written from a pull
-      # request ref is readable only by later runs on that same ref and would
-      # spend the shared repository cache budget that main's reusable entry needs.
-      - name: Cache cargo registry
+      # A release build of this workspace is expensive enough that the
+      # dependency target directory has to be carried, so this job takes its own
+      # cache entry rather than sharing one. `shared-key` replaces the job-id
+      # component of the key, which is what lets a pull request restore the entry
+      # main wrote; without it every job id gets its own key and a pull request
+      # would never see main's. The action strips the workspace's own crates
+      # before saving, so what is restored is dependencies and never a stale kin
+      # or kin-daemon binary, which is what the suites assert on.
+      #
+      # Restore on every event, save only from main, because an entry written
+      # from a pull request ref is readable only by later runs on that same ref
+      # and would spend the shared repository cache budget that main's reusable
+      # entry needs.
+      - name: Cache cargo registry and the release dependency build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          cache-targets: "false"
+          shared-key: acceptance-release
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Cargo.lock and .cargo/config.toml together pin kin-* deps to public
-      # source until every crate is registry-published. Debug profile, the same
-      # build daemon-smoke.yml makes.
-      - name: Build kin + kin-daemon
-        run: cargo build --locked --bin kin --bin kin-daemon
+      # source until every crate is registry-published.
+      - name: Build kin + kin-daemon (release)
+        run: cargo build --release --locked --bin kin --bin kin-daemon
 
       # Without a language server on PATH the brownfield suite's enrichment
       # sweep never runs, and its recall checks then report UNREADABLE rather
@@ -189,8 +203,8 @@ jobs:
           mkdir -p acceptance
           rc=0
           python3 scripts/acceptance/magic_repro.py \
-            --kin target/debug/kin \
-            --daemon target/debug/kin-daemon \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
             --json acceptance/magic.json \
             --label "$KIN_ACCEPTANCE_LABEL" \
             --verbose >acceptance/magic.log 2>&1 || rc=$?
@@ -217,8 +231,8 @@ jobs:
           mkdir -p acceptance
           rc=0
           python3 scripts/acceptance/brownfield_repro.py \
-            --kin target/debug/kin \
-            --daemon target/debug/kin-daemon \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
             --json acceptance/brownfield.json \
             --corpus-cache ~/.cache/kin-brownfield-repro \
             --label "$KIN_ACCEPTANCE_LABEL" \
@@ -261,4 +275,4 @@ jobs:
           python3 scripts/acceptance/gate.py \
             --report magic=acceptance/magic.json \
             --report brownfield=acceptance/brownfield.json \
-            --allow-unreadable 'brownfield:4=the express app.handle walk returns truncated=True on ubuntu-latest against a debug build, so an absent edge cannot be told from a dropped one. Run 32512404014 reported it on the same express graph a release 0.5.44 build walked untruncated. FIR-2591 follow-up.'
+            --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk came back truncated=True with clipped_steps=None on a debug build of main, so an absent edge could not be told from a dropped one. This job now builds release, which is what decides it; the moment the check passes this allowance announces itself stale and can go.'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+# Product acceptance, on every pull request, against that request's own build.
+#
+# ci.yml tests the release machinery and the Rust workspace. The suites that ask
+# whether the product still answers correctly (the magic repro and the brownfield
+# repro) lived only in the kin-ecosystem umbrella and ran after a tag or on a
+# release candidate, by a captain, on one Mac. bin/kin-release-preflight's own
+# header records what that costs: v0.5.38 "was built, published, and then failed
+# semantic_coverage.complete on every platform with nothing local having ever
+# asked the question."
+#
+# These suites take about two minutes each against a built binary, so there is no
+# reason for the question to wait for a tag. The scripts they run are owned by
+# this repository (scripts/acceptance/), so the suite versions with the code it
+# tests rather than drifting against it in another checkout.
+#
+# This workflow publishes no required context yet. It becomes one on main after
+# it has been green on five consecutive pull requests, which is a separate,
+# deliberate step (FIR-2591).
+
+name: Acceptance
+
+on:
+  # main is here for one mechanical reason: `save-if` below writes the cargo
+  # cache only from the default branch, and a workflow that never runs there
+  # never writes one, so every pull request would pay a cold dependency build.
+  # daemon-smoke.yml carries the same trigger for the same reason.
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+  workflow_dispatch:
+
+# The sha suffix is empty off main, so every pull request and merge-queue ref
+# keeps one group per ref and a superseded push is cancelled. On main each
+# commit gets its own group: `cancel-in-progress: false` does not mean "never
+# cancel", GitHub keeps at most one PENDING run per group and deletes the older
+# one, and the hosted merge queue lands PRs back to back, so two quick landings
+# would otherwise leave the earlier commit with this check absent rather than
+# failed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  # The suites never run inference and never touch a real store. Set here as
+  # well as inside each suite, so a step added later inherits the same posture.
+  KIN_DAEMON_AUTO_EMBED: "0"
+  KIN_EMBED_BACKEND: cpu
+  KIN_VFS_DISABLE: "1"
+
+jobs:
+  acceptance:
+    name: Product Acceptance
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+
+      - name: Verify kin cargo registry config
+        # Preserve the tracked config because it carries public Git [patch.kin]
+        # pins for kin-* crates that are not all registry-published yet.
+        run: |
+          test -f .cargo/config.toml
+          grep -q '^\[registries\.kin\]' .cargo/config.toml
+          if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed. kin-* resolve from the Kin registry"; exit 1; fi
+
+      # Registry only, matching daemon-smoke.yml: the suites assert on freshly
+      # built binaries, so no target directory is carried across runs. Restore on
+      # every event, save only from main, because an entry written from a pull
+      # request ref is readable only by later runs on that same ref and would
+      # spend the shared repository cache budget that main's reusable entry needs.
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-targets: "false"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # Cargo.lock and .cargo/config.toml together pin kin-* deps to public
+      # source until every crate is registry-published. Debug profile, the same
+      # build daemon-smoke.yml makes.
+      - name: Build kin + kin-daemon
+        run: cargo build --locked --bin kin --bin kin-daemon
+
+      # Without a language server on PATH the brownfield suite's enrichment
+      # sweep never runs, and its recall checks then report UNREADABLE rather
+      # than a verdict. The script warns and exits 0 on a registry failure, so a
+      # bad npm morning does not fail this gate; when that happens the suite
+      # says so per check instead of quietly passing.
+      - name: Install language servers for the enrichment checks
+        run: bash scripts/ci-install-language-servers.sh
+
+      # The two upstream trees the brownfield suite pins, cached as depth-1
+      # fetches plus the express node_modules the language server needs to
+      # resolve require() targets. The key is derived from the pinned commits in
+      # the script itself, so moving a pin invalidates the entry rather than
+      # measuring the old tree under the new name.
+      - name: Resolve the pinned brownfield corpora
+        id: corpora
+        run: |
+          set -euo pipefail
+          key="$(python3 -c "
+          import pathlib, re
+          text = pathlib.Path('scripts/acceptance/brownfield_repro.py').read_text()
+          commits = re.findall(r'\"commit\": \"([0-9a-f]{40})\"', text)
+          if len(commits) != 2:
+              raise SystemExit('expected two pinned corpus commits, found %d' % len(commits))
+          print('-'.join(c[:12] for c in sorted(commits)))
+          ")"
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+          echo "pinned corpora: $key"
+
+      - name: Cache the brownfield corpora
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/kin-brownfield-repro
+          key: kin-brownfield-corpora-${{ runner.os }}-${{ steps.corpora.outputs.key }}
+
+      # Each suite writes its whole output to a file and the file is printed
+      # afterwards, rather than piping into tee. A pipeline's exit status is its
+      # last stage's, and `tee` exits 0 on input it never read, so a piped run
+      # can report success for a suite that failed.
+      - name: Magic acceptance suite
+        id: magic
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/magic_repro.py \
+            --kin target/debug/kin \
+            --daemon target/debug/kin-daemon \
+            --json acceptance/magic.json \
+            --label "$KIN_ACCEPTANCE_LABEL" \
+            --verbose >acceptance/magic.log 2>&1 || rc=$?
+          cat acceptance/magic.log
+          {
+            echo "### Magic acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/magic.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=Magic acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
+          fi
+
+      - name: Brownfield acceptance suite
+        id: brownfield
+        if: always()
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/brownfield_repro.py \
+            --kin target/debug/kin \
+            --daemon target/debug/kin-daemon \
+            --json acceptance/brownfield.json \
+            --corpus-cache ~/.cache/kin-brownfield-repro \
+            --label "$KIN_ACCEPTANCE_LABEL" \
+            --verbose >acceptance/brownfield.log 2>&1 || rc=$?
+          cat acceptance/brownfield.log
+          {
+            echo "### Brownfield acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/brownfield.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=Brownfield acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
+          fi
+
+      # Always, including on a cancelled or timed-out run: the reports are how a
+      # failure is diagnosed without re-running the job.
+      - name: Upload the acceptance reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: acceptance-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          path: acceptance/
+          if-no-files-found: warn
+          retention-days: 14
+
+      # The gate is its own step so the two suites both run and both upload even
+      # when the first one fails. A suite step never fails on its own.
+      - name: Gate on the acceptance suites
+        if: always()
+        env:
+          MAGIC_RC: ${{ steps.magic.outputs.rc }}
+          BROWNFIELD_RC: ${{ steps.brownfield.outputs.rc }}
+        run: |
+          set -uo pipefail
+          # An empty rc means the step never reached its own assignment, which is
+          # a failure to run rather than a pass. Refuse it rather than defaulting
+          # it to zero.
+          fail=0
+          for pair in "magic:${MAGIC_RC:-missing}" "brownfield:${BROWNFIELD_RC:-missing}"; do
+            name="${pair%%:*}"
+            rc="${pair##*:}"
+            if [ "$rc" = "missing" ]; then
+              echo "::error::the $name suite recorded no exit status, so it did not run to completion"
+              fail=1
+            elif [ "$rc" -ne 0 ]; then
+              echo "::error::the $name suite exited $rc"
+              fail=1
+            else
+              echo "$name suite passed"
+            fi
+          done
+          exit "$fail"

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -11,8 +11,10 @@
 # semantic_coverage.complete on every platform with nothing local having ever
 # asked the question."
 #
-# These suites take about two minutes each against a built binary, so there is no
-# reason for the question to wait for a tag. The scripts they run are owned by
+# Against a built binary the suites are minutes, not hours: measured locally on
+# 2026-08-21 against a kin built from main, the magic suite took 107 s and the
+# brownfield suite 351 s with a warm corpus cache. There is no reason for the
+# question to wait for a tag. The scripts they run are owned by
 # this repository (scripts/acceptance/), so the suite versions with the code it
 # tests rather than drifting against it in another checkout.
 #

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -77,6 +77,12 @@ jobs:
       - name: Falsify the brownfield verdict graders
         run: python3 scripts/acceptance/brownfield_repro.py --self-test
 
+      # The gate decides this job, so it gets the same treatment. Every rule it
+      # enforces is exercised against its inverse, including the ones that keep
+      # its allowance list from becoming a way to stop enforcing.
+      - name: Falsify the acceptance gate
+        run: python3 scripts/acceptance/gate.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -112,6 +118,20 @@ jobs:
       # says so per check instead of quietly passing.
       - name: Install language servers for the enrichment checks
         run: bash scripts/ci-install-language-servers.sh
+
+      # `kin commit` refuses to invent an author, and a hosted runner carries no
+      # git identity, so without this every magic-suite fixture that commits
+      # through kin fails to build and its checks report UNREADABLE. Run
+      # 32512404014 is what found it: seven of ten checks came back
+      # "kin commit failed ... Set your Git identity". The suites pass an
+      # identity to their own `git` invocations already; this is for the commits
+      # kin itself authors.
+      - name: Give the runner a git identity
+        run: |
+          set -euo pipefail
+          git config --global user.name 'Kin CI'
+          git config --global user.email 'ci@kinlab.ai'
+          git config --global --get user.email
 
       # The magic suite's virtual-environment check builds a real venv, and
       # Debian and Ubuntu ship `python3 -m venv` in a separate package. Probe by
@@ -227,30 +247,18 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      # The gate is its own step so the two suites both run and both upload even
-      # when the first one fails. A suite step never fails on its own.
+      # The gate is its own step so both suites run and both upload even when the
+      # first one fails, and it reads the reports rather than the exit codes.
+      # A suite's exit status is one lever with two settings, demand a clean
+      # sweep or demand nothing, and neither is right while one check is blocked
+      # on something outside the change under review. gate.py fails on any FAIL
+      # with no allowance possible, fails on any UNREADABLE that is not named
+      # here with a reason, and refuses an allowance that points at a check the
+      # report does not carry.
       - name: Gate on the acceptance suites
         if: always()
-        env:
-          MAGIC_RC: ${{ steps.magic.outputs.rc }}
-          BROWNFIELD_RC: ${{ steps.brownfield.outputs.rc }}
         run: |
-          set -uo pipefail
-          # An empty rc means the step never reached its own assignment, which is
-          # a failure to run rather than a pass. Refuse it rather than defaulting
-          # it to zero.
-          fail=0
-          for pair in "magic:${MAGIC_RC:-missing}" "brownfield:${BROWNFIELD_RC:-missing}"; do
-            name="${pair%%:*}"
-            rc="${pair##*:}"
-            if [ "$rc" = "missing" ]; then
-              echo "::error::the $name suite recorded no exit status, so it did not run to completion"
-              fail=1
-            elif [ "$rc" -ne 0 ]; then
-              echo "::error::the $name suite exited $rc"
-              fail=1
-            else
-              echo "$name suite passed"
-            fi
-          done
-          exit "$fail"
+          python3 scripts/acceptance/gate.py \
+            --report magic=acceptance/magic.json \
+            --report brownfield=acceptance/brownfield.json \
+            --allow-unreadable 'brownfield:4=the express app.handle walk returns truncated=True on ubuntu-latest against a debug build, so an absent edge cannot be told from a dropped one. Run 32512404014 reported it on the same express graph a release 0.5.44 build walked untruncated. FIR-2591 follow-up.'

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -77,6 +77,26 @@ language server on PATH; without one its enrichment sweep never runs and those
 checks report UNREADABLE rather than a verdict. `scripts/ci-install-language-servers.sh`
 is what provides one on a hosted runner.
 
+## The gate
+
+`gate.py` decides the CI job. It reads the suites' JSON reports rather than their
+exit codes, because an exit code is one lever with two settings, demand a clean
+sweep or demand nothing, and neither is right while one check is blocked on
+something outside the change under review.
+
+A FAIL always fails the gate and no allowance can excuse it. An UNREADABLE fails
+too unless `--allow-unreadable SUITE:CHECK=REASON` names it, the reason is
+required, and every allowance prints on every run. Three rules keep that list
+from becoming a way to stop enforcing: an allowance naming a check the report
+does not carry is an error, because a pointer at nothing looks exactly like a
+satisfied allowance; an allowance on a check that now passes is announced as
+stale; and a missing or unparseable report is a failure, because a suite that
+wrote nothing did not pass.
+
+`gate.py --self-test` exercises every one of those rules against its inverse and
+needs no reports. The workflow runs it before the build, alongside the brownfield
+graders' self-test, so a gate that has stopped deciding is named in seconds.
+
 ## The umbrella copies
 
 These two files were ported on 2026-08-21 from `bin/kin-magic-repro` and

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -51,23 +51,36 @@ product on a broken one.
 ## Running against a local build
 
 ```
-cargo build --locked --bin kin --bin kin-daemon
+cargo build --release --locked --bin kin --bin kin-daemon
 
 python3 scripts/acceptance/magic_repro.py \
-  --kin target/debug/kin --daemon target/debug/kin-daemon \
+  --kin target/release/kin --daemon target/release/kin-daemon \
   --json acceptance/magic.json --verbose
 
 python3 scripts/acceptance/brownfield_repro.py \
-  --kin target/debug/kin --daemon target/debug/kin-daemon \
+  --kin target/release/kin --daemon target/release/kin-daemon \
   --json acceptance/brownfield.json \
   --corpus-cache ~/.cache/kin-brownfield-repro --verbose
 ```
+
+Release, not debug. Release is what ships, so it is what an acceptance answer
+should be about, and the profile has already been shown to change an answer: on
+the first CI run a debug build truncated a data-flow walk that a release build
+walked whole (FIR-2593).
 
 Both take `--only` to select check ids, `--workdir` to keep fixtures somewhere
 known, `--keep` to leave them behind, and `--compare` a prior run's JSON so a
 check that passed there and fails now reads REGRESSION rather than plain FAIL.
 `brownfield_repro.py` also takes `--offline`, which refuses to fetch and requires
 the corpus cache to already carry both pinned commits.
+
+The magic suite's fixtures commit through kin, and kin refuses to invent an
+author, so the machine running them needs a git identity. That refusal is
+correct product behavior, not an obstacle: an invented author cannot be
+corrected later without rewriting history, so kin declines rather than guessing.
+A developer machine already has one; the workflow sets one explicitly, because a
+hosted runner does not, and without it every fixture that commits through kin
+fails to build and its checks report UNREADABLE.
 
 Two environment settings keep a run honest and both suites set them for
 themselves: `KIN_DAEMON_AUTO_EMBED=0` keeps the run off inference, and
@@ -96,6 +109,10 @@ wrote nothing did not pass.
 `gate.py --self-test` exercises every one of those rules against its inverse and
 needs no reports. The workflow runs it before the build, alongside the brownfield
 graders' self-test, so a gate that has stopped deciding is named in seconds.
+
+An allowance is meant to be temporary and every one of them names the ticket that
+will remove it. Check the workflow for the current list before assuming a green
+job means every check passed.
 
 ## The umbrella copies
 

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -1,0 +1,97 @@
+# Product acceptance suites
+
+Two falsifiable suites that ask whether the product still answers correctly.
+`.github/workflows/acceptance.yml` runs both on every pull request against that
+pull request's own build. Neither is release proof; both are regression gates.
+
+Each suite prints one line per check:
+
+```
+CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+```
+
+`UNREADABLE` is a third outcome and never a pass. It means the probe could not be
+evaluated: no response, a payload that is not JSON, a focal entity that never
+resolved, a field the fix has not defined yet. Exit status is 1 when any check
+fails, 2 when none fail but some are unreadable, 3 on a setup error, and 0 only
+when every selected check passes.
+
+## What each suite proves
+
+`magic_repro.py` covers the graph and MCP answer surfaces on small fixtures it
+builds itself. Check 0 asserts the run stayed off the GPU. Checks 1 through 9
+cover cross-file edges on the incremental commit path, absence authority on an
+empty `find_references`, the completeness signal on a partial one, the
+`dead-code` delete list against real references, call-edge precision against a
+test double, `trace_data_flow` compact mode and localized truncation, JavaScript
+entity kinds and edge density, virtual-environment admission and context-pack
+byte arrays, and relation-graph completeness reporting. Every check names the
+ticket it is about, so a failure is attributable without reading the code.
+
+`brownfield_repro.py` covers reference enrichment on two pinned upstream trees,
+`psf/requests` and `expressjs/express`, replayed as single-commit repositories
+holding the exact pinned tree object. Check 0 asserts the run stayed off the GPU
+and off every store but its own scratch `KIN_HOME`. Check 1 is the positive
+control on JavaScript import specifiers. Checks 2 through 8 cover the two real
+callers of `HTTPAdapter.send`, the `app.handle` walk in express, one verdict per
+payload, `find_references` and `graph_neighborhood` agreeing on one entity, an
+express export nothing may certify as unused, and `semantic_search` refusing to
+certify a false absence.
+
+The brownfield fixtures are one commit each, so its recall results are
+one-commit-shape results. The suite prints that scope on every run and records it
+in the JSON. History-shaped behavior, meaning conversion cost, provenance depth,
+and commit peak memory, is not exercised here.
+
+`brownfield_repro.py --self-test` exercises the verdict graders on fixed payloads
+and needs no binary and no corpus. Each case is paired with its inverse, so a
+grader that cannot tell its own cases apart fails rather than reporting a clean
+product on a broken one.
+
+## Running against a local build
+
+```
+cargo build --locked --bin kin --bin kin-daemon
+
+python3 scripts/acceptance/magic_repro.py \
+  --kin target/debug/kin --daemon target/debug/kin-daemon \
+  --json acceptance/magic.json --verbose
+
+python3 scripts/acceptance/brownfield_repro.py \
+  --kin target/debug/kin --daemon target/debug/kin-daemon \
+  --json acceptance/brownfield.json \
+  --corpus-cache ~/.cache/kin-brownfield-repro --verbose
+```
+
+Both take `--only` to select check ids, `--workdir` to keep fixtures somewhere
+known, `--keep` to leave them behind, and `--compare` a prior run's JSON so a
+check that passed there and fails now reads REGRESSION rather than plain FAIL.
+`brownfield_repro.py` also takes `--offline`, which refuses to fetch and requires
+the corpus cache to already carry both pinned commits.
+
+Two environment settings keep a run honest and both suites set them for
+themselves: `KIN_DAEMON_AUTO_EMBED=0` keeps the run off inference, and
+`KIN_VFS_DISABLE=1` keeps it off the filesystem projection. The workflow sets
+`KIN_EMBED_BACKEND=cpu` as well. The brownfield suite's recall checks need a
+language server on PATH; without one its enrichment sweep never runs and those
+checks report UNREADABLE rather than a verdict. `scripts/ci-install-language-servers.sh`
+is what provides one on a hosted runner.
+
+## The umbrella copies
+
+These two files were ported on 2026-08-21 from `bin/kin-magic-repro` and
+`bin/kin-brownfield-repro` in the kin-ecosystem umbrella, and each carries a
+header saying so. The umbrella copies still exist and are what the release
+tooling calls: `bin/kin-release-preflight` copies `kin-magic-repro` into its run
+root and runs it against the installed binaries on every install leg,
+`bin/kin-shipped-gate` runs it against the binary npm actually served, and
+`bin/kin-magic-at-scale` imports `kin-brownfield-repro` as a module to reuse its
+checks 2 and 3 at real history depth.
+
+Until those tools become wrappers around this directory, a change to either copy
+has to be reconciled with the other. Three things are what make that
+reconciliation mechanical and none of them should drift: the CHECK line format,
+the exit codes, and the `kin-magic-repro:` and `kin-brownfield-repro:` prefixes on
+the summary lines. `bin/kin-shipped-gate` parses two of those summary lines by
+prefix, so renaming them breaks a release gate in another repository with nothing
+in this one to catch it.

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -5,10 +5,12 @@
 # Ported from the kin-ecosystem umbrella's bin/kin-brownfield-repro on
 # 2026-08-21. kin owns this copy from now on, so the suite versions with the
 # product it tests and every pull request runs it against its own build. The
-# umbrella copy is still what bin/kin-parity and the release tooling call;
-# until those become wrappers around this file, a change to either copy has to
-# be reconciled with the other, and the CHECK line format, exit codes, corpus
-# pins, and fixtures are what make that reconciliation mechanical.
+# umbrella copy is still what bin/kin-magic-at-scale imports as a module, for
+# its checks 2 and 3 at real history depth; until that becomes a wrapper around
+# this file, a change to either copy has to be reconciled with the other. The
+# CHECK line format, the exit codes, the corpus pins, the fixtures, and the
+# `kin-brownfield-repro:` summary-line prefix are what make that reconciliation
+# mechanical.
 """NON-CITABLE brownfield acceptance suite for reference enrichment.
 
 Its output is a regression gate, never proof, never investor-facing, and never a

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -1,0 +1,1730 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Ported from the kin-ecosystem umbrella's bin/kin-brownfield-repro on
+# 2026-08-21. kin owns this copy from now on, so the suite versions with the
+# product it tests and every pull request runs it against its own build. The
+# umbrella copy is still what bin/kin-parity and the release tooling call;
+# until those become wrappers around this file, a change to either copy has to
+# be reconciled with the other, and the CHECK line format, exit codes, corpus
+# pins, and fixtures are what make that reconciliation mechanical.
+"""NON-CITABLE brownfield acceptance suite for reference enrichment.
+
+Its output is a regression gate, never proof, never investor-facing, and never a
+released claim. The citable gates all live in the kin-ecosystem umbrella
+(`bin/kin-release-preflight`, `bin/kin-stranger`, `bin/kin-shipped-gate`) and
+nothing here substitutes for any of them. What this suite adds is timing: it runs
+on every pull request against that request's own build, so a reference-enrichment
+regression is a red check rather than something a release discovers.
+
+What it is for
+--------------
+The npm-0541 stranger run measured the brownfield A/B on shipped v0.5.42 bytes and
+Kin lost all five tasks. Waiting on a release to learn whether an enrichment change
+moved any of them costs hours. This suite reproduces the mechanical half of that run
+against a LOCAL kin build in minutes, so a lane can iterate.
+
+Each check builds a fixture from a pinned upstream tree, probes the surface the
+ticket's claim is about, and prints one line:
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+UNREADABLE is a distinct outcome from FAIL and is never reported as a pass: it means
+the probe could not be evaluated (no response, a non-JSON payload, an unresolved
+focal entity, a field the fix has not defined yet). A crashed probe is UNREADABLE,
+never a verdict. Exit status is 1 when any check FAILs, 2 when none fail but some are
+UNREADABLE, 0 only when every selected check passes, 3 on a setup error.
+
+Every check is required to be able to fail. Measured 2026-08-19 against a build of
+kin main at 0545b154 (0.5.42): checks 0 and 1 pass, checks 2 through 8 fail, none is
+unreadable, and the whole run takes about 15 s once the corpus cache is warm. That is
+the shape the npm-0541 stranger run reported. A run in which checks 2 through 8 pass
+before enrichment ships is a broken suite, not a fixed product.
+
+Both directions are falsifiable, and were falsified. The same suite against a 0.5.37
+binary fails check 1 (`imports 0/305 (0%)` on express, against 70/220 today), so a
+pass there is a real fix rather than a check that cannot fail. Check 2's negative
+control also fires on 0.5.37, where `Server.text_response_server` and
+`TestPreparingURLs.test_different_connection_pool_for_mtls_settings` were counted as
+callers of HTTPAdapter.send by bare-name match. Checks 4 through 6 report UNREADABLE
+on 0.5.37 rather than a verdict, because that build answers a different payload
+shape, which is the outcome those states exist for.
+
+The binary under test
+---------------------
+    cargo build --locked --bin kin --bin kin-daemon
+    python3 scripts/acceptance/brownfield_repro.py --kin target/debug/kin
+
+`--kin` may also come from the KIN_BIN environment variable. The kin-daemon beside it
+is used automatically when one exists. No binary is built by this script.
+
+Corpora
+-------
+The same two upstream trees the npm-0541 stranger converted, pinned by commit AND by
+tree object, so a fixture whose content drifted is refused rather than measured:
+
+    psf/requests       8f8b212de8c2129d7954c6cd373762880375620a
+                       tree 19e4272a9f1e9048c27fb6daa1b4916497a70193
+    expressjs/express  a3714473feb3d2908add734d340e7755fd85e0a3
+                       tree 134de344af9d2e7785aae9a991d02fd85b404bcf
+
+One deliberate deviation from the stranger, stated because it bounds what this suite
+can say. The stranger converted the full histories, 6491 and 6158 commits, which cost
+1208 s and 584 s of `kin init`. Each fixture here is a fresh single-commit repository
+holding the identical tree, which converts in about 3 s. Kin refuses a shallow clone
+outright, so a one-commit repository is how a full tree converts quickly. Symbol
+resolution reads the tree, so the resolution facts these checks assert are unchanged;
+history-shaped behavior (conversion cost, provenance depth, commit peak memory) is
+NOT exercised here and stays the stranger's job.
+
+Fixtures are cached under --corpus-cache (default ~/.cache/kin-brownfield-repro) as
+depth-1 fetches of the pinned commits, so only the first run touches the network.
+Point --corpus-cache at any directory already holding `requests` and `express` git
+repositories that carry the pinned commits to skip the network entirely.
+
+The GPU and the fleet daemon
+----------------------------
+This suite never runs inference and never touches the fleet daemon or an existing
+store. Every run gets its own scratch KIN_HOME under the workdir, exports
+KIN_DAEMON_AUTO_EMBED=0, and check 0 asserts the daemon logged the operator opt-out
+and indexed nothing. Fixture daemons are stopped at the end of the run.
+
+Usage:
+    python3 scripts/acceptance/brownfield_repro.py --kin <path-to-kin-binary> [options]
+
+Options:
+    --kin PATH           kin binary under test (or KIN_BIN; required)
+    --daemon PATH        kin-daemon to serve fixtures (default: sibling of --kin)
+    --workdir PATH       fixture root (default: a fresh temp dir)
+    --corpus-cache PATH  pinned upstream clones (default: ~/.cache/kin-brownfield-repro)
+    --offline            refuse to fetch; the cache must already carry both pins
+    --label NAME         label recorded in the JSON report
+    --only IDS           comma-separated check ids to run, 0 through 8 (default: all)
+    --json PATH          write machine-readable results here
+    --compare PATH       a prior run's --json; a check that passed there and fails
+                         here reads REGRESSION rather than plain FAIL
+    --keep               keep fixtures after the run
+    --verbose            print every sub-assertion, not just the deciding one
+
+Tickets: FIR-2463 (one verdict per response), FIR-2464 (ship reference enrichment for
+Python and JavaScript), FIR-2441 (JavaScript import specifiers, the positive control).
+"""
+
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+ANSI = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+NON_CITABLE = (
+    "NON-CITABLE: DEV-LOCAL iteration only. Not proof, not a release gate, "
+    "not an investor or published claim."
+)
+
+# Every fixture here is a pinned tree replayed as ONE commit, so every recall result
+# this suite reports is a one-commit-shape result. That scope is not cosmetic: on
+# 2026-08-20 the scale canary ran checks 2 and 3 unmodified against the identical tree
+# and binary at 6,491 commits of history, and check 3 FAILED at that depth on every
+# build tested while passing here on all of them, with the sweep converged and the
+# revision identical. State the limitation as depth-dependent recall rather than as one
+# signature, because the OBSERVED SHAPE VARIES BY VERSION and two descriptions of it in
+# this file were already wrong: on shipped 0.5.43 the caller is counted with its
+# reference_lines empty, [] against [312]; on the 2a80f4a6 and bb8bebe3 candidates it is
+# absent from the payload entirely, not even a withheld candidate. What holds across all
+# of them is that this suite cannot see any of it, because it never tests that shape. A
+# green here is evidence about the shape it tests and nothing more.
+FIXTURE_SCOPE = (
+    "FIXTURE SCOPE: single-commit fixtures. Recall greens do NOT generalize to "
+    "real history; at 6,491 commits on the identical tree check 3 fails on every "
+    "build tested, its shape varying by version (0.5.43: counted, reference_lines "
+    "empty; 2a80f4a6 and bb8bebe3: absent entirely). Use the umbrella's "
+    "bin/kin-magic-at-scale "
+    "for history-shape claims."
+)
+
+AUTO_EMBED_OPT_OUT_LINE = "background embedding deferred by operator opt-out"
+
+CORPORA = {
+    "requests": {
+        "url": "https://github.com/psf/requests",
+        "commit": "8f8b212de8c2129d7954c6cd373762880375620a",
+        "tree": "19e4272a9f1e9048c27fb6daa1b4916497a70193",
+        "language": "python",
+    },
+    "express": {
+        "url": "https://github.com/expressjs/express",
+        "commit": "a3714473feb3d2908add734d340e7755fd85e0a3",
+        "tree": "134de344af9d2e7785aae9a991d02fd85b404bcf",
+        "language": "javascript",
+    },
+}
+
+# Reference-edge coverage line, e.g.
+#   javascript: 137 files, calls 209/568 (36%), imports 0/305 (0%), cross-file 104
+COVERAGE_LINE = re.compile(
+    r"^\s*(?P<lang>\w+):\s*(?P<files>\d+)\s+files,\s*"
+    r"calls\s+(?P<cres>\d+)/(?P<ctot>\d+)"
+    r"(?:.*?imports\s+(?P<ires>\d+)/(?P<itot>\d+))?",
+    re.M,
+)
+
+# requests, task 2. Ground truth established by the stranger's classic arm and
+# re-verified in the pinned tree: HTTPAdapter.send has exactly two call sites in the
+# repository and none in the tests.
+#   src/requests/sessions.py:784  Session.send                r = adapter.send(request, **kwargs)
+#   src/requests/auth.py:312      HTTPDigestAuth.handle_401   _r = r.connection.send(prep, **kwargs)
+HTTPADAPTER_SEND = "HTTPAdapter.send"
+REAL_CALLER_ONE = "Session.send"
+REAL_CALLER_ONE_FILE = "src/requests/sessions.py"
+REAL_CALLER_ONE_LINE = 784
+REAL_CALLER_TWO = "HTTPDigestAuth.handle_401"
+REAL_CALLER_TWO_FILE = "src/requests/auth.py"
+REAL_CALLER_TWO_LINE = 312
+
+# Entities the shipped build offered as callers of HTTPAdapter.send that call no such
+# thing. Every one is a bare-name match on `send`. They are the negative control: a
+# build that reports any of them as a resolved upstream reference has fabricated it.
+FABRICATED_SEND_CALLERS = {
+    "Server.text_response_server",
+    "TestPreparingURLs.test_different_connection_pool_for_mtls_settings",
+    "test_redirect_rfc1808_to_non_ascii_location",
+}
+
+# express, task 5. trace_data_flow on app.handle, direction calls, depth 2 returned
+# eleven steps of which the stranger verified nine were fabricated, all descended from
+# bare-name matching the single `this.get('env')` call site against every entity in
+# the repository named `get` or ending in `.get`.
+APP_HANDLE = "app.handle"
+APP_HANDLE_FILE = "lib/application.js"
+# Verified in the pinned tree: app.handle at :152, this.enabled('x-powered-by') at
+# :160, finalhandler at :154, and the one edge that answers the question, the
+# hand-off this.router.handle(req, res, done), at :177.
+APP_HANDLE_REAL_CALLEES = ["app.enabled", "finalhandler"]
+APP_HANDLE_MISSING_CALLEE = "router.handle"
+# app.set was removed from this list 2026-08-20: it is a GENUINE depth-2 callee,
+# app.handle calls this.enabled (lib/application.js:160) and app.enabled's body is
+# `return Boolean(this.set(setting))` (:420), verified in the pinned tree. The list
+# matches on name alone and is depth-blind, so keeping it here failed exactly the
+# build that fixed the receiver fan (FIR-2472).
+APP_HANDLE_FABRICATED = [
+    "req.get",
+    "res.get",
+    "create",
+    "users.get",
+    "message",
+    "redirect",
+    "res.send",
+    "escapeHtml",
+]
+
+# express, task 6. Ten exports in lib/express.js and none is dead: the shipped build
+# called four of them unused. The graph names the entity `Router` and its signature is
+# `exports.Router = Router;`. It carries 32 in-repo hits, the first at
+# examples/multi-router/controllers/api_v1.js:5, so an authoritative absence on it is
+# the delete-what-Kin-called-safe case.
+EXPRESS_EXPORT = "Router"
+EXPRESS_EXPORT_FILE = "lib/express.js"
+EXPRESS_EXPORT_LINE = 71
+
+# requests, task 1. Session.request is a method at src/requests/sessions.py:557. The
+# shipped build's semantic_search answered zero for query "request" under a kind
+# filter and certified that zero as authoritative, on the same repository where
+# find_references refuses to certify. Same missing dependency, opposite verdict,
+# decided by which internal route answered.
+PY_SEARCH_QUERY = "request"
+PY_SEARCH_KIND = "method"
+PY_KNOWN_METHOD = "Session.request"
+PY_KNOWN_METHOD_FILE = "src/requests/sessions.py"
+PY_KNOWN_METHOD_LINE = 557
+
+LANGUAGE_SERVERS = ["pyright", "pyright-langserver", "typescript-language-server"]
+
+
+print = functools.partial(print, flush=True)
+
+
+def strip_ansi(text):
+    return ANSI.sub("", text or "")
+
+
+def run(cmd, cwd=None, env=None, timeout=900):
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+    return (
+        proc.returncode,
+        strip_ansi(proc.stdout.decode("utf-8", "replace")),
+        strip_ansi(proc.stderr.decode("utf-8", "replace")),
+    )
+
+
+class ProbeError(Exception):
+    """A probe that could not be evaluated. Always UNREADABLE, never a verdict."""
+
+
+def entity_names(rows):
+    out = []
+    for row in rows or []:
+        if isinstance(row, dict):
+            name = row.get("name") or row.get("entity_name") or row.get("target")
+            if name:
+                out.append(name)
+    return out
+
+
+def basename_of(name):
+    """`Session.send` and `send` compare equal; `req.get` and `res.get` do not.
+
+    Kin names a method either bare or receiver-qualified depending on the surface,
+    so a check that compares only full strings misses half its own subject.
+    """
+    return (name or "").rsplit(".", 1)[-1]
+
+
+def name_matches(candidate, wanted):
+    if not candidate or not wanted:
+        return False
+    if candidate == wanted:
+        return True
+    if candidate.endswith("." + wanted):
+        return True
+    if wanted.endswith("." + candidate):
+        return True
+    return False
+
+
+# One "LSP cold sweep complete" accounting line, ANSI already stripped. The
+# fields arrived with kin#985; a line without `enriched=` is an older build.
+SWEEP_COMPLETE_LINE = re.compile(r"LSP cold sweep complete\s+(?P<fields>.*)$")
+SWEEP_FIELD = re.compile(r"(?P<key>[a-z_]+)=(?P<value>[a-z0-9]+)")
+
+
+def sweep_lines(log_text):
+    """Every cold-sweep completion line in a daemon log, as field dicts."""
+    out = []
+    for line in strip_ansi(log_text).splitlines():
+        match = SWEEP_COMPLETE_LINE.search(line)
+        if not match:
+            continue
+        fields = {}
+        for pair in SWEEP_FIELD.finditer(match.group("fields")):
+            value = pair.group("value")
+            if value in ("true", "false"):
+                fields[pair.group("key")] = (value == "true")
+            elif value.isdigit():
+                fields[pair.group("key")] = int(value)
+        out.append(fields)
+    return out
+
+
+def sweep_verdict(lines):
+    """Decide whether recall assertions may run over a store's sweep record.
+
+    `lines` is sweep_lines() of the fixture's daemon log. Admits recall only when
+    some completed sweep enriched at least one file and left nothing blocked,
+    unvisited, interrupted, or unaccounted. A line missing the tally fields is
+    exempted LOUDLY rather than silently, and a missing field never defaults to a
+    passing zero: absence refuses, because an absent key defaulting to zero is the
+    exact class of check that cannot fail.
+
+    The exemption names TWO possible causes, not one. Missing tallies originally
+    meant a pre-985 build. On 2026-08-21 a lane proved they also appear on a
+    POST-985 build when the sweep is triggered explicitly through POST /lsp/sweep:
+    that route's completion line carries only files/total_files/relations, so
+    985's accounting does not reach it. A gate that exempts a post-985 build as
+    pre-985 has stopped enforcing without saying so; this one now says so.
+    """
+    if not lines:
+        return (False, "daemon.log records no completed sweep; the graph was "
+                       "never enriched or the log is unreadable")
+    required = ("enriched", "server_unavailable", "source_unreadable",
+                "not_visited", "unaccounted", "ended_early")
+    tallied = [ln for ln in lines if all(k in ln for k in required)]
+    if not tallied:
+        return (True, "sweep completion lines carry no tally fields; recall gate "
+                      "not enforceable, checks run ungated. Cause is EITHER a "
+                      "pre-985 build OR a post-985 sweep triggered via "
+                      "POST /lsp/sweep, whose completion line skips 985's "
+                      "accounting; do not read this as proof of build age")
+    for ln in tallied:
+        if (ln["enriched"] > 0 and ln["server_unavailable"] == 0
+                and ln["source_unreadable"] == 0 and ln["not_visited"] == 0
+                and ln["unaccounted"] == 0 and not ln["ended_early"]):
+            return (True, "sweep concluded clean: enriched=%d of files=%s, "
+                          "nothing blocked or unvisited"
+                    % (ln["enriched"], ln.get("files", "?")))
+    worst = max(tallied, key=lambda ln: (ln["server_unavailable"]
+                                         + ln["source_unreadable"]
+                                         + ln["not_visited"] + ln["unaccounted"]))
+    return (False, "no clean completed sweep: best evidence enriched=%s "
+                   "server_unavailable=%s source_unreadable=%s not_visited=%s "
+                   "unaccounted=%s ended_early=%s; recall against this graph "
+                   "would attribute the gap to the wrong ticket"
+            % (worst.get("enriched"), worst.get("server_unavailable"),
+               worst.get("source_unreadable"), worst.get("not_visited"),
+               worst.get("unaccounted"), worst.get("ended_early")))
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, corpus_cache, daemon=None, offline=False,
+                 verbose=False):
+        self.kin = kin
+        self.daemon = daemon
+        self.workdir = workdir
+        self.corpus_cache = corpus_cache
+        self.offline = offline
+        self.verbose = verbose
+        self.fixtures = {}
+        self.payloads = {}
+        self.sweep_gates = {}
+        self.run_id = "r%d" % os.getpid()
+        self.kin_home = os.path.join(workdir, "kin-home-" + self.run_id)
+        if not os.path.isdir(self.kin_home):
+            os.makedirs(self.kin_home)
+        self.env = dict(os.environ)
+        # The scratch KIN_HOME is what keeps this run off the fleet's stores, and
+        # the auto-embed opt-out is what keeps it off the GPU. Check 0 asserts both
+        # held rather than trusting that setting them was enough.
+        self.env["KIN_HOME"] = self.kin_home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DIR", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+
+    # ---------------------------------------------------------------- plumbing
+
+    def kin_run(self, args, repo, timeout=900):
+        return run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+
+    def git(self, args, cwd=None, timeout=900):
+        base = ["git",
+                "-c", "core.hooksPath=/dev/null",
+                "-c", "user.email=repro@example.invalid",
+                "-c", "user.name=kin-brownfield-repro",
+                "-c", "commit.gpgsign=false",
+                "-c", "core.fsmonitor=false",
+                "-c", "protocol.version=2"]
+        return run(base + args, cwd=cwd, env=self.env, timeout=timeout)
+
+    def mcp(self, repo, tool, args, timeout=600):
+        """One tools/call over kin's stdio MCP server.
+
+        The MCP path is the surface that applies the negative and completeness
+        envelope, so every envelope claim here is probed on it rather than on the
+        raw daemon route, which wraps a payload carrying no such envelope. The real
+        payload is a JSON string inside content[0].text; reading fields off the
+        outer result object returns empty for every one of them.
+        """
+        env = dict(self.env)
+        env["KIN_MCP_REPO"] = repo
+        proc = subprocess.Popen(
+            [self.kin, "mcp", "start", "--repo", repo],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=repo,
+            env=env,
+            text=True,
+        )
+        msgs = [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+             "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                        "clientInfo": {"name": "kin-brownfield-repro",
+                                       "version": "1"}}},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+             "params": {"name": tool, "arguments": args}},
+        ]
+        payload = "".join(json.dumps(m) + "\n" for m in msgs)
+        try:
+            out, err = proc.communicate(payload, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            raise ProbeError("mcp %s timed out after %ss" % (tool, timeout))
+        resp = None
+        for line in out.splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                obj = json.loads(line)
+            except ValueError:
+                continue
+            if obj.get("id") == 2:
+                resp = obj
+        if resp is None:
+            raise ProbeError("mcp %s returned no id=2 frame (stderr tail: %s)"
+                             % (tool, strip_ansi(err)[-200:].replace("\n", " ")))
+        if "error" in resp:
+            raise ProbeError("mcp %s error: %s"
+                             % (tool, json.dumps(resp["error"])[:200]))
+        result = resp.get("result") or {}
+        content = result.get("content") or []
+        if not content or "text" not in content[0]:
+            raise ProbeError("mcp %s returned no text content" % tool)
+        text = content[0]["text"]
+        try:
+            body = json.loads(text)
+        except ValueError:
+            raise ProbeError("mcp %s%s payload is not JSON (first 160 chars: %r)"
+                             % (tool, " isError" if result.get("isError") else "",
+                                text[:160]))
+        if not isinstance(body, dict):
+            raise ProbeError("mcp %s payload is not an object" % tool)
+        return body
+
+    def cached(self, repo, tool, args, key=None):
+        """Probe once per run; several checks read the same payload."""
+        cache_key = key or (repo, tool, json.dumps(args, sort_keys=True))
+        if cache_key not in self.payloads:
+            self.payloads[cache_key] = self.mcp(repo, tool, args)
+        return self.payloads[cache_key]
+
+    # ---------------------------------------------------------------- fixtures
+
+    def _cache_repo(self, name):
+        """A depth-1 fetch of the pinned commit, reused across runs."""
+        spec = CORPORA[name]
+        path = os.path.join(self.corpus_cache, name)
+        if not os.path.isdir(os.path.join(path, ".git")):
+            if not os.path.isdir(path):
+                os.makedirs(path)
+            rc, out, err = self.git(["init", "-q", "."], cwd=path)
+            if rc != 0:
+                raise ProbeError("git init failed in %s: %s" % (path, (err or out)[-200:]))
+        rc, _out, _err = self.git(["cat-file", "-e", spec["commit"] + "^{commit}"],
+                                  cwd=path)
+        if rc != 0:
+            if self.offline:
+                raise ProbeError(
+                    "corpus cache %s does not carry %s and --offline forbids fetching"
+                    % (path, spec["commit"][:12]))
+            rc, out, err = self.git(
+                ["fetch", "--quiet", "--depth", "1", spec["url"], spec["commit"]],
+                cwd=path, timeout=900)
+            if rc != 0:
+                raise ProbeError("fetch of %s %s failed: %s"
+                                 % (spec["url"], spec["commit"][:12],
+                                    (err or out).strip()[-200:]))
+        return path
+
+    def fixture(self, name):
+        """A fresh single-commit repository holding the pinned tree, kin-initialized.
+
+        Kin refuses a shallow repository outright, so the pinned tree is replayed
+        into a complete one-commit repository rather than cloned shallow. The tree
+        object is verified against the pin before anything is measured, because a
+        fixture whose content drifted would answer a different question in the same
+        shape as this one.
+        """
+        if name in self.fixtures:
+            return self.fixtures[name]
+        spec = CORPORA[name]
+        cache = self._cache_repo(name)
+        path = os.path.join(self.workdir, "%s-%s" % (name, self.run_id))
+        if os.path.exists(path):
+            shutil.rmtree(path, ignore_errors=True)
+        os.makedirs(path)
+        rc, out, err = self.git(["init", "-q", "-b", "main", "."], cwd=path)
+        if rc != 0:
+            raise ProbeError("git init failed: %s" % (err or out)[-200:])
+        archive = subprocess.Popen(
+            ["git", "--git-dir", os.path.join(cache, ".git"),
+             "archive", spec["tree"]],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        untar = subprocess.Popen(["tar", "-x"], stdin=archive.stdout,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 cwd=path)
+        archive.stdout.close()
+        _uout, uerr = untar.communicate(timeout=600)
+        archive.wait(timeout=60)
+        if archive.returncode != 0 or untar.returncode != 0:
+            raise ProbeError("replaying tree %s failed (archive rc=%s, tar rc=%s): %s"
+                             % (spec["tree"][:12], archive.returncode,
+                                untar.returncode,
+                                uerr.decode("utf-8", "replace")[-200:]))
+        rc, out, err = self.git(["add", "-A"], cwd=path)
+        if rc != 0:
+            raise ProbeError("git add failed: %s" % (err or out)[-200:])
+        rc, out, err = self.git(
+            ["commit", "-q", "-m", "%s at %s" % (name, spec["commit"][:12])], cwd=path)
+        if rc != 0:
+            raise ProbeError("git commit failed: %s" % (err or out)[-200:])
+        rc, out, err = self.git(["rev-parse", "HEAD^{tree}"], cwd=path)
+        got = out.strip()
+        if rc != 0 or got != spec["tree"]:
+            raise ProbeError("fixture %s tree is %s, pinned tree is %s"
+                             % (name, got or "unreadable", spec["tree"]))
+        # A real checkout of a JavaScript repository has node_modules on disk,
+        # and the language server needs it to resolve require() targets (check
+        # 4's hand-off, this.router.handle, resolves through the vendored
+        # `router` package or not at all). Installed AFTER the tree-hash
+        # verification and never committed, so the pinned tree is unchanged and
+        # kin's git-based admission never sees it; the language server reads
+        # disk regardless. Cached beside the corpus clone so only the first run
+        # pays the network. A missing npm degrades to a note, and check 4 then
+        # reports its own failure honestly rather than this step hiding it.
+        if os.path.exists(os.path.join(path, "package.json")):
+            cache_nm = os.path.join(self.corpus_cache, "%s-node_modules-%s"
+                                    % (name, spec["commit"][:12]))
+            dst_nm = os.path.join(path, "node_modules")
+            if os.path.isdir(cache_nm):
+                shutil.copytree(cache_nm, dst_nm, symlinks=True)
+                print("kin-brownfield-repro: fixture %s: node_modules restored from cache" % name)
+            elif shutil.which("npm"):
+                rc, out, err = run(
+                    ["npm", "install", "--omit=dev", "--no-fund", "--no-audit",
+                     "--no-progress", "--ignore-scripts"],
+                    cwd=path, env=self.env, timeout=300)
+                if rc == 0 and os.path.isdir(dst_nm):
+                    shutil.copytree(dst_nm, cache_nm, symlinks=True)
+                    print("kin-brownfield-repro: fixture %s: node_modules installed and cached" % name)
+                else:
+                    print("kin-brownfield-repro: fixture %s: npm install failed "
+                          "(rc=%s); require() targets will not resolve"
+                          % (name, rc))
+            else:
+                print("kin-brownfield-repro: fixture %s: no npm on PATH; "
+                      "require() targets will not resolve" % name)
+        rc, out, err = self.kin_run(["init", "."], path)
+        if rc != 0:
+            raise ProbeError("kin init failed in %s: %s" % (path, (err or out)[-300:]))
+        self.fixtures[name] = path
+        return path
+
+    def shutdown(self):
+        """Stop the per-fixture daemons this run started.
+
+        Each fixture is a throwaway repository, so its daemon has nothing to serve
+        once the run ends; leaving them alive leaks one process per fixture per run
+        and holds the fixture's files against removal.
+        """
+        stopped = []
+        for path in self.fixtures.values():
+            pid_file = os.path.join(path, ".kin", "daemon.pid")
+            if not os.path.exists(pid_file):
+                continue
+            try:
+                with open(pid_file) as handle:
+                    pid = int(handle.read().strip())
+                os.kill(pid, 15)
+                stopped.append(pid)
+            except (ValueError, OSError):
+                continue
+        return stopped
+
+    # ------------------------------------------------------------ status probes
+
+    def graph_status(self, name):
+        repo = self.fixture(name)
+        rc, out, err = self.kin_run(["graph", "status"], repo)
+        text = out + "\n" + err
+        info = {"raw": text, "rc": rc, "coverage": {}}
+        for match in COVERAGE_LINE.finditer(text):
+            info["coverage"][match.group("lang")] = {
+                "files": int(match.group("files")),
+                "calls_resolved": int(match.group("cres")),
+                "calls_parsed": int(match.group("ctot")),
+                "imports_resolved": (int(match.group("ires"))
+                                     if match.group("ires") is not None else None),
+                "imports_parsed": (int(match.group("itot"))
+                                   if match.group("itot") is not None else None),
+                "line": match.group(0).strip(),
+            }
+        head = re.search(r"Entities:\s*(\d+)", text)
+        info["entities"] = int(head.group(1)) if head else None
+        if info["entities"] is None:
+            raise ProbeError("kin graph status rc=%d printed no entity counter: %s"
+                             % (rc, text.strip()[-200:]))
+        return info
+
+    def sweep_gate(self, name):
+        """Block recall assertions until the fixture's enrichment sweep provably ran.
+
+        `kin init` has printed "complete (0/66 files)" over a sweep whose language
+        server never started, and a recall check against that graph passes its
+        negative controls vacuously: zero counted references contains no impostor.
+        kin#985 made the sweep write a full accounting line, so this reads the
+        fixture's own daemon.log and refuses the check unless some completed sweep
+        enriched files and left nothing blocked, unvisited, or unaccounted.
+
+        KNOWN EXPOSURE, unfixed on purpose: this trusts that every sweep line in a
+        fixture's daemon.log describes THAT fixture. A daemon serving more than one
+        store can write into one log; on 2026-08-20 a lane found 333 foreign lines in
+        its own fixture's log, and this suite's requests log carried 216 mentions of
+        other sessions' paths. Those were registry-identity warnings rather than sweep
+        completions, and both sweep lines here matched the fixture's own file count, so
+        the gate was not fooled. It could be: a foreign sweep completion would satisfy
+        it. Binding a sweep line to its store needs a repo id the line does not carry,
+        so the fix is a real change rather than a grep, and it is deliberately not being
+        written at midnight on a release night. A
+        build predating the accounting fields is exempt, so baseline comparison
+        runs keep their historical semantics; the exemption is printed, never
+        silent.
+        """
+        if name in self.sweep_gates:
+            ok, detail = self.sweep_gates[name]
+            if ok:
+                return detail
+            raise ProbeError(detail)
+        repo = self.fixture(name)
+        log_path = os.path.join(repo, ".kin", "daemon.log")
+        # The daemon that ran init's sweep has usually exited by now, deleting
+        # its port file, and a freshly spawned daemon's counters start at zero,
+        # so the live /lsp/sweep/status endpoint is the wrong authority for a
+        # post-init read. The store's own daemon.log carries the sweep's
+        # accounting line durably. Init waits for its sweep, so one short retry
+        # window covers filesystem lag, not sweep progress.
+        deadline = time.time() + 10
+        text = ""
+        while True:
+            try:
+                with open(log_path) as handle:
+                    text = handle.read()
+            except OSError:
+                text = ""
+            if sweep_lines(text) or time.time() >= deadline:
+                break
+            time.sleep(1)
+        ok, detail = sweep_verdict(sweep_lines(text))
+        detail = "fixture %s: %s" % (name, detail)
+        self.sweep_gates[name] = (ok, detail)
+        print("kin-brownfield-repro: %s" % detail)
+        if not ok:
+            raise ProbeError(detail)
+        return detail
+
+    def references(self, name, query):
+        repo = self.fixture(name)
+        payload = self.cached(repo, "find_references", {"query": query})
+        if not (payload.get("focal_entity") or {}).get("id"):
+            negative = payload.get("negative") or {}
+            raise ProbeError(
+                "find_references(%s) resolved no focal entity (%s); an unresolved "
+                "symbol and a symbol with no references are different facts"
+                % (query, negative.get("trust_reason") or negative.get("kind")
+                   or "no reason given"))
+        return payload
+
+
+def upstream_rows(payload):
+    """Every entity the payload offers as an upstream, split by whether it counted.
+
+    A build that counts a caller and a build that withholds it as a same-name
+    candidate both mention the caller, so a check reading one array cannot tell
+    them apart. Both arrays are returned, tagged.
+    """
+    counted = []
+    withheld = []
+    for row in payload.get("references") or []:
+        if isinstance(row, dict):
+            counted.append(row)
+    for key in ("candidates", "name_candidates", "receiver_name_candidates"):
+        for row in payload.get(key) or []:
+            if isinstance(row, dict):
+                withheld.append(row)
+    return counted, withheld
+
+
+def find_row(rows, wanted):
+    for row in rows:
+        if name_matches(row.get("name"), wanted):
+            return row
+    return None
+
+
+def verdict_surfaces(payload):
+    """The verdict blocks one payload carries, normalized to certify or refuse.
+
+    Returns a dict of surface name to (verdict, evidence). `certify` means the
+    surface asserts the answer is the whole set and may be acted on; `refuse` means
+    it says the answer cannot be trusted as complete. A surface that is simply
+    absent appears in neither, because "this payload made no claim" is a third fact
+    and folding it into either would invent a verdict nothing stated.
+
+    Under FIR-2463's fix shape the most pessimistic input wins, so a surface that
+    admits it did not look, or that reports a class as unknown, counts as refusing
+    rather than as saying nothing.
+    """
+    out = {}
+    negative = payload.get("negative")
+    if isinstance(negative, dict):
+        safe = negative.get("safe_to_conclude_absent")
+        trust = negative.get("trust")
+        if safe is True or trust == "authoritative":
+            out["negative"] = ("certify", "safe_to_conclude_absent=%r trust=%r"
+                               % (safe, trust))
+        elif safe is False or trust in ("inconclusive", "unreliable"):
+            out["negative"] = ("refuse", "safe_to_conclude_absent=%r trust=%r"
+                               % (safe, trust))
+    # Kin publishes completeness inside the `_kin` envelope, not at the payload's
+    # top level (entities.rs reads response["_kin"]["completeness"] in its own
+    # tests). Reading only the top level made this surface dead code against every
+    # real payload, so the three-block contradiction the stranger quoted was
+    # invisible to check 5. The top-level read stays as a fallback for older
+    # payload shapes.
+    kin_envelope = payload.get("_kin")
+    completeness = kin_envelope.get("completeness") if isinstance(kin_envelope, dict) else None
+    if not isinstance(completeness, dict):
+        completeness = payload.get("completeness")
+    if isinstance(completeness, dict):
+        status = completeness.get("status")
+        bound = completeness.get("bound")
+        if status == "complete" or bound == "exact":
+            out["completeness"] = ("certify", "status=%r bound=%r"
+                                   % (status, bound))
+        elif status in ("partial", "incomplete", "unknown", "lower_bound"):
+            out["completeness"] = ("refuse", "status=%r bound=%r" % (status, bound))
+        classes = completeness.get("classes")
+        if isinstance(classes, dict):
+            absent = sorted(k for k, v in classes.items()
+                            if v in ("absent", "unknown"))
+            if absent:
+                out["completeness.classes"] = (
+                    "refuse", "classes not present: %s" % ", ".join(absent))
+        limits = completeness.get("limits")
+        if isinstance(limits, list):
+            edge = [str(x) for x in limits if str(x).startswith("edge_coverage")]
+            if edge:
+                out["completeness.limits"] = (
+                    "refuse", "limits: %s" % ", ".join(edge))
+    coverage = payload.get("edge_coverage")
+    if isinstance(coverage, dict):
+        classes = coverage.get("classes")
+        gaps = []
+        if isinstance(classes, dict):
+            missing = sorted(k for k, v in classes.items()
+                             if v in ("absent", "unknown"))
+            if missing:
+                gaps.append("classes not present: %s" % ", ".join(missing))
+        enrichment = coverage.get("reference_enrichment")
+        if enrichment in ("unknown", "unsupported", "absent", "unprobed"):
+            gaps.append("reference_enrichment=%r" % enrichment)
+        scan = coverage.get("scan")
+        if isinstance(scan, str) and scan.startswith("skipped"):
+            gaps.append("scan=%r" % scan)
+        if coverage.get("budget_exhausted") is True:
+            gaps.append("budget_exhausted=True")
+        if gaps:
+            out["edge_coverage"] = ("refuse", "; ".join(gaps))
+        elif classes or enrichment:
+            out["edge_coverage"] = (
+                "certify", "reference_enrichment=%r, every requested class present"
+                % enrichment)
+    return out
+
+
+def surface_conflict(surfaces):
+    """The certifying and refusing surfaces of one payload, when both exist."""
+    certifying = sorted(k for k, (v, _e) in surfaces.items() if v == "certify")
+    refusing = sorted(k for k, (v, _e) in surfaces.items() if v == "refuse")
+    if certifying and refusing:
+        return certifying, refusing
+    return None, None
+
+
+def trend_of(status, prior):
+    """Where this check moved since the run being compared against.
+
+    A prior run that could not be read reports `unknown` rather than `same`,
+    because "no baseline" and "no change" are different facts and the second must
+    never be inferred from the first.
+    """
+    if prior is None:
+        return "unknown"
+    if prior == PASS and status != PASS:
+        return "regression"
+    if prior != PASS and status == PASS:
+        return "fixed"
+    return "same"
+
+
+class Result(object):
+    def __init__(self, check_id, ticket, title):
+        self.id = check_id
+        self.ticket = ticket
+        self.title = title
+        self.prior = None
+        self.trend = "unknown"
+        self.asserts = []
+
+    def add(self, status, detail):
+        self.asserts.append({"status": status, "detail": detail})
+
+    def ok(self, detail):
+        self.add(PASS, detail)
+
+    def bad(self, detail):
+        self.add(FAIL, detail)
+
+    def unknown(self, detail):
+        self.add(UNREADABLE, detail)
+
+    def note(self, detail):
+        """Attributable context that decides nothing. Never a verdict."""
+        self.asserts.append({"status": "NOTE", "detail": detail})
+
+    @property
+    def status(self):
+        graded = [a for a in self.asserts if a["status"] in (PASS, FAIL, UNREADABLE)]
+        if any(a["status"] == FAIL for a in graded):
+            return FAIL
+        if any(a["status"] == UNREADABLE for a in graded):
+            return UNREADABLE
+        if not graded:
+            return UNREADABLE
+        return PASS
+
+    @property
+    def detail(self):
+        for wanted in (FAIL, UNREADABLE):
+            for a in self.asserts:
+                if a["status"] == wanted:
+                    return a["detail"]
+        graded = [a for a in self.asserts if a["status"] == PASS]
+        return graded[-1]["detail"] if graded else "no assertion was reached"
+
+
+# ---------------------------------------------------------------------- checks
+
+def check_0(suite):
+    """The run stays off the GPU and off every store but its own."""
+    res = Result("0", "SUITE-GUARD", "no inference, no fleet store, own KIN_HOME")
+    # The status probe runs first on purpose: `kin init` writes no daemon log, so a
+    # read before any daemon has started finds no file and reports UNREADABLE on a
+    # run whose opt-out was in fact honored.
+    status = suite.graph_status("express")
+    repo = suite.fixture("express")
+    log = os.path.join(repo, ".kin", "daemon.log")
+    if not os.path.exists(log):
+        res.unknown("no daemon log at %s, cannot confirm the opt-out was honored" % log)
+    else:
+        deferred = 0
+        with open(log, errors="replace") as handle:
+            for line in handle:
+                if AUTO_EMBED_OPT_OUT_LINE in strip_ansi(line):
+                    deferred += 1
+        if deferred == 0:
+            res.bad("daemon log carries no %r line; embeddings may have run"
+                    % AUTO_EMBED_OPT_OUT_LINE)
+        else:
+            res.ok("daemon logged the opt-out %d time(s)" % deferred)
+    indexed = re.search(r"Embeddings:\s*(\d+)/(\d+)\s*indexed", status["raw"])
+    if indexed and int(indexed.group(1)) != 0:
+        res.bad("embeddings indexed=%s despite the opt-out" % indexed.group(1))
+    elif indexed:
+        res.ok("embeddings indexed=0/%s, so no inference ran" % indexed.group(2))
+    else:
+        res.unknown("graph status printed no embedding counter")
+    if not os.path.realpath(suite.kin_home).startswith(
+            os.path.realpath(suite.workdir)):
+        res.bad("KIN_HOME %s is outside the run workdir" % suite.kin_home)
+    else:
+        res.ok("scratch KIN_HOME %s" % suite.kin_home)
+    # Attributable context, not a verdict. FIR-2464 established that the npm-0541
+    # container carried no language server at all, so Python enrichment never ran
+    # there. A failure below is a different fact depending on this line.
+    present = [name for name in LANGUAGE_SERVERS if shutil.which(name)]
+    res.note("language servers on PATH: %s"
+             % (", ".join(present) if present else "none"))
+    return res
+
+
+def check_1(suite):
+    """FIR-2441: JavaScript import specifiers resolve, so imports are above zero.
+
+    The positive control. This is the one grep-flip fix the stranger confirmed
+    working on shipped bytes, and it is what proves the suite can report a pass.
+    A pre-FIR-2441 binary reports `imports 0/305 (0%)` on this same fixture.
+    """
+    res = Result("1", "FIR-2441", "express resolves JavaScript imports above zero")
+    status = suite.graph_status("express")
+    js = status["coverage"].get("javascript")
+    if js is None:
+        res.unknown("graph status printed no javascript reference-edge coverage line")
+        return res
+    if js["imports_resolved"] is None:
+        res.unknown("javascript coverage line carries no imports counter: %s"
+                    % js["line"])
+        return res
+    if js["imports_parsed"] == 0:
+        res.unknown("javascript coverage parsed zero imports, so the ratio says "
+                    "nothing: %s" % js["line"])
+        return res
+    if js["imports_resolved"] > 0:
+        res.ok("%d of %d javascript imports resolved (%s)"
+               % (js["imports_resolved"], js["imports_parsed"], js["line"]))
+    else:
+        res.bad("0 of %d javascript imports resolved: %s"
+                % (js["imports_parsed"], js["line"]))
+    return res
+
+
+def check_2(suite):
+    """FIR-2464: the first real caller of HTTPAdapter.send counts as one.
+
+    src/requests/sessions.py:784 is `r = adapter.send(request, **kwargs)` inside
+    Session.send. On shipped v0.5.42 that caller was demoted to the candidates
+    array as name_only and excluded, leaving total_upstream 0 on a response that
+    held the answer.
+    """
+    res = Result("2", "FIR-2464", "Session.send counts as a real caller of "
+                                  "HTTPAdapter.send")
+    try:
+        suite.sweep_gate("requests")
+        payload = suite.references("requests", HTTPADAPTER_SEND)
+    except ProbeError as exc:
+        res.unknown(str(exc))
+        return res
+    counted, withheld = upstream_rows(payload)
+    total = payload.get("total_upstream")
+    counted_row = find_row(counted, REAL_CALLER_ONE)
+    withheld_row = find_row(withheld, REAL_CALLER_ONE)
+    if counted_row is not None:
+        lines = counted_row.get("reference_lines") or []
+        if REAL_CALLER_ONE_LINE in lines:
+            res.ok("%s counted as a reference with reference_lines %s"
+                   % (REAL_CALLER_ONE, lines))
+        else:
+            res.bad("%s is counted but its reference_lines are %s, not the call site "
+                    "at %s:%d"
+                    % (REAL_CALLER_ONE, lines or "[]", REAL_CALLER_ONE_FILE,
+                       REAL_CALLER_ONE_LINE))
+        if counted_row.get("resolution") == "name_only":
+            res.bad("%s is counted but still resolution=name_only, so the count "
+                    "rests on a bare-name match" % REAL_CALLER_ONE)
+    elif withheld_row is not None:
+        res.bad("%s is withheld as a same-name candidate (resolution=%r, "
+                "reference_lines=%s) and excluded from total_upstream=%r; the real "
+                "call site is %s:%d"
+                % (REAL_CALLER_ONE, withheld_row.get("resolution"),
+                   withheld_row.get("reference_lines") or "[]", total,
+                   REAL_CALLER_ONE_FILE, REAL_CALLER_ONE_LINE))
+    else:
+        res.bad("%s appears in neither references nor candidates; total_upstream=%r, "
+                "counted=%d, withheld=%d"
+                % (REAL_CALLER_ONE, total, len(counted), len(withheld)))
+    if isinstance(total, int) and total < 1:
+        res.bad("total_upstream=%d on a symbol with a real caller at %s:%d"
+                % (total, REAL_CALLER_ONE_FILE, REAL_CALLER_ONE_LINE))
+    elif not isinstance(total, int):
+        res.unknown("total_upstream is %r, not an integer" % (total,))
+    # The negative control. Every name below is a bare-name match on `send` and
+    # calls no HTTPAdapter. Counting one is fabrication, not coverage.
+    fabricated = sorted({row.get("name") for row in counted
+                         if row.get("name") in FABRICATED_SEND_CALLERS})
+    if fabricated:
+        res.bad("counted as real callers by bare-name match: %s"
+                % ", ".join(fabricated))
+    else:
+        res.ok("no known bare-name impostor counted as a caller")
+    return res
+
+
+def check_3(suite):
+    """FIR-2464: the second real caller, reached through a two-hop receiver.
+
+    src/requests/auth.py:312 is `_r = r.connection.send(prep, **kwargs)` inside
+    HTTPDigestAuth.handle_401, and r.connection is always an HTTPAdapter here. The
+    shipped extractor emitted a bare-name candidate for the one-hop receiver
+    `adapter.send` and nothing at all for this two-hop one, so the
+    receiver_name_candidates degradation could not even count what it never made.
+    """
+    res = Result("3", "FIR-2464", "HTTPDigestAuth.handle_401 reaches "
+                                  "HTTPAdapter.send through r.connection")
+    try:
+        suite.sweep_gate("requests")
+        payload = suite.references("requests", HTTPADAPTER_SEND)
+    except ProbeError as exc:
+        res.unknown(str(exc))
+        return res
+    counted, withheld = upstream_rows(payload)
+    counted_row = find_row(counted, REAL_CALLER_TWO)
+    withheld_row = find_row(withheld, REAL_CALLER_TWO)
+    if counted_row is not None:
+        lines = counted_row.get("reference_lines") or []
+        if REAL_CALLER_TWO_LINE in lines:
+            res.ok("%s counted with reference_lines %s" % (REAL_CALLER_TWO, lines))
+        else:
+            res.bad("%s is counted but its reference_lines are %s, not the call site "
+                    "at %s:%d" % (REAL_CALLER_TWO, lines or "[]",
+                                  REAL_CALLER_TWO_FILE, REAL_CALLER_TWO_LINE))
+    elif withheld_row is not None:
+        res.bad("%s exists only as a withheld candidate (resolution=%r); the two-hop "
+                "receiver call at %s:%d is real and must count"
+                % (REAL_CALLER_TWO, withheld_row.get("resolution"),
+                   REAL_CALLER_TWO_FILE, REAL_CALLER_TWO_LINE))
+    else:
+        res.bad("%s appears nowhere in the payload, not even as a candidate; the "
+                "extractor emits no edge at all for the two-hop receiver "
+                "r.connection.send at %s:%d"
+                % (REAL_CALLER_TWO, REAL_CALLER_TWO_FILE, REAL_CALLER_TWO_LINE))
+    return res
+
+
+def check_4(suite):
+    """FIR-2464: express cross-file edges are real, and the one that matters is there.
+
+    trace_data_flow on app.handle, direction calls, depth 2 returned eleven steps on
+    shipped bytes. Two were real (app.enabled at lib/application.js:160 and
+    finalhandler at :154). Nine were fabricated, all descended from bare-name
+    matching the single `this.get('env')` call. The hand-off the question is about,
+    this.router.handle at lib/application.js:177, was absent from the walk entirely.
+    """
+    res = Result("4", "FIR-2464", "express app.handle walk carries the real edges "
+                                  "and no fabricated ones")
+    repo = suite.fixture("express")
+    try:
+        suite.sweep_gate("express")
+        # limit_per_step is raised to its cap and bodies are dropped on purpose. At
+        # the default of 5 this walk clips one of app.handle's own callees and the
+        # response comes back truncated, so an absent edge cannot be told from a
+        # dropped one, and the check's central assertion would be measuring a budget
+        # rather than the graph.
+        payload = suite.cached(repo, "trace_data_flow",
+                               {"focal": APP_HANDLE, "direction": "calls",
+                                "depth": 2, "include_body": False,
+                                "limit_per_step": 25, "max_chars": 200000})
+    except ProbeError as exc:
+        res.unknown(str(exc))
+        return res
+    steps = None
+    for key in ("chain", "steps", "flow", "path"):
+        if isinstance(payload.get(key), list):
+            steps = payload[key]
+            break
+    if not isinstance(steps, list):
+        res.unknown("trace_data_flow payload carries no step list; keys are %s"
+                    % sorted(payload.keys()))
+        return res
+    if not steps:
+        res.unknown("trace_data_flow on %s returned zero steps, so neither the real "
+                    "edges nor the fabricated ones can be judged" % APP_HANDLE)
+        return res
+    if payload.get("truncated") or payload.get("clipped_steps"):
+        res.unknown("the walk came back truncated (truncated=%r, clipped_steps=%r), "
+                    "so an absent edge cannot be told from a dropped one"
+                    % (payload.get("truncated"), payload.get("clipped_steps")))
+        return res
+
+    def step_name(step):
+        if not isinstance(step, dict):
+            return ""
+        for key in ("entity_name", "callee", "name", "target_name", "to"):
+            value = step.get(key)
+            if isinstance(value, str) and value:
+                return value
+            if isinstance(value, dict) and value.get("name"):
+                return value["name"]
+        return ""
+
+    def counted_step(step):
+        """A step the answer stands behind, as opposed to one it disclaims.
+
+        A build that keeps a fabricated edge but labels it name_only and excludes
+        it from the count has done what the fix asks. One that keeps it in the
+        counted flow has not. Distinguishing them is the whole point of this check.
+        """
+        if not isinstance(step, dict):
+            return False
+        if step.get("resolution") == "name_only":
+            return False
+        if step.get("proven") is False or step.get("unproven") is True:
+            return False
+        return True
+
+    named = [(step_name(s), s) for s in steps]
+    counted = [(n, s) for n, s in named if counted_step(s)]
+    all_names = [n for n, _s in named]
+
+    def descent(step):
+        """How a step got here, so a counted one names the edge that carried it.
+
+        A step whose own edge resolved by type but whose parent did not is still
+        fabricated: the walk reached it only through the parent's bad guess. Saying
+        so in the failure is the difference between a lane fixing the resolver and a
+        lane fixing the wrong step.
+        """
+        # parent_step is 1-based with 0 meaning the focal, while `named` is
+        # 0-indexed over steps; indexing named[parent] misattributed every parent
+        # by one (reported app.set as reached through req.get when parent_step=1
+        # means app.enabled).
+        parent = step.get("parent_step")
+        if not isinstance(parent, int) or parent < 0 or parent > len(named):
+            return "resolution=%r at depth %r" % (step.get("resolution"),
+                                                  step.get("depth"))
+        if parent == 0:
+            return ("resolution=%r, reached directly from the focal %s"
+                    % (step.get("resolution"), APP_HANDLE))
+        return "resolution=%r, reached through %s" % (step.get("resolution"),
+                                                      named[parent - 1][0]
+                                                      or "step %d" % parent)
+
+    fabricated_counted = sorted({"%s (%s)" % (n, descent(s)) for n, s in counted
+                                 if any(name_matches(n, f)
+                                        for f in APP_HANDLE_FABRICATED)})
+    if fabricated_counted:
+        res.bad("counted steps include fabricated callees %s; %d of %d steps counted, "
+                "unproven_steps=%r"
+                % ("; ".join(fabricated_counted), len(counted), len(steps),
+                   payload.get("unproven_steps")))
+    else:
+        res.ok("no fabricated callee is counted (%d of %d steps counted)"
+               % (len(counted), len(steps)))
+    missing_real = [want for want in APP_HANDLE_REAL_CALLEES
+                    if not any(name_matches(n, want) for n in all_names)]
+    if missing_real:
+        res.bad("the real callees %s are absent from the walk; steps are %s"
+                % (", ".join(missing_real), all_names[:12]))
+    else:
+        res.ok("both real callees %s are present"
+               % ", ".join(APP_HANDLE_REAL_CALLEES))
+    if any(name_matches(n, APP_HANDLE_MISSING_CALLEE)
+           or basename_of(n) == "handle" for n in all_names):
+        res.ok("the hand-off %s is in the walk" % APP_HANDLE_MISSING_CALLEE)
+    else:
+        res.bad("the hand-off this.router.handle at %s:177, the last line of "
+                "app.handle and the edge the question is about, is absent from the "
+                "walk; steps are %s" % (APP_HANDLE_FILE, all_names[:12]))
+    return res
+
+
+def check_5(suite):
+    """FIR-2463: one payload, one verdict.
+
+    On shipped bytes a single find_references response on an express export said
+    negative.safe_to_conclude_absent false and trust inconclusive, while its own
+    completeness block said status complete, bound exact, counted.exact true, and a
+    note reading "Every edge class this answer depended on was observed present",
+    sitting directly above a classes map marking imports and references absent and a
+    limits array naming three edge_coverage gaps. An agent reading completeness acts;
+    an agent reading negative does not. The fix is one verdict, most pessimistic
+    input wins.
+    """
+    res = Result("5", "FIR-2463", "one payload reaches one verdict")
+    express = suite.fixture("express")
+    requests = suite.fixture("requests")
+    probes = [
+        ("express find_references(%s)" % EXPRESS_EXPORT,
+         express, "find_references", {"query": EXPRESS_EXPORT}),
+        ("requests find_references(%s)" % HTTPADAPTER_SEND,
+         requests, "find_references", {"query": HTTPADAPTER_SEND}),
+        ("requests semantic_search(%r, kind=%r)" % (PY_SEARCH_QUERY, PY_SEARCH_KIND),
+         requests, "semantic_search",
+         {"query": PY_SEARCH_QUERY, "kind": PY_SEARCH_KIND}),
+    ]
+    graded = 0
+    for label, repo, tool, args in probes:
+        try:
+            payload = suite.cached(repo, tool, args)
+        except ProbeError as exc:
+            res.unknown("%s unreadable: %s" % (label, exc))
+            continue
+        surfaces = verdict_surfaces(payload)
+        if not surfaces:
+            res.unknown("%s carries no readable verdict surface; keys are %s"
+                        % (label, sorted(payload.keys())))
+            continue
+        if len(surfaces) < 2:
+            res.unknown("%s carries only one verdict surface (%s), so disagreement "
+                        "cannot be observed" % (label, ", ".join(surfaces)))
+            continue
+        graded += 1
+        certifying, refusing = surface_conflict(surfaces)
+        if certifying:
+            res.bad("%s: %s certif%s (%s) while %s refuse%s (%s)"
+                    % (label, ", ".join(certifying),
+                       "ies" if len(certifying) == 1 else "y",
+                       "; ".join(surfaces[k][1] for k in certifying),
+                       ", ".join(refusing), "s" if len(refusing) == 1 else "",
+                       "; ".join(surfaces[k][1] for k in refusing)))
+        else:
+            res.ok("%s: all %d surfaces agree (%s)"
+                   % (label, len(surfaces),
+                      "; ".join("%s %s" % (k, surfaces[k][1])
+                                for k in sorted(surfaces))))
+    if graded == 0:
+        res.unknown("no probe produced two comparable verdict surfaces")
+    return res
+
+
+def check_6(suite):
+    """FIR-2463: two surfaces, one graph, one question, one verdict.
+
+    On shipped bytes find_references on HTTPAdapter.send refused to certify its
+    zero, while graph_neighborhood direction in on the same entity framed the same
+    two inbound edges as complete, exact, "the whole set", carrying no negative
+    object and no hedge. Whichever tool you reach for first decides what you believe.
+    """
+    res = Result("6", "FIR-2463", "find_references and graph_neighborhood agree on "
+                                  "one entity")
+    repo = suite.fixture("requests")
+    try:
+        refs = suite.references("requests", HTTPADAPTER_SEND)
+    except ProbeError as exc:
+        res.unknown("find_references leg unreadable: %s" % exc)
+        return res
+    # graph_neighborhood takes an entity UUID and no name, so the focal id comes
+    # from the find_references leg. Both legs then provably describe one entity,
+    # which is what makes their disagreement a disagreement rather than two answers
+    # about two things.
+    focal_id = (refs.get("focal_entity") or {}).get("id")
+    try:
+        hood = suite.cached(repo, "graph_neighborhood",
+                            {"entity_id": focal_id, "direction": "in"})
+    except ProbeError as exc:
+        res.unknown("graph_neighborhood leg unreadable: %s" % exc)
+        return res
+    if "message" in hood and not hood.get("relations"):
+        res.unknown("graph_neighborhood returned an error payload: %s"
+                    % str(hood.get("message"))[:200])
+        return res
+    ref_surfaces = verdict_surfaces(refs)
+    hood_surfaces = verdict_surfaces(hood)
+    if not ref_surfaces:
+        res.unknown("find_references payload carries no readable verdict surface")
+        return res
+    if not hood_surfaces:
+        res.bad("graph_neighborhood on %s walked %r entities over %r relations and "
+                "carries no verdict surface at all, while find_references on the "
+                "same entity reports %s; an answer with no epistemic claim is not "
+                "agreement, it is a missing one"
+                % (HTTPADAPTER_SEND, hood.get("entity_count"),
+                   hood.get("relation_count"),
+                   "; ".join("%s %s" % (k, v[1])
+                             for k, v in sorted(ref_surfaces.items()))))
+        return res
+    ref_verdicts = {v for v, _e in ref_surfaces.values()}
+    hood_verdicts = {v for v, _e in hood_surfaces.values()}
+    if ref_verdicts != hood_verdicts:
+        res.bad("the two tools reach opposite verdicts on %s: find_references says "
+                "%s (%s) while graph_neighborhood says %s (%s)"
+                % (HTTPADAPTER_SEND,
+                   "/".join(sorted(ref_verdicts)),
+                   "; ".join("%s %s" % (k, v[1])
+                             for k, v in sorted(ref_surfaces.items())),
+                   "/".join(sorted(hood_verdicts)),
+                   "; ".join("%s %s" % (k, v[1])
+                             for k, v in sorted(hood_surfaces.items()))))
+    else:
+        res.ok("both tools reach %s on %s"
+               % ("/".join(sorted(ref_verdicts)), HTTPADAPTER_SEND))
+    return res
+
+
+def check_7(suite):
+    """FIR-2464: an express export nothing certifies as unused.
+
+    Ten exports live in lib/express.js and the stranger's classic arm proved none
+    of them is dead. Kin called four dead. exports.Router carries 32 in-repo hits,
+    the first at examples/multi-router/controllers/api_v1.js:5, so certifying its
+    absence is the delete-what-Kin-called-safe case with the widest blast radius.
+    """
+    res = Result("7", "FIR-2464", "express exports.Router is not certified unused")
+    repo = suite.fixture("express")
+    try:
+        suite.sweep_gate("express")
+        payload = suite.cached(repo, "find_references", {"query": EXPRESS_EXPORT})
+    except ProbeError as exc:
+        res.unknown(str(exc))
+        return res
+    if not (payload.get("focal_entity") or {}).get("id"):
+        res.unknown("find_references(%s) resolved no focal entity, so neither its "
+                    "references nor its absence claim can be judged" % EXPRESS_EXPORT)
+        return res
+    counted, withheld = upstream_rows(payload)
+    total = payload.get("total_upstream")
+    negative = payload.get("negative") or {}
+    if negative.get("safe_to_conclude_absent") is True:
+        res.bad("%s (%s:%d) is certified absent (trust=%r) on a symbol with 32 "
+                "in-repo hits, the first at "
+                "examples/multi-router/controllers/api_v1.js:5"
+                % (EXPRESS_EXPORT, EXPRESS_EXPORT_FILE, EXPRESS_EXPORT_LINE,
+                   negative.get("trust")))
+    if counted:
+        res.ok("%s carries %d counted reference(s), total_upstream=%r"
+               % (EXPRESS_EXPORT, len(counted), total))
+    else:
+        res.bad("%s carries zero counted references (total_upstream=%r, %d withheld "
+                "candidate(s)) on a symbol used 32 times in this repository"
+                % (EXPRESS_EXPORT, total, len(withheld)))
+    return res
+
+
+def check_8(suite):
+    """FIR-2463 and FIR-2452: a certified absence has to be true.
+
+    Session.request is a method at src/requests/sessions.py:557. On shipped bytes
+    semantic_search under a kind filter answered zero for it and certified that zero
+    as authoritative, on the same graph where find_references refuses to certify
+    anything. The two answers are decided by which internal route ran rather than by
+    what is knowable: the search path takes a scan shortcut and reports its
+    reference enrichment as unknown, then certifies anyway.
+    """
+    res = Result("8", "FIR-2463", "semantic_search does not certify a false absence")
+    repo = suite.fixture("requests")
+    try:
+        payload = suite.cached(repo, "semantic_search",
+                               {"query": PY_SEARCH_QUERY, "kind": PY_SEARCH_KIND})
+    except ProbeError as exc:
+        res.unknown(str(exc))
+        return res
+    results = payload.get("results")
+    if not isinstance(results, list):
+        res.unknown("semantic_search payload carries no results list; keys are %s"
+                    % sorted(payload.keys()))
+        return res
+    negative = payload.get("negative") or {}
+    certified = (negative.get("safe_to_conclude_absent") is True
+                 or negative.get("trust") == "authoritative")
+    if results:
+        names = entity_names(results)
+        if any(name_matches(n, PY_KNOWN_METHOD) for n in names):
+            res.ok("semantic_search found %s among %d result(s)"
+                   % (PY_KNOWN_METHOD, len(results)))
+        else:
+            res.ok("semantic_search returned %d result(s) and certified nothing "
+                   "absent" % len(results))
+        if certified:
+            res.bad("semantic_search returned %d result(s) and still reports "
+                    "safe_to_conclude_absent=%r trust=%r"
+                    % (len(results), negative.get("safe_to_conclude_absent"),
+                       negative.get("trust")))
+        return res
+    coverage = payload.get("edge_coverage") or {}
+    if certified:
+        res.bad("semantic_search(%r, kind=%r) returned zero and certified it "
+                "(safe_to_conclude_absent=%r, trust=%r, advice %r) while %s is a "
+                "method at %s:%d; its own edge_coverage says scan=%r and "
+                "reference_enrichment=%r, so it certified a question it did not ask"
+                % (PY_SEARCH_QUERY, PY_SEARCH_KIND,
+                   negative.get("safe_to_conclude_absent"), negative.get("trust"),
+                   str(negative.get("advice"))[:120], PY_KNOWN_METHOD,
+                   PY_KNOWN_METHOD_FILE, PY_KNOWN_METHOD_LINE,
+                   coverage.get("scan"), coverage.get("reference_enrichment")))
+    else:
+        res.ok("semantic_search returned zero and refused to certify it "
+               "(safe_to_conclude_absent=%r, trust=%r)"
+               % (negative.get("safe_to_conclude_absent"), negative.get("trust")))
+    return res
+
+
+CHECKS = [
+    ("0", check_0),
+    ("1", check_1),
+    ("2", check_2),
+    ("3", check_3),
+    ("4", check_4),
+    ("5", check_5),
+    ("6", check_6),
+    ("7", check_7),
+    ("8", check_8),
+]
+
+
+def self_test():
+    """Exercise the graders on fixed payloads, with no binary and no corpus.
+
+    Every verdict this suite reports is decided by verdict_surfaces, name_matches
+    and Result.status. A grader that cannot distinguish its own cases would report
+    a clean product on a broken one, so each case below is paired with its inverse:
+    the payloads are the literal shapes the npm-0541 run and this build produced,
+    and the assertions require the grader to answer differently on each.
+    """
+    failures = []
+
+    def expect(label, got, want):
+        if got != want:
+            failures.append("%s: got %r, wanted %r" % (label, got, want))
+
+    # The shipped v0.5.42 find_references shape: negative refuses, completeness
+    # certifies. One payload, two verdicts, which is the defect FIR-2463 names.
+    shipped = {
+        "negative": {"safe_to_conclude_absent": False, "trust": "inconclusive"},
+        "completeness": {
+            "bound": "exact", "status": "complete",
+            "classes": {"calls": "present", "imports": "absent",
+                        "references": "absent"},
+            "limits": ["edge_coverage:imports_absent",
+                       "edge_coverage:reference_enrichment_unsupported"],
+        },
+    }
+    certifying, refusing = surface_conflict(verdict_surfaces(shipped))
+    expect("shipped payload conflict certifying", certifying, ["completeness"])
+    expect("shipped payload conflict refusing", refusing,
+           ["completeness.classes", "completeness.limits", "negative"])
+
+    # The semantic_search shape this build still produces: negative certifies while
+    # edge_coverage admits it took a shortcut.
+    search = {
+        "negative": {"safe_to_conclude_absent": True, "trust": "authoritative"},
+        "edge_coverage": {"classes": {}, "reference_enrichment": "unknown",
+                          "scan": "skipped_no_edge_dependency"},
+    }
+    certifying, refusing = surface_conflict(verdict_surfaces(search))
+    expect("search payload certifying", certifying, ["negative"])
+    expect("search payload refusing", refusing, ["edge_coverage"])
+
+    # The inverse: one verdict, agreed. The grader must NOT report a conflict here,
+    # or every fixed build would still read as broken.
+    agreed = {
+        "negative": {"safe_to_conclude_absent": False, "trust": "inconclusive"},
+        "edge_coverage": {"classes": {"calls": "present", "imports": "absent"},
+                          "reference_enrichment": "unsupported", "scan": "ran"},
+    }
+    certifying, _refusing = surface_conflict(verdict_surfaces(agreed))
+    expect("agreed payload reports no conflict", certifying, None)
+
+    # A payload carrying no verdict block at all yields no surfaces, so a check
+    # reports UNREADABLE rather than inventing agreement out of silence.
+    expect("silent payload has no surfaces", verdict_surfaces({"entities": []}), {})
+
+    expect("bare name matches qualified", name_matches("Session.send", "send"), True)
+    expect("qualified matches bare", name_matches("send", "Session.send"), True)
+    expect("siblings do not match", name_matches("req.get", "res.get"), False)
+    expect("empty never matches", name_matches("", "send"), False)
+
+    counted, withheld = upstream_rows(
+        {"references": [{"name": "A"}],
+         "candidates": [{"name": "B", "resolution": "name_only"}]})
+    expect("counted rows", entity_names(counted), ["A"])
+    expect("withheld rows", entity_names(withheld), ["B"])
+
+    res = Result("t", "T", "t")
+    res.ok("fine")
+    res.note("context only")
+    expect("a note never decides a result", res.status, PASS)
+    res.unknown("cannot read")
+    expect("unreadable outranks pass", res.status, UNREADABLE)
+    res.bad("broken")
+    expect("fail outranks unreadable", res.status, FAIL)
+    expect("the deciding detail is the failure", res.detail, "broken")
+    expect("an empty result is unreadable, not a pass",
+           Result("t", "T", "t").status, UNREADABLE)
+    expect("a result holding only notes is unreadable",
+           (lambda r: (r.note("x"), r.status)[1])(Result("t", "T", "t")), UNREADABLE)
+
+    expect("no baseline is not no change", trend_of(FAIL, None), "unknown")
+    expect("pass to fail is a regression", trend_of(FAIL, PASS), "regression")
+    expect("fail to pass is fixed", trend_of(PASS, FAIL), "fixed")
+
+    # The recall gate's predicate, every refusal beside its passing inverse. The
+    # lines are the literal accounting shapes 985-era daemons wrote on this
+    # machine, including the one that hid a dead JS server behind a clean exit.
+    clean = ("LSP cold sweep complete files=37 total_files=37 relations=4441 "
+             "enriched=37 already_enriched=0 unsupported_language=0 "
+             "server_unavailable=0 source_unreadable=0 not_visited=0 "
+             "ended_early=false unaccounted=0")
+    dead_server = clean.replace("enriched=37", "enriched=0").replace(
+        "server_unavailable=0", "server_unavailable=37").replace(
+        "relations=4441", "relations=0")
+    expect("a clean converged sweep admits recall",
+           sweep_verdict(sweep_lines(clean))[0], True)
+    expect("a dead-server sweep refuses recall",
+           sweep_verdict(sweep_lines(dead_server))[0], False)
+    expect("an interrupted sweep refuses recall",
+           sweep_verdict(sweep_lines(clean.replace(
+               "ended_early=false", "ended_early=true")))[0], False)
+    expect("an unvisited remainder refuses recall",
+           sweep_verdict(sweep_lines(clean.replace(
+               "not_visited=0", "not_visited=5")))[0], False)
+    expect("a nothing-enriched sweep refuses recall",
+           sweep_verdict(sweep_lines(clean.replace(
+               "enriched=37", "enriched=0")))[0], False)
+    expect("an empty log refuses recall", sweep_verdict([])[0], False)
+    expect("one clean line among dead ones admits recall",
+           sweep_verdict(sweep_lines(dead_server + "\n" + clean))[0], True)
+    pre985 = "LSP cold sweep complete files=37 total_files=37 relations=4441"
+    ok985, detail985 = sweep_verdict(sweep_lines(pre985))
+    expect("a pre-tally line exempts rather than refuses", ok985, True)
+    expect("the exemption says so out loud",
+           "not enforceable" in detail985, True)
+    ansi_clean = "\x1b[32mINFO\x1b[0m kin_daemon::daemon: " + clean
+    expect("ANSI colour never hides a clean sweep",
+           sweep_verdict(sweep_lines(ansi_clean))[0], True)
+
+    for line in failures:
+        print("SELF-TEST FAIL %s" % line)
+    print("kin-brownfield-repro: self-test %s"
+          % ("FAILED (%d)" % len(failures) if failures else "passed"))
+    return 1 if failures else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        add_help=True, description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"),
+                        help="kin binary under test (or KIN_BIN); "
+                             "cargo build --bin kin --bin kin-daemon builds one")
+    parser.add_argument("--daemon",
+                        help="kin-daemon binary to serve the fixtures "
+                             "(default: the sibling of --kin when one exists)")
+    parser.add_argument("--workdir")
+    parser.add_argument("--corpus-cache",
+                        default=os.path.expanduser("~/.cache/kin-brownfield-repro"))
+    parser.add_argument("--offline", action="store_true")
+    parser.add_argument("--label", default="")
+    parser.add_argument("--only", default="")
+    parser.add_argument("--json", dest="json_out")
+    parser.add_argument("--compare")
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true",
+                        help="exercise the verdict graders on fixed payloads and "
+                             "exit; needs no kin binary and no corpus")
+    opts = parser.parse_args(argv)
+
+    if opts.self_test:
+        return self_test()
+
+    if not opts.kin:
+        sys.stderr.write("no kin binary: pass --kin or set KIN_BIN "
+                         "(cargo build --bin kin --bin kin-daemon produces one)\n")
+        return 3
+    kin = os.path.abspath(os.path.expanduser(opts.kin))
+    if not os.path.exists(kin):
+        sys.stderr.write("kin binary not found: %s\n" % kin)
+        return 3
+    rc, out, err = run([kin, "--version"], timeout=600)
+    version = strip_ansi(out).strip().splitlines()[-1] if out.strip() else "unknown"
+
+    daemon = opts.daemon and os.path.abspath(os.path.expanduser(opts.daemon))
+    if daemon is None:
+        sibling = os.path.join(os.path.dirname(kin), "kin-daemon")
+        daemon = sibling if os.path.exists(sibling) else None
+    if daemon and not os.path.exists(daemon):
+        sys.stderr.write("kin-daemon binary not found: %s\n" % daemon)
+        return 3
+
+    workdir = opts.workdir or tempfile.mkdtemp(prefix="kin-brownfield-repro-")
+    if not os.path.isdir(workdir):
+        os.makedirs(workdir)
+    corpus_cache = os.path.abspath(os.path.expanduser(opts.corpus_cache))
+    if not os.path.isdir(corpus_cache):
+        os.makedirs(corpus_cache)
+    wanted = [w.strip() for w in opts.only.split(",") if w.strip()] or None
+
+    suite = Suite(kin, workdir, corpus_cache, daemon=daemon, offline=opts.offline,
+                  verbose=opts.verbose)
+    print("kin-brownfield-repro: %s" % NON_CITABLE)
+    print("kin-brownfield-repro: %s" % FIXTURE_SCOPE)
+    print("kin-brownfield-repro: %s" % version)
+    print("kin-brownfield-repro: binary %s" % kin)
+    print("kin-brownfield-repro: daemon %s" % (daemon or "(resolved by kin itself)"))
+    print("kin-brownfield-repro: workdir %s" % workdir)
+    print("kin-brownfield-repro: corpus cache %s%s"
+          % (corpus_cache, " (offline)" if opts.offline else ""))
+    for name in sorted(CORPORA):
+        spec = CORPORA[name]
+        print("kin-brownfield-repro: corpus %s %s commit %s tree %s"
+              % (name, spec["url"], spec["commit"], spec["tree"]))
+
+    prior = {}
+    prior_label = ""
+    if opts.compare:
+        try:
+            with open(opts.compare) as handle:
+                loaded = json.load(handle)
+            prior_label = loaded.get("label") or os.path.basename(opts.compare)
+            prior = {row["id"]: row.get("status") for row in loaded.get("results", [])}
+            print("kin-brownfield-repro: comparing against %s (%s)"
+                  % (prior_label, opts.compare))
+        except (IOError, ValueError, KeyError) as exc:
+            # An unreadable baseline must not silently become "no regressions".
+            print("kin-brownfield-repro: comparison baseline unreadable (%s): %s"
+                  % (opts.compare, exc))
+            prior = None
+
+    results = []
+    for check_id, fn in CHECKS:
+        if wanted and check_id not in wanted:
+            continue
+        try:
+            res = fn(suite)
+        except ProbeError as exc:
+            res = Result(check_id, "?", "probe failure")
+            res.unknown(str(exc)[:300])
+        except Exception as exc:
+            res = Result(check_id, "?", "harness failure")
+            res.unknown("%s: %s" % (type(exc).__name__, str(exc)[:300]))
+        results.append(res)
+        res.prior = None if prior is None else prior.get(res.id)
+        res.trend = trend_of(res.status, res.prior)
+        marker = res.status
+        if res.trend == "regression":
+            marker = "%s REGRESSION-from-%s-in-%s" % (res.status, res.prior, prior_label)
+        elif res.trend == "fixed":
+            marker = "%s fixed-since-%s" % (res.status, prior_label)
+        elif res.trend == "unknown":
+            marker = "%s trend-unknown" % res.status
+        print("CHECK %s %s %s %s" % (res.id, res.ticket, marker, res.detail))
+        if opts.verbose:
+            for a in res.asserts:
+                print("      %-11s %s" % (a["status"], a["detail"]))
+
+    stopped = suite.shutdown()
+    if stopped:
+        print("kin-brownfield-repro: stopped %d fixture daemon(s)" % len(stopped))
+
+    failed = [r for r in results if r.status == FAIL]
+    unread = [r for r in results if r.status == UNREADABLE]
+    regressed = [r for r in results if r.trend == "regression"]
+    print("kin-brownfield-repro: %d pass, %d fail, %d unreadable"
+          % (len(results) - len(failed) - len(unread), len(failed), len(unread)))
+    if regressed:
+        print("kin-brownfield-repro: %d regression(s) against %s: %s"
+              % (len(regressed), prior_label,
+                 ", ".join("%s/%s" % (r.id, r.ticket) for r in regressed)))
+    print("kin-brownfield-repro: %s" % NON_CITABLE)
+    print("kin-brownfield-repro: %s" % FIXTURE_SCOPE)
+
+    if opts.json_out:
+        with open(opts.json_out, "w") as handle:
+            json.dump({"citable": False, "lane": "DEV-LOCAL",
+                       "fixture_scope": FIXTURE_SCOPE,
+                       "label": opts.label, "kin": kin, "version": version,
+                       "workdir": workdir, "daemon": daemon,
+                       "corpora": CORPORA,
+                       "compared_against": prior_label,
+                       "results": [{"id": r.id, "ticket": r.ticket, "title": r.title,
+                                    "status": r.status, "detail": r.detail,
+                                    "prior_status": r.prior, "trend": r.trend,
+                                    "asserts": r.asserts} for r in results]},
+                      handle, indent=2)
+        print("kin-brownfield-repro: json %s" % opts.json_out)
+
+    if not opts.keep and not opts.workdir:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    if failed:
+        return 1
+    if unread:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/acceptance/gate.py
+++ b/scripts/acceptance/gate.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Decide the acceptance job from the suites' own JSON reports.
+
+The suites exit 1 on any FAIL, 2 when none fail but some are UNREADABLE, and 3
+on a setup error. Gating on that number alone gives one lever with two settings:
+demand a clean sweep, or demand nothing. Neither is right while a single check is
+blocked on something outside the change under review.
+
+So the gate reads the reports instead. A FAIL is never tolerated and has no
+allowance. An UNREADABLE fails too, unless it is named in an allowance that
+carries a reason, and every allowance is printed on every run so a suppressed
+check is never quiet.
+
+Three rules keep the allowance list from becoming a way to stop enforcing:
+
+  * An allowance naming a check the report does not carry is an error. A pointer
+    at nothing looks exactly like a satisfied allowance, so a renamed or deleted
+    check must break the gate rather than silently widen it.
+  * An allowance on a check that now passes is reported loudly as stale. It does
+    not fail the run, because a check that recovers should not turn the fleet red
+    on the next unrelated pull request, but it is on the summary until removed.
+  * A missing or unreadable report is a failure. A suite that wrote nothing did
+    not pass, and an absent file and a clean file are different facts.
+
+Usage:
+    python3 scripts/acceptance/gate.py \\
+        --report magic=acceptance/magic.json \\
+        --report brownfield=acceptance/brownfield.json \\
+        --allow-unreadable 'brownfield:4=reason the check is blocked'
+
+Exit status is 0 when the gate passes and 1 when it does not. `--self-test`
+exercises every rule above against its inverse and needs no reports.
+"""
+
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import sys
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+print = functools.partial(print, flush=True)
+
+
+class GateError(Exception):
+    """A gate that could not be decided. Always a failure, never a pass."""
+
+
+def parse_pair(text, what):
+    if "=" not in text:
+        raise GateError("%s must be NAME=VALUE, got %r" % (what, text))
+    name, value = text.split("=", 1)
+    name = name.strip()
+    if not name:
+        raise GateError("%s carries an empty name: %r" % (what, text))
+    return name, value
+
+
+def parse_allowance(text):
+    name, reason = parse_pair(text, "--allow-unreadable")
+    if ":" not in name:
+        raise GateError(
+            "--allow-unreadable must be SUITE:CHECK=REASON, got %r" % text)
+    suite, check = name.split(":", 1)
+    suite = suite.strip()
+    check = check.strip()
+    reason = reason.strip()
+    if not suite or not check:
+        raise GateError("--allow-unreadable names an empty suite or check: %r" % text)
+    if not reason:
+        raise GateError(
+            "--allow-unreadable %s:%s carries no reason; an allowance without one "
+            "is a suppression nobody can review" % (suite, check))
+    return (suite, check), reason
+
+
+def load_report(path):
+    """The report's results, or a GateError naming why it could not be read."""
+
+    if not os.path.exists(path):
+        raise GateError("no report at %s; a suite that wrote nothing did not pass"
+                        % path)
+    try:
+        with open(path) as handle:
+            payload = json.load(handle)
+    except ValueError as exc:
+        raise GateError("report %s is not JSON: %s" % (path, exc))
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise GateError("report %s carries no results list" % path)
+    if not results:
+        raise GateError("report %s carries an empty results list; a suite that "
+                        "graded nothing did not pass" % path)
+    rows = {}
+    for row in results:
+        if not isinstance(row, dict) or "id" not in row:
+            raise GateError("report %s carries a result with no id" % path)
+        rows[str(row["id"])] = row
+    return rows
+
+
+def decide(reports, allowances):
+    """Return (failures, notes) for one already-loaded set of reports."""
+
+    failures = []
+    notes = []
+    for (suite, check), reason in sorted(allowances.items()):
+        if suite not in reports:
+            failures.append(
+                "allowance %s:%s names a suite this gate did not run" % (suite, check))
+            continue
+        if check not in reports[suite]:
+            failures.append(
+                "allowance %s:%s names a check the report does not carry; an "
+                "allowance pointing at nothing reads exactly like a satisfied one"
+                % (suite, check))
+            continue
+        status = reports[suite][check].get("status")
+        if status == PASS:
+            notes.append(
+                "STALE ALLOWANCE %s:%s now passes, so its allowance can go (%s)"
+                % (suite, check, reason))
+        elif status == UNREADABLE:
+            notes.append("ALLOWED %s:%s is %s (%s)" % (suite, check, status, reason))
+    for suite in sorted(reports):
+        for check in sorted(reports[suite], key=lambda k: (len(k), k)):
+            row = reports[suite][check]
+            status = row.get("status")
+            detail = str(row.get("detail") or "")[:300]
+            if status == FAIL:
+                failures.append("%s:%s FAIL %s" % (suite, check, detail))
+            elif status == UNREADABLE:
+                if (suite, check) in allowances:
+                    continue
+                failures.append("%s:%s UNREADABLE %s" % (suite, check, detail))
+            elif status != PASS:
+                failures.append(
+                    "%s:%s carries status %r, which this gate does not recognize"
+                    % (suite, check, status))
+    return failures, notes
+
+
+def annotate(kind, message):
+    print("::%s::%s" % (kind, message))
+
+
+def run(report_args, allowance_args):
+    allowances = {}
+    for text in allowance_args:
+        key, reason = parse_allowance(text)
+        allowances[key] = reason
+    reports = {}
+    failures = []
+    for text in report_args:
+        name, path = parse_pair(text, "--report")
+        try:
+            reports[name] = load_report(path)
+        except GateError as exc:
+            failures.append("%s: %s" % (name, exc))
+    if reports:
+        found, notes = decide(reports, allowances)
+        failures += found
+        for note in notes:
+            print(note)
+            if note.startswith("STALE"):
+                annotate("warning", note)
+    for name in sorted(reports):
+        counts = {}
+        for row in reports[name].values():
+            counts[row.get("status")] = counts.get(row.get("status"), 0) + 1
+        print("%s: %s" % (name, ", ".join("%s %s" % (counts[k], k)
+                                          for k in sorted(counts))))
+    if failures:
+        for line in failures:
+            annotate("error", line)
+        print("acceptance gate FAILED on %d finding(s)" % len(failures))
+        return 1
+    print("acceptance gate passed")
+    return 0
+
+
+def self_test():
+    """Exercise every rule against its inverse. No reports, no binary."""
+
+    problems = []
+
+    def expect(label, got, want):
+        if got != want:
+            problems.append("%s: got %r, wanted %r" % (label, got, want))
+
+    clean = {"magic": {"0": {"status": PASS, "detail": "fine"}}}
+    expect("a clean report passes", decide(clean, {})[0], [])
+
+    failing = {"magic": {"0": {"status": FAIL, "detail": "broken"}}}
+    expect("a FAIL fails", len(decide(failing, {})[0]), 1)
+    expect("a FAIL has no allowance",
+           len(decide(failing, {("magic", "0"): "please"})[0]), 1)
+
+    unread = {"magic": {"0": {"status": UNREADABLE, "detail": "no answer"}}}
+    expect("an UNREADABLE fails by default", len(decide(unread, {})[0]), 1)
+    expect("an allowed UNREADABLE passes",
+           decide(unread, {("magic", "0"): "blocked on X"})[0], [])
+    expect("an allowed UNREADABLE is announced",
+           decide(unread, {("magic", "0"): "blocked on X"})[1][0].startswith("ALLOWED"),
+           True)
+
+    expect("an allowance pointing at nothing fails",
+           len(decide(clean, {("magic", "9"): "gone"})[0]), 1)
+    expect("an allowance on an unrun suite fails",
+           len(decide(clean, {("other", "0"): "gone"})[0]), 1)
+    stale_failures, stale_notes = decide(clean, {("magic", "0"): "recovered"})
+    expect("a stale allowance does not fail", stale_failures, [])
+    expect("a stale allowance is announced",
+           stale_notes[0].startswith("STALE ALLOWANCE"), True)
+
+    weird = {"magic": {"0": {"status": "SKIPPED", "detail": ""}}}
+    expect("an unrecognized status fails", len(decide(weird, {})[0]), 1)
+
+    for text, label in (
+            ("magic:4", "an allowance with no reason"),
+            ("magic=only a reason", "an allowance with no check"),
+            ("magic:4=", "an allowance with an empty reason"),
+            (":4=reason", "an allowance with an empty suite")):
+        try:
+            parse_allowance(text)
+            problems.append("%s was accepted: %r" % (label, text))
+        except GateError:
+            pass
+    expect("a well formed allowance parses",
+           parse_allowance("brownfield:4=blocked on FIR-1"),
+           (("brownfield", "4"), "blocked on FIR-1"))
+
+    missing = "/nonexistent/acceptance-gate-self-test.json"
+    try:
+        load_report(missing)
+        problems.append("a missing report was accepted")
+    except GateError:
+        pass
+
+    for line in problems:
+        print("SELF-TEST FAIL %s" % line)
+    print("acceptance gate: self-test %s"
+          % ("FAILED (%d)" % len(problems) if problems else "passed"))
+    return 1 if problems else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        add_help=True, description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--report", action="append", default=[],
+                        metavar="NAME=PATH",
+                        help="a suite's JSON report, repeatable")
+    parser.add_argument("--allow-unreadable", action="append", default=[],
+                        metavar="SUITE:CHECK=REASON",
+                        help="tolerate one UNREADABLE check, repeatable; the "
+                             "reason is required and is printed on every run")
+    parser.add_argument("--self-test", action="store_true",
+                        help="exercise every rule against its inverse and exit")
+    opts = parser.parse_args(argv)
+
+    if opts.self_test:
+        return self_test()
+    if not opts.report:
+        sys.stderr.write("no reports: pass at least one --report NAME=PATH\n")
+        return 1
+    try:
+        return run(opts.report, opts.allow_unreadable)
+    except GateError as exc:
+        annotate("error", "acceptance gate could not be decided: %s" % exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -752,7 +752,7 @@ def check_1(suite):
         res.unknown(miss)
         return res
     files = sorted({r.get("file_path") for r in payload.get("references") or []})
-    if any(f and f.endswith("acceptance-canary-no-such-file.py") for f in files):
+    if any(f and f.endswith("storage.py") for f in files):
         res.ok("find_references(parse_note) crosses into storage.py")
     else:
         res.bad("find_references(parse_note) returned %d reference(s) %s; "

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -5,10 +5,12 @@
 # Ported from the kin-ecosystem umbrella's bin/kin-magic-repro on 2026-08-21.
 # kin owns this copy from now on, so the suite versions with the product it
 # tests and every pull request runs it against its own build. The umbrella copy
-# is still what bin/kin-parity and the release tooling call; until those become
-# wrappers around this file, a change to either copy has to be reconciled with
-# the other, and the CHECK line format, exit codes, and fixtures are what make
-# that reconciliation mechanical.
+# is still what bin/kin-release-preflight and bin/kin-shipped-gate call; until
+# those become wrappers around this file, a change to either copy has to be
+# reconciled with the other. The CHECK line format, the exit codes, the
+# fixtures, and the `kin-magic-repro:` summary-line prefix are what make that
+# reconciliation mechanical, and kin-shipped-gate parses two of those summary
+# lines by prefix.
 """Falsifiable repro suite for the 2026-08-17 isolation-experiment defects.
 
 Each check builds a fixture, probes the surface the ticket's claim is about, and

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -752,7 +752,7 @@ def check_1(suite):
         res.unknown(miss)
         return res
     files = sorted({r.get("file_path") for r in payload.get("references") or []})
-    if any(f and f.endswith("storage.py") for f in files):
+    if any(f and f.endswith("acceptance-canary-no-such-file.py") for f in files):
         res.ok("find_references(parse_note) crosses into storage.py")
     else:
         res.bad("find_references(parse_note) returned %d reference(s) %s; "

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -1,0 +1,1401 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Ported from the kin-ecosystem umbrella's bin/kin-magic-repro on 2026-08-21.
+# kin owns this copy from now on, so the suite versions with the product it
+# tests and every pull request runs it against its own build. The umbrella copy
+# is still what bin/kin-parity and the release tooling call; until those become
+# wrappers around this file, a change to either copy has to be reconciled with
+# the other, and the CHECK line format, exit codes, and fixtures are what make
+# that reconciliation mechanical.
+"""Falsifiable repro suite for the 2026-08-17 isolation-experiment defects.
+
+Each check builds a fixture, probes the surface the ticket's claim is about, and
+prints one line:
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+UNREADABLE is a distinct outcome from FAIL and is never reported as a pass: it
+means the probe could not be evaluated (no response, a non-JSON payload, a field
+whose name the fix has not defined yet). Exit status is 1 when any check FAILs,
+2 when none fail but some are UNREADABLE, 0 only when every selected check
+passes.
+
+Every check is required to be able to fail. Run the suite against the shipped
+0.5.36 binary first: a check that passes there is not testing its defect.
+Measured on 0.5.36 (4fd558da), checks 1-9 all FAIL.
+
+Usage:
+    python3 scripts/acceptance/magic_repro.py --kin <path-to-kin-binary> [options]
+
+Options:
+    --kin PATH        kin binary under test (required)
+    --workdir PATH    fixture root (default: a fresh temp dir)
+    --label NAME      label recorded in the JSON report
+    --only IDS        comma-separated check ids to run (default: all)
+    --json PATH       write machine-readable results here
+    --tips PATH       record this file's contents in the JSON as the composed set
+    --compare PATH    a prior run's --json output; each check is reported against
+                      its status there, so a check that passed in that run and
+                      fails in this one reads REGRESSION rather than plain FAIL
+    --keep            keep fixtures after the run
+    --verbose         print every sub-assertion, not just the deciding one
+
+The suite never runs GPU work: KIN_DAEMON_AUTO_EMBED=0 is exported for every
+fixture and check 0 asserts the daemon logged the operator opt-out.
+"""
+
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+ANSI = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+AUTO_EMBED_OPT_OUT_LINE = "background embedding deferred by operator opt-out"
+
+SPINE_REASON = re.compile(r"cross_repo|spine", re.I)
+EDGE_GAP_REASON = re.compile(
+    r"cross_file_edges_absent|edge_coverage|cross-file|cross_file|enrichment", re.I
+)
+CROSS_FILE_METRIC = re.compile(
+    r"Cross-file entity relations:\s*(\d+)\s+of\s+(\d+)", re.I
+)
+
+
+print = functools.partial(print, flush=True)
+
+
+def strip_ansi(text):
+    return ANSI.sub("", text or "")
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+    return (
+        proc.returncode,
+        strip_ansi(proc.stdout.decode("utf-8", "replace")),
+        strip_ansi(proc.stderr.decode("utf-8", "replace")),
+    )
+
+
+class McpError(Exception):
+    pass
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, verbose=False, daemon=None):
+        self.kin = kin
+        self.daemon = daemon
+        self.workdir = workdir
+        self.verbose = verbose
+        self.fixtures = {}
+        self.run_id = "r%d" % os.getpid()
+        self.env = dict(os.environ)
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env.pop("KIN_MCP_REPO", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+
+    # ---------------------------------------------------------------- plumbing
+
+    def kin_run(self, args, repo, timeout=600):
+        return run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+
+    def git(self, args, repo):
+        base = ["git", "-c", "core.hooksPath=/dev/null",
+                "-c", "user.email=repro@example.invalid",
+                "-c", "user.name=kin-magic-repro",
+                "-c", "commit.gpgsign=false"]
+        return run(base + args, cwd=repo, env=self.env)
+
+    def mcp(self, repo, tool, args, timeout=300):
+        """One tools/call over kin's stdio MCP server.
+
+        The MCP path is the surface that applies the negative/completeness
+        envelope, so envelope claims are probed here rather than on the raw
+        daemon route, which wraps a payload carrying no such envelope.
+        """
+        env = dict(self.env)
+        env["KIN_MCP_REPO"] = repo
+        proc = subprocess.Popen(
+            [self.kin, "mcp", "start", "--repo", repo],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=repo,
+            env=env,
+            text=True,
+        )
+        msgs = [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+             "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                        "clientInfo": {"name": "kin-magic-repro", "version": "1"}}},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 2, "method": tool,
+             "params": args} if tool.startswith("tools/") else
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+             "params": {"name": tool, "arguments": args}},
+        ]
+        payload = "".join(json.dumps(m) + "\n" for m in msgs)
+        try:
+            out, err = proc.communicate(payload, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            raise McpError("mcp %s timed out after %ss" % (tool, timeout))
+        resp = None
+        for line in out.splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                obj = json.loads(line)
+            except ValueError:
+                continue
+            if obj.get("id") == 2:
+                resp = obj
+        if resp is None:
+            raise McpError("mcp %s returned no id=2 frame (stderr tail: %s)"
+                           % (tool, strip_ansi(err)[-200:].replace("\n", " ")))
+        if "error" in resp:
+            raise McpError("mcp %s error: %s" % (tool, json.dumps(resp["error"])[:200]))
+        result = resp.get("result") or {}
+        if tool.startswith("tools/"):
+            return result, len(json.dumps(result))
+        content = result.get("content") or []
+        if not content or "text" not in content[0]:
+            raise McpError("mcp %s returned no text content" % tool)
+        text = content[0]["text"]
+        try:
+            payload = json.loads(text)
+        except ValueError:
+            raise McpError("mcp %s%s payload is not JSON (first 160 chars: %r)"
+                           % (tool, " isError" if result.get("isError") else "",
+                              text[:160]))
+        if result.get("isError") and not isinstance(payload, dict):
+            raise McpError("mcp %s isError with a non-object payload" % tool)
+        return payload, len(text)
+
+    # ---------------------------------------------------------------- fixtures
+
+    def fixture(self, name):
+        if name not in self.fixtures:
+            path = os.path.join(self.workdir, "%s-%s" % (name, self.run_id))
+            attempt = 0
+            while os.path.exists(path):
+                attempt += 1
+                path = os.path.join(self.workdir,
+                                    "%s-%s-%d" % (name, self.run_id, attempt))
+            os.makedirs(path)
+            getattr(self, "_build_" + name)(path)
+            self.fixtures[name] = path
+        return self.fixtures[name]
+
+    def shutdown(self):
+        """Stop the per-fixture daemons this run started.
+
+        Each fixture is a fresh repository, so its daemon has nothing to serve
+        once the run ends; leaving them alive leaks one process per fixture per
+        run and holds the fixture's files against removal.
+        """
+        stopped = []
+        for path in self.fixtures.values():
+            pid_file = os.path.join(path, ".kin", "daemon.pid")
+            if not os.path.exists(pid_file):
+                continue
+            try:
+                with open(pid_file) as handle:
+                    pid = int(handle.read().strip())
+                os.kill(pid, 15)
+                stopped.append(pid)
+            except (ValueError, OSError):
+                continue
+        return stopped
+
+    def _write(self, repo, rel, text):
+        full = os.path.join(repo, rel)
+        parent = os.path.dirname(full)
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent)
+        with open(full, "w") as handle:
+            handle.write(text)
+
+    def _kin_init(self, repo):
+        rc, out, err = self.kin_run(["init", "."], repo)
+        if rc != 0:
+            raise RuntimeError("kin init failed in %s: %s" % (repo, (err or out)[-300:]))
+
+    def _kin_commit(self, repo, message):
+        rc, out, err = self.kin_run(["commit", "-m", message], repo)
+        if rc != 0:
+            raise RuntimeError("kin commit failed in %s: %s" % (repo, (err or out)[-300:]))
+
+    def _build_incremental(self, repo):
+        """The greenfield shape: modules written and committed one at a time.
+
+        This is the ingestion path the isolation session used, and it is the
+        path FIR-2354 is about. The same sources bulk-converted through git DO
+        get cross-file edges, so the fixture must not be built in bulk.
+        """
+        self.git(["init", "-q", "."], repo)
+        self._write(repo, ".gitignore", "*.db\n__pycache__/\n")
+        self._write(repo, "pyproject.toml",
+                    '[project]\nname = "nk"\nversion = "0.1.0"\n\n'
+                    '[project.scripts]\nnk = "pkg.cli:main"\n')
+        self._write(repo, "pkg/__init__.py", "")
+        self._write(repo, "pkg/parsing.py", PARSING_PY)
+        self._kin_init(repo)
+        self._kin_commit(repo, "Add parsing module")
+        self._write(repo, "pkg/storage.py", STORAGE_PY)
+        self._kin_commit(repo, "Add storage module")
+        self._write(repo, "pkg/linkgraph.py", LINKGRAPH_PY)
+        self._kin_commit(repo, "Add link graph module")
+        self._write(repo, "pkg/cli.py", CLI_PY)
+        self._kin_commit(repo, "Add CLI entry point")
+
+    def _build_converted(self, repo):
+        """The brownfield shape: a git history converted by kin init.
+
+        FIR-2360's false edges were observed on a conversion, so the precision
+        fixture uses the path that emits cross-file edges at all.
+        """
+        self.git(["init", "-q", "."], repo)
+        self._write(repo, ".gitignore", "__pycache__/\n")
+        self._write(repo, "app/__init__.py", "")
+        self._write(repo, "app/adapter.py", ADAPTER_PY)
+        self._write(repo, "app/session.py", SESSION_PY)
+        self._write(repo, "app/pipeline.py", PIPELINE_PY)
+        self._write(repo, "tests/test_session.py", TEST_SESSION_PY)
+        self.git(["add", "-A"], repo)
+        rc, out, err = self.git(["commit", "-q", "-m", "initial fixture"], repo)
+        if rc != 0:
+            raise RuntimeError("git commit failed: %s" % (err or out)[-300:])
+        self._kin_init(repo)
+
+    def _build_js(self, repo):
+        self.git(["init", "-q", "."], repo)
+        self._write(repo, ".gitignore", "node_modules/\n")
+        self._write(repo, "lib/router.js", ROUTER_JS)
+        self._write(repo, "lib/app.js", APP_JS)
+        self.git(["add", "-A"], repo)
+        rc, out, err = self.git(["commit", "-q", "-m", "initial js fixture"], repo)
+        if rc != 0:
+            raise RuntimeError("git commit failed: %s" % (err or out)[-300:])
+        self._kin_init(repo)
+
+    def _build_venv(self, repo):
+        self.git(["init", "-q", "."], repo)
+        self._write(repo, ".gitignore", "*.log\n")
+        self._write(repo, "tool.py", "def run():\n    return \"ok\"\n")
+        self._kin_init(repo)
+        self._kin_commit(repo, "Add tool module")
+
+    # ------------------------------------------------------------ status probes
+
+    def graph_status(self, repo):
+        rc, out, err = self.kin_run(["graph", "status"], repo)
+        text = out + "\n" + err
+        info = {"raw": text, "rc": rc, "entities": None, "relations": None,
+                "files": None, "relation_kinds": {}, "kinds": {}, "cross_file": None}
+        head = re.search(r"Entities:\s*(\d+).*?relations:\s*(\d+).*?Files:\s*(\d+)", text)
+        if head:
+            info["entities"] = int(head.group(1))
+            info["relations"] = int(head.group(2))
+            info["files"] = int(head.group(3))
+        kinds = re.search(r"Entity-to-entity relation kinds:\s*(.*)", text)
+        if kinds:
+            for part in kinds.group(1).split(","):
+                bits = part.strip().split(":")
+                if len(bits) == 2 and bits[1].strip().isdigit():
+                    info["relation_kinds"][bits[0].strip()] = int(bits[1].strip())
+        ekinds = re.search(r"^Kinds:\s*(.*)$", text, re.M)
+        if ekinds:
+            for part in ekinds.group(1).split(","):
+                bits = part.strip().split(":")
+                if len(bits) == 2 and bits[1].strip().isdigit():
+                    info["kinds"][bits[0].strip()] = int(bits[1].strip())
+        metric = CROSS_FILE_METRIC.search(text)
+        if metric:
+            info["cross_file"] = (int(metric.group(1)), int(metric.group(2)))
+        if info["entities"] is None:
+            raise McpError("kin graph status rc=%d printed no counters: %s"
+                           % (rc, text.strip()[-200:]))
+        return info
+
+    def search_entities(self, repo, query):
+        rc, out, err = self.kin_run(["search", query], repo)
+        rows = []
+        for line in (out + "\n" + err).splitlines():
+            match = re.match(r"\s+(.+?)\s+\((\w+),\s*(\w+)\)\s+-\s+(.+?)\s*$", line)
+            if match and "fallback" not in line:
+                rows.append({"name": match.group(1), "kind": match.group(2),
+                             "language": match.group(3), "file": match.group(4)})
+        return rows
+
+    def inspect(self, repo, name):
+        rc, out, err = self.kin_run(["graph", "inspect", name], repo)
+        text = out + "\n" + err
+        if rc != 0:
+            return None
+        rels = []
+        for line in text.splitlines():
+            match = re.match(
+                r"\s*(<-|->)\s+(\w+)\s+(.+?)\s+\[(\w+)\]\s+\((.+?);", line)
+            if match:
+                rels.append({"dir": "in" if match.group(1) == "<-" else "out",
+                             "relation": match.group(2), "name": match.group(3),
+                             "kind": match.group(4), "file": match.group(5)})
+        return {"raw": text, "relations": rels}
+
+    def dead_code(self, repo):
+        rc, out, err = self.kin_run(["dead-code"], repo)
+        text = out + "\n" + err
+        rows = []
+        for line in text.splitlines():
+            match = re.match(r"\s+(\S+)\s+\((\w+),\s*(\w+)\)\s+-\s+(.+?)\s*$", line)
+            if match:
+                rows.append({"name": match.group(1), "kind": match.group(2),
+                             "file": match.group(4)})
+        return {"raw": text, "rows": rows, "rc": rc}
+
+    def references(self, repo, query, settle=2):
+        """find_references, retried once while the graph settles.
+
+        A commit's enrichment lands asynchronously, so a probe fired
+        immediately after the last fixture commit can hit a graph that has not
+        resolved the symbol yet. The retry is bounded and a symbol that never
+        resolves still reports unresolved rather than absent.
+        """
+        payload, _ = self.mcp(repo, "find_references", {"query": query})
+        if (payload.get("focal_entity") or {}).get("id"):
+            return payload
+        time.sleep(settle)
+        payload, _ = self.mcp(repo, "find_references", {"query": query})
+        return payload
+
+
+# ----------------------------------------------------------------- fixture code
+
+PARSING_PY = '''import re
+
+TAG_RE = re.compile(r"(?<![\\w#])#([A-Za-z][\\w/-]*)")
+
+
+def normalize_title(title):
+    return title.strip().lower()
+
+
+def strip_code(text):
+    return text.replace("`", "")
+
+
+def extract_tags(text):
+    return TAG_RE.findall(strip_code(text))
+
+
+def extract_links(text):
+    return [normalize_title(part) for part in text.split("|")]
+
+
+def parse_note(text, path):
+    return {"path": str(path), "tags": extract_tags(text), "links": extract_links(text)}
+'''
+
+STORAGE_PY = '''from .parsing import parse_note, normalize_title
+
+
+class Database:
+    def __init__(self, path):
+        self.path = path
+        self.notes = {}
+
+    def ingest_note(self, note):
+        key = normalize_title(note["path"])
+        self.notes[key] = note
+        return normalize_title(key)
+
+    def ingest_dir(self, root):
+        for name, text in root.items():
+            self.ingest_note(parse_note(text, name))
+        return len(self.notes)
+
+    def all_notes(self):
+        return list(self.notes.values())
+'''
+
+LINKGRAPH_PY = '''from .parsing import normalize_title
+from .storage import Database
+
+
+class LinkGraph:
+    def __init__(self, edges):
+        self.edges = edges
+
+    @staticmethod
+    def from_db(db: Database):
+        edges = {}
+        for note in db.all_notes():
+            edges[normalize_title(note["path"])] = [normalize_title(link)
+                                                    for link in note["links"]]
+        return LinkGraph(edges)
+
+    def backlinks(self, title):
+        return [src for src, dsts in self.edges.items() if title in dsts]
+'''
+
+CLI_PY = '''from .linkgraph import LinkGraph
+from .storage import Database
+
+
+def main():
+    db = Database(":memory:")
+    db.ingest_dir({"a.md": "hello #tag b|c"})
+    return LinkGraph.from_db(db).backlinks("b")
+'''
+
+ADAPTER_PY = '''class Adapter:
+    def send(self, request):
+        return {"ok": True, "request": request}
+
+    def close(self):
+        return None
+'''
+
+SESSION_PY = '''from .adapter import Adapter
+
+
+class Session:
+    def __init__(self):
+        self.adapter = Adapter()
+
+    def send(self, request):
+        return self.adapter.send(request)
+
+    def request(self, url):
+        return self.send({"url": url})
+
+    def shutdown(self):
+        return self.adapter.close()
+
+    def drain(self, thing):
+        return thing.close()
+'''
+
+PIPELINE_PY = '''from .session import Session
+
+
+def run_all(session: Session):
+    session.request("a")
+    session.send({"url": "b"})
+    session.shutdown()
+    session.drain(session.adapter)
+    return True
+'''
+
+TEST_SESSION_PY = '''from app.session import Session
+
+
+class FakeAdapter:
+    def send(self, request):
+        return {"ok": False, "request": request}
+
+    def close(self):
+        return None
+
+
+def test_session_send():
+    session = Session()
+    session.adapter = FakeAdapter()
+    assert session.send({"url": "u"})["ok"] is False
+'''
+
+ROUTER_JS = '''class Router {
+  constructor(options) {
+    this.options = options || {};
+    this.stack = [];
+  }
+
+  use(fn) {
+    this.stack.push(fn);
+    return this;
+  }
+
+  handle(req) {
+    return this.stack.map((fn) => fn(req));
+  }
+}
+
+function Layer(path) {
+  this.path = path;
+}
+
+Layer.prototype.match = function match(candidate) {
+  return this.path === candidate;
+};
+
+Layer.prototype.describe = function describe() {
+  return "layer:" + this.path;
+};
+
+const helpers = {
+  normalize(path) {
+    return String(path).toLowerCase();
+  },
+  join: function join(a, b) {
+    return helpers.normalize(a) + "/" + helpers.normalize(b);
+  },
+};
+
+const compose = (first, second) => (value) => second(first(value));
+
+module.exports = { Router, Layer, helpers, compose };
+'''
+
+APP_JS = '''const { Router, helpers } = require("./router");
+
+class Application {
+  constructor() {
+    this.router = new Router({});
+  }
+
+  mount(fn) {
+    this.router.use(fn);
+    return this;
+  }
+
+  route(path) {
+    return helpers.normalize(path);
+  }
+}
+
+module.exports = { Application };
+'''
+
+
+# ------------------------------------------------------------------- assertions
+
+def resolution_miss(payload, query):
+    """A payload whose focal entity never resolved answers nothing.
+
+    An unresolved symbol and a symbol with no references are different facts
+    and the second must never be inferred from the first.
+    """
+    if (payload.get("focal_entity") or {}).get("id"):
+        return None
+    negative = payload.get("negative") or {}
+    return "find_references(%s) resolved no focal entity (%s)" % (
+        query, negative.get("kind") or negative.get("subject") or "no reason given")
+
+
+def trend_of(status, prior):
+    """Where this check moved since the run being compared against.
+
+    A prior run that could not be read reports `unknown` rather than `same`,
+    because "no baseline" and "no change" are different facts and the second
+    must never be inferred from the first.
+    """
+    if prior is None:
+        return "unknown"
+    if prior == PASS and status != PASS:
+        return "regression"
+    if prior != PASS and status == PASS:
+        return "fixed"
+    return "same"
+
+
+class Result(object):
+    def __init__(self, check_id, ticket, title):
+        self.id = check_id
+        self.ticket = ticket
+        self.title = title
+        self.prior = None
+        self.trend = "unknown"
+        self.asserts = []
+
+    def add(self, status, detail):
+        self.asserts.append({"status": status, "detail": detail})
+
+    def ok(self, detail):
+        self.add(PASS, detail)
+
+    def bad(self, detail):
+        self.add(FAIL, detail)
+
+    def unknown(self, detail):
+        self.add(UNREADABLE, detail)
+
+    @property
+    def status(self):
+        if any(a["status"] == FAIL for a in self.asserts):
+            return FAIL
+        if any(a["status"] == UNREADABLE for a in self.asserts):
+            return UNREADABLE
+        if not self.asserts:
+            return UNREADABLE
+        return PASS
+
+    @property
+    def detail(self):
+        for wanted in (FAIL, UNREADABLE):
+            for a in self.asserts:
+                if a["status"] == wanted:
+                    return a["detail"]
+        return self.asserts[-1]["detail"]
+
+
+# ---------------------------------------------------------------------- checks
+
+def check_0(suite):
+    """The GPU opt-out is honored, so no check in this suite runs inference."""
+    res = Result("0", "GPU-OPTOUT", "auto-embed deferred by operator opt-out")
+    repo = suite.fixture("incremental")
+    log = os.path.join(repo, ".kin", "daemon.log")
+    if not os.path.exists(log):
+        res.unknown("no daemon log at %s, cannot confirm the opt-out was honored" % log)
+        return res
+    deferred = 0
+    with open(log, errors="replace") as handle:
+        for line in handle:
+            if AUTO_EMBED_OPT_OUT_LINE in strip_ansi(line):
+                deferred += 1
+    pid_file = os.path.join(repo, ".kin", "daemon.pid")
+    served = None
+    if os.path.exists(pid_file):
+        try:
+            with open(pid_file) as handle:
+                pid = handle.read().strip()
+            # /proc/<pid>/exe is the only read that returns the executable's
+            # real path on Linux. `ps -o comm=` there is the bare process name
+            # truncated to fifteen characters, so comparing it with an absolute
+            # path is a check that can never pass; it only ever worked on
+            # macOS, where comm carries the full path. The first Linux-leg run
+            # of this suite (2026-08-19) failed exactly that way.
+            exe_link = "/proc/%s/exe" % pid
+            if os.path.exists(exe_link):
+                try:
+                    served = os.readlink(exe_link)
+                except OSError:
+                    served = None
+            else:
+                prc, pout, _perr = run(["ps", "-p", pid, "-o", "comm="], timeout=30)
+                served = pout.strip() if prc == 0 else None
+        except (OSError, ValueError):
+            served = None
+    if served is None:
+        res.unknown("could not resolve which kin-daemon binary served the fixture")
+    elif suite.daemon and os.path.realpath(served) != os.path.realpath(suite.daemon):
+        res.bad("fixture served by %s, not the requested %s" % (served, suite.daemon))
+    else:
+        res.ok("fixture served by %s" % served)
+    status = suite.graph_status(repo)
+    indexed = re.search(r"Embeddings:\s*(\d+)/(\d+)\s*indexed", status["raw"])
+    if deferred == 0:
+        res.bad("daemon log carries no %r line; embeddings may have run"
+                % AUTO_EMBED_OPT_OUT_LINE)
+    else:
+        res.ok("daemon logged the opt-out %d time(s)" % deferred)
+    if indexed and int(indexed.group(1)) != 0:
+        res.bad("embeddings indexed=%s despite the opt-out" % indexed.group(1))
+    elif indexed:
+        res.ok("embeddings indexed=0/%s" % indexed.group(2))
+    return res
+
+
+def check_1(suite):
+    """FIR-2354: the incremental path must produce cross-file edges."""
+    res = Result("1", "FIR-2354", "cross-file edges on the incremental commit path")
+    repo = suite.fixture("incremental")
+    status = suite.graph_status(repo)
+    kinds = status["relation_kinds"]
+    if status["cross_file"] is not None:
+        seen, total = status["cross_file"]
+        if seen > 0:
+            res.ok("graph status reports %d of %d relations cross-file" % (seen, total))
+        else:
+            res.bad("graph status reports 0 of %d relations cross-file" % total)
+    elif "Imports" in kinds and kinds["Imports"] > 0:
+        res.ok("relation kinds carry Imports: %d" % kinds["Imports"])
+    else:
+        res.bad("relation kinds are %s: no Imports kind and no cross-file metric"
+                % (kinds or "{}"))
+    try:
+        payload = suite.references(repo, "parse_note")
+    except McpError as exc:
+        res.unknown("find_references(parse_note) unreadable: %s" % exc)
+        return res
+    miss = resolution_miss(payload, "parse_note")
+    if miss:
+        res.unknown(miss)
+        return res
+    files = sorted({r.get("file_path") for r in payload.get("references") or []})
+    if any(f and f.endswith("storage.py") for f in files):
+        res.ok("find_references(parse_note) crosses into storage.py")
+    else:
+        res.bad("find_references(parse_note) returned %d reference(s) %s; "
+                "storage.py imports and calls it"
+                % (len(payload.get("references") or []), files))
+    return res
+
+
+def check_2(suite):
+    """FIR-2353: an empty absence may never be authoritative, and its reason
+    must name the limiting factor rather than a cross-repo spine mismatch."""
+    res = Result("2", "FIR-2353", "absence authority on an empty find_references")
+    repo = suite.fixture("incremental")
+    try:
+        payload = suite.references(repo, "parse_note")
+    except McpError as exc:
+        res.unknown("find_references(parse_note) unreadable: %s" % exc)
+        return res
+    miss = resolution_miss(payload, "parse_note")
+    if miss:
+        res.unknown(miss)
+        return res
+    refs = payload.get("references") or []
+    if refs:
+        res.ok("references returned (%d), so the absence path is not exercised"
+               % len(refs))
+        return res
+    negative = payload.get("negative")
+    if not isinstance(negative, dict):
+        res.bad("empty result carries no negative object at all")
+        return res
+    safe = negative.get("safe_to_conclude_absent")
+    trust = negative.get("trust")
+    reason = negative.get("trust_reason") or ""
+    if safe is True or trust == "authoritative":
+        res.bad("empty result claims safe_to_conclude_absent=%r trust=%r on a graph "
+                "holding no cross-file edges" % (safe, trust))
+        return res
+    res.ok("safe_to_conclude_absent=%r trust=%r" % (safe, trust))
+    leading = reason.split(":", 1)[0].strip()
+    if EDGE_GAP_REASON.search(leading):
+        res.ok("trust_reason leads with the edge gap: %s" % leading)
+    elif SPINE_REASON.search(leading):
+        res.bad("trust_reason leads with %r, a cross-repo/spine cause, for a cross-file "
+                "edge gap: %s" % (leading, reason[:200]))
+    else:
+        res.bad("trust_reason does not lead with the limiting factor: %s"
+                % (reason[:200] or "(empty)"))
+    return res
+
+
+def check_3(suite):
+    """FIR-2357: a partial answer must say it is partial.
+
+    normalize_title has five call sites across three files in the fixture:
+    extract_links (parsing), ingest_note twice (storage), from_db twice
+    (linkgraph).
+    """
+    res = Result("3", "FIR-2357", "completeness signal on a partial find_references")
+    repo = suite.fixture("incremental")
+    try:
+        payload = suite.references(repo, "normalize_title")
+    except McpError as exc:
+        res.unknown("find_references(normalize_title) unreadable: %s" % exc)
+        return res
+    miss = resolution_miss(payload, "normalize_title")
+    if miss:
+        res.unknown(miss)
+        return res
+    refs = payload.get("references") or []
+    files = sorted({r.get("file_path") for r in refs if r.get("file_path")})
+    expected_files = {"pkg/parsing.py", "pkg/storage.py", "pkg/linkgraph.py"}
+    if expected_files.issubset(set(files)):
+        res.ok("all three calling files returned: %s" % files)
+        return res
+    signal = None
+    for key in ("completeness", "edge_coverage"):
+        if isinstance(payload.get(key), dict):
+            signal = key
+            break
+    if signal is None and isinstance(payload.get("negative"), dict):
+        signal = "negative"
+    if signal is None:
+        res.bad("partial answer (%d ref(s) from %s, ground truth 5 sites in 3 files) "
+                "carries no completeness signal" % (len(refs), files))
+        return res
+    res.ok("partial answer carries a %r signal" % signal)
+    marked = json.dumps(payload.get(signal))
+    if re.search(r"absent|partial|incomplete|unknown|false", marked, re.I):
+        res.ok("%s marks the answer partial" % signal)
+    else:
+        res.bad("%s is present but marks nothing partial: %s" % (signal, marked[:160]))
+    return res
+
+
+def check_4(suite):
+    """FIR-2356: dead-code must not contradict find_references, must not list a
+    declared entry point, and must label rows when coverage is incomplete."""
+    res = Result("4", "FIR-2356", "dead-code delete list against real references")
+    repo = suite.fixture("incremental")
+    dead = suite.dead_code(repo)
+    names = [row["name"] for row in dead["rows"]]
+    if "main" in names:
+        res.bad("dead-code lists 'main', the declared console entry point in pyproject.toml")
+    else:
+        res.ok("dead-code does not list the declared entry point")
+    contradictions = []
+    unreadable = []
+    for name in names:
+        try:
+            payload = suite.references(repo, name)
+        except McpError as exc:
+            unreadable.append("%s (%s)" % (name, exc))
+            continue
+        if resolution_miss(payload, name):
+            unreadable.append("%s (unresolved)" % name)
+            continue
+        if payload.get("references"):
+            callers = ", ".join(sorted({r.get("name", "?")
+                                        for r in payload["references"]})[:3])
+            contradictions.append("%s <- %s" % (name, callers))
+    if contradictions:
+        res.bad("dead-code lists %d entit(ies) find_references says have callers: %s"
+                % (len(contradictions), "; ".join(contradictions[:4])))
+    elif unreadable:
+        res.unknown("could not read references for %d listed entit(ies): %s"
+                    % (len(unreadable), unreadable[0]))
+    else:
+        res.ok("no listed entity has references (%d listed)" % len(names))
+    status = suite.graph_status(repo)
+    # The cross-file metric is the authority on whether this graph is missing the
+    # edge class the delete list rests on. The absence of an `Imports` relation
+    # kind is only a proxy for that, and a linker that resolves cross-file calls
+    # without minting a separate Imports kind makes the proxy wrong: a graph
+    # reporting 8 of 21 relations cross-file is not missing cross-file edges, so
+    # demanding an incompleteness label on it asks the tool to disclose a gap it
+    # does not have. Read the metric when it exists; fall back to the proxy only
+    # when nothing reports coverage at all.
+    if status["cross_file"] is not None:
+        incomplete = status["cross_file"][0] == 0
+        basis = "graph status reports %d of %d relations cross-file" % status["cross_file"]
+    else:
+        incomplete = "Imports" not in status["relation_kinds"]
+        basis = "no cross-file metric, and relation kinds are %s" % (
+            status["relation_kinds"] or "{}")
+    labeled = re.search(r"unverified|not verified|incomplete|coverage", dead["raw"], re.I)
+    if names and incomplete and not labeled:
+        res.bad("delete list printed with no unverified/coverage label although %s"
+                % basis)
+    elif names and incomplete:
+        res.ok("delete list is labeled for incomplete coverage (%s)" % basis)
+    else:
+        res.ok("coverage is not reported incomplete (%s)" % basis)
+    return res
+
+
+def check_5(suite):
+    """FIR-2360: a call edge must not resolve a production call site onto a test
+    double, and a genuinely ambiguous receiver must be marked name-only."""
+    res = Result("5", "FIR-2360", "call-edge precision against a test double")
+    repo = suite.fixture("converted")
+    sends = suite.inspect(repo, "Session.send")
+    if sends is None:
+        res.unknown("kin graph inspect Session.send did not resolve")
+        return res
+    false_edges = [r for r in sends["relations"]
+                   if r["dir"] == "out" and r["relation"] == "Calls"
+                   and r["file"].startswith("tests/")]
+    if false_edges:
+        res.bad("Session.send -> %s: a production call site resolved onto a test double"
+                % ", ".join(r["name"] for r in false_edges))
+    else:
+        res.ok("Session.send has no outgoing Calls edge into tests/")
+    try:
+        payload = suite.references(repo, "Adapter.send")
+    except McpError as exc:
+        res.unknown("find_references(Adapter.send) unreadable: %s" % exc)
+        return res
+    miss = resolution_miss(payload, "Adapter.send")
+    if miss:
+        res.unknown(miss)
+        return res
+    test_callers = [r for r in payload.get("references") or []
+                    if (r.get("file_path") or "").startswith("tests/")]
+    if test_callers:
+        res.bad("Adapter.send claims caller(s) %s; the test calls Session.send"
+                % ", ".join(r.get("name", "?") for r in test_callers))
+    else:
+        res.ok("Adapter.send claims no test caller")
+    drain = suite.inspect(repo, "Session.drain")
+    if drain is None:
+        res.unknown("kin graph inspect Session.drain did not resolve")
+        return res
+    candidates = [r for r in drain["relations"]
+                  if r["dir"] == "out" and r["relation"] == "Calls"]
+    if len(candidates) <= 1:
+        res.ok("the ambiguous receiver in Session.drain produced %d edge(s)"
+               % len(candidates))
+        return res
+    marker = re.search(r"name[_ -]?only|name_match|resolution", drain["raw"], re.I)
+    if marker:
+        res.ok("ambiguous candidates carry a resolution marker: %s" % marker.group(0))
+    else:
+        res.unknown("Session.drain fans out to %d candidates with no confidence "
+                    "marker; pending FIR-2360 field name"
+                    % len(candidates))
+    return res
+
+
+def check_6(suite):
+    """FIR-2361: a shape query must be cheap, and truncation must say where."""
+    res = Result("6", "FIR-2361", "trace_data_flow compact mode and localized truncation")
+    repo = suite.fixture("converted")
+    try:
+        tools, _ = suite.mcp(repo, "tools/list", {})
+    except McpError as exc:
+        res.unknown("tools/list unreadable: %s" % exc)
+        return res
+    schema = None
+    for tool in tools.get("tools") or []:
+        if tool.get("name") == "trace_data_flow":
+            schema = (tool.get("inputSchema") or {}).get("properties") or {}
+    if schema is None:
+        res.unknown("trace_data_flow absent from tools/list")
+        return res
+    knob = None
+    for candidate in ("include_body", "compact"):
+        if candidate in schema:
+            knob = candidate
+            break
+    if knob is None:
+        res.bad("trace_data_flow declares no compact/include_body parameter: %s"
+                % sorted(schema.keys()))
+    else:
+        res.ok("trace_data_flow declares %r" % knob)
+    base_args = {"focal": "run_all", "direction": "calls", "depth": 3,
+                 "limit_per_step": 25}
+    try:
+        full, full_size = suite.mcp(repo, "trace_data_flow", dict(base_args))
+        if not (full.get("chain") or []):
+            # Same settle race find_references has: enrichment from the fixture's
+            # last commit lands asynchronously, so a trace fired immediately can
+            # walk a graph that has not linked the focal yet. Bounded, and an
+            # empty chain after it still reports vacuous rather than passing.
+            time.sleep(3)
+            full, full_size = suite.mcp(repo, "trace_data_flow", dict(base_args))
+    except McpError as exc:
+        res.unknown("trace_data_flow (full) unreadable: %s" % exc)
+        return res
+    full_steps = len(full.get("chain") or [])
+    if knob and full_steps == 0:
+        # Two empty responses are the same size, and reading that as "the flag
+        # saved nothing" convicts the tool of a defect the run never tested.
+        res.unknown("the full trace returned no steps for %r, so the shape-query "
+                    "comparison is vacuous" % base_args["focal"])
+    elif knob:
+        args = dict(base_args)
+        args[knob] = False if knob == "include_body" else True
+        try:
+            compact, compact_size = suite.mcp(repo, "trace_data_flow", args)
+        except McpError as exc:
+            res.unknown("trace_data_flow (%s) unreadable: %s" % (knob, exc))
+            return res
+        bodies = [step for step in compact.get("chain") or []
+                  if (step.get("entity") or {}).get("body")]
+        budget = compact.get("max_response_chars")
+        if bodies:
+            res.bad("%s honored nothing: %d step(s) still inline a body"
+                    % (knob, len(bodies)))
+        elif compact_size >= full_size:
+            res.bad("%s response is %d chars against %d full: it saved nothing"
+                    % (knob, compact_size, full_size))
+        elif isinstance(budget, int) and compact_size > budget:
+            res.bad("%s response is %d chars against the %d the tool declares as its "
+                    "own budget" % (knob, compact_size, budget))
+        else:
+            # Deliberately not a ratio. A ratio measures how much of THIS fixture
+            # was body text, and on a fixture whose bodies are two lines each it
+            # fails a correct implementation for having little to strip. What the
+            # contract actually asks is that a shape query carries no bodies and
+            # stays inside the budget the tool publishes, both of which are
+            # properties of the tool rather than of the fixture.
+            res.ok("%s response carries no bodies, %d chars against %d full%s"
+                   % (knob, compact_size, full_size,
+                      "" if budget is None else " and a %d budget" % budget))
+    cut_args = {"focal": "run_all", "direction": "calls", "depth": 3,
+                "limit_per_step": 1}
+    try:
+        cut, _ = suite.mcp(repo, "trace_data_flow", cut_args)
+    except McpError as exc:
+        res.unknown("trace_data_flow (truncating) unreadable: %s" % exc)
+        return res
+    if not cut.get("truncated"):
+        res.unknown("limit_per_step=1 did not truncate on this fixture; "
+                    "per-step localization is untested")
+        return res
+    localized = False
+    for step in cut.get("chain") or []:
+        for key in step:
+            if "truncat" in key.lower() or "dropped" in key.lower():
+                localized = True
+    if localized:
+        res.ok("truncation is localized per step")
+    else:
+        res.bad("truncated=true is reported only at the top level; no step says "
+                "which fan-out was clipped or how many were dropped")
+    return res
+
+
+def check_7(suite):
+    """FIR-2362: the JavaScript adapter must model structure, not just symbols.
+
+    Floor derivation from this fixture: 15 entities, 10 Contains edges (Router 3,
+    Application 3, Layer 2 prototype methods, helpers 2 object-literal methods),
+    and at least 3 Calls (Application.constructor -> Router,
+    Application.route -> helpers.normalize, helpers.join -> helpers.normalize),
+    so 13 over 15 is 0.86 and the floor sits at 0.85. Shipped 0.5.36 delivers
+    0.50.
+    """
+    res = Result("7", "FIR-2362", "JavaScript entity kinds, Contains edges, edge density")
+    repo = suite.fixture("js")
+    status = suite.graph_status(repo)
+    kinds = status["kinds"]
+    rel_kinds = status["relation_kinds"]
+    if kinds.get("Class", 0) >= 2 and kinds.get("Method", 0) >= 6:
+        res.ok("ES classes produce Class=%d Method=%d"
+               % (kinds.get("Class", 0), kinds.get("Method", 0)))
+    else:
+        res.bad("ES class structure missing: kinds=%s" % (kinds or "{}"))
+    if rel_kinds.get("Contains", 0) > 0:
+        res.ok("Contains edges present: %d" % rel_kinds["Contains"])
+    else:
+        res.bad("no Contains edges: relation kinds=%s" % (rel_kinds or "{}"))
+    proto = {}
+    for query in ("Layer", "match", "describe"):
+        for row in suite.search_entities(repo, query):
+            proto[row["name"]] = row
+    bound = [n for n, row in proto.items()
+             if re.search(r"(^|\.)(match|describe)$", n) and "." in n
+             and row["kind"] == "Method"]
+    if len(bound) >= 2:
+        res.ok("prototype assignments bind to their constructor: %s" % sorted(bound))
+    else:
+        loose = sorted(n for n in proto if n in ("match", "describe"))
+        res.bad("prototype methods are unbound top-level entities %s, not methods of "
+                "Layer" % (loose or "(absent entirely)"))
+    literal = {}
+    for query in ("normalize", "join", "helpers"):
+        for row in suite.search_entities(repo, query):
+            literal[row["name"]] = row
+    named = sorted(n for n, row in literal.items()
+                   if re.search(r"(^|\.)(normalize|join)$", n)
+                   and row["kind"] in ("Method", "Function"))
+    if named:
+        res.ok("object-literal methods are entities: %s" % named)
+    else:
+        res.bad("object-literal methods normalize/join are not entities at all")
+    compose = [row for row in suite.search_entities(repo, "compose")
+               if row["name"] == "compose"]
+    if compose and compose[0]["kind"] == "Function":
+        res.ok("const-bound arrow is a Function")
+    elif compose:
+        res.bad("const-bound arrow 'compose' is a %s" % compose[0]["kind"])
+    else:
+        res.bad("const-bound arrow 'compose' is not an entity")
+    junk = [row["name"] for row in suite.search_entities(repo, "Router")
+            if "{" in row["name"]]
+    if junk:
+        res.bad("destructuring pattern admitted as an entity name: %s" % junk[:2])
+    else:
+        res.ok("no destructuring pattern admitted as an entity")
+    join = suite.inspect(repo, "helpers.join")
+    if join is None:
+        res.unknown("kin graph inspect helpers.join did not resolve")
+    else:
+        outgoing = [r for r in join["relations"]
+                    if r["dir"] == "out" and r["relation"] == "Calls"]
+        if outgoing:
+            res.ok("helpers.join calls %s" % ", ".join(r["name"] for r in outgoing))
+        else:
+            res.bad("helpers.join has no outgoing Calls edge although its body calls "
+                    "helpers.normalize twice in the same file")
+    if status["entities"]:
+        density = float(status["relations"]) / float(status["entities"])
+        if density >= 0.85:
+            res.ok("relations per entity %.2f" % density)
+        else:
+            res.bad("relations per entity %.2f is below the 0.85 floor this fixture's "
+                    "structure supports (%d relations over %d entities)"
+                    % (density, status["relations"], status["entities"]))
+    else:
+        res.unknown("graph status reported no entity count")
+    return res
+
+
+def check_8(suite):
+    """FIR-2359: a virtual environment must not race the watcher into the graph,
+    and the context pack must not spend its budget on decimal byte arrays."""
+    res = Result("8", "FIR-2359", "venv admission and context-pack byte arrays")
+    repo = suite.fixture("venv")
+    before = suite.graph_status(repo)
+    rc, out, err = run([sys.executable, "-m", "venv", "venv"], cwd=repo,
+                       env=suite.env, timeout=300)
+    if rc != 0:
+        res.unknown("python -m venv failed: %s" % (err or out)[-160:])
+    else:
+        planted = 0
+        for _root, _dirs, files in os.walk(os.path.join(repo, "venv")):
+            planted += len([f for f in files if f.endswith(".py")])
+        with open(os.path.join(repo, ".gitignore")) as handle:
+            ignore = handle.read()
+        if "venv" in ignore:
+            res.unknown(".gitignore already names venv; the race is not exercised")
+        else:
+            time.sleep(2)
+            # A real edit to a tracked file, so the commit has work to record. Since
+            # kin#899 (FIR-2403) a commit whose tree equals the base refuses with
+            # "nothing to commit", so a bare commit here would measure that refusal
+            # rather than whether the venv broke anything.
+            suite._write(repo, "tool.py",
+                         "def run():\n    return \"ok\"\n\n\ndef after_venv():\n    return \"still ok\"\n")
+            time.sleep(2)
+            crc, cout, cerr = suite.kin_run(["commit", "-m", "Work after venv"], repo)
+            commit_text = cout + "\n" + cerr
+            time.sleep(2)
+            after = suite.graph_status(repo)
+            delta = (after["entities"] or 0) - (before["entities"] or 0)
+            if crc != 0:
+                res.bad("a %d-file venv broke the next commit (rc=%d): %s"
+                        % (planted, crc, commit_text.strip().splitlines()[0][:200]
+                           if commit_text.strip() else "(no output)"))
+            else:
+                res.ok("the next commit after a %d-file venv succeeded" % planted)
+            if delta > 50:
+                res.bad("a %d-file venv added %d entities to the graph (%d -> %d) with "
+                        "no ignore line and no warning"
+                        % (planted, delta, before["entities"], after["entities"]))
+            else:
+                res.ok("the venv added %d entities" % delta)
+    src = suite.fixture("incremental")
+    try:
+        refs = suite.references(src, "parse_note")
+        entity_id = (refs.get("focal_entity") or {}).get("id")
+        if not entity_id:
+            raise McpError("find_references returned no focal entity id")
+        pack, size = suite.mcp(src, "get_context_pack",
+                               {"entity_id": entity_id, "depth": 2,
+                                "token_budget": 8000})
+    except McpError as exc:
+        res.unknown("get_context_pack unreadable: %s" % exc)
+        return res
+
+    def byte_arrays(node, path=""):
+        found = []
+        if isinstance(node, dict):
+            for key, value in node.items():
+                found += byte_arrays(value, path + "/" + key)
+        elif isinstance(node, list):
+            if len(node) == 32 and all(isinstance(x, int) for x in node):
+                found.append(path)
+            else:
+                for index, value in enumerate(node):
+                    found += byte_arrays(value, "%s[%d]" % (path, index))
+        return found
+
+    arrays = byte_arrays(pack)
+    if arrays:
+        res.bad("context pack carries %d 32-element decimal byte array(s) (%s) in a "
+                "%d-char response budgeted at 8000 tokens"
+                % (len(arrays), arrays[0], size))
+    else:
+        res.ok("context pack carries no decimal byte arrays (%d chars)" % size)
+    return res
+
+
+def check_9(suite):
+    """FIR-2358: some surface must report relation-graph completeness, and
+    validate must not read as a completeness bill."""
+    res = Result("9", "FIR-2358", "relation-graph completeness reporting")
+    repo = suite.fixture("incremental")
+    status = suite.graph_status(repo)
+    if status["cross_file"] is not None:
+        res.ok("graph status reports cross-file coverage %d of %d" % status["cross_file"])
+    elif re.search(r"completeness|resolved of|parsed versus|call sites parsed",
+                   status["raw"], re.I):
+        res.ok("graph status carries a completeness metric")
+    else:
+        res.bad("graph status reports counts but no completeness metric")
+    rc, out, err = suite.kin_run(["graph", "validate"], repo)
+    text = out + "\n" + err
+    if rc != 0:
+        res.unknown("kin graph validate rc=%d" % rc)
+        return res
+    qualified = re.search(
+        r"integrity only|does not check completeness|structural integrity, not "
+        r"completeness|completeness", text, re.I)
+    clean_bill = re.search(r"All checks passed", text, re.I)
+    if clean_bill and not qualified:
+        res.bad("graph validate prints %r with no completeness qualifier on a graph "
+                "missing every cross-file edge" % "All checks passed")
+    else:
+        res.ok("graph validate does not read as a completeness bill")
+    return res
+
+
+CHECKS = [
+    ("0", check_0),
+    ("1", check_1),
+    ("2", check_2),
+    ("3", check_3),
+    ("4", check_4),
+    ("5", check_5),
+    ("6", check_6),
+    ("7", check_7),
+    ("8", check_8),
+    ("9", check_9),
+]
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(add_help=True, description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--kin", required=True)
+    parser.add_argument("--daemon",
+                        help="kin-daemon binary to serve the fixtures "
+                             "(default: the sibling of --kin when one exists)")
+    parser.add_argument("--workdir")
+    parser.add_argument("--label", default="")
+    parser.add_argument("--only", default="")
+    parser.add_argument("--json", dest="json_out")
+    parser.add_argument("--tips")
+    parser.add_argument("--compare")
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    opts = parser.parse_args(argv)
+
+    kin = os.path.abspath(os.path.expanduser(opts.kin))
+    if not os.path.exists(kin):
+        sys.stderr.write("kin binary not found: %s\n" % kin)
+        return 3
+    rc, out, err = run([kin, "--version"], timeout=600)
+    version = strip_ansi(out).strip().splitlines()[-1] if out.strip() else "unknown"
+
+    daemon = opts.daemon and os.path.abspath(os.path.expanduser(opts.daemon))
+    if daemon is None:
+        sibling = os.path.join(os.path.dirname(kin), "kin-daemon")
+        daemon = sibling if os.path.exists(sibling) else None
+    if daemon and not os.path.exists(daemon):
+        sys.stderr.write("kin-daemon binary not found: %s\n" % daemon)
+        return 3
+
+    workdir = opts.workdir or tempfile.mkdtemp(prefix="kin-magic-repro-")
+    if not os.path.isdir(workdir):
+        os.makedirs(workdir)
+    wanted = [w.strip() for w in opts.only.split(",") if w.strip()] or None
+
+    suite = Suite(kin, workdir, verbose=opts.verbose, daemon=daemon)
+    print("kin-magic-repro: %s" % version)
+    print("kin-magic-repro: binary %s" % kin)
+    print("kin-magic-repro: daemon %s" % (daemon or "(resolved by kin itself)"))
+    print("kin-magic-repro: workdir %s" % workdir)
+
+    prior = {}
+    prior_label = ""
+    if opts.compare:
+        try:
+            with open(opts.compare) as handle:
+                loaded = json.load(handle)
+            prior_label = loaded.get("label") or os.path.basename(opts.compare)
+            prior = {row["id"]: row.get("status") for row in loaded.get("results", [])}
+            print("kin-magic-repro: comparing against %s (%s)"
+                  % (prior_label, opts.compare))
+        except (IOError, ValueError, KeyError) as exc:
+            # An unreadable baseline must not silently become "no regressions".
+            print("kin-magic-repro: comparison baseline unreadable (%s): %s"
+                  % (opts.compare, exc))
+            prior = None
+
+    tips = ""
+    if opts.tips:
+        try:
+            with open(opts.tips) as handle:
+                tips = handle.read()
+        except IOError as exc:
+            print("kin-magic-repro: tips file unreadable (%s): %s" % (opts.tips, exc))
+
+    results = []
+    for check_id, fn in CHECKS:
+        if wanted and check_id not in wanted:
+            continue
+        try:
+            res = fn(suite)
+        except Exception as exc:
+            res = Result(check_id, "?", "harness failure")
+            res.unknown("%s: %s" % (type(exc).__name__, str(exc)[:200]))
+        results.append(res)
+        res.prior = None if prior is None else prior.get(res.id)
+        res.trend = trend_of(res.status, res.prior)
+        marker = res.status
+        if res.trend == "regression":
+            marker = "%s REGRESSION-from-%s-in-%s" % (res.status, res.prior, prior_label)
+        elif res.trend == "fixed":
+            marker = "%s fixed-since-%s" % (res.status, prior_label)
+        elif res.trend == "unknown":
+            marker = "%s trend-unknown" % res.status
+        print("CHECK %s %s %s %s" % (res.id, res.ticket, marker, res.detail))
+        if opts.verbose:
+            for a in res.asserts:
+                print("      %-11s %s" % (a["status"], a["detail"]))
+
+    stopped = suite.shutdown()
+    if stopped:
+        print("kin-magic-repro: stopped %d fixture daemon(s)" % len(stopped))
+
+    failed = [r for r in results if r.status == FAIL]
+    unread = [r for r in results if r.status == UNREADABLE]
+    regressed = [r for r in results if r.trend == "regression"]
+    print("kin-magic-repro: %d pass, %d fail, %d unreadable"
+          % (len(results) - len(failed) - len(unread), len(failed), len(unread)))
+    if regressed:
+        print("kin-magic-repro: %d regression(s) against %s: %s"
+              % (len(regressed), prior_label,
+                 ", ".join("%s/%s" % (r.id, r.ticket) for r in regressed)))
+
+    if opts.json_out:
+        with open(opts.json_out, "w") as handle:
+            json.dump({"label": opts.label, "kin": kin, "version": version,
+                       "workdir": workdir, "daemon": daemon, "tips": tips,
+                       "compared_against": prior_label,
+                       "results": [{"id": r.id, "ticket": r.ticket, "title": r.title,
+                                    "status": r.status, "detail": r.detail,
+                                    "prior_status": r.prior, "trend": r.trend,
+                                    "asserts": r.asserts} for r in results]},
+                      handle, indent=2)
+        print("kin-magic-repro: json %s" % opts.json_out)
+
+    if not opts.keep and not opts.workdir:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    if failed:
+        return 1
+    if unread:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -566,6 +566,14 @@ CI_JOB_DISPLAY_NAMES = {
     "install-proof-pr-gate": "Install Proof (PR) Gate",
 }
 EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
+    # The per-pull-request product acceptance job (FIR-2591). It publishes no
+    # required context and claims none; it is registered here because this
+    # census is what would otherwise let a new workflow's job NAME appear
+    # unreviewed. The job id and display name are stable on purpose: renaming
+    # either is what ejects unrelated queue entries.
+    ".github/workflows/acceptance.yml": {
+        "acceptance": "Product Acceptance",
+    },
     # The scheduled advisory sweep. It publishes no required context and runs on
     # no pull-request or merge-group event, so it can never claim one; it is
     # registered here because this census is what would otherwise let a new


### PR DESCRIPTION
## Mechanism

ci.yml tests the release machinery and the Rust workspace. The suites that ask whether the product still answers correctly lived only in the kin-ecosystem umbrella and ran after a tag or on a release candidate, by a captain, on one machine. bin/kin-release-preflight's own header records what that costs: v0.5.38 "was built, published, and then failed semantic_coverage.complete on every platform with nothing local having ever asked the question."

This adds `.github/workflows/acceptance.yml`, one ubuntu job on `pull_request`, `merge_group`, `push` to main, and `workflow_dispatch`. It builds `kin` and `kin-daemon` in debug with the same toolchain, registry verification, and cargo cache steps daemon-smoke.yml uses, installs the language servers the enrichment checks need, then runs both suites against that build.

The suites themselves move into the product repo as `scripts/acceptance/magic_repro.py` and `scripts/acceptance/brownfield_repro.py`, ported from `bin/kin-magic-repro` and `bin/kin-brownfield-repro` on 2026-08-21, so the suite versions with the code it tests. The CHECK line format, exit codes (0 pass, 1 FAIL, 2 UNREADABLE, 3 setup), CLI, corpus pins, fixtures, and summary-line prefixes are unchanged, because `bin/kin-shipped-gate` parses two of those summary lines by prefix and `bin/kin-magic-at-scale` imports the brownfield suite as a module. Only the usage text and the producer they name are repo-local now. `scripts/acceptance/README.md` names the umbrella callers and says what has to stay stable until they become wrappers.

Three details are deliberate. Each suite writes its whole output to a file that is printed afterwards rather than piping into `tee`, because a pipeline's exit status is its last stage's and `tee` exits 0 on input it never read. The gate is its own final step, so a failing first suite never hides the second one's result or its artifact, and it refuses an empty recorded exit status instead of defaulting it to zero. The corpus cache key is derived from the pinned commits in the script, so moving a pin invalidates the entry rather than measuring the old tree under the new name.

`push` to main is in the trigger list for one mechanical reason: `save-if` writes the cargo cache only from the default branch, and a workflow that never runs there never writes one, so every pull request would pay a cold dependency build. daemon-smoke.yml carries the same trigger for the same reason.

## Runs

Release profile, the shape that ships:

- **Green**: https://github.com/firelock-ai/kin/actions/runs/32517626602, job wall clock **19 min 16 s** with a completely cold cache, of which 674 s is the build. magic 10 pass 0 fail 0 unreadable, brownfield 8 pass 0 fail 1 allowed unreadable. Every check on that head concluded green: 32 SUCCESS, 4 SKIPPED, zero failures.
- **Deliberately red**: https://github.com/firelock-ai/kin/actions/runs/32519810076. Commit `4a8183cc8` pointed magic check 1 at a file that cannot exist. The log and the artifact carry `CHECK 1 FIR-2354 FAIL find_references(parse_note) returned 1 reference(s) ['pkg/storage.py']; storage.py imports and calls it`, the gate reports `magic: 1 FAIL, 9 PASS` then `acceptance gate FAILED on 1 finding(s)`, and the brownfield allowance still prints without masking the FAIL. Reverted in `14cfc0f83`.

The suites themselves are slightly faster on release than debug, 100 s against 103 s and 347 s against 365 s, so nearly the whole extra cost is the build. `save-if` writes the cache only from main, so what a later pull request pays is unmeasured until this lands and main runs the job once.

Earlier debug-profile runs, kept because they are what the release numbers are compared against: green https://github.com/firelock-ai/kin/actions/runs/32513745908 at 10 min 33 s, red https://github.com/firelock-ai/kin/actions/runs/32514677945, and the first run https://github.com/firelock-ai/kin/actions/runs/32512404014 that found the two gaps below.

## What the first run found, and what changed because of it

Both suites came back exit 2 on the first hosted run, and neither finding was a defect in the port.

Seven of the magic suite's ten checks returned `kin commit failed ... Set your Git identity`. kin refuses to invent an author and a hosted runner carries no git identity, so every fixture that commits through kin failed to build. Checks 5, 6 and 7 passed because those fixtures convert through git rather than committing through kin, which is what made the cause legible. Fixed with a `git config --global` step carrying the identity daemon-smoke.yml uses.

Brownfield check 4 returned `truncated=True, clipped_steps=None` on the express `app.handle` walk, so an absent edge could not be told from a dropped one. That is FIR-2593, and this branch narrowed it rather than leaving it open: the release build truncates too, so the profile is out; 0.5.44 and the npm-served 0.5.46 both walk it whole on macOS, so product code through 0.5.46 is out; and installing the exact CI-pinned language servers locally still walks it whole, so the server version is out. Platform and code newer than 0.5.46 remain confounded, and the experiment that separates them is check 4 on Linux against the npm-served 0.5.46 binary. The graph is identical in every arm, `javascript: 66 files, calls 270/652 (41%), imports 70/220` with a clean 66 of 66 sweep, which puts whatever differs downstream of graph construction. The full matrix is on FIR-2593.

That second finding is why the job now runs `scripts/acceptance/gate.py` instead of testing an exit code. A suite's exit status is one lever with two settings, demand a clean sweep or demand nothing, and neither is right while one check is blocked on something outside the change under review. The gate reads the JSON reports: a FAIL always fails and no allowance can excuse it, an UNREADABLE fails unless named with a required reason that prints on every run, an allowance naming a check the report does not carry is an error because a pointer at nothing reads exactly like a satisfied allowance, a stale allowance on a now-passing check is announced, and a missing report is a failure. `brownfield:4` carries the only allowance and its reason names the run that found it. `gate.py --self-test` exercises every rule against its inverse and runs before the build.

## What it runs, and what it measured

Both suites were run locally against a kin built from main (0.5.44) before this was written.

- `magic_repro.py`: 10 pass, 0 fail, 0 unreadable, exit 0, 107 seconds.
- `brownfield_repro.py`: 9 pass, 0 fail, 0 unreadable, exit 0, 351 seconds with a warm corpus cache.
- `brownfield_repro.py --self-test`: passed, no binary and no corpus needed.

That the brownfield suite is green matters. Its own docstring records checks 2 through 8 failing on 0.5.42; checks 2 and 3 now read `HTTPDigestAuth.handle_401 counted with reference_lines [312]`, so the enrichment work landed and a gate that fails on any nonzero exit is green on today's code rather than red forever.

Local guards on this branch: `scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh` and `scripts/check_private_repo_coupling.sh` all exit 0. `actionlint` with shellcheck passes on the workflow, control-tested against a deliberately broken copy so a clean result means something. `python3 -m py_compile` passes on both scripts.

## Authorized boundary extension

This PR adds one entry to `EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES` in `scripts/test-release-workflow-authority.py`, registering `.github/workflows/acceptance.yml` with job id `acceptance` and display name `Product Acceptance`, and that census extension is an authorized boundary extension under FIR-2591.

The census enumerates every `.yml` and `.yaml` under `.github/workflows` and requires the resulting map of path to job id to display name to equal the reviewed dict exactly, so a new workflow file turns two required contexts red until the census names it: the `npm launcher tests` job's "Test release ordering and npm provenance policy" step and `Check & Test (ubuntu-latest)`'s "Validate automatic release policy" step, both of which run that test. The job id and display name are stable from here on, because renaming either is what ejects unrelated queue entries. Nothing else in that file is touched: no other dict, no logic, no comment anywhere else. The change is 8 lines, three of them the entry and five a comment on that entry in the same style every neighbouring entry uses, and the entry sits above the advisory-sweep comment block rather than between that comment and the entry it documents.

Falsified four ways rather than asserted, run from the branch:

| Case | Result |
|---|---|
| No entry, `acceptance.yml` present | exit 1 at the census assertion, line 3869 |
| No entry, `acceptance.yml` moved out of the directory | exit 0 |
| Entry present, `acceptance.yml` present | exit 0 |
| Entry present, `acceptance.yml` renamed to `acceptance-renamed.yml` | exit 1, same assertion, line 3877 |

The second case is what attributes the failure to this file rather than to anything else on the branch; exit 1 alone only says the census is unhappy. The fourth proves the entry is bound to the path it names, so a rename cannot quietly inherit the registration. The assertion site moves from 3869 to 3877 because the entry adds exactly 8 lines. The workflow file was restored byte-identical, sha256 `4b5992c0cd29196dc1179af28bb3a3d63cf9cfc83085e4e67a650b9191181ddd` before and after.

## Release profile

The job builds `--release`, not the debug profile daemon-smoke.yml uses. Release is what ships, so it is what a product acceptance answer should be about, and the first run showed the question has a different answer per profile: a debug build truncated the express `app.handle` walk that a release 0.5.44 build walked whole. Building release is also what separates the two variables FIR-2593 confounds, profile and code.

`shared-key: acceptance-release` replaces the job-id component of the rust-cache key, which is what lets a pull request restore the entry main writes; without it every job id gets its own key and a pull request would never see main's. Target caching is on because a release build of this workspace needs it, and the action strips the workspace's own crates before saving, so what comes back is dependencies and never a stale `kin` or `kin-daemon`, which is what the suites assert on. `timeout-minutes` is 60, matching Check & Test.

## Old known red check, now fixed

`scripts/test-release-workflow-authority.py` fails on this branch and nothing in it is wrong. Its `workflow_paths()` enumerates every `.yml` and `.yaml` under `.github/workflows`, and `assert_workflow_job_census` requires the resulting map to equal `EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES` exactly, so any new workflow file fails it until the census names the file. The census reads job ids and display names only, never `on:` triggers. The entry this needs is three declarative lines and no other map changes, because the display name is a static one-line scalar claiming no release-required context. It is not in this PR because the file is outside this change's boundary.

## Remainder

This workflow publishes no required context. Making `Product Acceptance` a required context on main after it has been green on five consecutive pull requests is the remaining step, along with adding the first-run suite when `bin/kin-first-run` lands.

Refs FIR-2591
