### PR TITLE
Key the release evidence to a main commit, so a tag no longer needs a frozen main

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1690,16 +1690,24 @@ jobs:
 
           # The gate's own narration goes to stderr so stdout carries exactly
           # the sha it verified and nothing a later comparison could mistake
-          # for one. A throw exits non-zero and takes the step with it.
+          # for one. A refusal is reported the way the gate's own command line
+          # reports it, because a stack trace buries the sentence that says
+          # which record was missing and an operator reading a blocked release
+          # needs that sentence first.
           proven="$(KIN_RELEASE_GATE="file://${gate}" \
             CANDIDATE_SHA="$SHA" \
             GITHUB_REPOSITORY="$REPO" \
             node --input-type=module -e '
               const { main } = await import(process.env.KIN_RELEASE_GATE);
-              const result = await main({
-                log: (line) => process.stderr.write(line + "\n"),
-              });
-              process.stdout.write(result.sha);
+              try {
+                const result = await main({
+                  log: (line) => process.stderr.write(line + "\n"),
+                });
+                process.stdout.write(result.sha);
+              } catch (error) {
+                process.stderr.write("::error::" + error.message + "\n");
+                process.exit(1);
+              }
             ')"
           if ! printf '%s' "$proven" | grep -Eq '^[0-9a-f]{40}$'; then
             echo "::error::the release proof gate returned '${proven}', which is not a candidate sha"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -151,6 +151,10 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RAW_TAG: ${{ github.event.client_payload.tag }}
           RAW_SHA: ${{ github.event.client_payload.sha }}
+          # Reading the proof loop's published candidates needs no more than the
+          # read-only workflow token this job already declares.
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           git fetch origin \
@@ -198,18 +202,80 @@ jobs:
           import sys, tomllib
           print(tomllib.loads(sys.stdin.read())["workspace"]["package"]["version"])
           ')"
-            # Both scheduled reconciliation and workflow_run retries normalize
-            # to the first reviewed main commit carrying this version. A later
-            # green commit must never be swept into an already-prepared release.
-            candidate="$sha"
+            # The oldest reviewed main commit carrying this version, which is
+            # the squash of the version bump. It is not the release; it is the
+            # floor of the range that can be, because nothing before it carries
+            # the version this tag names.
+            earliest="$sha"
             while IFS= read -r commit; do
               version="$(git show "$commit:Cargo.toml" | python3 -c '
           import sys, tomllib
           print(tomllib.loads(sys.stdin.read())["workspace"]["package"]["version"])
           ')"
               [ "$version" = "$current_version" ] || break
-              candidate="$commit"
+              earliest="$commit"
             done < <(git log --first-parent --format=%H "$sha" -- Cargo.toml)
+
+            # The release is the NEWEST reviewed main commit in that range for
+            # which the proof loop published both records. This is what lets
+            # main keep moving through a proof window. The candidate used to be
+            # the head of the version bump branch, and the train rewrites that
+            # head every cycle it finds drift, so evidence published for it went
+            # invisible the moment main moved and the fleet had to freeze main
+            # for the whole window or release a sha nobody had proven. A main
+            # commit is immutable, so its records stay addressable no matter
+            # what lands afterwards, and what lands afterwards is simply the
+            # next release's drift.
+            #
+            # This listing PROPOSES a candidate. It never proves one. The gate
+            # below reads the two exact forty-hex keys under the selected sha
+            # and is the only thing that admits a release, so a listing that is
+            # wrong costs a loud refusal rather than an unproven tag. A
+            # truncated listing is the one reading that could hide a newer
+            # proven candidate and silently ship an older one, so it refuses
+            # instead of taking the subset it can see.
+            proven="$RUNNER_TEMP/proven-candidates"
+            : > "$proven"
+            listing="$(gh api \
+              "repos/${REPO}/git/trees/release-evidence?recursive=1" \
+              2>/dev/null || true)"
+            if [ -n "$listing" ] && \
+               jq -e 'type == "object" and (.tree | type == "array")' \
+                 <<< "$listing" > /dev/null; then
+              if [ "$(jq -r '.truncated // false' <<< "$listing")" = true ]; then
+                echo "::error::the release-evidence listing is truncated, so a newer proven candidate could be invisible; refusing to select one"
+                exit 1
+              fi
+              jq -r '
+                [.tree[] | select(.type == "blob") | .path]
+                | map(capture("^evidence/(?<sha>[0-9a-f]{40})/(?<name>preflight\\.json|stranger\\.env)$"))
+                | group_by(.sha)
+                | map(select((map(.name) | unique | length) == 2) | .[0].sha)
+                | .[]
+              ' <<< "$listing" > "$proven"
+            fi
+            recorded="$(command grep -c '' "$proven" || true)"
+            echo "proof loop has recorded ${recorded} fully-evidenced candidate(s)"
+
+            candidate=""
+            if [ -s "$proven" ]; then
+              while IFS= read -r commit; do
+                if command grep -qxF "$commit" "$proven"; then
+                  candidate="$commit"
+                  break
+                fi
+                [ "$commit" = "$earliest" ] && break
+              done < <(git log --first-parent --format=%H "$sha")
+            fi
+            if [ -z "$candidate" ]; then
+              # A no-op, not a decline. Declining means the mint could act and
+              # something is blocking it; this means there is nothing to act on
+              # yet, which is the same shape as an already-existing tag and is
+              # deliberately not escalated.
+              echo "::notice::no reviewed main commit carrying ${current_version} has release proof records yet; the mint has no candidate."
+              echo "needed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             sha="$candidate"
           fi
 
@@ -1570,6 +1636,86 @@ jobs:
             exit 1
           fi
           echo "tag $TAG does not exist yet"
+
+      # The proof-loop refusal, on the artifact it is actually about.
+      #
+      # On 2026-08-20 the train merged its own bump kin#986, tagged v0.5.44 and
+      # promoted it to Latest with no preflight record for that candidate and no
+      # stranger run on its bytes. The gate that closed that hole lived in
+      # release-train.yml and held the version bump in draft, keyed on a branch
+      # head the train rewrites every cycle, which is what forced the fleet to
+      # freeze main for the length of every proof window. The refusal did not
+      # move because it was wrong. It moved because a tag run resolves its
+      # workflows from the tag and no fix landed later can repair it, so this,
+      # immediately before the ref is written, is the last place a release can
+      # still be refused for free. release.yml's finalize_release keeps the same
+      # refusal against promotion, so both decision points import one judge and
+      # cannot disagree about what counts as evidence while agreeing that they
+      # checked.
+      #
+      # Two assertions. The gate reads the two exact forty-hex keys under the
+      # candidate and refuses absence, an unreadable record, a failing verdict,
+      # a record about a different build, and a stranger run on bytes no
+      # preflight leg judged. Then the sha it verified is compared against the
+      # sha this job is about to tag. That comparison is the one that carries
+      # weight: selection above and verification here compute the candidate
+      # separately, and an edit that lets them drift apart refuses here rather
+      # than tagging a commit whose evidence is about another one.
+      #
+      # The tree diff after it is implied by that equality today and is written
+      # anyway, because the invariant this whole design rests on is "the tree
+      # that was proven is the tree that ships", and an invariant that lives
+      # only in a design document is one a later change can break silently.
+      # Do not read it as independent evidence; read it as the statement that
+      # fails first if the tag ever stops naming the candidate itself.
+      #
+      # The gate is read from protected main, not from the checked-out release
+      # commit, for the same reason the lane policy above is: the commit under
+      # judgement must not be able to lower the bar it is judged against.
+      - name: Require proof-loop artifacts for the release candidate
+        id: proof
+        if: >-
+          steps.resolve.outputs.needed == 'true' &&
+          steps.prior.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gate="$RUNNER_TEMP/check-release-proof-artifacts.mjs"
+          git show \
+            "refs/remotes/origin/main:scripts/check-release-proof-artifacts.mjs" \
+            > "$gate"
+          test -s "$gate"
+
+          # The gate's own narration goes to stderr so stdout carries exactly
+          # the sha it verified and nothing a later comparison could mistake
+          # for one. A throw exits non-zero and takes the step with it.
+          proven="$(KIN_RELEASE_GATE="file://${gate}" \
+            CANDIDATE_SHA="$SHA" \
+            GITHUB_REPOSITORY="$REPO" \
+            node --input-type=module -e '
+              const { main } = await import(process.env.KIN_RELEASE_GATE);
+              const result = await main({
+                log: (line) => process.stderr.write(`${line}\n`),
+              });
+              process.stdout.write(result.sha);
+            ')"
+          if ! printf '%s' "$proven" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::the release proof gate returned '${proven}', which is not a candidate sha"
+            exit 1
+          fi
+          if [ "$proven" != "$SHA" ]; then
+            echo "::error::the proof gate verified $proven but this job would tag $SHA; refusing to tag a commit whose evidence is about a different one"
+            exit 1
+          fi
+          delta="$(git diff --name-only "$proven" "$SHA")"
+          if [ -n "$delta" ]; then
+            echo "::error::the tagged tree is not the proven tree; these paths differ between $proven and $SHA:"
+            printf '%s\n' "$delta"
+            exit 1
+          fi
+          echo "release proof records verified for $SHA, and the tagged tree is the proven tree"
 
       - name: Mint kin-release-bot installation token
         id: app-token

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1697,7 +1697,7 @@ jobs:
             node --input-type=module -e '
               const { main } = await import(process.env.KIN_RELEASE_GATE);
               const result = await main({
-                log: (line) => process.stderr.write(`${line}\n`),
+                log: (line) => process.stderr.write(line + "\n"),
               });
               process.stdout.write(result.sha);
             ')"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -234,26 +234,47 @@ jobs:
             # truncated listing is the one reading that could hide a newer
             # proven candidate and silently ship an older one, so it refuses
             # instead of taking the subset it can see.
+            #
+            # An unreadable listing is not an empty one. This read used to
+            # discard both the error text and the exit status, so a transport
+            # failure, a GitHub error object and a genuinely empty evidence
+            # branch produced byte-identical green output and the mint no-opped
+            # on all three. Absence is a fact about the proof loop;
+            # unreadability is a fact about this read, and only one of them
+            # means there is nothing to release.
+            #
+            # It refuses rather than warning, for the same reason the
+            # truncation check below it does: a warning on a green run is the
+            # same silence this rekey exists to end. A false refusal costs one
+            # cycle and nothing else, because the mint reconciles every fifteen
+            # minutes and on every completed CI run, and it holds no state
+            # before this point. A false green costs every release until
+            # somebody happens to read a log line.
             proven="$RUNNER_TEMP/proven-candidates"
             : > "$proven"
-            listing="$(gh api \
+            read_error="$(mktemp)"
+            if ! listing="$(gh api \
               "repos/${REPO}/git/trees/release-evidence?recursive=1" \
-              2>/dev/null || true)"
-            if [ -n "$listing" ] && \
-               jq -e 'type == "object" and (.tree | type == "array")' \
-                 <<< "$listing" > /dev/null; then
-              if [ "$(jq -r '.truncated // false' <<< "$listing")" = true ]; then
-                echo "::error::the release-evidence listing is truncated, so a newer proven candidate could be invisible; refusing to select one"
-                exit 1
-              fi
-              jq -r '
-                [.tree[] | select(.type == "blob") | .path]
-                | map(capture("^evidence/(?<sha>[0-9a-f]{40})/(?<name>preflight\\.json|stranger\\.env)$"))
-                | group_by(.sha)
-                | map(select((map(.name) | unique | length) == 2) | .[0].sha)
-                | .[]
-              ' <<< "$listing" > "$proven"
+              2>"$read_error")"; then
+              echo "::error::could not read the release-evidence tree, so this mint cannot tell an unproven main from an unreadable listing; refusing to select a candidate: $(cat "$read_error")"
+              exit 1
             fi
+            if ! jq -e 'type == "object" and (.tree | type == "array")' \
+                 <<< "$listing" > /dev/null; then
+              echo "::error::the release-evidence listing is not a git tree object, so the mint cannot tell which candidates the proof loop published; refusing to select one"
+              exit 1
+            fi
+            if [ "$(jq -r '.truncated // false' <<< "$listing")" = true ]; then
+              echo "::error::the release-evidence listing is truncated, so a newer proven candidate could be invisible; refusing to select one"
+              exit 1
+            fi
+            jq -r '
+              [.tree[] | select(.type == "blob") | .path]
+              | map(capture("^evidence/(?<sha>[0-9a-f]{40})/(?<name>preflight\\.json|stranger\\.env)$"))
+              | group_by(.sha)
+              | map(select((map(.name) | unique | length) == 2) | .[0].sha)
+              | .[]
+            ' <<< "$listing" > "$proven"
             recorded="$(command grep -c '' "$proven" || true)"
             echo "proof loop has recorded ${recorded} fully-evidenced candidate(s)"
 

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -750,11 +750,28 @@ jobs:
           PR: ${{ steps.pr.outputs.number }}
         run: |
           set -euo pipefail
-          head_sha="$(gh pr view "$PR" \
+          # The draft state is read in the same call that reads the head,
+          # because a draft pull request is not taken by the merge queue and
+          # nothing in this repository un-drafts this one any more. The removed
+          # proof step was the only code that ever touched it, and it drafted
+          # the pull request while it held. A pull request left in draft by that
+          # step, or by a hand, would arm auto-merge here, report success, and
+          # then never land, every fifteen minutes, while the plan step's
+          # all-clear marker said the rail was moving.
+          #
+          # A freshly opened bump pull request is never a draft, so this is a
+          # no-op on an ordinary cycle. Marking ready re-triggers nothing: ci.yml
+          # runs on `pull_request` without a draft filter, so the checks the
+          # queue waits on are already running.
+          state="$(gh pr view "$PR" \
             --repo "$GITHUB_REPOSITORY" \
-            --json headRefOid \
-            --jq .headRefOid)"
+            --json headRefOid,isDraft)"
+          head_sha="$(jq -r '.headRefOid' <<< "$state")"
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+          if [ "$(jq -r '.isDraft' <<< "$state")" = true ]; then
+            echo "pull request #${PR} is a draft, which the merge queue never takes; marking it ready before arming auto-merge"
+            gh pr ready "$PR" --repo "$GITHUB_REPOSITORY"
+          fi
           gh pr merge "$PR" \
             --repo "$GITHUB_REPOSITORY" \
             --auto \

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -58,7 +58,7 @@ jobs:
       # reads exactly like one that never came, which is the reading that keeps
       # the alarm quiet. The artifact stays, because later cycles need this run
       # to be readable from outside it.
-      marker: ${{ steps.proof.outputs.marker || steps.plan.outputs.marker }}
+      marker: ${{ steps.plan.outputs.marker }}
     steps:
       - name: Mint repository-scoped release branch token
         id: app-token
@@ -719,118 +719,28 @@ jobs:
             -m "Activate protected checks for the automated release PR"
           git push origin "HEAD:refs/heads/${BRANCH}"
 
-      # A release bump is ready only when the candidate has been proven. On
-      # 2026-08-20 the train merged its own bump kin#986, tagged v0.5.44 and
-      # promoted it to Latest with no preflight record for that candidate and no
-      # stranger run on its bytes. The only thing that had ever stood between
-      # the autonomous cadence and an unproofed cut was a session-local holder
-      # monitor, correctly retired when its pause-era purpose ended, and the
-      # autopilot flew through the open gate the same evening. A gate that lives
-      # in a monitor can always be retired correctly again, so this one lives in
-      # the train.
+      # The version bump carries no release evidence and is not gated on any.
       #
-      # Keyed on the pull request head, which is the sha the proof loop judges
-      # and the same sha the arming step below pins the merge to with
-      # --match-head-commit. Gating one sha and merging another would leave open
-      # the window this step exists to close.
+      # It used to be. On 2026-08-20 the train merged its own bump kin#986,
+      # tagged v0.5.44 and promoted it to Latest with no preflight record for
+      # that candidate and no stranger run on its bytes, so a gate was added
+      # here keyed on this pull request's head. That key is what forced the
+      # fleet to freeze main: every cycle merges origin/main into this branch
+      # and mints a new head, and evidence published for the old head becomes
+      # invisible rather than wrong, so a release either froze main for its
+      # whole proof window or evidenced a sha nobody was releasing.
       #
-      # The policy is read from origin/main rather than from the checkout, for
-      # the same reason the release intent resolver is: the branch under
-      # judgement must not be able to lower the bar it is judged against.
-      - name: Require proof-loop artifacts for the candidate
-        id: proof
-        if: steps.plan.outputs.needed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ steps.pr.outputs.number }}
-          BASE_TAG: ${{ steps.plan.outputs.base_tag }}
-          MAIN_SHA: ${{ steps.plan.outputs.main_sha }}
-          DRIFT: ${{ steps.plan.outputs.drift }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          head_sha="$(gh pr view "$PR" \
-            --repo "$REPO" \
-            --json headRefOid \
-            --jq .headRefOid)"
-          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
-
-          gate="$RUNNER_TEMP/check-release-proof-artifacts.mjs"
-          git show \
-            "refs/remotes/origin/main:scripts/check-release-proof-artifacts.mjs" \
-            > "$gate"
-          test -s "$gate"
-
-          if out="$(CANDIDATE_SHA="$head_sha" GITHUB_REPOSITORY="$REPO" \
-            node "$gate" 2>&1)"; then
-            echo "held=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::${out}"
-            exit 0
-          fi
-
-          # Keep the whole failure on one line rather than its last line. A
-          # multi-line message whose final line is blank reads exactly like a
-          # pass, which is how a guard in this fleet once reported green while
-          # failing.
-          detail="$(printf '%s' "$out" \
-            | tr '\n' ' ' \
-            | sed -e 's/::error:://g' -e 's/  */ /g' -e 's/^ //' -e 's/ $//')"
-          echo "::notice::${detail}"
-
-          # Hold the bump in draft. Standing down is correct here and will be
-          # frequent, but standing down invisibly is how a held rail once sat
-          # for roughly twenty hours, so this writes the same marker the plan
-          # step writes and the alarm job reads.
-          if [ "$(gh pr view "$PR" --repo "$REPO" --json isDraft --jq .isDraft)" != "true" ]; then
-            gh pr ready "$PR" --repo "$REPO" --undo
-          fi
-
-          # One comment per candidate head, not one per cycle: this workflow
-          # runs on a schedule, and a hold that comments every cycle buries the
-          # PR it is trying to explain.
-          existing="$(gh pr view "$PR" --repo "$REPO" \
-            --json comments --jq '.comments[].body' 2>/dev/null || true)"
-          if [ "$(printf '%s' "$existing" | command grep -cF "$head_sha" || true)" -eq 0 ]; then
-            gh pr comment "$PR" --repo "$REPO" --body "$(printf '%s\n\n%s\n' \
-              "Held: the release proof loop has not recorded candidate ${head_sha}." \
-              "${detail}")"
-          fi
-
-          latest_tag="$(gh api "repos/${REPO}/releases/latest" --jq .tag_name 2>/dev/null || true)"
-          marker="$RUNNER_TEMP/release-hold-marker.json"
-          jq -n \
-            --arg detail "$detail" \
-            --arg latest_tag "$latest_tag" \
-            --arg base_tag "$BASE_TAG" \
-            --arg main_sha "$MAIN_SHA" \
-            --arg run_id "$GITHUB_RUN_ID" \
-            --arg run_url "${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}" \
-            --argjson drift "${DRIFT:-0}" \
-            '{
-              schema: "kin.release-hold.v1",
-              state: "held",
-              reason: "proof_artifacts_missing",
-              detail: $detail,
-              blocking_tag: "",
-              latest_tag: $latest_tag,
-              base_tag: $base_tag,
-              drift: $drift,
-              main_sha: $main_sha,
-              run_id: $run_id,
-              run_url: $run_url,
-              failed_release_run_id: null,
-              failed_release_run_url: null,
-              observed_at: (now | todateiso8601)
-            }' > "$marker"
-          {
-            echo "marker<<KIN_RELEASE_HOLD_MARKER"
-            jq -c . "$marker"
-            echo "KIN_RELEASE_HOLD_MARKER"
-            echo "held=true"
-          } >> "$GITHUB_OUTPUT"
-
+      # The refusal did not go away, it moved to the artifact that actually
+      # ships. release-tag.yml now selects the newest main commit carrying the
+      # staged version for which the proof loop published records, and refuses
+      # to create the tag ref without them. That is the stronger placement: a
+      # tag run resolves its workflows from the tag and can never be repaired,
+      # so refusing before the ref exists beats refusing after. release.yml's
+      # finalize_release still refuses to promote a tag with no records, so both
+      # decision points keep importing one judge. What this branch's head is at
+      # any moment no longer decides anything, which is what lets main move.
       - name: Arm protected auto-merge
-        if: steps.plan.outputs.needed == 'true' && steps.proof.outputs.held != 'true'
+        if: steps.plan.outputs.needed == 'true'
         env:
           # Register auto-merge as the release App, not GITHUB_TOKEN. GitHub
           # suppresses most workflow events caused by GITHUB_TOKEN; an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2341,19 +2341,60 @@ jobs:
       # commit the proof loop recorded and tags that exact sha, so the direct key
       # resolves and this job asks about the same object the mint did.
       #
-      # RESOLVE_FROM_COMMIT stays beside it for the tags cut before that rekey.
-      # Those point at the squash of a version bump pull request, whose records
-      # sit under that pull request's head, and Release Recovery can still
-      # re-run one. The gate tries the direct key first and bridges only when
-      # the record is ABSENT; an unreadable record still fails closed. A commit
-      # no merged pull request produced resolves to nothing and is refused,
-      # which is the intended answer for a hand-pushed tag.
+      # RESOLVE_FROM_COMMIT stays beside it, and it is worth being exact about
+      # what it still buys, because the obvious answer is wrong. It is NOT that
+      # Release Recovery can re-run a tag cut before the rekey: a tag run
+      # resolves its workflows AND its scripts from the tag, so recovering such
+      # a tag re-runs that tag's own frozen copy of this job and of the gate,
+      # and never reaches this line. What it buys is the sentence a refusal
+      # carries. The gate tries the direct key first and bridges only when the
+      # record is ABSENT; an unreadable record still fails closed. A tag whose
+      # record went missing therefore refuses by naming the branch it came from
+      # rather than only the file it could not find, and a commit no merged
+      # pull request produced resolves to nothing and is refused, which is the
+      # intended answer for a hand-pushed tag.
+      #
+      # The identity check below is what the mint already makes before it
+      # writes the tag ref, mirrored here. Without it a bridged answer would
+      # promote a tag on evidence about a different commit and a different
+      # tree, which is exactly the approximation this rekey removes. With it,
+      # a bridged answer can only ever shape a refusal; it can no longer admit
+      # one.
       - name: Require proof-loop artifacts for the tagged candidate
         env:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE_SHA: ${{ github.sha }}
           RESOLVE_FROM_COMMIT: ${{ github.sha }}
-        run: node scripts/check-release-proof-artifacts.mjs
+        run: |
+          set -euo pipefail
+          gate="${GITHUB_WORKSPACE}/scripts/check-release-proof-artifacts.mjs"
+          test -s "$gate"
+          # The gate's narration goes to stderr so stdout carries exactly the
+          # sha it verified and nothing the comparison below could mistake for
+          # one, and a refusal is reported as the sentence naming what was
+          # missing rather than as a stack trace.
+          proven="$(KIN_RELEASE_GATE="file://${gate}" \
+            node --input-type=module -e '
+              const { main } = await import(process.env.KIN_RELEASE_GATE);
+              try {
+                const result = await main({
+                  log: (line) => process.stderr.write(line + "\n"),
+                });
+                process.stdout.write(result.sha);
+              } catch (error) {
+                process.stderr.write("::error::" + error.message + "\n");
+                process.exit(1);
+              }
+            ')"
+          if ! printf '%s' "$proven" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::the release proof gate returned '${proven}', which is not a candidate sha"
+            exit 1
+          fi
+          if [ "$proven" != "$CANDIDATE_SHA" ]; then
+            echo "::error::the proof gate verified $proven but this job promotes $CANDIDATE_SHA; refusing to flip a tag to Latest on evidence about a different commit"
+            exit 1
+          fi
+          echo "release proof records verified for $CANDIDATE_SHA, the commit this job promotes"
 
       - name: Promote stable tag after public and npm proof
         if: ${{ !contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2329,23 +2329,29 @@ jobs:
         with:
           persist-credentials: false
 
-      # The same evidence the release train requires before it merges a bump,
-      # required again here against the tag actually being promoted. The train's
-      # gate protects the path the train owns; this one protects every other
-      # path into Latest, because a tag reaches Latest through this job no
-      # matter how it was minted. On 2026-08-20 v0.5.44 reached Latest with no
-      # preflight record and no stranger run, and nothing in the train knew the
+      # The same evidence release-tag.yml requires before it writes the tag ref,
+      # required again here against the tag actually being promoted. The mint's
+      # gate protects the path the mint owns; this one protects every other path
+      # into Latest, because a tag reaches Latest through this job no matter how
+      # it was minted. On 2026-08-20 v0.5.44 reached Latest with no preflight
+      # record and no stranger run, and nothing in the release chain knew the
       # proof loop existed.
       #
-      # A squash mints a new commit, so a tag's own sha is never the sha the
-      # proof loop judged: v0.5.44's tag commit a4ffe620 is kin#986's squash,
-      # while the preflight for that line judged the release-next head. The
-      # resolver bridges that through the merged pull request. A commit no
-      # merged pull request produced resolves to nothing and is refused, which
-      # is the intended answer for a hand-pushed tag.
+      # The tagged commit IS the candidate now: the mint selects the newest main
+      # commit the proof loop recorded and tags that exact sha, so the direct key
+      # resolves and this job asks about the same object the mint did.
+      #
+      # RESOLVE_FROM_COMMIT stays beside it for the tags cut before that rekey.
+      # Those point at the squash of a version bump pull request, whose records
+      # sit under that pull request's head, and Release Recovery can still
+      # re-run one. The gate tries the direct key first and bridges only when
+      # the record is ABSENT; an unreadable record still fails closed. A commit
+      # no merged pull request produced resolves to nothing and is refused,
+      # which is the intended answer for a hand-pushed tag.
       - name: Require proof-loop artifacts for the tagged candidate
         env:
           GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ github.sha }}
           RESOLVE_FROM_COMMIT: ${{ github.sha }}
         run: node scripts/check-release-proof-artifacts.mjs
 

--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -211,10 +211,16 @@ export async function fetchEvidence(
     );
   }
   if (response.status === 404) {
-    throw new Error(
+    const absent = new Error(
       `${path} does not exist on the ${EVIDENCE_REF} branch of ${repository}; ` +
       'the proof loop has not recorded this candidate, so it cannot be released',
     );
+    // Absence is the one condition a caller may act on differently, and the
+    // flag is what keeps that decision from being a string match on a message.
+    // Unreadability deliberately carries no flag: "we could not tell" must
+    // never widen a search.
+    absent.evidenceAbsent = true;
+    throw absent;
   }
   if (!response.ok) {
     throw new Error(
@@ -225,13 +231,18 @@ export async function fetchEvidence(
   return response.text();
 }
 
-// A squash merge mints a new commit, so the sha a tag points at is never the
-// sha the proof loop judged. Preflight runs on the release branch head, and the
-// tag lands on the squash of that branch onto main: v0.5.44's tag commit
-// a4ffe620 is kin#986's squash, while the preflight for that line judged the
-// release-next head. Resolving the originating pull request's head is what
-// connects the two, and it is the only link that survives a squash, because the
-// squash shares no sha, no parent and no tree with the branch it flattened.
+// The bridge for tags cut before the candidate became a main commit.
+//
+// Under that older scheme the proof loop judged the release branch head and the
+// tag landed on the squash of that branch onto main, so the two never shared a
+// sha: v0.5.44's tag commit a4ffe620 is kin#986's squash, while the preflight
+// for that line judged the release-next head. Resolving the originating pull
+// request's head is the only link that survives a squash, because the squash
+// shares no sha, no parent and no tree with the branch it flattened.
+//
+// Tags cut after the rekey point at the candidate itself and never reach this
+// function, because their direct key resolves. Release Recovery can still
+// re-run an older tag, which is why the bridge is kept rather than retired.
 //
 // A commit with no originating pull request resolves to nothing and the caller
 // refuses it. That is the intended answer for a tag minted through a path the
@@ -290,11 +301,55 @@ export async function resolveCandidateSha(
   return merged[0].head.sha;
 }
 
-// Two callers, one judge. CANDIDATE_SHA names the candidate directly, which is
-// what the release train has before it merges. RESOLVE_FROM_COMMIT names a
-// landed commit to bridge through its merged pull request, which is what the
-// promote gate has: by then the candidate has been squashed and its sha is
-// gone from history.
+// Find the candidate whose records this run is about, and read the first one.
+//
+// CANDIDATE_SHA names it directly, and that is what both live callers have: the
+// tag mint knows the main commit it selected, and the promote gate knows the
+// commit the tag points at, which under the current scheme is the same object.
+//
+// RESOLVE_FROM_COMMIT is the bridge for tags cut before that scheme landed.
+// Those tags point at the squash of a version bump pull request, and a squash
+// shares no sha, no parent and no tree with the branch it flattened, so their
+// records sit under that pull request's head instead. Release Recovery can
+// still re-run such a tag, so the bridge stays.
+//
+// Order matters and so does what may trigger it. The direct key is tried first,
+// and only an ABSENT record falls through to the bridge. An unreadable record,
+// a transport failure or a server error still fails closed right here, because
+// a check that widens its search when it cannot tell is a check that reports
+// success for the wrong reason.
+async function locateCandidate({ sha, resolveFromCommit, options, log }) {
+  if (sha) {
+    try {
+      return {
+        sha,
+        preflightText: await fetchEvidence(sha, PREFLIGHT_RECORD, options),
+      };
+    } catch (error) {
+      if (!error.evidenceAbsent || !resolveFromCommit) {
+        throw error;
+      }
+      log(
+        `No preflight record under ${sha}; bridging landed commit ` +
+        `${resolveFromCommit} through the pull request that produced it`,
+      );
+    }
+  }
+  if (!resolveFromCommit) {
+    throw new Error(
+      'no candidate given; set CANDIDATE_SHA, or RESOLVE_FROM_COMMIT to bridge ' +
+      'a landed commit through the pull request that produced it',
+    );
+  }
+  const bridged = await resolveCandidateSha(resolveFromCommit, options);
+  log(`Resolved candidate ${bridged} from landed commit ${resolveFromCommit}`);
+  return {
+    sha: bridged,
+    preflightText: await fetchEvidence(bridged, PREFLIGHT_RECORD, options),
+  };
+}
+
+// Two callers, one judge.
 export async function main({
   sha = process.env.CANDIDATE_SHA,
   resolveFromCommit = process.env.RESOLVE_FROM_COMMIT,
@@ -309,18 +364,14 @@ export async function main({
   const token = env.GH_TOKEN || env.GITHUB_TOKEN;
   const options = { repository, token, fetchImpl };
 
-  if (!sha && resolveFromCommit) {
-    sha = await resolveCandidateSha(resolveFromCommit, options);
-    log(`Resolved candidate ${sha} from landed commit ${resolveFromCommit}`);
-  }
-  if (!sha) {
-    throw new Error(
-      'no candidate given; set CANDIDATE_SHA, or RESOLVE_FROM_COMMIT to bridge ' +
-      'a landed commit through the pull request that produced it',
-    );
-  }
+  let preflightText;
+  ({ sha, preflightText } = await locateCandidate({
+    sha,
+    resolveFromCommit,
+    options,
+    log,
+  }));
 
-  const preflightText = await fetchEvidence(sha, PREFLIGHT_RECORD, options);
   let preflight;
   try {
     preflight = JSON.parse(preflightText);

--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -36,6 +36,11 @@ export const EVIDENCE_REF = 'release-evidence';
 export const PREFLIGHT_SCHEMA = 'kin.release-preflight.v1';
 export const PREFLIGHT_RECORD = 'preflight.json';
 export const STRANGER_RECORD = 'stranger.env';
+// The release train's version bump branch, and the ONLY branch whose head ever
+// carried proof records. It bounds the bridge below. release-train.yml declares
+// the same literal, and the authority suite pins the two together so they
+// cannot drift into a bridge that resolves somewhere nothing was ever proven.
+export const BUMP_BRANCH = 'automation/release-next';
 
 const COMMIT_SHA = /^[0-9a-f]{40}$/;
 const ARCHIVE_SHA = /^[0-9a-f]{64}$/;
@@ -281,14 +286,34 @@ export async function resolveCandidateSha(
     );
   }
   const pulls = await response.json();
-  const merged = (Array.isArray(pulls) ? pulls : []).filter(
+  const produced = (Array.isArray(pulls) ? pulls : []).filter(
     (pull) => pull?.merge_commit_sha === commitSha && COMMIT_SHA.test(pull?.head?.sha ?? ''),
   );
+  // Bounded to the bump branch. Under the current scheme the tagged commit is
+  // the candidate, so a tag reaching this function is one whose direct record
+  // was absent, and every ordinary main commit is the squash of some feature
+  // pull request whose head never carried a record. Without this bound the
+  // bridge would happily answer about that head, which is a promote gate
+  // looking somewhere nothing was ever proven. Checked against every tag this
+  // bridge exists for: v0.5.44, v0.5.45 and v0.5.46 each resolve through a
+  // pull request from this branch.
+  const merged = produced.filter((pull) => pull?.head?.ref === BUMP_BRANCH);
   if (merged.length === 0) {
+    if (produced.length === 0) {
+      throw new Error(
+        `no merged pull request produced ${commitSha}, so there is no candidate ` +
+        'branch head whose proof records could be found; a tag minted outside ' +
+        'the release train carries no evidence by construction',
+      );
+    }
+    const refs = [
+      ...new Set(produced.map((pull) => pull?.head?.ref ?? '<none>')),
+    ].join(', ');
     throw new Error(
-      `no merged pull request produced ${commitSha}, so there is no candidate ` +
-      'branch head whose proof records could be found; a tag minted outside ' +
-      'the release train carries no evidence by construction',
+      `${commitSha} was produced by a pull request from ${refs}, not from ` +
+      `${BUMP_BRANCH}; only the release train's bump branch ever carried proof ` +
+      'records, so bridging anywhere else would answer about a build nobody ' +
+      'proved',
     );
   }
   if (merged.length > 1) {

--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -246,8 +246,19 @@ export async function fetchEvidence(
 // shares no sha, no parent and no tree with the branch it flattened.
 //
 // Tags cut after the rekey point at the candidate itself and never reach this
-// function, because their direct key resolves. Release Recovery can still
-// re-run an older tag, which is why the bridge is kept rather than retired.
+// function, because their direct key resolves. Neither does a recovery re-run
+// of a pre-rekey tag, which is the reason this comment used to give and it was
+// wrong: a tag run resolves its workflows AND its scripts from the tag, so
+// re-running one executes that tag's own frozen release.yml and its own frozen
+// copy of this file. No edit here can reach it.
+//
+// What keeps the bridge is a rekeyed tag whose record went absent after the
+// fact. The evidence branch is append-only by construction and unprotected in
+// practice, so that is reachable, and the bound below turns it into a refusal
+// that names where the tag came from rather than only the file that was
+// missing. The promote gate compares the sha this returns against the sha it
+// is promoting, so a bridged answer can shape a refusal and can no longer
+// admit one.
 //
 // A commit with no originating pull request resolves to nothing and the caller
 // refuses it. That is the intended answer for a tag minted through a path the
@@ -332,11 +343,14 @@ export async function resolveCandidateSha(
 // tag mint knows the main commit it selected, and the promote gate knows the
 // commit the tag points at, which under the current scheme is the same object.
 //
-// RESOLVE_FROM_COMMIT is the bridge for tags cut before that scheme landed.
-// Those tags point at the squash of a version bump pull request, and a squash
-// shares no sha, no parent and no tree with the branch it flattened, so their
-// records sit under that pull request's head instead. Release Recovery can
-// still re-run such a tag, so the bridge stays.
+// RESOLVE_FROM_COMMIT is the bridge to a pull request head, which is the only
+// link that survives a squash: a squash shares no sha, no parent and no tree
+// with the branch it flattened. It is not what recovers a tag cut before the
+// rekey, because such a run resolves its workflows and its scripts from the
+// tag and never reaches this file. It stays because a tag whose direct record
+// went absent should refuse by naming where it came from, and because the
+// promote gate refuses anyway unless the sha returned here is the sha it
+// promotes.
 //
 // Order matters and so does what may trigger it. The direct key is tried first,
 // and only an ABSENT record falls through to the bridge. An unreadable record,

--- a/scripts/check-release-proof-artifacts.test.mjs
+++ b/scripts/check-release-proof-artifacts.test.mjs
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  BUMP_BRANCH,
   EVIDENCE_REF,
   PREFLIGHT_RECORD,
   PREFLIGHT_SCHEMA,
@@ -349,7 +350,7 @@ test('resolveCandidateSha bridges a squash to the branch head that was proven', 
     fetchImpl: async (url) => {
       seen = url;
       return jsonOk([
-        { number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD } },
+        { number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD, ref: BUMP_BRANCH } },
       ]);
     },
   });
@@ -369,7 +370,7 @@ test('resolveCandidateSha refuses a commit no merged pull request produced', asy
     resolveCandidateSha(SHA, {
       repository: REPO,
       fetchImpl: async () =>
-        jsonOk([{ number: 1, merge_commit_sha: OTHER_SHA, head: { sha: RC_HEAD } }]),
+        jsonOk([{ number: 1, merge_commit_sha: OTHER_SHA, head: { sha: RC_HEAD, ref: BUMP_BRANCH } }]),
     }),
     /no merged pull request produced/,
   );
@@ -381,8 +382,8 @@ test('resolveCandidateSha refuses to guess between two claimants', async () => {
       repository: REPO,
       fetchImpl: async () =>
         jsonOk([
-          { number: 1, merge_commit_sha: SHA, head: { sha: RC_HEAD } },
-          { number: 2, merge_commit_sha: SHA, head: { sha: OTHER_SHA } },
+          { number: 1, merge_commit_sha: SHA, head: { sha: RC_HEAD, ref: BUMP_BRANCH } },
+          { number: 2, merge_commit_sha: SHA, head: { sha: OTHER_SHA, ref: BUMP_BRANCH } },
         ]),
     }),
     /claimed as the merge commit of more than one pull request \(#1, #2\)/,
@@ -408,6 +409,40 @@ test('resolveCandidateSha fails closed on transport and server failure', async (
   );
 });
 
+// The bridge exists for tags cut before the candidate became a main commit,
+// and every one of those resolves through the release train's bump branch:
+// checked against v0.5.44, v0.5.45 and v0.5.46, whose tag commits are the
+// squashes of kin#986, kin#991 and kin#1001, all from automation/release-next.
+// Under the current scheme an ordinary main commit is the squash of a feature
+// pull request whose head never carried a record, so bridging to it would send
+// the promote gate looking somewhere nothing was ever proven.
+test('resolveCandidateSha refuses to bridge outside the release train', async () => {
+  await assert.rejects(
+    resolveCandidateSha(SHA, {
+      repository: REPO,
+      fetchImpl: async () =>
+        jsonOk([
+          {
+            number: 1049,
+            merge_commit_sha: SHA,
+            head: { sha: RC_HEAD, ref: 'feature/some-ordinary-branch' },
+          },
+        ]),
+    }),
+    /not from automation\/release-next; only the release train's bump branch/,
+  );
+});
+
+test('resolveCandidateSha still separates absence from a wrong branch', async () => {
+  await assert.rejects(
+    resolveCandidateSha(SHA, {
+      repository: REPO,
+      fetchImpl: async () => jsonOk([]),
+    }),
+    /no merged pull request produced/,
+  );
+});
+
 test('resolveCandidateSha refuses a loose ref', async () => {
   await assert.rejects(
     resolveCandidateSha('main', { repository: REPO, fetchImpl: async () => jsonOk([]) }),
@@ -424,7 +459,7 @@ test('main bridges a landed commit to the candidate that was proven', async () =
     log: (line) => lines.push(line),
     fetchImpl: async (url) => {
       if (url.includes('/pulls')) {
-        return jsonOk([{ number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD } }]);
+        return jsonOk([{ number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD, ref: BUMP_BRANCH } }]);
       }
       if (url.includes(PREFLIGHT_RECORD)) {
         const record = preflightRecord();
@@ -489,7 +524,7 @@ test('main bridges when the direct key is absent and a commit is given', async (
     log: (line) => lines.push(line),
     fetchImpl: async (url) => {
       if (url.includes('/pulls')) {
-        return jsonOk([{ number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD } }]);
+        return jsonOk([{ number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD, ref: BUMP_BRANCH } }]);
       }
       if (url.includes(`evidence/${SHA}/`)) {
         return { ok: false, status: 404, statusText: 'Not Found' };
@@ -527,7 +562,7 @@ test('main never bridges past a record it could not read', async () => {
         fetchImpl: async (url) => {
           if (url.includes('/pulls')) {
             bridged = true;
-            return jsonOk([{ number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD } }]);
+            return jsonOk([{ number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD, ref: BUMP_BRANCH } }]);
           }
           return unreadable;
         },

--- a/scripts/check-release-proof-artifacts.test.mjs
+++ b/scripts/check-release-proof-artifacts.test.mjs
@@ -446,3 +446,116 @@ test('main refuses when neither a candidate nor a commit to bridge is given', as
     /no candidate given/,
   );
 });
+
+// The promote gate passes both keys now that the mint tags the candidate
+// itself. The direct key is the answer, and the bridge must not even be asked:
+// a landed commit resolves through /pulls to the head of whatever feature pull
+// request produced it, which has no records and never did.
+test('main answers from the direct key without asking about pull requests', async () => {
+  const asked = [];
+  const result = await main({
+    sha: SHA,
+    resolveFromCommit: SHA,
+    repository: REPO,
+    env: {},
+    log: () => {},
+    fetchImpl: async (url) => {
+      asked.push(url);
+      if (url.includes(PREFLIGHT_RECORD)) {
+        return ok(JSON.stringify(preflightRecord()));
+      }
+      return ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`);
+    },
+  });
+  assert.equal(result.sha, SHA);
+  assert.equal(
+    asked.filter((url) => url.includes('/pulls')).length,
+    0,
+    'the direct key resolved, so nothing may bridge',
+  );
+});
+
+// A tag cut before the rekey points at the squash of a version bump pull
+// request, and its records sit under that pull request's head. Release
+// Recovery can still re-run one, so absence under the direct key falls
+// through to the bridge exactly once.
+test('main bridges when the direct key is absent and a commit is given', async () => {
+  const lines = [];
+  const result = await main({
+    sha: SHA,
+    resolveFromCommit: SHA,
+    repository: REPO,
+    env: {},
+    log: (line) => lines.push(line),
+    fetchImpl: async (url) => {
+      if (url.includes('/pulls')) {
+        return jsonOk([{ number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD } }]);
+      }
+      if (url.includes(`evidence/${SHA}/`)) {
+        return { ok: false, status: 404, statusText: 'Not Found' };
+      }
+      if (url.includes(PREFLIGHT_RECORD)) {
+        const record = preflightRecord();
+        record.legs.forEach((leg) => {
+          leg.result.expected.commit = RC_HEAD;
+        });
+        return ok(JSON.stringify(record));
+      }
+      return ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`);
+    },
+  });
+  assert.equal(result.sha, RC_HEAD);
+  assert.match(lines.join('\n'), new RegExp(`No preflight record under ${SHA}`));
+});
+
+// The bridge widens the search, so only a definite absence may trigger it. An
+// unreadable answer means we could not tell, and a check that widens when it
+// cannot tell is a check that reports success for the wrong reason.
+test('main never bridges past a record it could not read', async () => {
+  for (const unreadable of [
+    { ok: false, status: 500, statusText: 'Server Error' },
+    { ok: false, status: 403, statusText: 'Forbidden' },
+  ]) {
+    let bridged = false;
+    await assert.rejects(
+      main({
+        sha: SHA,
+        resolveFromCommit: SHA,
+        repository: REPO,
+        env: {},
+        log: () => {},
+        fetchImpl: async (url) => {
+          if (url.includes('/pulls')) {
+            bridged = true;
+            return jsonOk([{ number: 986, merge_commit_sha: SHA, head: { sha: RC_HEAD } }]);
+          }
+          return unreadable;
+        },
+      }),
+      new RegExp(`could not read .*HTTP ${unreadable.status}`),
+    );
+    assert.equal(bridged, false, 'an unreadable record must never widen the search');
+  }
+});
+
+// The mint passes the direct key alone, so absence there is terminal. Nothing
+// about a main commit's own pull request could name a proven candidate.
+test('main holds on absence when no commit to bridge from is given', async () => {
+  let bridged = false;
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: async (url) => {
+        if (url.includes('/pulls')) {
+          bridged = true;
+        }
+        return { ok: false, status: 404, statusText: 'Not Found' };
+      },
+    }),
+    /the proof loop has not recorded this candidate/,
+  );
+  assert.equal(bridged, false);
+});

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -32,6 +32,8 @@ ADVISORY_SWEEP = WORKFLOWS / "advisory-sweep.yml"
 ADVISORY_SWEEP_SCRIPT = ROOT / "scripts" / "advisory-sweep.mjs"
 HOLD_ALARM = ROOT / "scripts" / "release-hold-alarm.mjs"
 HOLD_ALARM_POLICY = "scripts/release-hold-alarm.mjs"
+PROOF_GATE = ROOT / "scripts" / "check-release-proof-artifacts.mjs"
+PROOF_GATE_POLICY = "scripts/check-release-proof-artifacts.mjs"
 INSTALL_PROOF_CANARY = WORKFLOWS / "install-proof-canary.yml"
 CAPABILITY_CONTRACT = ROOT / "scripts" / "verify-capability-proof.mjs"
 CAPABILITY_CONTRACT_POLICY = "scripts/verify-capability-proof.mjs"
@@ -1023,6 +1025,24 @@ def replace_exactly_once(
             f"{original!r}"
         )
     return source.replace(original, replacement, 1)
+
+
+def swap_release_tag_step_order(release_tag: str) -> str:
+    """Move the release proof gate after the tag write it exists to gate.
+
+    Both step names survive the swap, so the count check still passes and the
+    ordering check is the only thing that can catch it. That is the point: a
+    gate that runs after the ref is written reads exactly like a gate.
+    """
+
+    gate = "      - name: Require proof-loop artifacts for the release candidate\n"
+    write = "      - name: Create release tag ref\n"
+    placeholder = "      - name: kin-order-swap-placeholder\n"
+    swapped = replace_exactly_once(
+        release_tag, gate, placeholder, "proof gate order"
+    )
+    swapped = replace_exactly_once(swapped, write, gate, "proof gate order")
+    return replace_exactly_once(swapped, placeholder, write, "proof gate order")
 
 
 def write_node_validator_fixture_files(
@@ -7130,6 +7150,147 @@ def assert_recovery_abandonment_stand_down(release_recovery: str) -> None:
             )
 
 
+def assert_release_proof_key_authority(
+    release_train: str,
+    release_tag: str,
+    release: str,
+    proof_gate: str,
+) -> None:
+    """Pin the release evidence to a commit nothing rewrites, and to the tag.
+
+    This guard did not exist while the thing it guards was load-bearing. The
+    FIR-2525 proof gate lived in release-train.yml keyed on the head of
+    automation/release-next, the train mints a new head on every cycle that
+    finds drift, and nothing in this file noticed either fact. Removing that
+    step outright left the whole suite green, which is how a release chain
+    acquires a rule that only a runbook sentence enforces.
+
+    What is pinned now is the arrangement that replaced it. The candidate is a
+    main commit, so nothing can rewrite it out from under its records; the mint
+    refuses to write the tag ref without them; the tag names the exact sha the
+    gate verified; and the train keys nothing on a branch head any more, which
+    is the property that lets main keep moving through a proof window.
+    """
+
+    mint = workflow_job_blocks(release_tag).get("mint-release-tag")
+    if mint is None:
+        raise AssertionError("release-tag.yml no longer declares the mint job")
+
+    gate_anchor = "- name: Require proof-loop artifacts for the release candidate"
+    tag_write_anchor = "- name: Create release tag ref"
+    for anchor in (gate_anchor, tag_write_anchor):
+        if mint.count(anchor) != 1:
+            raise AssertionError(
+                f"the mint must declare exactly one {anchor!r} step, so the "
+                "release proof gate has one reviewed place to live"
+            )
+    if mint.index(gate_anchor) > mint.index(tag_write_anchor):
+        raise AssertionError(
+            "the release proof gate must run before the tag ref is written; a "
+            "tag run resolves its workflows from the tag and can never be "
+            "repaired, so a gate after the write refuses nothing"
+        )
+
+    gate_step = "\n".join(
+        job_step_active_lines(release_tag, "mint-release-tag", gate_anchor)
+    )
+    for needle, duty in (
+        (
+            f'"refs/remotes/origin/main:{PROOF_GATE_POLICY}"',
+            "read the gate from protected main rather than from the commit "
+            "under judgement",
+        ),
+        (
+            'CANDIDATE_SHA="$SHA"',
+            "ask about the exact sha it is going to tag",
+        ),
+        (
+            'if [ "$proven" != "$SHA" ]',
+            "refuse when the sha the gate verified is not the sha it would tag",
+        ),
+        (
+            'git diff --name-only "$proven" "$SHA"',
+            "state that the tree it tags is the tree that was proven",
+        ),
+    ):
+        if needle not in gate_step:
+            raise AssertionError(
+                f"the release proof gate must {duty}: {needle}"
+            )
+
+    resolve = "\n".join(
+        job_step_active_lines(
+            release_tag, "mint-release-tag", "name: Resolve exact coherent release"
+        )
+    )
+    for needle, duty in (
+        (
+            "git/trees/release-evidence?recursive=1",
+            "select the candidate from the records the proof loop published",
+        ),
+        (
+            '.truncated // false',
+            "refuse a truncated listing rather than shipping the older "
+            "candidate it can still see",
+        ),
+        (
+            'echo "needed=false"',
+            "stand down as a no-op when no candidate is proven, rather than "
+            "declining or tagging one that is not",
+        ),
+    ):
+        if needle not in resolve:
+            raise AssertionError(
+                f"the mint's candidate selection must {duty}: {needle}"
+            )
+
+    reconcile = workflow_job_blocks(release_train).get("reconcile")
+    if reconcile is None:
+        raise AssertionError("release-train.yml no longer declares the reconcile job")
+    if PROOF_GATE_POLICY in "\n".join(active_lines(reconcile)):
+        raise AssertionError(
+            "the release train must key nothing on the version bump branch's "
+            "head; that key is what forced the fleet to freeze main for the "
+            "length of every proof window, and the refusal now lives on the "
+            "tag the mint writes"
+        )
+
+    promote = "\n".join(
+        job_step_active_lines(
+            release, "finalize_release", "name: Require proof-loop artifacts"
+        )
+    )
+    for needle, duty in (
+        (
+            "CANDIDATE_SHA: ${{ github.sha }}",
+            "ask about the tagged commit directly, because the mint now tags "
+            "the candidate itself",
+        ),
+        (
+            "RESOLVE_FROM_COMMIT: ${{ github.sha }}",
+            "keep the bridge for tags cut before that rekey, whose records sit "
+            "under the pull request head instead",
+        ),
+    ):
+        if needle not in promote:
+            raise AssertionError(
+                f"the promote gate must {duty}: {needle}"
+            )
+
+    gate_source = "\n".join(active_lines(proof_gate))
+    if "absent.evidenceAbsent = true" not in gate_source:
+        raise AssertionError(
+            "the proof gate must mark an absent record as absent, so a caller "
+            "deciding to bridge is not matching on an error message"
+        )
+    if "if (!error.evidenceAbsent || !resolveFromCommit)" not in gate_source:
+        raise AssertionError(
+            "the proof gate must bridge only when the direct record is ABSENT; "
+            "widening the search on an unreadable record is a check reporting "
+            "success for the wrong reason"
+        )
+
+
 def assert_release_hold_marker_contract(
     release_train: str,
     release_sentinel: str,
@@ -7900,6 +8061,7 @@ def main() -> None:
     sast = SAST.read_text(encoding="utf-8")
     advisory_sweep = ADVISORY_SWEEP.read_text(encoding="utf-8")
     hold_alarm = HOLD_ALARM.read_text(encoding="utf-8")
+    proof_gate = PROOF_GATE.read_text(encoding="utf-8")
     release_bot_doc = RELEASE_BOT_DOC.read_text(encoding="utf-8")
     install_proof = INSTALL_PROOF.read_text(encoding="utf-8")
     install_proof_canary = INSTALL_PROOF_CANARY.read_text(encoding="utf-8")
@@ -8619,6 +8781,135 @@ def main() -> None:
                 "          steps.record.outputs.abandoned != 'true'",
                 "          # steps.record.outputs.abandoned != 'true'",
             )
+        ),
+    )
+
+    # Where the release evidence is keyed decides whether main has to hold
+    # still. Keyed to a branch head the train rewrites, it did; keyed to a main
+    # commit and checked against the tag, it does not. Nothing pinned that
+    # before, so the whole arrangement is pinned here together with the refusal
+    # it carries.
+    assert_release_proof_key_authority(
+        release_train, release_tag, release, proof_gate
+    )
+    expect_assertion(
+        "the mint stops comparing the proven sha to the sha it tags",
+        "refuse when the sha the gate verified",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            replace_exactly_once(
+                release_tag,
+                'if [ "$proven" != "$SHA" ]; then',
+                'if [ "$proven" = "never" ]; then',
+                "proof gate identity",
+            ),
+            release,
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the mint stops stating that the tagged tree is the proven tree",
+        "state that the tree it tags is the tree that was proven",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            replace_exactly_once(
+                release_tag,
+                'delta="$(git diff --name-only "$proven" "$SHA")"',
+                'delta=""',
+                "proof gate tree identity",
+            ),
+            release,
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the proof gate runs after the tag ref it was supposed to gate",
+        "must run before the tag ref is written",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            swap_release_tag_step_order(release_tag),
+            release,
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the mint takes a truncated evidence listing at face value",
+        "refuse a truncated listing",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            replace_exactly_once(
+                release_tag,
+                "jq -r '.truncated // false' <<< \"$listing\"",
+                "jq -r 'false' <<< \"$listing\"",
+                "truncated listing refusal",
+            ),
+            release,
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the train keys a release on the version bump branch's head again",
+        "must key nothing on the version bump branch's head",
+        lambda: assert_release_proof_key_authority(
+            replace_exactly_once(
+                release_train,
+                "      - name: Arm protected auto-merge\n",
+                "      - name: Require proof-loop artifacts for the candidate\n"
+                "        run: |\n"
+                "          git show "
+                f'"refs/remotes/origin/main:{PROOF_GATE_POLICY}" > gate\n'
+                "\n"
+                "      - name: Arm protected auto-merge\n",
+                "release train proof key",
+            ),
+            release_tag,
+            release,
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the promote gate stops asking about the tagged commit itself",
+        "ask about the tagged commit directly",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            release_tag,
+            replace_exactly_once(
+                release,
+                "          CANDIDATE_SHA: ${{ github.sha }}\n",
+                "",
+                "promote gate direct key",
+            ),
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the promote gate stops bridging tags cut before the rekey",
+        "keep the bridge for tags cut before that rekey",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            release_tag,
+            replace_exactly_once(
+                release,
+                "          RESOLVE_FROM_COMMIT: ${{ github.sha }}\n",
+                "",
+                "promote gate bridge",
+            ),
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the proof gate bridges on a record it could not read",
+        "must bridge only when the direct record is ABSENT",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            release_tag,
+            release,
+            replace_exactly_once(
+                proof_gate,
+                "if (!error.evidenceAbsent || !resolveFromCommit) {",
+                "if (!resolveFromCommit) {",
+                "proof gate absence-only bridge",
+            ),
         ),
     )
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1027,6 +1027,27 @@ def replace_exactly_once(
     return source.replace(original, replacement, 1)
 
 
+def workflow_active_text(block: str) -> str:
+    """Comment-stripped workflow text, safe for a job whose steps run shell.
+
+    `active_lines` is the general helper, and it also strips C-style block
+    comments so a JavaScript heredoc cannot hide a no-op validator. A shell
+    glob opens one of those: `refs/tags/*` starts a match that runs to the next
+    `*/`, which on release-train.yml is `${policy##*/` eleven thousand
+    characters later, swallowing most of the reconcile job. A guard reading a
+    workflow through that rule is structurally unable to see anything in the
+    swallowed range, and an absence check reading it would report absence for a
+    step that is right there. YAML and shell both comment with `#` alone, so
+    that is all this strips.
+    """
+
+    return "\n".join(
+        line.strip()
+        for line in block.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    )
+
+
 def swap_release_tag_step_order(release_tag: str) -> str:
     """Move the release proof gate after the tag write it exists to gate.
 
@@ -7247,7 +7268,7 @@ def assert_release_proof_key_authority(
     reconcile = workflow_job_blocks(release_train).get("reconcile")
     if reconcile is None:
         raise AssertionError("release-train.yml no longer declares the reconcile job")
-    if PROOF_GATE_POLICY in "\n".join(active_lines(reconcile)):
+    if PROOF_GATE_POLICY in workflow_active_text(reconcile):
         raise AssertionError(
             "the release train must key nothing on the version bump branch's "
             "head; that key is what forced the fleet to freeze main for the "
@@ -7278,6 +7299,38 @@ def assert_release_proof_key_authority(
             )
 
     gate_source = "\n".join(active_lines(proof_gate))
+
+    # The bridge is the one path in the gate that can answer about a sha nobody
+    # named, so it is bounded to the branch that is the only place a record was
+    # ever published. The bound is read out of the release train rather than
+    # written down twice: renaming the bump branch there must fail here until
+    # the gate follows, because a bridge pointed at a branch that no longer
+    # exists resolves the head of whatever feature pull request produced the
+    # tagged commit, and that head never carried a record.
+    bump_branch = re.search(
+        r"^BRANCH: (\S+)$", workflow_active_text(reconcile), re.MULTILINE
+    )
+    if bump_branch is None:
+        raise AssertionError(
+            "release-train.yml no longer names the bump branch it writes, so "
+            "the proof gate's bridge cannot be bounded to it"
+        )
+    if f"export const BUMP_BRANCH = '{bump_branch.group(1)}';" not in gate_source:
+        raise AssertionError(
+            "the proof gate's bridge must be bounded to the same bump branch "
+            f"the release train writes ({bump_branch.group(1)})"
+        )
+    if (
+        "produced.filter((pull) => pull?.head?.ref === BUMP_BRANCH)"
+        not in gate_source
+    ):
+        raise AssertionError(
+            "the proof gate must apply the bump-branch bound when it bridges, "
+            "or a tag whose records were removed resolves the head of the "
+            "feature pull request that produced it and asks about a build "
+            "nobody proved"
+        )
+
     if "absent.evidenceAbsent = true" not in gate_source:
         raise AssertionError(
             "the proof gate must mark an absent record as absent, so a caller "
@@ -8867,6 +8920,29 @@ def main() -> None:
             proof_gate,
         ),
     )
+    # The same regression, planted where the general comment stripper cannot
+    # see it. `refs/tags/*` opens a C-style block comment for `active_lines`,
+    # which then swallows the next eleven thousand characters of the reconcile
+    # job, and this anchor sits inside that range. Reading the job through that
+    # rule reports absence for a step that is right there, so the guard uses a
+    # shell-safe reader and this proves it.
+    expect_assertion(
+        "the train keys a release on the bump branch head inside the "
+        "block-comment blind spot",
+        "must key nothing on the version bump branch's head",
+        lambda: assert_release_proof_key_authority(
+            replace_exactly_once(
+                release_train,
+                '          test -s "$abandoned"\n',
+                '          test -s "$abandoned"\n'
+                f'          git show "refs/remotes/origin/main:{PROOF_GATE_POLICY}" > gate\n',
+                "release train proof key, blind spot",
+            ),
+            release_tag,
+            release,
+            proof_gate,
+        ),
+    )
     expect_assertion(
         "the promote gate stops asking about the tagged commit itself",
         "ask about the tagged commit directly",
@@ -8894,6 +8970,36 @@ def main() -> None:
                 "",
                 "promote gate bridge",
             ),
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the proof gate's bridge stops being bounded to the bump branch",
+        "must apply the bump-branch bound when it bridges",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            release_tag,
+            release,
+            replace_exactly_once(
+                proof_gate,
+                "produced.filter((pull) => pull?.head?.ref === BUMP_BRANCH)",
+                "produced.filter((pull) => pull !== null)",
+                "proof gate bump-branch bound",
+            ),
+        ),
+    )
+    expect_assertion(
+        "the bump branch is renamed in the train and not in the gate",
+        "must be bounded to the same bump branch",
+        lambda: assert_release_proof_key_authority(
+            replace_exactly_once(
+                release_train,
+                "          BRANCH: automation/release-next\n",
+                "          BRANCH: automation/release-later\n",
+                "bump branch rename",
+            ),
+            release_tag,
+            release,
             proof_gate,
         ),
     )

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1066,6 +1066,46 @@ def swap_release_tag_step_order(release_tag: str) -> str:
     return replace_exactly_once(swapped, placeholder, write, "proof gate order")
 
 
+def swap_train_undraft_after_arm(release_train: str) -> str:
+    """Arm the bump pull request before un-drafting it, instead of after.
+
+    Both commands survive, so the presence checks still pass and the ordering
+    check is the only thing that can catch it. Ordering is the whole point
+    here: `gh pr merge --auto` registered against a draft pull request is not
+    taken by the merge queue, so un-drafting afterwards leaves auto-merge armed
+    on a pull request nothing will merge.
+    """
+
+    lines = release_train.splitlines(keepends=True)
+
+    def find(predicate, start, label):
+        for index in range(start, len(lines)):
+            if predicate(lines[index]):
+                return index
+        raise AssertionError(f"release train un-draft order mutation found no {label}")
+
+    undraft_start = find(
+        lambda line: ".isDraft" in line and line.lstrip().startswith("if ["),
+        0,
+        "draft-state branch",
+    )
+    undraft_end = find(
+        lambda line: line.strip() == "fi", undraft_start, "end of the draft-state branch"
+    ) + 1
+    arm_start = find(
+        lambda line: 'gh pr merge "$PR"' in line, undraft_end, "arm command"
+    )
+    arm_end = find(
+        lambda line: "--match-head-commit" in line, arm_start, "end of the arm command"
+    ) + 1
+    return "".join(
+        lines[:undraft_start]
+        + lines[undraft_end:arm_end]
+        + lines[undraft_start:undraft_end]
+        + lines[arm_end:]
+    )
+
+
 def write_node_validator_fixture_files(
     root: Path,
     files: dict[str, object],
@@ -7255,6 +7295,19 @@ def assert_release_proof_key_authority(
             "candidate it can still see",
         ),
         (
+            'if ! listing="$(gh api',
+            "test the status of the listing read, because a transport "
+            "failure, a GitHub error object and an empty evidence branch "
+            "otherwise print the same green no-op and only one of them means "
+            "there is nothing to release",
+        ),
+        (
+            '2>"$read_error"',
+            "keep the error text from the listing read, because a refusal "
+            "that cannot say what went wrong is one an operator has to "
+            "reproduce before they can act on it",
+        ),
+        (
             'echo "needed=false"',
             "stand down as a no-op when no candidate is proven, rather than "
             "declining or tagging one that is not",
@@ -7268,12 +7321,49 @@ def assert_release_proof_key_authority(
     reconcile = workflow_job_blocks(release_train).get("reconcile")
     if reconcile is None:
         raise AssertionError("release-train.yml no longer declares the reconcile job")
+
     if PROOF_GATE_POLICY in workflow_active_text(reconcile):
         raise AssertionError(
             "the release train must key nothing on the version bump branch's "
             "head; that key is what forced the fleet to freeze main for the "
             "length of every proof window, and the refusal now lives on the "
             "tag the mint writes"
+        )
+
+    # The removed proof step was the only code that ever drafted or un-drafted
+    # the bump pull request, and it drafted it while it held. The arm step now
+    # runs on drift alone, so without this a draft left behind by that step
+    # arms auto-merge on a pull request the merge queue never takes: the bump
+    # never lands, no candidate is ever provable, and the plan step's all-clear
+    # marker reports a healthy rail every fifteen minutes while nothing moves.
+    arm = "\n".join(
+        job_step_active_lines(
+            release_train, "reconcile", "name: Arm protected auto-merge"
+        )
+    )
+    for needle, duty in (
+        (
+            'gh pr ready "$PR"',
+            "un-draft the bump pull request before it arms auto-merge, "
+            "because the merge queue never takes a draft and nothing else "
+            "here un-drafts one any more",
+        ),
+        (
+            "--json headRefOid,isDraft",
+            "read the draft state in the same call that reads the head, so "
+            "the check costs no extra round trip and cannot go stale between "
+            "two of them",
+        ),
+    ):
+        if needle not in arm:
+            raise AssertionError(
+                f"the release train's arm step must {duty}: {needle}"
+            )
+    if arm.index('gh pr ready "$PR"') > arm.index('gh pr merge "$PR"'):
+        raise AssertionError(
+            "the release train must un-draft the bump pull request BEFORE it "
+            "arms auto-merge; arming first is what leaves a draft armed and "
+            "unmergeable while the rail reports itself clear"
         )
 
     promote = "\n".join(
@@ -7289,8 +7379,22 @@ def assert_release_proof_key_authority(
         ),
         (
             "RESOLVE_FROM_COMMIT: ${{ github.sha }}",
-            "keep the bridge for tags cut before that rekey, whose records sit "
-            "under the pull request head instead",
+            "keep the bridge, which is what makes a tag with no direct record "
+            "refuse by naming where it came from rather than only naming the "
+            "file that was missing",
+        ),
+        (
+            "process.stdout.write(result.sha)",
+            "read back the sha the gate verified rather than only its exit "
+            "status, because the exit status alone cannot say which commit "
+            "the evidence was about",
+        ),
+        (
+            'if [ "$proven" != "$CANDIDATE_SHA" ]',
+            "refuse when the sha the gate verified is not the sha it "
+            "promotes; the mint makes that comparison before it writes the "
+            "ref, and without it here a bridged answer flips a tag to Latest "
+            "on evidence about a different commit and a different tree",
         ),
     ):
         if needle not in promote:
@@ -8959,8 +9063,8 @@ def main() -> None:
         ),
     )
     expect_assertion(
-        "the promote gate stops bridging tags cut before the rekey",
-        "keep the bridge for tags cut before that rekey",
+        "the promote gate stops bridging a tag with no direct record",
+        "keep the bridge, which is what makes a tag with no direct record",
         lambda: assert_release_proof_key_authority(
             release_train,
             release_tag,
@@ -9016,6 +9120,97 @@ def main() -> None:
                 "if (!resolveFromCommit) {",
                 "proof gate absence-only bridge",
             ),
+        ),
+    )
+    expect_assertion(
+        "the mint reads the evidence listing without testing whether it read one",
+        "test the status of the listing read",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            replace_exactly_once(
+                release_tag,
+                'if ! listing="$(gh api',
+                'if listing="$(gh api',
+                "listing read status",
+            ),
+            release,
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the mint throws away why the evidence listing could not be read",
+        "keep the error text from the listing read",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            replace_exactly_once(
+                release_tag,
+                '"repos/${REPO}/git/trees/release-evidence?recursive=1" \\\n'
+                '              2>"$read_error")"; then',
+                '"repos/${REPO}/git/trees/release-evidence?recursive=1" \\\n'
+                '              2>/dev/null)"; then',
+                "listing read diagnostics",
+            ),
+            release,
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the train arms auto-merge without un-drafting the bump pull request",
+        "un-draft the bump pull request before it arms auto-merge",
+        lambda: assert_release_proof_key_authority(
+            replace_exactly_once(
+                release_train,
+                '            gh pr ready "$PR" --repo "$GITHUB_REPOSITORY"\n',
+                "",
+                "release train un-draft",
+            ),
+            release_tag,
+            release,
+            proof_gate,
+        ),
+    )
+    # The same regression as an ordering change rather than a deletion. Both
+    # commands survive, so only the ordering check can catch it, and arming
+    # first is not a smaller mistake: auto-merge registered against a draft is
+    # what leaves the rail reporting itself clear while nothing lands.
+    expect_assertion(
+        "the train un-drafts the bump pull request after it has already armed",
+        "must un-draft the bump pull request BEFORE it",
+        lambda: assert_release_proof_key_authority(
+            swap_train_undraft_after_arm(release_train),
+            release_tag,
+            release,
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the promote gate stops reading back the sha the gate verified",
+        "read back the sha the gate verified",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            release_tag,
+            replace_exactly_once(
+                release,
+                "process.stdout.write(result.sha);",
+                'process.stdout.write("verified");',
+                "promote gate sha readback",
+            ),
+            proof_gate,
+        ),
+    )
+    expect_assertion(
+        "the promote gate stops comparing the proven sha to the one it promotes",
+        "not the sha it promotes",
+        lambda: assert_release_proof_key_authority(
+            release_train,
+            release_tag,
+            replace_exactly_once(
+                release,
+                'if [ "$proven" != "$CANDIDATE_SHA" ]; then',
+                'if [ "$proven" = "never" ]; then',
+                "promote gate identity",
+            ),
+            proof_gate,
         ),
     )
 


### PR DESCRIPTION
Release proof evidence is keyed to the head of `automation/release-next`, and the train merges `origin/main` into that branch on every cycle that finds drift, so the head moves whenever main does. Evidence published for the old head goes invisible rather than wrong, which leaves one way to run a release: freeze main for the whole proof window, or evidence a sha nobody is releasing. The fleet freezes main for roughly ninety minutes per release at 2.4 releases a day, merged fixes wait a median 6.0 h and a p90 of 34.4 h for a promoted tag, and on 2026-08-21 issue #1028 read "declined to mint for 4 consecutive cycles while 44 reviewed commits sat on main waiting to ship".

This moves the key off the moving branch and onto an immutable main commit.

## The scheme

The version bump lands first as an ordinary pull request under the full merge queue gate, and nothing about it carries release evidence any more, so what its branch head is at any moment stops deciding anything. The proof loop then runs against a main sha: `rc-build.yml` is dispatched on `main`, and `bin/kin-release-preflight` already reads the candidate sha back out of the archive provenance, so no local tool changes. The mint stops normalizing to the first commit carrying the staged version and instead walks main's first-parent history from HEAD down to that commit, selecting the newest one for which both records exist, and tags that exact sha.

Main never has to hold still. The candidate is immutable, so its records stay addressable no matter what lands afterwards, and what lands afterwards is simply the next release's drift.

## The tree-identity assertion

The tagged commit is the candidate, so the delta is empty rather than "the version bump files". The mint's new step makes that a check rather than a property of how two values happen to be computed:

```
if [ "$proven" != "$SHA" ]; then
  echo "::error::the proof gate verified $proven but this job would tag $SHA; refusing to tag a commit whose evidence is about a different one"
```

Selection and verification compute the candidate separately, so that comparison is what refuses if an edit ever lets them drift apart. The `git diff --name-only "$proven" "$SHA"` after it is implied by the equality today and is written anyway, because the invariant this rests on should not live only in a design document. Do not read it as independent evidence.

Verified against real GitHub before opening this: the gate's pass path returns `bb8bebe34057d9a6397db0b2ca49a7d096996800` on stdout with its narration on stderr, the absent path exits 1 with `::error::evidence/fc7fb9d4.../preflight.json does not exist`, and a deliberate sha mismatch refuses with the message above.

## Every current refusal survives

- **The FIR-2525 proof gate** moves rather than going away. It used to hold a version bump in draft; it now refuses to write the tag ref, which is the last place a release can be refused for free, since a tag run resolves its workflows from the tag and no later fix can repair it. `finalize_release` keeps the same refusal against promotion, so both decision points still import one judge.
- **The evidence key discipline.** `evidencePath` still refuses anything that is not forty hex characters, and the gate still reads two exact paths with no fallback. The listing the mint reads can only propose a candidate, and it refuses a `truncated: true` answer rather than shipping the older candidate it can still see.
- **The abandoned-tag rail**, the promotion order (`finalize_release` before `seal_release_completion`), and every `merge-base --is-ancestor` assertion are untouched. The candidate is on main, so the merge-group authority tier in `Verify required checks are green` keeps working unchanged. That is why this beats cutting a release branch, which would have cost three real ancestry assertions.
- **A tag with no direct record refuses by name.** `finalize_release` passes `CANDIDATE_SHA` beside `RESOLVE_FROM_COMMIT`, and the gate bridges through the pull request only when the direct record is ABSENT. An unreadable record still fails closed, because a check that widens its search when it cannot tell is a check reporting success for the wrong reason. What the bridge is not is a recovery path for a tag cut before this rekey. A tag run resolves its workflows AND its scripts from the tag, so recovering one re-runs that tag's own frozen `release.yml` and its own frozen gate and never reaches this code at all.
- **The bridge is bounded to the branch that ever carried records.** Under this scheme an ordinary main commit is the squash of a feature pull request whose head never carried one, so an unbounded bridge would send the promote gate looking somewhere nothing was proven. It now accepts only a pull request from `automation/release-next`, which makes it stricter than it is today, where any merged pull request satisfies it. Checked against every tag it exists for: the v0.5.44, v0.5.45 and v0.5.46 tag commits are the squashes of kin#986, kin#991 and kin#1001, each from that branch, and v0.5.46's head sha `a621321a4e72` is one of the two candidates on the evidence branch. A fabricated sha control returns HTTP 422, so the endpoint can still say no. The authority test reads the branch name out of `release-train.yml` rather than writing it down twice.

## Authority test: the guard did not exist

Running `scripts/test-release-workflow-authority.py` on this branch **before** its update returned exit 0 with the whole proof step deleted from `release-train.yml`. Nothing in 13,543 lines pinned where the release evidence was keyed, so the freeze was enforced by a runbook sentence alone. A 982-line census of the file confirmed it: the step name, the script name and both env names return count 0, against a positive control that finds all six in `.github/workflows/`.

So this adds the guard rather than adjusting one. `assert_release_proof_key_authority` pins that the mint declares exactly one proof-gate step, that it runs before the tag ref is written, that it reads the gate from protected main, that it compares the verified sha to the sha it would tag, that selection refuses a truncated listing and stands down as a no-op when nothing is proven, that the train keys nothing on the bump branch's head, and that the gate bridges only on absence.

Seventeen `expect_assertion` falsifications ship with it, including a step-order swap that keeps both step names so only the ordering check can catch it, and a rename of the bump branch in the train alone.

Red-green evidence, raw exit codes, no pipes:

| run | exit | result |
|---|---|---|
| baseline, unmodified worktree | 0 | green |
| workflow changes, test not yet updated | 0 | **green, which is the finding** |
| workflow changes plus the new guard | 0 | green, all 11 falsifications fired |
| sabotage: `release-tag.yml` reverted to `origin/main` | 1 | `the mint must declare exactly one '- name: Require proof-loop artifacts for the release candidate' step` |
| sabotage: `release.yml` reverted | 1 | `the promote gate must ask about the tagged commit directly` |
| sabotage: `release-train.yml` reverted | 1 | `the release train must key nothing on the version bump branch's head` |
| sabotage: gate script reverted | 1 | `the proof gate must mark an absent record as absent` |
| sabotage: the bridge's bump-branch bound removed | 1 | `the proof gate must apply the bump-branch bound when it bridges` |
| restored | 0 | green |

Also green: `test-assertion-reachability.py`, `check-rc-build-drift.mjs`, `actionlint` on all three workflows, `node --check`, `py_compile`, and 35 gate tests (6 new: four for the dual-key path, two for the bridge bound).

### A blind spot the new guard exposed

`active_lines`, the suite's general comment stripper, also removes C-style block comments so a JavaScript heredoc cannot hide a no-op validator. The shell glob in `refs/tags/*` opens one of those, and it runs to `${policy##*/` **11,397 characters later**, swallowing most of the reconcile job. An absence check reading the job through that rule is structurally blind in that range, which is exactly what my first version of the train guard was.

The guard now uses a shell-safe reader that strips only `#`, and a falsification plants the regression inside the swallowed range. Switching the guard back to the general reader makes that falsification report `falsification did not fail`, which is the harness saying the check cannot catch its own target. `active_lines` itself is unchanged, because the heredoc guards elsewhere want that rule.

The selection logic was driven against a local git fixture rather than reasoned about. Five cases: one proven commit selects it; two proven commits select the newer; a proven commit **before** the version bump selects nothing, because the walk stops at the bump; nothing proven selects nothing; the bump commit itself is selectable. The jq program was falsified separately against the live listing and a synthetic one: a preflight-only candidate is not selected, a short sha and a `.bak` path are dropped, and a duplicated preflight does not count as two records.

## One operational regression, found by falsifying my own assumption

The design assumes an ordinary main landing carries every context the mint requires. Measured rather than assumed: all ten main commits sampled on 2026-08-21 carry all nine, with only `DCO Sign-off` skipped, which the mint explicitly allows.

A **docs-only** landing does not. At `ebf3610ee457`, a README and llms-install change, `Falsify guards` and both `Feature permutation tests` contexts are ABSENT and `Windows installer + vector release build` carries a skipped instance, because ci.yml's docs-only classifier gates those jobs. So a candidate that lands on a docs-only commit can never be tagged. Under the old scheme this class did not exist, because the tagged commit was always the version bump squash and that touches `Cargo.toml`.

Frequency is one docs-only landing in the last 200 first-parent commits, and the failure is loud rather than dangerous: the mint names the missing context and refuses, so nothing unproven ships. It does cost a full proof window and a thirty-minute retry loop, so section 7.2 of the design adds a precondition that checks the candidate is mintable before preflight runs.

I did **not** add a selection-side guard, and that is a judgement worth a second opinion. Doing it correctly means duplicating either the `REQUIRED_CHECKS` list or ci.yml's docs-only classifier into the selection step, and both are drift hazards in the most dangerous block in the release chain. A one-line operator precondition against a one-in-200 event seemed the better trade, but it is a trade.

## Meeting the captain's constraint

The FIR-2525 proof gate stays binding, and strictly more so. `finalize_release` keeps its refusal unchanged in substance: it fails unless both records exist for the candidate, the preflight verdict is PASS, every leg names that exact commit, and the stranger ran an archive one of those legs judged. On top of that the mint now refuses to CREATE the tag on the same evidence, which is a refusal that did not exist before and which fires while a release can still be repaired. Two refusals where there was one, and the surviving one is the promote refusal the agreement names.

## Not claiming

The stranger stays on the critical path. FIR-2592 also asks for it to become continuous background validation, which means `judgeStranger` would stop requiring a stranger record. That is removing a refusal and it is a separate safety decision.

The hold alarm still goes red for the length of a proof window. It does that today under reason `proof_artifacts_missing` and will do it under `tag_staged` instead. The reason changes, the noise does not, and quieting a real safety signal deserves its own ticket.

Nothing here has run on GitHub. Every workflow assertion above was proven locally or against the read-only API. The lane's local gate does not run the repo's guard scripts or the Windows legs, so local green is not branch green; read this PR's final per-check lines after every check has a conclusion.

## Rollout

Land between windows only: GitHub Latest must equal the highest admissible tag and no `release.yml` run may be active. The first release after landing is the proof, and the thing to measure is how many commits land on main during the proof window, because that number is the freeze this removes. Rollback is a plain revert: three workflow files, one gate script and its tests, no new persistent state, no schema change.

Design document, failure modes and rollout detail: `.kin-coord/reports/unfreeze-design-20260821.md`.

## Refutation review, and the five edits it required

An independent reviewer was briefed to refute the claim that this is safe to land between windows, and returned LAND-WITH-EDITS. The mechanism held: two-bump races, off-main evidence, stale evidence, adversarial evidence paths and the version normalization all under-select rather than over-select, and the exact-key gate is real. The five required edits are applied in commit `5a05cb463`. **R1**, `release-train.yml`'s arm step now marks the bump pull request ready before it arms auto-merge, because the removed proof step was the only code that ever drafted or un-drafted that pull request, the merge queue never takes a draft, and the plan step's all-clear marker would have reported a moving rail while nothing landed. **R2**, the mint's evidence listing read now tests its own status and keeps its error text, so an unreadable listing refuses instead of reporting itself as an empty one; it refuses rather than warns for the same reason the truncation check beside it does, since a false refusal costs one fifteen-minute cycle and no state while a false green stalls every release. **R3**, the rollout gains its missing precondition, that main's workspace version equals the version of the current GitHub Latest tag at landing time, because a landed-but-untagged bump is the one state this change strands. **R4**, the bridge's stated reason was false in four places, not the one the review named, and all four now carry the true one. **R5**, the promote gate reads back the sha the gate verified and refuses when it is not the sha being promoted, mirroring the mint, so a bridged answer can shape a refusal and can no longer admit one.

The review is `review-unfreeze-pr1056.md`; the lane report at `.kin-coord/reports/unfreeze-20260821.md` carries its full path and the rerun evidence. Every guard was rerun after the edits, raw exit codes, no pipes: the authority test exits 0 with all seventeen falsifications firing, `node --test scripts/check-release-proof-artifacts.test.mjs` passes 35 of 35, `node --check` and `actionlint` on all three workflows are clean, and nine sabotages exit 1 with distinct named messages, four by reverting each touched file to the branch base and five by neutralizing one guard at a time.

Refs FIR-2592
