### PR TITLE
Stop the Windows install proof failing on a projection nobody configured

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -51,12 +51,29 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     # The Windows leg runs the full unconditional proof and uploads its
-    # artifacts, but its verdict does not yet gate the release: the installed
-    # daemon on Windows serves queries without publishing .kin/daemon.port, so
-    # the endpoint-provenance step cannot pass there yet. The release authority
-    # suite pins this posture to exactly the windows-latest row; a blocking
-    # Windows leg returns by deleting the experimental flag here and the
-    # posture assertion there in the same change.
+    # artifacts, but its verdict does not yet gate the release. The reason has
+    # moved, and this comment is what carries it, so it is worth keeping
+    # current: a stale cause here sends whoever picks the work up next after a
+    # defect that is already fixed.
+    #
+    # It is no longer the daemon endpoint file. kin#811 measured that the
+    # installed Windows daemon does publish `.kin/daemon.port`, and that the
+    # step could not read it because a `tee` pipeline held a handle the daemon
+    # inherited, so the shell resumed at the moment shutdown removed the file.
+    # That is fixed and proven fixed on released bytes.
+    #
+    # What fails now is one step earlier and it fails on the released binary
+    # rather than on this workflow. `kin setup status --json` reported
+    # `projection_mode=misconfigured` on a host where nothing is recorded and
+    # no projection is in force, which is a mode the chooser named rather than
+    # one anybody picked. Every release from v0.5.44 through v0.5.47 died on
+    # that same line in the step below. The product fix is FIR-2460 and it can
+    # only reach this leg by riding a release, because the leg installs what
+    # the public installer serves.
+    #
+    # So the flag comes out once a release carries that fix and the leg is
+    # green against its own bytes, together with the posture assertion the
+    # release authority suite pins to exactly the windows-latest row.
     continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       fail-fast: false
@@ -693,6 +710,13 @@ jobs:
             ["semantic_query_readiness", "unsupported"],
             ["daemon_running", "unsupported"],
             ["repo_init", "unsupported"],
+            // Nothing is recorded and nothing is in force on a fresh
+            // repo-free install, so the row has no configured projection to
+            // report on. Pinned rather than tolerated: `misconfigured` here
+            // was what failed this leg on every release from v0.5.44 through
+            // v0.5.47, and a pin is what makes the leg say so again the day it
+            // comes back rather than absorbing it.
+            ["projection_mode", "unsupported"],
             ["mcp_client_claude", "healthy"],
             ["mcp_client_cursor", "healthy"],
             ["mcp_client_gemini", "healthy"],
@@ -707,13 +731,23 @@ jobs:
             // own. Accept that single named reason and keep every other
             // degradation fatal, so a real regression in any other check still
             // fails this leg.
-            const onlyMissingRepositoryBlocks = report.checks.every(
+            // Work a correct install has not done yet, named as one check and
+            // one status. A public runner has never fetched the embedding
+            // model, so `embedding_model` reads `pending`, which is why the
+            // product's own readiness aggregate does not block on it either:
+            // it names expected first-run work rather than ground a working
+            // install lost. Tolerating it by name is the difference between a
+            // sweep that still fails when a second check goes pending and one
+            // that waves through every status it has never seen.
+            const firstRunPending = new Map([["embedding_model", "pending"]]);
+            const tolerated = report.checks.every(
               (check) =>
                 check.id === "repo_init" ||
                 check.status === "healthy" ||
-                check.status === "unsupported"
+                check.status === "unsupported" ||
+                firstRunPending.get(check.id) === check.status
             );
-            if (!onlyMissingRepositoryBlocks) {
+            if (!tolerated) {
               throw new Error(
                 `${reportPath}: overall healthy=${report.healthy}; non-healthy checks: ${nonHealthyChecks(report)}`
               );

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1440,6 +1440,81 @@ fn projection_mode_check_for(
     let advisory = live.mode == ProjectionMode::Shim
         && shim_usable
         && live.readable == crate::commands::projection::Tri::Yes;
+
+    // Nothing recorded and nothing in force is not a misconfiguration. It is
+    // an ordinary host where nobody has engaged a projection yet, and the
+    // recorded-mode branch above has already returned for every host where
+    // somebody did, so reaching here with nothing recorded means the mode in
+    // `detail` is one the chooser named rather than one a person picked.
+    // Calling that `misconfigured` reports a defect against a choice nobody
+    // made: every fresh native Windows install read exactly that in `kin
+    // doctor`, one line under `kin setup` printing that projfs was available
+    // and needed `kin vfs on` to engage, and the two surfaces contradicted
+    // each other about the same probe. Reserving `misconfigured` for a
+    // RECORDED mode that is not running is what keeps this row diagnostic on
+    // the day it fires.
+    //
+    // The row still names what is engageable rather than reporting an absence,
+    // because a host that can run a projection and is not running one has
+    // something a reader can act on. The advisory shim case keeps its own
+    // status ahead of this one: an installed shim that is simply not injected
+    // into this process is the more specific answer, and it is the more useful
+    // thing to tell that user.
+    //
+    // A projection that is installed and DEAD is not an unconfigured host,
+    // even with nothing recorded. Somebody put it there and the loader will
+    // not run it, which is the container case one branch up: every process on
+    // the box reads raw disk while the install looks intact. That keys on the
+    // evidence of breakage, the loader's refusal or an installed shim no probe
+    // can use, rather than on a driver merely being present, because a driver
+    // sitting on disk for a mount mode nobody engaged is the ordinary state
+    // this branch is about.
+    let installed_and_dead =
+        report.driver.refusal.is_some() || (report.shim.installed && !shim_usable);
+    if report.recorded.is_none() && !advisory && !installed_and_dead {
+        let engageable = report
+            .modes
+            .iter()
+            .find(|probe| probe.available)
+            .map(|probe| probe.mode);
+        let route = match engageable {
+            Some(mode) => format!(
+                "{mode} is available here, and `kin vfs on --mode {mode}` engages it and records \
+                 it once it is running"
+            ),
+            // Not "nothing is missing". Where no mode can be engaged yet there
+            // is still usually something the reader can do, and on Windows
+            // there always is: ProjFS ships on every SKU and only needs
+            // enabling. So the row names the first remedy a probe produced
+            // rather than reporting a bare absence, and `kin vfs status`,
+            // named in the fix below, carries the rest.
+            None => report
+                .modes
+                .iter()
+                .find_map(|probe| {
+                    probe.remedy.clone().map(|remedy| {
+                        format!("nothing is engageable yet: {} needs {remedy}", probe.mode)
+                    })
+                })
+                .unwrap_or_else(|| {
+                    "nothing is engageable here, and no probe named a remedy".to_string()
+                }),
+        };
+        return HealthCheck::new(
+            "projection_mode",
+            "Projection in force",
+            HealthStatus::Unsupported,
+            format!(
+                "no projection is configured and none is in force; the CLI and daemon answer \
+                 from the graph without one; {route}; {evidence}"
+            ),
+        )
+        .with_manual_fix(
+            "run `kin vfs on` to engage a projection and record it, or `kin vfs status` for what \
+             each mode would need here",
+        );
+    }
+
     let status = if advisory {
         HealthStatus::Stale
     } else {
@@ -4795,6 +4870,37 @@ mod tests {
         }
     }
 
+    /// The same fixture shaped like a real Windows host: the probes are the
+    /// two modes `fallback_order("windows")` returns, so there is a projfs row
+    /// carrying the `Enable-WindowsOptionalFeature` remedy and no shim row at
+    /// all. `report` above builds the Unix three, and a Windows assertion made
+    /// against those probes would be asserting about a machine that cannot
+    /// exist.
+    fn windows_report(
+        recorded: Option<ProjectionMode>,
+        available: &[ProjectionMode],
+        live: LiveProjection,
+    ) -> ProjectionReport {
+        ProjectionReport {
+            recorded,
+            modes: [ProjectionMode::ProjFs, ProjectionMode::Nfs]
+                .into_iter()
+                .map(|mode| mode_probe(mode, available.contains(&mode)))
+                .collect(),
+            driver: DriverProbe {
+                path: None,
+                refusal: None,
+                subcommands: None,
+            },
+            shim: ShimPresence {
+                path: PathBuf::from("C:/Users/u/.kin/lib/kin_vfs_shim.dll"),
+                installed: false,
+                engaged: false,
+            },
+            live,
+        }
+    }
+
     fn live(
         intent: ProjectionMode,
         mode: ProjectionMode,
@@ -5029,19 +5135,134 @@ mod tests {
             assert!(!is_failing(&check.status));
         }
 
-        let windows = projection_mode_check_for(&bare, "windows", &not_probed());
+        // Windows keeps no sanctioned absence, and what proves it moved. It
+        // used to be the status: the row read `misconfigured` there, which
+        // FIR-2460 removed, because a status is the wrong place to carry "you
+        // could enable something" and reporting a defect against a mode nobody
+        // chose is what made every fresh native Windows install read a fault
+        // in `kin doctor`. What the row must never do is tell a Windows user
+        // that nothing is missing, and that obligation now lives where it
+        // always belonged, in the text. So the assertion is that the row names
+        // the ProjFS remedy a user can paste, on the real Windows probes
+        // rather than on the Unix three.
+        let windows_off = windows_report(
+            None,
+            &[],
+            live(
+                ProjectionMode::ProjFs,
+                ProjectionMode::ProjFs,
+                Tri::No,
+                Tri::No,
+                true,
+            ),
+        );
+        let windows = projection_mode_check_for(&windows_off, "windows", &not_probed());
         assert!(
-            !matches!(windows.status, HealthStatus::Unsupported),
-            "Windows has no sanctioned skip, got {:?}",
+            !is_failing(&windows.status),
+            "a mode nobody chose is not a defect, got {:?}",
             windows.status
         );
         assert!(
-            !windows.detail.contains("none is configured")
-                && windows
-                    .platform_note
-                    .as_deref()
-                    .is_none_or(|note| !note.contains("would need")),
-            "Windows must not be told that nothing is missing: {windows:?}"
+            windows.detail.contains("nothing is engageable yet")
+                && windows.detail.contains("fixture remedy for projfs"),
+            "Windows must be told what it can still enable: {}",
+            windows.detail
+        );
+        // Falsification for the line above: strip every remedy the probes
+        // carry and the row can no longer name one, so the assertion is about
+        // the remedy reaching the text and not about the phrasing around it.
+        let mut remedyless = windows_off.clone();
+        for probe in &mut remedyless.modes {
+            probe.remedy = None;
+        }
+        let bare_windows = projection_mode_check_for(&remedyless, "windows", &not_probed());
+        assert!(
+            !bare_windows.detail.contains("fixture remedy for projfs"),
+            "the remedy must come from the probes: {}",
+            bare_windows.detail
+        );
+    }
+
+    /// FIR-2460, taken from the release run the Windows install-proof leg
+    /// failed on. Nothing is recorded, because setup records only a mode that
+    /// is in force by installation alone and Windows has no shim to install.
+    /// Nothing is mounted, because nobody ran `kin vfs on`. The chooser still
+    /// names projfs, since it is what this host could run, and the row used to
+    /// report that guess as `misconfigured`. A fault the reader did not cause
+    /// and cannot act on is not a diagnosis, and `kin setup` printed the
+    /// opposite about the same probe one screen earlier.
+    #[test]
+    fn nothing_recorded_and_nothing_in_force_is_not_a_misconfiguration() {
+        let fresh = windows_report(
+            None,
+            &[ProjectionMode::ProjFs],
+            live(
+                ProjectionMode::ProjFs,
+                ProjectionMode::ProjFs,
+                Tri::No,
+                Tri::No,
+                true,
+            ),
+        );
+        let check = projection_mode_check_for(&fresh, "windows", &not_probed());
+        assert!(
+            matches!(check.status, HealthStatus::Unsupported),
+            "an unconfigured host has no projection in force to report on, got {:?}",
+            check.status
+        );
+        assert!(!is_failing(&check.status));
+        assert!(
+            check.detail.contains("projfs is available here")
+                && check.detail.contains("kin vfs on --mode projfs"),
+            "the row must name the mode and the command that engages it: {}",
+            check.detail
+        );
+
+        // The control that keeps this row worth reading. Record the same mode
+        // and change nothing else: it is now a projection somebody configured
+        // that is not running, which is the one state this row exists to
+        // report, and it must still fail.
+        let mut recorded = fresh.clone();
+        recorded.recorded = Some(ProjectionMode::ProjFs);
+        let configured = projection_mode_check_for(&recorded, "windows", &not_probed());
+        assert!(
+            matches!(configured.status, HealthStatus::Misconfigured),
+            "a recorded mode that is not running must still fail, got {:?}",
+            configured.status
+        );
+        assert!(
+            configured
+                .detail
+                .contains("is recorded but is not what is running"),
+            "the failing row must say what it is failing about: {}",
+            configured.detail
+        );
+
+        // Not a Windows special case. macOS reaches the same state whenever the
+        // chooser prefers a mount mode and no shim was installed to record
+        // instead, which is the combination that failed the v0.5.41 release
+        // install proof on all three non-Linux legs.
+        let mac_fresh = report(
+            None,
+            &[ProjectionMode::Nfs],
+            live(
+                ProjectionMode::Nfs,
+                ProjectionMode::Nfs,
+                Tri::No,
+                Tri::No,
+                true,
+            ),
+        );
+        let mac = projection_mode_check_for(&mac_fresh, "macos", &not_probed());
+        assert!(
+            !is_failing(&mac.status),
+            "the same unconfigured state is not a defect on macOS either, got {:?}",
+            mac.status
+        );
+        assert!(
+            mac.detail.contains("nfs is available here"),
+            "the macOS row names its own mode: {}",
+            mac.detail
         );
     }
 

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -3685,6 +3685,35 @@ fn capture_mcp_repair_target_excluding(
     }))
 }
 
+/// Spell a launcher path the way its platform spells it, so what setup records
+/// can be compared against the launcher the installer wrote.
+///
+/// `Path::join` appends the platform separator and never touches what it was
+/// handed, so a `KIN_HOME` that arrived with forward slashes, which is how MSYS
+/// bash and every shell like it spells `$HOME` on Windows, produces
+/// `C:/Users/u/.kin\bin\kin.exe`. Windows opens that happily and no reader can
+/// compare it against the `C:\Users\u\.kin\bin\kin.exe` the installer wrote,
+/// which is why the release install proof reported the MCP entry malformed
+/// against a launcher that was sitting right there. A forward slash is not a
+/// legal character in a Windows filename, so rewriting it loses nothing.
+///
+/// The platform is an argument rather than read from `env::consts::OS` for the
+/// reason [`resolve_home_dir`] gives for the same choice: read ambiently, the
+/// Windows arm could only ever run on the one platform this fleet has no host
+/// for, and a test written on macOS would take the Unix arm and prove nothing
+/// while looking like it did.
+fn launcher_spelling_for(path: &str, os: &str) -> String {
+    if os == "windows" {
+        path.replace('/', "\\")
+    } else {
+        path.to_string()
+    }
+}
+
+fn launcher_spelling(path: &Path) -> String {
+    launcher_spelling_for(&path.to_string_lossy(), env::consts::OS)
+}
+
 pub(crate) fn managed_mcp_launcher() -> Result<String> {
     let name = if cfg!(windows) { "kin.exe" } else { "kin" };
     let path = kin_dir()?.join("bin").join(name);
@@ -3703,7 +3732,7 @@ pub(crate) fn managed_mcp_launcher() -> Result<String> {
             anyhow::bail!("managed Kin launcher is not executable: {}", path.display());
         }
     }
-    Ok(path.to_string_lossy().into_owned())
+    Ok(launcher_spelling(&path))
 }
 
 /// Resolve the stable launcher that ordinary setup, health, and doctor must
@@ -3726,10 +3755,10 @@ pub(crate) fn configured_mcp_launcher() -> Result<String> {
         let current_target = fs::canonicalize(&current).ok();
         if candidate_target.is_some() && candidate_target == current_target {
             validate_running_mcp_launcher(&path_candidate)?;
-            return Ok(path_candidate.to_string_lossy().into_owned());
+            return Ok(launcher_spelling(&path_candidate));
         }
     }
-    Ok(current.to_string_lossy().into_owned())
+    Ok(launcher_spelling(&current))
 }
 
 fn validate_running_mcp_launcher(path: &Path) -> Result<()> {
@@ -15109,6 +15138,44 @@ mod tests {
             requested: false,
         };
         assert!(fix_verdict(std::slice::from_ref(&unrequested)).is_ok());
+    }
+
+    /// FIR-2293, from the artifact the Windows install proof captured. The
+    /// proof runs the config writers with `KIN_HOME="$primary_home/.kin"`, and
+    /// MSYS bash spells `$HOME` as `C:/Users/runneradmin`, so `KIN_HOME`
+    /// reaches the process forward-slashed. `Path::join` then appended
+    /// backslashes and setup recorded `C:/Users/runneradmin/.kin\bin\kin.exe`
+    /// as the MCP command against an installed launcher of
+    /// `C:\Users\runneradmin\.kin\bin\kin.exe`. Windows opens both, so nothing
+    /// broke until a reader tried to compare them, and then the proof called
+    /// the entry malformed against a launcher sitting right where it said.
+    ///
+    /// Nothing exotic reaches this: a Windows user whose `KIN_HOME` came from
+    /// any shell that spells paths with forward slashes got the same entry.
+    #[test]
+    fn a_windows_launcher_is_recorded_the_way_windows_spells_it() {
+        assert_eq!(
+            super::launcher_spelling_for("C:/Users/runneradmin/.kin\\bin\\kin.exe", "windows"),
+            "C:\\Users\\runneradmin\\.kin\\bin\\kin.exe"
+        );
+        // A path that is already canonical comes back byte-identical, so the
+        // rewrite is idempotent and a correct entry is never turned into a
+        // different one on the next setup run.
+        assert_eq!(
+            super::launcher_spelling_for("C:\\Users\\runneradmin\\.kin\\bin\\kin.exe", "windows"),
+            "C:\\Users\\runneradmin\\.kin\\bin\\kin.exe"
+        );
+        // Unix keeps every byte it was handed. The forward slash is the
+        // separator there, and rewriting one would break every path recorded
+        // on the platforms this leg already gates.
+        assert_eq!(
+            super::launcher_spelling_for("/Users/runner/.kin/bin/kin", "macos"),
+            "/Users/runner/.kin/bin/kin"
+        );
+        assert_eq!(
+            super::launcher_spelling_for("/home/u/.kin/bin/kin", "linux"),
+            "/home/u/.kin/bin/kin"
+        );
     }
 
     /// Setup must never record a mount mode it did not engage. The v0.5.41

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1687,6 +1687,22 @@ def assert_windows_node_validator_behavior(step: str) -> None:
                 "/wrong/kin",
             ),
         )
+        # FIR-2293, named as its own class rather than left to the drift case
+        # above. `kin setup` recorded the MCP command by joining onto whatever
+        # `KIN_HOME` held, and MSYS bash hands it a forward-slashed `$HOME`, so
+        # a Windows install wrote `C:/Users/u/.kin\bin\kin.exe` against an
+        # installed launcher of `C:\Users\u\.kin\bin\kin.exe`. Windows opens
+        # both, so only a byte comparison against the installed launcher can
+        # tell them apart, and this arm is what keeps that able to fail.
+        reject(
+            f"{config_path} MCP command mixes path separators",
+            invalid_home=fixture_with_json_value(
+                home,
+                config_path,
+                ("mcpServers", "kin", "command"),
+                f"{VALIDATOR_HOME}/.kin\\bin\\kin.exe",
+            ),
+        )
         reject(
             f"{config_path} MCP args drift",
             invalid_home=fixture_with_json_value(

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1216,6 +1216,11 @@ WINDOWS_REQUIRED_VALIDATOR_CHECKS = {
     "semantic_query_readiness": "unsupported",
     "daemon_running": "unsupported",
     "repo_init": "unsupported",
+    # Nothing recorded and nothing in force on a fresh repo-free install, so
+    # there is no configured projection for the row to report on. Required
+    # rather than tolerated: `misconfigured` here is what failed the real leg
+    # on every release from v0.5.44 through v0.5.47.
+    "projection_mode": "unsupported",
     "mcp_client_claude": "healthy",
     "mcp_client_cursor": "healthy",
     "mcp_client_gemini": "healthy",
@@ -1230,6 +1235,13 @@ WINDOWS_REQUIRED_VALIDATOR_CHECKS = {
 WINDOWS_VALIDATOR_CHECKS = {
     **WINDOWS_REQUIRED_VALIDATOR_CHECKS,
     "retrieval_profile": "unsupported",
+    # The one first-run status the leg tolerates beyond healthy and
+    # not-applicable. A public runner has never fetched the embedding model, so
+    # a correct install reports `pending` here, and the step names this check
+    # and this status rather than accepting `pending` generally. Carried in the
+    # fixture for the reason `retrieval_profile` is: a fixture that omits a
+    # check the real report carries cannot fail the way the real leg does.
+    "embedding_model": "pending",
 }
 
 
@@ -1616,6 +1628,22 @@ def assert_windows_node_validator_behavior(step: str) -> None:
         reject(
             f"{report_path} degraded retrieval profile",
             fixture_with_check_status(proof, report_path, "retrieval_profile", "stale"),
+        )
+        # The first-run pending tolerance is one check and one status, not a
+        # standing pass for `pending`. These two arms are what say so: the
+        # named check may not drift to another non-healthy status, and no other
+        # check may borrow the tolerance by going pending itself. Both preserve
+        # the aggregate and hard-failure predicates, so only the tolerance
+        # sweep can reject them.
+        reject(
+            f"{report_path} embedding model drifts off pending",
+            fixture_with_check_status(proof, report_path, "embedding_model", "stale"),
+        )
+        reject(
+            f"{report_path} a second check borrows the pending tolerance",
+            fixture_with_check_status(
+                proof, report_path, "retrieval_profile", "pending"
+            ),
         )
         reject(
             f"{report_path} contradictory duplicate check",


### PR DESCRIPTION
The Windows install-proof leg has failed on every release since v0.5.44, and the
cause on record was four steps and one fix out of date. It does not die on
`.kin/daemon.port` any more and has not since kin#811 landed. It dies earlier,
on a health row that reported a defect for a projection nobody configured.

## The first failure

`Public Install Proof / windows-latest` fails at step 8, `Windows repo-free
provenance and setup proof`. Run 32549703841 (v0.5.47), job 96977531335, last
line:

```
Error: kin-windows-health.json: overall healthy=false; non-healthy checks: daemon_running=unsupported, ..., projection_mode=misconfigured, ..., embedding_model=pending, ...
```

Run 32457935946 (v0.5.46, job 96704152880), run 32432486992 (v0.5.45, job
96631266816) and run 32406932916 (v0.5.44, job 96556596265) fail at the same
step on the same list. Every other entry is `unsupported`, which the step
accepts. Only `projection_mode=misconfigured` and `embedding_model=pending` are
not, and the aggregate is flipped by the first of them alone.

The job's own artifact carries the row and its contradiction. From
`kin-windows-health.json`:

```
"id": "projection_mode", "status": "misconfigured",
"detail": "mode=projfs mounted=no readable=no writable=no degraded=yes; C:\Users\runneradmin\Kin\kin is not the root of a mounted filesystem"
```

From `kin-windows-setup.txt`, the same job, one screen earlier:

```
projfs is available but needs `kin vfs on --mode projfs` to engage; nothing is recorded until a projection is actually running.
```

Two surfaces, one probe, opposite verdicts. Setup was right.

## Mechanism

`crates/kin-cli/src/commands/health.rs:1369` computes `floor_is_kin_shipped =
floor_mode(os) == ProjectionMode::Shim`, which is false on Windows because the
floor there is ProjFS, and that excludes Windows from the sanctioned
no-projection branch at line 1370. With nothing recorded the row then falls
through `configured_and_broken` at line 1402, false because nothing was
recorded, and the shim advisory at line 1440, false because the live mode is
projfs, and lands on `Misconfigured` at line 1446 for a mode
`choose_mode(None, None, &modes)` had named on its own.

FIR-2454 removed the recording half of this on the setup side: with no shim
available, `projection_mode_to_record` records nothing on Windows. The probe was
never taught the same rule.

## What changes

`projection_mode_check_for` reports an unconfigured host as an unconfigured
host. It names what can be engaged, or the remedy the probes produced where
nothing can be, so Windows is still never told that nothing is missing, and
`misconfigured` is reserved for a recorded mode that is not running, which is
what makes the row diagnostic when it fires. A projection installed and dead
keeps failing, gated on the loader's refusal or an installed shim no probe can
use, so the container case stays exactly where it was.

`kin setup` also stopped recording an MCP launcher by joining onto whatever
`KIN_HOME` held. MSYS bash spells `$HOME` as `C:/Users/u`, so a Windows install
wrote `C:/Users/u/.kin\bin\kin.exe` against an installed launcher of
`C:\Users\u\.kin\bin\kin.exe`. Windows opens both, so nothing broke until a
reader compared them, and step 15 then called the entry malformed against a
launcher sitting exactly where it said. That is FIR-2293, the blocker one step
past this one, and it reaches any Windows user whose `KIN_HOME` came from a
shell that spells paths with forward slashes.

The leg's own assertion is pinned to the posture the fix produces.
`projection_mode` is required to be `unsupported`; `embedding_model` is
tolerated as `pending` by name, one check and one status, so a second check
going pending still fails the sweep. The Windows validator fixture in the
authority suite now carries both rows, which is what lets that harness fail the
way the real leg does, and it gains rejects for a projection row that is not
`unsupported`, an embedding row that drifts off `pending`, a second check
borrowing the tolerance, and an MCP command that mixes separators.

The matrix comment named the daemon endpoint file. It now names the failure that
is live and says what has to happen before the flag comes out.

## Why the leg is still experimental

It installs what the public installer serves, and a `local_artifact` run
collapses the matrix to Linux by design, so no product fix can appear in this
leg until a release carries it. Flipping `experimental: true` here would block
every release on a defect the released bytes still hold, which is the same
reason kin#811 gave for leaving it. The flag and its posture assertion come out
together once a release carries these two fixes and the leg is green against its
own bytes.

## Falsifications

Nine, each run with full output read and never through a pipe, each restored
byte-identical. Disabling the new branch fails the FIR-2460 test with `got
Misconfigured`. Dropping the engage route from the detail fails the
never-tells-you-nothing-is-missing test. Softening the recorded-mode branch
fails the control that keeps the row diagnostic. Removing the `projection_mode`
pin makes the authority suite accept a behaviorally invalid fixture. Making the
pending tolerance blanket stops the second-check arm being rejected. Removing
the tolerance stops the known-good fixture being accepted. Making the Windows
launcher arm identity, and applying its rewrite on Unix too, each fail the
FIR-2293 test. Pointing the mixed-separator reject at the valid command makes
the suite fail, which is what proves that arm discriminates.

## Gates

Hosted CI on head 8a4c92dd9: every check concluded, 35 SUCCESS, 4 SKIPPED, zero
failures. `Product Acceptance`, `Windows authority tests`, `Windows authority
CLI tests`, `Windows authority runtime tests`, `Install Proof (PR) Build`,
`Install Proof (PR) / ubuntu-latest`, `Install Proof (PR) Gate` and `Falsify
guards` all green.


`bin/kin-parity --checkout` on the lane worktree at 8a4c92dd9, branch
`chore/lane-winproof-kin`, dirty False: FINAL PASS-WITH-ALLOWANCES in 851s.
magic 10 pass / 0 fail. brownfield 8 pass / 0 fail / 1 unreadable, allowance
FIR-2464. firstrun 8 pass / 2 fail, allowances FIR-2596 and FIR-2580. All three
allowances are pre-existing and tracked, and none is in this diff's reach.

`cargo test -p kin-cli` for the touched crate: the targeted runs are green,
115 of 115 in `commands::health` and the new `commands::setup` launcher case,
each falsified. The full-crate run was still building locally when this landed,
and hosted CI answered it more completely in the meantime: `Check & Test
(ubuntu-latest)`, `Check & Test (macos-latest)` and both macOS shards run the
whole workspace on this exact head and are green.

`cargo fmt --all -- --check`: clean. Clippy exactly as ci.yml runs it, with the
45-entry debt allow-list, `--all-targets --all-features`: clean, no errors.

The ci.yml guard scripts, all rc=0: verify-zero-file-search.py,
zero_file_search_guard.sh, verify-hydration-semantics.py,
check_runtime_boundaries.sh, check_private_repo_coupling.sh,
test-private-repo-coupling.py, test-assertion-reachability.py,
test-release-policy-gate.sh, test-windows-authority-legs.sh,
check-rc-build-drift.mjs, check-kin-vfs-compat.mjs, and
test-release-workflow-authority.py.

No local Windows cross-target check was run, because the hosted legs are better
evidence and they are green on this branch: `Windows authority tests`, `Windows
authority CLI tests` and `Windows authority runtime tests` all passed on real
Windows, which is where the new code's platform arms are compiled and run.

No workflow job was added or removed, so the job census is unchanged.

Refs FIR-1921
Refs FIR-2206
Refs FIR-2293
Refs FIR-2460
