### PR TITLE
Never render a budget-elided list as an empty one, and advertise a ceiling a real client accepts

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -90,6 +90,15 @@ jobs:
       - name: Falsify the acceptance gate
         run: python3 scripts/acceptance/gate.py --self-test
 
+      # FIR-2600. The budget must never render a list it cut as an empty one,
+      # because an empty array is the shape a reader takes for "the walk found
+      # none". Each grader is handed the exact defect that shipped and has to
+      # fail on it; one of them passed a broken product during development
+      # because its fixture never reached the code under test, which is what
+      # this step exists to catch.
+      - name: Falsify the response-budget elision graders
+        run: python3 scripts/acceptance/response_budget_elisions.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -250,6 +259,34 @@ jobs:
             echo "::error title=Brownfield acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
+      - name: Response budget elision suite
+        id: response_budget
+        if: always()
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/response_budget_elisions.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/response_budget.json \
+            --label "$KIN_ACCEPTANCE_LABEL" \
+            --verbose >acceptance/response_budget.log 2>&1 || rc=$?
+          cat acceptance/response_budget.log
+          {
+            echo "### Response budget elision suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/response_budget.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=Response budget elision suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
+          fi
+
       # Always, including on a cancelled or timed-out run: the reports are how a
       # failure is diagnosed without re-running the job.
       - name: Upload the acceptance reports
@@ -275,4 +312,5 @@ jobs:
           python3 scripts/acceptance/gate.py \
             --report magic=acceptance/magic.json \
             --report brownfield=acceptance/brownfield.json \
+            --report response_budget=acceptance/response_budget.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk comes back truncated=True with clipped_steps=None on ubuntu-latest, so an absent edge cannot be told from a dropped one. Build profile, product code from 0.5.44 through 0.5.46, and the pinned language-server versions are all ruled out; platform and code newer than 0.5.46 are still confounded. The moment the check passes this allowance announces itself stale and can go.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1140,15 +1140,6 @@ jobs:
       - name: Test Private Repo Coupling Guard
         run: python3 scripts/test-private-repo-coupling.py
 
-      # FIR-2600. The response budget must never render a list it cut as an
-      # empty one, because an empty array is the shape a reader takes for "the
-      # walk found none". The suite that drives this against real binaries is a
-      # step in the acceptance workflow; what runs here is its falsifier, which
-      # hands every grader the exact defect that shipped and fails if the grader
-      # still passes. A grader that cannot fail is not a check.
-      - name: Falsify the response-budget elision graders
-        run: python3 scripts/acceptance/response_budget_elisions.py --self-test
-
       # The committed Cargo.lock plus .cargo/config.toml pins kin-* dependencies
       # to public source until every crate is registry-published.
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1140,6 +1140,15 @@ jobs:
       - name: Test Private Repo Coupling Guard
         run: python3 scripts/test-private-repo-coupling.py
 
+      # FIR-2600. The response budget must never render a list it cut as an
+      # empty one, because an empty array is the shape a reader takes for "the
+      # walk found none". The suite that drives this against real binaries is a
+      # step in the acceptance workflow; what runs here is its falsifier, which
+      # hands every grader the exact defect that shipped and fails if the grader
+      # still passes. A grader that cannot fail is not a check.
+      - name: Falsify the response-budget elision graders
+        run: python3 scripts/acceptance/response_budget_elisions.py --self-test
+
       # The committed Cargo.lock plus .cargo/config.toml pins kin-* dependencies
       # to public source until every crate is registry-published.
       - name: Build

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -22,7 +22,7 @@ use kin_ranking::entity_ranking::{
     trace_terminal_named, trace_walk_terminal, TraceExpansion, TraceTerminal,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use crate::commands::graph::{graph_source_record_from, GraphSourceRecord};
@@ -37,6 +37,7 @@ const DEFAULT_LIMIT_PER_STEP: usize = 5;
 const MAX_LIMIT_PER_STEP: usize = 25;
 const MAX_TOTAL_STEPS: usize = 200;
 
+use kin_mcp::budget::Elision;
 /// Serialized characters one response may occupy before this walk cuts its own
 /// payload, and the floor and ceiling a caller may move it to.
 ///
@@ -505,6 +506,19 @@ pub struct TraceDataFlowResponse {
     pub bodies_omitted: usize,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub steps_omitted: usize,
+    /// Every list the response budget cut, keyed by the field it cut, with what
+    /// survived, what was withheld, and why.
+    ///
+    /// `steps_omitted` said the same thing about `chain` and was not enough. A
+    /// reader looks at the array first, and a budget that cut a chain to nothing
+    /// handed back `"chain": []`, which is the shape that means the walk reached
+    /// nothing. So the chain now keeps at least one step and this map says what
+    /// it lost, and an empty `chain` means one thing only.
+    ///
+    /// Empty — and omitted — for a response that fit as built, so a walk the
+    /// budget never touched is unchanged by this.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub elisions: BTreeMap<String, Elision>,
     /// Steps this response reached through a `name_only` edge, out of
     /// `total_steps`.
     ///
@@ -1108,6 +1122,7 @@ pub fn build_trace_data_flow_response_within(
         clipped_steps,
         bodies_omitted: 0,
         steps_omitted: 0,
+        elisions: BTreeMap::new(),
         unproven_steps: 0,
         external_identities_merged,
         terminal_external_steps: 0,
@@ -1466,9 +1481,16 @@ fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
     if measure_response(response) > target {
         // Bisected rather than popped one step at a time: the same answer, in a
         // handful of serializations instead of one per dropped step.
+        //
+        // The floor is one step, not zero. A walk that reached 200 steps and
+        // returns `"chain": []` is indistinguishable from a walk that reached
+        // none, and no counter elsewhere in the response outranks the empty
+        // array for a reader. One surviving step plus the elision beside it says
+        // both what was reached and what was withheld.
         let full = std::mem::take(&mut response.chain);
-        let mut kept = 0usize;
-        let mut low = 0usize;
+        let floor = usize::from(!full.is_empty());
+        let mut kept = floor;
+        let mut low = floor;
         let mut high = full.len();
         while low <= high {
             let mid = (low + high) / 2;
@@ -1477,7 +1499,7 @@ fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
             if measure_response(response) <= target {
                 kept = mid;
                 low = mid + 1;
-            } else if mid == 0 {
+            } else if mid <= floor {
                 break;
             } else {
                 high = mid - 1;
@@ -1488,6 +1510,12 @@ fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
         response.total_steps = kept;
         response.steps_omitted = steps_omitted;
         if steps_omitted > 0 {
+            // The same loss in the shape every budgeted list reports it in, so a
+            // caller reads one key whether the tool cut a chain or a bucket of
+            // tests.
+            response
+                .elisions
+                .insert("chain".to_string(), Elision::budget(kept, steps_omitted));
             // Dropped steps are edges the caller did not receive, which is what
             // this flag has always meant. Dropped bodies are not.
             response.truncated = true;
@@ -1528,10 +1556,12 @@ fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
                 "the response exceeded its {ceiling}-character budget, so {cut}; bodies are cut \
                  before edges, so the chain's shape survives a cut that its source cannot"
             ),
-            remediation: "ask for the shape directly with include_body: false, or narrow the walk \
-                          with a smaller depth or limit_per_step; raise max_response_chars only if \
-                          the caller's own result limit accepts a larger payload"
-                .to_string(),
+            remediation: format!(
+                "ask for the shape directly with include_body: false, or narrow the walk with a \
+                 smaller depth or limit_per_step; raise max_response_chars, up to the {} this \
+                 server will build, only if the caller's own result limit accepts a larger payload",
+                kin_mcp::handlers::common::TRACE_MAX_MAX_RESPONSE_CHARS
+            ),
         },
     );
 }
@@ -2472,6 +2502,7 @@ mod tests {
             clipped_steps: Vec::new(),
             bodies_omitted: 0,
             steps_omitted: 0,
+            elisions: BTreeMap::new(),
             unproven_steps: 0,
             external_identities_merged: 0,
             terminal_external_steps: 0,
@@ -2570,6 +2601,68 @@ mod tests {
         assert!(
             serde_json::to_string_pretty(&response).unwrap().len() <= response.max_response_chars,
             "the payload must end up inside the budget it reports"
+        );
+    }
+
+    /// The defect FIR-2600 names, on the arm the daemon actually runs. A walk
+    /// that reached 200 steps and comes back with `"chain": []` is
+    /// indistinguishable from a walk that reached none, and `steps_omitted`
+    /// three fields away does not outrank the empty array for a reader. One step
+    /// survives, and `elisions.chain` says what the budget took and why.
+    #[test]
+    fn a_budget_never_returns_an_empty_chain_for_a_walk_that_found_steps() {
+        let mut response = fat_response(200, 2_000);
+        // The floor of the clamp, where the disclosure is a large fraction of the
+        // whole budget and the ladder would otherwise strip the chain to nothing
+        // to make room for the note explaining that it had.
+        response.max_response_chars = kin_mcp::handlers::common::TRACE_MIN_MAX_RESPONSE_CHARS;
+
+        enforce_response_budget(&mut response);
+
+        assert!(
+            !response.chain.is_empty(),
+            "the budget emptied a chain of 200 steps: {}",
+            serde_json::to_string_pretty(&response).unwrap()
+        );
+        let kept = response.chain.len();
+        assert_eq!(kept + response.steps_omitted, 200);
+        assert_eq!(response.total_steps, kept);
+        let elision = response
+            .elisions
+            .get("chain")
+            .expect("a cut chain publishes what it lost");
+        assert_eq!(elision.kept, kept);
+        assert_eq!(elision.elided, response.steps_omitted);
+        assert_eq!(elision.total, 200);
+        assert_eq!(elision.reason, kin_mcp::budget::ELISION_REASON_BUDGET);
+        assert!(response.truncated);
+    }
+
+    /// The direction that makes the rule worth having. A walk that reached
+    /// nothing answers with an empty chain and claims no elision, so an empty
+    /// `chain` means one thing. Without this, "never empty" could be satisfied
+    /// by inventing a step.
+    #[test]
+    fn a_walk_that_reached_nothing_still_answers_with_an_empty_chain() {
+        let mut response = fat_response(0, 0);
+        response.max_response_chars = kin_mcp::handlers::common::TRACE_MIN_MAX_RESPONSE_CHARS;
+
+        enforce_response_budget(&mut response);
+
+        assert!(
+            response.chain.is_empty(),
+            "an empty walk must report itself"
+        );
+        assert_eq!(response.total_steps, 0);
+        assert_eq!(response.steps_omitted, 0);
+        assert!(
+            response.elisions.is_empty(),
+            "nothing was withheld, so nothing may be claimed"
+        );
+        let rendered = serde_json::to_string_pretty(&response).unwrap();
+        assert!(
+            !rendered.contains("elisions"),
+            "an untouched response must not grow a key: {rendered}"
         );
     }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -538,7 +538,10 @@ enum Command {
         #[arg(long = "no-bodies", default_value_t = false)]
         no_bodies: bool,
         /// Serialized characters this response may occupy before the tool cuts
-        /// bodies, and then steps, to fit (default 80000).
+        /// bodies, and then steps, to fit. Defaults to the same budget every
+        /// retrieval tool answers under, and is clamped to the same ceiling; the
+        /// numbers live in one place, `kin_mcp::budget`, rather than being
+        /// written out here to go stale.
         #[arg(long = "max-response-chars", value_name = "C")]
         max_response_chars: Option<usize>,
         /// Walk through a type-annotation edge to a type this repository

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -32802,8 +32802,8 @@ mod tests {
                 "    hist = []  # keep track of history of redirects for this request\n".repeat(18)
             )
         };
-        let make_result = || LocateResult {
-            entities: (0..10)
+        let make_result = |hits: usize| LocateResult {
+            entities: (0..hits)
                 .map(|index| {
                     let mut entity = fused_locate_entity(&format!("resolve_redirects_{index}"));
                     entity.entity_id = format!("0000{index:04}-0000-4000-8000-000000000000");
@@ -32820,16 +32820,43 @@ mod tests {
         let query = "where HTTP redirects are actually resolved and followed";
         let budget = kin_mcp::budget::ResponseBudget::default().less_envelope_reserve();
 
+        // The fixture is sized against the budget rather than pinned at ten
+        // hits. A fixed count stops making this point the moment the default
+        // moves: at a large enough budget both arms fit whole, both keep every
+        // body, and the test passes while proving nothing. Raising the default
+        // from 30000 to 45000 is exactly what did that. Two payloads give the
+        // per-hit cost, and the count puts the arm without the copy just inside
+        // the bound, which is the only place the copy can be shown to evict an
+        // answer.
+        let per_hit = {
+            let one = mcp_result_text(&fused_semantic_locate_payload(
+                make_result(1),
+                query,
+                false,
+                false,
+            ))
+            .len();
+            let two = mcp_result_text(&fused_semantic_locate_payload(
+                make_result(2),
+                query,
+                false,
+                false,
+            ))
+            .len();
+            two.saturating_sub(one).max(1)
+        };
+        let hit_count = ((budget.max_chars * 2 / 3) / per_hit).max(4);
+
         let measure = |snippet_alias: bool| {
             let raw = mcp_result_text(&fused_semantic_locate_payload(
-                make_result(),
+                make_result(hit_count),
                 query,
                 false,
                 snippet_alias,
             ))
             .len();
             let bounded = mcp_result_text(&bound_mcp_tool_result(
-                fused_semantic_locate_payload(make_result(), query, false, snippet_alias),
+                fused_semantic_locate_payload(make_result(hit_count), query, false, snippet_alias),
                 "semantic_locate",
                 &budget,
             ));
@@ -32858,6 +32885,22 @@ mod tests {
         assert!(
             copy_raw > fixed_raw,
             "the copy is what costs: {copy_raw} against {fixed_raw}"
+        );
+        // The premise, asserted rather than assumed. Without the copy the
+        // response fits; with it, it does not. If the fixture ever stops
+        // straddling the bound this fails here, naming the sizes, instead of
+        // passing on a comparison of two whole responses.
+        assert!(
+            fixed_raw <= budget.max_chars,
+            "the arm without the copy must fit or the copy cannot be shown to evict anything: \
+             {fixed_raw} against {}",
+            budget.max_chars
+        );
+        assert!(
+            copy_raw > budget.max_chars,
+            "the arm with the copy must overflow or there is nothing to measure: {copy_raw} \
+             against {}",
+            budget.max_chars
         );
         assert!(
             fixed_with_source > copy_with_source,

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1224,6 +1224,28 @@ mod tests {
         );
     }
 
+    /// A list nothing was taken from must not grow an elision, whatever calls
+    /// the recorder. The ladder guards this at its call site; this guards the
+    /// recorder itself, so a second producer added later cannot publish a loss
+    /// of zero.
+    #[test]
+    fn recording_a_loss_of_nothing_writes_nothing() {
+        let mut payload = json!({ "entities": [] });
+        record_elision(&mut payload, "entities", 0, 0);
+        assert_eq!(payload, json!({ "entities": [] }), "{payload}");
+        record_elision(&mut payload, "entities", 1, 2);
+        assert_eq!(
+            payload["elisions"]["entities"]["elided"],
+            json!(2),
+            "{payload}"
+        );
+        assert_eq!(
+            payload["elisions"]["entities"]["total"],
+            json!(3),
+            "{payload}"
+        );
+    }
+
     /// The ceiling has to be a number a real MCP client accepts, and 400,000 was
     /// not: Claude Code caps one tool result at 25,000 tokens by default, and on
     /// the v0.5.47 candidate a caller who took the advertised ceiling at its word

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1234,24 +1234,38 @@ mod tests {
     fn the_advertised_ceiling_is_one_a_client_accepts() {
         const REFUSED_BY_A_REAL_CLIENT: usize = 117_313;
         const ACCEPTED_BY_A_REAL_CLIENT: usize = 55_000;
+        const OVERFLOWED_THE_MEASURED_STORE: usize = 30_000;
+
+        // Read through the clamp rather than off the constants, because what a
+        // caller is served is the only number that can refuse their result.
+        let served = |requested: Option<u64>| {
+            let mut args = HashMap::new();
+            if let Some(value) = requested {
+                args.insert("max_chars".to_string(), json!(value));
+            }
+            ResponseBudget::from_arguments(&args).max_chars
+        };
+        let ceiling = served(Some(u64::MAX));
+        let floor = served(Some(1));
+        let default = served(None);
+
         assert!(
-            RESPONSE_MAX_MAX_CHARS < REFUSED_BY_A_REAL_CLIENT,
-            "the ceiling advertises a size a client refused: {RESPONSE_MAX_MAX_CHARS}"
+            ceiling < REFUSED_BY_A_REAL_CLIENT,
+            "the ceiling serves a size a real client refused: {ceiling}"
         );
         assert!(
-            RESPONSE_MAX_MAX_CHARS >= ACCEPTED_BY_A_REAL_CLIENT,
-            "the ceiling sits under a size a client already took: {RESPONSE_MAX_MAX_CHARS}"
+            ceiling >= ACCEPTED_BY_A_REAL_CLIENT,
+            "the ceiling sits under a size a real client already took: {ceiling}"
         );
         assert!(
-            RESPONSE_MIN_MAX_CHARS < RESPONSE_DEFAULT_MAX_CHARS
-                && RESPONSE_DEFAULT_MAX_CHARS <= RESPONSE_MAX_MAX_CHARS,
-            "the default must sit inside its own clamp"
+            floor < default && default <= ceiling,
+            "the default {default} must sit inside its own clamp {floor}..{ceiling}"
         );
         // The old 30,000 default dropped 170 of 200 steps on the 783-entity store
         // the same run measured, and still withheld impact rows at 50,000.
         assert!(
-            RESPONSE_DEFAULT_MAX_CHARS > 30_000,
-            "the default is back at a size the measured store overflowed"
+            default > OVERFLOWED_THE_MEASURED_STORE,
+            "the default is back at a size the measured store overflowed: {default}"
         );
     }
 

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -30,21 +30,26 @@ use serde_json::{json, Map, Value};
 
 /// Serialized characters one retrieval response may occupy by default.
 ///
-/// Sized against **Claude Code**, the primary agent client for this server: it
-/// rejects a tool result above roughly 25,000 tokens and writes it to a file
-/// instead. JSON-wrapped source runs around 3.5 characters per token, so the
-/// refusal threshold sits near 87,000 characters, which is why the two measured
-/// payloads above (80,571 and 79,278) both tripped it while sitting inside the
-/// 80,000-character trace budget that was supposed to prevent exactly this.
+/// Sized against **Claude Code**, the primary agent client for this server. Its
+/// shipped default caps one MCP tool result at 25,000 tokens, read out of the
+/// 2.1.239 binary as `MAX_MCP_OUTPUT_TOKENS` falling back to 25000, and over
+/// that it refuses the result and writes it to a file the agent then has to
+/// `Read` with an offset.
 ///
-/// 30,000 characters is roughly 8,500 tokens: about a third of that ceiling. The
-/// margin is deliberate and is not a guess about tokenization. A response is
-/// counted by the client after its own JSON-RPC framing, an agent typically
-/// holds several tool results in one context window, and a budget chosen to
-/// *just* fit one client's limit becomes the next overflow the moment any client
-/// counts slightly differently. A caller with a larger window raises it per call
-/// with `max_chars`.
-pub const RESPONSE_DEFAULT_MAX_CHARS: usize = 30_000;
+/// The band around that cap is measured, not guessed. On the v0.5.47 candidate
+/// a `trace_data_flow` at `depth: 5, include_body: false` produced 117,313
+/// characters and the client refused them outright, while `impact_analysis`
+/// responses at 50,000 and 55,000 characters in the same session came back
+/// whole. So the refusal threshold sits above 55,000 and at or below 117,313.
+///
+/// 45,000 characters is three quarters of [`RESPONSE_MAX_MAX_CHARS`], which
+/// leaves a caller room to raise the bound on the same call. It is not a promise
+/// that every walk fits: the same run still withheld `impact_analysis` rows at
+/// 50,000. What it buys is a default that keeps roughly half again as much of a
+/// chain as 30,000 did, on a store where 30,000 dropped 170 of 200 steps, and
+/// every list the budget still cuts now says what it cut rather than rendering
+/// empty.
+pub const RESPONSE_DEFAULT_MAX_CHARS: usize = 45_000;
 
 /// Floor for a caller-supplied budget. Below this the envelope and the
 /// disclosure alone do not fit, so a smaller number could only be honoured by
@@ -52,9 +57,21 @@ pub const RESPONSE_DEFAULT_MAX_CHARS: usize = 30_000;
 pub const RESPONSE_MIN_MAX_CHARS: usize = 2_000;
 
 /// Ceiling for a caller-supplied budget. A caller with a larger window may raise
-/// the bound, but not to unbounded: the daemon serving this has other callers,
-/// and a response nothing can read is not worth building.
-pub const RESPONSE_MAX_MAX_CHARS: usize = 400_000;
+/// the bound, but not past what a real client will accept: the daemon serving
+/// this has other callers, and a response nothing can read is not worth
+/// building.
+///
+/// 400,000 sat here and was roughly four times what any measurement supports, so
+/// the tool advertised a ceiling that guaranteed a refusal to any caller who
+/// took it at its word, and one did: it asked for 120,000, got 117,313, and the
+/// client threw the whole result away.
+///
+/// 60,000 is just above the largest payload that run proved a client accepts and
+/// roughly half the smallest it proved refused. The token arithmetic agrees:
+/// 60,000 characters stays under a 25,000-token cap for any payload averaging
+/// more than 2.4 characters per token, and the refusal at 117,313 puts this
+/// JSON's own average below 4.69.
+pub const RESPONSE_MAX_MAX_CHARS: usize = 60_000;
 
 /// Characters held back from the budget for the disclosure a cut adds.
 ///
@@ -94,8 +111,9 @@ pub struct ResponseBudget {
     /// ceiling is not the published one. Carrying the difference lets the
     /// disclosure name both and the reserve between them, so one response stops
     /// reporting two budgets and explaining neither. Both strangers on the
-    /// v0.5.40 candidate spent attention deciding which of 30000 and 28000 was
-    /// real; the arithmetic joining them was in this file the whole time.
+    /// v0.5.40 candidate spent attention deciding which of the published default
+    /// and the reduced one was real; the arithmetic joining them was in this file
+    /// the whole time.
     pub envelope_reserve: usize,
 }
 
@@ -188,6 +206,76 @@ pub struct BudgetAccounting {
 impl BudgetAccounting {
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+}
+
+/// The reason code a budget elision carries, so a caller keying on it never has
+/// to parse prose.
+pub const ELISION_REASON_BUDGET: &str = "response_budget";
+
+/// Where a payload publishes what its lists lost.
+pub const ELISIONS_KEY: &str = "elisions";
+
+/// What one list lost to the response budget.
+///
+/// A list the budget cut must never render as an empty array. An empty array is
+/// the shape a caller reads as "the walk saw none", and no counter elsewhere in
+/// the response outranks it: two `impact_analysis` answers in one stranger
+/// session carried `"affected_tests": []` beside a `covering_tests: 16` that
+/// contradicted it, and both times the empty array won and the reader drew the
+/// wrong conclusion. A sibling `affected_tests_withheld: 15` was right there in
+/// the second one and did not save it either.
+///
+/// So a cut list keeps at least one entry and publishes this record beside it,
+/// and an empty array afterward means one thing only.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Elision {
+    /// Entries the budget withheld from this list.
+    pub elided: usize,
+    /// Entries the response still carries. Never zero when the walk found any.
+    pub kept: usize,
+    /// Entries the walk actually found, which is `kept + elided`.
+    pub total: usize,
+    /// Why they were withheld. [`ELISION_REASON_BUDGET`] today, named rather
+    /// than assumed, so a cut made later for a different reason cannot be read
+    /// as this one.
+    pub reason: String,
+}
+
+impl Elision {
+    /// One list's loss, from what survived and what did not.
+    pub fn budget(kept: usize, elided: usize) -> Self {
+        Self {
+            elided,
+            kept,
+            total: kept.saturating_add(elided),
+            reason: ELISION_REASON_BUDGET.to_string(),
+        }
+    }
+}
+
+/// Record one list's elision on the payload, under the top-level `elisions`
+/// map, keyed by the field that was cut.
+///
+/// One map rather than a sibling key per list: a caller asking "did this
+/// response lose anything" reads one key, and the answer has the same shape for
+/// `chain` as it has for `affected_tests`. The older `<field>_withheld` scalars
+/// stay beside it, because a client already reading them must not lose its
+/// counter to this change.
+pub fn record_elision(payload: &mut Value, field: &str, kept: usize, elided: usize) {
+    if elided == 0 {
+        return;
+    }
+    let entry = serde_json::to_value(Elision::budget(kept, elided)).unwrap_or(Value::Null);
+    match payload.get_mut(ELISIONS_KEY).and_then(Value::as_object_mut) {
+        Some(map) => {
+            map.insert(field.to_string(), entry);
+        }
+        None => {
+            let mut map = Map::new();
+            map.insert(field.to_string(), entry);
+            payload[ELISIONS_KEY] = Value::Object(map);
+        }
     }
 }
 
@@ -490,21 +578,28 @@ pub fn enforce(
     // first. This is the only stage that removes an answer, so it reports the
     // count withheld and the parameter that recovers them.
     //
-    // The first collection is the primary one and always keeps at least one
-    // entry. A bound is not a refusal: a caller handed an empty ranking cannot
-    // tell it from "nothing matched", which is the one reading a size cut must
-    // never produce.
+    // Every collection keeps at least one entry, not just the primary one. A
+    // bound is not a refusal: a caller handed an empty array cannot tell it from
+    // "nothing matched", which is the one reading a size cut must never produce,
+    // and the reading does not get safer further down the response. The floor
+    // used to be the primary alone, so the last bucket of an `impact_analysis`
+    // emptied first and `"affected_tests": []` shipped beside a
+    // `covering_tests: 16` that said sixteen tests cover it.
     let primary = shape.collections.first().copied();
     let mut withheld_any = false;
     for key in shape.collections.iter().rev() {
-        let floor = usize::from(Some(*key) == primary);
-        let withheld = trim_collection(payload, key, target, floor);
+        let found = payload
+            .get(*key)
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len);
+        let withheld = trim_collection(payload, key, target, 1);
         if withheld > 0 {
             accounting.bounded = true;
             withheld_any = true;
             cuts.push(format!(
-                "{withheld} entries withheld from the end of `{key}`"
+                "{withheld} of {found} entries withheld from the end of `{key}`"
             ));
+            record_elision(payload, key, found.saturating_sub(withheld), withheld);
             payload["truncated"] = Value::Bool(true);
         }
         if measure(payload) <= target {
@@ -682,8 +777,10 @@ fn disclose(
     if !remediation.is_empty() {
         remediation.push_str("; ");
     }
-    remediation
-        .push_str("or raise max_chars if the caller's own result limit accepts a larger payload");
+    remediation.push_str(&format!(
+        "or raise max_chars, up to the {RESPONSE_MAX_MAX_CHARS} this server will build, if the \
+         caller's own result limit accepts a larger payload"
+    ));
     let entry = json!({
         "component": "response_budget",
         "reason": "response_bounded",
@@ -969,11 +1066,16 @@ mod tests {
     }
 
     /// One response named two budgets and explained neither: the envelope
-    /// published 30000 while the arm that cut disclosed 28000. The disclosure
-    /// now carries the arithmetic joining them.
+    /// published the default while the arm that cut disclosed the default less
+    /// the reserve. The disclosure now carries the arithmetic joining them.
+    ///
+    /// Every number here is read off the constants rather than written out, so
+    /// moving the default moves the test with it instead of leaving a green
+    /// assertion about a budget nothing serves.
     #[test]
     fn a_default_budget_discloses_the_envelope_reserve_it_was_cut_by() {
-        let mut payload = locate_payload(40, 900);
+        let enforced = RESPONSE_DEFAULT_MAX_CHARS - RESPONSE_ENVELOPE_RESERVE_CHARS;
+        let mut payload = locate_payload(120, 900);
         let budget = ResponseBudget::default().less_envelope_reserve();
         enforce(&mut payload, "semantic_locate", &budget).expect("budgeted");
         let detail = payload["degradations"][0]["detail"]
@@ -981,15 +1083,17 @@ mod tests {
             .expect("a cut was disclosed")
             .to_string();
         assert!(
-            detail.contains("28000-character budget"),
+            detail.contains(&format!("{enforced}-character budget")),
             "must name what it enforced: {detail}"
         );
         assert!(
-            detail.contains("30000-character default")
-                && detail.contains("2000-character envelope reserve"),
+            detail.contains(&format!("{RESPONSE_DEFAULT_MAX_CHARS}-character default"))
+                && detail.contains(&format!(
+                    "{RESPONSE_ENVELOPE_RESERVE_CHARS}-character envelope reserve"
+                )),
             "must name the published default and the reserve between them: {detail}"
         );
-        assert_eq!(payload["degradations"][0]["max_chars"], json!(28_000));
+        assert_eq!(payload["degradations"][0]["max_chars"], json!(enforced));
     }
 
     /// A caller who named a ceiling is told that ceiling and nothing else: there
@@ -1025,6 +1129,150 @@ mod tests {
         assert_eq!(
             defaulted.less_envelope_reserve().max_chars,
             RESPONSE_DEFAULT_MAX_CHARS - RESPONSE_ENVELOPE_RESERVE_CHARS
+        );
+    }
+
+    /// The defect the v0.5.47 stranger run named twice in one session:
+    /// `"affected_tests": []` shipped beside a `covering_tests: 16` that
+    /// contradicted it, and the empty array won both times. `affected_tests` is
+    /// the last bucket, so the ladder emptied it first, and a sibling
+    /// `affected_tests_withheld: 15` sat right there and saved nobody.
+    ///
+    /// Every list the budget cuts now keeps an entry and publishes what it lost.
+    #[test]
+    fn a_budget_never_empties_a_list_it_cut() {
+        const BUCKETS: [&str; 4] = [
+            "affected_callers",
+            "affected_dependents",
+            "affected_contract_consumers",
+            "affected_tests",
+        ];
+        let mut payload = impact_payload(40);
+        let found: Vec<usize> = BUCKETS
+            .iter()
+            .map(|key| payload[*key].as_array().expect("bucket").len())
+            .collect();
+        assert!(
+            found.iter().all(|count| *count > 0),
+            "the fixture must fill every bucket or this proves nothing: {found:?}"
+        );
+        let budget = ResponseBudget {
+            max_chars: 4_000,
+            ..ResponseBudget::default()
+        };
+        let accounting = enforce(&mut payload, "impact_analysis", &budget).expect("budgeted");
+        assert!(accounting.bounded, "the fixture must overflow: {payload}");
+
+        let mut cut_any = false;
+        for (key, before) in BUCKETS.iter().zip(found) {
+            let kept = payload[*key].as_array().expect("bucket survives").len();
+            assert!(
+                kept > 0,
+                "`{key}` was emptied by the budget, which reads as \"the walk found none\": \
+                 {payload}"
+            );
+            if kept == before {
+                assert!(
+                    payload["elisions"].get(*key).is_none(),
+                    "`{key}` lost nothing and must claim nothing: {payload}"
+                );
+                continue;
+            }
+            cut_any = true;
+            let elision = &payload["elisions"][*key];
+            assert_eq!(elision["kept"], json!(kept), "{payload}");
+            assert_eq!(elision["elided"], json!(before - kept), "{payload}");
+            assert_eq!(elision["total"], json!(before), "{payload}");
+            assert_eq!(elision["reason"], json!(ELISION_REASON_BUDGET), "{payload}");
+            assert_eq!(
+                payload[format!("{key}_withheld")],
+                json!(before - kept),
+                "the older counter must still agree with the elision: {payload}"
+            );
+        }
+        assert!(
+            cut_any,
+            "a budget this small must have cut something: {payload}"
+        );
+    }
+
+    /// The other direction, which is what makes the first test worth anything: a
+    /// list the walk genuinely found nothing for stays empty and claims no
+    /// elision. Without this, "never empty" could be satisfied by inventing an
+    /// entry, and an empty array would still mean two things.
+    #[test]
+    fn an_empty_list_stays_empty_and_claims_no_elision() {
+        let mut payload = impact_payload(40);
+        payload["affected_tests"] = json!([]);
+        let budget = ResponseBudget {
+            max_chars: 4_000,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "impact_analysis", &budget).expect("budgeted");
+        assert_eq!(
+            payload["affected_tests"],
+            json!([]),
+            "a walk that found none must still report none: {payload}"
+        );
+        assert!(
+            payload["elisions"].get("affected_tests").is_none(),
+            "nothing was withheld, so nothing may be claimed: {payload}"
+        );
+        assert!(
+            payload.get("affected_tests_withheld").is_none(),
+            "nothing was withheld: {payload}"
+        );
+    }
+
+    /// The ceiling has to be a number a real MCP client accepts, and 400,000 was
+    /// not: Claude Code caps one tool result at 25,000 tokens by default, and on
+    /// the v0.5.47 candidate a caller who took the advertised ceiling at its word
+    /// asked for 120,000, got 117,313 characters, and had the whole result thrown
+    /// away. Responses of 50,000 and 55,000 characters in the same session came
+    /// back whole.
+    #[test]
+    fn the_advertised_ceiling_is_one_a_client_accepts() {
+        const REFUSED_BY_A_REAL_CLIENT: usize = 117_313;
+        const ACCEPTED_BY_A_REAL_CLIENT: usize = 55_000;
+        assert!(
+            RESPONSE_MAX_MAX_CHARS < REFUSED_BY_A_REAL_CLIENT,
+            "the ceiling advertises a size a client refused: {RESPONSE_MAX_MAX_CHARS}"
+        );
+        assert!(
+            RESPONSE_MAX_MAX_CHARS >= ACCEPTED_BY_A_REAL_CLIENT,
+            "the ceiling sits under a size a client already took: {RESPONSE_MAX_MAX_CHARS}"
+        );
+        assert!(
+            RESPONSE_MIN_MAX_CHARS < RESPONSE_DEFAULT_MAX_CHARS
+                && RESPONSE_DEFAULT_MAX_CHARS <= RESPONSE_MAX_MAX_CHARS,
+            "the default must sit inside its own clamp"
+        );
+        // The old 30,000 default dropped 170 of 200 steps on the 783-entity store
+        // the same run measured, and still withheld impact rows at 50,000.
+        assert!(
+            RESPONSE_DEFAULT_MAX_CHARS > 30_000,
+            "the default is back at a size the measured store overflowed"
+        );
+    }
+
+    /// A cut names the ceiling a caller may raise to, on the response that got
+    /// cut. The raw daemon route carries no `_kin` envelope, so this in-band line
+    /// is the only place that number reaches a caller there.
+    #[test]
+    fn a_cut_discloses_the_ceiling_a_caller_may_raise_to() {
+        let mut payload = locate_payload(40, 900);
+        let budget = ResponseBudget {
+            max_chars: 4_000,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "semantic_locate", &budget).expect("budgeted");
+        let remediation = payload["degradations"][0]["remediation"]
+            .as_str()
+            .expect("a cut was disclosed")
+            .to_string();
+        assert!(
+            remediation.contains(&RESPONSE_MAX_MAX_CHARS.to_string()),
+            "the response must name the ceiling it will serve: {remediation}"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -222,8 +222,8 @@ all take it. `id_space: \"artifact\"` means the hit is an artifact-level embeddi
 tracked file the parsers produced no entities for — so it carries `artifact_path` and NO \
 `entity_id`, and those tools will refuse it; read it with kin_artifact_read instead. Do \
 not synthesize an entity id from an artifact hit's path. The response bounds its own size \
-(max_chars, default 30000 serialized characters) so it is never refused by a client for being \
-too large: it is compact by default, meaning no per-signal `match_evidence` breakdown unless you \
+(max_chars, default 45000 serialized characters, ceiling 60000) so it is never refused by a \
+client for being too large: it is compact by default, meaning no per-signal `match_evidence` breakdown unless you \
 ask with explain=true or compact=false, and under pressure it sheds the per-file symbol roll-up, \
 then inline snippets, and only then withholds hits from the end of the page. Any cut is reported \
 in `degradations` and in `_kin.response`, which carries the budget applied and what the response \
@@ -1231,7 +1231,8 @@ unused from the absence of anything but `name_only` rows without confirming. \
 `total_upstream` of 0 with `unconfirmed_candidates` above 0 means this answer is holding \
 rows it could not confirm and the zero may not be read alone. \
 `_kin.verdict` is the one verdict for the whole response and outranks every count in it. \
-The response bounds its own size (max_chars, default 30000 serialized characters): a symbol \
+The response bounds its own size (max_chars, default 45000 serialized characters, ceiling \
+60000): a symbol \
 with hundreds of call sites sheds its inline snippets before it withholds any row, and any cut \
 is reported in `degradations` and in `_kin.response` with the size the response had before the \
 budget, so a short answer is never mistaken for a complete one.";
@@ -3208,8 +3209,10 @@ happens substrate-side and comes back as one structured response, so you don't l
 get_entity_source per hop and exhaust your tool-call budget. Ask for the chain's SHAPE with \
 include_body=false (names, kinds, roles, spans, edges, no source) — that is the cheap call, and \
 the one to reach for unless you mean to read the code. The response bounds its own size \
-(max_response_chars) and cuts bodies before edges, so it is never refused for being too large; \
-any cut is reported in `degradations` with the numbers. Tune depth and limit_per_step to control \
+(max_response_chars, default 45000, ceiling 60000) and cuts bodies before edges, so it is never \
+refused for being too large; any cut is reported in `degradations` with the numbers. A budget \
+that cut the chain never empties it: at least one step survives and `elisions.chain` names what \
+was kept, what was withheld, and why, so an empty `chain` always means the walk reached nothing. Tune depth and limit_per_step to control \
 breadth: the per-step cap keeps the most relevant neighbors (located over file-less, source over \
 test, Calls over Imports over References, the expanded node's own file first) rather than \
 whatever order the relation table returned, and any node whose fan-out was cut carries \
@@ -3416,8 +3419,14 @@ fn bound_trace_payload(result: &mut serde_json::Value, max_chars: usize) {
 
     // Bisected rather than popped one step at a time: the same answer, in a
     // handful of serializations instead of one per dropped step.
-    let mut kept = 0usize;
-    let mut low = 0usize;
+    //
+    // The floor is one step, not zero. A walk that found 200 steps and returns
+    // `"chain": []` is indistinguishable from a walk that found none, and the
+    // caller has no second field that outranks the empty array. One step plus
+    // the elision beside it says both what was reached and what was withheld.
+    let floor = usize::from(!full.is_empty());
+    let mut kept = floor;
+    let mut low = floor;
     let mut high = full.len();
     while low <= high {
         let mid = (low + high) / 2;
@@ -3426,7 +3435,7 @@ fn bound_trace_payload(result: &mut serde_json::Value, max_chars: usize) {
         if measure(result) <= target {
             kept = mid;
             low = mid + 1;
-        } else if mid == 0 {
+        } else if mid <= floor {
             break;
         } else {
             high = mid - 1;
@@ -3440,6 +3449,9 @@ fn bound_trace_payload(result: &mut serde_json::Value, max_chars: usize) {
         return;
     }
     result["steps_omitted"] = serde_json::Value::from(omitted);
+    // The same loss in the shape every budgeted list reports it in, so a caller
+    // reads one key whether the tool cut a chain or a bucket of tests.
+    crate::budget::record_elision(result, "chain", kept, omitted);
     // Dropped steps are edges the caller did not receive, which is what this flag
     // has always meant.
     result["truncated"] = serde_json::Value::Bool(true);
@@ -4705,6 +4717,76 @@ mod tests {
 
     fn make_entity(name: &str, file: &str) -> Entity {
         make_entity_in(LanguageId::Rust, name, file)
+    }
+
+    /// A chain payload in the shape the generic-`GraphStore` arm builds, sized
+    /// so the caller can force a cut.
+    fn chain_payload(steps: usize, signature_chars: usize) -> serde_json::Value {
+        let chain: Vec<serde_json::Value> = (0..steps)
+            .map(|index| {
+                serde_json::json!({
+                    "step": index + 1,
+                    "parent_step": index,
+                    "entity_id": format!("00000000-0000-0000-0000-{index:012}"),
+                    "entity_name": format!("hop_{index}"),
+                    "entity_kind": "Function",
+                    "entity_file": format!("src/hop_{index}.rs"),
+                    "relation": "Calls",
+                    "signature": "s".repeat(signature_chars),
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "focal": "entry",
+            "total_steps": steps,
+            "chain": chain,
+        })
+    }
+
+    /// A walk that reached steps must never answer with an empty chain, because
+    /// an empty chain is the shape that means the walk reached nothing and no
+    /// counter beside it outranks that reading. One step survives and
+    /// `elisions.chain` says what the budget took.
+    #[test]
+    fn a_budget_never_returns_an_empty_chain_for_a_walk_that_found_steps() {
+        let mut payload = chain_payload(200, 400);
+        bound_trace_payload(&mut payload, 2_000);
+        let kept = payload["chain"].as_array().expect("chain survives").len();
+        assert!(
+            kept > 0,
+            "the budget emptied a chain of 200 steps: {payload}"
+        );
+        let omitted = payload["steps_omitted"].as_u64().expect("a cut is counted") as usize;
+        assert_eq!(kept + omitted, 200, "{payload}");
+        assert_eq!(payload["total_steps"], serde_json::json!(kept), "{payload}");
+        let elision = &payload["elisions"]["chain"];
+        assert_eq!(elision["kept"], serde_json::json!(kept), "{payload}");
+        assert_eq!(elision["elided"], serde_json::json!(omitted), "{payload}");
+        assert_eq!(elision["total"], serde_json::json!(200), "{payload}");
+        assert_eq!(
+            elision["reason"],
+            serde_json::json!(crate::budget::ELISION_REASON_BUDGET),
+            "{payload}"
+        );
+        assert_eq!(payload["truncated"], serde_json::json!(true), "{payload}");
+    }
+
+    /// The direction that makes the rule mean something: a walk that reached
+    /// nothing still answers with an empty chain and claims no elision.
+    #[test]
+    fn a_walk_that_reached_nothing_still_answers_with_an_empty_chain() {
+        let mut payload = chain_payload(0, 0);
+        bound_trace_payload(&mut payload, 2_000);
+        assert_eq!(
+            payload["chain"],
+            serde_json::json!([]),
+            "an empty walk must report itself: {payload}"
+        );
+        assert!(
+            payload.get("elisions").is_none(),
+            "nothing was withheld, so nothing may be claimed: {payload}"
+        );
+        assert!(payload.get("steps_omitted").is_none(), "{payload}");
     }
 
     fn make_entity_in(language: LanguageId, name: &str, file: &str) -> Entity {

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4722,6 +4722,20 @@ mod tests {
     /// A chain payload in the shape the generic-`GraphStore` arm builds, sized
     /// so the caller can force a cut.
     fn chain_payload(steps: usize, signature_chars: usize) -> serde_json::Value {
+        chain_payload_padded(steps, signature_chars, 0)
+    }
+
+    /// The same payload with bulk the budget cannot trim, so a walk with an
+    /// empty chain still reaches the bisect. Without it an empty-chain fixture
+    /// is under budget, the bounder returns at its first line, and a test
+    /// asserting what it did not do can never fail. That was measured: the
+    /// unpadded version of the test below passed with the rule deliberately
+    /// broken.
+    fn chain_payload_padded(
+        steps: usize,
+        signature_chars: usize,
+        pad_chars: usize,
+    ) -> serde_json::Value {
         let chain: Vec<serde_json::Value> = (0..steps)
             .map(|index| {
                 serde_json::json!({
@@ -4738,6 +4752,7 @@ mod tests {
             .collect();
         serde_json::json!({
             "focal": "entry",
+            "focal_body": "b".repeat(pad_chars),
             "total_steps": steps,
             "chain": chain,
         })
@@ -4775,7 +4790,13 @@ mod tests {
     /// nothing still answers with an empty chain and claims no elision.
     #[test]
     fn a_walk_that_reached_nothing_still_answers_with_an_empty_chain() {
-        let mut payload = chain_payload(0, 0);
+        // Padded past the budget on purpose, so the bounder runs its bisect on an
+        // empty chain rather than returning at its first line.
+        let mut payload = chain_payload_padded(0, 0, 8_000);
+        assert!(
+            serde_json::to_string_pretty(&payload).unwrap().len() > 2_000,
+            "the fixture must reach the bounder or this proves nothing"
+        );
         bound_trace_payload(&mut payload, 2_000);
         assert_eq!(
             payload["chain"],

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -3,6 +3,70 @@
 
 use crate::types::{ToolAnnotations, ToolDefinition, ToolsListResult};
 
+/// The `max_chars` property every retrieval tool advertises, built from the
+/// budget's own constants.
+///
+/// Nine tools carried a byte-identical copy of this block with the numbers
+/// written out, so moving the ceiling meant editing ten homes and a release read
+/// whichever one was missed. The stranger who asked for 120,000 characters was
+/// reading one of those copies, which advertised 400,000 while a real client
+/// refused 117,313. There is one home now, and it is the constant.
+fn max_chars_property() -> serde_json::Value {
+    serde_json::json!({
+        "type": "integer",
+        "description": format!(
+            "Serialized characters this response may occupy (default {default}, clamped \
+             {min}..{max}). The ceiling is what a real MCP client accepts, not what this server \
+             could build. The tool enforces the budget itself: it sheds ranking explanation, then \
+             duplicated hit shapes, then inline source, and only then withholds entries, and it \
+             never empties a list it cut. A list the budget cut keeps at least one entry and is \
+             reported under `elisions` with what it kept, what it lost, and why, so an empty array \
+             always means the walk found none. Any cut is also reported in `degradations` and in \
+             `_kin.response`, which carries the size the response had before the budget.",
+            default = crate::budget::RESPONSE_DEFAULT_MAX_CHARS,
+            min = crate::budget::RESPONSE_MIN_MAX_CHARS,
+            max = crate::budget::RESPONSE_MAX_MAX_CHARS,
+        ),
+        "default": crate::budget::RESPONSE_DEFAULT_MAX_CHARS,
+        "minimum": crate::budget::RESPONSE_MIN_MAX_CHARS,
+        "maximum": crate::budget::RESPONSE_MAX_MAX_CHARS,
+    })
+}
+
+/// `trace_data_flow`'s own spelling of the same budget.
+fn trace_max_chars_property() -> serde_json::Value {
+    serde_json::json!({
+        "type": "integer",
+        "description": format!(
+            "Serialized characters this response may occupy (default {default}, clamped \
+             {min}..{max}, the same budget every retrieval tool answers under). The tool enforces \
+             it itself, dropping bodies before edges, and it never returns an empty chain for a \
+             walk that found steps: a cut chain keeps at least one step and reports the rest under \
+             `elisions.chain` and `steps_omitted`. `max_chars` is the same parameter under the \
+             name the other retrieval tools use.",
+            default = crate::budget::RESPONSE_DEFAULT_MAX_CHARS,
+            min = crate::budget::RESPONSE_MIN_MAX_CHARS,
+            max = crate::budget::RESPONSE_MAX_MAX_CHARS,
+        ),
+        "default": crate::budget::RESPONSE_DEFAULT_MAX_CHARS,
+        "minimum": crate::budget::RESPONSE_MIN_MAX_CHARS,
+        "maximum": crate::budget::RESPONSE_MAX_MAX_CHARS,
+    })
+}
+
+/// The alias spelling, which carries the same numbers so a caller cannot read
+/// two ceilings off one tool.
+fn trace_max_chars_alias_property() -> serde_json::Value {
+    serde_json::json!({
+        "type": "integer",
+        "description": "Alias for max_response_chars, the spelling shared with the other \
+                        retrieval tools.",
+        "default": crate::budget::RESPONSE_DEFAULT_MAX_CHARS,
+        "minimum": crate::budget::RESPONSE_MIN_MAX_CHARS,
+        "maximum": crate::budget::RESPONSE_MAX_MAX_CHARS,
+    })
+}
+
 /// A tool that only reads graph truth.
 ///
 /// `openWorldHint` is false on every tool this crate defines: the whole surface
@@ -308,7 +372,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "max_chars": max_chars_property(),
                         "query": { "type": "string", "description": "Name pattern to search for" },
                         "kind": { "type": "string", "description": "Entity kind filter (function, class, etc.)" },
                         "language": { "type": "string", "description": "Language filter (rust, typescript, etc.)" },
@@ -325,7 +389,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "max_chars": max_chars_property(),
                         "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "query": { "type": "string", "description": "Natural-language description of the code to find. Optional when paging with `cursor`." },
                         "queries": {
@@ -449,7 +513,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "max_chars": max_chars_property(),
                         "entity_id": { "type": "string", "description": "Focal entity UUID" },
                         "token_budget": { "type": "integer", "description": "Token budget (8000, 16000, or 32000)", "default": 16000 },
                         "depth": { "type": "integer", "description": "Dependency traversal depth", "default": 2 },
@@ -466,7 +530,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "max_chars": max_chars_property(),
                         "entity_id": { "type": "string", "description": "Focal entity UUID. Required if `query` is not given." },
                         "query": { "type": "string", "description": "Exact entity name to resolve to a focal entity. Required if `entity_id` is not given." },
                         "depth": { "type": "integer", "description": "Dependency traversal depth across the trace neighborhood", "default": 3 },
@@ -506,20 +570,8 @@ fn registered_tools() -> ToolsListResult {
                             "description": "Walk THROUGH a type-annotation edge to a type this repository defines (default false). A dataclass field typed with a repo class is a real flow into that class, so the hop is available; it is off by default because a shared type name otherwise joins every entity that annotates with it to every other one. An annotation target the repository does not define stays a leaf either way.",
                             "default": false
                         },
-                        "max_response_chars": {
-                            "type": "integer",
-                            "description": "Serialized characters this response may occupy (default 30000, the same default every retrieval tool answers under). The tool enforces it itself, dropping bodies before edges and reporting the cut in degradations, so a result is never refused for size. `max_chars` is the same parameter under the name the other retrieval tools use.",
-                            "default": 30000,
-                            "minimum": 2000,
-                            "maximum": 400000
-                        },
-                        "max_chars": {
-                            "type": "integer",
-                            "description": "Alias for max_response_chars, the spelling shared with the other retrieval tools.",
-                            "default": 30000,
-                            "minimum": 2000,
-                            "maximum": 400000
-                        }
+                        "max_response_chars": trace_max_chars_property(),
+                        "max_chars": trace_max_chars_alias_property()
                     },
                     "required": ["focal"]
                 }),
@@ -531,7 +583,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "max_chars": max_chars_property(),
                         "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "entity_id": { "type": "string", "description": "Exact entity UUID. Optional if query is provided." },
                         "query": { "type": "string", "description": "Exact symbol name to resolve. Optional if entity_id is provided." },
@@ -555,7 +607,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "max_chars": max_chars_property(),
                         "entity_ids": {
                             "type": "array",
                             "description": "Entity UUIDs to classify. Minimum 1, maximum 200.",
@@ -585,7 +637,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "max_chars": max_chars_property(),
                         "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "base": { "type": "string", "description": "Base semantic change ID (hex)" },
                         "head": { "type": "string", "description": "Head semantic change ID (hex)" },
@@ -668,7 +720,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "max_chars": max_chars_property(),
                         "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "query": {
                             "type": "string",
@@ -704,7 +756,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "max_chars": max_chars_property(),
                         "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "entity_id": { "type": "string", "description": "Entity UUID" },
                         "depth": { "type": "integer", "description": "Traversal depth", "default": 2 },
@@ -1453,6 +1505,61 @@ pub fn context_bench_tool_names() -> &'static [&'static str] {
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+
+    /// Every budget number a tool advertises has to be the number the budget
+    /// enforces. Nine schemas carried byte-identical copies of the default, the
+    /// floor and the ceiling written out, and one of those copies said 400,000
+    /// while a real client refused 117,313. A caller who reads a schema and gets
+    /// its result thrown away was told the wrong number by this file.
+    ///
+    /// This walks every declared tool rather than the ones known to carry the
+    /// parameter, so a schema added later with a hand-written number fails here.
+    #[test]
+    fn every_advertised_budget_matches_the_enforced_one() {
+        use crate::budget::{
+            RESPONSE_DEFAULT_MAX_CHARS, RESPONSE_MAX_MAX_CHARS, RESPONSE_MIN_MAX_CHARS,
+        };
+        let mut checked = 0usize;
+        for tool in &tool_definitions().tools {
+            let Some(properties) = tool.input_schema.get("properties") else {
+                continue;
+            };
+            for key in ["max_chars", "max_response_chars"] {
+                let Some(property) = properties.get(key) else {
+                    continue;
+                };
+                checked += 1;
+                assert_eq!(
+                    property["default"].as_u64(),
+                    Some(RESPONSE_DEFAULT_MAX_CHARS as u64),
+                    "{}.{key} advertises a default the budget does not serve: {property}",
+                    tool.name
+                );
+                assert_eq!(
+                    property["minimum"].as_u64(),
+                    Some(RESPONSE_MIN_MAX_CHARS as u64),
+                    "{}.{key} advertises a floor the budget does not serve: {property}",
+                    tool.name
+                );
+                assert_eq!(
+                    property["maximum"].as_u64(),
+                    Some(RESPONSE_MAX_MAX_CHARS as u64),
+                    "{}.{key} advertises a ceiling the budget does not serve: {property}",
+                    tool.name
+                );
+                let description = property["description"].as_str().unwrap_or_default();
+                assert!(
+                    !description.contains("400000"),
+                    "{}.{key} still names the ceiling that got a result refused: {description}",
+                    tool.name
+                );
+            }
+        }
+        assert!(
+            checked >= 11,
+            "the sweep found only {checked} budget parameters, so it is not reaching the schemas"
+        );
+    }
 
     #[test]
     fn all_tools_have_names_and_descriptions() {

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -1,8 +1,8 @@
 # Product acceptance suites
 
-Two falsifiable suites that ask whether the product still answers correctly.
-`.github/workflows/acceptance.yml` runs both on every pull request against that
-pull request's own build. Neither is release proof; both are regression gates.
+Three falsifiable suites that ask whether the product still answers correctly.
+`.github/workflows/acceptance.yml` runs all three on every pull request against
+that pull request's own build. None is release proof; all are regression gates.
 
 Each suite prints one line per check:
 
@@ -43,10 +43,26 @@ one-commit-shape results. The suite prints that scope on every run and records i
 in the JSON. History-shaped behavior, meaning conversion cost, provenance depth,
 and commit peak memory, is not exercised here.
 
-`brownfield_repro.py --self-test` exercises the verdict graders on fixed payloads
-and needs no binary and no corpus. Each case is paired with its inverse, so a
-grader that cannot tell its own cases apart fails rather than reporting a clean
-product on a broken one.
+`response_budget_elisions.py` covers the one rule the response budget owes every
+answer it shortens: a list it cut is never rendered as an empty one. An empty
+array is the shape a reader takes for "the walk found none", and the v0.5.47
+stranger read `"affected_tests": []` beside a `covering_tests: 16` twice in one
+session and drew the wrong conclusion both times, with a sibling
+`affected_tests_withheld` counter sitting in the same response. Check 0 cuts a
+trace and asserts the chain keeps a step and publishes `elisions.chain`. Check 1
+walks an entity with no callees and asserts the empty chain claims no elision, so
+an empty array still means one thing. Check 2 reads `tools/list` and asserts every
+advertised budget sits under what a real MCP client accepts. Check 3 runs one
+query at the ceiling and again at the floor and asserts nothing full in the first
+is empty in the second, which needs no counter to be true.
+
+`brownfield_repro.py --self-test` and `response_budget_elisions.py --self-test`
+exercise their verdict graders on fixed payloads and need no binary and no
+corpus. Each case is paired with its inverse, so a grader that cannot tell its
+own cases apart fails rather than reporting a clean product on a broken one. That
+pairing has already earned its keep: one elision grader passed a deliberately
+broken product because its fixture sat under the budget and never reached the
+code the check was about.
 
 ## Running against a local build
 
@@ -61,6 +77,10 @@ python3 scripts/acceptance/brownfield_repro.py \
   --kin target/release/kin --daemon target/release/kin-daemon \
   --json acceptance/brownfield.json \
   --corpus-cache ~/.cache/kin-brownfield-repro --verbose
+
+python3 scripts/acceptance/response_budget_elisions.py \
+  --kin target/release/kin --daemon target/release/kin-daemon \
+  --json acceptance/response_budget.json --verbose
 ```
 
 Release, not debug. Release is what ships, so it is what an acceptance answer
@@ -68,11 +88,13 @@ should be about, and the profile has already been shown to change an answer: on
 the first CI run a debug build truncated a data-flow walk that a release build
 walked whole (FIR-2593).
 
-Both take `--only` to select check ids, `--workdir` to keep fixtures somewhere
-known, `--keep` to leave them behind, and `--compare` a prior run's JSON so a
-check that passed there and fails now reads REGRESSION rather than plain FAIL.
-`brownfield_repro.py` also takes `--offline`, which refuses to fetch and requires
-the corpus cache to already carry both pinned commits.
+`magic_repro.py` and `brownfield_repro.py` take `--only` to select check ids,
+`--workdir` to keep fixtures somewhere known, `--keep` to leave them behind, and
+`--compare` a prior run's JSON so a check that passed there and fails now reads
+REGRESSION rather than plain FAIL. `brownfield_repro.py` also takes `--offline`,
+which refuses to fetch and requires the corpus cache to already carry both pinned
+commits. `response_budget_elisions.py` builds its own fixture, fetches nothing,
+and takes `--workdir` and `--verbose`.
 
 The magic suite's fixtures commit through kin, and kin refuses to invent an
 author, so the machine running them needs a git identity. That refusal is

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -1,0 +1,736 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove a budget-cut list never ships as an empty one, on the real binary.
+
+FIR-2600. The v0.5.47 brownfield stranger read `"affected_tests": []` beside a
+`covering_tests: 16` that contradicted it, twice in one session, and drew the
+wrong conclusion both times. An empty array is the shape a reader takes for "the
+walk found none", and no counter elsewhere in the response outranks it.
+
+So this suite asserts both directions on one walk each, because either half alone
+can be satisfied by a broken tool:
+
+  0  a walk the budget cut keeps at least one step and publishes `elisions.chain`
+     with a count and a reason that agree with `steps_omitted` and the chain
+  1  a walk that reached nothing still answers with an empty chain and claims no
+     elision, so an empty array means exactly one thing
+  2  the budget the tool advertises is the budget it enforces, and its ceiling is
+     one a real MCP client accepts
+
+Exit status is 0 when every check passed, 1 when one failed, 2 when one could not
+be read, and 3 when the run could not be set up. `--self-test` exercises every
+grader against its inverse and needs no binary, so a grader that cannot fail is
+a failure here rather than a silent pass in CI.
+"""
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+print = functools.partial(print, flush=True)
+
+# The largest payload the v0.5.47 stranger run proved a real MCP client refuses.
+# The ceiling this server advertises has to sit below it, or the tool is telling
+# callers to ask for a result their client will throw away.
+REFUSED_BY_A_REAL_CLIENT = 117313
+
+
+class SetupError(Exception):
+    """The run could not be set up. Never a pass, never a check failure."""
+
+
+class Result(object):
+    """One check's verdict, which starts unproven and can only be lowered."""
+
+    def __init__(self, ident, ticket, title):
+        self.id = ident
+        self.ticket = ticket
+        self.title = title
+        self.notes = []
+        self.failed = False
+        self.unread = False
+
+    def ok(self, detail):
+        self.notes.append(detail)
+
+    def bad(self, detail):
+        self.failed = True
+        self.notes.append(detail)
+
+    def unknown(self, detail):
+        self.unread = True
+        self.notes.append(detail)
+
+    @property
+    def status(self):
+        if self.failed:
+            return FAIL
+        if self.unread:
+            return UNREADABLE
+        return PASS
+
+    @property
+    def detail(self):
+        return "; ".join(self.notes)
+
+    def row(self):
+        return {
+            "id": self.id,
+            "ticket": self.ticket,
+            "title": self.title,
+            "status": self.status,
+            "detail": self.detail,
+        }
+
+
+def grade_cut_walk(payload):
+    """Grade a walk the budget cut. Returns a list of complaints, empty on pass.
+
+    Kept separate from the run so `--self-test` can hand it a payload carrying
+    the exact defect and watch it fail.
+    """
+    problems = []
+    chain = payload.get("chain")
+    if not isinstance(chain, list):
+        return ["the response carries no chain array"]
+    omitted = payload.get("steps_omitted")
+    if not isinstance(omitted, int) or omitted <= 0:
+        return ["the walk was not cut, so this check proves nothing"]
+    if not chain:
+        problems.append(
+            "the budget emptied a chain it cut: an empty array reads as "
+            "'the walk found none' and %d steps were withheld" % omitted
+        )
+    elisions = payload.get("elisions")
+    if not isinstance(elisions, dict) or "chain" not in elisions:
+        problems.append("a cut chain published no elision under `elisions.chain`")
+        return problems
+    elision = elisions["chain"]
+    if elision.get("elided") != omitted:
+        problems.append(
+            "elisions.chain.elided is %r and steps_omitted is %r"
+            % (elision.get("elided"), omitted)
+        )
+    if elision.get("kept") != len(chain):
+        problems.append(
+            "elisions.chain.kept is %r and the chain carries %d"
+            % (elision.get("kept"), len(chain))
+        )
+    if elision.get("total") != len(chain) + omitted:
+        problems.append(
+            "elisions.chain.total is %r and kept plus elided is %d"
+            % (elision.get("total"), len(chain) + omitted)
+        )
+    if not elision.get("reason"):
+        problems.append("elisions.chain names no reason")
+    return problems
+
+
+def grade_empty_walk(payload):
+    """Grade a walk that genuinely reached nothing."""
+    problems = []
+    chain = payload.get("chain")
+    if not isinstance(chain, list):
+        return ["the response carries no chain array"]
+    if chain:
+        return ["the fixture reached %d steps, so this check proves nothing" % len(chain)]
+    if payload.get("steps_omitted"):
+        problems.append(
+            "an untouched walk reports steps_omitted %r" % payload.get("steps_omitted")
+        )
+    elisions = payload.get("elisions") or {}
+    if elisions:
+        problems.append(
+            "a walk that withheld nothing claims an elision: %s" % json.dumps(elisions)
+        )
+    return problems
+
+
+def grade_advertised_budget(schema):
+    """Grade one tool's advertised budget against what a client accepts."""
+    problems = []
+    ceiling = schema.get("maximum")
+    default = schema.get("default")
+    floor = schema.get("minimum")
+    if not isinstance(ceiling, int):
+        return ["the schema advertises no maximum"]
+    if ceiling >= REFUSED_BY_A_REAL_CLIENT:
+        problems.append(
+            "the advertised ceiling %d is at or above the %d a real client refused"
+            % (ceiling, REFUSED_BY_A_REAL_CLIENT)
+        )
+    if not isinstance(default, int) or not isinstance(floor, int):
+        problems.append("the schema advertises no default or no minimum")
+        return problems
+    if not floor < default <= ceiling:
+        problems.append(
+            "the advertised default %d does not sit inside %d..%d"
+            % (default, floor, ceiling)
+        )
+    return problems
+
+
+class McpError(Exception):
+    """One MCP call that could not be read. Unreadable is not absent."""
+
+
+class Suite(object):
+    """One fixture repository, answered over kin's stdio MCP server.
+
+    The MCP path is the surface FIR-2600 is about: the stranger's client is what
+    read `"affected_tests": []`, and the raw daemon route carries neither the
+    `_kin` envelope nor the same wrapper, so probing it would answer a different
+    question from the one asked.
+    """
+
+    def __init__(self, kin, workdir, verbose, daemon=None):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.run_id = "r%d" % os.getpid()
+        self.kin_home = os.path.join(workdir, "kin-home-" + self.run_id)
+        if not os.path.isdir(self.kin_home):
+            os.makedirs(self.kin_home)
+        self.env = dict(os.environ)
+        self.env["KIN_HOME"] = self.kin_home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env.pop("KIN_MCP_REPO", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = os.path.abspath(daemon)
+        self.repo = None
+
+    def run(self, args, cwd=None, timeout=900):
+        proc = subprocess.run(
+            args,
+            cwd=cwd or self.repo,
+            env=self.env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+        if self.verbose:
+            print("$ %s -> %d" % (" ".join(args), proc.returncode))
+        return proc
+
+    def fixture(self):
+        """A repository with one deep call chain, tests that cover its base, and
+        one entity nothing calls.
+
+        The chain is deep enough that a small budget has to cut it. The tests
+        give `impact_analysis` a populated `affected_tests`, which is the bucket
+        that shipped empty. The isolated entity is the subject of the other
+        direction, where an empty answer is the true one.
+        """
+        repo = os.path.join(self.workdir, "fixture-" + self.run_id)
+        if os.path.isdir(repo):
+            shutil.rmtree(repo)
+        os.makedirs(os.path.join(repo, "src"))
+        os.makedirs(os.path.join(repo, "tests"))
+
+        lines = ["def hop_0(value):", '    """The base of the chain."""', "    return value"]
+        for index in range(1, 60):
+            lines += [
+                "",
+                "",
+                "def hop_%d(value):" % index,
+                '    """A hop carrying enough text to cost the budget real characters."""',
+                "    return hop_%d(value) + %d" % (index - 1, index),
+            ]
+        lines += [
+            "",
+            "",
+            "def entry(value):",
+            '    """The focal the deep walk starts from."""',
+            "    return hop_59(value)",
+            "",
+            "",
+            "def nothing_calls_this_and_it_calls_nothing():",
+            '    """An island, so an empty answer here is the true one."""',
+            "    return 0",
+            "",
+        ]
+        with open(os.path.join(repo, "src", "chain.py"), "w") as handle:
+            handle.write("\n".join(lines))
+
+        tests = ["from src.chain import hop_0", ""]
+        for index in range(24):
+            tests += [
+                "",
+                "def test_hop_0_case_%d():" % index,
+                '    """One covering test, so affected_tests has something to lose."""',
+                "    assert hop_0(%d) == %d" % (index, index),
+            ]
+        tests.append("")
+        with open(os.path.join(repo, "tests", "test_chain.py"), "w") as handle:
+            handle.write("\n".join(tests))
+
+        for args in (
+            ["git", "init", "--quiet"],
+            ["git", "-c", "core.hooksPath=/dev/null", "config", "user.email", "acceptance@firelock.invalid"],
+            ["git", "config", "user.name", "kin-response-budget-elisions"],
+            ["git", "add", "-A"],
+            ["git", "-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "fixture"],
+        ):
+            proc = self.run(args, cwd=repo, timeout=120)
+            if proc.returncode != 0:
+                raise SetupError(
+                    "%s failed: %s"
+                    % (" ".join(args), proc.stderr.decode("utf-8", "replace")[-500:])
+                )
+        self.repo = repo
+        proc = self.run([self.kin, "init"], cwd=repo, timeout=900)
+        if proc.returncode != 0:
+            raise SetupError("kin init failed: %s" % proc.stderr.decode("utf-8", "replace")[-1000:])
+        return repo
+
+    def mcp(self, method, params, timeout=600):
+        """One MCP request against a fresh stdio server, returning its payload.
+
+        `tools/list` returns the raw result. A `tools/call` pierces
+        `content[0].text` first, because the outer frame is an envelope and
+        reading payload keys off its top level comes back empty for every key.
+        """
+        env = dict(self.env)
+        env["KIN_MCP_REPO"] = self.repo
+        proc = subprocess.Popen(
+            [self.kin, "mcp", "start", "--repo", self.repo],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.repo,
+            env=env,
+            text=True,
+        )
+        if method == "tools/list":
+            call = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+        else:
+            call = {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": method, "arguments": params},
+            }
+        frames = [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "kin-response-budget-elisions", "version": "1"},
+                },
+            },
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            call,
+        ]
+        try:
+            out, err = proc.communicate(
+                "".join(json.dumps(frame) + "\n" for frame in frames), timeout=timeout
+            )
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            raise McpError("%s timed out after %ss" % (method, timeout))
+        response = None
+        for line in out.splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                frame = json.loads(line)
+            except ValueError:
+                continue
+            if frame.get("id") == 2:
+                response = frame
+        if response is None:
+            raise McpError(
+                "%s returned no id=2 frame (stderr tail: %s)"
+                % (method, err[-300:].replace("\n", " "))
+            )
+        if "error" in response:
+            raise McpError("%s error: %s" % (method, json.dumps(response["error"])[:300]))
+        result = response.get("result") or {}
+        if method == "tools/list":
+            return result
+        content = result.get("content") or []
+        if not content or "text" not in content[0]:
+            raise McpError("%s returned no text content" % method)
+        try:
+            return json.loads(content[0]["text"])
+        except ValueError as exc:
+            raise McpError("%s payload is not JSON (%s)" % (method, exc))
+
+
+def grade_buckets(payload, buckets):
+    """Grade every named list on one payload against the never-empty rule."""
+    problems = []
+    graded = 0
+    for key in buckets:
+        rows = payload.get(key)
+        if not isinstance(rows, list):
+            continue
+        withheld = payload.get(key + "_withheld")
+        elision = (payload.get("elisions") or {}).get(key)
+        if not withheld and not elision:
+            continue
+        graded += 1
+        if not rows:
+            problems.append(
+                "`%s` was cut to an empty array, which reads as 'the walk found none'" % key
+            )
+        if not elision:
+            problems.append("`%s` was cut and published no elision" % key)
+            continue
+        if elision.get("kept") != len(rows):
+            problems.append(
+                "elisions.%s.kept is %r and the array carries %d"
+                % (key, elision.get("kept"), len(rows))
+            )
+        if withheld is not None and elision.get("elided") != withheld:
+            problems.append(
+                "elisions.%s.elided is %r and %s_withheld is %r"
+                % (key, elision.get("elided"), key, withheld)
+            )
+        if elision.get("total") != len(rows) + (elision.get("elided") or 0):
+            problems.append(
+                "elisions.%s.total is %r and kept plus elided is %d"
+                % (key, elision.get("total"), len(rows) + (elision.get("elided") or 0))
+            )
+        if not elision.get("reason"):
+            problems.append("elisions.%s names no reason" % key)
+    return problems, graded
+
+
+def check_0(suite):
+    res = Result("0", "FIR-2600", "a budget-cut chain is elided, never emptied")
+    try:
+        payload = suite.mcp(
+            "trace_data_flow",
+            {
+                "focal": "entry",
+                "depth": 8,
+                "direction": "calls",
+                "limit_per_step": 25,
+                "include_body": False,
+                "max_chars": 2000,
+            },
+        )
+    except McpError as exc:
+        res.unknown("cut walk unreadable: %s" % exc)
+        return res
+    problems = grade_cut_walk(payload)
+    if problems:
+        for problem in problems:
+            res.bad(problem)
+        return res
+    res.ok(
+        "the cut walk kept %d of %d steps and published elisions.chain %s"
+        % (
+            len(payload["chain"]),
+            len(payload["chain"]) + payload["steps_omitted"],
+            json.dumps(payload["elisions"]["chain"], sort_keys=True),
+        )
+    )
+    return res
+
+
+def check_1(suite):
+    res = Result("1", "FIR-2600", "an empty chain still means the walk reached nothing")
+    try:
+        payload = suite.mcp(
+            "trace_data_flow",
+            {
+                "focal": "nothing_calls_this_and_it_calls_nothing",
+                "depth": 8,
+                "direction": "calls",
+                "include_body": False,
+            },
+        )
+    except McpError as exc:
+        res.unknown("empty walk unreadable: %s" % exc)
+        return res
+    problems = grade_empty_walk(payload)
+    if problems:
+        for problem in problems:
+            res.bad(problem)
+        return res
+    res.ok("the untouched walk reported an empty chain and claimed no elision")
+    return res
+
+
+def check_2(suite):
+    res = Result("2", "FIR-2600", "the advertised budget is one a client accepts")
+    try:
+        listing = suite.mcp("tools/list", {})
+    except McpError as exc:
+        res.unknown("tools/list unreadable: %s" % exc)
+        return res
+    tools = listing.get("tools")
+    if not isinstance(tools, list) or not tools:
+        res.unknown("the tool listing carried no tools")
+        return res
+    graded = 0
+    for tool in tools:
+        schema = tool.get("inputSchema") or tool.get("input_schema") or {}
+        properties = schema.get("properties") or {}
+        for key in ("max_chars", "max_response_chars"):
+            if key not in properties:
+                continue
+            graded += 1
+            for problem in grade_advertised_budget(properties[key]):
+                res.bad("%s.%s: %s" % (tool.get("name"), key, problem))
+    if graded == 0:
+        res.unknown("no tool advertised a budget parameter, so nothing was graded")
+        return res
+    if not res.failed:
+        res.ok("%d advertised budgets sit under what a real client accepts" % graded)
+    return res
+
+
+def check_3(suite):
+    res = Result("3", "FIR-2600", "no impact bucket the budget cuts ships empty")
+    buckets = [
+        "affected_callers",
+        "affected_dependents",
+        "affected_contract_consumers",
+        "affected_tests",
+    ]
+    try:
+        payload = suite.mcp(
+            "impact_analysis",
+            {"files": ["src/chain.py", "tests/test_chain.py"], "max_chars": 2500},
+        )
+    except McpError as exc:
+        res.unknown("impact_analysis unreadable: %s" % exc)
+        return res
+    problems, graded = grade_buckets(payload, buckets)
+    if problems:
+        for problem in problems:
+            res.bad(problem)
+        return res
+    if graded == 0:
+        res.unknown(
+            "the budget cut no bucket on this fixture, so the rule was not exercised"
+        )
+        return res
+    res.ok(
+        "%d cut buckets kept an entry and published an elision: %s"
+        % (graded, json.dumps(payload.get("elisions") or {}, sort_keys=True))
+    )
+    return res
+
+
+CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3)]
+
+
+def self_test():
+    """Exercise every grader against its inverse. No binary, no fixture."""
+    problems = []
+
+    def expect(label, got, want):
+        if got != want:
+            problems.append("%s: got %r, wanted %r" % (label, got, want))
+
+    whole = {
+        "chain": [{"step": 1}, {"step": 2}],
+        "steps_omitted": 3,
+        "elisions": {"chain": {"kept": 2, "elided": 3, "total": 5, "reason": "response_budget"}},
+    }
+    expect("a correct cut walk passes", grade_cut_walk(whole), [])
+
+    emptied = dict(whole)
+    emptied["chain"] = []
+    emptied["elisions"] = {"chain": {"kept": 0, "elided": 3, "total": 3, "reason": "response_budget"}}
+    expect("an emptied chain fails", len(grade_cut_walk(emptied)) >= 1, True)
+
+    silent = {"chain": [{"step": 1}], "steps_omitted": 3}
+    expect("a cut with no elision fails", len(grade_cut_walk(silent)) >= 1, True)
+
+    mismatched = {
+        "chain": [{"step": 1}],
+        "steps_omitted": 3,
+        "elisions": {"chain": {"kept": 9, "elided": 9, "total": 9, "reason": "response_budget"}},
+    }
+    expect("an elision that disagrees fails", len(grade_cut_walk(mismatched)) >= 1, True)
+
+    reasonless = {
+        "chain": [{"step": 1}],
+        "steps_omitted": 3,
+        "elisions": {"chain": {"kept": 1, "elided": 3, "total": 4}},
+    }
+    expect("an elision with no reason fails", len(grade_cut_walk(reasonless)) >= 1, True)
+
+    uncut = {"chain": [{"step": 1}], "steps_omitted": 0}
+    expect("an uncut walk proves nothing", len(grade_cut_walk(uncut)) >= 1, True)
+
+    expect("a true empty walk passes", grade_empty_walk({"chain": []}), [])
+    expect(
+        "an empty walk claiming an elision fails",
+        len(grade_empty_walk({"chain": [], "elisions": {"chain": {"elided": 4}}})) >= 1,
+        True,
+    )
+    expect(
+        "an empty walk reporting omissions fails",
+        len(grade_empty_walk({"chain": [], "steps_omitted": 4})) >= 1,
+        True,
+    )
+    expect(
+        "a non-empty walk proves nothing here",
+        len(grade_empty_walk({"chain": [{"step": 1}]})) >= 1,
+        True,
+    )
+
+    expect(
+        "an honest budget passes",
+        grade_advertised_budget({"default": 45000, "minimum": 2000, "maximum": 60000}),
+        [],
+    )
+    expect(
+        "the ceiling that got a result refused fails",
+        len(grade_advertised_budget({"default": 30000, "minimum": 2000, "maximum": 400000})) >= 1,
+        True,
+    )
+    expect(
+        "a default outside its own clamp fails",
+        len(grade_advertised_budget({"default": 90000, "minimum": 2000, "maximum": 60000})) >= 1,
+        True,
+    )
+    expect(
+        "a schema with no maximum fails",
+        len(grade_advertised_budget({"default": 45000, "minimum": 2000})) >= 1,
+        True,
+    )
+
+    honest = {
+        "affected_tests": [{"name": "test_a"}],
+        "affected_tests_withheld": 15,
+        "elisions": {
+            "affected_tests": {"kept": 1, "elided": 15, "total": 16, "reason": "response_budget"}
+        },
+    }
+    expect("an honest cut bucket passes", grade_buckets(honest, ["affected_tests"]), ([], 1))
+    reported = dict(honest)
+    reported["affected_tests"] = []
+    reported["elisions"] = {
+        "affected_tests": {"kept": 0, "elided": 15, "total": 15, "reason": "response_budget"}
+    }
+    expect(
+        "the shipped defect fails",
+        len(grade_buckets(reported, ["affected_tests"])[0]) >= 1,
+        True,
+    )
+    quiet = {"affected_tests": [], "affected_tests_withheld": 15}
+    expect(
+        "a cut bucket with no elision fails",
+        len(grade_buckets(quiet, ["affected_tests"])[0]) >= 1,
+        True,
+    )
+    untouched = {"affected_tests": []}
+    expect(
+        "an untouched bucket is not graded",
+        grade_buckets(untouched, ["affected_tests"]),
+        ([], 0),
+    )
+
+    for line in problems:
+        print("SELF-TEST FAIL %s" % line)
+    print(
+        "response budget elisions: self-test %s"
+        % ("FAILED (%d)" % len(problems) if problems else "passed")
+    )
+    return 1 if problems else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        add_help=True,
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"), help="path to the kin binary")
+    parser.add_argument(
+        "--daemon",
+        default=os.environ.get("KIN_DAEMON_BIN"),
+        help="path to the kin-daemon binary the server should spawn",
+    )
+    parser.add_argument("--workdir", default=None, help="where to build the fixture")
+    parser.add_argument("--json", default=None, help="write the report here")
+    parser.add_argument("--label", default="", help="label recorded in the report")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    opts = parser.parse_args(argv)
+
+    if opts.self_test:
+        return self_test()
+
+    if not opts.kin:
+        sys.stderr.write("no kin binary: pass --kin PATH or set KIN_BIN\n")
+        return 3
+    kin = os.path.abspath(opts.kin)
+    if not os.path.isfile(kin) or not os.access(kin, os.X_OK):
+        sys.stderr.write("kin binary %s is missing or not executable\n" % kin)
+        return 3
+
+    workdir = opts.workdir or tempfile.mkdtemp(prefix="kin-budget-elisions-")
+    if not os.path.isdir(workdir):
+        os.makedirs(workdir)
+    suite = Suite(kin, os.path.abspath(workdir), opts.verbose, opts.daemon)
+    try:
+        suite.fixture()
+    except (SetupError, subprocess.TimeoutExpired) as exc:
+        sys.stderr.write("setup failed: %s\n" % exc)
+        return 3
+
+    results = []
+    for ident, check in CHECKS:
+        try:
+            res = check(suite)
+        except subprocess.TimeoutExpired as exc:
+            res = Result(ident, "FIR-2600", "check %s" % ident)
+            res.unknown("timed out: %s" % exc)
+        marker = res.status
+        print("CHECK %s %s %s %s" % (res.id, res.ticket, marker, res.detail))
+        results.append(res)
+
+    failed = [r for r in results if r.status == FAIL]
+    unread = [r for r in results if r.status == UNREADABLE]
+    print(
+        "response budget elisions: %d PASS, %d FAIL, %d UNREADABLE"
+        % (len(results) - len(failed) - len(unread), len(failed), len(unread))
+    )
+    if opts.json:
+        directory = os.path.dirname(os.path.abspath(opts.json))
+        if directory and not os.path.isdir(directory):
+            os.makedirs(directory)
+        with open(opts.json, "w") as handle:
+            json.dump(
+                {"label": opts.label, "results": [r.row() for r in results]},
+                handle,
+                indent=2,
+                sort_keys=True,
+            )
+            handle.write("\n")
+    if failed:
+        return 1
+    if unread:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -278,12 +278,25 @@ class Suite(object):
         with open(os.path.join(repo, "tests", "test_chain.py"), "w") as handle:
             handle.write("\n".join(tests))
 
+        # Every git call carries the fixture's own identity and no hooks. A
+        # developer host's global hooks refuse an unsigned message, and a fixture
+        # commit that a host policy blocks is a setup error wearing the costume
+        # of a product failure.
+        git = [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "user.email=acceptance@firelock.invalid",
+            "-c",
+            "user.name=kin-response-budget-elisions",
+        ]
         for args in (
-            ["git", "init", "--quiet"],
-            ["git", "-c", "core.hooksPath=/dev/null", "config", "user.email", "acceptance@firelock.invalid"],
-            ["git", "config", "user.name", "kin-response-budget-elisions"],
-            ["git", "add", "-A"],
-            ["git", "-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "fixture"],
+            git + ["init", "--quiet"],
+            git + ["add", "-A"],
+            git + ["commit", "--quiet", "-s", "-m", "fixture"],
         ):
             proc = self.run(args, cwd=repo, timeout=120)
             if proc.returncode != 0:
@@ -503,35 +516,46 @@ def check_2(suite):
 
 
 def check_3(suite):
-    res = Result("3", "FIR-2600", "no impact bucket the budget cuts ships empty")
-    buckets = [
-        "affected_callers",
-        "affected_dependents",
-        "affected_contract_consumers",
-        "affected_tests",
-    ]
+    res = Result("3", "FIR-2600", "no ranked list the budget cuts ships empty")
+    lists = ["entities", "files"]
+    query = {"query": "hop", "limit": 60}
     try:
-        payload = suite.mcp(
-            "impact_analysis",
-            {"files": ["src/chain.py", "tests/test_chain.py"], "max_chars": 2500},
-        )
+        whole = suite.mcp("semantic_locate", dict(query, max_chars=60000))
+        cut = suite.mcp("semantic_locate", dict(query, max_chars=2000))
     except McpError as exc:
-        res.unknown("impact_analysis unreadable: %s" % exc)
+        res.unknown("semantic_locate unreadable: %s" % exc)
         return res
-    problems, graded = grade_buckets(payload, buckets)
-    if problems:
-        for problem in problems:
-            res.bad(problem)
+
+    # The same query at two budgets. Anything the walk found at the ceiling it
+    # still found at the floor, so a list that is full in one and empty in the
+    # other was emptied by the budget and by nothing else. This needs no counter
+    # to be true, which is why it is the check.
+    populated = [key for key in lists if whole.get(key)]
+    if not populated:
+        res.unknown("the ceiling call filled no list, so the rule was not exercised")
         return res
+    for key in populated:
+        rows = cut.get(key)
+        if not isinstance(rows, list) or not rows:
+            res.bad(
+                "`%s` held %d entries at the ceiling and %r at the floor, so the budget "
+                "emptied it" % (key, len(whole[key]), rows)
+            )
+    problems, graded = grade_buckets(cut, lists)
+    for problem in problems:
+        res.bad(problem)
     if graded == 0:
-        res.unknown(
-            "the budget cut no bucket on this fixture, so the rule was not exercised"
-        )
+        res.unknown("the floor call cut nothing, so the elision rule was not exercised")
         return res
-    res.ok(
-        "%d cut buckets kept an entry and published an elision: %s"
-        % (graded, json.dumps(payload.get("elisions") or {}, sort_keys=True))
-    )
+    if not res.failed:
+        res.ok(
+            "%d of %d lists were cut and every one kept an entry: %s"
+            % (
+                graded,
+                len(populated),
+                json.dumps(cut.get("elisions") or {}, sort_keys=True),
+            )
+        )
     return res
 
 


### PR DESCRIPTION
An empty array is the shape a reader takes for "the walk found none", and until now the response
budget could produce one by cutting. The v0.5.47 brownfield stranger read `"affected_tests": []`
beside a `covering_tests: 16` twice in one session and drew the wrong conclusion both times. The
second time a sibling `affected_tests_withheld: 15` was in the same response and saved nobody, which
is the whole lesson: the reader looks at the array, and no counter elsewhere outranks it.

## Three places could empty a list, and all three had the same shape

`crates/kin-mcp/src/budget.rs:595`. The ladder kept a floor of one entry for the primary collection
only, computed as `usize::from(Some(*key) == primary)`. Every other collection had a floor of zero,
and the loop runs `.rev()`, so `affected_tests`, listed last in the `impact_analysis` shape, was the
first bucket emptied and the last to survive. The floor is now one entry for every collection that
held one.

`crates/kin-mcp/src/handlers/entities.rs:3427`. `bound_trace_payload` bisected the chain from
`kept = 0`, so a walk that reached 200 steps could answer `"chain": []`.

`crates/kin-cli/src/commands/trace_data_flow.rs:1491`. `enforce_response_budget` carried the same
`kept = 0` bisect, and it is the arm the daemon actually runs for an MCP `trace_data_flow` call, so
this is the one the stranger hit. Both now floor at one step whenever the walk found any.

## The elision shape

Every cut list publishes what it lost, in one shape, under a top-level `elisions` map keyed by the
field it cut:

```json
"elisions": {
  "affected_tests": {"elided": 15, "kept": 1, "total": 16, "reason": "response_budget"}
}
```

The type is `kin_mcp::budget::Elision` (`crates/kin-mcp/src/budget.rs:232`), written by
`record_elision` (`crates/kin-mcp/src/budget.rs:265`), and both the generic ladder and the two trace
arms call the same recorder so they cannot drift apart. The CLI response carries it as a typed field
(`crates/kin-cli/src/commands/trace_data_flow.rs:521`), omitted entirely when nothing was cut. The
older `<field>_withheld` scalars stay beside it, because a client already reading them must not lose
its counter to this change, and `steps_omitted` keeps meaning what it meant. One map is what a
caller reads to answer "did this response lose anything", and the answer has the same shape for
`chain` as for `affected_tests`.

An empty array now means the walk found none, and the tests prove both directions.

## The budget numbers, and where each came from

`RESPONSE_MAX_MAX_CHARS` moves from 400000 to 60000 (`crates/kin-mcp/src/budget.rs:74`).

Claude Code caps one MCP tool result at 25000 tokens by default. That is read out of the installed
binary at `~/.local/share/claude/versions/2.1.239`, where the resolver reads `MAX_MCP_OUTPUT_TOKENS`
and falls back to a constant that `strings` resolves to `25000`. The stranger run measured the band
around that cap directly. Its report carries the refusal verbatim, `Error: result (117,313
characters across 3,702 lines) exceeds maximum allowed tokens`, and records `impact_analysis`
answering whole at `max_chars: 55000` and again at `50000` in the same session. So the refusal
threshold sits above 55000 and at or below 117313. 60000 is just above the largest size proved
accepted and roughly half the smallest proved refused, and the token arithmetic agrees: 60000
characters stays under 25000 tokens for any payload averaging more than 2.4 characters per token,
while the refusal at 117313 puts this JSON's own average below 4.69.

`RESPONSE_DEFAULT_MAX_CHARS` moves from 30000 to 45000 (`crates/kin-mcp/src/budget.rs:52`), three
quarters of the ceiling, so a caller still has room to raise it on the same call. The floor evidence
is the same run: the 30000 default dropped 170 of 200 steps on a 783-entity store, and rows were
still withheld at 50000. Raising the default does not make every walk fit, and the code says so
rather than implying otherwise. What it buys is half again as much chain by default, with every
remaining cut disclosed instead of silent.

Ten schemas carried those numbers as hand-written literals, which is why one of them could advertise
400000 while a real client refused 117313. They are now generated from the constants by
`max_chars_property` and its two trace siblings (`crates/kin-mcp/src/tools.rs:14`), and a test walks
every declared tool and fails if any schema stops matching. The stale `(default 80000)` in the CLI
help was deleted rather than corrected, because an extra home for a number is what made it stale.

The disclosure now names the ceiling a caller may raise to, in band on the response that got cut
(`crates/kin-mcp/src/budget.rs:780`). That matters most on the raw daemon route, which carries no
`_kin` envelope, so the degradation line is the only place the number reaches a caller there.

## The acceptance check

`scripts/acceptance/response_budget_elisions.py` drives the real binaries over kin's stdio MCP
server, which is the surface this ticket is about. It builds its own fixture repository, needs no
network, and runs four checks: a cut trace keeps a step and publishes `elisions.chain`; a walk with
no callees still answers with an empty chain and claims no elision; every budget in `tools/list`
sits under what a real client accepts; and one query run at the ceiling and again at the floor has
nothing full in the first and empty in the second, which needs no counter to be true. The acceptance
workflow runs its falsifier beside the other two self-tests, runs the suite against the pull
request's own release build, and the gate reads its report alongside magic and brownfield.

Against the fixed build:

```
CHECK 0 FIR-2600 PASS the cut walk kept 1 of 8 steps and published elisions.chain {"elided": 7, "kept": 1, "reason": "response_budget", "total": 8}
CHECK 1 FIR-2600 PASS the untouched walk reported an empty chain and claimed no elision
CHECK 2 FIR-2600 PASS 8 advertised budgets sit under what a real client accepts
CHECK 3 FIR-2600 PASS 1 of 2 lists were cut and every one kept an entry: {"entities": {"elided": 24, "kept": 1, "reason": "response_budget", "total": 25}}
response budget elisions: 4 PASS, 0 FAIL, 0 UNREADABLE   (exit 0)
```

Against a build with the three floors reverted:

```
CHECK 0 FIR-2600 FAIL the budget emptied a chain it cut: an empty array reads as 'the walk found none' and 8 steps were withheld
CHECK 3 FIR-2600 FAIL `files` held 1 entries at the ceiling and [] at the floor, so the budget emptied it
response budget elisions: 2 PASS, 2 FAIL, 0 UNREADABLE   (exit 1)
```

## Falsifications

Each new test was falsified by breaking the behavior it guards, and every break was restored
byte-identical afterward, confirmed with `git diff --quiet HEAD` returning 0. Exit statuses were
read raw, never through a pipe.

Reverting the never-empty floor on all three arms failed `a_budget_never_empties_a_list_it_cut`
(exit 101, naming `affected_dependents` emptied, with `"affected_tests":[]` and
`"affected_tests_withheld":40` in the printed payload), both
`a_budget_never_returns_an_empty_chain_for_a_walk_that_found_steps` tests (exit 101 each, "the budget
emptied a chain of 200 steps"), and the acceptance suite (exit 1, quoted above). Putting the ceiling
back to 400000 failed `the_advertised_ceiling_is_one_a_client_accepts` with "the ceiling serves a
size a real client refused: 400000". Claiming an elision on a list nothing was taken from failed all
three "claims no elision" tests with "nothing was withheld, so nothing may be claimed". Dropping the
ceiling from the remediation line failed `a_cut_discloses_the_ceiling_a_caller_may_raise_to`.
Hand-writing 30000 and 400000 back into one schema failed
`every_advertised_budget_matches_the_enforced_one`. Removing the recorder's zero guard failed
`recording_a_loss_of_nothing_writes_nothing`.

One falsification is worth reading on its own. The entities-side "walk reached nothing" test did not
fail when its rule was broken: exit 0. Its empty-chain fixture sat under the budget, so
`bound_trace_payload` returned at its first line and the test asserted something the function had
never done. The fixture is now padded past the budget with bulk the ladder cannot trim, and the
assertion that it reaches the bounder is in the test. That test would have shipped green and
guarded nothing.

## Gates run locally

`cargo fmt --all -- --check`, clippy with the ci.yml allow list under `RUSTFLAGS=-D warnings`,
`cargo test -p kin-mcp -p kin-ranking --no-fail-fast` (623 and 119 passed, 0 failed),
`cargo test -p kin-cli --no-fail-fast` (60 test binaries, all ok, 0 failed), and the guard scripts
ci.yml names: `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `check_runtime_boundaries.sh`,
`check_private_repo_coupling.sh`, `test-private-repo-coupling.py` and `verify-hydration-semantics.py`.
All exit 0. `bin/kin-parity` does not exist in this checkout, so it was not run. Hosted CI is the
gate of record for the full workspace, and `Product Acceptance` runs the suites against this pull
request's own build.

One local note, because it cost time and looks like a toolchain fault: typed inline in zsh,
`cargo clippy ... -- $allows` passes the 45-flag allow list as a single argument and clippy dies with
`unknown lint tool: ' clippy'`. CI is unaffected because its step runs under bash.

## Not in this change

`impact_analysis` can ship over its own budget, and this does not fix it. Measured through the MCP
path on the fixture, `_kin.response` reported `{"bounded": false, "chars_before_budget": 50354,
"max_chars": 2000}` while all four `affected_*` buckets were genuinely empty: the bulk sat in keys
the shape table does not list, so the ladder found nothing to cut and returned a 50354-character
answer against a 2000-character ceiling. That is the same class as FIR-2408 and wants its own
ticket, because widening the shape table decides which parts of an impact report are expendable and
that is a product call.

Item 3 of the ticket, a data-flow trace that can start from a parameter rather than an entity, is
untouched by design and needs its own ticket now that this one closes.

Closes FIR-2600
