### PR TITLE
Point the degraded-health warning at the command that explains it

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -4683,7 +4683,7 @@ pub(crate) fn validate_health_repo(health: &HealthResponse, working_dir: &Path) 
         warn!(
             repo_root = health.repo_root.as_deref().unwrap_or("<unknown>"),
             "daemon is up and serving but reports health=attention (degraded); \
-             continuing to use it. Run `kin status` for details."
+             continuing to use it. Run `kin doctor` for details."
         );
     }
     Ok(())


### PR DESCRIPTION
While a daemon reports health=attention, every kin invocation warns and sends the reader to kin status for details. kin status carries no health row at all; kin doctor is the surface that explains the degraded state, and the npm0547 stranger run on shipped 0.5.47 bytes measured both: 14 lines of kin status naming nothing, kin doctor explaining the vector salvage and background re-embed precisely. A pointer to a command that says nothing trains users to ignore a warning that prints on every command while the state lasts.

One string change in validate_health_repo; no test pinned the old text.

Closes FIR-2608
