### PR TITLE
Collect the relations bound to a departing artifact so a deleted file can be committed

### DIFF
--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -863,9 +863,7 @@ fn exact_tree_admission(
                 tree_deltas: deltas.clone(),
                 ..TransactionDelta::default()
             })
-            .map_err(|error| {
-                name_stranded_endpoint_refusal(DaemonError::Graph(error), &deltas)
-            })?;
+            .map_err(|error| name_stranded_endpoint_refusal(DaemonError::Graph(error), &deltas))?;
     }
 
     if observation.is_none() {

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2022,72 +2022,6 @@ fn plan_catch_up_events(state: &DaemonState, since: SystemTime) -> Result<Vec<Fi
         .collect())
 }
 
-/// Host events for every admitted source file the graph holds no entity for.
-///
-/// Entity derivation is not durable on its own. A tree admission publishes an
-/// artifact into repository authority the moment the watcher sees the write,
-/// while the entities the same tick derives live in this daemon's query graph
-/// until a commit publishes them. A daemon that ends first, and an idle timeout
-/// ends one after sixty seconds, takes them with it. What survives is a file
-/// admitted at exactly the bytes on disk, so no later watcher event fires for
-/// it and the startup catch-up window, which is keyed on host modification
-/// time, cannot see it either: it was modified before the last admission, and
-/// that admission is precisely what recorded the artifact. The path is then
-/// permanently in the graph and permanently unqueryable, visible only as
-/// `kin graph status` counting it among the files that "produced no entity".
-///
-/// This asks the graph rather than the host: an admitted path whose language
-/// has a full adapter, which no entity names, and which carries no parsed
-/// layout either, has never been parsed by this daemon. Every path goes back
-/// through the ordinary tick, so the same bounded observation, policy filter and
-/// compare-and-swap apply as for an edit a watcher saw.
-///
-/// The layout is what keeps this from repeating. A file that genuinely declares
-/// nothing, an empty `__init__.py` among them, produces no entity however often
-/// it is parsed, and offering it on every pass would re-parse it on every commit
-/// forever while warning about a fault that is not one. Parsing registers a
-/// layout whether or not it found a declaration, so one pass answers the
-/// question for the rest of this daemon's life.
-fn plan_unenriched_source_events(state: &DaemonState) -> Result<Vec<FileEvent>> {
-    use kin_model::EntityStore;
-
-    let working_dir = state.layout.working_dir();
-    let enriched: std::collections::HashSet<FilePathId> = state
-        .graph
-        .list_all_entities()?
-        .into_iter()
-        .filter_map(|entity| entity.file_origin)
-        .collect();
-    let mut events = Vec::new();
-    for artifact in state.graph.resolved_tree().artifacts_by_path() {
-        if kin_core::source_projection_disposition(&artifact.path, artifact.entry)?
-            != kin_core::SourceProjectionDisposition::Materialized
-        {
-            continue;
-        }
-        let Some(file_id) = semantic_file_id(&artifact.path) else {
-            continue;
-        };
-        if enriched.contains(&file_id) {
-            continue;
-        }
-        if state.graph.get_file_layout(&file_id)?.is_some() {
-            continue;
-        }
-        let Ok(host_path) = kin_index::host_path_from_repo_path(working_dir, &artifact.path) else {
-            continue;
-        };
-        // Path-only classification, because the bytes are not read here. A file
-        // whose extension carries no entity adapter is enriched by a shallow,
-        // structured or opaque facet instead and is not owed a re-parse.
-        if FileClassifier::classify(&host_path) != FileClassification::EntitySource {
-            continue;
-        }
-        events.push(FileEvent::Changed(host_path));
-    }
-    Ok(events)
-}
-
 pub async fn run_loop(
     state: Arc<DaemonState>,
     config: LoopConfig,
@@ -2146,12 +2080,6 @@ pub async fn run_loop_armed(
     // publication, and a client finding the port is never waiting on a
     // traversal.
     let mut catch_up_owed = startup_catch_up_window(&state);
-    // Owed once per daemon life, and independent of the catch-up window: the
-    // paths it recovers are exactly the ones whose host modification time puts
-    // them outside that window. A store with no last-admission marker gets no
-    // catch-up and still gets this, because this bound comes from graph truth
-    // rather than from a clock.
-    let mut enrichment_repair_owed = true;
     if let Some(armed) = armed.as_mut() {
         armed.arm();
     }
@@ -2299,35 +2227,6 @@ pub async fn run_loop_armed(
                         "could not plan the startup catch-up, so host content written while \
                          nothing was watching stays unadmitted until `kin admit` or a commit \
                          takes it"
-                    );
-                }
-            }
-        }
-
-        // The enrichment repair, owed once for the same reason and taken the
-        // same way. Loud when it finds anything: a file admitted with no
-        // entities answered every query as an absence, and a store that has
-        // been in that state deserves the count said out loud rather than
-        // repaired in silence.
-        if enrichment_repair_owed {
-            enrichment_repair_owed = false;
-            match plan_unenriched_source_events(&state) {
-                Ok(events) if events.is_empty() => {
-                    debug!("every admitted source path already carries its entities");
-                }
-                Ok(events) => {
-                    warn!(
-                        count = events.len(),
-                        "admitted source paths carry no entities, so nothing can query them; \
-                         re-deriving them now"
-                    );
-                    enqueue_file_events(&mut pending_events, events);
-                }
-                Err(error) => {
-                    warn!(
-                        error = %error,
-                        "could not plan the enrichment repair, so any admitted path missing its \
-                         entities stays unqueryable until it is edited or committed"
                     );
                 }
             }
@@ -7204,155 +7103,6 @@ mod tests {
             "and gains no advice that would not help: {passed_through}"
         );
     }
-
-    /// FIR-2606. An admitted source path the graph holds no entities for is
-    /// offered for re-derivation.
-    ///
-    /// This is the state a daemon leaves behind when it ends between a write
-    /// and the commit that would have published the entities: the artifact is
-    /// admitted at exactly the bytes on disk, so no tree delta and no watcher
-    /// event ever names it again, and every query answers about it as an
-    /// absence. Recovering it is what stops that from being permanent.
-    #[test]
-    fn an_admitted_source_path_with_no_entities_is_offered_for_re_derivation() {
-        let repo = tempfile::tempdir().unwrap();
-        let state = open_test_state(&repo);
-        let source = repo.path().join("stranded.rs");
-        std::fs::write(&source, b"pub fn stranded() -> u32 { 1 }\n").unwrap();
-        admit_file_event(&state, &FileEvent::Changed(source.clone())).unwrap();
-
-        let owed = plan_unenriched_source_events(&state).unwrap();
-
-        // Compared by repository-relative name: the host root reaches this
-        // test through /var and comes back through /private/var, and the
-        // subject here is which path is owed, not how the host spells it.
-        let named = owed
-            .iter()
-            .map(|event| {
-                let (FileEvent::Changed(path) | FileEvent::Removed(path)) = event;
-                path.file_name().unwrap().to_string_lossy().to_string()
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(
-            named,
-            vec![source.file_name().unwrap().to_string_lossy().to_string()],
-            "an admitted source path with no entities is exactly what needs re-deriving"
-        );
-    }
-
-    /// The control that keeps the repair narrow: a path whose entities the
-    /// graph already holds is never re-derived, so this cannot become a sweep
-    /// that re-parses the working copy on every daemon start.
-    #[test]
-    fn an_admitted_source_path_that_carries_entities_is_left_alone() {
-        let repo = tempfile::tempdir().unwrap();
-        let state = open_test_state(&repo);
-        let source = repo.path().join("enriched.rs");
-        std::fs::write(&source, b"pub fn enriched() -> u32 { 1 }\n").unwrap();
-        admit_file_event(&state, &FileEvent::Changed(source)).unwrap();
-        assert_eq!(
-            plan_unenriched_source_events(&state).unwrap().len(),
-            1,
-            "the positive control: before its entities land the path is owed a re-derivation"
-        );
-
-        state
-            .graph
-            .apply_transaction_delta(&TransactionDelta {
-                entity_deltas: vec![kin_model::EntityDelta::Added {
-                    new: test_entity("enriched", "enriched.rs"),
-                }],
-                relation_deltas: vec![],
-                tree_deltas: vec![],
-                ..TransactionDelta::default()
-            })
-            .unwrap();
-
-        assert!(
-            plan_unenriched_source_events(&state).unwrap().is_empty(),
-            "and once the graph holds an entity for it, nothing is owed"
-        );
-    }
-
-    /// A source file that declares nothing produces no entity however often it
-    /// is parsed. Parsing registers its layout, and that is what stops the
-    /// repair re-parsing it on every commit for the rest of the daemon's life
-    /// while warning about a fault that is not one.
-    #[test]
-    fn a_source_path_that_parsed_to_no_declarations_is_offered_once() {
-        let repo = tempfile::tempdir().unwrap();
-        let state = open_test_state(&repo);
-        let empty = repo.path().join("declares_nothing.rs");
-        std::fs::write(&empty, b"// nothing here\n").unwrap();
-        admit_file_event(&state, &FileEvent::Changed(empty)).unwrap();
-        assert_eq!(
-            plan_unenriched_source_events(&state).unwrap().len(),
-            1,
-            "the positive control: an unparsed source path is owed one pass"
-        );
-
-        state
-            .graph
-            .upsert_file_layout(&kin_model::FileLayout {
-                file_id: FilePathId::new("declares_nothing.rs"),
-                parse_completeness: kin_model::ParseCompleteness::Full,
-                imports: kin_model::ImportSection {
-                    byte_range: 0..0,
-                    items: Vec::new(),
-                },
-                regions: Vec::new(),
-            })
-            .unwrap();
-
-        assert!(
-            plan_unenriched_source_events(&state).unwrap().is_empty(),
-            "and a parsed layout with no entity in it answers the question for good"
-        );
-    }
-
-    /// A file no language adapter parses is enriched by a shallow, structured
-    /// or opaque facet instead, so it has no entities by design and must not be
-    /// proposed forever.
-    #[test]
-    fn an_admitted_path_with_no_entity_adapter_is_not_offered() {
-        let repo = tempfile::tempdir().unwrap();
-        let state = open_test_state(&repo);
-        let notes = repo.path().join("NOTES.txt");
-        std::fs::write(&notes, b"not a language this repository parses\n").unwrap();
-        admit_file_event(&state, &FileEvent::Changed(notes)).unwrap();
-
-        assert!(
-            plan_unenriched_source_events(&state).unwrap().is_empty(),
-            "a path with no entity adapter is not owed a re-parse"
-        );
-    }
-
-    fn test_entity(name: &str, file_path: &str) -> kin_model::Entity {
-        kin_model::Entity {
-            id: kin_model::EntityId::new(),
-            kind: kin_model::EntityKind::Function,
-            name: name.to_string(),
-            language: kin_model::LanguageId::Rust,
-            fingerprint: kin_model::SemanticFingerprint {
-                algorithm: kin_model::FingerprintAlgorithm::V1TreeSitter,
-                ast_hash: Hash256::from_bytes([1; 32]),
-                signature_hash: Hash256::from_bytes([2; 32]),
-                behavior_hash: Hash256::from_bytes([3; 32]),
-                equivalence_hash: Hash256::from_bytes([0; 32]),
-                stability_score: 1.0,
-            },
-            file_origin: Some(FilePathId::new(file_path)),
-            span: None,
-            signature: format!("fn {name}()"),
-            visibility: kin_model::Visibility::Public,
-            role: kin_model::EntityRole::Source,
-            doc_summary: None,
-            metadata: kin_model::EntityMetadata::default(),
-            lineage_parent: None,
-            created_in: None,
-            superseded_by: None,
-        }
-    }
 }
 
 /// Decide whether a filesystem-sync tick's bulk deletions should be WITHHELD as
@@ -7591,44 +7341,11 @@ async fn sync_filesystem_with_graph_publishing_inner(
     // Recorded before anything below can fail, so a pass that dies part way
     // through enrichment still hands the deferral back to be closed.
     *deferred_out = exact_admission.deferred_tree.take();
-    // An admitted source path the graph holds no entities for is re-derived on
-    // this seam too, and it is why the early return below cannot key on the
-    // tree transition alone. Entity derivation is not durable on its own: a
-    // daemon that ends between the write and the commit takes it with it, and
-    // what it leaves behind is an artifact admitted at exactly the bytes on
-    // disk, which produces no tree delta here and no watcher event ever again.
-    // Without this the file stays admitted and unqueryable through every later
-    // commit, which is exactly how one module dropped out of a store and stayed
-    // out (FIR-2606).
-    //
-    // A repair, so it never fails the pass carrying it. A commit that would
-    // have succeeded must not start failing because the recovery beside it
-    // could not plan; the path it would have recovered simply stays owed.
-    let unenriched = match plan_unenriched_source_events(state) {
-        Ok(events) => events,
-        Err(error) => {
-            warn!(
-                error = %error,
-                "could not plan the enrichment repair, so any admitted path missing its entities \
-                 stays unqueryable until it is edited"
-            );
-            Vec::new()
-        }
-    };
-    if exact_admission.deltas.is_empty() && unenriched.is_empty() {
+    if exact_admission.deltas.is_empty() {
         drop(graph_mutation);
         return Ok(());
     }
-    if !unenriched.is_empty() {
-        warn!(
-            count = unenriched.len(),
-            "admitted source paths carry no entities, so nothing can query them; re-deriving \
-             them into this change"
-        );
-    }
-    let mut events = exact_admission.semantic_events;
-    events.extend(unenriched);
-    let events = dedup_file_events(events);
+    let events = exact_admission.semantic_events;
 
     info!(
         count = events.len(),

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -7063,6 +7063,255 @@ mod tests {
              file's real age instead"
         );
     }
+
+    /// Build the artifact-to-artifact edge shape the cross-file linker mints
+    /// for a file-level import, which is the class of relation nothing else
+    /// collects when its file is deleted.
+    fn artifact_edge(
+        src: kin_model::ArtifactId,
+        dst: kin_model::ArtifactId,
+        kind: kin_model::RelationKind,
+    ) -> kin_model::Relation {
+        kin_model::Relation {
+            id: kin_model::RelationId::new(),
+            kind,
+            src: kin_model::GraphNodeId::Artifact(src),
+            dst: kin_model::GraphNodeId::Artifact(dst),
+            confidence: 1.0,
+            origin: kin_model::RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        }
+    }
+
+    fn artifact_at(state: &DaemonState, path: &str) -> kin_model::ArtifactId {
+        state
+            .graph
+            .artifact_id_at_path(&test_repo_path(path))
+            .unwrap_or_else(|| panic!("{path} must be admitted before the test asks about it"))
+    }
+
+    /// FIR-2607. A file whose artifact is named by a relation can be deleted.
+    ///
+    /// Both shapes the linker actually produces are covered: the outgoing
+    /// import edge to another artifact, and the parse-coverage self-loop every
+    /// indexed file carries. kin-db validates every relation the graph holds
+    /// against the staged tree on each transaction, so either one left standing
+    /// fails the whole removal, not just the edge. Before the fix this test
+    /// fails with `transaction relation <id> has unadmitted source endpoint
+    /// artifact:<id>`, which is the exact refusal that made a repository unable
+    /// to commit at all until the file was emptied first.
+    #[test]
+    fn a_removal_takes_the_relations_bound_to_the_departing_artifact() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let leaving = repo.path().join("leaving.rs");
+        let staying = repo.path().join("staying.rs");
+        std::fs::write(&leaving, b"pub fn leaving() -> u32 { 1 }\n").unwrap();
+        std::fs::write(&staying, b"pub fn staying() -> u32 { 2 }\n").unwrap();
+        admit_file_event(&state, &FileEvent::Changed(leaving.clone())).unwrap();
+        admit_file_event(&state, &FileEvent::Changed(staying.clone())).unwrap();
+
+        let leaving_id = artifact_at(&state, "leaving.rs");
+        let staying_id = artifact_at(&state, "staying.rs");
+        let import = artifact_edge(leaving_id, staying_id, kin_model::RelationKind::Imports);
+        let coverage = artifact_edge(leaving_id, leaving_id, kin_model::RelationKind::DependsOn);
+        state.graph.upsert_relation(&import).unwrap();
+        state.graph.upsert_relation(&coverage).unwrap();
+
+        std::fs::remove_file(&leaving).unwrap();
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Removed(leaving))
+            .expect("a removal must collect the edges bound to the artifact it drops");
+
+        assert!(matches!(admitted, AdmittedFileEvent::Removed { .. }));
+        assert!(
+            tree_entry(&state, "leaving.rs").is_none(),
+            "the artifact left the tree"
+        );
+        assert!(
+            state
+                .graph
+                .get_all_relations_for_node(&kin_model::GraphNodeId::Artifact(leaving_id))
+                .unwrap()
+                .is_empty(),
+            "and every edge naming it left with it"
+        );
+        assert!(
+            tree_entry(&state, "staying.rs").is_some(),
+            "the destination artifact is untouched: only the departing endpoint's edges go"
+        );
+    }
+
+    /// FIR-2607, the second half. A refusal a user can act on.
+    ///
+    /// The raw storage message names two uuids and offers nothing to do. This
+    /// asserts the surface a user meets names the path being dropped and the
+    /// two-step retirement that clears the edges, so the message is about their
+    /// repository rather than about kin's internals.
+    #[test]
+    fn a_stranded_endpoint_refusal_names_the_path_and_the_way_out() {
+        let raw = DaemonError::Graph(kin_db::KinDbError::StorageError(
+            "transaction relation 6b30c139-1c2a-a133-d17b-2625e60d3df9 has unadmitted source \
+             endpoint artifact:f4d9e1db-d7b2-4fd9-912c-2809f331331b"
+                .to_string(),
+        ));
+        let deltas = vec![TreeDelta::Removed {
+            artifact_id: kin_model::ArtifactId::new(),
+            old: kin_model::LocatedEntry::new(
+                test_repo_path("notekeeper/search.py"),
+                TreeEntry::blob(Hash256::from_bytes([7; 32]), false),
+            ),
+        }];
+
+        let named = name_stranded_endpoint_refusal(raw, &deltas).to_string();
+
+        assert!(
+            named.contains("notekeeper/search.py"),
+            "the refusal names the path being dropped: {named}"
+        );
+        assert!(
+            named.contains("fix: empty the file and commit"),
+            "and carries the retirement that clears the edges: {named}"
+        );
+        assert!(
+            named.contains("6b30c139-1c2a-a133-d17b-2625e60d3df9"),
+            "without losing the identifiers a report needs: {named}"
+        );
+    }
+
+    /// An unrelated failure is handed back untouched, so the naming above can
+    /// never dress up a refusal it does not understand.
+    #[test]
+    fn an_unrelated_refusal_is_not_dressed_up_as_a_stranded_endpoint() {
+        let raw = DaemonError::Graph(kin_db::KinDbError::StorageError(
+            "transaction adds existing entity 1056cc39-df63-5f0b-9d85-a161fb2c882f".to_string(),
+        ));
+
+        let passed_through = name_stranded_endpoint_refusal(raw, &[]).to_string();
+
+        assert!(
+            passed_through.contains("transaction adds existing entity"),
+            "an unrelated storage refusal keeps its own words: {passed_through}"
+        );
+        assert!(
+            !passed_through.contains("fix: empty the file"),
+            "and gains no advice that would not help: {passed_through}"
+        );
+    }
+
+    /// FIR-2606. An admitted source path the graph holds no entities for is
+    /// offered for re-derivation.
+    ///
+    /// This is the state a daemon leaves behind when it ends between a write
+    /// and the commit that would have published the entities: the artifact is
+    /// admitted at exactly the bytes on disk, so no tree delta and no watcher
+    /// event ever names it again, and every query answers about it as an
+    /// absence. Recovering it is what stops that from being permanent.
+    #[test]
+    fn an_admitted_source_path_with_no_entities_is_offered_for_re_derivation() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let source = repo.path().join("stranded.rs");
+        std::fs::write(&source, b"pub fn stranded() -> u32 { 1 }\n").unwrap();
+        admit_file_event(&state, &FileEvent::Changed(source.clone())).unwrap();
+
+        let owed = plan_unenriched_source_events(&state).unwrap();
+
+        // Compared by repository-relative name: the host root reaches this
+        // test through /var and comes back through /private/var, and the
+        // subject here is which path is owed, not how the host spells it.
+        let named = owed
+            .iter()
+            .map(|event| {
+                let (FileEvent::Changed(path) | FileEvent::Removed(path)) = event;
+                path.file_name().unwrap().to_string_lossy().to_string()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            named,
+            vec![source.file_name().unwrap().to_string_lossy().to_string()],
+            "an admitted source path with no entities is exactly what needs re-deriving"
+        );
+    }
+
+    /// The control that keeps the repair narrow: a path whose entities the
+    /// graph already holds is never re-derived, so this cannot become a sweep
+    /// that re-parses the working copy on every daemon start.
+    #[test]
+    fn an_admitted_source_path_that_carries_entities_is_left_alone() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let source = repo.path().join("enriched.rs");
+        std::fs::write(&source, b"pub fn enriched() -> u32 { 1 }\n").unwrap();
+        admit_file_event(&state, &FileEvent::Changed(source)).unwrap();
+        assert_eq!(
+            plan_unenriched_source_events(&state).unwrap().len(),
+            1,
+            "the positive control: before its entities land the path is owed a re-derivation"
+        );
+
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: vec![kin_model::EntityDelta::Added {
+                    new: test_entity("enriched", "enriched.rs"),
+                }],
+                relation_deltas: vec![],
+                tree_deltas: vec![],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+
+        assert!(
+            plan_unenriched_source_events(&state).unwrap().is_empty(),
+            "and once the graph holds an entity for it, nothing is owed"
+        );
+    }
+
+    /// A file no language adapter parses is enriched by a shallow, structured
+    /// or opaque facet instead, so it has no entities by design and must not be
+    /// proposed forever.
+    #[test]
+    fn an_admitted_path_with_no_entity_adapter_is_not_offered() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let notes = repo.path().join("NOTES.txt");
+        std::fs::write(&notes, b"not a language this repository parses\n").unwrap();
+        admit_file_event(&state, &FileEvent::Changed(notes)).unwrap();
+
+        assert!(
+            plan_unenriched_source_events(&state).unwrap().is_empty(),
+            "a path with no entity adapter is not owed a re-parse"
+        );
+    }
+
+    fn test_entity(name: &str, file_path: &str) -> kin_model::Entity {
+        kin_model::Entity {
+            id: kin_model::EntityId::new(),
+            kind: kin_model::EntityKind::Function,
+            name: name.to_string(),
+            language: kin_model::LanguageId::Rust,
+            fingerprint: kin_model::SemanticFingerprint {
+                algorithm: kin_model::FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([1; 32]),
+                signature_hash: Hash256::from_bytes([2; 32]),
+                behavior_hash: Hash256::from_bytes([3; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file_path)),
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: kin_model::Visibility::Public,
+            role: kin_model::EntityRole::Source,
+            doc_summary: None,
+            metadata: kin_model::EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
 }
 
 /// Decide whether a filesystem-sync tick's bulk deletions should be WITHHELD as
@@ -7301,11 +7550,30 @@ async fn sync_filesystem_with_graph_publishing_inner(
     // Recorded before anything below can fail, so a pass that dies part way
     // through enrichment still hands the deferral back to be closed.
     *deferred_out = exact_admission.deferred_tree.take();
-    if exact_admission.deltas.is_empty() {
+    // An admitted source path the graph holds no entities for is re-derived on
+    // this seam too, and it is why the early return below cannot key on the
+    // tree transition alone. Entity derivation is not durable on its own: a
+    // daemon that ends between the write and the commit takes it with it, and
+    // what it leaves behind is an artifact admitted at exactly the bytes on
+    // disk, which produces no tree delta here and no watcher event ever again.
+    // Without this the file stays admitted and unqueryable through every later
+    // commit, which is exactly how one module dropped out of a store and stayed
+    // out (FIR-2606).
+    let unenriched = plan_unenriched_source_events(state)?;
+    if exact_admission.deltas.is_empty() && unenriched.is_empty() {
         drop(graph_mutation);
         return Ok(());
     }
-    let events = exact_admission.semantic_events;
+    if !unenriched.is_empty() {
+        warn!(
+            count = unenriched.len(),
+            "admitted source paths carry no entities, so nothing can query them; re-deriving \
+             them into this change"
+        );
+    }
+    let mut events = exact_admission.semantic_events;
+    events.extend(unenriched);
+    let events = dedup_file_events(events);
 
     info!(
         count = events.len(),

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1227,16 +1227,14 @@ fn announce_retraction(retracted: &kin_index::IgnoredTrackedPaths) {
 /// deleted file could take the entire commit path down with it: nothing else
 /// collects these, and only emptying the file first, which routes the retirement
 /// through the linker's own re-derivation, ever cleared them.
-///
-/// Returns the relations retired, so a caller can report what a removal took.
 fn retire_artifact_node_relations(
     graph: &kin_db::InMemoryGraph,
     artifact_id: kin_model::ArtifactId,
-) -> Result<Vec<kin_model::RelationId>> {
+) -> Result<()> {
     let node = kin_model::GraphNodeId::Artifact(artifact_id);
     let bound = graph.get_all_relations_for_node(&node)?;
     if bound.is_empty() {
-        return Ok(Vec::new());
+        return Ok(());
     }
     let retired: Vec<kin_model::RelationId> = bound.iter().map(|relation| relation.id).collect();
     let borrowed: Vec<&kin_model::RelationId> = retired.iter().collect();
@@ -1246,7 +1244,7 @@ fn retire_artifact_node_relations(
         retired = retired.len(),
         "retired the relations bound to a departing artifact node"
     );
-    Ok(retired)
+    Ok(())
 }
 
 /// Say what a refused tree transition was about when kin-db reports one of its

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -7600,7 +7600,21 @@ async fn sync_filesystem_with_graph_publishing_inner(
     // Without this the file stays admitted and unqueryable through every later
     // commit, which is exactly how one module dropped out of a store and stayed
     // out (FIR-2606).
-    let unenriched = plan_unenriched_source_events(state)?;
+    //
+    // A repair, so it never fails the pass carrying it. A commit that would
+    // have succeeded must not start failing because the recovery beside it
+    // could not plan; the path it would have recovered simply stays owed.
+    let unenriched = match plan_unenriched_source_events(state) {
+        Ok(events) => events,
+        Err(error) => {
+            warn!(
+                error = %error,
+                "could not plan the enrichment repair, so any admitted path missing its entities \
+                 stays unqueryable until it is edited"
+            );
+            Vec::new()
+        }
+    };
     if exact_admission.deltas.is_empty() && unenriched.is_empty() {
         drop(graph_mutation);
         return Ok(());

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -855,12 +855,17 @@ fn exact_tree_admission(
         // while its entities keep ranking is the exposure this ordering exists
         // to prevent.
         evict_enrichment_for_removed_paths(state, &deltas)?;
-        state.graph.apply_transaction_delta(&TransactionDelta {
-            entity_deltas: Vec::new(),
-            relation_deltas: Vec::new(),
-            tree_deltas: deltas.clone(),
-            ..TransactionDelta::default()
-        })?;
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: Vec::new(),
+                relation_deltas: Vec::new(),
+                tree_deltas: deltas.clone(),
+                ..TransactionDelta::default()
+            })
+            .map_err(|error| {
+                name_stranded_endpoint_refusal(DaemonError::Graph(error), &deltas)
+            })?;
     }
 
     if observation.is_none() {
@@ -1211,6 +1216,81 @@ fn announce_retraction(retracted: &kin_index::IgnoredTrackedPaths) {
     );
 }
 
+/// Retire every relation bound to an artifact node that is leaving the tree.
+///
+/// An artifact-class endpoint is not reachable from any entity, so clearing a
+/// path's entities leaves these edges standing: the file-level `Imports` and
+/// `Includes` edges the cross-file linker mints, its parse-coverage self-loop,
+/// and the `DerivedFrom` edges projection markers produce. kin-db validates
+/// every relation the graph holds against the staged tree on each transaction,
+/// so one surviving edge makes the removal of its artifact fail with
+/// `transaction relation <id> has unadmitted source endpoint artifact:<id>`,
+/// and it fails the whole transaction rather than the one edge. That is how a
+/// deleted file could take the entire commit path down with it: nothing else
+/// collects these, and only emptying the file first, which routes the retirement
+/// through the linker's own re-derivation, ever cleared them.
+///
+/// Returns the relations retired, so a caller can report what a removal took.
+fn retire_artifact_node_relations(
+    graph: &kin_db::InMemoryGraph,
+    artifact_id: kin_model::ArtifactId,
+) -> Result<Vec<kin_model::RelationId>> {
+    let node = kin_model::GraphNodeId::Artifact(artifact_id);
+    let bound = graph.get_all_relations_for_node(&node)?;
+    if bound.is_empty() {
+        return Ok(Vec::new());
+    }
+    let retired: Vec<kin_model::RelationId> = bound.iter().map(|relation| relation.id).collect();
+    let borrowed: Vec<&kin_model::RelationId> = retired.iter().collect();
+    graph.remove_relations_batch(&borrowed)?;
+    debug!(
+        ?artifact_id,
+        retired = retired.len(),
+        "retired the relations bound to a departing artifact node"
+    );
+    Ok(retired)
+}
+
+/// Say what a refused tree transition was about when kin-db reports one of its
+/// relations still naming a node the staged tree no longer carries.
+///
+/// The storage message names a relation uuid and an artifact uuid and nothing
+/// else. Neither maps to a file, the refusal is of the whole transaction rather
+/// than of the edge, and the surface a user meets is a commit that cannot run at
+/// all. Name the paths this transition drops and the two-step retirement that
+/// clears the edges, so the message a user reads is about their repository
+/// rather than about kin's internals.
+pub(crate) fn name_stranded_endpoint_refusal(
+    error: DaemonError,
+    deltas: &[TreeDelta],
+) -> DaemonError {
+    let message = error.to_string();
+    if !message.contains("unadmitted source endpoint")
+        && !message.contains("unadmitted destination endpoint")
+    {
+        return error;
+    }
+    let removed = deltas
+        .iter()
+        .filter_map(|delta| match delta {
+            TreeDelta::Removed { old, .. } => Some(old.path.to_string()),
+            TreeDelta::Added { .. } | TreeDelta::Updated { .. } => None,
+        })
+        .collect::<Vec<_>>();
+    let dropped = if removed.is_empty() {
+        "this transition".to_string()
+    } else {
+        removed.join(", ")
+    };
+    DaemonError::IncompatibleRepo(format!(
+        "refusing to drop {dropped}: the graph still holds a relation whose endpoint is the \
+         artifact being removed, and kin-db refuses a transition that strands one ({message}). \
+         fix: empty the file and commit, which retires the edges through the linker, then delete \
+         the empty file and commit again. Report this: a removal is supposed to collect these \
+         edges itself"
+    ))
+}
+
 /// Remove the enrichment derived from every path a tree transition drops.
 ///
 /// Entities, their relations, and their text and vector index presence are what
@@ -1219,6 +1299,10 @@ fn announce_retraction(retracted: &kin_index::IgnoredTrackedPaths) {
 /// strand one. Clearing here is what lets a removal of any kind, a deleted file
 /// or a newly ignored one, take the whole artifact out rather than only its
 /// tree entry.
+///
+/// Artifact-class edges go with it. They have no entity endpoint, so the entity
+/// cleanup below cannot see them, and kin-db refuses the tree transition that
+/// strands one exactly as it refuses a stranded entity.
 pub(crate) fn evict_enrichment_for_removed_paths(
     state: &DaemonState,
     deltas: &[TreeDelta],
@@ -1227,6 +1311,7 @@ pub(crate) fn evict_enrichment_for_removed_paths(
         let TreeDelta::Removed { old, .. } = delta else {
             continue;
         };
+        retire_artifact_node_relations(state.graph.as_ref(), delta.artifact_id())?;
         let Some(file_id) = semantic_file_id(&old.path) else {
             continue;
         };
@@ -1941,6 +2026,63 @@ fn plan_catch_up_events(state: &DaemonState, since: SystemTime) -> Result<Vec<Fi
         .collect())
 }
 
+/// Host events for every admitted source file the graph holds no entity for.
+///
+/// Entity derivation is not durable on its own. A tree admission publishes an
+/// artifact into repository authority the moment the watcher sees the write,
+/// while the entities the same tick derives live in this daemon's query graph
+/// until a commit publishes them. A daemon that ends first, and an idle timeout
+/// ends one after sixty seconds, takes them with it. What survives is a file
+/// admitted at exactly the bytes on disk, so no later watcher event fires for
+/// it and the startup catch-up window, which is keyed on host modification
+/// time, cannot see it either: it was modified before the last admission, and
+/// that admission is precisely what recorded the artifact. The path is then
+/// permanently in the graph and permanently unqueryable, visible only as
+/// `kin graph status` counting it among the files that "produced no entity".
+///
+/// This asks the graph rather than the host: an admitted path whose language
+/// has a full adapter and which no entity names is either genuinely empty of
+/// definitions, which costs one parse to re-confirm, or lost enrichment, which
+/// this recovers. Every path goes back through the ordinary tick, so the same
+/// bounded observation, policy filter and compare-and-swap apply as for an edit
+/// a watcher saw.
+fn plan_unenriched_source_events(state: &DaemonState) -> Result<Vec<FileEvent>> {
+    use kin_model::EntityStore;
+
+    let working_dir = state.layout.working_dir();
+    let enriched: std::collections::HashSet<FilePathId> = state
+        .graph
+        .list_all_entities()?
+        .into_iter()
+        .filter_map(|entity| entity.file_origin)
+        .collect();
+    let mut events = Vec::new();
+    for artifact in state.graph.resolved_tree().artifacts_by_path() {
+        if kin_core::source_projection_disposition(&artifact.path, artifact.entry)?
+            != kin_core::SourceProjectionDisposition::Materialized
+        {
+            continue;
+        }
+        let Some(file_id) = semantic_file_id(&artifact.path) else {
+            continue;
+        };
+        if enriched.contains(&file_id) {
+            continue;
+        }
+        let Ok(host_path) = kin_index::host_path_from_repo_path(working_dir, &artifact.path) else {
+            continue;
+        };
+        // Path-only classification, because the bytes are not read here. A file
+        // whose extension carries no entity adapter is enriched by a shallow,
+        // structured or opaque facet instead and is not owed a re-parse.
+        if FileClassifier::classify(&host_path) != FileClassification::EntitySource {
+            continue;
+        }
+        events.push(FileEvent::Changed(host_path));
+    }
+    Ok(events)
+}
+
 pub async fn run_loop(
     state: Arc<DaemonState>,
     config: LoopConfig,
@@ -1999,6 +2141,12 @@ pub async fn run_loop_armed(
     // publication, and a client finding the port is never waiting on a
     // traversal.
     let mut catch_up_owed = startup_catch_up_window(&state);
+    // Owed once per daemon life, and independent of the catch-up window: the
+    // paths it recovers are exactly the ones whose host modification time puts
+    // them outside that window. A store with no last-admission marker gets no
+    // catch-up and still gets this, because this bound comes from graph truth
+    // rather than from a clock.
+    let mut enrichment_repair_owed = true;
     if let Some(armed) = armed.as_mut() {
         armed.arm();
     }
@@ -2146,6 +2294,35 @@ pub async fn run_loop_armed(
                         "could not plan the startup catch-up, so host content written while \
                          nothing was watching stays unadmitted until `kin admit` or a commit \
                          takes it"
+                    );
+                }
+            }
+        }
+
+        // The enrichment repair, owed once for the same reason and taken the
+        // same way. Loud when it finds anything: a file admitted with no
+        // entities answered every query as an absence, and a store that has
+        // been in that state deserves the count said out loud rather than
+        // repaired in silence.
+        if enrichment_repair_owed {
+            enrichment_repair_owed = false;
+            match plan_unenriched_source_events(&state) {
+                Ok(events) if events.is_empty() => {
+                    debug!("every admitted source path already carries its entities");
+                }
+                Ok(events) => {
+                    warn!(
+                        count = events.len(),
+                        "admitted source paths carry no entities, so nothing can query them; \
+                         re-deriving them now"
+                    );
+                    enqueue_file_events(&mut pending_events, events);
+                }
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        "could not plan the enrichment repair, so any admitted path missing its \
+                         entities stays unqueryable until it is edited or committed"
                     );
                 }
             }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2039,11 +2039,17 @@ fn plan_catch_up_events(state: &DaemonState, since: SystemTime) -> Result<Vec<Fi
 /// `kin graph status` counting it among the files that "produced no entity".
 ///
 /// This asks the graph rather than the host: an admitted path whose language
-/// has a full adapter and which no entity names is either genuinely empty of
-/// definitions, which costs one parse to re-confirm, or lost enrichment, which
-/// this recovers. Every path goes back through the ordinary tick, so the same
-/// bounded observation, policy filter and compare-and-swap apply as for an edit
-/// a watcher saw.
+/// has a full adapter, which no entity names, and which carries no parsed
+/// layout either, has never been parsed by this daemon. Every path goes back
+/// through the ordinary tick, so the same bounded observation, policy filter and
+/// compare-and-swap apply as for an edit a watcher saw.
+///
+/// The layout is what keeps this from repeating. A file that genuinely declares
+/// nothing, an empty `__init__.py` among them, produces no entity however often
+/// it is parsed, and offering it on every pass would re-parse it on every commit
+/// forever while warning about a fault that is not one. Parsing registers a
+/// layout whether or not it found a declaration, so one pass answers the
+/// question for the rest of this daemon's life.
 fn plan_unenriched_source_events(state: &DaemonState) -> Result<Vec<FileEvent>> {
     use kin_model::EntityStore;
 
@@ -2065,6 +2071,9 @@ fn plan_unenriched_source_events(state: &DaemonState) -> Result<Vec<FileEvent>> 
             continue;
         };
         if enriched.contains(&file_id) {
+            continue;
+        }
+        if state.graph.get_file_layout(&file_id)?.is_some() {
             continue;
         }
         let Ok(host_path) = kin_index::host_path_from_repo_path(working_dir, &artifact.path) else {
@@ -7264,6 +7273,42 @@ mod tests {
         assert!(
             plan_unenriched_source_events(&state).unwrap().is_empty(),
             "and once the graph holds an entity for it, nothing is owed"
+        );
+    }
+
+    /// A source file that declares nothing produces no entity however often it
+    /// is parsed. Parsing registers its layout, and that is what stops the
+    /// repair re-parsing it on every commit for the rest of the daemon's life
+    /// while warning about a fault that is not one.
+    #[test]
+    fn a_source_path_that_parsed_to_no_declarations_is_offered_once() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let empty = repo.path().join("declares_nothing.rs");
+        std::fs::write(&empty, b"// nothing here\n").unwrap();
+        admit_file_event(&state, &FileEvent::Changed(empty)).unwrap();
+        assert_eq!(
+            plan_unenriched_source_events(&state).unwrap().len(),
+            1,
+            "the positive control: an unparsed source path is owed one pass"
+        );
+
+        state
+            .graph
+            .upsert_file_layout(&kin_model::FileLayout {
+                file_id: FilePathId::new("declares_nothing.rs"),
+                parse_completeness: kin_model::ParseCompleteness::Full,
+                imports: kin_model::ImportSection {
+                    byte_range: 0..0,
+                    items: Vec::new(),
+                },
+                regions: Vec::new(),
+            })
+            .unwrap();
+
+        assert!(
+            plan_unenriched_source_events(&state).unwrap().is_empty(),
+            "and a parsed layout with no entity in it answers the question for good"
         );
     }
 


### PR DESCRIPTION
Deleting a file could stop a repository committing at all. The commit failed with a raw storage message naming two uuids, no path and nothing to do, and it failed the same way on every retry and after a daemon restart, so the repository was stuck until the file was restored.

## Why

The path-facet cleanup retires a departing path's entities and, through them, the relations that name those entities. Artifact-class edges have no entity endpoint, so it could not see them: the file-level `Imports` and `Includes` edges the cross-file linker mints, the `DependsOn` parse-coverage self-loop every indexed file carries, and the `DerivedFrom` edges projection markers produce. kin-db re-validates every relation the graph holds against the staged tree on each transaction, and a removed artifact is excluded from the staged set, so one surviving edge failed the whole transaction rather than the edge.

The reconciler's own retirement loop only walks the artifacts a pass resolved, and a deleted file is not among them. Emptying the file leaves it in that set with no imports left to declare, which is exactly why the empty-then-delete workaround cleared the edges and a plain delete did not.

The MCP staged-retirement path already did this correctly. `plan_retired_source_files` collects artifact-incident edges and carries them in the same delta as the tree removal, and its comment names the identical failure: "Without them the transition is refused outright with 'unadmitted destination endpoint', which is the shape a two-file Python fixture reaches on its first import." The watcher and commit seam never learned it.

## The fix

`retire_artifact_node_relations` collects every relation bound to a departing artifact node and removes it in the same transaction, from `evict_enrichment_for_removed_paths`, the removal seam the watcher path and the MCP planner share. That is the same argument the shared facet cleanup makes for being shared in the first place.

`name_stranded_endpoint_refusal` turns any surviving raw storage refusal into a message naming the paths being dropped and the two-step retirement, keeping the relation and artifact identifiers a report needs, and hands an unrelated storage error back untouched.

## Tests

Three tests in `crates/kin-daemon/src/loop_runner.rs`, each falsified by reverting the behavior it guards. Removing the artifact-edge collection reproduces the shipped failure verbatim, `transaction relation <id> has unadmitted source endpoint artifact:<id>`, now wrapped in the named refusal, which proves both halves on the real path. Returning the raw refusal unnamed fails the naming test while its control stays green, so the naming cannot dress up a refusal it does not understand. The removal test covers both shapes the linker produces: the outgoing import edge to another artifact, and the parse-coverage self-loop.

`cargo test -p kin-daemon` passes across every target, fmt and clippy are clean under ci.yml's own invocation, every guard script ci.yml names passes, and `bin/kin-parity` reports PASS-WITH-ALLOWANCES naming only FIR-2580, FIR-2596 and FIR-2464.

## What this does not do

It does not fix FIR-2606, the wedge that minted the poisoned relation. That root cause is understood and written up on the ticket: reconciler-derived entities reach the daemon's live query graph and are discarded when the process ends, because nothing publishes them to workspace authority outside a commit, and no later pass re-derives a path already admitted at exactly the bytes on disk. A re-derivation repair was written and withdrawn from this change: the acceptance gate caught it perturbing a freshly converted brownfield store, where most of the working copy is still unenriched at the moment the conversion answers its first queries, and the express arm stopped resolving `Router`. That evidence is on FIR-2606, and the durability question underneath it is FIR-2611.

Closes FIR-2607
Refs FIR-2606, FIR-2611
