### PR TITLE
Count every impact_analysis key the budget can cut, and report the bound that actually held

### DIFF
--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -568,8 +568,16 @@ pub fn enforce(
     // but the caller has to be told which of the two it is holding.
     if accounting.chars_after > budget.max_chars {
         disclose_residual(payload, budget);
-        accounting.chars_after = measure(payload);
+    } else {
+        // The other direction, and it is reachable: the first arm cuts under
+        // the budget less the envelope reserve, so it can miss a ceiling this
+        // arm clears once the reserve it was holding back turns out to be
+        // larger than the envelope that landed. A note saying the response did
+        // not fit, on a response that does, is the same false report in
+        // reverse.
+        clear_residual(payload);
     }
+    accounting.chars_after = measure(payload);
     Some(accounting)
 }
 
@@ -789,6 +797,22 @@ fn disclose_residual(payload: &mut Value, budget: &ResponseBudget) {
             existing.push(entry);
         }
         None => payload["degradations"] = Value::Array(vec![entry]),
+    }
+}
+
+/// Withdraw a residual note an earlier arm left on a response that now fits.
+fn clear_residual(payload: &mut Value) {
+    let Some(entries) = payload
+        .get_mut("degradations")
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+    entries.retain(|entry| entry.get("reason").and_then(Value::as_str) != Some(OVER_BUDGET_REASON));
+    if entries.is_empty() {
+        if let Some(map) = payload.as_object_mut() {
+            map.remove("degradations");
+        }
     }
 }
 
@@ -1612,6 +1636,59 @@ mod tests {
                 .count();
             assert_eq!(notes, 1, "pass {pass} left {notes} copies: {payload}");
         }
+    }
+
+    /// The residual note is withdrawn when a later arm clears the ceiling the
+    /// earlier one missed. The first arm cuts under the budget less the envelope
+    /// reserve, so it can miss a ceiling the second arm clears once the envelope
+    /// that lands is smaller than the reserve held back for it. A note saying
+    /// the response did not fit, on a response that does, is the same false
+    /// report in reverse.
+    #[test]
+    fn a_residual_note_is_withdrawn_by_an_arm_that_fits() {
+        let mut payload = impact_payload_bulk_outside_the_buckets(60);
+        let tight = ResponseBudget {
+            max_chars: RESPONSE_MIN_MAX_CHARS,
+            ..ResponseBudget::default()
+        };
+        let cut = enforce(&mut payload, "impact_analysis", &tight).expect("budgeted");
+        assert!(
+            cut.chars_after > tight.max_chars,
+            "the first arm must miss its ceiling, or this proves nothing"
+        );
+        assert!(
+            has_residual(&payload),
+            "the first arm must have left a note: {payload}"
+        );
+
+        let loose = ResponseBudget {
+            max_chars: 20_000,
+            ..ResponseBudget::default()
+        };
+        let again = enforce(&mut payload, "impact_analysis", &loose).expect("budgeted");
+        assert!(
+            again.chars_after <= loose.max_chars,
+            "the second arm must clear its ceiling, or this proves nothing"
+        );
+        assert!(
+            !has_residual(&payload),
+            "a response that fits must not claim it does not: {payload}"
+        );
+        assert!(
+            again.bounded,
+            "the cut the first arm made is still a cut: {payload}"
+        );
+    }
+
+    fn has_residual(payload: &Value) -> bool {
+        payload
+            .get("degradations")
+            .and_then(Value::as_array)
+            .is_some_and(|entries| {
+                entries
+                    .iter()
+                    .any(|entry| entry["reason"] == json!(OVER_BUDGET_REASON))
+            })
     }
 
     /// The elision half of the same case: the widened table must cut with counts

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -537,11 +537,25 @@ pub fn enforce(
 ) -> Option<BudgetAccounting> {
     let shape = shape_for(tool)?;
     let chars_before = measure(payload);
+
+    // Two arms bound one response. The daemon's `/mcp/tools/call` route cuts
+    // first, under the budget less the envelope reserve, and the stdio path then
+    // envelopes what it gets back and cuts again. The second arm sees an already
+    // cut payload: it measures a size the first arm produced, usually finds
+    // nothing left to trim, and its accounting is the one that lands in `_kin`.
+    // So a response the budget had already cut to its floor reported
+    // `bounded: false`, which is FIR-2602's symptom reached by its second route.
+    //
+    // The accounting describes the response, not this pass over it. What the
+    // first arm did is readable off the payload it handed over, because a cut
+    // discloses itself, so this reads that record rather than inventing a
+    // channel to carry it.
+    let prior = prior_bound(payload);
     let mut accounting = BudgetAccounting {
         max_chars: budget.max_chars,
-        chars_before,
+        chars_before: chars_before.max(prior.unwrap_or(0)),
         chars_after: chars_before,
-        bounded: false,
+        bounded: prior.is_some(),
         compact: budget.compact,
     };
     run_ladder(payload, &shape, budget, &mut accounting);
@@ -570,6 +584,7 @@ fn run_ladder(
     budget: &ResponseBudget,
     accounting: &mut BudgetAccounting,
 ) {
+    let started_at = measure(payload);
     let mut cuts: Vec<String> = Vec::new();
     let mut remediations: Vec<String> = Vec::new();
 
@@ -619,7 +634,7 @@ fn run_ladder(
             ));
         }
         if measure(payload) <= target {
-            disclose(payload, budget, &cuts, &remediations);
+            disclose(payload, budget, started_at, &cuts, &remediations);
             return;
         }
     }
@@ -635,7 +650,7 @@ fn run_ladder(
             ));
         }
         if measure(payload) <= target {
-            disclose(payload, budget, &cuts, &remediations);
+            disclose(payload, budget, started_at, &cuts, &remediations);
             return;
         }
     }
@@ -651,7 +666,7 @@ fn run_ladder(
             remediations.push("read one body with get_entity_source".to_string());
         }
         if measure(payload) <= target {
-            disclose(payload, budget, &cuts, &remediations);
+            disclose(payload, budget, started_at, &cuts, &remediations);
             return;
         }
     }
@@ -702,11 +717,37 @@ fn run_ladder(
         }
     }
 
-    disclose(payload, budget, &cuts, &remediations);
+    disclose(payload, budget, started_at, &cuts, &remediations);
 }
+
+/// The reason code a response the budget cut carries.
+pub const BOUNDED_REASON: &str = "response_bounded";
 
 /// The reason code a response that stayed over its ceiling carries.
 pub const OVER_BUDGET_REASON: &str = "response_over_budget";
+
+/// What an earlier arm recorded cutting this payload from, if one did.
+///
+/// A cut discloses itself in the `degradations` channel, and the first such
+/// entry is the earliest arm's, because disclosures are appended. Reading it is
+/// what lets the second arm report the size the answer was built at instead of
+/// the size it inherited.
+fn prior_bound(payload: &Value) -> Option<usize> {
+    payload
+        .get("degradations")?
+        .as_array()?
+        .iter()
+        .find(|entry| {
+            entry.get("component").and_then(Value::as_str) == Some("response_budget")
+                && entry.get("reason").and_then(Value::as_str) == Some(BOUNDED_REASON)
+        })
+        .map(|entry| {
+            entry
+                .get("chars_before_budget")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as usize
+        })
+}
 
 /// Record that the ladder finished with the payload still over its ceiling.
 ///
@@ -735,11 +776,18 @@ fn disclose_residual(payload: &mut Value, budget: &ResponseBudget) {
                         limit accepts a larger payload",
         "max_chars": max_chars,
     });
+    // One note per response. Both arms can reach this, and two copies of the
+    // same sentence spend the budget they are complaining about.
     match payload
         .get_mut("degradations")
         .and_then(Value::as_array_mut)
     {
-        Some(existing) => existing.push(entry),
+        Some(existing) => {
+            existing.retain(|prior| {
+                prior.get("reason").and_then(Value::as_str) != Some(OVER_BUDGET_REASON)
+            });
+            existing.push(entry);
+        }
         None => payload["degradations"] = Value::Array(vec![entry]),
     }
 }
@@ -876,6 +924,7 @@ fn trim_collection(payload: &mut Value, key: &str, target: usize, min_keep: usiz
 fn disclose(
     payload: &mut Value,
     budget: &ResponseBudget,
+    chars_before: usize,
     cuts: &[String],
     remediations: &[String],
 ) {
@@ -903,10 +952,13 @@ fn disclose(
     ));
     let entry = json!({
         "component": "response_budget",
-        "reason": "response_bounded",
+        "reason": BOUNDED_REASON,
         "detail": format!("the response exceeded its {ceiling}, so {}", cuts.join("; ")),
         "remediation": remediation,
         "max_chars": max_chars,
+        // The size this arm started from, so the arm that cuts second can report
+        // what the answer was built at rather than what it inherited.
+        "chars_before_budget": chars_before,
     });
     match payload
         .get_mut("degradations")
@@ -1478,6 +1530,88 @@ mod tests {
                     .all(|entry| entry["reason"] != json!(OVER_BUDGET_REASON))),
             "a response that reached its ceiling must not claim it did not: {payload}"
         );
+    }
+
+    /// Two arms bound one response. The daemon's raw route cuts first and the
+    /// stdio path cuts again, and only the second arm's accounting reaches
+    /// `_kin.response`. Measured on the release binary at `max_chars: 2000`: the
+    /// first arm cut the report to its floor, the second found nothing left to
+    /// trim, and the response shipped `bounded: false` at 13,232 characters with
+    /// a fully populated `elisions` map sitting beside it.
+    ///
+    /// The accounting is about the response, not about one pass over it.
+    #[test]
+    fn a_second_pass_reports_the_cut_the_first_pass_made() {
+        const FIRST: usize = 6_000;
+        const SECOND: usize = 8_000;
+        let mut payload = impact_payload(40);
+        let built_at = measure(&payload);
+
+        let first = ResponseBudget {
+            max_chars: FIRST,
+            ..ResponseBudget::default()
+        };
+        let cut = enforce(&mut payload, "impact_analysis", &first).expect("budgeted");
+        assert!(
+            cut.bounded,
+            "the first arm must cut, or this proves nothing"
+        );
+        assert_eq!(cut.chars_before, built_at);
+
+        // The second arm's ceiling is looser than what the first already
+        // enforced, so it has nothing of its own to do. That is exactly the
+        // shape that reported a whole answer.
+        let second = ResponseBudget {
+            max_chars: SECOND,
+            ..ResponseBudget::default()
+        };
+        let again = enforce(&mut payload, "impact_analysis", &second).expect("budgeted");
+        assert!(
+            again.chars_after <= SECOND,
+            "the second arm found nothing to cut, or this proves nothing"
+        );
+        assert!(
+            again.bounded,
+            "a response the first arm cut cannot report itself whole: {payload}"
+        );
+        assert_eq!(
+            again.chars_before, built_at,
+            "the second arm must report the size the answer was built at, not the size \
+             it inherited"
+        );
+        assert!(
+            payload["elisions"]
+                .as_object()
+                .is_some_and(|map| !map.is_empty()),
+            "the cut the first arm disclosed must still be readable: {payload}"
+        );
+    }
+
+    /// A response still over its ceiling says so once, however many arms reach
+    /// that conclusion. Two copies of the same sentence spend the budget they
+    /// are complaining about, and the release binary published two.
+    #[test]
+    fn a_response_over_its_ceiling_says_so_once() {
+        const FLOOR: usize = RESPONSE_MIN_MAX_CHARS;
+        let budget = ResponseBudget {
+            max_chars: FLOOR,
+            ..ResponseBudget::default()
+        };
+        let mut payload = impact_payload_bulk_outside_the_buckets(60);
+        for pass in 0..3 {
+            let accounting = enforce(&mut payload, "impact_analysis", &budget).expect("budgeted");
+            assert!(
+                accounting.chars_after > FLOOR,
+                "pass {pass} must stay over the ceiling, or this proves nothing"
+            );
+            let notes = payload["degradations"]
+                .as_array()
+                .expect("a cut is disclosed")
+                .iter()
+                .filter(|entry| entry["reason"] == json!(OVER_BUDGET_REASON))
+                .count();
+            assert_eq!(notes, 1, "pass {pass} left {notes} copies: {payload}");
+        }
     }
 
     /// The elision half of the same case: the widened table must cut with counts

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -197,7 +197,27 @@ pub struct BudgetAccounting {
     /// What the payload measured BEFORE the budget touched it.
     #[serde(rename = "chars_before_budget")]
     pub chars_before: usize,
-    /// True when something was actually removed.
+    /// What the payload measured when the ladder finished with it, which is the
+    /// size the response ships at.
+    ///
+    /// `chars_before` alone cannot say whether the bound held. An
+    /// `impact_analysis` answer reported `bounded: false` beside a
+    /// `chars_before_budget` of 50,354 against a 2,000-character ceiling and
+    /// shipped all 50,354, and nothing in the accounting distinguished that from
+    /// a response whose diagnostics were compacted away and which then fit.
+    /// Publishing the size the response actually shipped at is what separates
+    /// them, and it is the number a caller compares against `max_chars`.
+    ///
+    /// Measured before the envelope's own accounting stanza is rewritten, so it
+    /// is accurate to within the length of that stanza rather than to the byte.
+    #[serde(rename = "chars_after_budget", default)]
+    pub chars_after: usize,
+    /// True when the budget removed hits, bodies or breakdowns under pressure.
+    ///
+    /// False does not by itself mean the response is whole: compaction is the
+    /// documented default shape and is reported by `compact`, not here. What
+    /// false does mean, always, is that the response fits `max_chars`; read
+    /// `chars_after_budget` for the size it fits at.
     pub bounded: bool,
     /// True when explanation and per-signal breakdowns were shed.
     pub compact: bool,
@@ -409,19 +429,54 @@ fn shape_for(tool: &str) -> Option<ResponseShape> {
             bulk_keys: &[],
             narrow_param: "depth",
         },
-        // The four buckets an `ImpactReport` serializes as arrays of raw
-        // entities, most important first. `impacted_entities` was never a key
-        // this response carries, so naming it here left every rung of the ladder
-        // walking an array that does not exist: nothing was stripped and nothing
-        // was trimmed on a 416,567-character answer. `entity_impacts` is
-        // deliberately absent, because its per-entity counts ARE the answer and
-        // they are small.
+        // Every array an `impact_analysis` response carries, ranked by what a
+        // caller loses when it goes, because the ladder trims from the end.
+        //
+        // Naming only the four blast-radius buckets is what FIR-2602 was: a
+        // report over a wide diff can leave all four genuinely empty and still
+        // run to tens of thousands of characters, because `entity_impacts`
+        // carries a row per changed entity and the changed-id and attribution
+        // echoes carry one entry each. The ladder walked its four arrays, found
+        // nothing to cut, and returned 50,354 characters against a 2,000
+        // ceiling while reporting itself unbounded. A key the table does not
+        // name is a key the bounder cannot count, so the table names them all.
+        //
+        // The ranking, most important first:
+        //
+        // `entity_impacts` is the verdict. `proven_consumer_count` and
+        // `covering_tests` are what a caller reads to decide whether something
+        // is safe to change, and they were once left out on the grounds that
+        // they are small, which is true per row and false per report.
+        //
+        // The four blast-radius buckets come next, in the order kin#1062 fixed
+        // them in: callers before dependents, dependents before contract
+        // consumers, tests last of the four.
+        //
+        // Then the governance and input echoes. `unreviewed_agent_changes` is a
+        // judgment a caller cannot reconstruct; `changed_ids` is the target the
+        // caller named, so it is the one list the caller already holds.
+        //
+        // Then provenance and side channels: `actor_attribution` is answered in
+        // full by `kin_provenance_query`, and work items and annotations are
+        // adjacent records rather than blast radius.
+        //
+        // Ambient context sheds first. `cross_repo_impact` and `active_traffic`
+        // answer "who else is nearby", and `active_traffic` is already optional
+        // on the call.
         "impact_analysis" => ResponseShape {
             collections: &[
+                "entity_impacts",
                 "affected_callers",
                 "affected_dependents",
                 "affected_contract_consumers",
                 "affected_tests",
+                "unreviewed_agent_changes",
+                "changed_ids",
+                "actor_attribution",
+                "affected_work_items",
+                "affected_annotations",
+                "cross_repo_impact",
+                "active_traffic",
             ],
             body_keys: &["body"],
             explain_keys: &[],
@@ -485,9 +540,36 @@ pub fn enforce(
     let mut accounting = BudgetAccounting {
         max_chars: budget.max_chars,
         chars_before,
+        chars_after: chars_before,
         bounded: false,
         compact: budget.compact,
     };
+    run_ladder(payload, &shape, budget, &mut accounting);
+    accounting.chars_after = measure(payload);
+
+    // A response the ladder could not bring under its ceiling is the case
+    // FIR-2602 shipped silently: every rung ran, nothing was left to cut, and
+    // the accounting reported a whole answer. The ceiling is not always
+    // reachable, because a bound is not a refusal and every list keeps an entry,
+    // but the caller has to be told which of the two it is holding.
+    if accounting.chars_after > budget.max_chars {
+        disclose_residual(payload, budget);
+        accounting.chars_after = measure(payload);
+    }
+    Some(accounting)
+}
+
+/// Run the ladder over one payload, recording what it cost in `accounting`.
+///
+/// Split from [`enforce`] so the size the response ships at is measured on one
+/// path rather than on each of the ladder's several exits, which is what let a
+/// rung return early without anything measuring the result.
+fn run_ladder(
+    payload: &mut Value,
+    shape: &ResponseShape,
+    budget: &ResponseBudget,
+    accounting: &mut BudgetAccounting,
+) {
     let mut cuts: Vec<String> = Vec::new();
     let mut remediations: Vec<String> = Vec::new();
 
@@ -497,12 +579,12 @@ pub fn enforce(
     // This one is not disclosed as a cut, because it is the documented default
     // shape rather than something the budget took away under pressure.
     if budget.compact {
-        strip_keys(payload, &shape, shape.explain_keys, shape.top_explain_keys);
-        strip_keys(payload, &shape, shape.bulk_keys, &[]);
+        strip_keys(payload, shape, shape.explain_keys, shape.top_explain_keys);
+        strip_keys(payload, shape, shape.bulk_keys, &[]);
     }
 
     if measure(payload) <= budget.max_chars {
-        return Some(accounting);
+        return;
     }
 
     // The reserve holds room for the disclosure the cut adds, but it can never
@@ -518,7 +600,7 @@ pub fn enforce(
     // The disclosure names what happened; silence would leave the caller reading
     // an explain-less response it had explicitly asked to explain.
     if !budget.compact {
-        let stripped = strip_keys(payload, &shape, shape.explain_keys, shape.top_explain_keys);
+        let stripped = strip_keys(payload, shape, shape.explain_keys, shape.top_explain_keys);
         if stripped > 0 {
             accounting.bounded = true;
             cuts.push(format!(
@@ -528,7 +610,7 @@ pub fn enforce(
         // Bulk identity is shed here too. A caller that turned compaction off
         // asked to see the ranking, not to be served a response its client
         // refuses because every row carries four hash arrays.
-        let stripped = strip_keys(payload, &shape, shape.bulk_keys, &[]);
+        let stripped = strip_keys(payload, shape, shape.bulk_keys, &[]);
         if stripped > 0 {
             accounting.bounded = true;
             cuts.push(format!(
@@ -538,12 +620,12 @@ pub fn enforce(
         }
         if measure(payload) <= target {
             disclose(payload, budget, &cuts, &remediations);
-            return Some(accounting);
+            return;
         }
     }
 
     if !shape.duplicate_keys.is_empty() {
-        let stripped = strip_keys(payload, &shape, shape.duplicate_keys, &[]);
+        let stripped = strip_keys(payload, shape, shape.duplicate_keys, &[]);
         if stripped > 0 {
             accounting.bounded = true;
             cuts.push(format!(
@@ -554,12 +636,12 @@ pub fn enforce(
         }
         if measure(payload) <= target {
             disclose(payload, budget, &cuts, &remediations);
-            return Some(accounting);
+            return;
         }
     }
 
     if !shape.body_keys.is_empty() {
-        let stripped = strip_keys(payload, &shape, shape.body_keys, &[]);
+        let stripped = strip_keys(payload, shape, shape.body_keys, &[]);
         if stripped > 0 {
             accounting.bounded = true;
             cuts.push(format!(
@@ -570,7 +652,7 @@ pub fn enforce(
         }
         if measure(payload) <= target {
             disclose(payload, budget, &cuts, &remediations);
-            return Some(accounting);
+            return;
         }
     }
 
@@ -621,7 +703,45 @@ pub fn enforce(
     }
 
     disclose(payload, budget, &cuts, &remediations);
-    Some(accounting)
+}
+
+/// The reason code a response that stayed over its ceiling carries.
+pub const OVER_BUDGET_REASON: &str = "response_over_budget";
+
+/// Record that the ladder finished with the payload still over its ceiling.
+///
+/// Every list the budget cuts keeps at least one entry, so a response whose
+/// surviving entries alone exceed the budget cannot be cut further without
+/// producing the empty array FIR-2600 exists to prevent. That case is rare and
+/// it is real, and the only wrong answer is a quiet one: FIR-2602 shipped
+/// 50,354 characters against a 2,000-character ceiling and reported nothing at
+/// all. This says so in the channel the other cuts already use.
+///
+/// The note carries no size of its own. Appending it changes the size it would
+/// be reporting, so any number written here is stale the moment it is written;
+/// the accounting's `chars_after_budget` is measured after this note lands and
+/// is the one that holds.
+fn disclose_residual(payload: &mut Value, budget: &ResponseBudget) {
+    let max_chars = budget.max_chars;
+    let entry = json!({
+        "component": "response_budget",
+        "reason": OVER_BUDGET_REASON,
+        "detail": format!(
+            "the response did not reach its {max_chars}-character budget: every list the budget \
+             cuts keeps at least one entry, and what survived does not fit. Read the size it \
+             ships at from `_kin.response.chars_after_budget`, or from the bytes received"
+        ),
+        "remediation": "narrow the request, or raise max_chars if the caller's own result \
+                        limit accepts a larger payload",
+        "max_chars": max_chars,
+    });
+    match payload
+        .get_mut("degradations")
+        .and_then(Value::as_array_mut)
+    {
+        Some(existing) => existing.push(entry),
+        None => payload["degradations"] = Value::Array(vec![entry]),
+    }
 }
 
 /// Remove `keys` from every hit in every collection, and `top_keys` from the
@@ -1222,6 +1342,228 @@ mod tests {
             payload.get("affected_tests_withheld").is_none(),
             "nothing was withheld: {payload}"
         );
+    }
+
+    /// An impact response shaped the way the measured one was: every
+    /// `affected_*` bucket genuinely empty, and every byte of the payload in the
+    /// per-entity attribution, the changed-id echo and the actor attribution.
+    ///
+    /// That shape is what an `impact_analysis` over a wide diff returns. The
+    /// blast-radius buckets can be empty and the report still runs to tens of
+    /// thousands of characters, because `entity_impacts` carries one row per
+    /// changed entity and each row carries its consumer files.
+    fn impact_payload_bulk_outside_the_buckets(rows: usize) -> Value {
+        let entity_id = |index: usize| format!("9b9f577c-2cb3-43fd-a59b-ced58218{index:04}");
+        json!({
+            "affected_callers": [],
+            "affected_dependents": [],
+            "affected_contract_consumers": [],
+            "affected_tests": [],
+            "affected_work_items": [],
+            "affected_annotations": [],
+            "changed_ids": (0..rows).map(entity_id).collect::<Vec<_>>(),
+            "unreviewed_agent_changes": (0..rows / 2).map(entity_id).collect::<Vec<_>>(),
+            "actor_attribution": (0..rows)
+                .map(|index| json!([entity_id(index), "Assistant"]))
+                .collect::<Vec<_>>(),
+            "entity_impacts": (0..rows)
+                .map(|index| json!({
+                    "entity_id": entity_id(index),
+                    "consumer_count": index % 7,
+                    "strong_consumer_count": index % 5,
+                    "proven_consumer_count": index % 3,
+                    "contract_consumer_count": 0,
+                    "consumer_files": (0..6)
+                        .map(|file| format!(
+                            "src/requests/adapters/session_{index}_{file}.py"
+                        ))
+                        .collect::<Vec<_>>(),
+                    "covering_tests": index % 4,
+                    "consumers_migrated_in_diff": 0,
+                    "call_shapes": {
+                        "caller_keyword_names": ["stream", "timeout", "verify"],
+                        "any_var_keyword_caller": false,
+                        "all_consumers_shaped_calls": true,
+                    },
+                }))
+                .collect::<Vec<_>>(),
+        })
+    }
+
+    /// FIR-2602. The shape table listed only the four blast-radius buckets, so a
+    /// report whose bulk sits anywhere else walked every rung of the ladder
+    /// untouched: nothing was stripped, nothing was trimmed, and the accounting
+    /// reported `bounded: false` on a payload 25 times over its ceiling. Measured
+    /// through MCP on a build carrying kin#1062 as `{"bounded": false,
+    /// "chars_before_budget": 50354, "max_chars": 2000}` with all four buckets
+    /// genuinely empty.
+    ///
+    /// Both ceilings are asserted, because they prove different halves. At the
+    /// 2,000 the measured call used, twelve lists each keeping their floor entry
+    /// cannot fit and the response says so rather than shipping quiet. At a
+    /// ceiling a real call gets, the same report fits inside it.
+    #[test]
+    fn impact_bulk_outside_the_blast_radius_buckets_is_counted_and_bounded() {
+        const FLOOR: usize = RESPONSE_MIN_MAX_CHARS;
+        let mut payload = impact_payload_bulk_outside_the_buckets(60);
+        let before = measure(&payload);
+        assert!(
+            before > FLOOR * 10,
+            "the fixture must reproduce the measured overrun, not a near miss: {before}"
+        );
+        for bucket in [
+            "affected_callers",
+            "affected_dependents",
+            "affected_contract_consumers",
+            "affected_tests",
+        ] {
+            assert!(
+                payload[bucket].as_array().expect("bucket").is_empty(),
+                "the measured response had every blast-radius bucket empty"
+            );
+        }
+
+        let budget = ResponseBudget {
+            max_chars: FLOOR,
+            ..ResponseBudget::default()
+        };
+        let accounting = enforce(&mut payload, "impact_analysis", &budget).expect("budgeted");
+        assert_eq!(accounting.chars_before, before);
+        assert_eq!(
+            accounting.chars_after,
+            measure(&payload),
+            "the accounting must report the size the response actually shipped at"
+        );
+        assert!(
+            accounting.bounded,
+            "a response the budget had to cut cannot report itself unbounded: {payload}"
+        );
+        assert!(
+            accounting.chars_after < before / 10,
+            "the widened table must count the bulk it could not see before: \
+             {before} to {}",
+            accounting.chars_after
+        );
+        // Twelve lists at their floor plus the disclosure do not fit 2,000, and
+        // that is the one outcome that must never be silent.
+        assert!(
+            accounting.chars_after > budget.max_chars,
+            "this assertion guards the branch below; a fit here means the fixture changed"
+        );
+        let residual = payload["degradations"]
+            .as_array()
+            .expect("a cut is disclosed")
+            .iter()
+            .find(|entry| entry["reason"] == json!(OVER_BUDGET_REASON));
+        assert!(
+            residual.is_some(),
+            "a response still over its ceiling must say so: {payload}"
+        );
+
+        // The same report at a ceiling a real call gets fits inside it.
+        let mut payload = impact_payload_bulk_outside_the_buckets(60);
+        let budget = ResponseBudget::default();
+        let accounting = enforce(&mut payload, "impact_analysis", &budget).expect("budgeted");
+        assert!(
+            accounting.chars_after <= budget.max_chars,
+            "the response shipped {} characters against a {} ceiling: {payload}",
+            accounting.chars_after,
+            budget.max_chars
+        );
+        assert!(
+            payload["degradations"]
+                .as_array()
+                .map_or(true, |entries| entries
+                    .iter()
+                    .all(|entry| entry["reason"] != json!(OVER_BUDGET_REASON))),
+            "a response that reached its ceiling must not claim it did not: {payload}"
+        );
+    }
+
+    /// The elision half of the same case: the widened table must cut with counts
+    /// rather than by emptying, on every list it newly reaches.
+    #[test]
+    fn a_widened_impact_table_elides_with_counts_and_empties_nothing() {
+        const BUDGET: usize = 2_000;
+        let mut payload = impact_payload_bulk_outside_the_buckets(60);
+        let found: Vec<(String, usize)> = payload
+            .as_object()
+            .expect("object")
+            .iter()
+            .filter_map(|(key, value)| {
+                value
+                    .as_array()
+                    .filter(|rows| !rows.is_empty())
+                    .map(|rows| (key.clone(), rows.len()))
+            })
+            .collect();
+        assert!(
+            found.len() >= 3,
+            "the fixture must fill several lists or this proves nothing: {found:?}"
+        );
+        let budget = ResponseBudget {
+            max_chars: BUDGET,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "impact_analysis", &budget).expect("budgeted");
+
+        let mut cut_any = false;
+        for (key, before) in found {
+            let kept = payload[&key].as_array().expect("list survives").len();
+            assert!(
+                kept > 0,
+                "`{key}` was emptied by the budget, which reads as \"the walk found none\": \
+                 {payload}"
+            );
+            if kept == before {
+                continue;
+            }
+            cut_any = true;
+            let elision = &payload["elisions"][&key];
+            assert_eq!(elision["kept"], json!(kept), "{payload}");
+            assert_eq!(elision["elided"], json!(before - kept), "{payload}");
+            assert_eq!(elision["total"], json!(before), "{payload}");
+            assert_eq!(elision["reason"], json!(ELISION_REASON_BUDGET), "{payload}");
+        }
+        assert!(
+            cut_any,
+            "a 2000-character ceiling must have cut something: {payload}"
+        );
+    }
+
+    /// The invariant the two tests above are instances of, held across every
+    /// budgeted tool rather than on one fixture: an accounting that reports
+    /// `bounded: false` is asserting the response fits, so it must fit.
+    ///
+    /// This is the check that would have caught FIR-2602 in any tool, because
+    /// the defect was never about impact reports. It was about a shape table
+    /// that could fall behind the payload it describes without anything saying
+    /// so.
+    #[test]
+    fn an_unbounded_accounting_always_describes_a_response_that_fits() {
+        const BUDGET: usize = 2_000;
+        let budget = ResponseBudget {
+            max_chars: BUDGET,
+            ..ResponseBudget::default()
+        };
+        let cases: Vec<(&str, Value)> = vec![
+            (
+                "impact_analysis",
+                impact_payload_bulk_outside_the_buckets(60),
+            ),
+            ("impact_analysis", impact_payload(33)),
+            ("semantic_locate", locate_payload(30, 400)),
+            ("semantic_locate", locate_payload(1, 4)),
+        ];
+        for (tool, mut payload) in cases {
+            let accounting = enforce(&mut payload, tool, &budget).expect("budgeted");
+            assert_eq!(accounting.chars_after, measure(&payload), "{tool}");
+            assert!(
+                accounting.bounded || accounting.chars_after <= BUDGET,
+                "{tool} reported bounded false at {} characters against a {BUDGET} ceiling",
+                accounting.chars_after
+            );
+        }
     }
 
     /// A list nothing was taken from must not grow an elision, whatever calls

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1989,7 +1989,11 @@ fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &Respon
     write_response_accounting(annotated, &accounting);
     if let Some(applied) = crate::budget::enforce(annotated, tool_name, budget) {
         accounting = applied;
-        accounting.chars_before = chars_before;
+        // This arm's own measurement, taken before the placeholder stanza was
+        // written, is the more accurate one for this pass. It loses only to a
+        // larger number the ladder recovered from an earlier arm's disclosure,
+        // which is the size the answer was actually built at.
+        accounting.chars_before = accounting.chars_before.max(chars_before);
     }
     write_response_accounting(annotated, &accounting);
     if accounting.bounded {

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1979,6 +1979,10 @@ fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &Respon
     let mut accounting = crate::budget::BudgetAccounting {
         max_chars: budget.max_chars,
         chars_before,
+        // The placeholder carries a number of the same magnitude as the one that
+        // replaces it, so the stanza written first is the width of the stanza
+        // that ships and the ladder charges the budget for the right bytes.
+        chars_after: chars_before,
         bounded: false,
         compact: budget.compact,
     };

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -6619,8 +6619,11 @@ mod tests {
     /// characters and could not be called from Claude Code at all. kin#902 added
     /// an `impact_analysis` entry to the response budget, but it named
     /// `impacted_entities`, a key this response has never carried, so every rung
-    /// of the ladder walked an absent array and cut nothing. The buckets an
-    /// `ImpactReport` actually serializes are the four in `IMPACT_ENTITY_BUCKETS`.
+    /// of the ladder walked an absent array and cut nothing. The blast-radius
+    /// buckets an `ImpactReport` serializes as arrays of raw entities are the
+    /// four in `IMPACT_ENTITY_BUCKETS`, which is what the budget's table named
+    /// next. FIR-2602 then widened that table to every array the response
+    /// carries, because a report can leave all four empty and still be large.
     ///
     /// This drives the handler, then applies the same `ResponseBudget` the MCP
     /// path applies, and measures the bytes a caller would receive.

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -79,6 +79,18 @@ advertised budget sits under what a real MCP client accepts. Check 3 runs one
 query at the ceiling and again at the floor and asserts nothing full in the first
 is empty in the second, which needs no counter to be true.
 
+Check 4 covers the rule underneath that one: a response has to be counted before
+it can be cut. `impact_analysis` reported `bounded: false` beside a
+`chars_before_budget` of 50,354 against a 2,000-character ceiling and shipped all
+50,354, because the budget's shape table named only the four `affected_*` buckets
+and the bulk of an impact report is not in them (FIR-2602). The check runs one
+impact query at the ceiling and again at the floor over every list the report can
+carry, asserts none of them was emptied, and reads the response's own accounting:
+`bounded: false` asserts the response fits, so it has to fit, and a response that
+does not fit has to say so in `degradations`. A ceiling is not always reachable,
+because every cut list keeps a floor entry, and that case is fine as long as it is
+never quiet.
+
 `brownfield_repro.py --self-test` and `response_budget_elisions.py --self-test`
 exercise their verdict graders on fixed payloads and need no binary and no
 corpus. Each case is paired with its inverse, so a grader that cannot tell its

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -18,6 +18,15 @@ can be satisfied by a broken tool:
      elision, so an empty array means exactly one thing
   2  the budget the tool advertises is the budget it enforces, and its ceiling is
      one a real MCP client accepts
+  3  no ranked list the budget cuts ships empty
+  4  a response the budget could not bring under its ceiling says so, and one
+     reporting `bounded: false` is one that fits
+
+FIR-2602 is check 4. `impact_analysis` reported `{"bounded": false,
+"chars_before_budget": 50354, "max_chars": 2000}` and shipped all 50,354
+characters, because the shape table named only the four `affected_*` buckets and
+the bulk of an impact report is not in them. A bucket the table does not name is
+a bucket the bounder cannot count, and nothing in the response said so.
 
 Exit status is 0 when every check passed, 1 when one failed, 2 when one could not
 be read, and 3 when the run could not be set up. `--self-test` exercises every
@@ -45,6 +54,29 @@ print = functools.partial(print, flush=True)
 # The ceiling this server advertises has to sit below it, or the tool is telling
 # callers to ask for a result their client will throw away.
 REFUSED_BY_A_REAL_CLIENT = 117313
+
+
+# Every list an `impact_analysis` response carries, mirroring the shape table in
+# crates/kin-mcp/src/budget.rs. Listed here so a key added to the response and
+# not to the table is a check that grades nothing rather than a silent gap: the
+# check reports UNREADABLE when it grades none of them.
+IMPACT_LISTS = [
+    "entity_impacts",
+    "affected_callers",
+    "affected_dependents",
+    "affected_contract_consumers",
+    "affected_tests",
+    "unreviewed_agent_changes",
+    "changed_ids",
+    "actor_attribution",
+    "affected_work_items",
+    "affected_annotations",
+    "cross_repo_impact",
+    "active_traffic",
+]
+
+# The reason code a response still over its ceiling publishes.
+OVER_BUDGET_REASON = "response_over_budget"
 
 
 class SetupError(Exception):
@@ -178,6 +210,57 @@ def grade_advertised_budget(schema):
         problems.append(
             "the advertised default %d does not sit inside %d..%d"
             % (default, floor, ceiling)
+        )
+    return problems
+
+
+def grade_budget_accounting(payload):
+    """Grade one response's own account of what the budget did to it.
+
+    Two claims, both readable off the response alone:
+
+      * `bounded: false` asserts the response fits, so it has to fit. This is
+        the FIR-2602 defect exactly: false beside a size 25 times the ceiling.
+      * a response that does NOT fit says so in `degradations`, because every
+        list keeps a floor entry and a ceiling is not always reachable. Rare and
+        real is fine; quiet is not.
+    """
+    problems = []
+    accounting = ((payload.get("_kin") or {}).get("response")) or {}
+    if not accounting:
+        return ["the response carries no `_kin.response` accounting"]
+    max_chars = accounting.get("max_chars")
+    before = accounting.get("chars_before_budget")
+    after = accounting.get("chars_after_budget")
+    if not isinstance(max_chars, int) or not isinstance(before, int):
+        return ["the accounting names no max_chars or no chars_before_budget"]
+    if not isinstance(after, int):
+        return [
+            "the accounting reports no chars_after_budget, so nothing in the response "
+            "says what size it shipped at"
+        ]
+    bounded = accounting.get("bounded")
+    if bounded is not True and bounded is not False:
+        problems.append("the accounting reports bounded %r" % bounded)
+    if bounded is False and after > max_chars:
+        problems.append(
+            "the accounting reports bounded false at %d characters against a %d ceiling"
+            % (after, max_chars)
+        )
+    reasons = [
+        entry.get("reason")
+        for entry in (payload.get("degradations") or [])
+        if isinstance(entry, dict)
+    ]
+    if after > max_chars and OVER_BUDGET_REASON not in reasons:
+        problems.append(
+            "the response measures %d against a %d ceiling and publishes no %s "
+            "degradation" % (after, max_chars, OVER_BUDGET_REASON)
+        )
+    if after <= max_chars and OVER_BUDGET_REASON in reasons:
+        problems.append(
+            "the response fits at %d against a %d ceiling and claims it does not"
+            % (after, max_chars)
         )
     return problems
 
@@ -559,7 +642,78 @@ def check_3(suite):
     return res
 
 
-CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3)]
+def check_4(suite):
+    res = Result(
+        "4",
+        "FIR-2602",
+        "an impact response is counted whole, and never reports a bound it did not hold",
+    )
+    target = {"files": ["src/chain.py"], "include_traffic": False}
+    try:
+        whole = suite.mcp("impact_analysis", dict(target, max_chars=60000))
+        cut = suite.mcp("impact_analysis", dict(target, max_chars=2000))
+    except McpError as exc:
+        res.unknown("impact_analysis unreadable: %s" % exc)
+        return res
+
+    for label, payload in (("ceiling", whole), ("floor", cut)):
+        for problem in grade_budget_accounting(payload):
+            res.bad("%s call: %s" % (label, problem))
+
+    # The bulk of this fixture's impact report is outside the four `affected_*`
+    # buckets, which is the shape FIR-2602 was measured on. A list full at the
+    # ceiling and empty at the floor was emptied by the budget and by nothing
+    # else, and needs no counter to be true.
+    populated = [key for key in IMPACT_LISTS if whole.get(key)]
+    if not populated:
+        res.unknown("the ceiling call filled no impact list, so the rule was not exercised")
+        return res
+    outside = [
+        key
+        for key in populated
+        if not key.startswith("affected_") or key in ("affected_work_items", "affected_annotations")
+    ]
+    if not outside:
+        res.unknown(
+            "every populated list is a blast-radius bucket, so the FIR-2602 shape was "
+            "not reproduced"
+        )
+        return res
+    for key in populated:
+        rows = cut.get(key)
+        if not isinstance(rows, list) or not rows:
+            res.bad(
+                "`%s` held %d entries at the ceiling and %r at the floor, so the budget "
+                "emptied it" % (key, len(whole[key]), rows)
+            )
+
+    problems, graded = grade_buckets(cut, IMPACT_LISTS)
+    for problem in problems:
+        res.bad(problem)
+    if graded == 0:
+        res.unknown("the floor call cut no impact list, so the elision rule was not exercised")
+        return res
+
+    if not res.failed:
+        accounting = cut["_kin"]["response"]
+        res.ok(
+            "the report measured %d characters and was cut to %d against a %d ceiling; "
+            "%d of %d lists were cut and every one kept an entry, %d of them outside the "
+            "blast-radius buckets: %s"
+            % (
+                accounting["chars_before_budget"],
+                accounting["chars_after_budget"],
+                accounting["max_chars"],
+                graded,
+                len(populated),
+                len(outside),
+                json.dumps(cut.get("elisions") or {}, sort_keys=True),
+            )
+        )
+    return res
+
+
+CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3), ("4", check_4)]
 
 
 def self_test():
@@ -669,6 +823,86 @@ def self_test():
         "an untouched bucket is not graded",
         grade_buckets(untouched, ["affected_tests"]),
         ([], 0),
+    )
+
+    fitting = {
+        "_kin": {
+            "response": {
+                "max_chars": 2000,
+                "chars_before_budget": 50354,
+                "chars_after_budget": 1840,
+                "bounded": True,
+            }
+        }
+    }
+    expect("a response that fits passes", grade_budget_accounting(fitting), [])
+
+    shipped = {
+        "_kin": {
+            "response": {
+                "max_chars": 2000,
+                "chars_before_budget": 50354,
+                "chars_after_budget": 50354,
+                "bounded": False,
+            }
+        }
+    }
+    expect(
+        "the FIR-2602 shape fails",
+        len(grade_budget_accounting(shipped)) >= 1,
+        True,
+    )
+
+    silent = {
+        "_kin": {
+            "response": {
+                "max_chars": 2000,
+                "chars_before_budget": 50354,
+                "chars_after_budget": 2574,
+                "bounded": True,
+            }
+        }
+    }
+    expect(
+        "a response still over its ceiling and saying nothing fails",
+        len(grade_budget_accounting(silent)) >= 1,
+        True,
+    )
+    disclosed = dict(silent)
+    disclosed["degradations"] = [{"reason": OVER_BUDGET_REASON}]
+    expect("the same response, disclosed, passes", grade_budget_accounting(disclosed), [])
+
+    overclaimed = {
+        "_kin": {
+            "response": {
+                "max_chars": 2000,
+                "chars_before_budget": 50354,
+                "chars_after_budget": 1840,
+                "bounded": True,
+            }
+        },
+        "degradations": [{"reason": OVER_BUDGET_REASON}],
+    }
+    expect(
+        "a response that fits and claims it does not fails",
+        len(grade_budget_accounting(overclaimed)) >= 1,
+        True,
+    )
+
+    sizeless = {
+        "_kin": {
+            "response": {"max_chars": 2000, "chars_before_budget": 50354, "bounded": False}
+        }
+    }
+    expect(
+        "an accounting with no shipped size fails",
+        len(grade_budget_accounting(sizeless)) >= 1,
+        True,
+    )
+    expect(
+        "a response with no accounting at all fails",
+        len(grade_budget_accounting({"affected_tests": []})) >= 1,
+        True,
     )
 
     for line in problems:


### PR DESCRIPTION
`impact_analysis` returned 50,354 characters against a 2,000-character ceiling and reported
`"bounded": false`. Both halves of that were true of the code: the budget's shape table named
four keys for this tool, all four blast-radius buckets were genuinely empty, and the ladder
walked four arrays, found nothing to cut, and returned. Nothing measured the result, so the
accounting described a whole answer.

An `ImpactReport` serializes eight more arrays than the table named, and the handler adds two.
A report over a wide diff leaves the blast-radius buckets empty and still runs to tens of
thousands of characters, because `entity_impacts` carries a row per changed entity and the
changed-id and actor-attribution echoes carry one entry each. A key the table does not name is
a key the bounder cannot count.

## The ranking

Widening the table decides what an impact answer can afford to lose, because the ladder trims
from the end. The order, most important first, is written out in the code with its reasons:

`entity_impacts` is the verdict. `proven_consumer_count` and `covering_tests` are what a
caller reads to decide whether something is safe to change, and they were left out on the
grounds that they are small, which is true per row and false per report. The four
blast-radius buckets follow in the order kin#1062 fixed them in. Then
`unreviewed_agent_changes` and `changed_ids`: a governance judgment a caller cannot
reconstruct, and the target the caller already holds. Then `actor_attribution`,
`affected_work_items` and `affected_annotations`, which are provenance and adjacent records
rather than blast radius. Ambient context sheds first: `cross_repo_impact` and
`active_traffic`.

Every one of them cuts through the ladder kin#1062 already fixed, so each keeps its floor
entry and publishes the same `elisions` record. No list is ever emptied to make a response
fit.

## Counting is not enough on its own

Three things made the miscount invisible, and each is now closed.

`BudgetAccounting` gained `chars_after_budget`, the size the response ships at.
`chars_before_budget` alone cannot separate a response that compacted its diagnostics away and
then fit from one that shipped whole and over its cap. `bounded: false` now asserts that the
response fits, and the number proving it is in the same stanza.

The ladder moved into `run_ladder`, which returns nothing, and `enforce` measures once after
it. The several early returns are what let a rung exit without anything measuring the result.

A response the ladder cannot bring under its ceiling publishes a `response_over_budget`
degradation. Every cut list keeps a floor entry, so a ceiling is not always reachable; that
case is real, and the only wrong version of it is a quiet one. The note is withdrawn again by
an arm that does clear the ceiling, because the first arm cuts under the budget less the
envelope reserve and can miss a ceiling the second one makes once the envelope that lands is
smaller than the reserve held back for it. A note saying the response did not fit, on a
response that does, is the same false report in reverse.

## Two arms bound one response

Running the new acceptance check against the release binary found the same symptom by a second
route. The daemon's `/mcp/tools/call` route cuts first, under the budget less the envelope
reserve, and the stdio path envelopes what comes back and cuts again. Only the second arm's
accounting reaches `_kin.response`. So a report the first arm had already cut to its floor
reported `bounded: false` at 13,232 characters with a populated `elisions` map beside it, and
`chars_before_budget` described the size the second arm inherited.

The accounting is about the response, not about one pass over it. A cut discloses itself and
now records the size it cut from, so the second arm reads what the first did off the payload it
was handed. On the acceptance fixture that correction is large: the report's pre-budget size
reads 195,000 characters, where the old accounting reported 66,680.

## Measured

On the fixture, through MCP, on release binaries built from this branch:

```
CHECK 4 FIR-2602 PASS the report measured 195000 characters and was cut to 12781 against a
2000 ceiling; 4 of 4 lists were cut and every one kept an entry, 2 of them outside the
blast-radius buckets
```

`changed_ids` and `entity_impacts` are the two the old table could not see. The response still
measures 12,781 against 2,000, and what remains is not a list the ladder can trim: the `_kin`
envelope, the `negative` object, `edge_coverage` and the disclosures. The response says so now
instead of reporting itself whole.

## Tests

`scripts/acceptance/response_budget_elisions.py` gains check 4 beside kin#1062's checks. It
runs one impact query at the ceiling and again at the floor over every list the report can
carry, asserts none was emptied, asserts the elision counts agree, and grades the response's
own accounting. Its grader is exercised against its inverse in `--self-test`, including the
exact measured defect; neutering the grader turns the self-test red on five cases.

Six unit tests cover the fixture whose bulk lives outside the old table, the elision counts on
the newly reachable lists, the cross-tool invariant that an unbounded accounting always
describes a response that fits, the two-arm case, the single residual note, and its withdrawal.
Narrowing the table back to the four buckets fails three of them on
`reported bounded false at 58343 characters against a 2000 ceiling`.

One note on what `bounded: false` now promises. It promises the response fits, read off
`chars_after_budget`, and not that `chars_before_budget` is under the ceiling. Compaction is
measured after `chars_before_budget` and sheds only diagnostics, never rows, and on the
FIR-2408 fixture that was 78.5% of the payload. Calling that bounded would send every large but
complete impact answer through `verdict::mark_response_bounded`, which sets
`safe_to_conclude_absent: false`, so an answer that lost nothing a caller asked for would lose
its absence certification. `compact` already reports that shedding.

Closes FIR-2602
