### PR TITLE
Give the install proof a runaway backstop instead of a cap the healthy Windows leg reaches

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -49,7 +49,15 @@ jobs:
   install-proof:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    # 90 is a runaway backstop, not a ceiling the leg is expected to reach.
+    # v0.5.48's run proved the healthy Windows leg needs more than 45: with the
+    # projection defect fixed it ran deep into the real proof for the first
+    # time and was cancelled at 45m12s, and a timeout lands as CANCELLED, which
+    # the experimental waiver below does not absorb (continue-on-error covers
+    # failure only), so the cancellation skipped npm publish and promotion.
+    # A cap the leg can reach while healthy is therefore a release-killer on
+    # exactly the runs where the leg improves.
+    timeout-minutes: 90
     # The Windows leg runs the full unconditional proof and uploads its
     # artifacts, but its verdict does not yet gate the release. The reason has
     # moved, and this comment is what carries it, so it is worth keeping


### PR DESCRIPTION
v0.5.48's release run ended cancelled: the only cancelled job is the Windows install-proof leg, at exactly its own timeout-minutes 45 (started 08:45:58Z, completed 09:31:10Z). A job timeout lands as CANCELLED, and the experimental waiver's continue-on-error absorbs failure only, so the cancellation failed the install_proof node and npm publish, ghcr tagging, notarize, and promotion all skipped. No user saw 0.5.48.

The mechanism deserves precision: on v0.5.44 through v0.5.47 this leg failed fast on projection_mode=misconfigured and the waiver absorbed it. kin#1060 plus the FIR-2460 product fix let the leg pass that step for the first time (it passed live on this run), so the leg ran deep into the first-run and graph proofs and needed more than 45 minutes. The leg improving is what gated the release.

One line plus its comment: raise the job cap to 90 as a runaway backstop the leg is not expected to reach. The sweep for other homes found the only other timeout-minutes 45 in the release authority suite belongs to ci.yml's Windows authority jobs, untouched here. The residual class (a genuine runaway still cancels, unwaived) is recorded on FIR-2612 and goes to the trap catalogue; per-step budgets were considered and rejected because the long steps are shared with the non-experimental Unix rows, where a low budget would be a new release-killer.

Closes FIR-2612