### PR TITLE
Gate the release on the Windows install proof and stop it waiting on a daemon pipe

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -49,40 +49,33 @@ jobs:
   install-proof:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    # 90 is a runaway backstop, not a ceiling the leg is expected to reach.
-    # v0.5.48's run proved the healthy Windows leg needs more than 45: with the
-    # projection defect fixed it ran deep into the real proof for the first
-    # time and was cancelled at 45m12s, and a timeout lands as CANCELLED, which
-    # the experimental waiver below does not absorb (continue-on-error covers
-    # failure only), so the cancellation skipped npm publish and promotion.
-    # A cap the leg can reach while healthy is therefore a release-killer on
-    # exactly the runs where the leg improves.
+    # 90 is a runaway backstop, not a ceiling any leg is expected to reach.
+    # It was raised from 45 because v0.5.48's Windows leg was cancelled at
+    # 45m12s while healthy, and a timeout lands as CANCELLED, which skips npm
+    # publish and promotion. Every leg is gating now, so a cap a healthy leg
+    # can reach is a release-killer; leave the backstop generous.
     timeout-minutes: 90
-    # The Windows leg runs the full unconditional proof and uploads its
-    # artifacts, but its verdict does not yet gate the release. The reason has
-    # moved, and this comment is what carries it, so it is worth keeping
-    # current: a stale cause here sends whoever picks the work up next after a
-    # defect that is already fixed.
+    # Every row in the matrix below gates the release. There is no
+    # continue-on-error here and no experimental flag on any row, and the
+    # release authority suite asserts both absences, so tolerance cannot
+    # return to this job without review.
     #
-    # It is no longer the daemon endpoint file. kin#811 measured that the
-    # installed Windows daemon does publish `.kin/daemon.port`, and that the
-    # step could not read it because a `tee` pipeline held a handle the daemon
-    # inherited, so the shell resumed at the moment shutdown removed the file.
-    # That is fixed and proven fixed on released bytes.
-    #
-    # What fails now is one step earlier and it fails on the released binary
-    # rather than on this workflow. `kin setup status --json` reported
+    # Windows was the one tolerated row and its waiver is spent. Two defects
+    # kept it red and both are fixed on released bytes. kin#811 measured that
+    # the installed Windows daemon does publish `.kin/daemon.port`, and that
+    # the step could not read it because a `tee` pipeline held a handle the
+    # daemon inherited, so the shell resumed at the moment shutdown removed
+    # the file. Then `kin setup status --json` reported
     # `projection_mode=misconfigured` on a host where nothing is recorded and
-    # no projection is in force, which is a mode the chooser named rather than
-    # one anybody picked. Every release from v0.5.44 through v0.5.47 died on
-    # that same line in the step below. The product fix is FIR-2460 and it can
-    # only reach this leg by riding a release, because the leg installs what
-    # the public installer serves.
+    # no projection is in force, a mode the chooser named rather than one
+    # anybody picked, and every release from v0.5.44 through v0.5.47 died on
+    # that line. FIR-2460 fixed it and could only reach this leg by riding a
+    # release, because the leg installs what the public installer serves.
     #
-    # So the flag comes out once a release carries that fix and the leg is
-    # green against its own bytes, together with the posture assertion the
-    # release authority suite pins to exactly the windows-latest row.
-    continue-on-error: ${{ matrix.experimental == true }}
+    # v0.5.49 is that release. Its run concluded `Public Install Proof /
+    # windows-latest` SUCCESS against its own published bytes, which is the
+    # condition the waiver named for its own removal, so the flag is gone and
+    # a Windows failure now blocks a release exactly as a Linux one does.
     strategy:
       fail-fast: false
       # The reviewed release matrix is what every public release still proves.
@@ -90,7 +83,7 @@ jobs:
       # exist for exactly one platform, so it collapses to the Linux leg rather
       # than installing a released archive on the other four. Both lists are
       # decoded and pinned by the release authority suite, so neither can grow,
-      # shrink, or gain an experimental row unreviewed.
+      # shrink, or gain a tolerated row unreviewed.
       #
       # The pull-request list is the OVERRIDE and the release list is what an
       # absent input falls back to. That direction is the whole point: this
@@ -100,7 +93,7 @@ jobs:
       # release gate. Truthiness answers null and "" identically, so neither
       # spelling of absent can reach the one-platform list.
       matrix:
-        include: ${{ fromJSON(inputs.local_artifact && '[{"os":"ubuntu-latest","setup-shell":"bash"}]' || '[{"os":"ubuntu-latest","setup-shell":"bash"},{"os":"ubuntu-24.04-arm","setup-shell":"bash"},{"os":"macos-latest","setup-shell":"zsh"},{"os":"macos-15-intel","setup-shell":"zsh"},{"os":"windows-latest","setup-shell":"powershell","experimental":true}]') }}
+        include: ${{ fromJSON(inputs.local_artifact && '[{"os":"ubuntu-latest","setup-shell":"bash"}]' || '[{"os":"ubuntu-latest","setup-shell":"bash"},{"os":"ubuntu-24.04-arm","setup-shell":"bash"},{"os":"macos-latest","setup-shell":"zsh"},{"os":"macos-15-intel","setup-shell":"zsh"},{"os":"windows-latest","setup-shell":"powershell"}]') }}
     steps:
       - name: Public install (Unix)
         if: runner.os != 'Windows' && !inputs.local_artifact
@@ -921,8 +914,22 @@ jobs:
           fs.writeFileSync(process.env.ANTIGRAVITY_LEGACY, `${JSON.stringify(config, null, 2)}\n`);
           NODE
 
+          # Never pipe a command that can spawn the daemon, for the reason
+          # `kin status` above is not piped. `--intent agent` configures
+          # auto-daemon and this is an admitted repository, so setup starts a
+          # daemon here; on Windows that child inherits the pipe and holds the
+          # write end until it idles out, and `tee` then blocks reading a pipe
+          # nobody will close until the 1800 s idle window expires. That is
+          # what the two silent thirty-minute gaps in v0.5.49's Windows leg
+          # were: 3672 s of a 3684 s step, and 62 of the 63.5 minutes between
+          # the published tag and npm. Redirect, then print. Setup's own exit
+          # status is captured rather than left to `set -e` so a failure still
+          # reaches the job log instead of aborting before the `cat`.
+          setup_status=0
           kin setup --no-interactive --intent agent --shell "$PROOF_SHELL" \
-            2>&1 | tee "$captures/kin-setup.txt"
+            > "$captures/kin-setup.txt" 2>&1 || setup_status=$?
+          cat "$captures/kin-setup.txt"
+          if [ "$setup_status" -ne 0 ]; then exit "$setup_status"; fi
 
           # Normalize the real TOML Codex entry with Python's standard parser
           # so the later cross-platform Node validator can apply the same exact
@@ -963,10 +970,16 @@ jobs:
             chmod +x "$claude_fallback_bin/claude"
           fi
           claude_fallback_path="$claude_fallback_bin:$primary_home/.kin/bin:/usr/bin:/bin"
+          # Unpiped for the same reason as the setup above, and it cost the
+          # same: this second setup spawned the second daemon that held the
+          # second thirty-minute pipe.
+          fallback_setup_status=0
           HOME="$claude_fallback_home" USERPROFILE="$claude_fallback_home" \
           KIN_HOME="$primary_home/.kin" PATH="$claude_fallback_path" \
             kin setup --no-interactive --intent agent --shell "$PROOF_SHELL" \
-            2>&1 | tee "$captures/kin-claude-fallback-setup.txt"
+            > "$captures/kin-claude-fallback-setup.txt" 2>&1 || fallback_setup_status=$?
+          cat "$captures/kin-claude-fallback-setup.txt"
+          if [ "$fallback_setup_status" -ne 0 ]; then exit "$fallback_setup_status"; fi
           if [ -e "$claude_fallback_home/.claude.json" ]; then
             echo "Claude fallback proof unexpectedly wrote the primary ~/.claude.json path" >&2
             exit 1

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -914,17 +914,19 @@ jobs:
           fs.writeFileSync(process.env.ANTIGRAVITY_LEGACY, `${JSON.stringify(config, null, 2)}\n`);
           NODE
 
-          # Never pipe a command that can spawn the daemon, for the reason
-          # `kin status` above is not piped. `--intent agent` configures
-          # auto-daemon and this is an admitted repository, so setup starts a
-          # daemon here; on Windows that child inherits the pipe and holds the
-          # write end until it idles out, and `tee` then blocks reading a pipe
-          # nobody will close until the 1800 s idle window expires. That is
-          # what the two silent thirty-minute gaps in v0.5.49's Windows leg
-          # were: 3672 s of a 3684 s step, and 62 of the 63.5 minutes between
-          # the published tag and npm. Redirect, then print. Setup's own exit
-          # status is captured rather than left to `set -e` so a failure still
-          # reaches the job log instead of aborting before the `cat`.
+          # Never pipe setup, for the reason `kin status` above is not piped.
+          # Setup leaves a long-lived child behind in an admitted repository,
+          # and on Windows that child inherits the write end of the pipe and
+          # holds it until it idles out, so `tee` blocks reading a pipe nobody
+          # will close even though setup itself has finished and printed
+          # everything it will print. v0.5.49's Windows leg measured that wait
+          # twice, at 1805 s and 1868 s, which is the 1800 s daemon idle
+          # window plus startup and shutdown slack: 3672 s of a 3684 s step,
+          # and 62 of the 63.5 minutes between the published tag and npm.
+          # Redirecting ends the wait whatever the child turns out to be,
+          # because nothing waits on a file. Setup's own exit status is
+          # captured rather than left to `set -e` so a failure still reaches
+          # the job log instead of aborting before the `cat`.
           setup_status=0
           kin setup --no-interactive --intent agent --shell "$PROOF_SHELL" \
             > "$captures/kin-setup.txt" 2>&1 || setup_status=$?
@@ -971,8 +973,8 @@ jobs:
           fi
           claude_fallback_path="$claude_fallback_bin:$primary_home/.kin/bin:/usr/bin:/bin"
           # Unpiped for the same reason as the setup above, and it cost the
-          # same: this second setup spawned the second daemon that held the
-          # second thirty-minute pipe.
+          # same: this second setup left the child that held the second pipe
+          # for its own full idle window.
           fallback_setup_status=0
           HOME="$claude_fallback_home" USERPROFILE="$claude_fallback_home" \
           KIN_HOME="$primary_home/.kin" PATH="$claude_fallback_path" \

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -716,7 +716,7 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
     (
         ".github/workflows/install-proof.yml",
         "install-proof",
-    ): "44b510d0d82f7b56b525b08f38a3f84916243c30e9c365b340718670f95af1ca",
+    ): "3ab38cec398001873f4a29bb17ce14264b6eb54dbbe2b865ff109d1d4a74767d",
     (
         ".github/workflows/rc-build.yml",
         "build",
@@ -3003,66 +3003,114 @@ def assert_install_proof_runs_on_pull_requests(ci: str, install_proof: str) -> N
         )
 
 
-def assert_install_proof_windows_experimental_posture(install_proof: str) -> None:
-    """Pin the declared experimental scope of the install-proof matrix.
+def assert_install_proof_every_leg_gates_the_release(install_proof: str) -> None:
+    """Require every install-proof matrix row to gate the release.
 
-    The Windows leg still executes its full unconditional proof, but its
-    verdict is tolerated while the installed daemon does not publish an
-    endpoint file there. Tolerance is admitted only as the exact job-level
-    matrix guard — enforced as the single active ``continue-on-error``
-    mention in the entire job, so a step-level tolerance (which would spare
-    every leg, not one) cannot hide below the job header — and the
-    ``experimental: true`` flag only on the ``windows-latest`` row. Anything
-    looser — an unconditional ``continue-on-error``, a tolerated step, an
-    experimental Unix row, or a value other than ``true`` — silently removes
-    a reviewed OS from the release gate, so each is rejected here by name.
+    The windows-latest row carried ``experimental: true`` and the job carried
+    the matching ``continue-on-error`` guard, so the one platform most likely
+    to break shipped without a verdict. Two defects held that waiver open and
+    both are fixed on released bytes: kin#811's inherited-pipe read of
+    ``.kin/daemon.port``, then a projection chooser that named
+    ``projection_mode=misconfigured`` on a host where nothing was recorded,
+    which killed every release from v0.5.44 through v0.5.47. v0.5.49's run
+    concluded ``Public Install Proof / windows-latest`` SUCCESS against its
+    own published archives, which is the condition the waiver itself named
+    for its removal, so the waiver is spent.
+
+    Tolerance is therefore rejected in every spelling it could return in: a
+    job-level ``continue-on-error`` of any value, a step-level one, which
+    would spare every leg rather than one, and an ``experimental`` key on any
+    row of either decoded matrix, since that key is the half of the waiver a
+    reader would restore first. The reviewed platform set stays pinned here
+    too, so a row cannot be dropped in the same edit that would have
+    tolerated it.
     """
 
     jobs = workflow_job_blocks(install_proof)
     install_job = jobs.get("install-proof")
     if install_job is None:
         raise AssertionError(
-            "windows experimental posture lost the install-proof job"
+            "install-proof gating posture lost the install-proof job"
         )
     job_fields = job_top_level_mapping_fields(install_job)
     tolerance = [
         value.strip() for key, value in job_fields if key == "continue-on-error"
     ]
-    if tolerance != ["${{ matrix.experimental == true }}"]:
+    if tolerance:
         raise AssertionError(
-            "install-proof continue-on-error must be exactly the matrix "
-            f"experimental guard; found {tolerance}"
+            "install-proof admits no job-level continue-on-error; every "
+            f"matrix row gates the release; found {tolerance}"
         )
     tolerance_mentions = [
         line for line in active_lines(install_job) if "continue-on-error" in line
     ]
-    if tolerance_mentions != [
-        "continue-on-error: ${{ matrix.experimental == true }}"
-    ]:
+    if tolerance_mentions:
         raise AssertionError(
-            "install-proof admits exactly one continue-on-error, the "
-            "job-level matrix experimental guard; a step-level tolerance "
-            f"would spare every leg; found {tolerance_mentions}"
+            "install-proof admits no continue-on-error at all; a step-level "
+            "tolerance would spare every leg, not one; found "
+            f"{tolerance_mentions}"
         )
     release_rows, pull_request_rows = install_proof_matrix_rows(install_job)
     for label, rows in (("release", release_rows), ("pull request", pull_request_rows)):
-        experimental_rows = []
-        for row in rows:
-            if "experimental" not in row:
-                continue
-            if row["experimental"] is not True:
-                raise AssertionError(
-                    f"install-proof {label} matrix rows admit only a literal "
-                    f"`experimental: true`; found {row['experimental']!r} under "
-                    f"{row.get('os')}"
-                )
-            experimental_rows.append(row.get("os"))
-        expected = ["windows-latest"] if label == "release" else []
-        if experimental_rows != expected:
+        tolerated = [row.get("os") for row in rows if "experimental" in row]
+        if tolerated:
             raise AssertionError(
-                f"install-proof {label} experimental rows must be exactly "
-                f"{expected}; found {experimental_rows}"
+                f"install-proof {label} matrix rows admit no experimental "
+                f"key; the Windows waiver is spent; found it under {tolerated}"
             )
+    release_platforms = [row.get("os") for row in release_rows]
+    expected_platforms = [
+        "ubuntu-latest",
+        "ubuntu-24.04-arm",
+        "macos-latest",
+        "macos-15-intel",
+        "windows-latest",
+    ]
+    if release_platforms != expected_platforms:
+        raise AssertionError(
+            "install-proof release matrix must gate exactly "
+            f"{expected_platforms}; found {release_platforms}"
+        )
+
+
+def assert_install_proof_first_run_never_pipes_the_daemon_spawner(
+    first_run: str,
+) -> None:
+    """Keep every daemon-spawning command in the first-run step unpiped.
+
+    A piped command whose child is the daemon does not end when the command
+    ends. On Windows the daemon inherits the write end of the pipe and holds
+    it until idle shutdown, so the reader blocks for the full 1800 s idle
+    window while the step looks like it is working. v0.5.49's Windows leg
+    spent 3672 s of a 3684 s step in exactly two of those waits, both on a
+    ``kin setup --intent agent`` piped into ``tee``, and that step was 62 of
+    the 63.5 minutes between the published tag and npm.
+
+    `kin status` and the graph queries already carry that rule in prose. This
+    is the executable half: the first-run step captures by redirect and
+    prints with `cat`, never by pipe, and a setup that fails still reaches
+    the job log rather than aborting the step before the `cat`.
+    """
+
+    # The pipe scan runs first, so a capture that reverts to `tee` is named as
+    # the pipe it is rather than as a missing redirect line.
+    piped = [line for line in active_lines(first_run) if "| tee" in line]
+    if piped:
+        raise AssertionError(
+            "the first-run install proof captures by redirect, never by pipe: "
+            "a daemon that inherits the pipe holds it for its whole idle "
+            f"window and the step waits on it; found {piped}"
+        )
+    for policy in (
+        'kin setup --no-interactive --intent agent --shell "$PROOF_SHELL" \\',
+        '> "$captures/kin-setup.txt" 2>&1 || setup_status=$?',
+        'cat "$captures/kin-setup.txt"',
+        'if [ "$setup_status" -ne 0 ]; then exit "$setup_status"; fi',
+        '> "$captures/kin-claude-fallback-setup.txt" 2>&1 || fallback_setup_status=$?',
+        'cat "$captures/kin-claude-fallback-setup.txt"',
+        'if [ "$fallback_setup_status" -ne 0 ]; then exit "$fallback_setup_status"; fi',
+    ):
+        require(first_run, policy, "unpiped first-run setup capture")
 
 
 def assert_install_proof_repo_steps_cover_windows(install_proof: str) -> None:
@@ -9429,6 +9477,51 @@ def main() -> None:
     ):
         require(first_run, policy, "cross-step install-proof shell pin")
     assert_install_proof_init_log_authority(first_run)
+    assert_install_proof_first_run_never_pipes_the_daemon_spawner(first_run)
+    for label, original, mutation, expected in (
+        (
+            "the first setup goes back through a pipe",
+            '            > "$captures/kin-setup.txt" 2>&1 || setup_status=$?',
+            '            2>&1 | tee "$captures/kin-setup.txt"',
+            "never by pipe",
+        ),
+        (
+            "the fallback setup goes back through a pipe",
+            '            > "$captures/kin-claude-fallback-setup.txt" 2>&1 || fallback_setup_status=$?',
+            '            2>&1 | tee "$captures/kin-claude-fallback-setup.txt"',
+            "never by pipe",
+        ),
+        (
+            "a failing setup stops reaching the job log",
+            '          cat "$captures/kin-setup.txt"\n',
+            "",
+            "unpiped first-run setup capture",
+        ),
+        (
+            "a refused setup stops failing the install proof",
+            '          if [ "$setup_status" -ne 0 ]; then exit "$setup_status"; fi\n',
+            "",
+            "unpiped first-run setup capture",
+        ),
+        (
+            "a refused fallback setup stops failing the install proof",
+            '          if [ "$fallback_setup_status" -ne 0 ]; then exit "$fallback_setup_status"; fi\n',
+            "",
+            "unpiped first-run setup capture",
+        ),
+    ):
+        if original not in first_run:
+            raise AssertionError(
+                "first-run unpiped-setup falsification lost fixture for "
+                f"{label}: {original!r}"
+            )
+        expect_assertion(
+            label,
+            expected,
+            lambda mutated=first_run.replace(original, mutation, 1): (
+                assert_install_proof_first_run_never_pipes_the_daemon_spawner(mutated)
+            ),
+        )
     expect_assertion(
         "kin init writes its log into the worktree it admits",
         "outside the worktree it admits",
@@ -9941,7 +10034,7 @@ def main() -> None:
         ),
         (
             "the Windows matrix row disappears",
-            ',{"os":"windows-latest","setup-shell":"powershell","experimental":true}',
+            ',{"os":"windows-latest","setup-shell":"powershell"}',
             "",
             "windows-latest row",
         ),
@@ -9965,63 +10058,63 @@ def main() -> None:
             ),
         )
 
-    assert_install_proof_windows_experimental_posture(install_proof)
+    assert_install_proof_every_leg_gates_the_release(install_proof)
     for label, original, mutation, expected in (
         (
-            "the experimental flag spreads to a Unix matrix row",
+            "the Windows waiver returns as a matrix flag",
+            '{"os":"windows-latest","setup-shell":"powershell"}',
+            '{"os":"windows-latest","setup-shell":"powershell","experimental":true}',
+            "admit no experimental",
+        ),
+        (
+            "the waiver returns on a Unix row instead",
             '{"os":"ubuntu-latest","setup-shell":"bash"}',
             '{"os":"ubuntu-latest","setup-shell":"bash","experimental":true}',
-            "experimental rows must be exactly",
+            "admit no experimental",
         ),
         (
             "the install proof tolerates every leg unconditionally",
-            "    continue-on-error: ${{ matrix.experimental == true }}\n",
-            "    continue-on-error: true\n",
-            "matrix experimental guard",
+            "    strategy:\n",
+            "    continue-on-error: true\n    strategy:\n",
+            "no job-level continue-on-error",
         ),
         (
-            "the tolerance guard survives while the Windows flag disappears",
-            ',"experimental":true',
-            "",
-            "exactly ['windows-latest']",
-        ),
-        (
-            "an experimental value other than a literal true appears",
-            '"experimental":true',
-            '"experimental":"yes"',
-            "literal `experimental: true`",
-        ),
-        (
-            "the tolerance guard disappears while the flag stays",
-            "    continue-on-error: ${{ matrix.experimental == true }}\n",
-            "",
-            "matrix experimental guard",
+            "the matrix-guard spelling of the waiver returns",
+            "    strategy:\n",
+            "    continue-on-error: ${{ matrix.experimental == true }}\n    strategy:\n",
+            "no job-level continue-on-error",
         ),
         (
             "a step-level tolerance spares every leg below the job header",
             "      - name: Public install (Unix)\n",
             "      - name: Public install (Unix)\n"
             "        continue-on-error: true\n",
-            "exactly one continue-on-error",
+            "no continue-on-error at all",
         ),
         (
             "a quoted-key tolerance hides on a step",
             "      - name: Public install (Unix)\n",
             "      - name: Public install (Unix)\n"
             "        \"continue-on-error\": true\n",
-            "exactly one continue-on-error",
+            "no continue-on-error at all",
+        ),
+        (
+            "a reviewed platform is dropped from the gating matrix",
+            ',{"os":"macos-15-intel","setup-shell":"zsh"}',
+            "",
+            "must gate exactly",
         ),
     ):
         if original not in install_proof:
             raise AssertionError(
-                "windows experimental posture falsification lost fixture for "
+                "install-proof gating posture falsification lost fixture for "
                 f"{label}: {original!r}"
             )
         expect_assertion(
             label,
             expected,
             lambda mutated=install_proof.replace(original, mutation, 1): (
-                assert_install_proof_windows_experimental_posture(mutated)
+                assert_install_proof_every_leg_gates_the_release(mutated)
             ),
         )
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -3078,13 +3078,14 @@ def assert_install_proof_first_run_never_pipes_the_daemon_spawner(
 ) -> None:
     """Keep every daemon-spawning command in the first-run step unpiped.
 
-    A piped command whose child is the daemon does not end when the command
-    ends. On Windows the daemon inherits the write end of the pipe and holds
-    it until idle shutdown, so the reader blocks for the full 1800 s idle
-    window while the step looks like it is working. v0.5.49's Windows leg
-    spent 3672 s of a 3684 s step in exactly two of those waits, both on a
-    ``kin setup --intent agent`` piped into ``tee``, and that step was 62 of
-    the 63.5 minutes between the published tag and npm.
+    A pipeline outlives the command that wrote to it whenever a child
+    inherits the descriptor. On Windows that child holds the write end until
+    it idles out, so the reader blocks while the step looks like it is
+    working. v0.5.49's Windows leg spent 3672 s of a 3684 s step in exactly
+    two such waits, 1805 s and 1868 s, which is the 1800 s daemon idle window
+    plus slack; both were a ``kin setup --intent agent`` piped into ``tee``,
+    and that step was 62 of the 63.5 minutes between the published tag and
+    npm.
 
     `kin status` and the graph queries already carry that rule in prose. This
     is the executable half: the first-run step captures by redirect and
@@ -3098,7 +3099,7 @@ def assert_install_proof_first_run_never_pipes_the_daemon_spawner(
     if piped:
         raise AssertionError(
             "the first-run install proof captures by redirect, never by pipe: "
-            "a daemon that inherits the pipe holds it for its whole idle "
+            "a child that inherits the pipe holds it for its whole idle "
             f"window and the step waits on it; found {piped}"
         )
     for policy in (


### PR DESCRIPTION
v0.5.49's run concluded `Public Install Proof / windows-latest` SUCCESS against
its own published archives. That is the condition the experimental waiver named
for its own removal, so the flag and its `continue-on-error` guard come out and
the leg gates the release like every other one.

State that plainly: a Windows failure now blocks a release. That is the
contract's intent. Windows is the platform most likely to break and it has been
shipping without a verdict; four releases died on `projection_mode=misconfigured`
where the waiver absorbed the failure and nobody was stopped.

## The leg was 62 minutes, and 61 of them were a blocked pipe

The same run measured `windows-latest` at 62m25s while every other leg took about
a minute, which made it the tag-to-npm floor. All of it was one step, and inside
that step the job log carries exactly two gaps with no output: 1805.0s and
1867.6s, or 3672.6 of the step's 3684 seconds.

Both `kin setup --no-interactive --intent agent` calls were piped into `tee`.
Setup leaves a long-lived child behind in an admitted repository, and on Windows
that child inherits the write end of the pipe and holds it until it idles out,
so `tee` blocks reading a pipe nobody will close long after setup itself has
printed everything it will print. Both waits are the 1800s daemon idle window
(`MCP_IDLE_TIMEOUT_SECS` and `CLI_IDLE_CEILING_SECS`) plus startup and shutdown
slack.

Which child it is stays unproven and the fix does not depend on it. `auto_daemon`
writes a config rather than spawning, and setup's one `ensure_daemon_running`
call sits behind a `doctor --fix` repair branch, so an earlier draft of this
comment named a spawn site the code does not have. Redirecting ends the wait
whatever holds the descriptor, because nothing waits on a file.

The step's own comment already said not to do this, twenty lines above the first
offending pipe, and `install-proof-canary.yml` already captures setup the right
way. Both captures now redirect and print, and setup's exit status is captured so
a failure still reaches the job log instead of `set -e` aborting before the `cat`.

Expected effect is about 62 minutes down to about 2. That is a prediction from
the measurement, not a result, and it cannot be proven here: a pull-request
install-proof run collapses to the Linux leg by design, so only a release run
exercises this.

## Guards

`scripts/test-release-workflow-authority.py` flips with the workflow. The posture
assertion now rejects tolerance in every spelling it could return in, a job-level
`continue-on-error` of any value, a step-level one, and an `experimental` key on
any row of either decoded matrix, and it pins the five gating platforms so a row
cannot be dropped in the edit that would have tolerated it. A new assertion holds
the first-run step to redirect-never-pipe. The dynamic job context census sha
moves with the matrix row, and it was the only one of seven that moved.

Falsified two-sided against the committed tree: a returning matrix flag, a
returning job-level tolerance, either setup back through a pipe, and a dropped
exit-status propagation each go red naming the right cause, and the unmutated
tree passes.

## Follow-ups

The umbrella preflight `PORTED_FROM` pin needs its resync after this lands, since
the workflow sha moves. The mirrored "Validate installed capability proof" step is
unchanged, so that is a pin move with no assertion delta.

Refs FIR-2622, FIR-2612, FIR-2587, FIR-1921, FIR-2206, FIR-2454, FIR-2460.
FIR-2622 stays open until the next release measures the leg.
