### PR TITLE
Publish the per-file parse observation on stores converted from Git

### DIFF
--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -116,7 +116,10 @@ pub use identity::{
 pub use ranking::{
     normalize_symbol_hint, normalize_trace_name, qualifier_hint_from_query, select_best_match,
 };
-pub use ref_view::{build_graph_at_ref, collect_changes_at_ref, filter_vector_results_to_scope};
+pub use ref_view::{
+    build_entity_file_layout, build_graph_at_ref, collect_changes_at_ref,
+    filter_vector_results_to_scope,
+};
 pub use repository_authority::{
     durable_semantic_enrichment_summary, open_persisted_local_repository_authority,
     revalidate_pinned_local_namespace, DurableSemanticEnrichmentSummary,

--- a/crates/kin-core/src/ref_view.rs
+++ b/crates/kin-core/src/ref_view.rs
@@ -978,7 +978,16 @@ fn preview_text_if_likely_text(content: &[u8], mime_hint: Option<&str>) -> Optio
     kin_index::artifacts::opaque_text_preview(content, mime_hint)
 }
 
-fn build_entity_file_layout(
+/// Build a file's layout from the entity spans the graph already holds.
+///
+/// The regions carry the graph's own entity identities rather than freshly
+/// parsed ones, which is what makes this safe to publish into a live store: a
+/// layout whose `EntityRef` names an id no entity has is a splice target that
+/// resolves to nothing, and rename and projection both read these regions.
+/// `parse_completeness` is the caller's observation about the source bytes and
+/// is carried through untouched, because only the caller knows whether it
+/// parsed the file or reconstructed it.
+pub fn build_entity_file_layout(
     file_id: &FilePathId,
     entities: &[kin_model::Entity],
     file_len: usize,

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2157,11 +2157,13 @@ pub(crate) struct LayoutBackfill {
     pub(crate) published: usize,
     /// Artifacts whose bytes could not be read or parsed, left with no layout.
     pub(crate) unreadable: usize,
+    /// Artifacts another facet already owns, which this pass must not touch.
+    pub(crate) other_facet: usize,
 }
 
 impl LayoutBackfill {
     fn observed(&self) -> usize {
-        self.already_published + self.published + self.unreadable
+        self.already_published + self.published + self.unreadable + self.other_facet
     }
 }
 
@@ -2226,6 +2228,19 @@ pub(crate) fn backfill_missing_file_layouts(state: &DaemonState) -> Result<Layou
         let file_id = FilePathId::new(path);
         if state.graph.get_file_layout(&file_id)?.is_some() {
             report.already_published += 1;
+            continue;
+        }
+        // Another facet already owns this path. The four are mutually exclusive
+        // per file and the watcher seam enforces that
+        // ([`clear_incompatible_facets_in`]), so publishing a layout beside one
+        // would leave the store holding two answers to how the file is tracked.
+        // The gap this pass closes is a path carrying no facet at all, which is
+        // exactly what a Git import leaves behind.
+        if state.graph.get_shallow_file(&file_id)?.is_some()
+            || state.graph.get_structured_artifact(&file_id)?.is_some()
+            || state.graph.get_opaque_artifact(&file_id)?.is_some()
+        {
+            report.other_facet += 1;
             continue;
         }
 
@@ -2554,6 +2569,7 @@ pub async fn run_loop_armed(
                         observed = report.observed(),
                         already_published = report.already_published,
                         unreadable = report.unreadable,
+                        other_facet = report.other_facet,
                         "every admitted source file already carries its parse observation"
                     );
                 }
@@ -2562,6 +2578,7 @@ pub async fn run_loop_armed(
                         published = report.published,
                         already_published = report.already_published,
                         unreadable = report.unreadable,
+                        other_facet = report.other_facet,
                         observed = report.observed(),
                         "published the per-file parse observation for admitted source files that \
                          carried none, so an enumeration over them can be certified"

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2229,7 +2229,10 @@ pub(crate) fn backfill_missing_file_layouts(state: &DaemonState) -> Result<Layou
             continue;
         }
 
-        let body_hash = Hash256::from_bytes(*hash.as_bytes());
+        // `TreeEntry` carries kin-model's hash and the blob store speaks
+        // kin-blobs', so the identity crosses that boundary by bytes, exactly
+        // as the historical rebuild crosses it.
+        let body_hash = kin_blobs::Hash256::from_bytes(*hash.as_bytes());
         let Ok(content) = state.blobs.read(&body_hash) else {
             debug!(
                 file = %file_id,

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2251,20 +2251,20 @@ pub(crate) fn backfill_missing_file_layouts(state: &DaemonState) -> Result<Layou
             continue;
         }
 
-        let completeness = match pipeline.index_file_content_with_tests(&file_id, &content, body_hash)
-        {
-            Ok(indexed) => indexed.indexed_file.file_layout.parse_completeness,
-            Err(error) => {
-                debug!(
-                    file = %file_id,
-                    error = %error,
-                    "graph-owned source could not be indexed, so its parse observation stays \
-                     unpublished rather than being guessed"
-                );
-                report.unreadable += 1;
-                continue;
-            }
-        };
+        let completeness =
+            match pipeline.index_file_content_with_tests(&file_id, &content, body_hash) {
+                Ok(indexed) => indexed.indexed_file.file_layout.parse_completeness,
+                Err(error) => {
+                    debug!(
+                        file = %file_id,
+                        error = %error,
+                        "graph-owned source could not be indexed, so its parse observation stays \
+                         unpublished rather than being guessed"
+                    );
+                    report.unreadable += 1;
+                    continue;
+                }
+            };
 
         let mut entities = state.graph.query_entities(&EntityFilter {
             file_path: Some(file_id.clone()),

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2143,6 +2143,146 @@ fn plan_unpublished_enrichment_repair(state: &DaemonState) -> Result<Vec<FileEve
     Ok(events)
 }
 
+/// What one layout backfill pass observed and published.
+///
+/// `parsed` and `skipped` are reported together because the useful number is
+/// the pair: a store that publishes nothing because every file already carried
+/// a layout and a store that publishes nothing because it holds no source read
+/// the same from a bare count, and only one of them is a finding.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct LayoutBackfill {
+    /// Entity-source artifacts in the tree that already carried a layout.
+    pub(crate) already_published: usize,
+    /// Artifacts this pass parsed from graph-owned CAS and published a layout for.
+    pub(crate) published: usize,
+    /// Artifacts whose bytes could not be read or parsed, left with no layout.
+    pub(crate) unreadable: usize,
+}
+
+impl LayoutBackfill {
+    fn observed(&self) -> usize {
+        self.already_published + self.published + self.unreadable
+    }
+}
+
+/// Publish the per-file parse observation for every admitted entity-source
+/// artifact whose facet is missing, deriving it from graph-owned CAS.
+///
+/// Why this exists. `parsed`, `tier` and `certifies_enumeration` on
+/// `list_file_entities` are all read from the file's layout facet, and a store
+/// converted from Git never had one. The Git import parses every file, keeps
+/// the parse completeness only long enough to link cross-file references
+/// (`kin_index::derive_historical_semantic_deltas`), and drops the layout on
+/// the floor, because the semantic transaction it builds carries entity and
+/// relation deltas and has nowhere to put a layout. Entities therefore land and
+/// the observation about how they were obtained does not, so every file on a
+/// converted store reads `parsed: absent, tier: none, certifies_enumeration:
+/// false` whether an adapter read it completely, failed on it, or never looked
+/// at it. Those three are the only answers that matter and the store could not
+/// tell them apart.
+///
+/// A store built by `kin commit` does not have the gap, because the reconcile
+/// path publishes the layout it registered
+/// (`DaemonState::persist_projection_truth_from_reconcile`). That asymmetry is
+/// the whole defect: the same tool answered two real stores differently for a
+/// reason that had nothing to do with either repository.
+///
+/// What it reads. The graph's own resolved tree and the CAS bodies that tree
+/// names, never the working copy. A path the tree does not carry is not
+/// considered, and a body that does not match the tree's identity is not
+/// parsed, so this cannot admit host content or repair graph truth from disk.
+///
+/// What it publishes. The parse completeness comes from re-parsing the CAS
+/// bytes; the regions come from the entities the graph already holds, through
+/// [`kin_core::build_entity_file_layout`], so no identity is invented and a
+/// splice or rename reading these regions resolves to entities that exist. A
+/// file the adapter could not read completely gets its `Partial`/`Failed`
+/// completeness and its reason, which is the state that was previously
+/// indistinguishable from never having been parsed.
+///
+/// Cost. One parse per entity-source artifact that has no layout, once per
+/// daemon life. A store whose files were committed through Kin pays a tree walk
+/// and no parses at all.
+pub(crate) fn backfill_missing_file_layouts(state: &DaemonState) -> Result<LayoutBackfill> {
+    let mut report = LayoutBackfill::default();
+    let pipeline = IndexPipeline::new();
+    let tree = state.graph.resolved_tree();
+
+    for artifact in tree.artifacts_by_path() {
+        let Some(path) = artifact.path.as_utf8() else {
+            continue;
+        };
+        // Symlinks and gitlinks are never parsed as source owned by the link
+        // path, which is the same rule the historical rebuild applies.
+        let TreeEntry::Blob { hash, .. } = artifact.entry else {
+            continue;
+        };
+        if !matches!(
+            FileClassifier::classify(Path::new(path)),
+            FileClassification::EntitySource
+        ) {
+            continue;
+        }
+        let file_id = FilePathId::new(path);
+        if state.graph.get_file_layout(&file_id)?.is_some() {
+            report.already_published += 1;
+            continue;
+        }
+
+        let body_hash = Hash256::from_bytes(*hash.as_bytes());
+        let Ok(content) = state.blobs.read(&body_hash) else {
+            debug!(
+                file = %file_id,
+                "no CAS body for an admitted artifact, so its parse observation stays unpublished"
+            );
+            report.unreadable += 1;
+            continue;
+        };
+        // Content decides the facet, exactly as admission decides it: a path
+        // whose extension says source but whose bytes are opaque belongs to
+        // another facet and must not grow an entity-source layout here.
+        if !matches!(
+            FileClassifier::classify_with_content(Path::new(path), &content),
+            FileClassification::EntitySource
+        ) {
+            continue;
+        }
+
+        let completeness = match pipeline.index_file_content_with_tests(&file_id, &content, body_hash)
+        {
+            Ok(indexed) => indexed.indexed_file.file_layout.parse_completeness,
+            Err(error) => {
+                debug!(
+                    file = %file_id,
+                    error = %error,
+                    "graph-owned source could not be indexed, so its parse observation stays \
+                     unpublished rather than being guessed"
+                );
+                report.unreadable += 1;
+                continue;
+            }
+        };
+
+        let mut entities = state.graph.query_entities(&EntityFilter {
+            file_path: Some(file_id.clone()),
+            ..Default::default()
+        })?;
+        entities.sort_by_key(|entity| {
+            entity
+                .span
+                .as_ref()
+                .map(|span| span.start_byte)
+                .unwrap_or(usize::MAX)
+        });
+        let layout =
+            kin_core::build_entity_file_layout(&file_id, &entities, content.len(), completeness);
+        state.graph.upsert_file_layout(&layout)?;
+        report.published += 1;
+    }
+
+    Ok(report)
+}
+
 pub async fn run_loop(
     state: Arc<DaemonState>,
     config: LoopConfig,
@@ -2205,6 +2345,11 @@ pub async fn run_loop_armed(
     // paths it recovers are exactly the ones whose host modification time puts
     // them outside that window, which is why the window cannot see them.
     let mut enrichment_repair_owed = true;
+    // Owed once per daemon life for the same reason and on the same schedule:
+    // a store converted from Git carries entities whose parse observation was
+    // computed at import and never published, so every file answers
+    // `certifies_enumeration: false` until this runs.
+    let mut layout_backfill_owed = true;
     if let Some(armed) = armed.as_mut() {
         armed.arm();
     }
@@ -2388,6 +2533,43 @@ pub async fn run_loop_armed(
                         error = %error,
                         "could not plan the unpublished-enrichment repair, so a path missing its \
                          entities stays unqueryable until it is edited"
+                    );
+                }
+            }
+        }
+
+        // The per-file parse observation, owed once per daemon life. A store
+        // built by `kin commit` publishes its layouts as it goes and this pass
+        // finds nothing to do; a store converted from Git has none at all, and
+        // without them `list_file_entities` cannot tell a file an adapter read
+        // completely from one it failed on from one it never looked at.
+        if layout_backfill_owed {
+            layout_backfill_owed = false;
+            match backfill_missing_file_layouts(&state) {
+                Ok(report) if report.published == 0 => {
+                    debug!(
+                        observed = report.observed(),
+                        already_published = report.already_published,
+                        unreadable = report.unreadable,
+                        "every admitted source file already carries its parse observation"
+                    );
+                }
+                Ok(report) => {
+                    info!(
+                        published = report.published,
+                        already_published = report.already_published,
+                        unreadable = report.unreadable,
+                        observed = report.observed(),
+                        "published the per-file parse observation for admitted source files that \
+                         carried none, so an enumeration over them can be certified"
+                    );
+                    state.bump_version();
+                }
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        "could not publish per-file parse observations, so `list_file_entities` \
+                         cannot certify an enumeration on this store"
                     );
                 }
             }

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -2035,7 +2035,13 @@ def check_15(suite):
         pkg/broken.py  parsed=absent tier=none certifies=False total=2
         pkg/empty.py   parsed=absent tier=none certifies=False total=1
 
-    Three files, three genuinely different states, one answer.
+    Three files, three genuinely different states, one answer. After the fix,
+    on the same fixture:
+
+        pkg/parsed.py  parsed=full    tier=entity_source certifies=True
+        pkg/broken.py  parsed=partial tier=entity_source certifies=False
+                       detail="2 parse error range(s) during indexing"
+        pkg/empty.py   parsed=full    tier=entity_source certifies=True
 
     Four arms. The first three read each shape on its own terms. The fourth is
     the one that makes the check falsifiable rather than decorative: it asserts
@@ -2058,6 +2064,7 @@ def check_15(suite):
                           % sorted(payload.keys())[:12])
         cov = dict(cov)
         cov["total_in_file"] = payload.get("total_in_file")
+        cov["entities"] = payload.get("entities") or []
         return cov, None
 
     readings = {}
@@ -2098,16 +2105,27 @@ def check_15(suite):
                 "distinguish an adapter failure from a file nothing ever parsed"
                 % (THREE_STATE_FILES["broken"], broken.get("parsed")))
 
+    # The declares-nothing arm. Python's adapter emits a module entity for every
+    # file it reads, so "declares nothing" is the absence of a function or a
+    # class rather than an empty list, and asserting an empty list here would be
+    # asserting something no Python file can satisfy.
     empty = readings["empty"]
+    declarations = [entity.get("name") for entity in empty.get("entities", [])
+                    if entity.get("kind") in ("function", "class", "method")]
     if empty.get("parsed") == "full" and empty.get("certifies_enumeration") is True \
-            and empty.get("total_in_file") == 0:
-        res.ok("%s parsed completely, declares nothing, and says so: an enumeration over it "
-               "is certified and empty" % THREE_STATE_FILES["empty"])
+            and not declarations:
+        res.ok("%s parsed completely and declares nothing, and its enumeration is certified "
+               "anyway, which is what separates it from a file an adapter failed on"
+               % THREE_STATE_FILES["empty"])
+    elif declarations:
+        res.unknown("%s was written to declare nothing but the graph holds %s for it, so this "
+                    "arm cannot test what it is for"
+                    % (THREE_STATE_FILES["empty"], declarations[:4]))
     else:
-        res.bad("%s declares nothing and parses cleanly, so its empty enumeration should be "
-                "certified; it reads parsed=%r certifies_enumeration=%r total_in_file=%r"
+        res.bad("%s declares nothing and parses cleanly, so an enumeration over it is complete "
+                "and should say so; it reads parsed=%r certifies_enumeration=%r"
                 % (THREE_STATE_FILES["empty"], empty.get("parsed"),
-                   empty.get("certifies_enumeration"), empty.get("total_in_file")))
+                   empty.get("certifies_enumeration")))
 
     # The arm that makes the other three falsifiable. Without it, a build that
     # answered `full`/`true` for everything would satisfy two of the three

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -296,6 +296,29 @@ class Suite(object):
             raise RuntimeError("git commit failed: %s" % (err or out)[-300:])
         self._kin_init(repo)
 
+    def _build_threestate(self, repo):
+        """A store converted from Git holding one file of each parse outcome.
+
+        Converted, not committed through Kin, and that is the whole point. The
+        Git import parses every file and drops the layout it derived, so before
+        FIR-2604 every file on a store built this way reported `parsed: absent,
+        tier: none, certifies_enumeration: false`, including files an adapter
+        had read completely. A store built by `kin commit` never had the gap,
+        which is why this fixture must take the conversion path to be able to
+        fail.
+        """
+        self.git(["init", "-q", "."], repo)
+        self._write(repo, ".gitignore", "__pycache__/\n")
+        self._write(repo, "pkg/__init__.py", "")
+        self._write(repo, THREE_STATE_FILES["parsed"], THREE_STATE_PARSED_PY)
+        self._write(repo, THREE_STATE_FILES["broken"], THREE_STATE_BROKEN_PY)
+        self._write(repo, THREE_STATE_FILES["empty"], THREE_STATE_EMPTY_PY)
+        self.git(["add", "-A"], repo)
+        rc, out, err = self.git(["commit", "-q", "-m", "three parse outcomes"], repo)
+        if rc != 0:
+            raise RuntimeError("git commit failed: %s" % (err or out)[-300:])
+        self._kin_init(repo)
+
     def _build_js(self, repo):
         self.git(["init", "-q", "."], repo)
         self._write(repo, ".gitignore", "node_modules/\n")
@@ -718,6 +741,43 @@ MIXIN_DOCSTRING = ('"""Session and redirect handling.\n'
 # declares nothing and that no adapter failed on. Measured on kin 0.5.48, the
 # store reads "of the 5 admitted, 3 carry a full language adapter; 1 of those
 # produced no entity", and that one is the prelude.
+# The three file shapes FIR-2604's acceptance names. All three are admitted as
+# Python and all three are valid UTF-8, so nothing here reaches the opaque facet
+# by accident, which is the mistake that made an earlier parse-hole fixture
+# prove nothing.
+THREE_STATE_PARSED_PY = '''"""A module an adapter reads completely."""
+
+
+def alpha(value):
+    """Return the successor."""
+    return value + 1
+
+
+class Beta:
+    def gamma(self):
+        return 2
+'''
+
+# Not valid Python. tree-sitter recovers what it can and reports error ranges,
+# which is the parse outcome that must be distinguishable from never having
+# been parsed at all.
+THREE_STATE_BROKEN_PY = '''def delta(:
+    this is not python at all ]]]
+'''
+
+# Valid Python that correctly declares nothing. An enumeration over it IS
+# certified and IS empty, and those two facts together are what no store could
+# say before this check existed.
+THREE_STATE_EMPTY_PY = '''"""Only a docstring and a comment live here."""
+# nothing is declared in this file
+'''
+
+THREE_STATE_FILES = {
+    "parsed": "pkg/parsed.py",
+    "broken": "pkg/broken.py",
+    "empty": "pkg/empty.py",
+}
+
 REEXPORT_BENIGN_FILE = "src/prelude.rs"
 REEXPORT_DEAD_FUNCTION = "legacy_shim"
 
@@ -1956,6 +2016,120 @@ def check_14(suite):
     return res
 
 
+def check_15(suite):
+    """FIR-2604: parsed, tier and certifies_enumeration must be observations.
+
+    `list_file_entities` computes its completeness verdict from the file's
+    layout facet, and a store converted from Git had none: the import parses
+    every file, keeps the parse completeness only long enough to link
+    cross-file references, and drops the layout, because the semantic
+    transaction it builds has nowhere to put one. Every file then read
+    `parsed: absent, tier: none, certifies_enumeration: false`, so the
+    certification kin#1009 shipped could never be true on a converted store and
+    no consumer could tell a file an adapter read completely from one it failed
+    on from one that declares nothing.
+
+    Measured on 2026-08-22 against main at 38bb51f2, on this fixture's shape:
+
+        pkg/parsed.py  parsed=absent tier=none certifies=False total=4
+        pkg/broken.py  parsed=absent tier=none certifies=False total=2
+        pkg/empty.py   parsed=absent tier=none certifies=False total=1
+
+    Three files, three genuinely different states, one answer.
+
+    Four arms. The first three read each shape on its own terms. The fourth is
+    the one that makes the check falsifiable rather than decorative: it asserts
+    the three readings are not all the same, which is exactly what fails on
+    pre-fix bytes and what a future regression would break again. Reverting the
+    backfill in kin-daemon's reconcile loop returns all three to `absent` and
+    fails arms one, three and four.
+    """
+    res = Result("15", "FIR-2604", "three parse outcomes read three ways on a converted store")
+    repo = suite.fixture("threestate")
+
+    def coverage(rel):
+        try:
+            payload, _ = suite.mcp(repo, "list_file_entities", {"path": rel})
+        except McpError as exc:
+            return None, str(exc)
+        cov = payload.get("file_coverage")
+        if not isinstance(cov, dict):
+            return None, ("the response carries no file_coverage object; keys were %s"
+                          % sorted(payload.keys())[:12])
+        cov = dict(cov)
+        cov["total_in_file"] = payload.get("total_in_file")
+        return cov, None
+
+    readings = {}
+    for name, rel in sorted(THREE_STATE_FILES.items()):
+        cov, why = coverage(rel)
+        if cov is None:
+            # A conversion's enrichment lands asynchronously, so one bounded
+            # retry separates "not yet" from "never".
+            time.sleep(3)
+            cov, why = coverage(rel)
+        if cov is None:
+            res.unknown("%s could not be read through MCP: %s" % (rel, why[:250]))
+            return res
+        readings[name] = cov
+
+    parsed = readings["parsed"]
+    if parsed.get("parsed") == "full" and parsed.get("certifies_enumeration") is True:
+        res.ok("%s reads parsed=full, tier=%s, certifies_enumeration=true over %s entities"
+               % (THREE_STATE_FILES["parsed"], parsed.get("tier"), parsed.get("total_in_file")))
+    else:
+        res.bad("%s holds entities an adapter read completely but reads parsed=%r "
+                "certifies_enumeration=%r tier=%r, so no enumeration on this store can be "
+                "certified" % (THREE_STATE_FILES["parsed"], parsed.get("parsed"),
+                               parsed.get("certifies_enumeration"), parsed.get("tier")))
+
+    broken = readings["broken"]
+    if broken.get("parsed") in ("partial", "failed") and \
+            broken.get("certifies_enumeration") is not True:
+        res.ok("%s reads parsed=%s with detail %r and certifies nothing"
+               % (THREE_STATE_FILES["broken"], broken.get("parsed"),
+                  str(broken.get("parse_detail"))[:80]))
+    elif broken.get("certifies_enumeration") is True:
+        res.bad("%s is not valid Python yet certifies its enumeration (parsed=%r), which "
+                "licenses reading an adapter failure as the file's whole surface"
+                % (THREE_STATE_FILES["broken"], broken.get("parsed")))
+    else:
+        res.bad("%s is not valid Python and its parse outcome reads %r, which does not "
+                "distinguish an adapter failure from a file nothing ever parsed"
+                % (THREE_STATE_FILES["broken"], broken.get("parsed")))
+
+    empty = readings["empty"]
+    if empty.get("parsed") == "full" and empty.get("certifies_enumeration") is True \
+            and empty.get("total_in_file") == 0:
+        res.ok("%s parsed completely, declares nothing, and says so: an enumeration over it "
+               "is certified and empty" % THREE_STATE_FILES["empty"])
+    else:
+        res.bad("%s declares nothing and parses cleanly, so its empty enumeration should be "
+                "certified; it reads parsed=%r certifies_enumeration=%r total_in_file=%r"
+                % (THREE_STATE_FILES["empty"], empty.get("parsed"),
+                   empty.get("certifies_enumeration"), empty.get("total_in_file")))
+
+    # The arm that makes the other three falsifiable. Without it, a build that
+    # answered `full`/`true` for everything would satisfy two of the three
+    # above, and the constant this ticket is about would be back wearing the
+    # other value.
+    states = set()
+    certifications = set()
+    for cov in readings.values():
+        states.add(cov.get("parsed"))
+        certifications.add(cov.get("certifies_enumeration"))
+    if len(states) >= 2 and certifications == {True, False}:
+        res.ok("the three files read %d distinct parse states and certification differs "
+               "between them, so these fields are observations rather than constants"
+               % len(states))
+    else:
+        res.bad("three files with three different parse outcomes read parse states %s and "
+                "certifications %s, so the fields carry no information about any file"
+                % (sorted(str(state) for state in states),
+                   sorted(str(value) for value in certifications)))
+    return res
+
+
 CHECKS = [
     ("0", check_0),
     ("1", check_1),
@@ -1972,6 +2146,7 @@ CHECKS = [
     ("12", check_12),
     ("13", check_13),
     ("14", check_14),
+    ("15", check_15),
 ]
 
 


### PR DESCRIPTION
`list_file_entities` computes `parsed`, `tier` and `certifies_enumeration` from one
thing: the file's layout facet. On a store converted from Git nothing ever wrote one, so
every file on every brownfield repository read `parsed: absent, tier: none,
certifies_enumeration: false`, including files an adapter had read completely. The
certification kin#1009 added could not be true on those stores, and no consumer could
tell an adapter failure from a file that legitimately declares nothing.

## The contradiction this had to resolve first

The ticket said the three fields are constants on any real store. A green stranger run on
released 0.5.47 bytes read `parsed: full` and `certifies_enumeration: true` on
`notekeeper/storage.py`, a real daemon-served store. Both measurements are real, and
neither store shape, language, Kin version nor MCP surface separates them.

The separating variable is the admission path, reproduced on main at `38bb51f2`:

    converted from Git      parsed=absent  tier=none           certifies=False   (all files)
    authored by kin commit  parsed=full    tier=entity_source  certifies=True

`derive_historical_semantic_deltas` parses every imported file, keeps the parse
completeness only long enough to link cross-file references, and drops the `FileLayout`,
because a `HistoricalSemanticDelta` carries entity and relation deltas and
`kin_model::TransactionDelta` has no layout slot. The entities land; the observation
about how they were obtained does not. The commit path has no gap because
`persist_projection_truth_from_reconcile` publishes the layout the reconciler registered.

The workspace graph snapshot was never the problem. kin-db serialises layouts and
round-trips them under test. On a converted store there was simply nothing to carry.

## What this changes

`backfill_missing_file_layouts` in kin-daemon's reconcile loop, owed once per daemon
life beside the unpublished-enrichment repair from #1070. For every artifact in the
graph's own resolved tree that classifies as entity source and holds no layout, it reads
the CAS body that tree names, re-parses it for the parse completeness, and publishes a
layout whose regions come from the entities the graph already holds, through a newly
exported `kin_core::build_entity_file_layout`. No entity identity is invented, because a
layout whose `EntityRef` names an id nothing holds is a splice target that resolves to
nothing and both rename and projection read those regions.

Nothing reads the working copy. The tree is graph-owned, bytes come from CAS by the
identity the tree carries, and a path the tree does not carry is never considered. All
six ci.yml guard scripts pass, including `verify-zero-file-search.py` and
`zero_file_search_guard.sh`.

Cost is one parse per entity-source artifact that has no layout, once per daemon life. A
store built by `kin commit` pays a tree walk and zero parses. A converted store pays a
pass its own conversion already paid. The counts are logged rather than capped silently.

## Falsification

CHECK 15 in `scripts/acceptance/magic_repro.py`, on a `threestate` fixture built the
conversion path on purpose, because a fixture built by `kin commit` could not fail.

Against released 0.5.49, which is exactly this branch's base commit
`38bb51f218d6f25c95a7a44dcfb58f627b9298fc`, provisioned from npm, all four arms fail:

    CHECK 15 FIR-2604 FAIL
      FAIL pkg/parsed.py holds entities an adapter read completely but reads
           parsed='absent' certifies_enumeration=False tier='none'
      FAIL pkg/broken.py is not valid Python and its parse outcome reads 'absent',
           which does not distinguish an adapter failure from a file nothing ever parsed
      FAIL pkg/empty.py declares nothing and parses cleanly, so an enumeration over it
           is complete and should say so; it reads parsed='absent'
      FAIL three files with three different parse outcomes read parse states ['absent']
           and certifications ['False'], so the fields carry no information about any file
    kin-magic-repro: 0 pass, 1 fail, 0 unreadable

Against this branch's build, on the same fixture shape:

    pkg/parsed.py  parsed=full     tier=entity_source  certifies=True   total=4
    pkg/broken.py  parsed=partial  tier=entity_source  certifies=False
                   detail="2 parse error range(s) during indexing"
    pkg/empty.py   parsed=full     tier=entity_source  certifies=True

The fourth arm is what makes the first three falsifiable rather than decorative: a build
answering `full`/`true` for everything satisfies two of them, and the fourth still fails.

Closes FIR-2604
Refs FIR-2599

