### PR TITLE
Let repository authority publish a created file instead of writing it first

### DIFF
--- a/crates/kin-agent/src/belt.rs
+++ b/crates/kin-agent/src/belt.rs
@@ -516,6 +516,27 @@ pub fn run_write(repo: &Path, arguments: &Value) -> LocalOutcome {
     }
 }
 
+/// The outcome of a `write_file` whose file repository authority published for us.
+///
+/// The bytes reached the working copy through the commit rather than through this process,
+/// so nothing is written here; the model is told what landed and where.
+pub fn published_create(arguments: &Value) -> LocalOutcome {
+    let raw_path = arguments.get("path").and_then(Value::as_str).unwrap_or("");
+    let content = arguments
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    LocalOutcome {
+        text: format!(
+            "Created `{raw_path}` ({} bytes) and published it through repository authority, \
+             which wrote the file.",
+            content.len()
+        ),
+        is_error: false,
+        changed: Some(raw_path.to_string()),
+    }
+}
+
 impl LocalOutcome {
     /// A refusal the model is handed instead of a run, in the shape a run would have
     /// produced, so a routing failure reads to the caller exactly like a tool failure.

--- a/crates/kin-agent/src/lib.rs
+++ b/crates/kin-agent/src/lib.rs
@@ -41,6 +41,9 @@ pub enum ExitStatus {
     Deadline,
     EndpointError,
     McpError,
+    /// The run produced changes that repository authority never published. The task text
+    /// may read like a success, but nothing landed, so this must never pool with Success.
+    ChangesUnpublished,
 }
 
 impl ExitStatus {
@@ -52,6 +55,7 @@ impl ExitStatus {
             ExitStatus::Deadline => 3,
             ExitStatus::EndpointError => 4,
             ExitStatus::McpError => 5,
+            ExitStatus::ChangesUnpublished => 6,
         }
     }
 
@@ -63,6 +67,7 @@ impl ExitStatus {
             ExitStatus::Deadline => "deadline",
             ExitStatus::EndpointError => "endpoint_error",
             ExitStatus::McpError => "mcp_error",
+            ExitStatus::ChangesUnpublished => "changes_unpublished",
         }
     }
 }

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -104,6 +104,9 @@ struct Counters {
     kin_calls: u32,
     local_calls: u32,
     refused_calls: u32,
+    /// Local edits whose transaction the daemon refused to publish. A run holding one of
+    /// these wrote files and landed nothing, which must not read as a success.
+    unpublished_changes: u32,
     repairs: u32,
     unsafe_absence_events: u32,
     unreadable_results: u32,
@@ -122,6 +125,7 @@ impl Counters {
             kin_calls: 0,
             local_calls: 0,
             refused_calls: 0,
+            unpublished_changes: 0,
             repairs: 0,
             unsafe_absence_events: 0,
             unreadable_results: 0,
@@ -163,6 +167,7 @@ impl Counters {
             "kin_calls": self.kin_calls,
             "local_calls": self.local_calls,
             "refused_calls": self.refused_calls,
+            "unpublished_changes": self.unpublished_changes,
             "repairs": self.repairs,
             "unsafe_absence_events": self.unsafe_absence_events,
             "unreadable_results": self.unreadable_results,
@@ -653,35 +658,95 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                                 &plan,
                                                 &mut writer,
                                             )?;
-                                            let outcome = match tool {
-                                                LocalTool::Edit => {
-                                                    belt::run_edit(&repo, &call.arguments)
-                                                }
-                                                LocalTool::Write => {
-                                                    belt::run_write(&repo, &call.arguments)
-                                                }
-                                            };
-                                            // Stage what the harness just did, inside the
-                                            // open bracket, so the commit below has
-                                            // something to publish. An empty transaction
-                                            // is refused by design.
-                                            let staged = if outcome.is_error {
-                                                false
-                                            } else {
-                                                stage_planned_operation(
+                                            // Repository authority writes a created file
+                                            // itself as part of publishing the change. So
+                                            // a create is published FIRST and the local
+                                            // write is the fallback: writing it here
+                                            // first leaves an untracked path sitting on
+                                            // the exact workspace target, which
+                                            // `validate_reconciliation_targets` refuses,
+                                            // and every commit fails on the harness's own
+                                            // file.
+                                            let publish_first = bracket.transaction_id.is_some()
+                                                && matches!(plan, StagePlan::Create { .. });
+                                            let (outcome, provenance) = if publish_first {
+                                                let staged = stage_planned_operation(
                                                     &mut servers[index],
                                                     &mut bracket,
                                                     session.as_deref(),
                                                     &plan,
                                                     &mut writer,
-                                                )?
+                                                )?;
+                                                let provenance = close_transaction(
+                                                    &mut servers[index],
+                                                    bracket,
+                                                    staged,
+                                                    &mut writer,
+                                                )?;
+                                                if published_by_authority(&provenance) {
+                                                    (
+                                                        belt::published_create(&call.arguments),
+                                                        provenance,
+                                                    )
+                                                } else {
+                                                    // Nothing was published, so the file
+                                                    // does not exist yet. Write it, so the
+                                                    // model keeps its work, and tell the
+                                                    // model the change did not land rather
+                                                    // than reporting a bare success.
+                                                    counters.unpublished_changes += 1;
+                                                    let mut outcome =
+                                                        belt::run_write(&repo, &call.arguments);
+                                                    if !outcome.is_error {
+                                                        outcome.text = format!(
+                                                            "{} Repository authority did \
+                                                             not publish it: {}. The file \
+                                                             is on disk and uncommitted.",
+                                                            outcome.text,
+                                                            unpublished_reason(&provenance),
+                                                        );
+                                                    }
+                                                    (outcome, provenance)
+                                                }
+                                            } else {
+                                                let outcome = match tool {
+                                                    LocalTool::Edit => {
+                                                        belt::run_edit(&repo, &call.arguments)
+                                                    }
+                                                    LocalTool::Write => {
+                                                        belt::run_write(&repo, &call.arguments)
+                                                    }
+                                                };
+                                                // Stage what the harness just did, inside
+                                                // the open bracket, so the commit below
+                                                // has something to publish. An empty
+                                                // transaction is refused by design.
+                                                let staged = if outcome.is_error {
+                                                    false
+                                                } else {
+                                                    stage_planned_operation(
+                                                        &mut servers[index],
+                                                        &mut bracket,
+                                                        session.as_deref(),
+                                                        &plan,
+                                                        &mut writer,
+                                                    )?
+                                                };
+                                                let wanted_publication =
+                                                    !outcome.is_error && staged;
+                                                let provenance = close_transaction(
+                                                    &mut servers[index],
+                                                    bracket,
+                                                    wanted_publication,
+                                                    &mut writer,
+                                                )?;
+                                                if wanted_publication
+                                                    && !published_by_authority(&provenance)
+                                                {
+                                                    counters.unpublished_changes += 1;
+                                                }
+                                                (outcome, provenance)
                                             };
-                                            let provenance = close_transaction(
-                                                &mut servers[index],
-                                                bracket,
-                                                !outcome.is_error && staged,
-                                                &mut writer,
-                                            )?;
                                             if let Some(path) = outcome.changed.clone() {
                                                 // With several repositories attached the
                                                 // same relative path exists in more than
@@ -1139,7 +1204,7 @@ fn stage_planned_operation(
     }
     let outcome = server.client.call_tool("kin_transaction_stage", &arguments);
     let (is_error, detail) = match &outcome {
-        Ok(outcome) => (outcome.is_error, truncate(&outcome.text, 300)),
+        Ok(outcome) => (outcome.is_error, close_detail(&outcome.text)),
         Err(err) => (true, err.to_string()),
     };
     writer.trace(json!({
@@ -1190,7 +1255,7 @@ fn close_transaction(
         .client
         .call_tool(tool, &json!({ "transaction_id": transaction_id }));
     let (is_error, detail) = match &outcome {
-        Ok(outcome) => (outcome.is_error, truncate(&outcome.text, 300)),
+        Ok(outcome) => (outcome.is_error, close_detail(&outcome.text)),
         Err(err) => (true, err.to_string()),
     };
     writer.trace(json!({
@@ -1214,6 +1279,43 @@ fn close_transaction(
         "response": detail.clone(),
         "detail": if is_error { Value::String(detail) } else { Value::Null },
     }))
+}
+
+/// Whether repository authority actually published this bracket.
+///
+/// A clean close is not enough on its own: an abort closes cleanly too, and a run that
+/// read `closed_cleanly` alone would score an aborted transaction as a landed change.
+fn published_by_authority(provenance: &Value) -> bool {
+    provenance["closed_with"] == json!("kin_transaction_commit")
+        && provenance["closed_cleanly"] == json!(true)
+}
+
+/// What the server said when it declined to publish, in one line fit for the model.
+fn unpublished_reason(provenance: &Value) -> String {
+    for key in ["detail", "response", "reason"] {
+        if let Some(text) = provenance.get(key).and_then(Value::as_str) {
+            if !text.trim().is_empty() {
+                return text.to_string();
+            }
+        }
+    }
+    "the server gave no reason".to_string()
+}
+
+/// Truncate a server answer for the trace, keeping the part that says what happened.
+///
+/// Every Kin answer carries a `_kin` envelope longer than the old 300-character budget, so
+/// truncating the raw text spent the whole budget on the envelope and dropped the `message`
+/// key entirely. The envelope is graph freshness, which the trace records elsewhere; the
+/// failure reason is the thing a reader cannot reconstruct.
+fn close_detail(text: &str) -> String {
+    match serde_json::from_str::<Value>(text.trim()) {
+        Ok(Value::Object(mut payload)) => {
+            payload.remove("_kin");
+            truncate(&Value::Object(payload).to_string(), 300)
+        }
+        _ => truncate(text, 300),
+    }
 }
 
 fn extract_id(outcome: &ToolOutcome, keys: &[&str]) -> Option<String> {
@@ -1255,6 +1357,15 @@ fn finish(
     started: Instant,
     _reserved: Option<()>,
 ) -> anyhow::Result<RunOutcome> {
+    // A run that wrote files repository authority never published landed nothing, whatever
+    // the model's closing paragraph says. Downgrading here rather than at each exit path
+    // means no future exit can forget it. A run that stopped for its own reason keeps that
+    // reason, which is more specific than this one.
+    let status = if status == ExitStatus::Success && counters.unpublished_changes > 0 {
+        ExitStatus::ChangesUnpublished
+    } else {
+        status
+    };
     let record = writer.result(
         status.subtype(),
         status != ExitStatus::Success,

--- a/crates/kin-agent/tests/loop_integration.rs
+++ b/crates/kin-agent/tests/loop_integration.rs
@@ -124,9 +124,13 @@ fn write_fake_mcp_server(dir: &Path) -> PathBuf {
 }
 
 const FAKE_SERVER: &str = r#"#!/usr/bin/env python3
-import json, sys
+import json, os, sys
 
 LOG = sys.argv[1]
+
+# Staged operations per transaction, so a commit publishes what was staged rather than
+# answering yes to anything. The server runs with the repository as its cwd.
+STAGED = {}
 
 TOOLS = [
     {"name": "semantic_locate", "description": "Find entities by meaning.",
@@ -185,11 +189,35 @@ def call(name, args):
             if op.get("target") in TRACKED:
                 return payload({"error": "path " + op.get("target") + " is already tracked",
                                 "_kin": ENVELOPE}, is_error=True)
+        STAGED.setdefault(args.get("transaction_id"), []).extend(args.get("operations", []))
         return payload({"staged": len(args.get("operations", [])),
                         "transaction_id": "txn-fixture-1", "_kin": ENVELOPE})
     if name == "kin_transaction_commit":
-        return payload({"committed": True, "transaction_id": "txn-fixture-1", "_kin": ENVELOPE})
+        # The real daemon refuses to publish onto an untracked working-copy path, and
+        # materialises the file itself when it does publish. A stand-in that always
+        # answers "committed" cannot fail the way the product fails, which is how
+        # FIR-2624 shipped: the harness wrote the file first and every real commit was
+        # refused while this suite stayed green.
+        operations = STAGED.pop(args.get("transaction_id"), [])
+        for op in operations:
+            target = op.get("target")
+            if op.get("verb") in ("create", "add", "insert") and os.path.exists(target):
+                return payload({"message": "repository projection conflict: untracked "
+                                           "working-copy path " + os.path.abspath(target) +
+                                           " conflicts with exact workspace target " + target,
+                                "_kin": ENVELOPE}, is_error=True)
+        for op in operations:
+            target = op.get("target")
+            if op.get("verb") in ("create", "add", "insert"):
+                parent = os.path.dirname(target)
+                if parent:
+                    os.makedirs(parent, exist_ok=True)
+                with open(target, "w") as fh:
+                    fh.write(op.get("body", ""))
+        return payload({"committed": True, "published": len(operations),
+                        "transaction_id": "txn-fixture-1", "_kin": ENVELOPE})
     if name == "kin_transaction_abort":
+        STAGED.pop(args.get("transaction_id"), None)
         return payload({"aborted": True, "_kin": ENVELOPE})
     return payload({"error": "unknown tool " + name}, is_error=True)
 
@@ -617,6 +645,159 @@ fn a_new_file_is_staged_as_a_create_and_then_committed() {
     assert_eq!(staged["body_bytes"], body.len());
 }
 
+/// FIR-2624: a created file must be published by repository authority, not written to the
+/// working copy ahead of the commit.
+///
+/// The daemon refuses to publish onto an untracked working-copy path sitting on its exact
+/// workspace target, so a harness that writes first turns every commit into a refusal and
+/// lands nothing. The scripted server refuses on the same ground, which is what makes this
+/// test able to fail: restore the old ordering and the run ends `ChangesUnpublished` with
+/// the projection conflict in its trace.
+#[test]
+fn a_created_file_is_published_by_authority_rather_than_written_before_the_commit() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+    let body = "def shout(text):\n    return text.upper()\n";
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Adding the helper.",
+            Some(tool_call(
+                "c1",
+                "write_file",
+                json!({ "path": "src/shout.py", "content": body }),
+            )),
+        ),
+        completion("src/shout.py now holds shout.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+
+    assert_eq!(outcome.status, ExitStatus::Success);
+    assert_eq!(outcome.result["kin_agent"]["unpublished_changes"], 0);
+    // The bytes are on disk, and the only writer was the commit.
+    assert_eq!(
+        std::fs::read_to_string(repo.join("src/shout.py")).unwrap(),
+        body
+    );
+
+    let calls = mcp_log(&log);
+    let names: Vec<&str> = calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"kin_transaction_commit"),
+        "the create must be committed, not aborted: {names:?}"
+    );
+    assert!(
+        !names.contains(&"kin_transaction_abort"),
+        "a create the daemon can publish must never abort: {names:?}"
+    );
+
+    let trace = read_jsonl(&outcome.trace_path);
+    let write = trace
+        .iter()
+        .find(|row| row["tool"] == "write_file")
+        .expect("the local write is traced");
+    assert_eq!(write["provenance"]["bracketed"], true);
+    assert_eq!(
+        write["provenance"]["closed_with"], "kin_transaction_commit",
+        "the bracket must close by committing"
+    );
+    assert_eq!(
+        write["provenance"]["closed_cleanly"], true,
+        "the commit must be accepted, not refused on the harness's own file"
+    );
+
+    // The model is told publication happened, so it can tell a landed change from a file
+    // left sitting on disk.
+    let requests = endpoint.requests();
+    let observation = requests[1]["messages"].as_array().unwrap().last().unwrap()["content"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        observation.contains("published it through repository authority"),
+        "the model must be told the change landed: {observation}"
+    );
+}
+
+/// FIR-2625: a run whose change repository authority never published must not report
+/// success, and the reason must survive into the trace instead of being spent on the
+/// `_kin` envelope.
+#[test]
+fn a_refused_commit_downgrades_the_run_and_keeps_its_reason_in_the_trace() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+
+    // README.md is tracked in the fixture graph, so the scripted server refuses the stage
+    // by name, exactly as the daemon does.
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Rewriting the readme.",
+            Some(tool_call(
+                "c1",
+                "write_file",
+                json!({ "path": "README.md", "content": "# again\n" }),
+            )),
+        ),
+        completion("Readme rewritten.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+
+    // The model's closing paragraph reads like a success. The run does not.
+    assert_eq!(outcome.status, ExitStatus::ChangesUnpublished);
+    assert_eq!(outcome.status.code(), 6);
+    assert_eq!(outcome.result["subtype"], "changes_unpublished");
+    assert_eq!(outcome.result["is_error"], true);
+    assert_eq!(outcome.result["kin_agent"]["unpublished_changes"], 1);
+
+    // The reason reaches the trace. The `_kin` envelope alone is longer than the 300
+    // character budget, so truncating the raw answer dropped the message entirely.
+    let trace = read_jsonl(&outcome.trace_path);
+    let staged = trace
+        .iter()
+        .find(|row| row["tool"] == "kin_transaction_stage")
+        .expect("the stage call is traced");
+    assert_eq!(staged["is_error"], true);
+    let detail = staged["detail"].as_str().unwrap();
+    assert!(
+        detail.contains("already tracked"),
+        "the refusal reason must survive truncation, got: {detail}"
+    );
+    assert!(
+        !detail.contains("envelope_version"),
+        "the envelope must not be what the budget was spent on: {detail}"
+    );
+
+    // The model's work is not lost, and the model is told it did not land.
+    assert_eq!(
+        std::fs::read_to_string(repo.join("README.md")).unwrap(),
+        "# again\n"
+    );
+    let requests = endpoint.requests();
+    let observation = requests[1]["messages"].as_array().unwrap().last().unwrap()["content"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        observation.contains("did not publish it"),
+        "the model must be told the change did not land: {observation}"
+    );
+}
+
 /// A `write_file` over a path the graph already tracks is refused by repository authority
 /// rather than by the harness looking at the disk, and the refusal aborts the transaction.
 #[test]
@@ -642,7 +823,11 @@ fn a_write_over_a_tracked_path_is_refused_by_the_graph_and_aborts() {
 
     let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
         .expect("the run completes");
-    assert_eq!(outcome.status, ExitStatus::Success);
+    // Nothing was published, so the run does not get to call itself a success. The model
+    // still keeps its work: the harness falls back to the local write when the bracket
+    // could not publish, which is the only reason the file below exists.
+    assert_eq!(outcome.status, ExitStatus::ChangesUnpublished);
+    assert_eq!(outcome.result["kin_agent"]["unpublished_changes"], 1);
     assert_eq!(
         std::fs::read_to_string(repo.join("README.md")).unwrap(),
         "# rewritten\n"


### PR DESCRIPTION
`kin agent` wrote a new file to the working copy and then staged a `create` for that same
path, so every commit was refused with a projection conflict on the harness's own file and
no run ever landed anything. The daemon writes a created file itself as part of publishing
the change, so the local write was both fatal and redundant.

Found by performing FIR-2586's own acceptance clause against the npm-served 0.5.49 binary:
three `kin agent run` passes on `qwen/qwen3.6-35b-a3b@q8_0` through LM Studio, on fresh
Python fixtures under a scratch `KIN_HOME`. The model did well, reading the fixture through
`semantic_search`, `semantic_locate` and `get_entity_source` and using the real API names it
learned. Every `kin_transaction_begin` and every `kin_transaction_stage` was accepted. Every
`kin_transaction_commit` was refused, `kin log` gained nothing in any fixture, and all three
runs printed `kin agent: success` with `exit_code: 0` and `refused_calls: 0`.

The refusal, recovered by re-driving `kin mcp start` by hand because no run artefact carries
it:

```
exact MCP repository commit failed before authority moved: Core error:
repository projection conflict: untracked working-copy path
.../notekeeper/search.py conflicts with exact workspace target notekeeper/search.py
```

Falsified two-sided with no model in the loop. Positive arm, file written to disk first
exactly as the harness does: commit refused. Control arm, byte-identical minus that write:
`state: committed`, `entity_deltas: 2`, `relation_deltas: 61`, `kin log` gains the change,
`kin graph status` moves entities 17 to 19 and files 4 to 5, and the commit writes the file
to the working copy itself.

## What changes

**A create is published first, and the local write is the fallback.** When the bracket is
open and the plan is a create, the harness stages and commits and repository authority
writes the file. Only when publication does not happen does the local write run, so a
refusal never costs the model its work, and the model is told the change did not land
instead of reading a bare success.

**A refused close reaches the run's verdict.** A new `unpublished_changes` counter, a new
`ExitStatus::ChangesUnpublished` at exit code 6 and subtype `changes_unpublished`, and the
downgrade applied once inside `finish()` so no future exit path can forget it. A run that
stopped for its own reason keeps that reason, which is the more specific one.

**The reason survives into the trace.** Both the stage and the close spent their whole
300-character budget on the `_kin` envelope, so the `message` key never appeared. They now
strip the envelope before truncating. The envelope is graph freshness the trace records
elsewhere; the failure reason is the part a reader cannot reconstruct.

**The scripted MCP server now models the daemon.** It answered every commit with
`{"committed": true}`, which is why this shipped green. It keeps staged operations per
transaction, publishes them on commit by writing the files, and refuses a create onto a path
that already exists using the daemon's own projection-conflict wording.

## Evidence

`cargo test -p kin-agent` 33 unit and 13 integration passed with 1 pre-existing ignored,
`cargo test -p kin-cli agent` 5 passed, `cargo fmt --all -- --check` rc 0,
`scripts/verify-zero-file-search.py` rc 0 over 180 files,
`scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh` and
`scripts/check_private_repo_coupling.sh` all rc 0.

Two new tests, `a_created_file_is_published_by_authority_rather_than_written_before_the_commit`
and `a_refused_commit_downgrades_the_run_and_keeps_its_reason_in_the_trace`. One existing
test changed its expectation from `Success` to `ChangesUnpublished`, which is the lie this
PR removes rather than a regression.

Four falsification passes, each restored byte-identically with an empty
`git status --porcelain` and an empty `git diff HEAD --stat` afterwards:

1. Force the old ordering: five tests fail, including the existing create test at
   `ChangesUnpublished` where it expects `Success`.
2. Restore `truncate(&outcome.text, 300)` at both sites: the reason test fails naming the
   envelope the budget was spent on.
3. Remove the `finish()` downgrade: both honesty tests fail at `Success`.
4. Disable the stand-in's refusal arm and restore the old ordering together, which is the
   shipped state exactly: the existing create test goes **green**, which is the whole point.
   The new test still fails.

One risk was checked against the real daemon rather than assumed. The harness no longer
creates parent directories, since `create_dir_all` moved to the fallback path, so a create
into a directory that does not exist yet was staged by hand against shipped 0.5.49. It
commits cleanly and the commit creates the directory and writes the file.

Report with the run table, the full trace measurements and the lock timeline:
`.kin-coord/reports/localagent-20260822.md`.

## Proven end to end

The acceptance re-run was performed against binaries built from this branch and verified to
carry the change by `strings` with a control: "To change code, use edit_file" appears in
both the lane binary and shipped 0.5.49, while "published it through repository authority"
and "changes_unpublished" appear in the lane binary only.

Same model, same fixture seed, 73 seconds. Two `kin_transaction_commit` calls, both
accepted. `kin log` gains two changes on top of the seed, authored
`kin-agent/kin-agent (qwen qwen3.6-35b-a3b@q8_0)`, and `kin graph status` counts them:
entities 17 to 25, files 4 to 6. `result.json` reads `subtype: success` with
`unpublished_changes: 0`. On shipped 0.5.49 the same task attempted two commits, had both
refused, and left `kin log` holding only the seed.

The task asked for `notekeeper/query/search.py` on purpose, a path whose parent directory
does not exist, because this PR moves `create_dir_all` onto the fallback. The daemon created
the directory and wrote both files.

## Not claiming

Not claiming the acceptance is proven on release bytes. The re-run used a debug build,
because the release profile was abandoned after twenty minutes at load 152 on a box the
whole fix wave was building on. It proves the product logic, not what a user installs, and
FIR-2586 stays open until this lands and ships. Not claiming any timing above is a
performance result. Not claiming anything about `edit_file`, which still opens no transaction:
`plan_stage` returns `Unstageable` for every in-place edit, so kin#1052's `replace` verb is
still unreached. Not claiming a Windows or Linux result.

Refs FIR-2586
Closes FIR-2624
Closes FIR-2625
