### PR TITLE
Disclose what a context pack's token budget refused, instead of rendering the loss as absence

### DIFF
--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -286,12 +286,7 @@ pub fn build_context_response(
         format!(
             "  Dependencies: {} entries{}",
             dependencies_returned,
-            dependency_selection_note(
-                &selection,
-                dependencies_returned,
-                &elisions,
-                max_tokens
-            )
+            dependency_selection_note(&selection, dependencies_returned, &elisions, max_tokens)
         ),
         format!(
             "  Dependents: {} entries{}",
@@ -322,7 +317,11 @@ pub fn build_context_response(
         lines.push(format!(
             "  Raise --budget above {max_tokens} to recover the {total_elided} \
              {} the token budget withheld.",
-            if total_elided == 1 { "entry" } else { "entries" }
+            if total_elided == 1 {
+                "entry"
+            } else {
+                "entries"
+            }
         ));
     }
     lines.push(String::new());
@@ -935,7 +934,11 @@ mod tests {
     fn a_whole_pack_carries_no_budget_note_at_all() {
         let (graph, _) = calling_graph(2);
         let whole = context_for(&graph, "32k");
-        assert!(whole.budget_elisions.is_empty(), "{:?}", whole.budget_elisions);
+        assert!(
+            whole.budget_elisions.is_empty(),
+            "{:?}",
+            whole.budget_elisions
+        );
         let rendered = whole.lines.join("\n");
         assert!(
             !rendered.contains("withheld by the"),

--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -267,7 +267,21 @@ pub fn build_context_response(
 
     let mut lines = vec![
         format!("Context pack for '{}' ({:?}):", target.name, target.kind),
-        format!("  Budget: {}/{} tokens", pack.actual_tokens, max_tokens),
+        format!(
+            "  Budget: {}/{} tokens{}",
+            pack.actual_tokens,
+            max_tokens,
+            // A pack over its own budget is not a bug and not a rounding
+            // error: every section that had a candidate keeps one, so a
+            // section can never render as empty when the graph found rows.
+            // Saying so is cheaper than leaving a reader to explain a number
+            // that looks wrong.
+            if pack.actual_tokens > max_tokens {
+                " (over budget: every section keeps a row)"
+            } else {
+                ""
+            }
+        ),
         format!("  Focal: {} entries", pack.focal_entities.len()),
         format!(
             "  Dependencies: {} entries{}",

--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -825,4 +825,111 @@ mod tests {
             resolved.name
         );
     }
+
+    // ── What the token budget refused reaches both renderings (FIR-2482) ──
+
+    /// A focal calling `deps` entities, so a tight budget has rows to refuse.
+    fn calling_graph(deps: usize) -> (kin_db::InMemoryGraph, Entity) {
+        use kin_model::relation::{Relation, RelationKind, RelationOrigin};
+        use kin_model::GraphNodeId;
+        let graph = kin_db::InMemoryGraph::new();
+        let focal = test_entity("focal");
+        graph.upsert_entity(&focal).unwrap();
+        for index in 0..deps {
+            let dep = test_entity(&format!("dep_{index:04}"));
+            graph.upsert_entity(&dep).unwrap();
+            graph
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(focal.id),
+                    dst: GraphNodeId::Entity(dep.id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+        (graph, focal)
+    }
+
+    fn context_for(graph: &kin_db::InMemoryGraph, budget: &str) -> ContextResponse {
+        build_context_response(
+            graph,
+            &ContextRequest {
+                entity: "focal".to_string(),
+                budget: budget.to_string(),
+                assistant: None,
+            },
+        )
+        .unwrap()
+    }
+
+    /// Six rows on a focal with sixty dependencies printed "Dependencies: 6
+    /// entries", which is what a focal with six dependencies prints. The
+    /// rendering is the whole of what a `kin context` reader sees, so a cut it
+    /// does not name is a cut that did not happen as far as that reader knows.
+    #[test]
+    fn a_budget_cut_section_names_its_loss_in_the_lines_and_in_the_json() {
+        let (graph, _) = calling_graph(60);
+        let whole = context_for(&graph, "32k");
+        let full_deps = whole.pack.as_ref().unwrap().dependency_signatures.len();
+        assert!(
+            whole.budget_elisions.is_empty(),
+            "a generous budget refused nothing and must claim nothing: {:?}",
+            whole.budget_elisions
+        );
+
+        // Sized off the unconstrained pack so the cut lands mid-list however
+        // projection costs change later.
+        let tight = (whole.pack.as_ref().unwrap().actual_tokens / 2).to_string();
+        let cut = context_for(&graph, &tight);
+        let kept = cut.pack.as_ref().unwrap().dependency_signatures.len();
+        assert!(
+            kept > 0 && kept < full_deps,
+            "the budget must actually cut for this test to mean anything: kept {kept} of \
+             {full_deps}"
+        );
+
+        let elision = cut
+            .budget_elisions
+            .get("dependencies")
+            .unwrap_or_else(|| panic!("a cut section must publish an elision: {:?}", cut.lines));
+        assert_eq!(elision.kept, kept);
+        assert_eq!(elision.kept + elision.elided, elision.total);
+        assert_eq!(elision.reason, CONTEXT_ELISION_REASON_TOKEN_BUDGET);
+
+        let rendered = cut.lines.join("\n");
+        assert!(
+            rendered.contains(&format!(
+                "{} withheld by the {tight}-token budget",
+                elision.elided
+            )),
+            "the section line names what the budget took: {rendered}"
+        );
+        assert!(
+            rendered.contains(&format!("Raise --budget above {tight}")),
+            "the rendering names the lever that recovers it: {rendered}"
+        );
+    }
+
+    /// The other direction, and it is the one that gives an absent disclosure
+    /// its meaning: a pack that lost nothing says nothing, on both halves.
+    #[test]
+    fn a_whole_pack_carries_no_budget_note_at_all() {
+        let (graph, _) = calling_graph(2);
+        let whole = context_for(&graph, "32k");
+        assert!(whole.budget_elisions.is_empty(), "{:?}", whole.budget_elisions);
+        let rendered = whole.lines.join("\n");
+        assert!(
+            !rendered.contains("withheld by the"),
+            "nothing was withheld, so nothing may be claimed: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Raise --budget"),
+            "no lever is offered for a cut that did not happen: {rendered}"
+        );
+    }
 }

--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -309,6 +309,28 @@ pub fn build_context_response(
             withheld(kin_context::group::TESTS)
         ),
     ];
+    // Work items and annotations have never had a line of their own, because a
+    // pack usually carries none and a row of zeroes is noise. A section the
+    // budget took rows from is the case where saying nothing is the defect, so
+    // the line appears exactly when there is something to report.
+    for (group, label, held) in [
+        (
+            kin_context::group::WORK_ITEMS,
+            "Work items",
+            pack.work_items.len(),
+        ),
+        (
+            kin_context::group::ANNOTATIONS,
+            "Annotations",
+            pack.annotations.len(),
+        ),
+    ] {
+        let note = withheld(group);
+        if held == 0 && note.is_empty() {
+            continue;
+        }
+        lines.push(format!("  {label}: {held} entries{note}"));
+    }
     // One line naming the lever, because a per-section count says what was lost
     // and not what recovers it. Present only when something was cut, so a whole
     // pack never carries a note about a cut that did not happen.

--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use kin_model::EntityStore;
 use kin_model::{Entity, EntityFilter, EntityId, EntityKind, TokenBudget};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Resolve session id from KIN_SESSION_ID env var.
 ///
@@ -116,7 +117,38 @@ pub struct ContextResponse {
     /// the field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dependency_selection: Option<ContextDependencySelection>,
+    /// What the token budget refused, per section, under the same group names
+    /// and the same shape the `get_context_pack` MCP tool publishes.
+    ///
+    /// Empty when the budget refused nothing, so a reader keying on this map
+    /// never has to tell "lost nothing" from "does not report losses": the
+    /// human rendering says the same thing on the same run.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub budget_elisions: BTreeMap<String, ContextElision>,
 }
+
+/// What one pack section lost to the token budget.
+///
+/// The same four fields the MCP `elisions` map carries, so a reader moving
+/// between `kin context --json` and `get_context_pack` is not learning two
+/// vocabularies for one fact.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextElision {
+    /// Rows the token budget refused.
+    pub elided: usize,
+    /// Rows the pack still carries.
+    pub kept: usize,
+    /// Rows that were candidates, which is `kept + elided`.
+    pub total: usize,
+    /// What withheld them. `token_budget` here, named rather than assumed so a
+    /// cut made later for another reason cannot be read as this one.
+    pub reason: String,
+}
+
+/// The reason code a row the pack's token budget refused carries. Matches
+/// `kin_mcp::budget::ELISION_REASON_TOKEN_BUDGET`, which is the same fact
+/// reported on the other surface.
+pub const CONTEXT_ELISION_REASON_TOKEN_BUDGET: &str = "token_budget";
 
 pub async fn run(
     entity: String,
@@ -194,6 +226,7 @@ pub fn build_context_response(
             target: None,
             pack: None,
             dependency_selection: None,
+            budget_elisions: BTreeMap::new(),
         });
     };
     let opts = kin_context::ContextOptions {
@@ -210,26 +243,76 @@ pub fn build_context_response(
     let dependents_returned = count_dependents(&pack, &selection);
     let dependencies_returned = pack.dependency_signatures.len() - dependents_returned;
 
+    let max_tokens = token_budget.max_tokens();
+    // What the budget refused, per section. The pack's rows are the whole of
+    // what the rendering used to show, and a section trimmed from twelve rows
+    // to six printed "Dependencies: 6 entries", which is exactly what a focal
+    // with six dependencies prints. Nothing on the surface distinguished them.
+    let elisions = budget_elisions(
+        &selection,
+        &[
+            (kin_context::group::DEPENDENCIES, dependencies_returned),
+            (kin_context::group::DEPENDENTS, dependents_returned),
+            (
+                kin_context::group::TRANSITIVE_DEPS,
+                pack.transitive_deps.len(),
+            ),
+            (kin_context::group::TESTS, pack.tests.len()),
+            (kin_context::group::CONTRACTS, pack.contracts.len()),
+            (kin_context::group::WORK_ITEMS, pack.work_items.len()),
+            (kin_context::group::ANNOTATIONS, pack.annotations.len()),
+        ],
+    );
+    let withheld = |group: &str| -> String { budget_note(&elisions, group, max_tokens) };
+
     let mut lines = vec![
         format!("Context pack for '{}' ({:?}):", target.name, target.kind),
-        format!(
-            "  Budget: {}/{} tokens",
-            pack.actual_tokens,
-            token_budget.max_tokens()
-        ),
+        format!("  Budget: {}/{} tokens", pack.actual_tokens, max_tokens),
         format!("  Focal: {} entries", pack.focal_entities.len()),
         format!(
             "  Dependencies: {} entries{}",
             dependencies_returned,
-            dependency_selection_note(&selection, dependencies_returned)
+            dependency_selection_note(
+                &selection,
+                dependencies_returned,
+                &elisions,
+                max_tokens
+            )
         ),
-        format!("  Dependents: {} entries", dependents_returned),
-        format!("  Transitive: {} entries", pack.transitive_deps.len()),
-        format!("  Contracts: {} entries", pack.contracts.len()),
-        format!("  Tests: {} entries", pack.tests.len()),
-        String::new(),
-        "--- Context Pack ---".to_string(),
+        format!(
+            "  Dependents: {} entries{}",
+            dependents_returned,
+            withheld(kin_context::group::DEPENDENTS)
+        ),
+        format!(
+            "  Transitive: {} entries{}",
+            pack.transitive_deps.len(),
+            withheld(kin_context::group::TRANSITIVE_DEPS)
+        ),
+        format!(
+            "  Contracts: {} entries{}",
+            pack.contracts.len(),
+            withheld(kin_context::group::CONTRACTS)
+        ),
+        format!(
+            "  Tests: {} entries{}",
+            pack.tests.len(),
+            withheld(kin_context::group::TESTS)
+        ),
     ];
+    // One line naming the lever, because a per-section count says what was lost
+    // and not what recovers it. Present only when something was cut, so a whole
+    // pack never carries a note about a cut that did not happen.
+    let total_elided: usize = elisions.values().map(|elision| elision.elided).sum();
+    if total_elided > 0 {
+        lines.push(format!(
+            "  Raise --budget above {max_tokens} to recover the {total_elided} \
+             {} the token budget withheld.",
+            if total_elided == 1 { "entry" } else { "entries" }
+        ));
+    }
+    lines.push(String::new());
+    lines.push("--- Context Pack ---".to_string());
 
     for entry in &pack.focal_entities {
         lines.push(entry.content.clone());
@@ -257,8 +340,52 @@ pub fn build_context_response(
             same_file_candidates: selection.same_file_candidates(),
             same_file_dropped: selection.same_file_dropped(),
         }),
+        budget_elisions: elisions,
         pack: Some(pack),
     })
+}
+
+/// What the token budget refused, per section, keyed by the group names the two
+/// surfaces share.
+///
+/// Sections with nothing refused are absent rather than present with a zero, so
+/// the map answers "did this pack lose anything" by being empty or not.
+fn budget_elisions(
+    selection: &kin_context::DependencySelection,
+    sections: &[(&str, usize)],
+) -> BTreeMap<String, ContextElision> {
+    let mut elisions = BTreeMap::new();
+    for (group, kept) in sections {
+        let elided = selection.budget_elided(group);
+        if elided == 0 {
+            continue;
+        }
+        elisions.insert(
+            (*group).to_string(),
+            ContextElision {
+                elided,
+                kept: *kept,
+                total: kept.saturating_add(elided),
+                reason: CONTEXT_ELISION_REASON_TOKEN_BUDGET.to_string(),
+            },
+        );
+    }
+    elisions
+}
+
+/// The parenthetical a section line carries when the budget took rows from it.
+fn budget_note(
+    elisions: &BTreeMap<String, ContextElision>,
+    group: &str,
+    max_tokens: usize,
+) -> String {
+    match elisions.get(group) {
+        Some(elision) => format!(
+            " ({} withheld by the {max_tokens}-token budget)",
+            elision.elided
+        ),
+        None => String::new(),
+    }
 }
 
 /// Rows in the pack's dependency section that depend on the focal.
@@ -288,15 +415,41 @@ fn count_dependents(
 fn dependency_selection_note(
     selection: &kin_context::DependencySelection,
     returned: usize,
+    elisions: &BTreeMap<String, ContextElision>,
+    max_tokens: usize,
 ) -> String {
+    let budget = budget_note(elisions, kin_context::group::DEPENDENCIES, max_tokens);
     match selection.source() {
-        kin_context::DependencySource::DependencyEdges if returned == 0 => String::new(),
-        kin_context::DependencySource::DependencyEdges => " (dependency edges)".to_string(),
-        kin_context::DependencySource::SameFileFallback => format!(
-            " (same-file neighbors, no dependency edges; kept {} of {})",
-            selection.same_file_kept(),
-            selection.same_file_candidates()
-        ),
+        kin_context::DependencySource::DependencyEdges if returned == 0 => budget,
+        kin_context::DependencySource::DependencyEdges => format!(" (dependency edges){budget}"),
+        // Both causes, separately, whenever both are real. Nothing recovers the
+        // cap and `--budget` recovers the other, so folding them into one
+        // shortfall would rebuild the two-causes-one-number reading this
+        // disclosure exists to remove. Naming both is what keeps the whole
+        // shortfall accountable while the causes stay distinct.
+        kin_context::DependencySource::SameFileFallback => {
+            let candidates = selection.same_file_candidates();
+            let kept = selection.same_file_kept();
+            let refused = elisions
+                .get(kin_context::group::DEPENDENCIES)
+                .map_or(0, |elision| elision.elided);
+            let capped = candidates.saturating_sub(kept).saturating_sub(refused);
+            let mut note =
+                format!(" (same-file neighbors, no dependency edges; kept {kept} of {candidates}");
+            if refused > 0 {
+                note.push_str(&format!(
+                    "; {refused} withheld by the {max_tokens}-token budget"
+                ));
+            }
+            if capped > 0 {
+                note.push_str(&format!(
+                    "; {capped} past the {}-neighbor cap",
+                    kin_context::SAME_FILE_FALLBACK_MAX
+                ));
+            }
+            note.push(')');
+            note
+        }
     }
 }
 

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use kin_model::{
     relation::RelationKind, Annotation, AnnotationEntry, ArtifactContextEntry, ArtifactContextKind,
@@ -747,6 +747,9 @@ where
     let mut transitive_entries = Vec::new();
     let mut test_entries = Vec::new();
     let mut contract_entries = Vec::new();
+    // Groups already holding a row, so the never-empty floor below admits a
+    // group's first candidate and only its first.
+    let mut admitted_groups: HashSet<&'static str> = HashSet::new();
 
     // Codex benefits from reserving budget for the focal entity.
     let transitive_budget = match opts.assistant_hint {
@@ -801,7 +804,8 @@ where
         };
         let fits = match section {
             AssemblySection::Transitive => {
-                total_tokens + tokens <= budget_max && transitive_tokens + tokens <= transitive_budget
+                total_tokens + tokens <= budget_max
+                    && transitive_tokens + tokens <= transitive_budget
             }
             _ => total_tokens + tokens <= budget_max,
         };
@@ -811,10 +815,20 @@ where
         // here, at the only place that knows a row was ever a candidate, so
         // both surfaces can say what the budget took instead of rendering the
         // loss as absence.
-        if !fits {
+        //
+        // Every group that had a candidate keeps one, whatever it costs. A
+        // bound is not a refusal, and a caller handed an empty group cannot
+        // tell it from "the graph found none": that is the reading kin#1062
+        // removed from the response budget's own ladder, and the same reading
+        // arrives here through the earlier budget. Candidates are walked in
+        // weight order, so the row a group keeps is its most important one. The
+        // overshoot this can cost is bounded by one row per group and is
+        // reported, because `actual_tokens` is measured rather than assumed.
+        if !fits && admitted_groups.contains(target_group) {
             selection.refuse(target_group, entity_id);
             continue;
         }
+        admitted_groups.insert(target_group);
         total_tokens += tokens;
         let entry = ContextEntry {
             entity_id,
@@ -852,10 +866,13 @@ where
             // budget elision: a cap and a budget are different causes recovered
             // by different levers, and `Elision::reason` exists so one cannot
             // be read as the other.
-            if total_tokens + tokens > budget_max {
+            if total_tokens + tokens > budget_max
+                && admitted_groups.contains(group::DEPENDENCIES)
+            {
                 selection.refuse(group::DEPENDENCIES, entity.id);
                 continue;
             }
+            admitted_groups.insert(group::DEPENDENCIES);
             total_tokens += tokens;
             selection.same_file_neighbors.push(entity.id);
             dep_entries.push(ContextEntry {
@@ -889,10 +906,13 @@ where
                 }
                 let content = format_work_item(&item);
                 let tokens = estimate_tokens(&content);
-                if total_tokens + tokens > budget_max {
+                if total_tokens + tokens > budget_max
+                    && admitted_groups.contains(group::WORK_ITEMS)
+                {
                     selection.refuse(group::WORK_ITEMS, *eid);
                     continue;
                 }
+                admitted_groups.insert(group::WORK_ITEMS);
                 total_tokens += tokens;
                 work_entries.push(WorkItemEntry {
                     work_item: item,
@@ -912,10 +932,13 @@ where
                 }
                 let content = format_annotation(&ann);
                 let tokens = estimate_tokens(&content);
-                if total_tokens + tokens > budget_max {
+                if total_tokens + tokens > budget_max
+                    && admitted_groups.contains(group::ANNOTATIONS)
+                {
                     selection.refuse(group::ANNOTATIONS, *eid);
                     continue;
                 }
+                admitted_groups.insert(group::ANNOTATIONS);
                 total_tokens += tokens;
                 annotation_entries.push(AnnotationEntry {
                     annotation: ann,
@@ -3325,6 +3348,36 @@ mod tests {
             selection.budget_elided_unrecovered(group::DEPENDENCIES, |_| true),
             0,
             "a row the caller recovered elsewhere is not a row the answer lost"
+        );
+    }
+
+    #[test]
+    fn a_budget_too_small_for_any_row_still_keeps_one() {
+        let (store, focal) = calling_store(40);
+        // One token. Nothing fits, including the focal, so every candidate is
+        // a refusal and the group would have serialized as `[]`.
+        let opts = ContextOptions {
+            budget: TokenBudget::Custom(1),
+            ..ContextOptions::default()
+        };
+        let (pack, selection) =
+            build_context_pack_with_provenance(&store, &focal.id, &opts).unwrap();
+        assert_eq!(
+            pack.dependency_signatures.len(),
+            1,
+            "a group with candidates keeps one, so an empty group means the graph found none"
+        );
+        assert_eq!(
+            selection.budget_elided(group::DEPENDENCIES),
+            39,
+            "and says how many it could not keep"
+        );
+        assert!(
+            pack.actual_tokens > opts.budget.max_tokens(),
+            "the row it kept costs more than the budget, and the count says so rather \
+             than hiding it: {} against {}",
+            pack.actual_tokens,
+            opts.budget.max_tokens()
         );
     }
 

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -399,6 +399,12 @@ impl DependencySelection {
     }
 
     /// Record one candidate the token budget refused.
+    ///
+    /// Work items and annotations are scoped to an entity rather than being
+    /// one, so those groups file the scope's id and can file it more than once.
+    /// The count is still one per refused row, which is what both surfaces
+    /// render; only [`Self::budget_elided_unrecovered`]'s per-id filter is
+    /// meaningless there, and nothing asks it for those groups.
     fn refuse(&mut self, group: &'static str, entity_id: EntityId) {
         self.budget_elided.entry(group).or_default().push(entity_id);
     }

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use kin_model::{
     relation::RelationKind, Annotation, AnnotationEntry, ArtifactContextEntry, ArtifactContextKind,
@@ -312,6 +312,29 @@ impl DependencySource {
     }
 }
 
+/// The wire name of a pack group, shared by `kin context` and the
+/// `get_context_pack` MCP tool.
+///
+/// Named here rather than spelled at each call site because the token budget's
+/// elisions are keyed by these, and a group whose count is filed under a name
+/// no surface renders is a disclosure nobody reads.
+pub mod group {
+    /// Rows the focal depends on.
+    pub const DEPENDENCIES: &str = "dependencies";
+    /// Rows that depend on the focal.
+    pub const DEPENDENTS: &str = "dependents";
+    /// Rows reached at more than one hop.
+    pub const TRANSITIVE_DEPS: &str = "transitive_deps";
+    /// Tests covering the focal or its direct dependencies.
+    pub const TESTS: &str = "tests";
+    /// Contracts the focal participates in.
+    pub const CONTRACTS: &str = "contracts";
+    /// Open work items scoped to the focal or its direct dependencies.
+    pub const WORK_ITEMS: &str = "work_items";
+    /// Fresh annotations on the focal or its direct dependencies.
+    pub const ANNOTATIONS: &str = "annotations";
+}
+
 /// How a pack's dependency section was filled, and what filling it left out.
 ///
 /// These are selection facts only the builder holds: whether the same-file
@@ -325,6 +348,11 @@ pub struct DependencySelection {
     same_file_candidates: usize,
     same_file_neighbors: Vec<EntityId>,
     dependents: Vec<EntityId>,
+    /// Candidates the token budget refused, by the group each would have
+    /// joined. Ids rather than counts, because a caller can recover a refused
+    /// row by another route and a row that reached the answer is not one the
+    /// answer lost.
+    budget_elided: BTreeMap<&'static str, Vec<EntityId>>,
 }
 
 impl DependencySelection {
@@ -368,6 +396,42 @@ impl DependencySelection {
     pub fn same_file_dropped(&self) -> usize {
         self.same_file_candidates
             .saturating_sub(self.same_file_neighbors.len())
+    }
+
+    /// Record one candidate the token budget refused.
+    fn refuse(&mut self, group: &'static str, entity_id: EntityId) {
+        self.budget_elided.entry(group).or_default().push(entity_id);
+    }
+
+    /// Rows one group lost to the token budget, discounting any the caller
+    /// recovered by another route.
+    ///
+    /// The MCP pack recovers a certified caller this fold refused, from the
+    /// same reference authority `find_references` reads. A row that reached the
+    /// answer is not a row the answer lost, and claiming it in both places
+    /// would be a false report of loss, which is the same defect as silence
+    /// with its sign flipped.
+    pub fn budget_elided_unrecovered(
+        &self,
+        group: &str,
+        recovered: impl Fn(&EntityId) -> bool,
+    ) -> usize {
+        self.budget_elided
+            .get(group)
+            .map_or(0, |ids| ids.iter().filter(|id| !recovered(id)).count())
+    }
+
+    /// Rows one group lost to the token budget.
+    pub fn budget_elided(&self, group: &str) -> usize {
+        self.budget_elided_unrecovered(group, |_| false)
+    }
+
+    /// Every group the token budget took rows from, with its count.
+    pub fn budget_elisions(&self) -> impl Iterator<Item = (&'static str, usize)> + '_ {
+        self.budget_elided
+            .iter()
+            .filter(|(_, ids)| !ids.is_empty())
+            .map(|(group, ids)| (*group, ids.len()))
     }
 }
 
@@ -719,49 +783,51 @@ where
             content,
             tokens,
         } = candidate;
-        match section {
-            AssemblySection::Test => {
-                if total_tokens + tokens <= budget_max {
-                    total_tokens += tokens;
-                    test_entries.push(ContextEntry {
-                        entity_id,
-                        projection_level,
-                        content,
-                    });
+        // Which group this candidate would have joined, resolved before the
+        // admission decision so a refusal can be filed under the name the two
+        // surfaces render it by. `relation_for` is answerable here because
+        // `selection.dependents` is populated above and the same-file fallback
+        // has not run yet.
+        let target_group = match section {
+            AssemblySection::Test => group::TESTS,
+            AssemblySection::Contract => group::CONTRACTS,
+            AssemblySection::Transitive => group::TRANSITIVE_DEPS,
+            AssemblySection::DirectDep => match selection.relation_for(&entity_id) {
+                DependencyRelation::DependentEdge => group::DEPENDENTS,
+                DependencyRelation::DependencyEdge | DependencyRelation::SameFileNeighbor => {
+                    group::DEPENDENCIES
                 }
-            }
-            AssemblySection::Contract => {
-                if total_tokens + tokens <= budget_max {
-                    total_tokens += tokens;
-                    contract_entries.push(ContextEntry {
-                        entity_id,
-                        projection_level,
-                        content,
-                    });
-                }
-            }
-            AssemblySection::DirectDep => {
-                if total_tokens + tokens <= budget_max {
-                    total_tokens += tokens;
-                    dep_entries.push(ContextEntry {
-                        entity_id,
-                        projection_level,
-                        content,
-                    });
-                }
-            }
+            },
+        };
+        let fits = match section {
             AssemblySection::Transitive => {
-                if total_tokens + tokens <= budget_max
-                    && transitive_tokens + tokens <= transitive_budget
-                {
-                    total_tokens += tokens;
-                    transitive_tokens += tokens;
-                    transitive_entries.push(ContextEntry {
-                        entity_id,
-                        projection_level,
-                        content,
-                    });
-                }
+                total_tokens + tokens <= budget_max && transitive_tokens + tokens <= transitive_budget
+            }
+            _ => total_tokens + tokens <= budget_max,
+        };
+        // A refusal is the cut this fold makes, and it used to make it in
+        // silence: a dependency section trimmed from twelve rows to six
+        // serializes exactly like a focal that has six. The count is recorded
+        // here, at the only place that knows a row was ever a candidate, so
+        // both surfaces can say what the budget took instead of rendering the
+        // loss as absence.
+        if !fits {
+            selection.refuse(target_group, entity_id);
+            continue;
+        }
+        total_tokens += tokens;
+        let entry = ContextEntry {
+            entity_id,
+            projection_level,
+            content,
+        };
+        match section {
+            AssemblySection::Test => test_entries.push(entry),
+            AssemblySection::Contract => contract_entries.push(entry),
+            AssemblySection::DirectDep => dep_entries.push(entry),
+            AssemblySection::Transitive => {
+                transitive_tokens += tokens;
+                transitive_entries.push(entry);
             }
         }
     }
@@ -780,15 +846,23 @@ where
                 }
             }
             let tokens = estimate_tokens(&content);
-            if total_tokens + tokens <= budget_max {
-                total_tokens += tokens;
-                selection.same_file_neighbors.push(entity.id);
-                dep_entries.push(ContextEntry {
-                    entity_id: entity.id,
-                    projection_level: ProjectionLevel::SignatureOnly,
-                    content,
-                });
+            // Neighbours past `SAME_FILE_FALLBACK_MAX` are never seen by this
+            // loop and stay counted by `same_file_dropped`, which is the cap's
+            // own number. Only a neighbour the budget refused is filed as a
+            // budget elision: a cap and a budget are different causes recovered
+            // by different levers, and `Elision::reason` exists so one cannot
+            // be read as the other.
+            if total_tokens + tokens > budget_max {
+                selection.refuse(group::DEPENDENCIES, entity.id);
+                continue;
             }
+            total_tokens += tokens;
+            selection.same_file_neighbors.push(entity.id);
+            dep_entries.push(ContextEntry {
+                entity_id: entity.id,
+                projection_level: ProjectionLevel::SignatureOnly,
+                content,
+            });
         }
     }
 
@@ -815,13 +889,15 @@ where
                 }
                 let content = format_work_item(&item);
                 let tokens = estimate_tokens(&content);
-                if total_tokens + tokens <= budget_max {
-                    total_tokens += tokens;
-                    work_entries.push(WorkItemEntry {
-                        work_item: item,
-                        content,
-                    });
+                if total_tokens + tokens > budget_max {
+                    selection.refuse(group::WORK_ITEMS, *eid);
+                    continue;
                 }
+                total_tokens += tokens;
+                work_entries.push(WorkItemEntry {
+                    work_item: item,
+                    content,
+                });
             }
         }
     }
@@ -836,13 +912,15 @@ where
                 }
                 let content = format_annotation(&ann);
                 let tokens = estimate_tokens(&content);
-                if total_tokens + tokens <= budget_max {
-                    total_tokens += tokens;
-                    annotation_entries.push(AnnotationEntry {
-                        annotation: ann,
-                        content,
-                    });
+                if total_tokens + tokens > budget_max {
+                    selection.refuse(group::ANNOTATIONS, *eid);
+                    continue;
                 }
+                total_tokens += tokens;
+                annotation_entries.push(AnnotationEntry {
+                    annotation: ann,
+                    content,
+                });
             }
         }
     }

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -3232,4 +3232,119 @@ mod tests {
     fn normalize_preserves_normal_names() {
         assert_eq!(normalize_entity_name("process"), "process");
     }
+
+    // ── What the token budget refused (FIR-2482) ────────────────────────
+
+    /// A focal calling `deps` entities, so a tight budget has candidates to
+    /// refuse and a generous one admits every last row.
+    fn calling_store(deps: usize) -> (kin_db::InMemoryGraph, Entity) {
+        use kin_model::relation::{Relation, RelationKind, RelationOrigin};
+        let store = kin_db::InMemoryGraph::new();
+        let focal = make_entity("focal", EntityKind::Function);
+        store.upsert_entity(&focal).unwrap();
+        for index in 0..deps {
+            let dep = make_entity(&format!("dep_{index:04}"), EntityKind::Function);
+            store.upsert_entity(&dep).unwrap();
+            store
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(focal.id),
+                    dst: GraphNodeId::Entity(dep.id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+        (store, focal)
+    }
+
+    #[test]
+    fn a_budget_that_refused_a_row_says_how_many() {
+        let (store, focal) = calling_store(40);
+        let whole = ContextOptions {
+            budget: TokenBudget::Large32k,
+            ..ContextOptions::default()
+        };
+        let (full, full_selection) =
+            build_context_pack_with_provenance(&store, &focal.id, &whole).unwrap();
+        assert_eq!(
+            full_selection.budget_elided(group::DEPENDENCIES),
+            0,
+            "a budget that admitted everything must claim no loss"
+        );
+
+        let tight = ContextOptions {
+            budget: TokenBudget::Custom(full.actual_tokens / 2),
+            ..ContextOptions::default()
+        };
+        let (cut, selection) =
+            build_context_pack_with_provenance(&store, &focal.id, &tight).unwrap();
+        let kept = cut.dependency_signatures.len();
+        assert!(
+            kept > 0 && kept < full.dependency_signatures.len(),
+            "the budget must actually cut for this test to mean anything: kept {kept} of {}",
+            full.dependency_signatures.len()
+        );
+
+        // The count is the whole point: without it, `kept` rows is what a focal
+        // with `kept` dependencies looks like.
+        let elided = selection.budget_elided(group::DEPENDENCIES);
+        assert_eq!(
+            kept + elided,
+            full.dependency_signatures.len(),
+            "kept plus refused must equal what the generous budget admitted"
+        );
+        assert!(
+            selection
+                .budget_elisions()
+                .any(|(name, count)| name == group::DEPENDENCIES && count == elided),
+            "the refused group must appear in the elision listing"
+        );
+    }
+
+    #[test]
+    fn a_row_recovered_by_another_route_is_not_counted_as_lost() {
+        let (store, focal) = calling_store(40);
+        let whole = ContextOptions {
+            budget: TokenBudget::Large32k,
+            ..ContextOptions::default()
+        };
+        let (full, _) = build_context_pack_with_provenance(&store, &focal.id, &whole).unwrap();
+        let tight = ContextOptions {
+            budget: TokenBudget::Custom(full.actual_tokens / 2),
+            ..ContextOptions::default()
+        };
+        let (_, selection) = build_context_pack_with_provenance(&store, &focal.id, &tight).unwrap();
+        let elided = selection.budget_elided(group::DEPENDENCIES);
+        assert!(elided > 0, "the budget must have refused something");
+        assert_eq!(
+            selection.budget_elided_unrecovered(group::DEPENDENCIES, |_| true),
+            0,
+            "a row the caller recovered elsewhere is not a row the answer lost"
+        );
+    }
+
+    #[test]
+    fn a_pack_that_lost_nothing_claims_nothing() {
+        let (store, focal) = calling_store(3);
+        let opts = ContextOptions {
+            budget: TokenBudget::Large32k,
+            ..ContextOptions::default()
+        };
+        let (pack, selection) =
+            build_context_pack_with_provenance(&store, &focal.id, &opts).unwrap();
+        assert!(
+            !pack.dependency_signatures.is_empty(),
+            "the fixture must admit rows, or this asserts nothing"
+        );
+        assert_eq!(
+            selection.budget_elisions().count(),
+            0,
+            "a whole pack must carry no elision at all, so a disclosure means a cut"
+        );
+    }
 }

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -866,9 +866,7 @@ where
             // budget elision: a cap and a budget are different causes recovered
             // by different levers, and `Elision::reason` exists so one cannot
             // be read as the other.
-            if total_tokens + tokens > budget_max
-                && admitted_groups.contains(group::DEPENDENCIES)
-            {
+            if total_tokens + tokens > budget_max && admitted_groups.contains(group::DEPENDENCIES) {
                 selection.refuse(group::DEPENDENCIES, entity.id);
                 continue;
             }
@@ -906,8 +904,7 @@ where
                 }
                 let content = format_work_item(&item);
                 let tokens = estimate_tokens(&content);
-                if total_tokens + tokens > budget_max
-                    && admitted_groups.contains(group::WORK_ITEMS)
+                if total_tokens + tokens > budget_max && admitted_groups.contains(group::WORK_ITEMS)
                 {
                     selection.refuse(group::WORK_ITEMS, *eid);
                     continue;

--- a/crates/kin-context/src/lib.rs
+++ b/crates/kin-context/src/lib.rs
@@ -9,8 +9,8 @@ pub mod tokens;
 
 pub use builder::{
     build_context_pack, build_context_pack_from_plan, build_context_pack_with_provenance,
-    build_context_pack_with_traffic, build_context_pack_with_traffic_and_provenance, AssistantHint,
-    ContextOptions, DependencyRelation, DependencySelection, DependencySource,
+    build_context_pack_with_traffic, build_context_pack_with_traffic_and_provenance, group,
+    AssistantHint, ContextOptions, DependencyRelation, DependencySelection, DependencySource,
     SAME_FILE_FALLBACK_MAX,
 };
 pub use error::{ContextError, Result};

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -33168,11 +33168,19 @@ mod tests {
             let payload: serde_json::Value =
                 serde_json::from_str(&bounded).expect("a bounded locate response is still JSON");
             let hits = payload["entities"].as_array().expect("hits survive").len();
+            // The value, not the key. A row whose source the budget took
+            // keeps `body` as an explicit null beside a marker naming what
+            // went, so a row that carries nothing still answers `is_some()`.
+            // Counting keys makes every emptied row read as an answer, and the
+            // two arms tie at the hit count no matter what the budget did.
+            let carries = |hit: &serde_json::Value, key: &str| {
+                !matches!(hit.get(key), None | Some(serde_json::Value::Null))
+            };
             let with_source = payload["entities"]
                 .as_array()
                 .unwrap()
                 .iter()
-                .filter(|hit| hit.get("body").is_some() || hit.get("snippet").is_some())
+                .filter(|hit| carries(hit, "body") || carries(hit, "snippet"))
                 .count();
             (raw, bounded.len(), hits, with_source)
         };

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -233,8 +233,31 @@ impl BudgetAccounting {
 /// to parse prose.
 pub const ELISION_REASON_BUDGET: &str = "response_budget";
 
+/// The reason code a row cut by a pack's own token budget carries.
+///
+/// Deliberately not [`ELISION_REASON_BUDGET`]. The two budgets cut at different
+/// times, for different reasons, and are raised by different parameters: a
+/// caller widens the response budget with `max_chars` and the pack's with
+/// `token_budget`. A caller told only that something was withheld cannot act,
+/// and one told the wrong lever acts and gets the same answer back.
+pub const ELISION_REASON_TOKEN_BUDGET: &str = "token_budget";
+
+/// The reason code a dependent withheld by the certified-dependents cap
+/// carries. A cap is not a budget: no budget parameter recovers it, so reading
+/// it as one would send a caller to a lever that cannot help.
+pub const ELISION_REASON_DEPENDENTS_CAP: &str = "dependents_cap";
+
 /// Where a payload publishes what its lists lost.
 pub const ELISIONS_KEY: &str = "elisions";
+
+/// Per-row marker naming the budget that took this row's inline source.
+///
+/// A row that simply loses its `body` key is byte-identical to a row from a
+/// `compact: true` call, and sits beside the context pack's own `body: null`
+/// plus `body_unavailable`, which is its vocabulary for source the graph does
+/// not have. Both readings are wrong about a row the budget cut, and neither is
+/// corrected by a count elsewhere in the response: the reader looks at the row.
+pub const BODY_ELIDED_KEY: &str = "body_elided";
 
 /// What one list lost to the response budget.
 ///
@@ -263,13 +286,18 @@ pub struct Elision {
 }
 
 impl Elision {
-    /// One list's loss, from what survived and what did not.
+    /// One list's loss to the response budget.
     pub fn budget(kept: usize, elided: usize) -> Self {
+        Self::for_reason(kept, elided, ELISION_REASON_BUDGET)
+    }
+
+    /// One list's loss, from what survived, what did not, and what took it.
+    pub fn for_reason(kept: usize, elided: usize, reason: &str) -> Self {
         Self {
             elided,
             kept,
             total: kept.saturating_add(elided),
-            reason: ELISION_REASON_BUDGET.to_string(),
+            reason: reason.to_string(),
         }
     }
 }
@@ -283,10 +311,50 @@ impl Elision {
 /// stay beside it, because a client already reading them must not lose its
 /// counter to this change.
 pub fn record_elision(payload: &mut Value, field: &str, kept: usize, elided: usize) {
+    record_elision_for(payload, field, kept, elided, ELISION_REASON_BUDGET);
+}
+
+/// Record one list's elision under a named cause, merging with any already
+/// standing against that field.
+///
+/// One list can be cut twice. A context pack's own token budget refuses rows
+/// before the response budget ever sees the payload, and the daemon's raw route
+/// cuts once before the stdio path envelopes the result and cuts again. An
+/// entry that overwrote its predecessor would report only the last cut, so
+/// `total` would describe what the second cutter was handed rather than what
+/// the walk found, and the first cause would vanish. The counts add and the
+/// causes are kept in the order they happened.
+pub fn record_elision_for(
+    payload: &mut Value,
+    field: &str,
+    kept: usize,
+    elided: usize,
+    reason: &str,
+) {
     if elided == 0 {
         return;
     }
-    let entry = serde_json::to_value(Elision::budget(kept, elided)).unwrap_or(Value::Null);
+    let prior = payload
+        .get(ELISIONS_KEY)
+        .and_then(|map| map.get(field))
+        .and_then(|entry| serde_json::from_value::<Elision>(entry.clone()).ok());
+    let entry = match prior {
+        Some(prior) => {
+            let mut merged =
+                Elision::for_reason(kept, prior.elided.saturating_add(elided), &prior.reason);
+            if !merged
+                .reason
+                .split(", ")
+                .any(|already| already == reason)
+            {
+                merged.reason.push_str(", ");
+                merged.reason.push_str(reason);
+            }
+            merged
+        }
+        None => Elision::for_reason(kept, elided, reason),
+    };
+    let entry = serde_json::to_value(entry).unwrap_or(Value::Null);
     match payload.get_mut(ELISIONS_KEY).and_then(Value::as_object_mut) {
         Some(map) => {
             map.insert(field.to_string(), entry);
@@ -664,7 +732,8 @@ fn run_ladder(
     }
 
     if !shape.body_keys.is_empty() {
-        let stripped = strip_keys(payload, shape, shape.body_keys, &[]);
+        let carrying = rows_carrying(payload, shape, shape.body_keys);
+        let stripped = strip_keys_marking(payload, shape, shape.body_keys, &[], true);
         if stripped > 0 {
             accounting.bounded = true;
             cuts.push(format!(
@@ -672,6 +741,16 @@ fn run_ladder(
                  identity, location, and span"
             ));
             remediations.push("read one body with get_entity_source".to_string());
+            // The prose above has said this since the rung existed, and prose is
+            // not what a caller keys on. `elisions` is the one map that answers
+            // "did this response lose anything", and until now inline source
+            // could go without appearing in it at all.
+            record_elision(
+                payload,
+                "body",
+                carrying.saturating_sub(stripped),
+                stripped,
+            );
         }
         if measure(payload) <= target {
             disclose(payload, budget, started_at, &cuts, &remediations);
@@ -825,6 +904,24 @@ fn strip_keys(
     keys: &[&str],
     top_keys: &[&str],
 ) -> usize {
+    strip_keys_marking(payload, shape, keys, top_keys, false)
+}
+
+/// Remove `keys` from every hit, optionally leaving each stripped row a marker
+/// naming what went.
+///
+/// `mark` is what separates a row the budget cut from a row that never had the
+/// field. Diagnostics and duplicate roll-ups do not need it: a caller reads
+/// those as description, and their absence claims nothing about the code. A
+/// missing `body` does claim something, twice over, because it is also the
+/// shape of a `compact` call and of source the graph does not hold.
+fn strip_keys_marking(
+    payload: &mut Value,
+    shape: &ResponseShape,
+    keys: &[&str],
+    top_keys: &[&str],
+    mark: bool,
+) -> usize {
     let mut stripped = 0usize;
     for key in top_keys {
         if let Some(map) = payload.as_object_mut() {
@@ -836,6 +933,27 @@ fn strip_keys(
     if keys.is_empty() {
         return stripped;
     }
+    let strip_row = |map: &mut Map<String, Value>| -> bool {
+        let mut taken: Vec<Value> = Vec::new();
+        for key in keys {
+            if remove_present(map, key) {
+                taken.push(Value::from(*key));
+                // `body` keeps its place as an explicit null rather than
+                // vanishing, so a typed reader still finds the field and finds
+                // it empty, and the marker beside it says who emptied it.
+                if *key == "body" {
+                    map.insert((*key).to_string(), Value::Null);
+                }
+            }
+        }
+        if taken.is_empty() {
+            return false;
+        }
+        if mark {
+            map.insert(BODY_ELIDED_KEY.to_string(), Value::Array(taken));
+        }
+        true
+    };
     for collection in shape.collections {
         let Some(entries) = payload.get_mut(*collection).and_then(Value::as_array_mut) else {
             continue;
@@ -844,13 +962,7 @@ fn strip_keys(
             let Some(map) = entry.as_object_mut() else {
                 continue;
             };
-            let mut touched = false;
-            for key in keys {
-                if remove_present(map, key) {
-                    touched = true;
-                }
-            }
-            if touched {
+            if strip_row(map) {
                 stripped += 1;
             }
         }
@@ -860,18 +972,36 @@ fn strip_keys(
     // largest single body in a response that just dropped every other one.
     for focal in ["focal_entity", "focal"] {
         if let Some(map) = payload.get_mut(focal).and_then(Value::as_object_mut) {
-            let mut touched = false;
-            for key in keys {
-                if remove_present(map, key) {
-                    touched = true;
-                }
-            }
-            if touched {
+            if strip_row(map) {
                 stripped += 1;
             }
         }
     }
     stripped
+}
+
+/// How many rows carry at least one of `keys`, counted before a rung takes
+/// them, so the elision it publishes can say what the response held.
+fn rows_carrying(payload: &Value, shape: &ResponseShape, keys: &[&str]) -> usize {
+    let carries = |value: &Value| -> bool {
+        value.as_object().is_some_and(|map| {
+            keys.iter()
+                .any(|key| !matches!(map.get(*key), None | Some(Value::Null)))
+        })
+    };
+    let in_collections: usize = shape
+        .collections
+        .iter()
+        .filter_map(|collection| payload.get(*collection))
+        .filter_map(Value::as_array)
+        .map(|entries| entries.iter().filter(|entry| carries(entry)).count())
+        .sum();
+    let in_focal = ["focal_entity", "focal"]
+        .iter()
+        .filter_map(|focal| payload.get(*focal))
+        .filter(|value| carries(value))
+        .count();
+    in_collections + in_focal
 }
 
 /// Remove one key when it carries something. A key already absent, or already
@@ -919,7 +1049,16 @@ fn trim_collection(payload: &mut Value, key: &str, target: usize, min_keep: usiz
     payload[key] = Value::Array(full[..kept].to_vec());
     let withheld = full.len() - kept;
     if withheld > 0 {
-        payload[format!("{key}_withheld")] = Value::from(withheld);
+        // Added to, not overwritten. Two arms bound one response and a pack's
+        // own token budget cuts before either, so a list can arrive here having
+        // already lost rows. Assigning would make this scalar describe the last
+        // cut while `elisions` described them all, and the two channels are
+        // asserted against each other.
+        let prior = payload
+            .get(format!("{key}_withheld"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        payload[format!("{key}_withheld")] = Value::from(prior.saturating_add(withheld));
     }
     withheld
 }

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1920,6 +1920,180 @@ mod tests {
     /// the recorder. The ladder guards this at its call site; this guards the
     /// recorder itself, so a second producer added later cannot publish a loss
     /// of zero.
+    // ── The body a budget takes says so on the row (FIR-2482) ───────────
+
+    /// A context pack of `rows` dependencies, each carrying a body, plus a
+    /// focal that carries one too.
+    fn pack_payload(rows: usize, body_chars: usize) -> Value {
+        let dep = |index: usize| {
+            json!({
+                "id": format!("00000000-0000-0000-0000-{index:012}"),
+                "name": format!("dep_{index}"),
+                "kind": "function",
+                "signature": format!("fn dep_{index}()"),
+                "file_path": format!("src/f{index}.rs"),
+                "start_line": 1,
+                "end_line": 40,
+                "body": "x".repeat(body_chars),
+            })
+        };
+        json!({
+            "focal_entity": {
+                "id": "00000000-0000-0000-0000-ffffffffffff",
+                "name": "focal",
+                "body": "y".repeat(body_chars),
+            },
+            "dependencies": (0..rows).map(dep).collect::<Vec<_>>(),
+            "dependents": [],
+            "token_budget": 16000,
+        })
+    }
+
+    /// Every row of every listed collection, plus the focal, as objects.
+    fn rows_of(payload: &Value, keys: &[&str]) -> Vec<Map<String, Value>> {
+        let mut rows: Vec<Map<String, Value>> = keys
+            .iter()
+            .filter_map(|key| payload.get(*key))
+            .filter_map(Value::as_array)
+            .flat_map(|entries| entries.iter().filter_map(Value::as_object).cloned())
+            .collect();
+        if let Some(focal) = payload.get("focal_entity").and_then(Value::as_object) {
+            rows.push(focal.clone());
+        }
+        rows
+    }
+
+    #[test]
+    fn a_row_whose_body_the_budget_took_says_so() {
+        let mut payload = pack_payload(24, 900);
+        // Sized so shedding the bodies alone brings the response under, and the
+        // ladder never reaches the rung that withholds rows. Both cuts are real
+        // and both are disclosed, but mixing them here would leave the row
+        // count and the body count describing different populations, and this
+        // test is about the rows that stayed.
+        let budget = ResponseBudget {
+            max_chars: 12_000,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "get_context_pack", &budget).expect("get_context_pack is budgeted");
+        assert_eq!(
+            payload["dependencies"].as_array().map(Vec::len),
+            Some(24),
+            "the body rung alone must have sufficed: {payload}"
+        );
+
+        let rows = rows_of(&payload, &["dependencies"]);
+        assert_eq!(rows.len(), 25, "24 dependencies and the focal: {payload}");
+        for row in &rows {
+            // Removing the key outright is the shape of a `compact: true` call
+            // and of an entity whose source the graph does not hold. A row that
+            // lost its body to the budget must read as neither.
+            assert_eq!(
+                row.get("body"),
+                Some(&Value::Null),
+                "a stripped body keeps its field: {payload}"
+            );
+            assert_eq!(
+                row.get(BODY_ELIDED_KEY),
+                Some(&json!(["body"])),
+                "a stripped row names what the budget took: {payload}"
+            );
+            assert!(
+                row.get("body_unavailable").is_none(),
+                "a budget cut is not a graph gap, and one row cannot be both: {payload}"
+            );
+        }
+        let elision = payload["elisions"]["body"].clone();
+        assert_eq!(elision["elided"], json!(rows.len()), "{payload}");
+        assert_eq!(elision["kept"], json!(0), "{payload}");
+        assert_eq!(elision["reason"], json!(ELISION_REASON_BUDGET), "{payload}");
+    }
+
+    #[test]
+    fn a_row_that_never_had_a_body_is_neither_marked_nor_counted() {
+        let mut payload = pack_payload(24, 900);
+        // One row whose source the graph genuinely does not hold, in the
+        // vocabulary the pack handler uses for it.
+        payload["dependencies"][0]["body"] = Value::Null;
+        payload["dependencies"][0]["body_unavailable"] = json!("generated at build time");
+        let budget = ResponseBudget {
+            max_chars: 4_000,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "get_context_pack", &budget).expect("get_context_pack is budgeted");
+
+        let gap = payload["dependencies"][0].clone();
+        assert!(
+            gap.get(BODY_ELIDED_KEY).is_none(),
+            "the budget took nothing from this row and must claim nothing: {payload}"
+        );
+        assert_eq!(
+            gap["body_unavailable"],
+            json!("generated at build time"),
+            "the graph gap's own reason survives: {payload}"
+        );
+    }
+
+    #[test]
+    fn a_whole_response_claims_no_body_elision() {
+        let mut payload = pack_payload(2, 40);
+        let budget = ResponseBudget {
+            max_chars: RESPONSE_MAX_MAX_CHARS,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "get_context_pack", &budget).expect("get_context_pack is budgeted");
+        assert!(
+            payload.get(ELISIONS_KEY).is_none(),
+            "nothing was withheld, so nothing may be claimed: {payload}"
+        );
+        assert_eq!(
+            payload["dependencies"][0]["body"],
+            json!("x".repeat(40)),
+            "an untouched body is still its source: {payload}"
+        );
+    }
+
+    #[test]
+    fn two_cuts_on_one_list_add_up_rather_than_replacing_each_other() {
+        // What a pack's own token budget already recorded before the response
+        // budget ever sees the payload, in the shape the handler writes it.
+        let mut payload = pack_payload(24, 40);
+        record_elision_for(
+            &mut payload,
+            "dependencies",
+            24,
+            6,
+            ELISION_REASON_TOKEN_BUDGET,
+        );
+        payload["dependencies_withheld"] = json!(6);
+
+        let budget = ResponseBudget {
+            max_chars: 2_500,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "get_context_pack", &budget).expect("get_context_pack is budgeted");
+
+        let kept = payload["dependencies"].as_array().unwrap().len();
+        let elision = payload["elisions"]["dependencies"].clone();
+        let withheld = payload["dependencies_withheld"].as_u64().unwrap() as usize;
+        assert!(
+            kept < 24,
+            "the response budget must cut for this test to mean anything: {payload}"
+        );
+        // 30 candidates existed: the 24 that reached the response and the 6 the
+        // token budget already refused. Overwriting would report `total` as 24
+        // and lose the earlier cause entirely.
+        assert_eq!(elision["total"], json!(30), "{payload}");
+        assert_eq!(elision["kept"], json!(kept), "{payload}");
+        assert_eq!(elision["elided"], json!(30 - kept), "{payload}");
+        assert_eq!(withheld, 30 - kept, "the scalar and the map must agree: {payload}");
+        let reason = elision["reason"].as_str().unwrap();
+        assert!(
+            reason.contains(ELISION_REASON_TOKEN_BUDGET) && reason.contains(ELISION_REASON_BUDGET),
+            "both causes survive the merge, got {reason}: {payload}"
+        );
+    }
+
     #[test]
     fn recording_a_loss_of_nothing_writes_nothing() {
         let mut payload = json!({ "entities": [] });

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1907,10 +1907,6 @@ mod tests {
         }
     }
 
-    /// A list nothing was taken from must not grow an elision, whatever calls
-    /// the recorder. The ladder guards this at its call site; this guards the
-    /// recorder itself, so a second producer added later cannot publish a loss
-    /// of zero.
     // ── The body a budget takes says so on the row (FIR-2482) ───────────
 
     /// A context pack of `rows` dependencies, each carrying a body, plus a
@@ -2089,6 +2085,10 @@ mod tests {
         );
     }
 
+    /// A list nothing was taken from must not grow an elision, whatever calls
+    /// the recorder. The ladder guards this at its call site; this guards the
+    /// recorder itself, so a second producer added later cannot publish a loss
+    /// of zero.
     #[test]
     fn recording_a_loss_of_nothing_writes_nothing() {
         let mut payload = json!({ "entities": [] });

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -342,11 +342,7 @@ pub fn record_elision_for(
         Some(prior) => {
             let mut merged =
                 Elision::for_reason(kept, prior.elided.saturating_add(elided), &prior.reason);
-            if !merged
-                .reason
-                .split(", ")
-                .any(|already| already == reason)
-            {
+            if !merged.reason.split(", ").any(|already| already == reason) {
                 merged.reason.push_str(", ");
                 merged.reason.push_str(reason);
             }
@@ -745,12 +741,7 @@ fn run_ladder(
             // not what a caller keys on. `elisions` is the one map that answers
             // "did this response lose anything", and until now inline source
             // could go without appearing in it at all.
-            record_elision(
-                payload,
-                "body",
-                carrying.saturating_sub(stripped),
-                stripped,
-            );
+            record_elision(payload, "body", carrying.saturating_sub(stripped), stripped);
         }
         if measure(payload) <= target {
             disclose(payload, budget, started_at, &cuts, &remediations);
@@ -2086,7 +2077,11 @@ mod tests {
         assert_eq!(elision["total"], json!(30), "{payload}");
         assert_eq!(elision["kept"], json!(kept), "{payload}");
         assert_eq!(elision["elided"], json!(30 - kept), "{payload}");
-        assert_eq!(withheld, 30 - kept, "the scalar and the map must agree: {payload}");
+        assert_eq!(
+            withheld,
+            30 - kept,
+            "the scalar and the map must agree: {payload}"
+        );
         let reason = elision["reason"].as_str().unwrap();
         assert!(
             reason.contains(ELISION_REASON_TOKEN_BUDGET) && reason.contains(ELISION_REASON_BUDGET),

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1094,6 +1094,81 @@ pub fn handle_get_context_pack<G: GraphStore>(
         result["nearby_traffic"] = serde_json::to_value(&pack.traffic).map_err(McpError::Json)?;
     }
 
+    // What the pack's own token budget refused, in the map the response budget
+    // already publishes its cuts to.
+    //
+    // Two budgets cut this answer and only one of them was ever visible. The
+    // token budget runs first, inside the builder, and a dependency section it
+    // trimmed from twelve rows to six serialized exactly like a focal with six:
+    // `returned: 6` beside six rows, and nothing anywhere saying a row had been
+    // a candidate. That is the reading kin#1062 removed from the list case and
+    // kin#1068 from the impact case, arriving here through the earlier budget.
+    //
+    // One map, keyed by the group, with the cause named on each entry: a caller
+    // raises `token_budget` for these and `max_chars` for the response budget's,
+    // and being told the wrong lever costs a round trip that cannot help.
+    let recovered = |id: &kin_model::ids::EntityId| packed.contains(id);
+    let mut budget_groups: Vec<&str> = vec![
+        kin_context::group::DEPENDENCIES,
+        kin_context::group::DEPENDENTS,
+    ];
+    if !compact {
+        // A section `compact` never serves cannot be misread as an empty one,
+        // because dropping it is the documented shape of that mode. A section
+        // this mode does serve is absent only when it holds nothing, which is
+        // exactly the reading a budget cut must not produce.
+        budget_groups.extend([
+            kin_context::group::TRANSITIVE_DEPS,
+            kin_context::group::TESTS,
+            kin_context::group::CONTRACTS,
+            kin_context::group::WORK_ITEMS,
+            kin_context::group::ANNOTATIONS,
+        ]);
+    }
+    for group in budget_groups {
+        let elided = selection.budget_elided_unrecovered(group, recovered);
+        if elided == 0 {
+            continue;
+        }
+        let kept = result
+            .get(group)
+            .and_then(serde_json::Value::as_array)
+            .map_or(0, Vec::len);
+        // The scalar beside the map, written here so the response budget's own
+        // later cut of the same list adds to it rather than replacing it.
+        result[format!("{group}_withheld")] = serde_json::json!(elided);
+        crate::budget::record_elision_for(
+            &mut result,
+            group,
+            kept,
+            elided,
+            crate::budget::ELISION_REASON_TOKEN_BUDGET,
+        );
+    }
+    // The certified-dependents cap is the third cutter on this payload, and it
+    // was disclosed only as a nested counter inside `dependency_selection`,
+    // which is the sibling-counter shape that saved nobody in the stranger
+    // session kin#1062 was filed from. It carries its own reason because no
+    // budget parameter recovers it.
+    if dependents_withheld > 0 {
+        let kept = result
+            .get("dependents")
+            .and_then(serde_json::Value::as_array)
+            .map_or(0, Vec::len);
+        let prior = result
+            .get("dependents_withheld")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as usize;
+        result["dependents_withheld"] = serde_json::json!(prior + dependents_withheld);
+        crate::budget::record_elision_for(
+            &mut result,
+            "dependents",
+            kept,
+            dependents_withheld,
+            crate::budget::ELISION_REASON_DEPENDENTS_CAP,
+        );
+    }
+
     let json = serialize_with_measured_tokens(&mut result)?;
     Ok(ToolCallResult::text(json))
 }

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1047,6 +1047,11 @@ pub fn handle_get_context_pack<G: GraphStore>(
             // pack sees an arriving edge of a class that authority does not
             // read, and when the cap below withholds one.
             "certified_dependents": certified_ids.len(),
+            // The cap's own number, and only the cap's. The top-level
+            // `dependents_withheld` counts every cause together, because a
+            // caller asking "how many rows am I not seeing" wants one answer;
+            // this one stays because a caller already reading it must not have
+            // its meaning changed underneath it.
             "dependents_withheld": dependents_withheld,
             "same_file_candidates": selection.same_file_candidates(),
             "same_file_dropped": selection.same_file_dropped(),

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -91,6 +91,24 @@ does not fit has to say so in `degradations`. A ceiling is not always reachable,
 because every cut list keeps a floor entry, and that case is fine as long as it is
 never quiet.
 
+Checks 5 to 7 carry the same rule to the budget that cuts a context pack first
+(FIR-2482). A pack is bounded twice: its own token budget refuses candidates
+inside the builder, before the response budget sees the payload at all, and only
+the second cut was ever disclosed. A dependency section trimmed from twelve rows
+to six serialized six rows beside `returned: 6`, which is what a focal with six
+dependencies serializes, and `kin context` printed "Dependencies: 6 entries" for
+both. Check 5 packs one focal at a generous token budget and again at a tight
+one, with one identical generous `max_chars` on both so the response budget
+cannot be the cutter, and asserts every group that shrank publishes an elision
+naming `token_budget` rather than `response_budget`, because a caller told the
+wrong cause raises the wrong lever. Check 6 is the same defect one field down: a
+row whose inline source the response budget took used to lose the key outright,
+which is the shape of a `compact` call and of source the graph never had, so it
+now keeps a null `body` beside a marker naming what went. Check 7 drives
+`kin context`, whose rendered lines are the whole of what a reader of that
+surface sees, and asserts the lines and `--json` report the same cut and name the
+lever that recovers it.
+
 `memory_pressure_refusal.py` covers the back-off Kin owes a machine it is
 running on, and the disclosure it owes the person running it. A daemon that
 quietly stopped sweeping would look identical to one that had finished, since

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -92,6 +92,12 @@ IMPACT_LISTS = [
 # The reason code a response still over its ceiling publishes.
 OVER_BUDGET_REASON = "response_over_budget"
 
+# Callees on the wide focal. Sized so the whole pack clears the pack token
+# budget's 8,000 floor several times over while the serialized response stays
+# well under the 60,000-character response ceiling, which is what lets check 5
+# attribute a cut to one budget rather than to two.
+WIDE_CALLEES = 35
+
 
 class SetupError(Exception):
     """The run could not be set up. Never a pass, never a check failure."""
@@ -546,15 +552,17 @@ class Suite(object):
 
         # A second focal whose callees cost the pack's TOKEN budget without
         # costing its response budget much. Every parameter is `a<i>=0`, which
-        # the pack's estimator counts as four tokens across five characters, so
-        # fifty callees run to roughly 23,000 estimated tokens in about 36,000
-        # characters of compact JSON. That ratio is the point: the token budget
-        # has to cut this pack while the response budget, pinned at its ceiling
-        # on both calls, has nothing to do. Nothing here is named `hop`, so the
-        # locate-based checks above rank exactly what they ranked before.
+        # the pack's estimator counts as four tokens across roughly seven
+        # characters, so these callees run to about 16,000 estimated tokens in
+        # well under the 60,000-character response ceiling. That ratio is the
+        # point: the token budget has to cut this pack at its 8,000 floor while
+        # the response budget, pinned at its ceiling on both calls, has nothing
+        # to do, and check 5 asserts that rather than assuming it. Nothing here
+        # is named `hop`, so the locate-based checks above rank exactly what
+        # they ranked before.
         params = ", ".join("a%d=0" % index for index in range(100))
         wide = []
-        for index in range(50):
+        for index in range(WIDE_CALLEES):
             wide += [
                 "def wide_dep_%02d(%s):" % (index, params),
                 '    """A callee sized in tokens, not in characters."""',
@@ -563,8 +571,11 @@ class Suite(object):
                 "",
             ]
         wide += ["def wide_entry(value):", '    """The focal the pack budget arm packs."""', "    return ("]
-        for index in range(50):
-            wide.append("        wide_dep_%02d()" % index + (" +" if index < 49 else ""))
+        for index in range(WIDE_CALLEES):
+            wide.append(
+                "        wide_dep_%02d()" % index
+                + (" +" if index < WIDE_CALLEES - 1 else "")
+            )
         wide += ["    )", ""]
         with open(os.path.join(repo, "src", "wide.py"), "w") as handle:
             handle.write("\n".join(wide))

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -432,17 +432,67 @@ def grade_body_elisions(payload):
     return problems, marked
 
 
-def grade_cli_context(text, doc):
+def pack_sections(doc):
+    """Row counts per section of a `kin context --json` pack, by the same group
+    names the MCP tool publishes."""
+    pack = (doc or {}).get("pack") or {}
+    selection = (doc or {}).get("dependency_selection") or {}
+    dependents = selection.get("dependents_returned") or 0
+    signatures = pack.get("dependency_signatures")
+    counts = {}
+    if isinstance(signatures, list):
+        counts["dependencies"] = len(signatures) - dependents
+        counts["dependents"] = dependents
+    for key, field in (
+        ("transitive_deps", "transitive_deps"),
+        ("tests", "tests"),
+        ("contracts", "contracts"),
+    ):
+        rows = pack.get(field)
+        if isinstance(rows, list):
+            counts[key] = len(rows)
+    return counts
+
+
+def grade_cli_context(whole, cut, text):
     """Grade `kin context`, whose rendered lines are the whole of what a reader
     of that surface sees. A cut those lines do not name is, to that reader, a
-    cut that did not happen."""
+    cut that did not happen.
+
+    Graded off the same differential check 5 uses rather than off the
+    disclosure alone: a section full at a generous `--budget` and short at a
+    tight one was cut, whatever the response says about it. Grading only what
+    the disclosure claims would let a build that discloses nothing report that
+    nothing was cut, which is the defect wearing the check's own costume.
+    """
     problems = []
-    elisions = (doc or {}).get("budget_elisions") or {}
-    if not elisions:
-        return problems, 0
+    elisions = (cut or {}).get("budget_elisions") or {}
+    before, after = pack_sections(whole), pack_sections(cut)
     graded = 0
-    for key, elision in sorted(elisions.items()):
+    for key, full in sorted(before.items()):
+        if not full or after.get(key, 0) >= full:
+            continue
         graded += 1
+        kept = after.get(key, 0)
+        if key not in elisions:
+            problems.append(
+                "`%s` fell from %d rows to %d and the response publishes no elision for it"
+                % (key, full, kept)
+            )
+            continue
+        if elisions[key].get("total") != full:
+            problems.append(
+                "budget_elisions.%s.total is %r and the generous budget returned %d"
+                % (key, elisions[key].get("total"), full)
+            )
+        if elisions[key].get("kept") != kept:
+            problems.append(
+                "budget_elisions.%s.kept is %r and the pack carries %d"
+                % (key, elisions[key].get("kept"), kept)
+            )
+    if graded == 0:
+        return problems, 0
+    for key, elision in sorted(elisions.items()):
         elided = elision.get("elided")
         if not elided:
             problems.append("budget_elisions.%s claims nothing withheld" % key)
@@ -1053,19 +1103,27 @@ def check_6(suite):
 def check_7(suite):
     res = Result("7", "FIR-2482", "kin context names what its token budget withheld")
     # `kin context` takes any number, so unlike the MCP tool it can be driven
-    # well below the 8k floor the tool's bucketing imposes.
+    # well below the 8k floor the tool's bucketing imposes. The generous call is
+    # the control: a section full there and short here was cut by the token
+    # budget, which is true whether or not the response admits it.
+    rc_whole, raw_whole = suite.cli(
+        ["context", "wide_entry", "--budget", "200000", "--json"]
+    )
+    rc_json, raw_cut = suite.cli(["context", "wide_entry", "--budget", "2000", "--json"])
     rc_text, text = suite.cli(["context", "wide_entry", "--budget", "2000"])
-    rc_json, raw = suite.cli(["context", "wide_entry", "--budget", "2000", "--json"])
-    if rc_text != 0 or rc_json != 0:
-        res.unknown("kin context exited %d (text) and %d (json)" % (rc_text, rc_json))
+    if rc_whole != 0 or rc_json != 0 or rc_text != 0:
+        res.unknown(
+            "kin context exited %d (generous), %d (json), %d (text)"
+            % (rc_whole, rc_json, rc_text)
+        )
         return res
     try:
-        doc = json.loads(raw)
+        whole, cut = json.loads(raw_whole), json.loads(raw_cut)
     except ValueError as exc:
         res.unknown("kin context --json is not JSON (%s)" % exc)
         return res
 
-    problems, graded = grade_cli_context(text, doc)
+    problems, graded = grade_cli_context(whole, cut, text)
     for problem in problems:
         res.bad(problem)
     if graded == 0:
@@ -1074,7 +1132,7 @@ def check_7(suite):
     if not res.failed:
         res.ok(
             "%d sections report the same cut in the lines and in the json: %s"
-            % (graded, json.dumps(doc.get("budget_elisions") or {}, sort_keys=True))
+            % (graded, json.dumps(cut.get("budget_elisions") or {}, sort_keys=True))
         )
     return res
 
@@ -1412,44 +1470,99 @@ def self_test():
     gap_only = {"dependencies": [{"name": "d0", "body": None, "body_unavailable": "generated"}]}
     expect("a pure graph gap is not a budget cut", grade_body_elisions(gap_only)[1], 0)
 
-    cli_doc = {
-        "budget_elisions": {
-            "dependencies": {"kept": 4, "elided": 46, "total": 50, "reason": "token_budget"}
+    def cli_doc(rows, elisions=None):
+        doc = {
+            "pack": {"dependency_signatures": [{"entity_id": "e%d" % i} for i in range(rows)]},
+            "dependency_selection": {"dependents_returned": 0},
         }
-    }
+        if elisions:
+            doc["budget_elisions"] = elisions
+        return doc
+
+    cli_whole = cli_doc(50)
+    honest_cut = cli_doc(
+        4, {"dependencies": {"kept": 4, "elided": 46, "total": 50, "reason": "token_budget"}}
+    )
     cli_text = "  Dependencies: 4 entries (46 withheld by the 2000-token budget)\n  Raise --budget"
-    expect("a rendering that names its cut passes", grade_cli_context(cli_text, cli_doc)[0], [])
     expect(
-        "a rendering that hides its cut fails",
-        len(grade_cli_context("  Dependencies: 4 entries", cli_doc)[0]) >= 1,
+        "a rendering that names its cut passes",
+        grade_cli_context(cli_whole, honest_cut, cli_text)[0],
+        [],
+    )
+    expect(
+        "a rendering that names its cut grades one section",
+        grade_cli_context(cli_whole, honest_cut, cli_text)[1],
+        1,
+    )
+    expect(
+        "a cut section disclosing nothing at all fails",
+        len(grade_cli_context(cli_whole, cli_doc(4), "  Dependencies: 4 entries")[0]) >= 1,
+        True,
+    )
+    expect(
+        "a rendering that hides a cut it disclosed fails",
+        len(grade_cli_context(cli_whole, honest_cut, "  Dependencies: 4 entries")[0]) >= 1,
         True,
     )
     expect(
         "a rendering with no lever fails",
-        len(grade_cli_context("  Dependencies: 4 entries (46 withheld)", cli_doc)[0]) >= 1,
+        len(
+            grade_cli_context(
+                cli_whole, honest_cut, "  Dependencies: 4 entries (46 withheld)"
+            )[0]
+        )
+        >= 1,
         True,
     )
     expect(
         "a cut blamed on the wrong budget fails",
         len(
             grade_cli_context(
-                cli_text,
-                {
-                    "budget_elisions": {
+                cli_whole,
+                cli_doc(
+                    4,
+                    {
                         "dependencies": {
                             "kept": 4,
                             "elided": 46,
                             "total": 50,
                             "reason": "response_budget",
                         }
-                    }
-                },
+                    },
+                ),
+                cli_text,
             )[0]
         )
         >= 1,
         True,
     )
-    expect("a whole pack grades nothing here", grade_cli_context("  Dependencies: 50 entries", {})[1], 0)
+    expect(
+        "an elision that disagrees with the generous run fails",
+        len(
+            grade_cli_context(
+                cli_whole,
+                cli_doc(
+                    4,
+                    {
+                        "dependencies": {
+                            "kept": 4,
+                            "elided": 6,
+                            "total": 10,
+                            "reason": "token_budget",
+                        }
+                    },
+                ),
+                cli_text,
+            )[0]
+        )
+        >= 1,
+        True,
+    )
+    expect(
+        "a whole pack grades nothing here",
+        grade_cli_context(cli_whole, cli_doc(50), "  Dependencies: 50 entries")[1],
+        0,
+    )
 
     for line in problems:
         print("SELF-TEST FAIL %s" % line)

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -21,6 +21,20 @@ can be satisfied by a broken tool:
   3  no ranked list the budget cuts ships empty
   4  a response the budget could not bring under its ceiling says so, and one
      reporting `bounded: false` is one that fits
+  5  a pack cut by its own token budget publishes what it cut, under that
+     budget's name, and leaves no group empty
+  6  a row whose inline source the budget took says so on the row
+  7  `kin context` names the same cut in its lines and in its `--json`
+
+FIR-2482 is checks 5 to 7, and it is the same rule reached through the OTHER
+budget. A context pack is cut twice: its own token budget refuses candidates
+inside the builder, before the response budget sees anything, and only the
+second cut was ever disclosed. A dependency section trimmed from twelve rows to
+six serialized `returned: 6` beside six rows, which is exactly what a focal with
+six dependencies serializes, and `kin context` printed "Dependencies: 6 entries"
+for both. The body case is the same defect one field down: a row that lost its
+source to the budget lost the key outright, which is the shape of a `compact`
+call and of source the graph never had.
 
 FIR-2602 is check 4. `impact_analysis` reported `{"bounded": false,
 "chars_before_budget": 50354, "max_chars": 2000}` and shipped all 50,354
@@ -265,6 +279,187 @@ def grade_budget_accounting(payload):
     return problems
 
 
+# Groups a context pack's own token budget can cut, under the names both
+# `kin context` and `get_context_pack` publish them by. Listed here so a group
+# added to the pack and not to this list is a check that grades less rather than
+# a silent gap: the check reports UNREADABLE when it grades none of them.
+PACK_GROUPS = ["dependencies", "dependents", "transitive_deps", "tests", "contracts"]
+
+# The reason code a row the pack's token budget refused carries. Distinct from
+# `response_budget` on purpose: a caller raises one with `token_budget` and the
+# other with `max_chars`, and being told the wrong lever costs a round trip that
+# cannot help.
+TOKEN_BUDGET_REASON = "token_budget"
+
+
+def grade_pack_token_budget(whole, cut):
+    """Grade a pack cut by its token budget against the pack that was not.
+
+    The inference needs no counter: anything the walk found at the generous
+    budget it still found at the tight one, so a group full at the ceiling and
+    short at the floor was cut by the token budget and by nothing else. Two
+    things would break that, and both are asserted rather than assumed. The
+    caller pins one identical, generous `max_chars` on both calls, so the
+    response budget cannot be the cutter; and the focal's section must ride
+    dependency edges, so the same-file cap cannot be either.
+    """
+    problems = []
+    graded = 0
+    if not isinstance(whole, dict) or not isinstance(cut, dict):
+        return ["a pack response was not an object"], 0
+    source = (cut.get("dependency_selection") or {}).get("source")
+    if source != "dependency_edges":
+        problems.append(
+            "the focal fell back to same-file neighbours (source %r), so the cap and the "
+            "budget cannot be told apart on this fixture" % source
+        )
+    for key in PACK_GROUPS:
+        before = whole.get(key)
+        if not isinstance(before, list) or not before:
+            continue
+        after = cut.get(key)
+        if not isinstance(after, list):
+            problems.append(
+                "`%s` held %d entries at the generous budget and is absent at the tight "
+                "one, which reads as 'the graph found none'" % (key, len(before))
+            )
+            continue
+        if not after:
+            problems.append(
+                "`%s` held %d entries at the generous budget and [] at the tight one, so "
+                "the budget emptied it" % (key, len(before))
+            )
+        if len(after) >= len(before):
+            continue
+        graded += 1
+        elision = (cut.get("elisions") or {}).get(key)
+        if not elision:
+            problems.append(
+                "`%s` fell from %d to %d entries and published no elision"
+                % (key, len(before), len(after))
+            )
+            continue
+        if elision.get("kept") != len(after):
+            problems.append(
+                "elisions.%s.kept is %r and the array carries %d"
+                % (key, elision.get("kept"), len(after))
+            )
+        if elision.get("total") != len(before):
+            problems.append(
+                "elisions.%s.total is %r and the generous budget returned %d"
+                % (key, elision.get("total"), len(before))
+            )
+        if elision.get("elided") != len(before) - len(after):
+            problems.append(
+                "elisions.%s.elided is %r and %d entries went"
+                % (key, elision.get("elided"), len(before) - len(after))
+            )
+        if TOKEN_BUDGET_REASON not in (elision.get("reason") or ""):
+            problems.append(
+                "elisions.%s names %r, so a caller reads this as the response budget and "
+                "raises the wrong lever" % (key, elision.get("reason"))
+            )
+    # The other direction, and it is what gives an absent disclosure its
+    # meaning: a group the tight call returned whole must claim no loss.
+    for key in PACK_GROUPS:
+        before, after = whole.get(key), cut.get(key)
+        if not isinstance(before, list) or not isinstance(after, list):
+            continue
+        if len(after) < len(before):
+            continue
+        elision = (cut.get("elisions") or {}).get(key)
+        if elision and TOKEN_BUDGET_REASON in (elision.get("reason") or ""):
+            problems.append(
+                "`%s` returned all %d entries and still claims %r withheld"
+                % (key, len(before), elision.get("elided"))
+            )
+    return problems, graded
+
+
+def grade_body_elisions(payload):
+    """Grade a pack whose inline source the response budget took.
+
+    A row that simply loses its `body` key is byte-identical to a row from a
+    `compact` call and to one whose source the graph does not hold. Both
+    readings are wrong about a row the budget cut, and a count elsewhere in the
+    response does not correct either: the reader looks at the row.
+    """
+    problems = []
+    rows = [row for row in (payload.get("dependencies") or []) if isinstance(row, dict)]
+    focal = payload.get("focal_entity")
+    if isinstance(focal, dict):
+        rows.append(focal)
+    if not rows:
+        return ["the cut response carried no row to grade"], 0
+    elision = (payload.get("elisions") or {}).get("body")
+    marked = 0
+    for row in rows:
+        if row.get("body") not in (None, ""):
+            continue
+        if not row.get("body_elided") and not row.get("body_unavailable"):
+            problems.append(
+                "row %r carries no source and says nothing about why, which is the shape "
+                "of `compact` and of a graph gap alike" % row.get("name")
+            )
+            continue
+        if row.get("body_elided") and row.get("body_unavailable"):
+            problems.append(
+                "row %r claims the budget took its body AND that the graph never had it"
+                % row.get("name")
+            )
+        if row.get("body_elided"):
+            marked += 1
+    if marked == 0:
+        return problems, 0
+    if not elision:
+        problems.append("%d rows lost their body and no elision was published" % marked)
+        return problems, marked
+    if not elision.get("elided"):
+        problems.append("elisions.body claims nothing was withheld beside %d marked rows" % marked)
+    elif elision["elided"] < marked:
+        problems.append(
+            "elisions.body counts %r withheld and %d rows say they lost one"
+            % (elision.get("elided"), marked)
+        )
+    if not elision.get("reason"):
+        problems.append("elisions.body names no reason")
+    return problems, marked
+
+
+def grade_cli_context(text, doc):
+    """Grade `kin context`, whose rendered lines are the whole of what a reader
+    of that surface sees. A cut those lines do not name is, to that reader, a
+    cut that did not happen."""
+    problems = []
+    elisions = (doc or {}).get("budget_elisions") or {}
+    if not elisions:
+        return problems, 0
+    graded = 0
+    for key, elision in sorted(elisions.items()):
+        graded += 1
+        elided = elision.get("elided")
+        if not elided:
+            problems.append("budget_elisions.%s claims nothing withheld" % key)
+            continue
+        if elision.get("reason") != TOKEN_BUDGET_REASON:
+            problems.append(
+                "budget_elisions.%s names %r rather than the token budget"
+                % (key, elision.get("reason"))
+            )
+        if elision.get("kept", 0) + elided != elision.get("total"):
+            problems.append(
+                "budget_elisions.%s: kept %r plus elided %r is not total %r"
+                % (key, elision.get("kept"), elided, elision.get("total"))
+            )
+        if "%d withheld" % elided not in text:
+            problems.append(
+                "the rendering never names the %d entries withheld from `%s`" % (elided, key)
+            )
+    if graded and "--budget" not in text:
+        problems.append("the rendering names no lever that recovers what was withheld")
+    return problems, graded
+
+
 class McpError(Exception):
     """One MCP call that could not be read. Unreadable is not absent."""
 
@@ -348,6 +543,31 @@ class Suite(object):
         ]
         with open(os.path.join(repo, "src", "chain.py"), "w") as handle:
             handle.write("\n".join(lines))
+
+        # A second focal whose callees cost the pack's TOKEN budget without
+        # costing its response budget much. Every parameter is `a<i>=0`, which
+        # the pack's estimator counts as four tokens across five characters, so
+        # fifty callees run to roughly 23,000 estimated tokens in about 36,000
+        # characters of compact JSON. That ratio is the point: the token budget
+        # has to cut this pack while the response budget, pinned at its ceiling
+        # on both calls, has nothing to do. Nothing here is named `hop`, so the
+        # locate-based checks above rank exactly what they ranked before.
+        params = ", ".join("a%d=0" % index for index in range(100))
+        wide = []
+        for index in range(50):
+            wide += [
+                "def wide_dep_%02d(%s):" % (index, params),
+                '    """A callee sized in tokens, not in characters."""',
+                "    return a0",
+                "",
+                "",
+            ]
+        wide += ["def wide_entry(value):", '    """The focal the pack budget arm packs."""', "    return ("]
+        for index in range(50):
+            wide.append("        wide_dep_%02d()" % index + (" +" if index < 49 else ""))
+        wide += ["    )", ""]
+        with open(os.path.join(repo, "src", "wide.py"), "w") as handle:
+            handle.write("\n".join(wide))
 
         tests = ["from src.chain import hop_0", ""]
         for index in range(24):
@@ -470,6 +690,27 @@ class Suite(object):
             return json.loads(content[0]["text"])
         except ValueError as exc:
             raise McpError("%s payload is not JSON (%s)" % (method, exc))
+
+
+    def entity_id(self, name):
+        """One entity id, resolved the way an agent resolves one.
+
+        `get_context_pack` addresses its focal by id, so a check that drove a
+        name-taking sibling instead would be probing a different surface from
+        the one the claim is about.
+        """
+        payload = self.mcp("semantic_locate", {"query": name, "limit": 20})
+        for row in payload.get("entities") or []:
+            if row.get("name") == name:
+                found = row.get("entity_id") or row.get("id")
+                if found:
+                    return found
+        raise McpError("semantic_locate resolved no entity named %r" % name)
+
+    def cli(self, args, timeout=600):
+        """One `kin ...` invocation in the fixture, returning (rc, stdout)."""
+        proc = self.run([self.kin] + args, timeout=timeout)
+        return proc.returncode, proc.stdout.decode("utf-8", "replace")
 
 
 def grade_buckets(payload, buckets):
@@ -713,7 +954,130 @@ def check_4(suite):
     return res
 
 
-CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3), ("4", check_4)]
+def check_5(suite):
+    res = Result(
+        "5",
+        "FIR-2482",
+        "a pack cut by its own token budget says what it cut, and empties nothing",
+    )
+    try:
+        focal = suite.entity_id("wide_entry")
+        # One identical, generous `max_chars` on both calls, so the only budget
+        # that differs between them is the pack's own. `compact` keeps inline
+        # source out of the payload for the same reason: the arm is about rows
+        # the token budget refused, and bodies would put the response budget
+        # back in the picture on the generous call.
+        target = {"entity_id": focal, "compact": True, "include_traffic": False}
+        ceiling = dict(target, max_chars=60000, token_budget=200000)
+        floor = dict(target, max_chars=60000, token_budget=8000)
+        whole = suite.mcp("get_context_pack", ceiling)
+        cut = suite.mcp("get_context_pack", floor)
+    except McpError as exc:
+        res.unknown("get_context_pack unreadable: %s" % exc)
+        return res
+
+    # If the response budget touched either call the differential is measuring
+    # two cutters at once, which is exactly the confusion this check exists to
+    # remove. Read off each response's own accounting rather than assumed.
+    for label, payload in (("generous", whole), ("tight", cut)):
+        accounting = ((payload.get("_kin") or {}).get("response")) or {}
+        if accounting.get("bounded"):
+            res.unknown(
+                "the %s call was also cut by the response budget (%s), so the token "
+                "budget cannot be isolated on this fixture"
+                % (label, json.dumps(accounting, sort_keys=True))
+            )
+            return res
+
+    problems, graded = grade_pack_token_budget(whole, cut)
+    for problem in problems:
+        res.bad(problem)
+    if graded == 0:
+        res.unknown("the tight budget cut no group, so the rule was not exercised")
+        return res
+    if not res.failed:
+        res.ok(
+            "%d of %d groups were cut by the token budget and every one kept an entry: %s"
+            % (
+                graded,
+                len([key for key in PACK_GROUPS if whole.get(key)]),
+                json.dumps(cut.get("elisions") or {}, sort_keys=True),
+            )
+        )
+    return res
+
+
+def check_6(suite):
+    res = Result("6", "FIR-2482", "a row whose body the budget took says so on the row")
+    try:
+        focal = suite.entity_id("wide_entry")
+        payload = suite.mcp(
+            "get_context_pack",
+            {
+                "entity_id": focal,
+                "compact": False,
+                "include_traffic": False,
+                "token_budget": 200000,
+                "max_chars": 12000,
+            },
+        )
+    except McpError as exc:
+        res.unknown("get_context_pack unreadable: %s" % exc)
+        return res
+
+    problems, marked = grade_body_elisions(payload)
+    for problem in problems:
+        res.bad(problem)
+    if marked == 0:
+        res.unknown("the budget took no body, so the rule was not exercised")
+        return res
+    if not res.failed:
+        res.ok(
+            "%d rows name the budget that took their source, and elisions.body agrees: %s"
+            % (marked, json.dumps((payload.get("elisions") or {}).get("body"), sort_keys=True))
+        )
+    return res
+
+
+def check_7(suite):
+    res = Result("7", "FIR-2482", "kin context names what its token budget withheld")
+    # `kin context` takes any number, so unlike the MCP tool it can be driven
+    # well below the 8k floor the tool's bucketing imposes.
+    rc_text, text = suite.cli(["context", "wide_entry", "--budget", "2000"])
+    rc_json, raw = suite.cli(["context", "wide_entry", "--budget", "2000", "--json"])
+    if rc_text != 0 or rc_json != 0:
+        res.unknown("kin context exited %d (text) and %d (json)" % (rc_text, rc_json))
+        return res
+    try:
+        doc = json.loads(raw)
+    except ValueError as exc:
+        res.unknown("kin context --json is not JSON (%s)" % exc)
+        return res
+
+    problems, graded = grade_cli_context(text, doc)
+    for problem in problems:
+        res.bad(problem)
+    if graded == 0:
+        res.unknown("the tight budget cut no section, so the rule was not exercised")
+        return res
+    if not res.failed:
+        res.ok(
+            "%d sections report the same cut in the lines and in the json: %s"
+            % (graded, json.dumps(doc.get("budget_elisions") or {}, sort_keys=True))
+        )
+    return res
+
+
+CHECKS = [
+    ("0", check_0),
+    ("1", check_1),
+    ("2", check_2),
+    ("3", check_3),
+    ("4", check_4),
+    ("5", check_5),
+    ("6", check_6),
+    ("7", check_7),
+]
 
 
 def self_test():
@@ -904,6 +1268,177 @@ def self_test():
         len(grade_budget_accounting({"affected_tests": []})) >= 1,
         True,
     )
+
+    # ── FIR-2482: the pack's own token budget ───────────────────────────
+
+    def pack(deps, elisions=None, source="dependency_edges"):
+        doc = {
+            "dependencies": [{"name": "d%d" % index} for index in range(deps)],
+            "dependents": [{"name": "u0"}],
+            "dependency_selection": {"source": source},
+        }
+        if elisions:
+            doc["elisions"] = elisions
+        return doc
+
+    whole_pack = pack(20)
+    honest = pack(
+        6,
+        {"dependencies": {"kept": 6, "elided": 14, "total": 20, "reason": "token_budget"}},
+    )
+    expect("an honest pack cut passes", grade_pack_token_budget(whole_pack, honest)[0], [])
+    expect("an honest pack cut grades one group", grade_pack_token_budget(whole_pack, honest)[1], 1)
+
+    silent = pack(6)
+    expect(
+        "a pack cut with no elision fails",
+        len(grade_pack_token_budget(whole_pack, silent)[0]) >= 1,
+        True,
+    )
+    emptied = pack(
+        0,
+        {"dependencies": {"kept": 0, "elided": 20, "total": 20, "reason": "token_budget"}},
+    )
+    expect(
+        "a pack group emptied by the budget fails",
+        len(grade_pack_token_budget(whole_pack, emptied)[0]) >= 1,
+        True,
+    )
+    absent = {"dependents": [{"name": "u0"}], "dependency_selection": {"source": "dependency_edges"}}
+    expect(
+        "a pack group that vanished entirely fails",
+        len(grade_pack_token_budget(whole_pack, absent)[0]) >= 1,
+        True,
+    )
+    miscounted = pack(
+        6,
+        {"dependencies": {"kept": 9, "elided": 14, "total": 20, "reason": "token_budget"}},
+    )
+    expect(
+        "a pack elision that disagrees with its array fails",
+        len(grade_pack_token_budget(whole_pack, miscounted)[0]) >= 1,
+        True,
+    )
+    misattributed = pack(
+        6,
+        {"dependencies": {"kept": 6, "elided": 14, "total": 20, "reason": "response_budget"}},
+    )
+    expect(
+        "a token-budget cut blamed on the response budget fails",
+        len(grade_pack_token_budget(whole_pack, misattributed)[0]) >= 1,
+        True,
+    )
+    phantom = pack(
+        20,
+        {"dependencies": {"kept": 20, "elided": 3, "total": 23, "reason": "token_budget"}},
+    )
+    expect(
+        "a whole pack claiming a cut fails",
+        len(grade_pack_token_budget(whole_pack, phantom)[0]) >= 1,
+        True,
+    )
+    fallback = pack(
+        6,
+        {"dependencies": {"kept": 6, "elided": 14, "total": 20, "reason": "token_budget"}},
+        source="same_file_fallback",
+    )
+    expect(
+        "a pack whose section came from the cap is not gradeable here",
+        len(grade_pack_token_budget(whole_pack, fallback)[0]) >= 1,
+        True,
+    )
+
+    cut_bodies = {
+        "dependencies": [
+            {"name": "d0", "body": None, "body_elided": ["body"]},
+            {"name": "d1", "body": None, "body_elided": ["body"]},
+        ],
+        "elisions": {"body": {"kept": 0, "elided": 2, "total": 2, "reason": "response_budget"}},
+    }
+    expect("marked bodies pass", grade_body_elisions(cut_bodies)[0], [])
+    expect("marked bodies grade two rows", grade_body_elisions(cut_bodies)[1], 2)
+
+    stripped = {
+        "dependencies": [{"name": "d0"}, {"name": "d1"}],
+        "elisions": {"body": {"kept": 0, "elided": 2, "total": 2, "reason": "response_budget"}},
+    }
+    expect(
+        "a bodiless row that says nothing fails",
+        len(grade_body_elisions(stripped)[0]) >= 1,
+        True,
+    )
+    both = {
+        "dependencies": [
+            {"name": "d0", "body": None, "body_elided": ["body"], "body_unavailable": "gone"}
+        ],
+        "elisions": {"body": {"kept": 0, "elided": 1, "total": 1, "reason": "response_budget"}},
+    }
+    expect(
+        "a row claiming a cut and a gap at once fails",
+        len(grade_body_elisions(both)[0]) >= 1,
+        True,
+    )
+    uncounted = {
+        "dependencies": [{"name": "d0", "body": None, "body_elided": ["body"]}],
+    }
+    expect(
+        "marked rows with no elision fail",
+        len(grade_body_elisions(uncounted)[0]) >= 1,
+        True,
+    )
+    undercounted = {
+        "dependencies": [
+            {"name": "d0", "body": None, "body_elided": ["body"]},
+            {"name": "d1", "body": None, "body_elided": ["body"]},
+        ],
+        "elisions": {"body": {"kept": 0, "elided": 1, "total": 1, "reason": "response_budget"}},
+    }
+    expect(
+        "an elision counting fewer than the rows say fails",
+        len(grade_body_elisions(undercounted)[0]) >= 1,
+        True,
+    )
+    gap_only = {"dependencies": [{"name": "d0", "body": None, "body_unavailable": "generated"}]}
+    expect("a pure graph gap is not a budget cut", grade_body_elisions(gap_only)[1], 0)
+
+    cli_doc = {
+        "budget_elisions": {
+            "dependencies": {"kept": 4, "elided": 46, "total": 50, "reason": "token_budget"}
+        }
+    }
+    cli_text = "  Dependencies: 4 entries (46 withheld by the 2000-token budget)\n  Raise --budget"
+    expect("a rendering that names its cut passes", grade_cli_context(cli_text, cli_doc)[0], [])
+    expect(
+        "a rendering that hides its cut fails",
+        len(grade_cli_context("  Dependencies: 4 entries", cli_doc)[0]) >= 1,
+        True,
+    )
+    expect(
+        "a rendering with no lever fails",
+        len(grade_cli_context("  Dependencies: 4 entries (46 withheld)", cli_doc)[0]) >= 1,
+        True,
+    )
+    expect(
+        "a cut blamed on the wrong budget fails",
+        len(
+            grade_cli_context(
+                cli_text,
+                {
+                    "budget_elisions": {
+                        "dependencies": {
+                            "kept": 4,
+                            "elided": 46,
+                            "total": 50,
+                            "reason": "response_budget",
+                        }
+                    }
+                },
+            )[0]
+        )
+        >= 1,
+        True,
+    )
+    expect("a whole pack grades nothing here", grade_cli_context("  Dependencies: 50 entries", {})[1], 0)
 
     for line in problems:
         print("SELF-TEST FAIL %s" % line)

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -1089,8 +1089,14 @@ def check_6(suite):
     problems, marked = grade_body_elisions(payload)
     for problem in problems:
         res.bad(problem)
-    if marked == 0:
+    if marked == 0 and not problems:
+        # Only when the rule genuinely went unexercised. A response that broke
+        # the rule marked nothing precisely because it marks nothing, and
+        # appending "not exercised" to that verdict would soften a FAIL into a
+        # sentence arguing with itself.
         res.unknown("the budget took no body, so the rule was not exercised")
+        return res
+    if res.failed:
         return res
     if not res.failed:
         res.ok(


### PR DESCRIPTION
A context pack is cut by two budgets and only one of them ever said so. Its own
token budget refuses candidates inside the builder, before the response budget
sees the payload at all, and it refused them in silence: a dependency section
trimmed from twelve rows to six serialized six rows beside `returned: 6`, which
is exactly what a focal with six dependencies serializes, and `kin context`
printed `Dependencies: 6 entries` for both. That is the reading kin#1062 removed
from the list case and kin#1068 from the impact case, arriving through the
earlier budget, where neither fix could see it.

## What was silent

`crates/kin-context/src/builder.rs`. The admission fold dropped any candidate
whose tokens did not fit and counted nothing, across `dependencies`,
`dependents`, `transitive_deps`, `tests`, `contracts`, `work_items` and
`annotations`. There was no floor either, so a budget too small for any row
emptied every group, which is `"affected_tests": []` reached by a different
route.

`crates/kin-mcp/src/budget.rs`. The body rung stripped `body` from every row and
disclosed it only as prose inside one `degradations` string. The row lost the key
outright, so a row whose source the budget took was byte-identical to a row from
a `compact: true` call, and sat beside the pack handler's own `body: null` plus
`body_unavailable`, which is its vocabulary for source the graph does not hold.
Three readings, one shape.

Two smaller holes surfaced while fixing those, and both are closed here because
a fix whose own response still cuts in silence has not finished. `trim_collection`
assigned `<field>_withheld` instead of adding to it, so two arms cutting one list
reported only the second. The certified-dependents cap was disclosed only as a
counter nested inside `dependency_selection`, which is the sibling-counter shape
that saved nobody in the session kin#1062 was filed from.

## The disclosure

`DependencySelection` records the ids the token budget refused, keyed by the
group names both surfaces render by. Ids rather than counts, because this handler
recovers a certified caller the fold refused and a row that reached the answer is
not a row the answer lost; `budget_elided_unrecovered` is what stops the count
claiming it twice.

Every group that had a candidate now keeps one, whatever it costs, on kin#1062's
precedent that a bound is not a refusal. Candidates are walked in weight order,
so the row a group keeps is its most important one, the overshoot is bounded by
one row per group, and `actual_tokens` reports it rather than hiding it.

`handle_get_context_pack` publishes those counts into the same top-level
`elisions` map, under a new `token_budget` reason. The reason is distinct on
purpose: a caller raises one budget with `token_budget` and the other with
`max_chars`, and one told the wrong lever spends a round trip that cannot help.
`record_elision_for` merges rather than overwrites, so a list cut by both budgets
reports what the walk found instead of what the second cutter inherited, and both
causes survive.

The body rung publishes `elisions.body` and leaves each row it took from a null
`body` beside a `body_elided` naming what went. A row that never carried one is
neither marked nor counted, so `body_elided` and `body_unavailable` cannot appear
together.

`kin context` names the withheld count on each section line, carries the same
counts in `--json`, and prints the lever that recovers them. Under the same-file
fallback it names the budget's loss and the cap's separately, because nothing
recovers the cap and folding them into one shortfall would rebuild the
two-causes-one-number reading this change exists to remove.

## The checks

`scripts/acceptance/response_budget_elisions.py` gains checks 5, 6 and 7 beside
kin#1062's 0 to 3 and kin#1068's 4, plus a `src/wide.py` fixture whose callees
cost tokens without costing characters, so one budget can be isolated from the
other.

Check 5 packs one focal at a generous token budget and again at a tight one with
one identical generous `max_chars` on both, asserts off each response's own
accounting that the response budget touched neither, and asserts every group that
shrank published an elision naming `token_budget`. Check 6 asserts every row
missing its source says why, and that no row claims a cut and a graph gap at
once. Check 7 runs `kin context` at a generous `--budget` and again at a tight
one and grades the differential, then asserts the lines and `--json` report the
same cut and name the lever. Each reports UNREADABLE rather than PASS when its
rule was not exercised.

Against this branch's release build:

```
CHECK 5 FIR-2482 PASS 1 of 1 groups were cut by the token budget and every one kept an entry: {"dependencies": {"elided": 19, "kept": 17, "reason": "token_budget", "total": 36}}
CHECK 6 FIR-2482 PASS 2 rows name the budget that took their source, and elisions.body agrees: {"elided": 37, "kept": 0, "reason": "response_budget", "total": 37}
CHECK 7 FIR-2482 PASS 1 sections report the same cut in the lines and in the json: {"dependencies": {"elided": 31, "kept": 5, "reason": "token_budget", "total": 36}}
response budget elisions: 8 PASS, 0 FAIL, 0 UNREADABLE
```

Check 3 is kin#1062's own check and now reports an `elisions.body` beside its
`entities` entry, which is this change visible in a check that predates it.

## Falsifications, one per class

Exit statuses read raw, never through a pipe. Every revert was restored and the
tree confirmed clean with `git diff --quiet HEAD` returning 0.

*The token-budget disclosure.* `DependencySelection::refuse` made a no-op,
rebuilt, suite rerun: `CHECK 5 FAIL \`dependencies\` fell from 36 to 17 entries
and published no elision`, exit 1. Checks 0 to 4 and 6 stayed green, so the
revert is isolated to its class.

*The per-row body marker.* The body rung told not to mark what it strips,
rebuilt, suite rerun: `CHECK 6 FAIL row 'wide_dep_23' carries no source and says
nothing about why, which is the shape of \`compact\` and of a graph gap alike`,
exit 1. Checks 5 and 7 stayed green.

*The never-empty floor.* Dropping the `admitted_groups` guard fails
`a_budget_too_small_for_any_row_still_keeps_one` with `left: 0` against a group
of forty candidates. The acceptance fixture admits seventeen rows at the 8,000
floor, so this class is guarded by the unit test rather than by check 5, and that
is said here rather than implied.

*The elision merge.* Making `record_elision_for` overwrite fails
`two_cuts_on_one_list_add_up_rather_than_replacing_each_other`: `total` reports
24, the size the second cutter inherited, against the 30 the walk found, and the
`token_budget` cause vanishes from `reason` entirely.

*The withheld accumulation.* Assigning `<field>_withheld` instead of adding fails
the same test on its other assertion: the scalar reads 20 while the map reads 26.

*The graders.* Neutering each of the three new graders turns `--self-test` red on
7, 4 and 5 cases respectively, exit 1 each.

One falsification changed the design, which is the reason for running them.
Reverting the token-budget disclosure left check 7 UNREADABLE rather than FAIL,
because it graded only what the disclosure claimed and a build disclosing nothing
gave it nothing to grade. That is the defect wearing the check's own costume, so
check 7 now grades a generous control run against the tight one, exactly as check
5 does, and a section that shrank while disclosing nothing is a FAIL.

Closes FIR-2482
