### PR TITLE
Say what the shim cannot project, now that Node is not it

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -191,7 +191,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: e01e2e09793019c3157285cc780e5735914e37a9
+          ref: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -665,7 +665,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: e01e2e09793019c3157285cc780e5735914e37a9
+          EXPECTED_VFS_COMMIT: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,7 +528,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: e01e2e09793019c3157285cc780e5735914e37a9
+          ref: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -1154,7 +1154,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: e01e2e09793019c3157285cc780e5735914e37a9
+          EXPECTED_VFS_COMMIT: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1442,7 +1442,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: e01e2e09793019c3157285cc780e5735914e37a9
+          ref: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1510,7 +1510,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: e01e2e09793019c3157285cc780e5735914e37a9
+          EXPECTED_VFS_COMMIT: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1872,7 +1872,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: e01e2e09793019c3157285cc780e5735914e37a9
+      expected_vfs_commit: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.4.13"
+version = "0.4.14"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "557bc44b4a226d001883015d0945c4e0e26a290f8bbac99a5aeb1f57d0757a9a"
+checksum = "49e9e18523938c55a6bce736ba82079bc06693ff318db7b7965a6fab2fba2a3f"
 dependencies = [
  "lru",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "=0.7.50", registry = "kin", default-features = false }
-kin-vfs-core = { version = "=0.4.13", registry = "kin" }
+kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1389,12 +1389,25 @@ fn projection_mode_check_for(
         // projection that was measured outside the repository from one that was
         // only measured inside it.
         let detail = format!("{detail}; {}", outside.evidence());
-        return HealthCheck::new(
+        let check = HealthCheck::new(
             "projection_mode",
             "Projection in force",
             HealthStatus::Healthy,
             detail,
         );
+        // A working mode can still have a limit, and this is the row where a
+        // silent green would hide it. The shim interposes libc, so a binary
+        // that never calls libc reads the working copy while everything else
+        // reads graph truth; that stays true of a shim mode passing every
+        // probe. Carrying it as a platform note rather than a status keeps the
+        // row green, because the limit is a property of the mode rather than a
+        // defect in the install, and puts it in front of a reader who ran
+        // `kin doctor` and would otherwise have to know to run `kin vfs status`
+        // (FIR-2572).
+        return match live.mode.raw_syscall_note() {
+            Some(note) => check.with_platform_note(note),
+            None => check,
+        };
     }
 
     // A recorded mode that is not the one running, or one that is running and
@@ -5187,6 +5200,78 @@ mod tests {
             degraded,
             evidence: vec!["fixture evidence".to_string()],
         }
+    }
+
+    /// FIR-2572. A green projection row still names what its mode cannot do.
+    ///
+    /// The shim interposes libc, so a binary that never calls libc reads the
+    /// working copy while everything else reads graph truth, and that stays
+    /// true of a shim passing every probe this row takes. `kin vfs status`
+    /// said so and `kin doctor` did not, so a reader who ran doctor, saw a
+    /// green projection and stopped had no way to learn the limit existed.
+    ///
+    /// The note rides `platform_note`, so it must not move the status: a limit
+    /// that belongs to the mode is not a defect in the install, and a row that
+    /// went red over one would fail every correct shim install.
+    #[test]
+    fn a_green_shim_row_names_the_limit_and_a_green_mount_row_has_none() {
+        let shim = projection_mode_check_for_macos(&report(
+            Some(ProjectionMode::Shim),
+            &[ProjectionMode::Shim],
+            live(
+                ProjectionMode::Shim,
+                ProjectionMode::Shim,
+                Tri::NotApplicable,
+                Tri::Yes,
+                false,
+            ),
+        ));
+        assert!(
+            matches!(shim.status, HealthStatus::Healthy),
+            "naming the limit must not move the status, got {:?}",
+            shim.status
+        );
+        assert!(
+            !blocks_readiness(&shim),
+            "a mode's limit must never block readiness"
+        );
+        let note = shim
+            .platform_note
+            .as_deref()
+            .expect("a green shim row carries the shim's limit");
+        assert!(
+            note.contains("libc") && note.contains("Go"),
+            "the limit must name what it is about: {note}"
+        );
+        assert!(
+            !note.contains("Node is not projected"),
+            "Node is projected under the shim since FIR-2572: {note}"
+        );
+
+        // The control. A mount is served by the kernel and has no such limit,
+        // so an unconditional note would be a false warning on every mount
+        // host and this assertion is what keeps the note attached to the mode
+        // rather than to the row.
+        let mount = projection_mode_check_for_macos(&report(
+            Some(ProjectionMode::Nfs),
+            &[ProjectionMode::Nfs],
+            live(
+                ProjectionMode::Nfs,
+                ProjectionMode::Nfs,
+                Tri::Yes,
+                Tri::Yes,
+                false,
+            ),
+        ));
+        assert!(
+            matches!(mount.status, HealthStatus::Healthy),
+            "the mount fixture must be green for this control to mean anything, got {:?}",
+            mount.status
+        );
+        assert_eq!(
+            mount.platform_note, None,
+            "a mount projects every process on the host and must carry no such limit"
+        );
     }
 
     /// The three fixtures the row exists to tell apart: everything present, no

--- a/crates/kin-cli/src/commands/projection.rs
+++ b/crates/kin-cli/src/commands/projection.rs
@@ -160,20 +160,28 @@ impl ProjectionMode {
     /// rather than of the host.
     ///
     /// The shim is injected through `LD_PRELOAD` and `DYLD_INSERT_LIBRARIES`,
-    /// which interpose libc and nothing else. A runtime that issues raw
-    /// syscalls goes straight past it: Node's libuv calls `statx` directly, so
-    /// inside a projected repository Node reads raw disk on the same path where
-    /// git, Python and the coreutils read graph truth (FIR-2572). No further
-    /// hook closes that, so the product says it rather than leaving a user to
-    /// find it. A mount has no such gap, because the kernel serves every
+    /// which interpose libc and nothing else, so what it cannot project is a
+    /// binary that reaches the kernel without libc at all. A Go binary built
+    /// the usual way is that binary: it issues its own syscalls, and inside a
+    /// projected repository it reads the working copy on the same path where
+    /// git, Node, Python and the coreutils read graph truth.
+    ///
+    /// This note used to name Node, and named it wrongly. libuv issues `statx`
+    /// itself rather than calling a libc stat entry point, which did put Node
+    /// in this class for a release (FIR-2572), but it reaches the kernel
+    /// through glibc's `syscall(2)` wrapper rather than through the
+    /// instruction, and a wrapper is a symbol the shim can interpose like any
+    /// other. It does now, so Node reads the projection here. A binary with no
+    /// libc call to interpose is the case that remains, and it has no symbol to
+    /// hook. A mount has no such gap at all, because the kernel serves every
     /// process on the host.
     pub(crate) fn raw_syscall_note(self) -> Option<&'static str> {
         match self {
             Self::Shim => Some(
-                "Node is not projected in this mode: the shim interposes libc, and libuv issues \
-                 raw syscalls that no injected library can see, so Node reads raw disk here while \
-                 git, Python and the coreutils read graph truth. The nfs and fuse mounts project \
-                 every process on the host, Node included.",
+                "A binary that reaches the kernel without libc is not projected in this mode: \
+                 the shim interposes libc, so a Go binary making its own syscalls reads the \
+                 working copy here while git, Node, Python and the coreutils read graph truth. \
+                 The nfs and fuse mounts project every process on the host.",
             ),
             Self::Nfs | Self::Fuse | Self::ProjFs => None,
         }
@@ -2366,22 +2374,39 @@ Options:
         );
     }
 
-    /// FIR-2572: the shim cannot interpose a raw syscall, so Node reads raw
-    /// disk inside a projected repository while every libc caller does not.
-    /// The status block has to say so under the shim, and must not say it under
-    /// a mount, where the kernel serves every process.
+    /// FIR-2572: the shim interposes libc, so what it cannot project is a
+    /// binary that never calls libc. The status block has to say so under the
+    /// shim, and must not say it under a mount, where the kernel serves every
+    /// process.
+    ///
+    /// It must also no longer say it about Node. The note named Node for a
+    /// release, correctly at the time, because libuv issued `statx` itself; the
+    /// shim now interposes the `syscall(2)` wrapper libuv reaches it through,
+    /// and a measured static Go binary is the case that remains. A note still
+    /// telling a JavaScript developer their toolchain is unprojected would send
+    /// them to a mount they no longer need, so the old sentence is asserted
+    /// gone rather than merely replaced.
     #[test]
     fn the_status_block_declares_the_shim_raw_syscall_gap_and_only_there() {
         let shim_note = ProjectionMode::Shim
             .raw_syscall_note()
             .expect("the shim mode declares its raw-syscall gap");
         assert!(
-            shim_note.contains("Node"),
-            "the note must name the runtime it is about: {shim_note}"
+            shim_note.contains("libc"),
+            "the note must name what the gap is about: {shim_note}"
+        );
+        assert!(
+            shim_note.contains("Go"),
+            "the note must name a binary actually in the class: {shim_note}"
+        );
+        assert!(
+            !shim_note.contains("Node is not projected"),
+            "Node is projected under the shim since FIR-2572; the note must not send a \
+             JavaScript developer to a mount they do not need: {shim_note}"
         );
         assert!(
             shim_note.contains("nfs") && shim_note.contains("fuse"),
-            "the note must name the modes that do project Node: {shim_note}"
+            "the note must name the modes with no such gap: {shim_note}"
         );
         for mode in [
             ProjectionMode::Nfs,

--- a/crates/kin-cli/tests/projection_modes.rs
+++ b/crates/kin-cli/tests/projection_modes.rs
@@ -545,9 +545,14 @@ fn vfs_status_names_the_bound_root_and_refuses_to_call_an_unserved_one_in_force(
         );
     }
 
-    // FIR-2572: shim mode declares what it cannot project, in the same block.
+    // FIR-2572: shim mode declares what it cannot project, in the same block,
+    // and that is a binary with no libc call to interpose rather than Node.
     assert!(
-        served.contains("Node is not projected in this mode"),
+        served.contains("A binary that reaches the kernel without libc is not projected"),
         "shim mode must declare the raw-syscall gap:\n{served}"
+    );
+    assert!(
+        !served.contains("Node is not projected"),
+        "Node is projected under the shim since FIR-2572:\n{served}"
     );
 }

--- a/docs/projection.md
+++ b/docs/projection.md
@@ -50,13 +50,22 @@ process reading raw disk. Nothing crashes when that happens, which is exactly
 why it needs to be reported rather than assumed.
 
 One gap is not about refusal at all. The shim interposes libc and nothing else,
-so a runtime that issues raw syscalls goes straight around it. Node is the one
-most people hit: libuv calls `statx` directly, so inside a projected repository
-Node reads raw disk on the same path where git, Python and the coreutils read
-graph truth. No further hook closes that, so `kin vfs status` prints the limit
-under `shim` rather than leaving you to find it. The `nfs` and `fuse` mounts
-have no such gap, because the kernel serves every process on the host. If your
-toolchain is Node, prefer a mount.
+so a binary that reaches the kernel without libc goes straight around it. A Go
+binary built the usual way is that binary: it issues its own syscalls, and
+inside a projected repository it reads the working copy on the same path where
+git, Node, Python and the coreutils read graph truth. Nothing can hook a call
+that names no symbol, so `kin vfs status` prints the limit under `shim` rather
+than leaving you to find it. The `nfs` and `fuse` mounts have no such gap,
+because the kernel serves every process on the host. If your toolchain is Go,
+prefer a mount.
+
+Node used to be in that class and no longer is, which is worth knowing if you
+read the older advice. libuv issues `statx` itself rather than calling a libc
+stat entry point, so for a release `node` answered a stat from the working copy
+where every libc caller got the fail-closed error. It reaches the kernel through
+glibc's `syscall(2)` wrapper rather than through the instruction, though, and a
+wrapper is a symbol like any other, so the shim interposes it and Node now reads
+the projection here.
 
 Between the two mounts, each platform's native one comes first. macOS carries an
 NFS client in the base system while FUSE there needs FUSE-T or macFUSE

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -14070,7 +14070,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: e01e2e09793019c3157285cc780e5735914e37a9",
+        "expected_vfs_commit: b1355e67df7dc020002c3a73fb99692c2f3fa7b4",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
`kin vfs status` told every user "Node is not projected in this mode", and `docs/projection.md` told them to prefer a mount if their toolchain is Node. That was true when it was written. It is false as of kin-vfs#124, and this PR moves the pin that makes it false and corrects every surface that still says it.

Closes FIR-2572

## What changed under it

libuv's `uv__fs_statx` issues `statx` itself rather than calling a libc stat entry point, so inside a projected repository `node` answered a stat from the working copy on the exact path where `python`, `git` and the coreutils got the fail-closed `EIO`. The ticket concluded no `LD_PRELOAD` could interpose that. It was wrong. libuv never issues the instruction itself, and the glibc `syscall(2)` wrapper it calls instead is an ordinary exported symbol. kin-vfs#124 hooks that wrapper. `SYS_statx` routes into the same `statx` hook glibc's own symbol reaches, and every other syscall number is forwarded untouched. Measured two-sided on Debian 12 aarch64 with node v22.23.2 and glibc 2.36, `node fs.statSync` went from reading 41 disk bytes to failing `EIO` alongside every libc caller, with a path outside the projection still reading normally for all of them.

## The pin, and its eighth home

The immutable kin-vfs pin moves from `e01e2e09` to `b1355e67`. It has eight homes across three files, not the five a grep of `release.yml` finds. `rc-build.yml` carries two, and `scripts/test-release-workflow-authority.py:13979` asserts the install-proof job carries that exact string, so a pin move that stops at `*.yml` leaves the release authority guard failing against a sha nothing builds. After the move a tree-wide `git grep` for the old sha returns nothing and the new one is present in all three files, with the guard script run as the positive control.

`kin-vfs-core` moves `=0.4.13` to `=0.4.14` in the same breath, because `release.yml` refuses a tag where Kin resolves one version and the pinned checkout builds another. The crate itself did not change in #124. The bump is the workspace version the shim's own release gate required. The lock entry keeps its `sparse+` source and its checksum, and the change was gated `--locked` rather than through DEV-LOCAL, which cannot validate a pin because it replaces the crate under test with a local path.

## The note

The gap is real and stays named, aimed at the class that still has it rather than at Node. The shim interposes libc, so what it cannot project is a binary that reaches the kernel without libc at all. A static Go binary (`CGO_ENABLED=0`) read both the stat and the bytes from disk under the fixed shim while coreutils `stat` failed `EIO` in the same container. That class has no symbol to interpose and belongs to the `nfs` and `fuse` mounts.

`kin doctor` now carries the limit too. Its projection row was green and silent about it, so a reader who ran doctor, saw a green projection and stopped had no way to learn the limit existed without knowing to run `kin vfs status`. It rides `platform_note`, so a mode's limit never moves the status and never blocks readiness, and the mount control asserts the note stays attached to the mode rather than to the row.

## Falsification

Each of the three note tests asserts the old sentence is **gone**, not merely that a new one is present, because a note that regains Node is the failure being guarded.

- `the_status_block_declares_the_shim_raw_syscall_gap_and_only_there` requires the note to name `libc` and `Go` while carrying no trace of "Node is not projected". It also requires the note to be absent under every mount mode.
- `a_green_shim_row_names_the_limit_and_a_green_mount_row_has_none` requires the doctor row to stay `Healthy` while carrying the limit, and never to block readiness. Its control requires a green **mount** row to carry `platform_note == None`, which an unconditional note would fail.
- `vfs_status_names_the_bound_root_and_refuses_to_call_an_unserved_one_in_force` requires the rendered status block to carry the new sentence and not the old one.

## Gates

`cargo fmt --all -- --check` clean. `cargo test -p kin-cli --lib projection` 41 passed, the new doctor-row test passed on its own name, `cargo test -p kin-cli --test projection_modes` 15 passed, and `python3 scripts/test-release-workflow-authority.py` exits 0 after the pin move. The `bin/kin-parity` verdict and the clippy leg go in a comment when they finish, because the host is carrying ten lanes at load 127 and the build is being starved rather than failing. Hosted CI is the gate of record for the full workspace and for the pin, which DEV-LOCAL cannot validate anyway.

## Not claiming

This does not close every bypass, and that is why the note is corrected rather than deleted. The measurements cover one Node version, one libc and one architecture, so a musl target, a different libuv, or a Node that gained an io_uring fs path is outside them. io_uring itself was measured and is not currently in play. Node creates rings under `seccomp=unconfined` on kernel 6.12 but does not route these fs operations through them, so the libc hooks still fire on both the sync and async legs. That is a monitored risk rather than a closed one, and kin-vfs#124's check asserts that Node and libc agree rather than asserting a mechanism, so a future bypass trips it without being named in advance.
