### PR TITLE
Keep a scratch KIN_HOME from reading the operator's repository registry

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -123,6 +123,16 @@ jobs:
       - name: Falsify the init-memory graders
         run: python3 scripts/acceptance/init_memory_repro.py --self-test
 
+      # FIR-2467. A scratch KIN_HOME is meant to be a sealed world, and the
+      # cross-repo registry used to sit outside it, so a fixture daemon pinned
+      # sibling authority for every repository on the operator's machine. The
+      # graders here decide whether a view is sealed, and every one of them is
+      # paired with the input that must produce the opposite verdict: two of
+      # these cases were added because a mutation that deleted a whole branch
+      # of the grader left the self-test green.
+      - name: Falsify the registry isolation graders
+        run: python3 scripts/acceptance/registry_home_isolation.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -398,6 +408,34 @@ jobs:
             echo "::error title=Init-memory acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
+      - name: Registry home isolation suite
+        id: registryisolation
+        if: always()
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/registry_home_isolation.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/registry_isolation.json \
+            --label "$KIN_ACCEPTANCE_LABEL" \
+            --verbose >acceptance/registry_isolation.log 2>&1 || rc=$?
+          cat acceptance/registry_isolation.log
+          {
+            echo "### Registry home isolation suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/registry_isolation.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=Registry home isolation suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
+          fi
+
       # Always, including on a cancelled or timed-out run: the reports are how a
       # failure is diagnosed without re-running the job.
       - name: Upload the acceptance reports
@@ -427,4 +465,5 @@ jobs:
             --report parsehole=acceptance/parsehole.json \
             --report memory_pressure=acceptance/memory_pressure.json \
             --report initmemory=acceptance/initmemory.json \
+            --report registry_isolation=acceptance/registry_isolation.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk comes back truncated=True with clipped_steps=None on ubuntu-latest, so an absent edge cannot be told from a dropped one. Build profile, product code from 0.5.44 through 0.5.46, and the pinned language-server versions are all ruled out; platform and code newer than 0.5.46 are still confounded. The moment the check passes this allowance announces itself stale and can go.'

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -799,10 +799,11 @@ fn current_repo_status() -> Option<CurrentRepoStatus> {
 
 /// Which daemons a `--all` sweep is entitled to stop.
 ///
-/// The supervisor is a machine-level singleton: its directory hangs off
-/// `registry_path()`, which resolves from the real home, while `KIN_HOME` moves
-/// only store and install state. One supervisor therefore holds daemons from
-/// several managed homes, and an unscoped `--all` reaches every one of them.
+/// The supervisor is a machine-level singleton: its directory comes from
+/// `supervisor_root()`, which resolves from the real home, while `KIN_HOME`
+/// moves store and install state, the cross-repo registry included. One
+/// supervisor therefore holds daemons from several managed homes, and an
+/// unscoped `--all` reaches every one of them.
 /// That is how a pinned session stopped daemons it did not own.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StopScope {

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -3470,10 +3470,7 @@ where
 }
 
 fn supervisor_dir() -> PathBuf {
-    kin_core::registry::registry_path()
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from(".kin"))
+    kin_core::registry::supervisor_root()
 }
 
 const SUPERVISOR_PID_FILE: &str = "supervisor.pid";

--- a/crates/kin-core/src/layout.rs
+++ b/crates/kin-core/src/layout.rs
@@ -365,8 +365,13 @@ impl KinLayout {
     }
 }
 
-/// The global home Kin directory `~/.kin` — the cross-repo registry/cache root,
-/// not a servable repo. Returns `None` when no home directory is resolvable.
+/// The real home's `.kin`, which is an install-root identity rather than a
+/// servable repo. Returns `None` when no home directory is resolvable.
+///
+/// It is not where the cross-repo registry necessarily lives. That file follows
+/// [`crate::registry::managed_kin_home`], so this directory holds it only when
+/// `KIN_HOME` is unset. Callers here are asking what a directory *is*, not
+/// where to read the registry.
 pub fn global_home_kin_dir() -> Option<PathBuf> {
     directories::BaseDirs::new().map(|dirs| dirs.home_dir().join(".kin"))
 }

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -1594,11 +1594,24 @@ fn write_registry_atomically(
 /// machine-level singleton and comes from [`supervisor_root`]; see
 /// [`managed_kin_home`] for the boundary each variable actually draws.
 pub fn registry_path() -> PathBuf {
-    if let Some(path) = std::env::var_os("KIN_REGISTRY_PATH") {
+    resolve_registry_path(|key| std::env::var_os(key), managed_kin_home)
+}
+
+/// The policy behind [`registry_path`], with the environment and the managed
+/// home taken as arguments.
+///
+/// Taking both by argument is what lets the split between this and
+/// [`resolve_supervisor_root`] be proven from one fixed environment, rather than
+/// by mutating a process-global table that every other test also reads.
+pub(crate) fn resolve_registry_path(
+    var_os: impl Fn(&str) -> Option<std::ffi::OsString>,
+    managed_home: impl FnOnce() -> PathBuf,
+) -> PathBuf {
+    if let Some(path) = var_os("KIN_REGISTRY_PATH") {
         return PathBuf::from(path);
     }
 
-    managed_kin_home().join("registry.toml")
+    managed_home().join("registry.toml")
 }
 
 /// Directory of the machine-level daemon supervisor.
@@ -2644,18 +2657,103 @@ mod tests {
         );
     }
 
-    /// The distinction the supervisor scoping contract rests on: a pinned
-    /// `KIN_HOME` moves the managed home while the supervisor's own directory,
-    /// which hangs off [`registry_path`], stays put.
-    #[test]
-    fn pinning_kin_home_does_not_move_the_registry_path() {
-        let pinned = managed_home_with(false, &[("KIN_HOME", "/scratch/home")]);
-        let unpinned = managed_home_with(false, &[]);
-        assert_ne!(pinned, unpinned);
+    /// A fake environment, so the split below is proven without writing to the
+    /// process-global table every other test in this binary also reads.
+    fn fake_env(env: &[(&str, &str)]) -> impl Fn(&str) -> Option<std::ffi::OsString> {
+        let owned: Vec<(String, String)> = env
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |key| {
+            owned
+                .iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| std::ffi::OsString::from(value))
+        }
+    }
 
-        // `registry_path` reads only `KIN_REGISTRY_PATH` and the real home, so
-        // no value of `KIN_HOME` can appear in it.
-        assert!(!registry_path().starts_with("/scratch/home"));
+    /// The split this seam exists to draw, read from one fixed environment: a
+    /// pinned `KIN_HOME` moves the registry with the rest of the store, and does
+    /// not move the machine-level supervisor.
+    ///
+    /// FIR-2467. Before this, both hung off the real home, so a daemon under a
+    /// scratch home pinned sibling authority for every repository on the box.
+    #[test]
+    fn pinning_kin_home_moves_the_registry_and_not_the_supervisor() {
+        let env = [("KIN_HOME", "/scratch/home")];
+        let managed = managed_home_with(false, &env);
+        assert_eq!(managed, PathBuf::from("/scratch/home"));
+
+        let registry = resolve_registry_path(fake_env(&env), || managed.clone());
+        assert_eq!(registry, PathBuf::from("/scratch/home/registry.toml"));
+
+        let supervisor =
+            resolve_supervisor_root(fake_env(&env), || Some(PathBuf::from("/base-home")));
+        assert_eq!(supervisor, PathBuf::from("/base-home/.kin"));
+        assert!(!supervisor.starts_with("/scratch/home"));
+    }
+
+    /// With no `KIN_HOME`, the two land where they always did: side by side in
+    /// the real home. The default install is the case this fix must not move.
+    #[test]
+    fn an_unpinned_home_keeps_the_registry_beside_the_supervisor() {
+        let managed = managed_home_with(false, &[]);
+        assert_eq!(managed, PathBuf::from("/base-home/.kin"));
+
+        let registry = resolve_registry_path(fake_env(&[]), || managed.clone());
+        let supervisor =
+            resolve_supervisor_root(fake_env(&[]), || Some(PathBuf::from("/base-home")));
+
+        assert_eq!(registry, PathBuf::from("/base-home/.kin/registry.toml"));
+        assert_eq!(supervisor, PathBuf::from("/base-home/.kin"));
+        assert_eq!(registry.parent(), Some(supervisor.as_path()));
+    }
+
+    /// `KIN_REGISTRY_PATH` still names the file outright and still carries the
+    /// supervisor to its parent, which is how every isolated harness in this
+    /// fleet pins both today.
+    #[test]
+    fn an_explicit_registry_path_still_carries_the_supervisor() {
+        let env = [
+            ("KIN_REGISTRY_PATH", "/pinned/dir/registry.toml"),
+            ("KIN_HOME", "/scratch/home"),
+        ];
+        assert_eq!(
+            resolve_registry_path(fake_env(&env), || PathBuf::from("/scratch/home")),
+            PathBuf::from("/pinned/dir/registry.toml")
+        );
+        assert_eq!(
+            resolve_supervisor_root(fake_env(&env), || Some(PathBuf::from("/base-home"))),
+            PathBuf::from("/pinned/dir")
+        );
+    }
+
+    /// The edge answers the previous `registry_path().parent()` derivation
+    /// produced, kept exactly rather than tidied.
+    ///
+    /// A bare filename's parent is the empty path, not `.kin`: only an empty
+    /// `KIN_REGISTRY_PATH`, whose parent is `None`, ever reached that fallback.
+    /// Both are odd, and both are what shipped, so both are asserted here. This
+    /// test is the reason to believe the supervisor did not move: it failed on
+    /// the first run, against an expectation that had guessed rather than read.
+    #[test]
+    fn the_supervisor_keeps_its_old_answers_at_the_edges() {
+        assert_eq!(
+            resolve_supervisor_root(fake_env(&[("KIN_REGISTRY_PATH", "registry.toml")]), || {
+                Some(PathBuf::from("/base-home"))
+            }),
+            PathBuf::from("")
+        );
+        assert_eq!(
+            resolve_supervisor_root(fake_env(&[("KIN_REGISTRY_PATH", "")]), || Some(PathBuf::from(
+                "/base-home"
+            ))),
+            PathBuf::from(".kin")
+        );
+        assert_eq!(
+            resolve_supervisor_root(fake_env(&[]), || None),
+            PathBuf::from("./.kin")
+        );
     }
 
     #[test]

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! Global Kin registry at `~/.kin/registry.toml`.
+//! Cross-repo Kin registry at `<managed Kin home>/registry.toml`.
 //!
 //! Lets MCP servers and cross-repo queries discover all Kin repositories on
-//! disk regardless of where they live.
+//! disk regardless of where they live. The file is store state, so `KIN_HOME`
+//! bounds it like the rest of the store: see [`registry_path`].
 
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
@@ -180,7 +181,7 @@ pub struct RegisteredRepo {
 }
 
 impl KinRegistry {
-    /// Load from `~/.kin/registry.toml`, or return empty if it doesn't exist.
+    /// Load from [`registry_path`], or return empty if it doesn't exist.
     ///
     /// Acquires a shared (read) lock to prevent reading a partially-written file.
     pub fn load() -> Result<Self, Box<dyn std::error::Error>> {
@@ -208,7 +209,7 @@ impl KinRegistry {
         }
     }
 
-    /// Save to `~/.kin/registry.toml`.
+    /// Save to [`registry_path`].
     ///
     /// Acquires an exclusive lock, writes atomically (tmp → rename).
     pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
@@ -241,7 +242,7 @@ impl KinRegistry {
         }
     }
 
-    /// Update `~/.kin/registry.toml` under one exclusive read-modify-write lock.
+    /// Update [`registry_path`] under one exclusive read-modify-write lock.
     ///
     /// Registry writers must use this API instead of a separate `load` followed
     /// by `save`; keeping the lock across the caller's mutation prevents one
@@ -1579,30 +1580,71 @@ fn write_registry_atomically(
     Ok(())
 }
 
-/// `~/.kin/registry.toml` path (cross-platform).
+/// The cross-repo registry this process is bounded by: `KIN_REGISTRY_PATH`, or
+/// `registry.toml` inside the managed Kin home.
 ///
-/// This also fixes the supervisor directory, which is this path's parent. That
-/// makes the supervisor a machine-level singleton keyed on the real home (or an
-/// explicit `KIN_REGISTRY_PATH`), deliberately *not* on `KIN_HOME`: see
+/// The registry is store state, so it honors `KIN_HOME` exactly as the rest of
+/// the store does. A process pinned to a scratch home discovers only the
+/// repositories that home registered, and the operator's real registry is
+/// reachable only from the real home. Without that, a fixture daemon under a
+/// scratch home pinned sibling authority for every repository on the box, so
+/// tests observed machine state and could be perturbed by it.
+///
+/// The supervisor directory is deliberately *not* this path's parent. It is a
+/// machine-level singleton and comes from [`supervisor_root`]; see
 /// [`managed_kin_home`] for the boundary each variable actually draws.
 pub fn registry_path() -> PathBuf {
     if let Some(path) = std::env::var_os("KIN_REGISTRY_PATH") {
         return PathBuf::from(path);
     }
 
-    directories::BaseDirs::new()
-        .map(|b| b.home_dir().to_path_buf())
+    managed_kin_home().join("registry.toml")
+}
+
+/// Directory of the machine-level daemon supervisor.
+///
+/// Keyed on the real home, or on the parent of an explicit `KIN_REGISTRY_PATH`,
+/// deliberately *not* on `KIN_HOME`. One supervisor holds daemons launched under
+/// several managed homes, so every daemon records [`managed_kin_home`] and the
+/// census partitions on it. Moving the supervisor with `KIN_HOME` would hide
+/// from a pinned session the daemons it shares the box with, which is the
+/// opposite of what that variable is for.
+pub fn supervisor_root() -> PathBuf {
+    resolve_supervisor_root(
+        |key| std::env::var_os(key),
+        || directories::BaseDirs::new().map(|b| b.home_dir().to_path_buf()),
+    )
+}
+
+/// The policy behind [`supervisor_root`], with the environment and the OS home
+/// lookup taken as arguments.
+///
+/// This reproduces, case for case, what the supervisor directory was before the
+/// registry moved into the managed home: the parent of an explicit
+/// `KIN_REGISTRY_PATH`, or `<real home>/.kin`.
+pub(crate) fn resolve_supervisor_root(
+    var_os: impl Fn(&str) -> Option<std::ffi::OsString>,
+    base_dirs_home: impl FnOnce() -> Option<PathBuf>,
+) -> PathBuf {
+    if let Some(path) = var_os("KIN_REGISTRY_PATH") {
+        return PathBuf::from(path)
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from(".kin"));
+    }
+
+    base_dirs_home()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".kin")
-        .join("registry.toml")
 }
 
 /// The managed Kin install root this process resolves: `KIN_HOME`, then the
 /// `KIN_DIR` compatibility alias, then `<home>/.kin`.
 ///
 /// This is the boundary `KIN_HOME` genuinely draws. It bounds store and install
-/// state; it does not move the supervisor, whose directory comes from
-/// [`registry_path`] and therefore from the real home. One supervisor can
+/// state, the cross-repo [`registry_path`] included; it does not move the
+/// supervisor, whose directory comes from [`supervisor_root`] and therefore
+/// from the real home. One supervisor can
 /// consequently hold daemons launched under several managed homes, so every
 /// daemon records the value this returns and the census partitions on it.
 ///

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -2745,9 +2745,9 @@ mod tests {
             PathBuf::from("")
         );
         assert_eq!(
-            resolve_supervisor_root(fake_env(&[("KIN_REGISTRY_PATH", "")]), || Some(PathBuf::from(
-                "/base-home"
-            ))),
+            resolve_supervisor_root(fake_env(&[("KIN_REGISTRY_PATH", "")]), || Some(
+                PathBuf::from("/base-home")
+            )),
             PathBuf::from(".kin")
         );
         assert_eq!(

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -187,10 +187,7 @@ impl SupervisorState {
 }
 
 fn supervisor_dir() -> PathBuf {
-    kin_core::registry::registry_path()
-        .parent()
-        .map(std::path::Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from(".kin"))
+    kin_core::registry::supervisor_root()
 }
 
 #[derive(Debug)]

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -1,7 +1,7 @@
 # Product acceptance suites
 
-Six falsifiable suites that ask whether the product still answers correctly.
-`.github/workflows/acceptance.yml` runs all six on every pull request against
+Seven falsifiable suites that ask whether the product still answers correctly.
+`.github/workflows/acceptance.yml` runs all seven on every pull request against
 that pull request's own build. None is release proof; all are regression gates.
 
 Each suite prints one line per check:
@@ -98,13 +98,25 @@ every counter on every surface keeps reporting the unenriched files as pending
 work, so each check grades the refusal and the disclosure together and pairs
 both with an unpressured control (FIR-2614).
 
+`init_memory_repro.py` covers what a brownfield conversion holds while it runs.
+A full-history `psf/requests` conversion measured 11.72 GiB of resident set
+inside a 12 GiB container, because proving an import plan rebuilt the whole plan
+from raw objects and compared the two, holding several whole histories at once
+(FIR-2539). No functional test can see that class: a re-derivation that
+materializes a second copy returns the same verdict as one that streams it. The
+suite drives the live-heap guard in `crates/kin-core/tests/` and grades what
+proof 1 adds to the running peak, through a counting allocator rather than
+resident set, because RSS keeps counting freed pages and inside a memory-limited
+container both a fixed and an unfixed build report the ceiling rather than their
+demand.
+
 `registry_home_isolation.py` covers the boundary `KIN_HOME` is supposed to draw.
 The cross-repo registry is store state, and it used to sit outside that boundary
 because the registry file's parent doubled as the machine-level supervisor
 directory, so a daemon under a scratch home read the operator's registry and
 pinned sibling authority for every repository on the box (FIR-2467). The suite
 builds two homes, registers repositories into each, and asks `kin deps`, `kin
-registry list` and a scratch-home daemon's own log what they can see. Every check
+registry` and a scratch-home daemon's own log what they can see. Every check
 carries the control that keeps it from passing for the wrong reason, including
 one that requires an unbindable sibling in the scratch home to still draw the pin
 warning, so a sealed reading is a sealed daemon and not a daemon that stopped

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -1,7 +1,7 @@
 # Product acceptance suites
 
-Four falsifiable suites that ask whether the product still answers correctly.
-`.github/workflows/acceptance.yml` runs all four on every pull request against
+Six falsifiable suites that ask whether the product still answers correctly.
+`.github/workflows/acceptance.yml` runs all six on every pull request against
 that pull request's own build. None is release proof; all are regression gates.
 
 Each suite prints one line per check:
@@ -91,6 +91,30 @@ does not fit has to say so in `degradations`. A ceiling is not always reachable,
 because every cut list keeps a floor entry, and that case is fine as long as it is
 never quiet.
 
+`memory_pressure_refusal.py` covers the back-off Kin owes a machine it is
+running on, and the disclosure it owes the person running it. A daemon that
+quietly stopped sweeping would look identical to one that had finished, since
+every counter on every surface keeps reporting the unenriched files as pending
+work, so each check grades the refusal and the disclosure together and pairs
+both with an unpressured control (FIR-2614).
+
+`registry_home_isolation.py` covers the boundary `KIN_HOME` is supposed to draw.
+The cross-repo registry is store state, and it used to sit outside that boundary
+because the registry file's parent doubled as the machine-level supervisor
+directory, so a daemon under a scratch home read the operator's registry and
+pinned sibling authority for every repository on the box (FIR-2467). The suite
+builds two homes, registers repositories into each, and asks `kin deps`, `kin
+registry list` and a scratch-home daemon's own log what they can see. Every check
+carries the control that keeps it from passing for the wrong reason, including
+one that requires an unbindable sibling in the scratch home to still draw the pin
+warning, so a sealed reading is a sealed daemon and not a daemon that stopped
+pinning anything. Check 3 asserts the other half: the registry moves with
+`KIN_HOME` and the supervisor does not, because one supervisor holds daemons from
+several managed homes and following `KIN_HOME` would hide from a pinned session
+the daemons it shares the box with. Every probe leaves `KIN_REGISTRY_PATH` unset
+on purpose, since an explicit pin wins on both sides of that fix and a probe that
+kept one could not fail.
+
 `brownfield_repro.py --self-test` and `response_budget_elisions.py --self-test`
 exercise their verdict graders on fixed payloads and need no binary and no
 corpus. Each case is paired with its inverse, so a grader that cannot tell its
@@ -116,6 +140,10 @@ python3 scripts/acceptance/brownfield_repro.py \
 python3 scripts/acceptance/response_budget_elisions.py \
   --kin target/release/kin --daemon target/release/kin-daemon \
   --json acceptance/response_budget.json --verbose
+
+python3 scripts/acceptance/registry_home_isolation.py \
+  --kin target/release/kin --daemon target/release/kin-daemon \
+  --json acceptance/registry_isolation.json --verbose
 ```
 
 Release, not debug. Release is what ships, so it is what an acceptance answer
@@ -129,7 +157,9 @@ walked whole (FIR-2593).
 REGRESSION rather than plain FAIL. `brownfield_repro.py` also takes `--offline`,
 which refuses to fetch and requires the corpus cache to already carry both pinned
 commits. `response_budget_elisions.py` builds its own fixture, fetches nothing,
-and takes `--workdir` and `--verbose`.
+and takes `--workdir` and `--verbose`. `registry_home_isolation.py` builds both
+of its homes and all four of its repositories itself, fetches nothing, and takes
+`--keep` and `--verbose`.
 
 The magic suite's fixtures commit through kin, and kin refuses to invent an
 author, so the machine running them needs a git identity. That refusal is

--- a/scripts/acceptance/registry_home_isolation.py
+++ b/scripts/acceptance/registry_home_isolation.py
@@ -1,0 +1,816 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""NON-CITABLE acceptance suite for KIN_HOME registry isolation (FIR-2467).
+
+Its output is a regression gate, never proof, never investor-facing and never a
+released claim. It shares the CHECK line format, the exit codes and the
+`--self-test` discipline of its siblings in this directory, so a reader who
+knows one knows all of them.
+
+What it is for
+--------------
+KIN_HOME is the boundary that bounds store state, and the cross-repo registry is
+store state. It did not used to behave that way. The registry file's parent
+directory doubled as the machine-level supervisor directory, so keying the
+supervisor on the real home kept the registry there too, and a daemon launched
+under a scratch KIN_HOME read the operator's registry and pinned sibling
+authority for every repository on the box.
+
+That is an isolation leak in both directions. A fixture observes machine state
+it cannot control and cannot reproduce, and the machine's repository set leaks
+into an environment whose whole purpose was to be sealed.
+
+The two homes this suite builds
+-------------------------------
+A throwaway HOME stands in for the operator's real home, and a separate
+directory is the scratch KIN_HOME. Repositories are registered into one or the
+other, then queried from the scratch home with KIN_REGISTRY_PATH deliberately
+UNSET, because an explicit registry pin wins on both sides of this fix and a
+probe that set one would be asking a question it could not fail.
+
+The outsider is registered with KIN_REGISTRY_PATH pinned at the throwaway home's
+registry rather than by leaning on HOME resolution, so the operator's own
+registry is never a possible target of a write no matter how a platform resolves
+its home directory.
+
+Every check is paired with its control, because a build that had simply stopped
+answering would pass the sealed half of every one of them.
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+UNREADABLE is a distinct outcome from FAIL and is never reported as a pass: it
+means the probe could not be evaluated (no output, a non-JSON payload, a field
+this build does not define). A crashed probe is UNREADABLE, never a verdict.
+Exit status is 1 when any check FAILs, 2 when none fail but some are UNREADABLE,
+0 only when every check passes, 3 on a setup error.
+
+The binary under test
+---------------------
+    cargo build --release --locked --bin kin --bin kin-daemon
+    python3 scripts/acceptance/registry_home_isolation.py --kin target/release/kin
+
+`--kin` may also come from KIN_BIN. The kin-daemon beside it is used when one
+exists. No binary is built by this script.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+TICKET = "FIR-2467"
+
+# The daemon names a sibling it could not pin with this line. It is the exact
+# symptom FIR-2467 was filed on: a scratch-home daemon printing one of these for
+# every repository on the operator's machine.
+PIN_WARNING = "sibling repository authority could not be pinned at daemon startup"
+
+REGISTRY_ID = re.compile(r'^\s*id\s*=\s*"([^"]+)"', re.M)
+REGISTRY_PATH = re.compile(r'^\s*path\s*=\s*"([^"]+)"', re.M)
+# Daemon logs carry ANSI escapes between a field name and its value, so a
+# byte-level match for `repo_id=outsider` never fires on a coloured log.
+ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def strip_ansi(text):
+    return ANSI.sub("", text or "")
+
+
+def tail(text, limit=400):
+    """The END of a command's output, which is where its error is."""
+    text = (text or "").strip()
+    return text if len(text) <= limit else "..." + text[-limit:]
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    proc = subprocess.run(
+        cmd, cwd=cwd, env=env, timeout=timeout,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    return proc.returncode, proc.stdout
+
+
+def registry_entries(path):
+    """Every id-to-path pair a registry file names, or None when unreadable.
+
+    None and the empty mapping are different answers. A registry that is missing
+    or unparseable cannot ground a claim that something is absent from it, which
+    is the whole claim this suite makes.
+    """
+    try:
+        with open(path) as handle:
+            text = handle.read()
+    except (IOError, OSError):
+        return None
+    entries = {}
+    for block in text.split("[[repos]]")[1:]:
+        ids = REGISTRY_ID.findall(block)
+        paths = REGISTRY_PATH.findall(block)
+        if ids and paths:
+            entries[ids[0]] = paths[0]
+    return entries
+
+
+def id_for_path(entries, path):
+    """The id a registry gave one repository path, or None."""
+    wanted = os.path.realpath(path)
+    for repo_id, recorded in (entries or {}).items():
+        if os.path.realpath(recorded) == wanted:
+            return repo_id
+    return None
+
+
+def deps_ids(output):
+    """Repo ids from `kin deps --all --json`, or None when it will not parse."""
+    try:
+        payload = json.loads(output)
+    except ValueError:
+        return None
+    repositories = payload.get("repositories")
+    if not isinstance(repositories, list):
+        return None
+    ids = set()
+    for repo in repositories:
+        if not isinstance(repo, dict) or "id" not in repo:
+            return None
+        ids.add(str(repo["id"]))
+    return ids
+
+
+def listed_ids(output):
+    """Repo ids from the `kin registry list` text surface, or None.
+
+    The empty-registry line is a readable answer meaning no repositories, which
+    is not the same as a surface that could not be read at all.
+    """
+    text = strip_ansi(output or "")
+    if "No registered repositories." in text:
+        return set()
+    if "Registered repositories:" not in text:
+        return None
+    ids = set()
+    for line in text.splitlines():
+        if not line.startswith("  ") or not line.strip():
+            continue
+        fields = line.split()
+        if len(fields) >= 2 and fields[1].isdigit():
+            ids.add(fields[0])
+    return ids
+
+
+class Result(object):
+    def __init__(self, check_id, ticket, title):
+        self.id = check_id
+        self.ticket = ticket
+        self.title = title
+        self.asserts = []
+
+    def ok(self, detail):
+        self.asserts.append({"status": PASS, "detail": detail})
+
+    def bad(self, detail):
+        self.asserts.append({"status": FAIL, "detail": detail})
+
+    def unknown(self, detail):
+        self.asserts.append({"status": UNREADABLE, "detail": detail})
+
+    @property
+    def status(self):
+        graded = [a for a in self.asserts if a["status"] in (PASS, FAIL, UNREADABLE)]
+        if any(a["status"] == FAIL for a in graded):
+            return FAIL
+        if any(a["status"] == UNREADABLE for a in graded):
+            return UNREADABLE
+        if not graded:
+            return UNREADABLE
+        return PASS
+
+    @property
+    def detail(self):
+        for wanted in (FAIL, UNREADABLE):
+            for a in self.asserts:
+                if a["status"] == wanted:
+                    return a["detail"]
+        # Every passing assertion, not the last one. Each check grades the
+        # sealed case AND its control, and a line naming only the control would
+        # read as a pass for a suite that never probed the case it exists for.
+        graded = [a["detail"] for a in self.asserts if a["status"] == PASS]
+        return "; ".join(graded) if graded else "no assertion was reached"
+
+
+# ---------------------------------------------------------------------- suite
+
+class Suite(object):
+    """Two homes, four repositories, and one question asked from the scratch one.
+
+    `real_home` stands in for the operator's home directory and is where the
+    outsider is registered. `scratch_home` is the KIN_HOME every probe runs
+    under. Nothing in this suite ever writes to the machine's own home.
+    """
+
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.real_home = os.path.join(workdir, "real-home-%d" % os.getpid())
+        self.scratch_home = os.path.join(workdir, "kin-home-%d" % os.getpid())
+        os.makedirs(os.path.join(self.real_home, ".kin"), exist_ok=True)
+        os.makedirs(self.scratch_home, exist_ok=True)
+
+        base = dict(os.environ)
+        # A scratch KIN_HOME keeps this run off the fleet's stores and the
+        # auto-embed opt-out keeps it off the GPU. Neither is a nicety: this
+        # suite is meant to run on every pull request beside other work.
+        base["KIN_DAEMON_AUTO_EMBED"] = "0"
+        base["KIN_EMBED_BACKEND"] = "cpu"
+        base["KIN_VFS_DISABLE"] = "1"
+        base["HOME"] = self.real_home
+        base.pop("KIN_MCP_REPO", None)
+        base.pop("KIN_DIR", None)
+        if daemon:
+            base["KIN_DAEMON_BIN"] = daemon
+
+        # The environment under test. KIN_REGISTRY_PATH is removed rather than
+        # merely left alone: an inherited pin wins on both sides of this fix,
+        # so a probe that kept one would be asking a question it could not fail.
+        self.env = dict(base)
+        self.env["KIN_HOME"] = self.scratch_home
+        self.env.pop("KIN_REGISTRY_PATH", None)
+
+        # The stand-in for the operator's home. The registry is named outright
+        # here so the write lands in the throwaway home whatever a platform
+        # believes the home directory is.
+        self.real_registry = os.path.join(self.real_home, ".kin", "registry.toml")
+        self.real_env = dict(base)
+        self.real_env["KIN_HOME"] = os.path.join(self.real_home, ".kin")
+        self.real_env["KIN_REGISTRY_PATH"] = self.real_registry
+
+        self.scratch_registry = os.path.join(self.scratch_home, "registry.toml")
+        self.repos = {}
+
+    # -- fixture construction
+
+    def git(self, args, cwd):
+        base = ["git",
+                "-c", "core.hooksPath=/dev/null",
+                "-c", "user.email=repro@example.invalid",
+                "-c", "user.name=kin-registry-isolation-repro",
+                "-c", "commit.gpgsign=false"]
+        return run(base + args, cwd=cwd, env=self.env)
+
+    def fixture(self, name, env):
+        """A small Python library, admitted through `kin init` under `env`.
+
+        The repository is registered by the product's own registration path
+        rather than by writing a registry file, so what this suite seals is the
+        thing a real `kin init` produces.
+        """
+        if name in self.repos:
+            return self.repos[name]
+        repo = os.path.join(self.workdir, name)
+        os.makedirs(os.path.join(repo, "pkg"), exist_ok=True)
+        rc, out = self.git(["init", "--initial-branch=main"], repo)
+        if rc != 0:
+            raise RuntimeError("git init failed in %s: %s" % (repo, tail(out)))
+        for index in range(3):
+            with open(os.path.join(repo, "pkg", "module%d.py" % index), "w") as handle:
+                handle.write(
+                    "def handler%d(payload):\n"
+                    "    \"\"\"Return the payload unchanged.\"\"\"\n"
+                    "    return payload\n" % index
+                )
+        self.git(["add", "--all"], repo)
+        rc, out = self.git(["commit", "-m", "a python library"], repo)
+        if rc != 0:
+            raise RuntimeError("git commit failed in %s: %s" % (repo, tail(out)))
+        rc, out = run([self.kin, "init"], cwd=repo, env=env, timeout=900)
+        if rc != 0:
+            raise RuntimeError("kin init failed in %s: %s" % (repo, tail(out)))
+        self.repos[name] = repo
+        return repo
+
+    def stop_daemon(self, repo, env):
+        run([self.kin, "daemon", "stop"], cwd=repo, env=env, timeout=180)
+
+    def unbind(self, repo, env):
+        """Stop this repository's daemon, then take its `.kin` away.
+
+        A registered repository whose store is gone is one whose authority
+        cannot be pinned, which is what makes the daemon say so. The daemon is
+        stopped first because a running worker holds the store it serves.
+        """
+        self.stop_daemon(repo, env)
+        shutil.rmtree(os.path.join(repo, ".kin"), ignore_errors=True)
+
+    def setup(self):
+        """Build both homes and leave the registries in their final state."""
+        self.probe = self.fixture("probe", self.env)
+        self.roommate = self.fixture("roommate", self.env)
+        stranger = self.fixture("stranger", self.env)
+        outsider = self.fixture("outsider", self.real_env)
+        self.unbind(stranger, self.env)
+        self.unbind(outsider, self.real_env)
+        self.stop_daemon(self.roommate, self.env)
+
+    # -- probes
+
+    def kin_run(self, args, repo=None, timeout=600):
+        return run([self.kin] + args, cwd=repo or self.probe, env=self.env, timeout=timeout)
+
+    def daemon_log(self):
+        return os.path.join(self.probe, ".kin", "daemon.log")
+
+    def restart_probe_daemon(self):
+        """A daemon that read the registry in its FINAL state, and only that.
+
+        Authority pinning happens once, at daemon startup, so a worker started
+        before the fixtures were finished would have read a different registry.
+        The log is truncated between the stop and the start so what it holds is
+        this startup's and not an earlier one's.
+        """
+        self.stop_daemon(self.probe, self.env)
+        try:
+            with open(self.daemon_log(), "w"):
+                pass
+        except (IOError, OSError):
+            pass
+        return self.kin_run(["graph", "status"])
+
+    def read_daemon_log(self):
+        try:
+            with open(self.daemon_log(), errors="replace") as handle:
+                return strip_ansi(handle.read())
+        except (IOError, OSError):
+            return None
+
+
+# --------------------------------------------------------------------- checks
+
+def homes(suite, res):
+    """Both registries, or None when either cannot ground an absence claim."""
+    scratch = registry_entries(suite.scratch_registry)
+    real = registry_entries(suite.real_registry)
+    if scratch is None:
+        res.unknown("the scratch home's registry at %s could not be read, so no "
+                    "claim about what it does or does not name is grounded"
+                    % suite.scratch_registry)
+        return None
+    if real is None:
+        res.unknown("the stand-in home's registry at %s could not be read, so "
+                    "there is no foreign repository to be sealed from"
+                    % suite.real_registry)
+        return None
+    foreign = set(real) - set(scratch)
+    if not foreign:
+        res.unknown("the stand-in home's registry names nothing the scratch home "
+                    "does not, so a sealed reading below would be vacuous")
+        return None
+    return scratch, real, foreign
+
+
+def grade_view(res, surface, seen, scratch, foreign, roommate_id):
+    """Grade one cross-repo surface's repo-id set against both homes."""
+    if seen is None:
+        res.unknown("%s could not be read as a repository listing" % surface)
+        return
+    leaked = seen & foreign
+    if leaked:
+        res.bad("%s under the scratch KIN_HOME names %d repository id(s) "
+                "registered only in the operator's home: %s"
+                % (surface, len(leaked), ", ".join(sorted(leaked))))
+    else:
+        stray = seen - set(scratch)
+        if stray:
+            res.bad("%s under the scratch KIN_HOME names %d repository id(s) this "
+                    "run never registered anywhere: %s"
+                    % (surface, len(stray), ", ".join(sorted(stray))))
+        else:
+            res.ok("%s named %d id(s), all of them this scratch home's own, and "
+                   "none of the %d registered only in the operator's home"
+                   % (surface, len(seen), len(foreign)))
+    # The control. Without it, a surface that had simply stopped answering would
+    # pass the sealed assertion above for the wrong reason.
+    if roommate_id is None:
+        res.unknown("the scratch home's registry names no id for the roommate "
+                    "repository, so this surface's control cannot be graded")
+    elif roommate_id in seen:
+        res.ok("control: the sibling registered in the SCRATCH home (%s) still "
+               "resolves on the same surface" % roommate_id)
+    else:
+        res.bad("control: the sibling registered in the SCRATCH home (%s) does "
+                "not resolve, so this surface is sealed by being empty rather "
+                "than by honouring KIN_HOME" % roommate_id)
+
+
+def check_0(suite):
+    """`kin deps --all` under a scratch KIN_HOME sees only that home's repos."""
+    res = Result("0", TICKET, "kin deps is bounded by KIN_HOME")
+    both = homes(suite, res)
+    if both is None:
+        return res
+    scratch, _real, foreign = both
+    rc, out = suite.kin_run(["deps", "--all", "--json"])
+    if rc != 0:
+        res.unknown("kin deps --all --json exited %d: %s" % (rc, tail(out)))
+        return res
+    grade_view(res, "kin deps --all --json", deps_ids(out), scratch, foreign,
+               id_for_path(scratch, suite.roommate))
+    return res
+
+
+def check_1(suite):
+    """`kin registry list` is bounded by the same home as every other surface."""
+    res = Result("1", TICKET, "kin registry list is bounded by KIN_HOME")
+    both = homes(suite, res)
+    if both is None:
+        return res
+    scratch, _real, foreign = both
+    rc, out = suite.kin_run(["registry", "list"])
+    if rc != 0:
+        res.unknown("kin registry list exited %d: %s" % (rc, tail(out)))
+        return res
+    grade_view(res, "kin registry list", listed_ids(out), scratch, foreign,
+               id_for_path(scratch, suite.roommate))
+    return res
+
+
+def check_2(suite):
+    """A scratch-home daemon pins no authority for the operator's repositories.
+
+    This is the reported symptom of FIR-2467 rather than a proxy for it: the
+    fixture daemon's own log carried one pin warning per repository on the box.
+    The control is a second unbindable repository registered in the SCRATCH
+    home, which MUST produce that warning, so an absent warning above is a
+    sealed daemon and not a daemon that stopped pinning anything.
+    """
+    res = Result("2", TICKET, "a scratch-home daemon pins no foreign authority")
+    both = homes(suite, res)
+    if both is None:
+        return res
+    scratch, real, foreign = both
+    rc, out = suite.restart_probe_daemon()
+    if rc != 0:
+        res.unknown("the command that starts the probe daemon exited %d: %s"
+                    % (rc, tail(out)))
+        return res
+    log = suite.read_daemon_log()
+    if not log or not log.strip():
+        res.unknown("the daemon log at %s is missing or empty, so what the "
+                    "daemon pinned cannot be read" % suite.daemon_log())
+        return res
+
+    named = sorted(i for i in foreign if i in log) + \
+        sorted(p for p in (real.get(i) for i in foreign) if p and p in log)
+    if named:
+        res.bad("the daemon under the scratch KIN_HOME names %d repository "
+                "registered only in the operator's home: %s"
+                % (len(named), ", ".join(named[:4])))
+    else:
+        res.ok("the daemon log names none of the %d repository id(s) or path(s) "
+               "registered only in the operator's home" % len(foreign))
+
+    stranger_id = id_for_path(scratch, os.path.join(suite.workdir, "stranger"))
+    if stranger_id is None:
+        res.unknown("the scratch home's registry names no id for the stranger "
+                    "repository, so this check's control cannot be graded")
+    elif PIN_WARNING in log and stranger_id in log:
+        res.ok("control: the unbindable sibling in the SCRATCH home (%s) still "
+               "draws the pin warning, so this log can carry one" % stranger_id)
+    else:
+        res.unknown("control: the unbindable sibling in the SCRATCH home (%s) drew "
+                    "no pin warning, so an absent warning above proves nothing "
+                    "about isolation" % stranger_id)
+    return res
+
+
+def check_3(suite):
+    """KIN_HOME moves the registry and still does NOT move the supervisor.
+
+    The other half of the same seam, and the reason this fix is a split rather
+    than a move. The supervisor is a machine-level singleton on purpose: one
+    supervisor holds daemons from several managed homes, and following KIN_HOME
+    would hide from a pinned session the daemons it shares the box with.
+    """
+    res = Result("3", TICKET, "the supervisor stays machine-level")
+    rc, out = suite.kin_run(["graph", "status"])
+    if rc != 0:
+        res.unknown("kin graph status exited %d, so no daemon was started to "
+                    "place a supervisor: %s" % (rc, tail(out)))
+        return res
+
+    marks = ("supervisor.pid", "supervisor.port", "supervisor.lock")
+    real_dir = os.path.join(suite.real_home, ".kin")
+    at_real = [m for m in marks if os.path.exists(os.path.join(real_dir, m))]
+    at_scratch = [m for m in marks if os.path.exists(os.path.join(suite.scratch_home, m))]
+
+    if not at_real and not at_scratch:
+        res.unknown("no supervisor file appeared in either home, so where the "
+                    "supervisor lives cannot be read from this run")
+        return res
+    if at_real:
+        res.ok("the supervisor is in the real home at %s (%s)"
+               % (real_dir, ", ".join(at_real)))
+    else:
+        res.bad("no supervisor file is in the real home at %s, so the supervisor "
+                "did not stay machine-level" % real_dir)
+    if at_scratch:
+        res.bad("the supervisor followed KIN_HOME into %s (%s), which would hide "
+                "from a pinned session the daemons it shares the box with"
+                % (suite.scratch_home, ", ".join(at_scratch)))
+    else:
+        res.ok("no supervisor file followed KIN_HOME into %s" % suite.scratch_home)
+    # The registry, unlike the supervisor, MUST have moved. Without this the
+    # check would pass on a build where KIN_HOME moved nothing at all.
+    if os.path.exists(suite.scratch_registry):
+        res.ok("control: the registry did move with KIN_HOME, to %s"
+               % suite.scratch_registry)
+    else:
+        res.bad("control: no registry exists at %s, so KIN_HOME moved the "
+                "registry nowhere" % suite.scratch_registry)
+    return res
+
+
+CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3)]
+
+
+# ------------------------------------------------------------------ self-test
+
+def _grade(seen, scratch, foreign, roommate_id):
+    res = Result("x", TICKET, "grader under test")
+    grade_view(res, "surface", seen, scratch, foreign, roommate_id)
+    return res.status
+
+
+def _diagnosis(seen, scratch, foreign, roommate_id):
+    """The status AND the words the grader used to reach it.
+
+    Status alone cannot falsify this grader. A foreign id is by construction
+    also an id the scratch home never registered, so the leak branch and the
+    stray branch both FAIL on the same input and deleting either one leaves the
+    verdict unchanged. What the operator is told is the part that differs, so
+    that is what gets asserted.
+    """
+    res = Result("x", TICKET, "grader under test")
+    grade_view(res, "surface", seen, scratch, foreign, roommate_id)
+    return res.status, res.detail
+
+
+def self_test():
+    """Falsify every grader here, each case paired with its inverse.
+
+    Needs no binary, no corpus and no daemon. A suite whose graders are never
+    falsified is a suite that reports PASS for reasons nobody has checked.
+    """
+    cases = []
+
+    def case(name, got, want):
+        cases.append((name, got, want))
+
+    listing = json.dumps({"schema": "x", "repositories": [{"id": "a"}, {"id": "b"}]})
+    case("deps ids read", deps_ids(listing), {"a", "b"})
+    case("deps empty reads empty",
+         deps_ids(json.dumps({"schema": "x", "repositories": []})), set())
+    case("deps non-json is unreadable", deps_ids("not json at all"), None)
+    case("deps without repositories is unreadable",
+         deps_ids(json.dumps({"schema": "x"})), None)
+    case("deps row without an id is unreadable",
+         deps_ids(json.dumps({"repositories": [{"entities": 1}]})), None)
+
+    text = "Registered repositories:\n  probe    42 entities  now  -\n"
+    case("listing ids read", listed_ids(text), {"probe"})
+    case("listing ids read through colour",
+         listed_ids("Registered repositories:\n  \x1b[32mprobe\x1b[0m    42 entities\n"),
+         {"probe"})
+    case("empty listing reads empty",
+         listed_ids("No registered repositories.\nhint: ..."), set())
+    case("unrecognized listing is unreadable", listed_ids("something else"), None)
+
+    case("ansi stripped", strip_ansi("\x1b[31mrepo_id\x1b[0m=x"), "repo_id=x")
+    case("tail keeps the end", tail("abcdef", limit=3), "..." + "def")
+
+    scratch = {"probe": "/w/probe", "roommate": "/w/roommate"}
+    case("id for a known path", id_for_path(scratch, "/w/roommate"), "roommate")
+    case("id for an unknown path", id_for_path(scratch, "/w/elsewhere"), None)
+    case("id from an unreadable registry", id_for_path(None, "/w/roommate"), None)
+
+    # The grader itself, both directions.
+    case("a leaked foreign id FAILs",
+         _grade({"probe", "roommate", "outsider"}, scratch, {"outsider"}, "roommate"),
+         FAIL)
+    case("a sealed view with its control PASSes",
+         _grade({"probe", "roommate"}, scratch, {"outsider"}, "roommate"), PASS)
+    case("a sealed view with no control FAILs",
+         _grade({"probe"}, scratch, {"outsider"}, "roommate"), FAIL)
+    case("an id from neither home FAILs",
+         _grade({"probe", "roommate", "somebody-elses"}, scratch, {"outsider"}, "roommate"),
+         FAIL)
+    # Each failing branch is named by the diagnosis it prints, because both
+    # branches FAIL on a leaked id and neither can be falsified by status.
+    leak_status, leak_detail = _diagnosis(
+        {"probe", "roommate", "outsider"}, scratch, {"outsider"}, "roommate")
+    case("a leak is diagnosed as the operator's home",
+         (leak_status, "registered only in the operator's home" in leak_detail,
+          "outsider" in leak_detail),
+         (FAIL, True, True))
+    stray_status, stray_detail = _diagnosis(
+        {"probe", "roommate", "somebody-elses"}, scratch, {"outsider"}, "roommate")
+    case("an id from neither home is diagnosed as unregistered",
+         (stray_status, "never registered anywhere" in stray_detail,
+          "somebody-elses" in stray_detail),
+         (FAIL, True, True))
+    sealed_status, sealed_detail = _diagnosis(
+        {"probe", "roommate"}, scratch, {"outsider"}, "roommate")
+    case("a sealed view says so and names its control",
+         (sealed_status, "none of the 1 registered only in the operator's home"
+          in sealed_detail, "control:" in sealed_detail),
+         (PASS, True, True))
+    case("an unreadable surface is UNREADABLE",
+         _grade(None, scratch, {"outsider"}, "roommate"), UNREADABLE)
+    case("a control with no id is UNREADABLE",
+         _grade({"probe"}, scratch, {"outsider"}, None), UNREADABLE)
+
+    # The verdict ladder: FAIL outranks UNREADABLE outranks PASS, and a check
+    # that graded nothing is never a pass.
+    ladder = Result("y", TICKET, "ladder")
+    case("nothing graded is UNREADABLE", ladder.status, UNREADABLE)
+    ladder.ok("fine")
+    case("only passes is PASS", ladder.status, PASS)
+    ladder.unknown("cannot say")
+    case("one unreadable outranks passes", ladder.status, UNREADABLE)
+    ladder.bad("broken")
+    case("one fail outranks everything", ladder.status, FAIL)
+    case("detail names the failure", ladder.detail, "broken")
+
+    joined = Result("z", TICKET, "detail")
+    joined.ok("case sealed")
+    joined.ok("control resolved")
+    case("detail joins every passing assertion", joined.detail,
+         "case sealed; control resolved")
+
+    # The registry reader, against files rather than strings, because what it
+    # actually has to survive is a real registry's shape.
+    work = tempfile.mkdtemp(prefix="kin-registry-isolation-selftest-")
+    try:
+        good = os.path.join(work, "registry.toml")
+        with open(good, "w") as handle:
+            handle.write('[[repos]]\nid = "probe"\npath = "/w/probe"\nentities = 3\n\n'
+                         '[[repos]]\nid = "roommate"\npath = "/w/roommate"\nentities = 4\n')
+        case("registry entries read", registry_entries(good),
+             {"probe": "/w/probe", "roommate": "/w/roommate"})
+        empty = os.path.join(work, "empty.toml")
+        with open(empty, "w") as handle:
+            handle.write("repos = []\n")
+        case("an empty registry reads empty", registry_entries(empty), {})
+        case("a missing registry is unreadable",
+             registry_entries(os.path.join(work, "absent.toml")), None)
+
+        # `homes` must refuse to grade rather than pass, in each way it can be
+        # ungrounded.
+        class Fake(object):
+            pass
+
+        fake = Fake()
+        fake.scratch_registry = os.path.join(work, "absent.toml")
+        fake.real_registry = good
+        res = Result("h", TICKET, "homes")
+        case("an unreadable scratch registry refuses to grade",
+             (homes(fake, res) is None, res.status), (True, UNREADABLE))
+
+        fake.scratch_registry = good
+        fake.real_registry = os.path.join(work, "absent.toml")
+        res = Result("h", TICKET, "homes")
+        case("an unreadable stand-in registry refuses to grade",
+             (homes(fake, res) is None, res.status), (True, UNREADABLE))
+
+        fake.real_registry = good
+        res = Result("h", TICKET, "homes")
+        # Returning None is the assertion, not the status. A Result that graded
+        # nothing reads UNREADABLE on its own, so status alone cannot tell a
+        # guard that fired from a guard that was deleted.
+        case("no foreign repository at all refuses to grade",
+             (homes(fake, res) is None, res.status), (True, UNREADABLE))
+
+        fake.scratch_registry = empty
+        res = Result("h", TICKET, "homes")
+        got = homes(fake, res)
+        case("a real foreign repository grades",
+             got is not None and got[2] == {"probe", "roommate"}, True)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    bad = [(name, got, want) for name, got, want in cases if got != want]
+    for name, got, want in bad:
+        print("SELFTEST FAIL %s: got %r, wanted %r" % (name, got, want))
+    print("kin-registry-isolation-repro: self-test %d/%d cases"
+          % (len(cases) - len(bad), len(cases)))
+    return 1 if bad else 0
+
+
+# ----------------------------------------------------------------------- main
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"),
+                        help="the kin binary under test")
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"),
+                        help="the kin-daemon beside it")
+    parser.add_argument("--json", dest="json_path", default=None,
+                        help="write the machine-readable report here, for scripts/acceptance/gate.py")
+    parser.add_argument("--label", default=os.environ.get("KIN_ACCEPTANCE_LABEL"),
+                        help="an opaque run label recorded in the report")
+    parser.add_argument("--keep", action="store_true", help="keep the fixtures")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true",
+                        help="falsify this suite's graders and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if not args.kin:
+        print("kin-registry-isolation-repro: no kin binary. Pass --kin or set KIN_BIN.")
+        return 3
+    # Absolute, because every command below runs with cwd inside a fixture in a
+    # temp directory, and a relative path would resolve against that fixture
+    # rather than against the checkout.
+    kin = os.path.abspath(os.path.expanduser(args.kin))
+    if not os.path.isfile(kin) or not os.access(kin, os.X_OK):
+        print("kin-registry-isolation-repro: %s is not an executable file" % kin)
+        return 3
+    daemon = args.daemon and os.path.abspath(os.path.expanduser(args.daemon))
+    if not daemon:
+        beside = os.path.join(os.path.dirname(kin), "kin-daemon")
+        daemon = beside if os.path.isfile(beside) else None
+
+    workdir = tempfile.mkdtemp(prefix="kin-registry-isolation-repro-")
+    suite = None
+    try:
+        suite = Suite(kin, workdir, daemon=daemon, verbose=args.verbose)
+        try:
+            suite.setup()
+        except Exception as error:  # noqa: BLE001 - a fixture that will not build is setup
+            print("kin-registry-isolation-repro: fixture setup failed: %s: %s"
+                  % (type(error).__name__, error))
+            return 3
+        results = []
+        for check_id, check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - a crashed probe is UNREADABLE
+                result = Result(check_id, TICKET, "probe crashed")
+                result.unknown("%s: %s" % (type(error).__name__, error))
+                results.append(result)
+        for result in results:
+            print("CHECK %s %s %s %s" % (result.id, result.ticket, result.status, result.detail))
+        failed = [r for r in results if r.status == FAIL]
+        unreadable = [r for r in results if r.status == UNREADABLE]
+        print("kin-registry-isolation-repro: %d checks, %d pass, %d FAIL, %d UNREADABLE"
+              % (len(results), len(results) - len(failed) - len(unreadable),
+                 len(failed), len(unreadable)))
+        if args.json_path:
+            # The gate reads this rather than the exit code, because an exit
+            # status is one lever with two settings and a check blocked on
+            # something outside the change under review needs a third.
+            payload = {
+                "suite": "registry_home_isolation",
+                "ticket": TICKET,
+                "label": args.label,
+                "kin": kin,
+                "results": [
+                    {"id": r.id, "ticket": r.ticket, "title": r.title,
+                     "status": r.status, "detail": r.detail, "asserts": r.asserts}
+                    for r in results
+                ],
+            }
+            directory = os.path.dirname(os.path.abspath(args.json_path))
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            with open(args.json_path, "w") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+        if failed:
+            return 1
+        if unreadable:
+            return 2
+        return 0
+    finally:
+        # Every daemon this suite started, stopped. A worker left running holds
+        # a store open for whatever runs next in the same job.
+        if suite is not None:
+            for name, repo in suite.repos.items():
+                env = suite.real_env if name == "outsider" else suite.env
+                run([kin, "daemon", "stop"], cwd=repo, env=env, timeout=180)
+        if not args.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/acceptance/registry_home_isolation.py
+++ b/scripts/acceptance/registry_home_isolation.py
@@ -328,14 +328,18 @@ class Suite(object):
         self.stop_daemon(repo, env)
         shutil.rmtree(os.path.join(repo, ".kin"), ignore_errors=True)
 
+    def own_repos(self):
+        """The repositories this run registered under the scratch KIN_HOME."""
+        return [self.probe, self.roommate, self.stranger]
+
     def setup(self):
         """Build both homes and leave the registries in their final state."""
         self.probe = self.fixture("probe", self.env)
         self.roommate = self.fixture("roommate", self.env)
-        stranger = self.fixture("stranger", self.env)
-        outsider = self.fixture("outsider", self.real_env)
-        self.unbind(stranger, self.env)
-        self.unbind(outsider, self.real_env)
+        self.stranger = self.fixture("stranger", self.env)
+        self.outsider = self.fixture("outsider", self.real_env)
+        self.unbind(self.stranger, self.env)
+        self.unbind(self.outsider, self.real_env)
         self.stop_daemon(self.roommate, self.env)
 
     # -- probes
@@ -377,28 +381,50 @@ class Suite(object):
 # --------------------------------------------------------------------- checks
 
 def homes(suite, res):
-    """Both registries, or None when either cannot ground an absence claim."""
+    """What this run registered where, or None when absence cannot be grounded.
+
+    Returns `(own, foreign, paths)`: the ids this run registered under the
+    scratch KIN_HOME, the id it registered only in the stand-in real home, and
+    the id-to-path map both readings came from.
+
+    The ids are resolved by repository PATH across both registry files rather
+    than by set-differencing them, because on unfixed bytes the scratch home has
+    no registry at all: every `kin init` landed in the real home, including the
+    three that named the scratch one. Differencing the files there yields nothing
+    to compare and the whole suite reports UNREADABLE, which fails the gate but
+    never names the leak. Resolving by path states the defect instead: these are
+    the repositories this run put in the scratch home, this is the one it did
+    not, and here is a scratch-home surface naming it.
+    """
     scratch = registry_entries(suite.scratch_registry)
     real = registry_entries(suite.real_registry)
-    if scratch is None:
-        res.unknown("the scratch home's registry at %s could not be read, so no "
-                    "claim about what it does or does not name is grounded"
-                    % suite.scratch_registry)
+    if scratch is None and real is None:
+        res.unknown("neither registry could be read (%s, %s), so no claim about "
+                    "what either names is grounded"
+                    % (suite.scratch_registry, suite.real_registry))
         return None
-    if real is None:
-        res.unknown("the stand-in home's registry at %s could not be read, so "
-                    "there is no foreign repository to be sealed from"
-                    % suite.real_registry)
+
+    paths = {}
+    for entries in (real or {}, scratch or {}):
+        paths.update(entries)
+
+    foreign_id = id_for_path(paths, suite.outsider)
+    if foreign_id is None:
+        res.unknown("no registry names an id for the outsider repository at %s, "
+                    "so there is nothing for a scratch home to be sealed from"
+                    % suite.outsider)
         return None
-    foreign = set(real) - set(scratch)
-    if not foreign:
-        res.unknown("the stand-in home's registry names nothing the scratch home "
-                    "does not, so a sealed reading below would be vacuous")
+
+    own = {i for i in (id_for_path(paths, repo) for repo in suite.own_repos()) if i}
+    if not own:
+        res.unknown("no registry names an id for any repository this run "
+                    "registered under the scratch KIN_HOME, so a sealed reading "
+                    "would have nothing to be sealed around")
         return None
-    return scratch, real, foreign
+    return own, {foreign_id}, paths
 
 
-def grade_view(res, surface, seen, scratch, foreign, roommate_id):
+def grade_view(res, surface, seen, own, foreign, roommate_id):
     """Grade one cross-repo surface's repo-id set against both homes."""
     if seen is None:
         res.unknown("%s could not be read as a repository listing" % surface)
@@ -409,7 +435,7 @@ def grade_view(res, surface, seen, scratch, foreign, roommate_id):
                 "registered only in the operator's home: %s"
                 % (surface, len(leaked), ", ".join(sorted(leaked))))
     else:
-        stray = seen - set(scratch)
+        stray = seen - set(own)
         if stray:
             res.bad("%s under the scratch KIN_HOME names %d repository id(s) this "
                     "run never registered anywhere: %s"
@@ -421,8 +447,8 @@ def grade_view(res, surface, seen, scratch, foreign, roommate_id):
     # The control. Without it, a surface that had simply stopped answering would
     # pass the sealed assertion above for the wrong reason.
     if roommate_id is None:
-        res.unknown("the scratch home's registry names no id for the roommate "
-                    "repository, so this surface's control cannot be graded")
+        res.unknown("no registry names an id for the roommate repository, so "
+                    "this surface's control cannot be graded")
     elif roommate_id in seen:
         res.ok("control: the sibling registered in the SCRATCH home (%s) still "
                "resolves on the same surface" % roommate_id)
@@ -438,13 +464,13 @@ def check_0(suite):
     both = homes(suite, res)
     if both is None:
         return res
-    scratch, _real, foreign = both
+    own, foreign, _paths = both
     rc, out, err = suite.kin_run_split(["deps", "--all", "--json"])
     if rc != 0:
         res.unknown("kin deps --all --json exited %d: %s" % (rc, tail(err or out)))
         return res
-    grade_view(res, "kin deps --all --json", deps_ids(out), scratch, foreign,
-               id_for_path(scratch, suite.roommate))
+    grade_view(res, "kin deps --all --json", deps_ids(out), own, foreign,
+               id_for_path(_paths, suite.roommate))
     return res
 
 
@@ -454,7 +480,7 @@ def check_1(suite):
     both = homes(suite, res)
     if both is None:
         return res
-    scratch, _real, foreign = both
+    own, foreign, _paths = both
     # `kin registry` with no subcommand IS the listing; `registry list` is not a
     # subcommand and exits 2. The first draft of this probe asked for one and got
     # UNREADABLE, which is that outcome working.
@@ -462,8 +488,8 @@ def check_1(suite):
     if rc != 0:
         res.unknown("kin registry exited %d: %s" % (rc, tail(err or out)))
         return res
-    grade_view(res, "kin registry", listed_ids(out), scratch, foreign,
-               id_for_path(scratch, suite.roommate))
+    grade_view(res, "kin registry", listed_ids(out), own, foreign,
+               id_for_path(_paths, suite.roommate))
     return res
 
 
@@ -480,7 +506,7 @@ def check_2(suite):
     both = homes(suite, res)
     if both is None:
         return res
-    scratch, real, foreign = both
+    _own, foreign, paths = both
     rc, out = suite.restart_probe_daemon()
     if rc != 0:
         res.unknown("the command that starts the probe daemon exited %d: %s"
@@ -493,7 +519,7 @@ def check_2(suite):
         return res
 
     named = sorted(i for i in foreign if i in log) + \
-        sorted(p for p in (real.get(i) for i in foreign) if p and p in log)
+        sorted(p for p in (paths.get(i) for i in foreign) if p and p in log)
     if named:
         res.bad("the daemon under the scratch KIN_HOME names %d repository "
                 "registered only in the operator's home: %s"
@@ -502,10 +528,10 @@ def check_2(suite):
         res.ok("the daemon log names none of the %d repository id(s) or path(s) "
                "registered only in the operator's home" % len(foreign))
 
-    stranger_id = id_for_path(scratch, os.path.join(suite.workdir, "stranger"))
+    stranger_id = id_for_path(paths, suite.stranger)
     if stranger_id is None:
-        res.unknown("the scratch home's registry names no id for the stranger "
-                    "repository, so this check's control cannot be graded")
+        res.unknown("no registry names an id for the stranger repository, so "
+                    "this check's control cannot be graded")
     elif PIN_WARNING in log and stranger_id in log:
         res.ok("control: the unbindable sibling in the SCRATCH home (%s) still "
                "draws the pin warning, so this log can carry one" % stranger_id)
@@ -703,36 +729,84 @@ def self_test():
              registry_entries(os.path.join(work, "absent.toml")), None)
 
         # `homes` must refuse to grade rather than pass, in each way it can be
-        # ungrounded.
+        # ungrounded, and must ground itself on registered PATHS so the unfixed
+        # shape (no scratch registry at all, every repo in the real home) still
+        # names the leak instead of reporting UNREADABLE.
         class Fake(object):
             pass
 
-        fake = Fake()
-        fake.scratch_registry = os.path.join(work, "absent.toml")
-        fake.real_registry = good
-        res = Result("h", TICKET, "homes")
-        case("an unreadable scratch registry refuses to grade",
-             (homes(fake, res) is None, res.status), (True, UNREADABLE))
+        absent = os.path.join(work, "absent.toml")
+        unfixed = os.path.join(work, "unfixed.toml")
+        with open(unfixed, "w") as handle:
+            handle.write('[[repos]]\nid = "probe"\npath = "/w/probe"\n\n'
+                         '[[repos]]\nid = "roommate"\npath = "/w/roommate"\n\n'
+                         '[[repos]]\nid = "stranger"\npath = "/w/stranger"\n\n'
+                         '[[repos]]\nid = "outsider"\npath = "/w/outsider"\n')
 
-        fake.scratch_registry = good
-        fake.real_registry = os.path.join(work, "absent.toml")
-        res = Result("h", TICKET, "homes")
-        case("an unreadable stand-in registry refuses to grade",
-             (homes(fake, res) is None, res.status), (True, UNREADABLE))
+        def fake(scratch_path, real_path):
+            f = Fake()
+            f.scratch_registry = scratch_path
+            f.real_registry = real_path
+            f.probe, f.roommate, f.stranger = "/w/probe", "/w/roommate", "/w/stranger"
+            f.outsider = "/w/outsider"
+            f.own_repos = lambda: [f.probe, f.roommate, f.stranger]
+            return f
 
-        fake.real_registry = good
         res = Result("h", TICKET, "homes")
-        # Returning None is the assertion, not the status. A Result that graded
-        # nothing reads UNREADABLE on its own, so status alone cannot tell a
-        # guard that fired from a guard that was deleted.
-        case("no foreign repository at all refuses to grade",
-             (homes(fake, res) is None, res.status), (True, UNREADABLE))
+        case("neither registry readable refuses to grade",
+             (homes(fake(absent, absent), res) is None, res.status), (True, UNREADABLE))
 
-        fake.scratch_registry = empty
         res = Result("h", TICKET, "homes")
-        got = homes(fake, res)
-        case("a real foreign repository grades",
-             got is not None and got[2] == {"probe", "roommate"}, True)
+        case("no outsider anywhere refuses to grade",
+             (homes(fake(good, absent), res) is None, res.status), (True, UNREADABLE))
+
+        # Both registries as the product actually leaves them. Fixed: the three
+        # scratch repos in the scratch home, the outsider alone in the real one.
+        fixed_scratch = os.path.join(work, "fixed-scratch.toml")
+        with open(fixed_scratch, "w") as handle:
+            handle.write('[[repos]]\nid = "probe"\npath = "/w/probe"\n\n'
+                         '[[repos]]\nid = "roommate"\npath = "/w/roommate"\n\n'
+                         '[[repos]]\nid = "stranger"\npath = "/w/stranger"\n')
+        fixed_real = os.path.join(work, "fixed-real.toml")
+        with open(fixed_real, "w") as handle:
+            handle.write('[[repos]]\nid = "outsider"\npath = "/w/outsider"\n')
+
+        # An outsider and nothing else. Without the guard this grades every id
+        # the surface names as stray and FAILs, which is a confident wrong
+        # diagnosis: there is no scratch-home repository to be sealed around.
+        res = Result("h", TICKET, "homes")
+        case("an outsider with no scratch repos refuses to grade",
+             (homes(fake(absent, fixed_real), res) is None, res.status),
+             (True, UNREADABLE))
+
+        # The unfixed shape: one registry, in the real home, holding everything.
+        res = Result("h", TICKET, "homes")
+        got = homes(fake(absent, unfixed), res)
+        case("the unfixed shape still grounds a verdict",
+             (got is not None and got[0] == {"probe", "roommate", "stranger"}
+              and got[1] == {"outsider"}),
+             True)
+        # ...and grading it names the leak rather than shrugging at it.
+        unfixed_status, unfixed_detail = _diagnosis(
+            {"probe", "roommate", "stranger", "outsider"},
+            {"probe", "roommate", "stranger"}, {"outsider"}, "roommate")
+        case("the unfixed shape FAILs and names the outsider",
+             (unfixed_status, "registered only in the operator's home" in unfixed_detail,
+              "outsider" in unfixed_detail),
+             (FAIL, True, True))
+
+        # The fixed shape: two registries, the outsider only in the real one.
+        res = Result("h", TICKET, "homes")
+        got = homes(fake(fixed_scratch, fixed_real), res)
+        case("the fixed shape grounds the same verdict",
+             (got is not None and got[0] == {"probe", "roommate", "stranger"}
+              and got[1] == {"outsider"}),
+             True)
+        sealed_status, sealed_text = _diagnosis(
+            {"probe", "roommate", "stranger"}, {"probe", "roommate", "stranger"},
+            {"outsider"}, "roommate")
+        case("the fixed shape PASSes on the same grader",
+             (sealed_status, "outsider" in sealed_text), (PASS, False))
     finally:
         shutil.rmtree(work, ignore_errors=True)
 

--- a/scripts/acceptance/registry_home_isolation.py
+++ b/scripts/acceptance/registry_home_isolation.py
@@ -98,6 +98,21 @@ def run(cmd, cwd=None, env=None, timeout=600):
     return proc.returncode, proc.stdout
 
 
+def run_split(cmd, cwd=None, env=None, timeout=600):
+    """Like `run`, with stderr kept apart from stdout.
+
+    kin writes a correctness-relevant-override warning to stderr on every command
+    this suite runs, because the suite pins the embedding backend. Merged into
+    stdout that line sits in front of the JSON payload and no parser reaches it,
+    which reads as an unreadable product rather than an unreadable probe.
+    """
+    proc = subprocess.run(
+        cmd, cwd=cwd, env=env, timeout=timeout,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
 def registry_entries(path):
     """Every id-to-path pair a registry file names, or None when unreadable.
 
@@ -139,9 +154,12 @@ def deps_ids(output):
         return None
     ids = set()
     for repo in repositories:
-        if not isinstance(repo, dict) or "id" not in repo:
+        # `kin.deps.v1` names the field `repo_id`. A payload that does not carry
+        # it is a schema this probe does not understand, which is unreadable and
+        # never an empty answer.
+        if not isinstance(repo, dict) or "repo_id" not in repo:
             return None
-        ids.add(str(repo["id"]))
+        ids.add(str(repo["repo_id"]))
     return ids
 
 
@@ -325,6 +343,10 @@ class Suite(object):
     def kin_run(self, args, repo=None, timeout=600):
         return run([self.kin] + args, cwd=repo or self.probe, env=self.env, timeout=timeout)
 
+    def kin_run_split(self, args, repo=None, timeout=600):
+        return run_split([self.kin] + args, cwd=repo or self.probe, env=self.env,
+                         timeout=timeout)
+
     def daemon_log(self):
         return os.path.join(self.probe, ".kin", "daemon.log")
 
@@ -417,9 +439,9 @@ def check_0(suite):
     if both is None:
         return res
     scratch, _real, foreign = both
-    rc, out = suite.kin_run(["deps", "--all", "--json"])
+    rc, out, err = suite.kin_run_split(["deps", "--all", "--json"])
     if rc != 0:
-        res.unknown("kin deps --all --json exited %d: %s" % (rc, tail(out)))
+        res.unknown("kin deps --all --json exited %d: %s" % (rc, tail(err or out)))
         return res
     grade_view(res, "kin deps --all --json", deps_ids(out), scratch, foreign,
                id_for_path(scratch, suite.roommate))
@@ -427,17 +449,20 @@ def check_0(suite):
 
 
 def check_1(suite):
-    """`kin registry list` is bounded by the same home as every other surface."""
-    res = Result("1", TICKET, "kin registry list is bounded by KIN_HOME")
+    """`kin registry` is bounded by the same home as every other surface."""
+    res = Result("1", TICKET, "kin registry is bounded by KIN_HOME")
     both = homes(suite, res)
     if both is None:
         return res
     scratch, _real, foreign = both
-    rc, out = suite.kin_run(["registry", "list"])
+    # `kin registry` with no subcommand IS the listing; `registry list` is not a
+    # subcommand and exits 2. The first draft of this probe asked for one and got
+    # UNREADABLE, which is that outcome working.
+    rc, out, err = suite.kin_run_split(["registry"])
     if rc != 0:
-        res.unknown("kin registry list exited %d: %s" % (rc, tail(out)))
+        res.unknown("kin registry exited %d: %s" % (rc, tail(err or out)))
         return res
-    grade_view(res, "kin registry list", listed_ids(out), scratch, foreign,
+    grade_view(res, "kin registry", listed_ids(out), scratch, foreign,
                id_for_path(scratch, suite.roommate))
     return res
 
@@ -574,17 +599,22 @@ def self_test():
     def case(name, got, want):
         cases.append((name, got, want))
 
-    listing = json.dumps({"schema": "x", "repositories": [{"id": "a"}, {"id": "b"}]})
+    listing = json.dumps({"schema": "kin.deps.v1",
+                          "repositories": [{"repo_id": "a"}, {"repo_id": "b"}]})
     case("deps ids read", deps_ids(listing), {"a", "b"})
+    case("a deps payload behind a log line is unreadable",
+         deps_ids("WARN correctness-relevant override active\n" + listing), None)
+    case("the pre-rename field name is not accepted",
+         deps_ids(json.dumps({"repositories": [{"id": "a"}]})), None)
     case("deps empty reads empty",
          deps_ids(json.dumps({"schema": "x", "repositories": []})), set())
     case("deps non-json is unreadable", deps_ids("not json at all"), None)
     case("deps without repositories is unreadable",
          deps_ids(json.dumps({"schema": "x"})), None)
-    case("deps row without an id is unreadable",
+    case("deps row without a repo_id is unreadable",
          deps_ids(json.dumps({"repositories": [{"entities": 1}]})), None)
 
-    text = "Registered repositories:\n  probe    42 entities  now  -\n"
+    text = "Registered repositories:\n  probe                 2 entities  (no deps)  11s ago\n"
     case("listing ids read", listed_ids(text), {"probe"})
     case("listing ids read through colour",
          listed_ids("Registered repositories:\n  \x1b[32mprobe\x1b[0m    42 entities\n"),


### PR DESCRIPTION
A scratch `KIN_HOME` now bounds the cross-repo registry, so a daemon started
under one stops reading the operator's repositories.

## What a user hit

Start a daemon under a scratch `KIN_HOME` and its log carried one "sibling
repository authority could not be pinned at daemon startup" warning per
repository on the box. That warning comes from
`pin_registered_local_repository_authorities` in `kin-daemon/src/state.rs`,
which runs at startup and loads the registry, and the registry it loaded was the
one in the operator's real home. A scratch home is meant to be a sealed world,
so anything trusting `KIN_HOME` as an isolation boundary was trusting something
the daemon did not honor. Tests observed machine state and could be perturbed by
it. The same seam put foreign repositories in front of `kin deps`,
`kin registry`, `kin setup` and the MCP global mode.

## What changed

One function was serving two roles. `registry_path()` resolved from the real
home on purpose, because the registry file's parent directory doubled as the
supervisor directory, and the supervisor is a machine-level singleton by design.
Keying it on the real home for the supervisor's sake dragged the registry along.

The two roles are now split at the resolution seam rather than per caller.
`registry_path()` resolves `KIN_REGISTRY_PATH`, then `registry.toml` inside the
managed Kin home, so the registry is store state bounded like the rest of the
store. A new `supervisor_root()` reproduces the old derivation case for case for
the supervisor's two callers, in `kin-cli/src/daemon_client.rs` and
`kin-daemon/src/supervisor.rs`. Both have injected-argument policy functions, so
the split is provable from one fixed environment instead of by mutating the
process-global environment table that every other test in the binary also reads.

Nothing moves for a default install. With `KIN_HOME` unset, `managed_kin_home()`
is `<home>/.kin`, so the registry stays exactly where it was, beside the
supervisor, and `an_unpinned_home_keeps_the_registry_beside_the_supervisor`
asserts that case directly. `KIN_REGISTRY_PATH` still wins on both sides, which
is what every isolated harness in this fleet pins today, so no existing
integration test changes behavior.

One consequence worth naming rather than leaving to be discovered. On Windows
with `KIN_HOME` unset, the registry now resolves through `managed_kin_home()`,
which prefers `%USERPROFILE%`, where before it resolved through
`directories::BaseDirs`, whose Windows `home_dir` comes from
`dirs_sys::known_folder_profile()`. Those are the same path on a normal install
and can differ on a redirected profile. This is the fix working rather than a
side effect: the registry is store state, the rest of the store already resolves
through `managed_kin_home()`, and `layout.rs` already lists `registry.toml` in
`MANAGED_HOME_MARKERS` as an entry a managed install root carries. The two
agreeing is the more correct arrangement. The supervisor keeps the old
`BaseDirs` derivation exactly, which is what `supervisor_root()` is for.

## The acceptance check

`scripts/acceptance/registry_home_isolation.py`, suite `registry_isolation`,
four checks, wired into `acceptance.yml` the way its siblings are: graders
falsified before the build, the suite run against the pull request's own
binaries, and the report added to the gate invocation. No allowance was added
and none was deleted.

The fixture builds two homes and four repositories, all registered through
`kin init` rather than by writing a registry file. Checks 0 and 1 ask
`kin deps --all --json` and `kin registry` what they can see. Check 2 reads the
probe daemon's own log for the pin warning, which is the reported symptom
itself rather than a proxy for it. Check 3 asserts the other half of the seam,
that the registry moves with `KIN_HOME` and the supervisor does not.

Every probe leaves `KIN_REGISTRY_PATH` unset on purpose. That is the
load-bearing detail: an explicit pin wins on both sides of this seam, so a probe
that kept one could not fail. Every check is also paired with a control, because
a build that had simply stopped answering would pass the sealed half of all four.

`kin xref` is covered through check 2 rather than driven directly.
`commands/xref.rs` does not read the registry itself; it delegates to the daemon,
which answers from the spine, and the spine's sibling authority set is exactly
what `pin_registered_local_repository_authorities` freezes at daemon startup. So
the isolation question for `xref` is settled at the authority set, which is what
check 2 reads at its source. No check in this suite executes `kin xref`, and that
is a deliberate choice rather than an omission.

## Falsification

Both arms ran the same suite against release binaries built from this branch,
one build at a time on one target directory, each verified by a direct registry
probe before the suite was allowed to grade anything.

Pre-fix, with the seam reverted:

```
CHECK 0 FIR-2467 FAIL kin deps --all --json under the scratch KIN_HOME names 1 repository id(s) registered only in the operator's home: outsider
CHECK 1 FIR-2467 FAIL kin registry under the scratch KIN_HOME names 1 repository id(s) registered only in the operator's home: outsider
CHECK 2 FIR-2467 FAIL the daemon under the scratch KIN_HOME names 2 repository registered only in the operator's home: outsider, /private/var/folders/.../outsider
CHECK 3 FIR-2467 FAIL control: no registry exists at /var/folders/.../kin-home-49585/registry.toml, so KIN_HOME moved the registry nowhere
kin-registry-isolation-repro: 4 checks, 0 pass, 4 FAIL, 0 UNREADABLE
```

Post-fix, on this branch:

```
CHECK 0 FIR-2467 PASS kin deps --all --json named 3 id(s), all of them this scratch home's own, and none of the 1 registered only in the operator's home; control: the sibling registered in the SCRATCH home (roommate) still resolves on the same surface
CHECK 1 FIR-2467 PASS kin registry named 3 id(s), all of them this scratch home's own, and none of the 1 registered only in the operator's home; control: the sibling registered in the SCRATCH home (roommate) still resolves on the same surface
CHECK 2 FIR-2467 PASS the daemon log names none of the 1 repository id(s) or path(s) registered only in the operator's home; control: the unbindable sibling in the SCRATCH home (stranger) still draws the pin warning, so this log can carry one
CHECK 3 FIR-2467 PASS the supervisor is in the real home at .../real-home-67267/.kin (supervisor.pid, supervisor.port, supervisor.lock); no supervisor file followed KIN_HOME into .../kin-home-67267; control: the registry did move with KIN_HOME, to .../kin-home-67267/registry.toml
```

Every control fired. The roommate still resolves, the unbindable stranger still
draws the pin warning, and the registry did move.

The Rust arm falsifies the same way. Reverting `registry_path` to the real-home
derivation fails `pinning_kin_home_moves_the_registry_and_not_the_supervisor`,
printing the defect as `left: "/Users/.../.kin/registry.toml"` against
`right: "/scratch/home/registry.toml"`. Making the supervisor follow `KIN_HOME`
instead fails that test and `an_explicit_registry_path_still_carries_the_supervisor`.
The grader self-test is 41 of 41 across twelve mutations, one per grader branch,
twelve caught. Two of those cases exist because an earlier pass could not fail:
a foreign id is by construction also an id the scratch home never registered, so
both failure branches fired on the same input and deleting either left the
verdict unchanged. Those cases now assert the diagnosis text, not only the verdict.

## What this does not fix

FIR-2580 is a different seam and is deliberately left alone. Its defect is that a
daemon spawned under an explicit `KIN_HOME` registers with no home, so
`partition_by_home` classifies it as `Unrecorded`. That record is the
supervisor's daemon census, not the repo registry, and nothing here touches it.
FIR-2580 stays open.

## Re-verified before opening this pull request

Independently of the run above, on this branch after rebasing onto `main`:
`cargo fmt --all -- --check` clean, the ci.yml clippy invocation with the debt
allow-list clean under `-D warnings`, `cargo test -p kin-core registry` at 78
passed and 0 failed including the four new tests, the grader self-test at 41 of
41, and `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`,
`zero_file_search_guard.sh`, `verify-zero-file-search.py` and
`test-private-repo-coupling.py` all green. The pre-fix and post-fix `CHECK` lines
quoted above are from the original two-arm run and were not reproduced here.

The rebase itself had one conflict. `main` added the init-memory suite in the
same three places this branch adds its own, so git interleaved them into one
broken step. Both suites are additive and independent, so the resolution keeps
both, and the resulting workflow parses with both suites present as separate
steps and both reports passed to the gate. Rebasing also left the acceptance
README claiming six suites when there are now seven, with the init-memory one
undescribed, so this branch carries a commit fixing the catalogue. That commit
also drops `kin registry list` from the prose, since `RegistryAction` carries no
`List` variant and the listing is the no-subcommand arm.

Closes FIR-2467
