### PR TITLE
Ask what the operator wants before asking what the machine has

### DIFF
--- a/crates/kin-core/src/memory_pressure.rs
+++ b/crates/kin-core/src/memory_pressure.rs
@@ -345,6 +345,17 @@ pub enum HeavyWork {
     EmbedBatch,
     /// One ambient admission tick: a complete working-copy walk planned into a
     /// tree transition, from a host event nobody asked for.
+    ///
+    /// Measured and never refused. Holding it is not the same trade as holding
+    /// the two above: a sweep held costs relations the next sweep restores and
+    /// a batch held costs vectors the next batch restores, while admission held
+    /// costs the thing itself, since it is the path by which a written file
+    /// becomes queryable at all. On a machine that stays loaded the tick that
+    /// would admit never comes, so the file stays invisible for as long as the
+    /// machine is busy. Neither measured failure implicated it, and it is one
+    /// bounded walk over a working copy. It keeps its place here because the
+    /// reconcile loop is the cheapest cadence in the daemon to publish the
+    /// footprint standing from, and a labelled call is what publishes it.
     AmbientAdmission,
 }
 
@@ -624,11 +635,18 @@ impl Verdict {
                 describe(work, level, pressure.reading(), did)
             }
         };
+        // Admission is measured and never refused, at any rung. See
+        // [`HeavyWork::AmbientAdmission`] for why holding it is a different
+        // trade from holding the two passes that actually spend the machine.
+        if work == HeavyWork::AmbientAdmission {
+            return Verdict::Proceed;
+        }
         match level {
             PressureLevel::Unknown | PressureLevel::Nominal => Verdict::Proceed,
             PressureLevel::Elevated => match work {
                 HeavyWork::EmbedBatch => Verdict::Shrink { reason: reason() },
-                HeavyWork::LspSweep | HeavyWork::AmbientAdmission => Verdict::Proceed,
+                HeavyWork::LspSweep => Verdict::Proceed,
+                HeavyWork::AmbientAdmission => unreachable!("returned above"),
             },
             PressureLevel::Critical => Verdict::Refuse { reason: reason() },
         }
@@ -1332,16 +1350,50 @@ mod tests {
                 "absence of evidence is not pressure"
             );
         }
+        assert_eq!(unknown.unknown_reason().is_some(), true);
+    }
+
+    /// Admission is measured and never refused, at any rung.
+    ///
+    /// It was refused when this seam landed and that was FIR-2632's sibling
+    /// half: on a machine that stays loaded the tick that would admit never
+    /// comes, so a file somebody wrote stops being queryable for as long as
+    /// their machine is busy. The model says so here, so it cannot drift from
+    /// the loop that obeys it.
+    #[test]
+    fn ambient_admission_is_never_refused_at_any_rung() {
+        let bars = Thresholds::default();
+        for pressure in [
+            MemoryPressure::Known(reading(12 * GIB, GIB)),
+            MemoryPressure::Known(reading(12 * GIB, 9 * GIB + GIB / 2)),
+            MemoryPressure::Known(reading(12 * GIB, 11 * GIB + GIB / 2)),
+            MemoryPressure::Forced {
+                level: PressureLevel::Critical,
+            },
+        ] {
+            assert_eq!(
+                Verdict::for_reading(HeavyWork::AmbientAdmission, &pressure, &bars),
+                Verdict::Proceed,
+                "a written file must not stop being queryable because the machine is busy"
+            );
+        }
+        // Including when this daemon's own tree is far over its budget.
+        let over = standing(32 * GIB, 0, 0, 8 * GIB);
+        assert_eq!(
+            Verdict::decide(
+                HeavyWork::AmbientAdmission,
+                &MemoryPressure::Known(reading(128 * GIB, 8 * GIB)),
+                Some(&over),
+                &bars
+            ),
+            Verdict::Proceed
+        );
     }
 
     #[test]
     fn critical_pressure_refuses_every_heavy_work_with_a_named_reason() {
         let pressure = MemoryPressure::Known(reading(12 * GIB, 11 * GIB + GIB / 2));
-        for work in [
-            HeavyWork::LspSweep,
-            HeavyWork::EmbedBatch,
-            HeavyWork::AmbientAdmission,
-        ] {
+        for work in [HeavyWork::LspSweep, HeavyWork::EmbedBatch] {
             let verdict = Verdict::for_reading(work, &pressure, &Thresholds::default());
             assert!(
                 verdict.refused(),

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -947,12 +947,35 @@ pub(crate) fn auto_embed_enabled() -> bool {
 /// daemon eligible for idle shutdown: a backlog no worker will drain must not
 /// read as work in flight.
 fn start_or_defer_background_embed(state: &DaemonState) -> bool {
-    // Asked before the queue is built rather than after, because building it
+    // The opt-out is asked FIRST, and this order is the whole of FIR-2632.
+    //
+    // Pressure is a question about work somebody wants done. An operator who
+    // turned background embedding off wants none of it, so on a loaded host the
+    // earlier order answered a question nobody had asked: it declined the pass
+    // for memory, wrote a refusal into the store, and put "background embedding
+    // did not start" on `kin doctor`, `kin graph status` and the MCP envelope,
+    // about a pass that was never going to start for a reason that had nothing
+    // to do with memory. The opt-out's own line never printed, so an operator
+    // checking that their opt-out took effect saw a memory complaint instead.
+    //
+    // It hid because it needs a loaded host to appear at all. Quiet CI is never
+    // near the bar, so `a_cli_spawned_daemon_honours_the_background_embed_opt_out`
+    // was green there and red on any busy machine.
+    if !auto_embed_enabled() {
+        state.pause_background_embed();
+        warn!(
+            trigger = AUTO_EMBED_ENV,
+            "background embedding deferred by operator opt-out: no vectors will be generated, and semantic coverage stays as it is until an explicit embed request runs"
+        );
+        return false;
+    }
+    // Now that the pass is genuinely wanted, ask whether the machine has room
+    // for it. Before the queue is built rather than after, because building it
     // walks the graph for everything the index is missing and a machine with no
     // room should not pay for a queue nothing is going to drain. The pass is
-    // deferred exactly the way an operator opt-out defers it, so a daemon that
-    // declines here stays eligible for idle shutdown instead of reading as
-    // work in flight.
+    // deferred exactly the way the opt-out above defers it, so a daemon that
+    // declines here stays eligible for idle shutdown instead of reading as work
+    // in flight.
     let call = pressure_verdict(kin_core::memory_pressure::HeavyWork::EmbedBatch);
     publish_footprint_standing(state, &call);
     if let kin_core::memory_pressure::Verdict::Refuse { reason } = &call.verdict {
@@ -963,14 +986,6 @@ fn start_or_defer_background_embed(state: &DaemonState) -> bool {
             kin_core::memory_pressure::HeavyWork::EmbedBatch,
             &call,
             &reason,
-        );
-        return false;
-    }
-    if !auto_embed_enabled() {
-        state.pause_background_embed();
-        warn!(
-            trigger = AUTO_EMBED_ENV,
-            "background embedding deferred by operator opt-out: no vectors will be generated, and semantic coverage stays as it is until an explicit embed request runs"
         );
         return false;
     }
@@ -7406,6 +7421,55 @@ mod memory_pressure_tests {
         );
     }
 
+    /// FIR-2632. An opted-out daemon on a full machine says the opt-out, and
+    /// says nothing about memory.
+    ///
+    /// Pressure is a question about work somebody wants done. Asking it first
+    /// meant an operator who had turned background embedding off got a memory
+    /// refusal written into their store and printed on `kin doctor`,
+    /// `kin graph status` and the MCP envelope, about a pass that was never
+    /// going to run for a reason that had nothing to do with memory, while the
+    /// opt-out's own line never printed at all.
+    ///
+    /// Both halves are asserted, because the disclosure is the part that
+    /// reached three surfaces and the return value alone would have passed
+    /// throughout.
+    #[test]
+    fn an_opted_out_daemon_on_a_full_machine_discloses_no_memory_refusal() {
+        let _lock = crate::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let state = open_store(dir.path());
+        let _forced = EnvVarGuard::set("KIN_MEMORY_PRESSURE", "critical");
+        let _opted_out = EnvVarGuard::set(super::AUTO_EMBED_ENV, "0");
+
+        assert!(
+            !start_or_defer_background_embed(&state),
+            "the pass is deferred either way; what differs is why"
+        );
+        assert!(
+            PressureRefusal::read(state.layout.root()).is_none(),
+            "work nobody asked for must not be reported as work memory prevented: {:?}",
+            PressureRefusal::read(state.layout.root())
+        );
+    }
+
+    /// The same machine with the opt-out absent still refuses for memory, so
+    /// the fix above is a precedence change and not a way of turning the gate
+    /// off.
+    #[test]
+    fn a_wanted_pass_on_the_same_full_machine_still_refuses_for_memory() {
+        let _lock = crate::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let state = open_store(dir.path());
+        let _forced = EnvVarGuard::set("KIN_MEMORY_PRESSURE", "critical");
+        let _wanted = EnvVarGuard::unset(super::AUTO_EMBED_ENV);
+
+        assert!(!start_or_defer_background_embed(&state));
+        let record = PressureRefusal::read(state.layout.root())
+            .expect("a pass somebody wanted, declined for memory, is disclosed");
+        assert_eq!(record.work, "embed-batch");
+    }
+
     #[test]
     fn a_critical_machine_defers_the_background_embedding_pass() {
         let _lock = crate::test_env_lock();
@@ -7484,21 +7548,30 @@ mod memory_pressure_tests {
         assert_eq!(embed_batch_under_pressure(512, &call.verdict), 512);
     }
 
+    /// FIR-2632's sibling half, at the seam the reconcile loop reads.
+    ///
+    /// Admission is measured and never held. It was held when this landed, on
+    /// the reasoning that a tick can wait because its events go back on the
+    /// queue, and that holds for one tick and fails for a machine that stays
+    /// loaded: the tick that would admit never comes and a written file stops
+    /// being queryable for as long as the machine is busy.
     #[test]
-    fn ambient_admission_is_refused_while_the_explicit_seam_is_not_gated_here() {
-        // The ambient tick can wait: its events go back on the queue and the
-        // last complete admission stays where it was. A commit is a command
-        // someone ran, and this module never refuses one.
+    fn ambient_admission_is_measured_and_never_held() {
         let _lock = crate::test_env_lock();
         let _budget = super::budget_no_test_can_fill();
         let _forced = EnvVarGuard::set("KIN_MEMORY_PRESSURE", "critical");
         let ambient = pressure_verdict(HeavyWork::AmbientAdmission);
-        assert!(matches!(ambient.verdict, Verdict::Refuse { .. }));
-        assert!(ambient
-            .verdict
-            .reason()
-            .expect("refused")
-            .contains("nothing is lost"));
+        assert_eq!(
+            ambient.verdict,
+            Verdict::Proceed,
+            "a file somebody wrote must not wait on a busy machine"
+        );
+        // The call still carries the level, which is what the reconcile loop
+        // publishes the footprint standing from.
+        assert_eq!(
+            ambient.level,
+            kin_core::memory_pressure::PressureLevel::Critical
+        );
     }
 }
 

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2423,10 +2423,6 @@ pub async fn run_loop_armed(
     // larger than `batch_size` is deferred instead of silently discarded.
     let mut pending_events: VecDeque<FileEvent> = VecDeque::new();
     let mut backlog_warning_active = false;
-    // The pressure level this loop has already spoken about, so a machine that
-    // stays critical is disclosed once instead of on every tick it holds work
-    // back.
-    let mut announced_pressure: Option<kin_core::memory_pressure::PressureLevel> = None;
     // The admission policy the last complete pass planned against, kept so the
     // event filter below costs no authority load of its own. `None` until the
     // first pass resolves one, which is the safe direction: nothing is dropped
@@ -2780,41 +2776,35 @@ pub async fn run_loop_armed(
             "processing file events (after dedup)"
         );
 
-        // Ask the machine before walking the working copy. An ambient tick is
-        // a complete scan planned into a tree transition, from a host event
-        // nobody asked for, and it is the one admission that can wait: the
-        // events go back on the queue and nothing about them is lost, because
-        // this tick publishes nothing and the last complete admission stays
-        // where it was, so the startup catch-up window still covers every path
-        // held back here.
+        // Sample what this daemon is holding, and publish it. This loop turns
+        // on its own interval whether or not there is anything to admit, which
+        // makes it the cheapest cadence in the daemon to hang the standing on.
         //
-        // The explicit seams are deliberately not gated. A commit is a command
-        // a person ran, and refusing it would trade a machine Kin might have
-        // saved for work the user asked for and would have to do again.
+        // It does NOT gate admission, and that is FIR-2632's sibling half.
+        // Ambient admission was gated here when the seam landed, on the
+        // reasoning that a tick can wait because its events go back on the
+        // queue. That reasoning holds for one tick and fails for a machine that
+        // stays loaded: the tick that would admit never comes, and a file
+        // somebody wrote stops being queryable for as long as their machine is
+        // busy. On this fleet's own box that is hours.
+        //
+        // Admission is different in kind from the passes this seam exists to
+        // hold. A sweep held costs cross-file relations that the next sweep
+        // restores. An embed batch held costs vectors the next batch restores.
+        // Admission held costs the thing itself: it is the path by which a
+        // written file becomes queryable at all, and withholding it is the
+        // FIR-2606 failure class arriving by a new route, this time with a
+        // warning line nobody reads instead of silence. Neither measured
+        // failure implicated it either: the sweep peaked at 18.2 GB and the
+        // full-history init died in conversion, and an ambient tick is one
+        // bounded walk over a working copy.
+        //
+        // So the machine is measured here and never obeyed here. The passes
+        // that actually spend it, the cold sweep and the embedding batch, keep
+        // their gates.
         let pressure =
             crate::daemon::pressure_verdict(kin_core::memory_pressure::HeavyWork::AmbientAdmission);
         crate::daemon::publish_footprint_standing(&state, &pressure);
-        if let kin_core::memory_pressure::Verdict::Refuse { reason } = &pressure.verdict {
-            if announced_pressure != Some(pressure.level) {
-                crate::daemon::disclose_pressure_refusal(
-                    &state,
-                    kin_core::memory_pressure::HeavyWork::AmbientAdmission,
-                    &pressure,
-                    reason,
-                );
-                announced_pressure = Some(pressure.level);
-            }
-            enqueue_file_events(&mut pending_events, watcher_batch);
-            state
-                .reconciliation_status
-                .store(RECON_IDLE, Ordering::Relaxed);
-            tokio::time::sleep(interval).await;
-            continue;
-        }
-        if announced_pressure.is_some_and(|level| level != pressure.level) {
-            crate::daemon::clear_pressure_refusal(&state);
-        }
-        announced_pressure = Some(pressure.level);
 
         // Serialize exact-tree admission and semantic enrichment with every
         // other graph-authority mutation, including commit and checkout. The


### PR DESCRIPTION
Pressure is a question about work somebody wants done, and the seam that landed in kin#1074
was asking it first.

An operator who had turned background embedding off got a memory refusal written into their
store and printed on `kin doctor`, `kin graph status` and the MCP envelope, about a pass
that was never going to run, for a reason that had nothing to do with memory. The opt-out's
own line never printed, so someone checking that their opt-out had taken effect saw a
memory complaint instead. The opt-out is consulted first now.

This is a precedence fix and not a way of turning the gate off. A test asserts that on the
same forced-critical machine, with the opt-out absent, the pass is still refused for memory
and still discloses it.

It hid because it needs a loaded host to appear at all. Quiet CI is never near the bar, so
`a_cli_spawned_daemon_honours_the_background_embed_opt_out` was green there and red on any
busy machine, which is also why both acceptance suites' check 0 read red on a pressured box
while hosted CI stayed green.

## The sibling half: admission was being held

Ambient admission was gated on the reasoning that a tick can wait, because its events go
back on the queue and nothing is lost. That holds for one tick and fails for a machine that
stays loaded: the tick that would admit never comes, and a file somebody wrote stops being
queryable for as long as their machine is busy. On this fleet's own box that is hours.

Admission is different in kind from the passes this seam exists to hold. A sweep held costs
cross-file relations the next sweep restores. An embed batch held costs vectors the next
batch restores. Admission held costs the thing itself, because it is the path by which a
written file becomes queryable at all, and withholding it is the FIR-2606 failure class
arriving by a new route, this time behind a warning line nobody reads. Neither measured
failure implicated it either: the sweep peaked at 18.2 GB and the full-history init died in
conversion, while an ambient tick is one bounded walk over a working copy.

So the reconcile loop measures the machine and never obeys it. It keeps the reading, because
that loop turns on its own interval and is the cheapest cadence in the daemon to publish the
footprint standing from. The model says the same thing rather than returning a refusal its
only caller ignores, so the two cannot drift apart.

The cold sweep and the embedding batch, which are what actually spent the machine, keep
their gates unchanged.

Refs FIR-2614, FIR-2632
