### PR TITLE
Grade which budget an elision names, not merely that it names one

### DIFF
--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -970,5 +970,16 @@ mod tests {
             !rendered.contains("Raise --budget"),
             "no lever is offered for a cut that did not happen: {rendered}"
         );
+        // The other side of the over-budget note. Without this the note could
+        // fire on every pack and every test here would still pass, which is a
+        // fixture sitting entirely on one side of the branch.
+        assert!(
+            !rendered.contains("over budget"),
+            "a pack inside its budget must not report itself over one: {rendered}"
+        );
+        assert!(
+            whole.pack.as_ref().unwrap().actual_tokens <= 32_000,
+            "the fixture must actually fit, or the assertion above proves nothing"
+        );
     }
 }

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -92,6 +92,27 @@ IMPACT_LISTS = [
 # The reason code a response still over its ceiling publishes.
 OVER_BUDGET_REASON = "response_over_budget"
 
+# The reason code a cut made by the response budget carries. Checks 0 to 4 drive
+# tools that have no pack token budget at all, so a cut there can only have come
+# from this one, and an elision naming anything else is a misattribution rather
+# than a second cause. Asserted because the graders were one-sided without it: a
+# build that stamped every elision `token_budget` passed all of them, which sends
+# a caller to raise a lever that tool does not have.
+RESPONSE_BUDGET_REASON = "response_budget"
+
+
+def grade_reason(label, elision):
+    """Grade one elision's cause on a tool the pack token budget cannot reach."""
+    reason = elision.get("reason") or ""
+    if not reason:
+        return ["%s names no reason" % label]
+    if reason != RESPONSE_BUDGET_REASON:
+        return [
+            "%s names %r, and this tool has no budget but the response budget, so a "
+            "caller reads it as one it cannot raise" % (label, reason)
+        ]
+    return []
+
 # Callees on the wide focal. Sized so the whole pack clears the pack token
 # budget's 8,000 floor several times over while the serialized response stays
 # well under the 60,000-character response ceiling, which is what lets check 5
@@ -185,8 +206,7 @@ def grade_cut_walk(payload):
             "elisions.chain.total is %r and kept plus elided is %d"
             % (elision.get("total"), len(chain) + omitted)
         )
-    if not elision.get("reason"):
-        problems.append("elisions.chain names no reason")
+    problems.extend(grade_reason("elisions.chain", elision))
     return problems
 
 
@@ -809,8 +829,7 @@ def grade_buckets(payload, buckets):
                 "elisions.%s.total is %r and kept plus elided is %d"
                 % (key, elision.get("total"), len(rows) + (elision.get("elided") or 0))
             )
-        if not elision.get("reason"):
-            problems.append("elisions.%s names no reason" % key)
+        problems.extend(grade_reason("elisions.%s" % key, elision))
     return problems, graded
 
 
@@ -1191,6 +1210,43 @@ def self_test():
         "elisions": {"chain": {"kept": 1, "elided": 3, "total": 4}},
     }
     expect("an elision with no reason fails", len(grade_cut_walk(reasonless)) >= 1, True)
+
+    # The fires-always mutant for the cause: a build that stamps every elision
+    # `token_budget` used to pass every grader here, because they asked only
+    # whether a reason was present. These tools have no pack token budget, so
+    # that reason cannot be true of them, and a caller who believes it raises a
+    # lever the tool does not have.
+    misattributed_walk = {
+        "chain": [{"step": 1}],
+        "steps_omitted": 3,
+        "elisions": {"chain": {"kept": 1, "elided": 3, "total": 4, "reason": "token_budget"}},
+    }
+    expect(
+        "a response-budget cut claiming the token budget fails",
+        len(grade_cut_walk(misattributed_walk)) >= 1,
+        True,
+    )
+    misattributed_bucket = {
+        "entities": [{"a": 1}],
+        "entities_withheld": 5,
+        "elisions": {
+            "entities": {"kept": 1, "elided": 5, "total": 6, "reason": "token_budget"}
+        },
+    }
+    expect(
+        "the same misattribution fails on a ranked list",
+        len(grade_buckets(misattributed_bucket, ["entities"])[0]) >= 1,
+        True,
+    )
+    honest_bucket = dict(misattributed_bucket)
+    honest_bucket["elisions"] = {
+        "entities": {"kept": 1, "elided": 5, "total": 6, "reason": "response_budget"}
+    }
+    expect(
+        "the honest cause still passes",
+        grade_buckets(honest_bucket, ["entities"])[0],
+        [],
+    )
 
     uncut = {"chain": [{"step": 1}], "steps_omitted": 0}
     expect("an uncut walk proves nothing", len(grade_cut_walk(uncut)) >= 1, True)


### PR DESCRIPTION
kin#1084 landed a reason on every elision so a caller knows which budget cut its
answer and which lever recovers it. The graders it landed beside asked only
whether a reason was present, so the distinction they exist to protect was never
actually checked.

The mutant that found it is the one the wave asks for: make the branch fire
always. Stamping every elision `token_budget` passed the whole acceptance suite.
Checks 0 to 4 drive `trace_data_flow`, `semantic_locate` and `impact_analysis`,
none of which has a pack token budget at all, so that reason cannot be true of
them; a caller who believes it raises a lever the tool does not have, gets the
same answer back, and has been told a cut was recoverable when it was not. The
unit tests caught the mutant. The suite that runs against real binaries did not,
and that is the one a stranger's CI reports on.

`grade_reason` now grades the cause, and both graders call it. A cut on a tool
the pack budget cannot reach must name `response_budget` and nothing else.

The same one-sidedness sat in the CLI. `kin context` prints "over budget: every
section keeps a row" when the never-empty floor pushes a pack past its own
budget, and nothing asserted the note was absent on a pack that fits, so making
that branch fire always left all 26 context tests green. The whole-pack test now
asserts the note is absent and asserts the fixture actually fits, because an
absence assertion over a fixture that was never inside its budget proves nothing.

## Falsified

Exit statuses read raw. Neutering `grade_reason` turns `--self-test` red on three
cases, exit 1, and the intact suite exits 0. Making the CLI note fire always
fails `a_whole_pack_carries_no_budget_note_at_all` with "a pack inside its budget
must not report itself over one"; before this change the same mutant left 26
passed, 0 failed.

Two mutants from the same sweep were already dead and stay recorded here rather
than fixed: stamping every elision `token_budget` fails three kin-mcp unit tests,
and marking every row whether or not the budget took anything from it fails
`a_row_that_never_had_a_body_is_neither_marked_nor_counted`.

## Gates

`cargo test -p kin-cli --lib commands::context` 26 passed, `cargo fmt --all --
--check` clean, clippy with the 45-lint allow list under `RUSTFLAGS=-D warnings`
exit 0, and the guard steps enumerated from a real CI job's own step list rather
than grepped out of ci.yml, because a failed guard step skips every step after it
in that job: zero file-search and its answer-module arm, hydration replay,
runtime boundaries, private repo coupling and its guard test, installer checksum
fixtures and the release gate assertions. All exit 0.

Relates to FIR-2482
