### PR TITLE
Let the heap probe see inside the phase that holds the peak

### DIFF
--- a/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
+++ b/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
@@ -185,6 +185,11 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
         peak as f64 / 1024.0 / 1024.0,
         PEAK_HEAP_CEILING / 1024 / 1024
     );
+    // Printed on every run, not only on a breach. A guard that shows its
+    // working only when it fails leaves the number that is about to become a
+    // failure invisible until it is one, and this table is the only view of
+    // what a conversion holds and where.
+    println!("{}", support::phase_attribution_table());
     println!(
         "{PROOF_PHASE} added {} bytes to the peak, ceiling {} MiB",
         proof_growth

--- a/crates/kin-core/tests/support/mod.rs
+++ b/crates/kin-core/tests/support/mod.rs
@@ -100,6 +100,20 @@ unsafe impl GlobalAlloc for Counting {
 /// admission phase under this prefix.
 pub const PHASE_PREFIX: &str = "kin.init.";
 
+/// The other span namespace worth sampling: kin-db's own commit preparation.
+///
+/// `kin.init.commit_bootstrap_transaction` hands the whole history to kin-db and
+/// is where the peak now sits, so a probe that stops at kin's own spans reports
+/// one opaque number for the largest phase in the ladder. kin-db reports its
+/// preparation laps as spans as of kin-db#220, which is in the pinned 0.7.49, so
+/// the laps are already there to be sampled and only this filter kept them out.
+pub const DB_PHASE_PREFIX: &str = "kindb.";
+
+/// Whether a span name belongs to a phase this probe accounts for.
+fn is_sampled_phase(phase: &str) -> bool {
+    phase.starts_with(PHASE_PREFIX) || phase.starts_with(DB_PHASE_PREFIX)
+}
+
 /// One reading of the counters at a phase boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PhaseSample {
@@ -142,7 +156,7 @@ where
     fn on_enter(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
         if let Some(span) = ctx.span(id) {
             let phase = span.name();
-            if phase.starts_with(PHASE_PREFIX) {
+            if is_sampled_phase(phase) {
                 record(PhaseSample {
                     phase,
                     entering: true,
@@ -156,7 +170,7 @@ where
     fn on_exit(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
         if let Some(span) = ctx.span(id) {
             let phase = span.name();
-            if phase.starts_with(PHASE_PREFIX) {
+            if is_sampled_phase(phase) {
                 record(PhaseSample {
                     phase,
                     entering: false,


### PR DESCRIPTION
Let the heap probe see inside the phase that holds the peak, and report where
the peak actually is.

## Why

kin#1083 stopped the init ladder materializing a second whole history to prove
the first. What it left behind is a wall it did not touch: on a 256-commit
fixture `kin.init.commit_bootstrap_transaction` grows peak live heap by
**359.3 MiB** and retains 2.2, and on full-history psf/requests in a 7 GiB cgroup
both the pre-fix and post-fix builds are OOM-killed in exactly that phase.

FIR-2522 question 3 assumes the cause is that kin-db replays the whole history in
one transaction, and proposes streaming it. That is a large change to load-bearing
code, so it is worth knowing whether it is the right one before writing it.

The probe could not answer, because it matched only the `kin.init.` prefix and
reported one opaque number for the largest phase in the ladder. kin-db has
reported its preparation laps as spans since kin-db#220, which is in the pinned
0.7.49, so the laps were already there and only this filter kept them out.

## What the widened probe says

```
peak growth by phase (MiB grew / MiB retained):
     448.8 /      0.0  kin.init.build_bootstrap_transaction
     359.3 /      2.2  kin.init.commit_bootstrap_transaction
     359.3 /      0.0  kindb.commit.transaction_hash      <-- all of it
       0.0 /     86.5  kindb.commit.prepare_successor
       0.0 /     84.4  kindb.prepare.admit
       0.0 /    154.9  kindb.prepare.workspace
       0.0 /      0.0  kindb.prepare.history_replay
       0.0 /      1.4  kindb.prepare.roots
       0.0 /      0.7  kindb.prepare.storage_admission
```

**Every `kindb.prepare.*` lap grows the peak by 0.0 MiB, `prepare_successor`
included.** The replay is not the wall. The whole 359.3 MiB is
`kindb.commit.transaction_hash`, and it retains none of it.

That relocates FIR-2522 question 3 rather than answering it. Streaming the
transaction into the replay would have cost a great deal and moved nothing that
this fixture can see. The cost is in hashing the transaction, which happens
before the replay and once per commit, and it is two whole-transaction
materializations living at the same time: `canonical_json_bytes` builds a
complete `serde_json::Value` tree of the transaction and then encodes that whole
tree into a `Vec<u8>`, and `hash_serialized` needs the encoded length before the
bytes, so it holds the buffer rather than feeding a hasher. Both are in
kin-model, not kin-db.

I am not fixing that here. This PR is the instrument and the reading; the fix is
its own change in its own repo, against these numbers rather than against prose.

## What changed

Two test-only edits. `crates/kin-core/tests/support/mod.rs` samples the `kindb.`
span namespace as well as `kin.init.`, and the deep-history guard prints its
attribution table on every run instead of only on a breach, because a guard that
shows its working only when it fails leaves the number that is about to become a
failure invisible until it is one.

No product code, no proof, no ceiling moved. The guard's own assertions are
unchanged and still pass: proof 1 peak growth 0 bytes against a 16 MiB ceiling,
total 995.3 MiB against a 1400 MiB backstop.

## Gates

fmt clean, clippy exit 0 under CI's own debt allow list, `zero_file_search_guard.sh`
and `verify-hydration-semantics.py` pass, `heap_phase_probe` (the test that
falsifies the probe separates retained from churned memory) passes.

Refs FIR-2522
