### PR TITLE
Stop the resource-profile knob from making kin complain about the machine

### DIFF
--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2544,6 +2544,14 @@ fn main() -> Result<()> {
     // process, and mutating the environment is only safe while the process is
     // still single-threaded. An operator's explicit KIN_RESOURCE_PROFILE wins.
     kin_cli::resource_profile::apply_product_default();
+    // ...then let the repository's recorded profile take over from that default,
+    // exactly as kin-daemon does, so the two agree by construction. Without this
+    // the daemon runs under the repository's profile and this process does not,
+    // and every command in such a repository reports a behavior-env divergence
+    // whose remedy cannot clear it.
+    if let Ok(cwd) = std::env::current_dir() {
+        kin_cli::resource_profile::apply_repository_profile_at(&cwd);
+    }
     if kin_migrate::run_migration_process_host_if_requested()? {
         return Ok(());
     }

--- a/crates/kin-cli/src/resource_profile.rs
+++ b/crates/kin-cli/src/resource_profile.rs
@@ -183,6 +183,18 @@ pub fn repository_profile_for<'a>(
 /// value it adopted, or `None` when it left the environment alone.
 pub fn apply_repository_profile(configured: Option<&str>) -> Option<String> {
     let current = std::env::var(RESOURCE_PROFILE_ENV).ok();
+    // A value this repository already selected in a PARENT process is not an
+    // operator's export, and must not be mistaken for one. The CLI adopts the
+    // profile and then spawns the daemon, so the daemon always inherits a set
+    // variable; without this it read its own parent's repository choice as an
+    // operator override and `kin resources inspect` went back to printing
+    // "(set by operator)" for a profile nobody typed, which is the FIR-2434 lie
+    // this whole area exists to prevent.
+    if inherited_repository_profile(current.as_deref(), |key| std::env::var(key).ok()) {
+        REPOSITORY_CONFIG_SELECTED.store(true, Ordering::Relaxed);
+        PRODUCT_SELECTED.store(false, Ordering::Relaxed);
+        return current;
+    }
     let current_is_product_default =
         inherited_product_default(current.as_deref(), |key| std::env::var(key).ok());
     let adopt = repository_profile_for(configured, current.as_deref(), current_is_product_default)?
@@ -196,6 +208,28 @@ pub fn apply_repository_profile(configured: Option<&str>) -> Option<String> {
     PRODUCT_SELECTED.store(false, Ordering::Relaxed);
     REPOSITORY_CONFIG_SELECTED.store(true, Ordering::Relaxed);
     Some(adopt)
+}
+
+/// Adopt the resource profile recorded by the repository containing `from`, if
+/// there is one, while the process is still single-threaded.
+///
+/// Both binaries call this, and that is the whole point. `kin-daemon` adopting
+/// the repository profile while `kin` did not made the two environments differ
+/// on exactly `KIN_RESOURCE_PROFILE`, which is a `BEHAVIOR_ENV_VARS` member, so
+/// every `kin resources inspect` and `kin embed` in a repository that recorded a
+/// profile printed a divergence warning whose stated remedy cannot work: the
+/// restart it asks for re-adopts the same value from the same file. Under
+/// `KIN_STRICT_BEHAVIOR_ENV` it was not a warning but a hard failure. Using the
+/// feature must not make the tool complain about the machine, which is the
+/// defect class FIR-2504 was opened about in the first place.
+///
+/// Every failure is silent by design: this runs before argument parsing, outside
+/// a repository it has nothing to adopt, and a config that will not parse is
+/// reported with its real message by the command that actually needs it.
+pub fn apply_repository_profile_at(from: &std::path::Path) -> Option<String> {
+    let layout = kin_core::KinLayout::discover(from)?;
+    let config = kin_core::KinConfig::load_or_default(&layout.config_path()).ok()?;
+    apply_repository_profile(config.resources.normalized_profile().as_deref())
 }
 
 /// Whether a value already in effect is one this repository's config selected,
@@ -259,6 +293,41 @@ mod tests {
         assert_eq!(repository_profile_for(None, Some("proof"), false), None);
         assert_eq!(repository_profile_for(Some("  "), None, false), None);
         assert_eq!(repository_profile_for(Some(""), None, false), None);
+    }
+
+    /// The spawn case, which is the one that regressed. The CLI adopts the
+    /// repository profile and then spawns the daemon, so the daemon inherits a
+    /// set variable that looks exactly like an operator's export. It must read
+    /// the marker and keep calling the profile a repository choice.
+    #[test]
+    fn a_child_inheriting_the_repository_marker_keeps_the_repository_provenance() {
+        let _guard = kin_core::test_env::EnvVarGuard::set(RESOURCE_PROFILE_ENV, "ci");
+        let _marker =
+            kin_core::test_env::EnvVarGuard::set(RESOURCE_PROFILE_REPOSITORY_CONFIG_ENV, "ci");
+        let _product = kin_core::test_env::EnvVarGuard::unset(RESOURCE_PROFILE_PRODUCT_DEFAULT_ENV);
+        reset_product_selected_for_tests();
+        reset_repository_config_selected_for_tests();
+
+        // The child passes its own config value; what matters is that it reads
+        // the inherited marker rather than treating the set variable as an
+        // operator's.
+        assert_eq!(apply_repository_profile(Some("ci")), Some("ci".to_string()));
+        assert!(
+            repository_config_selected(),
+            "an inherited repository profile was read as an operator override"
+        );
+        assert!(!product_selected());
+
+        // The direction that makes it mean something: a marker naming a
+        // different value is a stale inheritance and must NOT confer provenance.
+        let _stale =
+            kin_core::test_env::EnvVarGuard::set(RESOURCE_PROFILE_REPOSITORY_CONFIG_ENV, "proof");
+        reset_repository_config_selected_for_tests();
+        apply_repository_profile(Some("ci"));
+        assert!(
+            !repository_config_selected(),
+            "a marker naming another value conferred repository provenance"
+        );
     }
 
     /// The marker has to name the value in effect, or an inherited marker from a

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2029,8 +2029,10 @@ const GRAPH_STATUS_WRITER_SETTLE_FLOOR: Duration = Duration::from_millis(50);
 /// step that is merely between lock-points settles inside a few tens of
 /// milliseconds, and answering live is always better than answering stale. It
 /// is deliberately small because status is what settle loops poll, and it
-/// doubles per attempt, so the total added latency in the contended case is
-/// under a tenth of a second and nothing is held while it elapses.
+/// doubles per attempt, so with three attempts a fully contended call waits
+/// 25 ms then 50 ms, 75 ms in total, and nothing is held while it elapses.
+/// The last attempt does not wait at all: the loop exits immediately after it,
+/// so a backoff there would buy the writer no time and cost the caller 100 ms.
 const GRAPH_STATUS_ATTEMPT_BACKOFF: Duration = Duration::from_millis(25);
 
 /// The last settled `kin_graph_status` observation of one selected graph.
@@ -2315,6 +2317,11 @@ impl GraphStatusBlocked {
 /// progress is the thing that unblocks the sample.
 async fn graph_status_attempt_backoff(attempt: usize) {
     tokio::task::yield_now().await;
+    // Nothing follows the final attempt but the answer, so sleeping after it
+    // delays the caller without giving the writer another chance to finish.
+    if attempt + 1 >= GRAPH_STATUS_STABLE_READ_ATTEMPTS {
+        return;
+    }
     let shift = u32::try_from(attempt).unwrap_or(u32::MAX).min(4);
     tokio::time::sleep(GRAPH_STATUS_ATTEMPT_BACKOFF.saturating_mul(1 << shift)).await;
 }

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -262,10 +262,12 @@ fn parse_allowed_repo_ids() -> Option<HashSet<String>> {
 ///
 /// The layout is resolved here rather than reused from `async_main` because the
 /// environment must be mutated before the runtime exists, and `async_main` does
-/// not run until after it is built. `parse_args` is pure over the process
-/// arguments, so calling it twice costs nothing and changes nothing. Every
-/// failure is silent on purpose: an argument or layout problem is reported once,
-/// with its real message, by `async_main`.
+/// not run until after it is built. Calling `parse_args` twice is safe rather
+/// than pure: it reads only the process arguments and the working directory, and
+/// its one side effect, printing usage and exiting on a malformed argument, is
+/// the same action either call site would take. Every failure here is silent on
+/// purpose: an argument or layout problem is reported once, with its real
+/// message, by `async_main`.
 fn apply_repository_resource_profile() {
     let Ok(args) = parse_args() else {
         return;
@@ -273,15 +275,15 @@ fn apply_repository_resource_profile() {
     if args.supervisor || args.compat_json {
         return;
     }
+    // The same helper the CLI calls, so the two processes can never drift apart
+    // on this variable and produce a behavior-env divergence nobody can clear.
+    // `--repo` may name a `.kin` directory directly, which discovery does not
+    // walk up from, so the resolved layout's working directory is what is
+    // handed over rather than the raw argument.
     let Some(layout) = resolve_layout(&args.repo) else {
         return;
     };
-    let Ok(config) = kin_core::KinConfig::load_or_default(&layout.config_path()) else {
-        return;
-    };
-    kin_cli::resource_profile::apply_repository_profile(
-        config.resources.normalized_profile().as_deref(),
-    );
+    kin_cli::resource_profile::apply_repository_profile_at(layout.working_dir());
 }
 
 fn resolve_layout(path: &Path) -> Option<KinLayout> {

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1920,6 +1920,10 @@ impl DaemonState {
     /// part-way through a fill still knows what earlier runs of this store
     /// finished. The cost is one stat on a path taken once per embed interval
     /// and once per readiness probe.
+    pub fn embedding_coverage_ever_complete(&self) -> bool {
+        self.layout.kindb_embedding_coverage_marker_path().exists()
+    }
+
     /// Publish the batch size the background embedding queue will run with.
     /// Called once by the daemon runtime after it resolves its configuration.
     pub fn publish_embed_batch_size(&self, size: usize) {
@@ -1933,10 +1937,6 @@ impl DaemonState {
             0 => None,
             size => Some(size),
         }
-    }
-
-    pub fn embedding_coverage_ever_complete(&self) -> bool {
-        self.layout.kindb_embedding_coverage_marker_path().exists()
     }
 
     /// Publish the has-ever-completed marker if embedding coverage is now whole.

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -1743,6 +1743,16 @@ def check_13(suite):
     """
     res = Result("13", "FIR-2504", "resource knobs survive a daemon restart")
     repo = suite.fixture("incremental")
+    try:
+        return _check_13(suite, res, repo)
+    finally:
+        # The fixture is shared, and several arms return early. Leave no
+        # [resources] section behind for whatever check runs next.
+        suite.kin_run(["resources", "set", "--clear"], repo)
+        suite.kin_run(["daemon", "stop"], repo)
+
+
+def _check_13(suite, res, repo):
 
     rc, out, err = suite.kin_run(
         ["resources", "set", "--profile", "ci", "--embed-batch-size", "16"], repo)
@@ -1824,7 +1834,32 @@ def check_13(suite):
     else:
         res.ok("the restarted daemon's background embed batch is the recorded 16")
 
-    # Arm 5, the negative control.
+    # Arm 5. The knobs are still set from arm 1, which is what this needs.
+    # Using the feature must not make the
+    # tool complain about the machine: kin#1075 shipped the daemon adopting the
+    # repository profile while the CLI did not, so the two environments differed
+    # on KIN_RESOURCE_PROFILE, every command in such a repository printed a
+    # behavior-env divergence whose stated remedy cannot clear it (the restart it
+    # asks for re-adopts the same value from the same file), and under
+    # KIN_STRICT_BEHAVIOR_ENV=1 it was a hard failure rather than a warning.
+    rc, out, err = suite.kin_run(["resources", "inspect"], repo)
+    if "KIN_RESOURCE_PROFILE" in (err or "") and "differs between this command" in (err or ""):
+        res.bad("recording a profile makes the CLI report a behavior-env divergence it "
+                "cannot clear: %s" % " ".join((err or "").split())[:220])
+    else:
+        res.ok("recording a profile produces no behavior-env divergence")
+
+    strict_env = dict(suite.env)
+    strict_env["KIN_STRICT_BEHAVIOR_ENV"] = "1"
+    strict = run([suite.kin, "resources", "inspect"], cwd=repo, env=strict_env)
+    if strict[0] != 0:
+        res.bad("kin resources inspect exits %d under KIN_STRICT_BEHAVIOR_ENV=1 in a "
+                "repository that recorded a profile: %s"
+                % (strict[0], " ".join((strict[2] or strict[1]).split())[:220]))
+    else:
+        res.ok("the same command exits 0 under KIN_STRICT_BEHAVIOR_ENV=1")
+
+    # Arm 6, the negative control.
     rc, out, err = suite.kin_run(["resources", "set", "--clear"], repo)
     if rc != 0:
         res.unknown("kin resources set --clear rc=%d: %s" % (rc, (err or out).strip()[-200:]))
@@ -1848,7 +1883,7 @@ def check_13(suite):
                % (cleared_embed.get("embed_batch_size"),
                   cleared_actual.get("resource_profile_repository_config")))
 
-    # Arm 6: the provenance field has to move in BOTH directions or it is
+    # Arm 7: the provenance field has to move in BOTH directions or it is
     # decoration. Set says this repository chose it, cleared says kin did, and
     # the two cannot both be true of one field.
     if cleared_actual.get("resource_profile_product_selected") is not True:


### PR DESCRIPTION
Stop the resource-profile knob from making kin complain about the machine

Fix-forward on kin#1075, which shipped a defect of exactly the class the ticket
it closed was opened about.

kin#1075 taught kin-daemon to adopt a repository's recorded resource profile and
did not teach kin. KIN_RESOURCE_PROFILE is a BEHAVIOR_ENV_VARS member, so the
two processes then differed on it and every command in a repository that
recorded a profile printed a behavior-env divergence naming
cli="interactive" daemon="ci". The remedy it printed, restart the daemon, cannot
clear it, because the restart re-adopts the same value from the same file. Under
KIN_STRICT_BEHAVIOR_ENV=1 it was not a warning at all but a hard failure, rc=1.
Reproduced against real binaries with a control before any of this was written.

Both binaries now share one helper, apply_repository_profile_at, called from
kin's main immediately after apply_product_default exactly as the daemon calls
it, so the two agree by construction for the same reason both already apply the
product default.

That fix exposed a second defect. The CLI adopts the profile and then spawns the
daemon, so the daemon inherits a set variable indistinguishable from an
operator's export, and kin resources inspect went back to reporting
"(set by operator)" for a profile nobody typed. That is the FIR-2434 lie,
reintroduced. The mechanism to prevent it already existed in kin#1075 and had no
non-test caller: inherited_repository_profile is now wired into
apply_repository_profile, with a test covering both directions including the
stale marker that must not confer provenance.

Magic check 13 gains two arms, falsified both ways on real binaries: recording a
profile produces no divergence on stderr, and the same command exits 0 under
KIN_STRICT_BEHAVIOR_ENV=1. With the CLI adoption reverted both go red and every
other arm stays green. The check also now clears the shared fixture in a finally
block, so an early return cannot hand a recorded profile to the next check.

Three review nits from the independent verification, all real. The doc block for
embedding_coverage_ever_complete had been split so it sat above and appeared to
document publish_embed_batch_size. The status sampling loop claimed contended
latency under a tenth of a second while three backoffs totalled 175 ms, and the
final one bought nothing because the loop exits right after it: it no longer
sleeps on the last attempt, so the real figure is 75 ms and the doc says so.
parse_args was documented as pure while it prints and exits on a malformed
argument.

Closes FIR-2637
Refs FIR-2504
Refs FIR-2636

Signed-off-by: Troy Fortin <troy@firelock.ai>


## Evidence

Reproduced before changing anything, on binaries built from main at d37a2eb5a,
with a control that isolates the cause:

```
CONTROL (nothing recorded)
  kin resources inspect                           rc=0, clean stderr
  KIN_STRICT_BEHAVIOR_ENV=1 kin resources inspect rc=0

SUBJECT (profile ci recorded, daemon restarted)
  kin resources inspect                           rc=0, WARN on stderr:
    KIN_RESOURCE_PROFILE: cli="interactive" daemon="ci"
    remedy: restart the daemon so it re-inherits the current environment
  KIN_STRICT_BEHAVIOR_ENV=1 kin resources inspect rc=1, the same text as Error
```

After the fix, on binaries built from this branch, same fixture and same script:
no divergence on stderr, strict mode rc=0, and the selector line reads
`(from this repository's [resources] config; unset in the environment)` rather
than `(set by operator)`.

Falsification, both arms, on real binaries. Reverting only the CLI adoption and
rebuilding `kin` alone:

```
CHECK 13 FIR-2504 FAIL
  FAIL  recording a profile makes the CLI report a behavior-env divergence it cannot clear
  FAIL  kin resources inspect exits 1 under KIN_STRICT_BEHAVIOR_ENV=1
  PASS  (every other arm)
```

With the fix in place the same check is 9 arms PASS, and check 14 is unchanged at
5 arms PASS.

One correction on my own method, recorded because it nearly cost the result. My
first repro script decided the verdict by grepping stderr for the string
`KIN_RESOURCE_PROFILE`, and after the fix an unrelated env-audit warning naming
the same variable kept the verdict reading REPRODUCES against a build that had
fixed it. It was only caught because the strict exit code had flipped to 0 and
contradicted the verdict line. The script now matches the divergence sentence
and keys on the exit code.

## Not fixed here, on purpose

With the CLI now carrying the profile, the startup env audit prints
`correctness-relevant override active: KIN_RESOURCE_PROFILE set to non-default
value` on every command in a repository that recorded one. It is the same
warning an operator who exported the variable gets today, so it is consistent
rather than a new lie, but it is real noise this feature introduces. Filed as
FIR-2636 rather than silenced: weakening a correctness-relevant override warning
deserves its own change with its own falsification, not a ride-along.

FIR-2135's `find_references` half, which kin#1075 closed without touching, is
split out as FIR-2633 with the mechanism, both line numbers, and an acceptance
spec. FIR-2135 carries a correction comment saying plainly that it is Done
because that PR said so and only half of it earned that.

## Gate

`cargo fmt --all` clean. Guard scripts `zero_file_search_guard.sh`,
`check_runtime_boundaries.sh` and `check_private_repo_coupling.sh` all exit 0.
Clippy run with the repo's own allow-list composed exactly as ci.yml composes it.
Magic checks 13 and 14 pass on binaries built from this branch, and both new arms
flip red when the fix is reverted.
