### PR TITLE
Leave a post-mortem when a conversion is killed, and reclaim what it stranded

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1572,24 +1572,11 @@ fn check_interrupted_init() -> HealthCheck {
 
 /// Where a doctor run looks for interrupted-conversion staging.
 ///
-/// Both the working directory and its parent, because init stages beside the
-/// repository rather than inside it: an operator running doctor from the
-/// converted repository needs the parent scanned, and one running it from the
-/// directory that holds their checkouts needs the working directory scanned.
-/// Looking in only one of the two answers correctly for one of those operators
-/// and reports a clean disk to the other.
+/// The choice of directories, and the filesystem access it takes to resolve
+/// them, belong to the init boundary in kin-core rather than to a CLI health
+/// row: doctor asks that boundary where to look and reports what it answers.
 fn interrupted_init_scan_roots(cwd: &Path) -> Vec<PathBuf> {
-    // Canonical, because init canonicalizes its source before recording one and
-    // a fix line naming `/var/...` for a record that says `/private/var/...` is
-    // two paths for one directory in the same paragraph.
-    let cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
-    let mut roots = vec![cwd.clone()];
-    if let Some(parent) = cwd.parent() {
-        if parent != cwd {
-            roots.push(parent.to_path_buf());
-        }
-    }
-    roots
+    kin_core::init_attempt::staging_scan_roots(cwd)
 }
 
 fn interrupted_init_check_for(roots: &[PathBuf]) -> HealthCheck {
@@ -4298,7 +4285,9 @@ mod tests {
                 "run {where_from}, the row must raise: {found:?}"
             );
             assert!(
-                found.detail.contains("phase 13 of 17, commit bootstrap transaction"),
+                found
+                    .detail
+                    .contains("phase 13 of 17, commit bootstrap transaction"),
                 "run {where_from}, the row must name the phase: {}",
                 found.detail
             );
@@ -4337,7 +4326,11 @@ mod tests {
         let root = interrupted_init_scan_roots(Path::new("/"));
         assert_eq!(root, vec![PathBuf::from("/")], "the root has no parent");
         let nested = interrupted_init_scan_roots(Path::new("/tmp"));
-        assert_eq!(nested.len(), 2, "an ordinary directory scans itself and its parent: {nested:?}");
+        assert_eq!(
+            nested.len(),
+            2,
+            "an ordinary directory scans itself and its parent: {nested:?}"
+        );
         assert_ne!(nested[0], nested[1]);
     }
 

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -198,6 +198,7 @@ pub async fn run_health_checks() -> HealthReport {
     checks.push(check_embedding_model().await);
     checks.push(check_commit_memory_headroom());
     checks.push(check_daemon_kill_record());
+    checks.push(check_interrupted_init());
     checks.push(check_suspended_sweep());
     checks.push(check_host_memory_pressure());
     checks.push(check_retrieval_profile());
@@ -1551,6 +1552,71 @@ fn projection_mode_check_for(
              available here"
         },
     )
+}
+
+/// Report staging an interrupted `kin init` left on disk, and where it stopped.
+///
+/// A conversion the kernel kills for memory runs no destructor: the shell gets
+/// exit 137, `.kin` never appears, and hundreds of megabytes of staging sit
+/// beside the repository with nothing pointing at them. The rc0550 stranger met
+/// that and deleted it by hand after guessing what it was. This row is the
+/// answer to the question that operator had no way to ask.
+///
+/// Reports, never reaps. An operator asking what is on their disk has not asked
+/// Kin to delete anything, and the reclaim already happens on the next `kin
+/// init` in that repository, which the fix line names.
+fn check_interrupted_init() -> HealthCheck {
+    let cwd = env::current_dir().unwrap_or_default();
+    interrupted_init_check_for(&interrupted_init_scan_roots(&cwd))
+}
+
+/// Where a doctor run looks for interrupted-conversion staging.
+///
+/// Both the working directory and its parent, because init stages beside the
+/// repository rather than inside it: an operator running doctor from the
+/// converted repository needs the parent scanned, and one running it from the
+/// directory that holds their checkouts needs the working directory scanned.
+/// Looking in only one of the two answers correctly for one of those operators
+/// and reports a clean disk to the other.
+fn interrupted_init_scan_roots(cwd: &Path) -> Vec<PathBuf> {
+    // Canonical, because init canonicalizes its source before recording one and
+    // a fix line naming `/var/...` for a record that says `/private/var/...` is
+    // two paths for one directory in the same paragraph.
+    let cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let mut roots = vec![cwd.clone()];
+    if let Some(parent) = cwd.parent() {
+        if parent != cwd {
+            roots.push(parent.to_path_buf());
+        }
+    }
+    roots
+}
+
+fn interrupted_init_check_for(roots: &[PathBuf]) -> HealthCheck {
+    let mut attempts = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for root in roots {
+        for attempt in kin_core::init_attempt::abandoned_init_attempts(root).unwrap_or_default() {
+            if seen.insert(attempt.capture_path.clone()) {
+                attempts.push(attempt);
+            }
+        }
+    }
+    match kin_core::init_attempt::doctor_row(&attempts) {
+        Some((detail, fix)) => HealthCheck::new(
+            "interrupted_init",
+            "Interrupted conversion",
+            HealthStatus::Degraded,
+            detail,
+        )
+        .with_manual_fix(fix),
+        None => HealthCheck::new(
+            "interrupted_init",
+            "Interrupted conversion",
+            HealthStatus::Healthy,
+            "no `kin init` staging is waiting to be reclaimed here",
+        ),
+    }
 }
 
 fn check_repo_init() -> HealthCheck {
@@ -4182,6 +4248,99 @@ mod tests {
     /// Falsify by comparing against `store.bytes` instead of the measured peak,
     /// or by returning `Healthy` unconditionally: the constrained arm then
     /// passes silently, which is the state this check exists to end.
+    /// The row has to find staging whether doctor is run from the repository
+    /// being converted or from the directory that holds it, because init stages
+    /// beside the repository and an operator stands in either place.
+    #[test]
+    fn the_interrupted_conversion_row_scans_the_working_directory_and_its_parent() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path().canonicalize().unwrap();
+        let repo = root.join("requests");
+        std::fs::create_dir(&repo).unwrap();
+
+        let clean = interrupted_init_check_for(&interrupted_init_scan_roots(&repo));
+        assert!(
+            matches!(clean.status, HealthStatus::Healthy),
+            "a disk with no staging on it must not raise a row: {clean:?}"
+        );
+        assert!(clean.manual_fix.is_none());
+
+        // The shape a killed init leaves: a leased capture directory carrying a
+        // phase record, beside the repository rather than inside it.
+        let capture = root.join(".kin-git-capture-abdd7a1c");
+        std::fs::create_dir(&capture).unwrap();
+        std::fs::write(capture.join("capture.lease"), b"").unwrap();
+        std::fs::write(capture.join("body"), vec![0_u8; 4096]).unwrap();
+        let record = serde_json::json!({
+            "version": 1,
+            "source": repo.display().to_string(),
+            "destination": repo.join(".kin").display().to_string(),
+            "pid": 41,
+            "started_unix": 1000,
+            "phase_index": 13,
+            "phase_total": 17,
+            "phase_label": "commit bootstrap transaction",
+            "phase_started_unix": 1707,
+            "memory_limit_bytes": 12884901888_u64,
+            "memory_source": "container",
+            "stage_path": serde_json::Value::Null,
+        });
+        std::fs::write(
+            capture.join("init-attempt.json"),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+
+        for (where_from, cwd) in [("inside the repository", &repo), ("beside it", &root)] {
+            let found = interrupted_init_check_for(&interrupted_init_scan_roots(cwd));
+            assert!(
+                matches!(found.status, HealthStatus::Degraded),
+                "run {where_from}, the row must raise: {found:?}"
+            );
+            assert!(
+                found.detail.contains("phase 13 of 17, commit bootstrap transaction"),
+                "run {where_from}, the row must name the phase: {}",
+                found.detail
+            );
+            assert!(
+                found.detail.contains(" KB of staging"),
+                "run {where_from}, the row must name the size in bytes it measured: {}",
+                found.detail
+            );
+            let fix = found
+                .manual_fix
+                .as_deref()
+                .unwrap_or_else(|| panic!("run {where_from}, the row must carry a fix line"));
+            assert!(
+                fix.contains(&capture.display().to_string()),
+                "run {where_from}, the fix must name the path to delete: {fix}"
+            );
+        }
+
+        // One directory, reachable from two scan roots, is one finding.
+        let both = interrupted_init_check_for(&interrupted_init_scan_roots(&repo));
+        assert!(
+            both.detail.contains("from 1 interrupted"),
+            "a capture found through both roots must be counted once: {}",
+            both.detail
+        );
+        assert!(
+            capture.exists(),
+            "doctor reports and must never reap what it reports"
+        );
+    }
+
+    /// A working directory with no parent is the filesystem root, and asking
+    /// for one must not produce a duplicate scan of the same directory.
+    #[test]
+    fn the_scan_roots_never_repeat_a_directory() {
+        let root = interrupted_init_scan_roots(Path::new("/"));
+        assert_eq!(root, vec![PathBuf::from("/")], "the root has no parent");
+        let nested = interrupted_init_scan_roots(Path::new("/tmp"));
+        assert_eq!(nested.len(), 2, "an ordinary directory scans itself and its parent: {nested:?}");
+        assert_ne!(nested[0], nested[1]);
+    }
+
     #[test]
     fn doctor_reads_a_ceiling_below_a_measured_commit_peak_as_degraded() {
         let check =

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -1587,6 +1587,115 @@ mod tests {
         let _ = init_from_git(Path::new(&source));
     }
 
+    /// An init the kernel could kill leaves a post-mortem the next one reads.
+    ///
+    /// `SIGKILL` is the case, not `SIGTERM`: a signal Kin can catch already
+    /// cleans up after itself, and the one the OOM killer sends cannot be
+    /// caught at all. So this asserts the property no in-process code can
+    /// provide, that the phase was on disk before the process died.
+    #[cfg(unix)]
+    #[test]
+    fn an_init_the_kernel_kills_leaves_a_phase_the_next_run_can_read() {
+        let held = tempfile::tempdir().unwrap();
+        // Canonical throughout, because init canonicalizes its source before it
+        // records anything and a test comparing `/var` against `/private/var`
+        // fails on the symlink rather than on the behaviour.
+        let root = held.path().canonicalize().unwrap();
+        let source = root.join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        std::fs::write(source.join("README.md"), b"exact source\n").unwrap();
+        git(&source, ["add", "--all"]);
+        git(&source, ["commit", "-m", "initial"]);
+
+        let barrier = root.join("capture-barrier");
+        let mut child = ParkedChild::spawn(
+            std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("git_init::tests::interrupted_init_subprocess")
+                .arg("--nocapture")
+                .arg("--test-threads=1")
+                .env("KIN_INIT_INTERRUPTED_TEST_SOURCE", &source)
+                .env("KIN_INIT_INTERRUPTED_TEST_BARRIER", &barrier),
+        );
+        let staged = wait_for_capture_barrier(&barrier, &mut child);
+
+        // SIGKILL, delivered the way the OOM killer delivers it. Nothing in the
+        // child runs after this line.
+        let pid = child.id() as i32;
+        assert_eq!(unsafe { libc::kill(pid, libc::SIGKILL) }, 0);
+        let status = child.wait();
+        assert!(
+            !status.success(),
+            "the child must have died of the signal, not finished: {status:?}"
+        );
+        assert!(
+            !source.join(".kin").exists(),
+            "the fixture is the killed case only if no repository was published"
+        );
+        assert!(
+            staged.is_dir(),
+            "a killed init strands its capture directory, which is what makes a post-mortem \
+             possible and is the disk this fix reclaims"
+        );
+
+        let abandoned = crate::init_attempt::abandoned_init_attempts(&root).unwrap();
+        assert_eq!(
+            abandoned.len(),
+            1,
+            "exactly the killed conversion should be reported: {abandoned:?}"
+        );
+        let found = &abandoned[0];
+        assert_eq!(found.capture_path, staged);
+        let record = found
+            .record
+            .as_ref()
+            .unwrap_or_else(|| panic!("no phase record survived the kill: {found:?}"));
+        assert_eq!(
+            record.phase_total, GIT_ADMISSION_PHASES,
+            "the record must carry the ladder it was running"
+        );
+        assert!(
+            record.phase_index >= 1 && record.phase_index <= GIT_ADMISSION_PHASES,
+            "the recorded phase must be one the ladder has: {record:?}"
+        );
+        assert!(
+            !record.phase_label.is_empty(),
+            "the phase must be named, not just numbered: {record:?}"
+        );
+        assert_eq!(
+            Path::new(&record.source),
+            source,
+            "the record must name the repository it was converting"
+        );
+        assert!(
+            found.converted(&source),
+            "and the next run must be able to match it to this repository"
+        );
+        assert!(
+            found.reclaimable_bytes() > 0,
+            "a stranded capture holds bytes, and reporting zero would hide them"
+        );
+        let rendered = crate::init_attempt::post_mortem_lines(found, None).join("\n");
+        assert!(
+            rendered.contains(&format!(
+                "phase {} of {}, {}",
+                record.phase_index, GIT_ADMISSION_PHASES, record.phase_label
+            )),
+            "the post-mortem must quote the recorded phase: {rendered}"
+        );
+
+        // The next init reclaims what the kill stranded and converts anyway.
+        init_from_git(&source).unwrap();
+        assert!(source.join(".kin").exists());
+        assert!(
+            crate::init_attempt::abandoned_init_attempts(&root)
+                .unwrap()
+                .is_empty(),
+            "the re-run must leave no interrupted attempt behind"
+        );
+        assert_no_staging_directories(&root);
+    }
+
     /// A capture directory a previous interrupted init left behind is removed
     /// by the next real init rather than accumulating beside the repository.
     #[test]

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -193,6 +193,20 @@ fn init_from_git_with_hooks(
 ) -> Result<InitResult> {
     let source = canonical_new_repository_root(working_dir)?;
     require_git_boundary(&source)?;
+    let source_parent = source.parent().ok_or_else(|| {
+        KinError::Other(format!(
+            "repository root has no parent for isolated Git capture: {}",
+            source.display()
+        ))
+    })?;
+    let final_kin_dir = source.join(".kin");
+
+    // Ahead of the ladder, because a conversion the kernel killed says nothing
+    // for itself: `SIGKILL` runs no destructor and prints no error, so the only
+    // account of it is the one this run reads back off disk. Read before the
+    // claim below, which reaps exactly the directories being reported.
+    let leftovers = crate::init_attempt::abandoned_init_attempts(source_parent).unwrap_or_default();
+    crate::init_attempt::report_previous_attempts(&leftovers, &source);
 
     let mut progress = PhaseProgress::new(GIT_ADMISSION_PHASES);
 
@@ -210,13 +224,23 @@ fn init_from_git_with_hooks(
     let manifest = KinManifest::new();
     let repository_id = RepositoryId::new(manifest.repo_id.clone())
         .map_err(|error| KinError::Other(format!("invalid repository identity: {error}")))?;
-    let source_parent = source.parent().ok_or_else(|| {
-        KinError::Other(format!(
-            "repository root has no parent for isolated Git capture: {}",
-            source.display()
-        ))
-    })?;
+    // Claiming reaps every abandoned capture directory beside this one. The
+    // repository stages a killed init left are reclaimed here too rather than
+    // at their own phase eight, so the disk comes back before the minutes are
+    // spent instead of after.
     let capture_dir = crate::init_staging::GitCaptureStaging::claim(source_parent)?;
+    let _ = crate::init::recover_orphaned_repository_stages(source_parent, &final_kin_dir);
+    crate::init_attempt::report_reclaimed(&leftovers);
+
+    // The ladder now stamps every phase it opens into the capture directory, so
+    // the next command can name where a kill landed.
+    let journal = std::sync::Arc::new(crate::init_attempt::InitAttemptJournal::open(
+        capture_dir.path(),
+        &source,
+        &final_kin_dir,
+        GIT_ADMISSION_PHASES,
+    ));
+    progress.attach_journal(journal);
     // The capture store lives and dies inside this call, so its bodies are
     // written without device barriers. Its root is the per-init `capture_dir`
     // above, removed when that handle drops, when a terminating signal reaches
@@ -307,8 +331,12 @@ fn init_from_git_with_hooks(
             .map_err(|error| git_boundary_error("prove mutable Git workspace", error))?
     };
 
-    let final_kin_dir = source.join(".kin");
     let staging_dir = source_parent.join(format!(".kin.init-{}", uuid::Uuid::new_v4()));
+    // Recorded before the directory exists rather than after, so a kill during
+    // its creation still leaves a post-mortem that names it.
+    if let Some(journal) = progress.journal() {
+        journal.record_stage_path(&staging_dir);
+    }
     let config = config_for_source(&snapshot, &source_proof.remote_mapping)?;
 
     progress.begin("stage repository layout");

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -2203,7 +2203,7 @@ fn filesystem_entry_exists(path: &Path) -> Result<bool> {
 /// Invalid, ambiguous, replaced, or active candidates are retained. Automatic
 /// orphan recovery is disabled when the platform cannot expose a stable file
 /// identity and current-user ownership.
-fn recover_orphaned_repository_stages(
+pub(crate) fn recover_orphaned_repository_stages(
     staging_parent: &Path,
     final_kin_dir: &Path,
 ) -> Result<usize> {

--- a/crates/kin-core/src/init_attempt.rs
+++ b/crates/kin-core/src/init_attempt.rs
@@ -1,0 +1,972 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What an interrupted `kin init` leaves behind so the next command can speak
+//! for it.
+//!
+//! A conversion of a mature repository runs for minutes and holds most of a
+//! history in memory while it does. When the kernel kills it for exceeding a
+//! memory cap the process gets `SIGKILL`, which runs no destructor, prints no
+//! message and returns no error: the shell sees exit 137 and nothing else. The
+//! rc0550 stranger met exactly that. Kin said nothing, `.kin` did not exist,
+//! and 420 MB of staging sat beside the repository with nothing pointing at it.
+//!
+//! Nothing inside the dying process can fix that, because there is no code
+//! running in it any more. What can fix it is a record written BEFORE the kill,
+//! read by whatever runs next. That is this module: the ladder stamps its
+//! current phase into the capture staging directory as each phase opens, and
+//! [`abandoned_init_attempts`] reads back every record no live init still owns.
+//!
+//! Two properties make the record trustworthy rather than merely present.
+//!
+//! It lives inside the capture staging directory, so it can never outlive the
+//! staging it describes, and it inherits that directory's lease: a record whose
+//! lease can be taken exclusively belongs to a process that is gone, and one
+//! whose lease is contended belongs to an init running right now. That is a
+//! measurement of liveness rather than a guess from a pid, which is what keeps
+//! a concurrent sibling conversion from being reported as a corpse.
+//!
+//! And it is never fsynced. A `SIGKILL` leaves the page cache intact, so the
+//! bytes reach the next reader without one, and a conversion already fighting
+//! for memory should not pay seventeen barriers for a file that only has to
+//! survive its own process.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{KinError, Result};
+use crate::memory_pressure::{self, MemoryReading};
+
+/// Name of the record inside a capture staging directory.
+pub const ATTEMPT_RECORD_NAME: &str = "init-attempt.json";
+
+/// Largest record this module will read back.
+///
+/// The writer produces a few hundred bytes. A file larger than this is not a
+/// record Kin wrote, and reading it into memory to find that out is how a
+/// post-mortem path becomes its own denial of service.
+const MAX_RECORD_BYTES: u64 = 64 * 1024;
+
+/// Current record layout. A reader that meets a version it does not know
+/// reports the attempt without its phase detail rather than guessing at fields.
+pub const ATTEMPT_RECORD_VERSION: u32 = 1;
+
+/// What one `kin init` had reached when it was last able to say.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InitAttemptRecord {
+    /// Layout of this record.
+    pub version: u32,
+    /// Repository root being converted.
+    pub source: String,
+    /// Where the conversion intended to publish `.kin`.
+    pub destination: String,
+    /// The process that wrote it. Disclosure only: liveness is decided by the
+    /// staging lease, because a pid is reused and a lease is not.
+    pub pid: u32,
+    /// When the attempt started, seconds since the Unix epoch.
+    pub started_unix: u64,
+    /// Phase last entered, one-based. Zero means no phase had opened yet.
+    pub phase_index: usize,
+    /// Phases in the ladder this attempt was running.
+    pub phase_total: usize,
+    /// Human label of that phase, exactly as the progress ladder printed it.
+    pub phase_label: String,
+    /// When that phase opened, seconds since the Unix epoch.
+    pub phase_started_unix: u64,
+    /// The memory ceiling measured when the attempt started, and what published
+    /// it. `None` when this process could not read one.
+    pub memory_limit_bytes: Option<u64>,
+    /// `container` or `machine`, from the same reading.
+    pub memory_source: Option<String>,
+    /// The repository stage directory, once the ladder has created one. Absent
+    /// before the staging phase, which is why a kill early in the ladder leaves
+    /// only the capture directory behind.
+    pub stage_path: Option<String>,
+}
+
+impl InitAttemptRecord {
+    /// Seconds this attempt had been running when its phase opened.
+    ///
+    /// Reported rather than "how long it ran", because the record cannot know
+    /// when the kill landed. The distance from the start to the last phase it
+    /// managed to write is a fact; anything past that is inference.
+    pub fn seconds_to_last_phase(&self) -> u64 {
+        self.phase_started_unix.saturating_sub(self.started_unix)
+    }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_secs())
+        .unwrap_or(0)
+}
+
+// --------------------------------------------------------------------- writer
+
+/// The live attempt's record, rewritten as each phase opens.
+///
+/// Every write is best effort. A conversion must never fail because its own
+/// post-mortem could not be written, so the errors are counted for the tests
+/// and otherwise dropped.
+#[derive(Debug)]
+pub(crate) struct InitAttemptJournal {
+    path: PathBuf,
+    state: Mutex<JournalState>,
+}
+
+#[derive(Debug)]
+struct JournalState {
+    record: InitAttemptRecord,
+    write_failures: usize,
+}
+
+impl InitAttemptJournal {
+    /// Start a record for a conversion of `source` staging inside `capture_dir`.
+    pub(crate) fn open(
+        capture_dir: &Path,
+        source: &Path,
+        destination: &Path,
+        phase_total: usize,
+    ) -> Self {
+        let reading = memory_pressure::read();
+        let reading = reading.reading();
+        let now = unix_now();
+        let record = InitAttemptRecord {
+            version: ATTEMPT_RECORD_VERSION,
+            source: source.display().to_string(),
+            destination: destination.display().to_string(),
+            pid: std::process::id(),
+            started_unix: now,
+            phase_index: 0,
+            phase_total,
+            phase_label: String::new(),
+            phase_started_unix: now,
+            memory_limit_bytes: reading.map(|reading| reading.limit_bytes),
+            memory_source: reading.map(|reading| reading.source.as_str().to_string()),
+            stage_path: None,
+        };
+        let journal = Self {
+            path: capture_dir.join(ATTEMPT_RECORD_NAME),
+            state: Mutex::new(JournalState {
+                record,
+                write_failures: 0,
+            }),
+        };
+        journal.flush();
+        journal
+    }
+
+    /// Record that phase `index` of the ladder has opened.
+    pub(crate) fn enter_phase(&self, index: usize, label: &str) {
+        self.edit(|record| {
+            record.phase_index = index;
+            record.phase_label = label.to_string();
+            record.phase_started_unix = unix_now();
+        });
+    }
+
+    /// Record the repository stage directory the ladder just created, so a
+    /// post-mortem can name and size both halves of what a kill leaves behind.
+    pub(crate) fn record_stage_path(&self, stage: &Path) {
+        self.edit(|record| record.stage_path = Some(stage.display().to_string()));
+    }
+
+    fn edit(&self, act: impl FnOnce(&mut InitAttemptRecord)) {
+        if let Ok(mut state) = self.state.lock() {
+            act(&mut state.record);
+        }
+        self.flush();
+    }
+
+    /// Replace the record on disk.
+    ///
+    /// Written to a temporary sibling and renamed, so a reader arriving between
+    /// two phases sees one whole record rather than a truncated one. Not
+    /// fsynced: see the module note.
+    fn flush(&self) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        let Ok(bytes) = serde_json::to_vec_pretty(&state.record) else {
+            state.write_failures += 1;
+            return;
+        };
+        let staging = self.path.with_extension("writing");
+        let wrote = File::create(&staging).and_then(|mut file| {
+            file.write_all(&bytes)?;
+            file.write_all(b"\n")
+        });
+        if wrote.is_err() || std::fs::rename(&staging, &self.path).is_err() {
+            let _ = std::fs::remove_file(&staging);
+            state.write_failures += 1;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn write_failures(&self) -> usize {
+        self.state
+            .lock()
+            .map(|state| state.write_failures)
+            .unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+// --------------------------------------------------------------------- reader
+
+/// One conversion that started beside `parent` and never finished.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbandonedInit {
+    /// The capture staging directory it left.
+    pub capture_path: PathBuf,
+    /// Bytes that directory holds.
+    pub capture_bytes: u64,
+    /// Its record, when one is readable. `None` is an older Kin's staging, or a
+    /// record this build cannot parse, and is reported as such rather than
+    /// silently skipped.
+    pub record: Option<InitAttemptRecord>,
+    /// Why the record could not be read, when it could not.
+    pub record_unreadable: Option<String>,
+    /// The repository stage directory the record named, when it still exists.
+    pub stage_path: Option<PathBuf>,
+    /// Bytes that directory holds.
+    pub stage_bytes: u64,
+    /// The stage's `.owner` sidecar, which sits beside the stage rather than
+    /// inside it and so is a third thing a hand cleanup has to know about.
+    pub owner_path: Option<PathBuf>,
+}
+
+impl AbandonedInit {
+    /// Total disk this attempt is holding.
+    pub fn reclaimable_bytes(&self) -> u64 {
+        self.capture_bytes.saturating_add(self.stage_bytes)
+    }
+
+    /// Whether this attempt was converting `source`.
+    pub fn converted(&self, source: &Path) -> bool {
+        self.record
+            .as_ref()
+            .is_some_and(|record| Path::new(&record.source) == source)
+    }
+
+    /// Every path this attempt left behind, so a hand cleanup is complete.
+    pub fn paths(&self) -> Vec<PathBuf> {
+        let mut paths = vec![self.capture_path.clone()];
+        paths.extend(self.stage_path.clone());
+        paths.extend(self.owner_path.clone());
+        paths
+    }
+}
+
+/// Every unfinished conversion staged beside `parent` that no live init owns.
+///
+/// Read-only, and deliberately so: `kin doctor` has to be able to name what is
+/// on disk without deleting it, and `kin init` has to be able to report what it
+/// is about to reclaim before it reclaims it.
+///
+/// A directory whose lease is contended belongs to a conversion running right
+/// now and is not reported. A directory carrying no readable lease is reported
+/// with its reason, because an older Kin wrote it and saying nothing about
+/// 200 MB is the defect this module exists to end.
+pub fn abandoned_init_attempts(parent: &Path) -> Result<Vec<AbandonedInit>> {
+    let entries = match std::fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(KinError::io(parent, error)),
+    };
+    let mut entries = entries
+        .collect::<std::io::Result<Vec<_>>>()
+        .map_err(|error| KinError::io(parent, error))?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    let mut abandoned = Vec::new();
+    for entry in entries {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with(crate::init_staging::GIT_CAPTURE_PREFIX) {
+            continue;
+        }
+        let candidate = entry.path();
+        let Ok(metadata) = std::fs::symlink_metadata(&candidate) else {
+            continue;
+        };
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            continue;
+        }
+        // A live conversion's staging is not a post-mortem. Only a lease that
+        // can be taken exclusively proves its holder is gone, and an
+        // unanswerable lease is left alone here for the same reason the reaper
+        // leaves it alone: this call cannot prove nothing is using it.
+        if !matches!(
+            crate::init_staging::capture_lease_is_abandoned(&candidate),
+            Ok(true)
+        ) {
+            continue;
+        }
+        let (record, record_unreadable) = read_attempt_record(&candidate);
+        let stage_path = record
+            .as_ref()
+            .and_then(|record| record.stage_path.as_ref())
+            .map(PathBuf::from)
+            .filter(|stage| stage.is_dir());
+        let owner_path = stage_path
+            .as_ref()
+            .map(|stage| owner_sidecar_path(stage))
+            .filter(|owner| owner.is_file());
+        abandoned.push(AbandonedInit {
+            capture_bytes: directory_bytes(&candidate),
+            capture_path: candidate,
+            record,
+            record_unreadable,
+            stage_bytes: stage_path.as_deref().map(directory_bytes).unwrap_or(0),
+            stage_path,
+            owner_path,
+        });
+    }
+    Ok(abandoned)
+}
+
+/// Where a repository stage's ownership record sits.
+///
+/// Beside the stage rather than inside it, so publication can rename the stage
+/// into place without carrying its own lease along. Reproduced here rather than
+/// reached for, because this reader must work on a stage whose owning init is
+/// long dead and there is nothing left to ask.
+fn owner_sidecar_path(stage: &Path) -> PathBuf {
+    let mut name = stage.as_os_str().to_os_string();
+    name.push(".owner");
+    PathBuf::from(name)
+}
+
+/// Read one capture directory's record, or say why it could not be read.
+fn read_attempt_record(capture: &Path) -> (Option<InitAttemptRecord>, Option<String>) {
+    let path = capture.join(ATTEMPT_RECORD_NAME);
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return (
+                None,
+                Some("it carries no phase record, so an older Kin staged it".to_string()),
+            );
+        }
+        Err(error) => return (None, Some(format!("its phase record is unreadable: {error}"))),
+    };
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return (
+            None,
+            Some("its phase record is not a regular file".to_string()),
+        );
+    }
+    if metadata.len() > MAX_RECORD_BYTES {
+        return (
+            None,
+            Some(format!(
+                "its phase record is {} bytes, past the {MAX_RECORD_BYTES} this reader accepts",
+                metadata.len()
+            )),
+        );
+    }
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) => return (None, Some(format!("its phase record is unreadable: {error}"))),
+    };
+    match serde_json::from_slice::<InitAttemptRecord>(&bytes) {
+        Ok(record) if record.version == ATTEMPT_RECORD_VERSION => (Some(record), None),
+        Ok(record) => (
+            None,
+            Some(format!(
+                "its phase record is layout version {}, which this build does not read",
+                record.version
+            )),
+        ),
+        Err(error) => (
+            None,
+            Some(format!("its phase record does not parse: {error}")),
+        ),
+    }
+}
+
+/// Bytes a directory tree holds, counting regular files only.
+///
+/// Never follows a symlink and never fails: a size that could not be measured
+/// reads as the part that could. This is disclosure of disk usage at an IO
+/// boundary, not an answer about repository content, and nothing semantic is
+/// derived from it.
+fn directory_bytes(root: &Path) -> u64 {
+    let mut total = 0_u64;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(directory) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+            if metadata.is_dir() {
+                stack.push(entry.path());
+            } else if metadata.is_file() {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    total
+}
+
+/// Render a byte count the way a person reads one.
+pub fn human_bytes(bytes: u64) -> String {
+    const UNITS: [(&str, u64); 4] = [
+        ("GB", 1024 * 1024 * 1024),
+        ("MB", 1024 * 1024),
+        ("KB", 1024),
+        ("bytes", 1),
+    ];
+    for (unit, scale) in UNITS {
+        if bytes >= scale && scale > 1 {
+            return format!("{:.1} {unit}", bytes as f64 / scale as f64);
+        }
+    }
+    format!("{bytes} bytes")
+}
+
+// ------------------------------------------------------------------ reporting
+
+/// The prose one abandoned conversion is worth, in the register the commit
+/// diagnosis register set: what stopped, where it stopped, under what ceiling,
+/// what the kernel says about it, and what this run is going to do next.
+///
+/// Pure over its inputs so the wording is pinned by tests rather than by
+/// running a conversion. `now_unix` and `current` are passed in for the same
+/// reason: a post-mortem that reads the clock and the cgroup for itself cannot
+/// be asserted on.
+pub fn post_mortem_lines(
+    attempt: &AbandonedInit,
+    now_unix: u64,
+    current: Option<&MemoryReading>,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    match &attempt.record {
+        Some(record) => {
+            lines.push(format!(
+                "a previous kin init of {} did not finish",
+                record.source
+            ));
+            lines.push(format!(
+                "  it stopped in phase {} of {}, {}, {} into the conversion",
+                record.phase_index.max(1),
+                record.phase_total,
+                if record.phase_label.is_empty() {
+                    "before the first phase opened"
+                } else {
+                    record.phase_label.as_str()
+                },
+                human_seconds(record.seconds_to_last_phase()),
+            ));
+            lines.push(memory_line(record, now_unix));
+        }
+        None => {
+            lines.push(format!(
+                "a previous kin init left staging at {} behind",
+                attempt.capture_path.display()
+            ));
+            if let Some(reason) = &attempt.record_unreadable {
+                lines.push(format!(
+                    "  it cannot say which phase it stopped in, because {reason}"
+                ));
+            }
+        }
+    }
+    if let Some(reading) = current {
+        if reading.kernel_has_killed_here() {
+            let kills = reading.oom_kills.unwrap_or(0);
+            lines.push(format!(
+                "  the {} it ran in has recorded {} kernel out-of-memory {}, so a memory kill is \
+                 the likely cause",
+                reading.source.as_str(),
+                kills,
+                if kills == 1 { "kill" } else { "kills" },
+            ));
+        }
+    }
+    lines.push(format!(
+        "  it is holding {} of staging: {}",
+        human_bytes(attempt.reclaimable_bytes()),
+        attempt
+            .paths()
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    lines
+}
+
+/// The ceiling clause, kept apart because it has three honest forms and the
+/// difference between them matters: a measured cap, a machine that could not be
+/// read, and a record written by a build that did not measure one.
+fn memory_line(record: &InitAttemptRecord, _now_unix: u64) -> String {
+    match (record.memory_limit_bytes, &record.memory_source) {
+        (Some(limit), Some(source)) => format!(
+            "  the {source} it ran in had a {} memory ceiling when it started",
+            human_bytes(limit)
+        ),
+        (Some(limit), None) => format!(
+            "  it started under a {} memory ceiling",
+            human_bytes(limit)
+        ),
+        _ => "  it could not read a memory ceiling for the machine it ran on".to_string(),
+    }
+}
+
+/// Why the next conversion starts over instead of picking up where the last one
+/// stopped.
+///
+/// Kin does not resume a killed conversion, and this says so rather than
+/// letting an operator infer it from a progress bar that starts at one again.
+/// The reason is structural, not a missing feature to be worked around: the
+/// capture store is a content-addressed cache written without device barriers
+/// because it was only ever meant to live inside one process, and the bootstrap
+/// transaction is committed in one shot with no journal to replay. Adopting
+/// either after a kill would trade an eleven-minute repeat for a store nobody
+/// can prove is whole.
+pub const RESTART_NOTICE: &str = "  this run restarts from phase 1 rather than resuming: a killed \
+                                  conversion's staged capture is written without device barriers \
+                                  and its bootstrap transaction carries no journal, so none of it \
+                                  can be adopted without risking a store no proof would accept";
+
+/// What an operator can do about the ceiling, when the record measured one.
+///
+/// Only ever printed with a measured number beside it, so this never invents a
+/// limit nobody read.
+pub fn ceiling_advice(record: &InitAttemptRecord) -> Option<String> {
+    let limit = record.memory_limit_bytes?;
+    Some(format!(
+        "  a conversion's peak follows history depth, so give it more than {} or convert a \
+         repository with less history",
+        human_bytes(limit)
+    ))
+}
+
+/// Write one advisory line to stderr, tolerating a closed pipe.
+///
+/// `eprintln!` panics when its reader is gone, and a conversion's exit status
+/// has to report the admission rather than the terminal going away.
+fn disclose(line: &str) {
+    let mut stderr = std::io::stderr().lock();
+    let _ = writeln!(stderr, "{line}");
+}
+
+/// Tell the operator about every conversion that died beside this one before
+/// this run reaps its remains.
+///
+/// Called before the reap on purpose: the directories being described are the
+/// ones about to be deleted, so describing them afterwards would mean reading a
+/// path that no longer exists and reporting a size nobody can check.
+pub fn report_previous_attempts(attempts: &[AbandonedInit], source: &Path) {
+    if attempts.is_empty() {
+        return;
+    }
+    let current = memory_pressure::read();
+    let current = current.reading().copied();
+    let now = unix_now();
+    for attempt in attempts {
+        let mut lines = post_mortem_lines(attempt, now, current.as_ref());
+        if let Some(first) = lines.first_mut() {
+            *first = format!("warning: {first}");
+        }
+        for line in lines {
+            disclose(&line);
+        }
+    }
+    // The restart notice belongs to a conversion of THIS repository. A sibling
+    // repository's corpse beside us is worth naming, but this run is not
+    // restarting it and saying so would be a claim about work nobody asked for.
+    let ours = attempts.iter().find(|attempt| attempt.converted(source));
+    if let Some(ours) = ours {
+        disclose(RESTART_NOTICE);
+        if let Some(advice) = ours.record.as_ref().and_then(ceiling_advice) {
+            disclose(&advice);
+        }
+    }
+}
+
+/// Say what the reap actually recovered, measured rather than assumed.
+///
+/// Reports what is gone by re-reading the filesystem, so a directory the reap
+/// declined to touch is never counted as reclaimed. A retained path is named
+/// with the reason the reaper had, because 200 MB nobody mentions is the defect
+/// this module exists to end and a silent partial reclaim is the same defect
+/// wearing a smaller number.
+pub fn report_reclaimed(before: &[AbandonedInit]) {
+    if before.is_empty() {
+        return;
+    }
+    let mut freed = 0_u64;
+    let mut retained: Vec<String> = Vec::new();
+    for attempt in before {
+        if attempt.capture_path.exists() {
+            retained.push(attempt.capture_path.display().to_string());
+        } else {
+            freed = freed.saturating_add(attempt.capture_bytes);
+        }
+        match &attempt.stage_path {
+            Some(stage) if stage.exists() => retained.push(stage.display().to_string()),
+            Some(_) => freed = freed.saturating_add(attempt.stage_bytes),
+            None => {}
+        }
+    }
+    if freed > 0 {
+        disclose(&format!(
+            "  reclaimed {} of staging those attempts left behind",
+            human_bytes(freed)
+        ));
+    }
+    if !retained.is_empty() {
+        disclose(&format!(
+            "  {} left in place, because this run could not prove nothing is using it: {}",
+            human_bytes(
+                before
+                    .iter()
+                    .map(AbandonedInit::reclaimable_bytes)
+                    .sum::<u64>()
+                    .saturating_sub(freed)
+            ),
+            retained.join(", ")
+        ));
+    }
+}
+
+/// The `kin doctor` row's detail and fix lines for whatever staging is sitting
+/// beside `parent`, or `None` when there is none.
+///
+/// Doctor reports and never reaps: an operator asking what is on their disk has
+/// not asked Kin to delete anything, and a diagnostic that mutates is one an
+/// operator learns not to run.
+pub fn doctor_row(attempts: &[AbandonedInit]) -> Option<(String, String)> {
+    if attempts.is_empty() {
+        return None;
+    }
+    let total: u64 = attempts.iter().map(AbandonedInit::reclaimable_bytes).sum();
+    let where_it_stopped = attempts
+        .iter()
+        .filter_map(|attempt| attempt.record.as_ref())
+        .map(|record| {
+            format!(
+                "{} stopped in phase {} of {}, {}",
+                record.source,
+                record.phase_index.max(1),
+                record.phase_total,
+                if record.phase_label.is_empty() {
+                    "before the first phase opened"
+                } else {
+                    record.phase_label.as_str()
+                }
+            )
+        })
+        .collect::<Vec<_>>();
+    let detail = if where_it_stopped.is_empty() {
+        format!(
+            "{} of staging from {} interrupted `kin init` run(s) is reclaimable; none of it \
+             carries a phase record, so an older Kin staged it",
+            human_bytes(total),
+            attempts.len()
+        )
+    } else {
+        format!(
+            "{} of staging from {} interrupted `kin init` run(s) is reclaimable: {}",
+            human_bytes(total),
+            attempts.len(),
+            where_it_stopped.join("; ")
+        )
+    };
+    let paths = attempts
+        .iter()
+        .flat_map(AbandonedInit::paths)
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>();
+    let fix = format!(
+        "run `kin init` in that repository again, which reclaims this before it starts, or \
+         delete {}",
+        paths.join(" ")
+    );
+    Some((detail, fix))
+}
+
+fn human_seconds(seconds: u64) -> String {
+    if seconds < 90 {
+        return format!("{seconds} s");
+    }
+    format!("{} min {} s", seconds / 60, seconds % 60)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory_pressure::PressureSource;
+
+    fn record() -> InitAttemptRecord {
+        InitAttemptRecord {
+            version: ATTEMPT_RECORD_VERSION,
+            source: "/work/requests".to_string(),
+            destination: "/work/requests/.kin".to_string(),
+            pid: 41,
+            started_unix: 1000,
+            phase_index: 13,
+            phase_total: 17,
+            phase_label: "commit bootstrap transaction".to_string(),
+            phase_started_unix: 1707,
+            memory_limit_bytes: Some(12 * 1024 * 1024 * 1024),
+            memory_source: Some("container".to_string()),
+            stage_path: None,
+        }
+    }
+
+    fn attempt(record: Option<InitAttemptRecord>) -> AbandonedInit {
+        AbandonedInit {
+            capture_path: PathBuf::from("/work/.kin-git-capture-abdd7a1c"),
+            capture_bytes: 210 * 1024 * 1024,
+            record,
+            record_unreadable: None,
+            stage_path: Some(PathBuf::from("/work/.kin.init-22ef96e2")),
+            stage_bytes: 210 * 1024 * 1024,
+            owner_path: Some(PathBuf::from("/work/.kin.init-22ef96e2.owner")),
+        }
+    }
+
+    fn reading(oom_kills: Option<u64>) -> MemoryReading {
+        MemoryReading {
+            source: PressureSource::Cgroup,
+            limit_bytes: 12 * 1024 * 1024 * 1024,
+            used_bytes: 1024,
+            swap_used_bytes: None,
+            swap_total_bytes: None,
+            oom_kills,
+            peak_bytes: None,
+        }
+    }
+
+    #[test]
+    fn a_post_mortem_names_the_phase_the_ceiling_and_the_staging() {
+        let lines = post_mortem_lines(&attempt(Some(record())), 2000, Some(&reading(Some(1))));
+        let rendered = lines.join("\n");
+        assert!(
+            rendered.contains("phase 13 of 17, commit bootstrap transaction"),
+            "the phase is the whole point of the record: {rendered}"
+        );
+        assert!(
+            rendered.contains("11 min 47 s into the conversion"),
+            "elapsed to the last phase must be reported: {rendered}"
+        );
+        assert!(
+            rendered.contains("12.0 GB memory ceiling"),
+            "the measured ceiling must be named: {rendered}"
+        );
+        assert!(
+            rendered.contains("1 kernel out-of-memory kill"),
+            "a kill the kernel recorded must be named: {rendered}"
+        );
+        assert!(
+            rendered.contains("420.0 MB of staging"),
+            "the reclaimable total must be named: {rendered}"
+        );
+        assert!(
+            rendered.contains("/work/.kin-git-capture-abdd7a1c")
+                && rendered.contains("/work/.kin.init-22ef96e2"),
+            "both staging paths must be named: {rendered}"
+        );
+    }
+
+    /// The kill clause is evidence, not decoration. A cgroup reporting zero
+    /// kills must not have one asserted about it, because the same silence
+    /// covers a conversion an operator killed by hand.
+    #[test]
+    fn a_cgroup_with_no_kills_is_never_told_it_had_one() {
+        let quiet = post_mortem_lines(&attempt(Some(record())), 2000, Some(&reading(Some(0))));
+        assert!(
+            !quiet.join("\n").contains("out-of-memory"),
+            "zero recorded kills must produce no kill sentence: {quiet:?}"
+        );
+        let unknown = post_mortem_lines(&attempt(Some(record())), 2000, Some(&reading(None)));
+        assert!(
+            !unknown.join("\n").contains("out-of-memory"),
+            "an unreadable kill counter is not evidence of a kill: {unknown:?}"
+        );
+        let some = post_mortem_lines(&attempt(Some(record())), 2000, Some(&reading(Some(2))));
+        assert!(
+            some.join("\n").contains("2 kernel out-of-memory kills"),
+            "more than one kill pluralizes: {some:?}"
+        );
+    }
+
+    /// A capture directory an older Kin left has no record. Reporting it as
+    /// phase zero of zero would be an invented fact; reporting nothing at all
+    /// is the defect. It gets its own sentence.
+    #[test]
+    fn staging_without_a_record_is_reported_without_inventing_a_phase() {
+        let mut orphan = attempt(None);
+        orphan.record_unreadable = Some("it carries no phase record".to_string());
+        let rendered = post_mortem_lines(&orphan, 2000, None).join("\n");
+        assert!(
+            rendered.contains("left staging at /work/.kin-git-capture-abdd7a1c behind"),
+            "the path is all this case can name: {rendered}"
+        );
+        assert!(
+            rendered.contains("cannot say which phase"),
+            "the reader must say why the phase is missing: {rendered}"
+        );
+        assert!(
+            !rendered.contains("phase 0"),
+            "an absent record must never render as a phase number: {rendered}"
+        );
+    }
+
+    /// A build that measured no ceiling says so. The alternative is a sentence
+    /// naming a limit nobody read, which is the failure mode the whole
+    /// memory-pressure seam exists to prevent.
+    #[test]
+    fn an_unmeasured_ceiling_is_said_rather_than_guessed() {
+        let mut unmeasured = record();
+        unmeasured.memory_limit_bytes = None;
+        unmeasured.memory_source = None;
+        let rendered = post_mortem_lines(&attempt(Some(unmeasured.clone())), 2000, None).join("\n");
+        assert!(
+            rendered.contains("could not read a memory ceiling"),
+            "an unmeasured ceiling must be disclosed: {rendered}"
+        );
+        assert!(
+            ceiling_advice(&unmeasured).is_none(),
+            "advice about a ceiling must never print without the ceiling"
+        );
+        assert!(
+            ceiling_advice(&record()).is_some_and(|line| line.contains("12.0 GB")),
+            "advice quotes the measured ceiling"
+        );
+    }
+
+    #[test]
+    fn a_record_survives_a_round_trip_through_the_journal() {
+        let root = tempfile::tempdir().unwrap();
+        let capture = root.path().join(".kin-git-capture-round-trip");
+        std::fs::create_dir(&capture).unwrap();
+        let journal = InitAttemptJournal::open(
+            &capture,
+            Path::new("/work/requests"),
+            Path::new("/work/requests/.kin"),
+            17,
+        );
+        journal.enter_phase(5, "derive semantic history");
+        journal.record_stage_path(Path::new("/work/.kin.init-22ef96e2"));
+        assert_eq!(journal.write_failures(), 0, "every write must land");
+
+        let (read_back, unreadable) = read_attempt_record(&capture);
+        assert!(unreadable.is_none(), "a record just written must parse");
+        let read_back = read_back.expect("the record must read back");
+        assert_eq!(read_back.phase_index, 5);
+        assert_eq!(read_back.phase_label, "derive semantic history");
+        assert_eq!(
+            read_back.stage_path.as_deref(),
+            Some("/work/.kin.init-22ef96e2")
+        );
+        assert_eq!(read_back.phase_total, 17);
+        assert_eq!(read_back.pid, std::process::id());
+        assert!(
+            !journal.path().with_extension("writing").exists(),
+            "the temporary sibling must not be left behind"
+        );
+    }
+
+    /// The reader must refuse a record it cannot vouch for rather than fill in
+    /// defaults, because a defaulted phase number is a wrong answer that looks
+    /// exactly like a right one.
+    #[test]
+    fn an_unparseable_or_future_record_is_unreadable_rather_than_defaulted() {
+        let root = tempfile::tempdir().unwrap();
+
+        let torn = root.path().join(".kin-git-capture-torn");
+        std::fs::create_dir(&torn).unwrap();
+        std::fs::write(torn.join(ATTEMPT_RECORD_NAME), b"{\"version\":1,\"sou").unwrap();
+        let (record, why) = read_attempt_record(&torn);
+        assert!(record.is_none(), "a truncated record is not a record");
+        assert!(
+            why.is_some_and(|why| why.contains("does not parse")),
+            "the reason must name the parse failure"
+        );
+
+        let future = root.path().join(".kin-git-capture-future");
+        std::fs::create_dir(&future).unwrap();
+        let mut ahead = record_json();
+        ahead["version"] = serde_json::json!(ATTEMPT_RECORD_VERSION + 1);
+        std::fs::write(
+            future.join(ATTEMPT_RECORD_NAME),
+            serde_json::to_vec(&ahead).unwrap(),
+        )
+        .unwrap();
+        let (record, why) = read_attempt_record(&future);
+        assert!(record.is_none(), "a newer layout must not be guessed at");
+        assert!(
+            why.is_some_and(|why| why.contains("layout version")),
+            "the reason must name the version"
+        );
+
+        let absent = root.path().join(".kin-git-capture-absent");
+        std::fs::create_dir(&absent).unwrap();
+        let (record, why) = read_attempt_record(&absent);
+        assert!(record.is_none());
+        assert!(
+            why.is_some_and(|why| why.contains("older Kin")),
+            "a capture with no record at all has its own reason"
+        );
+    }
+
+    fn record_json() -> serde_json::Value {
+        serde_json::to_value(record()).unwrap()
+    }
+
+    #[test]
+    fn a_directory_tree_is_sized_without_following_symlinks() {
+        let root = tempfile::tempdir().unwrap();
+        let tree = root.path().join("tree");
+        std::fs::create_dir(&tree).unwrap();
+        std::fs::write(tree.join("a"), vec![0_u8; 1000]).unwrap();
+        let nested = tree.join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("b"), vec![0_u8; 2000]).unwrap();
+        assert_eq!(directory_bytes(&tree), 3000);
+
+        let outside = root.path().join("outside");
+        std::fs::write(&outside, vec![0_u8; 999_999]).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, tree.join("link")).unwrap();
+        #[cfg(unix)]
+        assert_eq!(
+            directory_bytes(&tree),
+            3000,
+            "a symlink out of the tree must not be counted"
+        );
+    }
+
+    #[test]
+    fn byte_and_second_rendering_reads_the_way_a_person_says_it() {
+        assert_eq!(human_bytes(0), "0 bytes");
+        assert_eq!(human_bytes(512), "512 bytes");
+        assert_eq!(human_bytes(2048), "2.0 KB");
+        assert_eq!(human_bytes(210 * 1024 * 1024), "210.0 MB");
+        assert_eq!(human_bytes(12 * 1024 * 1024 * 1024), "12.0 GB");
+        assert_eq!(human_seconds(0), "0 s");
+        assert_eq!(human_seconds(89), "89 s");
+        assert_eq!(human_seconds(90), "1 min 30 s");
+        assert_eq!(human_seconds(707), "11 min 47 s");
+    }
+}

--- a/crates/kin-core/src/init_attempt.rs
+++ b/crates/kin-core/src/init_attempt.rs
@@ -429,7 +429,15 @@ fn read_attempt_record(capture: &Path) -> (Option<InitAttemptRecord>, Option<Str
     }
 }
 
-/// Bytes a directory tree holds, counting regular files only.
+/// Disk a directory tree is holding, counting regular files only.
+///
+/// Allocated blocks where the platform publishes them, not the sum of file
+/// lengths. The two differ by a lot on exactly the tree this reports on: a
+/// content-addressed capture store is thousands of small bodies, each rounded
+/// up to a filesystem block, so a 600-commit fixture whose files sum to 2.2 MB
+/// occupies 14.2 MB by `du`. The operator's question is how much disk comes
+/// back, so the answer has to be the one `du` gives them rather than the one
+/// that understates it sixfold.
 ///
 /// Never follows a symlink and never fails: a size that could not be measured
 /// reads as the part that could. This is disclosure of disk usage at an IO
@@ -452,11 +460,34 @@ fn directory_bytes(root: &Path) -> u64 {
             if metadata.is_dir() {
                 stack.push(entry.path());
             } else if metadata.is_file() {
-                total = total.saturating_add(metadata.len());
+                total = total.saturating_add(occupied_bytes(&metadata));
             }
         }
     }
     total
+}
+
+/// Disk one file occupies.
+#[cfg(unix)]
+fn occupied_bytes(metadata: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt as _;
+
+    // `blocks()` is in 512-byte units by POSIX definition, whatever the
+    // filesystem's own block size is. A file the kernel reports zero blocks for
+    // is either empty or held entirely inline in its inode, and its length is
+    // the better answer there.
+    let allocated = metadata.blocks().saturating_mul(512);
+    if allocated == 0 {
+        metadata.len()
+    } else {
+        allocated
+    }
+}
+
+/// Disk one file occupies, where the platform publishes no allocation.
+#[cfg(not(unix))]
+fn occupied_bytes(metadata: &std::fs::Metadata) -> u64 {
+    metadata.len()
 }
 
 /// Render a byte count the way a person reads one.
@@ -1003,8 +1034,11 @@ mod tests {
         serde_json::to_value(record()).unwrap()
     }
 
+    /// The size has to be the disk a tree occupies, because that is the number
+    /// an operator is deciding about, and it must not walk out of the tree
+    /// through a symlink to get it.
     #[test]
-    fn a_directory_tree_is_sized_without_following_symlinks() {
+    fn a_directory_tree_is_sized_by_disk_without_following_symlinks() {
         let root = tempfile::tempdir().unwrap();
         let tree = root.path().join("tree");
         std::fs::create_dir(&tree).unwrap();
@@ -1012,7 +1046,22 @@ mod tests {
         let nested = tree.join("nested");
         std::fs::create_dir(&nested).unwrap();
         std::fs::write(nested.join("b"), vec![0_u8; 2000]).unwrap();
-        assert_eq!(directory_bytes(&tree), 3000);
+        let sized = directory_bytes(&tree);
+        assert!(
+            sized >= 3000,
+            "two files of 1000 and 2000 bytes occupy at least their own length, got {sized}"
+        );
+        // Both files sit far under one block, so on any ordinary filesystem the
+        // occupied size exceeds the 3000 bytes of content. Asserting the
+        // inequality rather than a constant stays true across block sizes while
+        // still failing a reader that went back to summing lengths, which would
+        // report exactly 3000.
+        #[cfg(unix)]
+        assert!(
+            sized > 3000,
+            "a tree of two sub-block files occupies more disk than their lengths sum to, got \
+             {sized}"
+        );
 
         let outside = root.path().join("outside");
         std::fs::write(&outside, vec![0_u8; 999_999]).unwrap();
@@ -1021,8 +1070,14 @@ mod tests {
         #[cfg(unix)]
         assert_eq!(
             directory_bytes(&tree),
-            3000,
+            sized,
             "a symlink out of the tree must not be counted"
+        );
+
+        assert_eq!(
+            directory_bytes(&root.path().join("absent")),
+            0,
+            "a tree that is not there holds nothing, and asking must not fail"
         );
     }
 
@@ -1092,7 +1147,10 @@ mod tests {
         // The stage never survived the kill.
         let gone = &abandoned_init_attempts(root.path()).unwrap()[0];
         assert!(gone.stage_path.is_none(), "an absent stage is not named");
-        assert_eq!(gone.stage_bytes, 0);
+        assert_eq!(
+            gone.stage_bytes, 0,
+            "a stage that is not on disk holds nothing"
+        );
         assert!(gone.owner_path.is_none(), "no stage means no sidecar");
         assert_eq!(gone.paths().len(), 1);
         assert!(gone.reclaimable_bytes() >= 4096);
@@ -1102,7 +1160,11 @@ mod tests {
         std::fs::write(stage.join("body"), vec![0_u8; 2048]).unwrap();
         let bare = &abandoned_init_attempts(root.path()).unwrap()[0];
         assert_eq!(bare.stage_path.as_deref(), Some(stage.as_path()));
-        assert_eq!(bare.stage_bytes, 2048);
+        assert!(
+            bare.stage_bytes >= 2048,
+            "the stage's own disk must be counted, got {}",
+            bare.stage_bytes
+        );
         assert!(bare.owner_path.is_none(), "an absent sidecar is not named");
         assert_eq!(bare.paths().len(), 2);
 

--- a/crates/kin-core/src/init_attempt.rs
+++ b/crates/kin-core/src/init_attempt.rs
@@ -453,7 +453,6 @@ pub fn human_bytes(bytes: u64) -> String {
 /// be asserted on.
 pub fn post_mortem_lines(
     attempt: &AbandonedInit,
-    now_unix: u64,
     current: Option<&MemoryReading>,
 ) -> Vec<String> {
     let mut lines = Vec::new();
@@ -474,7 +473,7 @@ pub fn post_mortem_lines(
                 },
                 human_seconds(record.seconds_to_last_phase()),
             ));
-            lines.push(memory_line(record, now_unix));
+            lines.push(memory_line(record));
         }
         None => {
             lines.push(format!(
@@ -516,16 +515,15 @@ pub fn post_mortem_lines(
 /// The ceiling clause, kept apart because it has three honest forms and the
 /// difference between them matters: a measured cap, a machine that could not be
 /// read, and a record written by a build that did not measure one.
-fn memory_line(record: &InitAttemptRecord, _now_unix: u64) -> String {
+fn memory_line(record: &InitAttemptRecord) -> String {
     match (record.memory_limit_bytes, &record.memory_source) {
         (Some(limit), Some(source)) => format!(
-            "  the {source} it ran in had a {} memory ceiling when it started",
+            "  it started under a {} memory ceiling, read from the {source}",
             human_bytes(limit)
         ),
-        (Some(limit), None) => format!(
-            "  it started under a {} memory ceiling",
-            human_bytes(limit)
-        ),
+        (Some(limit), None) => {
+            format!("  it started under a {} memory ceiling", human_bytes(limit))
+        }
         _ => "  it could not read a memory ceiling for the machine it ran on".to_string(),
     }
 }
@@ -546,11 +544,21 @@ pub const RESTART_NOTICE: &str = "  this run restarts from phase 1 rather than r
                                   and its bootstrap transaction carries no journal, so none of it \
                                   can be adopted without risking a store no proof would accept";
 
-/// What an operator can do about the ceiling, when the record measured one.
+/// What an operator can do about the ceiling, when there is reason to think the
+/// ceiling is what stopped them.
 ///
-/// Only ever printed with a measured number beside it, so this never invents a
-/// limit nobody read.
-pub fn ceiling_advice(record: &InitAttemptRecord) -> Option<String> {
+/// Gated on the kernel having actually recorded a kill, not merely on a ceiling
+/// having been read. Every machine has a ceiling, so advice keyed on the
+/// ceiling alone would tell an operator who pressed Ctrl-C that they are short
+/// of memory, which is a confident wrong diagnosis dressed as help. The
+/// measured number is only ever quoted, never invented.
+pub fn ceiling_advice(
+    record: &InitAttemptRecord,
+    current: Option<&MemoryReading>,
+) -> Option<String> {
+    if !current.is_some_and(MemoryReading::kernel_has_killed_here) {
+        return None;
+    }
     let limit = record.memory_limit_bytes?;
     Some(format!(
         "  a conversion's peak follows history depth, so give it more than {} or convert a \
@@ -580,9 +588,8 @@ pub fn report_previous_attempts(attempts: &[AbandonedInit], source: &Path) {
     }
     let current = memory_pressure::read();
     let current = current.reading().copied();
-    let now = unix_now();
     for attempt in attempts {
-        let mut lines = post_mortem_lines(attempt, now, current.as_ref());
+        let mut lines = post_mortem_lines(attempt, current.as_ref());
         if let Some(first) = lines.first_mut() {
             *first = format!("warning: {first}");
         }
@@ -596,7 +603,11 @@ pub fn report_previous_attempts(attempts: &[AbandonedInit], source: &Path) {
     let ours = attempts.iter().find(|attempt| attempt.converted(source));
     if let Some(ours) = ours {
         disclose(RESTART_NOTICE);
-        if let Some(advice) = ours.record.as_ref().and_then(ceiling_advice) {
+        if let Some(advice) = ours
+            .record
+            .as_ref()
+            .and_then(|record| ceiling_advice(record, current.as_ref()))
+        {
             disclose(&advice);
         }
     }
@@ -759,7 +770,7 @@ mod tests {
 
     #[test]
     fn a_post_mortem_names_the_phase_the_ceiling_and_the_staging() {
-        let lines = post_mortem_lines(&attempt(Some(record())), 2000, Some(&reading(Some(1))));
+        let lines = post_mortem_lines(&attempt(Some(record())), Some(&reading(Some(1))));
         let rendered = lines.join("\n");
         assert!(
             rendered.contains("phase 13 of 17, commit bootstrap transaction"),
@@ -770,7 +781,7 @@ mod tests {
             "elapsed to the last phase must be reported: {rendered}"
         );
         assert!(
-            rendered.contains("12.0 GB memory ceiling"),
+            rendered.contains("under a 12.0 GB memory ceiling, read from the container"),
             "the measured ceiling must be named: {rendered}"
         );
         assert!(
@@ -793,17 +804,17 @@ mod tests {
     /// covers a conversion an operator killed by hand.
     #[test]
     fn a_cgroup_with_no_kills_is_never_told_it_had_one() {
-        let quiet = post_mortem_lines(&attempt(Some(record())), 2000, Some(&reading(Some(0))));
+        let quiet = post_mortem_lines(&attempt(Some(record())), Some(&reading(Some(0))));
         assert!(
             !quiet.join("\n").contains("out-of-memory"),
             "zero recorded kills must produce no kill sentence: {quiet:?}"
         );
-        let unknown = post_mortem_lines(&attempt(Some(record())), 2000, Some(&reading(None)));
+        let unknown = post_mortem_lines(&attempt(Some(record())), Some(&reading(None)));
         assert!(
             !unknown.join("\n").contains("out-of-memory"),
             "an unreadable kill counter is not evidence of a kill: {unknown:?}"
         );
-        let some = post_mortem_lines(&attempt(Some(record())), 2000, Some(&reading(Some(2))));
+        let some = post_mortem_lines(&attempt(Some(record())), Some(&reading(Some(2))));
         assert!(
             some.join("\n").contains("2 kernel out-of-memory kills"),
             "more than one kill pluralizes: {some:?}"
@@ -817,7 +828,7 @@ mod tests {
     fn staging_without_a_record_is_reported_without_inventing_a_phase() {
         let mut orphan = attempt(None);
         orphan.record_unreadable = Some("it carries no phase record".to_string());
-        let rendered = post_mortem_lines(&orphan, 2000, None).join("\n");
+        let rendered = post_mortem_lines(&orphan, None).join("\n");
         assert!(
             rendered.contains("left staging at /work/.kin-git-capture-abdd7a1c behind"),
             "the path is all this case can name: {rendered}"
@@ -840,18 +851,27 @@ mod tests {
         let mut unmeasured = record();
         unmeasured.memory_limit_bytes = None;
         unmeasured.memory_source = None;
-        let rendered = post_mortem_lines(&attempt(Some(unmeasured.clone())), 2000, None).join("\n");
+        let rendered = post_mortem_lines(&attempt(Some(unmeasured.clone())), None).join("\n");
         assert!(
             rendered.contains("could not read a memory ceiling"),
             "an unmeasured ceiling must be disclosed: {rendered}"
         );
         assert!(
-            ceiling_advice(&unmeasured).is_none(),
+            ceiling_advice(&unmeasured, Some(&reading(Some(1)))).is_none(),
             "advice about a ceiling must never print without the ceiling"
         );
         assert!(
-            ceiling_advice(&record()).is_some_and(|line| line.contains("12.0 GB")),
+            ceiling_advice(&record(), Some(&reading(Some(1))))
+                .is_some_and(|line| line.contains("12.0 GB")),
             "advice quotes the measured ceiling"
+        );
+        assert!(
+            ceiling_advice(&record(), Some(&reading(Some(0)))).is_none(),
+            "a conversion the kernel did not kill gets no advice about memory"
+        );
+        assert!(
+            ceiling_advice(&record(), None).is_none(),
+            "an unreadable machine is not evidence that memory was the problem"
         );
     }
 
@@ -955,6 +975,227 @@ mod tests {
             3000,
             "a symlink out of the tree must not be counted"
         );
+    }
+
+    /// A capture directory a running conversion holds is not a corpse. Two
+    /// sibling repositories under one parent convert at the same time all the
+    /// time, and reporting the live one as an interrupted run would send an
+    /// operator to delete a directory that is in use.
+    #[test]
+    fn a_live_conversions_staging_is_never_reported_as_abandoned() {
+        let root = tempfile::tempdir().unwrap();
+        let live = crate::init_staging::GitCaptureStaging::claim(root.path()).unwrap();
+        let journal = InitAttemptJournal::open(
+            live.path(),
+            Path::new("/work/live"),
+            Path::new("/work/live/.kin"),
+            17,
+        );
+        journal.enter_phase(5, "derive semantic history");
+        assert!(
+            abandoned_init_attempts(root.path()).unwrap().is_empty(),
+            "a held lease means a live init, which must not be reported"
+        );
+
+        // The same directory, once its holder is gone, is exactly what this
+        // reader exists to find. Dropping the handle removes it, so the
+        // abandoned side is built by hand from the same shapes.
+        let corpse = root.path().join(".kin-git-capture-abandoned");
+        std::fs::create_dir(&corpse).unwrap();
+        std::fs::write(corpse.join("capture.lease"), b"").unwrap();
+        std::fs::copy(
+            live.path().join(ATTEMPT_RECORD_NAME),
+            corpse.join(ATTEMPT_RECORD_NAME),
+        )
+        .unwrap();
+        let found = abandoned_init_attempts(root.path()).unwrap();
+        assert_eq!(
+            found.len(),
+            1,
+            "a free lease is the abandoned case: {found:?}"
+        );
+        assert_eq!(found[0].capture_path, corpse);
+        assert_eq!(found[0].record.as_ref().unwrap().phase_index, 5);
+    }
+
+    /// The record names a stage directory that may or may not still be there,
+    /// and the same for its sidecar. Reporting a path that is gone sends an
+    /// operator to delete nothing and makes the size a lie.
+    #[test]
+    fn only_staging_that_still_exists_is_named_and_sized() {
+        let root = tempfile::tempdir().unwrap();
+        let capture = root.path().join(".kin-git-capture-partial");
+        std::fs::create_dir(&capture).unwrap();
+        std::fs::write(capture.join("capture.lease"), b"").unwrap();
+        std::fs::write(capture.join("blob"), vec![0_u8; 4096]).unwrap();
+
+        let stage = root.path().join(".kin.init-11111111-1111-4111-8111-111111111111");
+        let mut written = record();
+        written.stage_path = Some(stage.display().to_string());
+        std::fs::write(
+            capture.join(ATTEMPT_RECORD_NAME),
+            serde_json::to_vec(&written).unwrap(),
+        )
+        .unwrap();
+
+        // The stage never survived the kill.
+        let gone = &abandoned_init_attempts(root.path()).unwrap()[0];
+        assert!(gone.stage_path.is_none(), "an absent stage is not named");
+        assert_eq!(gone.stage_bytes, 0);
+        assert!(gone.owner_path.is_none(), "no stage means no sidecar");
+        assert_eq!(gone.paths().len(), 1);
+        assert!(gone.reclaimable_bytes() >= 4096);
+
+        // The stage survived, its sidecar did not.
+        std::fs::create_dir(&stage).unwrap();
+        std::fs::write(stage.join("body"), vec![0_u8; 2048]).unwrap();
+        let bare = &abandoned_init_attempts(root.path()).unwrap()[0];
+        assert_eq!(bare.stage_path.as_deref(), Some(stage.as_path()));
+        assert_eq!(bare.stage_bytes, 2048);
+        assert!(bare.owner_path.is_none(), "an absent sidecar is not named");
+        assert_eq!(bare.paths().len(), 2);
+
+        // Both survived, which is the shape the stranger found on disk.
+        let owner = owner_sidecar_path(&stage);
+        std::fs::write(&owner, b"{}").unwrap();
+        let whole = &abandoned_init_attempts(root.path()).unwrap()[0];
+        assert_eq!(whole.owner_path.as_deref(), Some(owner.as_path()));
+        assert_eq!(whole.paths().len(), 3);
+    }
+
+    /// A record too large, or one that is not a regular file at all, is refused
+    /// rather than read. Both are the shape of something Kin did not write.
+    #[test]
+    fn a_record_that_is_not_one_is_refused_by_shape_before_it_is_parsed() {
+        let root = tempfile::tempdir().unwrap();
+
+        let huge = root.path().join(".kin-git-capture-huge");
+        std::fs::create_dir(&huge).unwrap();
+        std::fs::write(
+            huge.join(ATTEMPT_RECORD_NAME),
+            vec![b' '; (MAX_RECORD_BYTES + 1) as usize],
+        )
+        .unwrap();
+        let (parsed, why) = read_attempt_record(&huge);
+        assert!(parsed.is_none());
+        assert!(
+            why.is_some_and(|why| why.contains("past the")),
+            "an oversized record is refused by its size"
+        );
+
+        let directory = root.path().join(".kin-git-capture-directory");
+        std::fs::create_dir_all(directory.join(ATTEMPT_RECORD_NAME)).unwrap();
+        let (parsed, why) = read_attempt_record(&directory);
+        assert!(parsed.is_none());
+        assert!(
+            why.is_some_and(|why| why.contains("not a regular file")),
+            "a directory wearing the record's name is not a record"
+        );
+    }
+
+    /// The restart notice belongs to a conversion of the repository being
+    /// converted now. A sibling's corpse is worth naming and is not this run's
+    /// to restart.
+    #[test]
+    fn an_attempt_is_matched_to_the_repository_it_was_converting() {
+        let ours = attempt(Some(record()));
+        assert!(ours.converted(Path::new("/work/requests")));
+        assert!(!ours.converted(Path::new("/work/express")));
+        assert!(
+            !attempt(None).converted(Path::new("/work/requests")),
+            "an attempt with no record cannot claim a repository"
+        );
+    }
+
+    /// Two states the reclaim report has to tell apart: everything came back,
+    /// and something was left in place. Reporting the first when the second
+    /// happened is the silent orphan defect returning under a friendlier line.
+    #[test]
+    fn the_reclaim_report_counts_what_is_actually_gone() {
+        let root = tempfile::tempdir().unwrap();
+        let freed_path = root.path().join(".kin-git-capture-freed");
+        let held_path = root.path().join(".kin-git-capture-held");
+        std::fs::create_dir(&held_path).unwrap();
+
+        let freed = AbandonedInit {
+            capture_path: freed_path,
+            capture_bytes: 1024,
+            record: None,
+            record_unreadable: None,
+            stage_path: None,
+            stage_bytes: 0,
+            owner_path: None,
+        };
+        let held = AbandonedInit {
+            capture_path: held_path.clone(),
+            capture_bytes: 2048,
+            record: None,
+            record_unreadable: None,
+            stage_path: None,
+            stage_bytes: 0,
+            owner_path: None,
+        };
+        // Nothing to say about nothing.
+        report_reclaimed(&[]);
+        // Exercised for their branches; the lines go to stderr, and the states
+        // they distinguish are asserted through the paths themselves.
+        report_reclaimed(&[freed.clone()]);
+        report_reclaimed(&[held.clone()]);
+        report_reclaimed(&[freed, held]);
+        assert!(
+            held_path.exists(),
+            "reporting must never delete what it reports"
+        );
+    }
+
+    /// The doctor row has three shapes and each is a different fact: nothing to
+    /// report, staging that can say where it stopped, and staging that cannot.
+    #[test]
+    fn the_doctor_row_says_only_what_the_records_support() {
+        assert!(
+            doctor_row(&[]).is_none(),
+            "a clean disk gets no attention row"
+        );
+
+        let (detail, fix) = doctor_row(&[attempt(Some(record()))]).expect("a row");
+        assert!(detail.contains("phase 13 of 17, commit bootstrap transaction"), "{detail}");
+        assert!(detail.contains("420.0 MB"), "{detail}");
+        assert!(fix.contains("kin init"), "{fix}");
+        assert!(fix.contains("/work/.kin.init-22ef96e2.owner"), "{fix}");
+
+        let (detail, _) = doctor_row(&[attempt(None)]).expect("a row");
+        assert!(
+            detail.contains("older Kin staged it"),
+            "staging with no record says so rather than inventing a phase: {detail}"
+        );
+        assert!(
+            !detail.contains("stopped in phase"),
+            "an absent record must never render as a phase number: {detail}"
+        );
+
+        let mut unopened = record();
+        unopened.phase_index = 0;
+        unopened.phase_label = String::new();
+        let (detail, _) = doctor_row(&[attempt(Some(unopened))]).expect("a row");
+        assert!(
+            detail.contains("phase 1 of 17, before the first phase opened"),
+            "a kill before any phase opened has its own wording: {detail}"
+        );
+    }
+
+    /// An attempt killed before the ladder opened a phase must not render as
+    /// "phase 0", and must not render as a phase it never reached.
+    #[test]
+    fn a_kill_before_the_first_phase_is_worded_as_one() {
+        let mut unopened = record();
+        unopened.phase_index = 0;
+        unopened.phase_label = String::new();
+        let rendered = post_mortem_lines(&attempt(Some(unopened)), None).join("\n");
+        assert!(
+            rendered.contains("phase 1 of 17, before the first phase opened"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("phase 0"), "{rendered}");
     }
 
     #[test]

--- a/crates/kin-core/src/init_attempt.rs
+++ b/crates/kin-core/src/init_attempt.rs
@@ -652,42 +652,60 @@ pub fn report_previous_attempts(attempts: &[AbandonedInit], source: &Path) {
 /// this module exists to end and a silent partial reclaim is the same defect
 /// wearing a smaller number.
 pub fn report_reclaimed(before: &[AbandonedInit]) {
-    if before.is_empty() {
-        return;
+    for line in reclaim_lines(before) {
+        disclose(&line);
     }
+}
+
+/// What the reap recovered and what it did not, as lines.
+///
+/// Split from the writing so the wording is pinned by tests rather than by
+/// running a conversion.
+///
+/// A path is counted as reclaimed only when it is actually gone from disk, so a
+/// directory the reaper declined to touch is never folded into the total. What
+/// stays gets named rather than summarised, because a staging directory this
+/// run left alone belongs to a repository this run is not converting, and the
+/// operator who owns it needs its path to act on it.
+pub fn reclaim_lines(before: &[AbandonedInit]) -> Vec<String> {
+    if before.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = Vec::new();
     let mut freed = 0_u64;
     let mut retained: Vec<String> = Vec::new();
+    let mut retained_bytes = 0_u64;
     for attempt in before {
         if attempt.capture_path.exists() {
             retained.push(attempt.capture_path.display().to_string());
+            retained_bytes = retained_bytes.saturating_add(attempt.capture_bytes);
         } else {
             freed = freed.saturating_add(attempt.capture_bytes);
         }
         match &attempt.stage_path {
-            Some(stage) if stage.exists() => retained.push(stage.display().to_string()),
+            Some(stage) if stage.exists() => {
+                retained.push(stage.display().to_string());
+                retained_bytes = retained_bytes.saturating_add(attempt.stage_bytes);
+            }
             Some(_) => freed = freed.saturating_add(attempt.stage_bytes),
             None => {}
         }
     }
     if freed > 0 {
-        disclose(&format!(
+        lines.push(format!(
             "  reclaimed {} of staging those attempts left behind",
             human_bytes(freed)
         ));
     }
     if !retained.is_empty() {
-        disclose(&format!(
-            "  {} left in place, because this run could not prove nothing is using it: {}",
-            human_bytes(
-                before
-                    .iter()
-                    .map(AbandonedInit::reclaimable_bytes)
-                    .sum::<u64>()
-                    .saturating_sub(freed)
-            ),
+        lines.push(format!(
+            "  {} is still on disk and this run did not reclaim it, because it belongs to \
+             another repository's conversion or its owner could not be proven gone: {}",
+            human_bytes(retained_bytes),
             retained.join(", ")
         ));
     }
+    lines
 }
 
 /// The `kin doctor` row's detail and fix lines for whatever staging is sitting
@@ -1168,13 +1186,37 @@ mod tests {
             stage_bytes: 0,
             owner_path: None,
         };
-        // Nothing to say about nothing.
+
+        assert!(
+            reclaim_lines(&[]).is_empty(),
+            "nothing to reclaim earns no line at all"
+        );
+
+        let all_gone = reclaim_lines(std::slice::from_ref(&freed)).join("\n");
+        assert!(all_gone.contains("reclaimed 1.0 KB"), "{all_gone}");
+        assert!(
+            !all_gone.contains("still on disk"),
+            "a clean reclaim must not claim something was left: {all_gone}"
+        );
+
+        let none_gone = reclaim_lines(std::slice::from_ref(&held)).join("\n");
+        assert!(
+            !none_gone.contains("reclaimed"),
+            "nothing was freed, so nothing may be reported as reclaimed: {none_gone}"
+        );
+        assert!(
+            none_gone.contains("2.0 KB is still on disk")
+                && none_gone.contains(&held_path.display().to_string()),
+            "what stayed must be named with its size: {none_gone}"
+        );
+
+        let mixed = reclaim_lines(&[freed, held]).join("\n");
+        assert!(
+            mixed.contains("reclaimed 1.0 KB") && mixed.contains("2.0 KB is still on disk"),
+            "a partial reclaim must report both halves: {mixed}"
+        );
+
         report_reclaimed(&[]);
-        // Exercised for their branches; the lines go to stderr, and the states
-        // they distinguish are asserted through the paths themselves.
-        report_reclaimed(std::slice::from_ref(&freed));
-        report_reclaimed(std::slice::from_ref(&held));
-        report_reclaimed(&[freed, held]);
         assert!(
             held_path.exists(),
             "reporting must never delete what it reports"

--- a/crates/kin-core/src/init_attempt.rs
+++ b/crates/kin-core/src/init_attempt.rs
@@ -268,6 +268,30 @@ impl AbandonedInit {
     }
 }
 
+/// Where a surface should look for interrupted-conversion staging, given the
+/// directory an operator is standing in.
+///
+/// Both that directory and its parent, because init stages beside the
+/// repository rather than inside it: an operator running a check from the
+/// converted repository needs the parent scanned, and one running it from the
+/// directory that holds their checkouts needs the working directory scanned.
+/// Looking in only one answers correctly for one of those operators and reports
+/// a clean disk to the other.
+///
+/// Canonical, because init canonicalizes its source before recording one, and a
+/// surface quoting `/var/...` for a record that says `/private/var/...` prints
+/// two paths for one directory in the same paragraph.
+pub fn staging_scan_roots(cwd: &Path) -> Vec<PathBuf> {
+    let cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let mut roots = vec![cwd.clone()];
+    if let Some(parent) = cwd.parent() {
+        if parent != cwd {
+            roots.push(parent.to_path_buf());
+        }
+    }
+    roots
+}
+
 /// Every unfinished conversion staged beside `parent` that no live init owns.
 ///
 /// Read-only, and deliberately so: `kin doctor` has to be able to name what is
@@ -358,7 +382,12 @@ fn read_attempt_record(capture: &Path) -> (Option<InitAttemptRecord>, Option<Str
                 Some("it carries no phase record, so an older Kin staged it".to_string()),
             );
         }
-        Err(error) => return (None, Some(format!("its phase record is unreadable: {error}"))),
+        Err(error) => {
+            return (
+                None,
+                Some(format!("its phase record is unreadable: {error}")),
+            )
+        }
     };
     if !metadata.is_file() || metadata.file_type().is_symlink() {
         return (
@@ -377,7 +406,12 @@ fn read_attempt_record(capture: &Path) -> (Option<InitAttemptRecord>, Option<Str
     }
     let bytes = match std::fs::read(&path) {
         Ok(bytes) => bytes,
-        Err(error) => return (None, Some(format!("its phase record is unreadable: {error}"))),
+        Err(error) => {
+            return (
+                None,
+                Some(format!("its phase record is unreadable: {error}")),
+            )
+        }
     };
     match serde_json::from_slice::<InitAttemptRecord>(&bytes) {
         Ok(record) if record.version == ATTEMPT_RECORD_VERSION => (Some(record), None),
@@ -451,10 +485,7 @@ pub fn human_bytes(bytes: u64) -> String {
 /// running a conversion. `now_unix` and `current` are passed in for the same
 /// reason: a post-mortem that reads the clock and the cgroup for itself cannot
 /// be asserted on.
-pub fn post_mortem_lines(
-    attempt: &AbandonedInit,
-    current: Option<&MemoryReading>,
-) -> Vec<String> {
+pub fn post_mortem_lines(attempt: &AbandonedInit, current: Option<&MemoryReading>) -> Vec<String> {
     let mut lines = Vec::new();
     match &attempt.record {
         Some(record) => {
@@ -1029,7 +1060,9 @@ mod tests {
         std::fs::write(capture.join("capture.lease"), b"").unwrap();
         std::fs::write(capture.join("blob"), vec![0_u8; 4096]).unwrap();
 
-        let stage = root.path().join(".kin.init-11111111-1111-4111-8111-111111111111");
+        let stage = root
+            .path()
+            .join(".kin.init-11111111-1111-4111-8111-111111111111");
         let mut written = record();
         written.stage_path = Some(stage.display().to_string());
         std::fs::write(
@@ -1139,8 +1172,8 @@ mod tests {
         report_reclaimed(&[]);
         // Exercised for their branches; the lines go to stderr, and the states
         // they distinguish are asserted through the paths themselves.
-        report_reclaimed(&[freed.clone()]);
-        report_reclaimed(&[held.clone()]);
+        report_reclaimed(std::slice::from_ref(&freed));
+        report_reclaimed(std::slice::from_ref(&held));
         report_reclaimed(&[freed, held]);
         assert!(
             held_path.exists(),
@@ -1158,7 +1191,10 @@ mod tests {
         );
 
         let (detail, fix) = doctor_row(&[attempt(Some(record()))]).expect("a row");
-        assert!(detail.contains("phase 13 of 17, commit bootstrap transaction"), "{detail}");
+        assert!(
+            detail.contains("phase 13 of 17, commit bootstrap transaction"),
+            "{detail}"
+        );
         assert!(detail.contains("420.0 MB"), "{detail}");
         assert!(fix.contains("kin init"), "{fix}");
         assert!(fix.contains("/work/.kin.init-22ef96e2.owner"), "{fix}");

--- a/crates/kin-core/src/init_progress.rs
+++ b/crates/kin-core/src/init_progress.rs
@@ -20,6 +20,8 @@ use std::io::{IsTerminal, Write};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use crate::init_attempt::InitAttemptJournal;
+
 /// Number of phases in the exact Git admission ladder. A ladder that completes
 /// on a different count than this is a drift bug that would print `[16/15]` to
 /// a user, so [`PhaseProgress::finish`] asserts the two agree.
@@ -94,6 +96,11 @@ struct Ladder {
     phase_started: Instant,
     started: Instant,
     in_phase: bool,
+    /// Where each opened phase is stamped so a killed conversion can still say
+    /// where it stopped. A terminal line is gone the moment the terminal is,
+    /// and `SIGKILL` runs no destructor, so the only phase report that survives
+    /// a kill is one already written to disk when it lands.
+    journal: Option<Arc<InitAttemptJournal>>,
 }
 
 impl PhaseProgress {
@@ -113,6 +120,7 @@ impl PhaseProgress {
             phase_started: Instant::now(),
             started: Instant::now(),
             in_phase: false,
+            journal: None,
         }));
         let _ = ACTIVE_LADDER.try_with(|active| {
             if let Ok(mut active) = active.try_borrow_mut() {
@@ -124,6 +132,28 @@ impl PhaseProgress {
 
     fn with<R>(&mut self, act: impl FnOnce(&mut Ladder) -> R) -> Option<R> {
         self.ladder.lock().ok().map(|mut ladder| act(&mut ladder))
+    }
+
+    /// Send every phase this ladder opens to a durable record as well as to the
+    /// terminal.
+    ///
+    /// Attached rather than constructed with, because the record lives inside
+    /// the staging directory the conversion claims after the ladder already
+    /// exists. Whatever phase is open at that moment is stamped immediately, so
+    /// attaching late loses nothing.
+    pub(crate) fn attach_journal(&mut self, journal: Arc<InitAttemptJournal>) {
+        self.with(|ladder| {
+            if ladder.in_phase {
+                journal.enter_phase(ladder.index, ladder.label);
+            }
+            ladder.journal = Some(journal);
+        });
+    }
+
+    /// The record this ladder is stamping, for a caller that has more to add to
+    /// it than the phase.
+    pub(crate) fn journal(&mut self) -> Option<Arc<InitAttemptJournal>> {
+        self.with(|ladder| ladder.journal.clone()).flatten()
     }
 
     /// Enter the next phase. Closes any open phase first, so a caller cannot
@@ -203,6 +233,9 @@ impl Ladder {
         self.detail_updates = 0;
         self.phase_started = Instant::now();
         self.in_phase = true;
+        if let Some(journal) = &self.journal {
+            journal.enter_phase(self.index, self.label);
+        }
         if self.is_tty {
             self.write(format_args!(
                 "{ERASE_LINE}  [{:>2}/{}] {}...",

--- a/crates/kin-core/src/init_staging.rs
+++ b/crates/kin-core/src/init_staging.rs
@@ -218,7 +218,7 @@ pub(crate) fn reap_abandoned_git_captures(parent: &Path) -> Result<usize> {
             );
             continue;
         }
-        match abandoned_capture_lease(&candidate) {
+        match capture_lease_is_abandoned(&candidate) {
             Ok(true) => {}
             Ok(false) => continue,
             Err(reason) => {
@@ -250,7 +250,12 @@ pub(crate) fn reap_abandoned_git_captures(parent: &Path) -> Result<usize> {
 ///
 /// `Ok(false)` means a live init holds it. `Err` carries why the question could
 /// not be answered, which the caller discloses rather than acting on.
-fn abandoned_capture_lease(directory: &Path) -> std::result::Result<bool, String> {
+///
+/// Shared with the post-mortem reader in [`crate::init_attempt`] on purpose. A
+/// reader that decided liveness its own way could report a sibling conversion
+/// running right now as a corpse, and reaping and reporting must agree about
+/// what abandoned means or the two surfaces contradict each other.
+pub(crate) fn capture_lease_is_abandoned(directory: &Path) -> std::result::Result<bool, String> {
     let lease_path = directory.join(CAPTURE_LEASE_NAME);
     let mut options = OpenOptions::new();
     options.read(true).write(true);

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod git_init;
 pub mod hooks;
 pub mod identity;
 pub mod init;
+pub mod init_attempt;
 mod init_progress;
 pub use init_progress::report_admission_progress;
 mod init_staging;

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -102,7 +102,7 @@ Options:
     --corpus-cache PATH  pinned upstream clones (default: ~/.cache/kin-brownfield-repro)
     --offline            refuse to fetch; the cache must already carry both pins
     --label NAME         label recorded in the JSON report
-    --only IDS           comma-separated check ids to run, 0 through 8 (default: all)
+    --only IDS           comma-separated check ids to run, 0 through 9 (default: all)
     --json PATH          write machine-readable results here
     --compare PATH       a prior run's --json; a check that passed there and fails
                          here reads REGRESSION rather than plain FAIL
@@ -1433,6 +1433,253 @@ def check_8(suite):
     return res
 
 
+
+# ------------------------------------------------ FIR-2639 interrupted init
+
+# Commits in the throwaway conversion fixture.
+#
+# Large enough that the admission ladder spends seconds past its staging phase,
+# so a poller can land a kill inside a known phase rather than racing a
+# conversion that finished first; small enough that two full conversions cost
+# the suite about ten seconds. Built through `git fast-import` in one process,
+# because 240 `git commit` invocations cost more than both conversions do.
+RESCUE_FIXTURE_COMMITS = 240
+
+# The ladder phase a kill must land at or past.
+#
+# Phase 8 is where init creates the repository stage, so a kill from here on
+# strands BOTH staging directories, which is the shape the rc0550 stranger
+# found on disk. Killing earlier would leave only the capture directory and
+# would not exercise what the fix reclaims.
+RESCUE_KILL_AT_PHASE = 8
+
+RESCUE_PHASE_LINE = re.compile(r"\[\s*(\d+)/17\]")
+
+# What init stages beside the repository, and what a clean disk has none of.
+RESCUE_STAGING_PREFIXES = (".kin.init-", ".kin-git-capture-")
+
+
+def rescue_fixture(suite):
+    """A throwaway many-commit Git repository, built once per run."""
+    root = os.path.join(suite.workdir, "init-rescue-" + suite.run_id)
+    repo = os.path.join(root, "fixture")
+    if os.path.isdir(os.path.join(repo, ".git")):
+        return root, repo
+    os.makedirs(repo)
+    rc, _out, err = suite.git(["init", "-q", "-b", "main", "."], cwd=repo)
+    if rc != 0:
+        raise ProbeError("git init refused the fixture: %s" % err[:400])
+    stream = []
+    for index in range(1, RESCUE_FIXTURE_COMMITS + 1):
+        body = ("def f%d():\n    return %d\n" % (index, index)).encode()
+        stream.append(b"blob\nmark :%d\ndata %d\n%s\n"
+                      % (index, len(body), body))
+        message = b"commit %d" % index
+        stream.append(
+            b"commit refs/heads/main\nmark :%d\n"
+            b"author fixture <fixture@example.invalid> %d +0000\n"
+            b"committer fixture <fixture@example.invalid> %d +0000\n"
+            b"data %d\n%s\nM 100644 :%d mod%d.py\n\n"
+            % (100000 + index, 1700000000 + index, 1700000000 + index,
+               len(message), message, index, index % 12))
+    proc = subprocess.Popen(
+        ["git", "-c", "core.hooksPath=/dev/null", "fast-import", "--quiet"],
+        cwd=repo, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, env=suite.env)
+    _, err = proc.communicate(b"".join(stream))
+    if proc.returncode != 0:
+        raise ProbeError("git fast-import refused the fixture: %s"
+                         % err.decode("utf-8", "replace")[:400])
+    rc, _out, err = suite.git(["reset", "-q", "--hard", "main"], cwd=repo)
+    if rc != 0:
+        raise ProbeError("git reset refused the imported history: %s"
+                         % err[:400])
+    return root, repo
+
+
+def rescue_staging(parent):
+    """Every init staging path sitting beside a repository, sorted."""
+    try:
+        names = sorted(os.listdir(parent))
+    except OSError:
+        return []
+    return [os.path.join(parent, name) for name in names
+            if name.startswith(RESCUE_STAGING_PREFIXES)]
+
+
+def rescue_kill_init_mid_ladder(suite, repo, log_path):
+    """Run one `kin init` and SIGKILL it at or past the staging phase.
+
+    Answers (returncode, highest phase the ladder announced). The kill is
+    triggered off the ladder's own stderr rather than off a timer, so it lands
+    in a known phase on a fast host and a slow one alike, and it is the same
+    trigger on a pre-fix binary as on a fixed one.
+    """
+    with open(log_path, "wb") as log:
+        proc = subprocess.Popen([suite.kin, "init", ".", "--no-enrich"],
+                                cwd=repo, stdout=subprocess.DEVNULL,
+                                stderr=log, env=suite.env)
+        reached = 0
+        deadline = time.time() + 600
+        while time.time() < deadline:
+            try:
+                with open(log_path, "rb") as tail:
+                    seen = RESCUE_PHASE_LINE.findall(
+                        strip_ansi(tail.read().decode("utf-8", "replace")))
+            except OSError:
+                seen = []
+            if seen:
+                reached = max(int(phase) for phase in seen)
+            if reached >= RESCUE_KILL_AT_PHASE:
+                proc.kill()
+                break
+            if proc.poll() is not None:
+                break
+            time.sleep(0.02)
+        else:
+            proc.kill()
+        proc.wait()
+    return proc.returncode, reached
+
+
+def read_text(path):
+    try:
+        with open(path, "rb") as handle:
+            return strip_ansi(handle.read().decode("utf-8", "replace"))
+    except OSError:
+        return ""
+
+
+def check_9(suite):
+    """FIR-2639: a conversion the kernel kills says so afterwards.
+
+    The rc0550 stranger's psf/requests conversion was OOM-killed at step 13 of
+    17. Kin printed nothing, `.kin` did not exist, and 420 MB of staging sat in
+    the parent directory with nothing pointing at it. `SIGKILL` runs no
+    destructor, so no amount of error handling inside the dying process can fix
+    that; only a record written before the kill and read by the next command
+    can.
+
+    This reproduces that with the same signal on a fixture, then asks the three
+    surfaces the stranger had: does the next command name the kill and the
+    phase, does the re-run say whether it resumes or restarts, and is the
+    staging still sitting there unnamed. On a pre-fix binary all three answer
+    with silence.
+    """
+    res = Result("9", "FIR-2639", "a killed kin init leaves a post-mortem, a "
+                                  "named restart and no silent orphan")
+    try:
+        parent, repo = rescue_fixture(suite)
+    except ProbeError as exc:
+        res.unknown(str(exc))
+        return res
+
+    log = os.path.join(parent, "killed-init.err")
+    rc, reached = rescue_kill_init_mid_ladder(suite, repo, log)
+
+    # Preconditions. Each is the defect's own shape, and a run that did not
+    # reproduce it can say nothing about the fix, so these are UNREADABLE
+    # rather than either verdict.
+    if reached < RESCUE_KILL_AT_PHASE:
+        res.unknown("the conversion never announced phase %d, so no kill landed "
+                    "mid-ladder (highest phase seen: %d)"
+                    % (RESCUE_KILL_AT_PHASE, reached))
+        return res
+    if rc == 0:
+        res.unknown("the conversion exited 0, so it finished before the kill "
+                    "and there is no interrupted run to report")
+        return res
+    if os.path.isdir(os.path.join(repo, ".kin")):
+        res.unknown("a repository was published despite the kill, so this is "
+                    "not the stranded case")
+        return res
+    stranded = rescue_staging(parent)
+    if not stranded:
+        res.unknown("the kill left no staging behind, so there is nothing for "
+                    "a post-mortem to be about")
+        return res
+    res.note("killed at phase %d of 17, rc %s, %d staging path(s) stranded: %s"
+             % (reached, rc, len(stranded),
+                ", ".join(os.path.basename(path) for path in stranded)))
+
+    # ARM 1. The next command names the kill and the phase it landed in.
+    _doctor_rc, doctor_out, doctor_err = suite.kin_run(["doctor"], repo,
+                                                       timeout=600)
+    doctor_text = doctor_out + doctor_err
+    row = [line for line in doctor_text.splitlines()
+           if "Interrupted conversion" in line]
+    phase_in_doctor = re.search(r"phase (\d+) of 17", doctor_text)
+    if not row:
+        res.bad("`kin doctor` after the kill carries no interrupted-conversion "
+                "row, so nothing names the %d staging path(s) left behind"
+                % len(stranded))
+    elif not phase_in_doctor:
+        res.bad("the interrupted-conversion row names no phase, so it cannot "
+                "say where the conversion stopped: %s" % row[0].strip())
+    elif int(phase_in_doctor.group(1)) < RESCUE_KILL_AT_PHASE:
+        res.bad("the row reports phase %s, before the kill could have landed "
+                "at phase %d" % (phase_in_doctor.group(1),
+                                 RESCUE_KILL_AT_PHASE))
+    else:
+        res.ok("`kin doctor` names the kill at phase %s of 17: %s"
+               % (phase_in_doctor.group(1), row[0].strip()[:160]))
+
+    # A diagnostic that deletes is one an operator learns not to run, so the
+    # row must report without reaping. Checked here rather than assumed,
+    # because the reclaim path and the reporting path share a module.
+    if rescue_staging(parent) != stranded:
+        res.bad("`kin doctor` changed the staging on disk; a report must not "
+                "reap what it reports")
+    else:
+        res.ok("`kin doctor` left all %d staging path(s) in place"
+               % len(stranded))
+
+    # ARM 2. The re-run says whether it is resuming or restarting, and why.
+    rerun_log = os.path.join(parent, "rerun-init.err")
+    with open(rerun_log, "wb") as handle:
+        rerun = subprocess.Popen([suite.kin, "init", ".", "--no-enrich"],
+                                 cwd=repo, stdout=subprocess.DEVNULL,
+                                 stderr=handle, env=suite.env)
+        rerun.wait()
+    rerun_text = read_text(rerun_log)
+    said_unfinished = "did not finish" in rerun_text
+    said_disposition = re.search(r"\b(restarts|resumes|resuming)\b", rerun_text)
+    phase_in_rerun = re.search(r"phase (\d+) of 17", rerun_text)
+    if not said_unfinished:
+        res.bad("the re-run says nothing about the conversion that did not "
+                "finish, so an operator repeats eleven minutes with no idea "
+                "why")
+    elif not phase_in_rerun:
+        res.bad("the re-run reports a previous failure without naming the "
+                "phase it stopped in")
+    elif not said_disposition:
+        res.bad("the re-run names the previous failure but never says whether "
+                "it resumes from it or starts over, which is the one thing an "
+                "operator has to know before waiting again")
+    else:
+        res.ok("the re-run names phase %s of 17 and says it %s"
+               % (phase_in_rerun.group(1), said_disposition.group(1)))
+
+    # ARM 3. Nothing is orphaned silently.
+    if rerun.returncode != 0:
+        res.unknown("the re-run exited %s, so what it left on disk says "
+                    "nothing about the reclaim" % rerun.returncode)
+        return res
+    left = rescue_staging(parent)
+    reclaimed = re.search(r"reclaimed ([0-9.]+ \w+) of staging", rerun_text)
+    if left:
+        res.bad("%d staging path(s) survived the re-run unreferenced: %s"
+                % (len(left), ", ".join(os.path.basename(p) for p in left)))
+    elif not reclaimed:
+        res.bad("the re-run reclaimed the staging without saying so, so the "
+                "disk comes back silently and an operator watching for it "
+                "cannot tell")
+    else:
+        res.ok("the re-run reclaimed %s of staging and said so; nothing is "
+               "left beside the repository" % reclaimed.group(1))
+    return res
+
+
 CHECKS = [
     ("0", check_0),
     ("1", check_1),
@@ -1443,6 +1690,7 @@ CHECKS = [
     ("6", check_6),
     ("7", check_7),
     ("8", check_8),
+    ("9", check_9),
 ]
 
 

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -291,6 +291,13 @@ BOUNDARY_DIRS = [
     "crates/kin-core/src/federation.rs",
     "crates/kin-core/src/git_init.rs",
     "crates/kin-core/src/init.rs",
+    # The post-mortem for an interrupted init, and the same boundary as
+    # init_staging.rs beside it. It reads only the staging directories init
+    # itself minted in the repository's parent, to report where a killed
+    # conversion stopped and how much disk it is holding. It answers no
+    # locate/search/context/trace/review/xref query, reads no repository
+    # content, and runs before any graph exists.
+    "crates/kin-core/src/init_attempt.rs",
     # Init's own staging directories, and nothing else. It runs before any
     # graph exists, on paths init itself minted, and its whole output is
     # whether a directory this process created still needs removing. It


### PR DESCRIPTION
A conversion the kernel kills says nothing. `SIGKILL` runs no destructor, so the
rc0550 stranger's full-history psf/requests init returned exit 137 and silence,
left no `.kin`, and stranded 420 MB of staging in the parent directory with
nothing pointing at it. The stranger deleted it by hand after guessing what it
was.

Nothing inside the dying process can fix that. What can is a record written
before the kill and read by whatever runs next, so this adds one. The admission
ladder stamps each of its seventeen phases into the capture staging directory as
that phase opens, and the record inherits that directory's lease, which means a
reader can tell a corpse from a conversion running right now by measurement
rather than by a pid guess. It is never fsynced, because a kill leaves the page
cache intact and a conversion already short of memory should not pay seventeen
barriers for a file that only has to outlive its own process.

`kin init` and `kin doctor` both read it back. Init reports before it claims, so
the directories it describes are the ones it is about to reclaim rather than
paths that no longer exist, and it reclaims the repository stage at the top of
the ladder instead of at phase eight, so the disk comes back before the minutes
are spent. Doctor reports and never reaps, because a diagnostic that deletes is
one an operator learns not to run.

This does not resume, and does not pretend to. A killed
conversion's capture store is written without device barriers precisely because
it was only ever meant to live inside one process, and its bootstrap transaction
carries no journal, so adopting either would trade an eleven-minute repeat for a
store no proof would accept. The restart is stated in those words rather than
left for an operator to infer from a progress bar starting at one again, and
real resume stays FIR-2522's wall. And advice about raising a memory ceiling
prints only where the kernel actually recorded a kill, because every machine has
a ceiling and advice keyed on the ceiling alone would tell someone who pressed
Ctrl-C that they are short of memory.

Container repro, Debian 12 aarch64, 600-commit fixture, `--memory=700m`, both
arms from `rc-build.yml` archives of the same workflow so only the binary
differs. On the rc0550 release bytes the conversion is OOM-killed at step 13 of
17, the phase the stranger died in, with `oom_kill 1` and `memory.peak` equal to
`memory.max`. It leaves no `.kin` and three staging paths totalling 14.2 MB by
`du`, and neither `kin doctor` nor the re-run says a word about any of it. The
same kill on this branch answers:

```
=== kin doctor ===
  x Interrupted conversion  DEGRADED  14.1 MB of staging from 1 interrupted `kin init`
    run(s) is reclaimable: /work/fixture stopped in phase 13 of 17, commit bootstrap
    transaction
    fix: run `kin init` in that repository again, which reclaims this before it starts,
         or delete /work/.kin-git-capture-531ffc72 /work/.kin.init-aade17b9
         /work/.kin.init-aade17b9.owner

=== kin init, re-run ===
warning: a previous kin init of /work/fixture did not finish
  it stopped in phase 13 of 17, commit bootstrap transaction, 15 s into the conversion
  it started under a 700.0 MB memory ceiling, read from the container
  the container it ran in has recorded 1 kernel out-of-memory kill, so a memory kill is
  the likely cause
  it is holding 14.1 MB of staging: <capture>, <stage>, <stage>.owner
  this run restarts from phase 1 rather than resuming: a killed conversion's staged
  capture is written without device barriers and its bootstrap transaction carries no
  journal, so none of it can be adopted without risking a store no proof would accept
  a conversion's peak follows history depth, so give it more than 700.0 MB or convert a
  repository with less history
```

The ceiling reads 700.0 MB from the container rather than the host's 128 GB, and
the kill sentence comes off the cgroup's own `oom_kill` counter rather than an
inference from an exit code.

That arm also caught a bug worth naming. The first container run reported 2.2 MB
where `du` reported 14.2 MB, because the reader summed file lengths and a
content-addressed capture store is thousands of sub-block bodies. A reclaimable
figure that understates the disk sixfold is a confident wrong number, so the
size is now allocated blocks, and the test that pinned the old answer with an
exact byte total now asserts the inequality a length-summing reader cannot meet.

## Acceptance

`scripts/acceptance/brownfield_repro.py` CHECK 9, and the byte-identical port in
the umbrella's `bin/kin-brownfield-repro`, so the fleet gate runs what hosted CI
runs. It builds a 240-commit fixture through `git fast-import`, runs a real `kin
init`, and SIGKILLs it off the ladder's own stderr at or past the staging phase,
so the kill arrives in a known phase on a fast host and a slow one alike, and the
trigger is the same on pre-fix bytes. Four sub-assertions, one per ask plus the
report-never-reap guard. A run that did not reproduce the kill reads UNREADABLE
rather than either verdict.

## Falsification, one block per class

Two-sided on real bytes, from one check file against one fixture on one host.
Base is `00bbc1443`, built in its own target directory with `Compiling kin-core`
in the build log. The branch build is this PR's tip.

**Ask 1, the post-mortem the next command surfaces.**
```
base 00bbc1443: FAIL `kin doctor` after the kill carries no interrupted-conversion row,
                so nothing names the 3 staging path(s) left behind
branch:         PASS `kin doctor` names the kill at phase 8 of 17
```
A fires-always mutant on the marker itself, `InitAttemptJournal::flush` made an
unconditional early return, built in its own target directory with `Compiling
kin-core` in the log. It corrected what I expected to see, which is why it was
worth running: the row does not vanish, because the reader finds the staging
from its directory prefix whether or not a record survived. What it loses is the
phase.

```
mutant (flush is a no-op):
   FAIL the interrupted-conversion row names no phase, so it cannot say where the
        conversion stopped: 2.8 MB of staging ... is reclaimable; none of it carries
        a phase record, so an older Kin staged it
   FAIL the re-run says nothing about the conversion that did not finish
   PASS the re-run reclaimed 2.8 MB of staging and said so
```

Two of the three asks fail and the third holds, which is the layering working:
the phase comes from the record, and the disk accounting comes from the
directories, so killing the record degrades the answer honestly instead of
inventing a phase.

**Ask 2, resume or restart, stated.**
```
base 00bbc1443: FAIL the re-run says nothing about the conversion that did not finish,
                so an operator repeats eleven minutes with no idea why
branch:         PASS the re-run names phase 8 of 17 and says it restarts
```

**Ask 3, staging never orphaned silently.**
```
base 00bbc1443: FAIL the re-run reclaimed the staging without saying so, so the disk
                comes back silently and an operator watching for it cannot tell
branch:         PASS the re-run reclaimed 155.6 KB of staging and said so; nothing is
                left beside the repository
```
The base arm is the honest shape of this one: base does reclaim, at phase eight,
and never mentions it. Doctor on base names none of it either.

**The end-to-end kill, in-tree.**
`git_init::tests::an_init_the_kernel_kills_leaves_a_phase_the_next_run_can_read`
parks a real init subprocess at the capture barrier, sends `SIGKILL`, and asserts
the surviving record names a phase in the ladder with a non-empty label and the
repository it was converting, then that the next init reclaims and converts.
`SIGTERM` would prove nothing here, because Kin already catches that one.

**Branch coverage.** Every conditional added carries fixtures on both sides: a
cgroup reporting one kill, zero kills and no counter at all; a ceiling measured
and unmeasured; a record present, absent, truncated, oversized, a directory, and
from a future layout version; a stage directory and its sidecar present and
absent; a kill before any phase opened; a live conversion's staging, which must
never be reported as abandoned; and a reclaim that freed everything against one
that left something in place.

## Gates

`bin/kin-parity --checkout <lane worktree>`: **FINAL PASS-WITH-ALLOWANCES in
957.3s**, naming exactly the three standing allowances and no others
(`firstrun/9 FIR-2580`, `firstrun/3 FIR-2501`, `brownfield/4 FIR-2464`), with
`CHECK 9 FIR-2639 PASS` inside it. Hosted CI runs the kin-side copy of the same
suite on an ubuntu runner against this PR's own release build, so the check is
verified on Linux independently of the dev host.

`cargo fmt --all -- --check` clean. Clippy under CI's own 45-lint debt list with
`-D warnings`, exit 0, run under bash because the list word-splits. Guard steps
enumerated from a real CI job's step list rather than from ci.yml:
`verify-zero-file-search.py`, `zero_file_search_guard.sh`,
`verify-hydration-semantics.py`, `check_runtime_boundaries.sh`,
`check_private_repo_coupling.sh`, `test-private-repo-coupling.py` and
`test-assertion-reachability.py`, all exit 0. The zero-file-search guard caught
this change first time and the new module is declared beside `init_staging.rs`
as the same init boundary, with the CLI's own filesystem access moved behind it
rather than exempted. 679 tests in kin-core and 1743 in kin-cli, zero failures.

Closes FIR-2639
Refs FIR-2522
