### PR TITLE
Hold the enumeration certification honest in both directions

### DIFF
--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -361,6 +361,53 @@ async fn daemon_exits_after_idle_timeout_and_removes_endpoint_files() {
     .await;
 }
 
+/// Delete a control directory out from under a daemon that is still running.
+///
+/// `remove_dir_all` unlinks what it enumerated and then removes the directory,
+/// so a live daemon writing one new file into `.kin` between those two steps
+/// makes the final step fail with `DirectoryNotEmpty` and nothing about the
+/// behaviour under test has gone wrong. The daemon publishes into its own
+/// control directory on a cadence, most recently the memory-footprint standing
+/// FIR-2614 P2 added, so the window is real and it is not this test's subject:
+/// what is under test is that the daemon exits once the directory is gone.
+///
+/// Retrying is therefore the fix rather than serializing against the daemon,
+/// which no caller of `kin eject` can do either. A caller deleting this
+/// directory races the same way and retries the same way.
+///
+/// The final failure names the entries that survived. An `ENOTEMPTY` on its own
+/// says a writer won the race and not which one, and the next person to see
+/// this deserves better than the errno.
+fn remove_live_control_dir(kin_dir: &std::path::Path) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        match std::fs::remove_dir_all(kin_dir) {
+            Ok(()) => return,
+            Err(error)
+                if error.kind() == std::io::ErrorKind::DirectoryNotEmpty
+                    && std::time::Instant::now() < deadline =>
+            {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(error) => {
+                let survivors = std::fs::read_dir(kin_dir)
+                    .map(|entries| {
+                        entries
+                            .flatten()
+                            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                panic!(
+                    "could not remove {}: {error}. Entries a live daemon rewrote while this \
+                     ran: {survivors:?}"
+                    , kin_dir.display()
+                );
+            }
+        }
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn daemon_exits_after_dirty_repo_control_dir_is_removed() {
     let repo = tempfile::tempdir().unwrap();
@@ -382,7 +429,7 @@ async fn daemon_exits_after_dirty_repo_control_dir_is_removed() {
     wait_for_serving(&mut child, port).await;
     record_graph_mutation(repo.path(), port, "dirty-before-delete").await;
 
-    std::fs::remove_dir_all(repo.path().join(".kin")).unwrap();
+    remove_live_control_dir(&repo.path().join(".kin"));
 
     let exit = match tokio::time::timeout(Duration::from_secs(15), child.wait()).await {
         Ok(result) => result.expect("kin-daemon wait failed"),

--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -400,8 +400,8 @@ fn remove_live_control_dir(kin_dir: &std::path::Path) {
                     .unwrap_or_default();
                 panic!(
                     "could not remove {}: {error}. Entries a live daemon rewrote while this \
-                     ran: {survivors:?}"
-                    , kin_dir.display()
+                     ran: {survivors:?}",
+                    kin_dir.display()
                 );
             }
         }

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -2067,6 +2067,41 @@ def check_14(suite):
     return res
 
 
+# How long a check waits for a conversion's enrichment to land before it believes
+# the reading it was handed.
+ENRICHMENT_SETTLE_SECONDS = 30
+ENRICHMENT_POLL_SECONDS = 3
+
+
+def read_until_enriched(read, rel):
+    """Read `rel` through `read`, waiting out a conversion's asynchronous enrichment.
+
+    A store converted from Git gets its layout facet backfilled by the daemon's
+    reconcile loop after `kin init` has returned, so the first reader of a fresh
+    fixture can be handed `parsed='absent'` for a file an adapter read
+    completely. The retry these checks carried fired only when the call itself
+    failed, which is the one shape this race never takes: the call succeeds, and
+    the answer is simply older than the backfill.
+
+    That is not hypothetical. In acceptance run 32608116193 check 15 read all
+    three Python files as `parsed='absent'` and failed every arm, while check 17
+    read `pkg/parsed.py` on the same store moments later and got
+    `parsed=full tier=entity_source certifies_enumeration=True`. One store, two
+    answers, and the only difference was which check asked first.
+
+    The wait is bounded and the verdict when it expires is the reading itself, so
+    a backfill that never lands still fails the check. This buys latency, never a
+    pass. It is deliberately not used for a file that must STAY uncertified: an
+    expected `absent` is the answer there, not a stale one.
+    """
+    cov, why = read(rel)
+    deadline = time.time() + ENRICHMENT_SETTLE_SECONDS
+    while time.time() < deadline and (cov is None or cov.get("parsed") in (None, "absent")):
+        time.sleep(ENRICHMENT_POLL_SECONDS)
+        cov, why = read(rel)
+    return cov, why
+
+
 def check_15(suite):
     """FIR-2604: parsed, tier and certifies_enumeration must be observations.
 
@@ -2120,12 +2155,10 @@ def check_15(suite):
 
     readings = {}
     for name, rel in sorted(THREE_STATE_FILES.items()):
-        cov, why = coverage(rel)
-        if cov is None:
-            # A conversion's enrichment lands asynchronously, so one bounded
-            # retry separates "not yet" from "never".
-            time.sleep(3)
-            cov, why = coverage(rel)
+        # Every file here is one an adapter reads, so `absent` is either the
+        # backfill not having landed yet or the regression this check exists to
+        # catch. Waiting separates them; the reading decides.
+        cov, why = read_until_enriched(coverage, rel)
         if cov is None:
             res.unknown("%s could not be read through MCP: %s" % (rel, why[:250]))
             return res
@@ -2363,12 +2396,7 @@ def check_17(suite):
     # The positive arm, in the shape the stranger hit: a complete enumeration
     # that must say so.
     parsed_rel = THREE_STATE_FILES["parsed"]
-    cov, why = coverage(parsed_rel)
-    if cov is None:
-        # A conversion's enrichment lands asynchronously, so one bounded retry
-        # separates "not yet" from "never".
-        time.sleep(3)
-        cov, why = coverage(parsed_rel)
+    cov, why = read_until_enriched(coverage, parsed_rel)
     if cov is None:
         res.unknown("%s could not be read through MCP: %s" % (parsed_rel, why[:250]))
         return res

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -313,6 +313,7 @@ class Suite(object):
         self._write(repo, THREE_STATE_FILES["parsed"], THREE_STATE_PARSED_PY)
         self._write(repo, THREE_STATE_FILES["broken"], THREE_STATE_BROKEN_PY)
         self._write(repo, THREE_STATE_FILES["empty"], THREE_STATE_EMPTY_PY)
+        self._write(repo, NO_ADAPTER_FILE, NO_ADAPTER_BODY)
         self.git(["add", "-A"], repo)
         rc, out, err = self.git(["commit", "-q", "-m", "three parse outcomes"], repo)
         if rc != 0:
@@ -777,6 +778,21 @@ THREE_STATE_FILES = {
     "broken": "pkg/broken.py",
     "empty": "pkg/empty.py",
 }
+
+# A path no language adapter claims, admitted to the same converted store.
+#
+# FIR-2641's negative control, and the reason check 17 can fail in the direction
+# that matters. Every arm of check 15 reads a Python file, so a build that
+# certified everything would satisfy two of its three arms and its
+# not-a-constant arm as well, since `broken.py` supplies the second state on its
+# own. Certification is only worth anything if something is left uncertified,
+# and this is the file that must stay that way.
+NO_ADAPTER_FILE = "docs/notes.md"
+NO_ADAPTER_BODY = """# Notes
+
+This file has no language adapter. Nothing can enumerate it, so nothing may
+certify an enumeration of it.
+"""
 
 REEXPORT_BENIGN_FILE = "src/prelude.rs"
 REEXPORT_DEAD_FUNCTION = "legacy_shim"
@@ -2294,6 +2310,102 @@ def check_16(suite):
     return res
 
 
+def check_17(suite):
+    """FIR-2641: a complete enumeration must certify, and an unparsable one must not.
+
+    The rc0550 brown stranger asked `list_file_entities` for
+    `src/requests/sessions.py`, got all 32 entities with `truncated: false`, and
+    was told in the same payload `parsed: "absent", tier: "none",
+    certifies_enumeration: false`, with `limiting_factor: "file_not_parsed"`.
+    `kin graph status` on that store said `python: 37/37 (100%)`. The identical
+    contradiction appeared on express `lib/application.js`, so it was not
+    adapter-specific. The whole value of this surface over grep is that it can
+    certify completeness, and it was refusing to certify answers that were in
+    fact complete, which sends a reader back to grep for no reason.
+
+    kin#1080 fixed the cause: a store converted from Git never had a layout
+    facet, because the import parses every file and drops the layout it derived.
+    Verified on main at bfda9bab4, `pkg/parsed.py` reads `parsed=full,
+    tier=entity_source, certifies_enumeration=true`.
+
+    So this check exists to hold that fixed, and to close the half the existing
+    FIR-2604 check cannot reach. Every file that check reads is Python, so a
+    build that certified everything would pass it. The ticket's own acceptance
+    names the missing arm: a file with no language adapter must keep
+    `parsed: absent`. Certification means nothing unless something is left
+    uncertified.
+
+    Falsify by breaking the coverage join, which is what the ticket asks for:
+    query the observation under a key the store does not hold, and the positive
+    arm fails while the negative control still passes.
+
+    Numbered 17 because kin#1078 landed FIR-2524 as check 16 while this one was
+    in flight, and a landed number is named by allowance entries, so the free
+    number is taken rather than the one that merely looks next.
+    """
+    res = Result("17", "FIR-2641", "an enumeration certifies only when the file actually parsed")
+    repo = suite.fixture("threestate")
+
+    def coverage(rel):
+        try:
+            payload, _ = suite.mcp(repo, "list_file_entities", {"path": rel})
+        except McpError as exc:
+            return None, str(exc)
+        cov = payload.get("file_coverage")
+        if not isinstance(cov, dict):
+            return None, ("the response carries no file_coverage object; keys were %s"
+                          % sorted(payload.keys())[:12])
+        cov = dict(cov)
+        cov["total_in_file"] = payload.get("total_in_file")
+        cov["truncated"] = payload.get("truncated")
+        return cov, None
+
+    # The positive arm, in the shape the stranger hit: a complete enumeration
+    # that must say so.
+    parsed_rel = THREE_STATE_FILES["parsed"]
+    cov, why = coverage(parsed_rel)
+    if cov is None:
+        # A conversion's enrichment lands asynchronously, so one bounded retry
+        # separates "not yet" from "never".
+        time.sleep(3)
+        cov, why = coverage(parsed_rel)
+    if cov is None:
+        res.unknown("%s could not be read through MCP: %s" % (parsed_rel, why[:250]))
+        return res
+    if cov.get("certifies_enumeration") is True and cov.get("parsed") not in (None, "absent"):
+        res.ok("%s enumerates %s entities (truncated=%s) and certifies it, reading parsed=%s "
+               "tier=%s" % (parsed_rel, cov.get("total_in_file"), cov.get("truncated"),
+                            cov.get("parsed"), cov.get("tier")))
+    else:
+        res.bad("%s returned an enumeration of %s entities and refuses to certify it: "
+                "parsed=%r tier=%r certifies_enumeration=%r. That is the contradiction the "
+                "stranger hit, and following the envelope's own advice sends a reader back "
+                "to grep over a complete answer"
+                % (parsed_rel, cov.get("total_in_file"), cov.get("parsed"),
+                   cov.get("tier"), cov.get("certifies_enumeration")))
+
+    # The negative control. Without it the arm above is satisfied by a build
+    # that certifies everything, which is the same defect wearing the other
+    # value.
+    control, why = coverage(NO_ADAPTER_FILE)
+    if control is None:
+        # A surface that refuses the call outright is an acceptable answer for a
+        # file it cannot enumerate, and it is certainly not a false
+        # certification, so it is reported rather than failed.
+        res.ok("%s is refused by the surface rather than enumerated (%s), so nothing certifies "
+               "an enumeration of it" % (NO_ADAPTER_FILE, why[:120]))
+    elif control.get("certifies_enumeration") is True:
+        res.bad("%s has no language adapter, yet its enumeration is certified "
+                "(parsed=%r tier=%r). Certification that is unconditional carries no "
+                "information, which is the FIR-2604 constant back wearing the other value"
+                % (NO_ADAPTER_FILE, control.get("parsed"), control.get("tier")))
+    else:
+        res.ok("%s has no language adapter and stays uncertified (parsed=%r tier=%r), so "
+               "certification separates files rather than blessing them"
+               % (NO_ADAPTER_FILE, control.get("parsed"), control.get("tier")))
+    return res
+
+
 CHECKS = [
     ("0", check_0),
     ("1", check_1),
@@ -2312,6 +2424,7 @@ CHECKS = [
     ("14", check_14),
     ("15", check_15),
     ("16", check_16),
+    ("17", check_17),
 ]
 
 


### PR DESCRIPTION
The rc0550 brown stranger asked `list_file_entities` for `src/requests/sessions.py`, got all
32 entities with `truncated: false`, and was told in the same payload that the file never
parsed and its enumeration could not be certified. `kin graph status` on that store said
`python: 37/37 (100%)`. The same contradiction appeared on express `lib/application.js`, so
it was not adapter-specific. The whole value of this surface over grep is that it can certify
completeness, and it was refusing to certify answers that were in fact complete.

**kin#1080 already fixed it, and this change verifies that rather than assuming it.** On a
store taken through the conversion path, `pkg/parsed.py` now reads `parsed=full,
tier=entity_source, certifies_enumeration=true`. No code change is needed.

## What was still missing

The check that landed with kin#1080 reads three Python files. A build that certified
everything would satisfy two of its three arms, and its fourth arm too, because that one
asserts only that the three readings are not all identical and `broken.py` supplies the
second state by itself. So the existing check could not fail in the direction a regression
would actually take, which is the constant returning as an unconditional `true`.

FIR-2641's own acceptance names the gap: a file with no language adapter must keep
`parsed: absent`. Certification is worth nothing unless something is left uncertified.

## The check

Check 17, keyed FIR-2641, on the same converted fixture, which gains one file no adapter
claims. It is 17 rather than 16 because kin#1078 landed FIR-2524 as check 16 while this
one was in flight, and a landed number is named by allowance entries, so the free number
is taken rather than the one that merely looks next. Two arms, and they read differently:

```
PASS  pkg/parsed.py enumerates 4 entities (truncated=False) and certifies it, parsed=full tier=entity_source
PASS  docs/notes.md has no language adapter and stays uncertified (parsed='absent' tier='none')
```

Falsified the way the ticket asks, by breaking the coverage join so the layout is queried
under a key the store does not hold:

```
FAIL  pkg/parsed.py returned an enumeration of 4 entities and refuses to certify it:
      parsed='absent' tier='entity_source' certifies_enumeration=False
PASS  docs/notes.md has no language adapter and stays uncertified
```

The positive arm fails with the stranger's contradiction reproduced exactly, and the negative
control still passes, so the check is not merely sensitive to a broken build. Under the canary
the tier still reads `entity_source` while `parsed` reads `absent`, which is the tell that the
join broke rather than the observation.

A surface that refuses the call outright on the control file is reported rather than failed,
since refusing to enumerate a file it cannot read is a correct answer and is certainly not a
false certification.

## Also here: the control-directory teardown race

`daemon_exits_after_dirty_repo_control_dir_is_removed` deletes a control directory out
from under a live daemon and asserts the daemon exits. `remove_dir_all` unlinks what it
enumerated and then removes the directory, so a daemon writing one new file into `.kin`
between those two steps returns `DirectoryNotEmpty` and the test fails on the race rather
than on its subject. This lane widened that window itself: the memory-footprint standing
it added in P2 publishes into that directory on a cadence. The removal now retries for ten
seconds, which is what a caller of `kin eject` has to do as well, and the final failure
names the entries that survived, because an `ENOTEMPTY` on its own says a writer won and
not which one. The race is not hypothetical: it ejected kin#1086 from the merge queue
earlier today, and the ejection cost a CI run to diagnose from an errno.

## Also here: check 15 was racing the backfill

The first full run of check 17 turned up a defect in check 15 rather than in the new work.
Check 15 read all three Python files as `parsed='absent'` and failed every arm, while check
17 read `pkg/parsed.py` on the same store moments later and got `parsed=full
tier=entity_source certifies_enumeration=True`. One store, two answers, and the only
difference was which check asked first.

A store converted from Git gets its layout facet backfilled by the daemon's reconcile loop
after `kin init` has returned. Both checks carried a retry whose comment named that race,
and both retried only when the MCP call itself failed, which is the one shape the race never
takes: the call succeeds and the answer is simply older than the backfill. The retry could
not fire for the case it was written for, and check 17 was passing by running second rather
than by retrying.

Both now wait, bounded at thirty seconds, while a file an adapter reads still says `absent`.
The verdict when the wait expires is the reading itself, so a backfill that never lands
still fails the check. This buys latency, never a pass, and `docs/notes.md` is read without
the wait, because an expected `absent` there is the answer rather than a stale one.
Falsified three ways against the helper: a reader that never enriches still comes back
`absent` after the full bound, a reader that lands late is picked up, and the old shape
keeps the stale answer on that same sequence.

Refs FIR-2641
Refs FIR-2604


