### PR TITLE
Stop the commit-headroom row forecasting a kill from a model that measures the wrong thing

### DIFF
--- a/crates/kin-cli/src/commands/commit_progress.rs
+++ b/crates/kin-cli/src/commands/commit_progress.rs
@@ -323,11 +323,22 @@ fn memory_attribution(
 ///
 /// Stated once and shared with the `kin doctor` check that reports the same
 /// headroom before a commit is attempted, so the two surfaces cannot drift into
-/// describing the same cost differently.
+/// describing the same cost differently. It also reaches `kin commit --help`
+/// through `authority_not_git_note!`, so a wrong sentence here is wrong in three
+/// places at once, which is what happened.
+///
+/// FIR-2643: this used to assert that a commit's peak "follows the size of the
+/// store rather than the size of the edit". That is the claim the rc0550
+/// stranger measured against and it did not hold: a docstring-only commit on a
+/// 500 MiB store cost about 0.9 GB over an 8.16 GB resident baseline, while the
+/// store-size model predicted a 10.6 GiB floor. The sentence now says what is
+/// actually known and stops explaining a mechanism the one measurement that
+/// separated the terms contradicts.
 pub const COMMIT_MEMORY_REMEDY: &str =
-    "A commit prepares the whole repository successor in memory, so its peak follows the size of \
-     the store rather than the size of the edit. Re-run it with more memory available; \
-     `kin doctor` reports this headroom before a commit is attempted.";
+    "How much a commit costs is not yet modelled well enough to predict from the store alone; \
+     the one measurement that separated the terms found a small edit costing far less than the \
+     store size suggests. Re-run it with more memory available, or make the edit smaller; \
+     `kin doctor` reports the headroom it can measure before a commit is attempted.";
 
 /// The words both the commit line and `kin commit --help` are built from.
 ///

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1928,7 +1928,8 @@ enum McpAction {
     /// lands on the default PATH. Name the prefix outright when that is what
     /// you want: `npm install -g --prefix /usr/local @kinlab/kin`.
     Start {
-        /// Run in global mode, serving all registered repos from ~/.kin/registry.toml
+        /// Run in global mode, serving every repo in this home's registry
+        /// (KIN_REGISTRY_PATH, else <KIN_HOME>/registry.toml, else ~/.kin/registry.toml)
         #[arg(long)]
         global: bool,
         /// Bind this server to a specific Kin repository instead of relying on

--- a/crates/kin-core/src/dependencies.rs
+++ b/crates/kin-core/src/dependencies.rs
@@ -38,7 +38,10 @@ pub fn detect_dependencies(repo_path: &Path) -> Vec<RepoDependency> {
 
 /// Registry-aware version of [`detect_dependencies`].
 ///
-/// `registry_repo_ids` is the list of known repo IDs from `~/.kin/registry.toml`.
+/// `registry_repo_ids` is the list of known repo IDs from the registry this
+/// home resolves to ([`crate::registry::registry_path`]), which is
+/// `~/.kin/registry.toml` only when neither `KIN_REGISTRY_PATH` nor `KIN_HOME`
+/// is set.
 /// Dependencies whose names match a registry repo ID (with crate-name normalization:
 /// `kin-db` ↔ `kin_db`) get their `provider_repo` set automatically.
 pub fn detect_dependencies_with_registry(

--- a/crates/kin-migrate/src/finalize.rs
+++ b/crates/kin-migrate/src/finalize.rs
@@ -7,7 +7,9 @@
 //! preserve graph authority:
 //!
 //! 1. A persisted `.kidx` read index for fast CLI queries.
-//! 2. A registry entry in `~/.kin/registry.toml`.
+//! 2. A registry entry in the registry this home resolves to
+//!    (`KIN_REGISTRY_PATH`, else `<KIN_HOME>/registry.toml`, else
+//!    `~/.kin/registry.toml`).
 //! 3. A best-effort LSP cold-sweep trigger.
 //!
 use std::path::Path;
@@ -46,7 +48,7 @@ pub fn build_and_save_kidx(snapshot_path: &Path, graph: &kin_db::InMemoryGraph) 
     Ok(())
 }
 
-/// Register the repo in `~/.kin/registry.toml` with its entity count.
+/// Register the repo in this home's resolved registry with its entity count.
 pub fn update_registry(repo_root: &Path, entity_count: usize) -> Result<()> {
     let repo_id = repo_root
         .file_name()
@@ -97,7 +99,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         // Point the registry authority at a path whose parent directory does
         // not exist yet. That is the condition under test, and it keeps the
-        // test off the real `~/.kin/registry.toml`: writing there mutates the
+        // test off the operator's real resolved registry: writing there mutates the
         // developer's own repo list, and the exclusive lock it takes has no
         // timeout, so a `kin` process holding that lock would block this test
         // forever.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1290,7 +1290,7 @@ kin mcp start [options]
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--global` |  | Run in global mode, serving all registered repos from ~/.kin/registry.toml |
+| `--global` |  | Run in global mode, serving every repo in this home's registry (KIN_REGISTRY_PATH, else <KIN_HOME>/registry.toml, else ~/.kin/registry.toml) |
 | `--repo <path>` |  | Bind this server to a specific Kin repository instead of relying on the launching process's working directory. Overrides KIN_MCP_REPO. Use this for a global agent-CLI MCP entry that may launch outside any Kin repository (e.g. an umbrella workspace root). |
 | `--tool-profile <profile>` |  | Tool surface to serve: `agent-default` (the curated agent belt, and the default), `full` (every tool, roughly 12k extra tokens of schemas per session), `benchmark`, or `context-bench`. Overrides KIN_MCP_TOOL_PROFILE. |
 | `--no-spawn` |  | Never start or revive a daemon from this server: bind only a daemon that is already running, and answer graph tool calls with an honest "no daemon is running" error otherwise. This is the probe mode for watchdogs and boot-time checks (equivalent to KIN_NO_DAEMON=1): the MCP handshake and tool list are served in full, and nothing heavy is ever spawned by the check itself. |


### PR DESCRIPTION
Stop the commit-headroom row forecasting a kill from a model that measures the wrong thing

The rc0550 stranger watched kin doctor's "Commit memory headroom" row warn that
a commit could be killed mid-transaction, quoting a 10.6 GiB floor, before a
docstring-only commit on a 500 MiB requests store. The commit's attributable
cost was about 0.9 GB over an 8.16 GB baseline two resident daemons already
held. Roughly an order of magnitude out.

The cause is a category error, not calibration drift. MEASURED_COMMIT_PEAKS
holds whole-container peaks: whatever else was resident when the observation was
taken is inside the number. The check keys those totals to store size and
compares them against another machine's total ceiling, while the one
measurement that separated the terms shows the commit's own cost tracking the
size of the edit. Two quantities that are not the same quantity.

The full fix derives the prediction from transaction size, and its calibration
waits on FIR-2640 moving the commit-phase hash peak. This is the branch the
acceptance allows in the meantime: the row states its uncertainty class instead
of claiming a floor. It still reports the band, because the band caught a real
kill at 12283 MiB against a 12288 MiB ceiling and that observation stands. It no
longer says a commit here can be killed, and no longer claims a larger store
peaks higher, because neither survives its own evidence.

Finding the tests found a second home for the same wrong model. The shared
COMMIT_MEMORY_REMEDY asserted that a commit's peak "follows the size of the
store rather than the size of the edit", and it reaches three user-facing
surfaces: the doctor row, the commit-failure message, and kin commit --help
through authority_not_git_note!. It now says what is known and stops explaining
a mechanism the measurement contradicts.

Guarded by the_headroom_row_states_its_uncertainty_instead_of_forecasting_a_kill
across both warning bands, with positive controls so it cannot pass over a row
that was emptied rather than corrected. Restoring either removed claim turns it
red; verified.

Also, unrelated and batched per the wave ruling: five doc strings named
~/.kin/registry.toml as though it were the registry path. kin#1088's registry
seam made that wrong for anyone with KIN_HOME or KIN_REGISTRY_PATH set, and one
of the five is the user-facing help for kin mcp start --global. They now
describe the resolution, verified against resolve_registry_path and
resolve_managed_kin_home rather than restated from memory.

Refs FIR-2643
Refs FIR-2467

Signed-off-by: Troy Fortin <troy@firelock.ai>


## Why this is the honest first PR rather than the whole fix

The acceptance offers two branches: derive the prediction from transaction-size
inputs and land within 2x of the measured commit-attributable peak, or have the
row state its uncertainty class instead of claiming a floor. This takes the
second, deliberately.

The first branch needs calibration numbers, and FIR-2640 moves the ground under
them: it cuts the commit-phase hash peak by about 75 percent, so any curve fitted
today is fitted to a cost that is about to change. Building the model against
pre-2640 reality would produce a number that has to be thrown away, and shipping
a second wrong model is worse than shipping none.

Meanwhile the cried-wolf is live on every run. The row stops crying wolf today
and the model lands calibrated once the 0.7.15 pins move.

## What is claimed and what is not

Claimed: the row no longer forecasts a kill it cannot support, no longer asserts
a store-size floor, and says plainly that the peak it quotes is a whole-container
reading whose commit-attributable share is not separated.

Not claimed: that the quoted peaks are now correct, or that the banding is
calibrated. The bands are unchanged on purpose. The parity band caught a real
kill at 12283 MiB against a 12288 MiB ceiling, and narrowing it on the strength
of a better cost model is a separate change that owes its own evidence.

## Falsification

Restoring the removed kill forecast:

```
test ...the_headroom_row_states_its_uncertainty_instead_of_forecasting_a_kill FAILED
  the row forecasts a kill from a model an order of magnitude out: only 8.0 GiB
  of memory is available here, below the 12.0 GiB peak ... so a commit here can
  be killed mid-transaction. ...
```

The guard runs across both warning bands and carries positive controls, so it
cannot pass over a row that was emptied rather than corrected: the message must
still name the repository and peak it compares against, and must still offer a
manual fix.

Full crate: 1743 passed, 0 failed.

## The second home of the same wrong model

Worth calling out because it is the part I did not go looking for. The failing
test's output quoted the sentence back at me and it was not from the code I had
just edited. `COMMIT_MEMORY_REMEDY` asserted the store-size mechanism verbatim,
and it is shared by the doctor row, the commit-failure message, and
`kin commit --help`. One constant, three user-facing surfaces, all stating a
mechanism the one measurement that separated the terms contradicts.

## Batched doc fix

Five doc strings named `~/.kin/registry.toml` as though it were the registry
path. kin#1088's registry seam made that wrong for anyone with `KIN_HOME` or
`KIN_REGISTRY_PATH` set, and one is the user-facing help for
`kin mcp start --global`, mirrored into `docs/cli-reference.md`.

The replacement text was derived by reading `resolve_registry_path` and
`resolve_managed_kin_home` rather than restated from the ticket: the order is
`KIN_REGISTRY_PATH`, else `KIN_HOME` or `KIN_DIR`, else the OS home, and
`~/.kin/registry.toml` is the last of those rather than the rule.

## Gate

`cargo fmt --all` clean. Guard scripts `zero_file_search_guard.sh`,
`check_runtime_boundaries.sh`, `check_private_repo_coupling.sh` all exit 0.
`git diff --summary` empty, so no file mode moved.
