### PR TITLE
Pin kin-db 0.7.51 and the kin-model 0.7.16 it requires

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.50"
+version = "0.7.51"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "ff86bb2033c2d8253706a2c618b7783b6bdd1d1647fdfbca3a9e836ac6c02389"
+checksum = "48422b1faa853bcff592987c8ea9c4c3f29743a7d99cf6203e66525e01a6a495"
 dependencies = [
  "bincode",
  "bstr",
@@ -3502,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.13"
+version = "0.7.16"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "cd309d7ab7dd74066a146fdc9749e65328d82a0698c27f1f5b484f6ed676812d"
+checksum = "2290df9564cc5b6468bd572ca17856befc3802d9f2873c98481ad60870c0354a"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -6656,7 +6656,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.13", registry = "kin" }
+kin-model = { version = "=0.7.16", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.50", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.51", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.13"
+version = "0.7.16"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "cd309d7ab7dd74066a146fdc9749e65328d82a0698c27f1f5b484f6ed676812d"
+checksum = "2290df9564cc5b6468bd572ca17856befc3802d9f2873c98481ad60870c0354a"
 dependencies = [
  "chrono",
  "gix-hash",


### PR DESCRIPTION
## What this pin carries

kin-db 0.7.51 carries the brownfield conversion memory fix, which reached it through kin-model 0.7.16. That is the fix for the OOM kill that ends a full-history `kin init` on a requests-sized repository inside 12 GiB.

Two pins move, not one. kin-db 0.7.51 declares `kin-model = "=0.7.16"` as an exact requirement, and this workspace pinned kin-model at `=0.7.13`. Two differing exact requirements on one crate do not resolve, so bumping kin-db alone would not have built.

## The third home

`fuzz/` is a detached workspace with its own tracked lock. It takes kin-parser by path, and kin-parser inherits kin-model from this workspace root, so the root pin reaches `fuzz/Cargo.lock` even though no manifest under `fuzz/` names the crate. The Fuzz workflow fires on changes to the root `Cargo.toml` and runs `cargo metadata --locked` against that lock. Against the stale lock it exits 101, checked before the fix:

```
$ cargo metadata --locked --format-version 1 --manifest-path fuzz/Cargo.toml
error: cannot update the lock file .../fuzz/Cargo.lock because --locked was passed to prevent this
rc=101
```

After re-locking, with the workflow's own toolchain:

```
$ cargo +nightly-2026-06-17 metadata --locked --format-version 1 --manifest-path fuzz/Cargo.toml
rc_fuzz_metadata_locked=0
```

## Registry-only, no path patches

Both lock entries keep their `sparse+` source, and both checksums match the registry index read directly:

```
kin-db   0.7.51  sparse+https://kinlab.ai/registry/cargo/
                 48422b1faa853bcff592987c8ea9c4c3f29743a7d99cf6203e66525e01a6a495
kin-model 0.7.16 sparse+https://kinlab.ai/registry/cargo/
                 2290df9564cc5b6468bd572ca17856befc3802d9f2873c98481ad60870c0354a
```

All 8 external `kin-*` lock entries were checked for a `sparse+`/`git+` source plus a checksum, with zero violations.

One unrelated edge moved during the re-resolve. `winapi-util 0.1.11` requires `windows-sys >=0.48.0, <=0.61` and now selects 0.61.2 where it previously selected 0.48.0. Both versions were already in the lock and the set of windows-sys versions is identical before and after, so nothing was added or removed.

## Gate

Run from the lane worktree through `bin/kin-lane run`, target directory isolated, sccache wired, `KIN_EMBED_BACKEND=cpu` so the gate's daemons stay off the one Metal device. Exit codes read raw, never through a pipe.

```
cargo fmt --all -- --check                      rc=0
cargo clippy --all-targets --all-features       rc=0   (ci.yml's own 45-lint debt list, RUSTFLAGS=-D warnings)
cargo nextest run --workspace --locked          rc=0
  Summary [390.469s] 7143 tests run: 7143 passed (3 slow, 2 leaky), 13 skipped
cargo test --doc --locked                       rc=0
scripts/check_runtime_boundaries.sh             rc=0
scripts/check_private_repo_coupling.sh          rc=0
scripts/test-private-repo-coupling.py           rc=0
cargo metadata --locked (root)                  rc=0
cargo metadata --locked (fuzz)                  rc=0
```

The nextest figure is from a `--no-fail-fast` run. A first pass stopped at 146 of 7143 with two `kin-cli commands::bench_meta` failures, both on a deliberate 2-second bound around a host `git rev-parse HEAD` subprocess. That was host load, not the pin, and I diffed the environment rather than calling it flaky: the box was at load average 53 during the first pass and 41 at the start of the second, and the same two tests then passed in 0.434s and 0.564s against the 2-second bound they had blown through. The diff touches no `.rs` file at all.

Refs FIR-2539
Refs FIR-2522
