### PR TITLE
Name the acceptance verdict's one home, so a green suite step cannot read as proof

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -96,6 +96,16 @@ jobs:
       - name: Falsify the acceptance gate
         run: python3 scripts/acceptance/gate.py --self-test
 
+      # A green suite step is not a verdict, and this makes that a rule rather
+      # than a reading: every suite-run step must say the verdict comes from the
+      # gate step, keep its exit-code capture, and stay loud on failure, and
+      # exactly one step may carry the verdict name. The scanner is driven
+      # against its own mutants first, so a rule that cannot fail fails here.
+      - name: Falsify and enforce the workflow step visibility rule
+        run: |
+          python3 scripts/acceptance/test_workflow_step_visibility.py --self-test
+          python3 scripts/acceptance/test_workflow_step_visibility.py
+
       # FIR-2600. The budget must never render a list it cut as an empty one,
       # because an empty array is the shape a reader takes for "the walk found
       # none". Each grader is handed the exact defect that shipped and has to
@@ -246,7 +256,7 @@ jobs:
       # afterwards, rather than piping into tee. A pipeline's exit status is its
       # last stage's, and `tee` exits 0 on input it never read, so a piped run
       # can report success for a suite that failed.
-      - name: Magic acceptance suite
+      - name: Magic acceptance suite (verdict comes from the gate step)
         id: magic
         env:
           KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
@@ -273,7 +283,7 @@ jobs:
             echo "::error title=Magic acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
-      - name: Brownfield acceptance suite
+      - name: Brownfield acceptance suite (verdict comes from the gate step)
         id: brownfield
         if: always()
         env:
@@ -302,7 +312,7 @@ jobs:
             echo "::error title=Brownfield acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
-      - name: Response budget elision suite
+      - name: Response budget elision suite (verdict comes from the gate step)
         id: response_budget
         if: always()
         env:
@@ -330,7 +340,7 @@ jobs:
             echo "::error title=Response budget elision suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
-      - name: Parse-hole acceptance suite
+      - name: Parse-hole acceptance suite (verdict comes from the gate step)
         id: parsehole
         if: always()
         env:
@@ -358,7 +368,7 @@ jobs:
             echo "::error title=Parse-hole acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
-      - name: Memory-pressure refusal suite
+      - name: Memory-pressure refusal suite (verdict comes from the gate step)
         id: memorypressure
         if: always()
         env:
@@ -391,7 +401,7 @@ jobs:
       # peak, and only the counting allocator can see it. Resident set was tried
       # and rejected, because inside a memory-limited container both a fixed and
       # an unfixed build report the ceiling rather than their demand.
-      - name: Init-memory acceptance suite
+      - name: Init-memory acceptance suite (verdict comes from the gate step)
         id: initmemory
         if: always()
         env:
@@ -417,7 +427,7 @@ jobs:
             echo "::error title=Init-memory acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
-      - name: Registry home isolation suite
+      - name: Registry home isolation suite (verdict comes from the gate step)
         id: registryisolation
         if: always()
         env:
@@ -450,7 +460,7 @@ jobs:
       # makes unwritable, and points a real npm at a port nothing listens on so
       # the installer's own network error is what the classifier is graded
       # against.
-      - name: First-contact honesty suite
+      - name: First-contact honesty suite (verdict comes from the gate step)
         id: firstcontact
         if: always()
         env:
@@ -489,6 +499,12 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      # THE VERDICT LIVES HERE AND ONLY HERE. Every suite step above captures its
+      # own exit code and ends green by design, so all suites run and allowance
+      # semantics stay with the gate; a green suite step is not evidence of
+      # anything, which is why each one's name says the verdict comes from this
+      # step. scripts/acceptance/test_workflow_step_visibility.py enforces the
+      # naming so a reader cannot mistake a run step for the answer.
       # The gate is its own step so both suites run and both upload even when the
       # first one fails, and it reads the reports rather than the exit codes.
       # A suite's exit status is one lever with two settings, demand a clean
@@ -497,7 +513,7 @@ jobs:
       # with no allowance possible, fails on any UNREADABLE that is not named
       # here with a reason, and refuses an allowance that points at a check the
       # report does not carry.
-      - name: Gate on the acceptance suites
+      - name: Acceptance verdict, gated on the suite reports
         if: always()
         run: |
           python3 scripts/acceptance/gate.py \

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Enforce that no acceptance suite step can be mistaken for the verdict.
+
+Every suite step in .github/workflows/acceptance.yml captures its own exit code
+and ends green by design, so all suites run and allowance semantics stay with
+the gate. That design has a reading hazard, and it fired: a green suite step
+was cited as proof inside a failing job (relay-ci2-20260822.md). The workflow
+answers it with naming, and this check makes the naming a rule a diff cannot
+silently drop:
+
+  1. Every step that runs an acceptance suite for real (a scripts/acceptance
+     script writing --json into acceptance/) carries the suffix
+     "(verdict comes from the gate step)" in its name.
+  2. Every such step still captures its exit code (`|| rc=$?`) and carries the
+     ::error annotation template, so a failing suite is loud in the log even
+     though the step ends green.
+  3. Exactly one step name begins with "Acceptance verdict", and its run block
+     invokes scripts/acceptance/gate.py. The verdict has one home.
+
+Self-test: --self-test drives the scanner over embedded mutants (a suite step
+with the suffix missing, a second verdict-named step, a suite step without the
+error annotation, and a clean control) and fails if any mutant passes or the
+control fails. Exit 0 all good, 1 a rule is violated, 2 the workflow could not
+be parsed, 64 usage.
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+SUFFIX = "(verdict comes from the gate step)"
+VERDICT_PREFIX = "Acceptance verdict"
+WORKFLOW = ".github/workflows/acceptance.yml"
+
+STEP_RE = re.compile(r"^      - name: (?P<name>.+?)\s*$", re.M)
+
+
+def split_steps(text: str) -> list[tuple[str, str]]:
+    """Return (name, body) for every step, body running to the next step."""
+    steps = []
+    matches = list(STEP_RE.finditer(text))
+    if not matches:
+        return steps
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        steps.append((m.group("name"), text[m.start():end]))
+    return steps
+
+
+def is_suite_step(body: str) -> bool:
+    """A real suite run: an acceptance script writing --json into acceptance/.
+
+    The falsify steps run the same scripts with --self-test and no --json, and
+    the gate reads reports rather than writing one, so this shape selects
+    exactly the eight run steps and nothing else.
+    """
+    return bool(
+        re.search(r"scripts/acceptance/\w+\.py", body)
+        and re.search(r"--json acceptance/", body)
+    )
+
+
+def check(text: str) -> list[str]:
+    problems = []
+    steps = split_steps(text)
+    if not steps:
+        return ["no steps parsed from the workflow, so nothing was checked"]
+    verdict_steps = [(n, b) for n, b in steps if n.startswith(VERDICT_PREFIX)]
+    if len(verdict_steps) != 1:
+        problems.append(
+            "exactly one step name must begin with %r; found %d"
+            % (VERDICT_PREFIX, len(verdict_steps))
+        )
+    else:
+        if "scripts/acceptance/gate.py" not in verdict_steps[0][1]:
+            problems.append(
+                "the %r step must invoke scripts/acceptance/gate.py" % VERDICT_PREFIX
+            )
+    suite_steps = [(n, b) for n, b in steps if is_suite_step(b)]
+    if not suite_steps:
+        problems.append(
+            "no suite-run steps matched the scanner, so the rule guarded nothing"
+        )
+    for name, body in suite_steps:
+        if not name.endswith(SUFFIX):
+            problems.append(
+                "suite step %r must end with %r so it cannot read as the verdict"
+                % (name, SUFFIX)
+            )
+        if "|| rc=$?" not in body:
+            problems.append(
+                "suite step %r no longer captures its exit code; a raw exit would "
+                "let an allowed UNREADABLE redden the job past the gate" % name
+            )
+        if "::error title=" not in body:
+            problems.append(
+                "suite step %r carries no ::error annotation, so a failing suite "
+                "is quiet in the log" % name
+            )
+    return problems
+
+
+def make_step(name: str, body_lines: list[str]) -> str:
+    return "      - name: %s\n" % name + "".join("        %s\n" % l for l in body_lines)
+
+
+def self_test() -> int:
+    suite_body = [
+        "run: |",
+        "  python3 scripts/acceptance/example.py --json acceptance/example.json || rc=$?",
+        '  echo "::error title=Example suite failed::exit $rc"',
+    ]
+    gate_body = ["run: python3 scripts/acceptance/gate.py --report x=acceptance/x.json"]
+    control = (
+        make_step("Example suite %s" % SUFFIX, suite_body)
+        + make_step("Acceptance verdict, gated on the suite reports", gate_body)
+    )
+    failures = []
+    if check(control):
+        failures.append("control: a clean workflow was reported as violating")
+    mutants = {
+        "suffix missing": (
+            make_step("Example suite", suite_body)
+            + make_step("Acceptance verdict, gated", gate_body)
+        ),
+        "second verdict step": (
+            make_step("Example suite %s" % SUFFIX, suite_body)
+            + make_step("Acceptance verdict, gated", gate_body)
+            + make_step("Acceptance verdict, again", gate_body)
+        ),
+        "annotation missing": (
+            make_step(
+                "Example suite %s" % SUFFIX,
+                [
+                    "run: |",
+                    "  python3 scripts/acceptance/example.py --json acceptance/e.json || rc=$?",
+                ],
+            )
+            + make_step("Acceptance verdict, gated", gate_body)
+        ),
+        "verdict without gate.py": (
+            make_step("Example suite %s" % SUFFIX, suite_body)
+            + make_step("Acceptance verdict, gated", ["run: echo not the gate"])
+        ),
+    }
+    for label, mutant in mutants.items():
+        if not check(mutant):
+            failures.append("mutant %r passed the check, so the rule cannot fail" % label)
+    for f in failures:
+        print("SELF-TEST FAIL: %s" % f)
+    if failures:
+        return 1
+    print("self-test: control clean, all %d mutants caught" % len(mutants))
+    return 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv[1:]:
+        return self_test()
+    if sys.argv[1:]:
+        print("usage: test_workflow_step_visibility.py [--self-test]")
+        return 64
+    try:
+        text = open(WORKFLOW).read()
+    except OSError as exc:
+        print("cannot read %s: %s" % (WORKFLOW, exc))
+        return 2
+    problems = check(text)
+    for p in problems:
+        print("VIOLATION: %s" % p)
+    if problems:
+        return 1
+    print("workflow step visibility holds: every suite step defers to the one verdict step")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Every suite step in acceptance.yml captures its own exit code and ends green by design, so all suites run and allowance semantics stay with the gate. That design has a reading hazard and it fired tonight: a green suite step was cited as proof inside a failing job (relay-ci2-20260822.md). Making the steps fail raw is the wrong fix, because a suite's exit does not know about allowances and an allowed UNREADABLE would redden the job past the gate's own verdict.

So the fix is naming, enforced. The eight suite-run steps now end with (verdict comes from the gate step); the gate step is renamed Acceptance verdict, gated on the suite reports, and its comment states the verdict lives there and only there. scripts/acceptance/test_workflow_step_visibility.py makes the naming a rule a diff cannot silently drop: it scans the workflow, requires the suffix on every step that runs an acceptance script writing --json, requires the exit-code capture and the ::error annotation stay present on each, and requires exactly one step named as the verdict, invoking gate.py. It drives itself against four embedded mutants before enforcing (suffix missing, second verdict step, annotation missing, verdict without gate.py), and it is wired as an early workflow step running self-test then live.

Live falsification, run in this branch and restored: stripping one suffix yields VIOLATION: suite step 'Magic acceptance suite' must end with '(verdict comes from the gate step)' and exit 1. The step renames change no job id and no display name, so the required-check census is untouched.

The reading trap itself is going into the umbrella catalogue in a companion PR.

Refs FIR-2587