### PR TITLE
Compare the commit-headroom row against an observation, not against a model

### DIFF
--- a/crates/kin-cli/src/capability.rs
+++ b/crates/kin-cli/src/capability.rs
@@ -370,6 +370,33 @@ impl CapabilityDetection {
     }
 }
 
+/// Which reading supplied the ceiling in [`MemoryEvidence`].
+///
+/// A row that warns about running out of memory has to be able to say which
+/// number it read, because the two answers can differ by far more than the
+/// margin they get compared against. That is FIR-2638 in one sentence: the
+/// probe read the host figure for a process capped at twelve gigabytes,
+/// reported nineteen, and the kernel killed it with nothing disclosed. A reader
+/// inside a container cannot tell those apart from the byte count alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryLimitSource {
+    /// A cgroup memory cap, found by walking up from this process's own
+    /// `/proc/self/cgroup` path rather than by reading the hierarchy root.
+    ContainerLimit,
+    /// This host's physical RAM, because no cgroup cap binds tighter than it.
+    HostRam,
+}
+
+impl MemoryLimitSource {
+    /// How to name this ceiling to somebody deciding where to run a write.
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::ContainerLimit => "this container's memory cap",
+            Self::HostRam => "this host's RAM",
+        }
+    }
+}
+
 /// What the host can say about memory pressure, for a command that has to
 /// decide whether a failure it just saw was the machine running out of it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -377,6 +404,9 @@ pub struct MemoryEvidence {
     /// The ceiling this process actually runs under: the container limit when
     /// one is set, otherwise the host's physical RAM.
     pub limit_bytes: u64,
+    /// Which of those two `limit_bytes` came from, so a surface quoting it can
+    /// name what it read instead of leaving a reader to guess.
+    pub limit_source: MemoryLimitSource,
     /// Kernel OOM kills accounted to this cgroup. `None` means no accounting
     /// was readable, which is "not observed" and never "did not happen".
     pub cgroup_oom_kills: Option<u64>,
@@ -384,18 +414,30 @@ pub struct MemoryEvidence {
 
 /// Read what this host will say about memory pressure right now.
 pub fn memory_evidence() -> MemoryEvidence {
+    let (limit_bytes, limit_source) =
+        resolve_memory_limit(host_ram_bytes(), cgroup_memory_limit_bytes());
     MemoryEvidence {
-        limit_bytes: effective_memory_limit_bytes(),
+        limit_bytes,
+        limit_source,
         cgroup_oom_kills: cgroup_oom_kill_count(),
     }
 }
 
-/// The memory ceiling a Kin process runs under, in bytes.
-fn effective_memory_limit_bytes() -> u64 {
-    let host = (host_ram_gb() * 1024.0 * 1024.0 * 1024.0) as u64;
-    match cgroup_memory_limit_bytes() {
-        Some(limit) => host.min(limit),
-        None => host,
+fn host_ram_bytes() -> u64 {
+    (host_ram_gb() * 1024.0 * 1024.0 * 1024.0) as u64
+}
+
+/// The memory ceiling a Kin process runs under, and which reading supplied it.
+///
+/// Pure over both readings so the tie and both orderings are testable on any
+/// host. A cap equal to the host figure is attributed to the host, because the
+/// cap constrains nothing that the physical memory did not already constrain,
+/// and naming a container cap that binds nothing invites a reader to raise a
+/// limit that was never the wall.
+fn resolve_memory_limit(host: u64, cgroup: Option<u64>) -> (u64, MemoryLimitSource) {
+    match cgroup {
+        Some(limit) if limit < host => (limit, MemoryLimitSource::ContainerLimit),
+        _ => (host, MemoryLimitSource::HostRam),
     }
 }
 
@@ -660,5 +702,61 @@ mod tests {
         );
         assert_eq!(parse_meminfo_total_gb("MemFree: 100 kB\n"), None);
         assert_eq!(parse_meminfo_total_gb("MemTotal:       nope kB\n"), None);
+    }
+
+    /// The ceiling has to carry which reading produced it, in both directions.
+    ///
+    /// A byte count alone cannot tell a reader inside a container whether their
+    /// cap was seen at all, which is the shape FIR-2638 shipped: the host figure
+    /// answered for a capped process and the disclosure stayed silent through
+    /// the kill. A surface that quotes this number quotes the source beside it,
+    /// so it can only do that if the source travels with the number.
+    ///
+    /// Falsify by returning `HostRam` unconditionally, which leaves the byte
+    /// count correct and every band unchanged: only the first case below fails.
+    #[test]
+    fn the_memory_ceiling_names_which_reading_bound_it() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        assert_eq!(
+            resolve_memory_limit(19 * GIB, Some(12 * GIB)),
+            (12 * GIB, MemoryLimitSource::ContainerLimit),
+            "a cap under the host figure is the wall, and saying so is the FIR-2638 disclosure"
+        );
+        assert_eq!(
+            resolve_memory_limit(8 * GIB, Some(64 * GIB)),
+            (8 * GIB, MemoryLimitSource::HostRam),
+            "a cap the host cannot reach binds nothing"
+        );
+        assert_eq!(
+            resolve_memory_limit(16 * GIB, None),
+            (16 * GIB, MemoryLimitSource::HostRam),
+            "no cgroup accounting means the host figure, named as the host figure"
+        );
+        assert_eq!(
+            resolve_memory_limit(12 * GIB, Some(12 * GIB)),
+            (12 * GIB, MemoryLimitSource::HostRam),
+            "a cap level with the host constrains nothing the host did not, and pointing a \
+             reader at raising it would send them at the wrong wall"
+        );
+    }
+
+    /// Both names have to read as an answer to "which number is this".
+    #[test]
+    fn each_ceiling_source_names_itself_to_a_reader() {
+        assert!(
+            MemoryLimitSource::ContainerLimit
+                .describe()
+                .contains("container"),
+            "a capped process is told it is capped"
+        );
+        assert!(
+            MemoryLimitSource::HostRam.describe().contains("host"),
+            "an uncapped process is told it is reading the machine"
+        );
+        assert_ne!(
+            MemoryLimitSource::ContainerLimit.describe(),
+            MemoryLimitSource::HostRam.describe(),
+            "two sources that print the same words disclose nothing"
+        );
     }
 }

--- a/crates/kin-cli/src/commands/commit_progress.rs
+++ b/crates/kin-cli/src/commands/commit_progress.rs
@@ -432,6 +432,7 @@ mod tests {
     fn evidence(limit_bytes: u64, oom_kills: Option<u64>) -> crate::capability::MemoryEvidence {
         crate::capability::MemoryEvidence {
             limit_bytes,
+            limit_source: crate::capability::MemoryLimitSource::HostRam,
             cgroup_oom_kills: oom_kills,
         }
     }

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -1175,6 +1175,7 @@ mod tests {
     fn evidence(limit_bytes: u64, oom_kills: Option<u64>) -> crate::capability::MemoryEvidence {
         crate::capability::MemoryEvidence {
             limit_bytes,
+            limit_source: crate::capability::MemoryLimitSource::HostRam,
             cgroup_oom_kills: oom_kills,
         }
     }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -3874,27 +3874,45 @@ fn language_server_fix() -> String {
 /// Report the active retrieval quality profile and the effective lever set,
 /// so an operator can see at a glance whether they are getting full
 /// retrieval capability — and why not, when a lever is off.
-/// One commit peak measured on a real converted repository.
+/// One commit observation from a real converted repository.
+///
+/// `peak_bytes` is a WHOLE-MACHINE total taken while the commit ran, not the
+/// commit's own demand: everything else resident at the time is inside it. That
+/// distinction is FIR-2643. Keying these totals to store size and reading the
+/// result as what a commit costs put this row roughly an order of magnitude out,
+/// because the one measurement that separated the terms found a docstring-only
+/// edit on a 500 MiB store costing about 0.9 GB over a resident baseline of
+/// 8.16 GB, while the store-size reading implied a 10.6 GiB floor.
+///
+/// `observed_ceiling_bytes` is the size of the machine the total was taken
+/// inside, and it travels with the total because a total means nothing without
+/// it. 12283 MiB is comfortable in 24 GiB and is the last reading before a kill
+/// in 12288 MiB, and it was the second.
 struct MeasuredCommitPeak {
     repository: &'static str,
     store_bytes: u64,
     peak_bytes: u64,
+    observed_ceiling_bytes: u64,
 }
 
 const MIB: u64 = 1024 * 1024;
 
-/// Commit peaks measured on converted repositories, smallest store first.
+/// Commit observations from converted repositories, smallest store first.
 ///
-/// Every row is one observation, not a fitted curve, and the check below never
-/// interpolates or extrapolates between them. It quotes the largest row whose
-/// store is no larger than the store in front of it, so what a reader is told
-/// is always a repository that has actually been measured rather than a
-/// prediction about theirs. Below the smallest row nothing is claimed at all.
+/// Every row is one whole-machine total taken while a commit ran, never a fitted
+/// curve and never a commit's own demand, and the check below never interpolates
+/// or extrapolates between them. It quotes the largest row whose store is no
+/// larger than the store in front of it, so what a reader is told is always a
+/// machine that was actually measured rather than a prediction about theirs.
+/// Below the smallest row nothing is claimed at all.
 ///
-/// The two rows are why a curve would be wrong: a store less than half the size
-/// of the other peaked within 12% of it, because a commit prepares the whole
-/// repository successor in memory and the fixed part of that dominates. Both
-/// were measured in the same 5 CPU / 12 GiB container on `kin 0.5.40`, before
+/// The two rows are the table's own argument against a curve. `expressjs/express`
+/// holds a store 47% the size of `psf/requests` and its total lands within 12% of
+/// it. A quantity that barely moves when the store nearly halves is not a
+/// quantity the store predicts, which is why this check compares one ceiling
+/// against one observation and stops there.
+///
+/// Both were taken in the same 5 CPU / 12 GiB container on `kin 0.5.40`, before
 /// the workspace-graph scoping in `plan_native_commit_inner` cut what a commit
 /// holds at its peak. A build that peaks lower than a row makes this check
 /// conservative rather than wrong, which is the safe direction for a warning:
@@ -3905,25 +3923,31 @@ const MEASURED_COMMIT_PEAKS: &[MeasuredCommitPeak] = &[
         repository: "expressjs/express",
         store_bytes: 437 * MIB,
         peak_bytes: 10809 * MIB,
+        observed_ceiling_bytes: 12288 * MIB,
     },
     MeasuredCommitPeak {
         repository: "psf/requests",
         store_bytes: 922 * MIB,
         peak_bytes: 12283 * MIB,
+        observed_ceiling_bytes: 12288 * MIB,
     },
 ];
 
-/// How far above the quoted peak a ceiling has to sit, as a percentage of that
-/// peak, before this check calls it ok.
+/// How far above the quoted total a ceiling has to sit, as a percentage of that
+/// total, before this check calls it ok.
 ///
-/// The quoted row is a floor rather than a bound. The store in front of the
-/// check is at least as large as the row's store, and a larger store peaks
-/// higher: `psf/requests` holds barely more than twice `expressjs/express`'s
-/// store and peaks 13.6% above it, because a commit prepares the whole
-/// repository successor in memory and the fixed part of that dominates. So a
-/// ceiling merely level with the quoted peak is the edge rather than headroom,
-/// and calling that ok is what told an isolated stranger run its 12288 MiB
-/// container was fine six hours before a commit was killed at 12283 MiB.
+/// This is a repeatability figure, not a scaling claim. Two commits observed in
+/// the SAME 12 GiB container produced totals 13.6% apart, so a total is not
+/// reproducible closer than that even with the machine held fixed. A ceiling
+/// merely level with a quoted total therefore has no room in it, and calling
+/// that ok is what told an isolated stranger run its 12288 MiB container was
+/// fine six hours before a commit was killed at 12283 MiB.
+///
+/// FIR-2643: the margin used to be justified by "a larger store peaks higher",
+/// which the table's own two rows do not support and which put this row's
+/// forecast roughly an order of magnitude out. The band it opens is unchanged,
+/// because the kill it caught is unchanged. Only the reason it exists is stated
+/// correctly now.
 ///
 /// The number rounds the observed spread up, because the safe direction for a
 /// warning is to advise headroom nobody needs rather than to stay quiet about a
@@ -3932,21 +3956,27 @@ const MEASURED_COMMIT_PEAKS: &[MeasuredCommitPeak] = &[
 /// test instead of quietly narrowing the band this exists to open.
 const COMMIT_PEAK_COMFORT_MARGIN_PERCENT: u64 = 14;
 
-/// Report whether this machine has the memory a commit on this store has been
-/// measured to need.
+/// Report how this machine's memory ceiling compares with the totals commits on
+/// stores this size have already been observed reaching.
 ///
 /// A commit that runs out of memory is reported to the person running it as a
-/// closed socket, and the store size that decides it is knowable before any
-/// commit is attempted. This is that reading, published where a user looks
+/// closed socket, and by then the write is gone. The comparison this row makes
+/// needs no commit to have been attempted, so it is published where a user looks
 /// before they are surprised rather than after.
 ///
-/// It reports three bands. A ceiling clear of the quoted peak is healthy, one
+/// What it does not do, since FIR-2643, is predict what a commit here would
+/// cost. The observations it quotes are whole-machine totals, the commit's own
+/// share of them is not modelled, and the version of this row that derived one
+/// from store size ran roughly an order of magnitude high. It compares a ceiling
+/// against an observation, and it says that is what it is doing.
+///
+/// It reports three bands. A ceiling clear of the quoted total is healthy, one
 /// merely level with it is `Stale`, and one below it is `Degraded`. The middle
-/// band exists because the quoted peak is a floor for a store at least the
-/// quoted size, so parity with it is the edge rather than headroom.
+/// band exists because a total is not reproducible closer than the spread the
+/// table itself shows, so parity with one is the edge rather than headroom.
 ///
 /// It is advisory by construction and never blocks readiness, whichever band it
-/// lands in. A ceiling below a measured peak is a fact about a machine, not a
+/// lands in. A ceiling below an observed total is a fact about a machine, not a
 /// broken install, and a check that failed readiness on it would fail every
 /// correct install on a small host.
 fn check_commit_memory_headroom() -> HealthCheck {
@@ -4273,6 +4303,7 @@ fn commit_memory_headroom_check_for(
         );
     };
     let available = format_health_bytes(evidence.limit_bytes);
+    let ceiling_source = evidence.limit_source.describe();
     let measured = MEASURED_COMMIT_PEAKS
         .iter()
         .rev()
@@ -4283,8 +4314,8 @@ fn commit_memory_headroom_check_for(
             LABEL,
             HealthStatus::Healthy,
             format!(
-                "{} of memory available; this {} store is smaller than any store a commit peak \
-                 has been measured on, so no headroom claim is made about it",
+                "{} of memory here ({ceiling_source}); this {} store is smaller than any store a \
+                 commit has been observed on, so no headroom claim is made about it",
                 available,
                 format_health_bytes(store.bytes)
             ),
@@ -4292,6 +4323,8 @@ fn commit_memory_headroom_check_for(
     };
     let needed = format_health_bytes(measured.peak_bytes);
     let measured_store = format_health_bytes(measured.store_bytes);
+    let measured_machine = format_health_bytes(measured.observed_ceiling_bytes);
+    let room = format_observation_room(measured.peak_bytes, measured.observed_ceiling_bytes);
     let store_size = format_health_bytes(store.bytes);
     let ratio = format_store_ratio(store.bytes, measured.store_bytes);
     let comfortable = measured.peak_bytes.saturating_add(
@@ -4306,9 +4339,10 @@ fn commit_memory_headroom_check_for(
             LABEL,
             HealthStatus::Healthy,
             format!(
-                "{available} of memory available; a commit on {} ({measured_store} store) was \
-                 measured peaking at {needed}, and this ceiling clears that peak by at least \
-                 {}%. This {store_size} store is {ratio} the measured one",
+                "{available} of memory here ({ceiling_source}); a commit on {} ({measured_store} \
+                 store) was observed driving a {measured_machine} machine to {needed} in total, \
+                 and this ceiling clears that peak by at least {}%. This {store_size} store is \
+                 {ratio} the measured one",
                 measured.repository, COMMIT_PEAK_COMFORT_MARGIN_PERCENT
             ),
         );
@@ -4317,8 +4351,9 @@ fn commit_memory_headroom_check_for(
         (
             HealthStatus::Stale,
             format!(
-                "{available} of memory available is parity with the {needed} peak a commit on {} \
-                 ({measured_store} store) was measured at, not headroom over it",
+                "{available} of memory here ({ceiling_source}) is parity with the {needed} a \
+                 commit on {} ({measured_store} store) was observed reaching inside a \
+                 {measured_machine} machine, {room}, not headroom over it",
                 measured.repository
             ),
         )
@@ -4326,28 +4361,30 @@ fn commit_memory_headroom_check_for(
         (
             HealthStatus::Degraded,
             format!(
-                "only {available} of memory is available here, below the {needed} peak a commit \
-                 on {} ({measured_store} store) was already measured at",
+                "only {available} of memory here ({ceiling_source}), under the {needed} a commit \
+                 on {} ({measured_store} store) was already observed reaching inside a \
+                 {measured_machine} machine, {room}",
                 measured.repository
             ),
         )
     };
-    // The floor clause is claimed only where it is true. On a store no larger
-    // than the measured one the row is the measurement for that size, and
-    // saying it understates would be inventing a margin the table never showed.
-    let floor_note = if store.bytes > measured.store_bytes {
-        ", and a larger store peaks higher, so that measurement is a floor here rather than a bound"
-    } else {
-        ""
-    };
+    // What the row is allowed to say, and what it is not. The band above is an
+    // observation compared against this machine's own ceiling, so it is stated.
+    // What a commit HERE would cost is not modelled, so it is not stated, and
+    // the store ratio is offered as distance from the measured case rather than
+    // as a multiplier on the total. FIR-2643 is what the multiplier reading
+    // cost: a 10.6 GiB floor quoted over a commit that took about 0.9 GB.
     HealthCheck::new(
         ID,
         LABEL,
         status,
         format!(
-            "{opening}. This {store_size} store is {ratio} the measured one{floor_note}, so a \
-             commit here can be killed mid-transaction and report a closed connection. Do this \
-             write on a smaller repository or a larger machine. {}",
+            "{opening}. That figure is a whole-machine total with everything else that was \
+             resident inside it rather than a commit's own demand, so this row compares a ceiling \
+             against an observation and forecasts nothing about this write. This {store_size} \
+             store is {ratio} the measured one, which says how far it sits from the machine that \
+             was measured, not what a commit on it would cost. Do this write on a smaller \
+             repository or a larger machine. {}",
             crate::commands::commit_progress::COMMIT_MEMORY_REMEDY,
         ),
     )
@@ -4357,11 +4394,33 @@ fn commit_memory_headroom_check_for(
     )
 }
 
+/// What the machine an observation was taken in still had when the total peaked.
+///
+/// A total is unreadable without its machine: 12283 MiB is comfortable in 24 GiB
+/// and is the last reading before a kill in 12288 MiB. This is the phrase that
+/// carries that difference into the row, and it is why the table stores the
+/// machine beside the total.
+fn format_observation_room(peak_bytes: u64, observed_ceiling_bytes: u64) -> String {
+    let Some(room) = observed_ceiling_bytes
+        .checked_sub(peak_bytes)
+        .filter(|room| *room > 0)
+    else {
+        return "with nothing left in that machine".to_string();
+    };
+    format!(
+        "{} short of that machine's own ceiling",
+        format_health_bytes(room)
+    )
+}
+
 /// How many times the measured store this store is.
 ///
-/// The ratio is what turns a quoted peak into a floor: a reader whose store is
-/// twice the measured one is being told the least their commit can cost, not
-/// the most.
+/// The ratio says how far this store sits from the repository that was actually
+/// observed, so a reader can judge whether the observation is close enough to
+/// their case to act on. It is not a multiplier on the total. FIR-2643 is what
+/// happens when a ratio is read that way, and the table's own rows are the
+/// counter-example: a store 47% the size of the other lands within 12% of its
+/// total.
 fn format_store_ratio(store_bytes: u64, measured_bytes: u64) -> String {
     if measured_bytes == 0 {
         return "an unknown multiple of".to_string();
@@ -4494,6 +4553,16 @@ mod tests {
     fn memory(limit_bytes: u64) -> crate::capability::MemoryEvidence {
         crate::capability::MemoryEvidence {
             limit_bytes,
+            limit_source: crate::capability::MemoryLimitSource::HostRam,
+            cgroup_oom_kills: None,
+        }
+    }
+
+    /// The same ceiling, read off a container cap instead of the host figure.
+    fn capped_memory(limit_bytes: u64) -> crate::capability::MemoryEvidence {
+        crate::capability::MemoryEvidence {
+            limit_bytes,
+            limit_source: crate::capability::MemoryLimitSource::ContainerLimit,
             cgroup_oom_kills: None,
         }
     }
@@ -4631,7 +4700,7 @@ mod tests {
         );
     }
 
-    /// Parity with a measured peak is the edge, and it used to round up to ok.
+    /// Parity with an observed total is the edge, and it used to round up to ok.
     ///
     /// A one-file commit on a 922 MiB store peaked at 12283 MiB against a
     /// 12288 MiB ceiling. `kin doctor` had both numbers and called it ok six
@@ -4639,6 +4708,17 @@ mod tests {
     /// 12288 clears 12283. Amber is the whole finding: it costs a reader
     /// nothing to move the write to a smaller repository, and it costs them the
     /// write not to.
+    ///
+    /// FIR-2643 changed what this test requires of the WORDS and deliberately
+    /// left what it requires of the BAND alone. It used to demand the row call
+    /// the quoted total "a floor here rather than a bound", which is the
+    /// store-size extrapolation that ran roughly an order of magnitude high;
+    /// that clause is gone, and continuing to assert it would have pinned the
+    /// defect in place. What replaces it is the claim that survives its own
+    /// evidence: the quoted number is a whole-machine total, and the row has to
+    /// say so. The band is untouched, so a commit that would exceed this ceiling
+    /// still cannot be reported as safe, which is the kill this test was bought
+    /// by.
     ///
     /// Falsify by restoring the `>=` comparison against the bare peak: both
     /// arms below go `Healthy` again and the assertions name the status.
@@ -4674,10 +4754,29 @@ mod tests {
             stranger.detail
         );
         assert!(
-            stranger.detail.contains("2.0x the measured one")
-                && stranger.detail.contains("floor here rather than a bound"),
-            "a bigger store makes the quoted peak a floor, and the reader is owed that: {}",
+            stranger.detail.contains("2.0x the measured one"),
+            "the reader cannot judge how far the observation sits from their case without the \
+             store ratio: {}",
             stranger.detail
+        );
+        assert!(
+            stranger.detail.contains("whole-machine total"),
+            "the quoted number includes everything else that was resident, and a reader who \
+             takes it for a commit's own demand is reading the defect: {}",
+            stranger.detail
+        );
+        assert!(
+            stranger
+                .detail
+                .contains("5 MiB short of that machine's own ceiling"),
+            "12283 MiB inside 12288 MiB is the whole finding, and the row that omits the gap \
+             leaves a reader nothing to weigh: {}",
+            stranger.detail
+        );
+        assert!(
+            !matches!(stranger.status, HealthStatus::Healthy),
+            "a ceiling with no room over an observed total must never be reported as safe: {:?}",
+            stranger.status
         );
         assert!(
             stranger.detail.contains("smaller repository"),
@@ -4687,6 +4786,175 @@ mod tests {
         assert!(
             stranger.manual_fix.is_some(),
             "a warning a reader cannot act on is noise"
+        );
+    }
+
+    /// The row states what it does not know instead of forecasting a kill from
+    /// a model that measures the wrong thing.
+    ///
+    /// The rc0550 stranger watched this row warn that a commit could be killed
+    /// mid-transaction, quoting a 10.6 GiB floor, before a docstring-only commit
+    /// on a 500 MiB requests store. That commit's attributable cost was about
+    /// 0.9 GB over an 8.16 GB resident baseline. The forecast was roughly an
+    /// order of magnitude out because it read whole-machine totals as commit
+    /// demand and then scaled them by store size, and a warning that far off is
+    /// ignored by the third time a reader watches the write succeed anyway.
+    ///
+    /// Both warning bands are swept, because the row is one shared tail joined
+    /// to a band-specific opening and a correction applied to one is not a
+    /// correction. The positive controls are the point of the test: an emptied
+    /// row satisfies every negative assertion here, so the row must still name
+    /// the repository, the total, the store ratio and a fix a reader can act on.
+    ///
+    /// Falsify by restoring either removed claim. The kill forecast fails the
+    /// first assertion in each band; the store-size floor fails the second.
+    #[test]
+    fn the_headroom_row_states_its_uncertainty_instead_of_forecasting_a_kill() {
+        let bands = [
+            (
+                "degraded",
+                commit_memory_headroom_check_for(&footprint(1844 * MIB), &memory(8 * 1024 * MIB)),
+            ),
+            (
+                "parity",
+                commit_memory_headroom_check_for(&footprint(1844 * MIB), &memory(12288 * MIB)),
+            ),
+        ];
+        for (band, check) in bands {
+            assert!(
+                !check.detail.contains("can be killed"),
+                "{band}: the row forecasts a kill from a cost it does not model: {}",
+                check.detail
+            );
+            assert!(
+                !check.detail.contains("floor here rather than a bound")
+                    && !check.detail.contains("larger store peaks higher"),
+                "{band}: the row is extrapolating an observed total by store size again: {}",
+                check.detail
+            );
+            assert!(
+                check
+                    .detail
+                    .contains("not yet modelled well enough to predict from the store alone"),
+                "{band}: a row that drops the forecast owes the reader what it does not know: {}",
+                check.detail
+            );
+            assert!(
+                check.detail.contains("whole-machine total"),
+                "{band}: the quoted number carries everything else that was resident, and \
+                 leaving that out is what let it be read as commit demand: {}",
+                check.detail
+            );
+            // Positive controls. Every assertion above passes on an empty row.
+            assert!(
+                check.detail.contains("psf/requests") && check.detail.contains("12.0 GiB"),
+                "{band}: the row still owes the reader the repository and the total: {}",
+                check.detail
+            );
+            assert!(
+                check.detail.contains("2.0x the measured one"),
+                "{band}: the row still owes the reader how far its store sits from that one: {}",
+                check.detail
+            );
+            assert!(
+                check.detail.contains("smaller repository"),
+                "{band}: the row exists to redirect the write before it is spent: {}",
+                check.detail
+            );
+            assert!(
+                check.manual_fix.is_some(),
+                "{band}: a warning a reader cannot act on is noise"
+            );
+        }
+    }
+
+    /// Dropping the forecast is not permission to go quiet.
+    ///
+    /// The band is the half of this row grounded in an observation rather than a
+    /// model, and it is the half that caught the 12283 MiB commit inside the
+    /// 12288 MiB container. This sweeps the whole table instead of one fixture,
+    /// so a row measured later inherits the guarantee rather than needing its own
+    /// test, and it covers exact parity, one MiB under, and half the total.
+    ///
+    /// Falsify by comparing with `>` instead of `>=`, or by returning `Healthy`
+    /// from any band: the exact-parity arm fails first and names the total it
+    /// was judged against.
+    #[test]
+    fn the_headroom_row_never_reports_a_ceiling_at_or_under_an_observed_total_as_ok() {
+        for point in MEASURED_COMMIT_PEAKS {
+            for ceiling in [
+                point.peak_bytes,
+                point.peak_bytes - MIB,
+                point.peak_bytes / 2,
+            ] {
+                let check = commit_memory_headroom_check_for(
+                    &footprint(point.store_bytes),
+                    &memory(ceiling),
+                );
+                assert!(
+                    !matches!(check.status, HealthStatus::Healthy),
+                    "{} at a {} ceiling against an observed total of {}: a ceiling with no room \
+                     over an observation must not read ok, which is what called a 12288 MiB \
+                     container fine six hours before a commit was killed at 12283 MiB",
+                    point.repository,
+                    format_health_bytes(ceiling),
+                    format_health_bytes(point.peak_bytes)
+                );
+                assert!(
+                    check.detail.contains(point.repository),
+                    "the row has to name the observation it is judging against: {}",
+                    check.detail
+                );
+                assert!(
+                    check.manual_fix.is_some(),
+                    "every warning band carries a fix the reader can act on"
+                );
+            }
+        }
+    }
+
+    /// The row says which reading its ceiling came from.
+    ///
+    /// FIR-2638 shipped a probe that answered with the host figure for a process
+    /// capped at twelve gigabytes and stayed silent through the kill. A row that
+    /// prints a byte count without its source cannot be checked by the person it
+    /// is warning, and raising a container limit is a different action from
+    /// moving to a bigger host. Every band quotes the ceiling, so every band owes
+    /// the provenance, not only the red one.
+    ///
+    /// Falsify by dropping the source from the format strings, which fails all
+    /// three arms, or by hard-coding one source, which fails the other.
+    #[test]
+    fn the_headroom_row_names_the_reading_its_ceiling_came_from() {
+        let capped = commit_memory_headroom_check_for(
+            &footprint(1844 * MIB),
+            &capped_memory(8 * 1024 * MIB),
+        );
+        assert!(
+            capped.detail.contains("this container's memory cap"),
+            "a capped process is owed the fact that the cap is the wall it hit: {}",
+            capped.detail
+        );
+        let bare =
+            commit_memory_headroom_check_for(&footprint(1844 * MIB), &memory(8 * 1024 * MIB));
+        assert!(
+            bare.detail.contains("this host's RAM"),
+            "an uncapped process must not be sent to raise a limit it does not have: {}",
+            bare.detail
+        );
+        let healthy = commit_memory_headroom_check_for(
+            &footprint(922 * MIB),
+            &capped_memory(64 * 1024 * MIB),
+        );
+        assert!(
+            matches!(healthy.status, HealthStatus::Healthy),
+            "the fixture must exercise the ok band: {:?}",
+            healthy.status
+        );
+        assert!(
+            healthy.detail.contains("this container's memory cap"),
+            "the ok band quotes the same ceiling and owes the same provenance: {}",
+            healthy.detail
         );
     }
 

--- a/scripts/write-release-archive-docs.mjs
+++ b/scripts/write-release-archive-docs.mjs
@@ -87,15 +87,15 @@ Two decisions, both answered here, and one number to plan around first.
 
 ## Requirements
 
-A commit prepares the whole repository successor in memory, so its peak follows
-the size of the repository rather than the size of the edit, and on a converted
-repository it can reach 16 GB per repository per write. Give the machine or
-container that much free memory before you commit, because a commit that runs
-out of it is killed mid-transaction.
+Give the machine or container 16 GB per repository per write. A commit on a
+converted repository has been observed driving a whole 12 GiB machine to 12.0 GiB
+in total and being killed there, and how much of that total the commit itself
+needed is not modelled, so the figure is a margin over what has been observed
+rather than a prediction from the size of your repository or your edit.
 
-Run \`kin doctor\` inside the repository to see where you stand. It measures your
-store against the commit peaks Kin has recorded and tells you which side of that
-line you are on, before you spend a write finding out.
+Run \`kin doctor\` inside the repository to see where you stand. It compares this
+machine's memory ceiling against the totals Kin has recorded and tells you which
+side of that line you are on, before you spend a write finding out.
 
 ## 1. The executables
 

--- a/scripts/write-release-archive-docs.test.mjs
+++ b/scripts/write-release-archive-docs.test.mjs
@@ -69,6 +69,40 @@ test('every archive states the memory a commit needs before a reader picks a mac
   }
 });
 
+// FIR-2643: the same wrong model had three homes, and this was the one shipped
+// inside the archive. The requirement itself is grounded, a margin over a total
+// that has actually been observed, but the sentence that justified it explained
+// the cost as following repository size, which is the claim the one measurement
+// separating the terms contradicts: a docstring-only edit on a 500 MiB store
+// cost about 0.9 GB while the store-size reading implied a 10.6 GiB floor. A
+// requirement a reader disbelieves is a requirement they stop reading.
+test('the memory requirement does not explain itself with a model the measurement contradicts', () => {
+  for (const target of TARGETS) {
+    const { install } = generate(target);
+    assert.doesNotMatch(
+      install,
+      /peak follows\s+the size of the repository/,
+      `${target}: INSTALL.md still derives the commit cost from repository size`,
+    );
+    assert.doesNotMatch(
+      install,
+      /rather than the size of the edit/,
+      `${target}: INSTALL.md still contrasts store size against edit size as the model`,
+    );
+    // Positive controls: deleting the paragraph passes both assertions above.
+    assert.match(
+      install,
+      /not modelled/,
+      `${target}: INSTALL.md drops the requirement instead of stating its uncertainty`,
+    );
+    assert.match(
+      install,
+      /observed/,
+      `${target}: INSTALL.md states a figure with nothing observed behind it`,
+    );
+  }
+});
+
 // Requirements that arrive after the install steps are requirements nobody
 // used. The reader has already chosen the machine by then.
 test('the requirement is stated before the install steps', () => {


### PR DESCRIPTION
Finish FIR-2643. kin#1098 landed at 03:52Z carrying only half of it, and the half
that landed is the half that makes `kin doctor`'s "Commit memory headroom" row
contradict itself. Its corrected `COMMIT_MEMORY_REMEDY` says a commit's cost is not
modelled well enough to predict from the store, and it is appended to the end of a row
whose earlier clauses still assert exactly that model and forecast a kill from it.
That paragraph is live on `main` at `d6bdec887` right now. This is the other half.

## What was wrong

`MEASURED_COMMIT_PEAKS` holds whole-machine totals. Whatever else was resident when an
observation was taken is inside the number. The row keyed those totals to store size,
read the result as what a commit costs, scaled it by the store ratio, and forecast a
kill from the product. Those are not the same quantity.

The rc0550 stranger measured the gap: the row quoted a 10.6 GiB floor before a
docstring-only commit on a 500 MiB requests store whose attributable cost was about
0.9 GB over an 8.16 GB resident baseline. Roughly an order of magnitude out, and a
warning that far off gets ignored by the third time somebody watches the write succeed
anyway.

The table's own two rows say the same thing. `expressjs/express` holds a store 47% the
size of `psf/requests` and its total lands within 12% of it. A quantity that barely
moves when the store nearly halves is not a quantity the store predicts.

## What the row asserts now

It compares a ceiling against an observation, and it says that is what it is doing.

Each table row carries `observed_ceiling_bytes`, the machine its total was taken
inside, because a total is unreadable without one: 12283 MiB is comfortable in 24 GiB
and is the last reading before a kill in 12288 MiB. So the row reports that
`psf/requests` reached 12.0 GiB inside a 12.0 GiB machine, 5 MiB short of that
machine's own ceiling, rather than implying a commit needs 12 GiB. The store-size floor
clause and the kill forecast are both gone.

The bands are unchanged on purpose. The band is the half of this row grounded in an
observation rather than a model, and it is the half that caught the real kill at
12283 MiB against a 12288 MiB ceiling. The 14% comfort margin stays too, with its
reason corrected: two commits observed in the SAME 12 GiB container produced totals
13.6% apart, so a total is not reproducible closer than that even with the machine held
fixed. That is repeatability, not store scaling.

The ceiling also names which reading produced it. `MemoryEvidence` carries a
`MemoryLimitSource`, so a capped process reads `this container's memory cap` and an
uncapped one reads `this host's RAM`. A bare byte count is what FIR-2638 shipped: the
host figure answered for a process capped at twelve gigabytes, and a reader cannot tell
those apart without the source beside the number. A cap level with the host figure is
attributed to the host, because sending a reader to raise a limit that binds nothing
sends them at the wrong wall.

## The row, before and after

Rendered through the check's own seam, `commit_memory_headroom_check_for`, degraded
band, `footprint(1844 MiB)` against an 8 GiB ceiling. Before is what `main` prints
today.

Before:

> only 8.0 GiB of memory is available here, below the 12.0 GiB peak a commit on
> psf/requests (922 MiB store) was already measured at. This 1.8 GiB store is 2.0x the
> measured one, and a larger store peaks higher, so that measurement is a floor here
> rather than a bound, so a commit here can be killed mid-transaction and report a
> closed connection. Do this write on a smaller repository or a larger machine. How
> much a commit costs is not yet modelled well enough to predict from the store alone;
> the one measurement that separated the terms found a small edit costing far less than
> the store size suggests. ...

After:

> only 8.0 GiB of memory here (this host's RAM), under the 12.0 GiB a commit on
> psf/requests (922 MiB store) was already observed reaching inside a 12.0 GiB machine,
> 5 MiB short of that machine's own ceiling. That figure is a whole-machine total with
> everything else that was resident inside it rather than a commit's own demand, so
> this row compares a ceiling against an observation and forecasts nothing about this
> write. This 1.8 GiB store is 2.0x the measured one, which says how far it sits from
> the machine that was measured, not what a commit on it would cost. Do this write on a
> smaller repository or a larger machine. How much a commit costs is not yet modelled
> well enough to predict from the store alone; ...

## Why this branch of the acceptance

FIR-2643 offers two: derive the prediction from transaction-size inputs and land within
2x of the allocator-measured commit-attributable peak, or state the uncertainty class
instead of claiming a floor. This takes the second.

The first needs a number nobody has produced. The acceptance was corrected by its owner
on 2026-08-23 and is explicit that the calibration has to come from the counting global
allocator's per-phase attribution rather than a cgroup peak minus a resident baseline,
and that the stranger's 0.9 GB stands as evidence the old row is ten times out and is
not a calibration target. FIR-2640 also moves the commit-phase hash peak, so a curve
fitted today is fitted to a cost that is about to change. Fitting one anyway would ship
a second wrong model.

## A third home of the same wrong model

kin#1098 fixed `COMMIT_MEMORY_REMEDY`, which reaches the doctor row, the commit-failure
message and `kin commit --help`. A third home was still live and shipping.
`scripts/write-release-archive-docs.mjs` writes the `INSTALL.md` inside every release
archive, and its Requirements section told every reader that a commit's peak follows
repository size rather than edit size. The 16 GB requirement stands, since it is a
margin over a total that has actually been observed, so it and its existing assertion
are untouched. Its justification is now that observation. Guarded in that script's own
suite, which `.github/workflows/ci.yml` runs.

## Falsification

Every mutant was applied to a byte copy, the crate rebuilt with the rebuild asserted per
mutant by its `Compiling kin-cli v` line, the tests run, and the file restored from the
byte copy with `git status --porcelain` proving empty. Exit codes were read raw, never
through a pipe. Unmutated bases, so a red mutant cannot be confused with an already-red
tree: the `headroom` filter is 7 passed 0 failed, the `ceiling` filter is 12 passed 0
failed, and the whole crate is 1774 passed 0 failed.

| Mutant | Guard it kills |
|---|---|
| Restore the kill forecast | `the_headroom_row_states_its_uncertainty_instead_of_forecasting_a_kill`: "degraded: the row forecasts a kill from a cost it does not model" |
| Restore the store-size floor clause | same guard: "degraded: the row is extrapolating an observed total by store size again" |
| Empty the row rather than correct it | same guard, on a POSITIVE control: "degraded: the quoted number carries everything else that was resident, and leaving that out is what let it be read as commit demand" |
| Drop the comfort margin, so parity reads ok | `doctor_reads_a_ceiling_at_a_measured_commit_peak_as_parity_rather_than_ok`: "a ceiling exactly at the measured peak is parity, not headroom: Healthy", and `the_headroom_row_never_reports_a_ceiling_at_or_under_an_observed_total_as_ok`: "expressjs/express at a 10.6 GiB ceiling against an observed total of 10.6 GiB" |
| Hard-code the ceiling source | `the_headroom_row_names_the_reading_its_ceiling_came_from`: "a capped process is owed the fact that the cap is the wall it hit" |
| Always attribute the ceiling to the host | `the_memory_ceiling_names_which_reading_bound_it`: left `(12884901888, HostRam)`, right `(12884901888, ContainerLimit)` |
| Print the same words for both sources | `each_ceiling_source_names_itself_to_a_reader`: "a capped process is told it is capped" |
| Restore the archive doc's old mechanism sentence | "aarch64-apple-darwin: INSTALL.md still derives the commit cost from repository size" |
| Delete the archive doc's paragraph | its POSITIVE control: "aarch64-apple-darwin: INSTALL.md drops the requirement instead of stating its uncertainty" |

One existing test was rewritten rather than added to.
`doctor_reads_a_ceiling_at_a_measured_commit_peak_as_parity_rather_than_ok` used to
require the row to call the quoted total "a floor here rather than a bound", which is
the extrapolation this PR removes, so continuing to assert it would have pinned the
defect in place. It keeps its band and its numbers, gains an assertion on `5 MiB short
of that machine's own ceiling` so the 12283-against-12288 finding reaches the reader,
gains an explicit `!matches!(status, Healthy)`, and its docstring records why the words
changed and the band did not. The mutant above is its falsification.

One correction to the falsification pass itself, worth stating because it is the shape
this repo's trap catalogue keeps warning about. The comfort-margin mutant first ran
under the filter `headroom`, which does not match
`doctor_reads_a_ceiling_at_a_measured_commit_peak_as_parity_rather_than_ok`, so that
test never ran and reporting it as killed would have been a claim about a run that
never executed it. Re-run under the filter `ceiling`: base 12 passed 0 failed, mutant 10
passed 2 failed, both named above.

## Gate

`cargo test --locked -p kin-cli --lib`: 1774 passed, 0 failed, against 1769 before this
commit. `cargo test --locked -p kin-cli --all-targets`: 2482 passed, 0 failed, 1
ignored. `cargo test --locked -p kin-cli --doc`: 1 passed, 0 failed. All exit 0.

`cargo fmt --all -- --check` exit 0. Clippy exactly as `ci.yml` runs it, the 45-lint
debt list from `.github/clippy-allowed-lints.txt` under `RUSTFLAGS="-D warnings"`,
scoped to the crate this touches: `cargo clippy --locked -p kin-cli --all-targets
--all-features -- $allows` exit 0, run through `bash -c` because zsh does not word-split
the allow list.

Ten guard scripts `ci.yml` names, each run directly with its exit code read raw:
`verify-zero-file-search.py`, `zero_file_search_guard.sh`,
`verify-hydration-semantics.py`, `check_runtime_boundaries.sh`,
`check_private_repo_coupling.sh`, `test-private-repo-coupling.py`,
`test-assertion-reachability.py`, `test-release-workflow-authority.py`,
`check-rc-build-drift.mjs`, `check-kin-vfs-compat.mjs`. All ten exit 0. The node suites
`ci.yml` names: 154 pass 0 fail, plus 30 pass 0 fail.

`bin/kin-parity` on this exact head, release profile. Its build exited 0 in 379.1s and
its binary reports `kin 0.5.51 (77b56ff9be57cea6904f228ea1162b0bea27856c
chore/lane-relay1098-kin)`, so the suites graded this tree rather than a stale one.
Verdict: FINAL PASS-WITH-ALLOWANCES in 941.5s. magic PASS, 14 pass 0 fail 0 unreadable.
brownfield PASS-WITH-ALLOWANCES, 8 pass 0 fail 1 unreadable. firstrun
PASS-WITH-ALLOWANCES, 9 pass 2 fail 0 unreadable. The three allowances are the standing
ones and none of them belongs to this change: firstrun/9 FIR-2580, firstrun/3 FIR-2501,
brownfield/4 FIR-2464.

`git diff --summary` is empty, so no file mode moved.

Closes FIR-2643
Refs FIR-2638
