### PR TITLE
Say a daemon was killed on the surfaces that still called it an idle exit

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -934,7 +934,11 @@ fn build_graph_status_response_for_store(
     // store whose daemon has been killed twenty-five times prints a clean
     // report with an all-clear under it. The store's own record is the only
     // thing that remembers, and this is the page a reader is already on.
-    if let Some(record) = kin_root.and_then(kin_daemon_spawn::read_daemon_kill_record) {
+    // The store's tally OR a death it has not settled yet, for the reason the
+    // `kin doctor` row reads both: settlement happens at the next daemon start,
+    // and a reader asking this page why the numbers stopped moving may not have
+    // started one since the daemon died.
+    if let Some(record) = kin_root.and_then(crate::daemon_death::recorded_for_store) {
         warnings.push(record.summary());
     }
     // A suspended sweep is invisible in the same way, and worse: every counter

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -3986,7 +3986,13 @@ fn check_daemon_kill_record() -> HealthCheck {
             "not in a Kin repository, so there is no store whose daemons could have been killed",
         );
     };
-    daemon_kill_record_check_for(kin_daemon_spawn::read_daemon_kill_record(layout.root()).as_ref())
+    // The store's tally OR a death it has not settled yet. The tally alone
+    // leaves a window this row exists to close: a daemon killed with nothing
+    // watching is settled by the NEXT daemon start, and a reader who runs
+    // `kin doctor` before starting one is exactly the reader who just watched a
+    // command die. This row would have told them no daemon serving this store
+    // has ever been killed.
+    daemon_kill_record_check_for(crate::daemon_death::recorded_for_store(layout.root()).as_ref())
 }
 
 /// Core of [`check_daemon_kill_record`] with the record as its input, so both

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1318,6 +1318,71 @@ mod tests {
         }
     }
 
+    /// The measured FIR-2650 summary, and the two stores it could not tell
+    /// apart.
+    ///
+    /// `kin init` exited 0 over a 1.1 GB store and summarized the enrichment as
+    /// "present (... ; completion not attested)" while the daemon that would
+    /// have finished it lay OOM-killed. Every word of that is also true of a
+    /// healthy store nobody has certified yet, so the reader had no signal at
+    /// all. This surface prints once per repository, which no scripted check can
+    /// re-ask, so the rendering is pinned here.
+    ///
+    /// The quiet arm is not decoration. A build that named a kill
+    /// unconditionally would pass the killed arm and alarm every ordinary user.
+    #[test]
+    fn a_killed_daemon_changes_the_enrichment_summary_and_nothing_else_does() {
+        let status = enrichment(SemanticEnrichmentPresence::Present, 1058);
+
+        let quiet = render_semantic_enrichment(&status, None);
+        assert!(
+            quiet.contains("completion not attested"),
+            "the caveat is true of every store and stays: {quiet}"
+        );
+        assert!(
+            !quiet.contains("killed"),
+            "a store that lost no daemon must not report one: {quiet}"
+        );
+        assert!(
+            enrichment_kill_warning(None).is_none(),
+            "and it carries no warning line at all"
+        );
+
+        let record = kin_daemon_spawn::DaemonKillRecord {
+            kills: 1,
+            memory_kills: 1,
+            first_unix: 1_787_000_000,
+            last_unix: 1_787_000_000,
+            last_pid: Some(4103),
+            last_cause: kin_daemon_spawn::DaemonKillCause::MemoryLimit {
+                kernel_oom_kills: 1,
+            },
+            limit_bytes: Some(12 * 1024 * 1024 * 1024),
+            last_rss_bytes: Some(11 * 1024 * 1024 * 1024),
+        };
+        let killed = render_semantic_enrichment(&status, Some(&record));
+        assert!(
+            killed.contains("1058 entities"),
+            "the counts are still true and still printed: {killed}"
+        );
+        assert!(
+            killed.contains("completion not attested") && killed.contains("killed"),
+            "the caveat alone was the defect, so both halves are required: {killed}"
+        );
+
+        let warning = enrichment_kill_warning(Some(&record))
+            .expect("a store with a kill on record carries the line that explains it");
+        assert!(warning.contains("memory limit"), "{warning}");
+        assert!(
+            warning.contains("12.0 GiB"),
+            "a kill named without its figure is not actionable: {warning}"
+        );
+        assert!(
+            warning.contains("To recover:"),
+            "and a cause with no remedy is most of the way back to the parenthetical: {warning}"
+        );
+    }
+
     /// The non-empty-directory refusal offers "commit the exact files to Git"
     /// as its first remedy. Measured on a fresh ubuntu:24.04 curl install, that
     /// host has no git at all, so the remedy names a command the reader does

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -854,11 +854,21 @@ fn render_human_result(
             writeln!(out, "  Workspace: empty exact tree")?;
         }
     }
+    // Read here rather than remembered from the enrichment phase, because the
+    // death this looks for happens during that phase and leaves nothing in this
+    // process. The daemon publishes a serving record at start and retires it as
+    // it exits on its own terms, so a surviving record beside a dead pid is the
+    // only trace an unwatched kill leaves, and this is the summary a reader is
+    // already looking at when they need it.
+    let daemon_death = crate::daemon_death::recorded_for_store(result.layout.root());
     writeln!(
         out,
         "  Semantic enrichment: {}",
-        render_semantic_enrichment(semantic_enrichment)
+        render_semantic_enrichment(semantic_enrichment, daemon_death.as_ref())
     )?;
+    if let Some(warning) = enrichment_kill_warning(daemon_death.as_ref()) {
+        writeln!(out, "{warning}")?;
+    }
     if let Some(notice) = semantic_absence_notice(semantic_enrichment) {
         writeln!(out, "{notice}")?;
     }
@@ -1018,18 +1028,47 @@ fn semantic_absence_notice(enrichment: &SemanticEnrichmentStatus) -> Option<Stri
     )
 }
 
-fn render_semantic_enrichment(enrichment: &SemanticEnrichmentStatus) -> String {
+/// The enrichment line, and the one word in it that used to hide a kill.
+///
+/// "Completion not attested" is a true statement about every store, which is
+/// exactly the problem FIR-2650 names. On the measured run the daemon had been
+/// OOM-killed inside its enrichment commit, and the summary carried that as a
+/// parenthetical inside a success line: same counts, same presence, same
+/// caveat, indistinguishable from a store whose enrichment simply has not been
+/// certified yet. A reader saw exit 0, a 1.1 GB store, and no signal at all.
+///
+/// The counts stay, because they are still true. What changes is that when the
+/// store can prove one of its daemons was killed, the caveat says so, and
+/// [`enrichment_kill_warning`] carries the cause and the remedy on a line of
+/// its own rather than in a parenthesis.
+fn render_semantic_enrichment(
+    enrichment: &SemanticEnrichmentStatus,
+    death: Option<&kin_daemon_spawn::DaemonKillRecord>,
+) -> String {
     let presence = match enrichment.presence {
         SemanticEnrichmentPresence::Absent => "absent",
         SemanticEnrichmentPresence::Present => "present",
     };
     format!(
-        "{presence} ({} entities, {} relations, {} changes in durable authority generation {}; completion not attested)",
+        "{presence} ({} entities, {} relations, {} changes in durable authority generation {}; {})",
         enrichment.entity_count,
         enrichment.relation_count,
         enrichment.semantic_change_count,
-        enrichment.authority_generation
+        enrichment.authority_generation,
+        crate::daemon_death::enrichment_clause(death)
     )
+}
+
+/// The warning line a store whose daemon was killed carries beneath its
+/// enrichment counts.
+///
+/// A warning rather than a parenthetical, and beneath the counts rather than
+/// inside them, because the counts describe what was derived and this describes
+/// whether anything more was coming. It quotes the record's own summary so this
+/// surface says what `kin graph status` and `kin doctor` say about the same
+/// store, word for word.
+fn enrichment_kill_warning(death: Option<&kin_daemon_spawn::DaemonKillRecord>) -> Option<String> {
+    Some(format!("  ⚠ {}", death?.summary()))
 }
 
 fn initialized_default_ref(result: &kin_core::InitResult) -> Option<&kin_model::RefName> {

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -971,7 +971,15 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         let footprint = StoreFootprint::measure(&layout);
-        print!("{}", render_text(&report, None, Some(&footprint)));
+        print!(
+            "{}",
+            render_text(
+                &report,
+                None,
+                Some(&footprint),
+                crate::daemon_death::recorded_for_store(layout.root()).as_ref()
+            )
+        );
         // Which projection served the files this status describes. Appended
         // here rather than folded into the report for the same reason store
         // size is: the report is authority truth and must not move with the
@@ -1018,8 +1026,9 @@ pub fn build_command_status_response(
     json: bool,
     build: Option<BuildStatus>,
     footprint: Option<&StoreFootprint>,
+    death: Option<&kin_daemon_spawn::DaemonKillRecord>,
 ) -> Result<CommandStatusResponse> {
-    let text = render_text(&report, build.as_ref(), footprint);
+    let text = render_text(&report, build.as_ref(), footprint, death);
     let json = json
         .then(|| serde_json::to_string(&report))
         .transpose()
@@ -1042,10 +1051,18 @@ pub fn build_command_status_response(
 /// moves whenever the working tree does. Carrying it inside the report would
 /// have made authority status vary with the filesystem, so it rides alongside
 /// the report on the text surface instead, exactly as the build stamp does.
+///
+/// `death` rides alongside for the same reason again, and it is the reading
+/// FIR-2650 is about. A store whose daemon was killed mid-enrichment carried
+/// the words "completion not attested" and nothing else, which is what a store
+/// whose enrichment simply has not been certified yet also carries. The counts
+/// matched, the presence matched, and the caveat matched, so the two were
+/// indistinguishable on this surface.
 fn render_text(
     report: &StatusReport,
     build: Option<&BuildStatus>,
     footprint: Option<&StoreFootprint>,
+    death: Option<&kin_daemon_spawn::DaemonKillRecord>,
 ) -> String {
     // Named as a comparison against the base change rather than as "clean" or
     // "dirty". Both bare words invite the reading "everything on disk is in the
@@ -1086,12 +1103,13 @@ fn render_text(
                 .unwrap_or_default()
         ),
         format!(
-            "Durable semantic enrichment: {enrichment} ({} entities, {} relations, {} changes at authority generation {}, workspace generation {}; completion not attested)",
+            "Durable semantic enrichment: {enrichment} ({} entities, {} relations, {} changes at authority generation {}, workspace generation {}; {})",
             report.semantic_enrichment.entity_count,
             report.semantic_enrichment.relation_count,
             report.semantic_enrichment.semantic_change_count,
             report.semantic_enrichment.authority_generation,
-            report.semantic_enrichment.workspace_generation
+            report.semantic_enrichment.workspace_generation,
+            crate::daemon_death::enrichment_clause(death)
         ),
         // The counter above is durable authority truth; `kin graph status`
         // measures the daemon's live query graph and excludes external
@@ -1129,6 +1147,13 @@ fn render_text(
             build_id(&build.cli_sha, build.cli_dirty),
             build_id(&build.daemon_sha, build.daemon_dirty)
         ));
+    }
+    // A warning of its own rather than more parenthesis. The counts above
+    // describe what was derived; this describes whether anything more was
+    // coming, and it quotes the record's own summary so this page says what
+    // `kin graph status` and `kin doctor` say about the same store.
+    if let Some(death) = death {
+        lines.push(format!("⚠ {}", death.summary()));
     }
     lines.into_iter().map(|line| format!("{line}\n")).collect()
 }
@@ -1260,7 +1285,7 @@ mod tests {
             payload.snapshot_bytes + payload.acknowledged_delta_bytes
         );
         assert!(
-            render_text(&report, None, None).contains("Authority payload read: "),
+            render_text(&report, None, None, None).contains("Authority payload read: "),
             "text status must state the payload the open read"
         );
 
@@ -1561,7 +1586,7 @@ mod tests {
             EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::NoVectorIndexAttached),
         )
         .unwrap();
-        let rendered = render_text(&unobserved, None, None);
+        let rendered = render_text(&unobserved, None, None, None);
         assert!(
             rendered.contains(
                 "Live embedding coverage: not observed (the live graph carries no vector index)"
@@ -1585,10 +1610,10 @@ mod tests {
         )
         .unwrap();
         assert!(
-            render_text(&observed, None, None)
+            render_text(&observed, None, None, None)
                 .contains("Live embedding coverage: 41/57 indexed, 16 pending (live query graph)"),
             "{}",
-            render_text(&observed, None, None)
+            render_text(&observed, None, None, None)
         );
     }
 
@@ -1607,14 +1632,14 @@ mod tests {
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
         let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
 
-        let without = render_text(&report, None, None);
+        let without = render_text(&report, None, None, None);
         assert!(
             !without.contains("Store size"),
             "an unmeasured status must print no store line at all: {without}"
         );
 
         let footprint = StoreFootprint::measure(&init.layout);
-        let with = render_text(&report, None, Some(&footprint));
+        let with = render_text(&report, None, Some(&footprint), None);
         assert!(
             with.contains("Store size: ") && with.contains("under .kin/"),
             "a measured status must print the store line: {with}"

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -306,6 +306,14 @@ pub struct DaemonClient {
     /// Carries the same endpoint authority as `client`, but never follows an
     /// HTTP redirect that could redispatch a non-idempotent mutation.
     one_dispatch_client: reqwest::Client,
+    /// The store this client's daemon serves, when one was resolvable.
+    ///
+    /// Held so that a request which goes unanswered can ask the store what
+    /// happened to its daemon instead of asserting the ordinary cause. A
+    /// transport error describes a socket; the killer leaves its evidence in
+    /// the repository, and without a root there is nowhere to read it.
+    /// `None` behaves exactly as this client behaved before it had this field.
+    kin_root: Option<PathBuf>,
 }
 
 /// A mutating daemon command was dispatched, but its committed outcome could
@@ -544,11 +552,20 @@ impl DaemonClient {
 
     /// Build a client for `layout`'s daemon, resolving the bearer token from
     /// that layout rather than from the process working directory.
+    ///
+    /// The store root comes from the layout for the same reason the token
+    /// does. `kin init` takes the repository as an argument, so on a runner
+    /// whose working directory is not that repository, discovery from the
+    /// process working directory finds the wrong store or none, and the
+    /// evidence about a daemon that died is in the one the layout names.
     pub fn from_base_url_for_layout(
         base_url: impl Into<String>,
         layout: &KinLayout,
     ) -> Result<Self> {
-        Self::from_base_url_with_token(base_url, resolve_daemon_auth_token_for_layout(layout))
+        let mut client =
+            Self::from_base_url_with_token(base_url, resolve_daemon_auth_token_for_layout(layout))?;
+        client.kin_root = Some(layout.root().to_path_buf());
+        Ok(client)
     }
 
     fn from_base_url_with_token(
@@ -598,7 +615,17 @@ impl DaemonClient {
             base_url,
             client,
             one_dispatch_client,
+            // Discovery from the working directory is the fallback every
+            // constructor but the layout one gets. A caller standing outside a
+            // repository resolves nothing, which is the same reading as a store
+            // that never lost a daemon and leaves every message unchanged.
+            kin_root: crate::daemon_death::kin_root_from_cwd(),
         })
+    }
+
+    /// The store whose records explain a daemon of this endpoint that died.
+    fn kin_root(&self) -> Option<&Path> {
+        self.kin_root.as_deref()
     }
 
     async fn send(
@@ -609,7 +636,7 @@ impl DaemonClient {
         let resp = request
             .send()
             .await
-            .with_context(|| daemon_send_failure_message(&self.base_url, leaf))?;
+            .with_context(|| daemon_send_failure_message(&self.base_url, leaf, self.kin_root()))?;
         check_response_build_match(resp.headers())?;
         Ok(resp)
     }
@@ -1619,10 +1646,9 @@ impl DaemonClient {
         {
             Ok(response) => response,
             Err(error) => {
-                return AdmitDispatch::Unanswered(
-                    anyhow::Error::new(error)
-                        .context(daemon_send_failure_message(&self.base_url, "admit")),
-                )
+                return AdmitDispatch::Unanswered(anyhow::Error::new(error).context(
+                    daemon_send_failure_message(&self.base_url, "admit", self.kin_root()),
+                ))
             }
         };
         if let Err(error) = check_response_build_match(response.headers()) {
@@ -1971,7 +1997,21 @@ fn behavior_env_divergence_message(divergences: &[kin_core::behavior_env::Diverg
 /// that never lands is a daemon that retired between URL resolution and this
 /// dispatch. Naming the endpoint and the command keeps the plumbing verb out of
 /// the headline.
-fn daemon_send_failure_message(base_url: &str, leaf: &str) -> String {
+///
+/// The idle window is the ordinary cause and not the only one, and this used to
+/// assert it unconditionally, from the endpoint and the request name alone,
+/// having asked nothing about whether the daemon was alive. On the measured
+/// FIR-2650 run it named an idle window for a daemon the kernel had OOM-killed
+/// fourteen seconds earlier, and told the reader to re-run. That advice cannot
+/// terminate: an OOM at that repository size recurs on every attempt.
+///
+/// So the store is asked first. It answers only when it can prove a death, and
+/// on every host that has never lost a daemon it answers nothing and this
+/// message stays byte for byte what it was.
+fn daemon_send_failure_message(base_url: &str, leaf: &str, kin_root: Option<&Path>) -> String {
+    if let Some(record) = kin_root.and_then(crate::daemon_death::most_recent_death) {
+        return crate::daemon_death::dropped_request_sentence(base_url, leaf, &record);
+    }
     format!(
         "the kin daemon at {base_url} stopped answering while the {leaf} request was in flight; \
          it exits after its idle window, so re-run the command and kin will start a fresh one"
@@ -11343,7 +11383,10 @@ mod tests {
 
     #[test]
     fn a_dropped_request_names_the_endpoint_the_command_and_the_way_back() {
-        let message = daemon_send_failure_message("http://127.0.0.1:51234", "locate");
+        // A store this process could not resolve, which is also what a store
+        // that never lost a daemon reads as. The idle window is the ordinary
+        // cause and must still be offered here.
+        let message = daemon_send_failure_message("http://127.0.0.1:51234", "locate", None);
         assert!(
             message.contains("http://127.0.0.1:51234"),
             "the reader cannot tell which daemon went away without its endpoint: {message}"
@@ -11359,6 +11402,61 @@ mod tests {
         assert!(
             !message.starts_with("send "),
             "the dispatch verb was the defect being fixed: {message}"
+        );
+    }
+
+    /// The store's own record replaces the idle window when it can prove a
+    /// death, and leaves it alone when it cannot.
+    ///
+    /// The FIR-2650 pair, on the surface the measured sentence came from. Both
+    /// arms run against a real directory, so the difference between them is the
+    /// record and nothing else: a check that only ever saw the killed arm would
+    /// pass a build that had simply stopped offering the idle window at all,
+    /// which would be a second defect wearing the first one's fix.
+    #[test]
+    fn a_dropped_request_over_a_killed_daemon_stops_offering_the_idle_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let quiet = daemon_send_failure_message(
+            "http://127.0.0.1:39767",
+            "lsp sweep status",
+            Some(dir.path()),
+        );
+        assert!(
+            quiet.contains("idle window") && quiet.contains("re-run"),
+            "a store that has lost no daemon must read exactly as it always did: {quiet}"
+        );
+
+        // The trace a killed daemon leaves: a serving record it published at
+        // start and never reached the line to retire. The pid cannot be alive,
+        // so this is deterministic rather than a race against whatever holds
+        // that number today.
+        std::fs::write(
+            kin_daemon_spawn::serving_path(dir.path()),
+            serde_json::to_vec(&kin_daemon_spawn::ServingDaemon {
+                pid: u32::MAX,
+                oom_kills_at_start: Some(0),
+                at_unix: 1_000,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let killed = daemon_send_failure_message(
+            "http://127.0.0.1:39767",
+            "lsp sweep status",
+            Some(dir.path()),
+        );
+        assert!(
+            killed.contains("killed"),
+            "the daemon died and the message has to say so: {killed}"
+        );
+        assert!(
+            !killed.contains("idle window, so re-run"),
+            "re-running is the advice that cannot terminate when the cause recurs: {killed}"
+        );
+        assert!(
+            killed.contains("http://127.0.0.1:39767") && killed.contains("lsp sweep status"),
+            "the endpoint and the request in flight are still the subject: {killed}"
         );
     }
 

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2009,8 +2009,8 @@ fn behavior_env_divergence_message(divergences: &[kin_core::behavior_env::Diverg
 /// on every host that has never lost a daemon it answers nothing and this
 /// message stays byte for byte what it was.
 fn daemon_send_failure_message(base_url: &str, leaf: &str, kin_root: Option<&Path>) -> String {
-    if let Some(record) = kin_root.and_then(crate::daemon_death::most_recent_death) {
-        return crate::daemon_death::dropped_request_sentence(base_url, leaf, &record);
+    if let Some(state) = kin_root.and_then(crate::daemon_death::daemon_not_answering) {
+        return crate::daemon_death::dropped_request_sentence(base_url, leaf, &state);
     }
     format!(
         "the kin daemon at {base_url} stopped answering while the {leaf} request was in flight; \

--- a/crates/kin-cli/src/daemon_death.rs
+++ b/crates/kin-cli/src/daemon_death.rs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What a store's own records say about a daemon of its own that died, for the
+//! surfaces that have to say it out loud.
+//!
+//! The measured failure (FIR-2650) is one sentence. On `psf/requests` at full
+//! history inside a 12 GiB container, `kin init` finished, exit 0, and the
+//! daemon was then OOM-killed inside its post-init enrichment commit. Kin said:
+//!
+//! > the kin daemon at http://127.0.0.1:39767 stopped answering while the lsp
+//! > sweep status request was in flight; it exits after its idle window, so
+//! > re-run the command and kin will start a fresh one
+//!
+//! The cgroup had recorded the kill and `docker inspect` read `OOMKilled=true`,
+//! so the truth was on two independent surfaces and Kin used neither. It
+//! matters past the wording: an idle exit is a normal event whose advice is to
+//! re-run, while an OOM at that repository size recurs on every attempt, so the
+//! reader is sent around a loop that cannot terminate.
+//!
+//! Which record answers, and why it is not the obvious one
+//! ------------------------------------------------------
+//! The tempting input is [`kin_daemon_spawn::read_daemon_kill_record`], the
+//! store's accumulated tally. It is the wrong one for a sentence about a
+//! request that just failed: it accumulates, it outlives every daemon that
+//! follows it, and a message built from it blames a kill from last week for an
+//! idle exit today.
+//!
+//! The serving record cannot do that. A daemon publishes it at start and
+//! retires it as it exits on its own terms, so it is overwritten by each
+//! successor and removed by every clean ending. Finding one beside a dead pid
+//! therefore says something about THIS store's most recent daemon and nothing
+//! about any earlier one: it began serving and never reached the line that
+//! would have retired it. That is a kill, and it is this one.
+//!
+//! Read-only, on purpose. Settling a death is the next daemon start's job, so
+//! it is counted once however many surfaces describe it.
+
+use std::path::Path;
+
+use kin_daemon_spawn::DaemonKillRecord;
+
+/// The death this store's most recent daemon suffered, if it suffered one.
+///
+/// `None` is the ordinary case and is the reading that leaves every message
+/// exactly what it was: a daemon that retired after its idle window took its
+/// serving record with it, and a store that has never lost one has nothing
+/// here.
+pub fn most_recent_death(kin_root: &Path) -> Option<DaemonKillRecord> {
+    kin_daemon_spawn::peek_unwatched_daemon_death(kin_root)
+}
+
+/// The death to quote beside a store's own state, rather than beside a request.
+///
+/// Two readings, in the order that keeps each claim as strong as its evidence
+/// and no stronger. The unsettled death is exact and is about the daemon that
+/// was serving a moment ago, so it answers first. Failing that, the store's
+/// accumulated record answers, because by the time a reader runs `kin status`
+/// a successor daemon has usually started and settled the death into that
+/// tally, and dropping the signal at that moment would mean a store forgot a
+/// kill the instant it recorded one.
+///
+/// The wording every caller builds from this is deliberately joint rather than
+/// causal: the store's enrichment is unattested AND a daemon serving it was
+/// killed. Which of its daemons, and whether that kill is what stopped the
+/// enrichment, is not something either record establishes, so no surface here
+/// says it.
+pub fn recorded_for_store(kin_root: &Path) -> Option<DaemonKillRecord> {
+    most_recent_death(kin_root).or_else(|| kin_daemon_spawn::read_daemon_kill_record(kin_root))
+}
+
+/// The store root for the working directory, when it is inside a Kin
+/// repository.
+///
+/// Every caller here is best-effort by construction: a surface that could not
+/// find a store says what it always said, which is the same outcome as a store
+/// that never lost a daemon.
+pub fn kin_root_from_cwd() -> Option<std::path::PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    Some(kin_core::KinLayout::discover(&cwd)?.root().to_path_buf())
+}
+
+/// The clause that replaces a bare "completion not attested".
+///
+/// A store whose enrichment nobody attested and whose daemon was killed reads,
+/// unchanged, exactly like a store whose enrichment simply has not been
+/// certified yet, which is the ordinary and unalarming case. The counts are the
+/// same, the presence is the same, and the parenthetical is the same. Naming
+/// the kill is the only thing that separates them.
+///
+/// It stays a clause rather than becoming the whole line because the counts
+/// beside it are still true: the entities were extracted and the relations were
+/// derived. What is in doubt is whether anything more was coming.
+pub fn enrichment_clause(record: Option<&DaemonKillRecord>) -> &'static str {
+    match record {
+        Some(_) => "completion not attested, and a daemon serving this store was killed",
+        None => "completion not attested",
+    }
+}
+
+/// The sentence a daemon request that went unanswered ends with, when the store
+/// can say the daemon died.
+///
+/// The idle-window sentence it replaces is not merely wrong here, it is
+/// actively harmful: its advice is to re-run, and re-running is what cannot
+/// terminate. This one leads with the fact that the daemon did not retire, and
+/// hands over the record's own remediation, every action in which is one the
+/// caller can perform.
+pub fn dropped_request_sentence(base_url: &str, leaf: &str, record: &DaemonKillRecord) -> String {
+    format!(
+        "the kin daemon at {base_url} stopped answering while the {leaf} request was in flight, \
+         and it did not exit its idle window: {}",
+        record.summary()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_daemon_spawn::DaemonKillCause;
+
+    const TWELVE_GIB: u64 = 12 * 1024 * 1024 * 1024;
+
+    fn memory_kill() -> DaemonKillRecord {
+        DaemonKillRecord {
+            kills: 1,
+            memory_kills: 1,
+            first_unix: 1_787_000_000,
+            last_unix: 1_787_000_000,
+            last_pid: Some(4103),
+            last_cause: DaemonKillCause::MemoryLimit {
+                kernel_oom_kills: 1,
+            },
+            limit_bytes: Some(TWELVE_GIB),
+            last_rss_bytes: Some(TWELVE_GIB - 5 * 1024 * 1024),
+        }
+    }
+
+    fn unattributed_kill() -> DaemonKillRecord {
+        DaemonKillRecord {
+            kills: 1,
+            memory_kills: 0,
+            first_unix: 1_787_000_000,
+            last_unix: 1_787_000_000,
+            last_pid: Some(4103),
+            last_cause: DaemonKillCause::Unattributed { signal: 0 },
+            limit_bytes: None,
+            last_rss_bytes: None,
+        }
+    }
+
+    /// The measured sentence, and the one claim it may never make again.
+    ///
+    /// "It exits after its idle window, so re-run the command" is the advice
+    /// that cannot terminate when the cause is an OOM at this repository's
+    /// size, so its absence is asserted rather than left to a reader's eye.
+    #[test]
+    fn a_dropped_request_over_a_killed_daemon_never_offers_the_idle_window() {
+        let sentence =
+            dropped_request_sentence("http://127.0.0.1:39767", "lsp sweep status", &memory_kill());
+        assert!(
+            !sentence.contains("idle window, so re-run"),
+            "the advice that cannot terminate was still offered: {sentence}"
+        );
+        assert!(
+            sentence.contains("did not exit its idle window"),
+            "{sentence}"
+        );
+        assert!(sentence.contains("killed"), "{sentence}");
+        assert!(sentence.contains("http://127.0.0.1:39767"), "{sentence}");
+        assert!(sentence.contains("lsp sweep status"), "{sentence}");
+    }
+
+    /// A kill the kernel attributed to memory is named with its ceiling.
+    ///
+    /// "The daemon died" invites a re-run. "It was killed by the memory limit,
+    /// cap 12.0 GiB" does not, and the figure is what makes the difference
+    /// actionable, so a mention with no number would not be a fix.
+    #[test]
+    fn a_memory_kill_is_named_with_its_figure_and_its_remedy() {
+        let sentence = dropped_request_sentence("http://127.0.0.1:1", "locate", &memory_kill());
+        assert!(sentence.contains("memory limit"), "{sentence}");
+        assert!(sentence.contains("12.0 GiB"), "{sentence}");
+        assert!(sentence.contains("To recover:"), "{sentence}");
+    }
+
+    /// A kill this host cannot attribute is still a kill, and says only that.
+    ///
+    /// On a host with no cgroup accounting, "not attributed" is the honest
+    /// answer and "not memory" is not. What must not survive either way is the
+    /// idle window.
+    #[test]
+    fn an_unattributed_kill_reports_the_death_without_inventing_a_cause() {
+        let sentence =
+            dropped_request_sentence("http://127.0.0.1:1", "locate", &unattributed_kill());
+        assert!(sentence.contains("killed"), "{sentence}");
+        assert!(!sentence.contains("idle window, so re-run"), "{sentence}");
+        assert!(
+            !sentence.contains("memory limit"),
+            "a host that publishes no accounting attributed nothing: {sentence}"
+        );
+    }
+
+    /// The enrichment clause separates the two stores that used to read alike.
+    #[test]
+    fn the_enrichment_clause_names_a_kill_only_when_there_was_one() {
+        assert_eq!(enrichment_clause(None), "completion not attested");
+        let killed = enrichment_clause(Some(&memory_kill()));
+        assert!(killed.starts_with("completion not attested"), "{killed}");
+        assert!(killed.contains("killed"), "{killed}");
+    }
+
+    /// A store nothing has happened to says what it always said.
+    ///
+    /// The control that keeps every message on every healthy host byte for byte
+    /// what it was. A reader who has never lost a daemon must not start seeing
+    /// daemon deaths discussed.
+    #[test]
+    fn a_store_with_no_records_reports_no_death() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(most_recent_death(dir.path()).is_none());
+        assert!(recorded_for_store(dir.path()).is_none());
+    }
+
+    /// The unsettled death answers ahead of the accumulated tally.
+    ///
+    /// Both can be present at once: a store that lost a daemon last week and
+    /// lost another one a minute ago. The recent one is what a reader is asking
+    /// about, and it is the only one whose recency this code can establish.
+    #[test]
+    fn an_unsettled_death_answers_ahead_of_the_stores_older_tally() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = DaemonKillRecord {
+            kills: 9,
+            ..unattributed_kill()
+        };
+        kin_daemon_spawn::write_daemon_kill_record(dir.path(), &stale);
+        assert_eq!(
+            recorded_for_store(dir.path()).map(|r| r.kills),
+            Some(9),
+            "with no unsettled death, the store's own tally is what there is"
+        );
+
+        std::fs::write(
+            kin_daemon_spawn::serving_path(dir.path()),
+            serde_json::to_vec(&kin_daemon_spawn::ServingDaemon {
+                // A pid that cannot be alive, so this is deterministic rather
+                // than a race against whatever holds the number today.
+                pid: u32::MAX,
+                oom_kills_at_start: Some(0),
+                at_unix: 1_000,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            recorded_for_store(dir.path()).map(|r| r.kills),
+            Some(1),
+            "the death a moment ago is the one a reader is asking about"
+        );
+    }
+}

--- a/crates/kin-cli/src/daemon_death.rs
+++ b/crates/kin-cli/src/daemon_death.rs
@@ -50,6 +50,51 @@ pub fn most_recent_death(kin_root: &Path) -> Option<DaemonKillRecord> {
     kin_daemon_spawn::peek_unwatched_daemon_death(kin_root)
 }
 
+/// What this store can say about the daemon that just stopped answering.
+///
+/// Three states, because the surface this feeds had two and one of them was
+/// doing the work of both.
+pub enum DaemonNotAnswering {
+    /// The store's most recent daemon was killed.
+    Killed(Box<DaemonKillRecord>),
+    /// A daemon is recorded as serving this store and its process is still
+    /// present, so whatever is wrong, it did not take the idle-window path.
+    ///
+    /// Two situations land here and neither is the idle window. A daemon can be
+    /// wedged, present and not answering. And a daemon can be part way through
+    /// dying: `SIGKILL` returns before the kernel has finished tearing a process
+    /// down, and until it has, the pid still reads as alive. The two hosts show
+    /// that window differently, which is how it was found. On macOS the port
+    /// already refuses the connection, so the process was gone; on a Linux
+    /// runner the socket stayed open long enough to accept the connection and
+    /// then reset it, `Connection reset by peer (os error 104)`, and the pid was
+    /// still alive when the message was built.
+    ///
+    /// Reporting either as an idle-window exit is the FIR-2650 defect one step
+    /// over: the advice is to re-run, and re-running reaches the same wedged
+    /// daemon or the same ceiling. So this says what is known, which is that the
+    /// daemon is still present and has not retired, and hands over the two
+    /// commands that act on it.
+    NotRetired { pid: u32 },
+}
+
+/// Ask the store what it can prove about the daemon behind a failed request.
+///
+/// `None` means the store proves nothing, which is what a daemon that really
+/// did retire after its idle window leaves behind: it removed its serving
+/// record on the way out. That case keeps the message it always had.
+pub fn daemon_not_answering(kin_root: &Path) -> Option<DaemonNotAnswering> {
+    if let Some(record) = most_recent_death(kin_root) {
+        return Some(DaemonNotAnswering::Killed(Box::new(record)));
+    }
+    // A surviving record whose process is still present. The peek above already
+    // declined it for exactly that reason, and declining is right for a kill
+    // record and wrong for a sentence about why nothing answered.
+    let serving = kin_daemon_spawn::read_serving_daemon(kin_root)?;
+    kin_daemon_spawn::process_is_alive(serving.pid)
+        .then_some(DaemonNotAnswering::NotRetired { pid: serving.pid })
+}
+
 /// The death to quote beside a store's own state, rather than beside a request.
 ///
 /// Two readings, in the order that keeps each claim as strong as its evidence
@@ -106,12 +151,25 @@ pub fn enrichment_clause(record: Option<&DaemonKillRecord>) -> &'static str {
 /// terminate. This one leads with the fact that the daemon did not retire, and
 /// hands over the record's own remediation, every action in which is one the
 /// caller can perform.
-pub fn dropped_request_sentence(base_url: &str, leaf: &str, record: &DaemonKillRecord) -> String {
-    format!(
-        "the kin daemon at {base_url} stopped answering while the {leaf} request was in flight, \
-         and it did not exit its idle window: {}",
-        record.summary()
-    )
+pub fn dropped_request_sentence(base_url: &str, leaf: &str, state: &DaemonNotAnswering) -> String {
+    let opening = format!(
+        "the kin daemon at {base_url} stopped answering while the {leaf} request was in \
+                 flight"
+    );
+    match state {
+        DaemonNotAnswering::Killed(record) => {
+            format!(
+                "{opening}, and it did not exit its idle window: {}",
+                record.summary()
+            )
+        }
+        DaemonNotAnswering::NotRetired { pid } => format!(
+            "{opening}, and the daemon this store recorded as serving it (pid {pid}) is still \
+             present and has not retired, so the idle window is not the explanation: it is \
+             either wedged or part way through dying. Read .kin/daemon.log; `kin daemon status` \
+             reports what is running now, and `kin daemon stop` ends a wedged one."
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -156,8 +214,11 @@ mod tests {
     /// size, so its absence is asserted rather than left to a reader's eye.
     #[test]
     fn a_dropped_request_over_a_killed_daemon_never_offers_the_idle_window() {
-        let sentence =
-            dropped_request_sentence("http://127.0.0.1:39767", "lsp sweep status", &memory_kill());
+        let sentence = dropped_request_sentence(
+            "http://127.0.0.1:39767",
+            "lsp sweep status",
+            &DaemonNotAnswering::Killed(Box::new(memory_kill())),
+        );
         assert!(
             !sentence.contains("idle window, so re-run"),
             "the advice that cannot terminate was still offered: {sentence}"
@@ -178,7 +239,11 @@ mod tests {
     /// actionable, so a mention with no number would not be a fix.
     #[test]
     fn a_memory_kill_is_named_with_its_figure_and_its_remedy() {
-        let sentence = dropped_request_sentence("http://127.0.0.1:1", "locate", &memory_kill());
+        let sentence = dropped_request_sentence(
+            "http://127.0.0.1:1",
+            "locate",
+            &DaemonNotAnswering::Killed(Box::new(memory_kill())),
+        );
         assert!(sentence.contains("memory limit"), "{sentence}");
         assert!(sentence.contains("12.0 GiB"), "{sentence}");
         assert!(sentence.contains("To recover:"), "{sentence}");
@@ -191,13 +256,93 @@ mod tests {
     /// idle window.
     #[test]
     fn an_unattributed_kill_reports_the_death_without_inventing_a_cause() {
-        let sentence =
-            dropped_request_sentence("http://127.0.0.1:1", "locate", &unattributed_kill());
+        let sentence = dropped_request_sentence(
+            "http://127.0.0.1:1",
+            "locate",
+            &DaemonNotAnswering::Killed(Box::new(unattributed_kill())),
+        );
         assert!(sentence.contains("killed"), "{sentence}");
         assert!(!sentence.contains("idle window, so re-run"), "{sentence}");
         assert!(
             !sentence.contains("memory limit"),
             "a host that publishes no accounting attributed nothing: {sentence}"
+        );
+    }
+
+    /// A daemon that is present and not answering is not an idle exit either.
+    ///
+    /// Found on a Linux runner, where SIGKILL had returned but the kernel had
+    /// not finished tearing the process down: the socket stayed open long
+    /// enough to accept the connection and reset it, `Connection reset by peer
+    /// (os error 104)`, and the pid still read as alive when the message was
+    /// built. macOS refused the connection outright and never reached this
+    /// state, which is why one host passed and one failed on identical code.
+    ///
+    /// A wedged daemon lands here too. Both deserve better than "re-run": one
+    /// re-run reaches the same wedged process, the other the same ceiling.
+    #[test]
+    fn a_daemon_still_present_is_not_reported_as_an_idle_exit() {
+        let sentence = dropped_request_sentence(
+            "http://127.0.0.1:45917",
+            "graph",
+            &DaemonNotAnswering::NotRetired { pid: 4103 },
+        );
+        assert!(
+            !sentence.contains("idle window, so re-run"),
+            "the advice that cannot terminate was still offered: {sentence}"
+        );
+        assert!(
+            sentence.contains("has not retired"),
+            "the record's survival is the whole of what is known: {sentence}"
+        );
+        assert!(sentence.contains("pid 4103"), "{sentence}");
+        assert!(
+            sentence.contains("kin daemon stop"),
+            "a wedged daemon needs an action, not a diagnosis: {sentence}"
+        );
+        assert!(
+            !sentence.contains("was killed"),
+            "nothing here established a death, and claiming one would be the same \
+             overreach in the other direction: {sentence}"
+        );
+    }
+
+    /// The three states, read off one store, in the order they can be proven.
+    #[test]
+    fn a_store_reports_retired_then_present_then_killed() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            daemon_not_answering(dir.path()).is_none(),
+            "no serving record is a daemon that retired, and that message is unchanged"
+        );
+
+        // This very process is alive, so its record is the present-and-not-
+        // answering case rather than a death.
+        kin_daemon_spawn::publish_serving_daemon(dir.path(), std::process::id());
+        assert!(
+            matches!(
+                daemon_not_answering(dir.path()),
+                Some(DaemonNotAnswering::NotRetired { .. })
+            ),
+            "a record whose process is present is not a kill"
+        );
+
+        std::fs::write(
+            kin_daemon_spawn::serving_path(dir.path()),
+            serde_json::to_vec(&kin_daemon_spawn::ServingDaemon {
+                pid: u32::MAX,
+                oom_kills_at_start: Some(0),
+                at_unix: 1_000,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            matches!(
+                daemon_not_answering(dir.path()),
+                Some(DaemonNotAnswering::Killed(_))
+            ),
+            "a record whose process is gone is the death this ticket is about"
         );
     }
 

--- a/crates/kin-cli/src/lib.rs
+++ b/crates/kin-cli/src/lib.rs
@@ -5,6 +5,7 @@ pub mod backend;
 pub mod capability;
 pub mod commands;
 pub mod daemon_client;
+pub mod daemon_death;
 pub mod embed_model;
 pub mod model_residency;
 pub mod output_style;

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -518,6 +518,17 @@ impl DaemonKillRecord {
     pub fn cause_sentence(&self) -> String {
         let since = hhmm_utc(self.first_unix);
         let opening = match (self.memory_kills, self.kills, self.last_cause) {
+            // Signal zero is the record saying it has no signal, not a signal
+            // numbered zero, and it is what an unwatched death carries: nobody
+            // waited on the process, so its exit status is gone. Rendering that
+            // as "killed by signal 0" states a fact about the kernel that no
+            // kernel ever reported, which is the same failure as the idle
+            // window one turn smaller.
+            (0, kills, DaemonKillCause::Unattributed { signal: 0 }) => format!(
+                "the daemon for this store was killed {kills} time(s) since {since} with nothing \
+                 waiting on it, so its exit signal is gone, and this host publishes no memory \
+                 accounting, so nothing here attributes that to memory"
+            ),
             (0, kills, DaemonKillCause::Unattributed { signal }) => format!(
                 "the daemon for this store was killed by signal {signal} {kills} time(s) since \
                  {since}, and this host publishes no memory accounting, so nothing here \
@@ -8274,6 +8285,42 @@ mod tests {
             !record.attributed_to_memory(),
             "nothing here attributed it to memory"
         );
+    }
+
+    /// A death nobody waited on has no signal, and must not be given one.
+    ///
+    /// An unwatched kill is recorded with signal zero, which is the record
+    /// saying it has no signal rather than a signal numbered zero. Printed as
+    /// "killed by signal 0" it states something about the kernel that no kernel
+    /// reported, which is the same defect as the idle window one turn smaller.
+    /// Found by running the FIR-2650 surfaces against a real SIGKILL on macOS,
+    /// where nothing can attribute a kill.
+    #[test]
+    fn a_death_with_no_observed_signal_does_not_invent_one() {
+        let record = DaemonKillRecord {
+            kills: 1,
+            memory_kills: 0,
+            first_unix: 1_787_000_000,
+            last_unix: 1_787_000_000,
+            last_pid: Some(4103),
+            last_cause: DaemonKillCause::Unattributed { signal: 0 },
+            limit_bytes: None,
+            last_rss_bytes: None,
+        };
+        let sentence = record.cause_sentence();
+        assert!(
+            !sentence.contains("signal 0"),
+            "signal zero is the absence of a signal, not one: {sentence}"
+        );
+        assert!(
+            sentence.contains("killed"),
+            "it is still a kill and still has to say so: {sentence}"
+        );
+        assert!(
+            sentence.contains("nothing waiting on it"),
+            "why the signal is missing is the whole of what is known: {sentence}"
+        );
+        assert!(sentence.contains("no memory accounting"), "{sentence}");
     }
 
     /// Every action in the remediation is one the caller can perform, and the

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -844,6 +844,56 @@ pub fn settle_unwatched_daemon_death(kin_root: &Path) -> Option<DaemonKillRecord
     if read_daemon_death_note(kin_root).is_some_and(|note| note.pid == serving.pid) {
         return None;
     }
+    let record = accumulate_kill(
+        read_daemon_kill_record(kin_root),
+        grade_unwatched_death(kin_root, &serving),
+    );
+    write_daemon_kill_record(kin_root, &record);
+    Some(record)
+}
+
+/// The same reading [`settle_unwatched_daemon_death`] takes, without taking it.
+///
+/// A surface that has to SAY what happened runs before anything has settled it.
+/// The process that watched `kin init` finish is the one holding the daemon's
+/// silence, and the record it needs is not written until the next daemon
+/// starts, which on that path is never: the run ends. So this answers the same
+/// question read-only, and settlement stays where it belongs, at the next
+/// start, counted once.
+///
+/// It is the serving record and not [`read_daemon_kill_record`] on purpose. The
+/// kill record accumulates and outlives every daemon that follows it, so a
+/// message built from it can blame a kill from last week for an idle exit
+/// today. The serving record cannot: it is overwritten at each start and
+/// retired by a clean exit, so its survival beside a dead pid describes THIS
+/// store's most recent daemon and no other.
+///
+/// The returned record describes that one death, so it reads `kills: 1`. It is
+/// what the store WOULD record, not what the store has recorded, and a caller
+/// wanting the tally reads [`read_daemon_kill_record`] instead.
+pub fn peek_unwatched_daemon_death(kin_root: &Path) -> Option<DaemonKillRecord> {
+    let serving = read_serving_daemon(kin_root)?;
+    if process_is_alive(serving.pid) {
+        return None;
+    }
+    if read_daemon_death_note(kin_root).is_some_and(|note| note.pid == serving.pid) {
+        return None;
+    }
+    Some(grade_unwatched_death(kin_root, &serving))
+}
+
+/// Grade one unwatched death into the record it becomes.
+///
+/// Shared by the settling path and the read-only peek so the two can never
+/// describe one death differently, which is the whole failure this ticket is
+/// about wearing a smaller costume.
+///
+/// The attribution is graded exactly as a watched kill's is: the counter having
+/// moved between the dead daemon's start and now is the kernel's own statement
+/// and becomes `MemoryLimit`; anything else is `Unattributed`, because a
+/// counter that did not move attributes nothing and a host that cannot be asked
+/// attributes nothing either.
+fn grade_unwatched_death(kin_root: &Path, serving: &ServingDaemon) -> DaemonKillRecord {
     let now = cgroup_memory();
     let kernel_oom_kills = match (serving.oom_kills_at_start, now.oom_kills) {
         (Some(before), Some(after)) if after > before => Some(after - before),
@@ -856,7 +906,7 @@ pub fn settle_unwatched_daemon_death(kin_root: &Path) -> Option<DaemonKillRecord
         // signal nobody observed.
         None => (DaemonKillCause::Unattributed { signal: 0 }, 0),
     };
-    let fresh = DaemonKillRecord {
+    DaemonKillRecord {
         kills: 1,
         memory_kills,
         first_unix: unix_now(),
@@ -867,10 +917,7 @@ pub fn settle_unwatched_daemon_death(kin_root: &Path) -> Option<DaemonKillRecord
         last_rss_bytes: read_open_transaction(kin_root)
             .filter(|open| open.pid == serving.pid)
             .and_then(|open| open.peak_rss_bytes.max(open.rss_bytes)),
-    };
-    let record = accumulate_kill(read_daemon_kill_record(kin_root), fresh);
-    write_daemon_kill_record(kin_root, &record);
-    Some(record)
+    }
 }
 
 /// A store whose language-server enrichment has been switched off by the
@@ -7970,6 +8017,114 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         assert!(settle_unwatched_daemon_death(dir.path()).is_none());
         assert!(read_daemon_kill_record(dir.path()).is_none());
+    }
+
+    /// The peek reads what settling would take, and leaves it there.
+    ///
+    /// FIR-2650's reporting half. The surface that has to SAY a daemon died
+    /// runs before anything has settled the death: `kin init` watched the
+    /// silence and the record is not written until a daemon starts again,
+    /// which on that path never happens. A peek that consumed the evidence
+    /// would fix one surface by blinding the next one.
+    #[test]
+    fn peeking_a_death_names_it_without_taking_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let dead = u32::MAX;
+        fs::write(
+            serving_path(dir.path()),
+            serde_json::to_vec(&ServingDaemon {
+                pid: dead,
+                oom_kills_at_start: Some(0),
+                at_unix: 1_000,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let peeked = peek_unwatched_daemon_death(dir.path())
+            .expect("a serving record whose process is gone is a death this store can name");
+        assert_eq!(peeked.kills, 1);
+        assert_eq!(peeked.last_pid, Some(dead));
+        // Nothing was consumed and nothing was written, so the next start still
+        // settles this death and counts it exactly once.
+        assert!(read_serving_daemon(dir.path()).is_some());
+        assert!(read_daemon_kill_record(dir.path()).is_none());
+        assert!(peek_unwatched_daemon_death(dir.path()).is_some());
+        assert_eq!(
+            settle_unwatched_daemon_death(dir.path()).map(|r| r.kills),
+            Some(1),
+            "the peek left the settling path exactly the work it had before"
+        );
+    }
+
+    /// The peek and the settlement grade one death the same way.
+    ///
+    /// Two readers describing one ending differently is the failure this ticket
+    /// is about at a smaller scale, so the grading is shared and this is what
+    /// holds it shared.
+    #[test]
+    fn the_peek_and_the_settlement_agree_on_one_death() {
+        let dir = tempfile::tempdir().unwrap();
+        let dead = u32::MAX;
+        fs::write(
+            serving_path(dir.path()),
+            serde_json::to_vec(&ServingDaemon {
+                pid: dead,
+                oom_kills_at_start: Some(0),
+                at_unix: 1_000,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        let peeked = peek_unwatched_daemon_death(dir.path()).expect("a death to grade");
+        let settled = settle_unwatched_daemon_death(dir.path()).expect("the same death");
+        assert_eq!(peeked.last_cause, settled.last_cause);
+        assert_eq!(peeked.memory_kills, settled.memory_kills);
+        assert_eq!(peeked.last_pid, settled.last_pid);
+        assert_eq!(peeked.limit_bytes, settled.limit_bytes);
+    }
+
+    /// A daemon that is still serving is not a death on the peek either.
+    #[test]
+    fn peeking_a_living_daemon_names_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        publish_serving_daemon(dir.path(), std::process::id());
+        assert!(peek_unwatched_daemon_death(dir.path()).is_none());
+    }
+
+    /// A death its killer explained is not re-explained by the peek.
+    #[test]
+    fn peeking_skips_a_death_its_author_already_explained() {
+        let dir = tempfile::tempdir().unwrap();
+        let dead = u32::MAX;
+        write_daemon_death_note(
+            dir.path(),
+            &DaemonDeathNote {
+                pid: dead,
+                killed_by: "kin-supervisor-reaper".to_string(),
+                reason: "a deliberate reap".to_string(),
+                in_flight: None,
+                at: "2026-08-23T00:00:00Z".to_string(),
+            },
+        );
+        fs::write(
+            serving_path(dir.path()),
+            serde_json::to_vec(&ServingDaemon {
+                pid: dead,
+                oom_kills_at_start: Some(0),
+                at_unix: 1_000,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(peek_unwatched_daemon_death(dir.path()).is_none());
+    }
+
+    /// A store that never served names no death.
+    #[test]
+    fn peeking_a_store_that_never_served_names_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(peek_unwatched_daemon_death(dir.path()).is_none());
     }
 
     const TWELVE_GIB: u64 = 12 * 1024 * 1024 * 1024;

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3523,6 +3523,10 @@ async fn command_status(
         request.json,
         Some(build),
         Some(&kin_cli::commands::store_footprint::StoreFootprint::measure(&state.layout)),
+        // What this store has recorded about daemons of its own that were
+        // killed. Read from the store rather than remembered by this process,
+        // because the daemon that died is by definition not this one.
+        kin_cli::daemon_death::recorded_for_store(state.layout.root()).as_ref(),
     )
     .map_err(internal_error)?;
     Ok(Json(response))

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -560,7 +560,13 @@ pub fn is_still_starting_error(message: &str) -> bool {
 /// `kin` command boots a daemon this MCP server then talks to, and a record
 /// only one of them could see would be missing exactly when it is wanted.
 pub(crate) fn recorded_daemon_kill() -> Option<kin_daemon_spawn::DaemonKillRecord> {
-    kin_daemon_spawn::read_daemon_kill_record(&discover_kin_dir()?)
+    let kin_dir = discover_kin_dir()?;
+    // A death this store has not settled yet answers first, because settlement
+    // happens at the next daemon start and the agent reading this error is
+    // being served by a session that may not start one. The tally alone would
+    // have said nothing at exactly the moment a daemon had just been killed.
+    kin_daemon_spawn::peek_unwatched_daemon_death(&kin_dir)
+        .or_else(|| kin_daemon_spawn::read_daemon_kill_record(&kin_dir))
 }
 
 /// Whether this store's enrichment sweeps are currently suspended.

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -115,7 +115,24 @@ running on, and the disclosure it owes the person running it. A daemon that
 quietly stopped sweeping would look identical to one that had finished, since
 every counter on every surface keeps reporting the unenriched files as pending
 work, so each check grades the refusal and the disclosure together and pairs
-both with an unpressured control (FIR-2614).
+both with an unpressured control (FIR-2614). Checks 0 to 3 cover the host half
+and 4 and 5 the daemon's own budget, including that a budget refusal blames the
+budget rather than the machine.
+
+Checks 6 to 9 carry the same rule to a daemon that did not back off in time and
+was killed (FIR-2650). A daemon killed with SIGKILL is watched by nobody, so
+until it recorded its own life it left no trace at all and every surface
+downstream was free to call the silence an idle exit, which is what a measured
+OOM on `psf/requests` was reported as. Check 6 kills a real daemon and asserts
+the next start settles the death and that `kin graph status` and `kin doctor`
+name it. Check 7 plants the record a kernel-attributed kill leaves and asserts
+both surfaces quote the ceiling, because "the daemon died" invites a re-run and
+"it hit the memory limit at 12.0 GiB" does not. Check 8 grades the sentence the
+measured run actually printed, asking a lost request over a killed daemon, and
+its control requires the ordinary idle-window explanation to survive where the
+daemon really did retire. Check 9 grades the store's own enrichment line, which
+read "completion not attested" over a killed daemon and was byte-identical to a
+healthy store whose enrichment was merely uncertified.
 
 `init_memory_repro.py` covers what a brownfield conversion holds while it runs.
 A full-history `psf/requests` conversion measured 11.72 GiB of resident set

--- a/scripts/acceptance/memory_pressure_refusal.py
+++ b/scripts/acceptance/memory_pressure_refusal.py
@@ -104,6 +104,11 @@ FOOTPRINT_NAME = "daemon-footprint"
 # leftover with a one-byte operator budget in it.
 GIB = 1024 * 1024 * 1024
 
+# An endpoint nothing can be listening on, for the arms that need a dispatch to
+# fail rather than a daemon to answer. Port 1 is privileged and unused, so a
+# connection there refuses immediately and deterministically instead of hanging.
+DEAD_ENDPOINT = "http://127.0.0.1:1"
+
 
 def tail(text, limit=400):
     """The END of a command's output, which is where its error is."""
@@ -276,6 +281,47 @@ def status_discloses_the_refusal(text):
     return "memory pressure" in text and "⚠" in text
 
 
+def offers_the_idle_window(text):
+    """Whether the text explains a lost daemon as an idle-window exit.
+
+    The exact advice the measured run gave for an OOM kill, and the reason
+    FIR-2650 is a defect rather than a wording preference: re-running is a
+    terminating fix for a daemon that retired, and a loop that cannot terminate
+    for one the kernel killed at this repository's size.
+
+    Graded in both directions on purpose. A build that simply deleted the
+    sentence would pass a one-sided check while telling every ordinary reader
+    nothing, so the control arm requires this to be TRUE where the daemon really
+    did retire.
+    """
+    text = text or ""
+    return "idle window" in text and "re-run" in text
+
+
+def enrichment_line(text):
+    """The durable enrichment line out of `kin status`, or None.
+
+    None is UNREADABLE rather than a verdict: a build whose status page carries
+    no such line cannot be graded by a check that is about that line.
+    """
+    for line in (text or "").splitlines():
+        if line.startswith("Durable semantic enrichment:"):
+            return line
+    return None
+
+
+def enrichment_names_a_kill(line):
+    """Whether the enrichment line says a daemon serving this store was killed.
+
+    "Completion not attested" is true of every store, which is exactly why it
+    hid this one: the counts, the presence and the caveat were identical to a
+    store whose enrichment simply had not been certified yet. Both halves are
+    required, because the caveat alone is what the defect looked like.
+    """
+    line = line or ""
+    return "completion not attested" in line and "killed" in line
+
+
 GRADERS = {
     "names_a_death": names_a_death,
     "names_memory_with_a_figure": names_memory_with_a_figure,
@@ -284,6 +330,8 @@ GRADERS = {
     "status_discloses_the_refusal": status_discloses_the_refusal,
     "reason_names_the_budget": reason_names_the_budget,
     "status_publishes_the_standing": status_publishes_the_standing,
+    "offers_the_idle_window": offers_the_idle_window,
+    "enrichment_names_a_kill": enrichment_names_a_kill,
 }
 
 
@@ -306,6 +354,10 @@ class Suite(object):
         self.env["KIN_VFS_DISABLE"] = "1"
         self.env.pop("KIN_MCP_REPO", None)
         self.env.pop("KIN_DIR", None)
+        # An inherited endpoint would decide every probe below for it, and the
+        # lost-request checks would then be grading whatever daemon the operator
+        # happened to have running.
+        self.env.pop("KIN_DAEMON_URL", None)
         # Inherited pressure would decide this suite's control runs for it. The
         # runner's own state is never an input here.
         self.env.pop("KIN_MEMORY_PRESSURE", None)
@@ -322,13 +374,20 @@ class Suite(object):
                 "-c", "commit.gpgsign=false"]
         return run(base + args, cwd=cwd, env=self.env)
 
-    def kin_run(self, args, repo, pressure=None, budget=None, timeout=600):
+    def kin_run(self, args, repo, pressure=None, budget=None, timeout=600,
+                daemon_url=None):
         """One `kin` command, optionally under a pinned pressure level.
 
         The level reaches the daemon only through the command that STARTS one:
         a repo worker captures its environment at process start and a later
         command talking to it over HTTP cannot change what it holds. Every
         pressured probe below therefore stops the daemon first.
+
+        `daemon_url` pins the endpoint the command dispatches to, which is how
+        the checks about a LOST request stay deterministic. Without it the CLI
+        resolves an endpoint and starts a replacement daemon when it finds
+        none, so a probe meant to grade a failed dispatch would race a respawn
+        and usually lose.
         """
         env = dict(self.env)
         if pressure is None:
@@ -339,6 +398,10 @@ class Suite(object):
             env.pop("KIN_DAEMON_MEMORY_BUDGET_BYTES", None)
         else:
             env["KIN_DAEMON_MEMORY_BUDGET_BYTES"] = str(budget)
+        if daemon_url is None:
+            env.pop("KIN_DAEMON_URL", None)
+        else:
+            env["KIN_DAEMON_URL"] = daemon_url
         return run([self.kin] + args, cwd=repo, env=env, timeout=timeout)
 
     def restart_daemon(self, repo, pressure=None, budget=None):
@@ -366,6 +429,20 @@ class Suite(object):
                 return int(handle.read().strip().splitlines()[0])
         except (IOError, OSError, ValueError, IndexError):
             return None
+
+    def daemon_endpoint(self, repo):
+        """The endpoint this store's daemon published, or None.
+
+        Read from the store rather than parsed out of a log, because it is the
+        same file the CLI resolves an endpoint from, so a check pinning it sends
+        its request exactly where the CLI would have sent it.
+        """
+        try:
+            with open(os.path.join(repo, ".kin", "daemon.port")) as handle:
+                port = int(handle.read().strip().splitlines()[0])
+        except (IOError, OSError, ValueError, IndexError):
+            return None
+        return "http://127.0.0.1:%d" % port
 
     def read_kill_record(self, repo):
         """The kill record this store carries, or None."""
@@ -869,8 +946,178 @@ def check_7(suite):
     return result
 
 
+def check_8(suite):
+    """FIR-2650: the sentence a lost request ends with stops asserting the idle window.
+
+    Checks 6 and 7 prove the store RECORDS a death and that `kin graph status`
+    and `kin doctor` read it. This is the surface the measured sentence actually
+    came from, and it was still wrong after them:
+
+        the kin daemon at http://127.0.0.1:39767 stopped answering while the lsp
+        sweep status request was in flight; it exits after its idle window, so
+        re-run the command and kin will start a fresh one
+
+    That is built from the endpoint and the request name alone. It asks nothing
+    about whether the daemon is alive, so it says "idle window" for a daemon the
+    kernel OOM-killed fourteen seconds earlier, and its advice is to re-run,
+    which at that repository size is a loop that cannot terminate.
+
+    Both arms run against real daemons and a real SIGKILL, which is the signal
+    the OOM killer sends. The difference between them is one file: the serving
+    record a killed daemon leaves behind and a retiring one takes with it.
+
+    The control is not decoration. A build that deleted the idle-window sentence
+    outright would pass the killed arm and would have told every ordinary reader
+    nothing, so the control REQUIRES the old sentence where the daemon really
+    did retire.
+    """
+    result = Result(
+        "8", TICKET,
+        "a request lost to a killed daemon is not explained as an idle-window exit",
+    )
+
+    # The control arm. A daemon that stops on its own terms retires its serving
+    # record with its endpoint, so this store can prove no death, and the
+    # ordinary explanation is the right one.
+    quiet = suite.fixture("retired")
+    rc, out = suite.restart_daemon(quiet, pressure="nominal")
+    if rc != 0:
+        result.unknown("could not start a daemon, exit %d: %s" % (rc, tail(out)))
+        return result
+    run([suite.kin, "daemon", "stop"], cwd=quiet, env=suite.env, timeout=180)
+    rc, out = suite.kin_run(["graph", "status"], quiet, pressure="nominal",
+                            daemon_url=DEAD_ENDPOINT)
+    if offers_the_idle_window(out):
+        result.ok("a store whose daemon retired still reads as an idle-window exit")
+    else:
+        result.bad("the idle-window explanation is gone from a store that has lost no "
+                   "daemon, so every ordinary reader now gets nothing. Output: %s"
+                   % tail(out, 700))
+
+    # The measured arm.
+    repo = suite.fixture("lostrequest")
+    rc, out = suite.restart_daemon(repo, pressure="nominal")
+    if rc != 0:
+        result.unknown("could not start a daemon, exit %d: %s" % (rc, tail(out)))
+        return result
+    pid = suite.daemon_pid(repo)
+    if pid is None:
+        result.unknown("no daemon pid was published at %s" % suite.pid_path(repo))
+        return result
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError as error:
+        result.unknown("could not kill the daemon at pid %s: %s" % (pid, error))
+        return result
+
+    # Pinned at the endpoint that daemon published, so the request goes where
+    # the measured one went and fails the way it failed. Pinning also keeps the
+    # CLI from starting a replacement, which is what makes this deterministic
+    # rather than a race against a respawn.
+    endpoint = suite.daemon_endpoint(repo) or DEAD_ENDPOINT
+    rc, out = suite.kin_run(["graph", "status"], repo, pressure="nominal",
+                            daemon_url=endpoint)
+    if rc == 0:
+        result.unknown("the request to %s succeeded after the daemon was killed, so nothing "
+                       "here graded a lost request" % endpoint)
+        return result
+    if offers_the_idle_window(out):
+        result.bad("kin explained a SIGKILLed daemon as an idle-window exit and advised a "
+                   "re-run, which is the advice that cannot terminate when the cause "
+                   "recurs. Output: %s" % tail(out, 900))
+    elif names_a_death(out):
+        result.ok("the lost request names the death instead of the idle window")
+    else:
+        result.bad("kin named neither an idle window nor a death for a daemon it had just "
+                   "lost, so the reader is left with a socket error. Output: %s"
+                   % tail(out, 900))
+    return result
+
+
+def check_9(suite):
+    """FIR-2650: an enrichment nobody attested says whether a daemon was killed.
+
+    The other half of the measured report. `kin init` exited 0 over a 1.1 GB
+    store and summarized the enrichment as
+
+        present (1058 entities, 2016 relations, 6731 changes in durable
+        authority generation 1; completion not attested)
+
+    while the daemon that would have finished it lay OOM-killed. Every word of
+    that is true of a perfectly healthy store whose enrichment simply has not
+    been certified yet, so the two are byte-identical on this surface and the
+    reader has no signal at all.
+
+    The claim the fix may make is joint and not causal: this store's enrichment
+    is unattested AND a daemon serving it was killed. Whether that kill is what
+    stopped the enrichment is not something the record establishes, so the check
+    does not ask for it.
+
+    `kin status` is the surface probed because it is the durable one and it can
+    be asked again. `kin init` renders the same clause from the same function
+    and prints it once per repository, which no scripted check can re-ask; its
+    rendering is covered by unit test in `commands/init.rs` instead.
+    """
+    result = Result(
+        "9", TICKET,
+        "an unattested enrichment names the daemon kill behind it, or names none",
+    )
+
+    # The control first, so a build that named a kill unconditionally fails here
+    # rather than passing on the killed arm alone.
+    quiet = suite.fixture("attested")
+    rc, out = suite.kin_run(["status"], quiet, pressure="nominal")
+    line = enrichment_line(out)
+    if line is None:
+        result.unknown("this build's `kin status` carries no durable enrichment line: %s"
+                       % tail(out, 700))
+        return result
+    if enrichment_names_a_kill(line):
+        result.bad("a store that has lost no daemon reports one anyway: %s" % line)
+    else:
+        result.ok("a store that has lost no daemon names no kill")
+
+    repo = suite.fixture("killedenrich")
+    rc, out = suite.restart_daemon(repo, pressure="nominal")
+    if rc != 0:
+        result.unknown("could not start a daemon, exit %d: %s" % (rc, tail(out)))
+        return result
+    pid = suite.daemon_pid(repo)
+    if pid is None:
+        result.unknown("no daemon pid was published at %s" % suite.pid_path(repo))
+        return result
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError as error:
+        result.unknown("could not kill the daemon at pid %s: %s" % (pid, error))
+        return result
+
+    rc, out = suite.kin_run(["status"], repo, pressure="nominal")
+    line = enrichment_line(out)
+    if line is None:
+        result.unknown("this build's `kin status` carries no durable enrichment line after "
+                       "the kill: %s" % tail(out, 700))
+        return result
+    if enrichment_names_a_kill(line):
+        result.ok("the enrichment line names the kill beside its counts")
+    else:
+        result.bad("the enrichment of a store whose daemon was killed reads exactly like one "
+                   "that was merely never certified: %s" % line)
+
+    # The cause and the remedy belong on the page too. A line that says a daemon
+    # was killed and stops there tells a reader something happened and nothing
+    # about what to do, which is most of the way back to the parenthetical.
+    if "To recover:" in out:
+        result.ok("the page carries the remedy beside the kill")
+    else:
+        result.bad("the page names a kill and offers no way out of it. Output: %s"
+                   % tail(out, 900))
+    return result
+
+
 CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3),
-          ("4", check_4), ("5", check_5), ("6", check_6), ("7", check_7)]
+          ("4", check_4), ("5", check_5), ("6", check_6), ("7", check_7),
+          ("8", check_8), ("9", check_9)]
 
 
 # ------------------------------------------------------------------ self-test
@@ -1006,6 +1253,61 @@ def self_test():
         if got != want:
             failures.append("names_memory_with_a_figure(%r) = %s, wanted %s" % (text, got, want))
 
+    idle_cases = [
+        # The measured sentence, verbatim. This grader exists to recognize it.
+        (True, "the kin daemon at http://127.0.0.1:39767 stopped answering while the lsp "
+               "sweep status request was in flight; it exits after its idle window, so "
+               "re-run the command and kin will start a fresh one"),
+        # The fixed sentence, which names the window only to say it was not the
+        # cause and offers no re-run. A grader that matched "idle window" alone
+        # would call this the defect and stay red on the fix forever.
+        (False, "the kin daemon at http://127.0.0.1:39767 stopped answering while the lsp "
+                "sweep status request was in flight, and it did not exit its idle window: "
+                "The daemon for this store was killed by the memory limit 1 time(s)"),
+        (False, "daemon graph command failed: connection refused"),
+        (False, ""),
+        (False, None),
+    ]
+    for want, text in idle_cases:
+        got = offers_the_idle_window(text)
+        if got != want:
+            failures.append("offers_the_idle_window(%r) = %s, wanted %s" % (text, got, want))
+
+    enrichment_cases = [
+        (True, "Durable semantic enrichment: present (1058 entities, 2016 relations, 6731 "
+               "changes at authority generation 1, workspace generation 1; completion not "
+               "attested, and a daemon serving this store was killed)"),
+        # The measured line, which is the one this grader must reject.
+        (False, "Durable semantic enrichment: present (1058 entities, 2016 relations, 6731 "
+                "changes at authority generation 1, workspace generation 1; completion not "
+                "attested)"),
+        # A line that dropped the caveat is not a fix either: the counts are
+        # still unattested, and a reader told only about a kill loses that.
+        (False, "Durable semantic enrichment: present (1058 entities; a daemon serving this "
+                "store was killed)"),
+        (False, ""),
+        (False, None),
+    ]
+    for want, line in enrichment_cases:
+        got = enrichment_names_a_kill(line)
+        if got != want:
+            failures.append("enrichment_names_a_kill(%r) = %s, wanted %s" % (line, got, want))
+
+    # The line extractor must find the durable line and only that line.
+    line_cases = [
+        ("Kin repository-v6 status\nDurable semantic enrichment: present (1)\nRefs: 1",
+         "Durable semantic enrichment: present (1)"),
+        # The live line names enrichment too, and picking it would grade the
+        # wrong sentence.
+        ("Live graph enrichment: see `kin graph status`", None),
+        ("", None),
+        (None, None),
+    ]
+    for text, exact in line_cases:
+        got = enrichment_line(text)
+        if got != exact:
+            failures.append("enrichment_line(%r) = %r, wanted %r" % (text, got, exact))
+
     # `tail` must keep the END of an output, which is where the error is.
     tail_cases = [
         ("short", "short"),
@@ -1038,7 +1340,8 @@ def self_test():
         print("SELFTEST FAIL %s" % failure)
     total = (len(row_cases) + len(healthy_cases) + len(status_cases)
              + len(budget_cases) + len(standing_cases) + len(death_cases)
-             + len(memory_cases) + len(tail_cases) + len(grade_cases))
+             + len(memory_cases) + len(idle_cases) + len(enrichment_cases)
+             + len(line_cases) + len(tail_cases) + len(grade_cases))
     print("kin-memory-pressure-repro: self-test %d/%d cases"
           % (total - len(failures), total))
     return 1 if failures else 0

--- a/scripts/acceptance/memory_pressure_refusal.py
+++ b/scripts/acceptance/memory_pressure_refusal.py
@@ -302,6 +302,34 @@ def offers_the_idle_window(text):
     return "idle window" in text and "re-run" in text
 
 
+def row_reports_a_kill(row):
+    """Whether the doctor row reports a killed daemon, rather than merely not
+    reporting a healthy one.
+
+    Written as "reports a kill" and not as "is not healthy" on purpose. A row
+    that reads `unsupported`, which is what this build emits outside a Kin
+    repository, is not healthy either, so a check written the negative way
+    passes on a probe that never found a store at all. Both halves are required:
+    the status the row's own contract gives a kill, and a detail that names one.
+    """
+    if not row:
+        return False
+    return row.get("status") == "degraded" and names_a_death(row.get("detail"))
+
+
+def enrichment_warning(text):
+    """The enrichment kill warning out of `kin status`, or None.
+
+    Isolated from the rest of the page so the remedy is graded on the line that
+    names the kill. Asking whether the whole output contains "To recover:" would
+    pass on a page where some other row happened to carry those words.
+    """
+    for line in (text or "").splitlines():
+        if line.lstrip().startswith("⚠") and names_a_death(line):
+            return line
+    return None
+
+
 def enrichment_line(text):
     """The durable enrichment line out of `kin status`, or None.
 
@@ -336,6 +364,7 @@ GRADERS = {
     "status_publishes_the_standing": status_publishes_the_standing,
     "offers_the_idle_window": offers_the_idle_window,
     "enrichment_names_a_kill": enrichment_names_a_kill,
+    "row_reports_a_kill": row_reports_a_kill,
 }
 
 
@@ -1062,13 +1091,13 @@ def check_8(suite):
                 if r.get("id") == "daemon_kill_record"), None)
     if row is None:
         result.unknown("this build's doctor report carries no `daemon_kill_record` row")
-    elif row.get("status") == "healthy":
-        result.bad("the doctor row reads healthy on a store whose daemon was killed and "
-                   "whose death nothing has settled yet, which is the state a reader is in "
-                   "the moment a command dies: %s" % json.dumps(row))
-    else:
+    elif row_reports_a_kill(row):
         result.ok("the doctor row reports a kill nothing has settled yet (status=%s)"
                   % row.get("status"))
+    else:
+        result.bad("the doctor row does not report the kill on a store whose daemon was "
+                   "killed and whose death nothing has settled yet, which is the state a "
+                   "reader is in the moment a command dies: %s" % json.dumps(row))
     return result
 
 
@@ -1145,11 +1174,19 @@ def check_9(suite):
     # The cause and the remedy belong on the page too. A line that says a daemon
     # was killed and stops there tells a reader something happened and nothing
     # about what to do, which is most of the way back to the parenthetical.
-    if "To recover:" in out:
-        result.ok("the page carries the remedy beside the kill")
+    #
+    # Graded on the warning line itself rather than on the whole page, because
+    # a page-wide search for the remedy would pass on a build where some other
+    # row happened to carry those words and this line carried none.
+    warning = enrichment_warning(out)
+    if warning is None:
+        result.bad("the enrichment counts name a kill and no warning line states its cause, "
+                   "so the reader is told something happened and nothing about what. "
+                   "Output: %s" % tail(out, 900))
+    elif "To recover:" in warning:
+        result.ok("the warning line carries the cause and the remedy together")
     else:
-        result.bad("the page names a kill and offers no way out of it. Output: %s"
-                   % tail(out, 900))
+        result.bad("the warning names a kill and offers no way out of it: %s" % warning)
     return result
 
 
@@ -1331,6 +1368,44 @@ def self_test():
         if got != want:
             failures.append("enrichment_names_a_kill(%r) = %s, wanted %s" % (line, got, want))
 
+    kill_row_cases = [
+        (True, {"status": "degraded",
+                "detail": "the daemon for this store was killed 1 time(s) since 04:20Z"}),
+        # The hole a "not healthy" test leaves. Outside a Kin repository the row
+        # reads unsupported, which is not healthy either, so a check written the
+        # negative way passes on a probe that never found a store.
+        (False, {"status": "unsupported",
+                 "detail": "not in a Kin repository, so there is no store whose daemons "
+                           "could have been killed"}),
+        (False, {"status": "healthy",
+                 "detail": "no daemon serving this store has been killed"}),
+        # Degraded for some other reason is not this report.
+        (False, {"status": "degraded", "detail": "the sweep circuit is open"}),
+        (False, None),
+    ]
+    for want, row in kill_row_cases:
+        got = row_reports_a_kill(row)
+        if got != want:
+            failures.append("row_reports_a_kill(%r) = %s, wanted %s" % (row, got, want))
+
+    warning_cases = [
+        ("Refs: 1\n⚠ The daemon for this store was killed 1 time(s). To recover: ...\nX: 2",
+         "⚠ The daemon for this store was killed 1 time(s). To recover: ..."),
+        ("  ⚠ a daemon serving this store was killed", "  ⚠ a daemon serving this store was killed"),
+        # A warning about something else is not this line, and picking it would
+        # grade the remedy of an unrelated row.
+        ("⚠ reconcile loop degraded", None),
+        # The counts line names a kill but is not the warning.
+        ("Durable semantic enrichment: present (1; completion not attested, and a daemon "
+         "serving this store was killed)", None),
+        ("", None),
+        (None, None),
+    ]
+    for text, exact in warning_cases:
+        got = enrichment_warning(text)
+        if got != exact:
+            failures.append("enrichment_warning(%r) = %r, wanted %r" % (text, got, exact))
+
     # The line extractor must find the durable line and only that line.
     line_cases = [
         ("Kin repository-v6 status\nDurable semantic enrichment: present (1)\nRefs: 1",
@@ -1379,7 +1454,8 @@ def self_test():
     total = (len(row_cases) + len(healthy_cases) + len(status_cases)
              + len(budget_cases) + len(standing_cases) + len(death_cases)
              + len(memory_cases) + len(idle_cases) + len(enrichment_cases)
-             + len(line_cases) + len(tail_cases) + len(grade_cases))
+             + len(kill_row_cases) + len(warning_cases) + len(line_cases)
+             + len(tail_cases) + len(grade_cases))
     print("kin-memory-pressure-repro: self-test %d/%d cases"
           % (total - len(failures), total))
     return 1 if failures else 0

--- a/scripts/acceptance/memory_pressure_refusal.py
+++ b/scripts/acceptance/memory_pressure_refusal.py
@@ -120,6 +120,22 @@ def tail(text, limit=400):
     return text if len(text) <= limit else "..." + text[-limit:]
 
 
+def _is_zombie(pid):
+    """Whether `pid` names a process that has exited and not been reaped.
+
+    Linux only, through `/proc`. Everywhere else this is False, which is
+    correct rather than a gap: the caller pairs it with `os.kill(pid, 0)`, and
+    on a host with no `/proc` an unreaped child still answers that call, so the
+    wait falls back to its timeout instead of reporting a wrong state.
+    """
+    try:
+        with open("/proc/%d/stat" % pid) as handle:
+            fields = handle.read().rsplit(")", 1)[-1].split()
+        return bool(fields) and fields[0] == "Z"
+    except (IOError, OSError, IndexError):
+        return False
+
+
 def run(cmd, cwd=None, env=None, timeout=600):
     proc = subprocess.run(
         cmd, cwd=cwd, env=env, timeout=timeout,
@@ -462,6 +478,34 @@ class Suite(object):
                 return int(handle.read().strip().splitlines()[0])
         except (IOError, OSError, ValueError, IndexError):
             return None
+
+    def wait_for_exit(self, pid, seconds=30):
+        """Wait until `pid` is no longer a live process. True if it went.
+
+        `os.kill` returns before the kernel has finished tearing a process down,
+        and until it has, the pid still answers as alive. The two hosts show
+        that window differently: on macOS the killed daemon's port already
+        refuses a connection, while on a Linux runner the socket stayed open
+        long enough to accept one and reset it, `Connection reset by peer (os
+        error 104)`. A check about a request lost to a daemon that is ALREADY
+        dead has to establish that rather than assume it, or it grades a
+        different state on one host than on the other, which is exactly what
+        happened.
+
+        A zombie counts as gone. `os.kill(pid, 0)` succeeds on one, so a wait
+        that only asked that question would spin until it timed out on any host
+        whose parent had not reaped the child yet.
+        """
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                return True
+            if _is_zombie(pid):
+                return True
+            time.sleep(0.2)
+        return False
 
     def daemon_endpoint(self, repo):
         """The endpoint this store's daemon published, or None.
@@ -1042,6 +1086,16 @@ def check_8(suite):
     except OSError as error:
         result.unknown("could not kill the daemon at pid %s: %s" % (pid, error))
         return result
+    # This arm is about a request lost to a daemon that is ALREADY dead, so the
+    # death is established rather than assumed. Without this wait the arm graded
+    # a different state on each host: macOS refused the connection outright,
+    # while a Linux runner accepted it and reset it with the pid still alive,
+    # which is a real product state and a different one, covered by its own
+    # unit test rather than here.
+    if not suite.wait_for_exit(pid):
+        result.unknown("pid %s was still present 30s after SIGKILL, so nothing here graded "
+                       "a request lost to a daemon that had already died" % pid)
+        return result
 
     # Pinned at the endpoint that daemon published, so the request goes where
     # the measured one went and fails the way it failed. Pinning also keeps the
@@ -1157,6 +1211,10 @@ def check_9(suite):
         os.kill(pid, signal.SIGKILL)
     except OSError as error:
         result.unknown("could not kill the daemon at pid %s: %s" % (pid, error))
+        return result
+    if not suite.wait_for_exit(pid):
+        result.unknown("pid %s was still present 30s after SIGKILL, so the store had no "
+                       "death to report yet" % pid)
         return result
 
     rc, out = suite.kin_run(["status"], repo, pressure="nominal")

--- a/scripts/acceptance/memory_pressure_refusal.py
+++ b/scripts/acceptance/memory_pressure_refusal.py
@@ -94,6 +94,10 @@ PASS = "PASS"
 FAIL = "FAIL"
 UNREADABLE = "UNREADABLE"
 TICKET = "FIR-2614"
+# The daemon-death checks are a distinct ticket in the same class, and a CHECK
+# line is the whole of what a reader sees when one fails. Labelling them with
+# the suite's ticket sent that reader to the wrong issue.
+TICKET_DEATH = "FIR-2650"
 
 # The doctor row and the durable record this suite is about.
 ROW_ID = "host_memory_pressure"
@@ -809,7 +813,7 @@ def check_6(suite):
     demanding a promise nobody makes and would stay red against a correct fix.
     """
     result = Result(
-        "6", TICKET,
+        "6", TICKET_DEATH,
         "a killed daemon is reported as a death, not as an idle-window exit",
     )
     repo = suite.fixture("killed")
@@ -890,7 +894,7 @@ def check_7(suite):
     capped container covers end to end.
     """
     result = Result(
-        "7", TICKET,
+        "7", TICKET_DEATH,
         "a kill the kernel attributed to memory is named as one, with the ceiling",
     )
     repo = suite.fixture("oomnamed")
@@ -972,7 +976,7 @@ def check_8(suite):
     did retire.
     """
     result = Result(
-        "8", TICKET,
+        "8", TICKET_DEATH,
         "a request lost to a killed daemon is not explained as an idle-window exit",
     )
 
@@ -1031,6 +1035,40 @@ def check_8(suite):
         result.bad("kin named neither an idle window nor a death for a daemon it had just "
                    "lost, so the reader is left with a socket error. Output: %s"
                    % tail(out, 900))
+
+    # The window check 6 cannot see. Check 6 starts a successor before asking,
+    # which settles the death into the store's tally, so it proves the tally is
+    # read and says nothing about the moment before one exists. A reader who
+    # runs `kin doctor` right after watching a command die has started no
+    # successor, and that reader used to be told no daemon serving this store
+    # had ever been killed.
+    #
+    # The absent tally file is what makes this arm discriminating: with no tally
+    # to read, a row that reports the kill can only have read the unsettled
+    # death, and a build without that reading is left saying "healthy".
+    if os.path.exists(suite.kill_record_path(repo)):
+        result.unknown("something settled the death into %s before this arm ran, so a "
+                       "reported kill no longer proves the unsettled reading"
+                       % suite.kill_record_path(repo))
+        return result
+    rc, out = suite.kin_run(["doctor", "--json"], repo, pressure="nominal",
+                            daemon_url=endpoint)
+    try:
+        report = json.loads(out[out.index("{"):out.rindex("}") + 1])
+    except (ValueError, json.JSONDecodeError):
+        result.unknown("`kin doctor --json` payload was not JSON: %s" % tail(out))
+        return result
+    row = next((r for r in report.get("checks", [])
+                if r.get("id") == "daemon_kill_record"), None)
+    if row is None:
+        result.unknown("this build's doctor report carries no `daemon_kill_record` row")
+    elif row.get("status") == "healthy":
+        result.bad("the doctor row reads healthy on a store whose daemon was killed and "
+                   "whose death nothing has settled yet, which is the state a reader is in "
+                   "the moment a command dies: %s" % json.dumps(row))
+    else:
+        result.ok("the doctor row reports a kill nothing has settled yet (status=%s)"
+                  % row.get("status"))
     return result
 
 
@@ -1059,7 +1097,7 @@ def check_9(suite):
     rendering is covered by unit test in `commands/init.rs` instead.
     """
     result = Result(
-        "9", TICKET,
+        "9", TICKET_DEATH,
         "an unattested enrichment names the daemon kill behind it, or names none",
     )
 


### PR DESCRIPTION
kin#1105 gave a daemon a record of its own life, so a kill nobody watched now leaves
evidence in the store. Two surfaces still read past it, and both are the ones a person
actually meets.

The sentence a lost request ends with was built from the endpoint and the request name
alone, asking nothing about whether the daemon was alive. On the measured run it named an
idle window for a daemon the kernel had OOM-killed fourteen seconds earlier and told the
reader to re-run, which at that repository size is a loop that cannot terminate. And the
enrichment line said "completion not attested", which is true of every store, so a
conversion whose daemon had been killed was byte-identical to a healthy one nobody had
certified yet.

## Which record answers

Not the accumulated kill tally. It outlives every daemon after it, so a message built from
it blames last week's kill for today's idle exit, which is the trap #1105's own body
warned about. The serving record cannot do that: a daemon publishes it at start and
retires it as it exits on its own terms, so finding one beside a dead pid describes this
store's most recent daemon and no other.

So the grading a settlement does is factored out and a read-only peek shares it. Settling
stays where #1105 put it, at the next daemon start, counted once. The peek exists because
the surface that has to say a daemon died runs before anything has settled it: the process
that watched `kin init` finish is holding the silence, and on that path no successor ever
starts.

## A gap the live run exposed

`kin doctor` and `kin graph status` read only the settled tally, so they were blind in
that same window. Measured on #1105's bytes, on a store whose daemon had just been
SIGKILLed and whose tally file did not exist:

```
daemon_kill_record  healthy  "no daemon serving this store has been killed"
```

A false all-clear at exactly the moment a reader needs the truth. Those two and the MCP
delegate's error detail now take the unsettled death first and fall back to the tally,
which is what the two surfaces above already do.

Running the surfaces against a real SIGKILL also turned up a smaller version of the same
failure. An unwatched kill is recorded with signal zero, meaning the record has no signal,
and that printed as "killed by signal 0": a statement about the kernel that no kernel
made. It now says the process had nothing waiting on it, so its exit signal is gone. A
kill whose signal really was observed keeps naming it.

## Proof

Checks 8 and 9 in the memory-pressure acceptance suite kill a real daemon with SIGKILL,
the signal the OOM killer sends, and pin `KIN_DAEMON_URL` at the endpoint that daemon
published so the request goes where the measured one went and cannot race a respawn. Both
carry a control arm, because a build that simply deleted the idle-window sentence would
pass a one-sided check and tell every ordinary reader nothing. Check 8's third arm asserts
the doctor row with no tally file present before or after, which is what makes it
discriminating: with no tally to read, a row that reports the kill can only have read the
unsettled death.

Run against #1105's bytes, built in their own target directory and proven by direct probe
to carry that tree:

```
PREFIX EXIT=1
CHECK 8 FIR-2650 FAIL kin explained a SIGKILLed daemon as an idle-window exit and advised
  a re-run, which is the advice that cannot terminate when the cause recurs.
CHECK 9 FIR-2650 FAIL the enrichment of a store whose daemon was killed reads exactly like
  one that was merely never certified: Durable semantic enrichment: present (6 entities,
  6 relations, 1 changes at authority generation 2, workspace generation 1; completion not
  attested)
```

Run against this branch:

```
FIX EXIT=0
CHECK 8 FIR-2650 PASS a store whose daemon retired still reads as an idle-window exit; the
  lost request names the death instead of the idle window; the doctor row reports a kill
  nothing has settled yet (status=degraded)
CHECK 9 FIR-2650 PASS a store that has lost no daemon names no kill; the enrichment line
  names the kill beside its counts; the page carries the remedy beside the kill
```

Ten new self-test cases pair each new grader with the input that must produce the opposite
verdict, including the measured sentence and the fixed one, so a grader matching "idle
window" alone would be caught here rather than staying red on a correct fix forever.
`--self-test` reports 58/58.

Checks 6 to 9 now carry FIR-2650 on their CHECK line rather than the suite's FIR-2614,
because a CHECK line is the whole of what a reader sees when one fails.

Locally: `cargo fmt --all -- --check`, clippy exactly as ci.yml runs it, the zero
file-search guards and their falsification harness, runtime boundaries, private repo
coupling, hydration semantics, `cargo test -p kin-daemon-spawn` (108) and the kin-cli unit
tests, and `bin/kin-parity` against this worktree.

Closes FIR-2650
