### PR TITLE
Pin kin-db 0.7.52, which takes 3.29 GiB off a full-history conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.51"
+version = "0.7.52"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "48422b1faa853bcff592987c8ea9c4c3f29743a7d99cf6203e66525e01a6a495"
+checksum = "5e74f738f5c5070fdaa9219ac85a12ddb659c758cb6b3b5207e3c6b8f19d265f"
 dependencies = [
  "bincode",
  "bstr",
@@ -6656,7 +6656,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.51", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.52", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
A full-history conversion of psf/requests peaks at 8.54 GiB of live heap on kin-db 0.7.52, against 11.83 GiB on 0.7.51. This pin is how kin gets that.

kin-db#224 stopped `apply_workspace` holding whole graph snapshots nothing reads. Preparing a workspace successor carried the repository's entire change map four times over at its high point, and two of those copies existed only so that four fields could be compared. The desired graph is now exported as those four domains and consumed at its last reader. The rematerialized successor is narrowed the same way at the call. Underneath both, the snapshot export gained a consuming form that moves the stores out instead of cloning them under a read lock.

Measured before this pin was written, with kin built in a lane worktree against the kin-db branch and every other dependency still resolving from the registry, through kin's own `init_real_repo_heap_attribution` probe on a full clone of psf/requests at 6,731 commits, HEAD `8f8b212de8c2129d7954c6cd373762880375620a`:

```
before   peak live heap 12,703,567,141 bytes (11.83 GiB)
after    peak live heap  9,169,123,381 bytes  (8.54 GiB), outcome ok
```

The saving lands entirely in the phase FIR-2648 attributed it to. `kindb.prepare.workspace` grows 1,133.9 MiB instead of 4,504.6 MiB, its parent `kin.init.commit_bootstrap_transaction` falls by the same 3,370.7 MiB, and every phase the change does not touch matches the earlier measurement to the tenth of a MiB.

## Gate

A registry pin cannot be gated by the DEV-LOCAL lane, because that lane replaces the crate under test with a local path. Gated instead against the registry resolution this PR actually changes:

```
cargo nextest run --workspace --locked
  Summary [394.969s] 7161 tests run: 7161 passed (3 slow, 5 leaky), 14 skipped
  rc=0

cargo test --doc --locked
  rc=0, zero failures across 23 doc targets
```

The lock entry keeps its registry source and its checksum, which is the thing a path patch would have stripped:

```
name = "kin-db"
version = "0.7.52"
source = "sparse+https://kinlab.ai/registry/cargo/"
checksum = "5e74f738f5c5070fdaa9219ac85a12ddb659c758cb6b3b5207e3c6b8f19d265f"
```

Two files move, not three. `fuzz/Cargo.lock` carries no `kin-db` entry at all, and `cargo update -p kin-db` inside that workspace answers "package ID specification `kin-db` did not match any packages", so a kin-db-only pin leaves it alone. The positive control is that the same file does carry `kin-model`.

## Claims this does not make

That the conversion fits a 12 GiB or a 4 GiB container. The container arms run against release-candidate archives and are reported separately. That the 4 GiB bar is met: at 4 GiB a conversion dies in step 11, "build bootstrap transaction", and this change is not in that phase.

Refs FIR-2648.
