### PR TITLE
Release the import plan's change bodies once proof 1 has read them

### DIFF
--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -18,8 +18,8 @@ use kin_git::{
     check_git_admission_blockers, plan_semantic_git_import, preflight_git_migration,
     reprove_git_migration, reprove_git_migration_after_publication,
     seal_all_content_observation_observed, AdmittedContentClosure, GitLocalIgnoreSourceKind,
-    GitMigrationPreflightProof, LosslessGitRepository, SealedContentObservation,
-    SealedContentSource,
+    GitMigrationPreflightProof, LosslessGitRepository, ProvedImportClosure,
+    SealedContentObservation, SealedContentSource,
 };
 use kin_model::{
     compute_resolved_tree_hash, AdmissionCase, AuthorId, ChangeStore,
@@ -329,6 +329,23 @@ fn init_from_git_with_hooks(
         let _span = info_span!("kin.init.source_proof_staged").entered();
         preflight_git_migration(&source, &snapshot, &semantic_plan, &capture_store)
             .map_err(|error| git_boundary_error("prove mutable Git workspace", error))?
+    };
+
+    // Proof 1 is the last reader of a change's BODY. Everything after it reads
+    // the plan's proved facts, and every one of those readers was checked by
+    // name: the plan fingerprint hashes each change's id, the snapshot binding
+    // reads the five raw-snapshot fields, the index and worktree observations
+    // read the workspace seed, and the published seal reads the commit trees
+    // and the seed tree. What the plan still held past this line was an entity,
+    // relation and tree delta set for every commit in history, live across the
+    // conversion's peak inside the bootstrap commit, answering nothing.
+    //
+    // Consuming the plan is what frees them. The closure carries the facts and
+    // never carried the bodies, so a future reader that wants one has to say so
+    // rather than be handed silence.
+    let semantic_plan = {
+        let _span = info_span!("kin.init.release_plan_bodies").entered();
+        ProvedImportClosure::from_proved_plan(semantic_plan)
     };
 
     let staging_dir = source_parent.join(format!(".kin.init-{}", uuid::Uuid::new_v4()));

--- a/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
+++ b/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
@@ -110,6 +110,31 @@ const BIND_PHASE: &str = "kin.init.bind_historical_semantics";
 /// dependency pin.
 const BIND_PEAK_GROWTH_PERCENT_OF_RETAINED: usize = 175;
 
+/// The phase that gives up the import plan's change bodies.
+///
+/// Proof 1 is the last reader of a change's body. Everything after it reads the
+/// plan's proved facts, so the phase below converts the plan into a closure
+/// carrying those facts and drops the bodies. It exists as a named phase
+/// precisely so this guard can watch the live heap fall across it.
+const RELEASE_PHASE: &str = "kin.init.release_plan_bodies";
+
+/// How much of what the binding phase retained must actually be given back,
+/// in percent.
+///
+/// Calibrated inside the run rather than against a constant, for the reason
+/// `BIND_PEAK_GROWTH_PERCENT_OF_RETAINED` gives: both figures scale with
+/// commits multiplied by per-commit churn, so a byte floor written for this
+/// fixture would say nothing about a repository. The binding phase produces one
+/// copy of every commit's entity, relation and tree deltas and retains it; once
+/// proof 1 has read them for the last time, that copy is what this phase hands
+/// back.
+///
+/// The floor sits at 50 percent, well under what a working release gives back
+/// and far above the zero a build that keeps the bodies produces. There is
+/// nothing legitimate in between: either the plan is consumed into a closure
+/// without the bodies or it is not.
+const RELEASE_DROP_PERCENT_OF_BIND_RETAINED: usize = 50;
+
 /// Backstop on total peak live heap for admitting `COMMITS` commits.
 ///
 /// Deliberately loose, and deliberately NOT the headline. The total is set by
@@ -121,7 +146,15 @@ const BIND_PEAK_GROWTH_PERCENT_OF_RETAINED: usize = 175;
 ///
 /// What this one catches is a gross regression: a new whole-history structure
 /// large enough to move even a bootstrap-dominated total.
-const PEAK_HEAP_CEILING: usize = 1400 * 1024 * 1024;
+///
+/// Tightened from 1400 MiB once two whole-history holders came out of a
+/// conversion. Measured on this fixture, release, one host: 660.9 MiB before
+/// the import plan's change bodies were released after proof 1 and 577.5 MiB
+/// after. 900 MiB stays a loose backstop rather than a discriminator, which is
+/// deliberate: the release floor below is what carries this class, and a total
+/// tuned tight enough to grade it would fail on a different allocator instead
+/// of on a defect.
+const PEAK_HEAP_CEILING: usize = 900 * 1024 * 1024;
 
 fn git(repo: &Path, args: &[&str]) {
     let status = Command::new("git")
@@ -211,6 +244,21 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
         .iter()
         .find(|(phase, _, _)| *phase == BIND_PHASE)
         .map(|(_, grew, retained)| (*grew, *retained));
+    // The release phase gives memory BACK, and `peak_growth_by_phase` reports
+    // what a phase retained with a saturating subtraction, so a phase that
+    // frees reads zero there and says nothing. Read the entry and exit samples
+    // directly instead, and measure the drop.
+    let release_drop = support::samples()
+        .iter()
+        .position(|sample| sample.phase == RELEASE_PHASE && sample.entering)
+        .and_then(|entered| {
+            let samples = support::samples();
+            let entry = samples[entered];
+            samples[entered + 1..]
+                .iter()
+                .find(|sample| sample.phase == RELEASE_PHASE && !sample.entering)
+                .map(|exit| entry.live.saturating_sub(exit.live))
+        });
 
     println!(
         "peak live heap admitting {COMMITS} commits: {peak} bytes ({:.1} MiB), backstop {} MiB",
@@ -236,6 +284,15 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
         bind.map(|(_, retained)| retained.to_string())
             .unwrap_or_else(|| "NO SAMPLE".to_string()),
         BIND_PEAK_GROWTH_PERCENT_OF_RETAINED
+    );
+    println!(
+        "{RELEASE_PHASE} gave back {} bytes of the {} bytes {BIND_PHASE} retained, floor {} percent",
+        release_drop
+            .map(|bytes| bytes.to_string())
+            .unwrap_or_else(|| "NO SAMPLE".to_string()),
+        bind.map(|(_, retained)| retained.to_string())
+            .unwrap_or_else(|| "NO SAMPLE".to_string()),
+        RELEASE_DROP_PERCENT_OF_BIND_RETAINED
     );
 
     // An absent sample is not a pass. If the phase never opened, the guard
@@ -286,6 +343,28 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
          ceiling. That phase derives one set of deltas per commit and keeps exactly one copy \
          of them, so growth of about two copies means the derived set and the plan's set are \
          alive at the same time. On a real conversion that is gigabytes.\n\n{}",
+        support::phase_attribution_table()
+    );
+    // Same two refusals as above, for the same reasons: an absent phase measured
+    // nothing, and a zero denominator would let any drop at all pass.
+    let release_drop = release_drop.unwrap_or_else(|| {
+        panic!(
+            "no {RELEASE_PHASE} sample was recorded, so this run proved nothing about \
+             whether the import plan's change bodies are given back after proof 1. Either \
+             the phase span was renamed or the conversion no longer releases them.\n\n{}",
+            support::phase_attribution_table()
+        )
+    });
+    let release_percent = release_drop.saturating_mul(100) / bind_retained;
+    assert!(
+        release_percent >= RELEASE_DROP_PERCENT_OF_BIND_RETAINED,
+        "{RELEASE_PHASE} gave back {release_drop} bytes, {release_percent} percent of the \
+         {bind_retained} bytes {BIND_PHASE} retained, under the \
+         {RELEASE_DROP_PERCENT_OF_BIND_RETAINED} percent floor. Proof 1 is the last reader \
+         of a change's body, so past that point the plan's entity, relation and tree deltas \
+         for every commit in history answer no question and must be released. Holding them \
+         to the end of a conversion is over a gigabyte live across the peak on a mid-size \
+         repository.\n\n{}",
         support::phase_attribution_table()
     );
     assert!(

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -71,5 +71,6 @@ pub use sealed_observation::{
     SealedContentObservation, SealedContentSource,
 };
 pub use semantic_import::{
-    plan_semantic_git_import, GitWorkspaceSeed, HistoricalSemanticBinding, SemanticGitImportPlan,
+    plan_semantic_git_import, GitWorkspaceSeed, HistoricalSemanticBinding, ProvedImportClosure,
+    ProvedPlanFacts, SemanticGitImportPlan,
 };

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -43,7 +43,7 @@ use crate::lossless::{
     capture_lossless_git_repository, open_repo, reject_shallow_repository, GitObjectFormat,
     LosslessGitRepository,
 };
-use crate::semantic_import::SemanticGitImportPlan;
+use crate::semantic_import::{ProvedPlanFacts, SemanticGitImportPlan};
 
 /// Successful, point-in-time proof that one Git workspace can be admitted
 /// without flattening index or worktree state into repository authority.
@@ -501,10 +501,10 @@ pub fn reprove_git_migration(
     repo_path: &Path,
     baseline: &GitMigrationPreflightProof,
     snapshot: &LosslessGitRepository,
-    plan: &SemanticGitImportPlan,
+    plan: &impl ProvedPlanFacts,
     blob_store: &BlobStore,
 ) -> Result<GitMigrationPreflightProof> {
-    preflight_git_migration_with_hook(
+    prove_from_plan_facts(
         repo_path,
         snapshot,
         plan,
@@ -545,13 +545,13 @@ pub fn reprove_git_migration_after_publication(
     published_kin_dir: &Path,
     baseline: &GitMigrationPreflightProof,
     snapshot: &LosslessGitRepository,
-    plan: &SemanticGitImportPlan,
+    plan: &impl ProvedPlanFacts,
     blob_store: &BlobStore,
 ) -> Result<GitMigrationPreflightProof> {
     let source_worktree =
         fs::canonicalize(repo_path).map_err(|error| GitError::io(repo_path, error))?;
     let published_kin_dir = canonical_published_kin_dir(&source_worktree, published_kin_dir)?;
-    preflight_git_migration_with_hook(
+    prove_from_plan_facts(
         &source_worktree,
         snapshot,
         plan,
@@ -646,9 +646,42 @@ fn preflight_git_migration_with_hook(
     // Structurally rebuilding the plan is what a baselined re-proof reuses
     // rather than repeats; the binding comparison below is cheap and runs
     // either way. Both halves of the reasoning are at `reprove_git_migration`.
+    //
+    // This is the only step in a source proof that needs a whole plan, which is
+    // why it is the only thing separating this entry point from the shared body
+    // below, and why a re-proof can be handed a closure that never carried the
+    // change bodies.
     if baseline.is_none() {
         plan.validate(blob_store)?;
     }
+    prove_from_plan_facts(
+        repo_path,
+        snapshot,
+        plan,
+        blob_store,
+        published_kin_dir,
+        baseline,
+        after_first_observation,
+    )
+}
+
+/// The observation half of every source proof, over the plan facts alone.
+///
+/// Everything below reads the plan through [`ProvedPlanFacts`], so a proof
+/// taken against a whole plan and one taken against the closure derived from it
+/// cannot compute different bytes: there is one implementation of the
+/// fingerprint, one of the snapshot binding, and one of the index and worktree
+/// observation, and each takes whichever value it is handed.
+#[allow(clippy::too_many_arguments)]
+fn prove_from_plan_facts(
+    repo_path: &Path,
+    snapshot: &LosslessGitRepository,
+    plan: &impl ProvedPlanFacts,
+    blob_store: &BlobStore,
+    published_kin_dir: Option<&Path>,
+    baseline: Option<ProofBaseline<'_>>,
+    after_first_observation: impl FnOnce(),
+) -> Result<GitMigrationPreflightProof> {
     bind_plan_to_snapshot(snapshot, plan)?;
     // A pure function of the plan, which no observation mutates. Derived once
     // per proof rather than once per observation, and still derived rather than
@@ -689,13 +722,13 @@ fn preflight_git_migration_with_hook(
 
 fn bind_plan_to_snapshot(
     snapshot: &LosslessGitRepository,
-    plan: &SemanticGitImportPlan,
+    plan: &impl ProvedPlanFacts,
 ) -> Result<()> {
-    if plan.repository_id != snapshot.repository_id
-        || plan.object_format != snapshot.object_format
-        || plan.external_objects != snapshot.objects
-        || plan.refs != snapshot.refs
-        || plan.head != snapshot.head
+    if plan.proved_repository_id() != &snapshot.repository_id
+        || plan.proved_object_format() != snapshot.object_format
+        || plan.proved_external_objects() != snapshot.objects.as_slice()
+        || plan.proved_refs() != &snapshot.refs
+        || plan.proved_head() != &snapshot.head
     {
         return Err(preflight_error(
             "semantic import plan is not bound to the supplied lossless snapshot",
@@ -707,7 +740,7 @@ fn bind_plan_to_snapshot(
 fn observe(
     repo_path: &Path,
     expected_snapshot: &LosslessGitRepository,
-    plan: &SemanticGitImportPlan,
+    plan: &impl ProvedPlanFacts,
     blob_store: &BlobStore,
     expected_entries: &BTreeMap<RepoPath, ExpectedIndexEntry>,
     published_kin_dir: Option<&Path>,
@@ -773,9 +806,9 @@ fn observe(
 
     let remote_mapping = remote_mapping_facts(&repo)?;
     let absent_index_allowed = matches!(snapshot.head, WorkspaceHead::Symbolic { .. })
-        && plan.workspace_seed.base_target.is_none()
-        && plan.workspace_seed.base_commit_oid.is_none()
-        && plan.workspace_seed.base_tree_hash.is_none()
+        && plan.proved_workspace_seed().base_target.is_none()
+        && plan.proved_workspace_seed().base_commit_oid.is_none()
+        && plan.proved_workspace_seed().base_tree_hash.is_none()
         && expected_entries.is_empty();
     let (index_file, raw_index) = read_strict_index(&repo, absent_index_allowed)?;
     let mut divergence = DivergenceLog::default();
@@ -820,11 +853,11 @@ fn observe(
         source_worktree,
         source_git_dir,
         object_format: snapshot.object_format,
-        head: plan.workspace_seed.head.clone(),
+        head: plan.proved_workspace_seed().head.clone(),
         refs: snapshot.refs.clone(),
-        base_target: plan.workspace_seed.base_target.clone(),
-        base_commit_oid: plan.workspace_seed.base_commit_oid,
-        base_tree_hash: plan.workspace_seed.base_tree_hash,
+        base_target: plan.proved_workspace_seed().base_target.clone(),
+        base_commit_oid: plan.proved_workspace_seed().base_commit_oid,
+        base_tree_hash: plan.proved_workspace_seed().base_tree_hash,
         snapshot_fingerprint,
         semantic_plan_fingerprint,
         index,
@@ -841,7 +874,7 @@ fn observe(
 
 fn expected_index_entries(
     snapshot: &LosslessGitRepository,
-    plan: &SemanticGitImportPlan,
+    plan: &impl ProvedPlanFacts,
 ) -> Result<BTreeMap<RepoPath, ExpectedIndexEntry>> {
     let mut blob_oids = BTreeMap::<Hash256, GitObjectId>::new();
     for record in snapshot
@@ -860,7 +893,7 @@ fn expected_index_entries(
     }
 
     let mut expected = BTreeMap::new();
-    for artifact in plan.workspace_seed.base_tree.artifacts_by_path() {
+    for artifact in plan.proved_workspace_seed().base_tree.artifacts_by_path() {
         let entry = match artifact.entry {
             TreeEntry::Blob { hash, executable } => ExpectedIndexEntry {
                 mode: if executable {
@@ -2733,36 +2766,44 @@ fn fingerprint_snapshot(snapshot: &LosslessGitRepository) -> Hash256 {
     hash.finish()
 }
 
-fn fingerprint_plan(plan: &SemanticGitImportPlan) -> Result<Hash256> {
+/// Fingerprint the proved facts of an import plan.
+///
+/// Reads through [`ProvedPlanFacts`], so the whole plan the first proof holds
+/// and the closure every later proof holds produce the same bytes by
+/// construction rather than by two implementations agreeing.
+fn fingerprint_plan(plan: &impl ProvedPlanFacts) -> Result<Hash256> {
     let mut hash = FramedHash::new(b"kin.git.semantic.import-plan.v1");
     hash.bytes(
         fingerprint_snapshot(&LosslessGitRepository {
-            repository_id: plan.repository_id.clone(),
-            object_format: plan.object_format,
-            objects: plan.external_objects.clone(),
-            refs: plan.refs.clone(),
-            head: plan.head.clone(),
+            repository_id: plan.proved_repository_id().clone(),
+            object_format: plan.proved_object_format(),
+            objects: plan.proved_external_objects().to_vec(),
+            refs: plan.proved_refs().clone(),
+            head: plan.proved_head().clone(),
         })
         .as_bytes(),
     );
-    hash.u64(plan.changes.len() as u64);
-    for change in &plan.changes {
-        hash.bytes(change.id.0.as_bytes());
+    hash.u64(plan.proved_change_count() as u64);
+    for change_id in plan.proved_change_ids() {
+        hash.bytes(change_id.0.as_bytes());
     }
-    hash.u64(plan.aliases.len() as u64);
-    for alias in &plan.aliases {
+    hash.u64(plan.proved_aliases().len() as u64);
+    for alias in plan.proved_aliases() {
         hash.bytes(alias.oid.as_bytes());
         hash.bytes(alias.change_id.0.as_bytes());
     }
-    hash.u64(plan.commit_trees.len() as u64);
-    for (oid, tree) in plan.commit_trees.iter() {
+    hash.u64(plan.proved_commit_trees().len() as u64);
+    for (oid, tree) in plan.proved_commit_trees().iter() {
         hash.bytes(oid.as_bytes());
         hash.bytes(compute_resolved_tree_hash(tree)?.as_bytes());
     }
-    encode_head(&mut hash, &plan.workspace_seed.head);
-    encode_optional_ref_target(&mut hash, plan.workspace_seed.base_target.as_ref());
-    encode_optional_oid(&mut hash, plan.workspace_seed.base_commit_oid.as_ref());
-    match plan.workspace_seed.base_tree_hash {
+    encode_head(&mut hash, &plan.proved_workspace_seed().head);
+    encode_optional_ref_target(&mut hash, plan.proved_workspace_seed().base_target.as_ref());
+    encode_optional_oid(
+        &mut hash,
+        plan.proved_workspace_seed().base_commit_oid.as_ref(),
+    );
+    match plan.proved_workspace_seed().base_tree_hash {
         Some(tree_hash) => {
             hash.u64(1);
             hash.bytes(tree_hash.as_bytes());

--- a/crates/kin-git/src/sealed_observation.rs
+++ b/crates/kin-git/src/sealed_observation.rs
@@ -97,6 +97,19 @@ impl AdmittedContentClosure for SemanticGitImportPlan {
     }
 }
 
+impl AdmittedContentClosure for crate::semantic_import::ProvedImportClosure {
+    fn closure_repository_id(&self) -> &RepositoryId {
+        &self.repository_id
+    }
+
+    fn admitted_trees(&self) -> Vec<&ResolvedTree> {
+        self.commit_trees
+            .values()
+            .chain(std::iter::once(&self.workspace_seed.base_tree))
+            .collect()
+    }
+}
+
 impl AdmittedContentClosure for AdmittedSemanticGitImportPlan {
     fn closure_repository_id(&self) -> &RepositoryId {
         &self.repository_id

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -128,6 +128,154 @@ pub struct SemanticGitImportPlan {
     pub default_ref_mutation: Option<DefaultRefMutation>,
 }
 
+/// The plan fields every Git source proof reads.
+///
+/// Every proof in a conversion reads the same nine things out of an import
+/// plan: the five raw-snapshot fields it must stay bound to, the change ids and
+/// aliases and commit trees its fingerprint covers, and the workspace seed the
+/// index and worktree observations are taken against. None of them is a change
+/// BODY. Naming that set as a trait is what lets one proof hold a whole plan
+/// and the proofs after it hold only the closure, without the two ever
+/// computing a fingerprint from different inputs.
+pub trait ProvedPlanFacts {
+    fn proved_repository_id(&self) -> &RepositoryId;
+    fn proved_object_format(&self) -> GitObjectFormat;
+    fn proved_external_objects(&self) -> &[ExternalObjectRecord];
+    /// How many changes the plan carries, hashed before the ids themselves.
+    fn proved_change_count(&self) -> usize;
+    /// Change ids in the plan's own parent-first order.
+    fn proved_change_ids(&self) -> impl Iterator<Item = SemanticChangeId> + '_;
+    fn proved_aliases(&self) -> &[ExternalChangeAlias];
+    fn proved_commit_trees(&self) -> &BTreeMap<GitObjectId, ResolvedTree>;
+    fn proved_refs(&self) -> &RepositoryRefState;
+    fn proved_head(&self) -> &WorkspaceHead;
+    fn proved_workspace_seed(&self) -> &GitWorkspaceSeed;
+}
+
+impl ProvedPlanFacts for SemanticGitImportPlan {
+    fn proved_repository_id(&self) -> &RepositoryId {
+        &self.repository_id
+    }
+    fn proved_object_format(&self) -> GitObjectFormat {
+        self.object_format
+    }
+    fn proved_external_objects(&self) -> &[ExternalObjectRecord] {
+        &self.external_objects
+    }
+    fn proved_change_count(&self) -> usize {
+        self.changes.len()
+    }
+    fn proved_change_ids(&self) -> impl Iterator<Item = SemanticChangeId> + '_ {
+        self.changes.iter().map(|change| change.id)
+    }
+    fn proved_aliases(&self) -> &[ExternalChangeAlias] {
+        &self.aliases
+    }
+    fn proved_commit_trees(&self) -> &BTreeMap<GitObjectId, ResolvedTree> {
+        &self.commit_trees
+    }
+    fn proved_refs(&self) -> &RepositoryRefState {
+        &self.refs
+    }
+    fn proved_head(&self) -> &WorkspaceHead {
+        &self.head
+    }
+    fn proved_workspace_seed(&self) -> &GitWorkspaceSeed {
+        &self.workspace_seed
+    }
+}
+
+/// What a conversion still needs from its import plan once the first source
+/// proof has been taken.
+///
+/// A conversion holds its `SemanticGitImportPlan` from the phase that derives
+/// it to the phase that seals the published repository, and after the first
+/// proof nothing reads a change's body again. Every later reader was checked by
+/// name: the plan fingerprint hashes each change's ID, the snapshot binding
+/// reads the five raw-snapshot fields, the index and worktree observations read
+/// the workspace seed, and the published seal reads the commit trees and the
+/// seed tree. What stays behind is `entity_deltas`, `relation_deltas` and
+/// `tree_deltas` for every commit in history, live across the conversion's
+/// peak, answering no question.
+///
+/// This is a type rather than a mutation on purpose. Emptying the plan's
+/// vectors in place would leave a structure that still looks whole and would
+/// answer a future reader with silence, which is the failure class this whole
+/// area keeps producing. A closure that never carried the bodies cannot.
+///
+/// It is built by consuming the plan, so the bodies are freed at the call
+/// rather than copied out beside them, and `commit_trees` moves as the shared
+/// pointer it already is.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProvedImportClosure {
+    pub repository_id: RepositoryId,
+    pub object_format: GitObjectFormat,
+    pub external_objects: Vec<ExternalObjectRecord>,
+    /// Change ids in the plan's parent-first order, which is every byte any
+    /// proof after the first ever took from `changes`.
+    pub change_ids: Vec<SemanticChangeId>,
+    pub aliases: Vec<ExternalChangeAlias>,
+    pub commit_trees: Arc<BTreeMap<GitObjectId, ResolvedTree>>,
+    pub refs: RepositoryRefState,
+    pub head: WorkspaceHead,
+    pub workspace_seed: GitWorkspaceSeed,
+}
+
+impl ProvedImportClosure {
+    /// Take from a proved plan exactly what the proofs after it read.
+    ///
+    /// Consuming rather than borrowing is the point: the change bodies are
+    /// dropped at this call instead of living on beside a copy of everything
+    /// else.
+    pub fn from_proved_plan(plan: SemanticGitImportPlan) -> Self {
+        let change_ids = plan.changes.iter().map(|change| change.id).collect();
+        Self {
+            repository_id: plan.repository_id,
+            object_format: plan.object_format,
+            external_objects: plan.external_objects,
+            change_ids,
+            aliases: plan.aliases,
+            commit_trees: plan.commit_trees,
+            refs: plan.refs,
+            head: plan.head,
+            workspace_seed: plan.workspace_seed,
+        }
+    }
+}
+
+impl ProvedPlanFacts for ProvedImportClosure {
+    fn proved_repository_id(&self) -> &RepositoryId {
+        &self.repository_id
+    }
+    fn proved_object_format(&self) -> GitObjectFormat {
+        self.object_format
+    }
+    fn proved_external_objects(&self) -> &[ExternalObjectRecord] {
+        &self.external_objects
+    }
+    fn proved_change_count(&self) -> usize {
+        self.change_ids.len()
+    }
+    fn proved_change_ids(&self) -> impl Iterator<Item = SemanticChangeId> + '_ {
+        self.change_ids.iter().copied()
+    }
+    fn proved_aliases(&self) -> &[ExternalChangeAlias] {
+        &self.aliases
+    }
+    fn proved_commit_trees(&self) -> &BTreeMap<GitObjectId, ResolvedTree> {
+        &self.commit_trees
+    }
+    fn proved_refs(&self) -> &RepositoryRefState {
+        &self.refs
+    }
+    fn proved_head(&self) -> &WorkspaceHead {
+        &self.head
+    }
+    fn proved_workspace_seed(&self) -> &GitWorkspaceSeed {
+        &self.workspace_seed
+    }
+}
+
 impl SemanticGitImportPlan {
     /// This plan's own raw Git state, which every re-derivation starts from.
     fn raw_snapshot(&self) -> LosslessGitRepository {

--- a/scripts/acceptance/init_memory_repro.py
+++ b/scripts/acceptance/init_memory_repro.py
@@ -121,6 +121,10 @@ BIND_LINE = re.compile(
     r"kin\.init\.bind_historical_semantics grew the peak by (\d+) bytes "
     r"while retaining (\d+) bytes, ceiling (\d+) percent"
 )
+RELEASE_LINE = re.compile(
+    r"kin\.init\.release_plan_bodies gave back (\d+) bytes of the (\d+) bytes "
+    r"kin\.init\.bind_historical_semantics retained, floor (\d+) percent"
+)
 
 
 def read_guard_output(text):
@@ -170,6 +174,42 @@ def grade_ratio(grew, retained, cap_percent):
     detail = ("binding historical semantics grew the peak by %d percent of what it retained "
               "(%d over %d bytes), ceiling %d percent" % (percent, grew, retained, cap_percent))
     if percent >= cap_percent:
+        return FAIL, detail
+    return PASS, detail
+
+
+def read_release_figures(text):
+    """Pull what the release phase gave back, against what binding retained.
+
+    Separate from the two readers above for the same reason they are separate
+    from each other: it grades a FLOOR rather than a ceiling, and a suite that
+    graded only the earlier figures would report them PASS over a guard that
+    went red on this one.
+    """
+    release = RELEASE_LINE.search(text or "")
+    if not release:
+        return (None, None, None)
+    return (int(release.group(1)), int(release.group(2)), int(release.group(3)))
+
+
+def grade_floor(given_back, retained, floor_percent):
+    """PASS at or over the floor, FAIL under it, UNREADABLE with no denominator.
+
+    The direction is the opposite of `grade_ratio` on purpose. This one asks
+    whether enough memory came BACK, so more is better and the comparison is
+    the other way round. A phase that retained nothing gives the ratio no
+    denominator, which is UNREADABLE rather than a pass, exactly as there.
+    """
+    if given_back is None or retained is None or floor_percent is None:
+        return UNREADABLE, "the guard printed no release-phase figures, so nothing was graded"
+    if retained == 0:
+        return UNREADABLE, ("the binding phase retained nothing, so there was nothing for the "
+                            "release to give back and this graded nothing")
+    percent = given_back * 100 // retained
+    detail = ("releasing the plan's change bodies gave back %d percent of what binding "
+              "retained (%d of %d bytes), floor %d percent"
+              % (percent, given_back, retained, floor_percent))
+    if percent < floor_percent:
         return FAIL, detail
     return PASS, detail
 
@@ -307,7 +347,21 @@ def check_2(suite):
     return result
 
 
-CHECKS = [check_0, check_1, check_2]
+def check_3(suite):
+    """The import plan's change bodies are given back once proof 1 has read them."""
+    result = Result("3", "the plan's change bodies are released after proof 1")
+    code, out = suite.guard_output()
+    given_back, retained, floor = read_release_figures(out)
+    if given_back is None and code != 0:
+        result.unknown("the guard produced no release figures and exited %d: %s"
+                       % (code, tail(out)))
+        return result
+    status, detail = grade_floor(given_back, retained, floor)
+    {PASS: result.ok, FAIL: result.bad, UNREADABLE: result.unknown}[status](detail)
+    return result
+
+
+CHECKS = [check_0, check_1, check_2, check_3]
 
 
 def self_test():
@@ -372,10 +426,45 @@ def self_test():
     if read_bind_figures("") != (None, None, None):
         failures.append("parser invented binding figures from empty output")
 
+    # The floor grader runs the comparison the other way round, so its own
+    # inverse is the case that would pass if the direction were flipped: a
+    # release that gave back nothing.
+    floor_cases = [
+        ("everything given back passes", 87404386, 86996112, 50, PASS),
+        ("exactly at the floor passes", 50, 100, 50, PASS),
+        ("nothing given back fails", 0, 86996112, 50, FAIL),
+        ("under the floor fails", 40, 100, 50, FAIL),
+        ("nothing retained is unreadable", 100, 0, 50, UNREADABLE),
+        ("nothing measured is unreadable", None, None, None, UNREADABLE),
+    ]
+    for title, given_back, retained, floor, wanted in floor_cases:
+        got, detail = grade_floor(given_back, retained, floor)
+        if got != wanted:
+            failures.append("%s: wanted %s, got %s (%s)" % (title, wanted, got, detail))
+
+    release_line = ("kin.init.release_plan_bodies gave back 87404386 bytes of the 86996112 "
+                    "bytes kin.init.bind_historical_semantics retained, floor 50 percent\n")
+    if read_release_figures(release_line) != (87404386, 86996112, 50):
+        failures.append("parser misread the release line: %r"
+                        % (read_release_figures(release_line),))
+    if read_release_figures("error: could not compile") != (None, None, None):
+        failures.append("parser invented release figures from output that carries none")
+    if read_release_figures("") != (None, None, None):
+        failures.append("parser invented release figures from empty output")
+
+    # A floor that cannot reject the defect is not a floor. Drive the measured
+    # pre-fix and post-fix figures through the shipped floor.
+    got, _ = grade_floor(0, 86996112, 50)
+    if got != FAIL:
+        failures.append("the shipped release floor does not reject the pre-fix figure")
+    got, _ = grade_floor(87404386, 86996112, 50)
+    if got != PASS:
+        failures.append("the shipped release floor rejects the post-fix figure")
+
     for failure in failures:
         print("SELFTEST FAIL %s" % failure)
     print("kin-init-memory-repro self-test: %d case(s), %d failure(s)"
-          % (len(cases) + len(ratio_cases) + 8, len(failures)))
+          % (len(cases) + len(ratio_cases) + len(floor_cases) + 13, len(failures)))
     return 1 if failures else 0
 
 


### PR DESCRIPTION
A conversion held its import plan from the phase that derives it to the phase that seals the published repository, and after the first source proof nothing read a change's body again.

Every later reader was checked by name in the source rather than taken from the ticket. `plan.validate` runs only when there is no baseline, so proof 1 does it and proofs 2 and 3 do not. The snapshot binding reads five raw-snapshot fields. The plan fingerprint reads those five, then the change count and each change's ID and nothing else from it, then the aliases, the commit trees and the workspace seed. The index and worktree observations read the workspace seed: across the whole observation body every `plan.` access is `plan.workspace_seed.*`. The published seal reads the commit trees and the seed tree.

So past proof 1 the plan's `entity_deltas`, `relation_deltas` and `tree_deltas` for every commit in history have no reader at all, and they are live across the conversion's peak inside the bootstrap commit.

## What changed

`ProvedPlanFacts` names the set the proofs actually read. `ProvedImportClosure` carries that set and never carried the bodies, and it is built by consuming the plan, so the bodies are freed at the call rather than copied out beside them and the commit trees move as the shared pointer they already are. A conversion converts its plan the moment proof 1 returns, inside a named phase span so the guard can watch the live heap fall across it.

This is a type rather than a mutation on purpose. Emptying the plan's vectors in place would leave a structure that still looks whole and would answer a future reader with silence, which is the failure class this area keeps producing.

One implementation of the fingerprint, the snapshot binding and the observation serves both shapes, so a proof taken against a whole plan and one taken against its closure cannot compute different bytes. The proof entry point was split so the only step needing a whole plan stays on the entry point that has one. The two reprove functions take an `impl ProvedPlanFacts` rather than the closure outright, so a caller still holding a whole plan compiles unchanged, and `cargo check --workspace --all-targets` passes with no call site edited outside `git_init`.

## Proof

The deep-history guard gained a floor: the live heap must fall across `kin.init.release_plan_bodies` by at least 50 percent of what `kin.init.bind_historical_semantics` retained. `peak_growth_by_phase` reports what a phase retained with a saturating subtraction, so a phase that frees reads zero there and says nothing; the guard reads the entry and exit samples directly instead.

Release, 256-commit fixture, one host:

```
after    total 605569268 bytes (577.5 MiB), release gave back 87404386 of 86996112 bytes, 100 percent
before   total 692968782 bytes (660.9 MiB)     [origin/main, this lane's work stashed]
mutant   total 693348270 bytes (661.2 MiB), release gave back 0 bytes, 0 percent, rc=101 FAILED
```

660.9 MiB to 577.5 MiB is a fall of 87,399,514 bytes, which is what the release gives back to within 4,872 bytes. The arithmetic closes on the one phase. The mutant holds the plan past proof 1 and builds the closure from a clone, so the bodies stay live to the end; it was built and run rather than reasoned about, with `Compiling kin-core` printed once, and its total lands on the base's, which is what says it reproduces the defect rather than merely failing.

`scripts/acceptance/init_memory_repro.py` grades it as CHECK 3, so the class is caught by the workflow rather than only by the guard:

```
CHECK 0 FIR-2539 PASS proof 1 peak growth is 1.4 MiB, under the 16 MiB ceiling
CHECK 1 FIR-2539 PASS total peak live heap is 577.5 MiB, under the 900 MiB ceiling
CHECK 2 FIR-2539 PASS binding historical semantics grew the peak by 118 percent of what it retained, ceiling 175 percent
CHECK 3 FIR-2539 PASS releasing the plan's change bodies gave back 100 percent of what binding retained, floor 50 percent
kin-init-memory-repro: 4 checks, 4 pass, 0 FAIL, 0 UNREADABLE
```

The suite's own graders were falsified in `--self-test`: 29 cases, zero failures, and the self-test proven able to fail by relaxing the floor comparison from `<` to `<=`, which fires the at-the-floor case.

`scripts/verify-hydration-semantics.py` passes with 13 guarded functions matching the manifest at `HYDRATION_SEMANTICS_VERSION=9`. The fingerprint's bytes are unchanged by construction, because both shapes feed the same implementation.

Gates on this branch, each through `bin/kin-lane run` from the lane worktree: `cargo fmt --all -- --check` clean, clippy with ci.yml's own allow-list rc=0, `cargo nextest run --workspace --no-fail-fast` 7170 passed and 0 failed with 14 skipped, `cargo test --doc` rc=0, and the four guard scripts ci.yml names all passing.

## Claims this does not make

That a conversion now fits 4 GiB. At 4 GiB it dies in step 11, "build bootstrap transaction", which is the SECOND half of FIR-2649: a third complete `SemanticGitImportPlan` built with `TreeRetention::Whole` inside `AdmittedSemanticGitImportPlan::validate`, beside the two plans already held. That half is not in this change. The obstacle is real and named in the ticket: `derive_admitted_semantic_git_history` resolves against `plan.commit_trees` for every commit, so the fresh plan cannot drop its trees as it derives them, and the shape that works is the visitor restructure kin#1083 used for the other validate.

That the whole-repository figure is measured. The numbers above are the 256-commit fixture; the real-corpus arm is reported separately.

Refs FIR-2649.
