### PR TITLE
Narrow a trace's fan-out instead of amputating its depth, and name every boundary it crosses

### DIFF
--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -938,7 +938,8 @@ pub fn build_trace_data_flow_response_within(
                         // `raise` and also by an ordinary call is on the data
                         // path, and a boundary one edge can name stays named
                         // when a weaker anonymous edge arrives beside it.
-                        candidate.call_edges += usize::from(rel.kind == RelationKind::Calls);
+                        candidate.call_edges +=
+                            usize::from(kin_index::is_raise_classifiable_call_edge(rel));
                         candidate.raise_call_edges +=
                             usize::from(kin_index::is_raise_target_edge(rel));
                         if candidate
@@ -964,7 +965,9 @@ pub fn build_trace_data_flow_response_within(
                         candidate_index.insert((next_id, role), candidates.len());
                         let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
                         candidates.push(FanoutCandidate {
-                            call_edges: usize::from(rel.kind == RelationKind::Calls),
+                            call_edges: usize::from(kin_index::is_raise_classifiable_call_edge(
+                                rel,
+                            )),
                             raise_call_edges: usize::from(kin_index::is_raise_target_edge(rel)),
                             entity,
                             role,
@@ -1444,6 +1447,11 @@ struct FanoutCandidate {
 
 impl FanoutCandidate {
     /// Whether this candidate is only ever thrown, never called for its value.
+    ///
+    /// Only parse-authored call edges vote. An LSP call-hierarchy edge cannot
+    /// see a `raise`, so its silence is not a claim that the call was ordinary,
+    /// and counting it made this answer `false` for every candidate on any
+    /// repository with a language server installed.
     fn is_raise_target(&self) -> bool {
         self.call_edges > 0 && self.raise_call_edges == self.call_edges
     }
@@ -3763,6 +3771,19 @@ mod boundary_and_ranking_tests {
         relation
     }
 
+    /// The second call edge a repository with a language server carries for
+    /// every resolved call: it says the call exists and nothing about the
+    /// syntax, because an LSP call hierarchy cannot see a `raise`.
+    fn lsp_call(src: EntityId, dst: EntityId) -> Relation {
+        let mut relation = call(src, dst);
+        relation.origin = RelationOrigin::Lsp;
+        relation.evidence = vec![RelationEvidence {
+            parser_rule: Some("lsp_call_hierarchy".to_string()),
+            ..RelationEvidence::default()
+        }];
+        relation
+    }
+
     fn exception_class(name: &str, file: &str) -> Entity {
         let mut entity = make_entity(name, file);
         entity.kind = EntityKind::Class;
@@ -3928,6 +3949,59 @@ mod boundary_and_ranking_tests {
             "one slot, and it belongs to the hop the value travels along; a \
              mention of the exception class is not a reason to promote a throw \
              site. Got {names:?}"
+        );
+    }
+
+    /// FIR-2642, and the reason this whole signal was dead on real bytes. Every
+    /// resolved call on a repository with a language server reaches the graph
+    /// twice, once from the parser and once from the LSP call hierarchy, and
+    /// only the parser can see a `raise`. Letting the LSP edge vote made "every
+    /// call edge is a raise" false for every candidate, so the demotion never
+    /// once fired on the corpus it was written from and inverting the ranking
+    /// changed nothing.
+    ///
+    /// Measured on a converted `psf/requests`: `SSLError` arrived on
+    /// `[Inferred, raise_target_call]` and `[Lsp, lsp_call_hierarchy]`, one of
+    /// two, so the rule read false.
+    #[test]
+    fn a_language_server_edge_does_not_get_a_vote_on_what_a_raise_is() {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("Adapter.send", "pkg/adapters.py");
+        let ssl_error = exception_class("SSLError", "pkg/adapters.py");
+        let pool_key = make_entity("build_pool_key", "pkg/pool.py");
+        for entity in [&focal, &ssl_error, &pool_key] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        for relation in [
+            raise_call(focal.id, ssl_error.id),
+            lsp_call(focal.id, ssl_error.id),
+            call(focal.id, pool_key.id),
+            lsp_call(focal.id, pool_key.id),
+        ] {
+            graph.upsert_relation(&relation).unwrap();
+        }
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding),
+            &graph,
+            &TraceDataFlowRequest {
+                focal: focal.id.to_string(),
+                depth: Some(2),
+                direction: Some(TraceDirection::Calls),
+                limit_per_step: Some(1),
+                include_body: Some(false),
+                max_response_chars: None,
+                include_type_edges: None,
+            },
+        )
+        .unwrap();
+
+        let names = step_names(&response);
+        assert_eq!(
+            names.first().map(String::as_str),
+            Some("build_pool_key"),
+            "the one slot belongs to the hop the value travels along; an LSP              edge that cannot see a `raise` must not vote the throw site back              onto the data path. Got {names:?}"
         );
     }
 

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -933,13 +933,14 @@ pub fn build_trace_data_flow_response_within(
                             candidate.confidence = rel.confidence;
                             candidate.resolution = RelationResolution::of(rel);
                         }
-                        // These two fold across EVERY edge rather than moving
-                        // with the strongest one. A class reached by a `raise`
-                        // and also by an ordinary call is on the data path, and
-                        // a boundary one edge can name stays named when a
-                        // weaker anonymous edge arrives beside it.
-                        candidate.raise_target =
-                            candidate.raise_target && kin_index::is_raise_target_edge(rel);
+                        // These two accumulate across EVERY edge rather than
+                        // moving with the strongest one. A class reached by a
+                        // `raise` and also by an ordinary call is on the data
+                        // path, and a boundary one edge can name stays named
+                        // when a weaker anonymous edge arrives beside it.
+                        candidate.call_edges += usize::from(rel.kind == RelationKind::Calls);
+                        candidate.raise_call_edges +=
+                            usize::from(kin_index::is_raise_target_edge(rel));
                         if candidate
                             .crossing
                             .as_ref()
@@ -963,7 +964,8 @@ pub fn build_trace_data_flow_response_within(
                         candidate_index.insert((next_id, role), candidates.len());
                         let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
                         candidates.push(FanoutCandidate {
-                            raise_target: kin_index::is_raise_target_edge(rel),
+                            call_edges: usize::from(rel.kind == RelationKind::Calls),
+                            raise_call_edges: usize::from(kin_index::is_raise_target_edge(rel)),
                             entity,
                             role,
                             relation_kind: rel.kind,
@@ -1423,11 +1425,28 @@ struct FanoutCandidate {
     /// Read off the edge that reached it, because the edge is where the module
     /// pin and the receiver text live; the entity carries only identity.
     crossing: Option<kin_index::TraceCrossing>,
-    /// Every edge into this candidate was the operand of a `raise`, so it is a
-    /// throw site rather than a hop a value travels along. False as soon as one
-    /// ordinary call reaches it: a class that is both raised and constructed is
-    /// on the data path.
-    raise_target: bool,
+    /// Call edges into this candidate, and how many of them were the operand of
+    /// a `raise`. A candidate is a throw site when it has call edges and every
+    /// one of them is a raise: a class that is also constructed normally is on
+    /// the data path and must not be demoted.
+    ///
+    /// Counted rather than folded into a bool, because a bool was order-
+    /// dependent and measurably wrong. Folding with `&&` meant whichever edge
+    /// happened to create the candidate set the starting value, so one
+    /// reference edge arriving first left the flag false for the whole
+    /// candidate. On a converted `psf/requests` that was every exception class
+    /// in `HTTPAdapter.send`'s fan-out, so the demotion this field exists for
+    /// never once fired on the corpus it was written from, and a check that
+    /// inverted the ordering could not tell the difference.
+    call_edges: usize,
+    raise_call_edges: usize,
+}
+
+impl FanoutCandidate {
+    /// Whether this candidate is only ever thrown, never called for its value.
+    fn is_raise_target(&self) -> bool {
+        self.call_edges > 0 && self.raise_call_edges == self.call_edges
+    }
 }
 
 /// Order one side of a node's fan-out by relevance, most relevant first.
@@ -1443,7 +1462,7 @@ fn sort_by_relevance(candidates: &mut [FanoutCandidate], node: &FrontierNode) {
             node.file.as_deref(),
             node.dir.as_deref(),
             left.confidence,
-            left.raise_target,
+            left.is_raise_target(),
         );
         let right_score = kin_ranking::entity_ranking::trace_fanout_score(
             &right.entity,
@@ -1451,7 +1470,7 @@ fn sort_by_relevance(candidates: &mut [FanoutCandidate], node: &FrontierNode) {
             node.file.as_deref(),
             node.dir.as_deref(),
             right.confidence,
-            right.raise_target,
+            right.is_raise_target(),
         );
         right_score
             .cmp(&left_score)
@@ -3845,6 +3864,117 @@ mod boundary_and_ranking_tests {
             Some("build_pool_key"),
             "and the data-flow hop leads, so a reader who stops at the first \
              row stops on the one that carries the value. Got {names:?}"
+        );
+    }
+
+    /// A relation that is a mention rather than a call, which is what a real
+    /// store carries beside a call edge and what a hand-built fixture had never
+    /// had.
+    fn reference(src: EntityId, dst: EntityId) -> Relation {
+        let mut relation = call(src, dst);
+        relation.kind = RelationKind::References;
+        relation
+    }
+
+    /// FIR-2642. A reference edge beside the raise must not undo the demotion.
+    ///
+    /// This is the defect a hand-built fixture could not see. The flag was
+    /// folded with `&&` across every edge, so whichever edge happened to create
+    /// the candidate set its starting value and one non-call edge arriving
+    /// first left it false forever. On a converted `psf/requests` that was
+    /// every exception class in `HTTPAdapter.send`'s fan-out: the demotion
+    /// never fired on the corpus it was written from, and inverting the whole
+    /// ranking signal changed the answer not at all, which is the definition of
+    /// a check that cannot fail.
+    #[test]
+    fn a_reference_edge_beside_the_raise_does_not_promote_a_throw_site() {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("Adapter.send", "pkg/adapters.py");
+        let ssl_error = exception_class("SSLError", "pkg/adapters.py");
+        let pool_key = make_entity("build_pool_key", "pkg/pool.py");
+        for entity in [&focal, &ssl_error, &pool_key] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        // The reference edge is upserted FIRST, which is the order that made
+        // the fold answer wrong.
+        for relation in [
+            reference(focal.id, ssl_error.id),
+            raise_call(focal.id, ssl_error.id),
+            call(focal.id, pool_key.id),
+        ] {
+            graph.upsert_relation(&relation).unwrap();
+        }
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding),
+            &graph,
+            &TraceDataFlowRequest {
+                focal: focal.id.to_string(),
+                depth: Some(2),
+                direction: Some(TraceDirection::Calls),
+                limit_per_step: Some(1),
+                include_body: Some(false),
+                max_response_chars: None,
+                include_type_edges: None,
+            },
+        )
+        .unwrap();
+
+        let names = step_names(&response);
+        assert_eq!(
+            names.first().map(String::as_str),
+            Some("build_pool_key"),
+            "one slot, and it belongs to the hop the value travels along; a \
+             mention of the exception class is not a reason to promote a throw \
+             site. Got {names:?}"
+        );
+    }
+
+    /// The other direction, so the rule is about calls and not about counting
+    /// edges. A class the focal both raises AND constructs normally is on the
+    /// data path, and demoting it would cost the recall the marker exists to
+    /// protect.
+    #[test]
+    fn a_class_that_is_also_constructed_normally_is_not_a_throw_site() {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("Adapter.send", "pkg/adapters.py");
+        let both = exception_class("Retry", "pkg/adapters.py");
+        let elsewhere = make_entity("build_pool_key", "pkg/pool.py");
+        for entity in [&focal, &both, &elsewhere] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        for relation in [
+            raise_call(focal.id, both.id),
+            call(focal.id, both.id),
+            call(focal.id, elsewhere.id),
+        ] {
+            graph.upsert_relation(&relation).unwrap();
+        }
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding),
+            &graph,
+            &TraceDataFlowRequest {
+                focal: focal.id.to_string(),
+                depth: Some(2),
+                direction: Some(TraceDirection::Calls),
+                limit_per_step: Some(1),
+                include_body: Some(false),
+                max_response_chars: None,
+                include_type_edges: None,
+            },
+        )
+        .unwrap();
+
+        let names = step_names(&response);
+        assert_eq!(
+            names.first().map(String::as_str),
+            Some("Retry"),
+            "same file beats another directory once the throw-site demotion no \
+             longer applies, and it must not apply to a class that is also \
+             called for its value. Got {names:?}"
         );
     }
 

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -1695,7 +1695,7 @@ mod tests {
     use kin_model::relation::{Relation, RelationOrigin};
     use std::sync::Arc;
 
-    fn make_entity(name: &str, file: &str) -> Entity {
+    pub(super) fn make_entity(name: &str, file: &str) -> Entity {
         Entity {
             id: EntityId::new(),
             kind: EntityKind::Function,
@@ -1735,7 +1735,7 @@ mod tests {
 
     /// The shape a symbol the graph owns no file for actually has: identity, no
     /// location, no span, and (in the measured repository) `Module` kind.
-    fn make_external_entity(name: &str) -> Entity {
+    pub(super) fn make_external_entity(name: &str) -> Entity {
         let mut entity = make_entity(name, "unused");
         entity.kind = EntityKind::Module;
         entity.file_origin = None;
@@ -1760,7 +1760,7 @@ mod tests {
         }
     }
 
-    fn step_names(response: &TraceDataFlowResponse) -> Vec<String> {
+    pub(super) fn step_names(response: &TraceDataFlowResponse) -> Vec<String> {
         response
             .chain
             .iter()
@@ -1784,7 +1784,8 @@ mod tests {
 
     /// Synthesize an absent repository authority. The body itself isn't
     /// required for the chain-shape tests; we only assert on identity fields.
-    fn empty_binding() -> (tempfile::TempDir, kin_core::LocalRepositoryAuthorityBinding) {
+    pub(super) fn empty_binding() -> (tempfile::TempDir, kin_core::LocalRepositoryAuthorityBinding)
+    {
         let temp = tempfile::tempdir().unwrap();
         let kin_root = temp.path().join(".kin");
         std::fs::create_dir_all(kin_root.join("objects")).unwrap();
@@ -3404,5 +3405,299 @@ mod tests {
             "its one neighbor is the focal, which the response already carries"
         );
         assert!(!response.truncated);
+    }
+}
+
+#[cfg(test)]
+mod boundary_and_ranking_tests {
+    //! FIR-2642, from the rc0550 brown stranger run. Two halves of one
+    //! contract: Kin must say where the in-repo graph ends and name the
+    //! crossing.
+    //!
+    //! Half one. `trace_data_flow(HTTPAdapter.send, direction=calls, depth=3,
+    //! limit_per_step=12)` spent nine of its twelve depth-1 slots on exception
+    //! classes, which are `raise` targets in `except` blocks and not data flow
+    //! at all. They crowded out the hop that governs connection reuse, and the
+    //! stranger's verdict was that the Kin arm trusted alone writes a wrong
+    //! answer. The edge was in the graph; the failure is ranking.
+    //!
+    //! Half two. `router.handle` is an external node connected to nothing. The
+    //! graph knows a boundary exists and says nothing about the other side, so
+    //! a reader cannot tell an npm package from a builtin from a typo.
+
+    use super::tests::{empty_binding, make_entity, make_external_entity, step_names};
+    use super::*;
+    use kin_db::InMemoryGraph;
+    use kin_model::relation::{Relation, RelationEvidence, RelationOrigin};
+    use kin_model::{EntityKind, GraphNodeId, RelationId, RelationKind};
+
+    /// An ordinary call: the kind of edge a data-flow walk is following.
+    fn call(src: EntityId, dst: EntityId) -> Relation {
+        Relation {
+            id: RelationId::new(),
+            kind: RelationKind::Calls,
+            src: GraphNodeId::Entity(src),
+            dst: GraphNodeId::Entity(dst),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![],
+        }
+    }
+
+    /// A call the parser read as the operand of a `raise`, which is a throw
+    /// site rather than a hop the value travels along.
+    fn raise_call(src: EntityId, dst: EntityId) -> Relation {
+        let mut relation = call(src, dst);
+        relation.evidence = vec![RelationEvidence {
+            parser_rule: Some(kin_index::RAISE_TARGET_CALL_RULE.to_string()),
+            ..RelationEvidence::default()
+        }];
+        relation
+    }
+
+    fn exception_class(name: &str, file: &str) -> Entity {
+        let mut entity = make_entity(name, file);
+        entity.kind = EntityKind::Class;
+        entity
+    }
+
+    /// The measured shape, reduced to the one comparison that decides it: a
+    /// raise target sitting in the SAME FILE as the focal, against a
+    /// data-flow callee one file away.
+    ///
+    /// Same-file locality outranks declaration kind in the fan-out order, so
+    /// without a raise-target signal the two exception constructors take both
+    /// slots and the hop the question is about is dropped. This is the requests
+    /// shape with the file boundary moved so the fixture needs no store.
+    fn raise_crowding_graph() -> (InMemoryGraph, EntityId) {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("Adapter.send", "pkg/adapters.py");
+        let ssl_error = exception_class("SSLError", "pkg/adapters.py");
+        let proxy_error = exception_class("ProxyError", "pkg/adapters.py");
+        let pool_key = make_entity("build_pool_key", "pkg/pool.py");
+
+        for entity in [&focal, &ssl_error, &proxy_error, &pool_key] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        for relation in [
+            raise_call(focal.id, ssl_error.id),
+            raise_call(focal.id, proxy_error.id),
+            call(focal.id, pool_key.id),
+        ] {
+            graph.upsert_relation(&relation).unwrap();
+        }
+        (graph, focal.id)
+    }
+
+    #[test]
+    fn a_raise_target_does_not_take_a_slot_from_a_data_flow_hop() {
+        let (graph, focal) = raise_crowding_graph();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding),
+            &graph,
+            &TraceDataFlowRequest {
+                focal: focal.to_string(),
+                depth: Some(2),
+                direction: Some(TraceDirection::Calls),
+                limit_per_step: Some(2),
+                include_body: Some(false),
+                max_response_chars: None,
+                include_type_edges: None,
+            },
+        )
+        .unwrap();
+
+        let names = step_names(&response);
+        assert!(
+            names.iter().any(|n| n == "build_pool_key"),
+            "a `raise` target is a throw site, not a hop the value travels \
+             along, so it must not spend a scarce fan-out slot on one: the \
+             stranger lost the connection-reuse path exactly this way and \
+             would have written a wrong answer from it. Got {names:?}"
+        );
+    }
+
+    #[test]
+    fn a_raise_target_is_still_reported_when_the_budget_allows_it() {
+        // The recall half. Demoting a raise target orders it last; it must
+        // never drop it, because "what does this throw" is a real question and
+        // the edge is real evidence.
+        let (graph, focal) = raise_crowding_graph();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding),
+            &graph,
+            &TraceDataFlowRequest {
+                focal: focal.to_string(),
+                depth: Some(2),
+                direction: Some(TraceDirection::Calls),
+                limit_per_step: Some(8),
+                include_body: Some(false),
+                max_response_chars: None,
+                include_type_edges: None,
+            },
+        )
+        .unwrap();
+
+        let names = step_names(&response);
+        for expected in ["build_pool_key", "SSLError", "ProxyError"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "a wide enough step reports every callee including the throw \
+                 sites; ranking may reorder and must not remove. Missing \
+                 {expected} from {names:?}"
+            );
+        }
+        assert_eq!(
+            names.first().map(String::as_str),
+            Some("build_pool_key"),
+            "and the data-flow hop leads, so a reader who stops at the first \
+             row stops on the one that carries the value. Got {names:?}"
+        );
+    }
+
+    #[test]
+    fn an_external_step_names_the_module_it_crosses_into() {
+        // Half two. `router.handle` reached through `require('router')` must
+        // say `router`, so a reader can tell an npm package from a builtin
+        // from a typo without leaving the tool.
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("app.handle", "lib/application.js");
+        let external = make_external_entity("router.handle");
+        graph.upsert_entity(&focal).unwrap();
+        graph.upsert_entity(&external).unwrap();
+        let mut relation = call(focal.id, external.id);
+        relation.import_source = Some("router".to_string());
+        graph.upsert_relation(&relation).unwrap();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding),
+            &graph,
+            &TraceDataFlowRequest {
+                focal: focal.id.to_string(),
+                depth: Some(1),
+                direction: Some(TraceDirection::Calls),
+                limit_per_step: Some(8),
+                include_body: Some(false),
+                max_response_chars: None,
+                include_type_edges: None,
+            },
+        )
+        .unwrap();
+
+        let step = response
+            .chain
+            .iter()
+            .find(|s| s.entity.entity_name == "router.handle")
+            .expect("the external step is in the chain");
+        assert!(step.entity.external, "the fixture's premise");
+        let crossing = step
+            .entity
+            .crossing
+            .as_ref()
+            .expect("an external record must carry a crossing, known or not");
+        assert_eq!(
+            crossing.specifier.as_deref(),
+            Some("router"),
+            "the graph holds the specifier the importing file named, so the \
+             answer must say it rather than emit a bare external symbol"
+        );
+    }
+
+    #[test]
+    fn an_external_step_the_graph_cannot_place_says_so_rather_than_going_quiet() {
+        // The disclosure half, and the one that matters more. With import
+        // edges absent the graph genuinely does not know what is on the other
+        // side. Saying nothing reads as an in-repo symbol; saying "unknown"
+        // reads as a boundary, which is the truth.
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("app.handle", "lib/application.js");
+        let external = make_external_entity("router.handle");
+        graph.upsert_entity(&focal).unwrap();
+        graph.upsert_entity(&external).unwrap();
+        graph.upsert_relation(&call(focal.id, external.id)).unwrap();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding),
+            &graph,
+            &TraceDataFlowRequest {
+                focal: focal.id.to_string(),
+                depth: Some(1),
+                direction: Some(TraceDirection::Calls),
+                limit_per_step: Some(8),
+                include_body: Some(false),
+                max_response_chars: None,
+                include_type_edges: None,
+            },
+        )
+        .unwrap();
+
+        let step = response
+            .chain
+            .iter()
+            .find(|s| s.entity.entity_name == "router.handle")
+            .expect("the external step is in the chain");
+        let crossing = step
+            .entity
+            .crossing
+            .as_ref()
+            .expect("an external record carries a crossing even when unknown");
+        assert_eq!(
+            crossing.specifier, None,
+            "the graph holds no specifier here, so inventing one would be worse \
+             than the silence it replaces"
+        );
+        assert_eq!(
+            crossing.status, "unknown",
+            "and the record must say the boundary is unplaced rather than \
+             leave a bare symbol that reads like an in-repo entity"
+        );
+    }
+
+    #[test]
+    fn an_in_repo_step_carries_no_crossing_at_all() {
+        // The bound. A crossing on a step the repository owns would be a
+        // boundary that is not there, and every reader would learn to ignore
+        // the field.
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("app.handle", "lib/application.js");
+        let local = make_entity("app.route", "lib/application.js");
+        graph.upsert_entity(&focal).unwrap();
+        graph.upsert_entity(&local).unwrap();
+        graph.upsert_relation(&call(focal.id, local.id)).unwrap();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding),
+            &graph,
+            &TraceDataFlowRequest {
+                focal: focal.id.to_string(),
+                depth: Some(1),
+                direction: Some(TraceDirection::Calls),
+                limit_per_step: Some(8),
+                include_body: Some(false),
+                max_response_chars: None,
+                include_type_edges: None,
+            },
+        )
+        .unwrap();
+
+        let step = response
+            .chain
+            .iter()
+            .find(|s| s.entity.entity_name == "app.route")
+            .expect("the local step is in the chain");
+        assert!(!step.entity.external, "the fixture's premise");
+        assert!(
+            step.entity.crossing.is_none(),
+            "a step the repository owns crosses nothing"
+        );
     }
 }

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -22,7 +22,7 @@ use kin_ranking::entity_ranking::{
     trace_terminal_named, trace_walk_terminal, TraceExpansion, TraceTerminal,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use crate::commands::graph::{graph_source_record_from, GraphSourceRecord};
@@ -516,6 +516,17 @@ pub struct TraceDataFlowResponse {
     pub bodies_omitted: usize,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub steps_omitted: usize,
+    /// How many of `steps_omitted` went as whole branches the budget narrowed
+    /// away, rather than off the end of the chain. Zero — and omitted — when
+    /// the suffix fallback did the cutting or when nothing was cut at all.
+    ///
+    /// Worth its own count because the two losses are different answers. A
+    /// narrowed chain still reaches as deep as the walk did and lists fewer
+    /// neighbours per node; an amputated one is shallower than the walk was,
+    /// and a reader who cannot tell them apart cannot tell whether the far end
+    /// of the answer is missing.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub fanout_narrowed: usize,
     /// Every list the response budget cut, keyed by the field it cut, with what
     /// survived, what was withheld, and why.
     ///
@@ -1162,6 +1173,7 @@ pub fn build_trace_data_flow_response_within(
         clipped_steps,
         bodies_omitted: 0,
         steps_omitted: 0,
+        fanout_narrowed: 0,
         elisions: BTreeMap::new(),
         unproven_steps: 0,
         external_identities_merged,
@@ -1504,8 +1516,33 @@ fn measure_response(response: &TraceDataFlowResponse) -> usize {
 /// still answers "what does this reach"; a chain missing edges answers a
 /// different, smaller question, and a caller cannot tell which question was
 /// answered unless the cut says so. Bodies go first, then the focal's body, then
-/// steps from the tail — a suffix, because the chain is discovery-ordered, so
-/// removing the end never orphans a surviving step's parent.
+/// steps.
+///
+/// ## Why the step cut narrows before it amputates
+///
+/// A suffix cut is safe, because the chain is discovery-ordered and removing
+/// the end never orphans a surviving step's parent. It is also what produced a
+/// wrong answer. Discovery order is breadth-first, so the tail of the chain is
+/// its DEEPEST steps, and cutting a suffix spends the whole budget on the
+/// shallow fan-out and amputates the far end, which is where a trace stops
+/// being a list of neighbours and becomes an answer.
+///
+/// Measured on a converted `psf/requests` by the rc0550 stranger at the
+/// documented cheap settings (`depth: 3`, `limit_per_step: 12`,
+/// `include_body: false`): 67 of 117 steps went, and the survivors did not
+/// include `_urllib3_request_context`, one hop past
+/// `build_connection_pool_key_attributes`, which is the function that folds
+/// `verify` into the urllib3 pool key. Read alone the answer said `verify`
+/// reaches TLS at `cert_verify` and stopped, missing the half that governs
+/// connection reuse. The stranger's words: "If I had trusted the Kin arm alone
+/// I would have written a wrong answer." The edge was in the graph the whole
+/// time.
+///
+/// So the cut now gives up whole branches, least relevant first, and only falls
+/// back to the suffix when nothing is left to narrow, so a pathological walk is
+/// still answered rather than refused. The rule itself is
+/// [`kin_mcp::budget::narrow_fanout_to_fit`], shared with the MCP arm so the
+/// two surfaces cannot drift.
 fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
     let ceiling = response.max_response_chars;
     if measure_response(response) <= ceiling {
@@ -1535,52 +1572,83 @@ fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
 
     let mut steps_omitted = 0usize;
     if measure_response(response) > target {
-        // Bisected rather than popped one step at a time: the same answer, in a
-        // handful of serializations instead of one per dropped step.
-        //
-        // The floor is one step, not zero. A walk that reached 200 steps and
-        // returns `"chain": []` is indistinguishable from a walk that reached
-        // none, and no counter elsewhere in the response outranks the empty
-        // array for a reader. One surviving step plus the elision beside it says
-        // both what was reached and what was withheld.
         let full = std::mem::take(&mut response.chain);
-        let floor = usize::from(!full.is_empty());
-        let mut kept = floor;
-        let mut low = floor;
-        let mut high = full.len();
-        while low <= high {
-            let mid = (low + high) / 2;
-            response.chain = full[..mid].to_vec();
-            response.total_steps = mid;
-            if measure_response(response) <= target {
-                kept = mid;
-                low = mid + 1;
-            } else if mid <= floor {
-                break;
-            } else {
-                high = mid - 1;
+        // Narrow first. Every candidate the shared rule offers is measured the
+        // way this response will be sent, so the arithmetic is the budget's own
+        // rather than an estimate of it.
+        let narrowed = kin_mcp::budget::narrow_fanout_to_fit(
+            &full,
+            &|step: &TraceStep| step.step as u64,
+            &|step: &TraceStep| Some(step.parent_step as u64),
+            &mut |kept: &[TraceStep]| {
+                response.chain = kept.to_vec();
+                response.total_steps = kept.len();
+                measure_response(response) <= target
+            },
+        );
+        let kept_chain = match narrowed {
+            Some(kept) => {
+                response.fanout_narrowed = full.len() - kept.len();
+                kept
             }
-        }
-        steps_omitted = full.len() - kept;
-        response.chain = full[..kept].to_vec();
-        response.total_steps = kept;
+            None => {
+                // Nothing narrow enough fits, so fall back to the suffix, which
+                // always terminates.
+                //
+                // Bisected rather than popped one step at a time: the same
+                // answer, in a handful of serializations instead of one per
+                // dropped step.
+                //
+                // The floor is one step, not zero. A walk that reached 200 steps
+                // and returns `"chain": []` is indistinguishable from a walk
+                // that reached none, and no counter elsewhere in the response
+                // outranks the empty array for a reader. One surviving step plus
+                // the elision beside it says both what was reached and what was
+                // withheld.
+                let floor = usize::from(!full.is_empty());
+                let mut kept = floor;
+                let mut low = floor;
+                let mut high = full.len();
+                while low <= high {
+                    let mid = (low + high) / 2;
+                    response.chain = full[..mid].to_vec();
+                    response.total_steps = mid;
+                    if measure_response(response) <= target {
+                        kept = mid;
+                        low = mid + 1;
+                    } else if mid <= floor {
+                        break;
+                    } else {
+                        high = mid - 1;
+                    }
+                }
+                full[..kept].to_vec()
+            }
+        };
+        steps_omitted = full.len() - kept_chain.len();
+        response.chain = kept_chain;
+        response.total_steps = response.chain.len();
         response.steps_omitted = steps_omitted;
         if steps_omitted > 0 {
             // The same loss in the shape every budgeted list reports it in, so a
             // caller reads one key whether the tool cut a chain or a bucket of
             // tests.
-            response
-                .elisions
-                .insert("chain".to_string(), Elision::budget(kept, steps_omitted));
+            response.elisions.insert(
+                "chain".to_string(),
+                Elision::budget(response.chain.len(), steps_omitted),
+            );
             // Dropped steps are edges the caller did not receive, which is what
             // this flag has always meant. Dropped bodies are not.
             response.truncated = true;
             // A clip recorded against a step that is no longer here would send a
-            // caller re-querying a node the response does not name.
-            let kept_steps = response.chain.len();
+            // caller re-querying a node the response does not name. Membership
+            // rather than `clip.step <= kept`: a narrowed chain is no longer a
+            // prefix, so a bound on the index would keep clips for steps that
+            // went and drop clips for steps that stayed.
+            let surviving: BTreeSet<usize> = response.chain.iter().map(|step| step.step).collect();
             response
                 .clipped_steps
-                .retain(|clip| clip.step <= kept_steps);
+                .retain(|clip| clip.step == 0 || surviving.contains(&clip.step));
         }
     }
 
@@ -1592,15 +1660,24 @@ fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
     } else {
         "bodies_omitted"
     };
+    // Named for HOW the steps went, because "from the end of the chain" and
+    // "as whole branches" leave a caller in different places: the first says
+    // the far end of the answer is missing, the second says every node lists
+    // fewer neighbours and the depth is intact.
+    let how = if response.fanout_narrowed > 0 {
+        "as whole branches, least relevant first"
+    } else {
+        "from the end of the chain"
+    };
     let cut = match (
         bodies_omitted + usize::from(focal_body_omitted),
         steps_omitted,
     ) {
         (bodies, 0) => format!("{bodies} inlined bodies were dropped"),
-        (0, steps) => format!("{steps} steps were dropped from the end of the chain"),
+        (0, steps) => format!("{steps} steps were dropped {how}"),
         (bodies, steps) => format!(
-            "{bodies} inlined bodies were dropped, and {steps} steps after that were dropped from \
-             the end of the chain"
+            "{bodies} inlined bodies were dropped, and {steps} steps after that were dropped \
+             {how}"
         ),
     };
     record_degradation(
@@ -2559,6 +2636,7 @@ mod tests {
             clipped_steps: Vec::new(),
             bodies_omitted: 0,
             steps_omitted: 0,
+            fanout_narrowed: 0,
             elisions: BTreeMap::new(),
             unproven_steps: 0,
             external_identities_merged: 0,
@@ -2658,6 +2736,210 @@ mod tests {
         assert!(
             serde_json::to_string_pretty(&response).unwrap().len() <= response.max_response_chars,
             "the payload must end up inside the budget it reports"
+        );
+    }
+
+    /// The measured shape, in miniature: a focal with a wide fan-out, one deep
+    /// branch hanging off its FIRST child, and steps numbered in discovery
+    /// order, which is breadth-first, so the deep steps are last.
+    ///
+    /// `psf/requests` gave `HTTPAdapter.send` twelve depth-1 children and put
+    /// `_urllib3_request_context` at depth 3, which is where the tail is.
+    fn wide_then_deep_response(
+        width: usize,
+        deep: usize,
+        pad_chars: usize,
+    ) -> TraceDataFlowResponse {
+        let mut response = fat_response(0, 0);
+        let mut chain: Vec<TraceStep> = Vec::new();
+        let push = |chain: &mut Vec<TraceStep>, name: String, parent: usize, depth: usize| {
+            let entity = make_entity(&name, "src/step.rs");
+            let mut record = entity_record(&entity, None, None);
+            record.signature = Some("s".repeat(pad_chars));
+            chain.push(TraceStep {
+                step: chain.len() + 1,
+                role: "callee".to_string(),
+                relation_kind: "Calls".to_string(),
+                resolution: RelationResolution::TypeResolved.as_str().to_string(),
+                parent_step: parent,
+                depth,
+                entity: record,
+                fanout_truncated: false,
+                fanout_dropped: 0,
+                terminal: None,
+            });
+        };
+        for index in 1..=width {
+            push(&mut chain, format!("neighbour_{index}"), 0, 1);
+        }
+        let mut parent = 1usize;
+        for level in 0..deep {
+            push(&mut chain, format!("deep_{level}"), parent, level + 2);
+            parent = chain.len();
+        }
+        response.bodies_included = false;
+        response.total_steps = chain.len();
+        response.chain = chain;
+        response
+    }
+
+    /// The smallest payload narrowing can produce for [`wide_then_deep_response`]:
+    /// the focal's first child and the deep branch below it, which is what
+    /// "every node keeps its first child" leaves behind.
+    ///
+    /// Computed rather than guessed, so these tests calibrate against the
+    /// serializer instead of against a number that drifts the first time a field
+    /// is added to a step.
+    fn narrowest_budget(width: usize, deep: usize, pad_chars: usize) -> usize {
+        let mut floor = wide_then_deep_response(width, deep, pad_chars);
+        let survivors: BTreeSet<usize> = std::iter::once(1)
+            .chain((width + 1)..=(width + deep))
+            .collect();
+        floor.chain.retain(|step| survivors.contains(&step.step));
+        floor.total_steps = floor.chain.len();
+        serde_json::to_string_pretty(&floor).map_or(usize::MAX, |json| json.len())
+            + TRACE_DISCLOSURE_RESERVE_CHARS
+    }
+
+    /// FIR-2642. The budget must give up the focal's least relevant neighbours
+    /// before it gives up the end of the chain, because the end of the chain is
+    /// the answer.
+    ///
+    /// Measured on a converted `psf/requests` at the stranger's own settings:
+    /// the suffix cut returned nothing past depth 2 while the walk had reached
+    /// depth 3, so the response said `verify` reaches TLS at `cert_verify` and
+    /// stopped, missing the pool-key path that governs connection reuse.
+    #[test]
+    fn the_budget_narrows_the_fan_out_before_it_amputates_the_chain() {
+        let mut response = wide_then_deep_response(12, 2, 900);
+        response.max_response_chars = narrowest_budget(12, 2, 900);
+        let deepest = response
+            .chain
+            .last()
+            .expect("the fixture has a deep end")
+            .entity
+            .entity_name
+            .clone();
+        assert!(
+            serde_json::to_string_pretty(&response).unwrap().len() > response.max_response_chars,
+            "the fixture must start over budget or this proves nothing"
+        );
+
+        enforce_response_budget(&mut response);
+
+        assert!(
+            step_names(&response).contains(&deepest),
+            "the budget amputated the deep end instead of narrowing the fan-out: {:?}",
+            step_names(&response)
+        );
+        assert!(
+            response.fanout_narrowed > 0,
+            "a narrowed cut must say it narrowed"
+        );
+        assert_eq!(
+            response.fanout_narrowed, response.steps_omitted,
+            "every step this cut dropped went as part of a branch"
+        );
+        // No survivor may name a parent the response no longer carries, which is
+        // the property a prefix cut got for free and this one has to earn.
+        let present: BTreeSet<usize> = response.chain.iter().map(|step| step.step).collect();
+        assert!(
+            response
+                .chain
+                .iter()
+                .all(|step| step.parent_step == 0 || present.contains(&step.parent_step)),
+            "a surviving step names a parent the cut removed: {present:?}"
+        );
+        let cut = response
+            .degradations
+            .iter()
+            .find(|d| d.component == "response_budget")
+            .expect("the cut must be disclosed");
+        assert!(
+            cut.detail.contains("as whole branches"),
+            "the disclosure must say which cut a caller received: {}",
+            cut.detail
+        );
+        assert!(
+            serde_json::to_string_pretty(&response).unwrap().len() <= response.max_response_chars,
+            "the payload must end up inside the budget it reports"
+        );
+    }
+
+    /// The other direction, so the disclosure cannot be a constant. A chain with
+    /// no node wider than one child has no branch to give up, so the suffix cut
+    /// runs, `fanout_narrowed` stays zero, and the wording says end-of-chain.
+    #[test]
+    fn a_chain_with_nothing_to_narrow_still_takes_the_suffix_cut_and_says_so() {
+        let mut response = fat_response(200, 0);
+        response.bodies_included = false;
+        for step in &mut response.chain {
+            step.entity.body = None;
+            step.entity.span_coherence = None;
+            step.entity.signature = Some("s".repeat(400));
+        }
+        response.max_response_chars = 8_000;
+
+        enforce_response_budget(&mut response);
+
+        assert!(response.steps_omitted > 0, "the fixture must reach the cut");
+        assert_eq!(
+            response.fanout_narrowed, 0,
+            "a spine has no branch to give up, so nothing may claim it narrowed one"
+        );
+        let cut = response
+            .degradations
+            .iter()
+            .find(|d| d.component == "response_budget")
+            .expect("the cut must be disclosed");
+        assert!(
+            cut.detail.contains("from the end of the chain"),
+            "the suffix cut must still say so: {}",
+            cut.detail
+        );
+    }
+
+    /// A clip is a pointer into `chain`, and a narrowed chain is no longer a
+    /// prefix, so keeping clips by index would keep pointers to steps that went
+    /// and drop pointers to steps that stayed.
+    #[test]
+    fn a_narrowed_chain_keeps_exactly_the_clips_whose_steps_survived() {
+        let mut response = wide_then_deep_response(12, 2, 900);
+        for step in [1usize, 12, 14] {
+            response.clipped_steps.push(TraceFanoutClip {
+                step,
+                entity_id: format!("clip-{step}"),
+                entity_name: format!("step_{step}"),
+                dropped_callees: 3,
+                dropped_callers: 0,
+                limit_per_step: 12,
+            });
+        }
+        // Calibrated on THIS response, clips included, because the clips are
+        // part of what the budget measures.
+        let mut floor = response.clone();
+        floor.chain.retain(|step| [1, 13, 14].contains(&step.step));
+        floor.total_steps = floor.chain.len();
+        response.max_response_chars =
+            serde_json::to_string_pretty(&floor).unwrap().len() + TRACE_DISCLOSURE_RESERVE_CHARS;
+
+        enforce_response_budget(&mut response);
+
+        let present: BTreeSet<usize> = response.chain.iter().map(|step| step.step).collect();
+        assert!(
+            present.contains(&1) && present.contains(&14),
+            "the fixture must keep the first neighbour and the deep end: {present:?}"
+        );
+        assert!(
+            !present.contains(&12),
+            "the fixture must drop the last neighbour or the clip test proves nothing: \
+             {present:?}"
+        );
+        let clipped: BTreeSet<usize> = response.clipped_steps.iter().map(|c| c.step).collect();
+        assert_eq!(
+            clipped,
+            BTreeSet::from([1, 14]),
+            "a clip must name a step the response still carries, and must not lose one it does"
         );
     }
 

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -378,9 +378,14 @@ pub struct TraceEntityRecord {
     /// Null whenever no body was served, since the pairing is what it describes.
     pub span_coherence: Option<String>,
     /// Where the in-repo graph ends, for a step sitting on the boundary.
-    /// Present on exactly the records `external` is true for; a step the
-    /// repository owns crosses nothing and carries none.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Non-null on exactly the records `external` is true for; a step the
+    /// repository owns crosses nothing and carries an explicit null.
+    ///
+    /// Always serialized, never skipped: this array's keys are uniform by
+    /// contract, and a sometimes-absent key is the shape that broke a
+    /// consumer's parser twice. `every_step_carries_the_same_keys_admitted_or_external`
+    /// caught this field trying to become the third time.
+    #[serde(default)]
     pub crossing: Option<kin_index::TraceCrossing>,
 }
 

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -3790,32 +3790,45 @@ mod boundary_and_ranking_tests {
         entity
     }
 
-    /// The measured shape, reduced to the one comparison that decides it: a
-    /// raise target sitting in the SAME FILE as the focal, against a
-    /// data-flow callee one file away.
+    /// The measured shape: everything in ONE file, as `psf/requests` has it,
+    /// where `HTTPAdapter.send` and the exceptions it throws share
+    /// `adapters.py` and locality decides nothing.
     ///
-    /// Same-file locality outranks declaration kind in the fan-out order, so
-    /// without a raise-target signal the two exception constructors take both
-    /// slots and the hop the question is about is dropped. This is the requests
-    /// shape with the file boundary moved so the fixture needs no store.
+    /// Three candidates, so both terms that matter are exercised. `pool_key` is
+    /// a Function and wins on declaration kind, which is what actually delivers
+    /// "data flow above throw sites" on real bytes. `Retryer` is a Class the
+    /// focal calls ordinarily, and it is the only candidate the raise marker
+    /// itself decides against: alike in every other term, so if the marker goes
+    /// inert, `SSLError` outranks it on name length alone.
     fn raise_crowding_graph() -> (InMemoryGraph, EntityId) {
         let graph = InMemoryGraph::new();
         let focal = make_entity("Adapter.send", "pkg/adapters.py");
         let ssl_error = exception_class("SSLError", "pkg/adapters.py");
         let proxy_error = exception_class("ProxyError", "pkg/adapters.py");
-        let pool_key = make_entity("build_pool_key", "pkg/pool.py");
+        let retryer = exception_class("Retryer", "pkg/adapters.py");
+        let pool_key = make_entity("build_pool_key", "pkg/adapters.py");
 
-        for entity in [&focal, &ssl_error, &proxy_error, &pool_key] {
+        for entity in [&focal, &ssl_error, &proxy_error, &retryer, &pool_key] {
             graph.upsert_entity(entity).unwrap();
         }
         for relation in [
             raise_call(focal.id, ssl_error.id),
             raise_call(focal.id, proxy_error.id),
+            call(focal.id, retryer.id),
             call(focal.id, pool_key.id),
         ] {
             graph.upsert_relation(&relation).unwrap();
         }
         (graph, focal.id)
+    }
+
+    /// Where each name landed in the fan-out, so a test can assert an ORDER
+    /// rather than only a membership.
+    fn rank_of(names: &[String], wanted: &str) -> usize {
+        names
+            .iter()
+            .position(|name| name == wanted)
+            .unwrap_or_else(|| panic!("{wanted} is not in the walk: {names:?}"))
     }
 
     #[test]
@@ -3839,12 +3852,12 @@ mod boundary_and_ranking_tests {
         .unwrap();
 
         let names = step_names(&response);
-        assert!(
-            names.iter().any(|n| n == "build_pool_key"),
-            "a `raise` target is a throw site, not a hop the value travels \
-             along, so it must not spend a scarce fan-out slot on one: the \
-             stranger lost the connection-reuse path exactly this way and \
-             would have written a wrong answer from it. Got {names:?}"
+        assert_eq!(
+            names,
+            vec!["build_pool_key".to_string(), "Retryer".to_string()],
+            "two slots go to the hop the value travels through and to the \
+             class the focal actually constructs; a throw site takes neither. \
+             Got {names:?}"
         );
     }
 
@@ -3872,7 +3885,7 @@ mod boundary_and_ranking_tests {
         .unwrap();
 
         let names = step_names(&response);
-        for expected in ["build_pool_key", "SSLError", "ProxyError"] {
+        for expected in ["build_pool_key", "Retryer", "SSLError", "ProxyError"] {
             assert!(
                 names.iter().any(|n| n == expected),
                 "a wide enough step reports every callee including the throw \
@@ -3880,6 +3893,11 @@ mod boundary_and_ranking_tests {
                  {expected} from {names:?}"
             );
         }
+        assert!(
+            rank_of(&names, "Retryer") < rank_of(&names, "SSLError"),
+            "and the throw sites sit below the class the focal constructs, \
+             which is the one comparison the raise marker decides. Got {names:?}"
+        );
         assert_eq!(
             names.first().map(String::as_str),
             Some("build_pool_key"),
@@ -3912,8 +3930,8 @@ mod boundary_and_ranking_tests {
         let graph = InMemoryGraph::new();
         let focal = make_entity("Adapter.send", "pkg/adapters.py");
         let ssl_error = exception_class("SSLError", "pkg/adapters.py");
-        let pool_key = make_entity("build_pool_key", "pkg/pool.py");
-        for entity in [&focal, &ssl_error, &pool_key] {
+        let retryer = exception_class("Retryer", "pkg/adapters.py");
+        for entity in [&focal, &ssl_error, &retryer] {
             graph.upsert_entity(entity).unwrap();
         }
         // The reference edge is upserted FIRST, which is the order that made
@@ -3921,7 +3939,7 @@ mod boundary_and_ranking_tests {
         for relation in [
             reference(focal.id, ssl_error.id),
             raise_call(focal.id, ssl_error.id),
-            call(focal.id, pool_key.id),
+            call(focal.id, retryer.id),
         ] {
             graph.upsert_relation(&relation).unwrap();
         }
@@ -3945,10 +3963,10 @@ mod boundary_and_ranking_tests {
         let names = step_names(&response);
         assert_eq!(
             names.first().map(String::as_str),
-            Some("build_pool_key"),
-            "one slot, and it belongs to the hop the value travels along; a \
-             mention of the exception class is not a reason to promote a throw \
-             site. Got {names:?}"
+            Some("Retryer"),
+            "one slot, and it belongs to the class the focal constructs rather than the one it \
+             throws; a mention of the exception class is not a reason to promote a throw site. \
+             Got {names:?}"
         );
     }
 
@@ -3968,15 +3986,15 @@ mod boundary_and_ranking_tests {
         let graph = InMemoryGraph::new();
         let focal = make_entity("Adapter.send", "pkg/adapters.py");
         let ssl_error = exception_class("SSLError", "pkg/adapters.py");
-        let pool_key = make_entity("build_pool_key", "pkg/pool.py");
-        for entity in [&focal, &ssl_error, &pool_key] {
+        let retryer = exception_class("Retryer", "pkg/adapters.py");
+        for entity in [&focal, &ssl_error, &retryer] {
             graph.upsert_entity(entity).unwrap();
         }
         for relation in [
             raise_call(focal.id, ssl_error.id),
             lsp_call(focal.id, ssl_error.id),
-            call(focal.id, pool_key.id),
-            lsp_call(focal.id, pool_key.id),
+            call(focal.id, retryer.id),
+            lsp_call(focal.id, retryer.id),
         ] {
             graph.upsert_relation(&relation).unwrap();
         }
@@ -4000,8 +4018,9 @@ mod boundary_and_ranking_tests {
         let names = step_names(&response);
         assert_eq!(
             names.first().map(String::as_str),
-            Some("build_pool_key"),
-            "the one slot belongs to the hop the value travels along; an LSP              edge that cannot see a `raise` must not vote the throw site back              onto the data path. Got {names:?}"
+            Some("Retryer"),
+            "the one slot belongs to the class the focal constructs; an LSP edge that cannot see \
+             a `raise` must not vote the throw site back level with it. Got {names:?}"
         );
     }
 

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -377,6 +377,11 @@ pub struct TraceEntityRecord {
     /// Whether the span that cut `body` was proven to describe those exact bytes.
     /// Null whenever no body was served, since the pairing is what it describes.
     pub span_coherence: Option<String>,
+    /// Where the in-repo graph ends, for a step sitting on the boundary.
+    /// Present on exactly the records `external` is true for; a step the
+    /// repository owns crosses nothing and carries none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crossing: Option<kin_index::TraceCrossing>,
 }
 
 /// One step in the data-flow chain.
@@ -749,7 +754,7 @@ pub fn build_trace_data_flow_response_within(
     let focal_record = bodies_included
         .then(|| source_record_or_none(projection.as_ref(), &focal_entity))
         .flatten();
-    let focal_entity_record = entity_record(&focal_entity, focal_record.as_ref());
+    let focal_entity_record = entity_record(&focal_entity, focal_record.as_ref(), None);
 
     // The kinds a data-flow claim actually rests on.
     let reference_kinds = [
@@ -912,6 +917,25 @@ pub fn build_trace_data_flow_response_within(
                             candidate.confidence = rel.confidence;
                             candidate.resolution = RelationResolution::of(rel);
                         }
+                        // These two fold across EVERY edge rather than moving
+                        // with the strongest one. A class reached by a `raise`
+                        // and also by an ordinary call is on the data path, and
+                        // a boundary one edge can name stays named when a
+                        // weaker anonymous edge arrives beside it.
+                        candidate.raise_target =
+                            candidate.raise_target && kin_index::is_raise_target_edge(rel);
+                        if candidate
+                            .crossing
+                            .as_ref()
+                            .is_none_or(|crossing| crossing.specifier.is_none())
+                        {
+                            if let Some(named) =
+                                kin_index::trace_crossing_for(&candidate.entity, Some(rel))
+                                    .filter(|crossing| crossing.specifier.is_some())
+                            {
+                                candidate.crossing = Some(named);
+                            }
+                        }
                     }
                     None => {
                         let Some(entity) = graph
@@ -921,12 +945,15 @@ pub fn build_trace_data_flow_response_within(
                             continue;
                         };
                         candidate_index.insert((next_id, role), candidates.len());
+                        let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
                         candidates.push(FanoutCandidate {
+                            raise_target: kin_index::is_raise_target_edge(rel),
                             entity,
                             role,
                             relation_kind: rel.kind,
                             confidence: rel.confidence,
                             resolution: RelationResolution::of(rel),
+                            crossing,
                         });
                     }
                 }
@@ -1009,7 +1036,11 @@ pub fn build_trace_data_flow_response_within(
                             .then(|| source_record_or_none(projection.as_ref(), &candidate.entity))
                             .flatten();
                         let promoted = &mut chain[existing - 1];
-                        promoted.entity = entity_record(&candidate.entity, source.as_ref());
+                        promoted.entity = entity_record(
+                            &candidate.entity,
+                            source.as_ref(),
+                            candidate.crossing.clone(),
+                        );
                         // A promoted record is located by construction, so the
                         // external boundary no longer applies to it; the edge
                         // that reached it is unchanged, so the annotation one
@@ -1070,7 +1101,11 @@ pub fn build_trace_data_flow_response_within(
                     resolution: candidate.resolution.as_str().to_string(),
                     parent_step: node.step,
                     depth: next_depth,
-                    entity: entity_record(&candidate.entity, source.as_ref()),
+                    entity: entity_record(
+                        &candidate.entity,
+                        source.as_ref(),
+                        candidate.crossing.clone(),
+                    ),
                     fanout_truncated: false,
                     fanout_dropped: 0,
                     terminal: terminal.map(|terminal| terminal.as_str().to_string()),
@@ -1367,6 +1402,15 @@ struct FanoutCandidate {
     /// the same neighbor replaces them, so the step reports what the edge it
     /// names actually proved.
     resolution: RelationResolution,
+    /// Where the in-repo graph ends, when this candidate sits on the boundary.
+    /// Read off the edge that reached it, because the edge is where the module
+    /// pin and the receiver text live; the entity carries only identity.
+    crossing: Option<kin_index::TraceCrossing>,
+    /// Every edge into this candidate was the operand of a `raise`, so it is a
+    /// throw site rather than a hop a value travels along. False as soon as one
+    /// ordinary call reaches it: a class that is both raised and constructed is
+    /// on the data path.
+    raise_target: bool,
 }
 
 /// Order one side of a node's fan-out by relevance, most relevant first.
@@ -1382,6 +1426,7 @@ fn sort_by_relevance(candidates: &mut [FanoutCandidate], node: &FrontierNode) {
             node.file.as_deref(),
             node.dir.as_deref(),
             left.confidence,
+            left.raise_target,
         );
         let right_score = kin_ranking::entity_ranking::trace_fanout_score(
             &right.entity,
@@ -1389,6 +1434,7 @@ fn sort_by_relevance(candidates: &mut [FanoutCandidate], node: &FrontierNode) {
             node.file.as_deref(),
             node.dir.as_deref(),
             right.confidence,
+            right.raise_target,
         );
         right_score
             .cmp(&left_score)
@@ -1403,7 +1449,11 @@ fn sort_by_relevance(candidates: &mut [FanoutCandidate], node: &FrontierNode) {
 /// entirely for a shape query). When it is absent the span still comes from the
 /// entity's own graph span, because a caller asking for the shape of a chain
 /// still needs to know where each step lives.
-fn entity_record(entity: &Entity, source: Option<&GraphSourceRecord>) -> TraceEntityRecord {
+fn entity_record(
+    entity: &Entity,
+    source: Option<&GraphSourceRecord>,
+    crossing: Option<kin_index::TraceCrossing>,
+) -> TraceEntityRecord {
     let (start_line, end_line) = match (source, entity.span.as_ref()) {
         (Some(record), _) => (Some(record.start_line), Some(record.end_line)),
         (None, Some(span)) => {
@@ -1424,6 +1474,7 @@ fn entity_record(entity: &Entity, source: Option<&GraphSourceRecord>) -> TraceEn
         signature: (!entity.signature.is_empty()).then(|| entity.signature.clone()),
         body: source.map(|record| record.body.clone()),
         span_coherence: source.map(|record| record.span_coherence.clone()),
+        crossing,
     }
 }
 
@@ -2468,7 +2519,7 @@ mod tests {
         let mut chain = Vec::new();
         for index in 1..=steps {
             let step_entity = make_entity(&format!("step_{index}"), "src/step.rs");
-            let mut record = entity_record(&step_entity, None);
+            let mut record = entity_record(&step_entity, None, None);
             record.body = Some("x".repeat(body_chars));
             record.span_coherence = Some("verified".to_string());
             chain.push(TraceStep {
@@ -2490,7 +2541,7 @@ mod tests {
             focal_name: entity.name.clone(),
             focal_kind: "Function".to_string(),
             focal_file: Some("src/focal.rs".to_string()),
-            focal_entity: entity_record(&entity, None),
+            focal_entity: entity_record(&entity, None, None),
             direction: "calls".to_string(),
             depth: 1,
             limit_per_step: 25,

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -63,9 +63,10 @@ pub use linker::{
     INCREMENTAL_LINKER_CHECKPOINT_VERSION, KIN_INDEX_CRATE_VERSION,
 };
 pub use linker::{
-    is_external_import_placeholder, is_unresolved_receiver_placeholder,
-    split_unresolved_receiver_token, unresolved_receiver_display_name,
-    EXTERNAL_IMPORT_REFERENCE_RULE, UNRESOLVED_RECEIVER_CALL_RULE,
+    is_external_import_placeholder, is_raise_target_edge, is_unresolved_receiver_placeholder,
+    split_unresolved_receiver_token, trace_crossing_for, unresolved_receiver_display_name,
+    TraceCrossing, EXTERNAL_IMPORT_REFERENCE_RULE, RAISE_TARGET_CALL_RULE,
+    UNRESOLVED_RECEIVER_CALL_RULE,
 };
 pub use overlay::{apply_file_removal, apply_to_graph, ApplyResult};
 pub use pipeline::{

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -63,10 +63,10 @@ pub use linker::{
     INCREMENTAL_LINKER_CHECKPOINT_VERSION, KIN_INDEX_CRATE_VERSION,
 };
 pub use linker::{
-    is_external_import_placeholder, is_raise_target_edge, is_unresolved_receiver_placeholder,
-    split_unresolved_receiver_token, trace_crossing_for, unresolved_receiver_display_name,
-    TraceCrossing, EXTERNAL_IMPORT_REFERENCE_RULE, RAISE_TARGET_CALL_RULE,
-    UNRESOLVED_RECEIVER_CALL_RULE,
+    is_external_import_placeholder, is_raise_classifiable_call_edge, is_raise_target_edge,
+    is_unresolved_receiver_placeholder, split_unresolved_receiver_token, trace_crossing_for,
+    unresolved_receiver_display_name, TraceCrossing, EXTERNAL_IMPORT_REFERENCE_RULE,
+    RAISE_TARGET_CALL_RULE, UNRESOLVED_RECEIVER_CALL_RULE,
 };
 pub use overlay::{apply_file_removal, apply_to_graph, ApplyResult};
 pub use pipeline::{

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -3912,6 +3912,112 @@ const UNRESOLVED_RECEIVER_KIND_TAG: &str = "UnresolvedReceiver";
 /// nothing this repository defines.
 pub const UNRESOLVED_RECEIVER_CALL_RULE: &str = "unresolved_receiver_call";
 
+/// Evidence marker for a call the parser read as the operand of a `raise`.
+///
+/// `raise SSLError(...)` in an `except` block is a call edge like any other and
+/// is genuinely evidence, but it is a throw site rather than a hop a value
+/// travels along. A trace walking data flow needs to tell the two apart: on a
+/// converted `psf/requests`, nine of the twelve depth-1 slots a stranger's
+/// trace returned were exception constructors, and they crowded out the hop
+/// that governs connection reuse. Carried as a `parser_rule` because that field
+/// is already persisted on relation evidence, so no schema in `kin-model` moves.
+pub const RAISE_TARGET_CALL_RULE: &str = "raise_target_call";
+
+/// What lies on the other side of a boundary step, or an explicit statement
+/// that the graph does not know.
+///
+/// An external record used to carry identity and nothing else, so `router.handle`
+/// arrived as a bare symbol with no way to tell an npm package from a Node
+/// builtin from a typo. The graph knows a boundary exists; when it also knows
+/// the specifier the importing file named, saying it costs nothing, and when it
+/// does not, saying THAT is the answer. Silence is the one option that reads
+/// like an in-repo entity.
+///
+/// Lives here rather than on either surface because `trace_data_flow` has two
+/// implementations, the CLI one the daemon route serves and the MCP one the
+/// in-process arm serves, and a boundary rule that differs by whether a daemon
+/// is up is the divergence class FIR-2507 was filed about.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceCrossing {
+    /// `named` when the graph holds the specifier, `unknown` when it holds only
+    /// the fact of the boundary.
+    pub status: String,
+    /// The module specifier the importing file named (`router`, `urllib3`),
+    /// when an edge into this symbol recorded one. Absent under `unknown`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub specifier: Option<String>,
+    /// The receiver the call was written through, when the edge recorded one
+    /// and no specifier is available. `this.router` says more than nothing
+    /// about where to look without claiming to name a package.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receiver: Option<String>,
+    /// Why the status reads the way it does, in a sentence a caller can act on.
+    pub note: String,
+}
+
+/// Whether this edge is a call the parser read as the operand of a `raise`.
+///
+/// Reads the marker the linker persisted on the edge's own evidence, so a
+/// language whose adapter does not record raise sites reports `false` and its
+/// traces rank exactly as they did.
+pub fn is_raise_target_edge(rel: &Relation) -> bool {
+    rel.kind == RelationKind::Calls
+        && rel
+            .evidence
+            .iter()
+            .any(|evidence| evidence.parser_rule.as_deref() == Some(RAISE_TARGET_CALL_RULE))
+}
+
+/// The crossing record for a step, built from the edge that reached it.
+///
+/// Reads only what the graph already persisted: `import_source`, set by the
+/// cross-repo tier when the parser pinned the module a symbol came from, and
+/// the unresolved-receiver evidence token, which carries the receiver as source
+/// spells it. Nothing is inferred from a name, so a symbol the graph cannot
+/// place reports `unknown` rather than a guess.
+pub fn trace_crossing_for(entity: &Entity, reached_by: Option<&Relation>) -> Option<TraceCrossing> {
+    if entity.file_origin.is_some() {
+        return None;
+    }
+    let specifier = reached_by
+        .and_then(|rel| rel.import_source.as_deref())
+        .map(str::trim)
+        .filter(|source| !source.is_empty())
+        .map(str::to_string);
+    if let Some(specifier) = specifier {
+        return Some(TraceCrossing {
+            note: format!(
+                "the importing file named `{specifier}`; the graph holds no entities for what that resolves to"
+            ),
+            status: "named".to_string(),
+            specifier: Some(specifier),
+            receiver: None,
+        });
+    }
+    let receiver = reached_by
+        .and_then(|rel| {
+            rel.evidence
+                .iter()
+                .find(|e| e.parser_rule.as_deref() == Some(UNRESOLVED_RECEIVER_CALL_RULE))
+        })
+        .and_then(|e| e.token.as_deref())
+        .and_then(|token| token.rsplit_once('.').map(|(receiver, _)| receiver))
+        .filter(|receiver| !receiver.is_empty())
+        .map(str::to_string);
+    let note = match receiver.as_deref() {
+        Some(receiver) => format!(
+            "the call was written through `{receiver}` and no edge records which module it comes from, so this symbol could be a package, a builtin or a typo"
+        ),
+        None => "no edge into this symbol records a module, so this symbol could be a package, a builtin or a typo".to_string(),
+    };
+    Some(TraceCrossing {
+        status: "unknown".to_string(),
+        specifier: None,
+        receiver,
+        note,
+    })
+}
+
 /// Returns whether a relation exactly matches the linker's external-import
 /// placeholder contract. This does not inspect graph membership; callers must
 /// separately establish that the destination is absent from the local entity

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -3821,25 +3821,35 @@ pub(crate) fn relation_evidence(
         return evidence;
     };
     let span = site.to_source_span(caller_file);
-    // The syntactic role the adapter classified, carried onto the persisted
-    // evidence so a consumer that never sees the parse can still tell a throw
-    // site from a hop. `parser_rule` is the field that already exists for
-    // exactly this, and it is what the trace surfaces read.
     let rule = site.syntactic_role.map(|role| match role {
         RelationSyntacticRole::RaiseTarget => RAISE_TARGET_CALL_RULE.to_string(),
     });
     if evidence.is_empty() {
-        return vec![RelationEvidence {
+        let mut only = RelationEvidence {
             source_span: Some(span),
-            parser_rule: rule,
             ..RelationEvidence::default()
-        }];
+        };
+        only.parser_rule = rule;
+        return vec![only];
     }
     for record in &mut evidence {
         record.source_span = Some(span.clone());
-        if record.parser_rule.is_none() {
-            record.parser_rule.clone_from(&rule);
-        }
+    }
+    // The syntactic role the adapter classified, carried onto the persisted
+    // evidence so a consumer that never sees the parse can still tell a throw
+    // site from a hop it should spend a trace slot on.
+    //
+    // A record of its own rather than a field on the shape record, because a
+    // shaped call already spends `parser_rule` on its aggregation certificate
+    // and `rename` matches that string exactly. Deliberately span-free: every
+    // consumer that counts occurrences reads spans, so a marker with none adds
+    // no occurrence, no reference line and no evidence a reader could mistake
+    // for a second call site.
+    if let Some(rule) = rule {
+        evidence.push(RelationEvidence {
+            parser_rule: Some(rule),
+            ..RelationEvidence::default()
+        });
     }
     evidence
 }
@@ -3954,13 +3964,15 @@ pub struct TraceCrossing {
     /// the fact of the boundary.
     pub status: String,
     /// The module specifier the importing file named (`router`, `urllib3`),
-    /// when an edge into this symbol recorded one. Absent under `unknown`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// when an edge into this symbol recorded one. Explicitly null under
+    /// `unknown`, because the keys of this object are uniform for the same
+    /// reason the step's are.
+    #[serde(default)]
     pub specifier: Option<String>,
     /// The receiver the call was written through, when the edge recorded one
     /// and no specifier is available. `this.router` says more than nothing
     /// about where to look without claiming to name a package.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub receiver: Option<String>,
     /// Why the status reads the way it does, in a sentence a caller can act on.
     pub note: String,

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -20,7 +20,7 @@ use kin_model::{
 };
 use kin_parser::{
     is_call_extraction_incomplete_marker, is_python_builtin_name, CallArgShape, ExtractedRelation,
-    FileImport,
+    FileImport, RelationSyntacticRole,
 };
 
 use crate::error::{IndexError, Result as IndexResult};
@@ -3821,14 +3821,25 @@ pub(crate) fn relation_evidence(
         return evidence;
     };
     let span = site.to_source_span(caller_file);
+    // The syntactic role the adapter classified, carried onto the persisted
+    // evidence so a consumer that never sees the parse can still tell a throw
+    // site from a hop. `parser_rule` is the field that already exists for
+    // exactly this, and it is what the trace surfaces read.
+    let rule = site.syntactic_role.map(|role| match role {
+        RelationSyntacticRole::RaiseTarget => RAISE_TARGET_CALL_RULE.to_string(),
+    });
     if evidence.is_empty() {
         return vec![RelationEvidence {
             source_span: Some(span),
+            parser_rule: rule,
             ..RelationEvidence::default()
         }];
     }
     for record in &mut evidence {
         record.source_span = Some(span.clone());
+        if record.parser_rule.is_none() {
+            record.parser_rule.clone_from(&rule);
+        }
     }
     evidence
 }

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -3978,6 +3978,23 @@ pub struct TraceCrossing {
     pub note: String,
 }
 
+/// Whether this call edge came from a parse, so its silence about `raise` is
+/// evidence rather than ignorance.
+///
+/// A resolved call reaches the graph twice on a repository with a language
+/// server: once from the parser, carrying the syntax it read, and once from the
+/// LSP call hierarchy, carrying only that the call exists. Only the parser can
+/// see a `raise`, so an LSP edge that does not mark one is not saying the call
+/// was ordinary; it is saying nothing at all, and letting it vote made the
+/// raise demotion structurally impossible on any repository with a language
+/// server installed. Measured on a converted `psf/requests`: every neighbour of
+/// `HTTPAdapter.send` arrived on two call edges, one `Parsed` or `Inferred` and
+/// one `Lsp`, so "every call edge is a raise" was false for `SSLError` even
+/// though the only edge that could classify it said `raise_target_call`.
+pub fn is_raise_classifiable_call_edge(rel: &Relation) -> bool {
+    rel.kind == RelationKind::Calls && !matches!(rel.origin, RelationOrigin::Lsp)
+}
+
 /// Whether this edge is a call the parser read as the operand of a `raise`.
 ///
 /// Reads the marker the linker persisted on the edge's own evidence, so a

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -908,12 +908,21 @@ fn run_ladder(
             .get(*key)
             .and_then(Value::as_array)
             .map_or(0, Vec::len);
-        let withheld = trim_collection(payload, key, target, 1);
+        let (withheld, narrowed) = trim_collection(payload, key, target, 1);
         if withheld > 0 {
             accounting.bounded = true;
             withheld_any = true;
+            // Which cut, not just how much. A list narrowed by branch still
+            // reaches as deep as the walk did; one cut from the end does not,
+            // and a reader who cannot tell them apart cannot tell whether the
+            // far end of the answer is missing.
+            let how = if narrowed {
+                "as whole branches, least relevant first"
+            } else {
+                "from the end of the list"
+            };
             cuts.push(format!(
-                "{withheld} of {found} entries withheld from the end of `{key}`"
+                "{withheld} of {found} entries withheld from `{key}`, {how}"
             ));
             record_elision(payload, key, found.saturating_sub(withheld), withheld);
             payload["truncated"] = Value::Bool(true);
@@ -1217,15 +1226,24 @@ fn trim_parented_collection(
 /// gives up whole branches least relevant first and leaves the depth intact. A
 /// collection that names no parents, or that no amount of narrowing fits, takes
 /// the suffix cut as before.
-fn trim_collection(payload: &mut Value, key: &str, target: usize, min_keep: usize) -> usize {
+///
+/// Returns the count withheld and whether it was narrowed, so the caller can say
+/// which cut a reader received rather than reporting every cut as an end-of-list
+/// one.
+fn trim_collection(
+    payload: &mut Value,
+    key: &str,
+    target: usize,
+    min_keep: usize,
+) -> (usize, bool) {
     let Some(full) = payload.get(key).and_then(Value::as_array).cloned() else {
-        return 0;
+        return (0, false);
     };
     if full.len() <= min_keep || measure(payload) <= target {
-        return 0;
+        return (0, false);
     }
     if let Some(withheld) = trim_parented_collection(payload, key, target, min_keep, &full) {
-        return withheld;
+        return (withheld, true);
     }
     let mut kept = min_keep;
     let mut low = min_keep;
@@ -1256,7 +1274,7 @@ fn trim_collection(payload: &mut Value, key: &str, target: usize, min_keep: usiz
             .unwrap_or(0) as usize;
         payload[format!("{key}_withheld")] = Value::from(prior.saturating_add(withheld));
     }
-    withheld
+    (withheld, false)
 }
 
 /// Append the cuts to the `degradations` channel the retrieval tools already
@@ -1456,6 +1474,67 @@ mod tests {
             roomy.len(),
             13,
             "one branch was enough, so only one may go: {roomy:?}"
+        );
+    }
+
+    /// The generic trimmer's own half of FIR-2642. A collection whose entries
+    /// name a parent is a tree, and this stage used to take its tail, which on
+    /// a real response landed on top of the walk's own cut and took the deep
+    /// end twice.
+    #[test]
+    fn the_trimmer_narrows_a_parented_collection_and_keeps_its_deep_entry() {
+        let steps = breadth_first_walk(12, 2);
+        let deepest = steps.last().expect("a deep end").0;
+        let entries: Vec<Value> = steps
+            .iter()
+            .map(|(step, parent)| {
+                json!({"step": step, "parent_step": parent, "pad": "p".repeat(400)})
+            })
+            .collect();
+        let mut payload = json!({"chain": entries});
+        let target = measure(&payload) / 2;
+
+        let (withheld, narrowed) = trim_collection(&mut payload, "chain", target, 1);
+
+        assert!(narrowed, "a parented collection must be narrowed, not cut");
+        assert!(withheld > 0, "the fixture must reach the cut");
+        let kept: Vec<u64> = payload["chain"]
+            .as_array()
+            .expect("chain survives")
+            .iter()
+            .map(|entry| entry["step"].as_u64().unwrap_or(0))
+            .collect();
+        assert!(
+            kept.contains(&deepest),
+            "the trimmer amputated the deep end instead of narrowing: {kept:?}"
+        );
+        assert!(measure(&payload) <= target, "{kept:?}");
+        assert_eq!(payload["chain_withheld"], json!(withheld));
+    }
+
+    /// The direction that keeps the branch meaningful: a flat collection has no
+    /// parents to reason about, so it still takes the suffix cut and still says
+    /// so.
+    #[test]
+    fn the_trimmer_still_cuts_a_flat_collection_from_its_tail() {
+        let entries: Vec<Value> = (0..40)
+            .map(|index| json!({"name": format!("hit_{index}"), "pad": "p".repeat(400)}))
+            .collect();
+        let mut payload = json!({"entities": entries});
+        let target = measure(&payload) / 2;
+
+        let (withheld, narrowed) = trim_collection(&mut payload, "entities", target, 1);
+
+        assert!(withheld > 0, "the fixture must reach the cut");
+        assert!(
+            !narrowed,
+            "a collection with no parents cannot be narrowed by branch"
+        );
+        let kept = payload["entities"].as_array().expect("entities survive");
+        assert_eq!(
+            kept.first().and_then(|entry| entry["name"].as_str()),
+            Some("hit_0"),
+            "a suffix cut keeps the front"
         );
     }
 

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -393,14 +393,23 @@ pub fn measure(value: &Value) -> usize {
 ///
 /// ## What this does instead
 ///
-/// A branch is one child of one node, taken with everything below it. Children
-/// arrive already ordered by relevance, so a node's LAST child is the one it can
-/// most afford to lose. Wide nodes are shaved first, because a wide fan-out is
-/// where the budget actually went, and narrowing a node from twelve children to
-/// eight costs a caller far less than losing the end of every chain. Every node
-/// keeps its first child, so narrowing can thin a walk and can never sever it,
-/// and a dropped branch takes its descendants with it, so no surviving step
-/// names a parent the caller no longer has.
+/// A branch is one child of one node, taken with everything below it. Wide nodes
+/// are shaved first, because a wide fan-out is where the budget actually went,
+/// and narrowing a node from twelve children to eight costs a caller far less
+/// than losing the end of every chain. Every node keeps one child, so narrowing
+/// can thin a walk and can never sever it, and a dropped branch takes its
+/// descendants with it, so no surviving step names a parent the caller no longer
+/// has.
+///
+/// Within a node, the SHALLOWEST branches go first, and the one it keeps is the
+/// one that reaches deepest. Relevance breaks ties, which is what children
+/// arrive ordered by. Keeping merely the first child was not enough and the
+/// difference is the whole defect: on the measured `psf/requests` walk the hop
+/// that carries the answer hangs off the focal's FIFTH child, so a rule that
+/// preserves the leftmost spine preserved a branch that ends at depth one and
+/// gave up the branch that reaches depth three. That made the answer depend on
+/// how large the walk happened to be, which is luck rather than a rule: the same
+/// query returned the hop at 129 discovered steps and lost it at 200.
 ///
 /// ## Why it lives here
 ///
@@ -438,13 +447,62 @@ pub fn narrow_fanout_to_fit<T: Clone>(
         }
     }
 
-    // The drop order: every node's children from least relevant inward, never
-    // its first, widest nodes first so the budget is reclaimed where it was
-    // spent. Ties broken by parent id so the order is deterministic.
-    let mut by_width: Vec<(u64, &Vec<u64>)> = children
+    // How far below each node the walk reached. Computed bottom-up over the
+    // children map, memoized, and cycle-safe, because a chain is a tree only by
+    // construction and a malformed one must not hang the bounder.
+    let mut reach: BTreeMap<u64, usize> = BTreeMap::new();
+    let mut order: Vec<u64> = children.keys().copied().collect();
+    for kids in children.values() {
+        order.extend(kids.iter().copied());
+    }
+    for _ in 0..=children.len() {
+        let mut changed = false;
+        for node in &order {
+            let deepest = children
+                .get(node)
+                .map(|kids| {
+                    kids.iter()
+                        .map(|kid| 1 + reach.get(kid).copied().unwrap_or(0))
+                        .max()
+                        .unwrap_or(0)
+                })
+                .unwrap_or(0);
+            if reach.get(node).copied().unwrap_or(0) < deepest {
+                reach.insert(*node, deepest);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    // The drop order: within a node, shallowest branch first and least relevant
+    // among equals, so the branch it keeps is the one that reaches deepest.
+    // Across nodes, widest first, so the budget is reclaimed where it was spent.
+    // Ties broken by parent id so the order is deterministic.
+    let mut by_width: Vec<(u64, Vec<u64>)> = children
         .iter()
         .filter(|(_, kids)| kids.len() > 1)
-        .map(|(parent, kids)| (*parent, kids))
+        .map(|(parent, kids)| {
+            let mut ordered: Vec<u64> = kids.clone();
+            // Sorted into GIVE-UP order: shallowest first, and among equally
+            // deep branches the one relevance put last.
+            let rank: BTreeMap<u64, usize> = kids
+                .iter()
+                .enumerate()
+                .map(|(at, kid)| (*kid, at))
+                .collect();
+            ordered.sort_by(|left, right| {
+                reach
+                    .get(left)
+                    .copied()
+                    .unwrap_or(0)
+                    .cmp(&reach.get(right).copied().unwrap_or(0))
+                    .then_with(|| rank[right].cmp(&rank[left]))
+            });
+            (*parent, ordered)
+        })
         .collect();
     by_width.sort_by(|left, right| {
         right
@@ -458,9 +516,9 @@ pub fn narrow_fanout_to_fit<T: Clone>(
     loop {
         let mut moved = false;
         for (_parent, kids) in &by_width {
-            // Keep the first child always; peel from the end inward.
+            // Keep one child always; peel from the give-up end inward.
             if kids.len() > 1 + round {
-                drop_order.push(kids[kids.len() - 1 - round]);
+                drop_order.push(kids[round]);
                 moved = true;
             }
         }
@@ -1411,11 +1469,11 @@ mod tests {
     #[test]
     fn a_dropped_branch_takes_its_descendants_with_it() {
         let mut steps = breadth_first_walk(8, 1);
-        // Hang a child off the LAST depth-1 step, which is the first branch the
-        // drop order gives up. Without the descendant walk it would survive its
-        // own parent.
+        // A SECOND deep branch, off the last depth-1 step. Two branches reach
+        // equally far, so relevance decides which is given up, and the one that
+        // goes has a descendant that must go with it.
         steps.push((100, 8));
-        let kept = narrowed(&steps, 5).expect("narrowing fits inside five steps");
+        let kept = narrowed(&steps, 2).expect("two steps is the floor, and it fits");
         let present: BTreeSet<u64> = kept.iter().map(|step| step.0).collect();
         for (step, parent) in &kept {
             assert!(
@@ -1424,8 +1482,40 @@ mod tests {
             );
         }
         assert!(
+            !present.contains(&8),
+            "the fixture must give up the less relevant of the two deep \
+             branches or nothing is being tested: {present:?}"
+        );
+        assert!(
             !present.contains(&100),
             "the orphan outlived the branch it hung off: {present:?}"
+        );
+    }
+
+    /// FIR-2642, the rule that makes the fix a rule rather than luck. The branch
+    /// a node keeps is the one that reaches deepest, not the one relevance
+    /// happened to list first.
+    ///
+    /// On the measured `psf/requests` walk the hop that carries the answer hangs
+    /// off `HTTPAdapter.send`'s FIFTH child, so keeping the first child kept a
+    /// branch ending at depth one and gave up the branch reaching depth three.
+    /// The same query returned the hop at 129 discovered steps and lost it at
+    /// 200, which is a result that depends on how big the walk happened to be.
+    #[test]
+    fn the_branch_a_node_keeps_is_the_one_that_reaches_deepest() {
+        // Six shallow children first, then a seventh whose branch goes two
+        // deeper. Relevance order puts the deep one last on purpose.
+        let mut steps: Vec<(u64, u64)> = (1..=7).map(|step| (step, 0)).collect();
+        steps.push((8, 7));
+        steps.push((9, 8));
+
+        let kept = narrowed(&steps, 3).expect("three steps fit");
+        let present: BTreeSet<u64> = kept.iter().map(|step| step.0).collect();
+        assert_eq!(
+            present,
+            BTreeSet::from([7, 8, 9]),
+            "the node kept its shallowest branch and amputated its deepest: \
+             {present:?}"
         );
     }
 

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -24,7 +24,7 @@
 //! a whole answer from a bounded one and knows which parameter recovers the
 //! rest.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 
 use serde_json::{json, Map, Value};
 
@@ -368,6 +368,147 @@ pub fn record_elision_for(
 /// budget for a payload no caller receives.
 pub fn measure(value: &Value) -> usize {
     serde_json::to_string_pretty(value).map_or(usize::MAX, |json| json.len())
+}
+
+/// Give up a chain's least load-bearing branches until it fits, and hand back
+/// what survived.
+///
+/// ## Why a suffix cut alone produced a wrong answer
+///
+/// A budgeted chain used to be cut as a prefix: keep `chain[..k]` and drop the
+/// rest. That is safe, because a discovery-ordered chain lists children after
+/// their parents and removing the end never orphans a surviving `parent_step`.
+/// It is also what produced a wrong answer. Discovery order is breadth-first,
+/// so the tail of the chain is its DEEPEST steps, and a suffix cut therefore
+/// spends the whole budget on the shallow fan-out and amputates the far end,
+/// which is where a trace stops being a list of neighbours and becomes an
+/// answer.
+///
+/// Measured on a converted `psf/requests` at the documented cheap settings
+/// (`depth: 3`, `limit_per_step: 12`, `include_body: false`): 67 of 117 steps
+/// went, and `_urllib3_request_context` was not among the survivors. Read
+/// alone, the response said `verify` reaches TLS at `cert_verify` and stopped,
+/// missing the half that governs connection reuse. The edge was in the graph
+/// the whole time.
+///
+/// ## What this does instead
+///
+/// A branch is one child of one node, taken with everything below it. Children
+/// arrive already ordered by relevance, so a node's LAST child is the one it can
+/// most afford to lose. Wide nodes are shaved first, because a wide fan-out is
+/// where the budget actually went, and narrowing a node from twelve children to
+/// eight costs a caller far less than losing the end of every chain. Every node
+/// keeps its first child, so narrowing can thin a walk and can never sever it,
+/// and a dropped branch takes its descendants with it, so no surviving step
+/// names a parent the caller no longer has.
+///
+/// ## Why it lives here
+///
+/// `trace_data_flow` has two implementations: the CLI one the daemon route
+/// serves and the MCP one the in-process arm serves. A budget rule that
+/// differed by whether a daemon happened to be up is the two-surface divergence
+/// class this codebase keeps paying for, so the rule is written once, generically
+/// over the step type, and both arms call it.
+///
+/// `fits` is called on candidate survivor sets, bisected over the drop order, so
+/// a caller pays a handful of serializations rather than one per branch. It may
+/// mutate whatever it needs to measure and is not required to leave it restored:
+/// callers install the returned chain themselves.
+///
+/// Returns `None` when there is nothing to narrow or when no amount of narrowing
+/// fits, which is the caller's signal to fall back to the suffix cut so a
+/// pathological walk is still answered rather than refused. `Some(kept)` is
+/// always strictly shorter than `steps`.
+pub fn narrow_fanout_to_fit<T: Clone>(
+    steps: &[T],
+    id_of: &dyn Fn(&T) -> u64,
+    parent_of: &dyn Fn(&T) -> Option<u64>,
+    fits: &mut dyn FnMut(&[T]) -> bool,
+) -> Option<Vec<T>> {
+    // Children in the order they were discovered, which is the order relevance
+    // put them in. A step that names itself as its own parent is skipped rather
+    // than trusted: it would make the descendant walk below cyclic.
+    let mut children: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
+    for step in steps {
+        if let Some(parent) = parent_of(step) {
+            let id = id_of(step);
+            if id != parent {
+                children.entry(parent).or_default().push(id);
+            }
+        }
+    }
+
+    // The drop order: every node's children from least relevant inward, never
+    // its first, widest nodes first so the budget is reclaimed where it was
+    // spent. Ties broken by parent id so the order is deterministic.
+    let mut by_width: Vec<(u64, &Vec<u64>)> = children
+        .iter()
+        .filter(|(_, kids)| kids.len() > 1)
+        .map(|(parent, kids)| (*parent, kids))
+        .collect();
+    by_width.sort_by(|left, right| {
+        right
+            .1
+            .len()
+            .cmp(&left.1.len())
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    let mut drop_order: Vec<u64> = Vec::new();
+    let mut round = 0usize;
+    loop {
+        let mut moved = false;
+        for (_parent, kids) in &by_width {
+            // Keep the first child always; peel from the end inward.
+            if kids.len() > 1 + round {
+                drop_order.push(kids[kids.len() - 1 - round]);
+                moved = true;
+            }
+        }
+        if !moved {
+            break;
+        }
+        round += 1;
+    }
+    if drop_order.is_empty() {
+        return None;
+    }
+
+    let retained = |dropped: usize| -> Vec<T> {
+        let mut condemned: BTreeSet<u64> = drop_order[..dropped].iter().copied().collect();
+        // Breadth-first over the children map rather than one pass over
+        // `steps`, so the closure does not silently depend on children being
+        // listed after their parents.
+        let mut queue: VecDeque<u64> = condemned.iter().copied().collect();
+        while let Some(id) = queue.pop_front() {
+            for kid in children.get(&id).into_iter().flatten() {
+                if condemned.insert(*kid) {
+                    queue.push_back(*kid);
+                }
+            }
+        }
+        steps
+            .iter()
+            .filter(|step| !condemned.contains(&id_of(step)))
+            .cloned()
+            .collect()
+    };
+
+    // Bisected for the FEWEST drops that fit. One drop is the floor: zero drops
+    // is the input, and the input is why this was called.
+    let mut low = 1usize;
+    let mut high = drop_order.len();
+    let mut chosen: Option<Vec<T>> = None;
+    while low <= high {
+        let mid = low + (high - low) / 2;
+        let kept = retained(mid);
+        if fits(&kept) {
+            chosen = Some(kept);
+            high = mid - 1;
+        } else {
+            low = mid + 1;
+        }
+    }
+    chosen
 }
 
 /// One tool's payload shape, in the terms the budget acts on.
@@ -1008,19 +1149,83 @@ fn remove_present(map: &mut Map<String, Value>, key: &str) -> bool {
     }
 }
 
-/// Withhold entries from the tail of one collection until the payload fits,
-/// returning how many were withheld.
+/// Narrow a collection whose entries name a parent, when every entry does.
+///
+/// `None` means this is not a parented collection, or that no amount of
+/// narrowing fits inside `target` and `min_keep`, which is the caller's signal
+/// to take the suffix cut instead. `Some(withheld)` leaves the narrowed array
+/// installed and the withheld counter updated exactly as the suffix path does.
+///
+/// Every entry must carry both keys before this fires. A collection where only
+/// some do is one this rule cannot reason about, and guessing at the rest would
+/// be a cut nobody could predict.
+fn trim_parented_collection(
+    payload: &mut Value,
+    key: &str,
+    target: usize,
+    min_keep: usize,
+    full: &[Value],
+) -> Option<usize> {
+    let parented = full.iter().all(|entry| {
+        entry.get("step").and_then(Value::as_u64).is_some()
+            && entry.get("parent_step").and_then(Value::as_u64).is_some()
+    });
+    if !parented {
+        return None;
+    }
+    let kept = narrow_fanout_to_fit(
+        full,
+        &|entry: &Value| entry["step"].as_u64().unwrap_or(0),
+        &|entry: &Value| entry["parent_step"].as_u64(),
+        &mut |candidate: &[Value]| {
+            payload[key] = Value::Array(candidate.to_vec());
+            measure(payload) <= target
+        },
+    )?;
+    if kept.len() < min_keep {
+        return None;
+    }
+    let withheld = full.len() - kept.len();
+    payload[key] = Value::Array(kept);
+    if withheld > 0 {
+        let prior = payload
+            .get(format!("{key}_withheld"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        payload[format!("{key}_withheld")] = Value::from(prior.saturating_add(withheld));
+    }
+    Some(withheld)
+}
+
+/// Withhold entries from one collection until the payload fits, returning how
+/// many were withheld.
 ///
 /// Bisected rather than popped one at a time: the same answer, in a handful of
-/// serializations instead of one per withheld entry. A suffix is what makes the
-/// cut safe for a walk whose entries reference earlier ones by index, because
-/// removing the end never orphans a surviving entry's parent.
+/// serializations instead of one per withheld entry.
+///
+/// A suffix is what makes the cut safe for a collection whose entries reference
+/// earlier ones by index, because removing the end never orphans a surviving
+/// entry's parent. It is also what makes it wrong for such a collection, and the
+/// two are the same fact: entries that name a parent are a TREE listed
+/// breadth-first, so its tail is its deepest entries and a suffix cut amputates
+/// the far end of every branch. A `trace_data_flow` chain is exactly that, and
+/// on a converted `psf/requests` this stage took the last eight of a chain the
+/// walk's own budget had already shortened, on top of the walk's cut, both from
+/// the deep end.
+///
+/// So a parented collection is narrowed by [`narrow_fanout_to_fit`] first, which
+/// gives up whole branches least relevant first and leaves the depth intact. A
+/// collection that names no parents, or that no amount of narrowing fits, takes
+/// the suffix cut as before.
 fn trim_collection(payload: &mut Value, key: &str, target: usize, min_keep: usize) -> usize {
     let Some(full) = payload.get(key).and_then(Value::as_array).cloned() else {
         return 0;
     };
     if full.len() <= min_keep || measure(payload) <= target {
         return 0;
+    }
+    if let Some(withheld) = trim_parented_collection(payload, key, target, min_keep, &full) {
+        return withheld;
     }
     let mut kept = min_keep;
     let mut low = min_keep;
@@ -1126,6 +1331,133 @@ fn disclose(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The measured shape, in miniature: a focal with a WIDE fan-out and one
+    /// narrow deep branch hanging off its first child.
+    ///
+    /// Steps are numbered in discovery order, which is breadth-first, so the
+    /// deep steps are last. That is the whole reason a suffix cut removes the
+    /// answer: `psf/requests` gave `HTTPAdapter.send` twelve depth-1 children
+    /// and put `_urllib3_request_context` at depth 3, where the tail is.
+    ///
+    /// Returns `(step, parent_step)` pairs. `parent 0` is the focal.
+    fn breadth_first_walk(width: usize, deep: usize) -> Vec<(u64, u64)> {
+        let mut steps: Vec<(u64, u64)> = (1..=width as u64).map(|step| (step, 0)).collect();
+        let mut parent = 1u64;
+        for _ in 0..deep {
+            let step = steps.len() as u64 + 1;
+            steps.push((step, parent));
+            parent = step;
+        }
+        steps
+    }
+
+    fn narrowed(steps: &[(u64, u64)], budget: usize) -> Option<Vec<(u64, u64)>> {
+        narrow_fanout_to_fit(
+            steps,
+            &|step: &(u64, u64)| step.0,
+            &|step: &(u64, u64)| Some(step.1),
+            &mut |kept: &[(u64, u64)]| kept.len() <= budget,
+        )
+    }
+
+    /// FIR-2642, the defect itself. A budget that holds six of fourteen steps
+    /// must spend them on the answer's depth rather than on the focal's widest
+    /// neighbours, because the deep end is where a trace stops being a list of
+    /// neighbours and becomes an answer.
+    #[test]
+    fn narrowing_keeps_the_deep_step_a_suffix_cut_amputates() {
+        let steps = breadth_first_walk(12, 2);
+        let deepest = steps.last().expect("the walk has a deep end").0;
+
+        // The premise, stated as an assertion so the test cannot pass on a
+        // fixture that never had the problem: the suffix cut of the same size
+        // loses the deep step.
+        let suffix: Vec<u64> = steps[..6].iter().map(|step| step.0).collect();
+        assert!(
+            !suffix.contains(&deepest),
+            "the fixture must reproduce the amputation or this proves nothing: {suffix:?}"
+        );
+
+        let kept = narrowed(&steps, 6).expect("narrowing fits inside six steps");
+        let names: Vec<u64> = kept.iter().map(|step| step.0).collect();
+        assert!(
+            names.contains(&deepest),
+            "the budget amputated the deep end instead of narrowing the fan-out: {names:?}"
+        );
+        assert!(kept.len() <= 6, "{names:?}");
+    }
+
+    /// Every surviving step must name a parent the caller still has, or a
+    /// consumer walking `parent_step` lands on a step that is not in the array.
+    #[test]
+    fn a_dropped_branch_takes_its_descendants_with_it() {
+        let mut steps = breadth_first_walk(8, 1);
+        // Hang a child off the LAST depth-1 step, which is the first branch the
+        // drop order gives up. Without the descendant walk it would survive its
+        // own parent.
+        steps.push((100, 8));
+        let kept = narrowed(&steps, 5).expect("narrowing fits inside five steps");
+        let present: BTreeSet<u64> = kept.iter().map(|step| step.0).collect();
+        for (step, parent) in &kept {
+            assert!(
+                *parent == 0 || present.contains(parent),
+                "step {step} names parent {parent}, which the cut removed: {present:?}"
+            );
+        }
+        assert!(
+            !present.contains(&100),
+            "the orphan outlived the branch it hung off: {present:?}"
+        );
+    }
+
+    /// Narrowing thins a walk; it never severs one. Asked for a budget no
+    /// amount of narrowing can meet, it answers `None` so the caller falls back
+    /// to the suffix cut rather than receiving a walk with no first child.
+    #[test]
+    fn narrowing_refuses_rather_than_severing_a_walk_it_cannot_fit() {
+        let steps = breadth_first_walk(12, 2);
+        // The narrowest survivor is the focal's first child and the deep branch
+        // below it: three steps. One is below that floor.
+        assert!(narrowed(&steps, 1).is_none(), "a walk was severed to fit");
+        let floor = narrowed(&steps, 3).expect("three steps is the floor, and it fits");
+        assert_eq!(
+            floor.iter().map(|step| step.0).collect::<Vec<_>>(),
+            vec![1, 13, 14],
+            "the survivor at the floor is the first child and its descendants"
+        );
+    }
+
+    /// A walk with nothing to narrow reports that, rather than returning a
+    /// no-op the caller would read as a cut it did not make.
+    #[test]
+    fn a_walk_with_no_node_wider_than_one_child_has_nothing_to_narrow() {
+        let steps = breadth_first_walk(1, 4);
+        assert!(
+            narrow_fanout_to_fit(
+                &steps,
+                &|step: &(u64, u64)| step.0,
+                &|step: &(u64, u64)| Some(step.1),
+                &mut |_kept: &[(u64, u64)]| false,
+            )
+            .is_none(),
+            "a spine has no branch to give up"
+        );
+    }
+
+    /// The fewest drops that fit, not the first that does. A caller who raises
+    /// `max_response_chars` by a little must get back more of the chain, and a
+    /// greedy cut that overshot would hand back the same short answer.
+    #[test]
+    fn narrowing_gives_up_the_fewest_branches_that_fit() {
+        let steps = breadth_first_walk(12, 2);
+        let roomy = narrowed(&steps, 13).expect("thirteen of fourteen steps fit");
+        assert_eq!(
+            roomy.len(),
+            13,
+            "one branch was enough, so only one may go: {roomy:?}"
+        );
+    }
 
     fn locate_payload(hits: usize, body_chars: usize) -> Value {
         let entities: Vec<Value> = (0..hits)

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3361,13 +3361,25 @@ struct TraceFanoutCandidate {
     confidence: f32,
     /// Where the in-repo graph ends, when this candidate sits on the boundary.
     crossing: Option<kin_index::TraceCrossing>,
-    /// Every edge into this candidate was the operand of a `raise`.
-    raise_target: bool,
+    /// Call edges into this candidate, and how many were the operand of a
+    /// `raise`. Counted rather than folded into a bool, for the reason the CLI
+    /// arm's sibling field records: a fold made the answer depend on which edge
+    /// happened to arrive first, and on a real store that left the flag false
+    /// for every exception class it was written to demote.
+    call_edges: usize,
+    raise_call_edges: usize,
     /// Classification of the edge this candidate is currently described by.
     /// It moves with `relation_kind` and `confidence` when a stronger edge to
     /// the same neighbor replaces them, so the step reports what the edge it
     /// names actually proved.
     resolution: RelationResolution,
+}
+
+impl TraceFanoutCandidate {
+    /// Whether this candidate is only ever thrown, never called for its value.
+    fn is_raise_target(&self) -> bool {
+        self.call_edges > 0 && self.raise_call_edges == self.call_edges
+    }
 }
 
 /// Order one side of a node's fan-out by relevance, most relevant first, with
@@ -3380,7 +3392,7 @@ fn sort_trace_candidates(candidates: &mut [TraceFanoutCandidate], node: &TraceFr
             node.file.as_deref(),
             node.dir.as_deref(),
             left.confidence,
-            left.raise_target,
+            left.is_raise_target(),
         );
         let right_score = trace_fanout_score(
             &right.entity,
@@ -3388,7 +3400,7 @@ fn sort_trace_candidates(candidates: &mut [TraceFanoutCandidate], node: &TraceFr
             node.file.as_deref(),
             node.dir.as_deref(),
             right.confidence,
-            right.raise_target,
+            right.is_raise_target(),
         );
         right_score
             .cmp(&left_score)
@@ -3855,10 +3867,11 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                             candidate.confidence = rel.confidence;
                             candidate.resolution = RelationResolution::of(rel);
                         }
-                        // Folded across every edge, not moved with the
+                        // Accumulated across every edge, not moved with the
                         // strongest one; mirrors the CLI arm exactly.
-                        candidate.raise_target =
-                            candidate.raise_target && kin_index::is_raise_target_edge(rel);
+                        candidate.call_edges += usize::from(rel.kind == RelationKind::Calls);
+                        candidate.raise_call_edges +=
+                            usize::from(kin_index::is_raise_target_edge(rel));
                         if candidate
                             .crossing
                             .as_ref()
@@ -3880,7 +3893,8 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                         candidate_index.insert((next_id, role), candidates.len());
                         let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
                         candidates.push(TraceFanoutCandidate {
-                            raise_target: kin_index::is_raise_target_edge(rel),
+                            call_edges: usize::from(rel.kind == RelationKind::Calls),
+                            raise_call_edges: usize::from(kin_index::is_raise_target_edge(rel)),
                             entity,
                             role,
                             relation_kind: rel.kind,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3472,8 +3472,147 @@ fn trace_step_value(
     value
 }
 
-/// Bound this arm's payload, dropping steps from the TAIL of the chain until it
-/// fits, and disclosing the cut.
+/// Push one degradation onto the response, creating the array if this is the
+/// first.
+fn append_trace_degradation(result: &mut serde_json::Value, disclosure: serde_json::Value) {
+    match result
+        .get_mut("degradations")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        Some(existing) => existing.push(disclosure),
+        None => result["degradations"] = serde_json::Value::Array(vec![disclosure]),
+    }
+}
+
+/// Drop the least relevant branches until the chain fits, and report how many
+/// went.
+///
+/// A branch is one child of one node, taken with everything below it. Children
+/// arrive already ordered by relevance, so the LAST child of a node is the one
+/// that node can most afford to lose, and dropping a whole branch is what keeps
+/// every surviving step's `parent_step` pointing at a step the caller still has.
+///
+/// Wide nodes are shaved first, because a wide fan-out is where the budget
+/// actually goes and because narrowing a node from twelve children to eight
+/// costs a caller far less than losing the end of the chain. Every node keeps at
+/// least its first child, so narrowing can thin a walk but can never sever it.
+///
+/// Bisected over the drop order rather than measured once per branch, for the
+/// same reason the suffix cut is: one serialization per step is the cost this
+/// whole function exists to avoid.
+fn narrow_trace_fanout_to_fit(
+    result: &mut serde_json::Value,
+    discovered: &[serde_json::Value],
+    target: usize,
+    measure: fn(&serde_json::Value) -> usize,
+) -> usize {
+    let step_of = |value: &serde_json::Value| value["step"].as_u64().unwrap_or(0);
+    let parent_of = |value: &serde_json::Value| value["parent_step"].as_u64();
+
+    // Children in the order they were discovered, which is the order relevance
+    // put them in.
+    let mut children: std::collections::BTreeMap<u64, Vec<u64>> = std::collections::BTreeMap::new();
+    for value in discovered {
+        if let Some(parent) = parent_of(value) {
+            if step_of(value) != parent {
+                children.entry(parent).or_default().push(step_of(value));
+            }
+        }
+    }
+
+    // The drop order: every node's children from least relevant inward, never
+    // its first, widest nodes first so the budget is reclaimed where it was
+    // spent.
+    let mut by_width: Vec<(u64, Vec<u64>)> = children
+        .iter()
+        .filter(|(_, kids)| kids.len() > 1)
+        .map(|(parent, kids)| (*parent, kids.clone()))
+        .collect();
+    by_width.sort_by(|left, right| {
+        right
+            .1
+            .len()
+            .cmp(&left.1.len())
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    let mut drop_order: Vec<u64> = Vec::new();
+    let mut round = 0usize;
+    loop {
+        let mut moved = false;
+        for (_parent, kids) in &by_width {
+            // Keep the first child always; peel from the end inward.
+            if kids.len() > 1 + round {
+                drop_order.push(kids[kids.len() - 1 - round]);
+                moved = true;
+            }
+        }
+        if !moved {
+            break;
+        }
+        round += 1;
+    }
+    if drop_order.is_empty() {
+        return 0;
+    }
+
+    let retained = |dropped_count: usize| -> Vec<serde_json::Value> {
+        let mut condemned: std::collections::BTreeSet<u64> =
+            drop_order[..dropped_count].iter().copied().collect();
+        // A dropped branch takes its descendants with it, or their `parent_step`
+        // would name a step the caller no longer has. One forward pass suffices
+        // because children always follow their parents.
+        for value in discovered {
+            if let Some(parent) = parent_of(value) {
+                if condemned.contains(&parent) {
+                    condemned.insert(step_of(value));
+                }
+            }
+        }
+        discovered
+            .iter()
+            .filter(|value| !condemned.contains(&step_of(value)))
+            .cloned()
+            .collect()
+    };
+
+    let mut low = 0usize;
+    let mut high = drop_order.len();
+    let mut chosen: Option<Vec<serde_json::Value>> = None;
+    let mut chosen_drops = 0usize;
+    while low <= high {
+        let mid = (low + high) / 2;
+        let kept = retained(mid);
+        result["chain"] = serde_json::Value::Array(kept.clone());
+        result["total_steps"] = serde_json::Value::from(kept.len());
+        if measure(result) <= target {
+            chosen_drops = discovered.len() - kept.len();
+            chosen = Some(kept);
+            if mid == 0 {
+                break;
+            }
+            high = mid - 1;
+        } else {
+            low = mid + 1;
+        }
+    }
+    match chosen {
+        Some(kept) => {
+            result["chain"] = serde_json::Value::Array(kept.clone());
+            result["total_steps"] = serde_json::Value::from(kept.len());
+            chosen_drops
+        }
+        None => {
+            // Nothing narrow enough fits; hand the whole chain back and let the
+            // suffix cut run, which always terminates.
+            result["chain"] = serde_json::Value::Array(discovered.to_vec());
+            result["total_steps"] = serde_json::Value::from(discovered.len());
+            0
+        }
+    }
+}
+
+/// Bound this arm's payload, narrowing each node's fan-out before it will
+/// amputate depth, and disclosing the cut.
 ///
 /// This arm serves no bodies, so it has none to cut first: what it can shed is
 /// steps. It still needs the bound, because 200 steps of identity, span, and
@@ -3481,9 +3620,34 @@ fn trace_step_value(
 /// client refuses is worse than a short one — the caller gets neither the chain
 /// nor a way to ask for less.
 ///
-/// A suffix is what makes the cut safe: the chain is discovery-ordered, so
-/// children always sit after their parents and removing the end never orphans a
-/// surviving step's `parent_step`.
+/// A suffix is what makes the fallback cut safe: the chain is discovery-ordered,
+/// so children always sit after their parents and removing the end never orphans
+/// a surviving step's `parent_step`.
+///
+/// ## Why a suffix cut alone produced a wrong answer
+///
+/// The chain is discovery-ordered, which means breadth-first, which means the
+/// tail is the DEEPEST steps. A suffix cut therefore spends the whole budget on
+/// the shallow fan-out and amputates the far end of every chain, and the far end
+/// is where a trace stops being a list of neighbours and becomes an answer.
+///
+/// Measured on a converted `psf/requests` by the rc0550 stranger, at the
+/// documented cheap settings (`depth: 3`, `limit_per_step: 12`,
+/// `include_body: false`): 67 of 117 steps dropped, and the survivors did not
+/// include `_urllib3_request_context`, which is one hop past
+/// `build_connection_pool_key_attributes` and is the function that folds
+/// `verify` into the urllib3 pool key. Read alone the response said `verify`
+/// reaches TLS at `cert_verify` and stopped, missing the half that governs
+/// connection reuse. The stranger's words: "If I had trusted the Kin arm alone I
+/// would have written a wrong answer." The edge was in the graph the whole time.
+///
+/// So the cut now narrows before it amputates. A node's fan-out was already
+/// ordered by relevance ([`kin_ranking::entity_ranking::trace_fanout_score`]),
+/// so its LAST child is the one it can most afford to lose; dropping that child
+/// and its descendants keeps every remaining `parent_step` valid and costs the
+/// chain its least-relevant branch instead of its deepest reach. Only when
+/// nothing is left to narrow does the suffix cut run, so a pathological walk
+/// still fits rather than being refused.
 fn bound_trace_payload(result: &mut serde_json::Value, max_chars: usize) {
     fn measure(value: &serde_json::Value) -> usize {
         serde_json::to_string_pretty(value).map_or(usize::MAX, |json| json.len())
@@ -3492,7 +3656,35 @@ fn bound_trace_payload(result: &mut serde_json::Value, max_chars: usize) {
         return;
     }
     let target = max_chars.saturating_sub(TRACE_DISCLOSURE_RESERVE_CHARS);
+    let discovered: Vec<serde_json::Value> =
+        result["chain"].as_array().cloned().unwrap_or_default();
+    let narrowed = narrow_trace_fanout_to_fit(result, &discovered, target, measure);
     let full: Vec<serde_json::Value> = result["chain"].as_array().cloned().unwrap_or_default();
+    if narrowed > 0 {
+        result["fanout_narrowed"] = serde_json::Value::from(narrowed);
+    }
+    if measure(result) <= target {
+        result["total_steps"] = serde_json::Value::from(full.len());
+        let omitted = discovered.len() - full.len();
+        if omitted == 0 {
+            return;
+        }
+        result["steps_omitted"] = serde_json::Value::from(omitted);
+        crate::budget::record_elision(result, "chain", full.len(), omitted);
+        result["truncated"] = serde_json::Value::Bool(true);
+        let disclosure = serde_json::json!({
+            "component": "response_budget",
+            "reason": "fanout_narrowed",
+            "detail": format!(
+                "the response exceeded its {max_chars}-character budget, so {omitted} of the \
+                 least relevant branches were dropped, narrowest-relevance first, rather than \
+                 the deepest steps of the chain; re-query a node with a smaller limit_per_step, \
+                 or raise max_chars to receive them"
+            ),
+        });
+        append_trace_degradation(result, disclosure);
+        return;
+    }
 
     // Bisected rather than popped one step at a time: the same answer, in a
     // handful of serializations instead of one per dropped step.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3359,6 +3359,10 @@ struct TraceFanoutCandidate {
     role: &'static str,
     relation_kind: RelationKind,
     confidence: f32,
+    /// Where the in-repo graph ends, when this candidate sits on the boundary.
+    crossing: Option<kin_index::TraceCrossing>,
+    /// Every edge into this candidate was the operand of a `raise`.
+    raise_target: bool,
     /// Classification of the edge this candidate is currently described by.
     /// It moves with `relation_kind` and `confidence` when a stronger edge to
     /// the same neighbor replaces them, so the step reports what the edge it
@@ -3376,6 +3380,7 @@ fn sort_trace_candidates(candidates: &mut [TraceFanoutCandidate], node: &TraceFr
             node.file.as_deref(),
             node.dir.as_deref(),
             left.confidence,
+            left.raise_target,
         );
         let right_score = trace_fanout_score(
             &right.entity,
@@ -3383,6 +3388,7 @@ fn sort_trace_candidates(candidates: &mut [TraceFanoutCandidate], node: &TraceFr
             node.file.as_deref(),
             node.dir.as_deref(),
             right.confidence,
+            right.raise_target,
         );
         right_score
             .cmp(&left_score)
@@ -3399,7 +3405,10 @@ fn sort_trace_candidates(candidates: &mut [TraceFanoutCandidate], node: &TraceFr
 /// This arm serves no bodies — it answers from a generic graph store with no
 /// repository authority to project source through — so `body` is null on every
 /// record here and `bodies_included` on the response says so.
-fn trace_entity_value(entity: &kin_model::entity::Entity) -> serde_json::Value {
+fn trace_entity_value(
+    entity: &kin_model::entity::Entity,
+    crossing: Option<&kin_index::TraceCrossing>,
+) -> serde_json::Value {
     let (start_line, end_line) = match entity.span.as_ref() {
         Some(span) => {
             let (start, end) = presentation_span_lines(span);
@@ -3419,6 +3428,7 @@ fn trace_entity_value(entity: &kin_model::entity::Entity) -> serde_json::Value {
         "signature": (!entity.signature.is_empty()).then(|| entity.signature.clone()),
         "body": serde_json::Value::Null,
         "span_coherence": serde_json::Value::Null,
+        "crossing": crossing,
     })
 }
 
@@ -3433,6 +3443,7 @@ fn trace_step_value(
     depth: usize,
     entity: &kin_model::entity::Entity,
     terminal: Option<TraceTerminal>,
+    crossing: Option<&kin_index::TraceCrossing>,
 ) -> serde_json::Value {
     let mut value = serde_json::json!({
         "step": step,
@@ -3452,7 +3463,7 @@ fn trace_step_value(
         // broke a consumer's parser twice.
         "terminal": terminal.map(TraceTerminal::as_str),
     });
-    let record = trace_entity_value(entity);
+    let record = trace_entity_value(entity, crossing);
     if let (Some(target), Some(source)) = (value.as_object_mut(), record.as_object()) {
         for (key, entry) in source {
             target.insert(key.clone(), entry.clone());
@@ -3732,6 +3743,22 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                             candidate.confidence = rel.confidence;
                             candidate.resolution = RelationResolution::of(rel);
                         }
+                        // Folded across every edge, not moved with the
+                        // strongest one; mirrors the CLI arm exactly.
+                        candidate.raise_target =
+                            candidate.raise_target && kin_index::is_raise_target_edge(rel);
+                        if candidate
+                            .crossing
+                            .as_ref()
+                            .is_none_or(|crossing| crossing.specifier.is_none())
+                        {
+                            if let Some(named) =
+                                kin_index::trace_crossing_for(&candidate.entity, Some(rel))
+                                    .filter(|crossing| crossing.specifier.is_some())
+                            {
+                                candidate.crossing = Some(named);
+                            }
+                        }
                     }
                     None => {
                         let Some(entity) = store.get_entity(&next_id).map_err(McpError::graph)?
@@ -3739,12 +3766,15 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                             continue;
                         };
                         candidate_index.insert((next_id, role), candidates.len());
+                        let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
                         candidates.push(TraceFanoutCandidate {
+                            raise_target: kin_index::is_raise_target_edge(rel),
                             entity,
                             role,
                             relation_kind: rel.kind,
                             confidence: rel.confidence,
                             resolution: RelationResolution::of(rel),
+                            crossing,
                         });
                     }
                 }
@@ -3839,6 +3869,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                             promoted_depth,
                             &candidate.entity,
                             promoted_terminal,
+                            candidate.crossing.as_ref(),
                         );
                         chain[existing - 1] = promoted;
                         // The record that replaced the placeholder brings its
@@ -3881,6 +3912,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                     next_depth,
                     &candidate.entity,
                     terminal,
+                    candidate.crossing.as_ref(),
                 ));
                 step_language.insert(step_index, candidate.entity.language);
                 if terminal.is_none() && next_depth < depth {
@@ -4004,7 +4036,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
         "focal_name": focal_entity.name.clone(),
         "focal_kind": format!("{:?}", focal_entity.kind),
         "focal_file": focal_entity.file_origin.as_ref().map(|p| p.to_string()),
-        "focal_entity": trace_entity_value(&focal_entity),
+        "focal_entity": trace_entity_value(&focal_entity, None),
         "direction": direction,
         "depth": depth,
         "limit_per_step": limit_per_step,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3377,6 +3377,11 @@ struct TraceFanoutCandidate {
 
 impl TraceFanoutCandidate {
     /// Whether this candidate is only ever thrown, never called for its value.
+    ///
+    /// Only parse-authored call edges vote. An LSP call-hierarchy edge cannot
+    /// see a `raise`, so its silence is not a claim that the call was ordinary,
+    /// and counting it made this answer `false` for every candidate on any
+    /// repository with a language server installed.
     fn is_raise_target(&self) -> bool {
         self.call_edges > 0 && self.raise_call_edges == self.call_edges
     }
@@ -3869,7 +3874,8 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                         }
                         // Accumulated across every edge, not moved with the
                         // strongest one; mirrors the CLI arm exactly.
-                        candidate.call_edges += usize::from(rel.kind == RelationKind::Calls);
+                        candidate.call_edges +=
+                            usize::from(kin_index::is_raise_classifiable_call_edge(rel));
                         candidate.raise_call_edges +=
                             usize::from(kin_index::is_raise_target_edge(rel));
                         if candidate
@@ -3893,7 +3899,9 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                         candidate_index.insert((next_id, role), candidates.len());
                         let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
                         candidates.push(TraceFanoutCandidate {
-                            call_edges: usize::from(rel.kind == RelationKind::Calls),
+                            call_edges: usize::from(kin_index::is_raise_classifiable_call_edge(
+                                rel,
+                            )),
                             raise_call_edges: usize::from(kin_index::is_raise_target_edge(rel)),
                             entity,
                             role,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3484,22 +3484,13 @@ fn append_trace_degradation(result: &mut serde_json::Value, disclosure: serde_js
     }
 }
 
-/// Drop the least relevant branches until the chain fits, and report how many
-/// went.
+/// Narrow this arm's chain to fit, and report how many steps went.
 ///
-/// A branch is one child of one node, taken with everything below it. Children
-/// arrive already ordered by relevance, so the LAST child of a node is the one
-/// that node can most afford to lose, and dropping a whole branch is what keeps
-/// every surviving step's `parent_step` pointing at a step the caller still has.
-///
-/// Wide nodes are shaved first, because a wide fan-out is where the budget
-/// actually goes and because narrowing a node from twelve children to eight
-/// costs a caller far less than losing the end of the chain. Every node keeps at
-/// least its first child, so narrowing can thin a walk but can never sever it.
-///
-/// Bisected over the drop order rather than measured once per branch, for the
-/// same reason the suffix cut is: one serialization per step is the cost this
-/// whole function exists to avoid.
+/// The rule itself lives in [`crate::budget::narrow_fanout_to_fit`], written
+/// once and shared with the CLI arm the daemon route serves, because a budget
+/// rule that differed by whether a daemon was up is the two-surface divergence
+/// class this codebase keeps paying for. All this wrapper does is read the two
+/// keys off a JSON step and install the result.
 fn narrow_trace_fanout_to_fit(
     result: &mut serde_json::Value,
     discovered: &[serde_json::Value],
@@ -3508,98 +3499,22 @@ fn narrow_trace_fanout_to_fit(
 ) -> usize {
     let step_of = |value: &serde_json::Value| value["step"].as_u64().unwrap_or(0);
     let parent_of = |value: &serde_json::Value| value["parent_step"].as_u64();
-
-    // Children in the order they were discovered, which is the order relevance
-    // put them in.
-    let mut children: std::collections::BTreeMap<u64, Vec<u64>> = std::collections::BTreeMap::new();
-    for value in discovered {
-        if let Some(parent) = parent_of(value) {
-            if step_of(value) != parent {
-                children.entry(parent).or_default().push(step_of(value));
-            }
-        }
-    }
-
-    // The drop order: every node's children from least relevant inward, never
-    // its first, widest nodes first so the budget is reclaimed where it was
-    // spent.
-    let mut by_width: Vec<(u64, Vec<u64>)> = children
-        .iter()
-        .filter(|(_, kids)| kids.len() > 1)
-        .map(|(parent, kids)| (*parent, kids.clone()))
-        .collect();
-    by_width.sort_by(|left, right| {
-        right
-            .1
-            .len()
-            .cmp(&left.1.len())
-            .then_with(|| left.0.cmp(&right.0))
-    });
-    let mut drop_order: Vec<u64> = Vec::new();
-    let mut round = 0usize;
-    loop {
-        let mut moved = false;
-        for (_parent, kids) in &by_width {
-            // Keep the first child always; peel from the end inward.
-            if kids.len() > 1 + round {
-                drop_order.push(kids[kids.len() - 1 - round]);
-                moved = true;
-            }
-        }
-        if !moved {
-            break;
-        }
-        round += 1;
-    }
-    if drop_order.is_empty() {
-        return 0;
-    }
-
-    let retained = |dropped_count: usize| -> Vec<serde_json::Value> {
-        let mut condemned: std::collections::BTreeSet<u64> =
-            drop_order[..dropped_count].iter().copied().collect();
-        // A dropped branch takes its descendants with it, or their `parent_step`
-        // would name a step the caller no longer has. One forward pass suffices
-        // because children always follow their parents.
-        for value in discovered {
-            if let Some(parent) = parent_of(value) {
-                if condemned.contains(&parent) {
-                    condemned.insert(step_of(value));
-                }
-            }
-        }
-        discovered
-            .iter()
-            .filter(|value| !condemned.contains(&step_of(value)))
-            .cloned()
-            .collect()
-    };
-
-    let mut low = 0usize;
-    let mut high = drop_order.len();
-    let mut chosen: Option<Vec<serde_json::Value>> = None;
-    let mut chosen_drops = 0usize;
-    while low <= high {
-        let mid = (low + high) / 2;
-        let kept = retained(mid);
-        result["chain"] = serde_json::Value::Array(kept.clone());
-        result["total_steps"] = serde_json::Value::from(kept.len());
-        if measure(result) <= target {
-            chosen_drops = discovered.len() - kept.len();
-            chosen = Some(kept);
-            if mid == 0 {
-                break;
-            }
-            high = mid - 1;
-        } else {
-            low = mid + 1;
-        }
-    }
-    match chosen {
-        Some(kept) => {
-            result["chain"] = serde_json::Value::Array(kept.clone());
+    let narrowed = crate::budget::narrow_fanout_to_fit(
+        discovered,
+        &step_of,
+        &parent_of,
+        &mut |kept: &[serde_json::Value]| {
+            result["chain"] = serde_json::Value::Array(kept.to_vec());
             result["total_steps"] = serde_json::Value::from(kept.len());
-            chosen_drops
+            measure(result) <= target
+        },
+    );
+    match narrowed {
+        Some(kept) => {
+            let dropped = discovered.len() - kept.len();
+            result["chain"] = serde_json::Value::Array(kept);
+            result["total_steps"] = serde_json::Value::from(discovered.len() - dropped);
+            dropped
         }
         None => {
             // Nothing narrow enough fits; hand the whole chain back and let the
@@ -3660,9 +3575,10 @@ fn bound_trace_payload(result: &mut serde_json::Value, max_chars: usize) {
         result["chain"].as_array().cloned().unwrap_or_default();
     let narrowed = narrow_trace_fanout_to_fit(result, &discovered, target, measure);
     let full: Vec<serde_json::Value> = result["chain"].as_array().cloned().unwrap_or_default();
-    if narrowed > 0 {
-        result["fanout_narrowed"] = serde_json::Value::from(narrowed);
-    }
+    // Always written, zero included. A count that appears only when it fired
+    // is the sometimes-absent key that broke a consumer's parser twice, and a
+    // reader cannot tell "narrowed nothing" from "this build cannot narrow".
+    result["fanout_narrowed"] = serde_json::Value::from(narrowed);
     if measure(result) <= target {
         result["total_steps"] = serde_json::Value::from(full.len());
         let omitted = discovered.len() - full.len();
@@ -3672,14 +3588,18 @@ fn bound_trace_payload(result: &mut serde_json::Value, max_chars: usize) {
         result["steps_omitted"] = serde_json::Value::from(omitted);
         crate::budget::record_elision(result, "chain", full.len(), omitted);
         result["truncated"] = serde_json::Value::Bool(true);
+        // `steps_omitted` and not a reason of its own: the reason code names
+        // the lever a caller raises, and that lever is `max_response_chars`
+        // whichever way the cut was made. WHICH cut it was belongs in the
+        // detail and in `fanout_narrowed` beside it.
         let disclosure = serde_json::json!({
             "component": "response_budget",
-            "reason": "fanout_narrowed",
+            "reason": "steps_omitted",
             "detail": format!(
-                "the response exceeded its {max_chars}-character budget, so {omitted} of the \
-                 least relevant branches were dropped, narrowest-relevance first, rather than \
-                 the deepest steps of the chain; re-query a node with a smaller limit_per_step, \
-                 or raise max_chars to receive them"
+                "the response exceeded its {max_chars}-character budget, so {omitted} steps were \
+                 dropped as whole branches, least relevant first, rather than from the end of the \
+                 chain; re-query a node with a smaller limit_per_step, or raise \
+                 max_response_chars to receive them"
             ),
         });
         append_trace_degradation(result, disclosure);
@@ -4262,6 +4182,10 @@ pub fn handle_trace_data_flow<G: GraphStore>(
             .map(|value| value as usize),
     );
     result["max_response_chars"] = serde_json::Value::from(max_response_chars);
+    // Set before the bound so it is on every response, not only the cut ones.
+    // The bounder returns at its first line when the payload already fits, and
+    // a key that appears only after a cut cannot be read as a zero.
+    result["fanout_narrowed"] = serde_json::Value::from(0);
     bound_trace_payload(&mut result, max_response_chars);
     // Counted from the chain rather than during the walk, so the numbers
     // describe the steps this payload carries after `bound_trace_payload` has

--- a/crates/kin-parser/src/adapter.rs
+++ b/crates/kin-parser/src/adapter.rs
@@ -331,6 +331,7 @@ pub fn site_from_node(node: &Node) -> RelationSite {
         start_col: start.column as u32,
         end_line: end.row as u32,
         end_col: end.column as u32,
+        syntactic_role: None,
     }
 }
 

--- a/crates/kin-parser/src/extract.rs
+++ b/crates/kin-parser/src/extract.rs
@@ -191,6 +191,24 @@ pub struct CallArgShape {
 ///
 /// Adapters that do not record sites leave [`ExtractedRelation::site`] `None`,
 /// and the edge is stored exactly as it was before, without a span.
+/// The syntactic position a relation's site occupies, when it changes what the
+/// relation means to a reader.
+///
+/// One variant today, and the channel exists because a `raise` target is a call
+/// edge that is real evidence and is NOT a hop a value travels along. A trace
+/// walking data flow has to tell them apart, and only the parser can: by the
+/// time the linker sees the edge, `raise SSLError(...)` and `SSLError(...)` are
+/// the same call to the same class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RelationSyntacticRole {
+    /// The call is the value a `raise` throws. Only the DIRECT operand:
+    /// `raise Wrapper(build())` marks the wrapper, and `build()` stays an
+    /// ordinary call, because demoting a real hop for its neighbour's syntax
+    /// would cost exactly the recall this marker exists to protect.
+    RaiseTarget,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RelationSite {
     pub start_byte: usize,
@@ -199,6 +217,11 @@ pub struct RelationSite {
     pub start_col: u32,
     pub end_line: u32,
     pub end_col: u32,
+    /// What this site is syntactically, when that changes what the relation
+    /// means. Absent for every ordinary site, and for every adapter that does
+    /// not classify one, so an unset role reads exactly as it always did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub syntactic_role: Option<RelationSyntacticRole>,
 }
 
 impl RelationSite {

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -1852,6 +1852,23 @@ fn stamp_class_attribute_declaration(
     }
 }
 
+/// Whether this `call` node is the value a `raise` throws.
+///
+/// Only the DIRECT operand counts. `raise Wrapper(build())` throws the wrapper;
+/// `build()` is an ordinary call that happens to sit inside the same statement,
+/// and marking it would demote a real hop because of its neighbour's syntax.
+///
+/// A `raise` target is a call edge and stays one: it is real evidence that this
+/// function can throw that class. What it is not is a hop a value travels
+/// along, and a trace walking data flow spends its budget as if it were. On a
+/// converted `psf/requests`, nine of twelve depth-1 slots went to exception
+/// constructors and the hop governing connection reuse was left out of the
+/// answer entirely.
+fn python_call_is_raise_target(call: &tree_sitter::Node) -> bool {
+    call.parent()
+        .is_some_and(|parent| parent.kind() == "raise_statement")
+}
+
 /// Extract all function/method calls within a function/method body.
 fn extract_calls_from_context(
     node: &tree_sitter::Node,
@@ -1872,11 +1889,16 @@ fn extract_calls_from_context(
                 extract_named_callee(&function, source, class_ctx, receiver_types)
             });
             if let Some(callee) = callee {
+                let site = RelationSite {
+                    syntactic_role: python_call_is_raise_target(&child)
+                        .then_some(crate::extract::RelationSyntacticRole::RaiseTarget),
+                    ..site_from_node(&child)
+                };
                 relations.push(ExtractedRelation {
                     // The call expression itself, so a reference row can report the
                     // line the call is written on rather than the line the caller's
                     // definition starts on.
-                    site: Some(site_from_node(&child)),
+                    site: Some(site),
                     receiver: callee.receiver,
                     call_shape: Some(extract_call_arg_shape(&child, source)),
                     kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -3025,6 +3025,44 @@ class Response:
     }
 
     #[test]
+    fn a_raise_marks_the_class_it_throws_and_nothing_else() {
+        // FIR-2642. `raise SSLError(...)` is a real call edge and real evidence
+        // that this function can throw, and it is NOT a hop a value travels
+        // along. Only the DIRECT operand is marked: `raise Wrapper(build())`
+        // throws the wrapper, and demoting `build()` for its neighbour's syntax
+        // would cost the recall the marker exists to protect.
+        use crate::extract::RelationSyntacticRole;
+        let adapter = PythonAdapter;
+        let source =
+            b"def go(x):\n    if x:\n        raise Wrapper(build())\n    return SSLError()\n";
+        let tree = adapter.parse(source).unwrap();
+        let output = adapter
+            .extract(&tree, source, &FilePathId::new("m.py"))
+            .unwrap();
+        let mut marked: Vec<(&str, bool)> = output
+            .relations
+            .iter()
+            .filter(|rel| rel.kind == kin_model::RelationKind::Calls)
+            .map(|rel| {
+                (
+                    rel.dst_name.as_str(),
+                    rel.site
+                        .as_ref()
+                        .and_then(|site| site.syntactic_role)
+                        .is_some_and(|role| role == RelationSyntacticRole::RaiseTarget),
+                )
+            })
+            .collect();
+        marked.sort();
+        assert_eq!(
+            marked,
+            vec![("SSLError", false), ("Wrapper", true), ("build", false)],
+            "the raised class is marked, the call inside its arguments is not, \
+             and a constructor called outside a raise is not"
+        );
+    }
+
+    #[test]
     fn a_type_checking_guarded_import_binds_the_name_its_annotation_uses() {
         // PEP 484 says an import that exists only for annotations belongs
         // behind `if TYPE_CHECKING:`, and requests puts

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -52,9 +52,10 @@ pub use extract::{
     attach_file_context_metadata, attach_file_reference_parse_counts,
     call_extraction_incomplete_marker, is_call_extraction_incomplete_marker, CallArgShape,
     ExtractedEntity, ExtractedRelation, ExtractedTest, ExtractedTestKind, FileImport, ImportedName,
-    ParseOutput, RelationSite, CALL_EXTRACTION_INCOMPLETE_MARKER_V1, COMMAND_EFFECT_CONTRACT_KEY,
-    FILE_IMPORT_CONTEXT_KEY, FILE_PARSED_CALL_SITES_KEY, FILE_PARSED_EXTERNAL_MODULE_IMPORTS_KEY,
-    FILE_PARSED_IMPORT_STATEMENTS_KEY, FILE_SURFACE_CONTEXT_KEY,
+    ParseOutput, RelationSite, RelationSyntacticRole, CALL_EXTRACTION_INCOMPLETE_MARKER_V1,
+    COMMAND_EFFECT_CONTRACT_KEY, FILE_IMPORT_CONTEXT_KEY, FILE_PARSED_CALL_SITES_KEY,
+    FILE_PARSED_EXTERNAL_MODULE_IMPORTS_KEY, FILE_PARSED_IMPORT_STATEMENTS_KEY,
+    FILE_SURFACE_CONTEXT_KEY,
 };
 pub use languages::{
     attach_go_command_effect_contract_metadata, is_python_builtin_name, AdapterRegistry, CAdapter,

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -491,6 +491,7 @@ fn trace_role_rank(role: &EntityRole) -> usize {
 /// The comparable relevance key for one fan-out candidate. Higher is kept.
 pub type TraceFanoutScore = (
     bool,
+    bool,
     usize,
     usize,
     bool,
@@ -507,13 +508,25 @@ pub type TraceFanoutScore = (
 /// Compared as a tuple, most significant first:
 /// 1. the graph holds a location for it (a file-less placeholder never takes a
 ///    slot from a symbol a caller can open)
-/// 2. role rank (source over test; see [`trace_role_rank`])
-/// 3. relation rank (Calls over Imports over References)
-/// 4. declared in the same FILE as the node being expanded
-/// 5. declared in the same DIRECTORY as it
-/// 6. declaration kind rank (functions and methods over constants)
-/// 7. the edge's own confidence
-/// 8. shorter name, which only ever breaks a tie the seven signals above left
+/// 2. NOT a `raise` target (see below)
+/// 3. role rank (source over test; see [`trace_role_rank`])
+/// 4. relation rank (Calls over Imports over References)
+/// 5. declared in the same FILE as the node being expanded
+/// 6. declared in the same DIRECTORY as it
+/// 7. declaration kind rank (functions and methods over constants)
+/// 8. the edge's own confidence
+/// 9. shorter name, which only ever breaks a tie the eight signals above left
+///
+/// The raise-target signal sits second, ABOVE locality, because locality is
+/// what let it go wrong: exception classes commonly live beside the code that
+/// throws them, so same-file and same-directory both favour them over the
+/// callee that carries the value onward. Measured on a converted `psf/requests`
+/// by a stranger: nine of the twelve depth-1 slots on `HTTPAdapter.send` went
+/// to `SSLError`, `InvalidURL`, `ProxyError`, `RetryError`, `ReadTimeout` and
+/// `InvalidHeader`, and the hop governing connection reuse was not in the
+/// answer at all. It demotes rather than filters, because "what does this
+/// throw" is a real question and the edge is real evidence; a step wide enough
+/// to hold them still reports them, just last.
 ///
 /// `parent_file` and `parent_dir` describe the node whose fan-out is being cut,
 /// not the focal: locality is what makes a chain readable, and at depth 3 the
@@ -527,6 +540,7 @@ pub fn trace_fanout_score(
     parent_file: Option<&str>,
     parent_dir: Option<&str>,
     confidence: f32,
+    raise_target: bool,
 ) -> TraceFanoutScore {
     let same_file = parent_file
         .zip(entity.file_origin.as_ref())
@@ -542,6 +556,7 @@ pub fn trace_fanout_score(
     let confidence = (confidence.clamp(0.0, 1.0) * 1000.0).round() as u32;
     (
         !trace_entity_is_external(entity),
+        !raise_target,
         trace_role_rank(&entity.role),
         trace_relation_rank(relation_kind),
         same_file,

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -831,13 +831,53 @@ mod tests {
     }
 
     fn score(entity: &Entity) -> TraceFanoutScore {
+        scored(entity, false)
+    }
+
+    /// The same key with the raise-target signal set, so the tests below can
+    /// compare a throw site against the hop it used to outrank.
+    fn scored(entity: &Entity, raise_target: bool) -> TraceFanoutScore {
         trace_fanout_score(
             entity,
             RelationKind::Calls,
             Some("src/requests/sessions.py"),
             Some("src/requests"),
             1.0,
+            raise_target,
         )
+    }
+
+    #[test]
+    fn a_raise_target_loses_to_a_data_flow_hop_it_would_otherwise_outrank() {
+        // FIR-2642. Locality is what let this go wrong: an exception class
+        // beside the code that throws it wins same-file and same-directory
+        // against the callee that carries the value onward. The signal sits
+        // above both so that comparison can no longer come out the wrong way.
+        let thrown = fanout_entity("SSLError", Some("src/requests/sessions.py"));
+        let hop = fanout_entity("build_pool_key", Some("src/requests/adapters.py"));
+        assert!(
+            scored(&thrown, false) > scored(&hop, false),
+            "the fixture's premise: without the signal the same-file throw \
+             site wins"
+        );
+        assert!(
+            scored(&hop, false) > scored(&thrown, true),
+            "with it, the hop the value travels along wins"
+        );
+    }
+
+    #[test]
+    fn demoting_a_raise_target_orders_it_and_never_removes_it() {
+        // The recall half, at the level the ordering is defined. Two throw
+        // sites still compare against each other by every signal below, so a
+        // step wide enough to hold them reports them in a stable order rather
+        // than collapsing them.
+        let first = fanout_entity("SSLError", Some("src/requests/sessions.py"));
+        let second = fanout_entity("InvalidURL", Some("src/other/exceptions.py"));
+        assert!(
+            scored(&first, true) > scored(&second, true),
+            "same-file still decides between two throw sites"
+        );
     }
 
     #[test]
@@ -875,6 +915,7 @@ mod tests {
             Some("src/requests/sessions.py"),
             Some("src/requests"),
             1.0,
+            false,
         );
         let referenced = trace_fanout_score(
             &entity,
@@ -882,6 +923,7 @@ mod tests {
             Some("src/requests/sessions.py"),
             Some("src/requests"),
             1.0,
+            false,
         );
         assert!(called > referenced);
     }
@@ -895,6 +937,7 @@ mod tests {
             Some("src/requests/sessions.py"),
             Some("src/requests"),
             1.0,
+            false,
         );
         let guessed = trace_fanout_score(
             &entity,
@@ -902,6 +945,7 @@ mod tests {
             Some("src/requests/sessions.py"),
             Some("src/requests"),
             0.4,
+            false,
         );
         assert!(certain > guessed);
     }

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -491,12 +491,12 @@ fn trace_role_rank(role: &EntityRole) -> usize {
 /// The comparable relevance key for one fan-out candidate. Higher is kept.
 pub type TraceFanoutScore = (
     bool,
-    bool,
     usize,
     usize,
     bool,
     bool,
     usize,
+    bool,
     u32,
     std::cmp::Reverse<usize>,
 );
@@ -508,25 +508,38 @@ pub type TraceFanoutScore = (
 /// Compared as a tuple, most significant first:
 /// 1. the graph holds a location for it (a file-less placeholder never takes a
 ///    slot from a symbol a caller can open)
-/// 2. NOT a `raise` target (see below)
-/// 3. role rank (source over test; see [`trace_role_rank`])
-/// 4. relation rank (Calls over Imports over References)
-/// 5. declared in the same FILE as the node being expanded
-/// 6. declared in the same DIRECTORY as it
-/// 7. declaration kind rank (functions and methods over constants)
+/// 2. role rank (source over test; see [`trace_role_rank`])
+/// 3. relation rank (Calls over Imports over References)
+/// 4. declared in the same FILE as the node being expanded
+/// 5. declared in the same DIRECTORY as it
+/// 6. declaration kind rank (functions and methods over constants)
+/// 7. NOT a `raise` target (see below)
 /// 8. the edge's own confidence
 /// 9. shorter name, which only ever breaks a tie the eight signals above left
 ///
-/// The raise-target signal sits second, ABOVE locality, because locality is
-/// what let it go wrong: exception classes commonly live beside the code that
-/// throws them, so same-file and same-directory both favour them over the
-/// callee that carries the value onward. Measured on a converted `psf/requests`
-/// by a stranger: nine of the twelve depth-1 slots on `HTTPAdapter.send` went
-/// to `SSLError`, `InvalidURL`, `ProxyError`, `RetryError`, `ReadTimeout` and
-/// `InvalidHeader`, and the hop governing connection reuse was not in the
-/// answer at all. It demotes rather than filters, because "what does this
-/// throw" is a real question and the edge is real evidence; a step wide enough
-/// to hold them still reports them, just last.
+/// The raise-target signal sits BELOW declaration kind, where it separates two
+/// otherwise equal candidates and can never evict one in favour of a candidate
+/// of a different kind. That position is measured, not assumed, and the
+/// measurement is the point.
+///
+/// Ranking it second, above locality and kind, is the obvious reading of "a
+/// throw site is not a hop" and it makes the tool's answer WORSE. At a fixed
+/// `limit_per_step`, demoting a candidate promotes whatever ranked next, and on
+/// a converted `psf/requests` what ranked next was `HTTPAdapter` itself,
+/// `Response` and `RequestEncodingMixin._encode_params`. Those are hubs. Six
+/// cheap terminal exception classes came out of `HTTPAdapter.send`'s twelve
+/// depth-1 slots and six expensive ones went in, the walk grew from 129
+/// discovered steps to its 200-step ceiling, and the hop that carries the
+/// answer, `_urllib3_request_context` at depth 3, stopped arriving at the
+/// default budget. Below kind it does not move at all: the walk stays at 129,
+/// the hop comes back, and `SSLError` is still in the answer, still last.
+///
+/// `declaration_kind_rank` is what actually delivers "data flow above throw
+/// sites" on real bytes, because exception classes are Classes and the callees
+/// that carry a value are Functions and Methods. This signal orders throw sites
+/// among their own kind, which is all a fan-out cap ever needed from it. It
+/// demotes rather than filters either way, because "what does this throw" is a
+/// real question and the edge is real evidence.
 ///
 /// `parent_file` and `parent_dir` describe the node whose fan-out is being cut,
 /// not the focal: locality is what makes a chain readable, and at depth 3 the
@@ -556,12 +569,12 @@ pub fn trace_fanout_score(
     let confidence = (confidence.clamp(0.0, 1.0) * 1000.0).round() as u32;
     (
         !trace_entity_is_external(entity),
-        !raise_target,
         trace_role_rank(&entity.role),
         trace_relation_rank(relation_kind),
         same_file,
         same_dir,
         declaration_kind_rank(&entity.kind),
+        !raise_target,
         confidence,
         std::cmp::Reverse(entity.name.len()),
     )
@@ -848,21 +861,45 @@ mod tests {
     }
 
     #[test]
-    fn a_raise_target_loses_to_a_data_flow_hop_it_would_otherwise_outrank() {
-        // FIR-2642. Locality is what let this go wrong: an exception class
-        // beside the code that throws it wins same-file and same-directory
-        // against the callee that carries the value onward. The signal sits
-        // above both so that comparison can no longer come out the wrong way.
+    fn a_raise_target_loses_to_an_equal_candidate_that_is_not_one() {
+        // FIR-2642. The comparison this signal decides, and the only one it is
+        // allowed to decide: two candidates alike in every other term, one of
+        // them only ever thrown.
         let thrown = fanout_entity("SSLError", Some("src/requests/sessions.py"));
-        let hop = fanout_entity("build_pool_key", Some("src/requests/adapters.py"));
+        let ordinary = fanout_entity("SSLError2", Some("src/requests/sessions.py"));
         assert!(
-            scored(&thrown, false) > scored(&hop, false),
-            "the fixture's premise: without the signal the same-file throw \
-             site wins"
+            scored(&ordinary, false) > scored(&thrown, true),
+            "the candidate that is not a throw site wins"
         );
         assert!(
+            scored(&thrown, false) > scored(&ordinary, false),
+            "the fixture's premise: with neither marked, the shorter name wins, \
+             so the signal is what reverses them rather than a tie"
+        );
+    }
+
+    #[test]
+    fn a_raise_target_never_outranks_a_hop_of_a_stronger_kind() {
+        // And the term it must NOT override. Ranking a raise target below a
+        // whole declaration kind was measured on a converted psf/requests and
+        // cost the answer: it evicted six cheap exception classes from the
+        // depth-1 cap and admitted six hubs, the walk grew from 129 steps to
+        // its 200-step ceiling, and the hop at depth 3 stopped arriving.
+        let mut hop = fanout_entity("build_pool_key", Some("src/requests/sessions.py"));
+        hop.kind = EntityKind::Function;
+        let mut thrown = fanout_entity("SSLError", Some("src/requests/sessions.py"));
+        thrown.kind = EntityKind::Class;
+        assert!(
             scored(&hop, false) > scored(&thrown, true),
-            "with it, the hop the value travels along wins"
+            "a function the value travels through outranks a class that is \
+             only thrown"
+        );
+        let mut other_class = fanout_entity("HTTPAdapter", Some("src/requests/sessions.py"));
+        other_class.kind = EntityKind::Class;
+        assert!(
+            scored(&hop, false) > scored(&other_class, false),
+            "and it outranks an ordinary class too, which is what stops the \
+             raise signal from promoting a hub into a slot a throw site held"
         );
     }
 

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -66,7 +66,12 @@ control on JavaScript import specifiers. Checks 2 through 8 cover the two real
 callers of `HTTPAdapter.send`, the `app.handle` walk in express, one verdict per
 payload, `find_references` and `graph_neighborhood` agreeing on one entity, an
 express export nothing may certify as unused, and `semantic_search` refusing to
-certify a false absence.
+certify a false absence. Check 9 kills a `kin init` mid-conversion and asserts the
+next command names the kill, the re-run says whether it resumes or restarts, and
+nothing is orphaned silently. Check 10 replays the rc0550 brown stranger's task 3
+verbatim, at that run's own budget, and requires the walk to reach the hop that
+folds `verify` into the urllib3 pool key and every external node it touches to
+name what it crosses into.
 
 The brownfield fixtures are one commit each, so its recall results are
 one-commit-shape results. The suite prints that scope on every run and records it

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -1747,12 +1747,17 @@ def check_10(suite):
     this a ranking failure. If the wider walk misses it too, the edge is not in the
     graph and that is a different defect, reported UNREADABLE rather than FAIL.
 
-    The third is the ordering: no raise target may rank above a row the value
-    actually travels through, in the same node's fan-out. It demotes rather than
-    filters, so their presence is fine and their position is not. Measured on both
-    builds this arm passes, because `declaration_kind_rank` already sorted Class
-    below Function; it is a regression guard rather than the falsifying arm, and
-    saying otherwise would be inventing a result.
+    The third is the ordering, and it is a TRIPWIRE rather than evidence. It says
+    no raise target may rank above a row the value actually travels through, in
+    the same node's fan-out. On this corpus it passes on every build tried,
+    including three built to break it: released bytes with no raise marker at all,
+    a build with the raise term inverted so throw sites outrank data flow, and a
+    build with `declaration_kind_rank` inverted so classes outrank functions. A
+    check that cannot fail is not evidence, so this arm is not offered as any. It
+    is kept because it would still catch a gross regression on a corpus that
+    exposes one, and the ordering it describes IS guarded, at the level where the
+    comparison is decidable: the unit tests in kin-ranking and kin-cli, which do
+    fail when the term is inverted.
 
     The fourth and fifth are half two of the ticket, on both corpora: every external
     node an answer touches must name its crossing, so a caller can tell an npm
@@ -1852,7 +1857,12 @@ def check_10(suite):
                 % (len(misordered), sample))
     else:
         present = sorted({name for name in names if name in TRACE_RAISE_TARGETS})
-        res.ok("no raise target ranks above a data-flow row%s"
+        res.ok("no raise target ranks above a data-flow row%s. TRIPWIRE, not "
+               "evidence: this arm also passed on released bytes carrying no "
+               "raise marker, on a build with the raise term inverted, and on a "
+               "build with declaration_kind_rank inverted, so it has never been "
+               "shown to fail on this corpus; the ordering is guarded by the "
+               "kin-ranking and kin-cli unit tests, which do"
                % (" (%s present and ranked below)" % ", ".join(present) if present
                   else "; none appeared in the walk"))
 

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -1718,6 +1718,7 @@ def check_9(suite):
     else:
         res.ok("the re-run reclaimed %s of staging and said so; nothing is "
                "left beside the repository" % reclaimed.group(1))
+    return res
 
 
 def check_10(suite):
@@ -1919,8 +1920,6 @@ def check_10(suite):
             res.ok("on express, all %d external node(s) name their crossing%s"
                    % (len(js_external),
                       " (specifiers %s)" % ", ".join(named[:6]) if named else ""))
-
-
     return res
 
 
@@ -2165,6 +2164,17 @@ def main(argv):
         except Exception as exc:
             res = Result(check_id, "?", "harness failure")
             res.unknown("%s: %s" % (type(exc).__name__, str(exc)[:300]))
+        # A check that falls off its own end returns None, and None then blows up
+        # three stages later on an attribute nobody can trace back to the check
+        # that caused it. Measured: a rebase moved one check's `return res` onto
+        # the next check's tail, `--only 10` ran the surviving one and stayed
+        # green, and the full run died in the reporter with a traceback naming
+        # the reporter. Name the check instead, and never report it as a pass.
+        if res is None:
+            res = Result(check_id, "?", "harness failure")
+            res.unknown("check_%s returned no Result, so it fell off its own "
+                        "end; a check that reports nothing is never a pass"
+                        % check_id)
         results.append(res)
         res.prior = None if prior is None else prior.get(res.id)
         res.trend = trend_of(res.status, res.prior)

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -206,6 +206,35 @@ FABRICATED_SEND_CALLERS = {
     "test_redirect_rfc1808_to_non_ascii_location",
 }
 
+# requests, rc0550 brown task 3. The stranger asked where `verify` lands inside
+# HTTPAdapter.send and got an answer one hop short, which would have been WRONG if
+# trusted: `verify` reaches TLS at cert_verify AND at the pool-key path that governs
+# connection reuse, and only the second was missing. These are the stranger's own
+# parameters, not a shape chosen to pass. The defect only appears at this budget.
+TRACE_FOCAL = "HTTPAdapter.send"
+TRACE_DEPTH = 3
+TRACE_LIMIT_PER_STEP = 12
+
+# The hop the answer turns on. build_connection_pool_key_attributes' entire body is
+# `return _urllib3_request_context(request, verify, cert, self.poolmanager)`, and
+# _urllib3_request_context folds verify into the urllib3 pool key, which is what stops
+# a verify=False connection being reused for a verify=True request.
+TRACE_LOAD_BEARING = "_urllib3_request_context"
+TRACE_LOAD_BEARING_PARENT = "build_connection_pool_key_attributes"
+
+# The six exception classes that took nine of the twelve depth-1 slots on the measured
+# run. Every one is a `raise` target inside an `except` block, not data flow. They are
+# the negative control for ordering: they may appear, because "what does this throw" is
+# a real question, but never above a row the value actually travels through.
+TRACE_RAISE_TARGETS = {
+    "SSLError",
+    "InvalidURL",
+    "ProxyError",
+    "RetryError",
+    "ReadTimeout",
+    "InvalidHeader",
+}
+
 # express, task 5. trace_data_flow on app.handle, direction calls, depth 2 returned
 # eleven steps of which the stranger verified nine were fabricated, all descended from
 # bare-name matching the single `this.get('env')` call site against every entity in
@@ -748,6 +777,18 @@ def upstream_rows(payload):
             if isinstance(row, dict):
                 withheld.append(row)
     return counted, withheld
+
+
+def trace_steps(payload):
+    """The step list a trace payload carries, under whichever key this build uses.
+
+    Returns None when no list is present, which is a different fact from an empty
+    walk and is graded UNREADABLE rather than FAIL by every caller.
+    """
+    for key in ("chain", "steps", "flow", "path"):
+        if isinstance(payload.get(key), list):
+            return payload[key]
+    return None
 
 
 def find_row(rows, wanted):
@@ -1677,6 +1718,151 @@ def check_9(suite):
     else:
         res.ok("the re-run reclaimed %s of staging and said so; nothing is "
                "left beside the repository" % reclaimed.group(1))
+
+
+def check_10(suite):
+    """FIR-2642: the trace answers the question, and says where the graph ends.
+
+    This check IS the rc0550 brown stranger's task 3, replayed with the stranger's
+    own parameters. That matters more than it looks: the defect only exists at this
+    budget. Raise limit_per_step or max_chars and the load-bearing hop comes back,
+    which is how a check written for convenience would pass on the broken build.
+
+    What the stranger asked: where does `verify` land inside HTTPAdapter.send. The
+    true answer has TWO landing points, cert_verify (which sets attributes on the
+    connection) and _urllib3_request_context (which folds verify into the urllib3
+    pool key, governing connection reuse). The shipped build returned only the
+    first. Nine of its twelve depth-1 slots went to exception classes, `raise`
+    targets in `except` blocks that are not data flow at all, and they crowded out
+    the hop that mattered. The stranger's verdict, quoted: "If I had trusted the Kin
+    arm alone I would have written a wrong answer."
+
+    Four arms.
+
+    The first is the answer itself: the walk must contain _urllib3_request_context.
+    The second distinguishes the two ways that can fail, because blaming ranking for
+    a missing edge would be a confident wrong finding: when the hop is absent at the
+    stranger's budget, a WIDER probe runs, and only if the wider walk finds it is
+    this a ranking failure. If the wider walk misses it too, the edge is not in the
+    graph and that is a different defect, reported UNREADABLE rather than FAIL.
+
+    The third is the ordering that causes it: no raise target may rank above a row
+    the value actually travels through, at the same depth. It demotes rather than
+    filters, so their presence is fine and their position is not.
+
+    The fourth is half two of the ticket: every external node the answer touches
+    must name its crossing, so a caller can tell an npm package from a builtin from
+    a typo instead of reading a bare symbol.
+    """
+    res = Result("10", "FIR-2642", "the trace reaches the pool-key hop and names "
+                                  "every boundary it touches")
+    repo = suite.fixture("requests")
+    try:
+        suite.sweep_gate("requests")
+        payload = suite.cached(repo, "trace_data_flow",
+                               {"focal": TRACE_FOCAL, "direction": "calls",
+                                "depth": TRACE_DEPTH, "include_body": False,
+                                "limit_per_step": TRACE_LIMIT_PER_STEP})
+    except ProbeError as exc:
+        res.unknown(str(exc))
+        return res
+
+    steps = trace_steps(payload)
+    if steps is None:
+        res.unknown("trace_data_flow payload carries no step list; keys are %s"
+                    % sorted(payload.keys()))
+        return res
+    if not steps:
+        res.unknown("trace_data_flow on %s returned zero steps, so nothing about "
+                    "ranking or boundaries can be judged" % TRACE_FOCAL)
+        return res
+
+    names = [str(step.get("entity_name") or "") for step in steps]
+
+    # Arm one and two: the answer, and which failure it is when the answer is short.
+    if TRACE_LOAD_BEARING in names:
+        res.ok("the walk reaches %s at the stranger's own budget (depth=%d, "
+               "limit_per_step=%d), so the verify-to-TLS answer is complete from "
+               "Kin alone" % (TRACE_LOAD_BEARING, TRACE_DEPTH, TRACE_LIMIT_PER_STEP))
+    else:
+        omitted = payload.get("steps_omitted")
+        try:
+            wider = suite.cached(repo, "trace_data_flow",
+                                 {"focal": TRACE_FOCAL, "direction": "calls",
+                                  "depth": TRACE_DEPTH, "include_body": False,
+                                  "limit_per_step": 40, "max_chars": 400000},
+                                 key=(repo, "trace_wide", TRACE_FOCAL))
+            wider_steps = trace_steps(wider) or []
+        except ProbeError:
+            wider_steps = []
+        wider_names = [str(step.get("entity_name") or "") for step in wider_steps]
+        if TRACE_LOAD_BEARING in wider_names:
+            res.bad("the walk does not reach %s at the stranger's budget but a wider "
+                    "one does, so the edge is in the graph and the ranking spent the "
+                    "budget elsewhere: %r steps omitted, %d returned. Trusted alone "
+                    "this answer says verify reaches TLS at cert_verify and stops, "
+                    "missing the pool-key path that governs connection reuse"
+                    % (TRACE_LOAD_BEARING, omitted, len(steps)))
+        elif not wider_steps:
+            res.unknown("the walk does not reach %s and the wider probe returned "
+                        "nothing, so this cannot be told from a broken probe"
+                        % TRACE_LOAD_BEARING)
+        else:
+            res.unknown("neither the stranger's walk nor a wider one reaches %s, so "
+                        "the edge is absent from the graph rather than outranked; "
+                        "that is a different defect from this one and must not be "
+                        "reported as a ranking failure" % TRACE_LOAD_BEARING)
+
+    # Arm three: ordering. A raise target above a row the value travels through is
+    # the mechanism, and it is what a revert of the ranking change restores.
+    misordered = []
+    by_depth = {}
+    for index, step in enumerate(steps):
+        by_depth.setdefault(step.get("depth"), []).append((index, step))
+    for depth, rows in sorted(by_depth.items(), key=lambda item: (item[0] is None, item[0])):
+        last_flow = None
+        for position, (_index, step) in enumerate(rows):
+            if str(step.get("entity_name") or "") not in TRACE_RAISE_TARGETS:
+                last_flow = position
+        if last_flow is None:
+            continue
+        for position, (_index, step) in enumerate(rows[:last_flow]):
+            name = str(step.get("entity_name") or "")
+            if name in TRACE_RAISE_TARGETS:
+                misordered.append((depth, position, name))
+    if misordered:
+        sample = ", ".join("%s at depth %s position %d" % (name, depth, position)
+                           for depth, position, name in misordered[:6])
+        res.bad("%d raise target(s) rank above a row the value travels through: %s. "
+                "These are `raise` operands in `except` blocks, not data flow, and "
+                "at a bounded budget they take the slots the chain needs"
+                % (len(misordered), sample))
+    else:
+        present = sorted({name for name in names if name in TRACE_RAISE_TARGETS})
+        res.ok("no raise target ranks above a data-flow row%s"
+               % (" (%s present and ranked below)" % ", ".join(present) if present
+                  else "; none appeared in the walk"))
+
+    # Arm four: half two of the ticket. A boundary that stands mute cannot be told
+    # from a typo.
+    external = [step for step in steps if step.get("external") is True]
+    mute = []
+    for step in external:
+        crossing = step.get("crossing")
+        if not isinstance(crossing, dict) or not str(crossing.get("status") or "").strip():
+            mute.append(str(step.get("entity_name") or "?"))
+    if not external:
+        res.ok("the walk touched no external node, so no crossing was owed")
+    elif mute:
+        res.bad("%d of %d external node(s) name no crossing (%s); a bare external "
+                "symbol cannot be told from a package, a builtin or a typo"
+                % (len(mute), len(external), ", ".join(sorted(set(mute))[:6])))
+    else:
+        statuses = sorted({str(step["crossing"].get("status")) for step in external})
+        res.ok("all %d external node(s) name their crossing (status %s)"
+               % (len(external), "/".join(statuses)))
+
+
     return res
 
 
@@ -1691,6 +1877,7 @@ CHECKS = [
     ("7", check_7),
     ("8", check_8),
     ("9", check_9),
+    ("10", check_10),
 ]
 
 

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -102,7 +102,7 @@ Options:
     --corpus-cache PATH  pinned upstream clones (default: ~/.cache/kin-brownfield-repro)
     --offline            refuse to fetch; the cache must already carry both pins
     --label NAME         label recorded in the JSON report
-    --only IDS           comma-separated check ids to run, 0 through 9 (default: all)
+    --only IDS           comma-separated check ids to run, 0 through 10 (default: all)
     --json PATH          write machine-readable results here
     --compare PATH       a prior run's --json; a check that passed there and fails
                          here reads REGRESSION rather than plain FAIL
@@ -1737,7 +1737,7 @@ def check_10(suite):
     the hop that mattered. The stranger's verdict, quoted: "If I had trusted the Kin
     arm alone I would have written a wrong answer."
 
-    Four arms.
+    Five arms.
 
     The first is the answer itself: the walk must contain _urllib3_request_context.
     The second distinguishes the two ways that can fail, because blaming ranking for
@@ -1746,13 +1746,18 @@ def check_10(suite):
     this a ranking failure. If the wider walk misses it too, the edge is not in the
     graph and that is a different defect, reported UNREADABLE rather than FAIL.
 
-    The third is the ordering that causes it: no raise target may rank above a row
-    the value actually travels through, at the same depth. It demotes rather than
-    filters, so their presence is fine and their position is not.
+    The third is the ordering: no raise target may rank above a row the value
+    actually travels through, in the same node's fan-out. It demotes rather than
+    filters, so their presence is fine and their position is not. Measured on both
+    builds this arm passes, because `declaration_kind_rank` already sorted Class
+    below Function; it is a regression guard rather than the falsifying arm, and
+    saying otherwise would be inventing a result.
 
-    The fourth is half two of the ticket: every external node the answer touches
-    must name its crossing, so a caller can tell an npm package from a builtin from
-    a typo instead of reading a bare symbol.
+    The fourth and fifth are half two of the ticket, on both corpora: every external
+    node an answer touches must name its crossing, so a caller can tell an npm
+    package from a builtin from a typo instead of reading a bare symbol. The fifth
+    reads the express walk check 4 already runs, because task 5 is where the
+    complaint came from and a Python walk alone is thin evidence for it.
     """
     res = Result("10", "FIR-2642", "the trace reaches the pool-key hop and names "
                                   "every boundary it touches")
@@ -1868,6 +1873,52 @@ def check_10(suite):
         statuses = sorted({str(step["crossing"].get("status")) for step in external})
         res.ok("all %d external node(s) name their crossing (status %s)"
                % (len(external), "/".join(statuses)))
+
+    # Arm five: half two on the corpus the stranger actually filed it from. The
+    # requests walk above is a Python one and, once the budget narrows it, touches
+    # only a couple of boundary nodes, so it is thin evidence on its own. Task 5
+    # is where the complaint came from: `router.handle` arrived as an external
+    # node with nothing tying it to `require('router')` or to `router@^2.2.0`,
+    # and the stranger closed the gap with one grep. Same walk check 4 already
+    # runs, so the payload is cached and this arm costs no extra call.
+    try:
+        js = suite.cached(suite.fixture("express"), "trace_data_flow",
+                          {"focal": APP_HANDLE, "direction": "calls",
+                           "depth": 2, "include_body": False,
+                           "limit_per_step": 25, "max_chars": 200000})
+        js_steps = trace_steps(js) or []
+    except ProbeError as exc:
+        js_steps = None
+        res.note("the express boundary arm could not run: %s" % exc)
+    if js_steps is None:
+        pass
+    elif not js_steps:
+        res.unknown("the express walk on %s returned zero steps, so its boundaries "
+                    "cannot be judged" % APP_HANDLE)
+    else:
+        js_external = [step for step in js_steps if step.get("external") is True]
+        js_mute = []
+        for step in js_external:
+            crossing = step.get("crossing")
+            if (not isinstance(crossing, dict)
+                    or not str(crossing.get("status") or "").strip()):
+                js_mute.append(str(step.get("entity_name") or "?"))
+        if not js_external:
+            res.ok("the express walk touched no external node, so no crossing was "
+                   "owed there either")
+        elif js_mute:
+            res.bad("on express, %d of %d external node(s) name no crossing (%s); "
+                    "this is the task-5 shape, where the graph knows a boundary "
+                    "exists and nothing about the other side of it"
+                    % (len(js_mute), len(js_external),
+                       ", ".join(sorted(set(js_mute))[:6])))
+        else:
+            named = sorted({str(step["crossing"].get("specifier"))
+                            for step in js_external
+                            if step["crossing"].get("specifier")})
+            res.ok("on express, all %d external node(s) name their crossing%s"
+                   % (len(js_external),
+                      " (specifiers %s)" % ", ".join(named[:6]) if named else ""))
 
 
     return res

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -1815,11 +1815,17 @@ def check_10(suite):
 
     # Arm three: ordering. A raise target above a row the value travels through is
     # the mechanism, and it is what a revert of the ranking change restores.
+    # Grouped by parent_step, not by depth. The per-step cap cuts ONE node's
+    # fan-out, which is the list sort_trace_candidates orders, and depth mixes the
+    # fan-outs of every node at that level into an order nothing ever sorted. An
+    # earlier draft of this arm grouped by depth and passed on bytes that had never
+    # been fixed, which is the failure mode this suite exists to refuse.
     misordered = []
-    by_depth = {}
+    by_parent = {}
     for index, step in enumerate(steps):
-        by_depth.setdefault(step.get("depth"), []).append((index, step))
-    for depth, rows in sorted(by_depth.items(), key=lambda item: (item[0] is None, item[0])):
+        by_parent.setdefault(step.get("parent_step"), []).append((index, step))
+    for parent, rows in sorted(by_parent.items(),
+                               key=lambda item: (item[0] is None, item[0])):
         last_flow = None
         for position, (_index, step) in enumerate(rows):
             if str(step.get("entity_name") or "") not in TRACE_RAISE_TARGETS:
@@ -1829,10 +1835,11 @@ def check_10(suite):
         for position, (_index, step) in enumerate(rows[:last_flow]):
             name = str(step.get("entity_name") or "")
             if name in TRACE_RAISE_TARGETS:
-                misordered.append((depth, position, name))
+                misordered.append((parent, position, name))
     if misordered:
-        sample = ", ".join("%s at depth %s position %d" % (name, depth, position)
-                           for depth, position, name in misordered[:6])
+        sample = ", ".join("%s in the fan-out of step %s at position %d"
+                           % (name, parent, position)
+                           for parent, position, name in misordered[:6])
         res.bad("%d raise target(s) rank above a row the value travels through: %s. "
                 "These are `raise` operands in `except` blocks, not data flow, and "
                 "at a bounded budget they take the slots the chain needs"


### PR DESCRIPTION
A `trace_data_flow` walk that hit its budget came back one hop short of the answer, and the hop it
lost was the one that mattered. The rc0550 brown stranger asked where `verify` lands inside
`HTTPAdapter.send` on a converted `psf/requests` and got `cert_verify` and nothing else. The real
answer has two landing points, and the missing one, `_urllib3_request_context`, is what folds
`verify` into the urllib3 pool key and so governs connection reuse. Their words: "If I had trusted
the Kin arm alone I would have written a wrong answer." Separately, on express, an external node
arrived as a bare symbol with nothing saying whether it was an npm package, a Node builtin or a
typo.

Both halves are fixed, and check 10 in `scripts/acceptance/brownfield_repro.py` replays the
stranger's task at that run's own parameters so the class cannot come back quietly.

## The budget amputated depth instead of narrowing width

A budgeted chain was cut as a suffix, which is safe because children follow parents, and wrong for
the same reason: discovery order is breadth-first, so the tail of the chain is its deepest steps.
The walk reached depth 3 and the response carried nothing past depth 2. There were two such cuts on
one response, the walk's own and the collection trimmer inside `kin mcp start`, both from the end.

The rule now lives once, in `kin_mcp::budget::narrow_fanout_to_fit`, and gives up whole branches
rather than depth: least relevant first, widest nodes first, every node keeping the branch that
reaches deepest so a walk can be thinned and never severed, and a dropped branch taking its
descendants so no surviving step names a parent the caller cannot see. It falls back to the suffix
when nothing narrows enough. All three cuts call it: the CLI walk the daemon route serves, the
in-process MCP arm, and the generic trimmer, which now narrows any collection whose entries name a
parent because such a collection is a tree.

Two details are load-bearing and were each found by a measurement that contradicted the obvious
choice. The earlier work put the narrowing in the in-process arm only, and that is not the arm a
caller gets: `kin mcp start` talks to a daemon, and the daemon special-cases `trace_data_flow` so
the CLI implementation answers it. And keeping each node's first child was not enough, because the
hop hangs off the focal's fifth child, so the leftmost spine survived while the branch reaching
depth three was given up. That worked at 129 discovered steps and broke at 200, which is luck
rather than a rule.

## An external node now says where the graph ends

A boundary step carries a `crossing` record naming the module specifier when the graph holds one,
and saying plainly that it holds none when it does not, because silence is the one answer that
reads like an in-repo entity. On the pre-fix bytes 12 of 12 external nodes on requests and 7 of 7
on express named nothing; on this branch every one of them does.

## Two things the falsification found, and one it could not

Restoring exception-first ordering was supposed to fail the new check. It passed, with the returned
order unchanged, so the ranking signal was inert on the corpus it was written from. Two causes, both
measured. The raise flag was folded with `&&` across every edge, so whichever edge created the
candidate set the starting value. And every resolved call reaches the graph twice on a repository
with a language server, once from the parser and once from the LSP call hierarchy, and an LSP edge
cannot see a `raise`, so its silence was being read as a claim that the call was ordinary. A
candidate now counts only parse-authored call edges and is a throw site when it has them and every
one is a raise.

Making the signal live then broke the answer, which is the second finding. At a fixed
`limit_per_step`, demoting a candidate promotes whatever ranked next, and what ranked next were
hubs: `HTTPAdapter` itself, `Response`, `RequestEncodingMixin._encode_params`. Six cheap terminal
exception classes left the twelve depth-1 slots, six expensive ones took them, the walk grew to its
200-step ceiling and the hop stopped arriving. Measured with the term neutralised and everything
else identical, the walk is 129 steps and the hop is back. So the term moved below
`declaration_kind_rank`, where it separates two otherwise equal candidates and can evict nobody.
Kind rank is what actually delivers data flow above throw sites on real bytes, because exceptions
are Classes and the callees that carry a value are Functions.

The third thing is what the falsification could not do. Check 10's ordering arm passes on every
build tried, including released bytes with no raise marker, a build with the raise term inverted,
and a build with `declaration_kind_rank` inverted. A check that cannot fail is not evidence, so the
arm now says so in its own output and is kept as a tripwire; the ordering is guarded where the
comparison is decidable, in the kin-ranking and kin-cli unit tests, which do fail when the term is
inverted.

## Disclosure

`fanout_narrowed` counts the steps that went as branches and is published on every response, zero
included. The degradation keeps `reason: steps_omitted`, because a reason code names the lever a
caller raises and that lever is `max_response_chars` either way, and its detail says which cut was
made. Clips are kept by membership rather than by index, since a narrowed chain is no longer a
prefix.

## Evidence

Two-sided on real bytes, no hand mutation: `origin/main` built from a `git archive` of that ref
fails arms 1, 4 and 5; this branch passes all five. Four targeted mutants each kill exactly the arms
they should, and the unit mutants kill their tests. `bin/kin-parity --profile dev` against this
worktree reads PASS-WITH-ALLOWANCES: magic 14/14, brownfield 10 pass with check 4's existing
FIR-2464 allowance, firstrun 9 pass with its two existing allowances. Clippy runs clean with
`-D warnings` and the repo's 45-lint debt list, and the ci.yml guard scripts pass.

One check-9 defect came out of this too: the rebase that renumbered the incoming check onto slot 10
left main's check 9 without its `return res`, which `--only 10` could never see. The runner now
names a check that returns nothing instead of dying in the reporter.

Closes FIR-2642
