### PR TITLE
Stop the bootstrap build proving and reading history by copying it

### DIFF
--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -8,6 +8,7 @@
 //! local ignore overlay are committed together as graph-owned authority before
 //! the staged `.kin` repository is atomically published.
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -23,11 +24,11 @@ use kin_git::{
 };
 use kin_model::{
     compute_resolved_tree_hash, AdmissionCase, AuthorId, ChangeStore,
-    EffectiveAdmissionPolicyStamp, ExternalObjectId, ExternalObjectKind, FrozenLocalOverlay,
-    FrozenLocalOverlayDelta, GitExternalAuthorityDelta, GitMaterialHead, Hash256,
-    LocalAdmissionRuleSource, LocalAdmissionRuleSourceKind, LocatedEntry, OperationId,
-    RepositoryId, RepositoryTransaction, TreeDelta, WorkspaceExpectation, WorkspaceMutation,
-    WorkspaceSemanticDelta,
+    EffectiveAdmissionPolicyStamp, EntityId, ExternalObjectId, ExternalObjectKind,
+    FrozenLocalOverlay, FrozenLocalOverlayDelta, GitExternalAuthorityDelta, GitMaterialHead,
+    Hash256, LocalAdmissionRuleSource, LocalAdmissionRuleSourceKind, LocatedEntry, OperationId,
+    RepositoryId, RepositoryTransaction, SemanticChange, SemanticChangeId, TreeDelta,
+    WorkspaceExpectation, WorkspaceMutation, WorkspaceSemanticDelta,
 };
 use tracing::{info, info_span};
 
@@ -903,7 +904,13 @@ fn bind_workspace_authority(
         shared: workspace_policy.stamp(),
         local: local_overlay.stamp(),
     };
-    let semantic_delta = imported_workspace_semantic_delta(transaction, &workspace_seed)?;
+    let semantic_delta = {
+        // Named because it is the largest single term in this phase and was
+        // invisible inside it: the phase read as one opaque number while a
+        // whole second history sat underneath.
+        let _span = info_span!("kin.init.derive_workspace_semantics").entered();
+        imported_workspace_semantic_delta(transaction, &workspace_seed)?
+    };
     transaction.workspace_mutation = Some(WorkspaceMutation {
         workspace_id,
         expected: WorkspaceExpectation::MustNotExist,
@@ -919,6 +926,78 @@ fn bind_workspace_authority(
     });
     transaction.local_overlay_delta = Some(FrozenLocalOverlayDelta::initialize(local_overlay));
     Ok(())
+}
+
+/// Borrowed change-history view over a bootstrap transaction's own changes.
+///
+/// `ChangeStore::resolve_graph_at` is a kin-model default method whose only
+/// store dependency is `get_change`. Deriving the imported workspace's
+/// semantics used to reach it by staging every change in history into a fresh
+/// `InMemoryGraph`, which is the durable authority write path: it copies each
+/// change into the store, appends every entity's revision timeline, plans the
+/// revision vectors, and updates the entity and relation indexes, and all of it
+/// was discarded after one replay. On a mid-size repository that second history
+/// is the largest thing a conversion holds. This view serves the identical
+/// replay from the transaction's own changes, borrowed where they already are.
+///
+/// Nothing is validated less. The graph's `create_change` refused a duplicate
+/// change and called `validate_semantic_change`, which is
+/// `kin_model::validate_semantic_change_id`; `RepositoryTransaction::validate`
+/// runs both of those over the same `changes` before this function is reached
+/// and again after it.
+///
+/// The store methods the replay never reaches fail closed rather than answering
+/// an empty result, which is the shape kin-db's own base-resolution view uses
+/// for the same reason: a future caller that reaches one must be refused, not
+/// silently served nothing.
+struct BootstrapHistoryView<'a> {
+    changes: HashMap<SemanticChangeId, &'a SemanticChange>,
+}
+
+impl<'a> BootstrapHistoryView<'a> {
+    fn new(changes: &'a [SemanticChange]) -> Self {
+        Self {
+            changes: changes.iter().map(|change| (change.id, change)).collect(),
+        }
+    }
+
+    fn unsupported(operation: &str) -> KinError {
+        KinError::Other(format!(
+            "{operation} is unavailable through a bootstrap transaction history view"
+        ))
+    }
+}
+
+impl ChangeStore for BootstrapHistoryView<'_> {
+    type Error = KinError;
+
+    fn get_change(&self, id: &SemanticChangeId) -> Result<Option<SemanticChange>> {
+        Ok(self.changes.get(id).map(|change| (*change).clone()))
+    }
+
+    fn get_entity_history(&self, _id: &EntityId) -> Result<Vec<SemanticChange>> {
+        Err(Self::unsupported("entity history"))
+    }
+
+    fn find_merge_bases(
+        &self,
+        _a: &SemanticChangeId,
+        _b: &SemanticChangeId,
+    ) -> Result<Vec<SemanticChangeId>> {
+        Err(Self::unsupported("merge-base search"))
+    }
+
+    fn create_change(&self, _change: &SemanticChange) -> Result<()> {
+        Err(Self::unsupported("change creation"))
+    }
+
+    fn get_changes_since(
+        &self,
+        _base: &SemanticChangeId,
+        _head: &SemanticChangeId,
+    ) -> Result<Vec<SemanticChange>> {
+        Err(Self::unsupported("change-range listing"))
+    }
 }
 
 fn imported_workspace_semantic_delta(
@@ -949,13 +1028,8 @@ fn imported_workspace_semantic_delta(
         }
     };
 
-    let graph = kin_db::InMemoryGraph::new();
-    for change in &transaction.changes {
-        graph.create_change(change).map_err(|error| {
-            KinError::Other(format!("stage imported semantic history: {error}"))
-        })?;
-    }
-    let target = graph.resolve_graph_at(&change_id).map_err(|error| {
+    let history = BootstrapHistoryView::new(&transaction.changes);
+    let target = history.resolve_graph_at(&change_id).map_err(|error| {
         KinError::Other(format!("resolve imported workspace semantics: {error}"))
     })?;
     crate::diff_workspace_semantics(

--- a/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
+++ b/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
@@ -135,6 +135,38 @@ const RELEASE_PHASE: &str = "kin.init.release_plan_bodies";
 /// without the bodies or it is not.
 const RELEASE_DROP_PERCENT_OF_BIND_RETAINED: usize = 50;
 
+/// The phase that builds the bootstrap transaction.
+///
+/// It re-proves the admitted plan, moves that plan's fields into a transaction,
+/// and derives the imported workspace's semantics. Everything it allocates is
+/// transient: it retains 0.2 MiB on this fixture, so whatever it adds to the
+/// peak is memory a machine has to survive for a step that keeps nothing.
+const BUILD_PHASE: &str = "kin.init.build_bootstrap_transaction";
+
+/// The phase whose retained bytes are one copy of the admitted history.
+///
+/// The denominator, for the reason the binding ratio above gives: a byte
+/// ceiling written for this fixture would say nothing about a repository, and
+/// both figures scale with commits multiplied by per-commit churn.
+const ADMIT_PHASE: &str = "kin.init.admit_semantic_import";
+
+/// How far past one copy of the admitted history the bootstrap build may push
+/// the peak, in percent.
+///
+/// Measured on this fixture, release, one host, and quoted in the pull request
+/// that introduced this guard: 450 percent (377.0 MiB of growth against
+/// 83.7 MiB retained) while that phase re-proved the admitted plan by building
+/// a third complete import plan and staged the whole history into a second
+/// in-memory graph to derive the workspace's semantics, and 128 percent
+/// (107.8 MiB) once both were replaced by streaming and borrowed reads. The
+/// gate sits at 250, below the first and above the second.
+///
+/// A phase that proves and keeps nothing should not need several copies of
+/// what it is proving. This is the class the number carries; the total below
+/// stays a backstop and does not move when this one does, because on this
+/// fixture the run's peak is set by the commit phase after it.
+const BUILD_PEAK_GROWTH_PERCENT_OF_ADMITTED: usize = 250;
+
 /// Backstop on total peak live heap for admitting `COMMITS` commits.
 ///
 /// Deliberately loose, and deliberately NOT the headline. The total is set by
@@ -244,6 +276,14 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
         .iter()
         .find(|(phase, _, _)| *phase == BIND_PHASE)
         .map(|(_, grew, retained)| (*grew, *retained));
+    let build = growth
+        .iter()
+        .find(|(phase, _, _)| *phase == BUILD_PHASE)
+        .map(|(_, grew, _)| *grew);
+    let admitted = growth
+        .iter()
+        .find(|(phase, _, _)| *phase == ADMIT_PHASE)
+        .map(|(_, _, retained)| *retained);
     // The release phase gives memory BACK, and `peak_growth_by_phase` reports
     // what a phase retained with a saturating subtraction, so a phase that
     // frees reads zero there and says nothing. Read the entry and exit samples
@@ -284,6 +324,17 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
         bind.map(|(_, retained)| retained.to_string())
             .unwrap_or_else(|| "NO SAMPLE".to_string()),
         BIND_PEAK_GROWTH_PERCENT_OF_RETAINED
+    );
+    println!(
+        "{BUILD_PHASE} grew the peak by {} bytes against the {} bytes {ADMIT_PHASE} retained, \
+         ceiling {} percent",
+        build
+            .map(|bytes| bytes.to_string())
+            .unwrap_or_else(|| "NO SAMPLE".to_string()),
+        admitted
+            .map(|bytes| bytes.to_string())
+            .unwrap_or_else(|| "NO SAMPLE".to_string()),
+        BUILD_PEAK_GROWTH_PERCENT_OF_ADMITTED
     );
     println!(
         "{RELEASE_PHASE} gave back {} bytes of the {} bytes {BIND_PHASE} retained, floor {} percent",
@@ -365,6 +416,41 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
          for every commit in history answer no question and must be released. Holding them \
          to the end of a conversion is over a gigabyte live across the peak on a mid-size \
          repository.\n\n{}",
+        support::phase_attribution_table()
+    );
+    // Same two refusals as every ratio above: an absent phase measured nothing,
+    // and a zero denominator would let any growth at all pass.
+    let build = build.unwrap_or_else(|| {
+        panic!(
+            "no {BUILD_PHASE} sample was recorded, so this run proved nothing about what \
+             building the bootstrap transaction costs. Either the phase span was renamed or \
+             the probe was not installed before the measured call.\n\n{}",
+            support::phase_attribution_table()
+        )
+    });
+    let admitted = admitted.unwrap_or_else(|| {
+        panic!(
+            "no {ADMIT_PHASE} sample was recorded, so the bootstrap build has no copy of the \
+             admitted history to be measured against.\n\n{}",
+            support::phase_attribution_table()
+        )
+    });
+    assert!(
+        admitted > 0,
+        "{ADMIT_PHASE} retained nothing, so there is no copy of the admitted history to \
+         compare the bootstrap build's peak growth against and this check graded nothing.\n\n{}",
+        support::phase_attribution_table()
+    );
+    let build_percent = build.saturating_mul(100) / admitted;
+    assert!(
+        build_percent < BUILD_PEAK_GROWTH_PERCENT_OF_ADMITTED,
+        "{BUILD_PHASE} grew the peak by {build} bytes against the {admitted} bytes \
+         {ADMIT_PHASE} retained, {build_percent} percent, at or over the \
+         {BUILD_PEAK_GROWTH_PERCENT_OF_ADMITTED} percent ceiling. That phase re-proves the \
+         admitted plan and derives the imported workspace's semantics, and it keeps almost \
+         nothing, so growth of several copies of the history means it built one to prove or \
+         to read the other. On a real conversion that is gigabytes a machine has to survive \
+         for a step that retains nothing.\n\n{}",
         support::phase_attribution_table()
     );
     assert!(

--- a/crates/kin-git/src/admission_history.rs
+++ b/crates/kin-git/src/admission_history.rs
@@ -24,7 +24,7 @@ use kin_model::{
 use crate::error::{GitError, Result};
 use crate::lossless::{GitObjectFormat, LosslessGitRepository};
 use crate::semantic_import::{
-    plan_semantic_git_import, GitWorkspaceSeed, HistoricalSemanticBinding, SemanticGitImportPlan,
+    derive_enriched_semantic_git_history, GitWorkspaceSeed, SemanticGitImportPlan,
 };
 
 /// A deterministic semantic Git import whose every commit carries the exact
@@ -76,6 +76,29 @@ impl AdmittedSemanticGitImportPlan {
 
     /// Rebuild from the exact raw object/ref state and require the complete
     /// admitted history, policy states, trees, and aliases to match.
+    ///
+    /// The rebuild is compared commit by commit as it is derived, and every
+    /// derived commit is dropped once it has been checked. That is the same
+    /// comparison the whole-structure version made, on the same bytes, in the
+    /// same parent-first order. What it no longer does is build a third
+    /// complete import plan, derive the whole history twice to check that plan
+    /// against itself, and enrich it with a second copy of this history's
+    /// entity and relation deltas, all in order to check a plan it is already
+    /// holding. On a mid-size repository that third plan was the largest single
+    /// term in a conversion's peak.
+    ///
+    /// Every comparison against `self` survives, and there is one more of them
+    /// per commit than before, because a commit's exact resolved tree is now
+    /// checked at the commit that produced it rather than as a whole map at the
+    /// end. Two things are gone. One fresh derivation is no longer compared
+    /// against another fresh derivation of the same bytes in the same process,
+    /// which asserted nothing about `self`. And five field comparisons are
+    /// gone that checked `self` against copies of `self`: the re-derivation is
+    /// seeded from `self.repository_id`, `self.object_format`,
+    /// `self.external_objects`, `self.refs` and `self.head`, so each of those
+    /// was compared with its own value and could not fail. Those five still
+    /// reach a real assertion, through the per-commit change, alias and tree
+    /// comparisons that are computed from them.
     pub fn validate(&self, blob_store: &BlobStore) -> Result<()> {
         let snapshot = LosslessGitRepository {
             repository_id: self.repository_id.clone(),
@@ -84,7 +107,6 @@ impl AdmittedSemanticGitImportPlan {
             refs: self.refs.clone(),
             head: self.head.clone(),
         };
-        let semantic = plan_semantic_git_import(&snapshot, blob_store)?;
         let mut by_oid = BTreeMap::new();
         for change in &self.changes {
             let ChangeOrigin::GitCommit { oid } = change.origin else {
@@ -99,48 +121,33 @@ impl AdmittedSemanticGitImportPlan {
             }
         }
         // Lent, not copied. These deltas live in `self`, which outlives the
-        // call, and the enrichment fold below only reads them on its way into
-        // the derived plan. Collecting them into owned vectors here put a whole
-        // history's entity and relation deltas in memory a second time, at the
-        // one phase in the ladder where the working set is already largest, and
-        // the copy was dropped a few lines later without ever being read again.
-        let bindings = semantic
-            .changes
-            .iter()
-            .map(|base_change| {
-                let ChangeOrigin::GitCommit { oid } = base_change.origin else {
-                    unreachable!("the exact Git planner only emits Git-origin changes");
-                };
-                let admitted = by_oid.get(&oid).ok_or_else(|| {
-                    GitError::InvalidSnapshot(format!(
-                        "admitted semantic Git import is missing commit {oid}"
-                    ))
-                })?;
-                Ok(HistoricalSemanticBinding::borrowed(
-                    base_change.id,
-                    &admitted.entity_deltas,
-                    &admitted.relation_deltas,
-                ))
+        // call, and the walk below only reads them on their way into the one
+        // commit it is about to check and drop.
+        let held_semantics = |oid: GitObjectId| {
+            by_oid.get(&oid).map(|change| {
+                (
+                    change.entity_deltas.as_slice(),
+                    change.relation_deltas.as_slice(),
+                )
             })
-            .collect::<Result<Vec<_>>>()?;
-        let semantic = semantic.with_historical_semantics(blob_store, bindings)?;
+        };
 
-        // Compared commit by commit as the admitted history is re-derived, and
-        // each derived commit dropped once checked. Same values, same
-        // parent-first order, same refusal; what it no longer does is build a
-        // second whole admitted history, at the one moment in the ladder where
-        // the working set is already largest, to check the first.
+        let mut admission = AdmittedCommitDeriver::new(self.repository_id.clone());
         let mut checked = 0usize;
-        let derived = derive_admitted_semantic_git_history(
-            &semantic,
+        let derived = derive_enriched_semantic_git_history(
+            &snapshot,
             blob_store,
-            &mut |_oid, admitted, alias| {
+            &held_semantics,
+            &mut |oid, parent_oids, enriched, _enriched_alias, tree| {
+                let (admitted, alias) =
+                    admission.derive_commit(oid, parent_oids, tree, enriched, blob_store)?;
                 // Refuse at the commit that disagrees rather than carrying a
                 // flag to the end. A plan that has already failed can go on to
                 // trip a structural error further down the walk, and reporting
                 // that instead would name the wrong thing.
                 if self.changes.get(checked) != Some(&admitted)
                     || self.aliases.get(checked) != Some(&alias)
+                    || self.commit_trees.get(&oid) != Some(tree)
                 {
                     return Err(GitError::InvalidSnapshot(
                         ADMITTED_DETERMINISTIC_DERIVATION.to_string(),
@@ -150,22 +157,26 @@ impl AdmittedSemanticGitImportPlan {
                 Ok(())
             },
         )?;
+        let admitted = admission.finish(&derived.workspace_seed)?;
 
+        // Lengths, because per-commit equality proves that every DERIVED commit
+        // has a match at its own position and says nothing about a plan
+        // carrying something extra. That is the other half of what
+        // whole-structure equality asserted, and the count it is measured
+        // against is the walk's own: how many commits this repository's raw
+        // objects actually reach, rather than how many the visitor happened to
+        // be handed.
         if checked != derived.commits
+            || admitted.commits != derived.commits
             || self.changes.len() != derived.commits
             || self.aliases.len() != derived.commits
-            || self.commit_policies != derived.commit_policies
-            || self.workspace_policy != derived.workspace_policy
-            || self.workspace_base_change_id != derived.workspace_base_change_id
-            || self.repository_id != semantic.repository_id
-            || self.object_format != semantic.object_format
-            || self.external_objects != semantic.external_objects
-            || self.commit_trees != semantic.commit_trees
-            || self.refs != semantic.refs
-            || self.head != semantic.head
-            || self.workspace_seed != semantic.workspace_seed
-            || self.ref_mutations != semantic.ref_mutations
-            || self.default_ref_mutation != semantic.default_ref_mutation
+            || self.commit_trees.len() != derived.commits
+            || self.commit_policies != admitted.commit_policies
+            || self.workspace_policy != admitted.workspace_policy
+            || self.workspace_base_change_id != admitted.workspace_base_change_id
+            || self.workspace_seed != derived.workspace_seed
+            || self.ref_mutations != derived.ref_mutations
+            || self.default_ref_mutation != derived.default_ref_mutation
         {
             return Err(GitError::InvalidSnapshot(
                 ADMITTED_DETERMINISTIC_DERIVATION.to_string(),
@@ -237,16 +248,119 @@ struct DerivedAdmittedHistory {
     commits: usize,
 }
 
-/// Derive branch-versioned admission policy for every imported commit, handing
-/// each admitted change and alias to `visit` in parent-first order.
+/// One admitted commit, derived from its enriched form, its parents' object
+/// ids, and its exact resolved tree.
 ///
-/// Same arrangement as the exact planner: building the admitted plan and
-/// re-deriving one to check it against are the same walk with different
-/// visitors, so they cannot drift, and only the visitor decides what survives
-/// the commit it was handed. The policy map stays whole because a commit
-/// resolves against its first parent's policy and the workspace seed peels to
-/// one; it is the small structure here, where the admitted changes are the
+/// The single rule for what an admitted change is. Building the admitted plan
+/// and checking a held one against a fresh derivation are the same per-commit
+/// derivation with different callers, so the two cannot drift apart, and only
+/// the caller decides what survives the commit it was handed. What this carries
+/// between commits is one identity and one policy per commit: a commit resolves
+/// against its first parent's policy and the workspace seed peels to one, so
+/// these are the small structures here, where the admitted changes are the
 /// history-sized one.
+struct AdmittedCommitDeriver {
+    repository_id: RepositoryId,
+    admitted_ids: BTreeMap<GitObjectId, SemanticChangeId>,
+    policies: BTreeMap<GitObjectId, SharedAdmissionPolicy>,
+    derived: usize,
+}
+
+impl AdmittedCommitDeriver {
+    fn new(repository_id: RepositoryId) -> Self {
+        Self {
+            repository_id,
+            admitted_ids: BTreeMap::new(),
+            policies: BTreeMap::new(),
+            derived: 0,
+        }
+    }
+
+    /// Derive one commit, which must arrive after every one of its parents.
+    fn derive_commit(
+        &mut self,
+        oid: GitObjectId,
+        parent_oids: &[GitObjectId],
+        tree: &ResolvedTree,
+        mut admitted: SemanticChange,
+        blob_store: &BlobStore,
+    ) -> Result<(SemanticChange, ExternalChangeAlias)> {
+        let first_parent_policy = parent_oids
+            .first()
+            .map(|parent| {
+                self.policies.get(parent).ok_or_else(|| {
+                    GitError::InvalidSnapshot(format!(
+                        "first-parent policy for {parent} was not resolved before commit {oid}"
+                    ))
+                })
+            })
+            .transpose()?;
+        let sources = admission_sources_for_tree(tree, blob_store)?;
+        let (policy, delta) = derive_commit_policy(first_parent_policy, sources)?;
+        let parents = parent_oids
+            .iter()
+            .map(|parent| {
+                self.admitted_ids.get(parent).copied().ok_or_else(|| {
+                    GitError::InvalidSnapshot(format!(
+                        "admitted parent {parent} was not resolved before commit {oid}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        admitted.parents = parents;
+        admitted.admission_policy_delta = delta;
+        admitted.id = placeholder_change_id();
+        admitted.id = compute_semantic_change_id(&admitted)?;
+        validate_semantic_change_id(&admitted)?;
+
+        let alias = ExternalChangeAlias::new(self.repository_id.clone(), oid, admitted.id);
+        alias.validate_change(&admitted)?;
+        if self.admitted_ids.insert(oid, admitted.id).is_some()
+            || self.policies.insert(oid, policy).is_some()
+        {
+            return Err(GitError::InvalidSnapshot(format!(
+                "Git commit {oid} appears more than once in admitted history"
+            )));
+        }
+        self.derived += 1;
+        Ok((admitted, alias))
+    }
+
+    /// Resolve the workspace's own policy and admitted identity from the seed
+    /// the same derivation produced.
+    fn finish(self, seed: &GitWorkspaceSeed) -> Result<DerivedAdmittedHistory> {
+        let (workspace_policy, workspace_base_change_id) = match seed.base_commit_oid {
+            Some(oid) => (
+                self.policies.get(&oid).cloned().ok_or_else(|| {
+                    GitError::InvalidSnapshot(format!(
+                        "workspace base commit {oid} has no admitted policy"
+                    ))
+                })?,
+                Some(self.admitted_ids.get(&oid).copied().ok_or_else(|| {
+                    GitError::InvalidSnapshot(format!(
+                        "workspace base commit {oid} has no admitted semantic identity"
+                    ))
+                })?),
+            ),
+            None => (SharedAdmissionPolicy::empty(0), None),
+        };
+        Ok(DerivedAdmittedHistory {
+            commit_policies: self.policies,
+            workspace_policy,
+            workspace_base_change_id,
+            commits: self.derived,
+        })
+    }
+}
+
+/// Derive branch-versioned admission policy for every commit of a plan that is
+/// already held whole, handing each admitted change and alias to `visit` in
+/// parent-first order.
+///
+/// The caller here holds the enriched history and its trees already, so the
+/// walk reads both out of the plan. `AdmittedSemanticGitImportPlan::validate`
+/// takes the same per-commit derivation off a streaming re-derivation instead.
 fn derive_admitted_semantic_git_history(
     plan: &SemanticGitImportPlan,
     blob_store: &BlobStore,
@@ -262,10 +376,7 @@ fn derive_admitted_semantic_git_history(
         }
     }
 
-    let mut new_change_ids = BTreeMap::<GitObjectId, SemanticChangeId>::new();
-    let mut policies = BTreeMap::<GitObjectId, SharedAdmissionPolicy>::new();
-    let mut derived = 0usize;
-
+    let mut deriver = AdmittedCommitDeriver::new(plan.repository_id.clone());
     for original in &plan.changes {
         let oid = match original.origin {
             ChangeOrigin::GitCommit { oid } => oid,
@@ -286,82 +397,23 @@ fn derive_admitted_semantic_git_history(
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        let first_parent_policy = parent_oids
-            .first()
-            .map(|parent| {
-                policies.get(parent).ok_or_else(|| {
-                    GitError::InvalidSnapshot(format!(
-                        "first-parent policy for {parent} was not resolved before commit {oid}"
-                    ))
-                })
-            })
-            .transpose()?;
         let tree = plan.commit_trees.get(&oid).ok_or_else(|| {
             GitError::InvalidSnapshot(format!(
                 "Git commit {oid} has no graph-resolved tree for admission"
             ))
         })?;
-        let sources = admission_sources_for_tree(tree, blob_store)?;
-        let (policy, delta) = derive_commit_policy(first_parent_policy, sources)?;
-        let parents = parent_oids
-            .iter()
-            .map(|parent| {
-                new_change_ids.get(parent).copied().ok_or_else(|| {
-                    GitError::InvalidSnapshot(format!(
-                        "admitted parent {parent} was not resolved before commit {oid}"
-                    ))
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let mut admitted = original.clone();
-        admitted.parents = parents;
-        admitted.admission_policy_delta = delta;
-        admitted.id = placeholder_change_id();
-        admitted.id = compute_semantic_change_id(&admitted)?;
-        validate_semantic_change_id(&admitted)?;
-
-        let alias = ExternalChangeAlias::new(plan.repository_id.clone(), oid, admitted.id);
-        alias.validate_change(&admitted)?;
-        if new_change_ids.insert(oid, admitted.id).is_some()
-            || policies.insert(oid, policy).is_some()
-        {
-            return Err(GitError::InvalidSnapshot(format!(
-                "Git commit {oid} appears more than once in admitted history"
-            )));
-        }
+        let (admitted, alias) =
+            deriver.derive_commit(oid, &parent_oids, tree, original.clone(), blob_store)?;
         visit(oid, admitted, alias)?;
-        derived += 1;
     }
 
-    if derived != plan.changes.len() || policies.len() != plan.commit_trees.len() {
+    if deriver.derived != plan.changes.len() || deriver.policies.len() != plan.commit_trees.len() {
         return Err(GitError::InvalidSnapshot(
             "not every imported commit produced one admitted change, alias, and policy".to_string(),
         ));
     }
 
-    let (workspace_policy, workspace_base_change_id) = match plan.workspace_seed.base_commit_oid {
-        Some(oid) => (
-            policies.get(&oid).cloned().ok_or_else(|| {
-                GitError::InvalidSnapshot(format!(
-                    "workspace base commit {oid} has no admitted policy"
-                ))
-            })?,
-            Some(new_change_ids.get(&oid).copied().ok_or_else(|| {
-                GitError::InvalidSnapshot(format!(
-                    "workspace base commit {oid} has no admitted semantic identity"
-                ))
-            })?),
-        ),
-        None => (SharedAdmissionPolicy::empty(0), None),
-    };
-
-    Ok(DerivedAdmittedHistory {
-        commit_policies: policies,
-        workspace_policy,
-        workspace_base_change_id,
-        commits: derived,
-    })
+    deriver.finish(&plan.workspace_seed)
 }
 
 fn build_admitted_semantic_git_import_plan(

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -348,6 +348,97 @@ pub fn plan_semantic_git_import(
     build_semantic_git_import_plan(snapshot, blob_store)
 }
 
+/// What an enriched re-derivation still holds once every commit has been
+/// visited and dropped.
+///
+/// Deliberately not [`DerivedGitHistory`]: that carries the trees the walk had
+/// not finished with, and a caller checking history it already holds has no
+/// reader for them, so they are dropped here rather than handed back.
+pub(crate) struct DerivedEnrichedHistory {
+    pub(crate) workspace_seed: GitWorkspaceSeed,
+    pub(crate) ref_mutations: Vec<RefMutation>,
+    pub(crate) default_ref_mutation: Option<DefaultRefMutation>,
+    /// Commits derived, which a caller compares against what it holds.
+    pub(crate) commits: usize,
+}
+
+/// Re-derive exact semantic history from a lossless snapshot and re-apply the
+/// historical semantics the caller already holds, handing every commit to
+/// `visit` in parent-first order with its parents' object ids and its exact
+/// resolved tree.
+///
+/// This is [`SemanticGitImportPlan::validate`]'s walk with the enrichment
+/// [`SemanticGitImportPlan::with_historical_semantics`] performs folded into
+/// it. A caller that already holds the enriched history can therefore check it
+/// commit by commit rather than build a second complete history to compare
+/// against, which is what made re-proving a plan cost about as much as deriving
+/// one. Only the visitor decides what survives the commit it was handed; this
+/// walk keeps the frontier trees the derivation itself needs, plus one identity
+/// pair per commit, and nothing else.
+pub(crate) fn derive_enriched_semantic_git_history<'held>(
+    snapshot: &LosslessGitRepository,
+    blob_store: &BlobStore,
+    held_semantics: &dyn Fn(GitObjectId) -> Option<(&'held [EntityDelta], &'held [RelationDelta])>,
+    visit: &mut dyn FnMut(
+        GitObjectId,
+        &[GitObjectId],
+        SemanticChange,
+        ExternalChangeAlias,
+        &ResolvedTree,
+    ) -> Result<()>,
+) -> Result<DerivedEnrichedHistory> {
+    // Pre-enrichment identity to (object id, enriched identity). A derived
+    // change names its parents by the identity the unenriched walk computed,
+    // and re-applying held deltas changes every identity, so the walk carries
+    // that mapping rather than a second history. Parent-first order is what
+    // makes one pass enough.
+    let mut resolved = BTreeMap::<SemanticChangeId, (GitObjectId, SemanticChangeId)>::new();
+    let derived = derive_semantic_git_history(
+        snapshot,
+        blob_store,
+        TreeRetention::Frontier,
+        &mut |oid, mut change, _unenriched_alias, tree| {
+            let unenriched_id = change.id;
+            let mut parent_oids = Vec::with_capacity(change.parents.len());
+            let mut parents = Vec::with_capacity(change.parents.len());
+            for parent in &change.parents {
+                let (parent_oid, parent_id) = resolved.get(parent).copied().ok_or_else(|| {
+                    GitError::InvalidSnapshot(format!(
+                        "parent {parent} was not reidentified before change {unenriched_id}"
+                    ))
+                })?;
+                parent_oids.push(parent_oid);
+                parents.push(parent_id);
+            }
+            let Some((entity_deltas, relation_deltas)) = held_semantics(oid) else {
+                return Err(GitError::InvalidSnapshot(format!(
+                    "historical semantic deltas omit Git commit {oid}"
+                )));
+            };
+            change.parents = parents;
+            change.entity_deltas = entity_deltas.to_vec();
+            change.relation_deltas = relation_deltas.to_vec();
+            change.id = placeholder_change_id();
+            change.id = compute_semantic_change_id(&change)?;
+            validate_semantic_change_id(&change)?;
+            let alias = ExternalChangeAlias::new(snapshot.repository_id.clone(), oid, change.id);
+            alias.validate_change(&change)?;
+            if resolved.insert(unenriched_id, (oid, change.id)).is_some() {
+                return Err(GitError::InvalidSnapshot(format!(
+                    "pre-enrichment semantic identity {unenriched_id} maps to more than one Git commit"
+                )));
+            }
+            visit(oid, &parent_oids, change, alias, tree)
+        },
+    )?;
+    Ok(DerivedEnrichedHistory {
+        workspace_seed: derived.workspace_seed,
+        ref_mutations: derived.ref_mutations,
+        default_ref_mutation: derived.default_ref_mutation,
+        commits: derived.commits,
+    })
+}
+
 fn apply_historical_semantic_deltas_unchecked(
     mut plan: SemanticGitImportPlan,
     bindings: Vec<HistoricalSemanticBinding<'_>>,

--- a/scripts/acceptance/init_memory_repro.py
+++ b/scripts/acceptance/init_memory_repro.py
@@ -125,6 +125,10 @@ RELEASE_LINE = re.compile(
     r"kin\.init\.release_plan_bodies gave back (\d+) bytes of the (\d+) bytes "
     r"kin\.init\.bind_historical_semantics retained, floor (\d+) percent"
 )
+BUILD_LINE = re.compile(
+    r"kin\.init\.build_bootstrap_transaction grew the peak by (\d+) bytes against "
+    r"the (\d+) bytes kin\.init\.admit_semantic_import retained, ceiling (\d+) percent"
+)
 
 
 def read_guard_output(text):
@@ -190,6 +194,43 @@ def read_release_figures(text):
     if not release:
         return (None, None, None)
     return (int(release.group(1)), int(release.group(2)), int(release.group(3)))
+
+
+def read_build_figures(text):
+    """Pull the bootstrap build's growth, one copy of the admitted history, and its ceiling.
+
+    Its own reader for the reason every reader here has one: a suite that
+    grades only the earlier figures reports them PASS over a guard that went
+    red on this one, because the guard prints every figure before any
+    assertion runs.
+    """
+    build = BUILD_LINE.search(text or "")
+    if not build:
+        return (None, None, None)
+    return (int(build.group(1)), int(build.group(2)), int(build.group(3)))
+
+
+def grade_build_ratio(grew, retained, cap_percent):
+    """PASS under the ceiling, FAIL at or over it, UNREADABLE with no denominator.
+
+    Same direction as `grade_ratio` and a separate function because it names a
+    different phase and a different denominator. A phase that admitted nothing
+    gives the ratio no denominator, so the comparison would pass on any growth
+    at all. That is UNREADABLE, not a pass.
+    """
+    if grew is None or retained is None or cap_percent is None:
+        return UNREADABLE, "the guard printed no bootstrap-build figures, so nothing was graded"
+    if retained == 0:
+        return UNREADABLE, ("the admission phase retained nothing, so the bootstrap build's "
+                            "growth had no copy of the history to be measured against and "
+                            "this graded nothing")
+    percent = grew * 100 // retained
+    detail = ("building the bootstrap transaction grew the peak by %d percent of one copy of "
+              "the admitted history (%d over %d bytes), ceiling %d percent"
+              % (percent, grew, retained, cap_percent))
+    if percent >= cap_percent:
+        return FAIL, detail
+    return PASS, detail
 
 
 def grade_floor(given_back, retained, floor_percent):
@@ -361,7 +402,21 @@ def check_3(suite):
     return result
 
 
-CHECKS = [check_0, check_1, check_2, check_3]
+def check_4(suite):
+    """Building the bootstrap transaction does not copy the history to prove or to read it."""
+    result = Result("4", "the bootstrap build holds no extra copy of the history")
+    code, out = suite.guard_output()
+    grew, retained, cap = read_build_figures(out)
+    if grew is None and code != 0:
+        result.unknown("the guard produced no bootstrap-build figures and exited %d: %s"
+                       % (code, tail(out)))
+        return result
+    status, detail = grade_build_ratio(grew, retained, cap)
+    {PASS: result.ok, FAIL: result.bad, UNREADABLE: result.unknown}[status](detail)
+    return result
+
+
+CHECKS = [check_0, check_1, check_2, check_3, check_4]
 
 
 def self_test():
@@ -426,6 +481,30 @@ def self_test():
     if read_bind_figures("") != (None, None, None):
         failures.append("parser invented binding figures from empty output")
 
+    # The bootstrap-build grader and its parser, falsified against the real
+    # figures on both sides of the fix.
+    build_cases = [
+        ("one copy passes", 113059227, 87718554, 250, PASS),
+        ("the pre-fix figure fails", 395427091, 87722946, 250, FAIL),
+        ("exactly at the ceiling fails", 250, 100, 250, FAIL),
+        ("nothing admitted is unreadable", 100, 0, 250, UNREADABLE),
+        ("nothing measured is unreadable", None, None, None, UNREADABLE),
+    ]
+    for title, grew, retained, cap, wanted in build_cases:
+        got, detail = grade_build_ratio(grew, retained, cap)
+        if got != wanted:
+            failures.append("%s: wanted %s, got %s (%s)" % (title, wanted, got, detail))
+
+    build_line = ("kin.init.build_bootstrap_transaction grew the peak by 113059227 bytes "
+                  "against the 87718554 bytes kin.init.admit_semantic_import retained, "
+                  "ceiling 250 percent\n")
+    if read_build_figures(build_line) != (113059227, 87718554, 250):
+        failures.append("parser misread the build line: %r" % (read_build_figures(build_line),))
+    if read_build_figures("error: could not compile") != (None, None, None):
+        failures.append("parser invented build figures from output that carries none")
+    if read_build_figures("") != (None, None, None):
+        failures.append("parser invented build figures from empty output")
+
     # The floor grader runs the comparison the other way round, so its own
     # inverse is the case that would pass if the direction were flipped: a
     # release that gave back nothing.
@@ -464,7 +543,8 @@ def self_test():
     for failure in failures:
         print("SELFTEST FAIL %s" % failure)
     print("kin-init-memory-repro self-test: %d case(s), %d failure(s)"
-          % (len(cases) + len(ratio_cases) + len(floor_cases) + 13, len(failures)))
+          % (len(cases) + len(ratio_cases) + len(build_cases) + len(floor_cases) + 16,
+             len(failures)))
     return 1 if failures else 0
 
 


### PR DESCRIPTION
Step 11 of a Git conversion, "build bootstrap transaction", grew the peak live heap by 377.0 MiB on a 256-commit fixture and by 2,505.1 MiB on psf/requests at full history, while retaining 0.2 MiB. Everything it allocated was transient memory a machine had to survive so that a step which keeps nothing could reach a verdict it was always going to reach. Two structures made up that cost and both are gone. The phase now grows 107.8 MiB on the fixture and **0.0 MiB on psf/requests at full history**.

## The ticket's attribution was wrong, and the measurement is what says so

FIR-2649's second half predicts that step 11's cost is a third whole `SemanticGitImportPlan` built inside the admitted plan's `validate`. The streaming re-derivation was written first and measured, and the fixture's total peak did not move by one byte: 605,562,588 bytes before and 605,562,308 after, with `kin.init.build_bootstrap_transaction` still reading exactly 377.0 MiB. The binary was checked rather than assumed, with `strings` finding the new refusal `pre-enrichment semantic identity` in the release test binary.

So the phase was probed rather than reasoned about, and one span carried the whole number:

```
     377.0 /      0.2  kin.init.build_bootstrap_transaction
     377.0 /      0.2  kin.init.probe_bind_workspace_authority
       0.0 /      0.0  kin.init.probe_revalidate_admitted
       0.0 /      0.0  kin.init.probe_admitted_rederivation
       0.0 /      0.0  kin.init.probe_transaction_validate
```

`imported_workspace_semantic_delta` staged every change in history into a fresh `InMemoryGraph`, which is the durable authority write path: it copies each change into the store, appends every entity's revision timeline, plans the revision vectors and updates the entity and relation indexes, and all of it was discarded after one replay. kin-db had already found the same shape one layer down and fixed it the same way, which is why `resolve_workspace_base_graph_snapshot` reads through a borrowed `AuthorityHistoryView`. kin now does the same with a `BootstrapHistoryView` over the transaction's own changes, because the replay's only store dependency is `get_change`.

## What is proved, and what stopped being proved

The admitted plan's revalidation built a third complete import plan with every commit's tree, derived the whole history a second time to check that plan against itself, then copied this history's entity and relation deltas into it. It now re-derives once and compares each commit the instant it comes off the walk, dropping it before the next one.

Every comparison against the held plan survives, and there is one more of them per commit than before, because a commit's exact resolved tree is now checked at the commit that produced it rather than as a whole map at the end. Two things are gone. One fresh derivation is no longer compared against another fresh derivation of the same bytes in the same process, which asserted nothing about the plan being checked. And five field comparisons are gone that compared the plan against copies of itself: the re-derivation is seeded from the plan's own `repository_id`, `object_format`, `external_objects`, `refs` and `head`, so each was compared with its own value and could not fail. Those five still reach a real assertion through the per-commit change, alias and tree comparisons that are computed from them.

Nothing is validated less on the workspace side either. The graph's `create_change` refused a duplicate change and called `validate_semantic_change`, which is `kin_model::validate_semantic_change_id`, and `RepositoryTransaction::validate` runs both of those over the same `changes` before this function is reached and again after it.

`AdmittedCommitDeriver` carries the per-commit admitted derivation, and both the plan-building path and the streaming validate call it, so the two cannot drift.

## Falsification

The deep-history guard gained a ratio: `kin.init.build_bootstrap_transaction` may grow the peak by at most 250 percent of what `kin.init.admit_semantic_import` retains. A ratio rather than a byte count, because both figures scale with commits multiplied by per-commit churn.

Post-change, release, 256-commit fixture:

```
kin.init.build_bootstrap_transaction grew the peak by 113059227 bytes against
    the 87718554 bytes kin.init.admit_semantic_import retained, ceiling 250 percent
test result: ok. 1 passed
```

128 percent. Pre-change bytes, the same guard, with only `crates/kin-git/src` and `crates/kin-core/src` restored to `c9b99a93` and the guard file left in place. Both `Compiling kin-git` and `Compiling kin-core` printed, so the pre-change bytes were graded:

```
MUTANT rc=101
kin.init.build_bootstrap_transaction grew the peak by 395427091 bytes against
    the 87722946 bytes kin.init.admit_semantic_import retained, 450 percent,
    at or over the 250 percent ceiling
test result: FAILED
```

The acceptance suite grades the same ratio as CHECK 4, so a Linux runner reads it rather than only this host. Its self-test falsifies the new grader and parser: 37 cases, zero failures, and proven able to fail by relaxing the comparison from `>=` to `>`, which fires the at-the-ceiling case.

```
CHECK 0 FIR-2539 PASS proof 1 peak growth is 1.5 MiB, under the 16 MiB ceiling
CHECK 1 FIR-2539 PASS total peak live heap is 577.5 MiB, under the 900 MiB ceiling
CHECK 2 FIR-2539 PASS binding historical semantics grew the peak by 118 percent of what it retained
CHECK 3 FIR-2539 PASS releasing the plan's change bodies gave back 100 percent of what binding retained
CHECK 4 FIR-2539 PASS building the bootstrap transaction grew the peak by 128 percent of one copy of the admitted history
kin-init-memory-repro: 5 checks, 5 pass, 0 FAIL, 0 UNREADABLE
```

## The real corpus, and what this does not do

psf/requests at full history, 6,731 commits, through `crates/kin-core/tests/init_real_repo_heap_attribution.rs`. Two arms differing only in whether `crates/kin-git/src` and `crates/kin-core/src` are this branch's or `main`'s.

| phase | main | this branch |
|---|---|---|
| **kin.init.build_bootstrap_transaction** | **2505.1 / 1.2** | **0.0 / 1.2** |
| kindb.commit.transaction_hash | 1061.1 / 0.0 | 3566.2 / 0.0 |
| kindb.prepare.workspace | 1133.9 / 1702.4 | 1133.9 / 1702.4 |
| kin.init.bind_historical_semantics | 1272.1 / 1156.4 | 1272.1 / 1156.4 |
| **total peak live heap** | **7,944,408,066 (7.40 GiB)** | **7,944,408,066 (7.40 GiB)** |

**The total is identical to the byte and this change does not lower it.** Peak growth is measured against the running high-water mark, so a phase that stops setting the peak hands the accounting to whichever phase reaches higher afterwards, and here that phase reaches the same absolute height either way.

That is not an argument against landing it. The phases are additive on the running peak: the ladder climbs 2,876.0 MiB by the end of step 11 with this change and 5,381.1 MiB without it. The moment the commit phase's transients come down, that 2,505.1 MiB difference becomes the conversion's ceiling. This is what stops step 11 becoming the new ceiling as soon as kin-db's side is cut.

## Where the peak actually is

Both remaining terms are in kin-db, and the peak is reached at the very end of the ladder inside `kindb.prepare.workspace`:

- `kindb.commit.transaction_hash` grows 3,566.2 MiB and retains 0.0. `RepositoryTransaction::transaction_hash` clones the whole transaction to sort it into canonical order and then serializes that clone into one canonical JSON buffer to hash it, so a bootstrap commit holds the whole converted history three times over for the length of one hash. That is the largest single holder in a conversion today, it lives in kin-model, and it has no ticket yet.
- `kindb.prepare.workspace` grows 1,133.9 MiB and retains 1,702.4 MiB, which is FIR-2651.

Closes FIR-2649
