### PR TITLE
Pin kin-db 0.7.53, which takes 0.91 GiB off a full-history conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.52"
+version = "0.7.53"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "5e74f738f5c5070fdaa9219ac85a12ddb659c758cb6b3b5207e3c6b8f19d265f"
+checksum = "1150cc284803d305af666e91e92d52d34703930bf3a1c1c8cd05e20924b51b64"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.52", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.53", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
A full-history conversion of psf/requests peaks at 6.49 GiB of live heap on
kin-db 0.7.53 against 7.40 GiB on 0.7.52. This pin is how kin gets that.

kin-db#225 stopped the entity revision derivation copying the history to walk
it. Building an in-memory graph from a snapshot that carries changes and no
revisions derives every revision the change DAG publishes, and a conversion
reaches that path three times. The derivation needs the changes in parent-first
order and owns none of them, but taking them by value cost two whole copies of
the history at the one moment a conversion's working set is already largest:
one to build the iterator of clones the caller handed over, and one more inside
the ordering to fill its vector.

Measured before this pin was written, with kin built in a lane worktree against
the kin-db branch and every other dependency still resolving from the registry,
through kin's own `init_real_repo_heap_attribution` probe on a full clone of
psf/requests at 6,731 commits, HEAD
`8f8b212de8c2129d7954c6cd373762880375620a`:

```
before   peak live heap 7,944,408,066 bytes (7.40 GiB), outcome ok
after    peak live heap 6,971,499,562 bytes (6.49 GiB), outcome ok
```

`kindb.prepare.workspace` grows 0.0 MiB where it grew 1,133.9, and
`kindb.commit.prepare_successor` with it, so the phase that reached the top of
the ladder no longer pushes the peak at all. Every phase the change does not
touch is identical.

The lock entry keeps its `sparse+https://kinlab.ai/registry/cargo/` source and
carries the checksum the registry serves for 0.7.53,
`1150cc284803d305af666e91e92d52d34703930bf3a1c1c8cd05e20924b51b64`. The bump was
re-locked patch-off with `cargo update -p kin-db --precise 0.7.53`. That command
also moved one unrelated edge, `winapi-util` naming `windows-sys 0.61.2` instead
of `0.48.0`, which has nothing to do with this pin; it was put back, and
`cargo metadata --locked` and `cargo check --workspace --locked --all-targets`
both pass with the lock file byte-identical before and after, so the resolution
is stable rather than merely accepted once. A sweep for the old version returns
nothing, with a positive control confirming the new one is found in both homes.

Gated with `cargo nextest run --workspace --locked --no-fail-fast`, 7,225 passed
and 0 failed, and `cargo test --doc --locked`, both green on this exact lock.
The DEV-LOCAL gate is deliberately not used here, because it replaces the crate
under test with a local path and so cannot validate a registry pin.

What this does not claim: that the 8 GiB bar is met. The conversion's peak is now
set by `kindb.commit.transaction_hash`, which grows 3,566.2 MiB and retains
nothing, and that is FIR-2652.

Refs FIR-2651

Signed-off-by: Troy Fortin <troy@firelock.ai>

