### PR TITLE
Pin kin-db 0.7.54 and the kin-model 0.7.18 it requires

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.53"
+version = "0.7.54"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "1150cc284803d305af666e91e92d52d34703930bf3a1c1c8cd05e20924b51b64"
+checksum = "c101cf677f92c5845a98cf07fd0c59522942f24d2513a39175a1c63a799410bf"
 dependencies = [
  "bincode",
  "bstr",
@@ -3502,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.16"
+version = "0.7.18"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2290df9564cc5b6468bd572ca17856befc3802d9f2873c98481ad60870c0354a"
+checksum = "a83554b6983fb415d95edbf261542fc1a5e3ad5026e694a9c3306cc66f1b0b8c"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -6656,7 +6656,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.16", registry = "kin" }
+kin-model = { version = "=0.7.18", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.53", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.54", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.16"
+version = "0.7.18"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2290df9564cc5b6468bd572ca17856befc3802d9f2873c98481ad60870c0354a"
+checksum = "a83554b6983fb415d95edbf261542fc1a5e3ad5026e694a9c3306cc66f1b0b8c"
 dependencies = [
  "chrono",
  "gix-hash",


### PR DESCRIPTION
Carries the transaction hash's last whole-transaction materialization out of
the conversion. kin-model 0.7.18 hashes a transaction's canonical preimage as
it is produced rather than building the whole encoding first, and kin-db 0.7.54
consumes it, so `kindb.commit.transaction_hash` stops holding a copy of
everything the transaction carries. On a bootstrap commit that is the entire
converted history.

The hashed bytes do not move. kin-model's nine pinned preimage digests were
measured before the change and still pass, and its golden test compares the
streaming hash against both the buffered path and the retained reference that
clones and encodes as one tree.

Every pin home moved. The two manifest pins in `Cargo.toml`, and both tracked
lock files: `Cargo.lock` for kin-model and kin-db, `fuzz/Cargo.lock` for
kin-model, which carries no kin-db entry at all. A sweep for `0.7.16` and
`0.7.53` across the tree returns nothing, with a positive control on the new
versions returning every home that moved. Both locks were resolved patch-off
and every entry keeps its `sparse+` source and its checksum.

Refs FIR-2652
Refs FIR-2640

Signed-off-by: Troy Fortin <troy@firelock.ai>

