### PR TITLE
Pin kin-db 0.7.55, which takes the workspace lap's retained history to zero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.54"
+version = "0.7.55"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "c101cf677f92c5845a98cf07fd0c59522942f24d2513a39175a1c63a799410bf"
+checksum = "ec39ad7cdc4e91c061d539f30a3cbdf04655bc3c12b24063e2a709a1fea98b6b"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.54", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.55", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
## What the pinned release does

kin-db [#227](https://github.com/firelock-ai/kin-db/pull/227) stopped the shared replay decode holding a whole second copy of the authority snapshot. It cloned the snapshot in order to null `repository_authority`, rebuilt every index and Merkle root from the clone, and kept the result to the end of the preparation, to answer tree questions that read the change map alone. The field it cloned to null is already `None` in `prepare_successor`.

On psf/requests at full history, 6,731 commits, through kin's own `init_real_repo_heap_attribution` probe:

| phase | kin-db 0.7.54 | kin-db 0.7.55 |
|---|---|---|
| **kindb.prepare.workspace** | **2922.2 / 1706.0** | **2922.2 / 0.0** |
| kindb.commit.prepare_successor | 2973.4 / 1256.9 | 2922.2 / 1256.9 |
| kindb.prepare.admit | 0.0 / 1193.5 | 0.0 / 1193.5 |
| kin.init.bind_historical_semantics | 1275.6 / 1160.0 | 1275.6 / 1160.0 |
| kin.init.admit_semantic_import | 980.4 / 1174.9 | 980.4 / 1174.9 |
| **total peak live heap** | **6,984,075,842 (6.50 GiB), ok** | **6,984,075,910 (6.50 GiB), ok** |

Every phase the change does not touch matches to the tenth of a MiB, which is what says the two builds are otherwise the same code.

## The honest result

**The conversion's own peak does not move**, 68 bytes apart on 6.5 GiB, and that is not a defect in the cut. Peak growth is measured against the running high-water mark, and the same phase contains a larger transient that reaches the ceiling before the retention is allocated: `apply_workspace` builds and consumes the desired graph, which holds its own copy of the change map plus the entity revisions it derives across the whole history, and frees both before the replay is ever forced. The replay's 1,706 MiB moved into space the desired graph had just vacated. The measurement says it in one number: the lap GREW by exactly 2922.2 MiB in both arms while retaining 1706.0 and 0.0.

What this pin buys is that the space is now clear. A cut at the desired graph reaches the next high point instead of stopping at the replay's.

## The pin

Two homes: `Cargo.toml:158` and the `[[package]] kin-db` entry in `Cargo.lock`. `fuzz/Cargo.lock` carries **no** kin-db entry, which is a read with a positive control rather than an empty answer, since it does carry one kin-model entry.

```
$ git grep -n "0\.7\.54" -- .
CHANGELOG.md:14:- Pin kin-db 0.7.54 and the kin-model 0.7.18 it requires (#1114)
$ git grep -n "0\.7\.55" -- .
Cargo.lock:3287:version = "0.7.55"
Cargo.toml:158:kin-db = { version = "=0.7.55", registry = "kin", default-features = false }
```

The only `0.7.54` left is the changelog line recording the previous pin, which is history rather than a pin home.

The lock entry keeps its registry provenance, which is what says the pin was proven against the registry and not against a local path:

```
name = "kin-db"
version = "0.7.55"
source = "sparse+https://kinlab.ai/registry/cargo/"
checksum = "ec39ad7cdc4e91c061d539f30a3cbdf04655bc3c12b24063e2a709a1fea98b6b"
```

That checksum is the one the sparse index serves for 0.7.55, read from the index with 0.7.54 as the control that the read works.

One thing worth writing down rather than smoothing over. `cargo update -p kin-db --precise 0.7.55` also moved an edge that has nothing to do with this pin: `winapi-util` began naming `windows-sys 0.48.0` where it had named `0.61.2`. It was put back by hand and then proven stable rather than merely accepted: `cargo metadata --locked` passes and the lock file is byte-identical before and after the gate, sha256 `23bdc031ecb2ff79262c175fa87a15679684febbf2403ed6a8e3a30ce6e5a5a6`. The same edge moved for the 0.7.53 pin and was handled the same way.

## Gate

Gated on that exact lock, not on the one that existed before the revert. The DEV-LOCAL gate is deliberately not used, because it replaces the crate under test with a local path and so cannot validate a registry pin at all.

```
cargo metadata --locked                                 rc=0
cargo nextest run --workspace --locked --no-fail-fast   7225 tests run: 7225 passed, 14 skipped
cargo test --doc --locked                               rc=0
```

Closes FIR-2651.