### PR TITLE
Pin kin-db 0.7.56, and stop calling a killed, unreaped daemon still present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.55"
+version = "0.7.56"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "ec39ad7cdc4e91c061d539f30a3cbdf04655bc3c12b24063e2a709a1fea98b6b"
+checksum = "3801d324c4636b0e1631346323a347bcf8a8f2ecf2b52fede2cd454e602b4b9c"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.55", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.56", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2119,7 +2119,13 @@ impl ProcessLiveness {
 /// on. It lived here alone until 2026-08-24, and the copy that did NOT have it
 /// was the one the daemon-death path asks, so a killed-and-unreaped daemon was
 /// described to the reader as still present.
-#[cfg(any(target_os = "linux", test))]
+///
+/// `#[cfg(test)]` and not `any(target_os = "linux", test)`: this crate's own
+/// code now calls the shared implementation directly, so on a Linux non-test
+/// build the old condition admitted a function nobody calls, which `-D warnings`
+/// rejects as dead code. It compiled clean on macOS, where the same condition
+/// excluded it, so the divergence only ever appeared in CI.
+#[cfg(test)]
 fn linux_stat_line_is_zombie(stat: &str) -> bool {
     kin_daemon_spawn::stat_line_is_zombie(stat)
 }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2115,86 +2115,20 @@ impl ProcessLiveness {
 
 /// Whether a Linux `/proc/<pid>/stat` line describes a zombie.
 ///
-/// Split out from the probe below, and compiled under `test` on every platform,
-/// so this is not code that only ever builds on one target. Reading the wrong
-/// field is the failure mode that matters: it would answer "not a corpse"
-/// forever, which is exactly the bug being fixed, and it would do so silently.
+/// One implementation, in `kin-daemon-spawn`, which this crate already depends
+/// on. It lived here alone until 2026-08-24, and the copy that did NOT have it
+/// was the one the daemon-death path asks, so a killed-and-unreaped daemon was
+/// described to the reader as still present.
 #[cfg(any(target_os = "linux", test))]
 fn linux_stat_line_is_zombie(stat: &str) -> bool {
-    // Field 3 is the state character. `comm` (field 2) is parenthesized and may
-    // itself contain spaces and `)`, and it is the only field that can, so the
-    // state is the first whitespace-separated field after `comm`'s FINAL
-    // closing delimiter.
-    stat.rsplit_once(')')
-        .and_then(|(_, rest)| rest.split_whitespace().next())
-        .is_some_and(|state| state == "Z")
+    kin_daemon_spawn::stat_line_is_zombie(stat)
 }
 
 /// Has this PID already terminated, with only an unreaped process-table entry
-/// left behind?
-///
-/// `kill(pid, 0)` succeeds against a zombie, so a liveness probe built on the
-/// signal check alone reports a daemon that has already exited as still
-/// running — for as long as whichever process started it stays alive without
-/// waiting on it. That is the ordinary shape of an agent session: the MCP
-/// server starts a repo daemon, keeps running, and never reaps it, so `kin
-/// daemon stop` could watch the corpse for any length of time and never see it
-/// go away.
-///
-/// Reporting a zombie dead is affirmative rather than a guess, and it is
-/// strictly safer than the alternative: the process has terminated, it cannot
-/// execute, it holds no port, and its PID cannot be reused until it is reaped,
-/// so no successor can inherit a decision made here.
-///
-/// Callers must have established same-credential access first (this is only
-/// reached after `kill(pid, 0)` succeeded). Anything short of affirmative
-/// evidence of a corpse answers `false` and leaves the caller's conservative
-/// path intact.
+/// left behind? See [`kin_daemon_spawn::process_is_unreaped_corpse`].
 #[cfg(unix)]
 fn process_is_unreaped_corpse(pid: libc::pid_t) -> bool {
-    #[cfg(target_os = "linux")]
-    {
-        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
-            return false;
-        };
-        linux_stat_line_is_zombie(&stat)
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let mut info = unsafe { std::mem::zeroed::<libc::proc_bsdinfo>() };
-        let expected = std::mem::size_of::<libc::proc_bsdinfo>();
-        let written = unsafe {
-            libc::proc_pidinfo(
-                pid,
-                libc::PROC_PIDTBSDINFO,
-                0,
-                &mut info as *mut _ as *mut _,
-                expected as i32,
-            )
-        };
-        // `proc_pidinfo` reports failure as a zero return with `errno` set, so
-        // only zero is a result whose `errno` is this call's. A short non-zero
-        // return is undocumented and would leave `errno` holding whatever an
-        // earlier, unrelated call left there — and reading a stale `ESRCH` out
-        // of it would declare a LIVE daemon stopped, which is the one direction
-        // this must never fail in.
-        if written != 0 {
-            return false;
-        }
-        // Permission to inspect is already established by the caller's
-        // successful `kill(pid, 0)`, so `ESRCH` here is the kernel reporting
-        // that the process is gone rather than that this caller may not look.
-        // `EPERM` and every other failure stay indeterminate.
-        std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        // No affirmative corpse probe on this platform. Never guess: an
-        // unrecognised Unix keeps the conservative "signalable means alive"
-        // answer it had before.
-        let _ = pid;
-        false
-    }
+    kin_daemon_spawn::process_is_unreaped_corpse(pid)
 }
 
 /// Classify whether a process with the given PID exists.

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -3853,14 +3853,15 @@ fn process_has_exited(pid: libc::pid_t) -> std::io::Result<bool> {
 /// splitting the whole line on whitespace mis-parses any process whose name
 /// contains one. Everything after the final `)` is fixed-width and safe to
 /// split, which is what `proc(5)` documents and what every correct reader does.
-#[cfg(target_os = "linux")]
+///
+/// Not gated on the target: it parses a string rather than reading `/proc`, and
+/// a consumer's test binary compiles it on every host.
 fn proc_stat_fields_after_name(stat: &str) -> Option<Vec<&str>> {
     let tail = &stat[stat.rfind(')')? + 1..];
     Some(tail.split_whitespace().collect())
 }
 
 /// The single-character run state: field 3 overall, first after the name.
-#[cfg(target_os = "linux")]
 fn parse_proc_stat_state(stat: &str) -> Option<char> {
     proc_stat_fields_after_name(stat)?.first()?.chars().next()
 }
@@ -4784,6 +4785,80 @@ enum Liveness {
     Unknown,
 }
 
+/// Whether a Linux `/proc/<pid>/stat` line describes a zombie.
+///
+/// Reads the state through [`parse_proc_stat_state`], the parser this crate
+/// already uses for the same field, so there is one implementation of the
+/// "everything after the final `)`" rule rather than one per caller.
+pub fn stat_line_is_zombie(stat: &str) -> bool {
+    parse_proc_stat_state(stat) == Some('Z')
+}
+
+/// Has this PID already terminated, with only an unreaped process-table entry
+/// left behind?
+///
+/// `kill(pid, 0)` succeeds against a zombie, so a liveness probe built on the
+/// signal check alone reports a daemon that has already exited as still
+/// running, for as long as whichever process started it stays alive without
+/// waiting on it. That is the ordinary shape of an agent session, and of a
+/// container whose pid 1 does not reap what it adopts.
+///
+/// Reporting a zombie dead is affirmative rather than a guess, and it is
+/// strictly safer than the alternative: the process has terminated, it cannot
+/// execute, it holds no port, and its PID cannot be reused until it is reaped,
+/// so no successor can inherit a decision made here.
+///
+/// Only an affirmative corpse reading answers `true`. Anything short of that
+/// leaves the caller's conservative path intact.
+#[cfg(unix)]
+pub fn process_is_unreaped_corpse(pid: libc::pid_t) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        // `process_has_exited` is this crate's existing reader for exactly this
+        // question, errno handling included: an entry that is already gone
+        // answers the open with ENOENT and one collected mid-read answers with
+        // ESRCH, and both mean no task remains behind the pid. Only an
+        // affirmative reading answers `true`; an unreadable entry stays
+        // indeterminate and leaves the caller conservative.
+        process_has_exited(pid).unwrap_or(false)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut info = unsafe { std::mem::zeroed::<libc::proc_bsdinfo>() };
+        let expected = std::mem::size_of::<libc::proc_bsdinfo>();
+        let written = unsafe {
+            libc::proc_pidinfo(
+                pid,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                &mut info as *mut _ as *mut _,
+                expected as i32,
+            )
+        };
+        // `proc_pidinfo` reports failure as a zero return with `errno` set, so
+        // only zero is a result whose `errno` is this call's. A short non-zero
+        // return is undocumented and would leave `errno` holding whatever an
+        // earlier, unrelated call left there, and reading a stale `ESRCH` out of
+        // it would declare a LIVE daemon stopped, which is the one direction
+        // this must never fail in.
+        if written != 0 {
+            return false;
+        }
+        // Permission to inspect is already established by the caller's
+        // successful `kill(pid, 0)`, so `ESRCH` here is the kernel reporting
+        // that the process is gone rather than that this caller may not look.
+        std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        // No affirmative corpse probe on this platform. Never guess: an
+        // unrecognised Unix keeps the conservative "signalable means alive"
+        // answer it had before.
+        let _ = pid;
+        false
+    }
+}
+
 fn process_liveness(pid: u32) -> Liveness {
     #[cfg(unix)]
     {
@@ -4791,7 +4866,22 @@ fn process_liveness(pid: u32) -> Liveness {
             return Liveness::Dead;
         };
         if unsafe { libc::kill(pid, 0) } == 0 {
-            return Liveness::Alive;
+            // Signalable is not the same as running. A daemon that was killed
+            // and not yet reaped still answers this call, and reading it as
+            // alive is how a store with an unretired serving record beside a
+            // dead pid stopped being graded as a death: the reader was told the
+            // daemon was "still present, either wedged or part way through
+            // dying" about a process the kernel had already torn down, and
+            // `kin daemon stop` cannot act on a corpse.
+            //
+            // kin-cli's own liveness probe has answered this correctly since
+            // FIR-2650; this one had not, and it is the one the death path
+            // asks.
+            return if process_is_unreaped_corpse(pid) {
+                Liveness::Dead
+            } else {
+                Liveness::Alive
+            };
         }
         match std::io::Error::last_os_error().raw_os_error() {
             Some(libc::ESRCH) => Liveness::Dead,
@@ -8861,6 +8951,79 @@ Shared_Dirty:          0 kB\n";
             watch.last_published_rss(42),
             None,
             "a marker naming another pid is not this daemon's memory"
+        );
+    }
+
+    // ── An unreaped corpse is not a live daemon (FIR-2650, second half) ──
+
+    #[test]
+    fn a_zombie_stat_line_reads_as_a_corpse() {
+        assert!(stat_line_is_zombie("4242 (kin-daemon) Z 1 4242 4242 0 -1"));
+        assert!(!stat_line_is_zombie("4242 (kin-daemon) S 1 4242 4242 0 -1"));
+        assert!(!stat_line_is_zombie("4242 (kin-daemon) R 1 4242 4242 0 -1"));
+        // `comm` may contain spaces and parentheses, and it is the only field
+        // that can, so the state is read after its FINAL closing delimiter.
+        assert!(stat_line_is_zombie("4242 (kin daemon (probe)) Z 1 4242"));
+        assert!(!stat_line_is_zombie("4242 (kin daemon (probe)) S 1 4242"));
+        assert!(!stat_line_is_zombie("4242 (kin-daemon)"));
+        assert!(!stat_line_is_zombie(""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    // The zombie is the subject, not an accident. `clippy::zombie_processes`
+    // warns about exactly the state this test has to create, and calling
+    // `.wait()` would reap the corpse and leave nothing to probe. It is reaped
+    // when the test binary exits.
+    #[allow(clippy::zombie_processes)]
+    fn a_killed_and_unreaped_daemon_is_not_alive() {
+        // A real corpse rather than a synthetic one: `kill(pid, 0)` succeeds
+        // against it, which is exactly the reading that used to answer "alive".
+        // Deliberately never waited on, so the entry stays in the process table
+        // for the length of this test.
+        let child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("exit 0")
+            .spawn()
+            .expect("spawn a short-lived child");
+        let pid = child.id();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut became_a_corpse = false;
+        while std::time::Instant::now() < deadline {
+            if process_is_unreaped_corpse(pid as libc::pid_t) {
+                became_a_corpse = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(
+            became_a_corpse,
+            "the child never became an unreaped corpse, so this test graded nothing"
+        );
+
+        // The control that makes the assertion mean something: the corpse is
+        // still signalable, so a probe built on `kill(pid, 0)` alone would call
+        // it alive.
+        assert_eq!(
+            unsafe { libc::kill(pid as libc::pid_t, 0) },
+            0,
+            "the corpse must still answer kill(pid, 0), or this proves nothing"
+        );
+        assert!(
+            !process_is_alive(pid),
+            "a process that has exited is not alive, however unreaped it is"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_running_process_is_still_alive() {
+        // The other direction, so a probe that answered "dead" for everything
+        // would fail here rather than pass both tests.
+        assert!(
+            process_is_alive(std::process::id()),
+            "this very process is running"
         );
     }
 }


### PR DESCRIPTION
Two changes, batched so this waits on CI once.

## The pin

kin-db 0.7.56 assembles a snapshot frame in one buffer instead of two. Measured
in its own guard: framing grew the peak by 2.03 copies before, and by half that
after. On the real conversion corpus it moves the whole-run peak by 158 bytes on
6.98 GB, because framing's allocation sits under a mark the preparation lap
already set. That is worth saying plainly rather than quietly shipping: the cut
is real in isolation and invisible here, and FIR-2654 names the holder that
actually sets this ceiling.

## The defect this PR's own CI found

`memory_pressure:8` failed here while the same check was green on main. It is
not the pin, and it is not flaky.

`kin-daemon-spawn`'s liveness probe stopped at `kill(pid, 0)`, which succeeds
against a zombie. So a daemon that was SIGKILLed and not yet reaped left an
unretired serving record beside a pid that still answered the signal check,
`peek_unwatched_daemon_death` read Alive and declined to grade the death, and
kin told the reader:

> the daemon this store recorded as serving it (pid 43939) is still present and
> has not retired ... it is either wedged or part way through dying ... `kin
> daemon stop` ends a wedged one

The daemon is dead. `kin daemon stop` cannot act on a corpse. This is FIR-2650's
defect one step over: wrong about a death, with advice that does not terminate.
It happens wherever nobody reaps the daemon, which is the ordinary shape of an
agent session that starts one and keeps running, and of a container whose pid 1
does not reap what it adopts. Whether the runner reaps promptly is what decided
whether this check passed, which is why it looked intermittent.

`kin-cli`'s probe has read an unreaped corpse as dead since FIR-2650. The crate
that did not is the one the death path asks.

## What changed, and what deliberately did not

No new parser and no new `/proc` read. `kin-daemon-spawn` already had
`process_has_exited`, with the errno reasoning this needs, and
`parse_proc_stat_state`, with the everything-after-the-final-paren rule. The
corpse probe routes through both. The two pure string parsers stop being
target-gated, because a `#[cfg(test)]` gate is this crate's own test build and
not its consumers', which is what left kin-cli unable to delegate from a macOS
test binary. kin-cli keeps its enum, its Windows path and its tests, and
delegates to the one implementation.

`process_is_alive` stays one-directional for its other callers: it is used to
withhold destruction, and a corpse reading false only ever widens what may be
cleaned up, never what may be killed.

## Proof

A real corpse, not a synthetic one. Spawn a child, never wait on it, poll until
the platform probe calls it a corpse, assert `kill(pid, 0)` still returns 0 so a
signal-only probe would call it alive, then assert `process_is_alive` is false.
A live-process control asserts the other direction, so a probe that answered
"dead" for everything fails rather than passing both.

Falsified, each mutation reverted after reading the failure:

```
corpse never consulted             -> a_killed_and_unreaped_daemon_is_not_alive FAILS
state field read from first paren  -> a_zombie_stat_line_reads_as_a_corpse FAILS
zombie state char changed to 'X'   -> a_killed_and_unreaped_daemon_is_not_alive FAILS
control                            -> 117 pass, 0 fail
```

kin-daemon-spawn 117 pass. kin-cli daemon_client 134 pass. `cargo fmt --check`
clean. Clippy clean with the repo's own allow list under `-D warnings`; the
deliberate zombie carries a scoped `allow(clippy::zombie_processes)` with its
reason, since `.wait()` would reap the subject. `verify-zero-file-search.py` and
`check_runtime_boundaries.sh` both pass.

## Not claiming

That the whole workspace suite ran here. It did not; hosted CI is the gate of
record for that, and this branch is rebased onto `1fcffd7e` so it runs against
current main.

Closes FIR-2658
Refs FIR-2654, FIR-2650
