### PR TITLE
Hold the comfort margin to the table, and stop a headroom test underflowing

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -4890,7 +4890,7 @@ mod tests {
         for point in MEASURED_COMMIT_PEAKS {
             for ceiling in [
                 point.peak_bytes,
-                point.peak_bytes - MIB,
+                point.peak_bytes.saturating_sub(MIB),
                 point.peak_bytes / 2,
             ] {
                 let check = commit_memory_headroom_check_for(
@@ -5022,10 +5022,18 @@ mod tests {
 
     /// The comfort margin is read off the table, so it cannot fall behind it.
     ///
-    /// The margin exists because a larger store peaks higher than the row the
-    /// check quotes. The table itself measures how much higher, and a row added
-    /// later that spreads wider than the constant would silently shrink the
-    /// amber band back toward the rounding this replaced.
+    /// The margin is the spread the table itself measures between two totals
+    /// observed in the SAME machine, which is what makes it a repeatability
+    /// figure and not the store-size claim FIR-2643 removed. This docstring said
+    /// "a larger store peaks higher" until that sweep found it, three hundred
+    /// lines from the constant whose own docstring had already been corrected,
+    /// which is the shape a wrong model leaves behind: the sentence that
+    /// justifies a number outlives the number's own explanation.
+    ///
+    /// A row measured later that spreads wider than the constant would silently
+    /// shrink the amber band back toward the rounding this replaced, so the
+    /// constant is held to the table rather than to a number somebody
+    /// remembered.
     #[test]
     fn the_comfort_margin_covers_the_spread_the_table_shows() {
         let widest = MEASURED_COMMIT_PEAKS


### PR DESCRIPTION
Two leftovers from the FIR-2643 sweep, found uncommitted in a lane worktree after the session that wrote them ran out of usage. Both are small and both are real.

The ceiling sweep subtracted a fixed `MIB` from every measured peak, which panics in debug on any row smaller than that constant. `saturating_sub` keeps the sweep meaningful for a small row rather than depending on every future row being large enough.

The margin's docstring still justified the constant as "a larger store peaks higher", which is the store-size model FIR-2643 removed. It is the spread the table measures between two totals observed in the same machine, so it is a repeatability figure. The constant's own docstring had already been corrected three hundred lines away, which is the shape a wrong model leaves behind: the sentence that justifies a number outlives the number's own explanation.

`cargo test -p kin-cli --lib health::` passes 145. `cargo fmt --check` clean.

Refs FIR-2643