### PR TITLE
Pin kin-db 0.7.57, which proves a snapshot round-trips without keeping it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.56"
+version = "0.7.57"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "3801d324c4636b0e1631346323a347bcf8a8f2ecf2b52fede2cd454e602b4b9c"
+checksum = "0f948650fcc4782b952d257b4853c9c3548d1a0abe3c3eb1d0dd2f05cdfd0f8e"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.56", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.57", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
Pins kin-db 0.7.57, whose write path proves a snapshot round-trips without
keeping the snapshot it proves.

## What the release carries

Before writing bytes to the authority store, kin-db proved they decode by
decoding them into an owned `GraphSnapshot` and dropping it on the next line.
On a converted repository that discarded value is the repository: about 855 MiB
on psf/requests at full history, allocated while the encoded frame, the retained
import ladder, the successor authority state and the successor change map are
all still live. It is the last thing a conversion does, so every retained byte
underneath it is already committed when it happens.

The obligation stays and the retention goes. `DrainMap` and `DrainSeq` parse
every entry with its declared key and value types and drop each entry as soon as
it is proved, so a `Deserialize` impl that disagrees with its serializer is still
caught. Only the pre-validated arm changes; the unvalidated arm still owes the
semantic admission pass that walks the assembled snapshot, so it keeps the full
decode.

On kin-db's own live-heap harness, the same fixture its framing guard uses:
decoding a 10,277,527-byte snapshot grew the peak by 13,559,938 bytes, 1.32 of
the snapshot, and proving it round-trips grew the peak by 2,343 bytes.

kin pins kin-db exactly, so a conversion reaches that change only through this
pin.

## The pin

Both homes moved: `Cargo.toml` and `Cargo.lock`. A sweep for `0.7.56` across the
tree returns nothing, with a positive control on `0.7.57` returning both homes.
`fuzz/Cargo.lock` carries no kin-db entry at all, verified with a positive
control on the kin-model entry it does carry. The lock was resolved patch-off
and the kin-db entry keeps its `sparse+https://kinlab.ai/registry/cargo/` source
and its checksum.

## Gated

The DEV-LOCAL gate cannot validate a pin, because it replaces the crate under
test with a local path. So this ran registry-only against the committed lock:
`cargo nextest run --workspace --locked` and `cargo test --doc --locked` both
pass, `cargo fmt --all -- --check` is clean, and clippy is clean under
`RUSTFLAGS="-D warnings"` with the repo's own 45-lint debt allow list, run
exactly as ci.yml runs it. `verify-zero-file-search.py` and
`check_runtime_boundaries.sh` both pass.

## Not claiming

That the whole-run conversion peak has been measured on this pin. It has not.
The 855 MiB is the value kin-db's change stops retaining, measured by kin-db,
and the 2,343 bytes is its harness figure; what this pin's effect is on a real
conversion's peak is a separate measurement that has not been run here. Hosted
CI is the gate of record for the full workspace and the platform legs this host
does not run.

Refs FIR-2654
