### PR TITLE
Retire the eject journal when an eject finishes, and stop counting docs.url as a hook

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -152,6 +152,15 @@ jobs:
       - name: Falsify the first-contact honesty graders
         run: python3 scripts/acceptance/first_contact_honesty.py --self-test
 
+      # FIR-2664. A finished eject left its journal in the archived .kin, a
+      # `cp -r` of that archive back to .kin carried it along, and every commit
+      # after that answered HTTP 500 until the store was deleted. The graders
+      # here decide whether a commit landed, whether a refusal names the file
+      # and the remedy in words, and whether kin init refused over a hook; each
+      # is handed the exact text 0.5.52 shipped and has to fail on it.
+      - name: Falsify the eject-journal graders
+        run: python3 scripts/acceptance/eject_journal_repro.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -540,6 +549,34 @@ jobs:
             echo "::error title=First-contact honesty suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
+      - name: Eject-journal acceptance suite (verdict comes from the gate step)
+        id: ejectjournal
+        if: always()
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/eject_journal_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/eject_journal.json \
+            --label "$KIN_ACCEPTANCE_LABEL" \
+            --verbose >acceptance/eject_journal.log 2>&1 || rc=$?
+          cat acceptance/eject_journal.log
+          {
+            echo "### Eject-journal acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/eject_journal.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=Eject-journal acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
+          fi
+
       # Always, including on a cancelled or timed-out run: the reports are how a
       # failure is diagnosed without re-running the job.
       - name: Upload the acceptance reports
@@ -578,4 +615,5 @@ jobs:
             --report initmemory=acceptance/initmemory.json \
             --report registry_isolation=acceptance/registry_isolation.json \
             --report first_contact=acceptance/first_contact.json \
+            --report eject_journal=acceptance/eject_journal.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk comes back truncated=True with clipped_steps=None on ubuntu-latest, so an absent edge cannot be told from a dropped one. Build profile, product code from 0.5.44 through 0.5.46, and the pinned language-server versions are all ruled out; platform and code newer than 0.5.46 are still confounded. The moment the check passes this allowance announces itself stale and can go.'

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -194,9 +194,16 @@ fn build_commit_client(deadline: Option<std::time::Duration>) -> reqwest::Result
 /// A refusal the daemon states in words is worth exactly those words. Wrapping
 /// it in `daemon native commit failed (HTTP 409): {"error":...}` buries the
 /// sentence a person needs inside a serialized envelope they have to read past.
+///
+/// Two refusals are worded: a successor that would record nothing, and a
+/// working projection blocked on a file a person has to act on, such as the
+/// eject journal a copied `.kin` carries in. The second reached a stranger as
+/// `HTTP 500 Internal Server Error: Core error: ...` on 0.5.52, and the only
+/// exit that read found was deleting the store (FIR-2664).
 fn commit_refusal_message(body: &str) -> Option<String> {
     let parsed: serde_json::Value = serde_json::from_str(body).ok()?;
-    if parsed.get("error")? != "nothing_to_commit" {
+    let kind = parsed.get("error")?.as_str()?;
+    if !matches!(kind, "nothing_to_commit" | "projection_blocked") {
         return None;
     }
     Some(parsed.get("message")?.as_str()?.to_string())
@@ -741,6 +748,19 @@ mod tests {
     }
 
     /// A refusal the daemon states in words reaches the caller as those words.
+    #[test]
+    fn a_blocked_projection_refusal_is_reported_as_its_own_sentence() {
+        let body = serde_json::json!({
+            "error": "projection_blocked",
+            "message": "exact eject journal /r/.kin/reconciliation/exact-eject-journal.json is \
+                        bound elsewhere; remove the file and rerun",
+        })
+        .to_string();
+        let refusal = commit_refusal_message(&body).expect("a worded refusal");
+        assert!(refusal.starts_with("exact eject journal /r/"), "{refusal}");
+        assert!(!refusal.contains("HTTP"), "{refusal}");
+    }
+
     #[test]
     fn a_nothing_to_commit_refusal_is_reported_as_its_own_sentence() {
         let body = serde_json::json!({

--- a/crates/kin-cli/src/commands/eject.rs
+++ b/crates/kin-cli/src/commands/eject.rs
@@ -137,6 +137,9 @@ pub async fn run(yes: bool) -> Result<()> {
              independently backed up."
         );
     }
+    if let Some(note) = eject_outcome.retained_journal.as_deref() {
+        eprintln!("warning: {note}");
+    }
     Ok(())
 }
 

--- a/crates/kin-core/src/error.rs
+++ b/crates/kin-core/src/error.rs
@@ -39,6 +39,17 @@ pub enum KinError {
     #[error("repository projection conflict: {0}")]
     ProjectionConflict(String),
 
+    /// The working projection will not open until a person acts on the file
+    /// the message names.
+    ///
+    /// Neither a conflict nor an internal failure: the store is intact and the
+    /// sentence carries the remedy. A daemon answers it as a refusal in words
+    /// rather than as HTTP 500, because sending a reader to the daemon for a
+    /// file they can see is how a stale eject journal cost a stranger the whole
+    /// write path on 0.5.52 (FIR-2664).
+    #[error("{0}")]
+    ProjectionBlocked(String),
+
     #[error("repository authority commit outcome is indeterminate: {0}")]
     RepositoryCommitIndeterminate(String),
 

--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -1678,11 +1678,15 @@ pub struct ExactProjectionGitStage {
 }
 
 /// Result of one capability-anchored exact projection eject transaction.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExactProjectionEjectOutcome {
     /// Whether an existing regular-file or directory `.git` entry was retained
     /// and archived before the staged repository was installed.
     pub had_previous_git: bool,
+    /// Set when the eject completed but its journal could not be retired from
+    /// the archived `.kin`, naming the file and what to do about it. `None` is
+    /// the normal case: a finished transaction leaves no journal behind.
+    pub retained_journal: Option<String>,
 }
 
 impl std::fmt::Debug for ExactProjectionFreeze {
@@ -2928,7 +2932,13 @@ impl ExactProjectionFreeze {
                 previous_git_archived,
             );
             if rollback_complete {
-                if let Err(cleanup) = self.projection.remove_exact_eject_journal(&eject_journal) {
+                if let Err(cleanup) = self.projection.remove_exact_eject_journal(
+                    &eject_journal,
+                    &self
+                        .projection
+                        .reconciliation_control_path()
+                        .join(EXACT_EJECT_JOURNAL_FILE),
+                ) {
                     error = KinError::Other(format!(
                         "{error}; exact eject rollback completed but durable journal cleanup failed: {cleanup}"
                     ));
@@ -2937,8 +2947,36 @@ impl ExactProjectionFreeze {
             return Err(error);
         }
 
+        // The transaction is complete: the staged Git is installed at the root,
+        // the previous Git is archived, and `.kin` is detached into the archive
+        // with this handle still open on its reconciliation directory. The
+        // journal exists to recover a transaction that dies part way, and a
+        // finished one has nothing to recover, so it is retired here rather
+        // than left in the archive. Left there it made the archive a trap: a
+        // `.kin` copied back out of it carried a journal bound to inodes the
+        // copy did not have, every projection open after that refused, and the
+        // only exit a stranger found on 0.5.52 was deleting the store
+        // (FIR-2664).
+        let archived_journal = target
+            .display_path
+            .join(archived_kin_name)
+            .join(RECONCILIATION_CONTROL_DIRECTORY)
+            .join(EXACT_EJECT_JOURNAL_FILE);
+        let retained_journal = self
+            .projection
+            .remove_exact_eject_journal(&eject_journal, &archived_journal)
+            .err()
+            .map(|error| {
+                format!(
+                    "the eject completed, but its journal could not be retired and remains at {}: \
+                     {error}. Remove that file before reusing the archived kin/ directory",
+                    archived_journal.display()
+                )
+            });
+
         Ok(ExactProjectionEjectOutcome {
             had_previous_git: previous_git.is_some(),
+            retained_journal,
         })
     }
 
@@ -5451,6 +5489,29 @@ fn exact_relative_directory_components(relative: &Path, label: &str) -> Result<V
         .collect()
 }
 
+/// The refusal for an eject journal Kin will not act on.
+///
+/// Names the file, what is wrong with it, the archive the eject it records
+/// used when the journal could say, and the way out in both states that
+/// archive can be in. A refusal without those sent a stranger from `HTTP 500`
+/// to `rm -rf .kin/` on 0.5.52 (FIR-2664).
+#[cfg(unix)]
+fn exact_eject_journal_blocked(journal: &Path, archive: Option<&Path>, what: &str) -> KinError {
+    let archive = match archive {
+        Some(archive) => archive.display().to_string(),
+        None => "the .kin-ejected-* archive beside the repository".to_string(),
+    };
+    KinError::ProjectionBlocked(format!(
+        "exact eject journal {} {what}, so Kin will not replay the eject it records here. If that \
+         eject completed, the repository root holds an ordinary .git and {archive} holds kin/ and \
+         previous-git/, and this journal is a leftover: remove the file and rerun. If it did not, \
+         {archive} holds whatever the eject had moved when it stopped and the journal is the \
+         record of it; put those entries back by hand before removing it. To rebuild Kin from Git \
+         history instead, remove .kin/ and run `kin init`.",
+        journal.display()
+    ))
+}
+
 #[cfg(unix)]
 fn exact_eject_journal_name(bytes: &[u8], label: &str) -> Result<OsString> {
     use std::os::unix::ffi::OsStringExt as _;
@@ -6687,26 +6748,33 @@ impl ProjectionRoot {
         }
         let authenticated: AuthenticatedExactEjectJournal = serde_json::from_slice(&bytes)
             .map_err(|error| {
-                KinError::Other(format!(
-                    "decode exact eject journal {}: {error}",
-                    display.display()
-                ))
+                exact_eject_journal_blocked(
+                    &display,
+                    None,
+                    &format!("could not be decoded: {error}"),
+                )
             })?;
         let expected = self.authenticate_exact_eject_journal(&authenticated.journal)?;
         if !constant_time_bytes_equal(&authenticated.authentication, &expected) {
-            return Err(KinError::Other(format!(
-                "exact eject journal {} failed authentication",
-                display.display()
-            )));
+            return Err(exact_eject_journal_blocked(
+                &display,
+                None,
+                "failed authentication against this store's authority key",
+            ));
         }
         Ok(Some(authenticated.journal))
     }
 
+    /// Retire one journal through the open control handle.
+    ///
+    /// `display` is where that handle's directory lives now, which after a
+    /// finished eject is inside the archive rather than under the root.
     #[cfg(unix)]
-    fn remove_exact_eject_journal(&self, expected: &ExactEjectJournal) -> Result<()> {
-        let display = self
-            .reconciliation_control_path()
-            .join(EXACT_EJECT_JOURNAL_FILE);
+    fn remove_exact_eject_journal(
+        &self,
+        expected: &ExactEjectJournal,
+        display: &Path,
+    ) -> Result<()> {
         let actual = self.load_exact_eject_journal()?.ok_or_else(|| {
             KinError::Other(format!(
                 "exact eject journal disappeared before cleanup: {}",
@@ -6721,33 +6789,147 @@ impl ProjectionRoot {
         }
         self.control
             .remove_file(std::ffi::OsStr::new(EXACT_EJECT_JOURNAL_FILE))
-            .map_err(|error| KinError::io(&display, error))?;
-        sync_directory_capability(&self.control, &display)
+            .map_err(|error| KinError::io(display, error))?;
+        sync_directory_capability(&self.control, display)
+    }
+
+    /// Where the archive an eject journal names would be, for a message.
+    #[cfg(unix)]
+    fn exact_eject_journal_archive_display(&self, journal: &ExactEjectJournal) -> Option<PathBuf> {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        self.display_root
+            .parent()
+            .map(|parent| parent.join(std::ffi::OsStr::from_bytes(&journal.archive_name)))
+    }
+
+    /// Whether `journal` was written for a `.kin` that now lives detached in
+    /// the archive it names, so the copy of it found here is a leftover of a
+    /// finished eject rather than a transaction to recover.
+    ///
+    /// Every step binds by identity. The repository root, its parent, the
+    /// archive directory, the archived `.kin` and that `.kin`'s reconciliation
+    /// directory all have to be the inodes the journal recorded, and the
+    /// journal has to be at the detach phase, the only phase that moves
+    /// `.kin`. A `.kin` copied out of the archive carries the journal along
+    /// under fresh inodes of its own, which is the exact shape an identity
+    /// check alone reported as an invalid descriptor. Anything that cannot be
+    /// opened or does not match answers `false`, and the caller refuses with
+    /// the file and the way out named.
+    #[cfg(unix)]
+    fn exact_eject_journal_names_a_detached_kin(
+        &self,
+        journal: &ExactEjectJournal,
+        root_identity: TrackedEntryIdentity,
+    ) -> Result<bool> {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        if journal.phase != ExactEjectJournalPhase::DetachPending
+            || journal.root_identity != root_identity
+        {
+            return Ok(false);
+        }
+        let (namespace_parent, root_name) =
+            self.locate_open_directory(&self.root, root_identity, &self.display_root)?;
+        let namespace_parent_identity = tracked_open_directory_identity(&namespace_parent)
+            .map_err(|error| KinError::io(&self.display_root, error))?;
+        if namespace_parent_identity != journal.namespace_parent_identity
+            || root_name.as_bytes() != journal.root_name
+        {
+            return Ok(false);
+        }
+        let archive_name = exact_eject_journal_name(&journal.archive_name, "archive directory")?;
+        let archived_kin_name =
+            exact_eject_journal_name(&journal.archived_kin_name, "archived Kin")?;
+        let mut directory = namespace_parent;
+        for (name, expected) in [
+            (archive_name.as_os_str(), journal.archive_identity),
+            (archived_kin_name.as_os_str(), journal.kin_control_identity),
+            (
+                std::ffi::OsStr::new(RECONCILIATION_CONTROL_DIRECTORY),
+                journal.control_identity,
+            ),
+        ] {
+            let Ok(next) = open_directory_nofollow(&directory, name) else {
+                return Ok(false);
+            };
+            let Ok(identity) = tracked_open_directory_identity(&next) else {
+                return Ok(false);
+            };
+            if identity != expected {
+                return Ok(false);
+            }
+            directory = next;
+        }
+        Ok(true)
     }
 
     #[cfg(unix)]
     fn recover_exact_eject(&self) -> Result<()> {
-        use std::os::unix::ffi::OsStrExt as _;
-
         let Some(journal) = self.load_exact_eject_journal()? else {
             return Ok(());
         };
+        let journal_path = self
+            .reconciliation_control_path()
+            .join(EXACT_EJECT_JOURNAL_FILE);
+        let archive = self.exact_eject_journal_archive_display(&journal);
         self.revalidate_projection_lock()?;
         let root_identity = tracked_open_directory_identity(&self.root)
             .map_err(|error| KinError::io(&self.display_root, error))?;
         if journal.schema != EXACT_EJECT_JOURNAL_SCHEMA
             || uuid::Uuid::parse_str(&journal.transaction_id).is_err()
-            || journal.root_identity != root_identity
+        {
+            return Err(exact_eject_journal_blocked(
+                &journal_path,
+                archive.as_deref(),
+                "carries a schema or transaction id this build does not recognize",
+            ));
+        }
+        if journal.root_identity != root_identity
             || journal.kin_control_identity != self.kin_control_identity
             || journal.control_identity != self.control_identity
         {
-            return Err(KinError::Other(format!(
-                "exact eject journal {} has an invalid identity-bound descriptor",
-                self.reconciliation_control_path()
-                    .join(EXACT_EJECT_JOURNAL_FILE)
-                    .display()
-            )));
+            // The journal names a `.kin` other than the one it was found in.
+            // One shape of that is benign and common: a `.kin` copied back out
+            // of an eject archive carries the journal of the eject that
+            // detached the original, under inodes of its own. When the archive
+            // still holds that original, inode for inode, the eject it records
+            // finished and the copy has nothing to recover, so the journal is
+            // retired here and nothing in the namespace is touched. Every other
+            // mismatch is refused with the file and the way out named, because
+            // a descriptor that matches nothing could as easily be a forged
+            // one, and a forged one must never drive a namespace move.
+            if self.exact_eject_journal_names_a_detached_kin(&journal, root_identity)? {
+                return self.remove_exact_eject_journal(&journal, &journal_path);
+            }
+            return Err(exact_eject_journal_blocked(
+                &journal_path,
+                archive.as_deref(),
+                "is bound to a different repository or .kin directory than the one it was found \
+                 in, the shape a .kin copied out of an eject archive has",
+            ));
         }
+        self.replay_exact_eject_journal(&journal, root_identity, &journal_path)
+            .map_err(|error| match error {
+                KinError::ProjectionBlocked(_) => error,
+                error => exact_eject_journal_blocked(
+                    &journal_path,
+                    archive.as_deref(),
+                    &format!("could not be replayed: {error}"),
+                ),
+            })
+    }
+
+    /// Replay one journal whose identities all match this projection: finish
+    /// or roll back the namespace moves it records, then retire it.
+    #[cfg(unix)]
+    fn replay_exact_eject_journal(
+        &self,
+        journal: &ExactEjectJournal,
+        root_identity: TrackedEntryIdentity,
+        journal_path: &Path,
+    ) -> Result<()> {
+        use std::os::unix::ffi::OsStrExt as _;
 
         let (namespace_parent, root_name) =
             self.locate_open_directory(&self.root, root_identity, &self.display_root)?;
@@ -6990,7 +7172,7 @@ impl ProjectionRoot {
                 ensure_named_entry_absent(&self.root, git_name, &self.display_root.join(".git"))?
             }
         }
-        self.remove_exact_eject_journal(&journal)
+        self.remove_exact_eject_journal(journal, journal_path)
     }
 
     #[cfg(unix)]
@@ -14532,8 +14714,16 @@ mod tests {
         assert_eq!(
             outcome,
             ExactProjectionEjectOutcome {
-                had_previous_git: true
+                had_previous_git: true,
+                retained_journal: None,
             }
+        );
+        assert!(
+            !fixture
+                .archive
+                .join("kin/reconciliation/exact-eject-journal.json")
+                .exists(),
+            "a finished eject retires its journal from the archived .kin"
         );
         assert_eq!(
             std::fs::read(fixture.root.join(".git/stage-marker")).unwrap(),
@@ -14579,6 +14769,7 @@ mod tests {
             .unwrap();
 
         assert!(outcome.had_previous_git);
+        assert!(outcome.retained_journal.is_none());
         assert_eq!(
             std::fs::read(fixture.archive.join("previous-git/legacy-marker")).unwrap(),
             b"legacy Git"
@@ -14586,6 +14777,13 @@ mod tests {
         assert_eq!(
             std::fs::read(fixture.root.join(".git/stage-marker")).unwrap(),
             b"prepared Git"
+        );
+        assert!(
+            !fixture
+                .archive
+                .join("kin/reconciliation/exact-eject-journal.json")
+                .exists(),
+            "a finished eject retires its journal from the archived .kin"
         );
     }
 
@@ -14614,7 +14812,156 @@ mod tests {
             .unwrap();
 
         assert!(!outcome.had_previous_git);
+        assert!(outcome.retained_journal.is_none());
         assert!(!fixture.archive.join("previous-git").exists());
+        assert!(
+            !fixture
+                .archive
+                .join("kin/reconciliation/exact-eject-journal.json")
+                .exists(),
+            "a finished eject retires its journal from the archived .kin"
+        );
+    }
+
+    /// Copy a directory tree the way `cp -r` does: every entry gets an inode of
+    /// its own.
+    #[cfg(unix)]
+    fn copy_directory_recursively(source: &Path, destination: &Path) {
+        std::fs::create_dir(destination).unwrap();
+        for entry in std::fs::read_dir(source).unwrap() {
+            let entry = entry.unwrap();
+            let target = destination.join(entry.file_name());
+            if entry.file_type().unwrap().is_dir() {
+                copy_directory_recursively(&entry.path(), &target);
+            } else {
+                std::fs::copy(entry.path(), &target).unwrap();
+            }
+        }
+    }
+
+    /// Eject, put the journal back into the archive the way a 0.5.52 eject
+    /// left it, then copy the archived `.kin` back to the root the way the
+    /// rc0552n stranger did with `cp -r`.
+    ///
+    /// Returns the fixture, the carried journal's path under the root, and the
+    /// archived journal's path. The journal bytes are the real ones: they are
+    /// captured at the detach hook point, after `.kin` has moved and before a
+    /// finished transaction retires them.
+    #[cfg(unix)]
+    fn eject_then_copy_back_a_journal_carrying_kin() -> (ExactEjectFixture, PathBuf, PathBuf) {
+        let fixture = exact_eject_fixture(ExistingGitFixture::Directory);
+        let freeze = ExactProjectionFreeze::acquire_existing(&fixture.root).unwrap();
+        let verification = freeze
+            .verify_resolved_tree_from_blobs(&fixture.tree, &fixture.blobs)
+            .unwrap();
+        let target = ExactProjectionDetachTarget::open_existing(&fixture.archive).unwrap();
+        let stage = ExactProjectionGitStage::open_existing_unverified_for_test(&fixture.staged_git)
+            .unwrap();
+        let archived_journal = fixture
+            .archive
+            .join("kin/reconciliation/exact-eject-journal.json");
+        let mut leftover = Vec::new();
+        freeze
+            .replace_git_and_detach_verified_to_from_blobs_with_hook(
+                &verification,
+                &fixture.tree,
+                &fixture.blobs,
+                stage,
+                &target,
+                std::ffi::OsStr::new("kin"),
+                std::ffi::OsStr::new("previous-git"),
+                |point| {
+                    if point == ExactProjectionEjectHookPoint::AfterKinDetached {
+                        leftover = std::fs::read(&archived_journal).unwrap();
+                    }
+                },
+            )
+            .unwrap();
+        assert!(
+            !leftover.is_empty(),
+            "the detach hook point must see the journal in the archived .kin"
+        );
+        assert!(
+            !archived_journal.exists(),
+            "a finished eject retires its journal"
+        );
+        std::fs::write(&archived_journal, &leftover).unwrap();
+
+        copy_directory_recursively(&fixture.archive.join("kin"), &fixture.root.join(".kin"));
+        let carried = fixture
+            .root
+            .join(".kin/reconciliation/exact-eject-journal.json");
+        assert!(carried.is_file(), "the copy carries the journal along");
+        (fixture, carried, archived_journal)
+    }
+
+    /// A `.kin` copied back out of an eject archive carries the journal of the
+    /// eject that detached the original, and every projection open refused it
+    /// as an invalid identity-bound descriptor: after
+    /// `cp -r .kin-ejected-*/kin .kin`, every `kin commit` answered HTTP 500
+    /// on 0.5.52 and the store was deleted to get out (FIR-2664). The archive
+    /// still holds the original inode for inode, which proves the eject
+    /// finished, so the copy's journal is retired on open and nothing in the
+    /// namespace moves.
+    #[cfg(unix)]
+    #[test]
+    fn a_journal_carried_by_a_copied_kin_is_retired_when_the_archive_proves_the_eject_finished() {
+        let (fixture, carried, archived_journal) = eject_then_copy_back_a_journal_carrying_kin();
+
+        drop(ExactProjectionFreeze::acquire_existing(&fixture.root).unwrap());
+
+        assert!(!carried.exists(), "the carried journal is retired on open");
+        assert!(archived_journal.is_file(), "the archive is left as it was");
+        assert_eq!(
+            std::fs::read(fixture.root.join(".git/stage-marker")).unwrap(),
+            b"prepared Git",
+            "the installed Git stays installed"
+        );
+        assert!(fixture.archive.join("previous-git").is_dir());
+        assert!(fixture.archive.join("kin").is_dir());
+        assert!(fixture.root.join(".kin").is_dir());
+    }
+
+    /// The same carried journal with no archived `.kin` to prove anything
+    /// against is refused, and the refusal names the file, the archive it
+    /// expected and the way out, in a variant a daemon answers in words.
+    #[cfg(unix)]
+    #[test]
+    fn a_journal_bound_elsewhere_is_refused_with_the_file_and_the_remedy_named() {
+        let (fixture, carried, _archived_journal) = eject_then_copy_back_a_journal_carrying_kin();
+        std::fs::remove_dir_all(fixture.archive.join("kin")).unwrap();
+
+        let error = ExactProjectionFreeze::acquire_existing(&fixture.root)
+            .expect_err("a journal that matches nothing must be refused");
+
+        assert!(
+            matches!(error, KinError::ProjectionBlocked(_)),
+            "a person has to act on this, so it is a blocked projection: {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains(&carried.display().to_string()),
+            "{message}"
+        );
+        assert!(
+            message.contains(&fixture.archive.display().to_string()),
+            "{message}"
+        );
+        assert!(message.contains("remove the file and rerun"), "{message}");
+        assert!(message.contains("kin init"), "{message}");
+        assert!(
+            !message.contains("invalid identity-bound descriptor"),
+            "{message}"
+        );
+        assert!(
+            carried.is_file(),
+            "a refused journal is left for the person to act on"
+        );
+        assert_eq!(
+            std::fs::read(fixture.root.join(".git/stage-marker")).unwrap(),
+            b"prepared Git",
+            "a refusal moves nothing"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -5026,7 +5026,7 @@ async fn command_commit(
         crate::loop_runner::sync_filesystem_with_graph_deferring_tree_publication(&state),
     )
     .await
-    .map_err(internal_error)?;
+    .map_err(commit_admission_error)?;
 
     match command_commit_after_admission(&state, request, deferred_tree.as_ref()) {
         Ok(response) => {
@@ -5270,7 +5270,40 @@ fn refuse_a_successor_that_records_nothing(
     Some((StatusCode::CONFLICT, body.to_string()))
 }
 
+/// The response for a commit's admission that could not open the working
+/// projection.
+///
+/// A projection blocked on a file a person has to act on, such as the eject
+/// journal a copied `.kin` carries in, is a refusal in words rather than a
+/// daemon failure: the store is intact and the sentence names the file and the
+/// remedy. It is answered as 409 with that sentence in the body, which the CLI
+/// prints as its own line, so a reader is not sent to the daemon for a file
+/// they can see. On 0.5.52 it reached them as `HTTP 500 Internal Server Error:
+/// Core error: ...` (FIR-2664). Everything else stays an internal error.
+fn commit_admission_error(error: crate::error::DaemonError) -> (StatusCode, String) {
+    match projection_blocked_refusal(&error) {
+        Some(refusal) => refusal,
+        None => internal_error(error),
+    }
+}
+
+/// The worded refusal for a blocked projection, when `error` is one.
+fn projection_blocked_refusal(error: &crate::error::DaemonError) -> Option<(StatusCode, String)> {
+    let crate::error::DaemonError::Core(kin_core::KinError::ProjectionBlocked(message)) = error
+    else {
+        return None;
+    };
+    let body = serde_json::json!({
+        "error": "projection_blocked",
+        "message": message,
+    });
+    Some((StatusCode::CONFLICT, body.to_string()))
+}
+
 fn repository_commit_error(error: crate::error::DaemonError) -> (StatusCode, String) {
+    if let Some(refusal) = projection_blocked_refusal(&error) {
+        return refusal;
+    }
     let status = match &error {
         crate::error::DaemonError::Graph(kin_db::KinDbError::Model(
             kin_model::ModelError::Conflict(_),
@@ -13472,6 +13505,37 @@ mod tests {
         .unwrap_err();
         assert_eq!(conflict.0, StatusCode::INTERNAL_SERVER_ERROR);
         assert!(conflict.1.contains("conflicting"));
+    }
+
+    /// A projection blocked on a file a person has to act on is answered in
+    /// words, as 409 with the sentence in the body, on both commit paths. Any
+    /// other core error keeps its internal-error shape.
+    #[test]
+    fn a_blocked_projection_is_a_worded_refusal_rather_than_a_daemon_failure() {
+        let sentence = "exact eject journal /r/.kin/reconciliation/exact-eject-journal.json is \
+                        bound to a different .kin directory; remove the file and rerun";
+        let blocked = || {
+            crate::error::DaemonError::Core(kin_core::KinError::ProjectionBlocked(
+                sentence.to_string(),
+            ))
+        };
+
+        let (status, body) = commit_admission_error(blocked());
+        assert_eq!(status, StatusCode::CONFLICT);
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(body["error"], "projection_blocked");
+        assert_eq!(body["message"], sentence);
+
+        let (status, body) = repository_commit_error(blocked());
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(body.contains("projection_blocked"), "{body}");
+
+        let (status, body) = commit_admission_error(crate::error::DaemonError::Core(
+            kin_core::KinError::Other("something else entirely".to_string()),
+        ));
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(body.contains("something else entirely"), "{body}");
+        assert!(!body.contains("projection_blocked"), "{body}");
     }
 
     #[test]

--- a/crates/kin-git/src/admission_blockers.rs
+++ b/crates/kin-git/src/admission_blockers.rs
@@ -175,6 +175,52 @@ pub(crate) struct EffectiveHookSurface {
     pub(crate) hooks: Vec<LocalGitHookFact>,
     /// Legacy links an older Kin left under the resolved hook directory.
     pub(crate) kin_legacy: Vec<PathBuf>,
+    /// Entries under the resolved hook directory whose names Git never runs.
+    pub(crate) not_hooks: Vec<PathBuf>,
+}
+
+/// The hook names Git runs, from githooks(5).
+///
+/// Git looks a hook up by exactly these names under the hook directory, and
+/// any other entry there is inert however it is named or moded. gitoxide's
+/// init template writes `docs.url` beside the samples, and `kin eject` builds
+/// its replacement Git with gitoxide, so a count blind to names refused every
+/// repository Kin had just ejected and called a 34-byte URL a hook that runs
+/// (FIR-2664).
+const GIT_HOOK_NAMES: &[&[u8]] = &[
+    b"applypatch-msg",
+    b"pre-applypatch",
+    b"post-applypatch",
+    b"pre-commit",
+    b"pre-merge-commit",
+    b"prepare-commit-msg",
+    b"commit-msg",
+    b"post-commit",
+    b"pre-rebase",
+    b"post-checkout",
+    b"post-merge",
+    b"pre-push",
+    b"pre-receive",
+    b"update",
+    b"proc-receive",
+    b"post-receive",
+    b"post-update",
+    b"reference-transaction",
+    b"push-to-checkout",
+    b"pre-auto-gc",
+    b"post-rewrite",
+    b"sendemail-validate",
+    b"fsmonitor-watchman",
+    b"p4-changelist",
+    b"p4-prepare-changelist",
+    b"p4-post-changelist",
+    b"p4-pre-submit",
+    b"post-index-change",
+];
+
+/// Whether Git would ever look for a hook under this name.
+fn is_git_hook_name(name: &[u8]) -> bool {
+    GIT_HOOK_NAMES.contains(&name)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -221,6 +267,19 @@ impl EffectiveHookSurface {
                 )
             ));
         }
+        if !self.not_hooks.is_empty() {
+            notes.push(format!(
+                "{} file(s) under {} carry no name Git runs as a hook and were not counted: {}",
+                self.not_hooks.len(),
+                self.directory.display(),
+                render_paths(
+                    self.not_hooks
+                        .iter()
+                        .map(|path| path.display().to_string())
+                        .collect()
+                )
+            ));
+        }
         notes
     }
 }
@@ -257,6 +316,7 @@ pub(crate) fn effective_hook_surface(
             configured,
             hooks: Vec::new(),
             kin_legacy: Vec::new(),
+            not_hooks: Vec::new(),
         });
     }
     let entries = match fs::read_dir(&directory) {
@@ -267,6 +327,7 @@ pub(crate) fn effective_hook_surface(
                 configured,
                 hooks: Vec::new(),
                 kin_legacy: Vec::new(),
+                not_hooks: Vec::new(),
             });
         }
         Err(error) => return Err(GitError::io(&directory, error)),
@@ -278,6 +339,7 @@ pub(crate) fn effective_hook_surface(
 
     let mut hooks = Vec::new();
     let mut kin_legacy = Vec::new();
+    let mut not_hooks = Vec::new();
     for (name, entry) in entries {
         if name.ends_with(b".sample") {
             continue;
@@ -287,6 +349,10 @@ pub(crate) fn effective_hook_surface(
             fs::symlink_metadata(&path).map_err(|error| GitError::io(entry.path(), error))?;
         if is_legacy_kin_hook_link(&directory, &path, &metadata)? {
             kin_legacy.push(path);
+            continue;
+        }
+        if !is_git_hook_name(&name) {
+            not_hooks.push(path);
             continue;
         }
         hooks.push(LocalGitHookFact {
@@ -299,11 +365,13 @@ pub(crate) fn effective_hook_surface(
     }
     hooks.sort_by(|left, right| left.name.cmp(&right.name));
     kin_legacy.sort();
+    not_hooks.sort();
     Ok(EffectiveHookSurface {
         directory,
         configured,
         hooks,
         kin_legacy,
+        not_hooks,
     })
 }
 
@@ -884,6 +952,7 @@ mod tests {
             }),
             hooks: Vec::new(),
             kin_legacy: Vec::new(),
+            not_hooks: Vec::new(),
         };
         assert!(!surface.repository_scoped_hooks_path());
         let notes = surface.notes();
@@ -962,6 +1031,69 @@ mod tests {
 
         let report = fixture.report();
         assert!(report.is_clear(), "{report:?}");
+    }
+
+    /// `kin eject` builds its replacement Git with gitoxide, whose init
+    /// template writes `hooks/docs.url` beside the samples: a 34-byte URL, not
+    /// executable, and not a name Git ever runs. Counting it refused `kin init`
+    /// on every repository Kin had just ejected, and the refusal called it a
+    /// hook that runs (FIR-2664).
+    #[test]
+    fn a_docs_url_beside_the_samples_is_not_a_hook_and_is_named_as_uncounted() {
+        let fixture = Fixture::clean();
+        git(&fixture.repo, &["config", "core.hooksPath", ""]);
+        fs::write(
+            fixture.repo.join(".git/hooks/docs.url"),
+            b"https://git-scm.com/docs/githooks\n",
+        )
+        .expect("docs.url");
+
+        let report = fixture.report();
+        assert!(report.is_clear(), "{report:?}");
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.contains("docs.url") && note.contains("not counted")),
+            "the uncounted entry is named rather than hidden: {report:?}"
+        );
+        let surface = surface_for(&fixture);
+        assert!(surface.hooks.is_empty(), "{surface:?}");
+        assert_eq!(surface.not_hooks.len(), 1, "{surface:?}");
+        assert!(surface.not_hooks[0].ends_with("docs.url"), "{surface:?}");
+    }
+
+    /// The name is the rule, not the mode: an executable Git would never look
+    /// for is still not a hook, and a hook-named file still blocks.
+    #[test]
+    fn only_names_git_runs_count_as_hooks() {
+        let fixture = Fixture::clean();
+        git(&fixture.repo, &["config", "core.hooksPath", ""]);
+        write_executable(
+            &fixture.repo.join(".git/hooks/README"),
+            b"#!/bin/sh\nexit 0\n",
+        );
+        let report = fixture.report();
+        assert!(report.is_clear(), "{report:?}");
+
+        let hook = fixture.repo.join(".git/hooks/pre-commit");
+        write_executable(&hook, b"#!/bin/sh\nexit 0\n");
+        // The refusal prints the canonical path, which on macOS differs from
+        // the fixture's `/var` spelling.
+        let hook = fs::canonicalize(&hook).expect("canonical hook path");
+        let refusal = fixture.refusal();
+        assert!(
+            refusal.contains(&format!("{} runs for this repository", hook.display())),
+            "the hook Git runs is named as one: {refusal}"
+        );
+        assert!(
+            !refusal.contains("README runs for this repository"),
+            "the executable Git never looks for is not called a hook: {refusal}"
+        );
+        assert!(
+            refusal.contains("README") && refusal.contains("not counted"),
+            "and it is named as uncounted rather than hidden: {refusal}"
+        );
     }
 
     /// Only a link that keeps its own name under `.kin/hooks` is Kin's.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -658,7 +658,13 @@ metadata and the pre-eject repository-local `.git` entry are retained in a
 private sibling archive as `kin/` and `previous-git/`. Credential-free remote
 URLs, refspecs, branch tracking, and push defaults sealed during Git import are
 restored; credentials and ambient Git configuration are never copied. The
-command prints the exact archive path. Kin intentionally leaves irreversible
+command prints the exact archive path. A finished eject leaves no journal in
+the archived `kin/`, so copying that directory back to `.kin` re-attaches the
+store and the next `kin commit` records what changed in the working tree
+since. An archive an older Kin wrote still carries its eject journal; a copy
+made from it is accepted the same way once the archive proves the eject
+finished, and a journal Kin cannot verify is refused with the file and the
+remedy named. Kin intentionally leaves irreversible
 archive deletion to the operator after an independent backup; the eject
 transaction never follows an ambient path to recursively delete detached
 authority. The capability-anchored transaction is currently supported on Unix

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -238,6 +238,27 @@ dies of something that is not the network, the check reports UNREADABLE and says
 which reason it got, because a classifier that was never asked the question has
 not answered it.
 
+`eject_journal_repro.py` covers the eject archive round trip the rc0552n green
+stranger lost on 0.5.52 (FIR-2664). A finished `kin eject` left its journal in
+the archived `kin/` at the detach phase, `cp -r` of that archive back to `.kin`
+carried the journal along under fresh inodes, and every `kin commit` after that
+answered `HTTP 500 ... invalid identity-bound descriptor` until the store was
+deleted. Check `archive` asserts a finished eject leaves no journal beside the
+archived authority key. Check `copyback` copies the archived `kin/` back with
+`cp -R` and requires the next commit to land. Check `carried` plants a journal
+in the exact shape 0.5.52 wrote, keyed to the fixture's own authority key and
+bound to the archived `kin/`, lets the copy carry it back, and requires the
+commit to land and the carried copy to be retired while the archive's own is
+untouched. Check `refusal` plants a journal bound to nothing the store can
+verify and requires the refusal to name the file and the remedy in words, with
+no `HTTP 500`, `Internal Server Error` or `Core error` in it, then removes the
+file as the message says and requires the same store to commit. Check `hook`
+covers the second half of the same run: `kin eject` builds its replacement Git
+with gitoxide, whose template writes `.git/hooks/docs.url`, a URL Git never
+runs, and `kin init` refused the ejected repository over it; the check requires
+`kin init` to re-admit past it and, as its control, still to refuse an
+executable `pre-commit` by name. Eject is Unix-only, and so is the suite.
+
 `brownfield_repro.py --self-test` and `response_budget_elisions.py --self-test`
 exercise their verdict graders on fixed payloads and need no binary and no
 corpus. Each case is paired with its inverse, so a grader that cannot tell its
@@ -271,6 +292,10 @@ python3 scripts/acceptance/registry_home_isolation.py \
 python3 scripts/acceptance/first_contact_honesty.py \
   --kin target/release/kin --daemon target/release/kin-daemon \
   --json acceptance/first_contact.json --verbose
+
+python3 scripts/acceptance/eject_journal_repro.py \
+  --kin target/release/kin --daemon target/release/kin-daemon \
+  --json acceptance/eject_journal.json --verbose
 ```
 
 Release, not debug. Release is what ships, so it is what an acceptance answer

--- a/scripts/acceptance/eject_journal_repro.py
+++ b/scripts/acceptance/eject_journal_repro.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""NON-CITABLE acceptance suite for the eject archive round trip (FIR-2664).
+
+Its output is a regression gate, never proof, never investor-facing and never a
+released claim. It shares the CHECK line format, the exit codes and the
+`--self-test` discipline of its siblings in this directory, so a reader who
+knows one knows all of them.
+
+What it is for
+--------------
+The rc0552n green stranger ran `kin eject` on 0.5.52, copied the archived
+`kin/` back to `.kin` with `cp -r`, and lost `kin commit` for good: every
+attempt answered `daemon native commit failed (HTTP 500 Internal Server
+Error): Core error: exact eject journal ... has an invalid identity-bound
+descriptor`. A finished eject had left its journal behind in the archived
+`.kin` at the detach phase, the copy carried it along under fresh inodes, and
+every projection open after that refused. The only exit the stranger found was
+`rm -rf .kin/`. Then `kin init` refused the ejected repository over
+`.git/hooks/docs.url`, a 34-byte URL gitoxide's init template writes and Git
+never runs, which `kin eject` itself had put there.
+
+Five checks, each with its own control:
+
+  archive   a finished eject leaves no journal in the archived `kin/`, while
+            the same directory still carries the authority key
+  copyback  `cp -R` of the archived `kin/` back to `.kin` commits again
+  carried   a journal shaped exactly as 0.5.52 left it, planted into the
+            archive and carried back by the copy, is retired on the next
+            commit rather than refused
+  refusal   a journal bound to nothing this store can verify is refused with
+            the file and the remedy named, never as an HTTP 500, and the same
+            store commits once the file is gone
+  hook      `kin init` re-admits the ejected repository with gitoxide's
+            `docs.url` in place, and still refuses an executable `pre-commit`
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+UNREADABLE is a distinct outcome from FAIL and is never reported as a pass: it
+means the probe could not be evaluated (a fixture that never built, an eject
+that printed no archive path, a crashed probe). Exit status is 1 when any check
+FAILs, 2 when none fail but some are UNREADABLE, 0 only when every check passes,
+3 on a setup error.
+
+The binary under test
+---------------------
+    cargo build --release --locked --bin kin --bin kin-daemon
+    python3 scripts/acceptance/eject_journal_repro.py --kin target/release/kin
+
+`--kin` may also come from KIN_BIN. The kin-daemon beside it is used when one
+exists. No binary is built by this script. Eject is Unix-only, so this suite is.
+"""
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import uuid
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+TICKET = "FIR-2664"
+
+JOURNAL = "reconciliation/exact-eject-journal.json"
+AUTHORITY_KEY = "reconciliation/authority.key"
+# The domain separator kin-core prefixes before HMAC-SHA256 with the store's
+# 32-byte authority key. A journal authenticates only under the key of the
+# store it sits in, which is why a crafted one has to be keyed per fixture.
+JOURNAL_PREFIX = b"kin.exact-eject-journal.v1\x00"
+# The field order kin-core serializes, captured from the journal a 0.5.52 eject
+# left in the rc0552n archive. serde re-encodes the struct in this order before
+# checking the HMAC, so a crafted journal must encode in it too.
+JOURNAL_FIELDS = (
+    "schema", "transaction_id", "phase", "root_identity", "kin_control_identity",
+    "control_identity", "namespace_parent_identity", "root_name", "archive_name",
+    "archive_identity", "stage_parent_components", "stage_parent_identity",
+    "stage_name", "stage_identity", "stage_seal", "archived_kin_name",
+    "archived_git_name", "previous_git",
+)
+DOCS_URL = "https://git-scm.com/docs/githooks\n"
+SHIPPED_REFUSAL = (
+    "daemon native commit failed (HTTP 500 Internal Server Error): Core error: exact "
+    "eject journal /work/notekeeper/.kin/reconciliation/exact-eject-journal.json has an "
+    "invalid identity-bound descriptor"
+)
+
+
+def tail(text, limit=400):
+    """The END of a command's output, which is where its error is."""
+    text = (text or "").strip()
+    return text if len(text) <= limit else "..." + text[-limit:]
+
+
+def error_lines(text, limit=700):
+    """The lines that state an error, ahead of the tail.
+
+    A refused kin command prints environment warnings on the way in and its
+    `Error:` sentence on the way out, and which of the two a bounded tail keeps
+    depends on their lengths. The sentence is what a reader needs, so it leads.
+    """
+    lines = [line.strip() for line in (text or "").splitlines()
+             if "Error" in line or "error:" in line or "refused" in line]
+    stated = " | ".join(lines)
+    if not stated:
+        return tail(text, limit)
+    return stated if len(stated) <= limit else stated[:limit] + "..."
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    proc = subprocess.run(
+        cmd, cwd=cwd, env=env, timeout=timeout,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    return proc.returncode, proc.stdout
+
+
+class Result(object):
+    def __init__(self, check_id, title):
+        self.id = check_id
+        self.title = title
+        self.asserts = []
+
+    def ok(self, detail):
+        self.asserts.append({"status": PASS, "detail": detail})
+
+    def bad(self, detail):
+        self.asserts.append({"status": FAIL, "detail": detail})
+
+    def unknown(self, detail):
+        self.asserts.append({"status": UNREADABLE, "detail": detail})
+
+    @property
+    def status(self):
+        graded = [a for a in self.asserts if a["status"] in (PASS, FAIL, UNREADABLE)]
+        if any(a["status"] == FAIL for a in graded):
+            return FAIL
+        if any(a["status"] == UNREADABLE for a in graded):
+            return UNREADABLE
+        if not graded:
+            return UNREADABLE
+        return PASS
+
+    @property
+    def detail(self):
+        for wanted in (FAIL, UNREADABLE):
+            for a in self.asserts:
+                if a["status"] == wanted:
+                    return a["detail"]
+        graded = [a["detail"] for a in self.asserts if a["status"] == PASS]
+        return "; ".join(graded) if graded else "no assertion was reached"
+
+
+# ------------------------------------------------------------------- graders
+
+def commit_landed(rc, out):
+    """Whether `kin commit` recorded a change: exit 0 and the sentence it prints."""
+    return rc == 0 and "Created semantic change" in out
+
+
+def refusal_is_worded(out, journal_paths):
+    """Whether a refused commit names the journal and the way out, in words.
+
+    The shipped 0.5.52 text fails every clause that matters: it carries the path
+    but sends the reader to the daemon with `HTTP 500 Internal Server Error` and
+    `Core error`, and names no remedy. A refusal passes only when it names one
+    of the journal's paths (the daemon may print the canonical form), tells the
+    reader to remove the file, offers `kin init` as the rebuild, and never
+    mentions the transport.
+    """
+    return (
+        any(path in out for path in journal_paths)
+        and "remove the file" in out
+        and "kin init" in out
+        and "HTTP 500" not in out
+        and "Internal Server Error" not in out
+        and "Core error" not in out
+    )
+
+
+def init_refused_over(out, name):
+    """Whether `kin init` refused the repository over a hook of this name."""
+    return "admission blocker" in out and "Git hook" in out and name in out
+
+
+GRADERS = {
+    "commit_landed": commit_landed,
+    "refusal_is_worded": refusal_is_worded,
+    "init_refused_over": init_refused_over,
+}
+
+
+# ------------------------------------------------------------------ crafting
+
+def identity(path):
+    st = os.stat(path)
+    return {"device": st.st_dev, "inode": st.st_ino}
+
+
+NOWHERE = {"device": 0, "inode": 0}
+
+
+def craft_journal(key, root, archive, archived_kin, bound=True):
+    """An authenticated detach-phase journal in the shape 0.5.52 wrote.
+
+    `bound=True` binds it to the directories an eject of `root` into `archive`
+    would have recorded, with the archived `kin/` as the `.kin` it was written
+    for: the shape a copy carries back. `bound=False` binds every identity to
+    nothing, the shape nothing can verify.
+    """
+    parent = os.path.dirname(root)
+    ident = identity if bound else (lambda _path: dict(NOWHERE))
+    journal = {
+        "schema": 1,
+        "transaction_id": str(uuid.uuid4()),
+        "phase": "detach_pending",
+        "root_identity": ident(root),
+        "kin_control_identity": ident(archived_kin),
+        "control_identity": ident(os.path.join(archived_kin, "reconciliation")),
+        "namespace_parent_identity": ident(parent),
+        "root_name": list(os.fsencode(os.path.basename(root))),
+        "archive_name": list(os.fsencode(os.path.basename(archive))),
+        "archive_identity": ident(archive),
+        "stage_parent_components": [list(b".kin-eject-git-stage.gone"), list(b"worktree")],
+        "stage_parent_identity": dict(NOWHERE),
+        "stage_name": list(b".git"),
+        "stage_identity": ident(os.path.join(root, ".git")) if bound else dict(NOWHERE),
+        "stage_seal": {"digest": [0] * 32, "entry_count": 0, "multiply_linked_files": 0},
+        "archived_kin_name": list(b"kin"),
+        "archived_git_name": list(b"previous-git"),
+        "previous_git": None,
+    }
+    assert tuple(journal) == JOURNAL_FIELDS
+    encoded = json.dumps(journal, separators=(",", ":")).encode()
+    mac = hmac.new(key, JOURNAL_PREFIX + encoded, hashlib.sha256).digest()
+    return json.dumps({"journal": journal, "authentication": list(mac)},
+                      separators=(",", ":")).encode()
+
+
+def plant_journal(kin_dir, body):
+    path = os.path.join(kin_dir, JOURNAL)
+    with open(path, "wb") as handle:
+        handle.write(body)
+    os.chmod(path, 0o600)
+    return path
+
+
+def journal_paths(repo):
+    """Both spellings of the journal path a daemon might print."""
+    return sorted({
+        os.path.join(repo, ".kin", JOURNAL),
+        os.path.join(os.path.realpath(repo), ".kin", JOURNAL),
+    })
+
+
+# ------------------------------------------------------------------- fixtures
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.kin_home = os.path.join(workdir, "kin-home-%d" % os.getpid())
+        os.makedirs(self.kin_home, exist_ok=True)
+        self.env = dict(os.environ)
+        # A scratch KIN_HOME keeps this run off the fleet's stores and the
+        # auto-embed opt-out keeps it off the GPU.
+        self.env["KIN_HOME"] = self.kin_home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DIR", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self.repos = {}
+        self.commits = 0
+
+    def log(self, line):
+        if self.verbose:
+            print("  " + line, flush=True)
+
+    def git(self, args, cwd):
+        base = ["git",
+                "-c", "core.hooksPath=/dev/null",
+                "-c", "commit.gpgsign=false"]
+        return run(base + args, cwd=cwd, env=self.env)
+
+    def kin_run(self, args, repo, timeout=600):
+        rc, out = run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+        self.log("kin %s -> %d" % (" ".join(args), rc))
+        return rc, out
+
+    def kin_commit(self, repo, title):
+        """A fresh file and a `kin commit` recording it."""
+        self.commits += 1
+        with open(os.path.join(repo, "note%d.py" % self.commits), "w") as handle:
+            handle.write("def note%d():\n    return %d\n" % (self.commits, self.commits))
+        # A commit needs a daemon, and a repository that was just ejected or
+        # re-attached has none running; `kin graph status` starts one.
+        self.kin_run(["graph", "status"], repo)
+        return self.kin_run(["commit", "-m", title], repo)
+
+    def daemon_stop(self, repo):
+        if os.path.isdir(os.path.join(repo, ".kin")):
+            self.kin_run(["daemon", "stop"], repo)
+
+    def fresh_repo(self, name):
+        """A one-file Git repository admitted through `kin init`, plus one
+        commit through kin so the store has a workspace generation of its own.
+        """
+        repo = os.path.join(self.workdir, "trees", name)
+        os.makedirs(repo)
+        rc, out = self.git(["init", "-q", "--initial-branch=main"], repo)
+        if rc != 0:
+            raise RuntimeError("git init failed: %s" % tail(out))
+        # Persisted, not `-c`: `kin commit` resolves its author from the
+        # repository's own configuration and refuses to invent one.
+        self.git(["config", "user.email", "repro@example.invalid"], repo)
+        self.git(["config", "user.name", "kin-eject-journal-repro"], repo)
+        with open(os.path.join(repo, "app.py"), "w") as handle:
+            handle.write("def hello():\n    return 'hi'\n")
+        self.git(["add", "--all"], repo)
+        rc, out = self.git(["commit", "-q", "-m", "a python module"], repo)
+        if rc != 0:
+            raise RuntimeError("git commit failed: %s" % tail(out))
+        rc, out = self.kin_run(["init"], repo, timeout=900)
+        if rc != 0:
+            raise RuntimeError("kin init failed in %s: %s" % (repo, tail(out)))
+        rc, out = self.kin_commit(repo, "a commit before eject")
+        if not commit_landed(rc, out):
+            raise RuntimeError("the control commit before eject did not land (rc=%d): %s"
+                               % (rc, tail(out)))
+        return repo
+
+    def eject(self, repo):
+        """`kin eject --yes`, returning the archive path it printed."""
+        rc, out = self.kin_run(["eject", "--yes"], repo, timeout=900)
+        if rc != 0:
+            raise RuntimeError("kin eject failed (rc=%d): %s" % (rc, tail(out)))
+        match = re.search(r"^Recoverable eject archive: (.+)$", out, re.M)
+        if not match:
+            raise RuntimeError("kin eject printed no archive path: %s" % tail(out))
+        archive = match.group(1).strip()
+        if not os.path.isdir(os.path.join(archive, "kin")):
+            raise RuntimeError("the archive %s carries no kin/" % archive)
+        if os.path.isdir(os.path.join(repo, ".kin")):
+            raise RuntimeError("eject left .kin in place at %s" % repo)
+        return archive
+
+    def ejected(self, name):
+        """A repository ejected once: (repo, archive)."""
+        if name not in self.repos:
+            repo = self.fresh_repo(name)
+            self.repos[name] = (repo, self.eject(repo))
+        return self.repos[name]
+
+
+def copy_back(archive, repo):
+    """`cp -R <archive>/kin <repo>/.kin`, the stranger's own re-attach."""
+    rc, out = run(["cp", "-R", os.path.join(archive, "kin"), os.path.join(repo, ".kin")])
+    if rc != 0:
+        raise RuntimeError("cp -R failed: %s" % tail(out))
+
+
+# --------------------------------------------------------------------- checks
+
+def check_archive(suite):
+    """A finished eject retires its journal from the archived `kin/`."""
+    result = Result("archive", "a finished eject leaves no journal in the archived kin/")
+    repo, archive = suite.ejected("plain")
+    journal = os.path.join(archive, "kin", JOURNAL)
+    key = os.path.join(archive, "kin", AUTHORITY_KEY)
+    if not os.path.isfile(key):
+        result.unknown("the archived kin/ carries no %s, so the directory read is not the "
+                       "store's control directory" % AUTHORITY_KEY)
+        return result
+    if os.path.exists(journal):
+        result.bad("the archived kin/ still carries %s after a finished eject; a copy of "
+                   "this archive would carry it back" % journal)
+    else:
+        result.ok("no journal beside %s" % key)
+    return result
+
+
+def check_copyback(suite):
+    """The archived `kin/` copied back as `.kin` commits again."""
+    result = Result("copyback", "cp -R of the archived kin/ back to .kin commits again")
+    repo, archive = suite.ejected("plain")
+    copy_back(archive, repo)
+    rc, out = suite.kin_commit(repo, "a commit after the copy back")
+    if commit_landed(rc, out):
+        result.ok("the commit after cp -R landed")
+    else:
+        result.bad("the commit after cp -R did not land (rc=%d): %s" % (rc, error_lines(out)))
+    return result
+
+
+def check_carried(suite):
+    """A 0.5.52-shaped journal carried back by the copy is retired, not refused."""
+    result = Result("carried", "a journal a copied .kin carries in is retired when the "
+                               "archive proves the eject finished")
+    repo, archive = suite.ejected("carried")
+    archived_kin = os.path.join(archive, "kin")
+    with open(os.path.join(archived_kin, AUTHORITY_KEY), "rb") as handle:
+        key = handle.read()
+    if len(key) != 32:
+        result.unknown("the authority key is %d bytes, not the 32 the journal HMAC uses"
+                       % len(key))
+        return result
+    planted = plant_journal(archived_kin, craft_journal(key, repo, archive, archived_kin))
+    copy_back(archive, repo)
+    carried = os.path.join(repo, ".kin", JOURNAL)
+    if not os.path.isfile(carried):
+        result.unknown("the copy did not carry the planted journal to %s" % carried)
+        return result
+    rc, out = suite.kin_commit(repo, "a commit over a carried journal")
+    if not commit_landed(rc, out):
+        result.bad("the commit was refused over the carried journal (rc=%d): %s"
+                   % (rc, error_lines(out)))
+        return result
+    if os.path.exists(carried):
+        result.bad("the commit landed but the carried journal is still at %s" % carried)
+        return result
+    if not os.path.isfile(planted):
+        result.bad("retiring the carried copy removed the archive's own journal at %s"
+                   % planted)
+        return result
+    result.ok("the commit landed, the carried journal was retired, the archive is untouched")
+    return result
+
+
+def check_refusal(suite):
+    """A journal bound to nothing is refused in words, and the store survives it."""
+    result = Result("refusal", "a journal bound to nothing is refused with the file and "
+                               "the remedy named, never as HTTP 500")
+    repo = suite.fresh_repo("refused")
+    kin_dir = os.path.join(repo, ".kin")
+    with open(os.path.join(kin_dir, AUTHORITY_KEY), "rb") as handle:
+        key = handle.read()
+    nowhere = os.path.join(os.path.dirname(repo), ".kin-ejected-nowhere")
+    planted = plant_journal(kin_dir, craft_journal(key, repo, nowhere, kin_dir, bound=False))
+    rc, out = suite.kin_commit(repo, "a commit over an unverifiable journal")
+    if rc == 0:
+        result.bad("a journal bound to nothing was accepted and the commit landed: %s"
+                   % tail(out))
+        return result
+    if refusal_is_worded(out, journal_paths(repo)):
+        result.ok("refused in words, naming the file and the remedy")
+    else:
+        result.bad("the refusal does not name the file and the remedy in words: %s"
+                   % error_lines(out))
+        return result
+    # The control: the store is intact, and the remedy the message gives works.
+    os.remove(planted)
+    rc, out = suite.kin_commit(repo, "a commit after the remedy")
+    if commit_landed(rc, out):
+        result.ok("the commit landed once the file was removed, as the message said")
+    else:
+        result.bad("the remedy the message gives did not work (rc=%d): %s"
+                   % (rc, error_lines(out)))
+    return result
+
+
+def check_hook(suite):
+    """`kin init` re-admits the ejected repository over `docs.url`, and still
+    refuses an executable hook."""
+    result = Result("hook", "kin init re-admits an ejected repository past gitoxide's "
+                            "docs.url and still refuses a real hook")
+    repo, _archive = suite.ejected("hooked")
+    hooks = os.path.join(repo, ".git", "hooks")
+    # Pinned into the repository's own configuration, so the surface kin reads
+    # is this directory on every host. A machine whose global configuration
+    # sets core.hooksPath makes .git/hooks inert, and kin rightly leaves a
+    # host-scoped surface uncounted; without the pin both halves of this check
+    # would pass on such a machine without reading the file they are about.
+    rc, out = suite.git(["config", "core.hooksPath", hooks], repo)
+    if rc != 0:
+        result.unknown("could not pin core.hooksPath: %s" % tail(out))
+        return result
+    docs = os.path.join(hooks, "docs.url")
+    if os.path.isfile(docs):
+        provenance = "left by kin eject"
+    else:
+        # gitoxide stopped writing it; the rule under test is kin init's count,
+        # so plant the file the template used to write and say so.
+        os.makedirs(hooks, exist_ok=True)
+        with open(docs, "w") as handle:
+            handle.write(DOCS_URL)
+        provenance = "planted, kin eject no longer writes one"
+    rc, out = suite.kin_run(["init"], repo, timeout=900)
+    if rc == 0:
+        result.ok("kin init admitted the ejected repository with docs.url in place (%s)"
+                  % provenance)
+    else:
+        result.bad("kin init refused the ejected repository with docs.url in place (%s), "
+                   "rc=%d: %s" % (provenance, rc, error_lines(out)))
+        return result
+    # The control: a hook Git runs still blocks, and the refusal names it.
+    suite.daemon_stop(repo)
+    shutil.rmtree(os.path.join(repo, ".kin"))
+    hook = os.path.join(hooks, "pre-commit")
+    with open(hook, "w") as handle:
+        handle.write("#!/bin/sh\nexit 0\n")
+    os.chmod(hook, os.stat(hook).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    rc, out = suite.kin_run(["init"], repo, timeout=900)
+    if rc != 0 and init_refused_over(out, "pre-commit"):
+        result.ok("an executable pre-commit still blocks and is named")
+    elif rc == 0:
+        result.bad("an executable pre-commit hook no longer blocks kin init")
+    else:
+        result.bad("kin init refused but did not name the pre-commit hook: %s"
+                   % error_lines(out))
+    os.remove(hook)
+    return result
+
+
+CHECKS = [check_archive, check_copyback, check_carried, check_refusal, check_hook]
+DECLARED = ("archive", "copyback", "carried", "refusal", "hook")
+
+
+# ------------------------------------------------------------------ self-test
+
+def self_test():
+    """Falsify every grader against its own inverse, with no binary."""
+    failures = []
+    counted = [0]
+
+    def expect(label, got, want):
+        counted[0] += 1
+        if got != want:
+            failures.append("%s: got %r, wanted %r" % (label, got, want))
+
+    expect("a landed commit", commit_landed(0, "Created semantic change abc on branch"), True)
+    expect("a non-zero exit is not landed", commit_landed(1, "Created semantic change abc"), False)
+    expect("nothing to commit is not landed", commit_landed(0, "nothing to commit"), False)
+
+    paths = ["/r/.kin/reconciliation/exact-eject-journal.json",
+             "/private/r/.kin/reconciliation/exact-eject-journal.json"]
+    worded = ("Error: exact eject journal /r/.kin/reconciliation/exact-eject-journal.json is "
+              "bound to a different repository or .kin directory than the one it was found in, "
+              "so Kin will not replay the eject it records here. If that eject completed, the "
+              "repository root holds an ordinary .git and /.kin-ejected-x holds kin/ and "
+              "previous-git/, and this journal is a leftover: remove the file and rerun. To "
+              "rebuild Kin from Git history instead, remove .kin/ and run `kin init`.")
+    expect("a worded refusal passes", refusal_is_worded(worded, paths), True)
+    expect("the canonical spelling of the path passes",
+           refusal_is_worded(worded.replace("/r/", "/private/r/"), paths), True)
+    # The exact text 0.5.52 shipped. It names the path and nothing else a
+    # reader needs, and it must fail here or this suite guards nothing.
+    expect("the shipped HTTP 500 fails",
+           refusal_is_worded(SHIPPED_REFUSAL, ["/work/notekeeper/.kin/reconciliation/"
+                                               "exact-eject-journal.json"]), False)
+    expect("the remedy with the transport still showing fails",
+           refusal_is_worded("HTTP 500: " + worded, paths), False)
+    expect("a Core error prefix fails", refusal_is_worded("Core error: " + worded, paths), False)
+    expect("the remedy about a different file fails",
+           refusal_is_worded(worded, ["/elsewhere/exact-eject-journal.json"]), False)
+    expect("a refusal with no remedy fails",
+           refusal_is_worded("Error: exact eject journal " + paths[0] + " failed authentication",
+                             paths), False)
+    expect("a remedy without kin init fails",
+           refusal_is_worded(worded.replace("kin init", "reinstall"), paths), False)
+
+    refused = ("Error: admit exact reachable Git repository authority\n\nCaused by:\n    admit "
+               "this Git repository: this Git repository has 1 admission blocker(s):\n      - "
+               "Git hook /r/.git/hooks/pre-commit runs for this repository; move it aside")
+    expect("a hook refusal names its hook", init_refused_over(refused, "pre-commit"), True)
+    expect("a refusal over another hook is not this one",
+           init_refused_over(refused, "docs.url"), False)
+    expect("an admission is not a refusal",
+           init_refused_over("admitted exact Git repository in 0.1s", "pre-commit"), False)
+
+    # The crafted journal encodes in kin-core's field order and authenticates
+    # under the key it was given, and a changed byte changes the tag.
+    key = bytes(range(32))
+    with tempfile.TemporaryDirectory() as scratch:
+        root = os.path.join(scratch, "repo")
+        archive = os.path.join(scratch, ".kin-ejected-x")
+        kin = os.path.join(archive, "kin")
+        for path in (os.path.join(root, ".git"), os.path.join(kin, "reconciliation")):
+            os.makedirs(path)
+        body = json.loads(craft_journal(key, root, archive, kin))
+        expect("the journal keeps kin-core's field order", tuple(body["journal"]), JOURNAL_FIELDS)
+        expect("the journal is at the detach phase", body["journal"]["phase"], "detach_pending")
+        expect("the journal names the archived kin",
+               body["journal"]["kin_control_identity"], identity(kin))
+        encoded = json.dumps(body["journal"], separators=(",", ":")).encode()
+        tag = hmac.new(key, JOURNAL_PREFIX + encoded, hashlib.sha256).digest()
+        expect("the tag is the HMAC of the prefixed journal", bytes(body["authentication"]), tag)
+        other = hmac.new(key, JOURNAL_PREFIX + encoded.replace(b"detach", b"Detach"),
+                         hashlib.sha256).digest()
+        expect("a changed journal changes the tag", other == tag, False)
+        unbound = json.loads(craft_journal(key, root, archive, kin, bound=False))
+        expect("an unbound journal names nothing", unbound["journal"]["root_identity"], NOWHERE)
+
+    tail_cases = [("short", "short"), ("WARN noise " * 60 + "Error: the real cause", None)]
+    for text, exact in tail_cases:
+        got = tail(text, 40)
+        if exact is not None and got != exact:
+            failures.append("tail(%r) = %r, wanted %r" % (text, got, exact))
+        if exact is None and not got.endswith("Error: the real cause"):
+            failures.append("tail dropped the end of the output: %r" % got)
+
+    grade_cases = [
+        (PASS, [(PASS, "a")]),
+        (FAIL, [(PASS, "a"), (FAIL, "b")]),
+        (UNREADABLE, [(PASS, "a"), (UNREADABLE, "b")]),
+        (FAIL, [(UNREADABLE, "a"), (FAIL, "b")]),
+        (UNREADABLE, []),
+    ]
+    for want, entries in grade_cases:
+        result = Result("t", "t")
+        for status, detail in entries:
+            result.asserts.append({"status": status, "detail": detail})
+        if result.status != want:
+            failures.append("Result.status(%s) = %s, wanted %s" % (entries, result.status, want))
+
+    # The declared ids are the checks' own names, so a check added or renamed
+    # without its declaration cannot answer under a name nobody asked for.
+    expect("every declared id has a check",
+           tuple(c.__name__.replace("check_", "") for c in CHECKS), DECLARED)
+
+    for failure in failures:
+        print("SELFTEST FAIL %s" % failure)
+    total = counted[0] + len(tail_cases) + len(grade_cases)
+    print("kin-eject-journal-repro: self-test %d/%d cases" % (total - len(failures), total))
+    return 1 if failures else 0
+
+
+# ----------------------------------------------------------------------- main
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"),
+                        help="the kin binary under test")
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"),
+                        help="the kin-daemon beside it")
+    parser.add_argument("--json", dest="json_path", default=None,
+                        help="write the machine-readable report here, for scripts/acceptance/gate.py")
+    parser.add_argument("--label", default=os.environ.get("KIN_ACCEPTANCE_LABEL"),
+                        help="an opaque run label recorded in the report")
+    parser.add_argument("--keep", action="store_true", help="keep the fixtures")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true",
+                        help="falsify this suite's graders and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if not args.kin:
+        print("kin-eject-journal-repro: no kin binary. Pass --kin or set KIN_BIN.")
+        return 3
+    if os.name != "posix":
+        print("kin-eject-journal-repro: kin eject is Unix-only, and so is this suite.")
+        return 3
+    kin = os.path.abspath(os.path.expanduser(args.kin))
+    if not os.path.isfile(kin) or not os.access(kin, os.X_OK):
+        print("kin-eject-journal-repro: %s is not an executable file" % kin)
+        return 3
+    daemon = args.daemon and os.path.abspath(os.path.expanduser(args.daemon))
+    if not daemon:
+        beside = os.path.join(os.path.dirname(kin), "kin-daemon")
+        daemon = beside if os.path.isfile(beside) else None
+
+    workdir = tempfile.mkdtemp(prefix="kin-eject-journal-repro-")
+    suite = None
+    try:
+        suite = Suite(kin, workdir, daemon=daemon, verbose=args.verbose)
+        results = []
+        for check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - a crashed probe is UNREADABLE
+                result = Result(getattr(check, "__name__", "check").replace("check_", ""),
+                                "probe crashed")
+                result.unknown("%s: %s" % (type(error).__name__, error))
+                results.append(result)
+        for result in results:
+            print("CHECK %s %s %s %s" % (result.id, TICKET, result.status, result.detail))
+        # A suite that graded fewer checks than it declares exits like a clean
+        # pass unless it counts, so it counts: the ids that answered are the ids
+        # declared, in order, or the run is a setup failure.
+        answered = tuple(r.id for r in results)
+        if answered != DECLARED:
+            print("kin-eject-journal-repro: declared %s but %s answered" % (DECLARED, answered))
+            return 3
+        print("kin-eject-journal-repro: %d of %d declared checks answered"
+              % (len(answered), len(DECLARED)))
+        failed = [r for r in results if r.status == FAIL]
+        unreadable = [r for r in results if r.status == UNREADABLE]
+        print("kin-eject-journal-repro: %d checks, %d pass, %d FAIL, %d UNREADABLE"
+              % (len(results), len(results) - len(failed) - len(unreadable),
+                 len(failed), len(unreadable)))
+        if args.json_path:
+            payload = {
+                "suite": "eject_journal_repro",
+                "ticket": TICKET,
+                "label": args.label,
+                "kin": kin,
+                "results": [
+                    {"id": r.id, "ticket": TICKET, "title": r.title,
+                     "status": r.status, "detail": r.detail, "asserts": r.asserts}
+                    for r in results
+                ],
+            }
+            directory = os.path.dirname(os.path.abspath(args.json_path))
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            with open(args.json_path, "w") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+        if failed:
+            return 1
+        if unreadable:
+            return 2
+        return 0
+    finally:
+        if suite is not None:
+            trees = os.path.join(workdir, "trees")
+            if os.path.isdir(trees):
+                for name in os.listdir(trees):
+                    suite.daemon_stop(os.path.join(trees, name))
+        if not args.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
The core write survives an eject archive round trip now. On 0.5.52 a finished `kin eject` left its journal in the archived `kin/` at the detach phase. The rc0552n stranger copied that directory back to `.kin` with `cp -r`, the copy carried the journal along under fresh inodes, and every `kin commit` after that answered `daemon native commit failed (HTTP 500 Internal Server Error): Core error: exact eject journal ... has an invalid identity-bound descriptor` until the stranger deleted the store. Then `kin init` refused the ejected repository over `.git/hooks/docs.url`, a 34-byte URL file gitoxide's init template writes when `kin eject` builds the replacement Git, and a name Git never runs a hook under.

Both halves reproduced on the 0.5.52 release bytes in a fresh Debian container before any code changed, with the exact sentences the stranger saw. Removing only the journal made the same commit land, so the journal was the sole blocker and the copied store was otherwise sound.

## What changed

- kin-core: the eject transaction retires its journal once it has completed, through the control handle still open on the archived `.kin/reconciliation`. A finished transaction has nothing to recover. `ExactProjectionEjectOutcome.retained_journal` carries the one failure mode, and `kin eject` prints it as a warning naming the file.
- kin-core: `recover_exact_eject` recognises a journal a copied `.kin` carried in. It verifies, inode for inode, that the `.kin` the journal was written for is detached in the archive the journal names (repository root, its parent and name, the archive, the archived `kin/`, its `reconciliation/`, phase `detach_pending`), then retires the copy's journal and moves nothing. Every other mismatch, a bad decode, a failed authentication or a failed replay is a new `KinError::ProjectionBlocked` that names the file, the archive and the way out: remove the file if the eject completed, restore from the archive by hand if it did not, or `rm -rf .kin && kin init` to rebuild from Git history. A journal that matches nothing could be a forged one, so refusal stays the default.
- kin-daemon and kin-cli: a blocked projection is a worded 409 `projection_blocked` refusal on both commit paths, and the CLI prints it as its own sentence, the way `nothing_to_commit` already is. No more `HTTP 500`.
- kin-git: only the hook names in githooks(5) count as hooks in admission. Other entries under the hook directory are listed in a note as uncounted, never hidden. An executable `pre-commit` still blocks by name.
- `scripts/acceptance/eject_journal_repro.py` guards the class with five checks, each with its own control, wired into the acceptance workflow and the gate: `archive` (a finished eject leaves no journal beside the archived authority key), `copyback` (`cp -R` of the archived `kin/` back to `.kin` commits again), `carried` (a journal in the exact 0.5.52 shape, keyed to the fixture's authority key and carried back by the copy, is retired and the commit lands), `refusal` (a journal bound to nothing is refused in words naming the file and the remedy, with no `HTTP 500`, and the store commits once the file is gone), `hook` (`kin init` re-admits the ejected repository past `docs.url` and still refuses an executable `pre-commit`).

Unit tests: the three eject success tests now assert the archive carries no journal; two new kin-core tests cover the carried copy and the worded refusal, using the real journal bytes captured at the detach hook point; two new kin-git tests cover `docs.url` and the name rule; one each in kin-daemon and kin-cli cover the 409 shape and its printing. The 18 `eject_round_trip` integration tests pass unchanged.

## Falsification, verbatim

Suite against the fixed build: `archive PASS, copyback PASS, carried PASS, refusal PASS, hook PASS`.

The same suite against the pre-fix `kin 0.5.49` binary on the host, scratch `KIN_HOME`:

```
CHECK archive FIR-2664 FAIL the archived kin/ still carries .../kin/reconciliation/exact-eject-journal.json after a finished eject; a copy of this archive would carry it back
CHECK copyback FIR-2664 FAIL the commit after cp -R did not land (rc=1): Error: daemon native commit failed (HTTP 500 Internal Server Error): Core error: exact eject journal .../trees/plain/.kin/reconciliation/exact-eject-journal.json has an invalid identity-bound descriptor
CHECK carried FIR-2664 FAIL the commit was refused over the carried journal (rc=1): Error: daemon native commit failed (HTTP 500 Internal Server Error): Core error: exact eject journal .../trees/carried/.kin/reconciliation/exact-eject-journal.json has an invalid identity-bound descriptor
CHECK refusal FIR-2664 FAIL the refusal does not name the file and the remedy in words: Error: daemon native commit failed (HTTP 500 Internal Server Error): Core error: exact eject journal .../trees/refused/.kin/reconciliation/exact-eject-journal.json has an invalid identity-bound descriptor
CHECK hook FIR-2664 FAIL kin init refused the ejected repository with docs.url in place (left by kin eject), rc=1: Error: admit exact reachable Git repository authority
kin-eject-journal-repro: 5 checks, 0 pass, 5 FAIL, 0 UNREADABLE
```

Four mutations, each applied to the fixed tree, rebuilt, run, and restored. Each turned exactly its own check red and its own unit tests red, and left the other four checks green:

| mutation | suite | unit tests |
| -- | -- | -- |
| eject success no longer retires the journal | only `archive` FAIL | kin-core 61 passed, 4 FAILED (two success tests, both new journal tests) |
| the carried-journal disposition always answers false | only `carried` FAIL, refused as `... is bound to a different repository or .kin directory ...` | kin-core 64 passed, 1 FAILED (the carried test) |
| the hook-name rule removed | only `hook` FAIL, `kin init` refuses over docs.url again | kin-git 11 passed, 2 FAILED (both new hook tests) |
| the daemon no longer words a blocked projection | only `refusal` FAIL, the `HTTP 500 Internal Server Error: Core error:` shape is back | kin-daemon 1 FAILED (the 409 test) |

The suite's `--self-test` (28 cases) feeds the graders the exact 0.5.52 sentence as a case that must fail, and the suite refuses to exit clean unless the five declared check ids are the five that answered.

## Gates run locally

- `cargo fmt --all -- --check`: clean.
- clippy exactly as ci.yml runs it (`RUSTFLAGS='-D warnings' cargo clippy --all-targets --all-features -- <the allows in .github/clippy-allowed-lints.txt>`): rc 0, 540 targets checked, only the pre-existing `block v0.1.6` future-incompat note.
- `cargo test -p kin-core --lib` 686 passed; `-p kin-git --lib` 125 passed; `-p kin-daemon --lib api::tests` 323 passed; `-p kin-cli --lib commands::commit` 24 passed; `-p kin-cli --test eject_round_trip` 18 passed.
- Guard scripts ci.yml names, run in the worktree: `scripts/verify-zero-file-search.py` (PASSED, 181 files), `scripts/check_runtime_boundaries.sh` (passed), `scripts/falsify-zero-file-search.py` on a poisoned copy of `crates` and `scripts` (every enforced answer module fails its guards when poisoned), every command of the "Test release ordering and npm provenance policy" step (`test-release-workflow-authority.py`, `test_install_optional_vfs.py`, `test_installer_parity.py`, `verify-installer-release-assets.py`, `falsify-installer-release-assets.py`, `verify-installer-archive-binaries.py`, `falsify-installer-archive-binaries.py`, `test-npm-automatic-release.py`, `test-verify-npm-release.py`, `node --test` over its 13 files, `node --check` over its 10, `bash -n` over its 8), `bash scripts/test-release-policy-gate.sh`, and the acceptance workflow's own `test_workflow_step_visibility.py` and `gate.py --self-test`: all rc 0.
- `bin/kin-parity` from the lane worktree, release profile: `FINAL PASS-WITH-ALLOWANCES`, magic 21/21, brownfield 10 pass and 1 unreadable (check 4, the checked-in FIR-2464/FIR-2593 allowance), firstrun 9 pass and 2 fail (checks 3 FIR-2501 and 9 FIR-2580, both in the checked-in allowance list and both on main before this branch).
- Not run locally, CI runs them: `scripts/test-windows-authority-legs.sh` (Linux-only, builds a cargo package for the Windows leg helpers, untouched here), `npm test` for `packages/kin-mcp` (untouched), and the two allowlist-mutating legs of the zero-file-search falsifier (the allowlist is untouched).

## Not claiming

- Verified on a macOS dev build plus the suite, and by this workflow's own ubuntu build; not re-run on a Linux release archive, which this host cannot build.
- An archive an older Kin wrote and moved back with `mv` (inodes preserved) takes the replay path, finds the staged-Git temp directory gone, and is refused with the file and the remedy named. It is not made to work, and the suite does not cover it.
- A whole repository copied elsewhere with a leftover journal is refused with the remedy, not auto-retired.
- `kin doctor` gained no row for a present journal.
- Eject is Unix-only, and so is the suite; the hook-name rule compiles on Windows but its tests run on Unix fixtures.

Closes FIR-2664
