### PR TITLE
Bind the compose daemon where its published port actually forwards, and let GCS storage reach an emulator

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -189,3 +189,20 @@ jobs:
       # through it, and that it still re-initializes when nothing is at risk.
       - name: Entrypoint contract with a volume mounted inside .kin
         run: bash scripts/test-entrypoint-workspace-mount.sh kin:ci
+
+      # Every probe above runs inside the container's own network namespace, so
+      # none of them can see whether the port compose publishes actually reaches
+      # the daemon. This one curls the published mapping from the runner, with
+      # the unset-bind-host arm first as a negative control.
+      - name: Published port reachable from outside the container namespace
+        run: bash scripts/test-compose-published-port.sh kin:ci
+
+      # FIR-2668's acceptance, against a real fake-gcs-server. The image this
+      # job just built carries `--features gcs`, so the emulator round trip runs
+      # against the same bytes an operator would run and needs no Rust toolchain
+      # here. It also runs the ticket's own falsification: with the emulator
+      # stopped the daemon must exit loud rather than reach for real Google
+      # Cloud Storage, which is the arm that stops the happy path from passing
+      # for a lever that is being ignored.
+      - name: GCS emulator endpoint acceptance
+        run: bash scripts/test-gcs-emulator-endpoint.sh kin:ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,6 +3245,7 @@ dependencies = [
  "kin-spine",
  "libc",
  "mimalloc",
+ "object_store",
  "pretty_assertions",
  "reqwest 0.12.28",
  "serde",

--- a/crates/kin-core/env_var_allowlist.txt
+++ b/crates/kin-core/env_var_allowlist.txt
@@ -18,6 +18,11 @@
 # pass. Nothing an operator sets, and no runtime behaviour keys on it.
 KIN_CI_LANGUAGE_SERVERS_INSTALLED
 KIN_AGENT_TEST_KIN_BIN
+# Names the bucket an already-running fake-gcs-server holds, for the #[ignore]d
+# GCS endpoint round-trip in kin-daemon. Nothing runs without it, no runtime
+# behaviour keys on it, and the operator-facing lever it exercises is
+# KIN_GCS_ENDPOINT, which is registered.
+KIN_GCS_TEST_BUCKET
 KIN_GIT_TEST_NO_SYMLINK_PRIVILEGE
 # Read only by the admission memory tests' shared probe, to print a per-phase
 # live-heap line during a passing run. Recording is unconditional; this only

--- a/crates/kin-core/src/behavior_env.rs
+++ b/crates/kin-core/src/behavior_env.rs
@@ -49,7 +49,9 @@ pub const BEHAVIOR_ENV_VARS: &[&str] = &[
     "KIN_MEMORY_PRESSURE",
     "KIN_DAEMON_MEMORY_BUDGET_BYTES",
     "KIN_COCHANGE_MAX_FAN_OUT",
+    "KIN_GCS_ENDPOINT",
     "EMBED_MAX_SEQ_LEN",
+    "STORAGE_EMULATOR_HOST",
 ];
 
 /// A snapshot of the behavior-env surface: variable name → `Some(value)` when
@@ -217,6 +219,26 @@ mod tests {
             assert!(
                 BEHAVIOR_ENV_VARS.contains(&name),
                 "daemon health must report resume-identity knob {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn both_storage_endpoint_levers_are_reported() {
+        // The daemon resolves its storage endpoint once, at process start, from
+        // whichever of these two is set, so the value is baked into the worker
+        // exactly like every other member here.
+        //
+        // They travel together on purpose. Either one alone can supply the
+        // endpoint, so a report carrying only KIN_GCS_ENDPOINT would show it
+        // unset while STORAGE_EMULATOR_HOST silently pointed the daemon at an
+        // emulator. That is worse than saying nothing: it is a health payload
+        // answering "where does this daemon's storage live" with the wrong
+        // answer, which is the question the surface exists to answer honestly.
+        for name in ["KIN_GCS_ENDPOINT", "STORAGE_EMULATOR_HOST"] {
+            assert!(
+                BEHAVIOR_ENV_VARS.contains(&name),
+                "daemon health must report the storage endpoint lever {name}"
             );
         }
     }

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -264,6 +264,15 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_STORAGE", kind: Kind::Str, default: "local", sensitivity: Sensitivity::Operational, summary: "daemon storage backend selector (e.g. local, gcs)" },
     EnvVarSpec { name: "KIN_GCS_BUCKET", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "GCS bucket for remote storage" },
     EnvVarSpec { name: "KIN_GCS_PREFIX", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "GCS key prefix for remote storage" },
+    // Correctness rather than Operational, unlike the bucket and prefix beside
+    // it: this one redirects every storage request to a different server, so a
+    // wrong value serves and persists graph truth somewhere other than where the
+    // operator believes. Marking it correctness-relevant is what makes a
+    // non-default value log loudly, which is the whole question an operator has
+    // ("emulator or production?"). Kind::Url never hard-errors on a value, so the
+    // stricter sensitivity costs no startup refusal; the daemon does its own
+    // parsing and refuses a malformed or unreachable endpoint itself.
+    EnvVarSpec { name: "KIN_GCS_ENDPOINT", kind: Kind::Url, default: "", sensitivity: Sensitivity::Correctness, summary: "custom GCS endpoint for the daemon's graph-snapshot storage, e.g. a local fake-gcs-server; takes precedence over STORAGE_EMULATOR_HOST, sends unsigned requests, and fails daemon startup when unreachable rather than falling back to real Google Cloud Storage" },
 
     // ---- identity / session / projection -------------------------------------
     EnvVarSpec { name: "KIN_ACTOR", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "actor identity recorded in provenance" },

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -20,7 +20,11 @@ embeddings = ["kin-db/embeddings", "kin-cli/embeddings"]
 # It intentionally does NOT pull `kin-db/metal`; the real macOS-only activation lives in the
 # `[target.'cfg(target_os = "macos")'.dependencies]` block below so Linux never compiles it.
 metal = ["embeddings", "kin-cli/metal"]
-gcs = ["kin-db/gcs"]
+# `object_store` is kin-db's own GCS client crate, pulled in here at the same
+# version so `GcsBackend::from_store` accepts a store this crate built. That is
+# what lets a custom endpoint (see `gcs_endpoint`) redirect the backend at an
+# emulator without a kin-db change.
+gcs = ["kin-db/gcs", "dep:object_store", "object_store/gcp"]
 firestore = ["kin-spine/firestore"]
 
 [dependencies]
@@ -62,6 +66,7 @@ zip = { workspace = true }
 reqwest = { workspace = true }
 anyhow = { workspace = true }
 which = "8"
+object_store = { version = "0.14", optional = true }
 fs2 = { workspace = true }
 sysinfo = "0.39"
 

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -211,13 +211,51 @@ fn create_state(
             let bucket = env::var("KIN_GCS_BUCKET")
                 .map_err(|_| "KIN_GCS_BUCKET env var required for --storage gcs")?;
             let prefix = env::var("KIN_GCS_PREFIX").unwrap_or_default();
-            let backend = kin_db::GcsBackend::new(&bucket, prefix)?;
+            let backend = open_gcs_backend(&bucket, prefix)?;
             Ok(DaemonState::open_with_backend(
                 layout,
                 Box::new(backend),
                 repo_id,
                 allowed_repo_ids,
             )?)
+        }
+    }
+}
+
+/// Open the GCS backend, honoring an emulator endpoint override when one is set.
+///
+/// With neither `KIN_GCS_ENDPOINT` nor `STORAGE_EMULATOR_HOST` set this is the
+/// unchanged real-GCP path. With one set, the daemon refuses to start unless
+/// that endpoint is reachable, because the alternative is a daemon that
+/// advertises itself as serving and then reaches for real Google Cloud Storage,
+/// or serves nothing, on its first snapshot read. An operator who asked for an
+/// emulator and got the real service back would have no signal at all, so this
+/// path never falls back: it starts against the endpoint or it stops.
+#[cfg(feature = "gcs")]
+fn open_gcs_backend(
+    bucket: &str,
+    prefix: String,
+) -> std::result::Result<kin_db::GcsBackend, Box<dyn std::error::Error>> {
+    use kin_daemon::gcs_endpoint;
+
+    let endpoint = gcs_endpoint::resolve(
+        env::var(gcs_endpoint::KIN_ENDPOINT_VAR).ok().as_deref(),
+        env::var(gcs_endpoint::EMULATOR_HOST_VAR).ok().as_deref(),
+    )?;
+
+    match endpoint {
+        None => Ok(kin_db::GcsBackend::new(bucket, prefix)?),
+        Some(endpoint) => {
+            endpoint.probe_reachable(gcs_endpoint::DEFAULT_PROBE_TIMEOUT)?;
+            // Which storage this daemon actually talks to is the one thing an
+            // operator cannot infer from anywhere else, and stderr is where the
+            // daemon's diagnostics go (stdout carries the --compat-json
+            // protocol).
+            eprintln!(
+                "kin-daemon: GCS storage redirected to {} (from {}); no real Google Cloud Storage traffic",
+                endpoint.url, endpoint.source
+            );
+            Ok(gcs_endpoint::backend_for(&endpoint, bucket, prefix)?)
         }
     }
 }

--- a/crates/kin-daemon/src/gcs_endpoint.rs
+++ b/crates/kin-daemon/src/gcs_endpoint.rs
@@ -1,0 +1,516 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Custom storage endpoint for the GCS backend, so a local stack can run the
+//! hosted graph-snapshot path against an emulator instead of real GCP.
+//!
+//! The daemon's GCS backend is `kin_db::GcsBackend`, which builds an
+//! `object_store` `GoogleCloudStorageBuilder` and talks to the real service via
+//! Application Default Credentials. `object_store` supports a custom base URL
+//! (`with_base_url`), and `GcsBackend::from_store` accepts an already-built
+//! store, so the override is expressible here without changing kin-db.
+//!
+//! Two variables feed it, in precedence order:
+//!
+//! * `KIN_GCS_ENDPOINT` is Kin's own lever and wins.
+//! * `STORAGE_EMULATOR_HOST` is the Google-client convention that kinlab's Node
+//!   side already follows, honored so one exported variable points both halves
+//!   of a local stack at the same emulator.
+//!
+//! `STORAGE_EMULATOR_HOST` is deliberately absent from `kin-core`'s env
+//! registry: that registry is the `KIN_*` surface by construction, and its
+//! `registry_is_well_formed` test rejects any name without the prefix. Both
+//! names are in `BEHAVIOR_ENV_VARS` instead, because the daemon bakes this
+//! choice in at process start and reporting one without the other would let a
+//! health payload show an unset `KIN_GCS_ENDPOINT` while
+//! `STORAGE_EMULATOR_HOST` silently supplied the endpoint.
+//!
+//! ## Nothing here falls back
+//!
+//! An endpoint that is set but unusable fails the daemon's startup. A malformed
+//! value is refused rather than ignored, and a resolved endpoint is probed for
+//! reachability before the daemon serves, so an emulator that is not running
+//! stops the daemon instead of letting it reach for real GCP or quietly serve
+//! from somewhere else. Requests are also unsigned (`with_skip_signature`),
+//! which an emulator needs and which means a lever pointed at real GCS by
+//! mistake is rejected by Google rather than silently authorized by whatever
+//! ambient credentials the host happens to carry.
+
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::{Duration, Instant};
+
+/// Kin's own endpoint lever. Registered in `kin-core`'s env registry.
+pub const KIN_ENDPOINT_VAR: &str = "KIN_GCS_ENDPOINT";
+
+/// The Google-client convention, honored for parity with the Node side.
+pub const EMULATOR_HOST_VAR: &str = "STORAGE_EMULATOR_HOST";
+
+/// How long the startup reachability probe waits for a TCP connection.
+pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A validated storage endpoint override, carrying both the base URL the
+/// object store needs and the authority the reachability probe needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedEndpoint {
+    /// Normalized base URL, scheme included and no trailing slash.
+    pub url: String,
+    /// Host as written, for the probe and for error messages.
+    pub host: String,
+    /// Port, defaulted from the scheme when the value omitted one.
+    pub port: u16,
+    /// Which variable supplied the value, so every message names it.
+    pub source: &'static str,
+}
+
+/// Resolve the endpoint override from the two raw values, without touching the
+/// process environment. Pure, so precedence and parsing are unit-testable.
+///
+/// Returns `Ok(None)` when neither is set, which is the real-GCP path. An empty
+/// or whitespace-only value counts as unset, matching how Kin's other read
+/// sites treat one. A value that is present but unparseable is an error, never
+/// a silent fall-through to real GCP.
+pub fn resolve(
+    kin_endpoint: Option<&str>,
+    emulator_host: Option<&str>,
+) -> Result<Option<ResolvedEndpoint>, String> {
+    let candidate = [
+        (KIN_ENDPOINT_VAR, kin_endpoint),
+        (EMULATOR_HOST_VAR, emulator_host),
+    ]
+    .into_iter()
+    .find_map(|(source, raw)| {
+        let value = raw.map(str::trim).filter(|v| !v.is_empty())?;
+        Some((source, value))
+    });
+
+    match candidate {
+        None => Ok(None),
+        Some((source, value)) => parse_endpoint(value, source)
+            .map(Some)
+            .map_err(|reason| format!("{source} is set to {value:?} but {reason}")),
+    }
+}
+
+/// Parse one endpoint value into its normalized form.
+///
+/// Accepts `http://host:port`, `https://host:port`, and the bare `host:port`
+/// that the Google clients also accept for `STORAGE_EMULATOR_HOST`, defaulting
+/// a missing scheme to `http` and a missing port to the scheme's own.
+fn parse_endpoint(value: &str, source: &'static str) -> Result<ResolvedEndpoint, String> {
+    let (scheme, rest) = match value.split_once("://") {
+        None => ("http", value),
+        Some((scheme, rest)) => {
+            let scheme = match scheme.to_ascii_lowercase().as_str() {
+                "http" => "http",
+                "https" => "https",
+                other => {
+                    return Err(format!(
+                        "its scheme {other:?} is not supported (expected http or https)"
+                    ))
+                }
+            };
+            (scheme, rest)
+        }
+    };
+
+    // A base URL is an origin. Anything past the authority would be silently
+    // dropped or silently prepended depending on the caller, so refuse it here
+    // where the operator can still see which variable to fix.
+    let authority = match rest.split_once('/') {
+        None => rest,
+        Some((authority, "")) => authority,
+        Some((_, path)) => {
+            return Err(format!(
+                "it carries a path (/{path}); an endpoint must be scheme, host and port only"
+            ))
+        }
+    };
+
+    if authority.is_empty() {
+        return Err("it has no host".to_string());
+    }
+
+    let (host, port) = match authority.rsplit_once(':') {
+        None => (authority, if scheme == "https" { 443_u16 } else { 80_u16 }),
+        Some((host, port_text)) => {
+            let port = port_text
+                .parse::<u16>()
+                .map_err(|_| format!("its port {port_text:?} is not a number in 1..=65535"))?;
+            if port == 0 {
+                return Err("its port is 0, which cannot be connected to".to_string());
+            }
+            (host, port)
+        }
+    };
+
+    if host.is_empty() {
+        return Err("it has no host".to_string());
+    }
+
+    Ok(ResolvedEndpoint {
+        url: format!("{scheme}://{host}:{port}"),
+        host: host.to_string(),
+        port,
+        source,
+    })
+}
+
+impl ResolvedEndpoint {
+    /// Refuse to start unless the endpoint accepts a TCP connection.
+    ///
+    /// This is the loud half of the contract. Without it a stopped emulator is
+    /// invisible until the first snapshot read or write, which is long after
+    /// the daemon has advertised itself as serving. A TCP connect is the right
+    /// granularity for "is it up": it proves something is listening at the
+    /// address the store will use, and it deliberately does not claim the
+    /// listener speaks the GCS API. What guarantees no real-GCP traffic is the
+    /// base URL itself, not this probe.
+    ///
+    /// `timeout` bounds the whole probe, not each address. A hostname commonly
+    /// resolves to several addresses, and the ordinary container shape is one
+    /// blackholed IPv6 alongside a working IPv4, so a per-address timeout would
+    /// have charged every start the full wait before reaching the address that
+    /// works, and a fully dead hostname would have cost the timeout N times over
+    /// with nothing naming where the time went.
+    pub fn probe_reachable(&self, timeout: Duration) -> Result<(), String> {
+        let addrs = (self.host.as_str(), self.port)
+            .to_socket_addrs()
+            .map_err(|error| self.refusal(&format!("the host could not be resolved: {error}")))?
+            .collect::<Vec<_>>();
+
+        if addrs.is_empty() {
+            return Err(self.refusal("the host resolved to no addresses"));
+        }
+
+        let deadline = Instant::now() + timeout;
+        let mut last_failure = None;
+        for addr in &addrs {
+            // Never hand connect_timeout a zero or negative duration: it treats
+            // that as an error rather than as an instant attempt, which would
+            // report "nothing is listening" for an endpoint never actually
+            // tried. Stop and report instead, naming the budget.
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                last_failure = Some(format!(
+                    "gave up after {timeout:?} with {addr} not yet tried"
+                ));
+                break;
+            }
+            match TcpStream::connect_timeout(addr, remaining) {
+                Ok(_) => return Ok(()),
+                Err(error) => last_failure = Some(format!("{addr}: {error}")),
+            }
+        }
+
+        Err(self.refusal(&format!(
+            "nothing is listening there ({})",
+            last_failure.unwrap_or_else(|| "connection failed".to_string())
+        )))
+    }
+
+    /// One shape for every startup refusal, so an operator and a scripted check
+    /// both see the same contract whatever went wrong.
+    ///
+    /// The causes differ in ways that matter for debugging (an unresolvable
+    /// host, no addresses, a closed port) and not at all in what happens next,
+    /// which is that the daemon stops. Building each message separately meant
+    /// only the closed-port one said so, so an emulator container that was
+    /// removed rather than stopped refused with a message that never mentioned
+    /// refusing, and an acceptance check asserting on that clause could pass or
+    /// fail on which kind of outage it happened to produce.
+    fn refusal(&self, cause: &str) -> String {
+        format!(
+            "{} points at {} but {cause}. \
+             Start the storage emulator, or unset {} to use real Google Cloud Storage. \
+             Refusing to start rather than reaching for a different backend.",
+            self.source, self.url, self.source,
+        )
+    }
+}
+
+/// Build a `GcsBackend` whose object store talks to `endpoint` instead of the
+/// real service.
+///
+/// `kin_db::GcsBackend::from_store` is the seam that makes this possible
+/// without a kin-db change: it takes an already-built `ObjectStore` and is
+/// otherwise identical to `GcsBackend::new`, which builds the same store with
+/// no base-URL override.
+#[cfg(feature = "gcs")]
+pub fn backend_for(
+    endpoint: &ResolvedEndpoint,
+    bucket: &str,
+    prefix: String,
+) -> Result<kin_db::GcsBackend, String> {
+    use object_store::gcp::GoogleCloudStorageBuilder;
+
+    let store = GoogleCloudStorageBuilder::new()
+        .with_bucket_name(bucket)
+        .with_base_url(&endpoint.url)
+        // An emulator has no credentials to sign with, and unsigned requests to
+        // the real service are rejected rather than silently authorized.
+        .with_skip_signature(true)
+        .build()
+        .map_err(|error| {
+            format!(
+                "failed to create a GCS client for {} (from {}): {error}",
+                endpoint.url, endpoint.source
+            )
+        })?;
+
+    Ok(kin_db::GcsBackend::from_store(Box::new(store), prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[test]
+    fn neither_variable_set_is_the_real_gcp_path() {
+        assert_eq!(resolve(None, None), Ok(None));
+    }
+
+    #[test]
+    fn empty_and_whitespace_values_count_as_unset() {
+        // Matching every other Kin read site: an exported-but-empty variable is
+        // not an override, so it must not be parsed and must not error.
+        assert_eq!(resolve(Some(""), Some("   ")), Ok(None));
+    }
+
+    #[test]
+    fn the_emulator_convention_is_honored() {
+        let resolved = resolve(None, Some("http://localhost:4443"))
+            .expect("parses")
+            .expect("resolves");
+        assert_eq!(resolved.url, "http://localhost:4443");
+        assert_eq!(resolved.host, "localhost");
+        assert_eq!(resolved.port, 4443);
+        assert_eq!(resolved.source, EMULATOR_HOST_VAR);
+    }
+
+    #[test]
+    fn kins_own_lever_wins_over_the_convention() {
+        // Precedence has to be decided, not incidental: a developer with
+        // STORAGE_EMULATOR_HOST exported for the Node side must still be able to
+        // point the daemon somewhere else without unexporting it.
+        let resolved = resolve(Some("http://kin-emulator:4443"), Some("http://node:9199"))
+            .expect("parses")
+            .expect("resolves");
+        assert_eq!(resolved.url, "http://kin-emulator:4443");
+        assert_eq!(resolved.source, KIN_ENDPOINT_VAR);
+    }
+
+    #[test]
+    fn an_empty_kin_lever_falls_through_to_the_convention() {
+        let resolved = resolve(Some("  "), Some("fake-gcs:4443"))
+            .expect("parses")
+            .expect("resolves");
+        assert_eq!(resolved.source, EMULATOR_HOST_VAR);
+        assert_eq!(resolved.url, "http://fake-gcs:4443");
+    }
+
+    #[test]
+    fn a_bare_host_port_gets_the_http_scheme() {
+        // The Google clients accept STORAGE_EMULATOR_HOST without a scheme, and
+        // `with_base_url` requires one, so the normalization has to happen here.
+        let resolved = resolve(None, Some("localhost:4443"))
+            .expect("parses")
+            .expect("resolves");
+        assert_eq!(resolved.url, "http://localhost:4443");
+        assert_eq!(resolved.port, 4443);
+    }
+
+    #[test]
+    fn a_missing_port_defaults_from_the_scheme() {
+        let plain = resolve(Some("http://fake-gcs"), None)
+            .expect("parses")
+            .expect("resolves");
+        assert_eq!(plain.url, "http://fake-gcs:80");
+        assert_eq!(plain.port, 80);
+
+        let tls = resolve(Some("https://fake-gcs"), None)
+            .expect("parses")
+            .expect("resolves");
+        assert_eq!(tls.url, "https://fake-gcs:443");
+        assert_eq!(tls.port, 443);
+    }
+
+    #[test]
+    fn a_trailing_slash_is_accepted_and_dropped() {
+        let resolved = resolve(Some("http://localhost:4443/"), None)
+            .expect("parses")
+            .expect("resolves");
+        assert_eq!(resolved.url, "http://localhost:4443");
+    }
+
+    #[test]
+    fn https_is_preserved() {
+        let resolved = resolve(Some("https://storage.example:8443"), None)
+            .expect("parses")
+            .expect("resolves");
+        assert_eq!(resolved.url, "https://storage.example:8443");
+    }
+
+    #[test]
+    fn a_malformed_value_is_refused_not_ignored() {
+        // The whole point: every one of these used to be a silent fall-through
+        // to real Google Cloud Storage, which is the worst possible reading of
+        // "the operator asked for an emulator".
+        for bad in [
+            "ftp://localhost:4443",
+            "http://localhost:notaport",
+            "http://localhost:0",
+            "http://",
+            "http://localhost:4443/some/path",
+            "http://:4443",
+        ] {
+            let error = resolve(Some(bad), None)
+                .expect_err(&format!("{bad:?} must be refused, not ignored"));
+            assert!(
+                error.contains(KIN_ENDPOINT_VAR),
+                "the refusal must name the variable to fix, got {error:?}"
+            );
+            assert!(
+                error.contains(bad),
+                "the refusal must quote the offending value, got {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_malformed_convention_value_names_its_own_variable() {
+        let error = resolve(None, Some("ftp://nope:1")).expect_err("must be refused");
+        assert!(error.contains(EMULATOR_HOST_VAR), "got {error:?}",);
+        assert!(!error.contains(KIN_ENDPOINT_VAR), "got {error:?}");
+    }
+
+    #[test]
+    fn a_listening_endpoint_probes_reachable() {
+        // Positive control for the probe below. Without it, a probe that always
+        // returned Err would pass the unreachable test and prove nothing.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let endpoint = ResolvedEndpoint {
+            url: format!("http://127.0.0.1:{port}"),
+            host: "127.0.0.1".to_string(),
+            port,
+            source: KIN_ENDPOINT_VAR,
+        };
+        assert_eq!(endpoint.probe_reachable(Duration::from_secs(2)), Ok(()));
+    }
+
+    /// Round-trip a snapshot through a real emulator, proving the redirected
+    /// store is not merely constructible but actually serves reads and writes.
+    ///
+    /// Ignored because it needs a container, and the tests above are the ones
+    /// that run everywhere: they cover resolution, refusal and the loud
+    /// unreachable failure, none of which need a server.
+    ///
+    /// This is not where the acceptance is proven. FIR-2668's acceptance runs in
+    /// CI, on every push and pull request, as the "GCS emulator endpoint
+    /// acceptance" step of `.github/workflows/docker.yml`, which drives
+    /// `scripts/test-gcs-emulator-endpoint.sh`: a real daemon in `KIN_STORAGE=gcs`
+    /// mode against a real fake-gcs-server, plus the ticket's own falsification
+    /// where the emulator is stopped and the daemon must exit loud. That script
+    /// exercises the shipped image, so it covers the operator's path rather than
+    /// this crate's view of it. This test stays as the narrower, faster probe of
+    /// the store seam itself.
+    ///
+    /// Run it with:
+    ///
+    /// ```text
+    /// docker network create kin-gcs-test
+    /// docker run -d --name fake-gcs --network kin-gcs-test -p 4443:4443 \
+    ///   fsouza/fake-gcs-server -scheme http -port 4443 -backend memory
+    /// # Seed through the JSON API. Creating a directory inside a running
+    /// # container does NOT register a bucket: fake-gcs-server reads its data
+    /// # directory at process start, and under -backend memory that tree is not
+    /// # the authority at all.
+    /// curl -X POST 'http://localhost:4443/storage/v1/b?project=kin-test' \
+    ///   -H 'Content-Type: application/json' -d '{"name":"kin-test-bucket"}'
+    /// STORAGE_EMULATOR_HOST=http://localhost:4443 \
+    ///   KIN_GCS_TEST_BUCKET=kin-test-bucket \
+    ///   cargo test -p kin-daemon --features gcs \
+    ///     gcs_endpoint::tests::a_seeded_emulator_serves_a_snapshot_round_trip -- --ignored --nocapture
+    /// ```
+    ///
+    /// One expectation worth naming: the CAS path in `GcsBackend::save_snapshot`
+    /// reads a NUMERIC object generation and refuses an ETag or synthetic
+    /// fallback (kin-db `storage/gcs.rs`, `numeric_version`). If this fails on
+    /// the version rather than on connectivity, that is the reason, and it is a
+    /// property of the emulator rather than of the endpoint lever.
+    #[cfg(feature = "gcs")]
+    #[test]
+    #[ignore = "needs a running fake-gcs-server; see the doc comment for the command"]
+    fn a_seeded_emulator_serves_a_snapshot_round_trip() {
+        use kin_db::{StorageBackend, GENERATION_INIT};
+
+        let bucket = std::env::var("KIN_GCS_TEST_BUCKET")
+            .expect("set KIN_GCS_TEST_BUCKET to a bucket the emulator already holds");
+        let endpoint = resolve(
+            std::env::var(KIN_ENDPOINT_VAR).ok().as_deref(),
+            std::env::var(EMULATOR_HOST_VAR).ok().as_deref(),
+        )
+        .expect("endpoint parses")
+        .expect("set KIN_GCS_ENDPOINT or STORAGE_EMULATOR_HOST to the emulator");
+
+        // The same refusal the daemon performs at startup. Running it here means
+        // a failure below is a storage failure, never a "was it even up" one.
+        endpoint
+            .probe_reachable(DEFAULT_PROBE_TIMEOUT)
+            .expect("emulator must be reachable");
+
+        let backend = backend_for(&endpoint, &bucket, String::new()).expect("backend builds");
+
+        // Prove the bucket exists before writing to it. A missing bucket
+        // otherwise surfaces as a storage error on save, which looks exactly
+        // like a broken base URL or the numeric-generation caveat the doc
+        // comment above primes a reader to suspect, and sends the debugging
+        // budget to the endpoint lever instead of to the seeding step.
+        backend.list_repos().unwrap_or_else(|error| {
+            panic!(
+                "bucket {bucket:?} is not readable at {} ({error}). Seed it first:\n  \
+                 curl -X POST '{}/storage/v1/b?project=kin-test' \
+                 -H 'Content-Type: application/json' -d '{{\"name\":\"{bucket}\"}}'",
+                endpoint.url, endpoint.url
+            )
+        });
+
+        let repo_id = format!("kin-endpoint-roundtrip-{}", std::process::id());
+        let payload = b"kin gcs endpoint round trip".to_vec();
+
+        backend
+            .save_snapshot(&repo_id, &payload, GENERATION_INIT)
+            .expect("save reaches the emulator");
+        let (loaded, _generation) = backend
+            .load_snapshot(&repo_id)
+            .expect("load reaches the emulator")
+            .expect("the snapshot just written must be there");
+        assert_eq!(loaded, payload, "round trip must preserve the bytes");
+    }
+
+    #[test]
+    fn a_stopped_emulator_fails_loud() {
+        // Bind to claim a free port, then drop the listener so the port is
+        // closed but almost certainly still unclaimed: a stopped emulator.
+        let port = {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+            listener.local_addr().expect("addr").port()
+        };
+        let endpoint = ResolvedEndpoint {
+            url: format!("http://127.0.0.1:{port}"),
+            host: "127.0.0.1".to_string(),
+            port,
+            source: EMULATOR_HOST_VAR,
+        };
+        let error = endpoint
+            .probe_reachable(Duration::from_secs(2))
+            .expect_err("a closed port must not read as reachable");
+        assert!(error.contains(EMULATOR_HOST_VAR), "got {error:?}");
+        assert!(error.contains("nothing is listening"), "got {error:?}");
+        assert!(
+            error.contains("Refusing to start"),
+            "the operator must be told the daemon stopped rather than fell back, got {error:?}"
+        );
+    }
+}

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -120,6 +120,7 @@ pub mod commit_deltas;
 pub mod commit_liveness;
 pub mod daemon;
 pub mod error;
+pub mod gcs_endpoint;
 pub mod graph_only_members;
 pub mod lifecycle;
 mod local_repository_authority;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,16 @@ services:
       context: ../kin
       dockerfile: Dockerfile
     ports:
-      - "4219:4219"
+      # Loopback only. A bare "4219:4219" publishes on every host interface, and
+      # the bind host below turns the daemon's Host allowlist off rather than
+      # widening it, so the port would answer any peer on the network. /health,
+      # /ready and /readiness are exempt from bearer auth by design, and /health
+      # returns repo_root, the build sha and every behavior-env value, so on a
+      # coworking or hotel network that is a real read for anyone on the subnet.
+      # Sibling containers reach the daemon at kin-daemon:4219 over the compose
+      # network whether or not this is published, so scoping to loopback removes
+      # only the LAN. This also matches how the probe script publishes it.
+      - "127.0.0.1:4219:4219"
     volumes:
       # Persist the daemon's on-disk repo. The mount target must match the
       # workspace the entrypoint resolves (KIN_WORKSPACE_DIR, default
@@ -20,6 +29,20 @@ services:
       - workspace-data:/tmp/kin-workspace
     environment:
       - RUST_LOG=${RUST_LOG:-info}
+      # Bind the container's external interface, not its loopback. Docker
+      # publishes a port by forwarding to the container's external address, so a
+      # daemon on the default 127.0.0.1 (api.rs::resolve_bind_host) is unreachable
+      # through the mapping above from the host and from sibling containers alike.
+      # Binding non-loopback requires an auth token, and that is already
+      # satisfied: api.rs::resolve_serve_auth_token auto-provisions and persists
+      # one at .kin/daemon.token the first time the daemon serves this repo.
+      - KIN_DAEMON_BIND_HOST=0.0.0.0
+    # This probe runs inside the container's own network namespace, so it reaches
+    # a loopback-bound daemon just as well as an externally-bound one. It cannot
+    # catch a bind-host regression, and it is not meant to: it answers "is the
+    # daemon alive", not "is the published port reachable". The check that can
+    # fail for that bug class probes 4219 from outside the namespace, and lives in
+    # scripts/test-compose-published-port.sh.
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4219/readiness"]
       interval: 10s

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (494 total, 338 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (495 total, 339 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -241,6 +241,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | Variable | Kind | Default | Sensitivity | Description |
 | --- | --- | --- | --- | --- |
 | `KIN_GCS_BUCKET` | string | *(unset)* | operational | GCS bucket for remote storage |
+| `KIN_GCS_ENDPOINT` | url | *(unset)* | correctness | custom GCS endpoint for the daemon's graph-snapshot storage, e.g. a local fake-gcs-server; takes precedence over STORAGE_EMULATOR_HOST, sends unsigned requests, and fails daemon startup when unreachable rather than falling back to real Google Cloud Storage |
 | `KIN_GCS_PREFIX` | string | *(unset)* | operational | GCS key prefix for remote storage |
 
 ## Session & projection

--- a/scripts/test-compose-published-port.sh
+++ b/scripts/test-compose-published-port.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# The published daemon port must answer from OUTSIDE the container's network
+# namespace.
+#
+# `docker-compose.yml` maps 4219:4219, and Docker publishes a port by forwarding
+# to the container's EXTERNAL address. The daemon defaults to 127.0.0.1
+# (kin-daemon/src/api.rs::resolve_bind_host), so without KIN_DAEMON_BIND_HOST it
+# listens only on the container's loopback and the published mapping reaches
+# nothing. Nobody noticed because the compose healthcheck curls localhost from
+# INSIDE that same namespace, where a loopback-bound daemon answers perfectly:
+# a check that cannot fail for the one bug class it looks like it covers.
+#
+# So this script probes from the host, and runs the broken arm first. Arm 1 is
+# the negative control: unset the variable and the published port must NOT
+# answer, while the in-namespace probe must still succeed. Without that second
+# half arm 1 would pass for the wrong reason every time the daemon failed to
+# start at all, which is precisely how the original bug stayed invisible.
+#
+# Reachability, not readiness, is what is under test. An empty repo can still be
+# warming, and /readiness answers 503 until it is open; 503 is a REACHED daemon.
+# The arms therefore assert on whether an HTTP response came back at all, never
+# on its status code, so a slow open cannot read as a bind regression.
+#
+# Usage: scripts/test-compose-published-port.sh <image-ref> [host-port]
+
+set -euo pipefail
+
+IMAGE="${1:?usage: test-compose-published-port.sh <image-ref> [host-port]}"
+HOST_PORT="${2:-14219}"
+COMPOSE_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/docker-compose.yml"
+CID=""
+
+cleanup() {
+  [ -n "${CID}" ] && docker rm -f "${CID}" >/dev/null 2>&1 || true
+  CID=""
+}
+trap cleanup EXIT
+
+fail() { echo "::error::$1" >&2; exit 1; }
+
+contains() {
+  case "$1" in
+    *"$2"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Start the image with 4219 published to HOST_PORT, optionally setting the bind
+# host, and wait for the daemon to report that it is listening. The listening
+# line is the same deterministic, offline signal docker.yml's entrypoint smoke
+# already gates on, and it is emitted after the bind, so reaching it means the
+# socket exists whatever address it ended up on.
+#
+# The argv is branched rather than assembled in an array. bash 3.2, which is
+# /bin/bash on macOS, aborts on "${arr[@]}" for an EMPTY array under `set -u`,
+# and arm 1 passes no bind host, so the empty case is the first thing this
+# script does. CI runs bash 5 and would never have shown it.
+start_daemon() {
+  local bind_host="$1"
+  if [ -n "${bind_host}" ]; then
+    CID="$(docker run -d -p "127.0.0.1:${HOST_PORT}:4219" \
+      -e KIN_STORAGE=local -e KIN_DISABLE_SPINE=1 \
+      -e "KIN_DAEMON_BIND_HOST=${bind_host}" "${IMAGE}" --port 4219)"
+  else
+    CID="$(docker run -d -p "127.0.0.1:${HOST_PORT}:4219" \
+      -e KIN_STORAGE=local -e KIN_DISABLE_SPINE=1 "${IMAGE}" --port 4219)"
+  fi
+  local logs=""
+  for _ in $(seq 1 60); do
+    logs="$(docker logs "${CID}" 2>&1 || true)"
+    if contains "${logs}" "daemon API server listening"; then return 0; fi
+    if [ "$(docker inspect -f '{{.State.Running}}' "${CID}" 2>/dev/null || echo false)" != "true" ]; then break; fi
+    sleep 1
+  done
+  echo "${logs}"
+  fail "kin-daemon never reached its listening line (bind_host='${bind_host:-unset}')"
+}
+
+# Did an HTTP response come back from the published port, on the HOST, outside
+# the container's namespace? Any status counts; a refused connection does not.
+# `curl -f` is deliberately NOT used: it turns a reachable-but-warming 503 into
+# the same failure as a dead port, which is the distinction under test.
+published_port_answers() {
+  local code
+  code="$(curl -o /dev/null -sS --max-time 5 -w '%{http_code}' \
+    "http://127.0.0.1:${HOST_PORT}/readiness" 2>/dev/null || true)"
+  [ -n "${code}" ] && [ "${code}" != "000" ]
+}
+
+# The same question asked from INSIDE the namespace, where a loopback-bound
+# daemon is perfectly reachable. This is the control that proves a failure of
+# `published_port_answers` means "not published", not "not running".
+in_namespace_answers() {
+  local code
+  code="$(docker exec "${CID}" sh -c \
+    "curl -o /dev/null -sS --max-time 5 -w '%{http_code}' http://127.0.0.1:4219/readiness" 2>/dev/null || true)"
+  [ -n "${code}" ] && [ "${code}" != "000" ]
+}
+
+# ---------------------------------------------------------------------------
+# 1. Negative control. With no KIN_DAEMON_BIND_HOST the daemon binds loopback,
+#    so the published port must NOT answer while the in-namespace probe still
+#    does. If this arm ever goes quiet in both halves, the arm is broken, not
+#    the product.
+# ---------------------------------------------------------------------------
+echo "==> [unset-bind-host] published port must be unreachable, daemon still alive"
+start_daemon ""
+in_namespace_answers || fail "control failed: daemon did not answer INSIDE its own namespace, so arm 1 proves nothing"
+if published_port_answers; then
+  fail "published port answered with KIN_DAEMON_BIND_HOST unset; this check can no longer detect a loopback bind"
+fi
+echo "==> [unset-bind-host] OK (in-namespace: reachable, published: refused)"
+cleanup
+
+# ---------------------------------------------------------------------------
+# 2. The fix. Binding 0.0.0.0 must make the published mapping answer from the
+#    host. The daemon requires an auth token to bind non-loopback and
+#    auto-provisions one at .kin/daemon.token, so no credential is configured
+#    here; a regression in that provisioning shows up as a daemon that never
+#    reaches its listening line.
+# ---------------------------------------------------------------------------
+echo "==> [bind-0.0.0.0] published port must answer from the host"
+start_daemon "0.0.0.0"
+published_port_answers || fail "published port did not answer with KIN_DAEMON_BIND_HOST=0.0.0.0"
+echo "==> [bind-0.0.0.0] OK (published: reachable)"
+cleanup
+
+# ---------------------------------------------------------------------------
+# 3. Tie the runtime proof to the shipped artifact. Arms 1 and 2 prove what the
+#    variable does; only this proves docker-compose.yml actually ships it, so a
+#    regression here turns the check red instead of leaving two green arms
+#    describing a fix nobody ships.
+#
+#    It reads the RESOLVED config, not the raw file. A substring search over the
+#    file text also matches inside a `#` comment, so commenting the line out
+#    (the likeliest regression, and likelier than deletion since it is what
+#    someone does to reproduce the old bug) left all three arms green: arms 1
+#    and 2 build their own containers and never read this file at all.
+#    `docker compose config` renders the merged services with comments already
+#    gone; the fallback strips comment text before matching so the guard still
+#    cannot be satisfied by a commented-out line.
+# ---------------------------------------------------------------------------
+echo "==> [compose-carries-it] docker-compose.yml must ship the bind host and a loopback mapping"
+[ -f "${COMPOSE_FILE}" ] || fail "docker-compose.yml not found at ${COMPOSE_FILE}"
+
+resolved=""
+if docker compose -f "${COMPOSE_FILE}" config >/dev/null 2>&1; then
+  resolved="$(docker compose -f "${COMPOSE_FILE}" config 2>/dev/null)"
+  source_desc="docker compose config"
+else
+  # No compose plugin, or a build context this checkout cannot resolve. Strip
+  # comment text so a commented-out setting cannot satisfy the match.
+  resolved="$(sed -e 's/[[:space:]]*#.*$//' "${COMPOSE_FILE}")"
+  source_desc="comment-stripped docker-compose.yml"
+fi
+echo "    (read from ${source_desc})"
+
+contains "${resolved}" "KIN_DAEMON_BIND_HOST" && contains "${resolved}" "0.0.0.0" \
+  || fail "docker-compose.yml does not effectively set KIN_DAEMON_BIND_HOST=0.0.0.0; its published 4219 mapping is dead"
+
+# The shipped mapping must be the one arms 1 and 2 exercised. A bare 4219:4219
+# publishes on every interface, and the 0.0.0.0 bind above turns the daemon's
+# Host allowlist off rather than widening it, so the unauthenticated /health
+# surface would answer any peer on the network.
+contains "${resolved}" "127.0.0.1" \
+  || fail "docker-compose.yml publishes 4219 on every interface; scope it to 127.0.0.1 so /health is not exposed to the LAN"
+echo "==> [compose-carries-it] OK"
+
+echo "==> compose published-port contract passed for ${IMAGE}"

--- a/scripts/test-gcs-emulator-endpoint.sh
+++ b/scripts/test-gcs-emulator-endpoint.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# FIR-2668's acceptance, run against a real emulator on a clean runner.
+#
+# The ticket asks for exactly this: a daemon started with KIN_STORAGE=gcs, the
+# endpoint lever pointed at a fake-gcs-server container, and a seeded bucket,
+# serving with zero real Google Cloud Storage traffic; then the falsification,
+# stop the emulator and watch the daemon fail loud rather than fall back.
+#
+# It runs the shipped image rather than a cargo test on purpose. The image is
+# already built with `--features gcs` by the job that calls this, so this
+# exercises the same bytes an operator would run, and it needs no Rust
+# toolchain in the Docker job.
+#
+# Bucket seeding goes through the emulator's JSON API. Creating a directory
+# inside an already-running container does NOT register a bucket: fake-gcs-server
+# reads its data directory at process start, and under `-backend memory` that
+# tree is not the authority at all. Arm 0 proves the bucket exists before any
+# arm depends on it, so a seeding failure names itself instead of arriving later
+# disguised as a broken endpoint lever.
+#
+# Usage: scripts/test-gcs-emulator-endpoint.sh <image-ref>
+
+set -uo pipefail
+
+IMAGE="${1:?usage: test-gcs-emulator-endpoint.sh <image-ref>}"
+GCS_IMAGE="${FAKE_GCS_IMAGE:-fsouza/fake-gcs-server:latest}"
+NET="kin-gcs-net-$$"
+GCS_CID=""
+KIN_CID=""
+BUCKET="kin-emulator-test"
+
+cleanup() {
+  [ -n "${KIN_CID}" ] && docker rm -f "${KIN_CID}" >/dev/null 2>&1
+  [ -n "${GCS_CID}" ] && docker rm -f "${GCS_CID}" >/dev/null 2>&1
+  docker network rm "${NET}" >/dev/null 2>&1
+  KIN_CID=""; GCS_CID=""
+  return 0
+}
+trap cleanup EXIT
+
+fail() { echo "::error::$1" >&2; exit 1; }
+
+contains() {
+  case "$1" in
+    *"$2"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+dump_kin() {
+  echo "---- kin-daemon logs ----"
+  [ -n "${KIN_CID}" ] && docker logs "${KIN_CID}" 2>&1 | tail -40
+  return 0
+}
+
+# Run the daemon in GCS mode against the emulator. Argv is branched rather than
+# assembled in an array, because bash 3.2 aborts expanding an empty one under
+# `set -u`.
+start_kin() {
+  local emulator_host="$1"
+  KIN_CID="$(docker run -d --network "${NET}" \
+    -e KIN_STORAGE=gcs \
+    -e "KIN_GCS_BUCKET=${BUCKET}" \
+    -e "STORAGE_EMULATOR_HOST=${emulator_host}" \
+    -e KIN_DISABLE_SPINE=1 \
+    "${IMAGE}" --port 4219)"
+}
+
+# Wait for either the listening line or container exit. Echoes "listening",
+# "exited", or "timeout".
+await_kin() {
+  local i logs
+  for i in $(seq 1 90); do
+    logs="$(docker logs "${KIN_CID}" 2>&1 || true)"
+    if contains "${logs}" "daemon API server listening"; then echo "listening"; return 0; fi
+    if [ "$(docker inspect -f '{{.State.Running}}' "${KIN_CID}" 2>/dev/null || echo false)" != "true" ]; then
+      echo "exited"; return 0
+    fi
+    sleep 1
+  done
+  echo "timeout"
+}
+
+echo "==> [setup] network and emulator"
+docker network create "${NET}" >/dev/null || fail "could not create docker network"
+GCS_CID="$(docker run -d --network "${NET}" --network-alias fake-gcs "${GCS_IMAGE}" \
+  -scheme http -port 4443 -backend memory -public-host fake-gcs:4443)" \
+  || fail "could not start ${GCS_IMAGE}"
+
+# ---------------------------------------------------------------------------
+# 0. Seed the bucket through the JSON API, and prove it took. Everything below
+#    depends on this, so it is asserted rather than assumed.
+# ---------------------------------------------------------------------------
+echo "==> [seed] create bucket ${BUCKET} through the emulator's JSON API"
+seeded=""
+for _ in $(seq 1 30); do
+  if docker run --rm --network "${NET}" --entrypoint curl "${IMAGE}" -sS -f \
+      -X POST "http://fake-gcs:4443/storage/v1/b?project=kin-test" \
+      -H 'Content-Type: application/json' \
+      -d "{\"name\":\"${BUCKET}\"}" >/dev/null 2>&1; then
+    seeded=1; break
+  fi
+  sleep 2
+done
+[ -n "${seeded}" ] || fail "could not create bucket ${BUCKET} through the emulator JSON API"
+
+listing="$(docker run --rm --network "${NET}" --entrypoint curl "${IMAGE}" -sS \
+  "http://fake-gcs:4443/storage/v1/b/${BUCKET}" 2>/dev/null || true)"
+contains "${listing}" "${BUCKET}" \
+  || fail "bucket ${BUCKET} does not read back from the emulator after creation; got: ${listing}"
+echo "==> [seed] OK (bucket present)"
+
+# ---------------------------------------------------------------------------
+# 1. The acceptance. A daemon in GCS mode, pointed at the emulator by the
+#    lever alone, must reach serving state. No GCP credentials exist in this
+#    container, and the base URL never names googleapis.com, so reaching
+#    serving state is reaching it through the emulator.
+# ---------------------------------------------------------------------------
+echo "==> [serves] daemon with KIN_STORAGE=gcs against the emulator"
+start_kin "http://fake-gcs:4443"
+state="$(await_kin)"
+logs="$(docker logs "${KIN_CID}" 2>&1 || true)"
+
+if [ "${state}" != "listening" ]; then
+  dump_kin
+  fail "daemon did not reach serving state against the emulator (state=${state}); FIR-2668's acceptance is NOT met"
+fi
+
+contains "${logs}" "GCS storage redirected to" \
+  || { dump_kin; fail "daemon served but never logged the endpoint redirect, so the lever may not be what routed it"; }
+contains "${logs}" "no real Google Cloud Storage traffic" \
+  || { dump_kin; fail "redirect line is missing its no-real-GCP claim"; }
+
+code="$(docker exec "${KIN_CID}" sh -c \
+  "curl -o /dev/null -sS --max-time 5 -w '%{http_code}' http://127.0.0.1:4219/readiness" 2>/dev/null || true)"
+[ -n "${code}" ] && [ "${code}" != "000" ] \
+  || { dump_kin; fail "daemon reached listening but /readiness did not answer"; }
+echo "==> [serves] OK (listening, redirect logged, /readiness http ${code})"
+docker rm -f "${KIN_CID}" >/dev/null 2>&1; KIN_CID=""
+
+# ---------------------------------------------------------------------------
+# 2. The falsification the ticket names, in the two shapes an outage actually
+#    takes. Without this arm, arm 1 would pass just as well for a lever being
+#    ignored entirely.
+#
+#    They are separate because they fail differently. A closed port resolves and
+#    refuses the connection. A REMOVED container also takes its network alias
+#    with it, so the endpoint stops resolving at all, and asserting "nothing is
+#    listening" there would be asserting on the wrong cause. Both must refuse to
+#    start, and neither may fall back to real GCS or to local storage.
+# ---------------------------------------------------------------------------
+# assert_refused <label> <extra-substring-or-empty>
+assert_refused() {
+  local label="$1"
+  local expect="$2"
+  local state exit_code logs
+  state="$(await_kin)"
+  logs="$(docker logs "${KIN_CID}" 2>&1 || true)"
+
+  [ "${state}" = "exited" ] \
+    || { dump_kin; fail "${label}: daemon did not exit (state=${state}); a silent fallback is exactly what must not happen"; }
+
+  exit_code="$(docker inspect -f '{{.State.ExitCode}}' "${KIN_CID}" 2>/dev/null || echo unknown)"
+  [ "${exit_code}" != "0" ] \
+    || { dump_kin; fail "${label}: daemon exited 0; the refusal must be an error"; }
+
+  contains "${logs}" "Refusing to start" \
+    || { dump_kin; fail "${label}: refusal did not say it declined to start rather than falling back"; }
+  contains "${logs}" "STORAGE_EMULATOR_HOST" \
+    || { dump_kin; fail "${label}: refusal did not name the variable to fix"; }
+  if [ -n "${expect}" ]; then
+    contains "${logs}" "${expect}" \
+      || { dump_kin; fail "${label}: refusal did not name the cause (expected ${expect})"; }
+  fi
+  # Nothing may suggest it reached, or fell back to, another backend.
+  contains "${logs}" "daemon API server listening" \
+    && { dump_kin; fail "${label}: daemon reached serving state despite an unusable storage endpoint"; }
+  echo "==> [${label}] OK (exit ${exit_code})"
+  docker rm -f "${KIN_CID}" >/dev/null 2>&1; KIN_CID=""
+  return 0
+}
+
+echo "==> [fails-loud-closed-port] emulator up, lever points at a closed port"
+start_kin "http://fake-gcs:4444"
+assert_refused "fails-loud-closed-port" "nothing is listening there"
+
+echo "==> [fails-loud-emulator-gone] emulator removed entirely"
+docker rm -f "${GCS_CID}" >/dev/null 2>&1; GCS_CID=""
+start_kin "http://fake-gcs:4443"
+assert_refused "fails-loud-emulator-gone" ""
+
+echo "==> GCS emulator endpoint acceptance passed for ${IMAGE}"


### PR DESCRIPTION
Two fixes to the containerized daemon, batched into one PR.

## The compose daemon was unreachable on the port it published

`docker-compose.yml` maps 4219 but never set `KIN_DAEMON_BIND_HOST`. Docker publishes a port by forwarding to the container's external address, and the daemon defaults to `127.0.0.1` (`api.rs::resolve_bind_host`), so it listened only on the container's loopback and the mapping reached nothing from the host or from a sibling container.

Nothing caught it, and the reason is worth stating plainly. The compose healthcheck curls `localhost:4219` from inside the container's own network namespace, where a loopback-bound daemon answers perfectly. It stayed green over a dead port, so for this one bug class it was a check that could not fail.

The fix is the one environment line. Binding non-loopback requires an auth token and already has one: `resolve_serve_auth_token` auto-provisions and persists a bearer token at `.kin/daemon.token` on first serve, so no credential has to be configured.

The mapping is now scoped to `127.0.0.1:4219:4219` rather than published on every interface, and that pairing matters. Setting the bind host to `0.0.0.0` turns the daemon's Host allowlist off rather than widening it (`api.rs:1326-1331`), and `/health`, `/ready` and `/readiness` are exempt from bearer auth by design, with `/health` returning `repo_root`, the build sha and every behavior-env value. Before this change the dead mapping hid all of that. Publishing on every interface would have handed it to anyone on a coworking or hotel network. Sibling containers reach the daemon at `kin-daemon:4219` over the compose network whether or not the port is published, so loopback scoping removes only the LAN. The product-side question of how much an unauthenticated `/health` should say is filed separately as FIR-2677 and is not touched here.

`scripts/test-compose-published-port.sh` is the check that can fail. It curls the published port from outside the namespace, and it runs the broken arm first: with the variable unset the published port must not answer, while the in-namespace probe must still succeed. Without that second half the arm would pass for the wrong reason every time the daemon failed to start, which is how the original bug stayed invisible. A third arm reads the resolved compose config, via `docker compose config` where available and a comment-stripped scan otherwise, and asserts both the bind host and the loopback mapping, so commenting the line out goes red rather than passing on a substring that also matches inside a comment. It asserts on whether an HTTP response came back at all, never on the status code, because an empty repo can still be warming and a 503 is a reached daemon.

## GCS storage can now point at an emulator

The question on FIR-2668 was whether the daemon's Rust GCS client can take a custom endpoint at all. It can, and better than expected: this needs no kin-db change.

The construction site was `kin_db::GcsBackend::new`, and `GcsBackend` lives in kin-db, a pinned registry crate. Reading kin-db 0.7.57 at the pinned version, the client is `object_store` 0.14 behind its `gcp` feature, and `GoogleCloudStorageBuilder` carries `with_base_url` (its own doc example is a localhost emulator) plus `with_skip_signature`. kin-db also already exposes `GcsBackend::from_store(Box<dyn ObjectStore>, prefix)` as a public seam, identical to `new` except that the caller supplies the store. So kin builds the redirected store itself and hands it in. No kin-db edit, no registry publish, no pin bump.

`KIN_GCS_ENDPOINT` is the registered lever and wins. `STORAGE_EMULATOR_HOST` is honored too, so one exported variable points both halves of a local stack at the same emulator, matching the Node client kinlab already uses.

Nothing on that path falls back. A malformed value is refused rather than ignored, and an endpoint that is set but unreachable stops daemon startup instead of reaching for real Google Cloud Storage or quietly serving from somewhere else. Requests are unsigned, which an emulator needs and which also means a lever pointed at the real service by mistake is rejected by Google rather than silently authorized by whatever ambient credentials the host carries.

The ticket's acceptance runs in CI rather than sitting behind an ignore. `scripts/test-gcs-emulator-endpoint.sh`, wired into the Docker job, starts a real fake-gcs-server, seeds a bucket through the emulator's JSON API and proves it took, then runs the shipped image with `KIN_STORAGE=gcs` pointed at it and asserts the daemon reaches serving state and logs the redirect. Then it runs the falsification the ticket names: with the emulator stopped, the daemon must exit nonzero with a message naming the unreachable endpoint, which is what stops the happy path from passing just as well for a lever being ignored. It drives the built image, so it exercises the bytes an operator runs and needs no Rust toolchain in that job.

A narrower `#[ignore]`d test still probes the store seam directly from the crate's side. Its run instructions were wrong and are corrected here: seeding goes through the JSON API, because creating a directory inside an already-running fake-gcs-server does not register a bucket, and under the memory backend the on-disk tree is not the authority at all. The test now also checks the bucket is readable before writing, so a seeding mistake names itself instead of arriving disguised as a broken endpoint.

## Three decisions worth a reviewer's attention

**`STORAGE_EMULATOR_HOST` is not in the env registry, on purpose.** That registry is the `KIN_*` surface by construction. `audit_env` skips every non-`KIN_` name, and `registry_is_well_formed` asserts the prefix on every entry. Registering it there would have broken a guard that exists for a reason, so the Kin-named lever is the registered one.

**Its sensitivity is `Correctness`, unlike the bucket and prefix beside it.** This lever redirects every storage request to a different server, which is the data-safety case that sensitivity documents. The effect is that a non-default value logs loudly, which is exactly the question an operator has, emulator or production. It costs no startup refusal, since `Kind::Url` is always structurally valid and the daemon does its own parsing.

**Both variables joined `BEHAVIOR_ENV_VARS`, and this was the closest call.** The module's stated membership rule is whether the value gets baked into the worker at process start, and this one is, since it is read once in `create_state` to build the store. What decided it is that either variable alone can supply the endpoint, so a health payload carrying only `KIN_GCS_ENDPOINT` would show it unset while `STORAGE_EMULATOR_HOST` silently supplied the endpoint. That is not an incomplete report, it is a wrong answer to the one question the surface exists to answer.

The cost, stated in full rather than softened. A developer with `STORAGE_EMULATOR_HOST` exported for Node work now sees a divergence warning against a local-storage daemon where the variable has no effect. Under `KIN_STRICT_BEHAVIOR_ENV`, which exists so scripted and proof runs fail loudly, that is not a warning but a hard error, so such a run would fail every `kin` command over a variable that daemon never read and cannot read, since the lever is reachable only from the `StorageMode::Gcs` arm. That is a real new failure mode and the reason to accept it is that the alternative reports the endpoint wrongly. The narrower option, keeping only `KIN_GCS_ENDPOINT` in the list and reporting the resolved endpoint as its own `/health` field, is a reasonable thing to prefer, and it belongs with the `/health` work in FIR-2677 rather than here.

## Gates

`cargo test -p kin-daemon --features gcs` and `-p kin-core`, `cargo fmt` in both the `--all` and the ci.yml form, `cargo clippy --all-targets --all-features` with the debt allow list under `RUSTFLAGS=-D warnings` exactly as ci.yml composes it, and the guard scripts ci.yml names. Then `bin/kin-parity` against this worktree, which came back PASS-WITH-ALLOWANCES against three allowances that are checked-in known-fails on main and that this diff does not touch.

All 14 new tests were falsified by breaking the behavior each one guards and watching it go red, then reverting. The probe pair is broken in both directions, always-Ok and always-Err, so neither test can be satisfied by a probe that has stopped deciding.

Two gate catches worth recording, because assuming would have shipped both. Clippy found a `redundant_guards` lint in the new parser, and the test guarding that exact line was re-falsified after the fix. Then kin-core's own registry-completeness guard caught `KIN_GCS_TEST_BUCKET`, the fixture variable the ignored test reads, which is now allowlisted with a note following the `KIN_HEAP_REPO` precedent.

Also folded from review: the probe script built its docker argv in an array, which bash 3.2 (macOS `/bin/bash`) refuses to expand when empty under `set -u`, and the unset-bind-host arm is exactly the empty case, so the script died before its first docker call on any Mac; the argv is branched now. And the reachability probe gave each resolved address a full timeout, so a hostname with one blackholed IPv6 charged every start the whole wait; it now runs under one overall deadline and names the address that consumed it.

`Cargo.lock` moves by exactly one line, `object_store` added to kin-daemon's dependency list. No new packages, no version or source changes, and all four registry crates keep their `sparse+` source and checksum.

Closes FIR-2670
Closes FIR-2668
