### PR TITLE
Take kin-model 0.7.19 and kin-db 0.7.59 so a conversion stops hashing through a tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.57"
+version = "0.7.59"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "0f948650fcc4782b952d257b4853c9c3548d1a0abe3c3eb1d0dd2f05cdfd0f8e"
+checksum = "2a9608b37408e991813bedec15e99f034ba9a8f0db93e6d9fb6d068db5f804da"
 dependencies = [
  "bincode",
  "bstr",
@@ -3503,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.18"
+version = "0.7.19"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "a83554b6983fb415d95edbf261542fc1a5e3ad5026e694a9c3306cc66f1b0b8c"
+checksum = "bafee6c5697e85ce6fe4bc84bace8e7669bf7436853b5b5b90b92133e787b9f1"
 dependencies = [
  "chrono",
  "gix-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.18", registry = "kin" }
+kin-model = { version = "=0.7.19", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.57", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.59", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.18"
+version = "0.7.19"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "a83554b6983fb415d95edbf261542fc1a5e3ad5026e694a9c3306cc66f1b0b8c"
+checksum = "bafee6c5697e85ce6fe4bc84bace8e7669bf7436853b5b5b90b92133e787b9f1"
 dependencies = [
  "chrono",
  "gix-hash",


### PR DESCRIPTION
Two lines of `Cargo.toml` and four of `Cargo.lock`. kin-model 0.7.18 to 0.7.19
and kin-db 0.7.57 to 0.7.59.

## What the two releases do

Both replace the `serde_json::Value` tree their canonical encoder was built from
with one that writes the same bytes straight out of `Serialize`. FIR-2551 priced
that tree at eleven times the value it encodes and specified the fix; FIR-2665
found the same function from the container side and supplied the bootstrap-scale
numbers.

`RepositoryTransaction::canonical_hash` already avoided the whole-document tree
by walking its fields one at a time. That bounds the tree to one array element,
which is the right answer when the elements are small and no answer at all when
one of them is not. On a bootstrap the Git external authority is a single element
carrying the entire object closure, and a tree of that authority measured
60,495,152 bytes against the 60,554,406 the whole transaction hash cost. The same
number to within a tenth of a percent. **A bound that holds for every element but
one is not a bound.**

## What it buys

Absolute peak live heap of a whole-history bootstrap commit, measured in kin-db
against the published crates with a counting global allocator and a span sampler:

| fixture | before | after | cut |
| -- | -- | -- | -- |
| 400 commits, 1,190 objects | 89,026,747 | 35,934,780 | 59.6% |
| 1,200 commits, 3,647 objects | 369,241,619 | 143,273,955 | 61.2% |

Stable across a threefold change in size, which is what you would expect when the
term removed scales with the repository and the terms left behind do not scale as
fast.

## The bytes do not move

`transaction_hash` is stored in every `RepositoryCommitReceipt` and compared on
idempotent replay at `crates/kin-core/src/init.rs:323`, and change ids are
content-addressed. One byte of difference is every repository on disk failing to
recognise its own history.

kin-model keeps the tree walk as `canonical_json_bytes_via_tree`, the oracle, and
proves the two produce identical **bytes** rather than identical hashes, per
FIR-2549: the encoding sorts object keys, so a hash comparison normalises away
the field reorder most likely to appear. The differential runs over three
transaction fixtures and every change, alias, external object, Git authority
delta, workspace mutation, semantic delta, local overlay and merge delta they
carry. The serializer also asserts `is_human_readable`, because
`RepositoryTransaction` has a positional serde branch selected by that flag.

Every pinned digest in both crates still passes, and kin-model's own CI ran a
"kin-db suite against this kin-model" job before it merged.

## Gates

Per the workspace rule that the DEV-LOCAL gate cannot validate a pin, because it
replaces the crate under test with a local path:

- `cargo nextest run --workspace --locked`, exit 0, **7,245 of 7,245 passed**,
  14 skipped
- `cargo test --doc --locked`, exit 0. Stated precisely rather than left to
  imply coverage: that is 23 crates and exactly one doctest, because most of this
  workspace sets `doctest = false` or carries no doc examples. The nextest leg is
  what actually gates this change.
- lock entries keep a registry source and a checksum:

```
kin-model  0.7.19  sparse+https://kinlab.ai/registry/cargo/  bafee6c5697e85ce...
kin-db     0.7.59  sparse+https://kinlab.ai/registry/cargo/  2a9608b37408e991...
```

Neither release adds, removes or changes a public item, so there is nothing to
integrate. Both new modules are `pub(crate)` and the oracle kin-model kept is
`pub(crate)` plus `cfg(test)`.

One thing worth naming: an earlier unlocked `cargo metadata` probe of mine
silently re-resolved `winapi-util`'s `windows-sys` from 0.61.2 to 0.48.0 in the
tracked lock, and that hunk sat in the diff beside the two pin changes looking
entirely legitimate. It affects Windows only, so nothing local would ever have
compiled it. Reverted; the lock now carries the two versions and their two
checksums and nothing else.

One more thing the gates caught rather than I did. kin tracks **two**
`Cargo.lock` files, the workspace root and `fuzz/`, and the first push moved only
the root. The fuzz workspace still named kin-model 0.7.18, so its
`cargo metadata --locked` step failed both fuzz targets, which is that step doing
exactly the job its comment says it does. Re-locked in a second commit, two lines,
still `sparse+` with a checksum, and both locks now resolve under `--locked`.

Refs FIR-2665. Refs FIR-2551. Refs FIR-2549.
