### PR TITLE
Weigh every requested edge class in the one verdict, and report a class the build cannot produce as unproduced

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -161,6 +161,15 @@ jobs:
       - name: Falsify the eject-journal graders
         run: python3 scripts/acceptance/eject_journal_repro.py --self-test
 
+      # FIR-2672. The one verdict certified an answer as the whole set while
+      # its own completeness block recorded a requested edge class it could not
+      # read, on every release since the verdict existed. The graders here are
+      # handed the exact 0.5.52 envelope and have to fail on it, and the fixed
+      # shape and the all-present shape must both pass, so a grader that refuses
+      # everything fails here too.
+      - name: Falsify the verdict-limits graders
+        run: python3 scripts/acceptance/verdict_limits_repro.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -577,6 +586,34 @@ jobs:
             echo "::error title=Eject-journal acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
+      - name: Verdict-limits acceptance suite (verdict comes from the gate step)
+        id: verdictlimits
+        if: always()
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/verdict_limits_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/verdict_limits.json \
+            --label "$KIN_ACCEPTANCE_LABEL" \
+            --verbose >acceptance/verdict_limits.log 2>&1 || rc=$?
+          cat acceptance/verdict_limits.log
+          {
+            echo "### Verdict-limits acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/verdict_limits.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=Verdict-limits acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
+          fi
+
       # Always, including on a cancelled or timed-out run: the reports are how a
       # failure is diagnosed without re-running the job.
       - name: Upload the acceptance reports
@@ -616,4 +653,5 @@ jobs:
             --report registry_isolation=acceptance/registry_isolation.json \
             --report first_contact=acceptance/first_contact.json \
             --report eject_journal=acceptance/eject_journal.json \
+            --report verdict_limits=acceptance/verdict_limits.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk comes back truncated=True with clipped_steps=None on ubuntu-latest, so an absent edge cannot be told from a dropped one. Build profile, product code from 0.5.44 through 0.5.46, and the pinned language-server versions are all ruled out; platform and code newer than 0.5.46 are still confounded. The moment the check passes this allowance announces itself stale and can go.'

--- a/crates/kin-cli/src/commands/absence_qualifier.rs
+++ b/crates/kin-cli/src/commands/absence_qualifier.rs
@@ -41,6 +41,24 @@
 //! refuses on the MCP side, and `kin init` ships one today that misattributes a
 //! disabled sweep to a missing server (FIR-2531). One of those is enough.
 
+/// The marker every line of the qualifier block carries.
+///
+/// The block is one line per reason the verdict refused, each beginning with
+/// this phrase and the noun the absence is of, so "the answer minus its
+/// qualifiers" is a structural cut rather than a phrase match. The first time
+/// a second reason was rendered beside the first, a clarifying sentence went
+/// out without the phrase, and a test counting the answer's own lines counted
+/// it as the answer (FIR-2672).
+pub const QUALIFIER_MARK: &str = "Kin cannot rule out";
+
+/// `text` with the qualifier block removed: every line carrying
+/// [`QUALIFIER_MARK`], wherever it sits.
+pub fn without_qualifiers(text: &str) -> Vec<&str> {
+    text.lines()
+        .filter(|line| !line.contains(QUALIFIER_MARK))
+        .collect()
+}
+
 /// Render the qualifier for `tool`'s empty answer, or nothing when the verdict
 /// certifies.
 ///
@@ -120,7 +138,7 @@ pub fn qualify(
             .filter(|disclosed| !disclosed.is_empty());
         return vec![match disclosed {
             Some(disclosed) => format!(
-                "{indent}Kin cannot rule out {subject}: this answer carries [{disclosed}], so it \
+                "{indent}{QUALIFIER_MARK} {subject}: this answer carries [{disclosed}], so it \
                  may not reflect current truth."
             ),
             // No degraded signal and no absent class, so the reason the verdict
@@ -137,44 +155,90 @@ pub fn qualify(
             // An unconfigured spine, alone, is not a gap in THIS repository.
             None if only_unconfigured_federation(&negative) => return Vec::new(),
             None => match limiting_factor(&negative) {
-                Some(factor) => format!("{indent}Kin cannot rule out {subject}: {factor}."),
+                Some(factor) => format!("{indent}{QUALIFIER_MARK} {subject}: {factor}."),
                 None => format!(
-                    "{indent}Kin cannot rule out {subject}: this answer's coverage could not be \
+                    "{indent}{QUALIFIER_MARK} {subject}: this answer's coverage could not be \
                      established."
                 ),
             },
         }];
     }
 
+    // One marked line per reason, in the order the verdict weighs them: the
+    // class the build could not produce, the class the graph holds none of,
+    // then the signals below. The present classes are named on the last class
+    // line rather than on a line of their own, because a line without the
+    // marker is not part of the block a reader or a test can cut.
+    let subject = absence_subject(tool);
+    let stand_in = |short: &[&str]| -> String {
+        if present.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " Cross-file {} edges exist but do not stand in for {} edges.",
+                present.join(" and "),
+                short.join(" or ")
+            )
+        }
+    };
+    let short_all: Vec<&str> = unproduced.iter().chain(missing.iter()).copied().collect();
     let mut said = Vec::new();
     if !unproduced.is_empty() {
+        let tail = if missing.is_empty() {
+            stand_in(&short_all)
+        } else {
+            String::new()
+        };
         said.push(format!(
-            "{indent}Kin cannot rule out {}: this build produced no entity-level {} edge for \
+            "{indent}{QUALIFIER_MARK} {subject}: this build produced no entity-level {} edge for \
              {language} although the source carries {} sites, {}. The gap is in the linker, \
-             not in the code.",
-            absence_subject(tool),
+             not in the code.{tail}",
             unproduced.join(" or "),
             unproduced.join(" or "),
             absence_direction(tool)
         ));
     }
     if !missing.is_empty() {
+        let tail = stand_in(&short_all);
         said.push(format!(
-            "{indent}Kin cannot rule out {}: this graph holds no cross-file {} edges for \
-             {language}, {}.",
-            absence_subject(tool),
+            "{indent}{QUALIFIER_MARK} {subject}: this graph holds no cross-file {} edges for \
+             {language}, {}.{tail}",
             missing.join(" or "),
             absence_direction(tool)
         ));
     }
-    if !present.is_empty() {
-        let short: Vec<&str> = unproduced.iter().chain(missing.iter()).copied().collect();
+    // A second, independent reason does not vanish because the class gap won
+    // the state. On a daemon whose embedding worker had died beside a graph
+    // that linked only its calls, the sentences above named the edge gap and
+    // the worker's death went unsaid, so a reader learned one of the two
+    // things wrong with the answer (FIR-2672). The signals the verdict
+    // disclosed that are not the class facts already spoken follow, in the
+    // order the verdict weighs them: the structural gap first, then the run's
+    // own degradations.
+    let independent: Vec<&str> = negative
+        .get("degraded_signals")
+        .and_then(serde_json::Value::as_array)
+        .map(|signals| {
+            signals
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .filter(|label| {
+                    !label.starts_with("edge_coverage:") && !label.starts_with("absence_coverage:")
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    if !independent.is_empty() {
         said.push(format!(
-            "{indent}Cross-file {} edges exist but do not stand in for {} edges.",
-            present.join(" and "),
-            short.join(" or ")
+            "{indent}{QUALIFIER_MARK} {subject}: this answer also carries [{}], so it may not \
+             reflect current truth.",
+            independent.join(", ")
         ));
     }
+    debug_assert!(
+        said.iter().all(|line| line.contains(QUALIFIER_MARK)),
+        "every qualifying line carries the marker: {said:?}"
+    );
     said
 }
 

--- a/crates/kin-cli/src/commands/absence_qualifier.rs
+++ b/crates/kin-cli/src/commands/absence_qualifier.rs
@@ -79,13 +79,19 @@ pub fn qualify(
     };
 
     // Only the classes the gate rested on may be named, read off the record the
-    // verdict publishes rather than recomputed. Listing every absent class would
-    // tell a reader their import edges were the problem on a store where imports
-    // never mattered: Kin's linker mints no entity-level `Imports` relation on
-    // any language, so that class reads absent on healthy graphs too.
-    let missing: Vec<&'static str> = decided_by(tool, payload, envelope)
+    // verdict publishes rather than recomputed, so this renderer cannot name a
+    // class the decision did not use. Every requested class decides now
+    // (FIR-2672), and a class the build could not produce reads `unproduced`
+    // rather than `absent`, so the sentence below can say which it was.
+    let decided = decided_by(tool, payload, envelope);
+    let unproduced: Vec<&'static str> = decided
         .iter()
-        .filter(|class| state_of(class) == Some("absent"))
+        .filter(|class| state_of(class) == Some("unproduced"))
+        .map(|class| edge_class_noun(class))
+        .collect();
+    let missing: Vec<&'static str> = decided
+        .iter()
+        .filter(|class| matches!(state_of(class), Some("absent") | Some("unknown")))
         .map(|class| edge_class_noun(class))
         .collect();
     let present: Vec<&'static str> = ["calls", "imports", "references"]
@@ -99,7 +105,7 @@ pub fn qualify(
     // is whatever the verdict actually disclosed. This is also the whole of the
     // language-scoped path: `semantic_search` reads no edge class, so its
     // qualifier always renders from the disclosed signals.
-    if missing.is_empty() {
+    if missing.is_empty() && unproduced.is_empty() {
         let subject = absence_subject(tool);
         let disclosed = negative
             .get("degraded_signals")
@@ -140,18 +146,33 @@ pub fn qualify(
         }];
     }
 
-    let mut said = vec![format!(
-        "{indent}Kin cannot rule out {}: this graph holds no cross-file {} edges for {language}, \
-         {}.",
-        absence_subject(tool),
-        missing.join(" or "),
-        absence_direction(tool)
-    )];
+    let mut said = Vec::new();
+    if !unproduced.is_empty() {
+        said.push(format!(
+            "{indent}Kin cannot rule out {}: this build produced no entity-level {} edge for \
+             {language} although the source carries {} sites, {}. The gap is in the linker, \
+             not in the code.",
+            absence_subject(tool),
+            unproduced.join(" or "),
+            unproduced.join(" or "),
+            absence_direction(tool)
+        ));
+    }
+    if !missing.is_empty() {
+        said.push(format!(
+            "{indent}Kin cannot rule out {}: this graph holds no cross-file {} edges for \
+             {language}, {}.",
+            absence_subject(tool),
+            missing.join(" or "),
+            absence_direction(tool)
+        ));
+    }
     if !present.is_empty() {
+        let short: Vec<&str> = unproduced.iter().chain(missing.iter()).copied().collect();
         said.push(format!(
             "{indent}Cross-file {} edges exist but do not stand in for {} edges.",
             present.join(" and "),
-            missing.join(" or ")
+            short.join(" or ")
         ));
     }
     said

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -861,7 +861,7 @@ mod tests {
         let callee = entity("callee", "src/b.rs");
         graph.upsert_entity(&caller).unwrap();
         graph.upsert_entity(&callee).unwrap();
-        calls(&graph, &caller, &callee);
+        healthy_cross_file_coverage(&graph, &caller, &callee);
         let dir = tempfile::tempdir().unwrap();
         let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
 
@@ -1233,10 +1233,31 @@ mod tests {
     }
 
     fn calls(graph: &kin_db::InMemoryGraph, src: &Entity, dst: &Entity) {
+        links(graph, src, dst, RelationKind::Calls);
+    }
+
+    /// Every reference class the verdict reads, across one file boundary.
+    ///
+    /// A fixture whose coverage is meant to be healthy has to hold all three
+    /// since FIR-2672, because every requested class decides; one that links
+    /// its calls alone is honestly short of imports and references, and the
+    /// verdict says so.
+    fn healthy_cross_file_coverage(graph: &kin_db::InMemoryGraph, src: &Entity, dst: &Entity) {
+        for kind in [
+            RelationKind::Calls,
+            RelationKind::Imports,
+            RelationKind::References,
+        ] {
+            links(graph, src, dst, kind);
+        }
+    }
+
+    fn links(graph: &kin_db::InMemoryGraph, src: &Entity, dst: &Entity, kind: RelationKind) {
+        let label = format!("{kind:?}").to_ascii_lowercase();
         graph
             .upsert_relation(&Relation {
-                id: RelationId::from_content(&src.id.to_string(), &dst.id.to_string(), "calls"),
-                kind: RelationKind::Calls,
+                id: RelationId::from_content(&src.id.to_string(), &dst.id.to_string(), &label),
+                kind,
                 src: GraphNodeId::Entity(src.id),
                 dst: GraphNodeId::Entity(dst.id),
                 confidence: 1.0,
@@ -2203,7 +2224,7 @@ mod tests {
         }
         // Healthy cross-file coverage, so the only thing separating the two arms
         // below is the daemon's own health.
-        calls(&graph, &caller, &callee);
+        healthy_cross_file_coverage(&graph, &caller, &callee);
 
         let dir = tempfile::tempdir().unwrap();
         let layout = kin_core::KinLayout::new(dir.path().join(".kin"));

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -1232,6 +1232,59 @@ mod tests {
         assert!(response.lines[0].contains("'resolve_binary'"));
     }
 
+    /// FIR-2672, second finding, at the surface a person reads. Coverage short
+    /// on purpose (calls only) beside a failed embedding worker: the class gap
+    /// decides the state and the worker's death stays in the rendering, after
+    /// it. Drop either sentence from the qualifier and this goes red.
+    #[tokio::test]
+    async fn a_short_graph_on_a_degraded_daemon_renders_both_reasons() {
+        let graph = kin_db::InMemoryGraph::new();
+        let target = entity("orphan", "src/orphan.rs");
+        let caller = entity("caller", "src/a.rs");
+        let callee = entity("callee", "src/b.rs");
+        for e in [&target, &caller, &callee] {
+            graph.upsert_entity(e).unwrap();
+        }
+        calls(&graph, &caller, &callee);
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let degraded = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 3,
+            "graph_generation": 1,
+            "embed_worker_failed": true,
+        }));
+
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "orphan".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+            &degraded,
+        )
+        .await
+        .expect("impact response");
+        let rendered = response.lines.join("\n");
+
+        let class_gap = rendered
+            .find("holds no cross-file import or reference edges")
+            .unwrap_or_else(|| panic!("the short classes decide and must be named: {rendered}"));
+        let worker = rendered.find("embed_worker_failed").unwrap_or_else(|| {
+            panic!("the failed worker must stay named beside the class gap: {rendered}")
+        });
+        assert!(
+            class_gap < worker,
+            "the structural gap leads and the run degradation follows: {rendered}"
+        );
+    }
+
     fn calls(graph: &kin_db::InMemoryGraph, src: &Entity, dst: &Entity) {
         links(graph, src, dst, RelationKind::Calls);
     }

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -2109,10 +2109,35 @@ mod tests {
         assert!(response.truncated, "truncated flag must be set when capped");
     }
 
+    /// Two entities in different files joined by every reference class the
+    /// verdict reads, off to the side of whatever chain a fixture walks.
+    ///
+    /// This is what makes a fixture "a graph that links this language across
+    /// files": since FIR-2672 every requested class decides, so a graph that
+    /// links only its calls reads a chain end as a coverage gap rather than a
+    /// leaf, and honestly so. The witness pair is reached by no walk, so it
+    /// changes no chain, only what the graph is known to be able to hold.
+    fn seed_cross_file_witness(graph: &InMemoryGraph, extension: &str) {
+        let caller = make_entity("witness_caller", &format!("src/witness_caller.{extension}"));
+        let callee = make_entity("witness_callee", &format!("src/witness_callee.{extension}"));
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_entity(&callee).unwrap();
+        for kind in [
+            RelationKind::Calls,
+            RelationKind::Imports,
+            RelationKind::References,
+        ] {
+            graph
+                .upsert_relation(&make_relation(caller.id, callee.id, kind))
+                .unwrap();
+        }
+    }
+
     /// A hub whose fan-out is far wider than any per-step limit, so a walk over
     /// it examines many more relations than it can ever turn into steps.
     fn hub_graph(fan_out: usize) -> (InMemoryGraph, EntityId) {
         let graph = InMemoryGraph::new();
+        seed_cross_file_witness(&graph, "rs");
         let focal = make_entity("hub", "src/hub.rs");
         let focal_id = focal.id;
         graph.upsert_entity(&focal).unwrap();
@@ -3509,10 +3534,16 @@ mod tests {
     }
 
     /// Three entities in the given files, each calling the next, and the id of
-    /// the first. The files decide whether the graph holds cross-file call
-    /// edges, which is the fact a leaf terminal rests on.
+    /// the first. A chain that crosses files is a linked graph and carries the
+    /// witness pair that proves every class links across files, which is the
+    /// fact a leaf terminal rests on; a chain inside one file, or a lone
+    /// entity, is a graph that never linked anything.
     fn call_chain(nodes: &[(&str, &str)]) -> (InMemoryGraph, EntityId) {
         let graph = InMemoryGraph::new();
+        let distinct_files: BTreeSet<&str> = nodes.iter().map(|(_, file)| *file).collect();
+        if distinct_files.len() >= 2 {
+            seed_cross_file_witness(&graph, "py");
+        }
         let entities: Vec<Entity> = nodes
             .iter()
             .map(|(name, file)| make_entity(name, file))

--- a/crates/kin-cli/tests/declaration_resolution_e2e.rs
+++ b/crates/kin-cli/tests/declaration_resolution_e2e.rs
@@ -17,6 +17,7 @@
 //! tests pin the honest answer instead, and pin that a genuinely unreferenced
 //! entity still gets the plain empty one.
 
+use kin_cli::commands::absence_qualifier::{without_qualifiers, QUALIFIER_MARK};
 use kin_cli::commands::impact::{build_impact_response, ImpactRequest};
 use kin_cli::commands::refs::{build_refs_response, RefsRequest};
 use kin_db::InMemoryGraph;
@@ -341,7 +342,10 @@ fn refs_on_a_declaration_names_the_other_identities_sharing_the_name() {
 /// parse into a graph holding cross-file `Calls` and nothing else, so
 /// `imports` and `references` read absent, and a verdict that certified this
 /// absence would be certifying on coverage the graph does not have. The
-/// qualifier is therefore CORRECT here and is asserted rather than tolerated:
+/// qualifier is therefore CORRECT here and is asserted rather than tolerated,
+/// and it is cut as a block by the marker every qualifying line carries rather
+/// than by matching one phrase, since the block can hold more than one line
+/// once more than one input refuses (FIR-2672):
 /// the guard this test carries is about `empty_result_context`, the members and
 /// same-name note, which must stay conditional. A coverage-complete store with a
 /// genuinely dead focal is the other half of the control and lives in
@@ -354,17 +358,14 @@ fn genuinely_unreferenced_entity_still_gets_the_plain_empty_answer() {
         joined.contains("No incoming"),
         "must report the empty result: {joined}"
     );
-    let content: Vec<&str> = joined
-        .lines()
-        .filter(|line| !line.contains("Kin cannot rule out"))
-        .collect();
+    let content = without_qualifiers(&joined);
     assert_eq!(
         content.len(),
         2,
         "an entity with nothing further to report gets exactly the header and the empty line: {joined}"
     );
     assert!(
-        joined.contains("Kin cannot rule out references it did not see"),
+        joined.contains(&format!("{QUALIFIER_MARK} references it did not see")),
         "this fixture holds no cross-file imports or references edges, so the absence may not \
          be certified and the answer has to say so: {joined}"
     );

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -12937,15 +12937,17 @@ mod tests {
         // than asserting on the JSON we just wrote.
         // Coverage healthy, so the degraded flag is the ONLY variable. Without
         // this the gate refuses both arms for `edge_coverage_unreported`, which
-        // is the gate working correctly and a test proving nothing.
+        // is the gate working correctly and a test proving nothing. Healthy
+        // means every requested class present: each one decides (FIR-2672), so
+        // an absent import class refused the control arm on its own.
         let payload = serde_json::json!({
             "entity_impacts": [],
             kin_mcp::EDGE_COVERAGE_KEY: {
                 "scope": "language",
                 "language": "Rust",
                 "requested_classes": ["calls", "imports", "references"],
-                "classes": { "calls": "present", "imports": "absent", "references": "present" },
-                "cross_file_classes": ["calls", "references"],
+                "classes": { "calls": "present", "imports": "present", "references": "present" },
+                "cross_file_classes": ["calls", "imports", "references"],
                 "reference_enrichment": "available",
                 "budget_exhausted": false,
                 "entities_examined": 3,
@@ -16924,6 +16926,93 @@ mod tests {
         );
     }
 
+    /// One parsed relation of `kind` from `src` to `dst`.
+    fn link(state: &Arc<DaemonState>, src: &Entity, dst: &Entity, kind: kin_model::RelationKind) {
+        state
+            .graph
+            .upsert_relation(&kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind,
+                src: kin_model::GraphNodeId::Entity(src.id),
+                dst: kin_model::GraphNodeId::Entity(dst.id),
+                confidence: 1.0,
+                origin: kin_model::RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+    }
+
+    /// Link `src` to `dst` by every cross-file class the verdict weighs, which
+    /// is what a fixture that calls its coverage healthy has to hold. Every
+    /// requested class decides (FIR-2672), so calls alone leave the import and
+    /// reference classes short, the refusal over-determined, and a test that
+    /// meant to isolate a degradation passing for the wrong cause.
+    fn link_every_class(state: &Arc<DaemonState>, src: &Entity, dst: &Entity) {
+        for kind in [
+            kin_model::RelationKind::Calls,
+            kin_model::RelationKind::Imports,
+            kin_model::RelationKind::References,
+        ] {
+            link(state, src, dst, kind);
+        }
+    }
+
+    /// FIR-2672, second finding: two independent reasons, both named. The graph
+    /// links only its calls, so the import and reference classes are short and
+    /// decide the state, and the embedding worker has died as well. The line
+    /// that named only the winner sent a reader to fix the edge gap and never
+    /// told them about the worker, a second thing wrong with the same answer.
+    /// Drop either sentence from the rendering and this goes red.
+    #[tokio::test]
+    async fn a_degraded_daemon_with_short_coverage_renders_both_reasons() {
+        let state = test_state();
+        let caller = test_entity("caller", "src/a.py");
+        let callee = test_entity("callee", "src/b.py");
+        let orphan = test_entity("orphan", "src/orphan.py");
+        for entity in [&caller, &callee, &orphan] {
+            state.graph.upsert_entity(entity).unwrap();
+        }
+        link(&state, &caller, &callee, kin_model::RelationKind::Calls);
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state
+            .embed_worker_failed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/impact")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "entity": "orphan", "depth": 3 }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let result: kin_cli::commands::impact::ImpactResponse =
+            serde_json::from_slice(&body).unwrap();
+        let rendered = result.lines.join("\n");
+
+        let class_gap = rendered
+            .find("holds no cross-file import or reference edges")
+            .unwrap_or_else(|| panic!("the short classes decide and must be named: {rendered}"));
+        let worker = rendered.find("embed_worker_failed").unwrap_or_else(|| {
+            panic!("the failed worker must stay named beside the class gap: {rendered}")
+        });
+        assert!(
+            class_gap < worker,
+            "the structural gap leads and the run degradation follows: {rendered}"
+        );
+    }
+
     fn test_entity(name: &str, path: &str) -> Entity {
         Entity {
             id: EntityId::new(),
@@ -16959,29 +17048,20 @@ mod tests {
         }
     }
 
-    /// Two entities in different files joined by a `Calls` edge: the evidence
-    /// that this graph links references across files for the language, which is
-    /// what an absence claim over reference edges depends on. Without it an empty
-    /// reference answer is a fact about the graph rather than about the target.
+    /// Two entities in different files joined by every reference class: the
+    /// evidence that this graph links references across files for the language,
+    /// which is what an absence claim over reference edges depends on. Without it
+    /// an empty reference answer is a fact about the graph rather than about the
+    /// target. It used to link calls alone, which was the whole witness while
+    /// calls alone decided; every requested class decides now (FIR-2672), so a
+    /// calls-only witness leaves the import and reference classes short and the
+    /// absence refused for a reason the test never meant to exercise.
     fn seed_cross_file_call_witness(state: &Arc<DaemonState>) {
         let caller = test_entity("witness_caller", "src/witness_caller.py");
         let callee = test_entity("witness_callee", "src/witness_callee.py");
         state.graph.upsert_entity(&caller).unwrap();
         state.graph.upsert_entity(&callee).unwrap();
-        state
-            .graph
-            .upsert_relation(&kin_model::relation::Relation {
-                id: kin_model::ids::RelationId::new(),
-                kind: kin_model::relation::RelationKind::Calls,
-                src: kin_model::relation::GraphNodeId::Entity(caller.id),
-                dst: kin_model::relation::GraphNodeId::Entity(callee.id),
-                confidence: 1.0,
-                origin: kin_model::relation::RelationOrigin::Parsed,
-                created_in: None,
-                import_source: None,
-                evidence: Vec::new(),
-            })
-            .unwrap();
+        link_every_class(state, &caller, &callee);
     }
 
     fn install_repository_file(
@@ -26171,20 +26251,7 @@ mod tests {
             install_trace_fixture_file(&state, entity);
             state.graph.upsert_entity(entity).unwrap();
         }
-        state
-            .graph
-            .upsert_relation(&kin_model::Relation {
-                id: kin_model::RelationId::new(),
-                kind: kin_model::RelationKind::Calls,
-                src: kin_model::GraphNodeId::Entity(caller.id),
-                dst: kin_model::GraphNodeId::Entity(callee.id),
-                confidence: 1.0,
-                origin: kin_model::RelationOrigin::Parsed,
-                created_in: None,
-                import_source: None,
-                evidence: Vec::new(),
-            })
-            .unwrap();
+        link_every_class(&state, &caller, &callee);
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
@@ -26234,20 +26301,7 @@ mod tests {
             install_trace_fixture_file(&state, entity);
             state.graph.upsert_entity(entity).unwrap();
         }
-        state
-            .graph
-            .upsert_relation(&kin_model::Relation {
-                id: kin_model::RelationId::new(),
-                kind: kin_model::RelationKind::Calls,
-                src: kin_model::GraphNodeId::Entity(caller.id),
-                dst: kin_model::GraphNodeId::Entity(callee.id),
-                confidence: 1.0,
-                origin: kin_model::RelationOrigin::Parsed,
-                created_in: None,
-                import_source: None,
-                evidence: Vec::new(),
-            })
-            .unwrap();
+        link_every_class(&state, &caller, &callee);
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
@@ -26361,20 +26415,7 @@ mod tests {
         for entity in [&caller, &callee, &orphan] {
             state.graph.upsert_entity(entity).unwrap();
         }
-        state
-            .graph
-            .upsert_relation(&kin_model::Relation {
-                id: kin_model::RelationId::new(),
-                kind: kin_model::RelationKind::Calls,
-                src: kin_model::GraphNodeId::Entity(caller.id),
-                dst: kin_model::GraphNodeId::Entity(callee.id),
-                confidence: 1.0,
-                origin: kin_model::RelationOrigin::Parsed,
-                created_in: None,
-                import_source: None,
-                evidence: Vec::new(),
-            })
-            .unwrap();
+        link_every_class(&state, &caller, &callee);
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
@@ -31874,6 +31915,18 @@ mod tests {
         const BUDGET: usize = 6_000;
         let state = test_state();
         let ids = install_trace_chain(&state, 6);
+        // The chain links only its calls. Every requested class decides
+        // (FIR-2672), so a graph holding no import or reference edge carries the
+        // class-gap disclosure in the verdict, both notes and the absence object,
+        // and spends the budget under test on it: measured, the ladder then cut
+        // an edge where it used to cut only bodies. The witness pair, off to the
+        // side of the chain, keeps this a test of the ladder rather than of the
+        // disclosure.
+        let witness_a = test_entity("witness_a", "src/witness_a.py");
+        let witness_b = test_entity("witness_b", "src/witness_b.py");
+        state.graph.upsert_entity(&witness_a).unwrap();
+        state.graph.upsert_entity(&witness_b).unwrap();
+        link_every_class(&state, &witness_a, &witness_b);
         let app = router(Arc::clone(&state));
 
         let unbounded = call_mcp_tool_text(

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -38,8 +38,14 @@
 //! `classes` is the load-bearing field: `present` means a cross-file edge of
 //! that class was observed for the focal's language, `absent` means the scan
 //! completed and found none, `unknown` means the scan stopped on its budget
-//! before it could say. A consumer that cannot find this object must treat
-//! coverage as unknown rather than assuming either verdict.
+//! before it could say, and `unproduced` means the scan completed, observed no
+//! entity-rooted edge of that class at all, and the language's own parse side
+//! shows sites of the class the linker resolved into no entity-level edge, so
+//! the gap is in the build rather than in the code. Every state but `present`
+//! makes the response's one verdict inconclusive (FIR-2672): a class the answer
+//! could not have read is a class its counts cannot be whole over, whatever the
+//! reason. A consumer that cannot find this object must treat coverage as
+//! unknown rather than assuming either verdict.
 //!
 //! `reference_enrichment` carries the one fact the scan cannot observe from the
 //! graph: whether this BUILD can produce reference edges for the language at
@@ -103,6 +109,18 @@ enum ClassState {
     Absent,
     /// The scan stopped on its budget before it could observe one.
     Unknown,
+    /// The scan completed, observed no entity-rooted edge of this class at all,
+    /// and the language's parse side shows sites of the class that the linker
+    /// resolved into no entity-level edge.
+    ///
+    /// Not `Absent`, because `Absent` reads as a completed observation about the
+    /// code, and this is a completed observation about the build: the sites are
+    /// in the source, the linker saw them (an import it resolved at the artifact
+    /// level, a call site it counted), and no entity-level edge came out. The
+    /// rc0552s stranger's account of FIR-2672 rests on Kin having called that
+    /// `absent` for import sites no build had ever emitted an edge for. Not
+    /// `Unknown` either, because nothing was left unread; the scan finished.
+    Unproduced,
 }
 
 impl ClassState {
@@ -111,6 +129,7 @@ impl ClassState {
             ClassState::Present => "present",
             ClassState::Absent => "absent",
             ClassState::Unknown => "unknown",
+            ClassState::Unproduced => "unproduced",
         }
     }
 }
@@ -260,19 +279,21 @@ pub fn observe_cross_file_reference_coverage_for_languages_witnessed<S: EntitySt
     // `absent`, and certified on a class nothing had measured. A gate that only
     // fires when a scan happened to run is not a gate.
     let scan_needed = !deciding_classes_all_present(&merged, references_producible);
+    let mut unproduced_evidence = Map::new();
     if scan_needed {
+        let mut scans: Vec<LanguageScan> = Vec::new();
         for (index, language) in observed_languages.iter().enumerate() {
-            let (states, examined, budget_exhausted) =
-                observe_language(store, *language, &requested);
-            examined_total += examined;
-            any_budget_exhausted |= budget_exhausted;
-            for (slot, (_, state)) in merged.iter_mut().zip(states.iter()) {
+            let scan = observe_language(store, *language, &requested);
+            examined_total += scan.examined;
+            any_budget_exhausted |= scan.budget_exhausted;
+            for (slot, (_, state)) in merged.iter_mut().zip(scan.states.iter()) {
                 slot.1 = if index == 0 {
                     *state
                 } else {
                     weakest(slot.1, *state)
                 };
             }
+            scans.push(scan);
         }
         // A witness raises `unknown` to `present` and stops there. A scan that
         // ran to completion and observed a class absent is a stronger statement
@@ -282,6 +303,20 @@ pub fn observe_cross_file_reference_coverage_for_languages_witnessed<S: EntitySt
         for (kind, state) in merged.iter_mut() {
             if *state == ClassState::Unknown && witnessed.contains(kind) {
                 *state = ClassState::Present;
+            }
+        }
+        // A class every scan completed empty on, with no entity-rooted edge of
+        // it seen anywhere, is `unproduced` rather than `absent` when the parse
+        // side shows the linker had sites of that class to resolve. The two must
+        // not share a word: `absent` is a statement about the code and this is
+        // a statement about the build (FIR-2672).
+        for (kind, state) in merged.iter_mut() {
+            if *state != ClassState::Absent {
+                continue;
+            }
+            if let Some(evidence) = unproduced_evidence_for(*kind, &scans) {
+                *state = ClassState::Unproduced;
+                unproduced_evidence.insert(class_name(*kind).to_string(), evidence);
             }
         }
     }
@@ -333,7 +368,80 @@ pub fn observe_cross_file_reference_coverage_for_languages_witnessed<S: EntitySt
         } else {
             "skipped_answer_witnessed"
         },
+        // Why a class reads `unproduced`: the parse-side and artifact-level
+        // counts that separate a build gap from an unused feature of the code.
+        // Absent when no class was raised, so a reader never sees evidence for a
+        // verdict that was not reached.
+        "unproduced_evidence": if unproduced_evidence.is_empty() {
+            Value::Null
+        } else {
+            Value::Object(unproduced_evidence)
+        },
     })
+}
+
+/// The evidence that raises one class every language's scan completed empty on
+/// from `absent` to `unproduced`, or `None` when the code simply carries no such
+/// sites.
+///
+/// `imports`: no entity-rooted `Imports` relation was seen in any scan, and the
+/// linker demonstrably had import statements to resolve, either because it
+/// resolved some at the artifact level (the only level the linker emitted at
+/// before the entity-level emitter existed) or because the parse side counted
+/// statements naming modules inside this repository. A language whose specifier
+/// syntax cannot settle externality counts only the first, so a repository that
+/// imports nothing but its standard library is not called a build gap.
+///
+/// `calls`: no entity-rooted `Calls` relation was seen in any scan, and every
+/// file of the language recorded a call-site count whose sum is above zero. A
+/// partial measurement is not evidence, for the reason
+/// [`kin_core::reference_coverage::CallSiteMeasurement`] spells out.
+///
+/// `references` is never raised here: whether this build can produce that class
+/// is a fact about the language server, and `reference_enrichment` already
+/// carries it.
+fn unproduced_evidence_for(kind: RelationKind, scans: &[LanguageScan]) -> Option<Value> {
+    if scans.is_empty()
+        || scans
+            .iter()
+            .any(|scan| scan.budget_exhausted || scan.seen_any(kind))
+    {
+        return None;
+    }
+    match kind {
+        RelationKind::Imports => {
+            let artifact_edges: u64 = scans.iter().map(|scan| scan.artifact_import_edges).sum();
+            let parsed: u64 = scans
+                .iter()
+                .filter_map(|scan| scan.parsed_import_statements)
+                .sum();
+            let internal: u64 = scans
+                .iter()
+                .filter_map(|scan| scan.parsed_internal_import_statements())
+                .sum();
+            if artifact_edges == 0 && internal == 0 {
+                return None;
+            }
+            Some(json!({
+                "parsed_import_statements": parsed,
+                "parsed_internal_import_statements": internal,
+                "artifact_level_import_edges": artifact_edges,
+                "entity_level_import_edges": 0,
+            }))
+        }
+        RelationKind::Calls => {
+            let complete = scans.iter().all(|scan| scan.call_sites_complete);
+            let parsed: u64 = scans.iter().filter_map(|scan| scan.parsed_call_sites).sum();
+            if !complete || parsed == 0 {
+                return None;
+            }
+            Some(json!({
+                "parsed_call_sites": parsed,
+                "entity_level_call_edges": 0,
+            }))
+        }
+        _ => None,
+    }
 }
 
 /// Observe the language scope an absence claim covers, for a tool that
@@ -435,10 +543,13 @@ pub fn languages_of(entities: &[Entity]) -> Vec<LanguageId> {
 
 /// Whether every class the absence verdict rests on is already `present`.
 ///
-/// Narrowed by [`crate::negative::load_bearing_classes`] rather than by a rule
-/// of its own: Kin mints no entity-level `Imports` edge, so a rule that waited
-/// for every requested class would never skip a scan and would report every
-/// answer on every healthy graph as short of coverage.
+/// Every requested class, through [`crate::negative::deciding_classes`]. This
+/// used to be narrowed to `calls` on the grounds that Kin minted no entity-level
+/// `Imports` edge and a rule waiting for every class would never skip a scan.
+/// That narrowing is what let the verdict certify over `imports: absent`
+/// (FIR-2672); a scan that runs whenever a requested class is unwitnessed is
+/// the price of a verdict that means what it says, and it is bounded by
+/// [`WITNESS_BUDGET`].
 /// [`deciding_classes_all_present`], asked of a PUBLISHED observation.
 ///
 /// The private form above reads the scan's own working state and decides
@@ -520,9 +631,12 @@ fn deciding_classes_all_present(
 /// and a language-scoped list does not carry targets in other languages, which
 /// would report a cross-language edge as external.
 ///
-/// Attached only when a deciding class is short, so a healthy answer pays
+/// Attached only when `calls` or `references` is short, so a healthy answer pays
 /// nothing for a ratio it does not need, and a shortfall gets the number that
-/// says how big it is.
+/// says how big it is. An `imports` shortfall alone does not trigger the whole
+/// language walk this costs: the scan already published the import counts that
+/// decided it under `unproduced_evidence`, and until the entity-level import
+/// emitter lands that shortfall is every populated answer on every language.
 fn attach_reference_resolution<S: EntityStore>(
     store: &S,
     language: LanguageId,
@@ -532,12 +646,10 @@ fn attach_reference_resolution<S: EntityStore>(
         .get("classes")
         .and_then(Value::as_object)
         .map(|classes| {
-            let requested: Vec<String> = classes.keys().cloned().collect();
-            let deciding = crate::negative::load_bearing_classes(&requested);
-            !deciding.is_empty()
-                && deciding.iter().all(|class| {
-                    classes.get(class).and_then(Value::as_str) == Some(ClassState::Present.as_str())
-                })
+            classes
+                .iter()
+                .filter(|(class, _)| class.as_str() != "imports")
+                .all(|(_, state)| state.as_str() == Some(ClassState::Present.as_str()))
         })
         .unwrap_or(false);
     if already_covered {
@@ -808,23 +920,69 @@ fn requested_classes(kinds: &[RelationKind]) -> Vec<RelationKind> {
 }
 
 /// The less-authoritative of two observations. `present` only survives when both
-/// agree, and `absent` outranks `unknown` because a completed scan that found
-/// nothing is a stronger statement than one that never finished.
+/// agree; `unproduced` outranks `absent`, which outranks `unknown`, because each
+/// is a stronger statement than the next: a completed scan with parse-side
+/// evidence of sites, then a completed scan that found nothing, then a scan that
+/// never finished.
 fn weakest(left: ClassState, right: ClassState) -> ClassState {
     match (left, right) {
+        (ClassState::Unproduced, _) | (_, ClassState::Unproduced) => ClassState::Unproduced,
         (ClassState::Absent, _) | (_, ClassState::Absent) => ClassState::Absent,
         (ClassState::Unknown, _) | (_, ClassState::Unknown) => ClassState::Unknown,
         _ => ClassState::Present,
     }
 }
 
+/// What one language's witness search established, beyond the class states:
+/// the evidence [`unproduced_evidence_for`] reads to tell a build gap from an
+/// unused feature of the code.
+struct LanguageScan {
+    states: Vec<(RelationKind, ClassState)>,
+    examined: usize,
+    budget_exhausted: bool,
+    /// Classes an entity-rooted relation was seen for at all, cross-file or not.
+    /// A class seen intra-file only is producible and merely unused across
+    /// files, which is `absent` and not a build gap.
+    seen_any: Vec<RelationKind>,
+    /// Import statements the parser counted across the language's files, or
+    /// `None` when no file carries the count.
+    parsed_import_statements: Option<u64>,
+    /// Of those, how many name a module outside the repository, when the
+    /// language's specifier syntax settles it.
+    external_module_imports: Option<u64>,
+    /// Call sites the parser counted, or `None` when no file carries the count.
+    parsed_call_sites: Option<u64>,
+    /// Whether every file with entities carried a call-site count, so the sum
+    /// above is a measurement rather than a partial one.
+    call_sites_complete: bool,
+    /// `Imports` and `Includes` edges rooted at the language's files' artifacts,
+    /// counted only when the scan saw no entity-rooted import edge, because that
+    /// is the one case the count decides anything.
+    artifact_import_edges: u64,
+}
+
+impl LanguageScan {
+    fn seen_any(&self, kind: RelationKind) -> bool {
+        self.seen_any.contains(&kind)
+    }
+
+    /// Parsed import statements that name a module this repository could hold,
+    /// or `None` when the language cannot settle which ones those are.
+    fn parsed_internal_import_statements(&self) -> Option<u64> {
+        let parsed = self.parsed_import_statements?;
+        let external = self.external_module_imports?;
+        Some(parsed.saturating_sub(external))
+    }
+}
+
 /// Witness-search one language, returning each requested class's state, how many
-/// entities were examined, and whether the search stopped on its budget.
+/// entities were examined, whether the search stopped on its budget, and the
+/// parse-side and artifact-level facts a completed empty scan is read against.
 fn observe_language<S: EntityStore>(
     store: &S,
     language: kin_model::ids::LanguageId,
     requested: &[RelationKind],
-) -> (Vec<(RelationKind, ClassState)>, usize, bool) {
+) -> LanguageScan {
     let mut states: Vec<(RelationKind, ClassState)> = requested
         .iter()
         .copied()
@@ -833,6 +991,13 @@ fn observe_language<S: EntityStore>(
 
     let mut examined = 0usize;
     let mut budget_exhausted = false;
+    let mut seen_any: Vec<RelationKind> = Vec::new();
+    let mut parsed_import_statements: Option<u64> = None;
+    let mut external_module_imports: Option<u64> = None;
+    let mut parsed_call_sites: Option<u64> = None;
+    let mut files_with_entities = 0usize;
+    let mut files_with_call_counts = 0usize;
+    let mut artifact_import_edges = 0u64;
 
     if !states.is_empty() {
         match store.query_entities(&EntityFilter {
@@ -844,6 +1009,37 @@ fn observe_language<S: EntityStore>(
                     .iter()
                     .map(|entity| (entity.id, entity.file_origin.clone()))
                     .collect();
+                // The parse side, one entity per file: the extractor stamps the
+                // same per-file counts on every entity of the file.
+                let mut counted_files: std::collections::HashSet<&FilePathId> =
+                    std::collections::HashSet::new();
+                for entity in &candidates {
+                    let Some(file) = entity.file_origin.as_ref() else {
+                        continue;
+                    };
+                    if !counted_files.insert(file) {
+                        continue;
+                    }
+                    files_with_entities += 1;
+                    if let Some(count) =
+                        parsed_count(entity, kin_parser::FILE_PARSED_CALL_SITES_KEY)
+                    {
+                        parsed_call_sites = Some(parsed_call_sites.unwrap_or(0) + count);
+                        files_with_call_counts += 1;
+                    }
+                    if let Some(count) =
+                        parsed_count(entity, kin_parser::FILE_PARSED_IMPORT_STATEMENTS_KEY)
+                    {
+                        parsed_import_statements =
+                            Some(parsed_import_statements.unwrap_or(0) + count);
+                    }
+                    if let Some(count) =
+                        parsed_count(entity, kin_parser::FILE_PARSED_EXTERNAL_MODULE_IMPORTS_KEY)
+                    {
+                        external_module_imports =
+                            Some(external_module_imports.unwrap_or(0) + count);
+                    }
+                }
                 for entity in &candidates {
                     if states
                         .iter()
@@ -876,6 +1072,9 @@ fn observe_language<S: EntityStore>(
                         let Some(destination) = relation.dst.as_entity() else {
                             continue;
                         };
+                        if !seen_any.contains(&relation.kind) {
+                            seen_any.push(relation.kind);
+                        }
                         let source_file = endpoint_file(store, &files, &source);
                         let destination_file = endpoint_file(store, &files, &destination);
                         if let (Some(source_file), Some(destination_file)) =
@@ -894,6 +1093,21 @@ fn observe_language<S: EntityStore>(
                         }
                     }
                 }
+                // Artifact-level import edges, counted only when the scan
+                // finished without seeing an entity-rooted import, which is the
+                // one case the count decides anything: the linker resolved
+                // these files' imports and emitted no entity-level edge for
+                // them.
+                let imports_requested = states
+                    .iter()
+                    .any(|(kind, _)| *kind == RelationKind::Imports);
+                if imports_requested
+                    && !budget_exhausted
+                    && !seen_any.contains(&RelationKind::Imports)
+                {
+                    artifact_import_edges =
+                        artifact_import_edge_count(store, counted_files.into_iter());
+                }
             }
             // The store could not enumerate the language at all, so every class
             // stays unknown rather than being reported absent from a scan that
@@ -902,7 +1116,56 @@ fn observe_language<S: EntityStore>(
         }
     }
 
-    (states, examined, budget_exhausted)
+    LanguageScan {
+        states,
+        examined,
+        budget_exhausted,
+        seen_any,
+        parsed_import_statements,
+        external_module_imports,
+        parsed_call_sites,
+        call_sites_complete: files_with_entities > 0
+            && files_with_call_counts == files_with_entities,
+        artifact_import_edges,
+    }
+}
+
+/// A per-file count the extractor stamped on the entity, when it did.
+fn parsed_count(entity: &Entity, key: &str) -> Option<u64> {
+    entity.metadata.extra.get(key).and_then(Value::as_u64)
+}
+
+/// `Imports` and `Includes` edges rooted at the artifacts of `files`, the level
+/// the linker emitted import edges at before it emitted entity-level ones.
+///
+/// One bounded traversal per file. A file the store cannot map to an artifact
+/// contributes nothing, which errs towards `absent` rather than `unproduced`.
+fn artifact_import_edge_count<'a, S: EntityStore>(
+    store: &S,
+    files: impl Iterator<Item = &'a FilePathId>,
+) -> u64 {
+    const ARTIFACT_IMPORT_KINDS: [RelationKind; 2] =
+        [RelationKind::Imports, RelationKind::Includes];
+    let mut counted: std::collections::HashSet<kin_model::RelationId> =
+        std::collections::HashSet::new();
+    for file in files {
+        let Ok(path) = kin_model::RepoPath::from_bytes(file.0.as_bytes().to_vec()) else {
+            continue;
+        };
+        let Some(artifact) = store.artifact_id_at_path(&path) else {
+            continue;
+        };
+        let node = kin_model::GraphNodeId::Artifact(artifact);
+        let Ok(neighborhood) = store.traverse(&node, &ARTIFACT_IMPORT_KINDS, 1) else {
+            continue;
+        };
+        for relation in neighborhood.relations {
+            if relation.src == node && ARTIFACT_IMPORT_KINDS.contains(&relation.kind) {
+                counted.insert(relation.id);
+            }
+        }
+    }
+    counted.len() as u64
 }
 
 /// The file an endpoint belongs to, preferring the language-scoped entities
@@ -1028,6 +1291,187 @@ mod tests {
         assert_eq!(coverage["classes"]["calls"], json!("present"));
         assert_eq!(coverage["classes"]["imports"], json!("absent"));
         assert_eq!(coverage["cross_file_classes"], json!(["calls"]));
+    }
+
+    /// Stamp the per-file counts the extractor writes, on every entity of a file.
+    fn with_parse_counts(
+        mut entity: Entity,
+        imports: u64,
+        external: Option<u64>,
+        calls: Option<u64>,
+    ) -> Entity {
+        entity.metadata.extra.insert(
+            kin_parser::FILE_PARSED_IMPORT_STATEMENTS_KEY.to_string(),
+            json!(imports),
+        );
+        if let Some(external) = external {
+            entity.metadata.extra.insert(
+                kin_parser::FILE_PARSED_EXTERNAL_MODULE_IMPORTS_KEY.to_string(),
+                json!(external),
+            );
+        }
+        if let Some(calls) = calls {
+            entity.metadata.extra.insert(
+                kin_parser::FILE_PARSED_CALL_SITES_KEY.to_string(),
+                json!(calls),
+            );
+        }
+        entity
+    }
+
+    /// FIR-2672. A class the linker had sites for and produced no entity-level
+    /// edge of is `unproduced`, not `absent`: the parse side counted import
+    /// statements naming modules inside the repository, no entity-rooted import
+    /// edge exists anywhere in the language, and the scan finished. `absent`
+    /// would say the code has no such site, which is what 0.5.52 said about
+    /// import sites no build had ever emitted an edge for.
+    #[test]
+    fn an_import_class_the_linker_produced_nothing_for_reads_unproduced() {
+        let store = InMemoryGraph::new();
+        let caller = with_parse_counts(
+            entity("index_note", "pkg/search.py", LanguageId::Python),
+            2,
+            Some(1),
+            None,
+        );
+        let target = with_parse_counts(
+            entity("blank_code", "pkg/parsing.py", LanguageId::Python),
+            1,
+            Some(1),
+            None,
+        );
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+
+        let coverage = observe_cross_file_reference_coverage(
+            &store,
+            &target,
+            &[RelationKind::Calls, RelationKind::Imports],
+        );
+        assert_eq!(coverage["classes"]["calls"], json!("present"), "{coverage}");
+        assert_eq!(
+            coverage["classes"]["imports"],
+            json!("unproduced"),
+            "{coverage}"
+        );
+        let evidence = &coverage["unproduced_evidence"]["imports"];
+        assert_eq!(evidence["parsed_import_statements"], json!(3), "{coverage}");
+        assert_eq!(
+            evidence["parsed_internal_import_statements"],
+            json!(1),
+            "{coverage}"
+        );
+        assert_eq!(
+            evidence["entity_level_import_edges"],
+            json!(0),
+            "{coverage}"
+        );
+        assert_eq!(coverage["cross_file_classes"], json!(["calls"]));
+    }
+
+    /// The same graph with nothing to resolve stays `absent`. No file carries an
+    /// import count, so the code has no import site the build could have
+    /// missed, and calling that a build gap would make every leaf module read
+    /// as one.
+    #[test]
+    fn an_import_class_with_no_sites_to_resolve_stays_absent() {
+        let store = InMemoryGraph::new();
+        let caller = entity("index_note", "pkg/search.py", LanguageId::Python);
+        let target = entity("blank_code", "pkg/parsing.py", LanguageId::Python);
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+
+        let coverage = observe_cross_file_reference_coverage(
+            &store,
+            &target,
+            &[RelationKind::Calls, RelationKind::Imports],
+        );
+        assert_eq!(
+            coverage["classes"]["imports"],
+            json!("absent"),
+            "{coverage}"
+        );
+        assert_eq!(coverage["unproduced_evidence"], Value::Null, "{coverage}");
+    }
+
+    /// A class seen intra-file is one the build produces, so a graph that merely
+    /// uses no cross-file import stays `absent`, whatever the parse side counted.
+    #[test]
+    fn a_class_seen_intra_file_is_producible_and_stays_absent() {
+        let store = InMemoryGraph::new();
+        let caller = with_parse_counts(
+            entity("index_note", "pkg/search.py", LanguageId::Python),
+            2,
+            Some(0),
+            None,
+        );
+        let sibling = with_parse_counts(
+            entity("helper", "pkg/search.py", LanguageId::Python),
+            2,
+            Some(0),
+            None,
+        );
+        let target = entity("blank_code", "pkg/parsing.py", LanguageId::Python);
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&sibling).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&relation(caller.id, sibling.id, RelationKind::Imports))
+            .unwrap();
+        store
+            .upsert_relation(&relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+
+        let coverage = observe_cross_file_reference_coverage(
+            &store,
+            &target,
+            &[RelationKind::Calls, RelationKind::Imports],
+        );
+        assert_eq!(
+            coverage["classes"]["imports"],
+            json!("absent"),
+            "{coverage}"
+        );
+        assert_eq!(coverage["unproduced_evidence"], Value::Null, "{coverage}");
+    }
+
+    /// The call class reads the same way off a complete call-site measurement:
+    /// every file counted its sites, the sum is above zero, and no entity-rooted
+    /// call edge exists at all. A partial measurement is not evidence and stays
+    /// `absent`.
+    #[test]
+    fn a_call_class_with_counted_sites_and_no_edge_reads_unproduced_only_off_a_complete_count() {
+        for (complete, expected) in [(true, "unproduced"), (false, "absent")] {
+            let store = InMemoryGraph::new();
+            let first = with_parse_counts(
+                entity("index_note", "pkg/search.py", LanguageId::Python),
+                0,
+                None,
+                Some(3),
+            );
+            let second = with_parse_counts(
+                entity("blank_code", "pkg/parsing.py", LanguageId::Python),
+                0,
+                None,
+                if complete { Some(1) } else { None },
+            );
+            store.upsert_entity(&first).unwrap();
+            store.upsert_entity(&second).unwrap();
+
+            let coverage =
+                observe_cross_file_reference_coverage(&store, &second, &[RelationKind::Calls]);
+            assert_eq!(
+                coverage["classes"]["calls"],
+                json!(expected),
+                "complete={complete}: {coverage}"
+            );
+        }
     }
 
     /// Coverage is language-scoped: a store that links one language's calls
@@ -1237,10 +1681,11 @@ mod tests {
             );
         });
 
-        // The control that keeps this narrow, and the one that proves the host
-        // fact is what moved the decision rather than the change simply forcing
-        // a scan on everything: with no server installed the class was never
-        // producible, it is not load-bearing, and the witnessed skip stands.
+        // With no server installed the reference class was never producible
+        // and `reference_enrichment` refuses by name. The scan still runs,
+        // because since FIR-2672 every requested class decides and `imports`
+        // was not witnessed by the answer; it is bounded by `WITNESS_BUDGET`,
+        // and what it finds is published rather than guessed.
         test_support::with_language_servers(&[], || {
             let coverage = observe_cross_file_reference_coverage_witnessed(
                 &store,
@@ -1252,9 +1697,12 @@ mod tests {
                 coverage["reference_enrichment"],
                 json!("no_language_server")
             );
+            assert_eq!(coverage["scan"], "ran", "{coverage}");
+            assert_eq!(coverage["classes"]["calls"], json!("present"), "{coverage}");
             assert_eq!(
-                coverage["scan"], "skipped_answer_witnessed",
-                "an unproducible class must not cost a language-wide walk: {coverage}"
+                coverage["classes"]["imports"],
+                json!("absent"),
+                "{coverage}"
             );
         });
     }
@@ -1327,9 +1775,18 @@ mod tests {
         let callee = entity("inner", "nk/b.py", LanguageId::Python);
         store.upsert_entity(&caller).unwrap();
         store.upsert_entity(&callee).unwrap();
-        store
-            .upsert_relation(&relation(caller.id, callee.id, RelationKind::Calls))
-            .unwrap();
+        // Every requested class, across files. Since FIR-2672 every requested
+        // class decides, so a graph that links only its calls cannot certify a
+        // hop absent; this fixture links all three.
+        for kind in [
+            RelationKind::Calls,
+            RelationKind::Imports,
+            RelationKind::References,
+        ] {
+            store
+                .upsert_relation(&relation(caller.id, callee.id, kind))
+                .unwrap();
+        }
 
         let linked = observe_cross_file_reference_coverage(
             &store,
@@ -1341,14 +1798,10 @@ mod tests {
             ],
         );
         assert_eq!(linked["classes"]["calls"], json!("present"));
-        assert_eq!(
-            linked["classes"]["imports"],
-            json!("absent"),
-            "the fixture holds no import edge, and the deciding rule must not need one"
-        );
+        assert_eq!(linked["classes"]["imports"], json!("present"));
         assert!(
             deciding_classes_observed_present(&linked),
-            "cross-file calls decide a trace absence: {linked}"
+            "every requested class present decides a trace absence: {linked}"
         );
 
         let unlinked = InMemoryGraph::new();

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -771,6 +771,9 @@ impl CoverageSubstrate {
 const STATE_PRESENT: &str = "present";
 const STATE_ABSENT: &str = "absent";
 const STATE_UNKNOWN: &str = "unknown";
+/// A class the scan completed empty on while the parse side shows the linker
+/// had sites of it to resolve: a gap in the build, not the code (FIR-2672).
+const STATE_UNPRODUCED: &str = "unproduced";
 
 /// The completeness signal every retrieval response carries, empty or not
 /// (FIR-2357 item 1).
@@ -921,9 +924,12 @@ impl Completeness {
             .collect();
         let status = if deciding_states.is_empty() {
             STATE_UNKNOWN
-        } else if deciding_states.iter().any(|state| *state == STATE_ABSENT) {
+        } else if deciding_states
+            .iter()
+            .any(|state| *state == STATE_ABSENT || *state == STATE_UNPRODUCED)
+        {
             "partial"
-        } else if deciding_states.iter().any(|state| *state == STATE_UNKNOWN) {
+        } else if deciding_states.iter().any(|state| *state != STATE_PRESENT) {
             STATE_UNKNOWN
         } else {
             "complete"
@@ -2583,15 +2589,19 @@ mod tests {
                     "authority_revision": "sha256:complete",
                     "authority_roots": { "local": "local-root" },
                 },
+                // Every class but the one the case varies is present, and the
+                // host can produce reference edges. Since FIR-2672 every
+                // requested class decides, so a "fully resolved" fixture has
+                // to be one.
                 "edge_coverage": {
                     "scope": "language",
                     "language": "Python",
                     "classes": {
                         "calls": calls_state,
-                        "imports": "absent",
-                        "references": "absent",
+                        "imports": "present",
+                        "references": "present",
                     },
-                    "reference_enrichment": "unknown",
+                    "reference_enrichment": "available",
                     "budget_exhausted": false,
                 },
                 // Unambiguous on purpose, and present on purpose. The handler
@@ -2609,6 +2619,123 @@ mod tests {
             })
             .to_string(),
         )
+    }
+
+    /// The FIR-2672 shape at the envelope layer: the populated answer the
+    /// rc0552s stranger received on 0.5.52, `calls` and `references` present,
+    /// `imports` short, with a language server available and nothing else
+    /// wrong. Every field a reader acts on must follow the one verdict, and the
+    /// `disagreements` scanner is the invariant that says they do.
+    fn stranger_reference_payload(imports: &str) -> ToolCallResult {
+        ToolCallResult::text(
+            json!({
+                "total_upstream": 5,
+                "counts": {
+                    "counted": "referencing_entities",
+                    "referencing_entities": 5,
+                    "reference_sites": 5,
+                    "known_reference_sites": 5,
+                    "reference_sites_complete": true,
+                    "receiver_name_candidates": 0,
+                },
+                "references": vec![json!({"name": "extract_tags"}); 5],
+                "relation_kinds": ["calls", "imports", "references"],
+                "degradations": [],
+                "cross_repo": {
+                    "status": "available",
+                    "authority_complete": true,
+                    "authority_revision": "sha256:complete",
+                    "authority_roots": { "local": "local-root" },
+                },
+                "edge_coverage": {
+                    "scope": "language",
+                    "language": "Python",
+                    "requested_classes": ["calls", "imports", "references"],
+                    "classes": {
+                        "calls": "present",
+                        "imports": imports,
+                        "references": "present",
+                    },
+                    "reference_enrichment": "available",
+                    "budget_exhausted": false,
+                },
+                "focal_resolution": {
+                    "addressed_by": "entity_id",
+                    "same_name_candidates": 1,
+                    "matched": "exact_focal_name",
+                    "other_candidates": [],
+                },
+            })
+            .to_string(),
+        )
+    }
+
+    /// FIR-2672. A populated answer over a requested class it could not read
+    /// does not certify, every acted-on field follows, the class is named in
+    /// `limits` and in the limiting factor, and the response carries no
+    /// disagreement. With the one class present the same answer certifies.
+    #[test]
+    fn a_populated_answer_over_an_unread_class_does_not_certify_and_stays_consistent() {
+        for (state, label) in [
+            ("absent", "edge_coverage:imports_absent"),
+            ("unproduced", "edge_coverage:imports_unproduced"),
+        ] {
+            let annotated = finalize(
+                stranger_reference_payload(state),
+                ready_daemon_envelope(),
+                "find_references",
+            );
+            let value = annotated_value(&annotated);
+            let verdict = &value[ENVELOPE_KEY]["verdict"];
+            let completeness = &value[ENVELOPE_KEY]["completeness"];
+            assert_eq!(verdict["state"], "inconclusive", "{state}: {value}");
+            assert!(
+                verdict["limiting_factor"]
+                    .as_str()
+                    .is_some_and(|factor| factor.contains("imports")),
+                "{state}: the factor names the class: {verdict}"
+            );
+            assert_eq!(
+                verdict["inputs"]["edge_coverage"], "inconclusive",
+                "{state}"
+            );
+            assert_eq!(completeness["status"], "partial", "{state}: {completeness}");
+            assert_eq!(completeness["bound"], "at_least", "{state}: {completeness}");
+            assert_eq!(
+                completeness["counted"]["exact"], false,
+                "{state}: {completeness}"
+            );
+            assert_eq!(completeness["classes"]["imports"], state, "{completeness}");
+            assert!(
+                completeness["limits"]
+                    .as_array()
+                    .is_some_and(|limits| limits.iter().any(|limit| limit == label)),
+                "{state}: limits name the class: {completeness}"
+            );
+            assert!(
+                completeness["decided_by"]
+                    .as_array()
+                    .is_some_and(|decided| decided.iter().any(|class| class == "imports")),
+                "{state}: the class that refused is on the record of what decided: \
+                 {completeness}"
+            );
+            let found = crate::verdict::disagreements(&value);
+            assert!(found.is_empty(), "{state}: {found:?}");
+        }
+
+        let annotated = finalize(
+            stranger_reference_payload("present"),
+            ready_daemon_envelope(),
+            "find_references",
+        );
+        let value = annotated_value(&annotated);
+        assert_eq!(
+            value[ENVELOPE_KEY]["verdict"]["state"], "certified",
+            "{value}"
+        );
+        assert_eq!(value[ENVELOPE_KEY]["completeness"]["status"], "complete");
+        assert_eq!(value[ENVELOPE_KEY]["completeness"]["bound"], "exact");
+        assert!(crate::verdict::disagreements(&value).is_empty());
     }
 
     /// The FIR-2357 headline at the envelope layer. A NON-empty answer over a
@@ -2673,16 +2800,18 @@ mod tests {
         assert_eq!(completeness["bound"], "exact", "{completeness}");
         assert_eq!(completeness["counted"]["reported"], 5);
         assert_eq!(completeness["counted"]["exact"], true);
-        // `imports` is absent here and on every real graph, since Kin mints no
-        // entity-level import edge, so it is disclosed and does not decide.
-        // `references` is absent here too, and does not decide because this
-        // fixture's `reference_enrichment` reads `unknown`: nothing established
-        // that this host could produce the class. Where a host CAN produce it,
-        // `references` does decide (FIR-2505), which is the case the test below
-        // pins. Both directions of this contract hold only because the deciding
-        // set is computed from that fact rather than fixed.
-        assert_eq!(completeness["classes"]["imports"], "absent");
-        assert_eq!(completeness["decided_by"], json!(["calls"]));
+        // Every requested class decides and every one is present (FIR-2672).
+        // This used to pin `imports: absent` beside `decided_by: ["calls"]`,
+        // the shipped 0.5.52 shape, as the fully resolved case.
+        assert_eq!(completeness["classes"]["imports"], "present");
+        assert_eq!(
+            completeness["decided_by"],
+            json!(["calls", "imports", "references"])
+        );
+        assert!(
+            completeness["limits"].is_null() || completeness["limits"] == json!([]),
+            "nothing was short, so nothing is named as a limit: {completeness}"
+        );
     }
 
     /// FIR-2505 and FIR-2492, on the block that carried the sentence. Shipped
@@ -2726,8 +2855,8 @@ mod tests {
 
         assert_eq!(
             completeness["decided_by"],
-            json!(["calls", "references"]),
-            "a class this host could produce is one the verdict rests on: {completeness}"
+            json!(["calls", "imports", "references"]),
+            "every requested class is one the verdict rests on: {completeness}"
         );
         assert_eq!(completeness["status"], "partial", "{completeness}");
         assert_eq!(completeness["bound"], "at_least", "{completeness}");

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -7099,10 +7099,17 @@ mod tests {
             .upsert_relation(&make_relation(caller.id, target.id, RelationKind::Calls))
             .unwrap();
 
-        let args = HashMap::from([(
-            "entity_id".to_string(),
-            serde_json::json!(target.id.to_string()),
-        )]);
+        // Asked over the one class the row proves, so the answer witnesses every
+        // requested class and the scan is skipped. Asked over the default three,
+        // `imports` and `references` are unwitnessed and the scan runs, which
+        // since FIR-2672 is the honest reading of a graph holding one call edge.
+        let args = HashMap::from([
+            (
+                "entity_id".to_string(),
+                serde_json::json!(target.id.to_string()),
+            ),
+            ("relation_kinds".to_string(), serde_json::json!(["calls"])),
+        ]);
         let response = parsed_response(&crate::finalize_with_envelope(
             handle_find_references(&args, &store, None).await.unwrap(),
             structurally_ready_envelope(),
@@ -7207,7 +7214,10 @@ mod tests {
             "so the 1 is a floor rather than a fact: {completeness}"
         );
         assert_eq!(completeness["classes"]["calls"], "absent");
-        assert_eq!(completeness["decided_by"], serde_json::json!(["calls"]));
+        assert_eq!(
+            completeness["decided_by"],
+            serde_json::json!(["calls", "imports", "references"])
+        );
         assert!(
             completeness["limits"]
                 .as_array()
@@ -7303,11 +7313,14 @@ mod tests {
         assert!(response["references"].as_array().unwrap().is_empty());
         assert_eq!(
             response["edge_coverage"]["cross_file_classes"],
-            serde_json::json!(["calls"])
+            serde_json::json!(["calls", "imports", "references"]),
+            "every requested class is linked across files, which since FIR-2672 is what an \
+             earned absence needs: {}",
+            response["edge_coverage"]
         );
         assert_eq!(
             response["negative"]["safe_to_conclude_absent"], true,
-            "a graph that links calls across files still earns absence: {}",
+            "a graph that links every class across files still earns absence: {}",
             response["negative"]
         );
         assert_eq!(response["negative"]["trust"], "authoritative");
@@ -7380,6 +7393,9 @@ mod tests {
             ..RelationEvidence::default()
         }];
         store.upsert_relation(&relation).unwrap();
+        // The language links every class across files, so the verdict below is
+        // about the one proven caller and not about coverage (FIR-2672).
+        seed_cross_file_call_witness(&store);
         let registered_root = graph_root(&store);
 
         let spine = kin_spine::InMemorySpineBackend::new();
@@ -7635,12 +7651,13 @@ mod tests {
         );
 
         // FIR-2463, and the exact three-verdict shape a stranger quoted off
-        // shipped v0.5.42 bytes. `decided_by` here is `calls` alone, which IS
-        // present, so the completeness signal reached `complete` and `exact`
+        // shipped v0.5.42 bytes. `decided_by` used to be `calls` alone, which
+        // IS present, so the completeness signal reached `complete` and `exact`
         // over the same zero the negative beside it refused to certify, and its
-        // note called that zero the whole set. The substrate reading stays as
-        // measured, because it is the evidence; what a reader acts on follows
-        // the one verdict.
+        // note called that zero the whole set. Since FIR-2672 every requested
+        // class decides, so the two absent classes are on the record of what
+        // decided. The substrate reading stays as measured, because it is the
+        // evidence; what a reader acts on follows the one verdict.
         assert_eq!(
             response["_kin"]["verdict"]["state"], "inconclusive",
             "{}",
@@ -7659,7 +7676,7 @@ mod tests {
         );
         assert_eq!(
             response["_kin"]["completeness"]["decided_by"],
-            serde_json::json!(["calls"]),
+            serde_json::json!(["calls", "imports", "references"]),
             "{}",
             response["_kin"]["completeness"]
         );
@@ -8339,23 +8356,33 @@ mod tests {
             .to_string()
     }
 
-    /// A pair of entities in different files joined by a `Calls` edge: the
-    /// witness that this graph does link references across files for the
-    /// language, without which an empty walk is a fact about the graph rather
-    /// than about the focal.
+    /// A pair of entities in different files joined by every reference class
+    /// the verdict reads: the witness that this graph does link references
+    /// across files for the language, without which an empty walk is a fact
+    /// about the graph rather than about the focal.
     ///
-    /// A `Calls` edge is the whole witness on purpose. Kin resolves a cross-file
-    /// use into exactly this edge, plus an artifact-level import edge entity
-    /// queries never reach, so a fixture seeding an entity-level `Imports` edge
-    /// would assert authority on a shape no real graph produces.
+    /// This used to seed a `Calls` edge alone, on the reasoning that Kin
+    /// resolved a cross-file use into exactly that edge plus an artifact-level
+    /// import edge entity queries never reach, so an entity-level `Imports`
+    /// edge was "a shape no real graph produces". That sentence was the
+    /// codebase's own record of FIR-2672: since every requested class decides,
+    /// a graph that links only its calls is honestly short of imports and
+    /// references and cannot certify an absence, so a fixture standing for a
+    /// linked graph links all three.
     fn seed_cross_file_call_witness(store: &InMemoryGraph) {
         let caller = make_entity("witness_caller", "src/witness_caller.rs");
         let callee = make_entity("witness_callee", "src/witness_callee.rs");
         store.upsert_entity(&caller).unwrap();
         store.upsert_entity(&callee).unwrap();
-        store
-            .upsert_relation(&make_relation(caller.id, callee.id, RelationKind::Calls))
-            .unwrap();
+        for kind in [
+            RelationKind::Calls,
+            RelationKind::Imports,
+            RelationKind::References,
+        ] {
+            store
+                .upsert_relation(&make_relation(caller.id, callee.id, kind))
+                .unwrap();
+        }
     }
 
     /// `trace_data_flow` on this arm, with whatever arguments a test needs, and

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -449,20 +449,19 @@ fn reference_classes() -> Vec<String> {
 /// classes are still disclosed through [`edge_coverage_degradation_labels`], so a
 /// reader sees what the verdict rests on either way.
 ///
-/// A query that asked for no load-bearing class falls back to the classes it did
-/// ask for, so an `imports`-only or `references`-only query is still gated on
-/// what it actually read rather than on nothing.
+/// Every class the query asked for. This used to narrow to `calls`, on the
+/// reasoning above, and the narrowing is what FIR-2672 is: the verdict rested on
+/// `calls` alone, published `imports: absent` beside it as a limit nobody
+/// weighed, and certified an answer as the whole set while its own completeness
+/// block recorded the class it could not have read. A class the answer could not
+/// have read is a class its counts cannot be whole over, whatever the reason,
+/// so every requested class decides. What the narrowing was protecting against,
+/// every Python answer reading inconclusive because Kin minted no entity-level
+/// `Imports` edge, is now said in those words: the scan reports such a class
+/// `unproduced` rather than `absent`, and the verdict names the build gap as its
+/// limiting factor instead of hiding it.
 pub(crate) fn load_bearing_classes(requested: &[String]) -> Vec<String> {
-    let load_bearing: Vec<String> = requested
-        .iter()
-        .filter(|class| class.as_str() == "calls")
-        .cloned()
-        .collect();
-    if load_bearing.is_empty() {
-        requested.to_vec()
-    } else {
-        load_bearing
-    }
+    requested.to_vec()
 }
 
 /// Whether this answer's own observation says cross-file reference edges were
@@ -508,14 +507,13 @@ pub(crate) fn references_producible(payload: &Value) -> bool {
 /// absence is a finding rather than the ordinary silence of a language server
 /// that never ran.
 pub(crate) fn deciding_classes(requested: &[String], references_producible: bool) -> Vec<String> {
-    let mut deciding = load_bearing_classes(requested);
-    if references_producible
-        && requested.iter().any(|class| class == "references")
-        && !deciding.iter().any(|class| class == "references")
-    {
-        deciding.push("references".to_string());
-    }
-    deciding
+    // Every requested class decides (FIR-2672). `references` no longer joins
+    // conditionally: when this host cannot produce it, `reference_enrichment`
+    // refuses by name before any class is read, and when nobody established
+    // whether it can, an unread class is the unknown case the whole module
+    // refuses on rather than the healthy one.
+    let _ = references_producible;
+    load_bearing_classes(requested)
 }
 
 /// Why the graph cannot certify this absence, or `None` when every substrate the
@@ -618,10 +616,24 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
 
     if !requested.is_empty() {
         let required = deciding_classes(&requested, references_producible(payload));
+        let unproduced = classes_in_state(&required, states, "unproduced");
         let absent = classes_in_state(&required, states, "absent");
         let unknown = classes_in_state(&required, states, "unknown");
         let present = classes_in_state(&requested, states, "present");
 
+        if !unproduced.is_empty() {
+            // The build, not the code. The scan completed, saw no entity-rooted
+            // edge of the class at all, and the parse side shows sites the
+            // linker had to resolve, so no scan of this graph could have found a
+            // use that reaches the target through it (FIR-2672).
+            let missing = unproduced.join(", ");
+            gaps.push(format!(
+                "cross_file_edges_unproduced: this build produced no entity-level {missing} edge \
+                 for {language} although the source carries {missing} sites the linker \
+                 resolved, so a use that reaches the target through {missing} could not have \
+                 been found; the gap is in the linker, not in the code"
+            ));
+        }
         if !absent.is_empty() {
             let missing = absent.join(", ");
             // Naming what IS present matters as much as naming what is missing. The
@@ -786,19 +798,27 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
         _ => None,
     };
     if let Some(cause) = cause {
-        gaps.push(if requested.is_empty() {
-            format!(
-                "entity_index_unresolved: {cause}, so nothing resolves the program behind its \
+        // At the head of the list, not the tail. Since FIR-2672 every requested
+        // class refuses on its own, so a language whose reference edges could
+        // never exist reports the class gap and this one, and this is the
+        // sharper of the two: nothing a reader does about coverage moves a
+        // class the build or the host cannot produce.
+        gaps.insert(
+            0,
+            if requested.is_empty() {
+                format!(
+                    "entity_index_unresolved: {cause}, so nothing resolves the program behind its \
                  parsed declarations, and an empty name/kind filter cannot separate a declaration \
                  the repository does not have from one the extractor did not admit as an entity \
                  of that kind"
-            )
-        } else {
-            format!(
+                )
+            } else {
+                format!(
                 "reference_enrichment_unsupported: {cause}, so an empty result cannot separate a \
                  symbol nothing uses from one this graph could never have linked"
             )
-        });
+            },
+        );
     }
 
     // FIR-2496, and the gate every other one in this function was standing in
@@ -2572,12 +2592,16 @@ mod tests {
     /// `imports` stays absent because Kin's linker mints no entity-level
     /// `Imports` relation on any language, healthy or not.
     fn cross_file_edges_observed() -> Value {
+        // Every requested class present. This fixture used to read `imports:
+        // absent` and still stand for a healthy graph, because the verdict
+        // weighed `calls` alone; since FIR-2672 every requested class decides,
+        // so "healthy" means what it says.
         json!({
             "scope": "language",
             "language": "Rust",
             "requested_classes": ["calls", "imports", "references"],
-            "classes": { "calls": "present", "imports": "absent", "references": "present" },
-            "cross_file_classes": ["calls", "references"],
+            "classes": { "calls": "present", "imports": "present", "references": "present" },
+            "cross_file_classes": ["calls", "imports", "references"],
             "reference_enrichment": "available",
             "budget_exhausted": false,
             "entities_examined": 2,
@@ -4157,8 +4181,15 @@ mod tests {
     /// cross-file. This fixture claimed the resolution and denied the edges
     /// until FIR-2505, which is the same contradiction the express payload
     /// shipped, and it is why nothing here failed while a deletion was certified.
+    /// FIR-2672. This case used to assert that the shape certified, under the
+    /// reasoning that Kin minted no entity-level `Imports` edge and a gate on
+    /// the class would refuse every Python answer. It is the shape the rc0552s
+    /// stranger received, verbatim in every field that decides: `calls` and
+    /// `references` present, a language server available, `imports: absent`
+    /// disclosed one field away, and a certification over it. The rename it
+    /// made on the certified sites broke on the import sites Kin never read.
     #[test]
-    fn a_python_graph_that_resolves_its_imports_still_certifies_an_unused_symbol() {
+    fn a_python_graph_whose_import_edges_were_never_produced_does_not_certify_an_unused_symbol() {
         let mut payload = authoritative_empty_references("function");
         payload["focal_entity"]["name"] = json!("never_used_anywhere");
         payload["focal_entity"]["file_path"] = json!("pkg/parsing.py");
@@ -4177,36 +4208,35 @@ mod tests {
 
         assert_eq!(
             negative["safe_to_conclude_absent"],
-            json!(true),
-            "a language this build can enrich, whose cross-file uses resolve, still \
-             earns absence: {}",
-            negative
+            json!(false),
+            "a class the answer could not read is a class its absence cannot be certified \
+             over: {negative}"
         );
-        assert_eq!(negative["trust"], json!("authoritative"));
-        assert!(negative["advice"]
-            .as_str()
-            .unwrap()
-            .contains("Absence is authoritative"));
-        // Certified, and still honest about the class it did not observe. The
-        // verdict rests on the resolved calls and references; saying that no
-        // entity-level import edge was seen is what keeps the next reader from
-        // mistaking it for full coverage.
-        assert_eq!(
-            negative["degraded_signals"],
-            json!(["edge_coverage:imports_absent"])
-        );
-        // And FIR-2505's second half on the shape where it bites: an
-        // authoritative verdict that publishes a signal must recite it rather
-        // than claim the response carried none.
+        assert_eq!(negative["trust"], json!("inconclusive"));
         let reason = negative["trust_reason"].as_str().unwrap();
         assert!(
-            !reason.contains("no degraded signals"),
-            "a verdict disclosing imports_absent must not claim there were none: {reason}"
+            reason.starts_with("cross_file_edges_absent") && reason.contains("imports"),
+            "the reason leads with the class and its state: {reason}"
         );
-        assert!(
-            reason.contains("edge_coverage:imports_absent"),
-            "the reason recites what it disclosed: {reason}"
+        assert_eq!(
+            negative["degraded_signals"],
+            json!(["edge_coverage:imports_absent"]),
+            "and the class is still disclosed as the signal it always was"
         );
+
+        // The inverse: the same answer over a graph whose import edges exist
+        // certifies, so the refusal is the class and nothing else.
+        payload["edge_coverage"]["classes"]["imports"] = json!("present");
+        payload["edge_coverage"]["cross_file_classes"] = json!(["calls", "imports", "references"]);
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("empty references yields a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "{negative}"
+        );
+        assert_eq!(negative["trust"], json!("authoritative"));
+        assert_eq!(negative["degraded_signals"], json!([]));
     }
 
     /// The one gate reads two independent declarations, and a tool that
@@ -4278,11 +4308,15 @@ mod tests {
     /// repository and `express.static` 26 times.
     #[test]
     fn a_producible_reference_class_that_produced_nothing_blocks_the_deletion_verdict() {
-        let payload = json!({
+        let mut payload = json!({
             "entity_impacts": [],
             "dependents": [],
             "edge_coverage": express_deletion_coverage("absent", "available")
         });
+        // Isolate the class under test. The express shape carries `imports:
+        // absent` too, and since FIR-2672 that refuses on its own, so it would
+        // lead the sentence this case reads for `references`.
+        payload["edge_coverage"]["classes"]["imports"] = json!("present");
         for tool in ["impact_analysis", "get_context_pack"] {
             let gap = absence_coverage_gap(tool, &payload)
                 .unwrap_or_else(|| panic!("{tool} must not certify the express deletion shape"));
@@ -4321,31 +4355,38 @@ mod tests {
 
     /// The control FIR-2404's descendants exist to protect: the gate must not
     /// answer "uncertain" to everything. The identical question on a graph whose
-    /// enrichment actually delivered still certifies, so a genuinely dead entity
-    /// stays deletable and the verdict keeps its ability to say yes.
+    /// enrichment actually delivered, and whose every requested class is
+    /// present, still certifies, so a genuinely dead entity stays deletable and
+    /// the verdict keeps its ability to say yes. This is also FIR-2672's
+    /// inverse: the fix must not trade a false certification for a false
+    /// refusal.
     #[test]
     fn an_enriched_graph_still_certifies_the_same_deletion_question() {
-        let payload = json!({
+        let mut payload = json!({
             "entity_impacts": [],
             "dependents": [],
             "edge_coverage": express_deletion_coverage("present", "available")
         });
+        payload["edge_coverage"]["classes"]["imports"] = json!("present");
         for tool in ["impact_analysis", "get_context_pack"] {
             assert_eq!(
                 absence_coverage_gap(tool, &payload),
                 None,
-                "{tool} must still certify when the reference class is present"
+                "{tool} must still certify when every requested class is present"
             );
         }
     }
 
-    /// The boundary that keeps the gate narrow. Kin's linker mints no
-    /// entity-level `Imports` relation on any language, so `imports: absent` is
-    /// the reading on every real graph including the healthy ones, and gating on
-    /// it would report every answer everywhere as inconclusive. The express
-    /// payload named it as a limit and it is disclosed, not load-bearing.
+    /// FIR-2672. This used to assert the opposite, under the reasoning that Kin
+    /// minted no entity-level `Imports` edge on any language, so gating on the
+    /// class would report every answer everywhere as inconclusive. That is
+    /// exactly what happened to the rc0552s stranger: the express payload named
+    /// `imports_absent` as a limit, the verdict weighed `calls` alone, and a
+    /// deletion was certified over a class the answer could never have read.
+    /// A class the answer could not read is a class its counts cannot be whole
+    /// over, whatever the reason, and the gap says which reason it was.
     #[test]
-    fn imports_absent_alone_is_never_what_blocks_a_verdict() {
+    fn imports_absent_alone_blocks_a_verdict_and_names_itself() {
         let payload = json!({
             "entity_impacts": [],
             "edge_coverage": express_deletion_coverage("present", "available")
@@ -4354,7 +4395,30 @@ mod tests {
             payload["edge_coverage"]["classes"]["imports"],
             json!("absent")
         );
-        assert_eq!(absence_coverage_gap("impact_analysis", &payload), None);
+        let gap = absence_coverage_gap("impact_analysis", &payload)
+            .expect("an absent requested class refuses on its own");
+        assert!(
+            gap.starts_with("cross_file_edges_absent"),
+            "the gap leads with the class's state: {gap}"
+        );
+        assert!(
+            gap.contains("no cross-file imports edges for JavaScript"),
+            "and names the class and the language: {gap}"
+        );
+
+        // The build-gap reading of the same class, when the scan could say so.
+        let mut unproduced = payload.clone();
+        unproduced["edge_coverage"]["classes"]["imports"] = json!("unproduced");
+        let gap = absence_coverage_gap("impact_analysis", &unproduced)
+            .expect("an unproduced requested class refuses on its own");
+        assert!(
+            gap.starts_with("cross_file_edges_unproduced"),
+            "the gap leads with the class's state: {gap}"
+        );
+        assert!(
+            gap.contains("the gap is in the linker, not in the code"),
+            "and says where the gap is: {gap}"
+        );
     }
 
     /// A host that could never have produced the class keeps its own reason. The
@@ -4390,17 +4454,40 @@ mod tests {
     /// makes no claim about silence.
     #[test]
     fn a_certified_verdict_recites_its_disclosed_signals_instead_of_denying_them() {
-        let payload = json!({
+        // FIR-2672 closed the shape this case was written on: a coverage signal
+        // disclosed beside an authoritative verdict. Every disclosed coverage
+        // shortfall now refuses, so the invariant this case guards, that the
+        // reason sentence agrees with the `degraded_signals` beside it, is
+        // asserted on both arms it can still take: a verdict with nothing
+        // disclosed says so, and a verdict with a class disclosed short recites
+        // that class in its refusal rather than claiming there was nothing.
+        let mut payload = json!({
             "entity_impacts": [],
             "edge_coverage": express_deletion_coverage("present", "available")
         });
+        payload["edge_coverage"]["classes"]["imports"] = json!("present");
         let negative = negative_for("impact_analysis", &payload, &structural_ready_envelope())
             .expect("impact_analysis always qualifies");
-        assert_eq!(negative["trust"], json!("authoritative"));
+        assert_eq!(negative["trust"], json!("authoritative"), "{negative}");
+        assert_eq!(negative["degraded_signals"], json!([]), "{negative}");
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("no degraded signals"),
+            "a verdict with nothing disclosed says so: {reason}"
+        );
+        assert!(
+            reason.contains("structural_authoritative"),
+            "the substrate verdict is kept, not replaced: {reason}"
+        );
+
+        payload["edge_coverage"]["classes"]["imports"] = json!("absent");
+        let negative = negative_for("impact_analysis", &payload, &structural_ready_envelope())
+            .expect("impact_analysis always qualifies");
+        assert_eq!(negative["trust"], json!("inconclusive"), "{negative}");
         let signals = negative["degraded_signals"].as_array().unwrap().clone();
         assert!(
-            !signals.is_empty(),
-            "this shape discloses imports_absent, or the test is asserting nothing"
+            signals.contains(&json!("edge_coverage:imports_absent")),
+            "the short class is disclosed as a signal: {negative}"
         );
         let reason = negative["trust_reason"].as_str().unwrap();
         assert!(
@@ -4408,12 +4495,8 @@ mod tests {
             "a verdict publishing {signals:?} must not claim there were none: {reason}"
         );
         assert!(
-            reason.contains("edge_coverage:imports_absent"),
-            "the reason recites what it disclosed: {reason}"
-        );
-        assert!(
-            reason.contains("structural_authoritative"),
-            "the substrate verdict is kept, not replaced: {reason}"
+            reason.contains("imports"),
+            "the reason recites the class it disclosed: {reason}"
         );
     }
 
@@ -4586,7 +4669,11 @@ mod tests {
             embed_worker_failed: Some(true),
             ..Degraded::default()
         };
-        let payload = authoritative_empty_references("function");
+        // One coverage shortfall on purpose, so the second half of the
+        // assertion below has something to keep: the healthy fixture carries
+        // none since FIR-2672 made every class decide.
+        let mut payload = authoritative_empty_references("function");
+        payload["edge_coverage"]["classes"]["imports"] = json!("absent");
         let negative = negative_for("find_references", &payload, &env).unwrap();
         assert_eq!(negative["safe_to_conclude_absent"], json!(false));
         assert!(negative["trust_reason"]
@@ -5877,7 +5964,7 @@ mod tests {
             "scope": "language",
             "language": "Python",
             "requested_classes": ["calls", "imports", "references"],
-            "classes": {"calls": "present", "imports": "absent", "references": "absent"},
+            "classes": {"calls": "present", "imports": "present", "references": "present"},
             "reference_enrichment": "unknown",
             "budget_exhausted": false,
         });

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -631,7 +631,7 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
                 "cross_file_edges_unproduced: this build produced no entity-level {missing} edge \
                  for {language} although the source carries {missing} sites the linker \
                  resolved, so a use that reaches the target through {missing} could not have \
-                 been found; the gap is in the linker, not in the code"
+                 been found, and the gap is in the linker, not in the code"
             ));
         }
         if !absent.is_empty() {

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -222,7 +222,7 @@ impl Verdict {
         completeness.status = if completeness
             .classes
             .values()
-            .any(|state| state.as_str() == Some("absent"))
+            .any(|state| matches!(state.as_str(), Some("absent") | Some("unproduced")))
         {
             "partial".to_string()
         } else {
@@ -389,26 +389,56 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
         }
         return Reading::Certified;
     }
+    // Every requested class, and the most specific reason first (FIR-2672). A
+    // class this answer could not have read is a class its counts cannot be
+    // whole over, whatever kept it from being read, so the reading refuses on
+    // any state but `present` and says which state it was.
     let deciding = crate::negative::load_bearing_classes(&requested);
+    let state_of = |class: &String| {
+        states
+            .and_then(|states| states.get(class.as_str()))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+    };
+    let in_state = |wanted: &str| -> Vec<&str> {
+        deciding
+            .iter()
+            .filter(|class| state_of(class) == wanted)
+            .map(String::as_str)
+            .collect()
+    };
+    let unproduced = in_state("unproduced");
+    if !unproduced.is_empty() {
+        let missing = unproduced.join(", ");
+        return Reading::Inconclusive(format!(
+            "cross_file_edges_unproduced: this build produced no entity-level {missing} edge for \
+             {language} although the source carries {missing} sites the linker resolved, so a \
+             use that reaches the target through {missing} could not have been found; the gap \
+             is in the linker, not in the code"
+        ));
+    }
+    let absent = in_state("absent");
+    if !absent.is_empty() {
+        let missing = absent.join(", ");
+        return Reading::Inconclusive(format!(
+            "cross_file_edges_not_present: the graph was not observed to hold cross-file \
+             {missing} edges for {language}, so a use that reaches the target through {missing} \
+             could not have been found"
+        ));
+    }
     let unhealthy: Vec<&str> = deciding
         .iter()
-        .filter(|class| {
-            states
-                .and_then(|states| states.get(class.as_str()))
-                .and_then(Value::as_str)
-                != Some("present")
-        })
+        .filter(|class| state_of(class) != "present")
         .map(String::as_str)
         .collect();
     if unhealthy.is_empty() {
         Reading::Certified
     } else {
+        let missing = unhealthy.join(", ");
         Reading::Inconclusive(format!(
-            "cross_file_edges_not_present: the graph was not observed to hold cross-file {} \
-             edges for {language}, so a use that reaches the target through {} could not have \
-             been found",
-            unhealthy.join(", "),
-            unhealthy.join(", ")
+            "edge_coverage_unknown: whether the graph holds cross-file {missing} edges for \
+             {language} could not be established, so a use that reaches the target through \
+             {missing} may not have been found"
         ))
     }
 }
@@ -982,6 +1012,101 @@ mod tests {
             "the coverage input says nothing about an answer with no language: {}",
             verdict.to_value()
         );
+    }
+
+    /// A populated reference answer whose every other input is clean, with one
+    /// requested class in the state given.
+    fn populated_reference_payload(imports: &str) -> Value {
+        json!({
+            "references": [{"name": "index_note"}, {"name": "test_blank_code_masks_fences"}],
+            "total_upstream": 2,
+            "relation_kinds": ["calls", "imports", "references"],
+            "counts": {"receiver_name_candidates": 0},
+            "degradations": [],
+            "cross_repo": {
+                "status": "available",
+                "authority_complete": true,
+                "authority_revision": "sha256:complete",
+                "authority_roots": {"local": "local-root"},
+            },
+            "focal_resolution": {
+                "addressed_by": "entity_id",
+                "same_name_candidates": 1,
+                "matched": "exact_focal_name",
+                "other_candidates": [],
+            },
+            "edge_coverage": {
+                "scope": "language",
+                "language": "Python",
+                "requested_classes": ["calls", "imports", "references"],
+                "classes": {"calls": "present", "imports": imports, "references": "present"},
+                "reference_enrichment": "available",
+                "budget_exhausted": false,
+            },
+        })
+    }
+
+    /// FIR-2672, the sole-cause case. Every input is clean except one requested
+    /// class the answer could not read, and that alone makes the verdict
+    /// inconclusive and names the class, for each of the three states a class
+    /// can be short in. The shipped 0.5.52 verdict certified this exact shape
+    /// with `imports: absent`, because the reading weighed `calls` alone.
+    #[test]
+    fn a_requested_class_the_answer_could_not_read_is_the_sole_cause_of_an_inconclusive_verdict() {
+        for (state, leading) in [
+            ("absent", "cross_file_edges_absent"),
+            ("unproduced", "cross_file_edges_unproduced"),
+            ("unknown", "edge_coverage_unknown"),
+        ] {
+            let verdict = Verdict::compute(
+                "find_references",
+                &populated_reference_payload(state),
+                &Envelope::daemon(),
+                None,
+            )
+            .expect("a retrieval payload carries a verdict")
+            .to_value();
+            assert_eq!(verdict["state"], json!(INCONCLUSIVE), "{state}: {verdict}");
+            assert_eq!(
+                verdict["inputs"]["edge_coverage"],
+                json!(INCONCLUSIVE),
+                "{state}: the coverage input itself refuses: {verdict}"
+            );
+            let factor = verdict["limiting_factor"]
+                .as_str()
+                .expect("an inconclusive verdict names its limiting factor");
+            assert!(
+                factor.starts_with(leading) && factor.contains("imports"),
+                "{state}: the factor leads with the class's own state and names the class: \
+                 {factor}"
+            );
+            for input in ["withheld_candidates", "degradations"] {
+                assert_ne!(
+                    verdict["inputs"][input],
+                    json!(INCONCLUSIVE),
+                    "{state}: {input} was clean and must not be what refused: {verdict}"
+                );
+            }
+        }
+    }
+
+    /// The inverse of the case above, and the half that keeps the fix from
+    /// trading a false certification for a false refusal: the same answer with
+    /// every requested class present certifies, with no limiting factor.
+    #[test]
+    fn the_same_answer_with_every_class_present_still_certifies() {
+        let verdict = Verdict::compute(
+            "find_references",
+            &populated_reference_payload("present"),
+            &Envelope::daemon(),
+            None,
+        )
+        .expect("a retrieval payload carries a verdict")
+        .to_value();
+        assert_eq!(verdict["state"], json!(CERTIFIED), "{verdict}");
+        assert_eq!(verdict["limiting_factor"], Value::Null, "{verdict}");
+        assert_eq!(verdict["inputs"]["edge_coverage"], json!(CERTIFIED));
+        assert_eq!(verdict["inputs"]["absence_gate"], json!(CERTIFIED));
     }
 
     /// The budget path downgrades every verdict surface together. Leaving

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -65,6 +65,46 @@ const RESPONSE_BOUNDED_FACTOR: &str = "response_bounded: the response budget wit
                                        this answer, so its counts are a lower bound and its \
                                        absence claims are not authoritative";
 
+/// The one sentence a reader acts on, carrying every reason the inputs gave.
+///
+/// The most pessimistic input decides the STATE; it does not make the other
+/// inputs vanish. When the coverage reading and the run's own degradations both
+/// refused, a factor that kept only the first sent a reader to fix the edge gap
+/// and never told them the embedding worker had died, which is a second thing
+/// wrong with the same answer (FIR-2672). So the factor is one sentence of
+/// clauses, one per reason, in the readings' order: the absence gate's own
+/// composition first, then the coverage observation, withheld rows, the run's
+/// degradations and the completeness signal. Each clause is `label: text` and a
+/// label appears once, because the absence gate already composes the class gap
+/// and the degradations that the later readings repeat as named inputs.
+fn compose_limiting_factor(readings: &[(&str, Reading)]) -> Option<String> {
+    let mut labels: Vec<String> = Vec::new();
+    let mut clauses: Vec<String> = Vec::new();
+    for (_, reading) in readings {
+        let Reading::Inconclusive(reason) = reading else {
+            continue;
+        };
+        for clause in reason
+            .split("; ")
+            .map(str::trim)
+            .filter(|clause| !clause.is_empty())
+        {
+            let label = clause
+                .split(':')
+                .next()
+                .unwrap_or(clause)
+                .trim()
+                .to_string();
+            if labels.contains(&label) {
+                continue;
+            }
+            labels.push(label);
+            clauses.push(clause.to_string());
+        }
+    }
+    (!clauses.is_empty()).then(|| clauses.join("; "))
+}
+
 /// One input's reading of the same answer.
 enum Reading {
     /// The input observed nothing that stops this answer being acted on.
@@ -138,10 +178,7 @@ impl Verdict {
             return None;
         }
 
-        let limiting_factor = readings.iter().find_map(|(_, reading)| match reading {
-            Reading::Inconclusive(reason) => Some(reason.clone()),
-            _ => None,
-        });
+        let limiting_factor = compose_limiting_factor(&readings);
         let certified = limiting_factor.is_none();
         let inputs = readings
             .iter()
@@ -413,7 +450,7 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
         return Reading::Inconclusive(format!(
             "cross_file_edges_unproduced: this build produced no entity-level {missing} edge for \
              {language} although the source carries {missing} sites the linker resolved, so a \
-             use that reaches the target through {missing} could not have been found; the gap \
+             use that reaches the target through {missing} could not have been found, and the gap \
              is in the linker, not in the code"
         ));
     }
@@ -421,7 +458,7 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
     if !absent.is_empty() {
         let missing = absent.join(", ");
         return Reading::Inconclusive(format!(
-            "cross_file_edges_not_present: the graph was not observed to hold cross-file \
+            "cross_file_edges_absent: the graph was not observed to hold cross-file \
              {missing} edges for {language}, so a use that reaches the target through {missing} \
              could not have been found"
         ));
@@ -547,15 +584,21 @@ pub fn mark_response_bounded(annotated: &mut Value) {
     {
         verdict.insert("state".to_string(), json!(INCONCLUSIVE));
         verdict.insert("safe_to_conclude_absent".to_string(), json!(false));
-        verdict.insert(
-            "limiting_factor".to_string(),
-            json!(RESPONSE_BOUNDED_FACTOR),
-        );
+        // The budget cut leads the sentence and the reasons already in it
+        // follow, the same way the absence object below keeps its own; a factor
+        // that was replaced outright lost every other reason the answer had.
+        let factor = match verdict.get("limiting_factor").and_then(Value::as_str) {
+            Some(existing) if !existing.is_empty() => {
+                format!("{RESPONSE_BOUNDED_FACTOR}; {existing}")
+            }
+            _ => RESPONSE_BOUNDED_FACTOR.to_string(),
+        };
+        verdict.insert("limiting_factor".to_string(), json!(factor.clone()));
         verdict.insert(
             "note".to_string(),
             json!(format!(
                 "Treat this answer as a lower bound and do not act on an absence in it. Limiting \
-                 factor: {RESPONSE_BOUNDED_FACTOR}."
+                 factor: {factor}."
             )),
         );
         if let Some(inputs) = verdict.get_mut("inputs").and_then(Value::as_object_mut) {
@@ -736,6 +779,95 @@ fn headline_count_disagreements(response: &Value) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// FIR-2672, second finding. A verdict with two independent reasons names
+    /// both: the class gap decided the state and the failed embedding worker
+    /// stayed in the sentence after it, and the gap the absence gate and the
+    /// coverage reading both carry is said once. Remove a clause and the
+    /// reader loses one of the two things wrong with the answer.
+    #[test]
+    fn every_refusing_input_keeps_its_clause_in_the_factor() {
+        let readings = [
+            (
+                "absence_gate",
+                Reading::Inconclusive(
+                    "cross_file_edges_absent: the graph holds no cross-file imports edges for \
+                     python"
+                        .to_string(),
+                ),
+            ),
+            (
+                "edge_coverage",
+                Reading::Inconclusive(
+                    "cross_file_edges_absent: the graph was not observed to hold imports edges"
+                        .to_string(),
+                ),
+            ),
+            ("withheld_candidates", Reading::Certified),
+            (
+                "degradations",
+                Reading::Inconclusive(
+                    "retrieval_degraded: this query reported degradations [embed_worker_failed], \
+                     so it did not run at full capability"
+                        .to_string(),
+                ),
+            ),
+            ("completeness", Reading::Silent),
+        ];
+        let factor = compose_limiting_factor(&readings).expect("two inputs refused");
+        assert_eq!(
+            factor,
+            "cross_file_edges_absent: the graph holds no cross-file imports edges for python; \
+             retrieval_degraded: this query reported degradations [embed_worker_failed], so it \
+             did not run at full capability"
+        );
+        assert!(
+            compose_limiting_factor(&[
+                ("absence_gate", Reading::Certified),
+                ("degradations", Reading::Silent),
+            ])
+            .is_none(),
+            "no refusing input, no factor"
+        );
+    }
+
+    /// The same two reasons through `Verdict::compute` itself: a short class
+    /// and a run degradation on one populated answer. The class gap decides
+    /// and leads, the degradation follows in the same sentence, and the class
+    /// gap the absence gate and the coverage reading both carry is said once.
+    #[test]
+    fn a_verdict_with_two_refusing_inputs_names_both_in_order() {
+        let mut payload = populated_reference_payload("absent");
+        payload["degradations"] = json!([{"component": "embed_worker", "reason": "failed"}]);
+        let verdict = Verdict::compute("find_references", &payload, &Envelope::daemon(), None)
+            .expect("a retrieval payload carries a verdict")
+            .to_value();
+        assert_eq!(verdict["state"], json!(INCONCLUSIVE), "{verdict}");
+        assert_eq!(
+            verdict["inputs"]["edge_coverage"],
+            json!(INCONCLUSIVE),
+            "{verdict}"
+        );
+        assert_eq!(
+            verdict["inputs"]["degradations"],
+            json!(INCONCLUSIVE),
+            "{verdict}"
+        );
+        let factor = verdict["limiting_factor"].as_str().expect("named");
+        let class_gap = factor
+            .find("cross_file_edges_absent:")
+            .unwrap_or_else(|| panic!("the class gap is named: {factor}"));
+        let degraded = factor
+            .find("retrieval_degraded:")
+            .unwrap_or_else(|| panic!("the degradation stays named beside it: {factor}"));
+        assert!(class_gap < degraded, "the structural gap leads: {factor}");
+        assert_eq!(
+            factor.matches("cross_file_edges_absent:").count(),
+            1,
+            "one fact, one clause: {factor}"
+        );
+        assert!(factor.contains("embed_worker:failed"), "{factor}");
+    }
 
     /// A response whose blocks all agree with a certified verdict.
     fn agreeing_response() -> Value {

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -58,7 +58,12 @@ and `unproduced` means the scan completed, saw no entity-level edge of the class
 all, and the source carries sites of it that the linker resolved, so the gap is in
 the build rather than in the code. A verdict that certifies over a recorded limit
 was the shipped 0.5.52 behaviour (FIR-2672) and is now a contract violation the
-tests scan for.
+tests scan for. `limiting_factor` is one sentence of `label: text` clauses, one per
+input that refused, in the order the verdict weighs them (the absence gate's own
+composition, then the coverage observation, withheld rows, the run's own
+degradations and the completeness signal), each label once. The first clause is
+what decided the state and the rest are the other things wrong with the same
+answer, so a class gap never hides a dead embedding worker.
 
 ---
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -48,6 +48,18 @@ graph-relation readers) report `structural_authoritative` only with the graph
 initialized and loaded. Treat every other verdict as "ask again when the graph is
 ready" rather than as evidence of absence.
 
+Every retrieval answer, empty or not, also carries `_kin.verdict`, the one verdict
+for the response. It is computed from every block that qualifies the answer and the
+most pessimistic input wins: a requested edge class that `_kin.completeness.classes`
+records as anything but `present` makes the verdict `inconclusive`, with
+`limiting_factor` naming the class and its state. `absent` means the scan completed
+and found no such cross-file edge, `unknown` means the scan stopped on its budget,
+and `unproduced` means the scan completed, saw no entity-level edge of the class at
+all, and the source carries sites of it that the linker resolved, so the gap is in
+the build rather than in the code. A verdict that certifies over a recorded limit
+was the shipped 0.5.52 behaviour (FIR-2672) and is now a contract violation the
+tests scan for.
+
 ---
 
 ## Configuring the server

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -282,10 +282,16 @@ exact count; on a build whose linker does not, it falls back to the same focal
 over `calls` alone, a class the fixture proves present, and names which arm ran.
 Check `unproduced` requires the import class to read `unproduced` (a build whose
 linker emits no entity-level import edge) or `present` (one whose linker does),
-never `absent`, on a source whose files import one another. The self-test feeds
-the graders the exact 0.5.52 envelope, which must fail, beside the fixed shape
-and the all-present shape, which must pass. Both worlds pass, and the shipped
-shape fails in both.
+never `absent`, on a source whose files import one another. Check `two_reasons`
+runs the same query under the server's smallest response budget, which withholds
+rows and refuses on its own, and requires every input the verdict records as
+inconclusive to keep its clause in `limiting_factor`, each label once: the
+budget's clause beside the class gap on a build that cannot produce the import
+class, the budget's clause alone on one that can. The self-test feeds the
+graders the exact 0.5.52 envelope, which must fail, beside the fixed shape and
+the all-present shape, which must pass, and a factor that kept one clause and
+dropped the rest, which must fail. Both worlds pass, and the shipped shape fails
+in both.
 
 `brownfield_repro.py --self-test` and `response_budget_elisions.py --self-test`
 exercise their verdict graders on fixed payloads and need no binary and no

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -259,6 +259,34 @@ runs, and `kin init` refused the ejected repository over it; the check requires
 `kin init` to re-admit past it and, as its control, still to refuse an
 executable `pre-commit` by name. Eject is Unix-only, and so is the suite.
 
+`verdict_limits_repro.py` covers the one-verdict contract the rc0552s green
+stranger caught 0.5.52 breaking (FIR-2672): `find_references` on a Python
+function answered `verdict.state: certified`, `completeness.status: complete`,
+`bound: exact` and "the counts here are the whole set" in the same `_kin` block
+that recorded `classes.imports: absent` and `limits: [edge_coverage:imports_absent]`,
+and the rename the stranger made on the certified sites broke on the import
+sites Kin could never read. Every release since the one verdict existed (0.5.43)
+certified that way, because the verdict weighed `calls` alone. Check `invariant`
+queries a three-file Python package whose files reach one another through every
+class the verdict reads (imports, calls, and a class used as an annotation and
+read through its attributes, which a language server resolves into references)
+with the default classes, and requires that no requested class read anything but
+`present` while the verdict certifies: a short class must make the verdict
+inconclusive, be named in the limiting factor and in `limits`, and turn
+`status`, `bound` and `counted.exact` into a floor; with every class present the
+verdict must certify. Check `inverse` is the control that keeps that from being
+satisfied by refusing everything, and it prefers the genuine arm: on a build
+whose linker produces entity-level import edges, the default query has every
+requested class present and must certify with `limiting_factor: null` and an
+exact count; on a build whose linker does not, it falls back to the same focal
+over `calls` alone, a class the fixture proves present, and names which arm ran.
+Check `unproduced` requires the import class to read `unproduced` (a build whose
+linker emits no entity-level import edge) or `present` (one whose linker does),
+never `absent`, on a source whose files import one another. The self-test feeds
+the graders the exact 0.5.52 envelope, which must fail, beside the fixed shape
+and the all-present shape, which must pass. Both worlds pass, and the shipped
+shape fails in both.
+
 `brownfield_repro.py --self-test` and `response_budget_elisions.py --self-test`
 exercise their verdict graders on fixed payloads and need no binary and no
 corpus. Each case is paired with its inverse, so a grader that cannot tell its
@@ -296,6 +324,10 @@ python3 scripts/acceptance/first_contact_honesty.py \
 python3 scripts/acceptance/eject_journal_repro.py \
   --kin target/release/kin --daemon target/release/kin-daemon \
   --json acceptance/eject_journal.json --verbose
+
+python3 scripts/acceptance/verdict_limits_repro.py \
+  --kin target/release/kin --daemon target/release/kin-daemon \
+  --json acceptance/verdict_limits.json --verbose
 ```
 
 Release, not debug. Release is what ships, so it is what an acceptance answer

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -842,8 +842,12 @@ def verdict_surfaces(payload):
             out["completeness"] = ("refuse", "status=%r bound=%r" % (status, bound))
         classes = completeness.get("classes")
         if isinstance(classes, dict):
-            absent = sorted(k for k, v in classes.items()
-                            if v in ("absent", "unknown"))
+            # Any state but `present` is a class the answer could not read:
+            # `absent`, `unknown`, and since FIR-2672 `unproduced`, the class
+            # the build had sites for and emitted no edge of. A grader that
+            # listed the words it knew read the new one as healthy and flagged
+            # the correct refusal beside it as the contradiction.
+            absent = sorted(k for k, v in classes.items() if v != "present")
             if absent:
                 out["completeness.classes"] = (
                     "refuse", "classes not present: %s" % ", ".join(absent))
@@ -858,8 +862,7 @@ def verdict_surfaces(payload):
         classes = coverage.get("classes")
         gaps = []
         if isinstance(classes, dict):
-            missing = sorted(k for k, v in classes.items()
-                             if v in ("absent", "unknown"))
+            missing = sorted(k for k, v in classes.items() if v != "present")
             if missing:
                 gaps.append("classes not present: %s" % ", ".join(missing))
         enrichment = coverage.get("reference_enrichment")
@@ -2000,6 +2003,30 @@ def self_test():
     }
     certifying, _refusing = surface_conflict(verdict_surfaces(agreed))
     expect("agreed payload reports no conflict", certifying, None)
+
+    # FIR-2672's shape on a build whose linker emits no entity-level import
+    # edge: the class reads `unproduced`, every surface refuses, and the grader
+    # must read that as agreement. The version that knew only `absent` and
+    # `unknown` read `unproduced` as present and reported the one honest
+    # payload as a three-way contradiction.
+    unproduced = {
+        "negative": {"safe_to_conclude_absent": False, "trust": "inconclusive"},
+        "_kin": {"completeness": {
+            "bound": "at_least", "status": "partial",
+            "classes": {"calls": "present", "imports": "unproduced",
+                        "references": "present"},
+            "limits": ["edge_coverage:imports_unproduced", "verdict_inconclusive"]}},
+        "edge_coverage": {"classes": {"calls": "present", "imports": "unproduced",
+                                      "references": "present"},
+                          "reference_enrichment": "available", "scan": "ran"},
+    }
+    certifying, _refusing = surface_conflict(verdict_surfaces(unproduced))
+    expect("an unproduced class is read as a refusal everywhere", certifying, None)
+    expect("edge_coverage refuses on an unproduced class",
+           verdict_surfaces(unproduced)["edge_coverage"][0], "refuse")
+    expect("completeness.classes names the unproduced class",
+           verdict_surfaces(unproduced)["completeness.classes"][1],
+           "classes not present: imports")
 
     # A payload carrying no verdict block at all yields no surfaces, so a check
     # reports UNREADABLE rather than inventing agreement out of silence.

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -798,6 +798,44 @@ def find_row(rows, wanted):
     return None
 
 
+# The words a class state can carry, closed. `present` is the one state that
+# counts as coverage. The other three are the ways a class can be short:
+# `absent` (the scan completed and observed none), `unknown` (the scan could not
+# complete) and, since FIR-2672, `unproduced` (the build had sites for the class
+# and emitted no edge of it). A word outside the set is sorted into neither
+# bucket. The grader that read "everything but absent and unknown" as present
+# took `unproduced` for coverage and flagged the one honest refusal beside it as
+# the contradiction, which is the verdict's own trap one level up: a classifier
+# with an everything-else arm admits any new value into the wrong bucket without
+# a sound. The next word anyone adds lands in UnknownClassState instead.
+CLASS_PRESENT = frozenset(["present"])
+CLASS_SHORT = frozenset(["absent", "unknown", "unproduced"])
+
+
+class UnknownClassState(Exception):
+    """A class state outside the closed set. The payload cannot be graded."""
+
+
+def class_shortfall(classes, surface):
+    """The classes under `classes` that are short, sorted, or UnknownClassState.
+
+    A word the grader does not know is never sorted into either bucket; the
+    caller reports the payload UNREADABLE and names the word.
+    """
+    short = []
+    for name in sorted(classes):
+        state = classes[name]
+        if state in CLASS_PRESENT:
+            continue
+        if state in CLASS_SHORT:
+            short.append(name)
+            continue
+        raise UnknownClassState(
+            "%s carries a class state this grader does not know: %s=%r (known: %s)"
+            % (surface, name, state, ", ".join(sorted(CLASS_PRESENT | CLASS_SHORT))))
+    return short
+
+
 def verdict_surfaces(payload):
     """The verdict blocks one payload carries, normalized to certify or refuse.
 
@@ -809,7 +847,8 @@ def verdict_surfaces(payload):
 
     Under FIR-2463's fix shape the most pessimistic input wins, so a surface that
     admits it did not look, or that reports a class as unknown, counts as refusing
-    rather than as saying nothing.
+    rather than as saying nothing. Raises UnknownClassState on a class state
+    outside the closed set, so a caller grades that payload UNREADABLE.
     """
     out = {}
     negative = payload.get("negative")
@@ -842,12 +881,7 @@ def verdict_surfaces(payload):
             out["completeness"] = ("refuse", "status=%r bound=%r" % (status, bound))
         classes = completeness.get("classes")
         if isinstance(classes, dict):
-            # Any state but `present` is a class the answer could not read:
-            # `absent`, `unknown`, and since FIR-2672 `unproduced`, the class
-            # the build had sites for and emitted no edge of. A grader that
-            # listed the words it knew read the new one as healthy and flagged
-            # the correct refusal beside it as the contradiction.
-            absent = sorted(k for k, v in classes.items() if v != "present")
+            absent = class_shortfall(classes, "completeness.classes")
             if absent:
                 out["completeness.classes"] = (
                     "refuse", "classes not present: %s" % ", ".join(absent))
@@ -862,7 +896,7 @@ def verdict_surfaces(payload):
         classes = coverage.get("classes")
         gaps = []
         if isinstance(classes, dict):
-            missing = sorted(k for k, v in classes.items() if v != "present")
+            missing = class_shortfall(classes, "edge_coverage.classes")
             if missing:
                 gaps.append("classes not present: %s" % ", ".join(missing))
         enrichment = coverage.get("reference_enrichment")
@@ -1288,7 +1322,11 @@ def check_5(suite):
         except ProbeError as exc:
             res.unknown("%s unreadable: %s" % (label, exc))
             continue
-        surfaces = verdict_surfaces(payload)
+        try:
+            surfaces = verdict_surfaces(payload)
+        except UnknownClassState as exc:
+            res.unknown("%s unreadable: %s" % (label, exc))
+            continue
         if not surfaces:
             res.unknown("%s carries no readable verdict surface; keys are %s"
                         % (label, sorted(payload.keys())))
@@ -1347,8 +1385,12 @@ def check_6(suite):
         res.unknown("graph_neighborhood returned an error payload: %s"
                     % str(hood.get("message"))[:200])
         return res
-    ref_surfaces = verdict_surfaces(refs)
-    hood_surfaces = verdict_surfaces(hood)
+    try:
+        ref_surfaces = verdict_surfaces(refs)
+        hood_surfaces = verdict_surfaces(hood)
+    except UnknownClassState as exc:
+        res.unknown("verdict surfaces unreadable: %s" % exc)
+        return res
     if not ref_surfaces:
         res.unknown("find_references payload carries no readable verdict surface")
         return res
@@ -2027,6 +2069,30 @@ def self_test():
     expect("completeness.classes names the unproduced class",
            verdict_surfaces(unproduced)["completeness.classes"][1],
            "classes not present: imports")
+
+    # A state outside the closed set is sorted into neither bucket. The next
+    # word anyone adds must land here, as UnknownClassState naming the word and
+    # the surface, never as coverage and never as a silent refusal.
+    for surface, foreign in (
+        ("completeness.classes", {
+            "_kin": {"completeness": {
+                "bound": "at_least", "status": "partial",
+                "classes": {"calls": "present", "imports": "projected"}}}}),
+        ("edge_coverage.classes", {
+            "edge_coverage": {"classes": {"calls": "present", "imports": "projected"},
+                              "reference_enrichment": "available", "scan": "ran"}}),
+    ):
+        try:
+            verdict_surfaces(foreign)
+            outcome = "graded"
+        except UnknownClassState as exc:
+            outcome = str(exc)
+        expect("a foreign class state on %s is not graded" % surface,
+               outcome.startswith("%s carries a class state this grader does not know: "
+                                  "imports='projected'" % surface), True)
+    expect("the closed set is the four words the product publishes",
+           sorted(CLASS_PRESENT | CLASS_SHORT),
+           ["absent", "present", "unknown", "unproduced"])
 
     # A payload carrying no verdict block at all yields no surfaces, so a check
     # reports UNREADABLE rather than inventing agreement out of silence.

--- a/scripts/acceptance/verdict_limits_repro.py
+++ b/scripts/acceptance/verdict_limits_repro.py
@@ -42,6 +42,15 @@ winning. These checks hold the envelope to it on a live store:
               linker emits no entity-level import edge, and `present` on one
               whose linker does. `absent` on this source is the 0.5.52 wording
               this ticket is about.
+  two_reasons the same query under the server's smallest response budget,
+              which withholds rows and refuses on its own. Every input the
+              verdict records as inconclusive keeps its clause in
+              `limiting_factor`, each label once: the budget's clause beside
+              the class gap on a build that cannot produce the import class,
+              the budget's clause alone on one that can. The shape this guards
+              against kept one clause and dropped the rest, which one level up
+              is a CLI line naming the edge gap and not the dead embedding
+              worker beside it.
 
     CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
 
@@ -209,9 +218,65 @@ def import_class_never_absent_on_importing_source(payload):
     return classes["imports"] in ("unproduced", "present"), classes["imports"]
 
 
+# Which clause of `limiting_factor` each verdict input is entitled to, by the
+# label its reading writes. The absence gate composes its own clauses out of
+# every gap it pushed and is not held to one label.
+INPUT_CLAUSE_LABELS = {
+    "edge_coverage": ("cross_file_edges_", "edge_coverage_unknown"),
+    "withheld_candidates": ("withheld_candidates",),
+    "degradations": ("retrieval_degraded",),
+    "completeness": ("substrate_", "counts_are_a_floor"),
+    "response_budget": ("response_bounded",),
+}
+
+# The smallest response budget the server serves (`RESPONSE_MIN_MAX_CHARS`).
+# Asking for it on a populated answer withholds rows, which is the one refusal
+# an acceptance run can add to an answer on purpose.
+BUDGET_FLOOR_CHARS = 2000
+
+
+def factor_clauses(factor):
+    """The `label: text` clauses of one limiting factor, in order."""
+    clauses = [c.strip() for c in (factor or "").split("; ") if c.strip()]
+    return [(c.split(":", 1)[0].strip(), c) for c in clauses]
+
+
+def factor_carries_every_refusing_input(payload):
+    """Every input the verdict records as inconclusive has its clause in
+    `limiting_factor`, each label once, and a verdict no input refuses carries
+    no clause at all.
+
+    Returns (labels, problems). `labels` is None when the payload carries no
+    verdict inputs, which is UNREADABLE rather than a finding.
+    """
+    verdict = ((payload.get("_kin") or {}).get("verdict") or {})
+    inputs = verdict.get("inputs")
+    if not isinstance(inputs, dict) or verdict.get("state") not in ("certified", "inconclusive"):
+        return None, ["no verdict inputs"]
+    labels = [label for label, _ in factor_clauses(verdict.get("limiting_factor"))]
+    refusing = [name for name, state in inputs.items() if state == "inconclusive"]
+    problems = []
+    if refusing and verdict.get("state") != "inconclusive":
+        problems.append("inputs %s refuse while the verdict is %r" % (refusing, verdict.get("state")))
+    if refusing and not labels:
+        problems.append("inputs %s refuse and limiting_factor is empty" % refusing)
+    for name in refusing:
+        prefixes = INPUT_CLAUSE_LABELS.get(name)
+        if prefixes and not any(label.startswith(prefixes) for label in labels):
+            problems.append("input %s refuses and no clause of the factor is its (labels %s)"
+                            % (name, labels))
+    dupes = sorted({label for label in labels if labels.count(label) > 1})
+    if dupes:
+        problems.append("a label is said twice: %s" % dupes)
+    if not refusing and labels:
+        problems.append("no input refuses yet the factor reads %r" % labels)
+    return labels, problems
+
+
 GRADERS = {
     "verdict_honours_classes": verdict_honours_classes,
     "import_class_never_absent_on_importing_source": import_class_never_absent_on_importing_source,
+    "factor_carries_every_refusing_input": factor_carries_every_refusing_input,
 }
 
 
@@ -369,17 +434,19 @@ class Suite(object):
         self.repo = repo
         return repo
 
-    def references(self, kinds=None, attempts=10):
+    def references(self, kinds=None, attempts=10, extra=None):
         """find_references(blank_code), retried while the reference sweep
         settles, because `references` reads short until the language server has
-        run and that is a fact about timing rather than about the verdict."""
+        run and that is a fact about timing rather than about the verdict.
+        `extra` adds arguments to the call, such as a response budget."""
         repo = self.fixture()
-        key = tuple(kinds or ())
+        key = (tuple(kinds or ()), tuple(sorted((extra or {}).items())))
         if key in self.payloads:
             return self.payloads[key]
         args = {"query": "blank_code"}
         if kinds:
             args["relation_kinds"] = list(kinds)
+        args.update(extra or {})
         payload = None
         for attempt in range(attempts):
             self.kin_run(["graph", "status"], repo)
@@ -488,8 +555,45 @@ def check_unproduced(suite):
     return result
 
 
-CHECKS = [check_invariant, check_inverse, check_unproduced]
-DECLARED = ("invariant", "inverse", "unproduced")
+def check_two_reasons(suite):
+    result = Result("two_reasons", "a verdict with more than one reason to refuse names every "
+                                   "one of them in its limiting factor, each once")
+    # The response budget at the server's floor withholds rows from the
+    # populated answer, which downgrades the verdict independently of what the
+    # graph holds. Beside an import class this build cannot produce that is two
+    # reasons; on a build whose linker produces the class it is one, and the
+    # check says which world it graded. Either way every refusing input must
+    # keep its clause: the shape this guards against kept the budget's clause
+    # and dropped the rest, and one level up the CLI kept the class gap and
+    # dropped a dead embedding worker.
+    try:
+        payload = suite.references(extra={"max_chars": BUDGET_FLOOR_CHARS})
+    except Exception as error:  # noqa: BLE001
+        result.unknown("find_references(blank_code, max_chars=%d) unreadable: %s"
+                       % (BUDGET_FLOOR_CHARS, error))
+        return result
+    inputs = (((payload.get("_kin") or {}).get("verdict") or {}).get("inputs") or {})
+    if inputs.get("response_budget") != "inconclusive":
+        result.unknown("the response budget did not withhold rows at max_chars=%d (inputs %s), "
+                       "so no second reason was added and nothing was graded"
+                       % (BUDGET_FLOOR_CHARS, inputs))
+        return result
+    labels, problems = factor_carries_every_refusing_input(payload)
+    if labels is None:
+        result.unknown("the bounded answer carries no verdict inputs")
+        return result
+    refusing = sorted(name for name, state in inputs.items() if state == "inconclusive")
+    if problems:
+        result.bad("%s (refusing inputs %s, factor labels %s)"
+                   % ("; ".join(problems), refusing, labels))
+    else:
+        result.ok("%d refusing input(s) %s and the factor carries %s"
+                  % (len(refusing), refusing, labels))
+    return result
+
+
+CHECKS = [check_invariant, check_inverse, check_unproduced, check_two_reasons]
+DECLARED = ("invariant", "inverse", "unproduced", "two_reasons")
 
 
 # ------------------------------------------------------------------ self-test
@@ -555,6 +659,39 @@ def self_test():
            import_class_never_absent_on_importing_source(SHIPPED_0552), (False, "absent"))
     expect("no imports class is unreadable",
            import_class_never_absent_on_importing_source({"_kin": {}}), None)
+
+    def bounded(inputs, factor):
+        return {"_kin": {"verdict": {"state": "inconclusive", "limiting_factor": factor,
+                                     "inputs": inputs}}}
+    two = {"absence_gate": "inconclusive", "edge_coverage": "inconclusive",
+           "withheld_candidates": "certified", "degradations": "certified",
+           "completeness": "inconclusive", "response_budget": "inconclusive"}
+    full = ("response_bounded: the response budget withheld part of this answer; "
+            "cross_file_edges_unproduced: this build produced no entity-level imports edge for "
+            "Python; substrate_partial: the coverage classes this answer depended on were not "
+            "all observed present (calls, imports, references)")
+    expect("every refusing input has its clause",
+           factor_carries_every_refusing_input(bounded(two, full))[1], [])
+    expect("the factor a budget cut used to replace outright fails twice",
+           len(factor_carries_every_refusing_input(bounded(
+               two, "response_bounded: the response budget withheld part of this answer"))[1]), 2)
+    expect("a factor that kept only the first reading fails on the completeness clause",
+           factor_carries_every_refusing_input(bounded(
+               two, "response_bounded: x; cross_file_edges_unproduced: y"))[1],
+           ["input completeness refuses and no clause of the factor is its (labels "
+            "['response_bounded', 'cross_file_edges_unproduced'])"])
+    expect("a label said twice fails",
+           len(factor_carries_every_refusing_input(bounded(two, full + "; substrate_partial: again"))[1]),
+           1)
+    expect("a certified verdict with no clause passes",
+           factor_carries_every_refusing_input({"_kin": {"verdict": {
+               "state": "certified", "limiting_factor": None,
+               "inputs": {"edge_coverage": "certified"}}}})[1], [])
+    expect("a certified verdict carrying a clause fails",
+           len(factor_carries_every_refusing_input({"_kin": {"verdict": {
+               "state": "certified", "limiting_factor": "retrieval_degraded: x",
+               "inputs": {"edge_coverage": "certified"}}}})[1]), 1)
+    expect("no verdict inputs is unreadable", factor_carries_every_refusing_input({})[0], None)
 
     expect("every declared id has a check",
            tuple(c.__name__.replace("check_", "") for c in CHECKS), DECLARED)

--- a/scripts/acceptance/verdict_limits_repro.py
+++ b/scripts/acceptance/verdict_limits_repro.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""NON-CITABLE acceptance suite for the one-verdict contract (FIR-2672).
+
+Its output is a regression gate, never proof, never investor-facing and never a
+released claim. It shares the CHECK line format, the exit codes and the
+`--self-test` discipline of its siblings in this directory.
+
+What it is for
+--------------
+The rc0552s green stranger asked `find_references` for a Python function on
+0.5.52, got a verdict reading `state: certified`, `edge_coverage: certified`,
+`limiting_factor: null`, `completeness.status: complete`, `bound: exact`, and a
+note saying the counts were the whole set, in the same `_kin` block that
+recorded `classes.imports: "absent"` and `limits: ["edge_coverage:imports_absent"]`.
+It renamed the sites Kin certified and the code broke on the import sites Kin
+had never been able to read. Every release from 0.5.43, the first to carry the
+one verdict, certified the same way; the rule was born certifying over a
+recorded limit.
+
+The contract the MCP instructions state is one verdict per response, computed
+from every block that qualifies the answer, with the most pessimistic input
+winning. These checks hold the envelope to it on a live store:
+
+  invariant   on the default query (calls, imports, references), no requested
+              class in `completeness.classes` may read anything but `present`
+              while the verdict certifies; when one does, the verdict is
+              inconclusive, its limiting factor names the class, the
+              completeness status is not `complete`, the bound is a floor, and
+              `limits` names the class. When every class is present, the
+              verdict certifies. Either world passes; the shipped shape fails.
+  inverse     the control that keeps the invariant from being satisfied by
+              refusing everything. On a build whose linker produces import
+              edges, the default query has every requested class present and
+              must certify with `limiting_factor: null` and an exact count;
+              that is the genuine inverse. On a build whose linker does not,
+              the check falls back to the same focal over `calls` alone, a
+              class the fixture proves present, and says so in its detail.
+  unproduced  the import class is never `absent` on a source whose files
+              import one another: it reads `unproduced` on a build whose
+              linker emits no entity-level import edge, and `present` on one
+              whose linker does. `absent` on this source is the 0.5.52 wording
+              this ticket is about.
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+UNREADABLE is a distinct outcome from FAIL and is never reported as a pass.
+Exit status is 1 when any check FAILs, 2 when none fail but some are
+UNREADABLE, 0 only when every check passes, 3 on a setup error.
+
+The binary under test
+---------------------
+    cargo build --release --locked --bin kin --bin kin-daemon
+    python3 scripts/acceptance/verdict_limits_repro.py --kin target/release/kin
+
+`--kin` may also come from KIN_BIN. The kin-daemon beside it is used when one
+exists. The fixture is Python and the `references` class needs a Python
+language server (pyright) reachable by the daemon, as the acceptance workflow
+installs; without one, `references` reads short and the checks say so.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+TICKET = "FIR-2672"
+CLASSES = ("calls", "imports", "references")
+
+# The `_kin` block the rc0552s stranger received on 0.5.52, verbatim in every
+# field the graders read. It must fail the invariant grader or this suite
+# guards nothing.
+SHIPPED_0552 = {
+    "_kin": {
+        "completeness": {
+            "bound": "exact",
+            "classes": {"calls": "present", "imports": "absent", "references": "present"},
+            "counted": {"exact": True, "reported": 5, "unit": "referencing_entities"},
+            "decided_by": ["calls", "references"],
+            "limits": ["edge_coverage:imports_absent"],
+            "note": "This answer rested on the calls, references edge class(es), and each was "
+                    "observed present, so the counts here are the whole set.",
+            "status": "complete",
+            "substrate": "edges",
+        },
+        "verdict": {
+            "inputs": {"absence_gate": "certified", "completeness": "certified",
+                       "degradations": "not_applicable", "edge_coverage": "certified",
+                       "withheld_candidates": "certified"},
+            "limiting_factor": None,
+            "note": "Every input that could qualify this answer agreed, so the counts here are "
+                    "the whole set and an absence in it is authoritative.",
+            "safe_to_conclude_absent": False,
+            "state": "certified",
+        },
+    },
+    "references": [{}] * 5,
+    "relation_kinds": ["calls", "imports", "references"],
+}
+
+
+def tail(text, limit=400):
+    text = (text or "").strip()
+    return text if len(text) <= limit else "..." + text[-limit:]
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    proc = subprocess.run(cmd, cwd=cwd, env=env, timeout=timeout,
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    return proc.returncode, proc.stdout
+
+
+class Result(object):
+    def __init__(self, check_id, title):
+        self.id = check_id
+        self.title = title
+        self.asserts = []
+
+    def ok(self, detail):
+        self.asserts.append({"status": PASS, "detail": detail})
+
+    def bad(self, detail):
+        self.asserts.append({"status": FAIL, "detail": detail})
+
+    def unknown(self, detail):
+        self.asserts.append({"status": UNREADABLE, "detail": detail})
+
+    @property
+    def status(self):
+        graded = [a for a in self.asserts if a["status"] in (PASS, FAIL, UNREADABLE)]
+        if any(a["status"] == FAIL for a in graded):
+            return FAIL
+        if any(a["status"] == UNREADABLE for a in graded):
+            return UNREADABLE
+        if not graded:
+            return UNREADABLE
+        return PASS
+
+    @property
+    def detail(self):
+        for wanted in (FAIL, UNREADABLE):
+            for a in self.asserts:
+                if a["status"] == wanted:
+                    return a["detail"]
+        graded = [a["detail"] for a in self.asserts if a["status"] == PASS]
+        return "; ".join(graded) if graded else "no assertion was reached"
+
+
+# ------------------------------------------------------------------- graders
+
+def verdict_honours_classes(payload):
+    """Every requested class the answer could not read makes the verdict
+    inconclusive and names itself; every class present certifies.
+
+    Returns (verdict, problems). `verdict` is None when the payload does not
+    carry the fields, which is UNREADABLE rather than a finding.
+    """
+    kin = payload.get("_kin") or {}
+    comp = kin.get("completeness") or {}
+    verdict = kin.get("verdict") or {}
+    classes = comp.get("classes")
+    state = verdict.get("state")
+    if not isinstance(classes, dict) or state not in ("certified", "inconclusive"):
+        return None, ["no completeness.classes map or no verdict state"]
+    requested = [c for c in (payload.get("relation_kinds") or list(classes)) if c in classes]
+    if not requested:
+        return None, ["no requested class is in completeness.classes"]
+    short = [c for c in requested if classes.get(c) != "present"]
+    problems = []
+    limits = comp.get("limits") or []
+    counted = comp.get("counted") or {}
+    if short:
+        if state != "inconclusive":
+            problems.append("verdict is %r while %s read %s"
+                            % (state, ", ".join(short), [classes[c] for c in short]))
+        factor = verdict.get("limiting_factor") or ""
+        if not any(c in factor for c in short):
+            problems.append("limiting_factor %r names none of %s" % (factor[:120], short))
+        if comp.get("status") == "complete":
+            problems.append("completeness.status is complete over %s" % short)
+        if comp.get("bound") == "exact" or counted.get("exact") is True:
+            problems.append("bound/counted.exact claim an exact count over %s" % short)
+        if not any(any(l.startswith("edge_coverage:%s_" % c) for c in short) for l in limits):
+            problems.append("limits %s name none of %s" % (limits, short))
+        if (verdict.get("inputs") or {}).get("edge_coverage") == "certified":
+            problems.append("inputs.edge_coverage reads certified over %s" % short)
+    else:
+        if state != "certified":
+            problems.append("every class is present yet the verdict is %r (%s)"
+                            % (state, (verdict.get("limiting_factor") or "")[:160]))
+    return state, problems
+
+
+def import_class_never_absent_on_importing_source(payload):
+    """On a source whose files import one another the import class is a fact
+    about the build (`unproduced`) or a witnessed edge (`present`), never a
+    completed observation about the code (`absent`)."""
+    classes = ((payload.get("_kin") or {}).get("completeness") or {}).get("classes")
+    if not isinstance(classes, dict) or "imports" not in classes:
+        return None
+    return classes["imports"] in ("unproduced", "present"), classes["imports"]
+
+
+GRADERS = {
+    "verdict_honours_classes": verdict_honours_classes,
+    "import_class_never_absent_on_importing_source": import_class_never_absent_on_importing_source,
+}
+
+
+# ------------------------------------------------------------------- fixtures
+
+# Three files that reach one another through every class the verdict reads:
+# `search.py` and the test import from `parsing.py` (imports), call
+# `blank_code` (calls), and use the `Note` class as an annotation and read its
+# attributes (references, which a language server resolves). A fixture with
+# calls alone reads `references: absent` honestly, and the genuine inverse
+# needs every class present.
+FILES = {
+    "pkg/__init__.py": "",
+    "pkg/parsing.py": (
+        '"""Parsing helpers."""\n\n\n'
+        "class Note:\n"
+        '    """One parsed note: a title and the body under it."""\n\n'
+        "    def __init__(self, title: str, body: str) -> None:\n"
+        "        self.title = title\n"
+        "        self.body = body\n\n"
+        "    def word_count(self) -> int:\n"
+        "        return len(self.body.split())\n\n\n"
+        "def blank_code(text: str) -> str:\n"
+        '    """Mask fenced code so tags inside it are not markup."""\n'
+        "    out = []\n"
+        "    for line in text.splitlines():\n"
+        "        out.append('' if line.startswith('```') else line)\n"
+        "    return '\\n'.join(out)\n\n\n"
+        "def extract_tags(text: str) -> list:\n"
+        "    masked = blank_code(text)\n"
+        "    return [w[1:] for w in masked.split() if w.startswith('#')]\n\n\n"
+        "def parse_note(text: str) -> Note:\n"
+        "    title, _, body = text.partition('\\n')\n"
+        "    return Note(title.strip('# '), blank_code(body))\n"
+    ),
+    "pkg/search.py": (
+        "from pkg.parsing import Note, blank_code, extract_tags, parse_note\n\n\n"
+        "def index_note(text: str) -> dict:\n"
+        "    note: Note = parse_note(text)\n"
+        "    body = blank_code(text)\n"
+        "    return {'title': note.title, 'tags': extract_tags(text),\n"
+        "            'words': note.word_count(), 'raw_words': len(body.split())}\n"
+    ),
+    "tests/__init__.py": "",
+    # The test's name does not contain the focal's name on purpose: the query
+    # resolves its focal by name pattern, and a second match would make the
+    # focal ambiguous, which is a refusal of its own and not the one under test.
+    "tests/test_parsing.py": (
+        "from pkg.parsing import Note, blank_code, parse_note\n\n\n"
+        "def test_fenced_tags_are_masked():\n"
+        "    assert '#nope' not in blank_code('real #tag\\n```\\n#nope\\n```')\n\n\n"
+        "def test_parsed_title_is_kept():\n"
+        "    note: Note = parse_note('# Alpha\\nbody')\n"
+        "    assert note.title == 'Alpha'\n"
+    ),
+}
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.kin_home = os.path.join(workdir, "kin-home-%d" % os.getpid())
+        os.makedirs(self.kin_home, exist_ok=True)
+        self.env = dict(os.environ)
+        self.env["KIN_HOME"] = self.kin_home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DIR", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self.repo = None
+        self.payloads = {}
+
+    def log(self, line):
+        if self.verbose:
+            print("  " + line, flush=True)
+
+    def git(self, args, cwd):
+        base = ["git", "-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
+        return run(base + args, cwd=cwd, env=self.env)
+
+    def kin_run(self, args, repo, timeout=600):
+        rc, out = run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+        self.log("kin %s -> %d" % (" ".join(args), rc))
+        return rc, out
+
+    def mcp(self, repo, tool, args, timeout=300):
+        env = dict(self.env)
+        env["KIN_MCP_REPO"] = repo
+        proc = subprocess.Popen([self.kin, "mcp", "start", "--repo", repo],
+                                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, cwd=repo, env=env, text=True)
+        msgs = [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+             "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                        "clientInfo": {"name": "kin-verdict-limits-repro", "version": "1"}}},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+             "params": {"name": tool, "arguments": args}},
+        ]
+        try:
+            out, err = proc.communicate("".join(json.dumps(m) + "\n" for m in msgs),
+                                        timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            raise RuntimeError("mcp %s timed out after %ss" % (tool, timeout))
+        resp = None
+        for line in out.splitlines():
+            line = line.strip()
+            if line.startswith("{"):
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue
+                if obj.get("id") == 2:
+                    resp = obj
+        if resp is None:
+            raise RuntimeError("mcp %s returned no id=2 frame (stderr tail: %s)"
+                               % (tool, err[-300:].replace("\n", " ")))
+        if "error" in resp:
+            raise RuntimeError("mcp %s error: %s" % (tool, json.dumps(resp["error"])[:200]))
+        content = (resp.get("result") or {}).get("content") or []
+        if not content or "text" not in content[0]:
+            raise RuntimeError("mcp %s returned no text content" % tool)
+        return json.loads(content[0]["text"])
+
+    def fixture(self):
+        """A three-file Python package whose files import and call one another,
+        admitted through `kin init`, with its enrichment sweep given time."""
+        if self.repo:
+            return self.repo
+        repo = os.path.join(self.workdir, "importing")
+        for rel, body in FILES.items():
+            path = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as handle:
+                handle.write(body)
+        rc, out = self.git(["init", "-q", "--initial-branch=main"], repo)
+        if rc != 0:
+            raise RuntimeError("git init failed: %s" % tail(out))
+        self.git(["config", "user.email", "repro@example.invalid"], repo)
+        self.git(["config", "user.name", "kin-verdict-limits-repro"], repo)
+        self.git(["add", "--all"], repo)
+        rc, out = self.git(["commit", "-q", "-m", "a package whose files import one another"], repo)
+        if rc != 0:
+            raise RuntimeError("git commit failed: %s" % tail(out))
+        rc, out = self.kin_run(["init"], repo, timeout=900)
+        if rc != 0:
+            raise RuntimeError("kin init failed: %s" % tail(out))
+        self.repo = repo
+        return repo
+
+    def references(self, kinds=None, attempts=10):
+        """find_references(blank_code), retried while the reference sweep
+        settles, because `references` reads short until the language server has
+        run and that is a fact about timing rather than about the verdict."""
+        repo = self.fixture()
+        key = tuple(kinds or ())
+        if key in self.payloads:
+            return self.payloads[key]
+        args = {"query": "blank_code"}
+        if kinds:
+            args["relation_kinds"] = list(kinds)
+        payload = None
+        for attempt in range(attempts):
+            self.kin_run(["graph", "status"], repo)
+            payload = self.mcp(repo, "find_references", args)
+            classes = ((payload.get("_kin") or {}).get("completeness") or {}).get("classes") or {}
+            if all(classes.get(c) == "present" for c in classes if c != "imports"):
+                break
+            time.sleep(4)
+        self.payloads[key] = payload
+        return payload
+
+
+# --------------------------------------------------------------------- checks
+
+def check_invariant(suite):
+    result = Result("invariant", "the verdict never certifies over a requested class it could "
+                                 "not read, and certifies when every class is present")
+    try:
+        payload = suite.references()
+    except Exception as error:  # noqa: BLE001
+        result.unknown("find_references(blank_code) unreadable: %s" % error)
+        return result
+    refs = payload.get("references") or []
+    if not refs:
+        result.unknown("find_references(blank_code) returned no rows, so the populated-answer "
+                       "verdict is not exercised: %s" % tail(json.dumps(payload), 300))
+        return result
+    state, problems = verdict_honours_classes(payload)
+    classes = payload["_kin"]["completeness"].get("classes")
+    if state is None:
+        result.unknown("; ".join(problems))
+    elif problems:
+        result.bad("classes=%s verdict=%s: %s" % (json.dumps(classes), state, "; ".join(problems)))
+    else:
+        result.ok("%d rows, classes=%s, verdict=%s, limiting_factor=%s"
+                  % (len(refs), json.dumps(classes), state,
+                     (payload["_kin"]["verdict"].get("limiting_factor") or "null")[:90]))
+    return result
+
+
+def check_inverse(suite):
+    result = Result("inverse", "an answer with every requested class present certifies cleanly, "
+                               "with no limiting factor and an exact count")
+    # The genuine inverse first: the default query, on a build whose linker
+    # produces import edges, has every requested class present.
+    try:
+        payload = suite.references()
+    except Exception as error:  # noqa: BLE001
+        result.unknown("find_references(blank_code) unreadable: %s" % error)
+        return result
+    classes = ((payload.get("_kin") or {}).get("completeness") or {}).get("classes") or {}
+    if classes and all(classes.get(c) == "present" for c in CLASSES if c in classes):
+        return grade_inverse(result, payload, "every requested class present")
+    # The fallback control on a build whose linker produces no import edge: the
+    # same focal over `calls` alone, a class the fixture proves present. It is a
+    # control over a class that IS present, not over classes left unrequested
+    # by accident, and the detail says which arm ran.
+    try:
+        payload = suite.references(kinds=("calls",))
+    except Exception as error:  # noqa: BLE001
+        result.unknown("find_references(blank_code, calls) unreadable: %s" % error)
+        return result
+    calls_classes = ((payload.get("_kin") or {}).get("completeness") or {}).get("classes") or {}
+    if calls_classes.get("calls") != "present":
+        result.unknown("the calls class reads %r on the fixture, so no certified control is "
+                       "available" % calls_classes.get("calls"))
+        return result
+    return grade_inverse(result, payload, "control: calls alone, while imports reads %r on this "
+                                          "build" % classes.get("imports"))
+
+
+def grade_inverse(result, payload, arm):
+    refs = payload.get("references") or []
+    state, problems = verdict_honours_classes(payload)
+    kin = payload.get("_kin") or {}
+    comp = kin.get("completeness") or {}
+    factor = (kin.get("verdict") or {}).get("limiting_factor")
+    if state == "certified" and not problems and comp.get("bound") == "exact" and factor is None:
+        result.ok("%s: %d rows, certified, limiting_factor null, bound exact" % (arm, len(refs)))
+    else:
+        result.bad("%s: did not certify cleanly: state=%s limiting_factor=%s bound=%s %s"
+                   % (arm, state, (factor or "null")[:120], comp.get("bound"),
+                      "; ".join(problems)))
+    return result
+
+
+def check_unproduced(suite):
+    result = Result("unproduced", "the import class on an importing source reads unproduced or "
+                                  "present, never absent")
+    try:
+        payload = suite.references()
+    except Exception as error:  # noqa: BLE001
+        result.unknown("find_references(blank_code) unreadable: %s" % error)
+        return result
+    graded = import_class_never_absent_on_importing_source(payload)
+    if graded is None:
+        result.unknown("this build's completeness block carries no imports class")
+        return result
+    honest, state = graded
+    if honest:
+        result.ok("imports reads %r on a source whose files import one another" % state)
+    else:
+        result.bad("imports reads %r on a source whose files import one another; the class was "
+                   "never readable on this build, and absent says the code has no such site"
+                   % state)
+    return result
+
+
+CHECKS = [check_invariant, check_inverse, check_unproduced]
+DECLARED = ("invariant", "inverse", "unproduced")
+
+
+# ------------------------------------------------------------------ self-test
+
+def self_test():
+    failures = []
+    counted = [0]
+
+    def expect(label, got, want):
+        counted[0] += 1
+        if got != want:
+            failures.append("%s: got %r, wanted %r" % (label, got, want))
+
+    # The shipped 0.5.52 shape must fail, at every field a reader acts on.
+    state, problems = verdict_honours_classes(SHIPPED_0552)
+    expect("the shipped shape is graded", state, "certified")
+    expect("the shipped shape fails", len(problems) >= 5, True)
+    expect("the shipped shape's verdict is named", any("verdict is" in p for p in problems), True)
+    expect("the shipped shape's exact count is named",
+           any("exact" in p for p in problems), True)
+
+    def honest(imports="present", state="certified", factor=None, status="complete",
+               bound="exact", limits=None, edge_in="certified"):
+        return {
+            "_kin": {
+                "completeness": {"bound": bound, "status": status,
+                                 "classes": {"calls": "present", "imports": imports,
+                                             "references": "present"},
+                                 "counted": {"exact": bound == "exact", "reported": 5},
+                                 "limits": limits or []},
+                "verdict": {"state": state, "limiting_factor": factor,
+                            "inputs": {"edge_coverage": edge_in}},
+            },
+            "references": [{}] * 5,
+            "relation_kinds": ["calls", "imports", "references"],
+        }
+    expect("every class present and certified passes", verdict_honours_classes(honest())[1], [])
+    fixed = honest(imports="unproduced", state="inconclusive",
+                   factor="cross_file_edges_unproduced: this build produced no entity-level "
+                          "imports edge for Python", status="partial", bound="at_least",
+                   limits=["edge_coverage:imports_unproduced", "verdict_inconclusive"],
+                   edge_in="inconclusive")
+    expect("the fixed shape passes", verdict_honours_classes(fixed)[1], [])
+    expect("a fixed shape whose factor names another class fails",
+           len(verdict_honours_classes(dict(fixed, _kin={
+               "completeness": fixed["_kin"]["completeness"],
+               "verdict": dict(fixed["_kin"]["verdict"], limiting_factor="retrieval_degraded")}))[1]) >= 1,
+           True)
+    expect("all present but inconclusive fails (no false inconclusive)",
+           len(verdict_honours_classes(honest(state="inconclusive", factor="x"))[1]), 1)
+    expect("a payload with no classes is unreadable",
+           verdict_honours_classes({"_kin": {"verdict": {"state": "certified"}}})[0], None)
+    expect("calls-only query reads only calls",
+           verdict_honours_classes(dict(honest(imports="absent"),
+                                        relation_kinds=["calls"]))[1], [])
+
+    expect("unproduced is honest",
+           import_class_never_absent_on_importing_source(honest(imports="unproduced")),
+           (True, "unproduced"))
+    expect("present is honest",
+           import_class_never_absent_on_importing_source(honest()), (True, "present"))
+    expect("absent is the shipped wording",
+           import_class_never_absent_on_importing_source(SHIPPED_0552), (False, "absent"))
+    expect("no imports class is unreadable",
+           import_class_never_absent_on_importing_source({"_kin": {}}), None)
+
+    expect("every declared id has a check",
+           tuple(c.__name__.replace("check_", "") for c in CHECKS), DECLARED)
+
+    grade_cases = [(PASS, [(PASS, "a")]), (FAIL, [(PASS, "a"), (FAIL, "b")]),
+                   (UNREADABLE, [(PASS, "a"), (UNREADABLE, "b")]), (UNREADABLE, [])]
+    for want, entries in grade_cases:
+        r = Result("t", "t")
+        for status, detail in entries:
+            r.asserts.append({"status": status, "detail": detail})
+        if r.status != want:
+            failures.append("Result.status(%s) = %s, wanted %s" % (entries, r.status, want))
+
+    for failure in failures:
+        print("SELFTEST FAIL %s" % failure)
+    total = counted[0] + len(grade_cases)
+    print("kin-verdict-limits-repro: self-test %d/%d cases" % (total - len(failures), total))
+    return 1 if failures else 0
+
+
+# ----------------------------------------------------------------------- main
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path", default=None)
+    parser.add_argument("--label", default=os.environ.get("KIN_ACCEPTANCE_LABEL"))
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+    if not args.kin:
+        print("kin-verdict-limits-repro: no kin binary. Pass --kin or set KIN_BIN.")
+        return 3
+    kin = os.path.abspath(os.path.expanduser(args.kin))
+    if not os.path.isfile(kin) or not os.access(kin, os.X_OK):
+        print("kin-verdict-limits-repro: %s is not an executable file" % kin)
+        return 3
+    daemon = args.daemon and os.path.abspath(os.path.expanduser(args.daemon))
+    if not daemon:
+        beside = os.path.join(os.path.dirname(kin), "kin-daemon")
+        daemon = beside if os.path.isfile(beside) else None
+
+    workdir = tempfile.mkdtemp(prefix="kin-verdict-limits-repro-")
+    suite = None
+    try:
+        suite = Suite(kin, workdir, daemon=daemon, verbose=args.verbose)
+        results = []
+        for check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001
+                result = Result(check.__name__.replace("check_", ""), "probe crashed")
+                result.unknown("%s: %s" % (type(error).__name__, error))
+                results.append(result)
+        for result in results:
+            print("CHECK %s %s %s %s" % (result.id, TICKET, result.status, result.detail))
+        answered = tuple(r.id for r in results)
+        if answered != DECLARED:
+            print("kin-verdict-limits-repro: declared %s but %s answered" % (DECLARED, answered))
+            return 3
+        print("kin-verdict-limits-repro: %d of %d declared checks answered"
+              % (len(answered), len(DECLARED)))
+        failed = [r for r in results if r.status == FAIL]
+        unreadable = [r for r in results if r.status == UNREADABLE]
+        print("kin-verdict-limits-repro: %d checks, %d pass, %d FAIL, %d UNREADABLE"
+              % (len(results), len(results) - len(failed) - len(unreadable),
+                 len(failed), len(unreadable)))
+        if args.json_path:
+            payload = {"suite": "verdict_limits_repro", "ticket": TICKET, "label": args.label,
+                       "kin": kin,
+                       "results": [{"id": r.id, "ticket": TICKET, "title": r.title,
+                                    "status": r.status, "detail": r.detail, "asserts": r.asserts}
+                                   for r in results]}
+            directory = os.path.dirname(os.path.abspath(args.json_path))
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            with open(args.json_path, "w") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+        if failed:
+            return 1
+        if unreadable:
+            return 2
+        return 0
+    finally:
+        if suite is not None and suite.repo:
+            suite.kin_run(["daemon", "stop"], suite.repo)
+        if not args.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
The one verdict now means what it says. On 0.5.52, `find_references` on a Python function answered `verdict.state: certified`, `inputs.edge_coverage: certified`, `limiting_factor: null`, `completeness.status: complete`, `bound: exact` and a note calling the counts the whole set, in the same `_kin` block that recorded `classes.imports: absent` and `limits: [edge_coverage:imports_absent]`. The rc0552s stranger renamed the sites Kin certified and the code broke on the import sites Kin had never been able to read.

The mechanism in one line: the limits list was disclosure, never input. `limits` was computed over every requested class, while the verdict, the absence gate, the completeness status and the scan-skip rule all read a deciding set narrowed to `calls`, on the reasoning that Kin minted no entity-level `Imports` edge and weighing the class would refuse everything. That one sentence explains every symptom in the ticket, including `safe_to_conclude_absent: false` sitting inside a verdict whose note called an absence authoritative.

Reproduced on the exact candidate bytes (rc/0552b, sha `8b6e5433`, `kin 0.5.52 153460e99`, fresh container) and on the 1fcffd7e macOS build with the stranger's own pre-rename fixture, rebuilt from the two files it wrote in its transcript: identical fields, verbatim.

## Not a regression: the rule was born certifying over limits

The corrected bisect question, since entity-level import edges have never existed (#1123 fixes the emitter), is when the verdict began certifying over a recorded limit. At its birth. #966 introduced `_kin.verdict` with `edge_coverage_reading` narrowed to `calls` through `negative.rs::load_bearing_classes`, and `verdict.rs` has had three commits since, none widening it. On shipped macOS binaries with the same fixture: v0.5.39 carries no verdict block (the three-block era); v0.5.43, the first with the one verdict, certified over `imports unknown, references unknown`; every release from v0.5.44 through the frozen candidate certified over `imports absent`. What changed across releases was which classes were short, never whether a short class was weighed.

## The mechanism

`limits` was computed over every requested class (`edge_coverage_degradation_labels`: "the verdict consumes the load-bearing classes; this consumes all of them"), while the verdict, the absence gate, the completeness `status` and the scan-skip rule all read `load_bearing_classes`, which kept only `calls` on the reasoning that Kin minted no entity-level `Imports` edge and gating on it would refuse everything. So the limit was disclosure and never input. One level down, `ClassState::Absent` meant "the scan completed and observed none", a completed observation about the code, and it was what a class the build never emits was reported as.

## What changed

- `kin-mcp/edge_coverage.rs`: a fourth class state, `unproduced`. The witness scan assigns it from data it already holds: the scan completed, no entity-rooted relation of the class exists anywhere in the language (a class seen intra-file is producible and stays `absent`), and the parse side shows sites the linker had to resolve, which for `imports` is an artifact-level import edge on the language's files (on the fixture, `kin graph status` reads `imports 17/48`, all artifact level) or, where the language settles externality, a statement naming a module inside the repository, and for `calls` a complete per-file call-site count above zero. `references` is never raised here; `reference_enrichment` already carries the build and host fact for it. The evidence is published under `unproduced_evidence`. Why a third state and not `unknown`: nothing was left unread, the scan finished, and `unknown` tells a reader to retry, which cannot help. Why not `absent`: `absent` is a statement about the code and this is one about the build. Why measured and not a build constant: a constant would have to be flipped by hand when #1123 lands and would lie in one direction or the other until then; the measured state flips itself the moment the emitter produces an edge.
- `kin-mcp/negative.rs`: every requested class decides. `load_bearing_classes` returns the request, so the absence gate, the completeness block, the scan-skip rule and the verdict move together, which is the invariant the code insisted on. The gate gains the `unproduced` sentence ("the gap is in the linker, not in the code"), and the enrichment refusal now leads the composed reason rather than trailing it, since a class the build cannot produce is the sharper reason once the class gaps fire on the same classes.
- `kin-mcp/verdict.rs`: `edge_coverage_reading` refuses on any requested class not `present`, most specific state first (`cross_file_edges_unproduced`, `cross_file_edges_not_present`, `edge_coverage_unknown`); `project_onto_completeness` reads `unproduced` as partial.
- `kin-mcp/envelope.rs`: `completeness.status` is `partial` for an absent or unproduced deciding class.
- `kin-cli absence_qualifier.rs`: renders unproduced classes in their own sentence and names every non-present decided class.
- `docs/mcp-tools.md`: the contract and the three short states, in words.
- `scripts/acceptance/verdict_limits_repro.py`, three checks with controls, wired into the acceptance workflow and gate: `invariant` (default classes on a three-file Python package whose files import and call one another: a short class must make the verdict inconclusive, be named in the limiting factor and in `limits`, and turn `status`, `bound` and `counted.exact` into a floor; every class present must certify), `inverse` (the same focal over `calls` alone, which the fixture proves present, certifies with an exact count), `unproduced` (the import class reads `unproduced` on a build whose linker emits no entity-level import edge and `present` on one whose linker does, never `absent`). The self-test feeds the graders the exact 0.5.52 envelope, which must fail.

## The 38 tests that went red, and what they say now

36 kin-mcp tests and 2 kin-cli tests failed on the first run of the change, and none was bent to fit. They were three things. Twenty-eight inherited a shared fixture that declared "healthy coverage" with `imports: absent`: `negative.rs cross_file_edges_observed`, `envelope.rs reference_payload`, `entities.rs seed_cross_file_call_witness` (whose doc said an entity-level `Imports` edge "would assert authority on a shape no real graph produces", the codebase's own record of the gap), and the kin-cli impact fixtures; those fixtures now link every class, so "healthy" means what the tests always meant. Five pinned the narrowing in an assertion (`decided_by: ["calls"]`, `cross_file_classes: ["calls"]`, `degraded_signals` carrying `imports_absent` beside an authoritative verdict) and now assert the full deciding set. Five asserted the old rule as the behaviour under test and were rewritten to assert the contract, and the one to read is `imports_absent_alone_is_never_what_blocks_a_verdict`, whose name is the old rule stated as a guarantee; it is now `imports_absent_alone_blocks_a_verdict_and_names_itself`, and `a_python_graph_that_resolves_its_imports_still_certifies_an_unused_symbol`, the stranger's exact shape asserted as correct, is now `a_python_graph_whose_import_edges_were_never_produced_does_not_certify_an_unused_symbol` with the inverse arm beside it. One product change fell out of the reason-order tests: the enrichment refusal (`reference_enrichment_unsupported`) now leads the composed reason instead of trailing the class gaps, since a class the build cannot produce is the sharper reason once the class gaps fire on the same classes.

Until #1123 lands, a default `find_references` on a multi-file Python repository reads inconclusive with `cross_file_edges_unproduced` naming `imports`; that is the true state of the answer and it names the thing to fix. Once #1123 lands the class reads `present` and the same query certifies. Both are what the new checks accept, and the shipped shape is what they refuse.

## Tests

- kin-mcp (`cargo test -p kin-mcp --lib`, 650 pass, 0 fail). New:
  `verdict::tests::a_requested_class_the_answer_could_not_read_is_the_sole_cause_of_an_inconclusive_verdict`
  (every other input clean; for each of `absent`, `unproduced`, `unknown` the
  verdict is inconclusive, `inputs.edge_coverage` is inconclusive, the factor
  leads with the class's own state and names `imports`, and `withheld_candidates`
  and `degradations` did not refuse), `the_same_answer_with_every_class_present_still_certifies`
  (the inverse: same payload, `imports: present`, certified, no factor),
  `edge_coverage::tests::an_import_class_the_linker_produced_nothing_for_reads_unproduced`,
  `an_import_class_with_no_sites_to_resolve_stays_absent`,
  `a_class_seen_intra_file_is_producible_and_stays_absent`,
  `a_call_class_with_counted_sites_and_no_edge_reads_unproduced_only_off_a_complete_count`,
  `envelope::tests::a_populated_answer_over_an_unread_class_does_not_certify_and_stays_consistent`
  (the shipped shape at the envelope layer for `absent` and `unproduced`: every
  acted-on field follows the verdict, `limits` and `decided_by` name the class,
  and the `disagreements` scanner finds nothing; with the class present it
  certifies), `negative::tests::imports_absent_alone_blocks_a_verdict_and_names_itself`
  (rewritten from `imports_absent_alone_is_never_what_blocks_a_verdict`, which
  asserted the defect by name), and
  `a_python_graph_whose_import_edges_were_never_produced_does_not_certify_an_unused_symbol`
  (rewritten from `a_python_graph_that_resolves_its_imports_still_certifies_an_unused_symbol`,
  the stranger's shape asserted as correct).
- 36 kin-mcp tests and 2 kin-cli tests went red on the first run, and each was
  one of three things: a shared "healthy coverage" fixture that read
  `imports: absent` (`negative.rs cross_file_edges_observed`,
  `envelope.rs reference_payload`, `entities.rs seed_cross_file_call_witness`,
  whose doc said an entity-level `Imports` edge "would assert authority on a
  shape no real graph produces", and the kin-cli impact fixtures), now made
  healthy; an assertion on `decided_by` or `cross_file_classes` that pinned the
  narrowing, now the full set; or a reason-order test displaced by the new
  leading gap, given the class it did not mean to test. One design change came
  out of it: the enrichment refusal now leads the composed reason.
- kin-cli (`absence_qualifier`, `commands::refs`, `commands::impact`,
  `commands::dead_code`: 66 pass).
- `scripts/acceptance/verdict_limits_repro.py` on the fixed dev build: 3/3
  (`invariant`: 3 rows, classes calls present, imports unproduced, references
  absent, verdict inconclusive, factor `cross_file_edges_unproduced`; `inverse`:
  3 rows over calls alone, certified, bound exact; `unproduced`: imports reads
  unproduced). Self-test 19/19 with the shipped 0.5.52 envelope as a must-fail.
- The stranger's own fixture on the fixed dev build, default classes: 6 rows,
  `verdict inconclusive`, `inputs.edge_coverage inconclusive`,
  `limiting_factor: cross_file_edges_unproduced: this build produced no
  entity-level imports edge for Python although the source carries imports sites
  the linker resolved, so a use that reaches the target through imports could
  not have been found; the gap is in the linker, not in the code`,
  `status partial`, `bound at_least`, `counted.exact false`,
  `classes.imports unproduced`, `limits [edge_coverage:imports_unproduced,
  verdict_inconclusive]`, `negative.trust inconclusive`, and
  `edge_coverage.unproduced_evidence.imports = {artifact_level_import_edges: 17,
  entity_level_import_edges: 0, parsed_import_statements: 48}`
  (`/tmp/verdict2672/payload-fixed-dev.json`).

## Falsification, verbatim

Suite, fixed dev build: `invariant PASS, inverse PASS, unproduced PASS` (3/3), and
the stranger's own fixture reads inconclusive with `cross_file_edges_unproduced`
naming `imports` (section 5).

Class-level: the shipped 0.5.52 envelope, verbatim, fed to the suite's graders in
`--self-test` fails the invariant on five clauses (verdict certified over a short
class, factor names none of it, status complete, exact count, `inputs.edge_coverage`
certified). Every earlier release from v0.5.43 carries the same shape (section 2).

Per-check mutations on the fixed tree, each rebuilt, run against the suite and the
targeted unit tests, then restored (`/tmp/verdict2672/falsify.log`):

| mutation | suite | unit tests under the mutation |
| -- | -- | -- |
| M1: `load_bearing_classes` narrowed back to `calls` | `invariant FAIL` (certified while imports, references read unknown) and `unproduced FAIL` (imports reads unknown: the narrowed deciding set also skips the scan once calls is witnessed, so the class is never measured); `inverse PASS` | 4 FAILED: the sole-cause test, the envelope consistency test, `imports_absent_alone_blocks_a_verdict_and_names_itself`, `a_python_graph_whose_import_edges_were_never_produced_...`; 15 passed including both inverse tests |
| M2: `edge_coverage_reading` certifies over a short class | `invariant FAIL` on the clause `inputs.edge_coverage reads certified over [imports, references]`; the other two PASS | 2 FAILED: the sole-cause test (`inputs.edge_coverage`), the envelope consistency test; 17 passed |
| M3: `unproduced_evidence_for` always answers none | `unproduced FAIL` (imports reads absent on a source whose files import one another); `invariant PASS` (absent still refuses), `inverse PASS` | 2 FAILED: `an_import_class_the_linker_produced_nothing_for_reads_unproduced`, `a_call_class_with_counted_sites_and_no_edge_reads_unproduced_only_off_a_complete_count`; 17 passed |
| M4: `edge_coverage_reading` refuses every answer (the inverse) | `inverse UNREADABLE`, not PASS: the MCP server panicked on `response for find_references contradicts its own verdict: ["negative.trust reads authoritative under an inconclusive _kin.verdict ...` (the `disagreements` scanner, a debug assertion, caught the contradiction before the grader could), and the gate treats UNREADABLE as red; `invariant PASS`, `unproduced PASS` | 3 FAILED: `the_same_answer_with_every_class_present_still_certifies`, `a_clean_retrieval_payload_still_certifies`, the envelope consistency test's present arm; 16 passed |
| restored tree, rebuilt | 3/3 PASS | (source diff returned to the committed baseline after M1, M2, M3; after M4 the only difference was my own concurrent edit to the suite's `inverse` check, confirmed by `git status`) |

Read together: no check passes by accident. M1 shows the two checks the narrowing
defeats, M2 that the verdict's own input is asserted and not only the gate, M3 that
the third state is measured rather than declared, and M4 that a false refusal is
refused too, by two independent guards.

The genuine inverse, on real bytes. This branch merged with `origin/chore/lane-imports-kin`
(#1123, the entity-level import emitter; no file overlap, clean merge) built in a
scratch worktree as `kin 0.5.52 (83b1acabb detached)`:

- The stranger's own fixture, default classes: 7 rows, `verdict.state: certified`,
  every input certified, `limiting_factor: null`, `completeness.status: complete`,
  `bound: exact`, `counted.exact: true`, `classes: {calls: present, imports: present,
  references: present}`, `decided_by: [calls, imports, references]`, no limits,
  `negative.trust: authoritative`, `degraded_signals: []`
  (`/tmp/verdict2672/payload-merged.json`). The same query that reads
  `cross_file_edges_unproduced` on this branch alone reads certified once the
  edges exist, with no code change between the two runs.
- The suite on the same merged binaries: `invariant PASS` (6 rows, every class
  present, certified, factor null), `inverse PASS` on its genuine arm ("every
  requested class present: 6 rows, certified, limiting_factor null, bound
  exact"), `unproduced PASS` (imports reads present). On this branch alone the
  same suite reads `imports: unproduced` on `invariant`, takes the calls-only
  control on `inverse` and says so, and passes `unproduced`; both worlds pass,
  and the shipped shape fails in both.

## Gates run locally

Everything ran from the lane worktree through `bin/kin-lane run verdict2672 kin`, which builds under the lane's own target directory, against the tree that became the squashed head `9c1c1f568`. The squash changed no byte of it (`git diff --stat` between the last checkpoint and the squashed commit is empty), and the parity line below was run on the squashed commit itself.

- `cargo fmt --all -- --check`: clean.
- clippy exactly as ci.yml runs it (`cargo clippy --all-targets --all-features` under `RUSTFLAGS='-D warnings'` with ci.yml's allow list): rc 0. The only note is the `block v0.1.6` warning cargo prints for a dependency, which is on main today.
- `cargo test -p kin-mcp --lib`: 650 passed, 0 failed.
- `cargo test -p kin-cli --lib`: 1796 passed, 0 failed, after the trace fixtures below. The branch's first run read 1791 passed and 5 failed, all five in `commands::trace_data_flow`, whose call-chain and hub fixtures linked only calls; a chain that crosses files now carries an unrelated witness pair linking every class, a chain inside one file stays unlinked, and the lone entity stays blind, which is what those tests were always asserting about the graph.
- `cargo test -p kin-cli --tests -- refs impact dead_code mcp verdict`: 177 passed, 0 failed.
- The ci.yml guard scripts, from the worktree: 36 invocations, every one rc 0. `verify-zero-file-search.py`, `check_runtime_boundaries.sh`, `test-release-workflow-authority.py`, `test_install_optional_vfs.py`, `test_installer_parity.py`, the installer asset and archive verifiers with their falsifiers, `test-npm-automatic-release.py`, `test-verify-npm-release.py`, the thirteen `node --test` release scripts, the `node --check` and `bash -n` syntax legs, `test-release-policy-gate.sh`, `acceptance/test_workflow_step_visibility.py` (which admits the two new workflow steps), `acceptance/gate.py --self-test`, `verdict_limits_repro.py --self-test` (19 of 19, with the 0.5.52 envelope as the must-fail), and `falsify-zero-file-search.py` against a poisoned copy. Not run locally: `test-windows-authority-legs.sh` and the Windows legs themselves, the kin-mcp npm package tests, and the allowlist-mutating zero-file-search legs, which want the CI checkout. Hosted CI is the gate of record for those.
- `bin/kin-parity` on the branch before the trace-fixture fix (release build, `--jobs 6`): magic 21 of 21; firstrun green under its two checked-in allowances (check 3, FIR-2501; check 9, FIR-2580); brownfield read checks 5 and 6 FAIL, and that was the brownfield grader, not the product. Its `verdict_surfaces` counted a class as present unless it read `absent` or `unknown`, so the new `unproduced` word read as present and the grader called the surfaces inconsistent. The grader now treats any state other than `present` as short, its self-test carries the `unproduced` case, and the same release binaries then read 10 pass, 0 fail, 1 unreadable, the unreadable being check 4 (FIR-2464, a truncated walk), which parity already allows.
- `bin/kin-parity` on the squashed head `9c1c1f568` (release build, `--jobs 6`): running as this PR opens; its final line is edited in here before the PR lands.
- The new suite on this branch's build: `invariant PASS` (imports unproduced, references present, verdict inconclusive), `inverse PASS` on the named calls-only control, `unproduced PASS`. On the merged build with #1123: 3 of 3 on the genuine arm, quoted above.

## Not claiming

- That this makes `find_references` complete. Until #1123 lands, a default
  query on a multi-file Python repository reads inconclusive with
  `cross_file_edges_unproduced` naming `imports`; that is the true state of the
  answer and it names the thing to fix. The import sites are still not in the
  rows.
- That `unproduced` is measured for every language. It rests on the parser's
  per-file counts and on artifact-level import edges; a language whose parser
  records neither reads `absent` as before. `references` is never raised to it,
  because `reference_enrichment` already carries that fact.
- That the scan is free. A requested class the answer did not witness now costs
  the witness walk, bounded by `WITNESS_BUDGET`, on every populated answer until
  the class is witnessed; the O(files) artifact traversal runs only when the
  scan completed empty. The full kin-core coverage walk (`reference_resolution`)
  is not attached for an imports-only shortfall, on purpose.
- That every consumer of the wire word was updated. `kin refs`, `kin impact`
  and `kin dead-code` read `decided_by` and the class states through the same
  qualifier and were run; the acceptance suites other than this one were run
  through parity (see gates); external readers of `classes` will see a new word.
- Not re-run on a Linux release archive; verified on a macOS dev build, the
  suite, and by the CI acceptance job's own ubuntu build.

Closes FIR-2672
