### PR TITLE
Run the release version gate on release PRs, and make a stranded bump an error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,45 @@ jobs:
           done < <(git rev-list "${base}..${head}")
           exit "$missing"
 
+  # scripts/check-release-version.mjs has carried the right refusal since
+  # before the release train existed, and nothing ever ran it on a pull
+  # request. Its one real invocation is inside the train's own branch-writer
+  # step, which runs once against a tree that step just regenerated and never
+  # again on the head that merges, so a release pull request could lose its
+  # version bump afterwards and every check would stay green. The mint then
+  # reads a workspace version whose tag already exists, calls that nothing to
+  # release, and exits 0 on a fifteen-minute cron with no tag and no alarm.
+  #
+  # Scope is release pull requests, not all of them. The gate refuses a
+  # release-affecting diff that does not move the version, and demanding that
+  # of every pull request is a policy change wearing a bug fix's clothes. The
+  # branch condition is the half that cannot be dodged, because a ruleset owns
+  # that ref; the label is there so a hand-cut release is covered too.
+  release-version:
+    name: Release version gate
+    if: >-
+      github.event_name == 'pull_request' &&
+      (github.head_ref == 'automation/release-next' ||
+      contains(github.event.pull_request.labels.*.name, 'release:automated'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The gate reads Cargo.toml out of the base commit. A shallow
+          # pull-request checkout does not carry it, and `git show` would fail
+          # in a way that reads like a broken gate rather than a missing fetch.
+          fetch-depth: 0
+
+      # Base and labels arrive as environment variables, never interpolated
+      # into the command line: a pull-request label is attacker-controlled text
+      # and `--labels ${{ ... }}` would put it in an argv the shell expands.
+      - name: Check the workspace version moved with the release
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: node scripts/check-release-version.mjs
+
   npm-launchers:
     name: npm launcher tests
     runs-on: ubuntu-latest
@@ -105,6 +144,7 @@ jobs:
           node --test \
             ./scripts/check-glibc-floor.test.mjs \
             ./scripts/check-release-version.test.mjs \
+            ./scripts/release-intent.test.mjs \
             ./scripts/extract-release-notes.test.mjs \
             ./scripts/prepare-release.test.mjs \
             ./scripts/read-update-build-identity.test.cjs \
@@ -1004,6 +1044,7 @@ jobs:
             scripts/check-release-proof-artifacts.test.mjs \
             scripts/release-train-body.test.mjs \
             scripts/check-release-version.test.mjs \
+            scripts/release-intent.test.mjs \
             scripts/extract-release-notes.test.mjs \
             scripts/prepare-release.test.mjs \
             scripts/release-archive-shape.test.cjs \
@@ -1515,6 +1556,17 @@ jobs:
           fail_expected "python guard" "text_refs.rs" python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned"
 
           echo "Zero File-Search guards are falsifiable: every probe was caught."
+
+      # Both release version guards existed before this step did and neither
+      # could fail: the version gate ran on no pull request, and the mint read
+      # a version whose tag already existed and called that nothing to release.
+      # A suite written for guards of that shape is worth exactly as much as
+      # the run that watched it go red, so the falsifier poisons a copy of each
+      # gate and requires the suite to name the test that caught it. Half its
+      # probes break the refusal and half break the pass, because a gate that
+      # refused every quiet cycle would be switched off within a day.
+      - name: Falsify the release version guards
+        run: python3 ./scripts/falsify-release-version-guards.py
   # A skipped matrix job never expands, so its per-leg context names do not
   # appear at all rather than appearing skipped. `check-docs-only` exists for
   # exactly that reason and this is its counterpart: once the branch ruleset

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -3,8 +3,9 @@
 // Copyright 2026 Firelock, LLC
 
 import fs from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import { execFile } from 'node:child_process';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
 const run = promisify(execFile);
@@ -191,7 +192,33 @@ async function main() {
   if (result.failures.length > 0) process.exitCode = 1;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Run only when this file IS the entry point, comparing REAL paths.
+//
+// The usual idiom compares `import.meta.url` against
+// `pathToFileURL(process.argv[1])`. Node resolves symlinks for the first and
+// not the second, so invoking this file through a symlinked directory makes
+// the two disagree and the gate prints nothing and exits 0. Measured: the same
+// invocation against the same commit produced 0 bytes through `/tmp` and the
+// full report through `/private/tmp`. release-train.yml runs it from a copy in
+// `$RUNNER_TEMP/release-policy`, which is not a symlink today and is the only
+// reason the naive form has held.
+//
+// Unresolvable paths fall to running, not skipping. A gate that silently
+// declines to judge is worse than one that fails; a test that runs `main()` by
+// mistake fails loudly on the spot.
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  if (entry === self) return true;
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return true;
+  }
+}
+
+if (isDirectRun()) {
   main().catch((error) => {
     console.error(error.message);
     process.exitCode = 1;

--- a/scripts/check-release-version.test.mjs
+++ b/scripts/check-release-version.test.mjs
@@ -2,7 +2,12 @@
 // Copyright 2026 Firelock, LLC
 
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import {
   classifyPath,
@@ -88,4 +93,104 @@ test('skipped versions fail closed', () => {
     changedPaths: ['Cargo.toml'],
   });
   assert.equal(result.failures.length, 1);
+});
+
+// --------------------------------------------------------------------------
+// The gate as a pull request runs it.
+//
+// Every test above exercises a pure function, and this gate's defect was never
+// in one: the script has carried the right refusal since before the release
+// train existed and simply never ran on a pull request. So the end-to-end path
+// gets its own coverage, driven the way ci.yml drives it, through BASE_SHA and
+// PR_LABELS rather than through argv.
+// --------------------------------------------------------------------------
+
+const GATE = path.join(path.dirname(fileURLToPath(import.meta.url)), 'check-release-version.mjs');
+
+// Fixture commits are throwaway history, so the developer host's commit
+// hygiene hooks must not run against them.
+function git(root, args) {
+  const hooks = path.join(root, '.git', 'fixture-hooks-disabled');
+  return execFileSync('git', ['-c', `core.hooksPath=${hooks}`, ...args], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+}
+
+function write(root, relative, body) {
+  const target = path.join(root, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, body);
+}
+
+function releaseBase(version = '1.2.3') {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-version-gate-'));
+  git(root, ['init', '--quiet', '--initial-branch=main']);
+  git(root, ['config', 'user.name', 'Test']);
+  git(root, ['config', 'user.email', 'test@example.invalid']);
+  write(root, 'Cargo.toml', `[workspace.package]\nversion = "${version}"\n`);
+  write(root, 'crates/kin-cli/src/main.rs', 'fn main() {}\n');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'base']);
+  return { root, base: git(root, ['rev-parse', 'HEAD']).trim() };
+}
+
+function runGate(root, base, labels) {
+  try {
+    const stdout = execFileSync(process.execPath, [GATE], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, BASE_SHA: base, PR_LABELS: labels },
+    });
+    return { code: 0, stdout };
+  } catch (error) {
+    return { code: error.status, stdout: `${error.stdout ?? ''}${error.stderr ?? ''}` };
+  }
+}
+
+test('a release-affecting change with no bump is refused end to end', () => {
+  const { root, base } = releaseBase();
+  write(root, 'crates/kin-cli/src/main.rs', 'fn main() { println!("fix"); }\n');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'fix whose bump was dropped']);
+
+  const run = runGate(root, base, 'release:automated,release:patch');
+  assert.equal(run.code, 1);
+  assert.match(run.stdout, /1 release-affecting path\(s\) changed/);
+  assert.match(run.stdout, /stayed at 1\.2\.3/);
+});
+
+test('the same change with its bump passes end to end', () => {
+  // The half that matters. A gate that failed on everything would be no gate,
+  // and this is the run the release pull request has to be able to make green.
+  const { root, base } = releaseBase();
+  write(root, 'crates/kin-cli/src/main.rs', 'fn main() { println!("fix"); }\n');
+  write(root, 'Cargo.toml', '[workspace.package]\nversion = "1.2.4"\n');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'Release Kin v1.2.4']);
+
+  const run = runGate(root, base, 'release:automated,release:patch');
+  assert.equal(run.code, 0);
+  assert.match(run.stdout, /1\.2\.3 -> 1\.2\.4/);
+});
+
+test('a documentation-only release pull request needs no bump', () => {
+  const { root, base } = releaseBase();
+  write(root, 'docs/rail.md', 'notes\n');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'document the rail']);
+
+  const run = runGate(root, base, 'release:automated,release:patch');
+  assert.equal(run.code, 0);
+});
+
+test('a bump that skips a version is refused end to end', () => {
+  const { root, base } = releaseBase();
+  write(root, 'Cargo.toml', '[workspace.package]\nversion = "1.2.9"\n');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'Release Kin v1.2.9']);
+
+  const run = runGate(root, base, 'release:automated,release:patch');
+  assert.equal(run.code, 1);
+  assert.match(run.stdout, /requires 1\.2\.4/);
 });

--- a/scripts/check-release-version.test.mjs
+++ b/scripts/check-release-version.test.mjs
@@ -194,3 +194,38 @@ test('a bump that skips a version is refused end to end', () => {
   assert.equal(run.code, 1);
   assert.match(run.stdout, /requires 1\.2\.4/);
 });
+
+test('the gate runs from a copy reached through a symlinked directory', () => {
+  // release-train.yml runs this file from a copy in $RUNNER_TEMP/release-policy.
+  // The entry-point test used to compare `import.meta.url` against
+  // `pathToFileURL(process.argv[1])`, and Node resolves symlinks for the first
+  // and not the second, so a copy invoked through one made the gate print
+  // nothing and exit 0. Measured against the real release pull request that
+  // took 0.5.52 to 0.5.53: 0 bytes through `/tmp`, the full report through
+  // `/private/tmp`, same commit and same arguments.
+  const { root, base } = releaseBase();
+  write(root, 'crates/kin-cli/src/main.rs', 'fn main() { println!("fix"); }\n');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'fix whose bump was dropped']);
+
+  const real = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-version-policy-'));
+  const link = `${real}-link`;
+  fs.symlinkSync(real, link, 'dir');
+  const policy = path.join(link, 'check-release-version.mjs');
+  fs.copyFileSync(GATE, policy);
+
+  let code = 0;
+  let stdout = '';
+  try {
+    stdout = execFileSync(process.execPath, [policy], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, BASE_SHA: base, PR_LABELS: 'release:automated' },
+    });
+  } catch (error) {
+    code = error.status;
+    stdout = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+  assert.notEqual(stdout, '', 'the gate produced no output, so it judged nothing');
+  assert.equal(code, 1, 'the gate did not refuse a release-affecting diff with no bump');
+});

--- a/scripts/falsify-release-version-guards.py
+++ b/scripts/falsify-release-version-guards.py
@@ -40,7 +40,9 @@ INTENT = "scripts/release-intent.mjs"
 INTENT_SUITE = "scripts/release-intent.test.mjs"
 VERSION = "scripts/check-release-version.mjs"
 VERSION_SUITE = "scripts/check-release-version.test.mjs"
-COPIED = (INTENT, INTENT_SUITE, VERSION, VERSION_SUITE)
+PREPARE = "scripts/prepare-release.mjs"
+PREPARE_SUITE = "scripts/prepare-release.test.mjs"
+COPIED = (INTENT, INTENT_SUITE, VERSION, VERSION_SUITE, PREPARE, PREPARE_SUITE)
 
 
 class FalsificationError(RuntimeError):
@@ -222,6 +224,21 @@ PROBES: tuple[tuple[str, str, str, Callable[[Path], None]], ...] = (
             VERSION,
             "export function classifyPath(path) {",
             "export function classifyPath(path) {\n  if (path) return 'release';",
+        ),
+    ),
+    (
+        "the release generator's entry point goes back to unresolved paths",
+        PREPARE_SUITE,
+        "the generator runs from a copy reached through a symlinked directory",
+        lambda tree: poison(
+            tree,
+            PREPARE,
+            "  try {\n"
+            "    return realpathSync(entry) === realpathSync(self);\n"
+            "  } catch {\n"
+            "    return true;\n"
+            "  }",
+            "  return false;",
         ),
     ),
 )

--- a/scripts/falsify-release-version-guards.py
+++ b/scripts/falsify-release-version-guards.py
@@ -199,6 +199,21 @@ PROBES: tuple[tuple[str, str, str, Callable[[Path], None]], ...] = (
         ),
     ),
     (
+        "the version gate's entry point goes back to unresolved paths",
+        VERSION_SUITE,
+        "the gate runs from a copy reached through a symlinked directory",
+        lambda tree: poison(
+            tree,
+            VERSION,
+            "  try {\n"
+            "    return realpathSync(entry) === realpathSync(self);\n"
+            "  } catch {\n"
+            "    return true;\n"
+            "  }",
+            "  return false;",
+        ),
+    ),
+    (
         "the version gate starts demanding a bump for documentation",
         VERSION_SUITE,
         "a documentation-only release pull request needs no bump",

--- a/scripts/falsify-release-version-guards.py
+++ b/scripts/falsify-release-version-guards.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove the two release version guards can fail, one poisoned tree at a time.
+
+Both guards here are guards that already existed and could not fail. The
+release version gate has carried the right refusal since before the release
+train did and ran on no pull request; the release-intent gate read a version
+whose tag already existed, called that nothing to release, and exited 0 on a
+fifteen-minute cron with no tag cut and no alarm raised. A suite written for
+guards of that shape has to be watched failing before it counts as evidence.
+
+Each probe plants exactly one mutation in a copy of the tree and requires the
+suite that covers it to go red naming the test that caught it. Half the probes
+break the refusal, and half break the pass: a gate that refused every cycle
+would be switched off within a day, so the green rows carry the same burden of
+proof as the red ones.
+
+The wiring is falsified elsewhere and on purpose. Whether ci.yml actually runs
+the version gate on a pull request is asserted by
+`assert_release_version_gate_wired` in scripts/test-release-workflow-authority.py,
+which falsifies itself against a ci.yml with the job removed, the step
+commented out, and the tests dropped. That is the half of this defect no unit
+test can reach, because the script was always correct.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+INTENT = "scripts/release-intent.mjs"
+INTENT_SUITE = "scripts/release-intent.test.mjs"
+VERSION = "scripts/check-release-version.mjs"
+VERSION_SUITE = "scripts/check-release-version.test.mjs"
+COPIED = (INTENT, INTENT_SUITE, VERSION, VERSION_SUITE)
+
+
+class FalsificationError(RuntimeError):
+    """The suite did not fail where it must, so it proves nothing."""
+
+
+def probe_tree(destination: Path) -> Path:
+    for relative in COPIED:
+        source = ROOT / relative
+        if not source.is_file():
+            raise FalsificationError(f"cannot build a probe tree without {relative}")
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+    return destination
+
+
+def poison(tree: Path, relative: str, old: str, new: str) -> None:
+    """Plant one mutation at an anchor that appears exactly once.
+
+    Requiring uniqueness is what stops a probe from mutating a line the suite
+    never reads, leaving the suite correctly green while the probe reports that
+    it proved something.
+    """
+    path = tree / relative
+    source = path.read_text(encoding="utf-8")
+    found = source.count(old)
+    if found != 1:
+        raise FalsificationError(
+            f"probe could not plant its mutation: {relative} contains {found} "
+            f"occurrences of {old!r}, expected exactly one"
+        )
+    path.write_text(source.replace(old, new, 1), encoding="utf-8")
+
+
+def run_suite(tree: Path, suite: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", "--test", str(tree / suite)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=tree,
+    )
+
+
+def expect_failure(
+    label: str,
+    suite: str,
+    expected: str,
+    mutate: Callable[[Path], None],
+) -> str:
+    with tempfile.TemporaryDirectory() as temp:
+        tree = probe_tree(Path(temp))
+        mutate(tree)
+        result = run_suite(tree, suite)
+    if result.returncode == 0:
+        raise FalsificationError(
+            f"{label}: the suite passed against a poisoned tree, so it cannot "
+            "fail on this defect"
+        )
+    output = f"{result.stdout}{result.stderr}"
+    if "not ok" not in output or expected not in output:
+        raise FalsificationError(
+            f"{label}: the suite failed but never named {expected!r}, so the "
+            "failure is not evidence about this defect\n" + output[-4000:]
+        )
+    return f"{label} -> {expected}"
+
+
+# Anchors are the exact source lines the guards decide on. Each is unique in
+# its file, which `poison` enforces, so a probe cannot quietly mutate something
+# the suite does not read.
+PROBES: tuple[tuple[str, str, str, Callable[[Path], None]], ...] = (
+    (
+        "the mint stops refusing a release whose bump never landed",
+        INTENT_SUITE,
+        "a release-affecting commit stranded behind an existing tag refuses loudly",
+        lambda tree: poison(
+            tree,
+            INTENT,
+            "  if (tagExists && strandedPaths.length > 0) {",
+            "  if (false && tagExists && strandedPaths.length > 0) {",
+        ),
+    ),
+    (
+        "the mint refuses a quiet cycle it should have passed",
+        INTENT_SUITE,
+        "documentation stranded behind an existing tag stays a green no-op",
+        lambda tree: poison(
+            tree,
+            INTENT,
+            "export function classifyPath(path) {",
+            "export function classifyPath(path) {\n  if (path) return 'release';",
+        ),
+    ),
+    (
+        "the copied classifier drifts from the one the version gate uses",
+        INTENT_SUITE,
+        "the copied classifier agrees with the version gate on every branch",
+        lambda tree: poison(
+            tree,
+            INTENT,
+            "    lower.startsWith('.github/') ||\n"
+            "    lower.startsWith('docs/') ||\n"
+            "    lower === 'agents.md' ||",
+            "    lower.startsWith('docs/') ||\n" "    lower === 'agents.md' ||",
+        ),
+    ),
+    (
+        "a relative import creeps into the file the mint copies alone",
+        INTENT_SUITE,
+        "the gate imports nothing relative, so a single-file copy still runs",
+        lambda tree: poison(
+            tree,
+            INTENT,
+            "import { promisify } from 'node:util';",
+            "import { promisify } from 'node:util';\n"
+            "import { parseVersion } from './check-release-version.mjs';",
+        ),
+    ),
+    (
+        "the entry point goes back to comparing unresolved paths",
+        INTENT_SUITE,
+        "the gate runs from a copy reached through a symlinked directory",
+        lambda tree: poison(
+            tree,
+            INTENT,
+            "  try {\n"
+            "    return realpathSync(entry) === realpathSync(self);\n"
+            "  } catch {\n"
+            "    return true;\n"
+            "  }",
+            "  return false;",
+        ),
+    ),
+    (
+        "the version gate stops refusing a release-affecting diff with no bump",
+        VERSION_SUITE,
+        "a release-affecting change with no bump is refused end to end",
+        lambda tree: poison(
+            tree,
+            VERSION,
+            "  if (releasePaths.length > 0 && !versionMoved) {",
+            "  if (false && releasePaths.length > 0 && !versionMoved) {",
+        ),
+    ),
+    (
+        "the version gate stops refusing a bump that skips a version",
+        VERSION_SUITE,
+        "a bump that skips a version is refused end to end",
+        lambda tree: poison(
+            tree,
+            VERSION,
+            "  if (versionMoved && headVersion !== expected) {",
+            "  if (false && versionMoved && headVersion !== expected) {",
+        ),
+    ),
+    (
+        "the version gate starts demanding a bump for documentation",
+        VERSION_SUITE,
+        "a documentation-only release pull request needs no bump",
+        lambda tree: poison(
+            tree,
+            VERSION,
+            "export function classifyPath(path) {",
+            "export function classifyPath(path) {\n  if (path) return 'release';",
+        ),
+    ),
+)
+
+
+def main() -> int:
+    lines: list[str] = []
+    try:
+        for label, suite, expected, mutate in PROBES:
+            lines.append(expect_failure(label, suite, expected, mutate))
+    except FalsificationError as error:
+        print(
+            f"release version guard falsification FAILED\n  {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"the release version guards rejected all {len(PROBES)} poisoned trees:")
+    for line in lines:
+        print(f"  {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -3,8 +3,9 @@
 // Copyright 2026 Firelock, LLC
 
 import fs from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import { execFile } from 'node:child_process';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
 import { parseVersion, readManifestVersion } from './check-release-version.mjs';
@@ -316,7 +317,32 @@ async function main() {
   );
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Run only when this file IS the entry point, comparing REAL paths.
+//
+// The usual idiom compares `import.meta.url` against
+// `pathToFileURL(process.argv[1])`. Node resolves symlinks for the first and
+// not the second, so invoking this file through a symlinked directory makes
+// the two disagree and it generates nothing, writes no $GITHUB_OUTPUT, and
+// exits 0. release-train.yml runs it from a copy in
+// `$RUNNER_TEMP/release-policy`, which is exactly that shape and is not a
+// symlink today, which is the only reason the naive form has held.
+//
+// Unresolvable paths fall to running, not skipping. A generator that silently
+// declines to generate leaves the train reading an empty version; a test that
+// runs `main()` by mistake fails loudly on the spot.
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  if (entry === self) return true;
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return true;
+  }
+}
+
+if (isDirectRun()) {
   main().catch((error) => {
     console.error(error.message);
     process.exitCode = 1;

--- a/scripts/prepare-release.test.mjs
+++ b/scripts/prepare-release.test.mjs
@@ -2,7 +2,12 @@
 // Copyright 2026 Firelock, LLC
 
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import {
   removeChangelogSection,
@@ -141,4 +146,46 @@ checksum = "keep"
   // A fuzz target pinned at 0.0.0 and a registry dependency are untouched.
   assert.match(result.lock, /name = "kin-parser-fuzz"\nversion = "0.0.0"/);
   assert.match(result.lock, /name = "kin-model"\nversion = "0.7.1"/);
+});
+
+test('the generator runs from a copy reached through a symlinked directory', () => {
+  // release-train.yml runs this file from a copy in $RUNNER_TEMP/release-policy.
+  // The entry-point test used to compare `import.meta.url` against
+  // `pathToFileURL(process.argv[1])`, and Node resolves symlinks for the first
+  // and not the second, so a copy invoked through one generated nothing, wrote
+  // no $GITHUB_OUTPUT, and exited 0. The train would then read an empty version.
+  //
+  // Run with no arguments and no repository, so `main()` is reached and fails on
+  // its own missing input. The distinction being drawn is between a process that
+  // ran and one that never started, and only the second is silent.
+  const generator = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'prepare-release.mjs',
+  );
+  const real = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-prepare-policy-'));
+  const link = `${real}-link`;
+  fs.symlinkSync(real, link, 'dir');
+  const policy = path.join(link, 'prepare-release.mjs');
+  fs.copyFileSync(generator, policy);
+  // The sibling this file imports has to come too, exactly as release-train.yml
+  // copies all three policy scripts into one directory. Without it node fails on
+  // module resolution and writes to stderr, and this test would then pass on
+  // that error no matter what the entry point did.
+  fs.copyFileSync(
+    path.join(path.dirname(generator), 'check-release-version.mjs'),
+    path.join(link, 'check-release-version.mjs'),
+  );
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-prepare-cwd-'));
+
+  let output = '';
+  try {
+    output = execFileSync(process.execPath, [policy], {
+      cwd: empty,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+  assert.notEqual(output, '', 'the generator produced no output, so it never ran');
 });

--- a/scripts/release-intent.mjs
+++ b/scripts/release-intent.mjs
@@ -1,5 +1,7 @@
 import fs from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
 const run = promisify(execFile);
@@ -19,13 +21,26 @@ const run = promisify(execFile);
 //   - the version moves strictly forward of the newest existing vX.Y.Z tag.
 //
 // Decision:
-//   tag v<version> already exists      -> should_tag=false, exit 0 (idempotent;
+//   tag exists, tree matches it        -> should_tag=false, exit 0 (idempotent;
 //                                         a normal push that did not bump).
+//   tag exists, release-affecting work
+//   still sits after it                -> exit 1 (the bump is missing; see
+//                                         the paragraph below).
 //   invariants hold, tag absent        -> should_tag=true,  exit 0 (cut it).
 //   invariants fail, tag absent        -> exit 1 (a new version is staged but a
-//                                         release surface is out of sync — fail
-//                                         loud rather than cut a half-bumped
-//                                         release).
+//                                         release surface is out of sync, so
+//                                         it fails loud rather than cut a
+//                                         half-bumped release).
+//
+// The second row is the silent one. A version bump that never landed leaves
+// the workspace version equal to the last released version, whose tag
+// exists, so the idempotent branch used to swallow it: the mint reported a
+// green notice and exited 0 on a fifteen-minute cron while the release never
+// moved, and nothing else announced it, because the held-rail alarm only
+// fires on a `held` marker and a dropped bump writes `clear`. The two facts
+// that separate that row from a genuine no-op are whether the tag exists and
+// whether this tree still carries release-affecting content the tag does
+// not, so the gate reads exactly those two and refuses on both.
 //
 // In CI it appends `version`, `tag`, and `should_tag` to $GITHUB_OUTPUT so the
 // workflow stays thin. Run it locally (no args) to preview the verdict.
@@ -71,6 +86,46 @@ function readManifestVersion(text) {
     }
   }
   throw new Error(`could not read [workspace.package]/[package] version from manifest`);
+}
+
+// Is a changed path something a release actually ships?
+//
+// This mirrors `classifyPath` in scripts/check-release-version.mjs and is a
+// deliberate copy rather than an import. release-tag.yml copies THIS FILE
+// ALONE out of reviewed main into $RUNNER_TEMP, under a different basename,
+// and runs it there against a detached checkout, so any relative import here
+// resolves to a path that does not exist and the mint dies on a module
+// resolution error instead of judging the release. The two copies are held
+// together by a parity test over a shared corpus in release-intent.test.mjs,
+// and a structural test in the same file refuses any relative import added to
+// this one.
+export function classifyPath(path) {
+  const normalized = path.replaceAll('\\', '/').replace(/^\.\/+/, '');
+  const lower = normalized.toLowerCase();
+  const segments = lower.split('/');
+  const basename = segments.at(-1) ?? '';
+
+  if (
+    lower.startsWith('.github/') ||
+    lower.startsWith('docs/') ||
+    lower === 'agents.md' ||
+    lower === 'claude.md' ||
+    lower === 'license' ||
+    /\.(md|mdx|markdown|rst|adoc|txt)$/.test(lower)
+  ) {
+    return 'non-release';
+  }
+
+  if (
+    segments.some((segment) =>
+      ['test', 'tests', 'benches', 'bench', 'examples', 'example', 'fuzz', 'fixtures', 'snapshots']
+        .includes(segment)) ||
+    /(^test[-_].*|.*[-_.]test\.[^.]+|.*_test\.[^.]+)$/.test(basename)
+  ) {
+    return 'non-release';
+  }
+
+  return 'release';
 }
 
 function changelogHasSection(changelog, version) {
@@ -129,6 +184,78 @@ async function gitTags() {
   } catch {
     return [];
   }
+}
+
+// Release-affecting content this tree carries that the named tag does not.
+//
+// Two dots on purpose: this compares the two TREES, so a release-affecting
+// change that a later commit reverted correctly reports nothing stranded, and
+// no merge-listing quirk can undercount it the way a per-commit walk would.
+// The commit count is reported beside it and is descriptive only; the decision
+// is the path set.
+async function releaseDriftSinceTag(tag) {
+  const { stdout: names } = await run(
+    'git',
+    ['diff', '--name-only', '-z', `${tag}..HEAD`],
+    { maxBuffer: 16 * 1024 * 1024 },
+  );
+  const strandedPaths = names
+    .split('\0')
+    .filter(Boolean)
+    .filter((path) => classifyPath(path) === 'release');
+  let commitsSinceTag = 0;
+  try {
+    const { stdout: count } = await run('git', ['rev-list', '--count', `${tag}..HEAD`]);
+    commitsSinceTag = Number.parseInt(count.trim(), 10) || 0;
+  } catch {
+    commitsSinceTag = 0;
+  }
+  return { strandedPaths, commitsSinceTag };
+}
+
+// The whole verdict, as a pure function, so every row of the decision table is
+// reachable from a test without a repository, a tag, or a git process.
+export function decideReleaseIntent({
+  tag,
+  tagExists,
+  failures = [],
+  strandedPaths = [],
+  commitsSinceTag = 0,
+}) {
+  if (tagExists && strandedPaths.length > 0) {
+    return {
+      shouldTag: false,
+      exitCode: 1,
+      stranded: true,
+      summary:
+        `${tag} already exists, but this tree still carries ` +
+        `${strandedPaths.length} release-affecting path(s) it does not, across ` +
+        `${commitsSinceTag} commit(s). The version bump is missing, so this ` +
+        `release would be a silent no-op.`,
+    };
+  }
+  if (tagExists) {
+    return {
+      shouldTag: false,
+      exitCode: 0,
+      stranded: false,
+      summary: `${tag} already exists, so there is nothing to release.`,
+    };
+  }
+  if (failures.length === 0) {
+    return {
+      shouldTag: true,
+      exitCode: 0,
+      stranded: false,
+      summary: `${tag} is a coherent release. Ready to tag.`,
+    };
+  }
+  return {
+    shouldTag: false,
+    exitCode: 1,
+    stranded: false,
+    summary: `${tag} is staged but release surfaces are out of sync. Refusing to tag.`,
+  };
 }
 
 async function readFileOrNull(path) {
@@ -257,25 +384,24 @@ async function main() {
     failures.push(`${tag} would not move forward of the newest tag ${newest}`);
   }
 
-  let shouldTag;
-  let exitCode;
-  let summary;
-  if (tagExists) {
-    shouldTag = false;
-    exitCode = 0;
-    summary = `${tag} already exists — nothing to release.`;
-  } else if (failures.length === 0) {
-    shouldTag = true;
-    exitCode = 0;
-    summary = `${tag} is a coherent release — ready to tag.`;
-  } else {
-    shouldTag = false;
-    exitCode = 1;
-    summary = `${tag} is staged but release surfaces are out of sync — refusing to tag.`;
-  }
+  // Only ask git about drift when the tag exists, which is the one branch
+  // where the answer changes the verdict. A failure here is loud on purpose:
+  // `tagExists` already proves `git tag --list` worked and the tag is present,
+  // so a diff that cannot run is anomalous, and a swallowed error would put the
+  // gate straight back to reporting the silent no-op it exists to catch.
+  const drift = tagExists
+    ? await releaseDriftSinceTag(tag)
+    : { strandedPaths: [], commitsSinceTag: 0 };
+  const { shouldTag, exitCode, stranded, summary } = decideReleaseIntent({
+    tag,
+    tagExists,
+    failures,
+    strandedPaths: drift.strandedPaths,
+    commitsSinceTag: drift.commitsSinceTag,
+  });
 
   if (opts.json) {
-    console.log(JSON.stringify({ version, tag, npmVersion, newest, tagExists, shouldTag, hasChangelog, failures, warnings }, null, 2));
+    console.log(JSON.stringify({ version, tag, npmVersion, newest, tagExists, stranded, strandedPaths: drift.strandedPaths, commitsSinceTag: drift.commitsSinceTag, shouldTag, hasChangelog, failures, warnings }, null, 2));
   } else {
     console.log('Kin release-intent gate');
     console.log(`  workspace version : ${version}`);
@@ -285,17 +411,57 @@ async function main() {
     console.log(`  changelog section : ${hasChangelog ? 'present' : 'absent'}`);
     console.log(`  newest tag        : ${newest ?? '<none>'}`);
     console.log(`  tag ${tag}${' '.repeat(Math.max(0, 13 - tag.length))}: ${tagExists ? 'exists' : 'absent'}`);
+    console.log(`  stranded paths    : ${drift.strandedPaths.length}`);
+    for (const path of drift.strandedPaths.slice(0, 30)) console.log(`    - ${path}`);
+    if (drift.strandedPaths.length > 30) {
+      console.log(`    ... ${drift.strandedPaths.length - 30} more`);
+    }
     for (const w of warnings) console.log(`  warn: ${w}`);
     for (const f of failures) console.log(`  FAIL: ${f}`);
     console.log(`  => should_tag=${shouldTag}`);
     console.log(summary);
   }
 
+  // An annotation, not a runner-state write: release-tag.yml hands this process
+  // inert GITHUB_ENV/PATH/STATE files and fails the job if any of them grows, so
+  // the only way for a stranded release to say so where an operator will see it
+  // is a workflow command on stdout.
+  if (stranded) console.log(`::error::${summary}`);
+
   await emitOutputs({ version, tag, should_tag: String(shouldTag) });
   process.exitCode = exitCode;
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exitCode = 1;
-});
+// Run only when this file IS the entry point, so a test can import the pure
+// functions above without `main()` reading the test runner's own working tree.
+//
+// Compare REAL paths. The usual idiom compares `import.meta.url` against
+// `pathToFileURL(process.argv[1])`, and that is wrong here: Node resolves
+// symlinks for `import.meta.url` and does not for `argv[1]`, so invoking a copy
+// of this file through a symlinked directory makes the two disagree and the
+// gate exits 0 having judged nothing. release-tag.yml runs exactly that way, on
+// a copy under a different basename inside $RUNNER_TEMP, and the mint's next
+// step reads the outputs this file never wrote. Verified against a
+// `/tmp -> /private/tmp` copy, where the naive form did not run at all.
+//
+// Unresolvable paths fall to running, not skipping. A gate that silently
+// declines to judge is the failure this file exists to end; a test that runs
+// `main()` by mistake fails loudly on the spot.
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  if (entry === self) return true;
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return true;
+  }
+}
+
+if (isDirectRun()) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-intent.test.mjs
+++ b/scripts/release-intent.test.mjs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { classifyPath as intentClassifyPath, decideReleaseIntent } from './release-intent.mjs';
+import { classifyPath as versionClassifyPath } from './check-release-version.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const GATE = path.join(HERE, 'release-intent.mjs');
+
+// --------------------------------------------------------------------------
+// The verdict table.
+// --------------------------------------------------------------------------
+
+test('an existing tag with nothing after it is still an idempotent no-op', () => {
+  const verdict = decideReleaseIntent({ tag: 'v1.2.3', tagExists: true });
+  assert.equal(verdict.exitCode, 0);
+  assert.equal(verdict.shouldTag, false);
+  assert.equal(verdict.stranded, false);
+});
+
+test('an existing tag with release-affecting work after it refuses', () => {
+  const verdict = decideReleaseIntent({
+    tag: 'v1.2.3',
+    tagExists: true,
+    strandedPaths: ['crates/kin-cli/src/main.rs', 'Cargo.lock'],
+    commitsSinceTag: 7,
+  });
+  assert.equal(verdict.exitCode, 1);
+  assert.equal(verdict.shouldTag, false);
+  assert.equal(verdict.stranded, true);
+  assert.match(verdict.summary, /2 release-affecting path\(s\)/);
+  assert.match(verdict.summary, /7 commit\(s\)/);
+});
+
+test('documentation after an existing tag is not a stranded release', () => {
+  // The caller filters, so this is the shape it hands back for a docs-only
+  // range. Asserted here because it is the row that decides whether the gate
+  // is usable: a guard that refuses every quiet cycle gets switched off.
+  const verdict = decideReleaseIntent({
+    tag: 'v1.2.3',
+    tagExists: true,
+    strandedPaths: [],
+    commitsSinceTag: 4,
+  });
+  assert.equal(verdict.exitCode, 0);
+  assert.equal(verdict.stranded, false);
+});
+
+test('an absent tag with sound surfaces is ready to cut', () => {
+  const verdict = decideReleaseIntent({ tag: 'v1.2.4', tagExists: false });
+  assert.equal(verdict.exitCode, 0);
+  assert.equal(verdict.shouldTag, true);
+});
+
+test('an absent tag with a broken surface refuses', () => {
+  const verdict = decideReleaseIntent({
+    tag: 'v1.2.4',
+    tagExists: false,
+    failures: ['npm manifest is 1.2.3, workspace is 1.2.4'],
+  });
+  assert.equal(verdict.exitCode, 1);
+  assert.equal(verdict.shouldTag, false);
+  assert.equal(verdict.stranded, false);
+});
+
+test('a stranded release outranks an out-of-sync surface in the report', () => {
+  // Both are true at once whenever a bump is dropped mid-flight. The stranded
+  // diagnosis is the one that names the cause; reporting the surface mismatch
+  // instead would send the reader to regenerate files that are already right.
+  const verdict = decideReleaseIntent({
+    tag: 'v1.2.3',
+    tagExists: true,
+    failures: ['npm manifest is 1.2.2, workspace is 1.2.3'],
+    strandedPaths: ['crates/kin-cli/src/main.rs'],
+    commitsSinceTag: 1,
+  });
+  assert.equal(verdict.stranded, true);
+  assert.equal(verdict.exitCode, 1);
+});
+
+// --------------------------------------------------------------------------
+// The copied classifier, and the two things that keep the copy honest.
+// --------------------------------------------------------------------------
+
+// Every branch of the classifier, in both directions. A parity test over a
+// corpus that only exercised one branch would agree by accident.
+const CLASSIFIER_CORPUS = [
+  'Cargo.toml',
+  'Cargo.lock',
+  'fuzz/Cargo.lock',
+  'CHANGELOG.md',
+  'crates/kin-cli/Cargo.toml',
+  'crates/kin-cli/src/main.rs',
+  'crates/kin-core/src/lib.rs',
+  'crates/kin-core/tests/roundtrip.rs',
+  'crates/kin-core/benches/parse.rs',
+  'crates/kin-parser/examples/demo.rs',
+  'crates/kin-core/src/snapshots/fixture.json',
+  'packages/kin/index.js',
+  'packages/kin/package.json',
+  'scripts/install.sh',
+  'scripts/test-release-workflow-authority.py',
+  'scripts/check-release-version.test.mjs',
+  'scripts/release_test.py',
+  'Dockerfile',
+  '.cargo/config.toml',
+  '.github/workflows/ci.yml',
+  'docs/release-bot.md',
+  'README.md',
+  'AGENTS.md',
+  'CLAUDE.md',
+  'LICENSE',
+  'notes.txt',
+  'design.adoc',
+  './Cargo.toml',
+  'crates\\kin-cli\\src\\main.rs',
+];
+
+test('the copied classifier agrees with the version gate on every branch', () => {
+  for (const candidate of CLASSIFIER_CORPUS) {
+    assert.equal(
+      intentClassifyPath(candidate),
+      versionClassifyPath(candidate),
+      candidate,
+    );
+  }
+  // The corpus has to be able to disagree. A corpus of one verdict would pass
+  // against a classifier that returned that verdict for everything.
+  const verdicts = new Set(CLASSIFIER_CORPUS.map(intentClassifyPath));
+  assert.deepEqual([...verdicts].sort(), ['non-release', 'release']);
+});
+
+test('the gate imports nothing relative, so a single-file copy still runs', () => {
+  // release-tag.yml copies this file ALONE into $RUNNER_TEMP under another
+  // basename and runs it there. A relative import would resolve to a path that
+  // does not exist and the mint would die on module resolution rather than
+  // judge the release, which is why the classifier above is a copy.
+  const source = fs.readFileSync(GATE, 'utf8');
+  const specifiers = [...source.matchAll(/^import\s[^']*'([^']+)'/gm)].map((m) => m[1]);
+  assert.ok(specifiers.length > 0, 'no import statements were found to check');
+  const relative = specifiers.filter((s) => s.startsWith('.'));
+  assert.deepEqual(relative, [], `release-intent.mjs must not import ${relative.join(', ')}`);
+});
+
+// --------------------------------------------------------------------------
+// The gate as the mint actually invokes it.
+// --------------------------------------------------------------------------
+
+// Fixture commits are throwaway history, so the developer host's commit
+// hygiene hooks must not run against them.
+function git(root, args) {
+  const hooks = path.join(root, '.git', 'fixture-hooks-disabled');
+  return execFileSync('git', ['-c', `core.hooksPath=${hooks}`, ...args], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+}
+
+function write(root, relative, body) {
+  const target = path.join(root, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, body);
+}
+
+// A repository carrying every surface release-intent.mjs asserts, released at
+// v1.2.3, so the only variable left is what landed after the tag.
+function releasedRepository(version = '1.2.3') {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-intent-gate-'));
+  git(root, ['init', '--quiet', '--initial-branch=main']);
+  git(root, ['config', 'user.name', 'Test']);
+  git(root, ['config', 'user.email', 'test@example.invalid']);
+  write(root, 'Cargo.toml', `[workspace.package]\nversion = "${version}"\n`);
+  write(root, 'Cargo.lock', `[[package]]\nname = "kin-core"\nversion = "${version}"\n`);
+  write(root, 'fuzz/Cargo.lock', `[[package]]\nname = "kin-parser"\nversion = "${version}"\n`);
+  write(
+    root,
+    'crates/kin-cli/Cargo.toml',
+    `[dependencies]\nkin-spine = { path = "../kin-spine", version = "${version}" }\n`,
+  );
+  write(root, 'CHANGELOG.md', `## [${version}]\n\n- released\n`);
+  for (const pkg of ['kin-mcp', 'kin', 'boundary-contracts']) {
+    write(root, `packages/${pkg}/package.json`, JSON.stringify({ version }, null, 2));
+  }
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', `Release Kin v${version}`]);
+  git(root, ['tag', `v${version}`]);
+  return root;
+}
+
+// Run the gate the way release-tag.yml does: a copy of this file, under a
+// different basename, out of a directory that is not the checkout.
+function runGateAsMintDoes(root) {
+  const policyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-intent-policy-'));
+  const policy = path.join(policyDir, 'release-intent-policy.mjs');
+  fs.copyFileSync(GATE, policy);
+  const outputs = path.join(policyDir, 'intent.outputs');
+  fs.writeFileSync(outputs, '');
+  const result = execFileSync(process.execPath, [policy], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_OUTPUT: outputs },
+    // A non-zero exit is the point of most of these runs, so read the code
+    // rather than letting execFileSync throw it away as a stack trace.
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: false,
+  });
+  return { stdout: result, outputs: fs.readFileSync(outputs, 'utf8'), code: 0 };
+}
+
+function runGateExpectingFailure(root) {
+  try {
+    runGateAsMintDoes(root);
+  } catch (error) {
+    return { stdout: `${error.stdout ?? ''}${error.stderr ?? ''}`, code: error.status };
+  }
+  return null;
+}
+
+test('a release-affecting commit stranded behind an existing tag refuses loudly', () => {
+  const root = releasedRepository();
+  write(root, 'crates/kin-cli/src/main.rs', 'fn main() {}\n');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'ship a fix whose version bump was dropped']);
+
+  const failed = runGateExpectingFailure(root);
+  assert.ok(failed, 'the gate exited 0 on a release whose bump is missing');
+  assert.equal(failed.code, 1);
+  assert.match(failed.stdout, /::error::/);
+  assert.match(failed.stdout, /1 release-affecting path\(s\)/);
+  assert.match(failed.stdout, /should_tag=false/);
+});
+
+test('documentation stranded behind an existing tag stays a green no-op', () => {
+  // The half that matters. A gate that refused this would refuse every quiet
+  // cycle on the fifteen-minute cron and would be turned off within a day.
+  const root = releasedRepository();
+  write(root, 'docs/release-bot.md', 'notes\n');
+  write(root, 'README.md', 'notes\n');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'document the rail']);
+
+  const run = runGateAsMintDoes(root);
+  assert.match(run.stdout, /already exists/);
+  assert.doesNotMatch(run.stdout, /::error::/);
+  assert.match(run.outputs, /should_tag=false/);
+});
+
+test('a bumped workspace ahead of its tag is still ready to cut', () => {
+  // The stranded check must not fire on the ordinary release path, where the
+  // version has moved and its tag does not exist yet.
+  const root = releasedRepository();
+  for (const [file, body] of [
+    ['Cargo.toml', '[workspace.package]\nversion = "1.2.4"\n'],
+    ['Cargo.lock', '[[package]]\nname = "kin-core"\nversion = "1.2.4"\n'],
+    ['fuzz/Cargo.lock', '[[package]]\nname = "kin-parser"\nversion = "1.2.4"\n'],
+    [
+      'crates/kin-cli/Cargo.toml',
+      '[dependencies]\nkin-spine = { path = "../kin-spine", version = "1.2.4" }\n',
+    ],
+    ['CHANGELOG.md', '## [1.2.4]\n\n- next\n\n## [1.2.3]\n\n- released\n'],
+  ]) {
+    write(root, file, body);
+  }
+  for (const pkg of ['kin-mcp', 'kin', 'boundary-contracts']) {
+    write(root, `packages/${pkg}/package.json`, JSON.stringify({ version: '1.2.4' }, null, 2));
+  }
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'Release Kin v1.2.4']);
+
+  const run = runGateAsMintDoes(root);
+  assert.match(run.outputs, /should_tag=true/);
+  assert.match(run.outputs, /tag=v1\.2\.4/);
+});
+
+test('the gate runs from a copy reached through a symlinked directory', () => {
+  // The entry-point test used to compare `import.meta.url` against
+  // `pathToFileURL(process.argv[1])`. Node resolves symlinks for the first and
+  // not the second, so a copy invoked through one made the two disagree and the
+  // gate exited 0 having written no outputs at all. $RUNNER_TEMP is not a
+  // symlink today, which is the only reason that shape was survivable.
+  const root = releasedRepository();
+  const real = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-intent-real-'));
+  const link = `${real}-link`;
+  fs.symlinkSync(real, link, 'dir');
+  const policy = path.join(link, 'release-intent-policy.mjs');
+  fs.copyFileSync(GATE, policy);
+  const outputs = path.join(real, 'intent.outputs');
+  fs.writeFileSync(outputs, '');
+
+  execFileSync(process.execPath, [policy], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_OUTPUT: outputs },
+  });
+  assert.match(
+    fs.readFileSync(outputs, 'utf8'),
+    /should_tag=/,
+    'the gate wrote no outputs, so the mint would read an empty tag',
+  );
+});

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -961,6 +961,54 @@ def workflow_active_header_source(workflow: str) -> str:
     return classifier_active_job_source(workflow.split(marker, 1)[0])
 
 
+# Block comment delimiters, longest opener first so `<!--` is tried before any
+# prefix of it could match.
+BLOCK_COMMENTS = (("<!--", "-->"), ("<#", "#>"), ("/*", "*/"))
+
+
+def strip_block_comments(lines: list[str]) -> list[str]:
+    """Drop block comments written as block comments, and nothing else.
+
+    A block comment is recognized only where one is actually written: the
+    opener begins a line, and the closer ends that line or a later one.
+
+    This used to be three DOTALL regexes over the whole text, which cannot tell
+    a comment from a pair of shell globs. In ci.yml the `docs/*)` pattern in a
+    `case` arm opened one and `hashFiles('**/Cargo.lock')` closed it, and 46,138
+    characters, 48% of the file, vanished from every assertion built on the
+    result; release-train.yml lost 24% the same way. No workflow contains a real
+    block comment at all, so that stripping has only ever produced silent false
+    negatives, and an assertion that cannot see the line it names passes exactly
+    like one that checked it.
+    """
+
+    kept: list[str] = []
+    closer: str | None = None
+    for line in lines:
+        stripped = line.strip()
+        if closer is not None:
+            if stripped.endswith(closer):
+                closer = None
+            continue
+        consumed = False
+        for opener, end in BLOCK_COMMENTS:
+            if not stripped.startswith(opener):
+                continue
+            # A complete one-line comment closes itself; anything else opens a
+            # span that the next line ending in the closer will end.
+            if not (
+                stripped.endswith(end) and len(stripped) >= len(opener) + len(end)
+            ):
+                closer = end
+            consumed = True
+            break
+        # Blank lines pass through. `active_lines` drops them, and counting them
+        # here would make every file look like it had lost a comment.
+        if not consumed:
+            kept.append(line)
+    return kept
+
+
 def active_lines(source: str) -> list[str]:
     """Return a block's non-blank, non-comment lines, stripped of indentation.
 
@@ -971,13 +1019,9 @@ def active_lines(source: str) -> list[str]:
     user-facing warning become a valid no-op block while satisfying a guard.
     """
 
-    uncommented = source
-    for pattern in (r"<#.*?#>", r"/\*.*?\*/", r"<!--.*?-->"):
-        uncommented = re.sub(pattern, "", uncommented, flags=re.DOTALL)
-
     return [
         line.strip()
-        for line in uncommented.splitlines()
+        for line in strip_block_comments(source.splitlines())
         if line.strip()
         and not line.strip().startswith("#")
         and not line.strip().startswith("//")
@@ -4390,6 +4434,83 @@ def assert_installer_archive_binary_guard_wired(ci: str) -> None:
             "installer can abort on a complete archive and no pull request "
             "would go red"
         )
+
+
+# A fixture in the exact shape ci.yml carries: a `case` arm whose glob ends in
+# `/*`, a cache key holding `**/`, and a line between them that every assertion
+# reading this file depends on being able to see.
+ACTIVE_LINES_FIXTURE = """\
+case "$path" in
+  *.md | docs/*) ;;
+esac
+run: python3 ./scripts/the-line-between.py
+key: ${{ hashFiles('**/Cargo.lock') }}
+/* a real block comment
+   spanning two lines */
+const kept = 1;
+/* a one-line block comment */
+const alsoKept = 2;
+"""
+ACTIVE_LINES_SURVIVOR = "run: python3 ./scripts/the-line-between.py"
+
+
+def assert_active_lines_cannot_span_unrelated_shell(workflows: dict[Path, str]) -> None:
+    """Keep the comment stripper from eating the lines every assertion reads.
+
+    `active_lines` used to strip `<# #>`, `/* */` and `<!-- -->` with three
+    DOTALL regexes over the whole text, which cannot tell a comment from a pair
+    of shell globs. In ci.yml the `docs/*)` arm of a `case` opened one and
+    `hashFiles('**/Cargo.lock')` closed it: 46,138 characters, 48% of the file,
+    were removed before any assertion saw them, and release-train.yml lost 24%
+    the same way. An assertion that cannot see the line it names passes exactly
+    like one that checked it, which is the shape this whole suite exists to
+    prevent.
+
+    No workflow contains a real block comment, so that stripping never removed
+    one. The last check below is what keeps that true: if a workflow ever does
+    open a block comment, this fails and asks for the decision to be reviewed
+    here rather than discovered as a silent hole later.
+    """
+
+    kept = active_lines(ACTIVE_LINES_FIXTURE)
+    if ACTIVE_LINES_SURVIVOR not in kept:
+        raise AssertionError(
+            "active_lines dropped a line between two unrelated shell globs; a "
+            "glob is not a block comment and an assertion reading past one "
+            "would pass without seeing what it names"
+        )
+    for survivor in ("const kept = 1;", "const alsoKept = 2;"):
+        if survivor not in kept:
+            raise AssertionError(f"active_lines dropped live source: {survivor}")
+    for comment in ("a real block comment", "spanning two lines */", "a one-line block comment"):
+        if any(comment in line for line in kept):
+            raise AssertionError(
+                f"active_lines kept a real block comment: {comment}; a commented-out "
+                "validator would then satisfy a guard"
+            )
+
+    # The fixture has to be able to tell the two implementations apart. Without
+    # this, a fixture that both forms handle identically would report a fix
+    # that is not there.
+    superseded = ACTIVE_LINES_FIXTURE
+    for pattern in (r"<#.*?#>", r"/\*.*?\*/", r"<!--.*?-->"):
+        superseded = re.sub(pattern, "", superseded, flags=re.DOTALL)
+    if ACTIVE_LINES_SURVIVOR in {line.strip() for line in superseded.splitlines()}:
+        raise AssertionError(
+            "the active_lines fixture cannot distinguish the DOTALL form from "
+            "the line-oriented one, so it proves nothing"
+        )
+
+    for workflow, content in sorted(workflows.items()):
+        lines = content.splitlines()
+        dropped = len(lines) - len(strip_block_comments(lines))
+        if dropped:
+            raise AssertionError(
+                f"{workflow.relative_to(ROOT).as_posix()} opens a block comment "
+                f"and loses {dropped} line(s) before any assertion reads it. If "
+                "that comment is real, review this census; if it is a glob, the "
+                "stripper is wrong again"
+            )
 
 
 def assert_release_version_gate_wired(ci: str) -> None:
@@ -12300,6 +12421,7 @@ def main() -> None:
             ci_workflow.replace(INSTALLER_BINARY_FALSIFIER_POLICY, "scripts/absent.py")
         ),
     )
+    assert_active_lines_cannot_span_unrelated_shell(workflow_sources)
     assert_release_version_gate_wired(ci_workflow)
     expect_assertion(
         "ci.yml drops the job that runs the version gate on a release PR",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -96,6 +96,12 @@ INSTALLER_BINARY_GUARD = ROOT / "scripts" / "verify-installer-archive-binaries.p
 INSTALLER_BINARY_GUARD_POLICY = "scripts/verify-installer-archive-binaries.py"
 INSTALLER_BINARY_FALSIFIER = ROOT / "scripts" / "falsify-installer-archive-binaries.py"
 INSTALLER_BINARY_FALSIFIER_POLICY = "scripts/falsify-installer-archive-binaries.py"
+RELEASE_VERSION_GUARD = ROOT / "scripts" / "check-release-version.mjs"
+RELEASE_VERSION_GUARD_POLICY = "scripts/check-release-version.mjs"
+RELEASE_VERSION_SUITE_POLICY = "scripts/check-release-version.test.mjs"
+RELEASE_INTENT_SUITE_POLICY = "scripts/release-intent.test.mjs"
+RELEASE_VERSION_FALSIFIER = ROOT / "scripts" / "falsify-release-version-guards.py"
+RELEASE_VERSION_FALSIFIER_POLICY = "scripts/falsify-release-version-guards.py"
 TRUSTED_POLICY_PREFIX = "refs/remotes/origin/main:"
 TAG_LISTING_FORMAT = (
     "--format='%(refname:strip=2) "
@@ -540,6 +546,7 @@ MACOS_SHARD_DOCTESTS = "      run: cargo test --doc --locked"
 MACOS_SHARD_SUCCESS_GATE = 'if [ "$SHARDS" != "success" ]; then'
 CI_JOB_DISPLAY_NAMES = {
     "dco": "DCO Sign-off",
+    "release-version": "Release version gate",
     "npm-launchers": "npm launcher tests",
     "windows-authority-tests": "Windows authority tests",
     "windows-authority-cli-tests": "Windows authority CLI tests",
@@ -4382,6 +4389,96 @@ def assert_installer_archive_binary_guard_wired(ci: str) -> None:
             "ci.yml must run " + " and ".join(missing) + "; without both, the "
             "installer can abort on a complete archive and no pull request "
             "would go red"
+        )
+
+
+def assert_release_version_gate_wired(ci: str) -> None:
+    """Keep the version gate running on the pull request that carries a release.
+
+    `scripts/check-release-version.mjs` has carried the right refusal since
+    before the release train existed, and until this job it ran on no pull
+    request at all. Its one real invocation sits inside the train's own
+    branch-writer step, against a tree that step has just regenerated, so it
+    passes once and never re-runs on the head that merges. A release pull
+    request could therefore lose its version bump after that step and every
+    check would stay green, after which the mint reads a workspace version
+    whose tag already exists, reports nothing to release, and exits 0 on a
+    fifteen-minute cron with no tag cut and nothing raised.
+
+    Every clause below is load-bearing. The event restriction is what keeps the
+    job off the merge queue, where there is no pull request to read a base sha
+    from. The branch and label conditions are what scope it to releases: the
+    gate refuses a release-affecting diff that does not move the version, and
+    asking that of every pull request is a policy change wearing a bug fix's
+    clothes. `fetch-depth: 0` is what lets it read the base commit's manifest
+    at all. And the base and labels reach the script through the environment,
+    never interpolated into a command line, because a pull-request label is
+    text an outside contributor writes.
+    """
+
+    for path, policy in (
+        (RELEASE_VERSION_GUARD, RELEASE_VERSION_GUARD_POLICY),
+        (RELEASE_VERSION_FALSIFIER, RELEASE_VERSION_FALSIFIER_POLICY),
+    ):
+        if not path.is_file():
+            raise AssertionError(
+                f"{policy} is missing; a release pull request could drop its "
+                "version bump and no check would go red"
+            )
+
+    job = workflow_job_blocks(ci).get("release-version")
+    if job is None:
+        raise AssertionError(
+            "ci.yml must run the release version gate on pull requests; without "
+            "that job the gate's only invocation is the release train's own "
+            "branch writer, which never sees the head that merges"
+        )
+
+    # Comment-aware, but line by line rather than through `active_lines`.
+    # That helper strips `/* ... */` with DOTALL, and ci.yml carries a `/*` and
+    # a `*/` about 46,000 characters apart in unrelated shell, so running it
+    # over the whole workflow deletes roughly a third of the file and every
+    # assertion built on the result passes without ever seeing the lines it
+    # names.
+    job_lines = {
+        line.strip()
+        for line in job.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+    for clause in (
+        "github.event_name == 'pull_request' &&",
+        "(github.head_ref == 'automation/release-next' ||",
+        "contains(github.event.pull_request.labels.*.name, 'release:automated'))",
+        "fetch-depth: 0",
+        "BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+        "PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}",
+        f"run: node {RELEASE_VERSION_GUARD_POLICY}",
+    ):
+        if clause not in job_lines:
+            raise AssertionError(
+                "ci.yml must run the release version gate against the release "
+                f"pull request's own base and labels; missing `{clause}`"
+            )
+
+    # Match whole invocations rather than searching for the path, which a
+    # commented-out line would still satisfy.
+    ci_lines = {line.strip() for line in ci.splitlines()}
+    missing = sorted(
+        command
+        for command in (
+            f"run: python3 ./{RELEASE_VERSION_FALSIFIER_POLICY}",
+            f"./{RELEASE_INTENT_SUITE_POLICY} \\",
+            f"{RELEASE_INTENT_SUITE_POLICY} \\",
+            f"./{RELEASE_VERSION_SUITE_POLICY} \\",
+            f"{RELEASE_VERSION_SUITE_POLICY} \\",
+        )
+        if command not in ci_lines
+    )
+    if missing:
+        raise AssertionError(
+            "ci.yml must run " + " and ".join(missing) + "; the guards' own "
+            "suites and the run that watches them fail are the only evidence "
+            "that either gate can refuse anything"
         )
 
 
@@ -12201,6 +12298,81 @@ def main() -> None:
         "ci.yml must run",
         lambda: assert_installer_archive_binary_guard_wired(
             ci_workflow.replace(INSTALLER_BINARY_FALSIFIER_POLICY, "scripts/absent.py")
+        ),
+    )
+    assert_release_version_gate_wired(ci_workflow)
+    expect_assertion(
+        "ci.yml drops the job that runs the version gate on a release PR",
+        "ci.yml must run the release version gate on pull requests",
+        lambda: assert_release_version_gate_wired(
+            ci_workflow.replace("  release-version:\n", "  release-version-disabled:\n")
+        ),
+    )
+    expect_assertion(
+        "the version gate job survives with its command commented out",
+        "missing `run: node",
+        lambda: assert_release_version_gate_wired(
+            ci_workflow.replace(
+                f"run: node {RELEASE_VERSION_GUARD_POLICY}",
+                f"run: # node {RELEASE_VERSION_GUARD_POLICY}",
+            )
+        ),
+    )
+    expect_assertion(
+        "the version gate stops reading the release PR's own base commit",
+        "missing `BASE_SHA",
+        lambda: assert_release_version_gate_wired(
+            ci_workflow.replace(
+                "BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+                "BASE_SHA: ''",
+            )
+        ),
+    )
+    expect_assertion(
+        "the version gate loses the deep fetch its base manifest needs",
+        "missing `fetch-depth: 0`",
+        lambda: assert_release_version_gate_wired(
+            ci_workflow.replace(
+                "          # The gate reads Cargo.toml out of the base commit. A shallow\n"
+                "          # pull-request checkout does not carry it, and `git show` would fail\n"
+                "          # in a way that reads like a broken gate rather than a missing fetch.\n"
+                "          fetch-depth: 0\n",
+                "",
+            )
+        ),
+    )
+    expect_assertion(
+        "the version gate stops being scoped to the release branch",
+        "missing `(github.head_ref",
+        lambda: assert_release_version_gate_wired(
+            ci_workflow.replace(
+                "      (github.head_ref == 'automation/release-next' ||\n"
+                "      contains(github.event.pull_request.labels.*.name, 'release:automated'))\n",
+                "      true\n",
+            )
+        ),
+    )
+    expect_assertion(
+        "ci.yml keeps both version guards but drops their falsification",
+        "ci.yml must run",
+        lambda: assert_release_version_gate_wired(
+            ci_workflow.replace(
+                RELEASE_VERSION_FALSIFIER_POLICY, "scripts/absent.py"
+            )
+        ),
+    )
+    expect_assertion(
+        "ci.yml stops running the release-intent gate's own suite",
+        "ci.yml must run",
+        lambda: assert_release_version_gate_wired(
+            ci_workflow.replace(RELEASE_INTENT_SUITE_POLICY, "scripts/absent.test.mjs")
+        ),
+    )
+    expect_assertion(
+        "ci.yml stops running the version gate's own suite",
+        "ci.yml must run",
+        lambda: assert_release_version_gate_wired(
+            ci_workflow.replace(RELEASE_VERSION_SUITE_POLICY, "scripts/absent.test.mjs")
         ),
     )
     expect_assertion(


### PR DESCRIPTION
Two release guards existed and neither could fail. This runs the first one and makes the second refuse.

`scripts/check-release-version.mjs` has carried the right refusal since before the release train did, and it ran on no pull request. Its one real invocation sits inside `release-train.yml`'s own branch-writer step, against a tree that step has just regenerated, so it passes once and never re-runs on the head that merges. A new `ci.yml` job now runs it on the release pull request's own base and labels. Scope is release pull requests only, by the `automation/release-next` head ref or a `release:automated` label. Two scopes were possible and the narrow one is deliberate: the gate refuses a release-affecting diff that does not move the version, so running it on every pull request would demand a bump per release-affecting change. That is a policy change wearing a bug fix's clothes, and it would be reverted within a day. The branch condition is the half nobody can dodge, since a ruleset owns that ref. The label is there so a hand-cut release is covered too.

`scripts/release-intent.mjs` then converted a dropped bump into silence. A bump that never landed leaves the workspace version equal to the last released version, whose tag exists, so the idempotent branch short-circuited: the mint printed a green notice and exited 0 on a fifteen-minute cron with no tag cut and nothing raised. The held-rail alarm cannot reach it either, because a dropped bump writes a `clear` marker and that alarm only fires on `held`. The `tagExists` branch now splits. A tree that still carries release-affecting content its tag does not is an `::error::` and exit 1, naming the path count and the commits behind. A tree that matches its tag keeps the green no-op.

## What each guard reads

The version gate reads two things out of the pull request itself: `Cargo.toml` at the base commit, through `git show`, and the set of paths the diff touched. It cannot pass on a release pull request that lost its bump, because those are exactly the two facts that define the loss. It runs on the head that merges rather than on a tree the train regenerated, which is the difference between this job and the invocation that already existed.

The intent gate reads whether `v<workspace version>` is in `git tag --list`, and the two-dot tree diff between that tag and `HEAD`, classified by the same rules the version gate uses. It cannot report a green no-op while a bump is missing, because a missing bump is definitionally an existing tag with release-affecting content after it. Two dots on purpose: it compares trees, so a release-affecting change a later commit reverted correctly reports nothing stranded, and no merge-listing quirk can undercount it.

## Falsification

Every row below was run on the committed tree and restored. Ten of them are scripted in `scripts/falsify-release-version-guards.py`, which runs in the `Falsify guards` job; eight more are `expect_assertion` rows inside the authority suite; the last six were run by hand against a throwaway clone of this branch, so both guards have been watched failing on the real repository and not only on a fixture.

| Mutation | Check that goes red |
|---|---|
| `tagExists && strandedPaths.length > 0` neutered | a release-affecting commit stranded behind an existing tag refuses loudly |
| intent's `classifyPath` returns release for everything | documentation stranded behind an existing tag stays a green no-op |
| intent's `classifyPath` drops the `.github/` exclusion | the copied classifier agrees with the version gate on every branch |
| a relative import added to `release-intent.mjs` | the gate imports nothing relative, so a single-file copy still runs |
| entry point back to comparing unresolved paths | the gate runs from a copy reached through a symlinked directory |
| version gate's no-bump refusal neutered | a release-affecting change with no bump is refused end to end |
| version gate's skipped-version refusal neutered | a bump that skips a version is refused end to end |
| version gate's entry point back to unresolved paths | the gate runs from a copy reached through a symlinked directory |
| release generator's entry point back to unresolved paths | the generator runs from a copy reached through a symlinked directory |
| version gate's `classifyPath` returns release for everything | a documentation-only release pull request needs no bump |
| `release-version` job renamed away | `assert_release_version_gate_wired`, missing job |
| gate command commented out | same, missing `run: node scripts/check-release-version.mjs` |
| `BASE_SHA` emptied | same, missing `BASE_SHA` |
| `fetch-depth: 0` dropped | same |
| branch and label scope replaced with `true` | same, missing the head-ref clause |
| falsifier, intent suite, or version suite dropped from `ci.yml` | same, three rows |
| by hand: `v0.5.53` tagged 15 commits back on this branch | `release-intent.mjs` exits 1, `::error::`, 43 stranded paths across 15 commits |
| by hand: the same tag placed at `HEAD` | exits 0, zero stranded paths, no annotation |
| by hand: a release path touched on a branch off main with no bump | `check-release-version.mjs` exits 1 naming one release path |
| by hand: the same branch with `0.5.53 -> 0.5.54` | exits 0 |
| by hand: the version gate replayed against release PR #1125 through `/tmp` | 0 bytes, exit 0, judged nothing |
| by hand: the same replay through `/private/tmp` | full report, exit 0, `0.5.52 -> 0.5.53`, 6 release paths |

Half the probes break the refusal and half break the pass, because a gate that refused every quiet cycle would be switched off within a day.

## Two things worth knowing

The classifier in `release-intent.mjs` is a copy, not an import. `release-tag.yml` copies that file alone out of reviewed main into `$RUNNER_TEMP` under a different basename and runs it there, so a relative import would resolve to a path that does not exist and the mint would die on module resolution instead of judging the release. A parity test over a corpus that exercises every branch, plus a structural test that refuses any relative import, hold the copy in place.

Both entry points now compare real paths, and the second commit here is a defect this work turned up rather than one it set out to fix. The usual idiom compares `import.meta.url` against `pathToFileURL(process.argv[1])`, and Node resolves symlinks for the first and not the second, so a copy invoked through a symlinked directory makes them disagree and the script prints nothing and exits 0.

This was measured, not inferred. Replaying the last real release pull request, #1125 taking 0.5.52 to 0.5.53, against the same commit with the same arguments: `check-release-version.mjs` produced 0 bytes and exit 0 through `/tmp`, and the full report through `/private/tmp`. `release-tag.yml` runs the intent gate from a renamed copy in `$RUNNER_TEMP` and `release-train.yml` runs the version gate from a copy in `$RUNNER_TEMP/release-policy`. Neither is a symlink today, and that is the only reason the naive form has held. Both now fall to running rather than skipping when a path will not resolve, because a gate that silently declines to judge is worse than one that fails.

That replay is also the answer to the obvious question about guard 1: run properly, it passes the last real release pull request, 6 release paths and a patch bump to the expected version. It does not newly red the rail.

`scripts/prepare-release.mjs` carried the same idiom and is fixed here too, because `release-train.yml` runs it from that same policy directory. Every script the release rail copies out of reviewed main and runs from a temporary directory now compares real paths, except `scripts/check-release-proof-artifacts.mjs`, which is named in the report as unfixed. `resolve-release-intent.mjs`, `release-train-body.mjs` and `extract-release-notes.mjs` already did, so somebody hit this before and fixed it where they hit it.

The generator's test earns its place by having failed for the wrong reason first. It copied only the generator, so node failed on module resolution, wrote to stderr, and the assertion on non-empty output held no matter what the entry point did. The falsifier caught it. It now copies the sibling import too, exactly as `release-train.yml` copies all three policy scripts into one directory, so the entry point is the only variable left.

## One more check that could not fail

`active_lines` in `scripts/test-release-workflow-authority.py` stripped block comments with three DOTALL regexes over the whole text, and a regex like that cannot tell a comment from a pair of shell globs. In `ci.yml` the `docs/*)` arm of a `case` opened one and `hashFiles('**/Cargo.lock')` closed it: 46,138 characters, 48% of the file, were removed before any assertion saw them, and `release-train.yml` lost 24% the same way. No workflow contains a real block comment at all, so that stripping has only ever produced silent false negatives. I found it because my first wiring assertion used the helper and reported two steps as missing that were plainly present.

It is now line oriented. A block comment is recognized where one is written, opener beginning a line and closer ending one. All 1149 non-comment lines of `ci.yml` and all 716 of `release-train.yml` now reach the assertions, and the whole suite stays green, so nothing was relying on the blindness. The new assertion feeds it the two-glob fixture and requires the line between them to survive, requires real block comments to still strip, requires the fixture to be able to tell the two implementations apart, and refuses if any workflow ever opens a block comment at line start without that being reviewed there.

## Claims not being made

The mechanism the ticket names, a rebase silently dropping a bump as already upstream, is not guarded here and cannot be. Nothing in the fleet rebases: `compose` and the release train both merge, the queue squashes, and the release branch carries a `non_fast_forward` rule. That path is reachable only through a human running `git rebase` locally, and CI cannot prevent it. What is guarded is the consequence, which is real and was guarded by nothing.

This does not fire on kin `main` today. `main` carries `0.5.53` and no `v0.5.53` tag exists, so `tagExists` is false and the new branch is not reached. An expectation that this would alarm immediately on the existing backlog is not what the state supports. Whatever is holding that release is a different problem, and this changes nothing about it.

No Rust changed, so no clippy or workspace build was run locally. Hosted CI is the gate of record and the Windows legs run only there.

## What was run

`node --test` over both suites and both full `ci.yml` node test lists, 170 and 168 tests green; `python3 scripts/falsify-release-version-guards.py`; `python3 scripts/test-release-workflow-authority.py`; `python3 scripts/test-assertion-reachability.py`; `python3 scripts/acceptance/test_workflow_step_visibility.py`; `node scripts/check-rc-build-drift.mjs`; `bash scripts/test-release-policy-gate.sh`; `bash -n` on the gate shell scripts; `actionlint .github/workflows/ci.yml`; `cargo fmt --all -- --check`.

Closes FIR-2548
