### PR TITLE
Name only the limits that limited the answer

### DIFF
--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1139,7 +1139,21 @@ fn merge_file_coverage_classes(
     classes.insert("file_parsed".to_string(), json!(parsed));
     decided_by.push("file_parsed".to_string());
     if parsed != STATE_PRESENT {
-        limits.push(format!("file_parsed_{parsed}"));
+        // Name the cause when the answer carries one. `file_parsed_absent` is
+        // true and says nothing: a file no adapter claims and a file whose
+        // adapter fell over earn the same word, and only the second is evidence
+        // about the code, so a reader acting on the limit cannot tell which they
+        // have. `content_opaque` is computed from the adapter registry one file
+        // over, so this reads a cause rather than inferring one.
+        limits.push(
+            match coverage
+                .and_then(|coverage| coverage.get("opaque_reason"))
+                .and_then(Value::as_str)
+            {
+                Some(reason) => format!("file_content_opaque_{reason}"),
+                None => format!("file_parsed_{parsed}"),
+            },
+        );
     }
 
     let enriched = match coverage

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1103,6 +1103,21 @@ pub struct ReferenceRow {
     /// candidate rather than a reference (FIR-1552), and only a row with no
     /// other kind of edge behind it is one.
     pub receiver_name_guess: bool,
+    /// How the graph classifies the referencing entity: product source, a test,
+    /// vendored code, and so on.
+    ///
+    /// A caller's role changes what its reference means. Thirty callers that are
+    /// all tests is a different fact about blast radius than thirty production
+    /// call sites, and a reader who could not see which had to re-resolve every
+    /// row through `get_entity` to find out (FIR-1940). The role is already in
+    /// hand where the row is built, so it is served rather than dropped.
+    ///
+    /// `None` is load-bearing rather than a default. A federated spine xref row
+    /// has no local entity to read a role from (see `entity_id` above), and
+    /// [`EntityRole`](kin_model::EntityRole) defaults to `Source`, so a bare enum
+    /// would report every cross-repo caller as product code on no evidence at
+    /// all. Absent, not guessed.
+    pub role: Option<kin_model::EntityRole>,
 }
 
 /// Why a reference row carries no site lines.
@@ -1226,6 +1241,7 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
                 // Every contributing edge has to be a guess for the row to be
                 // one, so this starts true and any other edge clears it.
                 receiver_name_guess: true,
+                role: Some(entity.role),
             });
         if entry.file_path.is_none() {
             entry.file_path = file_path;
@@ -1329,6 +1345,7 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
                     // name guess, and starting true would leave a row created
                     // here in `candidates` if the assignment were ever removed.
                     receiver_name_guess: false,
+                    role: Some(entity.role),
                 });
             let tally = relation_reference_lines(&rel, entity.file_origin.as_ref());
             entry.reference_lines.extend(tally.lines);
@@ -3391,6 +3408,57 @@ mod override_composition_tests {
 
     fn rows_for(graph: &InMemoryGraph, focal: &EntityId) -> Vec<ReferenceRow> {
         collect_graph_reference_rows(graph, focal, &[RelationKind::Calls], None).unwrap()
+    }
+
+    /// A caller's role rides on the row it produces, and two callers with
+    /// different roles produce different rows.
+    ///
+    /// Thirty callers that are all tests is a different fact about blast radius
+    /// than thirty production call sites. The role is in hand where the row is
+    /// built and was dropped there, so a reader had to re-resolve every row
+    /// through `get_entity` to recover it (FIR-1940).
+    ///
+    /// Two roles rather than one, deliberately. A test asserting only that the
+    /// field is populated passes against a row that hardcodes `Source`, which is
+    /// the shape that would state the wrong fact about every test caller.
+    #[test]
+    fn a_reference_row_carries_the_calling_entitys_role() {
+        let graph = InMemoryGraph::new();
+        let focal = entity("HTTPAdapter.send", "src/requests/adapters.py");
+        let product_caller = entity("Session.send", "src/requests/sessions.py");
+        let mut test_caller = entity("test_send", "tests/test_requests.py");
+        test_caller.role = EntityRole::Test;
+        for e in [&focal, &product_caller, &test_caller] {
+            graph.upsert_entity(e).unwrap();
+        }
+        for caller in [&product_caller, &test_caller] {
+            graph
+                .upsert_relation(&relation(
+                    caller.id,
+                    focal.id,
+                    RelationKind::Calls,
+                    RelationOrigin::Lsp,
+                    0.95,
+                ))
+                .unwrap();
+        }
+        let rows = rows_for(&graph, &focal.id);
+        let role_of = |id: EntityId| {
+            rows.iter()
+                .find(|row| row.entity_id.as_deref() == Some(&id.to_string()[..]))
+                .unwrap_or_else(|| panic!("every proven caller is a row: {rows:?}"))
+                .role
+        };
+        assert_eq!(
+            role_of(product_caller.id),
+            Some(EntityRole::Source),
+            "a product caller reports the role the graph holds"
+        );
+        assert_eq!(
+            role_of(test_caller.id),
+            Some(EntityRole::Test),
+            "and a test caller reports a different one"
+        );
     }
 
     /// Both legs proven: the caller counts, and the row says which base it came

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -6723,7 +6723,10 @@ mod tests {
     #[tokio::test]
     async fn find_references_excludes_a_self_edge() {
         let store = InMemoryGraph::new();
-        let caller = make_entity("caller", "src/a.rs");
+        let mut caller = make_entity("caller", "src/a.rs");
+        // A role the graph did not default to, so the assertion below proves the
+        // VALUE reached the wire and not merely the key (FIR-1940).
+        caller.role = EntityRole::Test;
         let target = make_entity("recurse", "src/b.rs");
         store.upsert_entity(&caller).unwrap();
         store.upsert_entity(&target).unwrap();
@@ -6748,6 +6751,11 @@ mod tests {
             body["references"][0]["entity_id"],
             caller.id.to_string(),
             "the one row must be the external caller: {body:#}"
+        );
+        assert_eq!(
+            body["references"][0]["role"],
+            serde_json::json!("test"),
+            "a local row carries the caller's own role through the whole handler: {body:#}"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -7906,6 +7906,17 @@ mod tests {
         );
         assert_eq!(unfiltered["total_upstream"], 1);
         assert_eq!(unfiltered["references"][0]["name"], "caller");
+        // A federated row has no local entity, so it has no role to read. Null
+        // rather than the `EntityRole` default, which would label every
+        // cross-repo caller product code on no evidence (FIR-1940). Asserted on
+        // the row the spine path actually built, because a hand-made row proves
+        // the serializer and not this constructor.
+        assert_eq!(
+            unfiltered["references"][0]["role"],
+            serde_json::Value::Null,
+            "{}",
+            unfiltered["references"][0]
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1438,6 +1438,9 @@ fn spine_reference_rows(
             // payload could show that it was.
             resolution: None,
             receiver_name_guess: false,
+            // No local entity, so no role. Defaulting this to `Source` would
+            // report every federated caller as product code on no evidence.
+            role: None,
             // A federated xref reaches the focal directly in the other
             // repository's graph; nothing here is composed over an override.
             via_override_of: None,
@@ -1607,6 +1610,12 @@ fn reference_row_json(row: ReferenceRow, include_snippets: bool) -> serde_json::
         "entity_id": row.entity_id,
         "name": row.name,
         "kind": row.kind,
+        // How the graph classifies this CALLER: `source`, `test`, `vendored`,
+        // and so on. Thirty test callers and thirty production callers are
+        // different facts about blast radius, and this is the field that
+        // separates them without a per-row `get_entity` round-trip. Null for a
+        // federated row, which has no local entity to carry one.
+        "role": row.role,
         "file_path": row.file_path,
         // `start_line` locates the CALLER's definition; `reference_lines` locates
         // the usages inside it. Both are graph facts and both are 1-based, so an
@@ -3269,8 +3278,11 @@ focal: direction='calls' walks outward to callees, 'callers' walks inward to cal
 'both' merges them — recursing to depth N with a per-step fan-out cap, and inlining \
 each step's body (in product mode, served from graph source records). Address the focal \
 by entity_id or by exact name. Reach for it when you need to follow a path \"what does \
-this call, and what do those call?\" or \"trace this value back to its source\" and want \
-the chain in traversal order, not a bag of neighbors. Its value is that the whole walk \
+this call, and what do those call?\" and want the chain in traversal order, not a bag of \
+neighbors. The unit is the entity, not the value: it walks Calls/Imports/References edges \
+between functions, classes and modules, so a parameter or a variable is followed only as \
+far as the function that receives it, and never through an assignment, a field or a \
+return. It cannot trace a value back to its source. Its value is that the whole walk \
 happens substrate-side and comes back as one structured response, so you don't loop \
 get_entity_source per hop and exhaust your tool-call budget. Ask for the chain's SHAPE with \
 include_body=false (names, kinds, roles, spans, edges, no source) — that is the cheap call, and \
@@ -5124,6 +5136,87 @@ mod tests {
     };
     use kin_spine::SpineBackend as _;
 
+    /// A row as the wire carries it, so the field cannot be added to the struct
+    /// and dropped by the serializer.
+    ///
+    /// The federated case is asserted beside it because
+    /// [`kin_model::EntityRole`] defaults to `Source`: a row with no local
+    /// entity must report null, never the default, or every cross-repo caller
+    /// arrives labelled product code on no evidence.
+    #[test]
+    fn the_wire_row_carries_the_callers_role_and_a_federated_row_reports_null() {
+        let local = super::reference_row_json(
+            ReferenceRow {
+                entity_id: Some("local".to_string()),
+                name: "test_send".to_string(),
+                kind: Some("Function".to_string()),
+                file_path: Some("tests/test_requests.py".to_string()),
+                start_line: Some(4),
+                reference_lines: vec![7],
+                reference_lines_absent: None,
+                signature: None,
+                snippet: None,
+                relation_kinds: Vec::new(),
+                resolution: None,
+                via_override_of: None,
+                receiver_name_guess: false,
+                role: Some(EntityRole::Test),
+            },
+            false,
+        );
+        assert_eq!(local["role"], serde_json::json!("test"), "{local}");
+
+        let federated = super::reference_row_json(
+            ReferenceRow {
+                entity_id: None,
+                name: "consumer".to_string(),
+                kind: None,
+                file_path: Some("[other] src/app.py".to_string()),
+                start_line: None,
+                reference_lines: Vec::new(),
+                reference_lines_absent: Some(ReferenceLinesAbsent::FederatedXref),
+                signature: None,
+                snippet: None,
+                relation_kinds: Vec::new(),
+                resolution: None,
+                via_override_of: None,
+                receiver_name_guess: false,
+                role: None,
+            },
+            false,
+        );
+        assert_eq!(
+            federated["role"],
+            serde_json::Value::Null,
+            "a row with no local entity has no role to report: {federated}"
+        );
+    }
+
+    /// The description states the unit it walks and promises nothing finer.
+    ///
+    /// `trace_data_flow` walks entity-level Calls/Imports/References edges. There
+    /// is no `FlowsTo` relation kind and no `Parameter` entity kind in the model,
+    /// so "trace this value back to its source" was a promise the substrate
+    /// cannot keep, and a reader who took it spent a tool call learning that
+    /// (FIR-2603). The capability is a separate, much larger piece of work; this
+    /// guard is only that the description stops claiming it.
+    #[test]
+    fn the_trace_description_promises_entity_edges_and_never_value_tracing() {
+        let description = TRACE_DATA_FLOW_DESC;
+        assert!(
+            !description.contains("trace this value back to its source"),
+            "the description must not promise value-level tracing: {description}"
+        );
+        assert!(
+            description.contains("The unit is the entity, not the value"),
+            "and it must state the unit it does walk: {description}"
+        );
+        assert!(
+            description.contains("Calls/Imports/References edges"),
+            "naming the edge classes it follows: {description}"
+        );
+    }
+
     fn make_entity(name: &str, file: &str) -> Entity {
         make_entity_in(LanguageId::Rust, name, file)
     }
@@ -6804,14 +6897,32 @@ mod tests {
             !reason.contains("mismatch"),
             "an unregistered repository has nothing to mismatch: {reason}"
         );
+        // The state is reported in full under `cross_repo` above. What it must
+        // NOT do is limit the verdict: an install with no spine registered is
+        // the ordinary single-repo state, and quoting it back as the reason an
+        // answer about THIS repository could not be trusted is FIR-2633.
         let trust_reason = response["negative"]["trust_reason"].as_str().unwrap();
         assert!(
-            trust_reason.starts_with(SPINE_REPO_UNREGISTERED),
-            "the reason names the condition that held: {trust_reason}"
+            !trust_reason.contains(SPINE_REPO_UNREGISTERED),
+            "a spine that was never configured limited nothing: {trust_reason}"
         );
         assert!(
             !trust_reason.contains("mismatch"),
-            "and never the one that did not: {trust_reason}"
+            "and nothing mismatched: {trust_reason}"
+        );
+        assert_eq!(
+            response["negative"]["trust"], "authoritative",
+            "{}",
+            response["negative"]
+        );
+        let notes = response["negative"]["notes"]
+            .as_array()
+            .unwrap_or_else(|| panic!("the condition is still stated: {}", response["negative"]));
+        assert!(
+            notes.iter().any(|note| note
+                .as_str()
+                .is_some_and(|note| note.starts_with(SPINE_REPO_UNREGISTERED))),
+            "in the channel that limits nothing: {notes:?}"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -6777,6 +6777,77 @@ mod tests {
         assert!(body["references"].as_array().unwrap().is_empty());
     }
 
+    /// The single-repo case FIR-2633 is really about, driven through the real
+    /// producer rather than a hand-written payload.
+    ///
+    /// A store with no spine at all is the ordinary install, and every absent
+    /// `find_references` on one used to come back qualified by a limit about
+    /// other repositories. The producer's own word for the state is checked here
+    /// too: a fixture that guessed it would prove the gate against a status
+    /// nothing emits, which is how the sibling disclosure in this PR was a no-op
+    /// on every real store until an acceptance fixture caught it.
+    #[tokio::test]
+    async fn an_install_with_no_spine_is_not_limited_by_cross_repo_authority() {
+        let store = InMemoryGraph::new();
+        let target = make_entity("orphan", "src/orphan.rs");
+        store.upsert_entity(&target).unwrap();
+        // An empty answer is evidence about the target only once the graph can
+        // hold a cross-file reference at all.
+        seed_cross_file_call_witness(&store);
+
+        let live_root = graph_root(&store);
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        // The daemon authority with no spine backend, which is what a repository
+        // that has an id and no cross-repo topology actually is. The ambient
+        // path with no `KIN_REPO_ID` at all reports a different state, and that
+        // one is deliberately untouched here.
+        let response = parsed_response(&crate::finalize_with_envelope(
+            handle_find_references_with_authority(
+                &args,
+                &store,
+                FindReferencesAuthority {
+                    repo_id: "nk",
+                    graph_root: &live_root,
+                    spine: None,
+                },
+                None,
+            )
+            .await
+            .unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+
+        assert!(
+            response["references"].as_array().unwrap().is_empty(),
+            "the absence path is the one under test: {response:#}"
+        );
+        assert_eq!(
+            response["cross_repo"]["status"], "not_configured",
+            "the producer's own word for a store with no spine: {}",
+            response["cross_repo"]
+        );
+        let trust_reason = response["negative"]["trust_reason"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            !trust_reason.contains("cross_repo"),
+            "a spine that does not exist limited nothing: {trust_reason}"
+        );
+        let notes = response["negative"]["notes"]
+            .as_array()
+            .unwrap_or_else(|| panic!("the state is still reported: {}", response["negative"]));
+        assert!(
+            notes.iter().any(|note| note
+                .as_str()
+                .is_some_and(|note| note.starts_with("cross_repo_not_configured"))),
+            "in the channel that limits nothing: {notes:?}"
+        );
+    }
+
     #[tokio::test]
     async fn daemon_find_references_requires_exact_live_graph_root() {
         let graph = InMemoryGraph::new();

--- a/crates/kin-mcp/src/handlers/file_entities.rs
+++ b/crates/kin-mcp/src/handlers/file_entities.rs
@@ -233,6 +233,10 @@ fn tracking_tier<G: GraphStore>(store: &G, file_id: &FilePathId) -> Result<&'sta
 /// admitted, zero entities" as a parser defect and files it as one, which is the
 /// honesty failure this names rather than a coverage failure this fixes.
 ///
+/// The registry decides, not the tier. A file an adapter parsed can never reach
+/// this, because a parsed file's extension is one the registry claims by
+/// definition, so the two conditions agree wherever they overlap.
+///
 /// The adapter registry IS the supported set, and its own
 /// [`supported_languages_with_extensions`](kin_parser::languages::AdapterRegistry::supported_languages_with_extensions)
 /// documents that anything reporting Kin's supported languages must read it
@@ -241,11 +245,21 @@ fn tracking_tier<G: GraphStore>(store: &G, file_id: &FilePathId) -> Result<&'sta
 /// static table and reads no file, and it goes quiet on its own the day an
 /// adapter claims the extension.
 fn opaque_reason(path: &str, tier: &str) -> Option<String> {
-    // The tier is the gate. An empty `.py` file also holds zero entities, and
-    // deriving this flag from the entity count instead would report it as
-    // opaque, which is a confident wrong answer about a file an adapter read
-    // perfectly well.
-    if tier != "opaque_artifact" {
+    // Two tiers, because the store reaches this state by two routes and only one
+    // of them was visible from reading the ingest code. A converted repository
+    // serves `docs/notes.md` as `tracked_in_graph: true, tier: "none"`: the
+    // repository tree admits the path and no facet was ever written for it. The
+    // `opaque_artifact` row the ingest path builds is the other route. Gating on
+    // that row alone made this disclosure a no-op on exactly the store it exists
+    // for, which the acceptance fixture caught and the unit fixtures could not,
+    // because they build the row by hand.
+    //
+    // Every other tier is excluded because something DID read the file.
+    // `entity_source` means an adapter parsed it, so a `.py` file holding
+    // nothing is an empty file rather than an unreadable one, and
+    // `structured_artifact` means Kin understood the file structurally, which is
+    // the opposite of opaque even though it yields no entities.
+    if !matches!(tier, "opaque_artifact" | "none") {
         return None;
     }
     let Some(extension) = std::path::Path::new(path)
@@ -786,25 +800,38 @@ mod tests {
         store
             .upsert_file_layout(&layout_for("src/empty.py", ParseCompleteness::Full, 0))
             .unwrap();
+        // The shape a converted repository actually serves, which is not the one
+        // the ingest code reads like it produces: the repository tree admits the
+        // path and no facet was ever written, so the tier is `none` rather than
+        // `opaque_artifact`. Gating on the artifact row alone made this
+        // disclosure a no-op on every real store, and only the acceptance
+        // fixture could see it, because these fixtures build the row by hand.
+        admit(&store, "NOTES.md");
+        // Its control, and the reason the tier cannot decide this on its own: a
+        // Python file in the same no-facet state has an adapter that claims it,
+        // so nothing about its TYPE explains an empty enumeration.
+        admit(&store, "src/unparsed.py");
 
-        let markdown = call(&store, &[("path", serde_json::json!("README.md"))]).unwrap();
-        assert_eq!(
-            markdown[FILE_COVERAGE_KEY]["content_opaque"],
-            serde_json::json!(true),
-            "{markdown}"
-        );
-        assert_eq!(
-            markdown[FILE_COVERAGE_KEY]["opaque_reason"],
-            serde_json::json!("no_adapter_for_extension:md"),
-            "the disclosure names the extension nothing claims: {markdown}"
-        );
+        for path in ["README.md", "NOTES.md"] {
+            let payload = call(&store, &[("path", serde_json::json!(path))]).unwrap();
+            assert_eq!(
+                payload[FILE_COVERAGE_KEY]["content_opaque"],
+                serde_json::json!(true),
+                "{path}: {payload}"
+            );
+            assert_eq!(
+                payload[FILE_COVERAGE_KEY]["opaque_reason"],
+                serde_json::json!("no_adapter_for_extension:md"),
+                "{path} names the extension nothing claims: {payload}"
+            );
+        }
 
-        for path in ["src/thing.py", "src/empty.py"] {
+        for path in ["src/thing.py", "src/empty.py", "src/unparsed.py"] {
             let payload = call(&store, &[("path", serde_json::json!(path))]).unwrap();
             assert_eq!(
                 payload[FILE_COVERAGE_KEY]["content_opaque"],
                 serde_json::json!(false),
-                "{path} was read by an adapter: {payload}"
+                "{path} has an adapter that claims it, whatever its tier: {payload}"
             );
             assert_eq!(
                 payload[FILE_COVERAGE_KEY]["opaque_reason"],

--- a/crates/kin-mcp/src/handlers/file_entities.rs
+++ b/crates/kin-mcp/src/handlers/file_entities.rs
@@ -77,7 +77,10 @@ carries the `id` every other tool here takes (`get_entity_source`, `get_context_
 `visibility`, `signature`, and the defining span as both lines and bytes. \
 `file_coverage` says what the graph knows about the file itself: `parsed` is `full` when a \
 language adapter parsed it completely, `partial` or `failed` when it did not, and `absent` \
-when no adapter parsed it at all. Only a `full` parse licenses reading this list as the file's \
+when no adapter parsed it at all. When `absent` is because no adapter claims the file's type \
+at all -- Kin admits such a file, hashes it and stores a preview, and extracts nothing -- \
+`content_opaque` is true and `opaque_reason` names the extension, so a file that produced \
+zero entities by design is never read as one whose parse failed. Only a `full` parse licenses reading this list as the file's \
 whole surface, and `_kin.completeness` and `negative.safe_to_conclude_absent` are computed \
 from that fact rather than from store-wide health. A path the graph does not track is refused \
 by name instead of answered with an empty list, because those two answers are \
@@ -216,6 +219,56 @@ fn tracking_tier<G: GraphStore>(store: &G, file_id: &FilePathId) -> Result<&'sta
         return Ok("opaque_artifact");
     }
     Ok("none")
+}
+
+/// Why a file the graph admitted holds no entities, when the reason is its TYPE
+/// rather than anything about its content. `None` when the file's type is not
+/// the reason.
+///
+/// Kin admits every file it is given. One whose extension no language adapter
+/// claims is content-addressed, previewed and stored as an opaque artifact, and
+/// it then reports `parsed: absent` in exactly the words a file whose adapter
+/// fell over reports. Those are opposite facts, and only the second is evidence
+/// about the code. A reader who cannot separate them reads "seven markdown files
+/// admitted, zero entities" as a parser defect and files it as one, which is the
+/// honesty failure this names rather than a coverage failure this fixes.
+///
+/// The adapter registry IS the supported set, and its own
+/// [`supported_languages_with_extensions`](kin_parser::languages::AdapterRegistry::supported_languages_with_extensions)
+/// documents that anything reporting Kin's supported languages must read it
+/// rather than keep a second list, because two lists of one fact can only come
+/// to disagree. So this asks the registry. It is a path-string check against a
+/// static table and reads no file, and it goes quiet on its own the day an
+/// adapter claims the extension.
+fn opaque_reason(path: &str, tier: &str) -> Option<String> {
+    // The tier is the gate. An empty `.py` file also holds zero entities, and
+    // deriving this flag from the entity count instead would report it as
+    // opaque, which is a confident wrong answer about a file an adapter read
+    // perfectly well.
+    if tier != "opaque_artifact" {
+        return None;
+    }
+    let Some(extension) = std::path::Path::new(path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+    else {
+        return Some("no_adapter_for_path".to_string());
+    };
+    let claimed = kin_parser::languages::AdapterRegistry::new()
+        .supported_languages_with_extensions()
+        .into_iter()
+        .any(|(_, extensions)| {
+            extensions
+                .iter()
+                .any(|claimed| claimed.eq_ignore_ascii_case(&extension))
+        });
+    // An adapter does claim this extension, so whatever made the file opaque, it
+    // was not its type. Naming the type would be a guess dressed as a cause.
+    if claimed {
+        return None;
+    }
+    Some(format!("no_adapter_for_extension:{extension}"))
 }
 
 /// Whether the graph holds language-server-derived edges for this file's
@@ -436,6 +489,7 @@ pub fn handle_list_file_entities<G: GraphStore>(
     });
 
     let tier = tracking_tier(store, &file_id)?;
+    let opaque_reason = opaque_reason(&path, tier);
     // Admission identity, resolved through the repository tree rather than
     // through a path-keyed facet. This is the ordering `kin-context` documents:
     // a path the tree does not admit is a graph gap, and answering it from
@@ -503,6 +557,16 @@ pub fn handle_list_file_entities<G: GraphStore>(
             "path": path,
             "tracked_in_graph": tracked_in_graph,
             "tier": tier,
+            // Whether this file holds no entities because its TYPE is one no
+            // language adapter claims, as opposed to a parse that was attempted
+            // and fell short. `parsed: absent` alone cannot separate those, and
+            // reading the first as the second is how an admitted-and-unclaimed
+            // file gets filed as a parser defect. Always present, so "checked
+            // and no" is distinguishable from "not reported".
+            "content_opaque": opaque_reason.is_some(),
+            // The cause, naming the extension nothing claims. Null when
+            // `content_opaque` is false.
+            "opaque_reason": opaque_reason,
             "parsed": parsed.wire(),
             "parse_detail": parse_detail,
             "layout_entity_regions": layout_entity_regions,
@@ -678,6 +742,160 @@ mod tests {
         envelope.graph_state.entity_count = Some(42);
         envelope.graph_as_of = Some(serde_json::json!("change:deadbeef"));
         envelope
+    }
+
+    /// Put `path` in the store as an opaque artifact: admitted, hashed, and
+    /// holding no entities because nothing ever tried to extract any.
+    fn admit_opaque(store: &InMemoryGraph, path: &str) {
+        admit(store, path);
+        store
+            .upsert_opaque_artifact(&kin_model::layout::OpaqueArtifact {
+                file_id: FilePathId::new(path),
+                content_hash: Hash256::from_bytes([3; 32]),
+                mime_type: Some("text/md".to_string()),
+                text_preview: None,
+            })
+            .unwrap();
+    }
+
+    /// A file whose type no adapter claims says so, and a file an adapter read
+    /// says nothing of the kind.
+    ///
+    /// Kin admits every file it is given. Seven markdown files went into a graph,
+    /// produced zero entities, and every surface reported that the way it reports
+    /// a parse that failed. Those are opposite facts and only one is evidence
+    /// about the code, so a reader with no way to tell them apart files the first
+    /// as a parser defect.
+    ///
+    /// Three fixtures, and the second and third are the ones that make this able
+    /// to fail. A flag hardcoded true fails on the Python file; a flag derived
+    /// from "this file has zero entities" fails on the EMPTY Python file, which
+    /// an adapter read perfectly well and which correctly holds nothing.
+    #[test]
+    fn a_file_no_adapter_claims_discloses_its_type_and_a_parsed_file_does_not() {
+        let store = InMemoryGraph::new();
+        admit_opaque(&store, "README.md");
+        admit(&store, "src/thing.py");
+        store
+            .upsert_entity(&entity_at("thing", "src/thing.py", 0))
+            .unwrap();
+        store
+            .upsert_file_layout(&layout_for("src/thing.py", ParseCompleteness::Full, 1))
+            .unwrap();
+        admit(&store, "src/empty.py");
+        store
+            .upsert_file_layout(&layout_for("src/empty.py", ParseCompleteness::Full, 0))
+            .unwrap();
+
+        let markdown = call(&store, &[("path", serde_json::json!("README.md"))]).unwrap();
+        assert_eq!(
+            markdown[FILE_COVERAGE_KEY]["content_opaque"],
+            serde_json::json!(true),
+            "{markdown}"
+        );
+        assert_eq!(
+            markdown[FILE_COVERAGE_KEY]["opaque_reason"],
+            serde_json::json!("no_adapter_for_extension:md"),
+            "the disclosure names the extension nothing claims: {markdown}"
+        );
+
+        for path in ["src/thing.py", "src/empty.py"] {
+            let payload = call(&store, &[("path", serde_json::json!(path))]).unwrap();
+            assert_eq!(
+                payload[FILE_COVERAGE_KEY]["content_opaque"],
+                serde_json::json!(false),
+                "{path} was read by an adapter: {payload}"
+            );
+            assert_eq!(
+                payload[FILE_COVERAGE_KEY]["opaque_reason"],
+                serde_json::Value::Null,
+                "{path} has no opaque cause to name: {payload}"
+            );
+        }
+        assert_eq!(
+            call(&store, &[("path", serde_json::json!("src/empty.py"))]).unwrap()["total_in_file"],
+            serde_json::json!(0),
+            "and the empty control really is empty, or it proves nothing"
+        );
+    }
+
+    /// The reason is computed from the adapter registry rather than written down
+    /// here, so it names whatever extension it was actually given.
+    ///
+    /// A hardcoded `md` passes every assertion above. This is what fails it.
+    #[test]
+    fn the_opaque_reason_names_the_extension_it_was_given() {
+        let store = InMemoryGraph::new();
+        admit_opaque(&store, "docs/diagram.png");
+        let payload = call(&store, &[("path", serde_json::json!("docs/diagram.png"))]).unwrap();
+        assert_eq!(
+            payload[FILE_COVERAGE_KEY]["opaque_reason"],
+            serde_json::json!("no_adapter_for_extension:png"),
+            "{payload}"
+        );
+    }
+
+    /// The envelope's limit word carries the cause, so the one verdict a reader
+    /// acts on says why rather than only that.
+    ///
+    /// `file_parsed_absent` is true of a file nothing tried to parse and of a
+    /// file whose adapter fell over, and a reader acting on it cannot tell which
+    /// they have.
+    #[test]
+    fn the_limit_word_names_the_cause_when_the_answer_carries_one() {
+        let store = InMemoryGraph::new();
+        admit_opaque(&store, "README.md");
+        let limits = finalized_limits(&store, "README.md");
+        assert!(
+            limits.contains("file_content_opaque_no_adapter_for_extension:md"),
+            "the limit names the cause: {limits}"
+        );
+        assert!(
+            !limits.contains("file_parsed_absent"),
+            "and does not also state the symptom it replaces: {limits}"
+        );
+
+        // The control: a file an adapter tried and failed on keeps the generic
+        // word, because its type is not the reason and naming one would be a
+        // guess dressed as a cause.
+        let failed = InMemoryGraph::new();
+        admit(&failed, FILE);
+        failed
+            .upsert_file_layout(&layout_for(
+                FILE,
+                ParseCompleteness::Failed("syntax error".into()),
+                0,
+            ))
+            .unwrap();
+        let limits = finalized_limits(&failed, FILE);
+        assert!(
+            limits.contains("file_parsed_"),
+            "a failed parse keeps the parse word: {limits}"
+        );
+        assert!(
+            !limits.contains("content_opaque"),
+            "and never borrows the opaque cause: {limits}"
+        );
+    }
+
+    /// `_kin.completeness.limits` as the wire carries it, through the same
+    /// finalize the server runs.
+    fn finalized_limits(store: &InMemoryGraph, path: &str) -> String {
+        let args = HashMap::from([("path".to_string(), serde_json::json!(path))]);
+        let finalized = crate::finalize_with_envelope(
+            handle_list_file_entities(&args, store).expect("the tool answers"),
+            structural_authoritative_envelope(),
+            TOOL_NAME,
+        );
+        let crate::types::ContentBlock::Text { text } = &finalized.content[0];
+        let response: serde_json::Value = serde_json::from_str(text).expect("payload is JSON");
+        response[crate::ENVELOPE_KEY]["completeness"]["limits"]
+            .as_array()
+            .unwrap_or_else(|| panic!("the envelope reports limits: {response}"))
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect::<Vec<_>>()
+            .join(",")
     }
 
     #[test]

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1826,33 +1826,94 @@ fn focal_is_method(payload: &Value) -> bool {
         .is_some_and(kin_core::reference_coverage::kind_name_under_resolves_incoming_calls)
 }
 
-/// The label an unavailable cross-repo answer reports, and its detail.
+/// What a cross-repo authority report says about the answer beside it.
+///
+/// A spine that is configured and did not answer limits the answer. A spine that
+/// was never configured for this repository does not, and the two shared one
+/// channel until FIR-2633: a single-repo install pushed a gap whose own producer
+/// text ends "this is the ordinary single-repo state and says nothing about
+/// references inside this repository", and that sentence was then quoted back as
+/// the limiting factor that made the answer inconclusive. A limit the reader
+/// cannot act on, describing a state the response already reports in full under
+/// `cross_repo`, teaches the reader to discount every limit including the real
+/// ones.
+enum CrossRepoQualifier {
+    /// The spine answered completely. Nothing to report.
+    Complete,
+    /// A configured spine failed, went stale, or answered incompletely. The
+    /// answer is limited and the verdict follows.
+    Gap(String),
+    /// No spine is configured for this repository. Reported so a reader can see
+    /// cross-repo authority was considered, and never as a limit.
+    Note(String),
+}
+
+/// The qualifier an unavailable cross-repo answer earns, carrying the code of the
+/// condition that held beside its human detail.
 ///
 /// The producer names the condition that held under `code`, so the label is that
 /// name rather than one catch-all. `cross_repo_unavailable` remains the label for
 /// an answer carrying no code, because a reason with no computed condition behind
 /// it must not be dressed up as one.
-fn cross_repo_unavailable_gap(cross_repo: &Value) -> String {
-    let code = cross_repo
-        .get("code")
-        .and_then(Value::as_str)
-        .unwrap_or("cross_repo_unavailable");
+///
+/// [`SPINE_REPO_UNREGISTERED`](crate::handlers::entities::SPINE_REPO_UNREGISTERED)
+/// is the one code that is not a gap. The producer already separates it from
+/// `SPINE_ROOT_STALE` at its own source (FIR-2353), so this reads a distinction
+/// that exists rather than inventing one: an unregistered repository is the
+/// ordinary state of a single-repo install, while every other code describes a
+/// spine that IS configured and did not answer.
+fn cross_repo_unavailable_qualifier(cross_repo: &Value) -> CrossRepoQualifier {
+    let code = cross_repo.get("code").and_then(Value::as_str);
     let reason = cross_repo
         .get("reason")
         .and_then(Value::as_str)
         .unwrap_or("the cross-repo spine could not answer");
-    format!("{code}: {reason}")
+    let qualifier = format!("{}: {reason}", code.unwrap_or("cross_repo_unavailable"));
+    if code == Some(crate::handlers::entities::SPINE_REPO_UNREGISTERED) {
+        CrossRepoQualifier::Note(qualifier)
+    } else {
+        CrossRepoQualifier::Gap(qualifier)
+    }
 }
 
-fn cross_repo_references_gap(payload: &Value) -> Option<String> {
+/// The note a repository with no cross-repo spine configured earns.
+///
+/// Kept identical for both tools: it is one fact about the install, not about the
+/// query, and two spellings of it would read as two conditions.
+fn cross_repo_not_configured_note() -> CrossRepoQualifier {
+    CrossRepoQualifier::Note(
+        "cross_repo_not_configured: no cross-repo spine is configured, so this answer is \
+         scoped to this repository"
+            .to_string(),
+    )
+}
+
+/// Route a cross-repo qualifier to the channel it belongs in.
+///
+/// A gap flips the verdict; a note never does. A note that could move the verdict
+/// is a gap, and belongs in `trust_reason` instead.
+fn apply_cross_repo_qualifier(
+    qualifier: CrossRepoQualifier,
+    trustworthy: &mut bool,
+    trust_reason: &mut String,
+    notes: &mut Vec<String>,
+) {
+    match qualifier {
+        CrossRepoQualifier::Gap(reason) => push_gap(trustworthy, trust_reason, reason),
+        CrossRepoQualifier::Note(note) => notes.push(note),
+        CrossRepoQualifier::Complete => {}
+    }
+}
+
+fn cross_repo_references_qualifier(payload: &Value) -> CrossRepoQualifier {
     let Some(cross_repo) = payload.get("cross_repo") else {
-        return Some(
+        return CrossRepoQualifier::Gap(
             "cross_repo_authority_missing: find_references did not report cross-repo authority"
                 .to_string(),
         );
     };
     match cross_repo.get("status").and_then(Value::as_str) {
-        Some("unavailable") => Some(cross_repo_unavailable_gap(cross_repo)),
+        Some("unavailable") => cross_repo_unavailable_qualifier(cross_repo),
         Some("available") => {
             let authority_complete = cross_repo
                 .get("authority_complete")
@@ -1890,35 +1951,36 @@ fn cross_repo_references_gap(payload: &Value) -> Option<String> {
                 && anchor_is_bound
                 && relation_subtype_complete
             {
-                None
+                CrossRepoQualifier::Complete
             } else {
-                Some(format!(
+                CrossRepoQualifier::Gap(format!(
                     "cross_repo_authority_incomplete: spine topology or requested relation subtype is incomplete at revision {}",
                     revision.unwrap_or("unwatermarked")
                 ))
             }
         }
-        Some("not_configured") => {
-            Some("cross_repo_not_configured: cross-repo authority did not answer".to_string())
-        }
-        Some(status) => Some(format!(
+        // Not a gap. No spine is configured, so there is no cross-repo authority
+        // to have failed, and nothing about this repository's own graph is in
+        // question (FIR-2633).
+        Some("not_configured") => cross_repo_not_configured_note(),
+        Some(status) => CrossRepoQualifier::Gap(format!(
             "cross_repo_authority_unknown: unrecognized cross-repo authority status '{status}'"
         )),
-        None => {
-            Some("cross_repo_authority_missing: cross-repo authority status is missing".to_string())
-        }
+        None => CrossRepoQualifier::Gap(
+            "cross_repo_authority_missing: cross-repo authority status is missing".to_string(),
+        ),
     }
 }
 
-fn cross_repo_bulk_gap(payload: &Value) -> Option<String> {
+fn cross_repo_bulk_qualifier(payload: &Value) -> CrossRepoQualifier {
     let Some(cross_repo) = payload.get("cross_repo") else {
-        return Some(
+        return CrossRepoQualifier::Gap(
             "cross_repo_authority_missing: bulk reachability did not report cross-repo authority"
                 .to_string(),
         );
     };
     match cross_repo.get("status").and_then(Value::as_str) {
-        Some("unavailable") => Some(cross_repo_unavailable_gap(cross_repo)),
+        Some("unavailable") => cross_repo_unavailable_qualifier(cross_repo),
         Some("available") => {
             let authority_complete = cross_repo
                 .get("authority_complete")
@@ -1944,23 +2006,24 @@ fn cross_repo_bulk_gap(payload: &Value) -> Option<String> {
                 && subtype_complete
                 && verdicts_complete
             {
-                None
+                CrossRepoQualifier::Complete
             } else {
-                Some(format!(
+                CrossRepoQualifier::Gap(format!(
                     "cross_repo_authority_incomplete: bulk topology or requested relation subtype is incomplete at revision {}",
                     revision.unwrap_or("unwatermarked")
                 ))
             }
         }
-        Some("not_configured") => {
-            Some("cross_repo_not_configured: cross-repo authority did not answer".to_string())
-        }
-        Some(status) => Some(format!(
+        // Not a gap. No spine is configured, so there is no cross-repo authority
+        // to have failed, and nothing about this repository's own graph is in
+        // question (FIR-2633).
+        Some("not_configured") => cross_repo_not_configured_note(),
+        Some(status) => CrossRepoQualifier::Gap(format!(
             "cross_repo_authority_unknown: unrecognized cross-repo authority status '{status}'"
         )),
-        None => {
-            Some("cross_repo_authority_missing: cross-repo authority status is missing".to_string())
-        }
+        None => CrossRepoQualifier::Gap(
+            "cross_repo_authority_missing: cross-repo authority status is missing".to_string(),
+        ),
     }
 }
 
@@ -2134,16 +2197,27 @@ pub fn negative_for(
     // no such thing, and applying it there would report every answer on every
     // repository with no spine configured as a floor forever, which is the
     // "mark everything uncertain" regression arriving through a side door.
+    // Conditions this answer weighed and ruled out as limits. They are reported
+    // so a reader can see cross-repo authority was considered, and they never
+    // reach `trust`.
+    let mut notes: Vec<String> = Vec::new();
+
     if tool == "find_references" && claims_absence {
-        if let Some(reason) = cross_repo_references_gap(payload) {
-            push_gap(&mut trustworthy, &mut trust_reason, reason);
-        }
+        apply_cross_repo_qualifier(
+            cross_repo_references_qualifier(payload),
+            &mut trustworthy,
+            &mut trust_reason,
+            &mut notes,
+        );
     }
 
     if tool == "bulk_check_references" && claims_absence {
-        if let Some(reason) = cross_repo_bulk_gap(payload) {
-            push_gap(&mut trustworthy, &mut trust_reason, reason);
-        }
+        apply_cross_repo_qualifier(
+            cross_repo_bulk_qualifier(payload),
+            &mut trustworthy,
+            &mut trust_reason,
+            &mut notes,
+        );
     }
 
     // An empty edge set has two readings with opposite consequences: a focal
@@ -2358,6 +2432,12 @@ pub fn negative_for(
         )),
     );
     negative.insert("degraded_signals".to_string(), json!(degraded_signals));
+    // Stated conditions that are NOT limits, kept in their own key so nothing
+    // downstream can read one as a gap. `trust`, `trust_reason` and `advice` are
+    // computed above and none of them sees this array.
+    if !notes.is_empty() {
+        negative.insert("notes".to_string(), json!(notes));
+    }
     Some(Value::Object(negative))
 }
 
@@ -4829,11 +4909,18 @@ mod tests {
             .starts_with("spine_root_stale"));
     }
 
-    /// An unregistered repository is the ordinary single-repo state, and it must
-    /// not be reported as a mismatch of anything. The old wording made a healthy
-    /// local install look misconfigured.
+    /// An unregistered repository is the ordinary single-repo state. It must not
+    /// be reported as a mismatch of anything, and it must not be reported as the
+    /// limit that stopped this answer being trusted.
+    ///
+    /// The producer's own sentence ends "says nothing about references inside
+    /// this repository", and that sentence was being handed back as the limiting
+    /// factor for an answer about this repository (FIR-2633). A reader cannot act
+    /// on it, and the response already reports the state in full under
+    /// `cross_repo`. It is stated as a note instead, which is the channel a
+    /// condition that limits nothing belongs in.
     #[test]
-    fn an_unregistered_repository_is_not_reported_as_a_root_mismatch() {
+    fn an_unregistered_repository_is_stated_as_a_note_and_never_as_a_limit() {
         let mut payload = authoritative_empty_references("function");
         payload["cross_repo"] = json!({
             "status": "unavailable",
@@ -4843,9 +4930,124 @@ mod tests {
         });
         let negative =
             negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["trust"], json!("authoritative"), "{negative}");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "{negative}"
+        );
         let reason = negative["trust_reason"].as_str().unwrap();
-        assert!(reason.starts_with("spine_repo_unregistered"), "{reason}");
+        assert!(
+            !reason.contains("spine_repo_unregistered"),
+            "a spine that was never configured limited nothing: {reason}"
+        );
         assert!(!reason.contains("mismatch"), "nothing mismatched: {reason}");
+        assert!(
+            !negative["advice"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("spine_repo_unregistered"),
+            "and the advice must not instruct the reader to act on it: {negative}"
+        );
+        assert!(
+            note_matching(&negative, "spine_repo_unregistered").is_some(),
+            "the condition is still stated, in the channel that limits nothing: {negative}"
+        );
+    }
+
+    /// The note channel, read the way every assertion below reads it.
+    fn note_matching(negative: &Value, prefix: &str) -> Option<String> {
+        negative
+            .get("notes")?
+            .as_array()?
+            .iter()
+            .filter_map(Value::as_str)
+            .find(|note| note.starts_with(prefix))
+            .map(str::to_string)
+    }
+
+    /// A single-repo install has no cross-repo authority to have failed, so
+    /// `not_configured` states itself and leaves the verdict alone.
+    ///
+    /// This is the case FIR-2633 is about at its most common: every absent
+    /// `find_references` on every install with no spine came back inconclusive,
+    /// naming a limit about other repositories as the reason an answer about this
+    /// one could not be trusted.
+    #[test]
+    fn a_spine_that_was_never_configured_does_not_limit_a_single_repo_answer() {
+        let mut payload = authoritative_empty_references("function");
+        payload["cross_repo"] = json!({ "status": "not_configured" });
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["trust"], json!("authoritative"), "{negative}");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "{negative}"
+        );
+        assert!(
+            !negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .contains("cross_repo_not_configured"),
+            "{negative}"
+        );
+        let note = note_matching(&negative, "cross_repo_not_configured")
+            .unwrap_or_else(|| panic!("the state is still reported: {negative}"));
+        assert!(
+            note.contains("scoped to this repository"),
+            "and it says what it means rather than naming a failure: {note}"
+        );
+    }
+
+    /// The control that stops this fix becoming "never report cross-repo", for
+    /// both tools and every code that describes a spine which IS configured.
+    ///
+    /// Suppressing all cross-repo gaps would pass every assertion above and lose
+    /// a real one. These are the qualifiers that must stay gaps.
+    #[test]
+    fn a_configured_spine_that_did_not_answer_still_limits_the_answer() {
+        for status in [
+            json!({ "status": "unavailable", "code": "spine_root_stale", "reason": "root has advanced" }),
+            json!({ "status": "unavailable", "reason": "malformed spine xref response" }),
+            json!({ "status": "mystery" }),
+            json!({}),
+        ] {
+            for qualifier in [
+                cross_repo_references_qualifier(&json!({ "cross_repo": status.clone() })),
+                cross_repo_bulk_qualifier(&json!({ "cross_repo": status.clone() })),
+            ] {
+                assert!(
+                    matches!(qualifier, CrossRepoQualifier::Gap(_)),
+                    "a configured spine that did not answer is a real gap: {status}"
+                );
+            }
+        }
+    }
+
+    /// The same table from the other side: the two states that are NOT gaps, on
+    /// both tools. The bulk twin shares the classification and is asserted here
+    /// rather than left to be assumed from the `find_references` cases above.
+    #[test]
+    fn an_unconfigured_spine_is_a_note_on_both_reference_tools() {
+        for status in [
+            json!({ "status": "not_configured" }),
+            json!({
+                "status": "unavailable",
+                "code": "spine_repo_unregistered",
+                "reason": "no registered spine root",
+            }),
+        ] {
+            for qualifier in [
+                cross_repo_references_qualifier(&json!({ "cross_repo": status.clone() })),
+                cross_repo_bulk_qualifier(&json!({ "cross_repo": status.clone() })),
+            ] {
+                assert!(
+                    matches!(qualifier, CrossRepoQualifier::Note(_)),
+                    "an unconfigured spine states itself and limits nothing: {status}"
+                );
+            }
+        }
     }
 
     /// A reason with no computed code behind it keeps the catch-all label rather
@@ -4869,10 +5071,9 @@ mod tests {
     fn find_references_missing_or_unknown_cross_repo_authority_is_inconclusive() {
         for (cross_repo, expected_reason) in [
             (None, "cross_repo_authority_missing"),
-            (
-                Some(json!({ "status": "not_configured" })),
-                "cross_repo_not_configured",
-            ),
+            // `not_configured` is deliberately absent here: it is the one
+            // status that reports a spine which was never configured, so it is
+            // a note rather than a gap and is asserted as one above (FIR-2633).
             (
                 Some(json!({ "status": "mystery" })),
                 "cross_repo_authority_unknown",

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -2783,6 +2783,105 @@ def check_20(suite):
     return res
 
 
+def check_21(suite):
+    """A file no adapter claims must say WHY it holds nothing, and a file an
+    adapter read must not borrow that reason.
+
+    Kin admits every file it is given. One whose extension no language adapter
+    claims is content-addressed, previewed, stored as an opaque artifact, and
+    extracts nothing. Until now every surface reported that outcome in exactly
+    the words it uses for a parse that was attempted and fell short: `parsed:
+    absent`, and `file_parsed_absent` as the envelope's limiting factor. Those
+    are opposite facts and only the second is evidence about the code, so seven
+    markdown files going into a graph and producing nothing read as a parser
+    defect to the reader who put them there. Nothing anywhere named the cause.
+
+    Check 17 already proves the neighbouring fact, that such a file must not be
+    certified. This proves the one after it: the answer has to say why. The two
+    are separable, and a build can pass 17 while telling the reader nothing.
+
+    Three arms, and the second and third are what let this fail. The disclosure
+    is computed from the adapter registry, which is the one authority on the
+    supported set, so:
+
+    - `docs/notes.md` must carry `content_opaque` true and an `opaque_reason`
+      naming its own extension. A reason that named some other extension would
+      pass a weaker assertion.
+    - `pkg/parsed.py` must carry neither. A flag hardcoded true fails here.
+    - `pkg/empty.py` must carry neither, and it is the arm that matters most: an
+      adapter read it and it correctly holds nothing, so any version of this
+      derived from "the file has zero entities" reports it as opaque and fails.
+
+    Falsify by hardcoding the flag, or by deriving it from the entity count
+    rather than from the registry. The first goes red on the second arm, the
+    second on the third, and neither can go red on the first, which is why all
+    three are here.
+    """
+    res = Result("21", "MD-OPAQUE",
+                 "a file whose type no adapter claims discloses that as the reason")
+    repo = suite.fixture("threestate")
+
+    def coverage(rel):
+        try:
+            payload, _ = suite.mcp(repo, "list_file_entities", {"path": rel})
+        except McpError as exc:
+            return None, str(exc)
+        cov = payload.get("file_coverage")
+        if not isinstance(cov, dict):
+            return None, ("the response carries no file_coverage object; keys were %s"
+                          % sorted(payload.keys())[:12])
+        cov = dict(cov)
+        cov["total_in_file"] = payload.get("total_in_file")
+        return cov, None
+
+    # Arm 1: the unclaimed type names itself.
+    cov, why = coverage(NO_ADAPTER_FILE)
+    if cov is None:
+        res.unknown("%s could not be read through MCP: %s" % (NO_ADAPTER_FILE, why[:250]))
+    elif "content_opaque" not in cov:
+        res.unknown("%s reports no content_opaque field; file_coverage keys were %s"
+                    % (NO_ADAPTER_FILE, sorted(cov.keys())))
+    else:
+        extension = NO_ADAPTER_FILE.rsplit(".", 1)[-1]
+        reason = cov.get("opaque_reason")
+        if cov.get("content_opaque") is not True:
+            res.bad("%s has no language adapter and its enumeration is empty, yet the answer "
+                    "reports content_opaque=%r. The reader is left with parsed=%r, which is "
+                    "the same word a failed parse earns"
+                    % (NO_ADAPTER_FILE, cov.get("content_opaque"), cov.get("parsed")))
+        elif not isinstance(reason, str) or extension not in reason:
+            res.bad("%s is disclosed as opaque but the reason does not name its extension "
+                    "%r: opaque_reason=%r. A cause that names the wrong type is not a cause"
+                    % (NO_ADAPTER_FILE, extension, reason))
+        else:
+            res.ok("%s discloses its type as the reason it holds nothing: content_opaque=True "
+                   "opaque_reason=%r tier=%r" % (NO_ADAPTER_FILE, reason, cov.get("tier")))
+
+    # Arms 2 and 3: the controls. Without them the arm above is satisfied by a
+    # build that reports every file opaque, which carries no information at all.
+    for label in ("parsed", "empty"):
+        rel = THREE_STATE_FILES[label]
+        cov, why = coverage(rel)
+        if cov is None:
+            res.unknown("%s could not be read through MCP: %s" % (rel, why[:250]))
+            continue
+        if "content_opaque" not in cov:
+            res.unknown("%s reports no content_opaque field; keys were %s"
+                        % (rel, sorted(cov.keys())))
+        elif cov.get("content_opaque") is not False or cov.get("opaque_reason") is not None:
+            res.bad("%s was read by a language adapter and holds %s entities, yet it reports "
+                    "content_opaque=%r opaque_reason=%r. A file with no entities is not the "
+                    "same fact as a file with no adapter, and this control is what separates "
+                    "them"
+                    % (rel, cov.get("total_in_file"), cov.get("content_opaque"),
+                       cov.get("opaque_reason")))
+        else:
+            res.ok("%s holds %s entities and claims no opaque cause, so the disclosure is "
+                   "computed rather than unconditional"
+                   % (rel, cov.get("total_in_file")))
+    return res
+
+
 CHECKS = [
     ("0", check_0),
     ("1", check_1),
@@ -2805,6 +2904,7 @@ CHECKS = [
     ("18", check_18),
     ("19", check_19),
     ("20", check_20),
+    ("21", check_21),
 ]
 
 

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -2805,17 +2805,31 @@ def check_21(suite):
     supported set, so:
 
     - `docs/notes.md` must carry `content_opaque` true and an `opaque_reason`
-      naming its own extension. A reason that named some other extension would
-      pass a weaker assertion.
+      naming its own extension. Naming the extension, rather than merely being
+      present, is what makes this arm able to fail: a flag computed from anything
+      other than the registry names something else or nothing.
     - `pkg/parsed.py` must carry neither. A flag hardcoded true fails here.
-    - `pkg/empty.py` must carry neither, and it is the arm that matters most: an
-      adapter read it and it correctly holds nothing, so any version of this
-      derived from "the file has zero entities" reports it as opaque and fails.
+    - `pkg/empty.py` must carry neither. It is a docstring-only module that an
+      adapter read successfully, so it holds an entity rather than none; what it
+      controls is that the disclosure keys on the adapter and not on how thin a
+      file is.
 
-    Falsify by hardcoding the flag, or by deriving it from the entity count
-    rather than from the registry. The first goes red on the second arm, the
-    second on the third, and neither can go red on the first, which is why all
-    three are here.
+    Both mutations were run against a release build and both went red, each on a
+    different arm, which is the point of having three.
+
+    - Hardcoding the flag true fails on `pkg/parsed.py`, which reports 4 entities
+      and would be labelled opaque.
+    - Deriving the flag from the entity count fails on `docs/notes.md`, whose
+      reason then reads `no_adapter_for_extension:derived` and names no
+      extension at all.
+
+    One thing this suite deliberately does NOT prove, because its fixture cannot:
+    that a file an adapter read and found genuinely EMPTY is not reported opaque.
+    `pkg/empty.py` holds one entity, so a count-derived flag would not fire on it
+    here. That control lives in the unit fixtures beside the code
+    (`crates/kin-mcp/src/handlers/file_entities.rs`), where `src/empty.py` is
+    parsed `full` with zero entities. Said out loud because an arm that reads
+    like a control and is not one is worse than no arm.
     """
     res = Result("21", "MD-OPAQUE",
                  "a file whose type no adapter claims discloses that as the reason")

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -2847,8 +2847,8 @@ def check_21(suite):
         if cov.get("content_opaque") is not True:
             res.bad("%s has no language adapter and its enumeration is empty, yet the answer "
                     "reports content_opaque=%r. The reader is left with parsed=%r, which is "
-                    "the same word a failed parse earns"
-                    % (NO_ADAPTER_FILE, cov.get("content_opaque"), cov.get("parsed")))
+                    "the same word a failed parse earns. Whole file_coverage: %r"
+                    % (NO_ADAPTER_FILE, cov.get("content_opaque"), cov.get("parsed"), cov))
         elif not isinstance(reason, str) or extension not in reason:
             res.bad("%s is disclosed as opaque but the reason does not name its extension "
                     "%r: opaque_reason=%r. A cause that names the wrong type is not a cause"


### PR DESCRIPTION
Four response-honesty fixes in kin-mcp. Each one is a fact the response already held and did not
say, or a limit it named that limited nothing. Each carries its own check, and every check was proven
red under a named mutation before this was opened.

**A spine that was never configured is no longer a gap.** An unregistered repository and a repository
with no spine at all are the ordinary state of a single-repo install, and both were pushing a gap
that flipped the verdict to inconclusive. The gap text ended "this is the ordinary single-repo state
and says nothing about references inside this repository", and that sentence was then handed back as
the limiting factor for an answer about that repository. A reader cannot act on it, and the response
already reports the state in full under `cross_repo`. Cross-repo qualifiers now split three ways. A
configured spine that failed, went stale or answered incompletely is still a gap and still decides
the verdict. An unconfigured one is stated under a new `notes` array. `verdict.rs` reads
`interpretation`, `trust`, `trust_reason` and `advice` from the negative object and nothing else, so
a note cannot reach the verdict, which is the whole point of the separate channel.

**A reference row carries its caller's role.** The role was in hand where the row is built and
dropped there, so a reader could not separate thirty test callers from thirty production ones without
re-resolving every row through `get_entity`. It is an `Option` deliberately: a federated spine row
has no local entity, and `EntityRole` derives `Default = Source`, so a bare enum would label every
cross-repo caller product code on no evidence at all. `budget.rs` needs no change, checked rather
than assumed: the `find_references` `ResponseShape` lists only what the ladder may shed, and a
twenty-byte scalar nobody wants shed belongs in none of those arrays.

**`trace_data_flow` no longer promises to trace a value back to its source.** There is no `FlowsTo`
relation kind and no `Parameter` entity kind in the model, so the promise could not be kept by any
amount of walking. The description now states the unit it does walk: entity-level
Calls/Imports/References edges, so a parameter is followed only as far as the function that receives
it. No behavior change.

**A file whose type no adapter claims says so.** Kin admits such a file, hashes it, stores a preview
and extracts nothing, and every surface reported that in exactly the words it uses for a parse that
failed. Those are opposite facts and only one is evidence about the code, so markdown files going in
and producing nothing read as a parser defect. `list_file_entities` now carries `content_opaque` and
an `opaque_reason` naming the extension, computed from
`AdapterRegistry::supported_languages_with_extensions()`, which that module's own doc names as the
one authority every reporter must read rather than keep a second list. It is a path-string check
against a static table and reads no file; both Zero File-Search guards pass. The envelope's limit
word now carries the cause instead of the symptom.

## The acceptance check found a no-op the unit tests could not

Worth reading before the rest. The disclosure was first gated on the file's tier being
`opaque_artifact`, which is what the ingest path reads like it produces. The unit fixtures built that
row by hand and passed.

`magic_repro.py` check 21 failed on its first run against a real converted store. `docs/notes.md`
came back `tracked_in_graph: true, tier: "none", parsed: "absent"`. No facet of any kind was ever
written for it, so the row the gate waited on did not exist and the disclosure was a no-op on exactly
the store it was built for, with every unit test green. The gate now fires on `opaque_artifact` or
`none` and the registry decides rather than the tier, with a Python file in the same no-facet state
as the control, since an adapter claims its extension and nothing about its type explains an empty
enumeration. Tiers where something did read the file stay excluded: `entity_source` means an adapter
parsed it, and `structured_artifact` means Kin understood it structurally, which is the opposite of
opaque.

Applying the same question to the cross-repo change caught a second one. The end-to-end test asserts
the producer's own word for the state before asserting the verdict, and it failed first time: on the
ambient path with no `KIN_REPO_ID`, the producer emits an uncoded `unavailable` rather than
`not_configured`, so that shape is still a gap. It is left alone here on purpose. The brief named two
states and this is a third, and the reason carries no `code`, which this module refuses to promote
into a condition by design. The cleaner fix is at the producer, giving that condition a code the way
FIR-2353 gave `spine_repo_unregistered` one, after which the classifier handles it with no new
judgement. Flagged rather than smuggled in.

## Falsification

Fifteen mutation and check pairings, each applied to the committed tree, each proven red against a
check that guards the behavior it breaks, each restored and the tree verified clean. The runner
asserts the named test actually ran and that its line reads FAILED, because an exit code alone cannot
tell a red test from a build that never compiled.

| Mutation | Check that went red |
|---|---|
| `not_configured` is a gap again, both tools | `a_spine_that_was_never_configured_does_not_limit_a_single_repo_answer`, `an_unconfigured_spine_is_a_note_on_both_reference_tools` |
| `spine_repo_unregistered` is a gap again | `an_unregistered_repository_is_stated_as_a_note_and_never_as_a_limit`, `an_unregistered_repository_reports_itself_rather_than_a_root_mismatch` |
| the router sends every gap to notes | `the_spine_reason_leads_when_the_spine_is_the_only_gap` |
| every unavailable spine returns a note | `a_configured_spine_that_did_not_answer_still_limits_the_answer`, `the_spine_reason_leads_when_the_spine_is_the_only_gap` |
| unknown and missing statuses return notes | `a_configured_spine_that_did_not_answer_still_limits_the_answer`, `find_references_missing_or_unknown_cross_repo_authority_is_inconclusive` |
| one row construction site hardcodes `Some(Source)` | `a_reference_row_carries_the_calling_entitys_role`, and `find_references_excludes_a_self_edge` end to end |
| the serializer drops the `role` key | `the_wire_row_carries_the_callers_role_and_a_federated_row_reports_null` |
| the federated site defaults to `Some(Source)` | `filtered_find_references_keeps_unknown_federated_subtype_advisory` |
| restore the value-tracing clause | `the_trace_description_promises_entity_edges_and_never_value_tracing` |
| `content_opaque` hardcoded true | `a_file_no_adapter_claims_discloses_its_type_and_a_parsed_file_does_not`, and acceptance check 21 on its parsed-Python arm |
| the flag derived from the entity count | the same unit check on its zero-entity fixture, and acceptance check 21 on its reason arm |
| the reason hardcodes `md` | `the_opaque_reason_names_the_extension_it_was_given` |
| the limit word is generic again | `the_limit_word_names_the_cause_when_the_answer_carries_one` |

Three of those are over-suppression controls. They are what stops the cross-repo change becoming
"never report cross-repo", which would pass every positive assertion here and quietly lose a real
gap. The role check asserts two roles rather than one, because a check asserting only that the field
is populated survives a hardcoded `Source`, and the end-to-end caller is given `Test`, a role the
graph does not default to, so it proves the value reached the wire and not merely the key.

The opaque disclosure is checked in two places because neither alone is enough, and the two
mutations land on different arms. Hardcoding the flag true is caught by a Python file that reports
four entities. Deriving the flag from the entity count is caught by the markdown file's reason, which
then names no extension at all. The acceptance fixture's own `pkg/empty.py` is a docstring-only
module that holds one entity, so it is a control on "the adapter decides, not the file's thinness"
and it is NOT a zero-entity control; that one lives in the unit fixtures, where `src/empty.py` parses
`full` with zero entities. Both check docstrings say so, because an arm that reads like a control and
is not one is worse than no arm.

## What I ran

`cargo test -p kin-mcp` (662 passed, 0 failed), `cargo fmt -- --check`, `cargo clippy -p kin-mcp
--all-targets --all-features` with the allow list from `.github/clippy-allowed-lints.txt` under
`RUSTFLAGS=-D warnings`, and the four guard scripts `ci.yml` names:
`verify-zero-file-search.py`, `zero_file_search_guard.sh`, `check_runtime_boundaries.sh` and
`check_private_repo_coupling.sh`. All clean.

`bin/kin-parity` against this branch's own release build: PASS-WITH-ALLOWANCES, exit 0. magic 21 pass
/ 0 fail, brownfield 10 pass / 0 fail / 1 unreadable, firstrun 9 pass / 2 fail. All three non-passes
are pre-existing and named in the allowance list, none from this branch: FIR-2464, FIR-2501 and
FIR-2580. Check 21 was proven separately against a release build, green and red under both of its
mutations. Hosted CI is the gate of record and the Windows legs run only there.

## Tickets

Closes FIR-2694
Part of FIR-2633
Part of FIR-1940
Part of FIR-2603

One "Closes" and three "Part of". FIR-2694 is the markdown disclosure, filed with the mechanism, the
acceptance check and its mutations, and this PR completes it. The other three tickets are not
resolved by what is here, and a Closes line their own acceptance would contradict is worse than
none.

FIR-2633 names a specific defect, the bare `graph authority changed repeatedly during
find_references; retry` string in `kin-daemon/src/api.rs`, with a stated acceptance of a churn check
in `scripts/acceptance/magic_repro.py`. That is a different crate and a different fix. What is here
repairs another instance of the same class, in the advice path, and leaves the instance the ticket
names untouched.

FIR-1940 carries two items. This is half of item 1. Item 2, the six MCP client registrations
disagreeing on repo selection, is untouched, and the role classifier half of item 1 is a separate
change proved by an ingest test rather than a serializer test. One correction to that ticket's
premise while it is open: it says `semantic_locate` returns `match_evidence.role` on every hit, and
that is only true on the opt-in legacy cosine arm. The default fused arm emits `ranker`,
`score_source`, `name_match` and `definition` and no role, so both tools omitted it on the default
path and the comparison the ticket draws is not the real one.

FIR-2603 says in its own text that it needs a design rather than a patch, and its acceptance is
`verify` from `requests.get` reaching `HTTPAdapter.cert_verify`. A description edit does not approach
that; it stops the tool promising what the model cannot support.

FIR-2694 is the one this PR does complete. It was filed tonight rather than inherited, because the
markdown item arrived as an observation with no ticket behind it, and a fix with no ticket makes the
board under-report what the fleet actually repaired.

## Claims not being made

No daemon lock, gpu lock or quiet lock was taken, and nothing here binds the default port. The
`_kin.completeness.limits` assertion is read off the finalized response; whether the cause also
reaches `_kin.verdict.limiting_factor` runs through a separate composition path that was not traced.
The ambient no-`KIN_REPO_ID` cross-repo state is knowingly left as a gap, described above.
