### PR TITLE
Point the published surfaces at kinlab.ai, and answer the four questions the README never did

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ semantic authority to query and review. What a change touches shows up before
 it merges, and agents work from exact context instead of re-reading the
 repository.
 
-Kin is the semantic system of record for AI-written software. It is a public
+Kin is the semantic system of record for AI-written software. It is an early
 alpha, usable today as a local CLI, daemon, MCP server, review surface, and
 graph-backed filesystem projection. It is pre-1.0, so expect rough edges and
 breaking changes. See the [latest stable release](https://github.com/firelock-ai/kin/releases/latest)
@@ -469,6 +469,34 @@ across its supported runner matrix. The workflow itself is public:
 A green release establishes those exact artifacts and environments; it is not a
 claim that every distribution, tool, or repository shape is already covered.
 
+## FAQ
+
+### Does Kin replace Git?
+
+Beside Git today. Repository authority over time. Git stays an explicit
+import/export interoperability boundary during brownfield adoption, so a team
+can migrate an existing repository without giving up its editor, compiler,
+build system, or Git interoperability.
+
+### Does my code leave my machine?
+
+Kin keeps local repository work in your environment, so repository ingestion,
+graph storage, and local queries all run there. KinLab is a separate product
+that adds hosted collaboration under explicit access and early-access
+agreements.
+
+### Which agents does it work with?
+
+Working with Claude Code, Codex, Cursor, Gemini and anything else that speaks MCP
+stays first class. `kin setup --intent agent` configures every client it detects
+in one pass.
+
+### Does it block a merge?
+
+Review is advisory, so it flags risk without blocking and the merge decision
+stays with your team. `kin review shadow` hands evidence to a human or a CI
+policy and stops there.
+
 ## Proof posture
 
 The published preregistered Multi-SWE-Bench Go proof package is pinned to an
@@ -479,6 +507,15 @@ here pending independent verification.
 Read the methodology, task set, build identity, and artifacts in the
 [public proof package](https://firelock.ai/labs/kin-proof). Treat claims outside
 that measured scope as hypotheses until they have their own reproducible proof.
+
+## Writing
+
+Engineering notes from building Kin, written down so a stranger can reuse them,
+live at [kinlab.ai/blog](https://kinlab.ai/blog) with a feed at
+[kinlab.ai/rss.xml](https://kinlab.ai/rss.xml).
+
+- [The check that passed because it measured nothing](https://kinlab.ai/blog/checks-that-cannot-fail)
+- [Your code search says nothing uses it. Can you delete it?](https://kinlab.ai/blog/empty-answer-safe-to-delete)
 
 ## Learn and contribute
 

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -33,7 +33,7 @@
     "type": "git",
     "url": "git+https://github.com/firelock-ai/kin.git"
   },
-  "homepage": "https://github.com/firelock-ai/kin",
+  "homepage": "https://kinlab.ai",
   "bugs": {
     "url": "https://github.com/firelock-ai/kin/issues"
   },

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -19,7 +19,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/firelock-ai/kin",
+  "homepage": "https://kinlab.ai",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/firelock-ai/kin.git",

--- a/server.json
+++ b/server.json
@@ -3,6 +3,7 @@
   "name": "ai.kinlab/kin",
   "title": "Kin",
   "description": "The system of record for AI-written software.",
+  "websiteUrl": "https://kinlab.ai",
   "repository": {
     "url": "https://github.com/firelock-ai/kin",
     "source": "github"


### PR DESCRIPTION
The two published npm manifests set `homepage` to the GitHub repository, which
duplicates `repository` and leaves the product site off both package pages. They
now point at https://kinlab.ai; `repository` and `bugs` keep their GitHub URLs, so
nothing that resolves the source moves.

`server.json` gains `websiteUrl`, a documented property of the ServerDetail schema
the file already declares. The MCP registry serves that field back on the listing,
and until now the listing linked only to GitHub. The release workflows rewrite
`.version` and `.packages[0].version` with jq and preserve every other key, so the
new field survives a publish untouched. No version field is touched here.

The README gains two sections and loses one inconsistency. `## FAQ` answers the
four questions a reader actually types, and every answer sentence is drawn from a
sentence that already exists on kinlab.ai or in this file, so the section adds no
claim the product has not already made. The Git answer opens on the canon vision
line, which is the line the canon assigns to that objection. `## Writing` links the
blog, the feed and the two published posts, because the README is the most-read
page in the project and it sent a reader nowhere near the writing.

The maturity word becomes "early alpha", matching the site, llms.txt and every
other public surface. "pre-1.0" stays, since it says something the alpha word does
not.

The ripgrep image alt text was reported as carrying a bare entity count. It does
not on this tree, so it is left alone.

## Verified locally

- The README language-count guard from `ci.yml` passes, and it was falsified two
  ways first: a prose sentence claiming a wrong count exits 1, and renaming the
  `| Language | Extensions |` table exits 1. Both return to green on this tree.
- `npm test` and `npm run lint` for `packages/kin` (47 pass) and `packages/kin-mcp`
  (21 pass), and the `Test release ordering and npm provenance policy` step
  extracted from `ci.yml` (154 pass).
- `cargo fmt --all -- --check` clean.
- `server.json` validates against the `ServerDetail` definition of the schema it
  declares: `websiteUrl` is a known property, no unknown top-level keys remain,
  and both version fields read unchanged.
- The four links this adds all answer 200, with a fabricated `/blog` slug
  answering 404 as the control.

Refs FIR-1315
