### PR TITLE
Pin kin-db 0.7.60 and kin-model 0.7.20, preserving main's dependency resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -1130,7 +1130,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1239,7 +1239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4145,7 +4145,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5067,7 +5067,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5136,7 +5136,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5580,7 +5580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5724,7 +5724,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6657,7 +6657,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -1130,7 +1130,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1239,7 +1239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3285,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.59"
+version = "0.7.60"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2a9608b37408e991813bedec15e99f034ba9a8f0db93e6d9fb6d068db5f804da"
+checksum = "d968316efe650186062f10d97bc18de1a59169ad9e9d0aed739df9c12873834e"
 dependencies = [
  "bincode",
  "bstr",
@@ -3503,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.19"
+version = "0.7.20"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "bafee6c5697e85ce6fe4bc84bace8e7669bf7436853b5b5b90b92133e787b9f1"
+checksum = "34bd9edbec6bd133ba71d96721deac5bde53c58dd3f1ddf8a2cfd01994f0659a"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -4145,7 +4145,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5067,7 +5067,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5136,7 +5136,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5580,7 +5580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5724,7 +5724,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6657,7 +6657,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.19", registry = "kin" }
+kin-model = { version = "=0.7.20", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.59", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.60", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.19"
+version = "0.7.20"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "bafee6c5697e85ce6fe4bc84bace8e7669bf7436853b5b5b90b92133e787b9f1"
+checksum = "34bd9edbec6bd133ba71d96721deac5bde53c58dd3f1ddf8a2cfd01994f0659a"
 dependencies = [
  "chrono",
  "gix-hash",


### PR DESCRIPTION
Four lock lines, not sixteen. The twelve `windows-sys` edge moves this PR carried
earlier are gone, and the lock here is `main`'s own resolution with only the two
pinned versions and their two checksums changed.

## The pins

kin-model 0.7.20 anchors the Git authority delta at the byte level. That is the
payload the canonical encoder rewrite was entirely about, and the one class that
had no byte-level protection against that rewrite. kin-db 0.7.60 takes it.

Neither changes behaviour here. kin-db's regenerated schemas came out
byte-identical to 0.7.19's, which is what a test-coverage release should look
like.

It matters to this repo because the next kin-model lever is a hand-written
incremental preimage writer for that delta, and kin's bootstrap commit carries
the consequence if it emits different bytes. `transaction_hash` is stored in
every `RepositoryCommitReceipt` and compared on idempotent replay at
`crates/kin-core/src/init.rs:323`.

## The windows-sys edges, and a correction

Re-locking with `cargo update --precise` moved twelve third-party `windows-sys`
edges down off 0.61.2 onto 0.60.2, 0.59.0 and 0.52.0. An earlier version of this
body said that could not be reverted and that the Windows CI legs should judge
it. That was wrong. Here is what the check found.

Neither release moved a dependency requirement. kin-db 0.7.60's manifest diff is
its own version, its kin-model pin and the schema version marker. kin-model
0.7.20's is its own version plus two source files. Nothing in either release
forced the movement, so it was resolver churn riding along with the precise
update rather than a consequence of the pin.

Reverting it through cargo does not work, and the reason is worth writing down.
`cargo update -p windows-sys@0.52.0 --precise 0.61.2` moves the 0.52.0 node
rather than the edges pointing at it, and other dependents hold that node where
it is. The refusal is real, but it answers a different question than the one
being asked.

What does work is taking `main`'s lock and changing only the four pin lines. That
lock passes `cargo metadata --locked`, which is the check that rejects an
unsatisfiable resolution, so `main`'s edges are valid for these versions and no
dependency policy is being invented here. The twelve packages keep the
`windows-sys` they had before this PR.

## Gates

Per the workspace rule that DEV-LOCAL cannot validate a pin, because it replaces
the crate under test with a local path:

- `cargo test --doc --locked`, exit 0. Twenty-three crates carry a doctest
  header and one doctest executes, so the leg is thin but not vacuous.
- `cargo nextest run --workspace --locked`, exit 0, **7,270 of 7,270 passed**,
  14 skipped, run on `a38b52df8` with port 4219 confirmed free and the daemon
  lock held. Neither lockfile moved during the run.

- both locks pass `cargo metadata --locked`
- all four pin entries keep a registry source and a checksum:

```
Cargo.lock       kin-model  0.7.20  sparse+https://kinlab.ai/registry/cargo/
Cargo.lock       kin-db     0.7.60  sparse+https://kinlab.ai/registry/cargo/
fuzz/Cargo.lock  kin-model  0.7.20  sparse+https://kinlab.ai/registry/cargo/
```

- zero `source = "path"` entries in either lock

Both tracked lockfiles are updated. Missing `fuzz/Cargo.lock` is what turned both
fuzz targets red on the 0.7.19 pin, so it is in the checklist rather than in
anyone's memory.

Refs FIR-2551.
