### PR TITLE
Diagnose memory failures on what happened during the run, not on the container's whole history

### DIFF
--- a/crates/kin-cli/src/capability.rs
+++ b/crates/kin-cli/src/capability.rs
@@ -407,19 +407,134 @@ pub struct MemoryEvidence {
     /// Which of those two `limit_bytes` came from, so a surface quoting it can
     /// name what it read instead of leaving a reader to guess.
     pub limit_source: MemoryLimitSource,
-    /// Kernel OOM kills accounted to this cgroup. `None` means no accounting
-    /// was readable, which is "not observed" and never "did not happen".
+    /// Kernel OOM kills the cgroup recorded BETWEEN the baseline this evidence
+    /// was measured against and the moment it was taken.
+    ///
+    /// Not a lifetime total, and that distinction is the whole of FIR-1823.
+    /// The kernel's counter only ever counts upwards for as long as the cgroup
+    /// exists, so a container that killed something an hour ago answers the
+    /// question "have you ever" with a number, and a surface that reads it as
+    /// "did this run" hands a caller an unhedged wrong cause for a failure that
+    /// had nothing to do with memory. Two readings can tell those apart; one
+    /// cannot.
+    ///
+    /// `Some(0)` is the kernel saying nothing was killed while this run was
+    /// going on. `None` is this process being unable to say: no accounting was
+    /// readable, no baseline was taken, or the counter moved backwards because
+    /// the cgroup was not the same one both times. All three are "not
+    /// observed", and none of them is "did not happen".
     pub cgroup_oom_kills: Option<u64>,
+    /// Times the cgroup's charge was held at its own ceiling over that same
+    /// window, graded exactly as the kills above are.
+    ///
+    /// This is the evidence a run that was never killed used to leave nowhere a
+    /// reader could find it. A container that spends its life pinned against
+    /// the cap, reclaiming on every allocation, is in obvious memory trouble
+    /// and reports `oom_kills` of zero; before this field the only honest thing
+    /// any diagnosis could say about it was nothing at all. The 4 GiB arm on
+    /// 2026-08-25 recorded 6344 ceiling hits, and no kin surface read one of
+    /// them.
+    pub cgroup_ceiling_hits: Option<u64>,
 }
 
-/// Read what this host will say about memory pressure right now.
+/// The cumulative cgroup counters as they stood before a piece of work began.
+///
+/// Taken by a caller that intends to diagnose its own failure later, because
+/// the counters it will want are cumulative and a single reading of a
+/// cumulative counter cannot be attributed to anything. This is the same shape
+/// `kin_daemon_spawn` already grades a daemon's death with, for the same
+/// reason: the reading taken before is what makes the reading taken after mean
+/// something.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryBaseline {
+    oom_kills: Option<u64>,
+    ceiling_hits: Option<u64>,
+}
+
+impl MemoryBaseline {
+    /// The counters out of a reading already taken.
+    pub(crate) fn from_reading(cgroup: kin_daemon_spawn::CgroupMemory) -> Self {
+        Self {
+            oom_kills: cgroup.oom_kills,
+            ceiling_hits: cgroup.ceiling_hits,
+        }
+    }
+}
+
+/// Take the counters as they stand now, to compare a later reading against.
+pub fn memory_baseline() -> MemoryBaseline {
+    MemoryBaseline::from_reading(kin_daemon_spawn::cgroup_memory())
+}
+
+/// How far a cumulative counter advanced between two readings.
+///
+/// `None` unless both readings exist and the second is not behind the first. A
+/// counter that went backwards belongs to a cgroup that is not the one the
+/// baseline described, and a difference taken across two different scopes is
+/// not a measurement of anything.
+fn counter_advance(before: Option<u64>, after: Option<u64>) -> Option<u64> {
+    match (before, after) {
+        (Some(before), Some(after)) if after >= before => Some(after - before),
+        _ => None,
+    }
+}
+
+/// Read the ceiling this process runs under, attributing no counter movement.
+///
+/// For a caller that wants the ceiling and nothing else: a notice printed
+/// before any work starts, or a health row scoring the machine. Both counter
+/// fields come back `None`, because without a baseline there is no window to
+/// attribute movement to and reporting a lifetime total in a field documented
+/// as a per-run one is the defect this signature exists to make impossible.
+/// A caller that has to explain a failure it just saw takes
+/// [`memory_baseline`] first and calls [`memory_evidence_since`] instead.
 pub fn memory_evidence() -> MemoryEvidence {
-    let (limit_bytes, limit_source) =
-        resolve_memory_limit(host_ram_bytes(), cgroup_memory_limit_bytes());
+    evidence_from(host_ram_bytes(), kin_daemon_spawn::cgroup_memory(), None)
+}
+
+/// Read the ceiling, plus what the cgroup's counters did since `baseline`.
+pub fn memory_evidence_since(baseline: MemoryBaseline) -> MemoryEvidence {
+    evidence_from(
+        host_ram_bytes(),
+        kin_daemon_spawn::cgroup_memory(),
+        Some(baseline),
+    )
+}
+
+/// Core of both readers with every input passed in, so each branch is testable
+/// on any host.
+///
+/// The seam is here rather than one layer up because the branch that matters is
+/// the one no macOS developer can reach: a container with a violent history,
+/// judged against a baseline. A test that can only reach it through
+/// `/sys/fs/cgroup` is a test that never runs on the machine the code is
+/// written on.
+pub(crate) fn evidence_from(
+    host_ram_bytes: u64,
+    cgroup: kin_daemon_spawn::CgroupMemory,
+    baseline: Option<MemoryBaseline>,
+) -> MemoryEvidence {
+    let (limit_bytes, limit_source) = resolve_memory_limit(host_ram_bytes, cgroup.limit_bytes);
+    // No baseline is no window, and no window is no attribution. Falling back
+    // to the raw lifetime totals here is exactly FIR-1823, so the absent case
+    // reports nothing rather than reporting the container's whole history as
+    // though it belonged to whatever just failed.
+    let baseline = match baseline {
+        Some(baseline) => baseline,
+        None => {
+            return MemoryEvidence {
+                limit_bytes,
+                limit_source,
+                cgroup_oom_kills: None,
+                cgroup_ceiling_hits: None,
+            };
+        }
+    };
     MemoryEvidence {
         limit_bytes,
         limit_source,
-        cgroup_oom_kills: cgroup_oom_kill_count(),
+        cgroup_oom_kills: counter_advance(baseline.oom_kills, cgroup.oom_kills),
+        cgroup_ceiling_hits: counter_advance(baseline.ceiling_hits, cgroup.ceiling_hits),
     }
 }
 
@@ -494,17 +609,6 @@ fn cgroup_memory_limit_bytes() -> Option<u64> {
     kin_daemon_spawn::cgroup_memory().limit_bytes
 }
 
-/// How many times the kernel OOM-killed a process accounted to this cgroup, or
-/// `None` when no accounting is readable (off Linux, or neither hierarchy's
-/// file is present).
-///
-/// The distinction that matters to a caller is `Some(0)` against `None`: the
-/// first is the kernel saying nothing was killed, the second is this process
-/// being unable to ask.
-fn cgroup_oom_kill_count() -> Option<u64> {
-    kin_daemon_spawn::cgroup_memory().oom_kills
-}
-
 /// Whole-core count for a cgroup v2 `cpu.max` value ("<quota> <period>" in µs,
 /// or "max <period>"). Rounds a fractional quota up to one core; `None` when
 /// unlimited or unparsable.
@@ -539,6 +643,102 @@ fn parse_v1_cpu_quota(quota_us: i64, period_us: i64) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A container reading with a history: killed before, pinned before.
+    fn cgroup(oom_kills: Option<u64>, ceiling_hits: Option<u64>) -> kin_daemon_spawn::CgroupMemory {
+        kin_daemon_spawn::CgroupMemory {
+            limit_bytes: Some(4 * 1024 * 1024 * 1024),
+            oom_kills,
+            ceiling_hits,
+            ..kin_daemon_spawn::CgroupMemory::default()
+        }
+    }
+
+    const HOST_RAM: u64 = 64 * 1024 * 1024 * 1024;
+
+    /// FIR-1823, at the layer that decides it. Both counters are cumulative for
+    /// the container's whole life, so the number that answers "did this run"
+    /// is the difference across the run and never the total after it.
+    ///
+    /// The two arms are identical except for when the kill happened. A run that
+    /// began and ended at three killed nothing, however loudly the container's
+    /// history reads; a run that began at three and ended at four killed one.
+    /// Before the fix both of these reported three.
+    #[test]
+    fn counters_are_the_advance_across_the_run_not_the_containers_lifetime() {
+        let before = MemoryBaseline::from_reading(cgroup(Some(3), Some(900)));
+
+        let quiet = evidence_from(HOST_RAM, cgroup(Some(3), Some(900)), Some(before));
+        assert_eq!(
+            quiet.cgroup_oom_kills,
+            Some(0),
+            "a counter that did not move means this run killed nothing, not that three kills \
+             belong to it"
+        );
+        assert_eq!(quiet.cgroup_ceiling_hits, Some(0));
+
+        let killed = evidence_from(HOST_RAM, cgroup(Some(4), Some(1_244)), Some(before));
+        assert_eq!(
+            killed.cgroup_oom_kills,
+            Some(1),
+            "one kill during the run is one kill, not the four the container has ever seen"
+        );
+        assert_eq!(
+            killed.cgroup_ceiling_hits,
+            Some(344),
+            "the ceiling counter is graded the same way, for the same reason"
+        );
+    }
+
+    /// The reading with no baseline attributes nothing, whatever the container
+    /// has been through.
+    ///
+    /// This is the property the fix rests on. A caller that never took a
+    /// before-reading cannot be handed a per-run number, so the worst a future
+    /// edit reverting to this reader can produce is a hedged diagnosis, never a
+    /// confident wrong one.
+    #[test]
+    fn a_reading_with_no_baseline_attributes_no_counter_movement() {
+        let violent = evidence_from(HOST_RAM, cgroup(Some(9), Some(6_344)), None);
+        assert_eq!(
+            violent.cgroup_oom_kills, None,
+            "nine lifetime kills belong to no particular run and must be reported as belonging \
+             to none"
+        );
+        assert_eq!(violent.cgroup_ceiling_hits, None);
+        assert_eq!(
+            violent.limit_bytes,
+            4 * 1024 * 1024 * 1024,
+            "the ceiling is still read; it is the attribution that is withheld"
+        );
+    }
+
+    /// The three ways an advance is not measurable, each distinct from zero.
+    #[test]
+    fn an_unaskable_or_incoherent_counter_is_not_an_advance_of_zero() {
+        let unreadable = MemoryBaseline::from_reading(cgroup(None, None));
+        let now = evidence_from(HOST_RAM, cgroup(Some(4), Some(10)), Some(unreadable));
+        assert_eq!(
+            now.cgroup_oom_kills, None,
+            "a baseline nobody could read cannot be subtracted from"
+        );
+        assert_eq!(now.cgroup_ceiling_hits, None);
+
+        let readable = MemoryBaseline::from_reading(cgroup(Some(4), Some(10)));
+        let gone = evidence_from(HOST_RAM, cgroup(None, None), Some(readable));
+        assert_eq!(
+            gone.cgroup_oom_kills, None,
+            "a host that stopped answering reports nothing, not that nothing happened"
+        );
+
+        let backwards = evidence_from(HOST_RAM, cgroup(Some(1), Some(2)), Some(readable));
+        assert_eq!(
+            backwards.cgroup_oom_kills, None,
+            "a counter behind its own baseline belongs to a different cgroup, and the difference \
+             across two scopes measures nothing"
+        );
+        assert_eq!(backwards.cgroup_ceiling_hits, None);
+    }
 
     #[test]
     fn tier_names_match_env_override_tokens() {

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -133,11 +133,25 @@ async fn run_daemon_commit(
     // Opened before the request so the first phase the daemon enters is already
     // inside the window this reads.
     let mut tail = PhaseTail::open(&kin_root);
+    // Taken here for the same reason and over the same window as the phase
+    // tail. The cgroup's kill and ceiling counters are cumulative for the
+    // container's whole life, so the reading that matters is the difference
+    // across this request rather than the total after it. FIR-1823: without a
+    // before-reading, a kill from any earlier process in the same container
+    // made this commit report itself as the thing that ran out of memory.
+    let memory_baseline = crate::capability::memory_baseline();
     let response = stream_phases_while(quiet, &mut tail, request.send()).await;
     let response = match response {
         Ok(response) => response,
         Err(error) => {
-            return resolve_commit_after_lost_reply(layout, &kin_root, operation_id, error, quiet);
+            return resolve_commit_after_lost_reply(
+                layout,
+                &kin_root,
+                operation_id,
+                error,
+                quiet,
+                memory_baseline,
+            );
         }
     };
     if !response.status().is_success() {
@@ -289,6 +303,7 @@ fn resolve_commit_after_lost_reply(
     operation_id: kin_model::OperationId,
     error: reqwest::Error,
     quiet: bool,
+    memory_baseline: crate::capability::MemoryBaseline,
 ) -> Result<DaemonCommitResult> {
     let lookup = landed_commit_for_operation(layout, operation_id);
     let unreadable_authority = lookup.as_ref().err().map(|error| format!("{error:#}"));
@@ -332,7 +347,7 @@ fn resolve_commit_after_lost_reply(
                     abandoned.as_deref(),
                     daemon_alive,
                     unix_now(),
-                    &crate::capability::memory_evidence(),
+                    &crate::capability::memory_evidence_since(memory_baseline),
                 )
             });
             let error = match cause {

--- a/crates/kin-cli/src/commands/commit_progress.rs
+++ b/crates/kin-cli/src/commands/commit_progress.rs
@@ -220,14 +220,16 @@ fn human_bytes(bytes: u64) -> String {
 /// that survive a SIGKILL: the transaction marker the daemon published on its
 /// own beat, and this host's memory accounting read after the fact.
 ///
-/// Memory is attributed in two grades and they are labelled differently on
+/// Memory is attributed in three grades and they are labelled differently on
 /// purpose, the same way [`super::embed`] grades an embed that lost its daemon.
-/// A cgroup that recorded a kill is the kernel's own statement and is reported
-/// as observed. A resident set that had climbed to within
-/// [`NEAR_CEILING_FRACTION`] of the ceiling is a strong prior and nothing more,
-/// so it is reported as likely. With neither, the phase and the process death
-/// are still reported and memory is not mentioned at all: a daemon that died
-/// for another reason must not be handed a diagnosis nobody measured.
+/// A kill the cgroup recorded while this commit ran is the kernel's own
+/// statement and is reported as observed. A charge that hit the container's
+/// ceiling during the commit without anything being killed, and a resident set
+/// that had climbed to within [`NEAR_CEILING_FRACTION`] of the ceiling, are
+/// both strong priors and nothing more, so both are reported as likely. With
+/// none of the three, the phase and the process death are still reported and
+/// memory is not mentioned at all: a daemon that died for another reason must
+/// not be handed a diagnosis nobody measured.
 pub fn daemon_loss_explanation(
     abandoned: Option<&kin_daemon_spawn::OpenTransaction>,
     daemon_alive: bool,
@@ -301,20 +303,29 @@ fn memory_attribution(
     evidence: &crate::capability::MemoryEvidence,
 ) -> Option<String> {
     let observed_kills = evidence.cgroup_oom_kills.filter(|count| *count > 0);
+    let observed_ceiling_hits = evidence.cgroup_ceiling_hits.filter(|count| *count > 0);
     let near_ceiling = observed_rss(open)
         .is_some_and(|rss| rss as f64 >= evidence.limit_bytes as f64 * NEAR_CEILING_FRACTION);
-    let cause = match (observed_kills, near_ceiling) {
-        (Some(count), _) => format!(
+    let cause = match (observed_kills, observed_ceiling_hits, near_ceiling) {
+        (Some(count), _, _) => format!(
             "This machine's kernel recorded {count} out-of-memory kill(s) against the {} \
-             available here, so the commit ran out of memory.",
+             available here while this commit ran, so the commit ran out of memory.",
             human_bytes(evidence.limit_bytes)
         ),
-        (None, true) => format!(
+        // No byte figure here, for the reason [`super::embed`] gives at the
+        // same grade: the ceiling count and `limit_bytes` come from two
+        // separate walks up the cgroup tree, and pairing them would let a
+        // host-RAM figure be quoted as a ceiling a container reached.
+        (None, Some(hits), _) => format!(
+            "This container's memory charge was held at its ceiling {hits} time(s) while this \
+             commit ran, so it most likely ran out of memory."
+        ),
+        (None, None, true) => format!(
             "That is within {}% of the {} available here, so it most likely ran out of memory.",
             (100.0 - NEAR_CEILING_FRACTION * 100.0).round(),
             human_bytes(evidence.limit_bytes)
         ),
-        (None, false) => return None,
+        (None, None, false) => return None,
     };
     Some(format!("{cause} {COMMIT_MEMORY_REMEDY}"))
 }
@@ -434,6 +445,7 @@ mod tests {
             limit_bytes,
             limit_source: crate::capability::MemoryLimitSource::HostRam,
             cgroup_oom_kills: oom_kills,
+            cgroup_ceiling_hits: None,
         }
     }
 
@@ -555,6 +567,105 @@ mod tests {
         assert!(
             !explained.contains("ran out of memory"),
             "no measurement supports a memory diagnosis here: {explained}"
+        );
+    }
+
+    /// A container reading, for an arm that has to place a history before the
+    /// commit it is judging.
+    fn cgroup(
+        limit_bytes: u64,
+        oom_kills: u64,
+        ceiling_hits: u64,
+    ) -> kin_daemon_spawn::CgroupMemory {
+        kin_daemon_spawn::CgroupMemory {
+            limit_bytes: Some(limit_bytes),
+            oom_kills: Some(oom_kills),
+            ceiling_hits: Some(ceiling_hits),
+            ..kin_daemon_spawn::CgroupMemory::default()
+        }
+    }
+
+    /// The evidence one commit produces, from the readings that bracket it.
+    fn across_commit(
+        start: kin_daemon_spawn::CgroupMemory,
+        end: kin_daemon_spawn::CgroupMemory,
+    ) -> crate::capability::MemoryEvidence {
+        crate::capability::evidence_from(
+            64 * GIB,
+            end,
+            Some(crate::capability::MemoryBaseline::from_reading(start)),
+        )
+    }
+
+    /// FIR-1823 on the commit path, which carried the same defect as the embed
+    /// one and for the same reason.
+    ///
+    /// The daemon here died holding 2 GiB against a 64 GiB ceiling, which is no
+    /// memory failure by any reading. The only thing that ever made it look
+    /// like one was a kill counter that had been sitting at two since long
+    /// before this commit started.
+    #[test]
+    fn a_kill_from_before_this_commit_is_not_this_commits_kill() {
+        let marker = abandoned_marker(Some(2 * GIB), Some(2 * GIB));
+
+        let unmoved = across_commit(cgroup(64 * GIB, 2, 40), cgroup(64 * GIB, 2, 40));
+        let explained = daemon_loss_explanation(marker.as_deref(), false, 1_006, &unmoved)
+            .expect("a dead daemon holding a marker is still explained by its phase");
+        assert!(
+            !explained.contains("ran out of memory"),
+            "two kills that predate this commit are not evidence about this commit: {explained}"
+        );
+        assert!(
+            explained.contains("reconcile_workspace_and_commit_authority"),
+            "the phase is still worth reporting whatever killed it: {explained}"
+        );
+
+        // The control that proves the arm above can fail.
+        let moved = across_commit(cgroup(64 * GIB, 2, 40), cgroup(64 * GIB, 3, 40));
+        let killed = daemon_loss_explanation(marker.as_deref(), false, 1_006, &moved)
+            .expect("a kill during the commit must be explained in memory terms");
+        assert!(
+            killed.contains("recorded 1 out-of-memory kill(s)"),
+            "the count reported must be this commit's one, not the container's three: {killed}"
+        );
+        assert!(
+            killed.contains("so the commit ran out of memory"),
+            "a kill during the commit is the kernel's own statement: {killed}"
+        );
+    }
+
+    /// The ceiling-hit counter on the commit path.
+    ///
+    /// A commit whose container was held against its cap the whole time, with
+    /// a resident set nowhere near it because the kernel kept reclaiming, used
+    /// to produce no memory sentence at all.
+    #[test]
+    fn a_charge_pinned_at_the_ceiling_during_the_commit_is_reported_as_likely() {
+        let marker = abandoned_marker(Some(2 * GIB), Some(2 * GIB));
+
+        let pinned = across_commit(cgroup(12 * GIB, 1, 100), cgroup(12 * GIB, 1, 1_071));
+        let explained = daemon_loss_explanation(marker.as_deref(), false, 1_006, &pinned)
+            .expect("a dead daemon holding a marker must be explained");
+        assert!(
+            explained.contains("971 time(s)"),
+            "the count reported must be this commit's own advance: {explained}"
+        );
+        assert!(
+            explained.contains("most likely ran out of memory"),
+            "a ceiling the kernel absorbed is a prior, not a kill it performed: {explained}"
+        );
+        assert!(
+            !explained.contains("out-of-memory kill"),
+            "nothing was killed during this commit and nothing may say one was: {explained}"
+        );
+
+        // The control. Same history, and a counter that did not move.
+        let untouched = across_commit(cgroup(12 * GIB, 1, 1_071), cgroup(12 * GIB, 1, 1_071));
+        let quiet = daemon_loss_explanation(marker.as_deref(), false, 1_006, &untouched)
+            .expect("the phase still explains itself");
+        assert!(
+            !quiet.contains("ran out of memory"),
+            "1071 ceiling hits that all predate this commit say nothing about it: {quiet}"
         );
     }
 

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -369,12 +369,30 @@ fn human_bytes(bytes: u64) -> String {
 /// in that message names memory, the model that needs it, or the fact that
 /// lexical and graph retrieval never did.
 ///
-/// Two grades are produced and they are labelled differently on purpose. A
-/// cgroup that recorded a kill is the kernel's own statement and is reported as
-/// observed. A ceiling below what an embed needs is a strong prior and nothing
-/// more, so it is reported as likely. A disconnect with neither is left alone:
-/// a daemon that died for another reason on a large machine keeps its own
-/// error rather than being told it ran out of memory.
+/// Three grades are produced and they are labelled differently on purpose, in
+/// descending order of how much the machine actually proved.
+///
+/// A kill the cgroup recorded WHILE THIS PASS RAN is the kernel's own statement
+/// about this pass and is reported as observed. That window is the fix for
+/// FIR-1823: the counter is cumulative for the container's whole life, so the
+/// same number also counts a kill from an unrelated run an hour ago, and
+/// reading it without a baseline reported those as this embed's cause. The
+/// evidence carries the difference between two readings now, so a pass that
+/// killed nothing reads zero however violent the container's history was.
+///
+/// A charge that hit the ceiling during the pass without anything being killed
+/// is real pressure and a strong prior, so it is reported as likely. Nothing
+/// read this before: kin took only the kill count out of `memory.events` and
+/// ignored `max` beside it, so a run that spent its life pinned against the cap
+/// and a run that never came near it produced identical diagnoses. The 4 GiB
+/// container arm on 2026-08-25 hit its ceiling 6344 times, survived, and had
+/// nothing to show for it.
+///
+/// A ceiling below what an embed needs is a prior about the machine rather than
+/// an observation of the run, so it grades last and is also reported as likely.
+/// A disconnect with none of the three is left alone: a daemon that died for
+/// another reason on a large machine keeps its own error rather than being told
+/// it ran out of memory.
 fn embed_resource_exhaustion(
     rendered: &str,
     evidence: &crate::capability::MemoryEvidence,
@@ -383,18 +401,29 @@ fn embed_resource_exhaustion(
         return None;
     }
     let observed_kills = evidence.cgroup_oom_kills.filter(|count| *count > 0);
+    let observed_ceiling_hits = evidence.cgroup_ceiling_hits.filter(|count| *count > 0);
     let under_recommendation = evidence.limit_bytes < RECOMMENDED_EMBED_MEMORY_BYTES;
-    let cause = match (observed_kills, under_recommendation) {
-        (Some(count), _) => format!(
+    let cause = match (observed_kills, observed_ceiling_hits, under_recommendation) {
+        (Some(count), _, _) => format!(
             "the daemon was lost during this embed pass and this container's kernel recorded \
-             {count} out-of-memory kill(s), so the embed ran out of memory"
+             {count} out-of-memory kill(s) while it ran, so the embed ran out of memory"
         ),
-        (None, true) => format!(
+        // No byte figure in this sentence, deliberately. The ceiling count and
+        // `limit_bytes` are resolved by two separate walks up the cgroup tree,
+        // and `limit_bytes` falls back to host RAM whenever no cap below it is
+        // tighter, so pairing them would let a host-RAM number be quoted as the
+        // ceiling a container hit. The count is what is new here; the ceiling
+        // worth aiming at is named in the guidance below.
+        (None, Some(hits), _) => format!(
+            "the daemon was lost during this embed pass and this container's memory charge was \
+             held at its ceiling {hits} time(s) while it ran, so it most likely ran out of memory"
+        ),
+        (None, None, true) => format!(
             "the daemon was lost during this embed pass and only {} of memory is available to \
              it, so it most likely ran out of memory",
             human_bytes(evidence.limit_bytes)
         ),
-        (None, false) => return None,
+        (None, None, false) => return None,
     };
     Some(format!(
         "{cause}.\n\
@@ -468,6 +497,14 @@ pub async fn run(
     .entered();
     let layout = crate::commands::require_repository_layout()?;
 
+    // Taken before the first pass, and reused by every pass, because the
+    // counters it holds are cumulative for the container's whole life. A
+    // reading taken only after a failure cannot say whether the kill it counts
+    // happened during this embed or during something else an hour ago, and
+    // FIR-1823 is what saying so anyway looked like: an unhedged "the embed ran
+    // out of memory" for a daemon that died of something else entirely.
+    let memory_baseline = crate::capability::memory_baseline();
+
     if !json {
         if let Some(notice) = constrained_memory_notice(&crate::capability::memory_evidence()) {
             println!("{notice}");
@@ -484,6 +521,7 @@ pub async fn run(
                 rebuild,
                 cap_batch_size: true,
             },
+            memory_baseline,
         )
         .await?;
         if json {
@@ -527,6 +565,7 @@ pub async fn run(
                 rebuild: rebuild && pass == 1,
                 cap_batch_size: false,
             },
+            memory_baseline,
         )
         .await?;
         let result = response.result;
@@ -615,6 +654,7 @@ pub async fn run(
 async fn run_daemon_embed(
     layout: &kin_core::KinLayout,
     request: &EmbedRequest,
+    memory_baseline: crate::capability::MemoryBaseline,
 ) -> Result<EmbedResponse> {
     let daemon_url = std::env::var("KIN_DAEMON_URL")
         .ok()
@@ -634,7 +674,10 @@ async fn run_daemon_embed(
         // needs to see what the connection actually did still can, and a
         // failure this cannot attribute to memory is passed through untouched
         // rather than being given a diagnosis nobody proved.
-        match embed_resource_exhaustion(&rendered, &crate::capability::memory_evidence()) {
+        match embed_resource_exhaustion(
+            &rendered,
+            &crate::capability::memory_evidence_since(memory_baseline),
+        ) {
             Some(guidance) => anyhow::anyhow!("daemon embed failed: {rendered}\n\n{guidance}"),
             None => anyhow::anyhow!("daemon embed failed: {rendered}"),
         }
@@ -825,9 +868,10 @@ mod tests {
     use super::{
         constrained_memory_notice, effective_batch_size, embed_completion_line,
         embed_pass_should_continue, embed_resource_exhaustion, eta_suffix, format_duration_secs,
-        resolve_total_budget, should_queue_missing_embedding_pass, throughput_per_sec, EmbedResult,
-        PassCoverage, DEFAULT_BATCH_SIZE, DEFAULT_CONSTRAINED_TOTAL_SECONDS, EMBED_MODEL_DOWNLOAD,
-        EMBED_MODEL_ID, RECOMMENDED_EMBED_MEMORY_BYTES,
+        lost_the_daemon_mid_request, resolve_total_budget, should_queue_missing_embedding_pass,
+        throughput_per_sec, EmbedResult, PassCoverage, DEFAULT_BATCH_SIZE,
+        DEFAULT_CONSTRAINED_TOTAL_SECONDS, EMBED_MODEL_DOWNLOAD, EMBED_MODEL_ID,
+        RECOMMENDED_EMBED_MEMORY_BYTES,
     };
 
     fn result_with(pending_entities: usize, pending_artifacts: usize) -> EmbedResult {
@@ -1177,6 +1221,7 @@ mod tests {
             limit_bytes,
             limit_source: crate::capability::MemoryLimitSource::HostRam,
             cgroup_oom_kills: oom_kills,
+            cgroup_ceiling_hits: None,
         }
     }
 
@@ -1229,6 +1274,139 @@ mod tests {
         assert!(
             !guidance.contains("kernel recorded"),
             "nothing may claim a kill this host could not observe: {guidance}"
+        );
+    }
+
+    /// A container reading, for an arm that has to place a history before the
+    /// pass it is judging.
+    fn cgroup(
+        limit_bytes: u64,
+        oom_kills: u64,
+        ceiling_hits: u64,
+    ) -> kin_daemon_spawn::CgroupMemory {
+        kin_daemon_spawn::CgroupMemory {
+            limit_bytes: Some(limit_bytes),
+            oom_kills: Some(oom_kills),
+            ceiling_hits: Some(ceiling_hits),
+            ..kin_daemon_spawn::CgroupMemory::default()
+        }
+    }
+
+    /// The evidence one embed pass produces, from the readings that bracket it.
+    fn across_pass(
+        start: kin_daemon_spawn::CgroupMemory,
+        end: kin_daemon_spawn::CgroupMemory,
+    ) -> crate::capability::MemoryEvidence {
+        crate::capability::evidence_from(
+            64 * 1024 * 1024 * 1024,
+            end,
+            Some(crate::capability::MemoryBaseline::from_reading(start)),
+        )
+    }
+
+    /// A ceiling with room to spare, so nothing but the counters can produce a
+    /// diagnosis and an arm that stays silent stayed silent for the right
+    /// reason.
+    const ROOMY: u64 = 8 * 1024 * 1024 * 1024;
+
+    /// FIR-1823, end to end: two passes identical except for when the kill
+    /// happened.
+    ///
+    /// Arm one is a container that was killed three times before this pass ever
+    /// started and killed nothing during it. The counter reads three both
+    /// times. Before the fix that three was read as this pass's own and the
+    /// caller was told, flatly, that the embed ran out of memory.
+    ///
+    /// Arm two is the control that proves the first arm can fail. Same history,
+    /// same everything, one more kill by the end. Without it, code that simply
+    /// deleted the branch would pass arm one and nobody would know.
+    #[test]
+    fn a_kill_from_before_the_pass_is_not_this_passs_kill() {
+        assert!(
+            lost_the_daemon_mid_request(OOM_KILLED_MID_PASS),
+            "both arms below are about a daemon that was lost; if this stops being one, they \
+             pass for the wrong reason"
+        );
+
+        let unmoved = across_pass(cgroup(ROOMY, 3, 900), cgroup(ROOMY, 3, 900));
+        assert_eq!(
+            embed_resource_exhaustion(OOM_KILLED_MID_PASS, &unmoved),
+            None,
+            "a container with three historical kills and none during this pass has no memory \
+             diagnosis to offer about this pass"
+        );
+
+        let moved = across_pass(cgroup(ROOMY, 3, 900), cgroup(ROOMY, 4, 1_100));
+        let guidance = embed_resource_exhaustion(OOM_KILLED_MID_PASS, &moved)
+            .expect("a kill during the pass is the kernel's own statement about the pass");
+        assert!(
+            guidance.contains("recorded 1 out-of-memory kill(s)"),
+            "the count reported must be the pass's one, not the container's four: {guidance}"
+        );
+        assert!(
+            guidance.contains("so the embed ran out of memory"),
+            "a kill during the pass is reported as observed, not hedged: {guidance}"
+        );
+    }
+
+    /// The same historical kill must not upgrade the grade on a small machine
+    /// either.
+    ///
+    /// A ceiling under the recommendation already earns a hedged diagnosis on
+    /// its own, so the arm above cannot see this: silence there proves nothing
+    /// about whether the kill was consulted. Here the diagnosis is present and
+    /// the question is which sentence it is.
+    #[test]
+    fn a_historical_kill_does_not_promote_a_ceiling_inference_to_an_observation() {
+        let small = 512 * 1024 * 1024;
+        let unmoved = across_pass(cgroup(small, 3, 900), cgroup(small, 3, 900));
+        let guidance = embed_resource_exhaustion(OOM_KILLED_MID_PASS, &unmoved)
+            .expect("a ceiling under the recommendation is still a memory diagnosis");
+        assert!(
+            !guidance.contains("kernel recorded"),
+            "three kills that predate the pass are not evidence about the pass: {guidance}"
+        );
+        assert!(
+            guidance.contains("most likely"),
+            "with nothing observed during the pass, the ceiling is a prior and says so: \
+             {guidance}"
+        );
+    }
+
+    /// The ceiling-hit counter, which nothing in kin read until now.
+    ///
+    /// A container held against its cap for the whole pass, reclaiming on every
+    /// allocation and never killed, used to leave a diagnosis with nothing to
+    /// say: `oom_kill` reads zero and the ceiling is generous, so the pass came
+    /// back as an unexplained disconnect. The 4 GiB arm on 2026-08-25 recorded
+    /// 6344 of these beside a single kill, and no kin surface read one.
+    #[test]
+    fn a_charge_pinned_at_the_ceiling_during_the_pass_is_reported_as_likely() {
+        let pinned = across_pass(cgroup(ROOMY, 2, 900), cgroup(ROOMY, 2, 7_244));
+        let guidance = embed_resource_exhaustion(OOM_KILLED_MID_PASS, &pinned)
+            .expect("a charge held at the ceiling through the pass is memory pressure");
+        assert!(
+            guidance.contains("6344 time(s)"),
+            "the count reported must be the pass's own advance: {guidance}"
+        );
+        assert!(
+            guidance.contains("ceiling") && guidance.contains("most likely"),
+            "reaching the ceiling is pressure the kernel absorbed, not a kill it performed: \
+             {guidance}"
+        );
+        assert!(
+            !guidance.contains("kernel recorded"),
+            "nothing was killed during this pass and nothing may say one was: {guidance}"
+        );
+
+        // The control. Same generous ceiling, same violent history, and a
+        // counter that did not move during the pass. Without this, a fix that
+        // reported the lifetime total would pass the arm above.
+        let untouched = across_pass(cgroup(ROOMY, 2, 6_344), cgroup(ROOMY, 2, 6_344));
+        assert_eq!(
+            embed_resource_exhaustion(OOM_KILLED_MID_PASS, &untouched),
+            None,
+            "6344 ceiling hits that all predate the pass say nothing about the pass"
         );
     }
 

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -4561,6 +4561,7 @@ mod tests {
             limit_bytes,
             limit_source: crate::capability::MemoryLimitSource::HostRam,
             cgroup_oom_kills: None,
+            cgroup_ceiling_hits: None,
         }
     }
 
@@ -4570,6 +4571,7 @@ mod tests {
             limit_bytes,
             limit_source: crate::capability::MemoryLimitSource::ContainerLimit,
             cgroup_oom_kills: None,
+            cgroup_ceiling_hits: None,
         }
     }
 

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -193,10 +193,21 @@ pub struct CgroupMemory {
     /// Kernel OOM kills accounted to this cgroup, or `None` when no accounting
     /// is readable.
     pub oom_kills: Option<u64>,
+    /// How many times this cgroup's charge was held at its own ceiling, or
+    /// `None` when the kernel publishes no such count.
+    ///
+    /// This is the `max` key of cgroup v2's `memory.events`, and it answers a
+    /// question no other field here can. A run that spends its life pinned
+    /// against the cap, reclaimed hard on every allocation and never killed,
+    /// leaves `oom_kills` at zero and `peak_bytes` merely equal to the cap,
+    /// which is also what a run that touched the ceiling once looks like. This
+    /// counter separates them. v1 publishes nothing equivalent, so it is `None`
+    /// there, and `Some(0)` is the kernel saying the ceiling was never reached.
+    pub ceiling_hits: Option<u64>,
     /// Bytes charged to this cgroup right now, or `None` when no accounting is
     /// readable. This is the only field that answers "how close is this
-    /// container to its cap at this instant"; the two above answer what the cap
-    /// is and what has already been killed under it.
+    /// container to its cap at this instant"; the others answer what the cap
+    /// is, what has already been killed under it, and how often it was reached.
     pub current_bytes: Option<u64>,
     /// The high-water mark this cgroup has reached, or `None` when the kernel
     /// publishes none (cgroup v2 only, and only on kernels carrying
@@ -206,9 +217,11 @@ pub struct CgroupMemory {
 
 /// Read what this host will say about memory pressure right now.
 pub fn cgroup_memory() -> CgroupMemory {
+    let events = cgroup_memory_events();
     CgroupMemory {
         limit_bytes: cgroup_memory_limit_bytes(),
-        oom_kills: cgroup_oom_kill_count(),
+        oom_kills: events.oom_kills,
+        ceiling_hits: events.ceiling_hits,
         current_bytes: cgroup_memory_current_bytes(),
         peak_bytes: cgroup_memory_peak_bytes(),
     }
@@ -389,45 +402,70 @@ fn cgroup_memory_peak_bytes() -> Option<u64> {
     None
 }
 
-/// How many times the kernel OOM-killed a process accounted to this cgroup, or
-/// `None` when no accounting is readable (off Linux, or neither hierarchy's
+/// The event counters one cgroup block publishes about its own ceiling.
+///
+/// Read together, out of one file, because they are only comparable when they
+/// describe the same cgroup. Taking the kill count from a container's own
+/// `memory.events` and the ceiling count from the hierarchy root would produce
+/// two numbers about two different scopes and no way for a reader to tell.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct CgroupEventCounts {
+    /// The `oom_kill` key: kills the kernel accounted to this cgroup.
+    oom_kills: Option<u64>,
+    /// The `max` key: times the charge was held at this cgroup's own ceiling.
+    ceiling_hits: Option<u64>,
+}
+
+/// What this process's cgroup says about kills and ceiling hits, or an empty
+/// reading when no accounting is readable (off Linux, or neither hierarchy's
 /// file is present).
 ///
-/// Both hierarchies publish the counter under the same key, in different files:
-/// cgroup v2 in `memory.events`, v1 in `memory.oom_control`. Searched from this
-/// process's own cgroup upwards for the reason the limit is: at the root there
-/// is nothing to count.
+/// Both hierarchies publish the kill counter under the same key, in different
+/// files: cgroup v2 in `memory.events`, v1 in `memory.oom_control`. Searched
+/// from this process's own cgroup upwards for the reason the limit is: at the
+/// root there is nothing to count. The first block carrying `oom_kill` is the
+/// answer, and the ceiling count is taken from that same block, which is why
+/// v1 reads `None` for it: `memory.oom_control` publishes no `max` key and
+/// there is nothing to fall through to that would describe the same scope.
+///
+/// Both counters are cumulative for the cgroup's lifetime. A caller asking
+/// whether THIS run hit either of them must compare two readings; a single
+/// reading answers "ever", never "just now". That is FIR-1823.
 #[cfg(target_os = "linux")]
-fn cgroup_oom_kill_count() -> Option<u64> {
+fn cgroup_memory_events() -> CgroupEventCounts {
     let relative =
         read_cgroup_file("/proc/self/cgroup").and_then(|body| parse_proc_self_cgroup(&body));
     for mount in ["/sys/fs/cgroup", "/sys/fs/cgroup/memory"] {
         for dir in cgroup_search_dirs(mount, relative.as_deref()) {
             for name in ["memory.events", "memory.oom_control"] {
-                if let Some(count) = read_cgroup_file(&format!("{dir}/{name}"))
-                    .and_then(|raw| parse_oom_kill_count(&raw))
-                {
-                    return Some(count);
+                let Some(raw) = read_cgroup_file(&format!("{dir}/{name}")) else {
+                    continue;
+                };
+                if let Some(oom_kills) = parse_cgroup_counter(&raw, "oom_kill") {
+                    return CgroupEventCounts {
+                        oom_kills: Some(oom_kills),
+                        ceiling_hits: parse_cgroup_counter(&raw, "max"),
+                    };
                 }
             }
         }
     }
-    None
+    CgroupEventCounts::default()
 }
 
 #[cfg(not(target_os = "linux"))]
-fn cgroup_oom_kill_count() -> Option<u64> {
-    None
+fn cgroup_memory_events() -> CgroupEventCounts {
+    CgroupEventCounts::default()
 }
 
-/// The `oom_kill` counter out of a cgroup key/value block, or `None` when the
-/// block carries no such key.
+/// One named counter out of a cgroup key/value block, or `None` when the block
+/// carries no such key.
 #[cfg(any(target_os = "linux", test))]
-fn parse_oom_kill_count(contents: &str) -> Option<u64> {
+fn parse_cgroup_counter(contents: &str, key: &str) -> Option<u64> {
     contents.lines().find_map(|line| {
         let mut fields = line.split_whitespace();
         match (fields.next(), fields.next()) {
-            (Some("oom_kill"), Some(value)) => value.parse().ok(),
+            (Some(name), Some(value)) if name == key => value.parse().ok(),
             _ => None,
         }
     })
@@ -8209,19 +8247,55 @@ mod tests {
         // cgroup v2 `memory.events`, which is where a container's evidence
         // comes from.
         assert_eq!(
-            parse_oom_kill_count("low 0\nhigh 0\nmax 3\noom 1\noom_kill 1\n"),
+            parse_cgroup_counter("low 0\nhigh 0\nmax 3\noom 1\noom_kill 1\n", "oom_kill"),
             Some(1)
         );
         // cgroup v1 `memory.oom_control`, same key, different file.
         assert_eq!(
-            parse_oom_kill_count("oom_kill_disable 0\nunder_oom 0\noom_kill 2\n"),
+            parse_cgroup_counter("oom_kill_disable 0\nunder_oom 0\noom_kill 2\n", "oom_kill"),
             Some(2)
         );
         // A group that was never killed says so, which is not the same answer
         // as a host that cannot be asked.
-        assert_eq!(parse_oom_kill_count("low 0\nhigh 0\nmax 0\noom 0\n"), None);
-        assert_eq!(parse_oom_kill_count("oom_kill 0\n"), Some(0));
-        assert_eq!(parse_oom_kill_count("oom_kill notanumber\n"), None);
+        assert_eq!(
+            parse_cgroup_counter("low 0\nhigh 0\nmax 0\noom 0\n", "oom_kill"),
+            None
+        );
+        assert_eq!(parse_cgroup_counter("oom_kill 0\n", "oom_kill"), Some(0));
+        assert_eq!(
+            parse_cgroup_counter("oom_kill notanumber\n", "oom_kill"),
+            None
+        );
+    }
+
+    /// The ceiling-hit counter is a real key with a real value, and it is not
+    /// the kill counter.
+    ///
+    /// `max` is what a run pinned against its cap leaves behind when nothing is
+    /// killed, and reading only `oom_kill` made those runs indistinguishable
+    /// from runs that never approached the ceiling. The 4 GiB container arm on
+    /// 2026-08-25 recorded `max 6344` beside `oom_kill 1`: the two keys count
+    /// different things and neither substitutes for the other.
+    #[test]
+    fn ceiling_hits_are_read_from_the_max_key_and_are_not_the_kill_count() {
+        const PINNED: &str = "low 0\nhigh 0\nmax 6344\noom 9\noom_kill 1\n";
+        assert_eq!(parse_cgroup_counter(PINNED, "max"), Some(6344));
+        assert_eq!(
+            parse_cgroup_counter(PINNED, "oom_kill"),
+            Some(1),
+            "the two keys are read independently out of one block"
+        );
+        // A ceiling never reached says so, which is not the same answer as a
+        // hierarchy that publishes no such key at all.
+        assert_eq!(
+            parse_cgroup_counter("low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\n", "max"),
+            Some(0)
+        );
+        assert_eq!(
+            parse_cgroup_counter("oom_kill_disable 0\nunder_oom 0\noom_kill 2\n", "max"),
+            None,
+            "cgroup v1 publishes no ceiling-hit counter"
+        );
     }
 
     /// FIR-2653. One process's reading never carries a shared page whole.


### PR DESCRIPTION
The embed and commit memory diagnoses told people their run had run out of memory when it had not.
Both read the cgroup's `oom_kill` counter once, after a failure, and reported the number they found
as the cause. That counter is cumulative for the container's whole life, so a kill from any earlier
process in the same container made the current pass render an unhedged "so the embed ran out of
memory" for a daemon that died of something else. Somebody reading that goes and fixes a machine
that is not broken.

Both paths now take a baseline before their request goes out and diagnose on the difference between
the two readings. `MemoryEvidence` carries per-run counters instead of lifetime ones, and the reader
that takes no baseline attributes nothing at all, so the worst a future caller that skips the
baseline can produce is a hedged diagnosis rather than a confident wrong one. That is the ticket's
own second sanctioned fix direction, and it puts the defect out of reach by construction rather than
by discipline.

The same block carries a second counter nothing in kin has ever read. `memory.events` publishes
`max` beside `oom_kill`, counting how often the charge was held at the ceiling, and a container
pinned against its cap for a whole pass leaves that number large with `oom_kill` at zero. So every
diagnosis kin emitted was identical for a run that spent its life at the ceiling and a run that
never came near it. The 4 GiB container arm on 2026-08-25 recorded `max 6344` beside `oom_kill 1`,
and no kin surface read one of those 6344. `CgroupMemory` reads it now, out of the same block as the
kill count so the two always describe one cgroup, and both diagnoses report it as a likely cause,
kept distinct from a kill the kernel actually performed. The kill path is unchanged: file selection
still keys on the `oom_kill` key, and cgroup v1 reads `None` for the ceiling because
`memory.oom_control` publishes no such key.

Neither ceiling sentence quotes a byte figure, deliberately. The ceiling count and `limit_bytes`
come from two separate walks up the cgroup tree, and `limit_bytes` falls back to host RAM whenever
no cap below it is tighter, so pairing them would let a host-RAM number be quoted as the ceiling a
container reached.

Two readers of the lifetime counter were left alone on purpose. `kin-core/src/memory_pressure.rs`
and `kin-core/src/init_attempt.rs` are the live pressure probe rather than a post-failure diagnosis,
they already word the claim as a lifetime fact, and they belong to FIR-2678 and FIR-2638.
`CgroupMemory.oom_kills` keeps its lifetime meaning, so nothing moved underneath them.

## Falsification

Every row ran against the committed tree, one mutation at a time, restored afterwards. The restore
runs on an EXIT, INT and TERM trap, so an interrupted run cannot leave a mutation behind. Baseline
before each mutation was 68 selected tests green; after each restore, 68 green and a clean tree.

| Mutation | Tests that go RED |
|---|---|
| M1 `evidence_from` reports the raw lifetime counters instead of the advance, which is the pre-fix behavior | 7 red: `capability::counters_are_the_advance_across_the_run_not_the_containers_lifetime`, `capability::an_unaskable_or_incoherent_counter_is_not_an_advance_of_zero`, `embed::a_kill_from_before_the_pass_is_not_this_passs_kill`, `embed::a_historical_kill_does_not_promote_a_ceiling_inference_to_an_observation`, `embed::a_charge_pinned_at_the_ceiling_during_the_pass_is_reported_as_likely`, `commit_progress::a_kill_from_before_this_commit_is_not_this_commits_kill`, `commit_progress::a_charge_pinned_at_the_ceiling_during_the_commit_is_reported_as_likely` |
| M2 the baseline-free arm falls back to the lifetime counters | 1 red: `capability::a_reading_with_no_baseline_attributes_no_counter_movement` |
| M3 `counter_advance` uses `saturating_sub`, so a counter behind its own baseline reads as an advance | 1 red: `capability::an_unaskable_or_incoherent_counter_is_not_an_advance_of_zero` |
| M4 `parse_cgroup_counter` refuses the `max` key | 1 red: `ceiling_hits_are_read_from_the_max_key_and_are_not_the_kill_count`. `oom_kill_count_is_read_from_either_cgroup_hierarchy` stays green, which is what proves the kill path is untouched |
| M5 the embed diagnosis drops the ceiling grade | 1 red: `embed::a_charge_pinned_at_the_ceiling_during_the_pass_is_reported_as_likely` |
| M6 the commit diagnosis drops the ceiling grade | 1 red: `commit_progress::a_charge_pinned_at_the_ceiling_during_the_commit_is_reported_as_likely` |
| M7 the embed wiring reverts to the baseline-free `memory_evidence()` | **Nothing goes red.** Disclosed, not hidden. See below |

M7 is in the table because a mutation nothing catches is worth more said than left out. Reverting
the wiring fails safe: both counters come back `None`, the observed and ceiling grades stop firing,
and the diagnosis degrades to the static ceiling prior, so no wrong claim can reach a user through
that path. That is the whole point of making `memory_evidence()` attribute nothing, and M2 guards
it. What is not guarded is the capability quietly disappearing. Closing that needs the compiler
rather than a test: a newtype returned only by `memory_evidence_since` would make the revert fail to
build. Worth doing, not done here.

One thing the falsification caught about itself. The first pass filtered tests on
`capability::tests commands::embed::tests commands::commit_progress::tests cgroup`, and the new
parser test is named `ceiling_hits_are_read_from_the_max_key_and_are_not_the_kill_count`, which
contains no "cgroup". So M4 came back green with 69 tests run and looked exactly like a passing row.
Counting which kin-daemon-spawn tests the baseline actually selected is what caught it. The M4 row
above is from the corrected filter.

## What I ran

Everything on `fd45e97c0`, through `bin/kin-lane run fir1823 kin`, so every command resolved the
lane worktree and its own cargo target. Exit codes read from a captured file, never through a pipe.

- `cargo test -p kin-cli`: 2513 passed, 0 failed, 2 ignored across 59 test binaries, the lib suite
  among them at 1805 passed.
- `cargo test -p kin-daemon-spawn`: 118 passed, 0 failed. Both new tests confirmed present in the
  output by name rather than inferred from the total.
- `cargo fmt --all -- --check`: clean.
- Clippy exactly as `ci.yml` runs it: `RUSTFLAGS=-D warnings`, allow-list read from
  `.github/clippy-allowed-lints.txt` the same way the workflow reads it, then
  `cargo clippy --all-targets --all-features -- $allows`. Clean.
- The three guard scripts `ci.yml` names: `zero_file_search_guard.sh`,
  `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`. All pass.
- `bin/kin-parity --checkout <lane worktree>`: `FINAL PASS-WITH-ALLOWANCES in 826.5s
  (NON-CITABLE)`, exit 0. magic `21 pass / 0 fail / 0 unreadable`, brownfield
  `10 pass / 0 fail / 1 unreadable`, firstrun `9 pass / 2 fail / 0 unreadable`. The three
  allowances are `firstrun/9 FIR-2580`, `firstrun/3 FIR-2501` and `brownfield/4 FIR-2464`, each
  pre-registered against an existing ticket and none of them from this change. A second parity run
  returned the same verdict, the same allowances and the same per-leg counts.

Hosted CI is the gate of record and the Windows legs run only there. Nothing local proves them.

Closes FIR-1823

The ceiling-counter half has no ticket of its own. The validation report proposed either a new
ticket or folding it into FIR-1823; this folds it in.
