### PR TITLE
Weigh graph freshness in the one verdict instead of discarding the clock

### DIFF
--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -611,6 +611,89 @@ impl GraphBehind {
     }
 }
 
+/// Whether the daemon can name a complete admission at all, read on its own
+/// rather than through the unadmitted-path count.
+///
+/// [`GraphBehind`] answers "is there content on disk the graph never took", and
+/// it correctly says nothing when the working copy holds no new files. That made
+/// it the wrong carrier for a second, independent fact: whether graph truth was
+/// ever brought level with the repository in the first place. A store whose
+/// working copy is clean and whose graph was built long ago has nothing
+/// unadmitted and is still not current, so the clock was discarded by
+/// `GraphBehind::from_health`'s zero-count gate before anything could read it,
+/// and the answer certified (FIR-2226).
+///
+/// Read from the daemon's reconcile block, which is the same reading
+/// `GraphBehind` uses and carries the clock whether or not the count is zero.
+/// Note WHICH clock: it is the daemon's in-memory record of this process's own
+/// admissions, so a restart resets it. That is not a flaw in the reading, it is
+/// the condition the ticket is about, and it is exactly what makes
+/// [`Self::NoAdmissionRecorded`] worth reporting.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum GraphFreshness {
+    /// The daemon named a complete admission.
+    ///
+    /// This says an admission succeeded in this daemon's life and when. It does
+    /// NOT say the graph is current, because nothing on this surface measures
+    /// distance between graph truth and the repository, and a wall-clock
+    /// threshold would age against whatever repository the next user brings.
+    Recorded {
+        at: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        age_seconds: Option<u64>,
+    },
+    /// The daemon reported a reconcile reading and no complete admission inside
+    /// it, which is the restart case: the record lives in daemon memory, so a
+    /// restart erases it and every surface then reports that none has ever
+    /// succeeded in this daemon's life. An answer taken over that store is
+    /// answering from a graph nothing in this process ever brought level.
+    NoAdmissionRecorded,
+}
+
+impl GraphFreshness {
+    /// Read the clock out of a daemon `/health` body, independently of the
+    /// unadmitted-path count.
+    ///
+    /// `None` when the body carries no reconcile reading at all: a runtime that
+    /// reported nothing has nothing to say here, and inventing `current` for it
+    /// is the shape of wrong answer this type exists to stop. The two fields are
+    /// `skip_serializing_if = "Option::is_none"` at their producer, so their
+    /// absence from a reconcile block that IS present is itself the reading,
+    /// not a parse failure.
+    pub fn from_health(health: &Value) -> Option<Self> {
+        let reconcile = health.get("reconcile")?;
+        let Some(at) = reconcile
+            .get("last_admission_success_at")
+            .and_then(Value::as_str)
+        else {
+            return Some(Self::NoAdmissionRecorded);
+        };
+        Some(Self::Recorded {
+            at: at.to_string(),
+            age_seconds: reconcile
+                .get("last_admission_success_age_seconds")
+                .and_then(Value::as_u64),
+        })
+    }
+
+    /// The factor a store with no recorded admission carries into the verdict.
+    ///
+    /// `None` for a store that named one, because this surface has no basis to
+    /// refuse an answer over a clock it cannot compare to anything.
+    pub fn limiting_factor(&self) -> Option<String> {
+        match self {
+            Self::Recorded { .. } => None,
+            Self::NoAdmissionRecorded => Some(
+                "graph_admission_unrecorded: this daemon reports no complete admission of the \
+                 repository into graph truth, so how far the graph is behind the working tree is \
+                 unmeasured and an answer here cannot be read as covering current code"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
 impl Durability {
     /// Derive the durability state from the two counts the daemon observed.
     ///
@@ -1389,6 +1472,16 @@ pub struct Envelope {
     /// an all-clear.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub behind: Option<GraphBehind>,
+    /// Whether graph truth was ever brought level with the repository at all,
+    /// beside `behind` rather than inside it because the two count different
+    /// things and can disagree. `behind` answers "is there content on disk the
+    /// graph never took" and goes quiet on a clean working copy; this answers
+    /// "was the graph ever admitted", which a clean working copy says nothing
+    /// about. A store can hold zero unadmitted paths and still have been built
+    /// against content that has since moved, which is the pair FIR-2226 caught
+    /// certifying an all-clear.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness: Option<GraphFreshness>,
     /// Honest graph freshness context; omitted entirely when nothing is known.
     #[serde(default, skip_serializing_if = "GraphState::is_empty")]
     pub graph_state: GraphState,
@@ -1430,6 +1523,7 @@ impl Envelope {
             graph_as_of: None,
             durability: None,
             behind: None,
+            freshness: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 offline_fallback: Some(true),
@@ -1452,6 +1546,7 @@ impl Envelope {
             graph_as_of: None,
             durability: None,
             behind: None,
+            freshness: None,
             graph_state: GraphState::default(),
             degraded: Degraded::default(),
             completeness: None,
@@ -1619,6 +1714,7 @@ impl Envelope {
             graph_as_of: None,
             durability: None,
             behind: None,
+            freshness: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 daemon_unreachable: Some(true),
@@ -1646,6 +1742,7 @@ impl Envelope {
             graph_as_of: None,
             durability: None,
             behind: None,
+            freshness: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 workspace_mismatch: Some(true),
@@ -1698,6 +1795,10 @@ impl Envelope {
         // graph never met, and without it every surface built from the counts
         // above states an all-clear it did not verify.
         self.behind = GraphBehind::from_health(health);
+        // Read from the same reconcile block and deliberately NOT through
+        // `behind`: the count gates that object off on a clean working copy, and
+        // the clock is a fact about the graph rather than about the disk.
+        self.freshness = GraphFreshness::from_health(health);
         if let Some(behind) = self.behind.as_ref() {
             self.durability = self
                 .durability

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -997,6 +997,58 @@ mod tests {
             ));
         }
 
+        /// The readings array and the stamp's derivation agree on every name,
+        /// which neither side can prove on its own.
+        ///
+        /// kin#1123 asserts `edge_coverage_limits` picks up an input the
+        /// function was never told about, and it happens to use
+        /// `graph_freshness` as that unknown name, with the map built by hand.
+        /// The arms above assert `compute` puts `graph_freshness` into the map.
+        /// Both hardcode the string, so renaming the reading leaves both green
+        /// while the real behaviour breaks: the stamp would go on naming a key
+        /// nothing emits, and the emitted key would be one nothing names.
+        ///
+        /// So this asserts the join rather than either end. It reads the names
+        /// `compute` actually produced and requires the stamp to name each one
+        /// when that input refuses, which is a property over the real input set
+        /// and cannot be satisfied by a string written twice.
+        #[test]
+        fn every_input_compute_emits_is_one_the_stamp_can_name() {
+            let verdict = Verdict::compute(
+                "find_references",
+                &json!({ "references": [] }),
+                &with_clock(),
+                None,
+            )
+            .expect("the readings are not all silent");
+            let names: Vec<String> = verdict.inputs.keys().cloned().collect();
+            assert!(
+                names.iter().any(|name| name == "graph_freshness"),
+                "the seam must be in the stamp's input set at all: {names:?}"
+            );
+
+            for name in names {
+                if name == "edge_coverage" {
+                    continue;
+                }
+                let mut inputs = Map::new();
+                inputs.insert("edge_coverage".to_string(), json!(CERTIFIED));
+                inputs.insert(name.clone(), json!(INCONCLUSIVE));
+                let refusing = Verdict {
+                    certified: false,
+                    safe_to_conclude_absent: false,
+                    limiting_factor: Some(format!("{name}: refusing")),
+                    inputs,
+                };
+                assert!(
+                    refusing
+                        .edge_coverage_limits()
+                        .contains(&format!("{name}:inconclusive")),
+                    "the stamp must name {name}, which compute emits, without being told about it"
+                );
+            }
+        }
+
         /// End to end: neither store may pick up a freshness clause, and the
         /// input is present in the stamp as `not_applicable` rather than absent,
         /// so the seam is visible to a reader and to the next reading added.

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -169,6 +169,7 @@ impl Verdict {
             ("withheld_candidates", withheld_candidates_reading(payload)),
             ("degradations", degradations_reading(payload)),
             ("completeness", completeness_reading(envelope)),
+            ("graph_freshness", graph_freshness_reading(envelope)),
         ];
 
         if readings
@@ -571,6 +572,41 @@ fn degradations_reading(payload: &Value) -> Reading {
 }
 
 /// The completeness signal's own reading of the substrate and the numbers.
+/// Whether graph truth was ever brought level with the repository, as an input
+/// the one verdict weighs.
+///
+/// Freshness used to reach the verdict only through `absence_gate`, which picked
+/// it up from the absence module, which read `envelope.behind`, which
+/// `GraphBehind::from_health` returns `None` for whenever nothing on disk is
+/// unadmitted. Three gates, and the outermost closed on exactly the case the
+/// ticket is about: a store with a clean working copy whose graph was built long
+/// ago certified with no qualifier at all (FIR-2226).
+///
+/// What it refuses on is deliberately narrow. A daemon reporting no complete
+/// admission is refusing, because an answer taken over a graph nothing in this
+/// process ever brought level cannot be read as covering current code. A daemon
+/// that named one certifies, because this surface holds no second number to
+/// compare that clock against: the durable marker's `tracked_artifacts`, which
+/// is the comparison worth making, is not on the health wire, and a bare
+/// wall-clock threshold ages against whatever repository the next user brings.
+/// So this does NOT catch a months-stale store under a daemon that has been up
+/// the whole time and admitted once. That case waits for the durable marker to
+/// reach the wire, and saying so here is cheaper than having someone infer a
+/// guarantee this never made.
+///
+/// Silent, never certified, when the runtime reported no reconcile block at all:
+/// a silent input contributes no agreement, so a runtime with nothing to say
+/// cannot license anything.
+fn graph_freshness_reading(envelope: &Envelope) -> Reading {
+    let Some(freshness) = envelope.freshness.as_ref() else {
+        return Reading::Silent;
+    };
+    match freshness.limiting_factor() {
+        Some(factor) => Reading::Inconclusive(factor),
+        None => Reading::Certified,
+    }
+}
+
 fn completeness_reading(envelope: &Envelope) -> Reading {
     let Some(completeness) = &envelope.completeness else {
         return Reading::Silent;
@@ -861,6 +897,142 @@ fn headline_count_disagreements(response: &Value) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// FIR-2226. Freshness has to be an input the one verdict weighs. It used to
+    /// reach the verdict only through `absence_gate`, which read
+    /// `envelope.behind`, which `GraphBehind::from_health` returns `None` for
+    /// whenever nothing on disk is unadmitted, so a clean working copy over an
+    /// old graph certified with no qualifier.
+    ///
+    /// Driven through `with_health` rather than by building the state by hand,
+    /// because the question these arms have to answer is whether the reading
+    /// survives the shape the daemon actually sends. The field names below are
+    /// the producer's own (`crates/kin-cli/src/commands/resources.rs`), and both
+    /// are `skip_serializing_if = "Option::is_none"` there, which is why arm 2
+    /// omits the key rather than setting it null.
+    mod graph_freshness {
+        use super::*;
+
+        fn envelope_with(reconcile: Value) -> Envelope {
+            Envelope::daemon().with_health(&json!({
+                "graph_loaded": true,
+                "initialized": true,
+                "reconcile": reconcile,
+            }))
+        }
+
+        /// Arm 1, the positive control. A daemon that named an admission must
+        /// carry no freshness limit at all. Without this arm an implementation
+        /// that qualifies unconditionally passes arm 2 and is wrong.
+        #[test]
+        fn a_daemon_that_named_an_admission_is_not_limited_by_freshness() {
+            let envelope = envelope_with(json!({
+                "untracked_path_count": 0,
+                "last_admission_success_at": "2026-08-26T00:00:00Z",
+                "last_admission_success_age_seconds": 12,
+            }));
+            assert!(
+                matches!(graph_freshness_reading(&envelope), Reading::Certified),
+                "{:?}",
+                envelope.freshness
+            );
+        }
+
+        /// Arm 2, the case the ticket is about. Zero unadmitted paths, so
+        /// `behind` is silent by design, and no admission recorded, so the
+        /// answer is over a graph nothing in this process brought level.
+        #[test]
+        fn a_daemon_with_no_recorded_admission_refuses_on_a_clean_working_copy() {
+            let envelope = envelope_with(json!({ "untracked_path_count": 0 }));
+            assert!(
+                envelope.behind.is_none(),
+                "the count gate is what used to discard this reading: {:?}",
+                envelope.behind
+            );
+            let Reading::Inconclusive(factor) = graph_freshness_reading(&envelope) else {
+                panic!(
+                    "a graph nothing admitted cannot certify: {:?}",
+                    envelope.freshness
+                );
+            };
+            assert!(
+                factor.starts_with("graph_admission_unrecorded"),
+                "the factor names the condition that held: {factor}"
+            );
+        }
+
+        /// Arm 3. A runtime that reported no reconcile block has nothing to say,
+        /// and a silent input contributes no agreement, so it can neither refuse
+        /// nor license.
+        #[test]
+        fn a_runtime_reporting_no_reconcile_block_is_silent_rather_than_current() {
+            let envelope = Envelope::daemon().with_health(&json!({ "graph_loaded": true }));
+            assert!(envelope.freshness.is_none());
+            assert!(matches!(
+                graph_freshness_reading(&envelope),
+                Reading::Silent
+            ));
+        }
+
+        /// The reading has to reach the composed factor, not merely exist. This
+        /// is the arm that catches a sixth entry left out of the readings array,
+        /// and it asserts on the named factor rather than on `certified == false`
+        /// because a reading that silently returns `Silent` still leaves the
+        /// response reading certified.
+        #[test]
+        fn the_freshness_factor_reaches_the_one_verdict() {
+            let envelope = envelope_with(json!({ "untracked_path_count": 0 }));
+            let verdict = Verdict::compute(
+                "find_references",
+                &json!({ "references": [] }),
+                &envelope,
+                None,
+            )
+            .expect("a refusing input yields a verdict");
+            assert_eq!(
+                verdict
+                    .inputs
+                    .get("graph_freshness")
+                    .and_then(Value::as_str),
+                Some(INCONCLUSIVE),
+                "{:?}",
+                verdict.inputs
+            );
+            assert!(
+                verdict
+                    .limiting_factor
+                    .as_deref()
+                    .is_some_and(|factor| factor.contains("graph_admission_unrecorded")),
+                "the factor a reader acts on has to name it: {:?}",
+                verdict.limiting_factor
+            );
+            assert!(!verdict.certified);
+        }
+
+        /// The same call on a store that named an admission keeps the freshness
+        /// input out of the factor entirely, so the arm above cannot be passed
+        /// by a build that always refuses.
+        #[test]
+        fn a_named_admission_leaves_the_factor_alone() {
+            let envelope = envelope_with(json!({
+                "untracked_path_count": 0,
+                "last_admission_success_at": "2026-08-26T00:00:00Z",
+            }));
+            let verdict = Verdict::compute(
+                "find_references",
+                &json!({ "references": [] }),
+                &envelope,
+                None,
+            );
+            let factor = verdict.as_ref().and_then(|v| v.limiting_factor.as_deref());
+            assert!(
+                !factor
+                    .unwrap_or_default()
+                    .contains("graph_admission_unrecorded"),
+                "{factor:?}"
+            );
+        }
+    }
 
     /// FIR-2672, second finding. A verdict with two independent reasons names
     /// both: the class gap decided the state and the failed embedding worker

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -572,39 +572,39 @@ fn degradations_reading(payload: &Value) -> Reading {
 }
 
 /// The completeness signal's own reading of the substrate and the numbers.
-/// Whether graph truth was ever brought level with the repository, as an input
-/// the one verdict weighs.
+/// Graph freshness as a verdict input: wired, and deliberately weighing nothing
+/// until the durable marker reaches the health wire.
 ///
-/// Freshness used to reach the verdict only through `absence_gate`, which picked
-/// it up from the absence module, which read `envelope.behind`, which
-/// `GraphBehind::from_health` returns `None` for whenever nothing on disk is
-/// unadmitted. Three gates, and the outermost closed on exactly the case the
-/// ticket is about: a store with a clean working copy whose graph was built long
-/// ago certified with no qualifier at all (FIR-2226).
+/// The clock reaches the envelope now (see [`crate::envelope::GraphFreshness`]),
+/// which is the half of FIR-2226 that could be done honestly here. This is the
+/// seam that will carry it into the verdict, and it reports [`Reading::Silent`]
+/// in every state on purpose, contributing neither agreement nor refusal.
 ///
-/// What it refuses on is deliberately narrow. A daemon reporting no complete
-/// admission is refusing, because an answer taken over a graph nothing in this
-/// process ever brought level cannot be read as covering current code. A daemon
-/// that named one certifies, because this surface holds no second number to
-/// compare that clock against: the durable marker's `tracked_artifacts`, which
-/// is the comparison worth making, is not on the health wire, and a bare
-/// wall-clock threshold ages against whatever repository the next user brings.
-/// So this does NOT catch a months-stale store under a daemon that has been up
-/// the whole time and admitted once. That case waits for the durable marker to
-/// reach the wire, and saying so here is cheaper than having someone infer a
-/// guarantee this never made.
+/// **Why not refuse when no admission is recorded.** The wire's clock is the
+/// daemon's in-memory record, set only by a completed exact-tree admission pass,
+/// so a freshly initialized store whose daemon has not yet run one carries
+/// nothing. Absence is therefore the ordinary state of a healthy new store, not
+/// evidence of staleness, and refusing on it puts a floor under every answer on
+/// every such store. That is the regression `crate::negative`'s own gate comment
+/// warns about, and the acceptance suite's anti-vacuity control caught this
+/// module doing it.
 ///
-/// Silent, never certified, when the runtime reported no reconcile block at all:
-/// a silent input contributes no agreement, so a runtime with nothing to say
-/// cannot license anything.
+/// **Why not certify when one IS recorded.** A present clock proves an admission
+/// completed at some time. It does not prove the store is current, and the
+/// verdict's note asserts agreement of every input, so certifying here would
+/// state exactly the false all-clear for the case this cannot see: a months-stale
+/// store under a daemon that has been up the whole time and admitted once.
+///
+/// Both halves need the same missing fact, a reading the daemon does not
+/// publish: the durable last-admission marker, which survives a restart and
+/// carries `tracked_artifacts` beside its timestamp. With it, absence and
+/// staleness separate and this becomes a real input. Until then, silence is the
+/// only honest reading, and a silent input never contributes agreement, so
+/// nothing here can license an answer either.
 fn graph_freshness_reading(envelope: &Envelope) -> Reading {
-    let Some(freshness) = envelope.freshness.as_ref() else {
-        return Reading::Silent;
-    };
-    match freshness.limiting_factor() {
-        Some(factor) => Reading::Inconclusive(factor),
-        None => Reading::Certified,
-    }
+    // Read so the field is provably consumed and the seam is not decorative.
+    let _ = envelope.freshness.as_ref();
+    Reading::Silent
 }
 
 fn completeness_reading(envelope: &Envelope) -> Reading {
@@ -898,18 +898,20 @@ fn headline_count_disagreements(response: &Value) -> Vec<String> {
 mod tests {
     use super::*;
 
-    /// FIR-2226. Freshness has to be an input the one verdict weighs. It used to
-    /// reach the verdict only through `absence_gate`, which read
-    /// `envelope.behind`, which `GraphBehind::from_health` returns `None` for
-    /// whenever nothing on disk is unadmitted, so a clean working copy over an
-    /// old graph certified with no qualifier.
+    /// FIR-2226 step 1. The clock reaches the envelope; the verdict seam is
+    /// wired and deliberately weighs nothing yet.
     ///
-    /// Driven through `with_health` rather than by building the state by hand,
-    /// because the question these arms have to answer is whether the reading
-    /// survives the shape the daemon actually sends. The field names below are
-    /// the producer's own (`crates/kin-cli/src/commands/resources.rs`), and both
-    /// are `skip_serializing_if = "Option::is_none"` there, which is why arm 2
-    /// omits the key rather than setting it null.
+    /// The arms below assert exactly that and no more. An earlier version of
+    /// this change refused when no admission was recorded, and the acceptance
+    /// suite's anti-vacuity control caught it certifying nothing: absence of the
+    /// in-memory clock is the ordinary state of a healthy fresh store, so
+    /// refusing on it floors every answer on every such store. The arms are
+    /// written against what this can honestly claim rather than against what it
+    /// was hoped to do.
+    ///
+    /// Driven through `with_health` using the producer's own field names, and
+    /// both are `skip_serializing_if = "Option::is_none"` there, which is why the
+    /// no-clock arm omits the key rather than setting it null.
     mod graph_freshness {
         use super::*;
 
@@ -921,116 +923,112 @@ mod tests {
             }))
         }
 
-        /// Arm 1, the positive control. A daemon that named an admission must
-        /// carry no freshness limit at all. Without this arm an implementation
-        /// that qualifies unconditionally passes arm 2 and is wrong.
-        #[test]
-        fn a_daemon_that_named_an_admission_is_not_limited_by_freshness() {
-            let envelope = envelope_with(json!({
+        fn with_clock() -> Envelope {
+            envelope_with(json!({
                 "untracked_path_count": 0,
                 "last_admission_success_at": "2026-08-26T00:00:00Z",
                 "last_admission_success_age_seconds": 12,
-            }));
+            }))
+        }
+
+        fn without_clock() -> Envelope {
+            envelope_with(json!({ "untracked_path_count": 0 }))
+        }
+
+        /// The disclosure, which is what step 1 actually delivers. Both stores
+        /// below hold zero unadmitted paths, so `behind` is silent by design and
+        /// used to take the clock down with it.
+        #[test]
+        fn the_clock_is_published_even_when_nothing_is_unadmitted() {
+            let recorded = with_clock();
             assert!(
-                matches!(graph_freshness_reading(&envelope), Reading::Certified),
-                "{:?}",
-                envelope.freshness
+                recorded.behind.is_none(),
+                "the count gate is what used to discard this: {:?}",
+                recorded.behind
+            );
+            assert!(
+                matches!(
+                    recorded.freshness,
+                    Some(crate::envelope::GraphFreshness::Recorded { .. })
+                ),
+                "a clean working copy must not hide a clock the daemon sent: {:?}",
+                recorded.freshness
+            );
+            assert!(
+                matches!(
+                    without_clock().freshness,
+                    Some(crate::envelope::GraphFreshness::NoAdmissionRecorded)
+                ),
+                "and the absence of one is itself a reading, not a parse failure"
             );
         }
 
-        /// Arm 2, the case the ticket is about. Zero unadmitted paths, so
-        /// `behind` is silent by design, and no admission recorded, so the
-        /// answer is over a graph nothing in this process brought level.
+        /// A runtime that reported no reconcile block has nothing to publish.
+        /// Distinct from a block that carries no clock, and the two must not
+        /// collapse.
         #[test]
-        fn a_daemon_with_no_recorded_admission_refuses_on_a_clean_working_copy() {
-            let envelope = envelope_with(json!({ "untracked_path_count": 0 }));
-            assert!(
-                envelope.behind.is_none(),
-                "the count gate is what used to discard this reading: {:?}",
-                envelope.behind
-            );
-            let Reading::Inconclusive(factor) = graph_freshness_reading(&envelope) else {
-                panic!(
-                    "a graph nothing admitted cannot certify: {:?}",
-                    envelope.freshness
-                );
-            };
-            assert!(
-                factor.starts_with("graph_admission_unrecorded"),
-                "the factor names the condition that held: {factor}"
-            );
-        }
-
-        /// Arm 3. A runtime that reported no reconcile block has nothing to say,
-        /// and a silent input contributes no agreement, so it can neither refuse
-        /// nor license.
-        #[test]
-        fn a_runtime_reporting_no_reconcile_block_is_silent_rather_than_current() {
+        fn a_runtime_reporting_no_reconcile_block_publishes_nothing() {
             let envelope = Envelope::daemon().with_health(&json!({ "graph_loaded": true }));
             assert!(envelope.freshness.is_none());
+        }
+
+        /// The seam weighs nothing, with a clock. Certifying here would state
+        /// agreement this cannot support: a present clock proves an admission
+        /// happened at some time, not that the store is current, and the
+        /// verdict's note asserts every input agreed.
+        #[test]
+        fn a_recorded_clock_does_not_certify() {
             assert!(matches!(
-                graph_freshness_reading(&envelope),
+                graph_freshness_reading(&with_clock()),
                 Reading::Silent
             ));
         }
 
-        /// The reading has to reach the composed factor, not merely exist. This
-        /// is the arm that catches a sixth entry left out of the readings array,
-        /// and it asserts on the named factor rather than on `certified == false`
-        /// because a reading that silently returns `Silent` still leaves the
-        /// response reading certified.
+        /// The seam weighs nothing, without one. Refusing here floors every
+        /// answer on every freshly initialized store, because the wire's clock is
+        /// the daemon's in-memory record and a daemon that has not yet completed
+        /// an admission pass carries none. This arm is the one the acceptance
+        /// control already proved can fail.
         #[test]
-        fn the_freshness_factor_reaches_the_one_verdict() {
-            let envelope = envelope_with(json!({ "untracked_path_count": 0 }));
-            let verdict = Verdict::compute(
-                "find_references",
-                &json!({ "references": [] }),
-                &envelope,
-                None,
-            )
-            .expect("a refusing input yields a verdict");
-            assert_eq!(
-                verdict
-                    .inputs
-                    .get("graph_freshness")
-                    .and_then(Value::as_str),
-                Some(INCONCLUSIVE),
-                "{:?}",
-                verdict.inputs
-            );
-            assert!(
-                verdict
-                    .limiting_factor
-                    .as_deref()
-                    .is_some_and(|factor| factor.contains("graph_admission_unrecorded")),
-                "the factor a reader acts on has to name it: {:?}",
-                verdict.limiting_factor
-            );
-            assert!(!verdict.certified);
+        fn an_unrecorded_clock_does_not_refuse() {
+            assert!(matches!(
+                graph_freshness_reading(&without_clock()),
+                Reading::Silent
+            ));
         }
 
-        /// The same call on a store that named an admission keeps the freshness
-        /// input out of the factor entirely, so the arm above cannot be passed
-        /// by a build that always refuses.
+        /// End to end: neither store may pick up a freshness clause, and the
+        /// input is present in the stamp as `not_applicable` rather than absent,
+        /// so the seam is visible to a reader and to the next reading added.
         #[test]
-        fn a_named_admission_leaves_the_factor_alone() {
-            let envelope = envelope_with(json!({
-                "untracked_path_count": 0,
-                "last_admission_success_at": "2026-08-26T00:00:00Z",
-            }));
-            let verdict = Verdict::compute(
-                "find_references",
-                &json!({ "references": [] }),
-                &envelope,
-                None,
-            );
-            let factor = verdict.as_ref().and_then(|v| v.limiting_factor.as_deref());
-            assert!(
-                !factor
-                    .unwrap_or_default()
-                    .contains("graph_admission_unrecorded"),
-                "{factor:?}"
-            );
+        fn neither_store_puts_a_freshness_clause_in_the_verdict() {
+            for envelope in [with_clock(), without_clock()] {
+                let verdict = Verdict::compute(
+                    "find_references",
+                    &json!({ "references": [] }),
+                    &envelope,
+                    None,
+                );
+                let Some(verdict) = verdict else { continue };
+                assert_eq!(
+                    verdict
+                        .inputs
+                        .get("graph_freshness")
+                        .and_then(Value::as_str),
+                    Some(NOT_APPLICABLE),
+                    "the seam is wired and weighs nothing: {:?}",
+                    verdict.inputs
+                );
+                assert!(
+                    !verdict
+                        .limiting_factor
+                        .as_deref()
+                        .unwrap_or_default()
+                        .contains("graph_admission"),
+                    "no freshness clause may reach the factor yet: {:?}",
+                    verdict.limiting_factor
+                );
+            }
         }
     }
 


### PR DESCRIPTION
The MCP envelope threw away a freshness clock the daemon was already sending, and this publishes it.
The verdict seam for it is wired and deliberately weighs nothing yet, for reasons the acceptance
suite taught this branch rather than reasons it started with.

**Why the clock was invisible.** Graph-versus-repository distance reached the envelope through one
object, `GraphBehind`, and `GraphBehind::from_health` returns `None` the moment
`untracked_path_count` is zero. That gate is correct for what that object means, which is "is there
content on disk the graph never took". It is the wrong gate for a second, independent fact: whether
graph truth was ever brought level with the repository. A working copy with no new files says nothing
about that, so the clock was discarded before anything could read it.

**What lands.** `GraphFreshness` reads the clock from the same reconcile block independently of the
count, and a `freshness` field sits beside `behind` for the same reason `behind` sits beside
`durability`. An agent can now read it at all. A sixth `graph_freshness` reading joins the readings
array as the seam that will carry it into the verdict.

**What the seam does, which is nothing, on purpose.** It reports `Silent` in every state,
contributing neither agreement nor refusal.

It does not refuse when no admission is recorded. The wire's clock is the daemon's in-memory record,
set only by a completed exact-tree admission pass, so a freshly initialized store whose daemon has not
yet run one carries none. Absence is the ordinary state of a healthy new store rather than evidence
of staleness, and refusing on it puts a floor under every answer on every such store.

It does not certify when one is recorded either. A present clock proves an admission completed at
some time; it does not prove the store is current. The verdict's note asserts that every input
agreed, so certifying here would state exactly the false all-clear for the case this cannot see, a
months-stale store under a daemon that has been up the whole time and admitted once.

Both halves need the same missing fact: the durable last-admission marker on the health wire, which
survives a restart and carries `tracked_artifacts` beside its timestamp.

## How this PR was wrong first, and what caught it

An earlier head of this branch refused when no admission was recorded. Hosted CI failed it on
`verdict_limits:inverse`, which exists in its own docstring as "the control that keeps the invariant
from being satisfied by refusing everything", reporting `state=inconclusive` with this branch's own
`graph_admission_unrecorded` factor over a store that must certify.

The reasoning that produced it ran from the case it wanted to catch to the signal, and never asked
what else produces the same signal. Every unit arm drove a real `/health` body, which was the right
instinct and still insufficient, because those bodies were written by this lane rather than produced
by a real fresh daemon.

The control was not touched. A control that catches a real regression and is then adjusted to stop
catching it is worse than no control.

## Two corrections to the fix design, both found by asking the producer

The design named `tracked_artifacts` as the defensible key. **It is not on the health wire.** It
exists only in `crates/kin-core/src/last_admission.rs`, the durable on-disk marker. The daemon's
reconcile block carries exactly two freshness fields (`crates/kin-daemon/src/background_work.rs`) and
it is neither of them, and the MCP envelope builds from `/health`, so it never sees it. Keying on it
needs a producer change, so it waits for the later steps rather than being faked from what is on the
wire.

The design also says the two clock fields are always on the wire. Both are
`skip_serializing_if = "Option::is_none"` at their producer, so they are absent when None rather than
present and null. That absence is the reading rather than a parse failure, and an implementation
written on "always carries" would collapse two of the three states this needs to keep apart.

Both were caught the same way, by asserting the producer's own shape first and letting the assertion
fail, and it is the third time in this lane that a fixture written from a description rather than
from the producer would have proved the wrong thing.

## Falsification

Five mutations, each applied to the committed tree, each proven against a check that guards the
behavior it breaks, then restored and the tree verified clean.

| Mutation | Check that went red |
|---|---|
| the clock is gated on the untracked count again, the original defect restored | `the_clock_is_published_even_when_nothing_is_unadmitted` |
| the seam certifies on a present clock | `a_recorded_clock_does_not_certify`, `neither_store_puts_a_freshness_clause_in_the_verdict` |
| the seam refuses on an absent clock | `an_unrecorded_clock_does_not_refuse`, `neither_store_puts_a_freshness_clause_in_the_verdict` |
| the stamp reverts to a hardcoded list of input names | `every_input_compute_emits_is_one_the_stamp_can_name` |
| the sixth reading is dropped from the array | `every_input_compute_emits_is_one_the_stamp_can_name` |

The third has been proven twice, once by these arms and once for real: it is the exact shape hosted
CI rejected on the earlier head, so the acceptance suite has already demonstrated that this claim can
fail in production and not only in a unit fixture.

Every arm drives a real `/health` body through `with_health` using the producer's own field names.
Both freshness fields are `skip_serializing_if = "Option::is_none"` at their producer, so the
no-clock arm omits the key rather than setting it null.

## Interaction with kin#1123, now landed

kin#1123 added `Verdict::edge_coverage_limits()`, which answers what stops the `edge_coverage` block
licensing a certification on its own. As first written it iterated a hardcoded list of four input
names, exactly "every input except edge_coverage" in a five-input world. A sixth reading would have
been invisible to it. That is the same shape as a new edge class changing every consumer that weighs
it, with a verdict input in place of an edge class. It was raised while the decision was still free
and kin#1123 now derives the list from `self.inputs`, so this PR touches none of that function.

**One assertion here closes a hole neither PR closes alone.** kin#1123 asserts the derivation picks
up an input it was never told about, and it happens to use `graph_freshness` as that unknown name,
with the map built by hand. The arms here assert `compute` puts `graph_freshness` into the map. Both
hardcode the string. Rename the reading and both stay green while the real behaviour breaks: the
stamp goes on naming a key nothing emits, and the emitted key is one nothing names.

So `every_input_compute_emits_is_one_the_stamp_can_name` asserts the join instead of either end. It
reads the names `compute` actually produced and requires the stamp to name each one when that input
refuses. It is a property over the real input set rather than a string written twice, and reverting
the stamp to a hardcoded list turns it red.

Note what this assertion is not. It is not "graph_freshness appears in the stamp", which cannot
happen: the stamp collects inputs reading `inconclusive`, and this reading is `Silent` in every state
by design. What it proves is that the name this PR adds is one the derivation would name on the day
the reading starts refusing, which is the guarantee that matters and the one the hardcoded list would
have silently broken.

## What I ran

`cargo test -p kin-mcp` (667 passed, 0 failed), `cargo fmt -- --check`, `cargo clippy -p kin-mcp
--all-targets --all-features` with the allow list under `RUSTFLAGS=-D warnings`, and the four guard
scripts `ci.yml` names: `verify-zero-file-search.py`, `zero_file_search_guard.sh`,
`check_runtime_boundaries.sh` and `check_private_repo_coupling.sh`. All clean. Hosted CI is the gate
of record and the Windows legs run only there.

## Tickets

Part of FIR-2226

Step 1 of six. The ticket's first acceptance criterion names five surfaces; this adds the MCP
envelope to the one that already carried it. Two things stay open and are worth scoping before
someone pulls them.

The CLI half of the ticket's original complaint is still true. `degraded_reasons` nests the age clock
inside the `admission_failure_streak` gate, so a quiescent months-stale store logs zero admission
failures, the age never renders, and the health check returns Healthy. That is self-contained and
depends on nothing here.

The real unblock for the rest is putting the durable marker's reading on the health wire. The two
fields there today come from the daemon's in-memory record, which a restart erases by design; the
durable marker is what survives, and it carries `tracked_artifacts` beside its timestamp, the "31 of
125" number the ticket's own acceptance asks for. The artifact key, the months-stale-under-a-live-
daemon case, and any surface wanting to tell "restarted" from "never admitted" all wait on it.

## Claims not being made

That this closes the freshness gap. That a timestamped store is current: this certifies such a store
because it has no basis to refuse, not because it verified anything. No measurement of how often the
restart case fires in practice; the argument for taking it first is the code path, not a frequency I
measured.
