### PR TITLE
Stop the proof-artifact gate exiting 0 when its path crosses a symlink

### DIFF
--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -26,7 +26,8 @@
 // that merely also exists. Two independent existence checks would not.
 
 import process from 'node:process';
-import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 // Records live on an orphan branch rather than on main: they are per-candidate
 // evidence, they arrive after the commit they describe, and writing them to
@@ -432,7 +433,34 @@ export async function main({
   return { sha, archives, archive };
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Run only when this file IS the entry point, comparing REAL paths.
+//
+// The usual idiom compares `import.meta.url` against
+// `pathToFileURL(process.argv[1])`. Node resolves symlinks for the first and
+// not the second, so invoking this file through a symlinked directory makes the
+// two disagree and the gate reads nothing, judges nothing, and exits 0.
+// release-tag.yml copies it to $RUNNER_TEMP and runs it from there, which is
+// exactly that shape; $RUNNER_TEMP is not a symlink today, and that is the only
+// reason the naive form has held. Measured on this file: run from the checkout
+// it exits 1 with `::error::no repository given`, and run from a symlinked copy
+// it exits 0 having written nothing at all.
+//
+// Unresolvable paths fall to running, not skipping. A proof gate that silently
+// declines to judge is worse than one that fails; a test that runs `main()` by
+// mistake fails loudly on the spot.
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  if (entry === self) return true;
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return true;
+  }
+}
+
+if (isDirectRun()) {
   main().catch((error) => {
     console.error(`::error::${error.message}`);
     process.exit(1);

--- a/scripts/check-release-proof-artifacts.test.mjs
+++ b/scripts/check-release-proof-artifacts.test.mjs
@@ -2,7 +2,12 @@
 // Copyright 2026 Firelock, LLC
 
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import {
   BUMP_BRANCH,
@@ -593,4 +598,46 @@ test('main holds on absence when no commit to bridge from is given', async () =>
     /the proof loop has not recorded this candidate/,
   );
   assert.equal(bridged, false);
+});
+
+test('the gate runs from a copy reached through a symlinked directory', () => {
+  // release-tag.yml copies this file to $RUNNER_TEMP and runs it there. The
+  // entry-point test used to compare `import.meta.url` against
+  // `pathToFileURL(process.argv[1])`, and Node resolves symlinks for the first
+  // and not the second, so a copy invoked through one exited 0 having judged
+  // nothing. Measured before the fix: run from the checkout the gate exits 1
+  // with `::error::no repository given`, and run from a symlinked copy it exits
+  // 0 with zero bytes on both streams.
+  //
+  // Run with no repository so `main()` is reached and refuses on its own
+  // missing input. The distinction being drawn is between a process that ran
+  // and one that never started, and only the second is silent. This file
+  // imports nothing relative, so a lone copy resolves and the entry point is
+  // the only variable; a module-resolution error would otherwise write to
+  // stderr and satisfy the assertion without proving anything.
+  const gate = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'check-release-proof-artifacts.mjs',
+  );
+  const real = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-proof-gate-'));
+  const link = `${real}-link`;
+  fs.symlinkSync(real, link, 'dir');
+  const copy = path.join(link, 'check-release-proof-artifacts.mjs');
+  fs.copyFileSync(gate, copy);
+
+  const env = { ...process.env };
+  delete env.GITHUB_REPOSITORY;
+  let output = '';
+  try {
+    output = execFileSync(process.execPath, [copy], {
+      cwd: real,
+      encoding: 'utf8',
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+  assert.notEqual(output, '', 'the gate produced no output, so it never ran');
+  assert.match(output, /no repository given/);
 });

--- a/scripts/falsify-release-version-guards.py
+++ b/scripts/falsify-release-version-guards.py
@@ -42,7 +42,18 @@ VERSION = "scripts/check-release-version.mjs"
 VERSION_SUITE = "scripts/check-release-version.test.mjs"
 PREPARE = "scripts/prepare-release.mjs"
 PREPARE_SUITE = "scripts/prepare-release.test.mjs"
-COPIED = (INTENT, INTENT_SUITE, VERSION, VERSION_SUITE, PREPARE, PREPARE_SUITE)
+PROOF = "scripts/check-release-proof-artifacts.mjs"
+PROOF_SUITE = "scripts/check-release-proof-artifacts.test.mjs"
+COPIED = (
+    INTENT,
+    INTENT_SUITE,
+    VERSION,
+    VERSION_SUITE,
+    PREPARE,
+    PREPARE_SUITE,
+    PROOF,
+    PROOF_SUITE,
+)
 
 
 class FalsificationError(RuntimeError):
@@ -233,6 +244,21 @@ PROBES: tuple[tuple[str, str, str, Callable[[Path], None]], ...] = (
         lambda tree: poison(
             tree,
             PREPARE,
+            "  try {\n"
+            "    return realpathSync(entry) === realpathSync(self);\n"
+            "  } catch {\n"
+            "    return true;\n"
+            "  }",
+            "  return false;",
+        ),
+    ),
+    (
+        "the proof-artifact gate's entry point goes back to unresolved paths",
+        PROOF_SUITE,
+        "the gate runs from a copy reached through a symlinked directory",
+        lambda tree: poison(
+            tree,
+            PROOF,
             "  try {\n"
             "    return realpathSync(entry) === realpathSync(self);\n"
             "  } catch {\n"


### PR DESCRIPTION
The last script on the mint path that could exit 0 having never started.

`release-tag.yml` copies `scripts/check-release-proof-artifacts.mjs` to `$RUNNER_TEMP` and runs it there. Its entry-point test compared `import.meta.url` against `pathToFileURL(process.argv[1])`, and Node resolves symlinks for the first and not the second, so a copy invoked through a symlinked directory makes the two disagree and the gate reads nothing, judges nothing, and exits 0. A proof gate that silently declines to judge is the worst shape this defect takes, because it reports success without having read a single record.

Measured on this file, not inferred:

| Invocation | Exit | Bytes |
|---|---|---|
| `node scripts/check-release-proof-artifacts.mjs` from the checkout | 1 | 51, `::error::no repository given; set GITHUB_REPOSITORY` |
| the same file copied into a symlinked directory and run there | 0 | 0 on both streams |

`$RUNNER_TEMP` is not a symlink today, which is the only reason the naive form has held.

Same fix as the three that landed in #1128: compare `realpathSync` of both sides, and fall to running rather than skipping when a path will not resolve, because a gate that declines to judge is worse than one that fails.

## Why the test asserts two things

Non-empty output alone would pass on a stray error. That is not hypothetical: my first version of the generator's test in #1128 copied only the script and not the sibling it imports, so node failed on module resolution, wrote to stderr, and the assertion held no matter what the entry point did. The falsifier caught it.

So this test requires output, which separates a process that ran from one that never started, and it also requires the gate's own refusal text. This file imports nothing relative, only `node:process` and `node:url`, so a lone copy resolves and the entry point is genuinely the only variable.

## Falsification

The falsifier gains an eleventh probe: revert the real-path comparison to `return false` in a poisoned copy and require `the gate runs from a copy reached through a symlinked directory` to go red. It does. All eleven probes pass on the committed tree, and the falsifier runs in the `Falsify guards` job.

## The set is now closed, and what is left is tracked

Every script the release rail copies out of reviewed main and runs from a temporary directory compares real paths. `resolve-release-intent.mjs`, `release-train-body.mjs` and `extract-release-notes.mjs` already did, so this was hit and fixed once before, where it was hit. `release-intent.mjs`, `check-release-version.mjs` and `prepare-release.mjs` landed in #1128. This is the fifth.

Three others carry the idiom and are never run from a copy, so none is exposed: `check-glibc-floor.mjs`, `check-kin-vfs-compat.mjs` and `verify-npm-attestation.mjs`. They are tracked in FIR-2696 so the class has one home for the day somebody copies one into `$RUNNER_TEMP`, where it would become a gate that passes without reading anything and would look correct in review.

## What was run

`node --test` over both full `ci.yml` node test lists, 171 and 172 tests green; `python3 scripts/falsify-release-version-guards.py`, 11 probes; `python3 scripts/test-release-workflow-authority.py`; `python3 scripts/test-assertion-reachability.py`; `node --check` on the gate. No Rust changed, so no clippy or workspace build was run locally. Hosted CI is the gate of record.
