### PR TITLE
Relocate entities in the same transaction as the tree move, on the reconcile seam too

### DIFF
--- a/crates/kin-cli/tests/entity_file_retirement.rs
+++ b/crates/kin-cli/tests/entity_file_retirement.rs
@@ -11,6 +11,15 @@
 //! named the constraint outright with "absent from the staged tree"
 //! (FIR-2429).
 //!
+//! The rename half of FIR-2429 is here too, measured before it was written: a
+//! byte-identical `mv` of an entity-owning file left the repository unable to
+//! accept ANY further commit. The watcher refused the transition fourteen times
+//! over 59 seconds and went quiet, `kin locate` kept attributing the entity to
+//! a path no longer on disk, and every later `kin commit` answered HTTP 500
+//! with "transaction leaves entity ... absent from the staged tree". A control
+//! run on the same fixture without the rename committed cleanly and indexed a
+//! new symbol, which is what made that difference mean anything.
+//!
 //! A unit test on the planner cannot cover this, because the defect is in what
 //! survives one whole commit and reaches the next query. These drive `kin`
 //! itself and read `kin locate`, which is the surface the stale hit was found
@@ -179,5 +188,165 @@ fn deleting_a_file_that_owns_no_entity_still_commits() {
         "deleting a non-entity file must still commit: stdout={} stderr={}",
         String::from_utf8_lossy(&retired.stdout),
         String::from_utf8_lossy(&retired.stderr)
+    );
+}
+
+/// What `kin refs` prints for an entity, as one string.
+///
+/// Read as text on purpose: `--bulk-json` needs entity UUIDs the fixture does
+/// not hold, and the assertion below is about whether one known caller is still
+/// attributed, which the human rendering carries.
+fn references_text(runtime: &common::IsolatedDaemonRuntime, repo: &Path, entity: &str) -> String {
+    let output = require_kin(runtime, repo, &["refs", entity]);
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+/// Renaming a committed entity-owning file with a bare `mv`, then committing.
+///
+/// The incoming-edge assertion is the point of this test, not decoration. A
+/// relocation implemented as a removal plus an addition would satisfy every
+/// path assertion here and still mint new entity ids, orphaning every reference
+/// into the moved function, which `mcp_commit.rs` argues against in the same
+/// words. Only the caller attribution can see that, so it is checked before and
+/// after and required to be unchanged.
+///
+/// The trailing commit is the wedge assertion. Before the fix the repository
+/// stopped accepting commits entirely once a rename had been refused, so a test
+/// that only checked the rename's own commit would pass on a store that was
+/// already dead.
+///
+/// Falsify by reverting `path_relocations_in`'s use in `exact_tree_admission`
+/// so the reconcile seam publishes its tree deltas with an empty
+/// `entity_deltas` again, which is the `TreeDelta::Removed`-only shape it had:
+/// the rename commit then fails with "absent from the staged tree".
+#[test]
+fn renaming_a_committed_entity_owning_file_relocates_it_rather_than_stranding_it() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    fs::write(
+        repo.join("src/moved.py"),
+        b"def moved_target():\n    return 1\n",
+    )
+    .expect("add source");
+    fs::write(
+        repo.join("src/caller.py"),
+        b"from moved import moved_target\n\ndef moved_caller():\n    return moved_target()\n",
+    )
+    .expect("add caller");
+    require_kin(&runtime, &repo, &["commit", "-m", "publish movable source"]);
+
+    let before = located_paths(&runtime, &repo, "moved_target");
+    assert!(
+        before.iter().any(|path| path == "src/moved.py"),
+        "the fixture never made the file findable, so nothing below proves a relocation: \
+         {before:?}"
+    );
+    let references_before = references_text(&runtime, &repo, "moved_target");
+    assert!(
+        references_before.contains("src/caller.py"),
+        "the fixture never produced an incoming edge, so the half a remove-then-add pair \
+         destroys is not under test here: {references_before}"
+    );
+
+    // A bare filesystem move, which is what a person reorganizing a repository
+    // does. Nothing tells kin a rename happened.
+    fs::rename(repo.join("src/moved.py"), repo.join("src/renamed.py"))
+        .expect("rename the committed source");
+    let renamed = run_kin(&runtime, &repo, &["commit", "-m", "relocate the source"]);
+    assert!(
+        renamed.status.success(),
+        "committing a tree with an entity-owning file moved must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&renamed.stdout),
+        String::from_utf8_lossy(&renamed.stderr)
+    );
+
+    let after = located_paths(&runtime, &repo, "moved_target");
+    assert!(
+        !after.iter().any(|path| path == "src/moved.py"),
+        "a moved file is still ranked at the path it left: {after:?}"
+    );
+    assert!(
+        after.iter().any(|path| path == "src/renamed.py"),
+        "the moved entity is not ranked at the path it arrived on: {after:?}"
+    );
+
+    let references_after = references_text(&runtime, &repo, "moved_target");
+    assert!(
+        references_after.contains("src/caller.py"),
+        "the caller lost its edge into the moved function, which is what a removal plus an \
+         addition does and what relocating in one delta exists to prevent: {references_after}"
+    );
+
+    // The repository still accepts work. This is the half that made the defect
+    // a blocker rather than a stale-path annoyance.
+    fs::write(
+        repo.join("src/later.py"),
+        b"def later_symbol():\n    return 2\n",
+    )
+    .expect("add a later file");
+    let later = run_kin(&runtime, &repo, &["commit", "-m", "work after the rename"]);
+    assert!(
+        later.status.success(),
+        "a rename must not leave the repository unable to accept further commits: \
+         stdout={} stderr={}",
+        String::from_utf8_lossy(&later.stdout),
+        String::from_utf8_lossy(&later.stderr)
+    );
+    let later_paths = located_paths(&runtime, &repo, "later_symbol");
+    assert!(
+        later_paths.iter().any(|path| path == "src/later.py"),
+        "work committed after a rename never reached the graph: {later_paths:?}"
+    );
+}
+
+/// The in-place edit arm, which must not be read as a relocation.
+///
+/// A `TreeDelta::Updated` whose path did not change is an edit, and treating it
+/// as a move would rewrite `file_origin` to the path it already has. Cheap to
+/// hold, and it is the obvious way for the relocation filter to be written
+/// wrong.
+#[test]
+fn editing_a_committed_file_in_place_is_not_treated_as_a_relocation() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    fs::write(
+        repo.join("src/edited.py"),
+        b"def edited_target():\n    return 1\n",
+    )
+    .expect("add source");
+    require_kin(
+        &runtime,
+        &repo,
+        &["commit", "-m", "publish editable source"],
+    );
+    let before = located_paths(&runtime, &repo, "edited_target");
+    assert!(
+        before.iter().any(|path| path == "src/edited.py"),
+        "the fixture never made the file findable: {before:?}"
+    );
+
+    fs::write(
+        repo.join("src/edited.py"),
+        b"def edited_target():\n    return 2\n",
+    )
+    .expect("edit source in place");
+    let edited = run_kin(&runtime, &repo, &["commit", "-m", "edit in place"]);
+    assert!(
+        edited.status.success(),
+        "an in-place edit must still commit: stdout={} stderr={}",
+        String::from_utf8_lossy(&edited.stdout),
+        String::from_utf8_lossy(&edited.stderr)
+    );
+
+    let after = located_paths(&runtime, &repo, "edited_target");
+    assert!(
+        after.iter().any(|path| path == "src/edited.py"),
+        "an edited file must keep ranking at its own path: {after:?}"
     );
 }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -855,15 +855,42 @@ fn exact_tree_admission(
         // while its entities keep ranking is the exposure this ordering exists
         // to prevent.
         evict_enrichment_for_removed_paths(state, &deltas)?;
+        // A path change is not a removal, so the eviction above skips it and
+        // the entities on the old path have to move instead. They move in THIS
+        // transaction, beside the tree delta that carries them, because kin-db
+        // refuses a transition that leaves an entity on a path the staged tree
+        // no longer holds, and a relocation published as a second transaction
+        // is refused exactly as a stranded entity is (FIR-2429).
+        let relocations = path_relocations_in(&deltas);
+        let mut relocated_entities = Vec::new();
+        for (from_id, to_id) in &relocations {
+            relocated_entities.extend(
+                crate::mcp_commit::plan_entity_relocations(state.graph.as_ref(), from_id, to_id)
+                    .map_err(DaemonError::Graph)?,
+            );
+        }
         state
             .graph
             .apply_transaction_delta(&TransactionDelta {
-                entity_deltas: Vec::new(),
+                entity_deltas: relocated_entities,
                 relation_deltas: Vec::new(),
                 tree_deltas: deltas.clone(),
                 ..TransactionDelta::default()
             })
             .map_err(|error| name_stranded_endpoint_refusal(DaemonError::Graph(error), &deltas))?;
+        // After the transaction, in the order the MCP seam has always used.
+        // These records are not part of a TransactionDelta, so they were never
+        // inside one.
+        let mut moved_layouts = Vec::new();
+        for (from_id, to_id) in &relocations {
+            crate::mcp_commit::relocate_file_records(
+                state.graph.as_ref(),
+                from_id,
+                to_id,
+                &mut moved_layouts,
+            )
+            .map_err(DaemonError::Graph)?;
+        }
     }
 
     if observation.is_none() {
@@ -1299,6 +1326,31 @@ pub(crate) fn name_stranded_endpoint_refusal(
 /// Artifact-class edges go with it. They have no entity endpoint, so the entity
 /// cleanup below cannot see them, and kin-db refuses the tree transition that
 /// strands one exactly as it refuses a stranded entity.
+/// The `(from, to)` file ids of every tree delta that moved a path.
+///
+/// A byte-identical `mv` plans as [`TreeDelta::Updated`] with the same artifact
+/// id at a new path (`kin_core::exact_tree`), never as a removal plus an
+/// arrival, which is deliberate: the pair would mint new entity ids and orphan
+/// every incoming reference. So this reads the planner's own answer rather than
+/// inferring a rename from a removal and an addition that happen to match.
+///
+/// An `Updated` whose path did not change is an edit in place and is skipped;
+/// its entities keep the file origin they have.
+fn path_relocations_in(deltas: &[TreeDelta]) -> Vec<(FilePathId, FilePathId)> {
+    deltas
+        .iter()
+        .filter_map(|delta| {
+            let TreeDelta::Updated { old, new, .. } = delta else {
+                return None;
+            };
+            if old.path == new.path {
+                return None;
+            }
+            Some((semantic_file_id(&old.path)?, semantic_file_id(&new.path)?))
+        })
+        .collect()
+}
+
 pub(crate) fn evict_enrichment_for_removed_paths(
     state: &DaemonState,
     deltas: &[TreeDelta],

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -1817,6 +1817,81 @@ fn plan_retired_source_files(
 /// The layout and the non-entity facets carry the path in their key rather than
 /// in their body, so they are re-keyed rather than rebuilt: the bytes did not
 /// move, so every byte range in them is still correct.
+/// The entity relocations one path change requires, returned rather than
+/// applied.
+///
+/// Returned, because the caller's transaction is the only place they may land.
+/// kin-db refuses a tree transition that leaves an entity on a path the staged
+/// tree no longer carries, in those words, so a relocation published as a
+/// second transaction beside the tree move is refused exactly as a stranded
+/// entity is. Applying these here would work only where the caller is staging a
+/// prospective graph it publishes later, and the reconcile seam is not.
+///
+/// FIR-2429: a bare filesystem `mv` reached the reconcile seam with no entity
+/// relocation at all, and the repository stopped accepting commits.
+/// Typed rather than stringly: every failure here is the graph refusing a read
+/// or a write, so the daemon's reconcile seam can map it to `DaemonError::Graph`
+/// and the commit seam can add its own context. A `String` crossing this
+/// boundary would force one of the two to invent an error class.
+pub(crate) fn plan_entity_relocations(
+    graph: &kin_db::InMemoryGraph,
+    from_id: &FilePathId,
+    to_id: &FilePathId,
+) -> std::result::Result<Vec<EntityDelta>, kin_db::KinDbError> {
+    Ok(graph
+        .query_entities(&kin_model::EntityFilter {
+            file_path: Some(from_id.clone()),
+            ..Default::default()
+        })?
+        .into_iter()
+        .map(|old| {
+            let mut new = old.clone();
+            new.file_origin = Some(to_id.clone());
+            EntityDelta::Modified { old, new }
+        })
+        .collect())
+}
+
+/// Re-key the per-file records a path change moves: layout, shallow,
+/// structured and opaque.
+///
+/// These are not part of a [`TransactionDelta`], so they are applied here and
+/// stay outside the caller's transaction, which is where they already sat. Run
+/// after the transaction publishes, in the order the MCP seam has always used.
+pub(crate) fn relocate_file_records(
+    graph: &kin_db::InMemoryGraph,
+    from_id: &FilePathId,
+    to_id: &FilePathId,
+    layouts: &mut Vec<FileLayout>,
+) -> std::result::Result<(), kin_db::KinDbError> {
+    if let Some(layout) = graph.get_file_layout(from_id)? {
+        let mut moved = layout;
+        moved.file_id = to_id.clone();
+        graph.delete_file_layout(from_id)?;
+        graph.upsert_file_layout(&moved)?;
+        layouts.push(moved);
+    }
+    if let Some(shallow) = graph.get_shallow_file(from_id)? {
+        let mut moved = shallow;
+        moved.file_id = to_id.clone();
+        graph.delete_shallow_file(from_id)?;
+        graph.upsert_shallow_file(&moved)?;
+    }
+    if let Some(structured) = graph.get_structured_artifact(from_id)? {
+        let mut moved = structured;
+        moved.file_id = to_id.clone();
+        graph.delete_structured_artifact(from_id)?;
+        graph.upsert_structured_artifact(&moved)?;
+    }
+    if let Some(opaque) = graph.get_opaque_artifact(from_id)? {
+        let mut moved = opaque;
+        moved.file_id = to_id.clone();
+        graph.delete_opaque_artifact(from_id)?;
+        graph.upsert_opaque_artifact(&moved)?;
+    }
+    Ok(())
+}
+
 fn plan_renamed_source_files(
     prospective: &kin_db::InMemoryGraph,
     relocations: BTreeMap<String, (FilePathId, FilePathId)>,
@@ -1835,23 +1910,12 @@ fn plan_renamed_source_files(
                 format!("renamed source artifact disappeared during planning: {from_id}")
             })?;
 
-        let entity_deltas = prospective
-            .query_entities(&kin_model::EntityFilter {
-                file_path: Some(from_id.clone()),
-                ..Default::default()
-            })
-            .map_err(|error| format!("load entities on {from_id}: {error}"))?
-            .into_iter()
-            .map(|old| {
-                let mut new = old.clone();
-                new.file_origin = Some(to_id.clone());
-                EntityDelta::Modified { old, new }
-            })
-            .collect::<Vec<_>>();
-
+        // One transaction, entity relocation and tree move together. This is
+        // the shape the reconcile seam was missing.
         prospective
             .apply_transaction_delta(&TransactionDelta {
-                entity_deltas,
+                entity_deltas: plan_entity_relocations(prospective, &from_id, &to_id)
+                    .map_err(|error| format!("load entities on {from_id}: {error}"))?,
                 tree_deltas: vec![TreeDelta::Updated {
                     artifact_id: artifact.artifact_id,
                     old: artifact.located_entry(),
@@ -1861,59 +1925,8 @@ fn plan_renamed_source_files(
             })
             .map_err(|error| format!("relocate {from_id} to {to_id}: {error}"))?;
 
-        if let Some(layout) = prospective
-            .get_file_layout(&from_id)
-            .map_err(|error| format!("load layout for {from_id}: {error}"))?
-        {
-            let mut moved = layout;
-            moved.file_id = to_id.clone();
-            prospective
-                .delete_file_layout(&from_id)
-                .map_err(|error| format!("drop layout at {from_id}: {error}"))?;
-            prospective
-                .upsert_file_layout(&moved)
-                .map_err(|error| format!("install layout at {to_id}: {error}"))?;
-            layouts.push(moved);
-        }
-        if let Some(shallow) = prospective
-            .get_shallow_file(&from_id)
-            .map_err(|error| format!("load shallow record for {from_id}: {error}"))?
-        {
-            let mut moved = shallow;
-            moved.file_id = to_id.clone();
-            prospective
-                .delete_shallow_file(&from_id)
-                .map_err(|error| format!("drop shallow record at {from_id}: {error}"))?;
-            prospective
-                .upsert_shallow_file(&moved)
-                .map_err(|error| format!("install shallow record at {to_id}: {error}"))?;
-        }
-        if let Some(structured) = prospective
-            .get_structured_artifact(&from_id)
-            .map_err(|error| format!("load structured record for {from_id}: {error}"))?
-        {
-            let mut moved = structured;
-            moved.file_id = to_id.clone();
-            prospective
-                .delete_structured_artifact(&from_id)
-                .map_err(|error| format!("drop structured record at {from_id}: {error}"))?;
-            prospective
-                .upsert_structured_artifact(&moved)
-                .map_err(|error| format!("install structured record at {to_id}: {error}"))?;
-        }
-        if let Some(opaque) = prospective
-            .get_opaque_artifact(&from_id)
-            .map_err(|error| format!("load opaque record for {from_id}: {error}"))?
-        {
-            let mut moved = opaque;
-            moved.file_id = to_id.clone();
-            prospective
-                .delete_opaque_artifact(&from_id)
-                .map_err(|error| format!("drop opaque record at {from_id}: {error}"))?;
-            prospective
-                .upsert_opaque_artifact(&moved)
-                .map_err(|error| format!("install opaque record at {to_id}: {error}"))?;
-        }
+        relocate_file_records(prospective, &from_id, &to_id, layouts)
+            .map_err(|error| format!("relocate records {from_id} to {to_id}: {error}"))?;
     }
     Ok(())
 }


### PR DESCRIPTION
A byte-identical `mv` of an entity-owning file left the repository unable to accept any further commit. Not stale entities, and not a loud retry loop. Every subsequent `kin commit` returned HTTP 500.

That was measured before any of this was written, two arms on identical fixtures differing only in the rename. The watcher refused the transition fourteen times over 59 seconds and then stopped retrying. `kin locate` kept attributing the entity to `src/moved.py`, a file no longer on disk. The next `kin commit` exited 1 with `daemon native commit failed (HTTP 500 Internal Server Error): Graph error: storage error: transaction leaves entity ... on repository path src/moved.py absent from the staged tree; carry its exact entity removal or relocation in the same delta`. The control arm, same fixture with no rename, committed cleanly and indexed a new symbol.

## The defect is one empty field

The reconcile seam published its tree deltas with `entity_deltas: Vec::new()`. A rename plans as `TreeDelta::Updated` at a new path, `evict_enrichment_for_removed_paths` matches only `TreeDelta::Removed`, so nothing relocated the entities on the old path and kin-db refused the transition. It was right to refuse. What was missing is the relocation.

## One implementation on two seams

The MCP commit seam already relocated correctly, so its logic moves rather than being duplicated. It splits in two, because only half of it belongs inside a transaction.

`plan_entity_relocations` returns the `EntityDelta`s and applies nothing. `relocate_file_records` re-keys the layout, shallow, structured and opaque records, which are not part of a `TransactionDelta` and were never inside one, on either seam. The reconcile seam folds the entity deltas into the same `apply_transaction_delta` that already carried the tree deltas, then re-keys the records after, which is the order the commit seam has always used.

Both helpers return `kin_db::KinDbError` rather than `String`. Every failure in them is the graph refusing a read or a write, and no `DaemonError` variant carries a bare `String`, so a stringly-typed boundary would have forced the reconcile seam to invent an error class for a graph error it already types. The commit seam adds its own context on top, so its messages are unchanged, and its existing tests stay green, which is the proof that the extraction changed nothing there.

Renames are read off `TreeDelta::Updated` rather than paired from a removal and an addition. That is the argument `mcp_commit.rs` already makes in its own words: the pair mints new entity ids and orphans every incoming reference, so `find_references` would report a moved function as referenced by nothing. An `Updated` whose path did not change is an edit in place and is skipped.

## Falsification

The rename test goes red under the mutation that puts the reconcile seam back to its pre-fix shape, `entity_deltas: Vec::new()`, and it fails with the exact production error: `transaction leaves entity ... on repository path src/moved.py absent from the staged tree`.

| | Under the mutation |
|---|---|
| `renaming_a_committed_entity_owning_file_relocates_it_rather_than_stranding_it` | FAILED |
| `deleting_a_committed_entity_owning_file_retires_it_from_every_query_surface` | ok |
| `deleting_a_file_that_owns_no_entity_still_commits` | ok |
| `editing_a_committed_file_in_place_is_not_treated_as_a_relocation` | ok |

Only the rename test moved, so it discriminates rather than merely being sensitive. Thirteen tests green on the restored tree.

Some assertions in that test need their reasons stated. The caller's incoming edge is checked before and after and required to be unchanged, because a relocation implemented as a removal plus an addition would satisfy every path assertion here and still orphan every reference into the moved function. Nothing else in the test can see that. A commit *after* the rename must succeed, because a test that only checked the rename's own commit would pass on a repository that was already dead, and a dead repository is what made this a blocker. The in-place-edit control holds the other side, since treating an `Updated` with an unchanged path as a move is the obvious way to write the filter wrong.

## The workaround, until this lands

Measured against a build carrying no FIR-2429 fix, three escapes from the wedged state:

| Escape | `kin commit` | What it said |
|---|---|---|
| Bare `mv`, the wedge itself | rc 1 | `absent from the staged tree` |
| Move the file back to its original path | **rc 0** | `Created semantic change` |
| `git mv` to a new name from the wedged state | rc 1 | `absent from the staged tree` |
| Commit an unrelated new file while wedged | rc 1 | `absent from the staged tree` |

So: move the file back where it was and commit. Do not reach for `git mv`, which is the thing a person will try. It does not help. Kin does not read git's index, so `git mv` is a filesystem move plus a staging entry kin never consults.

## What was run

`cargo test -p kin-cli --test entity_file_retirement` under the daemon lock, thirteen green, twice: once on the fix and once again after the mutation was reverted. `cargo clippy --all-targets --all-features` with the allow list read from `.github/clippy-allowed-lints.txt` exactly as ci.yml reads it, under `RUSTFLAGS=-D warnings`. `cargo fmt -- --check`. The guard scripts ci.yml names: `zero_file_search_guard.sh`, `check_runtime_boundaries.sh` and `check_private_repo_coupling.sh`. Everything through `bin/kin-lane run`, which prints the checkout it resolved. Port 4219 was probed empty before every daemon run, and the lock was released after each.

`cargo test -p kin-daemon --locked`, 1073 passed and 0 failed. `cargo test -p kin-cli --locked`, 2508 passed and 0 failed. Both waited out a compute-quiet window another lane held for a heap probe, which is why they ran after the PR opened rather than before it.

## Not claimed

The recovery measurements used the daemon2468 branch build rather than a binary built from main. That branch leaves `loop_runner.rs` and `mcp_commit.rs` untouched, so it is behaviourally identical to main on this path, but it is not literally main's binary.

Nothing here touches kin-vfs. `kin-vfs/scripts/fuse-mount-proof.sh` still pins the pre-fix refusal for a delete through the mount, in its own words, and FIR-2429 says that check "should be updated deliberately" once the daemon gains this. Whether the watcher's *delete* half is itself complete is a separate question this PR neither asks nor answers: its own comment and the merged-work survey contradict each other, and one of them is stale. Both are filed as FIR-2701, which is the home for FIR-2429's remainder and asks that the disagreement be settled by running the script before anyone edits it. The `kin`-recorded rename path through `record_renamed_source_path` was already correct and its own test covers it. What changes here is the seam that never had one.

Part of FIR-2429
