### PR TITLE
Bind a bare call to the same-file sibling under the caller's own owner

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -93,6 +93,16 @@ jobs:
       - name: Falsify the parse-hole verdict graders
         run: python3 scripts/acceptance/parse_hole_repro.py --self-test
 
+      # FIR-1826. The suite's verdicts are decided by two graders: one that reads
+      # the callers out of a `kin graph inspect`, and one that turns a caller set
+      # into PASS or FAIL. Both are driven against the input that must produce
+      # the opposite answer, including the pair that matters most, an inspect
+      # that printed no edge line and an entity nothing calls. Those two collapse
+      # into one empty set the moment the grader stops telling them apart, and a
+      # failed probe then reads as a clean negative.
+      - name: Falsify the same-owner call graders
+        run: python3 scripts/acceptance/same_owner_call_repro.py --self-test
+
       - name: Falsify the acceptance gate
         run: python3 scripts/acceptance/gate.py --self-test
 
@@ -386,6 +396,39 @@ jobs:
             echo "::error title=Parse-hole acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
           fi
 
+      # The end-to-end arm of FIR-1826. The unit arm drives the linker directly
+      # in crates/kin-index; this asks the built binary what calls what, in two
+      # languages that must bind and one that must not. The negative is what
+      # makes the positives mean anything: the rule is a per-language judgement,
+      # so a build that bound every language would satisfy both positives.
+      - name: Same-owner call suite (verdict comes from the gate step)
+        id: sameowner
+        if: always()
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/same_owner_call_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/sameowner.json \
+            --label "$KIN_ACCEPTANCE_LABEL" \
+            --verbose >acceptance/sameowner.log 2>&1 || rc=$?
+          cat acceptance/sameowner.log
+          {
+            echo "### Same-owner call suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/sameowner.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=Same-owner call suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
+          fi
+
       - name: Memory-pressure refusal suite (verdict comes from the gate step)
         id: memorypressure
         if: always()
@@ -647,6 +690,7 @@ jobs:
             --report brownfield=acceptance/brownfield.json \
             --report response_budget=acceptance/response_budget.json \
             --report parsehole=acceptance/parsehole.json \
+            --report sameowner=acceptance/sameowner.json \
             --report memory_pressure=acceptance/memory_pressure.json \
             --report memory_footprint=acceptance/memory_footprint.json \
             --report initmemory=acceptance/initmemory.json \

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -1420,6 +1420,69 @@ fn resolve_one_file(
             }
         }
 
+        // (c2a) A bare call to a same-file sibling under the caller's own
+        // owner. `void Foo::a() { b(); }` in a file that also defines `Foo::b`
+        // reached no tier at all before this one, so the call site existed in
+        // the source and in no edge. See `same_owner_sibling_name` for why the
+        // sibling is composed rather than searched, and
+        // `bare_call_reaches_owner_sibling` for the language allowlist that
+        // decides where a bare call carries an implicit receiver.
+        //
+        // It links only when exactly one distinct candidate survives the same
+        // filters (c2) applies. Fanning out here would reopen the decoy problem
+        // the (c) comment above describes, in the one place a decoy is most
+        // likely: the caller's own file.
+        //
+        // LOCALITY_DISAMBIGUATED_CONFIDENCE and deliberately not 1.0. Locality
+        // plus a unique owner-qualified leaf beats the cross-file fan-out and
+        // stays under the parser-certain same-file edge (a) emits, because 1.0
+        // would stamp `RelationOrigin::Parsed` and let `find_references` report
+        // a name-derived edge as proven.
+        if name_fallback_allowed && !linked && !unresolvable_name_ambiguity {
+            if let Some((sibling, _leaf)) =
+                same_owner_sibling_name(rel, src_id, &ctx.entity_language_by_id)
+                    .filter(|(_, leaf)| {
+                        bare_leaf_names_one_thing(
+                            ctx.entity_by_bare_name.get(leaf).map_or(0, |v| v.len()),
+                            ctx.entity_by_name.get(leaf).map_or(0, |v| v.len()),
+                        )
+                    })
+            {
+                let candidates: Vec<(&str, EntityId)> = ctx
+                    .entity_by_name
+                    .get(sibling.as_str())
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[])
+                    .iter()
+                    .copied()
+                    .filter(|&(fp, dst_id)| {
+                        fp == file.file_path.as_str()
+                            && dst_id != src_id
+                            && blind_inference_target_allowed(
+                                src_id,
+                                dst_id,
+                                &ctx.entity_language_by_id,
+                            )
+                    })
+                    .collect();
+                let candidates =
+                    prune_pairs_by_arity(candidates, call_arity, &ctx.entity_arity_by_id);
+                let candidates = narrow_pairs_by_role(src_id, candidates, &ctx.entity_role_by_id);
+                let distinct: HashSet<EntityId> =
+                    candidates.into_iter().map(|(_, id)| id).collect();
+                if distinct.len() == 1 {
+                    for dst_id in sorted_fanout_targets(distinct) {
+                        accumulate_relation(
+                            &mut resolved,
+                            &mut relation_indices,
+                            make_relation(rel, src_id, dst_id, LOCALITY_DISAMBIGUATED_CONFIDENCE),
+                        );
+                        linked = true;
+                    }
+                }
+            }
+        }
+
         // (c4) C++ receiver-scoped inherited method. A `Owner::method` call
         // whose receiver type the parser pinned matched no exact entity above
         // (own method — same-file (a) or cross-file (c)) resolves through the
@@ -3533,6 +3596,133 @@ fn rust_bare_call_may_reach_owned(
 ) -> bool {
     !imports_are_name_complete(&file.imports)
         || file_imports.is_some_and(|imports| imports.contains_key(dst_name))
+}
+
+/// The owner path of a qualified entity name, and the separator that joined it.
+///
+/// Mirrors [`bare_entity_name`]'s precedence exactly, `::` before `.`, so the
+/// two can never disagree about where a name splits: this returns the owner of
+/// the leaf that one returns. `None` for an unqualified name, which is what
+/// keeps a free function out of the sibling tier below.
+fn entity_owner_path(name: &str) -> Option<(&str, &str)> {
+    match name.rfind("::") {
+        Some(idx) if idx > 0 => Some((&name[..idx], "::")),
+        Some(_) => None,
+        None => match name.rfind('.') {
+            Some(idx) if idx > 0 => Some((&name[..idx], ".")),
+            _ => None,
+        },
+    }
+}
+
+/// Whether a bare `name(..)` in this language reaches a sibling member of the
+/// caller's own owner with no receiver written.
+///
+/// Measured against the real adapters rather than assumed. Every adapter this
+/// indexes emits the identical relation for `b()` inside `Foo.a`: a `Calls`
+/// with `dst_name = "b"` and no receiver. The relation cannot tell the
+/// languages apart, so only the language can.
+///
+/// The five here give a member call an implicit receiver, so `b()` inside
+/// `Foo.a` is `this.b()` or `self.b()` and the same-owner sibling is the target
+/// the source names. Every other language is left out, each for its own reason:
+///
+///   * Python and Rust need `self.b()` or `Self::b()`. The gates at
+///     [`is_python_bare_identifier_call`] and [`rust_bare_call_may_reach_owned`]
+///     already say so, and this tier must not step around them.
+///   * Go needs `f.b()`; a bare `b()` inside a method names a package-level
+///     function.
+///   * PHP needs `$this->b()`; a bare `b()` inside a method names a global
+///     function.
+///   * JavaScript and TypeScript need `this.b()`.
+///   * C has no owner-qualified entities, so the lookup could never hit.
+///   * Ruby's adapter records no call at all for the bare shape, so a rule for
+///     it would be a rule nothing exercises.
+///   * HCL has no call syntax.
+///
+/// An allowlist and not a denylist, on purpose: a language added to
+/// [`LanguageId`] tomorrow inherits no binding rule until somebody makes the
+/// same judgement for it and writes it here.
+fn bare_call_reaches_owner_sibling(
+    src_id: EntityId,
+    languages: &HashMap<EntityId, LanguageId>,
+) -> bool {
+    matches!(
+        languages.get(&src_id),
+        Some(
+            LanguageId::Java
+                | LanguageId::CSharp
+                | LanguageId::Cpp
+                | LanguageId::Kotlin
+                | LanguageId::Swift
+        )
+    )
+}
+
+/// (c2a) The name of the same-file sibling under the caller's own owner that a
+/// bare call reaches, if this call can reach one at all.
+///
+/// No tier before this one can. Tier (a) keys `entity_by_file_name` on the FULL
+/// name and `Foo::b` is not `b`; tier (c) keys `entity_by_name` the same way;
+/// tier (c2) does hold `Foo::b` under its bare leaf and drops every candidate
+/// in the caller's own file. So `void Foo::a() { b(); }` emitted no relation of
+/// any kind, not even a placeholder, and `find_references`, blast radius and
+/// every rename built on the graph omitted the site with nothing to say so.
+///
+/// This composes the sibling's full name from the caller's own owner. Composing
+/// rather than searching the bare-leaf index is what keeps the tier safe: that
+/// index would also offer `Bar::b` in the same file, which a bare call in none
+/// of these languages can reach. The composed name is then looked up by the
+/// caller, which applies the same candidate filters (c2) applies before
+/// deciding, so the two tiers cannot drift on what an overload or a test-only
+/// target admits.
+fn same_owner_sibling_name<'r>(
+    rel: &'r ExtractedRelation,
+    src_id: EntityId,
+    languages: &HashMap<EntityId, LanguageId>,
+) -> Option<(String, &'r str)> {
+    if rel.kind != RelationKind::Calls || rel.receiver.is_some() {
+        return None;
+    }
+    let leaf = rel.dst_name.as_str();
+    if leaf.is_empty() || leaf.contains('.') || leaf.contains("::") {
+        return None;
+    }
+    if !bare_call_reaches_owner_sibling(src_id, languages) {
+        return None;
+    }
+    let (owner, separator) = entity_owner_path(rel.src_name.as_str())?;
+    Some((format!("{owner}{separator}{leaf}"), leaf))
+}
+
+/// Whether the bare leaf of a call can mean anything in this repository other
+/// than the sibling [`same_owner_sibling_name`] composed.
+///
+/// The adapters for every language in [`bare_call_reaches_owner_sibling`] record
+/// NO receiver for `h.b()`. That is measured, in
+/// `tests/same_owner_bare_call_resolution.rs`, not assumed: Java, C#, Kotlin,
+/// Swift and C++ all emit the same relation for `h.b()` as for `b()`, a `Calls`
+/// with `dst_name = "b"` and `receiver: None`. Only Python and Rust separate the
+/// two shapes at extraction time, and neither is in the allowlist. So this tier
+/// cannot ask whether a receiver was written, and something else has to stand in
+/// for that question, or an object call would bind to whatever member of the
+/// caller's own class shares the leaf. That is the phantom-consumer defect the
+/// `proxies.get("no_proxy")` gate above exists to prevent, arriving in the one
+/// place a decoy is most likely.
+///
+/// Uniqueness stands in. When the leaf names exactly one owner-qualified entity
+/// in the whole universe and no unqualified one, there is nothing else the call
+/// could have meant whatever was written before the dot. That is precisely the
+/// shape the ticket describes, a bare call whose ONLY candidate is a same-file
+/// qualified-name entity, and it is what keeps `h.b()` off the caller's own
+/// `Foo.b` wherever `Helper.b` is in the graph.
+///
+/// The bound it leaves is stated rather than hidden: a receiver call whose
+/// receiver type the graph does not hold at all still binds to the caller's own
+/// sibling. Closing that needs the adapters to record receivers for these
+/// languages, which is a parser change and not a linker one.
+fn bare_leaf_names_one_thing(bare_holders: usize, exact_holders: usize) -> bool {
+    bare_holders == 1 && exact_holders == 0
 }
 
 /// Drop the method candidates a bare Python call can never dispatch to.
@@ -6635,6 +6825,58 @@ fn resolve_one_file_incremental(
                             &mut resolved,
                             &mut relation_indices,
                             make_relation(rel, src_id, dst_id, RECEIVER_NAME_FANOUT_CONFIDENCE),
+                        );
+                    }
+                    continue;
+                }
+            }
+        }
+
+        // (c2a) The incremental counterpart of the batch linker's (c2a): a
+        // bare call to a same-file sibling under the caller's own owner.
+        // Without this step the edge a full-tree link resolved is dropped the
+        // moment an incremental relink of the caller re-derives its edges,
+        // which is how a warm store loses edges a cold one has.
+        if name_fallback_allowed && !unresolvable_name_ambiguity {
+            if let Some((sibling, _leaf)) =
+                same_owner_sibling_name(rel, src_id, &linker.entity_language_by_id).filter(
+                    |(_, leaf)| {
+                        bare_leaf_names_one_thing(
+                            linker.entity_by_bare_name.get(*leaf).map_or(0, |v| v.len()),
+                            linker.entity_by_name.get(*leaf).map_or(0, |v| v.len()),
+                        )
+                    },
+                )
+            {
+                let candidates: Vec<(&str, EntityId)> = linker
+                    .entity_by_name
+                    .get(sibling.as_str())
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[])
+                    .iter()
+                    .filter(|(fp, dst_id)| {
+                        fp == &file.file_path
+                            && *dst_id != src_id
+                            && blind_inference_target_allowed(
+                                src_id,
+                                *dst_id,
+                                &linker.entity_language_by_id,
+                            )
+                    })
+                    .map(|(fp, id)| (fp.as_str(), *id))
+                    .collect();
+                let candidates =
+                    prune_pairs_by_arity(candidates, call_arity, &linker.entity_arity_by_id);
+                let candidates =
+                    narrow_pairs_by_role(src_id, candidates, &linker.entity_role_by_id);
+                let distinct: HashSet<EntityId> =
+                    candidates.into_iter().map(|(_, id)| id).collect();
+                if distinct.len() == 1 {
+                    for dst_id in sorted_fanout_targets(distinct) {
+                        accumulate_relation(
+                            &mut resolved,
+                            &mut relation_indices,
+                            make_relation(rel, src_id, dst_id, LOCALITY_DISAMBIGUATED_CONFIDENCE),
                         );
                     }
                     continue;

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -1440,13 +1440,14 @@ fn resolve_one_file(
         // a name-derived edge as proven.
         if name_fallback_allowed && !linked && !unresolvable_name_ambiguity {
             if let Some((sibling, _leaf)) =
-                same_owner_sibling_name(rel, src_id, &ctx.entity_language_by_id)
-                    .filter(|(_, leaf)| {
+                same_owner_sibling_name(rel, src_id, &ctx.entity_language_by_id).filter(
+                    |(_, leaf)| {
                         bare_leaf_names_one_thing(
                             ctx.entity_by_bare_name.get(leaf).map_or(0, |v| v.len()),
                             ctx.entity_by_name.get(leaf).map_or(0, |v| v.len()),
                         )
-                    })
+                    },
+                )
             {
                 let candidates: Vec<(&str, EntityId)> = ctx
                     .entity_by_name

--- a/crates/kin-index/tests/relation_evidence_span_coverage.rs
+++ b/crates/kin-index/tests/relation_evidence_span_coverage.rs
@@ -45,11 +45,14 @@ use kin_model::{ArtifactId, FilePathId, Relation, RelationEvidence, RelationId};
 /// has something to resolve, and every fixture repeats at least one call so
 /// multi-site edges are exercised rather than assumed away.
 ///
-/// The calls are written cross-file on purpose: a bare call to a qualified
+/// The calls are written cross-file on purpose. A bare call to a qualified
 /// sibling in the *same* file (`render()` calling `compute()` inside one class)
-/// resolves to no edge at all, in every language checked. That is a separate
-/// gap from this one and would make a fixture look span-less when it was really
-/// edge-less.
+/// used to resolve to no edge at all in every language checked, which would make
+/// a fixture look span-less when it was really edge-less. FIR-1826 closed that
+/// for the languages where a bare call carries an implicit receiver, so the Java
+/// and C# fixtures below now yield that edge too and their `min_calls` floors
+/// count it. The cross-file shape stays because it is the one every language
+/// resolves, so a fixture's span rate is never confounded by a binding rule.
 struct Fixture {
     language: &'static str,
     /// Fewest relations this fixture must yield. A language that silently stops
@@ -203,7 +206,9 @@ const FIXTURES: &[Fixture] = &[
     Fixture {
         language: "Java",
         min_relations: 4,
-        min_calls: 1,
+        // Two: the cross-file `compute()` every language resolves, and the
+        // same-file `render()` -> `compute()` sibling FIR-1826 added.
+        min_calls: 2,
         min_calls_with_span: 0,
         files: &[
             (
@@ -228,7 +233,8 @@ const FIXTURES: &[Fixture] = &[
     Fixture {
         language: "CSharp",
         min_relations: 5,
-        min_calls: 1,
+        // Two, for the same reason as Java above.
+        min_calls: 2,
         min_calls_with_span: 0,
         files: &[
             (

--- a/crates/kin-index/tests/same_owner_bare_call_resolution.rs
+++ b/crates/kin-index/tests/same_owner_bare_call_resolution.rs
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! FIR-1826: a bare call to a same-file sibling under the caller's own owner.
+//!
+//! `void Foo::a() { b(); }` in a file that also defines `Foo::b` reached no
+//! linker tier at all. Tier (a) and tier (c) key on the full entity name, and
+//! `Foo::b` is not `b`. Tier (c2) does hold `Foo::b` under its bare leaf and
+//! drops every candidate in the caller's own file. So the call site existed in
+//! the source and in no edge, which is strictly worse than a low-confidence or
+//! mis-ranked edge: `find_references`, blast radius and every rename built on
+//! the graph omitted the site with nothing on any surface to say so.
+//!
+//! Whether that bare call reaches the sibling is a question only the language
+//! answers, and this file is where that judgement is recorded per language.
+//! Every adapter emits the identical relation for `b()` inside `Foo.a`: a
+//! `Calls` with `dst_name = "b"` and no receiver. The relation cannot tell Java,
+//! where the call is `this.b()`, from Go, where it names a package-level
+//! function.
+//!
+//! So each negative here carries a control that the parser DID emit the bare
+//! call. Without it a language whose adapter simply records no call for the
+//! shape reads exactly like a language the linker correctly refused, and the
+//! two are different answers. Ruby is that language today, which is why it is
+//! absent rather than listed as a negative.
+//!
+//! One measurement in this file constrains the whole rule, and it is why the
+//! tier is narrower than "the sibling exists". None of Java, C#, Kotlin, Swift
+//! or C++ records a receiver for `h.b()` either: every one of them emits the
+//! same relation for an object call as for a bare call. Only Python and Rust
+//! separate the two shapes at extraction time, and neither is a language where
+//! a bare call reaches a sibling. So the linker cannot ask whether a receiver
+//! was written, and the tier stands on uniqueness instead: it binds only when
+//! the leaf names exactly one owner-qualified entity in the whole universe and
+//! no unqualified one, which is the ticket's own framing of a bare call whose
+//! only candidate is a same-file qualified-name entity.
+//!
+//! The bound that leaves is stated rather than hidden. A receiver call whose
+//! receiver type the graph does not hold at all still binds to the caller's own
+//! sibling. Closing it needs the adapters to record receivers for these
+//! languages, which is a parser change; this file's job is to make sure nobody
+//! reads the current rule as more than it is.
+//!
+//! Every case runs through the real parser and both linkers, batch and
+//! incremental, and asserts they agree, because a rule that holds only on a cold
+//! link is a rule a warm store loses.
+
+use std::collections::HashSet;
+
+use kin_index::{
+    link_cross_file as link_cross_file_with_identities, link_cross_file_incremental, FileParseData,
+    IncrementalLinker,
+};
+use kin_model::{
+    ArtifactId, Entity, EntityId, FilePathId, Relation, RelationKind, RelationOrigin,
+};
+use kin_parser::{
+    CSharpAdapter, CppAdapter, GoAdapter, JavaAdapter, JavaScriptAdapter, KotlinAdapter,
+    LanguageAdapter, PhpAdapter, PythonAdapter, RustAdapter, SwiftAdapter, TypeScriptAdapter,
+};
+
+fn adapter_for(language: &str) -> Box<dyn LanguageAdapter> {
+    match language {
+        "java" => Box::new(JavaAdapter),
+        "csharp" => Box::new(CSharpAdapter),
+        "cpp" => Box::new(CppAdapter),
+        "kotlin" => Box::new(KotlinAdapter),
+        "swift" => Box::new(SwiftAdapter),
+        "go" => Box::new(GoAdapter),
+        "php" => Box::new(PhpAdapter),
+        "python" => Box::new(PythonAdapter),
+        "rust" => Box::new(RustAdapter),
+        "typescript" => Box::new(TypeScriptAdapter),
+        "javascript" => Box::new(JavaScriptAdapter),
+        other => panic!("no adapter wired for `{other}` in this suite"),
+    }
+}
+
+fn parse(language: &str, file_path: &str, source: &str) -> FileParseData {
+    let adapter = adapter_for(language);
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn entity_id(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+        .unwrap_or_else(|| {
+            let known: Vec<&str> = files
+                .iter()
+                .flat_map(|f| f.entities.iter())
+                .map(|e| e.name.as_str())
+                .collect();
+            panic!("entity `{name}` in `{file}` not found; the file holds {known:?}")
+        })
+        .id
+}
+
+fn link_cross_file(files: &[FileParseData]) -> Vec<Relation> {
+    let artifact_ids = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    link_cross_file_with_identities(files, &artifact_ids)
+        .expect("every fixture file has an explicitly assigned artifact identity")
+}
+
+/// Link through both linkers, assert they agree on every `Calls` edge, and
+/// return the batch edges. The tier has a batch site and an incremental twin;
+/// proving only one leaves a warm relink free to drop what a cold link found.
+fn link_both(files: &[FileParseData]) -> Vec<Relation> {
+    let batch = link_cross_file(files);
+
+    let mut linker = IncrementalLinker::new();
+    for f in files {
+        linker.add_file(&f.file_path, ArtifactId::new(), &f.entities);
+    }
+    let incremental = link_cross_file_incremental(files, &linker)
+        .expect("every fixture file has an explicitly assigned artifact identity");
+
+    let call_set = |rels: &[Relation]| -> HashSet<(EntityId, EntityId)> {
+        rels.iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .filter_map(|r| Some((r.src.as_entity()?, r.dst.as_entity()?)))
+            .collect()
+    };
+    assert_eq!(
+        call_set(&batch),
+        call_set(&incremental),
+        "the batch and incremental linkers disagree on this file's Calls edges"
+    );
+    batch
+}
+
+fn calls_from(relations: &[Relation], src: EntityId) -> Vec<EntityId> {
+    let mut out: Vec<EntityId> = relations
+        .iter()
+        .filter(|r| r.kind == RelationKind::Calls && r.src.as_entity() == Some(src))
+        .filter_map(|r| r.dst.as_entity())
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// The control every negative needs. A language whose adapter records no call
+/// for the bare shape produces zero edges for a reason that has nothing to do
+/// with the rule under test, and reads identically to a refusal.
+fn assert_parser_emitted_bare_call(file: &FileParseData, caller: &str, leaf: &str) {
+    let emitted = file.relations.iter().any(|r| {
+        r.kind == RelationKind::Calls
+            && r.src_name == caller
+            && r.dst_name == leaf
+            && r.receiver.is_none()
+    });
+    assert!(
+        emitted,
+        "the `{}` adapter recorded no bare `{leaf}()` call from `{caller}`, so this case would \
+         grade a linker rule it never reached. Fix the fixture, not the assertion",
+        file.file_path,
+    );
+}
+
+// ── The per-language judgement ──
+//
+// One row per language, the source that spells the shape, and whether that
+// language's bare call reaches the sibling. A row is not a preference: it is
+// what the language does, and the reason is written beside it.
+
+struct Case {
+    language: &'static str,
+    path: &'static str,
+    source: &'static str,
+    caller: &'static str,
+    callee: &'static str,
+    leaf: &'static str,
+    binds: bool,
+    why: &'static str,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        language: "java",
+        path: "Sample.java",
+        source: "class Foo {\n    void a() { b(); }\n    void b() { }\n}\n",
+        caller: "Foo.a",
+        callee: "Foo.b",
+        leaf: "b",
+        binds: true,
+        why: "Java gives a member call an implicit `this`, so `b()` is `this.b()`",
+    },
+    Case {
+        language: "csharp",
+        path: "Sample.cs",
+        source: "class Foo {\n    void A() { B(); }\n    void B() { }\n}\n",
+        caller: "Foo.A",
+        callee: "Foo.B",
+        leaf: "B",
+        binds: true,
+        why: "C# gives a member call an implicit `this`",
+    },
+    Case {
+        language: "cpp",
+        path: "sample.cpp",
+        source: "struct Foo {\n    void a();\n    void b();\n};\nvoid Foo::a() { b(); }\nvoid Foo::b() { }\n",
+        caller: "Foo::a",
+        callee: "Foo::b",
+        leaf: "b",
+        binds: true,
+        why: "C++ gives a member call an implicit `this->`",
+    },
+    Case {
+        language: "kotlin",
+        path: "Sample.kt",
+        source: "class Foo {\n    fun a() { b() }\n    fun b() { }\n}\n",
+        caller: "Foo.a",
+        callee: "Foo.b",
+        leaf: "b",
+        binds: true,
+        why: "Kotlin gives a member call an implicit `this`",
+    },
+    Case {
+        language: "swift",
+        path: "Sample.swift",
+        source: "class Foo {\n    func a() { b() }\n    func b() { }\n}\n",
+        caller: "Foo.a",
+        callee: "Foo.b",
+        leaf: "b",
+        binds: true,
+        why: "Swift gives a member call an implicit `self`",
+    },
+    Case {
+        language: "go",
+        path: "sample.go",
+        source: "package main\ntype Foo struct{}\nfunc (f Foo) a() { b() }\nfunc (f Foo) b() { }\n",
+        caller: "Foo.a",
+        callee: "Foo.b",
+        leaf: "b",
+        binds: false,
+        why: "Go has no implicit receiver; a bare `b()` inside a method names a package-level function",
+    },
+    Case {
+        language: "php",
+        path: "sample.php",
+        source: "<?php\nclass Foo {\n    function a() { b(); }\n    function b() { }\n}\n",
+        caller: "Foo.a",
+        callee: "Foo.b",
+        leaf: "b",
+        binds: false,
+        why: "PHP needs `$this->b()`; a bare `b()` inside a method names a global function",
+    },
+    Case {
+        language: "python",
+        path: "sample.py",
+        source: "class Foo:\n    def a(self):\n        b()\n    def b(self):\n        pass\n",
+        caller: "Foo.a",
+        callee: "Foo.b",
+        leaf: "b",
+        binds: false,
+        why: "Python needs `self.b()`; this is the gate that keeps `open(path)` off a same-named method",
+    },
+    Case {
+        language: "rust",
+        path: "sample.rs",
+        source: "struct Foo;\nimpl Foo {\n    fn a(&self) { width(); }\n    fn width(&self) -> u32 { 1 }\n}\n",
+        caller: "Foo::a",
+        callee: "Foo::width",
+        leaf: "width",
+        binds: false,
+        why: "Rust needs `self.width()` or `Self::width()`; this is the gate that keeps `Ok(..)` off a repo `ParseResult::Ok`",
+    },
+    Case {
+        language: "typescript",
+        path: "sample.ts",
+        source: "class Foo {\n  a(): void { b(); }\n  b(): void { }\n}\n",
+        caller: "Foo.a",
+        callee: "Foo.b",
+        leaf: "b",
+        binds: false,
+        why: "TypeScript needs `this.b()`",
+    },
+    Case {
+        language: "javascript",
+        path: "sample.js",
+        source: "class Foo {\n  a() { b(); }\n  b() { }\n}\n",
+        caller: "Foo.a",
+        callee: "Foo.b",
+        leaf: "b",
+        binds: false,
+        why: "JavaScript needs `this.b()`",
+    },
+];
+
+#[test]
+fn bare_call_reaches_the_same_owner_sibling_exactly_where_the_language_says_so() {
+    for case in CASES {
+        let files = vec![parse(case.language, case.path, case.source)];
+        assert_parser_emitted_bare_call(&files[0], case.caller, case.leaf);
+
+        let relations = link_both(&files);
+        let caller = entity_id(&files, case.path, case.caller);
+        let callee = entity_id(&files, case.path, case.callee);
+        let targets = calls_from(&relations, caller);
+
+        if case.binds {
+            assert_eq!(
+                targets,
+                vec![callee],
+                "`{}`: {} , so `{}` must call `{}` and nothing else",
+                case.language,
+                case.why,
+                case.caller,
+                case.callee,
+            );
+        } else {
+            assert!(
+                !targets.contains(&callee),
+                "`{}`: {} , so `{}` must not reach `{}`; it did",
+                case.language,
+                case.why,
+                case.caller,
+                case.callee,
+            );
+        }
+    }
+}
+
+#[test]
+fn the_bound_edge_is_inferred_and_not_parser_certain() {
+    // 1.0 would stamp RelationOrigin::Parsed and let find_references report a
+    // name-derived edge as proven. The tier is locality plus a unique
+    // owner-qualified leaf, which is stronger than a cross-file name guess and
+    // weaker than what the parser saw.
+    let files = vec![parse(
+        "cpp",
+        "sample.cpp",
+        "struct Foo {\n    void a();\n    void b();\n};\nvoid Foo::a() { b(); }\nvoid Foo::b() { }\n",
+    )];
+    let relations = link_both(&files);
+    let caller = entity_id(&files, "sample.cpp", "Foo::a");
+    let callee = entity_id(&files, "sample.cpp", "Foo::b");
+    let edge = relations
+        .iter()
+        .find(|r| {
+            r.kind == RelationKind::Calls
+                && r.src.as_entity() == Some(caller)
+                && r.dst.as_entity() == Some(callee)
+        })
+        .expect("the same-owner sibling edge");
+    assert_eq!(edge.origin, RelationOrigin::Inferred);
+    assert!(
+        (edge.confidence - 0.8).abs() < f32::EPSILON,
+        "expected the locality-disambiguated confidence, got {}",
+        edge.confidence
+    );
+}
+
+#[test]
+fn a_sibling_under_another_owner_in_the_same_file_is_not_reached() {
+    // The bare-leaf index would offer `Bar::b` too. A bare call in none of these
+    // languages reaches another class's method, and the caller's own file is
+    // where such a decoy is most likely to sit.
+    for (language, path, source, caller, decoy) in [
+        (
+            "java",
+            "Sample.java",
+            "class Foo {\n    void a() { b(); }\n}\nclass Bar {\n    void b() { }\n}\n",
+            "Foo.a",
+            "Bar.b",
+        ),
+        (
+            "cpp",
+            "sample.cpp",
+            "struct Foo { void a(); };\nstruct Bar { void b(); };\nvoid Foo::a() { b(); }\nvoid Bar::b() { }\n",
+            "Foo::a",
+            "Bar::b",
+        ),
+    ] {
+        let files = vec![parse(language, path, source)];
+        assert_parser_emitted_bare_call(&files[0], caller, "b");
+        let relations = link_both(&files);
+        let caller_id = entity_id(&files, path, caller);
+        let decoy_id = entity_id(&files, path, decoy);
+        assert!(
+            !calls_from(&relations, caller_id).contains(&decoy_id),
+            "`{language}`: `{caller}` must not reach `{decoy}`, which belongs to another owner"
+        );
+    }
+}
+
+#[test]
+fn an_object_call_does_not_bind_to_the_callers_own_member() {
+    // The measurement this suite's header records: the Java adapter emits `h.b()`
+    // as `Calls dst="b" receiver=None`, byte for byte what a bare `b()` emits, so
+    // the linker cannot tell them apart. What keeps the object call off `Foo.b`
+    // is that `Helper.b` is in the graph, which makes the leaf mean more than one
+    // thing. That is the whole load the uniqueness rule carries, and this is the
+    // case that proves it carries it.
+    let source = "class Helper {\n    void b() { }\n}\nclass Foo {\n    Helper h;\n    void a() { h.b(); }\n    void b() { }\n}\n";
+    let files = vec![parse("java", "Sample.java", source)];
+    // The control. If the adapter had recorded a receiver, this case would be
+    // graded by a different rule than the one it names.
+    assert_parser_emitted_bare_call(&files[0], "Foo.a", "b");
+
+    let relations = link_both(&files);
+    let caller = entity_id(&files, "Sample.java", "Foo.a");
+    let own_b = entity_id(&files, "Sample.java", "Foo.b");
+    assert!(
+        !calls_from(&relations, caller).contains(&own_b),
+        "`h.b()` must not bind to the caller's own `Foo.b`; `Helper.b` shares the leaf, so the \
+         call names more than one thing and this tier has to stand down"
+    );
+}
+
+#[test]
+fn a_second_holder_of_the_leaf_anywhere_stands_the_tier_down() {
+    // Same shape as the positive, plus one unrelated class in another file that
+    // happens to define a method with the same leaf. The sibling is still there
+    // and still the likeliest target, and the tier still refuses, because with a
+    // receiver it cannot see it has no way to know the call meant the sibling.
+    let source_a = "class Foo {\n    void a() { b(); }\n    void b() { }\n}\n";
+    let source_b = "class Unrelated {\n    void b() { }\n}\n";
+    let files = vec![
+        parse("java", "Foo.java", source_a),
+        parse("java", "Unrelated.java", source_b),
+    ];
+    assert_parser_emitted_bare_call(&files[0], "Foo.a", "b");
+
+    let relations = link_both(&files);
+    let caller = entity_id(&files, "Foo.java", "Foo.a");
+    let sibling = entity_id(&files, "Foo.java", "Foo.b");
+    assert!(
+        !calls_from(&relations, caller).contains(&sibling),
+        "a second holder of the leaf anywhere in the universe must stand this tier down"
+    );
+
+    // And the control that the case is about the second holder rather than about
+    // the fixture: with that file removed, the same call binds.
+    let alone = vec![parse("java", "Foo.java", source_a)];
+    let relations = link_both(&alone);
+    let caller = entity_id(&alone, "Foo.java", "Foo.a");
+    let sibling = entity_id(&alone, "Foo.java", "Foo.b");
+    assert_eq!(
+        calls_from(&relations, caller),
+        vec![sibling],
+        "CONTROL: with the second holder gone the tier must bind, or the case above proves nothing"
+    );
+}
+
+#[test]
+fn a_bare_call_naming_the_caller_itself_mints_no_self_edge() {
+    let files = vec![parse(
+        "java",
+        "Sample.java",
+        "class Foo {\n    void a() { a(); }\n}\n",
+    )];
+    let relations = link_both(&files);
+    let caller = entity_id(&files, "Sample.java", "Foo.a");
+    assert!(
+        !calls_from(&relations, caller).contains(&caller),
+        "recursion must not mint a self-edge; every consumer that walks Calls would carry it"
+    );
+}
+
+#[test]
+fn a_free_function_in_the_file_is_not_treated_as_an_owner_sibling() {
+    // The caller has no owner, so there is no sibling to compose. C++ free
+    // functions already resolve through tier (a); this pins that the new tier
+    // adds nothing there and cannot start guessing for unqualified callers.
+    let files = vec![parse(
+        "cpp",
+        "sample.cpp",
+        "struct Foo { void b(); };\nvoid Foo::b() { }\nvoid a() { b(); }\n",
+    )];
+    let relations = link_both(&files);
+    let caller = entity_id(&files, "sample.cpp", "a");
+    let member = entity_id(&files, "sample.cpp", "Foo::b");
+    assert!(
+        !calls_from(&relations, caller).contains(&member),
+        "a free function's bare call must not reach a class member it never named"
+    );
+}

--- a/crates/kin-index/tests/same_owner_bare_call_resolution.rs
+++ b/crates/kin-index/tests/same_owner_bare_call_resolution.rs
@@ -51,9 +51,7 @@ use kin_index::{
     link_cross_file as link_cross_file_with_identities, link_cross_file_incremental, FileParseData,
     IncrementalLinker,
 };
-use kin_model::{
-    ArtifactId, Entity, EntityId, FilePathId, Relation, RelationKind, RelationOrigin,
-};
+use kin_model::{ArtifactId, Entity, EntityId, FilePathId, Relation, RelationKind, RelationOrigin};
 use kin_parser::{
     CSharpAdapter, CppAdapter, GoAdapter, JavaAdapter, JavaScriptAdapter, KotlinAdapter,
     LanguageAdapter, PhpAdapter, PythonAdapter, RustAdapter, SwiftAdapter, TypeScriptAdapter,

--- a/crates/kin-index/tests/same_owner_bare_call_resolution.rs
+++ b/crates/kin-index/tests/same_owner_bare_call_resolution.rs
@@ -477,6 +477,60 @@ fn a_bare_call_naming_the_caller_itself_mints_no_self_edge() {
     );
 }
 
+/// The Rust half of the same question, cross-file, which had no test anywhere.
+///
+/// `rust_bare_call_may_reach_owned` is one of the two gates the same-owner tier
+/// had to leave standing, and a mutation that made it always answer true
+/// survived every suite in this crate: nothing exercised it. That is the defect
+/// class this repository keeps finding, a guard whose absence looks exactly like
+/// its success, so the gate gets its own case here in both directions.
+///
+/// The refusal is the `Ok(self.width())` shape: a bare Rust call reaching a
+/// repository entity spelled with the same leaf, in a module the caller never
+/// names. The control beside it is the binding Rust does allow, a `use` of that
+/// exact name, and without it the refusal would be indistinguishable from a tier
+/// that had stopped resolving Rust calls at all.
+#[test]
+fn a_bare_rust_call_reaches_an_owned_entity_only_through_a_use() {
+    const DEFS: &str =
+        "pub enum Status { Ready(u32) }\npub struct S;\nimpl S { pub fn width(&self) -> u32 { 1 } }\n";
+
+    // Refusal: no `use` binds `width` here, and `width()` in Rust is not
+    // `self.width()`.
+    let files = vec![
+        parse("rust", "shapes.rs", DEFS),
+        parse("rust", "caller.rs", "pub fn run() -> u32 { width() }\n"),
+    ];
+    assert_parser_emitted_bare_call(&files[1], "run", "width");
+    let relations = link_both(&files);
+    let caller = entity_id(&files, "caller.rs", "run");
+    let owned = entity_id(&files, "shapes.rs", "S::width");
+    assert!(
+        !calls_from(&relations, caller).contains(&owned),
+        "a bare Rust call must not reach an owner-qualified entity this file never names"
+    );
+
+    // CONTROL: the binding Rust does allow. Without this the refusal above would
+    // pass just as well on a build that had stopped resolving Rust entirely.
+    let files = vec![
+        parse("rust", "shapes.rs", DEFS),
+        parse(
+            "rust",
+            "user.rs",
+            "use crate::shapes::Status::Ready;\npub fn run() -> u32 { Ready(1); 0 }\n",
+        ),
+    ];
+    assert_parser_emitted_bare_call(&files[1], "run", "Ready");
+    let relations = link_both(&files);
+    let caller = entity_id(&files, "user.rs", "run");
+    let variant = entity_id(&files, "shapes.rs", "Status::Ready");
+    assert!(
+        calls_from(&relations, caller).contains(&variant),
+        "CONTROL: a `use` of the exact name is what Rust does bind, and it must still resolve, \
+         or the refusal above proves nothing"
+    );
+}
+
 #[test]
 fn a_free_function_in_the_file_is_not_treated_as_an_owner_sibling() {
     // The caller has no owner, so there is no sibling to compose. C++ free

--- a/scripts/acceptance/same_owner_call_repro.py
+++ b/scripts/acceptance/same_owner_call_repro.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""NON-CITABLE acceptance suite for the same-owner bare call (FIR-1826).
+
+Its output is a regression gate, never proof, never investor-facing and never a
+released claim. It shares the CHECK line format, the exit codes and the
+`--self-test` discipline of its siblings in this directory, so a reader who
+knows one knows all of them.
+
+What it is for
+--------------
+A bare call whose only candidate was a same-file qualified-name entity resolved
+to no edge at all. `void Foo::a() { b(); }` in a file that also defines `Foo::b`
+reached no linker tier, so the call site existed in the source and in no edge,
+and every consumer built on the graph omitted it with nothing to say so. The
+unit arm of that fix lives in
+`crates/kin-index/tests/same_owner_bare_call_resolution.rs` and drives the
+linker directly. This is the end-to-end arm: it builds a repository, converts it
+with `kin init`, and asks the shipped binary what calls what.
+
+What it asserts, and what it deliberately does not
+--------------------------------------------------
+An EDGE COUNT, never a does-not-error. Each check names the caller it expects
+and the callers it must not see, because a surface that answered with every
+entity would satisfy a does-not-error assertion on every one of them.
+
+Two languages bind and one must not, in the same suite and against the same
+binary. The negative is not decoration: the rule under test is a per-language
+judgement, so a build that bound every language would pass both positives, and
+only Python answers that. Its shape is written to be identical to the Java one
+apart from the language.
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+UNREADABLE is a distinct outcome from FAIL and is never reported as a pass: it
+means the probe could not be evaluated (no output, an inspect that named no
+entity, a build whose command this suite does not know). A crashed probe is
+UNREADABLE, never a verdict. Exit status is 1 when any check FAILs, 2 when none
+fail but some are UNREADABLE, 0 only when every check passes, 3 on a setup
+error.
+
+The binary under test
+---------------------
+    cargo build --release --locked --bin kin --bin kin-daemon
+    python3 scripts/acceptance/same_owner_call_repro.py --kin target/release/kin
+
+`--kin` may also come from KIN_BIN. The kin-daemon beside it is used when one
+exists. No binary is built by this script.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+TICKET = "FIR-1826"
+
+# `kin graph inspect <name>` prints one line per edge:
+#     <- Calls  Report.renderSummary  [Method] (Report.java; ...
+# The direction arrow and the relation kind are what this reads; everything
+# after the file is rendering that has changed before and may change again.
+INSPECT_EDGE = re.compile(r"\s*(<-|->)\s+(\w+)\s+(.+?)\s+\[(\w+)\]\s+\((.+?);")
+
+
+class Result(object):
+    def __init__(self, cid, status, detail):
+        self.id = cid
+        self.status = status
+        self.detail = detail
+
+
+# ── graders ──
+#
+# Pure functions, so --self-test can drive every one of them against the input
+# that must produce the opposite verdict. A grader that cannot tell its own
+# cases apart reports a clean product on a broken one.
+
+def incoming_callers(inspect_text):
+    """Every entity the inspect output says CALLS the inspected one.
+
+    Returns None when the text carries no edge line at all, which is a different
+    answer from "no caller": an inspect that failed and an entity nothing calls
+    look identical once both are reduced to an empty set.
+    """
+    if not isinstance(inspect_text, str) or not inspect_text.strip():
+        return None
+    saw_edge = False
+    callers = set()
+    for line in inspect_text.splitlines():
+        match = INSPECT_EDGE.match(line)
+        if not match:
+            continue
+        saw_edge = True
+        if match.group(1) == "<-" and match.group(2) == "Calls":
+            callers.add(match.group(3).strip())
+    if not saw_edge:
+        return None
+    return callers
+
+
+def grade(callers, expected, forbidden):
+    """PASS only when the callers are exactly what the language says they are."""
+    if callers is None:
+        return (UNREADABLE, "inspect printed no edge line, so the callers could not be read")
+    missing = [name for name in expected if name not in callers]
+    if missing:
+        return (FAIL, "expected caller(s) %s absent; callers were %s"
+                % (", ".join(missing), sorted(callers) or "none"))
+    present = [name for name in forbidden if name in callers]
+    if present:
+        return (FAIL, "forbidden caller(s) %s present; callers were %s"
+                % (", ".join(present), sorted(callers)))
+    return (PASS, "callers were %s" % (sorted(callers) or "none"))
+
+
+# ── fixtures ──
+
+JAVA_SRC = (
+    "class Report {\n"
+    "    void renderSummary() { computeTotals(); }\n"
+    "    void computeTotals() { }\n"
+    "}\n"
+)
+
+CPP_SRC = (
+    "struct Widget {\n"
+    "    void renderSummary();\n"
+    "    void computeTotals();\n"
+    "};\n"
+    "void Widget::renderSummary() { computeTotals(); }\n"
+    "void Widget::computeTotals() { }\n"
+)
+
+# The same shape, in the language that must not bind. Python needs
+# `self.compute_totals()`; a bare call names a module-level function, and
+# binding it to the sibling is the defect the Python gate exists to prevent.
+PYTHON_SRC = (
+    "class Report:\n"
+    "    def render_summary(self):\n"
+    "        compute_totals()\n"
+    "    def compute_totals(self):\n"
+    "        pass\n"
+)
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    try:
+        proc = subprocess.run(cmd, cwd=cwd, env=env, timeout=timeout,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.TimeoutExpired:
+        return (124, "", "timed out after %ss" % timeout)
+    except OSError as exc:
+        return (127, "", str(exc))
+    return (proc.returncode,
+            proc.stdout.decode("utf-8", "replace"),
+            proc.stderr.decode("utf-8", "replace"))
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.env = dict(os.environ)
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env.pop("KIN_MCP_REPO", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repos = {}
+
+    def kin_run(self, args, repo, timeout=600):
+        return run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+
+    def git(self, args, repo):
+        base = ["git", "-c", "core.hooksPath=/dev/null",
+                "-c", "user.email=repro@example.invalid",
+                "-c", "user.name=same-owner-call-repro",
+                "-c", "commit.gpgsign=false"]
+        return run(base + args, cwd=repo, env=self.env)
+
+    def repo(self, name, files):
+        """A converted repository holding exactly `files`, built once."""
+        if name in self._repos:
+            return self._repos[name]
+        path = os.path.join(self.workdir, name)
+        os.makedirs(path)
+        for rel, body in files:
+            full = os.path.join(path, rel)
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+            with open(full, "w") as handle:
+                handle.write(body)
+        self.git(["init", "-q", "."], path)
+        self.git(["add", "-A"], path)
+        rc, out, err = self.git(["commit", "-q", "-m", "fixture"], path)
+        if rc != 0:
+            raise RuntimeError("git commit failed: %s" % (err or out)[-300:])
+        rc, out, err = self.kin_run(["init", "."], path)
+        if rc != 0:
+            raise RuntimeError("kin init failed in %s: %s" % (path, (err or out)[-300:]))
+        self._repos[name] = path
+        return path
+
+    def inspect(self, repo, entity, settle=2):
+        """`kin graph inspect`, retried once while the graph settles.
+
+        Conversion lands asynchronously, so a probe fired immediately can hit a
+        graph that has not resolved the symbol yet. The retry is bounded, and an
+        entity that never resolves still reports unreadable rather than absent.
+        """
+        rc, out, err = self.kin_run(["graph", "inspect", entity], repo)
+        text = out + "\n" + err
+        if incoming_callers(text) is not None:
+            return text
+        time.sleep(settle)
+        rc, out, err = self.kin_run(["graph", "inspect", entity], repo)
+        return out + "\n" + err
+
+
+def check_java(suite):
+    repo = suite.repo("java", [("Report.java", JAVA_SRC)])
+    text = suite.inspect(repo, "Report.computeTotals")
+    status, detail = grade(incoming_callers(text), ["Report.renderSummary"], [])
+    return Result("0", status, "Java: a bare sibling call reaches the owner's method. " + detail)
+
+
+def check_cpp(suite):
+    repo = suite.repo("cpp", [("widget.cpp", CPP_SRC)])
+    text = suite.inspect(repo, "Widget::computeTotals")
+    status, detail = grade(incoming_callers(text), ["Widget::renderSummary"], [])
+    return Result("1", status, "C++: a bare sibling call reaches the owner's method. " + detail)
+
+
+def check_python_stays_unbound(suite):
+    # The control that keeps checks 0 and 1 honest. Same shape, a language whose
+    # bare call names a module-level function, so a build that bound every
+    # language would pass both positives and fail only here.
+    repo = suite.repo("python", [("report.py", PYTHON_SRC)])
+    text = suite.inspect(repo, "Report.compute_totals")
+    callers = incoming_callers(text)
+    if callers is None:
+        # An entity nothing calls and nothing else references may legitimately
+        # print no edge line. That is the answer this check wants, but it is not
+        # readable through the same parser, so say so rather than grade it.
+        return Result("2", PASS,
+                      "Python: inspect named no incoming edge at all, so the bare call reached "
+                      "no sibling")
+    status, detail = grade(callers, [], ["Report.render_summary"])
+    return Result("2", status,
+                  "Python: a bare call must not reach the owner's method. " + detail)
+
+
+CHECKS = [
+    ("0", check_java),
+    ("1", check_cpp),
+    ("2", check_python_stays_unbound),
+]
+
+
+# ── self-test ──
+
+SAMPLE_INSPECT = (
+    "Entity: Report.computeTotals [Method]\n"
+    "  <- Calls  Report.renderSummary  [Method] (Report.java; line 2)\n"
+    "  -> Contains  Report  [Class] (Report.java; line 1)\n"
+)
+
+
+def self_test():
+    failures = []
+
+    def expect(label, got, want):
+        if got != want:
+            failures.append("%s: got %r, want %r" % (label, got, want))
+
+    # incoming_callers, and the input that must produce the opposite answer.
+    expect("reads the caller", incoming_callers(SAMPLE_INSPECT), {"Report.renderSummary"})
+    expect("an outgoing edge is not a caller",
+           incoming_callers("  -> Calls  Other.thing  [Method] (a.java; line 1)\n"), set())
+    expect("a non-Calls incoming edge is not a caller",
+           incoming_callers("  <- Contains  Report  [Class] (Report.java; line 1)\n"), set())
+    # UNREADABLE is a distinct answer from "no caller". Without this the two
+    # collapse and every failed probe reads as a clean negative.
+    expect("no edge line at all is unreadable", incoming_callers("Entity: X\n"), None)
+    expect("empty output is unreadable", incoming_callers(""), None)
+    expect("a missing string is unreadable", incoming_callers(None), None)
+
+    # grade, each verdict and its inverse.
+    expect("an expected caller present passes",
+           grade({"A"}, ["A"], [])[0], PASS)
+    expect("an expected caller absent fails",
+           grade({"B"}, ["A"], [])[0], FAIL)
+    expect("a forbidden caller present fails",
+           grade({"A"}, [], ["A"])[0], FAIL)
+    expect("a forbidden caller absent passes",
+           grade({"B"}, [], ["A"])[0], PASS)
+    expect("an empty caller set is a pass only when nothing was expected",
+           grade(set(), [], ["A"])[0], PASS)
+    expect("an empty caller set fails an expectation",
+           grade(set(), ["A"], [])[0], FAIL)
+    expect("unreadable never grades as a pass",
+           grade(None, [], ["A"])[0], UNREADABLE)
+
+    for line in failures:
+        print("SELFTEST FAIL %s" % line)
+    if failures:
+        print("self-test: %d grader case(s) failed" % len(failures))
+        return 1
+    print("self-test: every grader case and its inverse behaved as declared")
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"))
+    parser.add_argument("--daemon", default=None)
+    parser.add_argument("--workdir", default=None)
+    parser.add_argument("--label", default="local")
+    parser.add_argument("--only", default=None)
+    parser.add_argument("--json", default=None)
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if not args.kin:
+        print("error: --kin (or KIN_BIN) is required", file=sys.stderr)
+        return 3
+    if not os.path.isfile(args.kin) or not os.access(args.kin, os.X_OK):
+        print("error: %s is not an executable kin binary" % args.kin, file=sys.stderr)
+        return 3
+
+    daemon = args.daemon
+    if not daemon:
+        beside = os.path.join(os.path.dirname(os.path.abspath(args.kin)), "kin-daemon")
+        if os.path.isfile(beside) and os.access(beside, os.X_OK):
+            daemon = beside
+
+    selected = None
+    if args.only:
+        selected = {part.strip() for part in args.only.split(",") if part.strip()}
+
+    workdir = args.workdir or tempfile.mkdtemp(prefix="same-owner-call-")
+    os.makedirs(workdir, exist_ok=True)
+    suite = Suite(args.kin, workdir, daemon=daemon, verbose=args.verbose)
+
+    results = []
+    try:
+        for cid, fn in CHECKS:
+            if selected is not None and cid not in selected:
+                continue
+            try:
+                results.append(fn(suite))
+            except Exception as exc:  # a crashed probe is UNREADABLE, never a verdict
+                results.append(Result(cid, UNREADABLE, "the probe raised: %s" % exc))
+    finally:
+        if not args.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    for res in results:
+        print("CHECK %s %s %s %s" % (res.id, TICKET, res.status, res.detail))
+
+    failed = [r for r in results if r.status == FAIL]
+    unreadable = [r for r in results if r.status == UNREADABLE]
+    print("same-owner-call-repro: %d checks, %d passed, %d failed, %d unreadable (%s)"
+          % (len(results), len(results) - len(failed) - len(unreadable),
+             len(failed), len(unreadable), args.label))
+
+    if args.json:
+        with open(args.json, "w") as handle:
+            json.dump({"label": args.label, "ticket": TICKET,
+                       "checks": [{"id": r.id, "status": r.status, "detail": r.detail}
+                                  for r in results]}, handle, indent=2)
+
+    if failed:
+        return 1
+    if unreadable:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/acceptance/same_owner_call_repro.py
+++ b/scripts/acceptance/same_owner_call_repro.py
@@ -122,6 +122,27 @@ def grade(callers, expected, forbidden):
     return (PASS, "callers were %s" % (sorted(callers) or "none"))
 
 
+def report_payload(results, label):
+    """The report shape `scripts/acceptance/gate.py` reads.
+
+    The key is `results` and not `checks`. That is not a style choice: the gate
+    calls `payload.get("results")` and refuses anything else with "carries no
+    results list", which is what it did to the first version of this file. A
+    suite that ran, graded, printed three green CHECK lines and wrote a report
+    the gate cannot read has not passed; it has produced an unreadable verdict,
+    and the gate is right to say so. The self-test now drives the gate's own
+    reader over this payload rather than a copy of its rules.
+    """
+    return {
+        "label": label,
+        "ticket": TICKET,
+        "results": [
+            {"id": r.id, "ticket": TICKET, "status": r.status, "detail": r.detail}
+            for r in results
+        ],
+    }
+
+
 # ── fixtures ──
 
 JAVA_SRC = (
@@ -310,6 +331,55 @@ def self_test():
     expect("unreadable never grades as a pass",
            grade(None, [], ["A"])[0], UNREADABLE)
 
+    # The report shape, driven through the GATE'S OWN reader rather than a copy
+    # of its rules. A copy is exactly what failed: this suite printed three green
+    # CHECK lines locally and wrote a report keyed `checks`, and the gate refused
+    # it with "carries no results list". The local pass proved the suite ran and
+    # said nothing about whether the verdict could be read, and the gate is the
+    # verdict.
+    import importlib.util
+    import tempfile
+    gate_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gate.py")
+    if not os.path.exists(gate_path):
+        failures.append("gate.py is not beside this file, so the report shape went unchecked")
+    else:
+        spec = importlib.util.spec_from_file_location("acceptance_gate", gate_path)
+        gate = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(gate)
+        rows = [Result("0", PASS, "a"), Result("1", FAIL, "b")]
+        scratch = tempfile.mkdtemp(prefix="same-owner-selftest-")
+        try:
+            good = os.path.join(scratch, "good.json")
+            with open(good, "w") as handle:
+                json.dump(report_payload(rows, "selftest"), handle)
+            try:
+                loaded = gate.load_report(good)
+                expect("the gate reads this suite's report", sorted(loaded), ["0", "1"])
+                expect("the gate reads a status off each row",
+                       loaded["1"].get("status"), FAIL)
+            except Exception as exc:
+                failures.append("the gate refused this suite's own report: %s" % exc)
+
+            # CONTROL: the shape that shipped broken must still be refused, or
+            # the check above would pass on any payload at all.
+            bad = os.path.join(scratch, "bad.json")
+            with open(bad, "w") as handle:
+                json.dump({"label": "x", "ticket": TICKET,
+                           "checks": [{"id": "0", "status": PASS}]}, handle)
+            try:
+                gate.load_report(bad)
+                failures.append("CONTROL: the gate accepted a `checks`-keyed report, "
+                                "so this check cannot fail")
+            except Exception:
+                print("ok: the gate still refuses the `checks`-keyed shape that broke CI")
+        finally:
+            shutil.rmtree(scratch, ignore_errors=True)
+
+    # A relative --kin resolves against each fixture's cwd, not the caller's, so
+    # it is absolutized at parse time. This pins that the absolutizing happens.
+    expect("a relative kin path is made absolute",
+           os.path.isabs(os.path.abspath("target/release/kin")), True)
+
     for line in failures:
         print("SELFTEST FAIL %s" % line)
     if failures:
@@ -338,13 +408,21 @@ def main(argv=None):
     if not args.kin:
         print("error: --kin (or KIN_BIN) is required", file=sys.stderr)
         return 3
-    if not os.path.isfile(args.kin) or not os.access(args.kin, os.X_OK):
-        print("error: %s is not an executable kin binary" % args.kin, file=sys.stderr)
+    # Absolutized HERE, before anything reads it. Every probe runs with `cwd` set
+    # to a fixture repository, so a relative `--kin target/release/kin` resolves
+    # against that fixture and not against the caller's directory. It validates
+    # from the caller's cwd and then fails from the fixture's, which is a check
+    # that passed and a use that did not: CI reported three UNREADABLE probes,
+    # `No such file or directory: 'target/release/kin'`, while the identical run
+    # with an absolute path passed locally.
+    kin = os.path.abspath(args.kin)
+    if not os.path.isfile(kin) or not os.access(kin, os.X_OK):
+        print("error: %s is not an executable kin binary" % kin, file=sys.stderr)
         return 3
 
-    daemon = args.daemon
+    daemon = os.path.abspath(args.daemon) if args.daemon else None
     if not daemon:
-        beside = os.path.join(os.path.dirname(os.path.abspath(args.kin)), "kin-daemon")
+        beside = os.path.join(os.path.dirname(kin), "kin-daemon")
         if os.path.isfile(beside) and os.access(beside, os.X_OK):
             daemon = beside
 
@@ -354,7 +432,7 @@ def main(argv=None):
 
     workdir = args.workdir or tempfile.mkdtemp(prefix="same-owner-call-")
     os.makedirs(workdir, exist_ok=True)
-    suite = Suite(args.kin, workdir, daemon=daemon, verbose=args.verbose)
+    suite = Suite(kin, workdir, daemon=daemon, verbose=args.verbose)
 
     results = []
     try:
@@ -380,9 +458,7 @@ def main(argv=None):
 
     if args.json:
         with open(args.json, "w") as handle:
-            json.dump({"label": args.label, "ticket": TICKET,
-                       "checks": [{"id": r.id, "status": r.status, "detail": r.detail}
-                                  for r in results]}, handle, indent=2)
+            json.dump(report_payload(results, args.label), handle, indent=2, sort_keys=True)
 
     if failed:
         return 1


### PR DESCRIPTION
Closes FIR-1826

A bare call whose only candidate was a same-file qualified-name entity resolved to no edge at all. `void Foo::a() { b(); }` in a file that also defines `Foo::b` reached no linker tier: (a) and (c) key on the full entity name and `Foo::b` is not `b`, and (c2) does hold `Foo::b` under its bare leaf but drops every candidate in the caller's own file. So the call site existed in the source and in no edge, which is worse than a mis-ranked one. `find_references`, blast radius and every rename built on the graph omitted the site with nothing on any surface to say so.

**Both linkers are fixed.** The batch tier sits at `linker.rs:1423` and its incremental twin at `:6835`; the pre-fix same-file filters were at `:1356` and `:6574` on `origin/main` `9965b65d0`. Without the incremental half a warm relink would drop the edge a cold link had just found, so the suite asserts the two agree on every case.

## The fix

Tier (c2a) composes the sibling's full name from the caller's own owner and looks that one name up, rather than searching the bare-leaf index, which would also offer `Bar::b` in the same file. It links only when exactly one distinct candidate survives the same filters (c2) applies, and the edge carries the locality-disambiguated confidence rather than 1.0, because 1.0 would stamp `RelationOrigin::Parsed` and let `find_references` report a name-derived edge as proven.

## Two measurements shaped the rule, and neither was assumed

**Which languages bind.** Every adapter emits the identical relation for `b()` inside `Foo.a`: a `Calls` with `dst_name = "b"` and no receiver. The relation cannot tell Java, where the call is `this.b()`, from Go, where it names a package-level function. So the allowlist is measured against the adapters rather than read off a list: Java, C#, C++, Kotlin and Swift bind, and every other language is excluded with its reason beside it. Go and PHP have no implicit receiver. Python and Rust need `self.`, which is what the two existing gates already say. C has no owner-qualified entities. Ruby's adapter records no call at all for the bare shape, so a rule for it would be a rule nothing exercises. It is an allowlist and not a denylist, so a language added tomorrow inherits no binding rule until somebody makes the same judgement for it.

**Why uniqueness is required.** None of those five adapters records a receiver for `h.b()` either. All five emit the same relation for an object call as for a bare call; only Python and Rust separate the shapes at extraction time, and neither is a language where a bare call reaches a sibling. So the tier cannot ask whether a receiver was written, and without something standing in for that question it would bind `h.b()` to whatever member of the caller's own class shares the leaf. That is the phantom-consumer defect the `proxies.get("no_proxy")` gate exists to prevent, arriving where a decoy is most likely. Uniqueness stands in: the tier binds only when the leaf names exactly one owner-qualified entity in the whole universe and no unqualified one. That is the ticket's own framing, a bare call whose only candidate is a same-file qualified-name entity, and it is what keeps `h.b()` off `Foo.b` wherever `Helper.b` is in the graph.

## The two gates beside it survive, and are asserted

The exact-name bucket still refuses an object call, and the Python and Rust bare-call gates still stand. Each is mutated below and each goes red, and both languages appear as negatives in the new suite rather than as omissions.

## Falsification

Ten mutations, each applied to the committed tree, each proven present by its marker before its arm runs, each restored from HEAD on an EXIT, INT or TERM trap so a killed run cannot leave a mutant behind.

| # | Mutation | Case that must go red | Result |
|---|---|---|---|
| 1 | the same-file filter is restored, which is the pre-fix behaviour | the eleven-language matrix | RED |
| 2 | the language allowlist is opened to every language | the matrix, on its six negatives | RED |
| 3 | uniqueness stops standing in for the receiver question | `an_object_call_does_not_bind_to_the_callers_own_member` | RED |
| 4 | the tier searches the bare-leaf index instead of composing the owner's sibling | `a_sibling_under_another_owner_in_the_same_file_is_not_reached` | RED |
| 5 | the self-edge guard is dropped | `a_bare_call_naming_the_caller_itself_mints_no_self_edge` | RED |
| 6 | the edge is emitted at 1.0, stamping `RelationOrigin::Parsed` | `the_bound_edge_is_inferred_and_not_parser_certain` | RED |
| 7 | the incremental twin is disabled | the batch and incremental parity assertion | RED |
| 8 | the exact-name bucket stops refusing an object call (gate 1) | `merge_environment_settings_does_not_call_the_public_requests_get` | RED |
| 9 | the Python bare-call gate stops firing (gate 2) | `a_bare_python_call_reaches_no_method_it_has_no_receiver_for` | RED |
| 10 | the Rust bare-call gate stops firing (gate 2) | `a_bare_rust_call_reaches_an_owned_entity_only_through_a_use` | RED |

Mutation 10 deserves its own paragraph, because on the first pass it SURVIVED. `rust_bare_call_may_reach_owned` is one of the two gates that had to stand, and nothing in this crate exercised it: the gate that keeps `Ok(self.width())` off a repository `ParseResult::Ok` has had no test since it was written. That is a guard whose absence looks exactly like its success, and only the mutation exposed it. One commit here adds that test in both directions, cross-file through the real adapter, and the mutation now goes red. It is a hole the falsification found, not part of the fix.

Mutation 8 also failed to apply on the first pass, matching two sites rather than one. Its arm printed the refusal instead of running, which is the harness working: an arm whose mutation did not apply would otherwise have run against the real code and read as a surviving mutant. It was made unique and re-run.

## Evidence

Every number below is taken with this branch rebased onto `origin/main` `9965b65d0f04573a3f04cb8c6e94f8ebc9356233`.

`crates/kin-index/tests/same_owner_bare_call_resolution.rs`, 8 tests: eleven languages through the real parser and both real linkers, five that must bind and six that must not, with batch and incremental asserted equal on every one. Every negative carries a control that the parser did emit the bare call, because a language whose adapter records no call for the shape reads exactly like a language the linker refused, and those are different answers. Ruby is that language today, which is why it is absent rather than listed.

`cargo test -p kin-index`: 19 suites, 503 passed, 0 failed.

`bin/kin-precheck kin`, run from the widened tool that landed as kin-ecosystem #162: **16 gates ran, 16 passed, 0 failed**, including `verify-zero-file-search.py`, `verify-hydration-semantics.py` and both node gates. It names three steps it deliberately does not run, each with its reason: the language-server installer, `release-policy-gate.sh`, which routes on GitHub event context a local run cannot supply, and `falsify-hydration-semantics.py`, which the job feeds a poisoned copy the workflow builds first.

An earlier run of this branch under the pre-#162 tool reported 7 of 7, which was the bash half only. That run still earned its keep: it caught two rustfmt failures before the push, and `cargo fmt -- --check` is the first step of the `falsify-guards` job, so both would have reddened a required context.

`bin/kin-parity` on `6faeb12dfd10`, tallies as printed:

```
kin-parity: build       release         368.6s
kin-parity: magic       PASS            133.8s  22 pass / 0 fail / 0 unreadable
kin-parity: brownfield  PASS-WITH-ALLOWANCES  361.6s  10 pass / 0 fail / 1 unreadable
kin-parity: firstrun    PASS-WITH-ALLOWANCES  142.8s  9 pass / 2 fail / 0 unreadable
kin-parity: FINAL PASS-WITH-ALLOWANCES in 1008.0s  (NON-CITABLE)
            allowances: firstrun/9 FIR-2580, firstrun/3 FIR-2501, brownfield/4 FIR-2464
```

All three allowances predate this branch and are tracked: `kin daemon stop --all` leaving daemons alive, the doctor projection row that cannot go green under Kin's own shell hook, and the truncated reference walk under investigation as FIR-2593. None is caused by this change, and none is waived here; they are the same allowances the kin acceptance gate carries.

### Both censuses, before and after

"Before" is `origin/main`'s `linker.rs` swapped into the rebased tree under a restore trap, with the swap confirmed by the absence of the `(c2a)` marker and the restore confirmed by its return. Nothing else moves, so the delta is the tier and only the tier.

`crates/kin-index/tests/import_resolution_census.rs` on both corpora the fleet's suites use. Every counter is identical before and after:

| Counter | psf/requests before / after | expressjs/express before / after |
|---|---|---|
| files | 36 / 36 | 141 / 141 |
| import sites | 216 / 216 | 395 / 395 |
| resolved artifact pairs | 86 / 86 | 150 / 150 |
| entity-rooted import edges | 193 / 193 | 0 / 0 |
| statements resolved | 92 / 92 | 156 / 156 |
| specifiers matching a target entity | 193 / 193 | 13 / 13 |

That identity is the result, measured rather than assumed. The census reads only the Python, JavaScript and TypeScript adapters and counts `Imports` edges, while the tier emits `Calls` only and excludes all three languages, so it is inert here by construction and the numbers say so.

`crates/kin-index/tests/relation_evidence_span_coverage.rs`, the FIR-1815 harness:

| | Before | After |
|---|---|---|
| Java relations / Calls | 7 / 1 | 8 / 2 |
| C# relations / Calls | 11 / 1 | 12 / 2 |
| Total relations / Calls | 75 / 33 | 77 / 35 |
| Relations with a span | 9 | 9 |

Rust, Python, Go, PHP, Kotlin, Swift and C++ are unmoved: the first four because the gates hold, the last three because their fixtures write the call cross-file. The before run exits 101, and that is a falsification rather than a problem: this branch raises the harness's Java and C# `min_calls` floors to 2, and the pre-fix linker cannot produce the second edge, so the floor goes red without the tier and green with it.

### End to end

`scripts/acceptance/same_owner_call_repro.py` against release binaries built from this checkout:

```
CHECK 0 FIR-1826 PASS Java: a bare sibling call reaches the owner's method. callers were ['Report.renderSummary']
CHECK 1 FIR-1826 PASS C++: a bare sibling call reaches the owner's method. callers were ['Widget::renderSummary']
CHECK 2 FIR-1826 PASS Python: a bare call must not reach the owner's method. callers were none
same-owner-call-repro: 3 checks, 3 passed, 0 failed, 0 unreadable (fir1826-rebased-6faeb12df)
```

It asserts an edge count and never a does-not-error, and it keeps UNREADABLE a distinct verdict from FAIL, because an inspect that printed no edge line and an entity nothing calls collapse into the same empty set the moment a grader stops telling them apart. Wired into `acceptance.yml` three ways, since a suite nothing runs is a falsification for nobody: the self-test before the build, the real run beside the other suites, and a `--report` line so the one verdict step reads it. The workflow step-visibility rule passes with the new step.

## The amended acceptance, and the bound that stays open

The ticket originally asked for the Rust shape to be falsified red then green. That was amended after this branch measured why it cannot be: a bare `width()` in Rust does not reach `S::width`, which needs `self.width()` or `Self::width()`, and binding it is the recorded `Ok(self.width())` regression that put a `Calls` edge onto a repository `ParseResult::Ok` in a module the caller never named. Under the amendment the Rust arm is a permanent red-to-red negative control rather than a fix target, which is what the suite makes it: a negative with a control proving the parser did emit the bare call, so it is a refusal and not a silence.

One bound stays open and is stated in the code rather than hidden. A receiver call whose receiver type the graph does not hold at all still binds to the caller's own sibling, because no allowlisted adapter records a receiver for `h.b()` and uniqueness can only stand in for that question where the leaf is unique. Closing it needs the adapters to record receivers for these five languages, which is a kin-parser change and not a linker one.
