### PR TITLE
Give import evidence a source span, and define rename's semantics for it

### DIFF
--- a/crates/kin-cli/src/commands/rename.rs
+++ b/crates/kin-cli/src/commands/rename.rs
@@ -211,14 +211,15 @@ where
                 source_id
             )
         })?;
-        let expected = relation_occurrence_count(&relation)?;
+        let (unspanned, spanned) = relation_occurrence_split(&relation)?;
         let group = grouped
             .entry(source_id)
             .or_insert_with(|| ReferenceGroup::new(source));
         group.expected = group
             .expected
-            .checked_add(expected)
+            .checked_add(unspanned)
             .ok_or_else(|| anyhow::anyhow!("rename reference occurrence count overflow"))?;
+        group.scoped.extend(spanned);
         group
             .kinds
             .insert(format!("{:?}", relation.kind).to_ascii_lowercase());
@@ -262,17 +263,6 @@ where
         }
         require_complete_layout(graph, file)?;
         let body = load_cached_body(&tree, file, &mut bodies, &mut load_source)?;
-        let occurrences = find_token_occurrences(body, &target.name, span, group.entity.language)?;
-        if occurrences.len() != group.expected {
-            bail!(
-                "rename authority is incomplete for entity {} in {}: graph relations plus declaration require {} '{}' occurrence(s) inside the exact source span, but repository CAS contains {}; refusing a partial or over-broad edit",
-                group.entity.id,
-                file,
-                group.expected,
-                target.name,
-                occurrences.len()
-            );
-        }
         let reason = if group.declaration && group.kinds.is_empty() {
             "declaration".to_string()
         } else if group.declaration {
@@ -280,10 +270,51 @@ where
         } else {
             relation_reason(&group.kinds)
         };
-        for (occurrence_index, occurrence) in occurrences.into_iter().enumerate() {
-            let key = (file.clone(), occurrence.start_byte, occurrence.end_byte);
-            if let Some(other_entity) = seen.insert(key, group.entity.id) {
+
+        // One search per span the group expects occurrences in, rather than one
+        // search over the source entity. The entity-wide pass runs only when
+        // some evidence asked for it, so an edge whose evidence named its own
+        // span is never searched across the whole entity.
+        //
+        // The entity pass keeps `declaration: true` for its first occurrence
+        // and a scoped pass never claims it: the declaration is a site in the
+        // entity's own span by definition, and a scoped span is a reference
+        // somewhere else.
+        let mut passes: Vec<(&kin_model::SourceSpan, usize, bool)> = Vec::new();
+        if group.expected > 0 || group.declaration {
+            passes.push((span, group.expected, true));
+        }
+        for (scoped_span, scoped_expected) in &group.scoped {
+            if scoped_span.file != *file {
                 bail!(
+                    "graph-linked rename evidence for entity {} names a span in {} but the entity's origin is {}",
+                    group.entity.id,
+                    scoped_span.file,
+                    file
+                );
+            }
+            passes.push((scoped_span, *scoped_expected, false));
+        }
+
+        for (search_span, expected, is_entity_span) in passes {
+            let occurrences =
+                find_token_occurrences(body, &target.name, search_span, group.entity.language)?;
+            if occurrences.len() != expected {
+                bail!(
+                "rename authority is incomplete for entity {} in {}: graph relations plus declaration require {} '{}' occurrence(s) inside the exact source span {}..{}, but repository CAS contains {}; refusing a partial or over-broad edit",
+                group.entity.id,
+                file,
+                expected,
+                target.name,
+                search_span.start_byte,
+                search_span.end_byte,
+                occurrences.len()
+            );
+            }
+            for (occurrence_index, occurrence) in occurrences.into_iter().enumerate() {
+                let key = (file.clone(), occurrence.start_byte, occurrence.end_byte);
+                if let Some(other_entity) = seen.insert(key, group.entity.id) {
+                    bail!(
                     "rename occurrence {}:{}..{} is claimed by overlapping graph source entities {} and {}; refusing to count one token as two relation sites",
                     file,
                     occurrence.start_byte,
@@ -291,20 +322,21 @@ where
                     other_entity,
                     group.entity.id
                 );
+                }
+                edits.push(RenameEdit {
+                    file: file.clone(),
+                    start_byte: occurrence.start_byte,
+                    end_byte: occurrence.end_byte,
+                    start_line: occurrence.start_line,
+                    start_col: occurrence.start_col,
+                    end_line: occurrence.end_line,
+                    end_col: occurrence.end_col,
+                    old_text: target.name.clone(),
+                    new_text: request.new_name.clone(),
+                    reason: reason.clone(),
+                    declaration: is_entity_span && group.declaration && occurrence_index == 0,
+                });
             }
-            edits.push(RenameEdit {
-                file: file.clone(),
-                start_byte: occurrence.start_byte,
-                end_byte: occurrence.end_byte,
-                start_line: occurrence.start_line,
-                start_col: occurrence.start_col,
-                end_line: occurrence.end_line,
-                end_col: occurrence.end_col,
-                old_text: target.name.clone(),
-                new_text: request.new_name.clone(),
-                reason: reason.clone(),
-                declaration: group.declaration && occurrence_index == 0,
-            });
         }
     }
     edits.sort_by(|left, right| {
@@ -470,11 +502,38 @@ where
             })
         });
         if imported_target {
-            bail!(
-                "{} imports '{}', but graph import evidence has no exact source span; refusing to skip or guess at that edit site",
-                importer_file,
-                target.name
-            );
+            // The parser sees this file importing the target. That used to be
+            // an automatic refusal, and the refusal was right at the time: an
+            // import edge is sourced at the importing file's module entity,
+            // whose span is the whole file, so the planner's only reachable
+            // span found every mention of the name rather than the import site
+            // and could not satisfy any count. FIR-1825 gave call sites spans
+            // and left import sites without; this is its residual, FIR-2690.
+            //
+            // The question is no longer "is it imported" but "did the site
+            // survive into the graph". Refuse only when it did not, so a store
+            // indexed before import spans existed still refuses loudly rather
+            // than renaming against evidence it does not have.
+            let spanned_here = graph
+                .get_all_relations_for_entity(&target.id)?
+                .into_iter()
+                .any(|relation| {
+                    relation.dst == GraphNodeId::Entity(target.id)
+                        && relation.kind == RelationKind::Imports
+                        && relation.evidence.iter().any(|evidence| {
+                            evidence
+                                .source_span
+                                .as_ref()
+                                .is_some_and(|span| span.file == importer_file)
+                        })
+                });
+            if !spanned_here {
+                bail!(
+                    "{} imports '{}', but graph import evidence has no exact source span; refusing to skip or guess at that edit site",
+                    importer_file,
+                    target.name
+                );
+            }
         }
         source_languages.insert(importer_file, indexed.language);
     }
@@ -521,7 +580,17 @@ fn prove_repository_occurrence_accounting(
         if entity_leaf(&relation_target.name) != target.name {
             continue;
         }
-        let count = relation_occurrence_count(relation)?;
+        // The repository-wide accounting wants the TOTAL, span or no span. Its
+        // observed side attributes every occurrence to the smallest entity span
+        // containing it, so a top-level import statement lands on the module
+        // entity, which is the same entity the import edge is sourced at. The
+        // split matters to the planner, which searches per span; it does not
+        // matter here, where both sides count whole entities.
+        let (unspanned, spanned) = relation_occurrence_split(relation)?;
+        let count = spanned
+            .iter()
+            .try_fold(unspanned, |total, (_, scoped)| total.checked_add(*scoped))
+            .ok_or_else(|| anyhow::anyhow!("repository rename occurrence count overflow"))?;
         let entry = expected.entry(source_id).or_default();
         *entry = entry
             .checked_add(count)
@@ -613,7 +682,19 @@ fn entity_leaf(name: &str) -> &str {
 
 struct ReferenceGroup {
     entity: Entity,
+    /// Occurrences expected inside the SOURCE ENTITY's own span, from evidence
+    /// that named no span of its own. This is every edge's behaviour before
+    /// FIR-2690 and stays exactly that.
     expected: usize,
+    /// Occurrences expected inside a span the evidence named itself.
+    ///
+    /// An entity-level import edge is sourced at the importing file's module
+    /// entity, whose span is the whole file. Searching that span finds every
+    /// mention of the name rather than the import site, so the count can never
+    /// match and `kin rename` refused outright. Evidence that carries its own
+    /// span is searched inside THAT span instead, which turns one impossible
+    /// whole-file check into one exact check per import statement.
+    scoped: Vec<(kin_model::SourceSpan, usize)>,
     kinds: BTreeSet<String>,
     relation_ids: BTreeSet<kin_model::RelationId>,
     declaration: bool,
@@ -624,6 +705,7 @@ impl ReferenceGroup {
         Self {
             entity,
             expected: 0,
+            scoped: Vec::new(),
             kinds: BTreeSet::new(),
             relation_ids: BTreeSet::new(),
             declaration: false,
@@ -631,26 +713,46 @@ impl ReferenceGroup {
     }
 }
 
-fn relation_occurrence_count(relation: &Relation) -> Result<usize> {
+/// Split a relation's expected occurrences into the ones searched inside the
+/// SOURCE ENTITY's span and the ones searched inside a span the evidence named.
+///
+/// Evidence that names no span behaves exactly as it always did: its count is
+/// added to the entity-wide expectation. Evidence that names one is checked
+/// inside that span alone, which is what makes an import edge renameable. An
+/// import edge is sourced at a module entity spanning the whole file, so the
+/// entity-wide search finds every mention of the name and the count can never
+/// match; the import statement's own span contains exactly the occurrences the
+/// evidence counted.
+///
+/// A relation with no evidence at all still expects one occurrence in the
+/// entity span, unchanged.
+fn relation_occurrence_split(
+    relation: &Relation,
+) -> Result<(usize, Vec<(kin_model::SourceSpan, usize)>)> {
     if relation.evidence.is_empty() {
-        return Ok(1);
+        return Ok((1, Vec::new()));
     }
-    relation
-        .evidence
-        .iter()
-        .try_fold(0_usize, |total, evidence| {
-            let count = usize::try_from(evidence.occurrence_count)
-                .context("rename relation occurrence count does not fit usize")?;
-            if count == 0 {
-                bail!(
-                    "rename relation {} carries a zero occurrence evidence record",
-                    relation.id
-                );
+    let mut unspanned = 0_usize;
+    let mut spanned = Vec::new();
+    for evidence in &relation.evidence {
+        let count = usize::try_from(evidence.occurrence_count)
+            .context("rename relation occurrence count does not fit usize")?;
+        if count == 0 {
+            bail!(
+                "rename relation {} carries a zero occurrence evidence record",
+                relation.id
+            );
+        }
+        match evidence.source_span.as_ref() {
+            Some(span) => spanned.push((span.clone(), count)),
+            None => {
+                unspanned = unspanned
+                    .checked_add(count)
+                    .ok_or_else(|| anyhow::anyhow!("rename relation occurrence count overflow"))?
             }
-            total
-                .checked_add(count)
-                .ok_or_else(|| anyhow::anyhow!("rename relation occurrence count overflow"))
-        })
+        }
+    }
+    Ok((unspanned, spanned))
 }
 
 fn require_complete_layout(graph: &impl GraphStore, file: &FilePathId) -> Result<()> {
@@ -1193,7 +1295,7 @@ mod tests {
                 ..kin_model::RelationEvidence::default()
             }],
         };
-        assert!(relation_occurrence_count(&relation)
+        assert!(relation_occurrence_split(&relation)
             .unwrap_err()
             .to_string()
             .contains("zero occurrence"));

--- a/crates/kin-cli/tests/repository_rename_planner.rs
+++ b/crates/kin-cli/tests/repository_rename_planner.rs
@@ -570,7 +570,25 @@ struct LanguageFixture {
     target_source: &'static str,
     caller_path: &'static str,
     caller_source: &'static str,
-    has_named_import_without_span: bool,
+    /// This language's fixture imports the target by name.
+    ///
+    /// It used to be `has_named_import_without_span`, and the refusal it drove
+    /// was correct while `FileImport` carried no span. FIR-2690 gave every
+    /// adapter one, so a named import is now a renameable SITE rather than a
+    /// reason to refuse, and these fixtures assert the edit instead of the
+    /// error. The spanless case still has a test: a hand-built graph whose
+    /// import evidence names no span, below, which must still refuse.
+    has_named_import: bool,
+    /// This language emits a MODULE entity for an ordinary source file.
+    ///
+    /// An entity-level import edge is sourced at the importing file's module
+    /// entity. JavaScript and TypeScript emit one only for index files
+    /// (FIR-2675), so for them there is no source entity to hang the edge on,
+    /// no edge, and therefore no spanned evidence however good the parser's
+    /// span is. Their refusal is real and is asserted below rather than hidden,
+    /// because a suite that quietly skips the languages it cannot serve reports
+    /// coverage it does not have.
+    emits_module_entity_per_file: bool,
     /// Whether this language's adapter records a call site, so its `Calls`
     /// evidence carries a `source_span` (FIR-1825). The planner does not read
     /// spans, so its behavior below is the same either way; this keeps the
@@ -592,7 +610,8 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         target_source: "pub fn target() -> u32 { 1 }\n",
         caller_path: "caller.rs",
         caller_source: "pub fn caller() -> u32 { target() + target() }\n",
-        has_named_import_without_span: false,
+        has_named_import: false,
+        emits_module_entity_per_file: true,
         records_call_sites: false,
     },
     LanguageFixture {
@@ -601,7 +620,8 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         target_source: "export function target(): number { return 1; }\n",
         caller_path: "caller.ts",
         caller_source: "import { target } from './defs';\nexport function caller(): number { return target() + target(); }\n",
-        has_named_import_without_span: true,
+        has_named_import: true,
+        emits_module_entity_per_file: false,
         records_call_sites: true,
     },
     LanguageFixture {
@@ -610,7 +630,8 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         target_source: "export function target() { return 1; }\n",
         caller_path: "caller.js",
         caller_source: "import { target } from './defs';\nexport function caller() { return target() + target(); }\n",
-        has_named_import_without_span: true,
+        has_named_import: true,
+        emits_module_entity_per_file: false,
         records_call_sites: true,
     },
     LanguageFixture {
@@ -619,7 +640,8 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         target_source: "def target():\n    return 1\n",
         caller_path: "caller.py",
         caller_source: "from defs import target\n\ndef caller():\n    return target() + target()\n",
-        has_named_import_without_span: true,
+        has_named_import: true,
+        emits_module_entity_per_file: true,
         records_call_sites: true,
     },
     LanguageFixture {
@@ -628,7 +650,8 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         target_source: "package main\n\nfunc target() int { return 1 }\n",
         caller_path: "caller.go",
         caller_source: "package main\n\nfunc caller() int { return target() + target() }\n",
-        has_named_import_without_span: false,
+        has_named_import: false,
+        emits_module_entity_per_file: true,
         records_call_sites: false,
     },
     LanguageFixture {
@@ -637,7 +660,8 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         target_source: "class Defs { static int target() { return 1; } }\n",
         caller_path: "Caller.java",
         caller_source: "class Caller { int caller() { return target() + target(); } }\n",
-        has_named_import_without_span: false,
+        has_named_import: false,
+        emits_module_entity_per_file: true,
         records_call_sites: false,
     },
     LanguageFixture {
@@ -646,7 +670,8 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         target_source: "int target(void) { return 1; }\n",
         caller_path: "caller.c",
         caller_source: "int caller(void) { return target() + target(); }\n",
-        has_named_import_without_span: false,
+        has_named_import: false,
+        emits_module_entity_per_file: true,
         records_call_sites: false,
     },
     LanguageFixture {
@@ -655,7 +680,8 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         target_source: "int target() { return 1; }\n",
         caller_path: "caller.cpp",
         caller_source: "int caller() { return target() + target(); }\n",
-        has_named_import_without_span: false,
+        has_named_import: false,
+        emits_module_entity_per_file: true,
         records_call_sites: false,
     },
 ];
@@ -787,13 +813,52 @@ fn real_linker_spanless_relations_are_exact_or_refused_across_eight_languages() 
                 Ok(bodies.get(path).unwrap().clone())
             },
         );
-        if fixture.has_named_import_without_span {
+        if fixture.has_named_import && !fixture.emits_module_entity_per_file {
+            // FIR-2675, not FIR-2690. The parser records this language's import
+            // span correctly; there is simply no module entity to source the
+            // edge at, so no entity-level import edge exists and no evidence
+            // carries the span. The refusal is right and stays asserted, so
+            // this suite says out loud which languages the import fix does not
+            // reach yet.
             let error = result.unwrap_err();
             assert!(
                 error
                     .to_string()
                     .contains("graph import evidence has no exact source span"),
-                "{} must refuse its unspanned named import: {error:#}",
+                "{} has no per-file module entity, so its import edge cannot exist yet: {error:#}",
+                fixture.name
+            );
+        } else if fixture.has_named_import {
+            // FIR-2690. This branch asserted the refusal until every adapter
+            // recorded an import span. It now asserts the thing the refusal was
+            // standing in for: the import statement is edited like any other
+            // reference site.
+            let plan = result.unwrap_or_else(|error| {
+                panic!(
+                    "{} imports the target by name and every adapter now records the site, so \
+                     the rename must reach it: {error:#}",
+                    fixture.name
+                )
+            });
+            let import_edits: Vec<&_> = plan
+                .edits
+                .iter()
+                .filter(|edit| edit.reason.contains("imports"))
+                .collect();
+            assert_eq!(
+                import_edits.len(),
+                1,
+                "{} must edit its import site exactly once, got {:?}",
+                fixture.name,
+                plan.edits
+            );
+            // The count is the assertion that matters. Three edits is what this
+            // fixture produced while the import site was unreachable, so a plan
+            // that still holds three is one where the span changed nothing.
+            assert_eq!(
+                plan.edits.len(),
+                4,
+                "{} expects the declaration, two call sites and the import site",
                 fixture.name
             );
         } else if target.name != "target" {

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -4616,6 +4616,13 @@ fn make_entity_import_relations(
                 resolved_path: Some(resolved_path.to_string()),
                 parser_rule: Some(IMPORT_SPECIFIER_BINDING_RULE.to_string()),
                 occurrence_count: 1,
+                // The import statement's own bytes, which is what makes this
+                // edge renameable. Without it a rename planner searches the
+                // SOURCE ENTITY's span, and this edge is sourced at the
+                // importing file's module entity whose span is the whole file,
+                // so it finds every mention of the name rather than the import
+                // site and refuses on a count it can never satisfy.
+                source_span: Some(import.site.to_source_span(&FilePathId::new(importer_file))),
                 ..RelationEvidence::default()
             }],
         });

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -6989,6 +6989,29 @@ mod tests {
         GraphNodeId, Hash256, LanguageId, SemanticFingerprint, SourceSpan, Visibility,
     };
     use kin_parser::ImportedName;
+
+    /// A well-formed but synthetic import site, for fixtures whose subject is
+    /// not the span.
+    ///
+    /// These fixtures hand-build `FileImport` to exercise resolution, so they
+    /// need the field to be present and shaped correctly and nothing more.
+    /// Every test whose subject IS the span parses real source and reads the
+    /// parser's own site; see `crates/kin-parser/tests/import_span_coverage.rs`.
+    /// Naming this "synthetic" rather than "default" is deliberate: a helper
+    /// called `default_site()` reads like something a production path could
+    /// reasonably reach for, and nothing in production may invent a span.
+    fn synthetic_import_site() -> kin_parser::RelationSite {
+        kin_parser::RelationSite {
+            start_byte: 0,
+            end_byte: 1,
+            start_line: 1,
+            start_col: 0,
+            end_line: 1,
+            end_col: 1,
+            syntactic_role: None,
+        }
+    }
+
     use std::sync::{Mutex, OnceLock};
 
     #[test]
@@ -7844,6 +7867,7 @@ mod tests {
                     entities: vec![caller.clone()],
                     relations,
                     imports: vec![FileImport {
+                        site: synthetic_import_site(),
                         module_path: "crate::model".to_string(),
                         specifiers: vec![],
                     }],
@@ -7921,6 +7945,7 @@ mod tests {
                     import_source: None,
                 }],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "../utils/tools".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "executeTool".to_string(),
@@ -7980,6 +8005,7 @@ mod tests {
                 import_source: None,
             }],
             imports: vec![FileImport {
+                site: synthetic_import_site(),
                 module_path: "../utils/tools".to_string(),
                 specifiers: vec![kin_parser::ImportedName {
                     local_name: "executeTool".to_string(),
@@ -8069,6 +8095,7 @@ mod tests {
             import_source: None,
         };
         let import = |module: &str, name: &str| FileImport {
+            site: synthetic_import_site(),
             module_path: module.to_string(),
             specifiers: vec![kin_parser::ImportedName {
                 local_name: name.to_string(),
@@ -8162,6 +8189,7 @@ mod tests {
             imports: vec![],
         };
         let header_import = |module: &str| FileImport {
+            site: synthetic_import_site(),
             module_path: module.to_string(),
             specifiers: vec![],
         };
@@ -8206,6 +8234,7 @@ mod tests {
     #[test]
     fn artifact_import_edges_parallel_match_serial() {
         let import = |module: &str, name: &str| FileImport {
+            site: synthetic_import_site(),
             module_path: module.to_string(),
             specifiers: vec![kin_parser::ImportedName {
                 local_name: name.to_string(),
@@ -8441,6 +8470,7 @@ mod tests {
                     import_source: None,
                 }],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "../utils/worker".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "execute".to_string(),
@@ -8495,6 +8525,7 @@ mod tests {
                     import_source: None,
                 }],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "json/macros.hpp".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "macros.hpp".to_string(),
@@ -8668,6 +8699,7 @@ void f();
                     import_source: None,
                 }],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "./util".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "util".to_string(),
@@ -8905,6 +8937,7 @@ void f();
 
     fn python_import(module_path: &str, names: &[&str]) -> FileImport {
         FileImport {
+            site: synthetic_import_site(),
             module_path: module_path.to_string(),
             specifiers: names
                 .iter()
@@ -9183,6 +9216,7 @@ void f();
                 entities: vec![caller.clone()],
                 relations: vec![bare_call("parse_file", "open")],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "notekeeper.compat".to_string(),
                     specifiers: Vec::new(),
                 }],
@@ -9524,6 +9558,7 @@ void f();
             .collect();
 
         let header = FileImport {
+            site: synthetic_import_site(),
             module_path: "helper.h".to_string(),
             specifiers: vec![],
         };
@@ -9537,6 +9572,7 @@ void f();
         );
 
         let module = FileImport {
+            site: synthetic_import_site(),
             module_path: "app.routing".to_string(),
             specifiers: vec![],
         };
@@ -9556,6 +9592,7 @@ void f();
     fn import_target_resolution_refuses_a_self_import() {
         let known: HashSet<&str> = ["lib/index.js"].into_iter().collect();
         let selfref = FileImport {
+            site: synthetic_import_site(),
             module_path: ".".to_string(),
             specifiers: vec![],
         };
@@ -9577,6 +9614,7 @@ void f();
 
         // `from .storage import Store, open_db`: ONE statement, two specifiers.
         let one_statement = vec![FileImport {
+            site: synthetic_import_site(),
             module_path: ".storage".to_string(),
             specifiers: vec![
                 ImportedName {
@@ -9603,6 +9641,7 @@ void f();
         // The same two names on separate lines: TWO statements.
         let two_statements = vec![
             FileImport {
+                site: synthetic_import_site(),
                 module_path: ".storage".to_string(),
                 specifiers: vec![ImportedName {
                     local_name: "Store".to_string(),
@@ -9611,6 +9650,7 @@ void f();
                 }],
             },
             FileImport {
+                site: synthetic_import_site(),
                 module_path: ".storage".to_string(),
                 specifiers: vec![ImportedName {
                     local_name: "open_db".to_string(),
@@ -9636,10 +9676,12 @@ void f();
         let known: HashSet<&str> = ["app/main.py", "app/storage.py"].into_iter().collect();
         let mixed = vec![
             FileImport {
+                site: synthetic_import_site(),
                 module_path: "re".to_string(),
                 specifiers: vec![],
             },
             FileImport {
+                site: synthetic_import_site(),
                 module_path: ".storage".to_string(),
                 specifiers: vec![],
             },
@@ -9860,6 +9902,7 @@ void f();
                     import_source: None,
                 }],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "./utils".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "myWork".to_string(),
@@ -9912,6 +9955,7 @@ void f();
                 entities: vec![importer.clone()],
                 relations: vec![],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "../utils/tools".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "executeTool".to_string(),
@@ -9956,6 +10000,7 @@ void f();
                 entities: vec![_importer.clone()],
                 relations: vec![],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "nlohmann/detail/input/binary_reader.hpp".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "binary_reader.hpp".to_string(),
@@ -10011,6 +10056,7 @@ void f();
                     import_source: None,
                 }],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "../utils/tools".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "executeTool".to_string(),
@@ -10048,6 +10094,7 @@ void f();
                 entities: vec![importer.clone()],
                 relations: vec![],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "./util".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "util".to_string(),
@@ -10384,6 +10431,7 @@ void f();
                     import_source: Some("../utils/tools".to_string()),
                 }],
                 imports: vec![FileImport {
+                    site: synthetic_import_site(),
                     module_path: "../utils/tools".to_string(),
                     specifiers: vec![kin_parser::ImportedName {
                         local_name: "executeTool".to_string(),
@@ -11545,6 +11593,7 @@ void f();
 
     fn include_import(module_path: &str) -> FileImport {
         FileImport {
+            site: synthetic_import_site(),
             module_path: module_path.to_string(),
             specifiers: vec![],
         }
@@ -12038,6 +12087,7 @@ void f();
 
     fn import_of(module_path: &str, local_name: &str) -> FileImport {
         FileImport {
+            site: synthetic_import_site(),
             module_path: module_path.to_string(),
             specifiers: vec![kin_parser::ImportedName {
                 local_name: local_name.to_string(),

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -31,6 +31,21 @@ use kin_parser::{
     PythonAdapter, TypeScriptAdapter,
 };
 
+/// A well-formed but synthetic import site. This suite's subject is cross-file
+/// resolution, not spans; the span's own coverage lives in
+/// `crates/kin-parser/tests/import_span_coverage.rs`, which parses real source.
+fn synthetic_import_site() -> kin_parser::RelationSite {
+    kin_parser::RelationSite {
+        start_byte: 0,
+        end_byte: 1,
+        start_line: 1,
+        start_col: 0,
+        end_line: 1,
+        end_col: 1,
+        syntactic_role: None,
+    }
+}
+
 // ---- helpers: direct entity construction (mirrors linker.rs unit-test idiom) ----
 
 fn zero_fp() -> SemanticFingerprint {
@@ -274,6 +289,7 @@ fn receiver_fanout_call_count(n: usize) -> usize {
         // all, and this helper would measure the FIR-1581 gate instead of the cap
         // it exists to measure. A glob import is the stand-down that gate documents.
         imports: vec![FileImport {
+            site: synthetic_import_site(),
             module_path: "crate::impls".to_string(),
             specifiers: vec![],
         }],

--- a/crates/kin-index/tests/relation_evidence_span_coverage.rs
+++ b/crates/kin-index/tests/relation_evidence_span_coverage.rs
@@ -682,14 +682,37 @@ fn print_table(rows: &[(String, Counts)], title: &str) {
 ///
 /// This total is a whole-fleet check. The per-language floors above are what
 /// keeps a language from silently losing its sites.
-const MEASURED_RELATIONS_WITH_SPAN: usize = 9;
+///
+/// FIR-2690 moved it from 9 to 10. That ticket is FIR-1825's residual: call
+/// sites got spans, import sites did not, and `kin rename` refused on any
+/// symbol another file imports because the only span it could reach was the
+/// importing file's MODULE entity, whose span is the whole file. Entity-level
+/// import edges now carry the import statement's own site, so one more relation
+/// in these fixtures is span-backed.
+///
+/// One, not thirteen, and the reason is worth knowing before the next author
+/// reads this number as coverage. These fixtures are call-resolution fixtures;
+/// they contain a single cross-file import edge between them. The claim "every
+/// language records an import span" is proven where it can be proven, in
+/// `kin-parser/tests/import_span_coverage.rs`, which parses a fixture per
+/// language and asserts each span is non-empty, inside the file, over bytes
+/// that mention the module path, and on a line that agrees with its own byte
+/// offset. This constant proves something different and narrower: that the
+/// linker carries a site the parser recorded all the way onto persisted
+/// evidence.
+const MEASURED_RELATIONS_WITH_SPAN: usize = 10;
 
 /// Span-backed evidence RECORDS, which exceed span-backed relations whenever one
 /// caller reaches one callee at more than one site. Each fixture calls `compute`
 /// twice from `run`, so the three site-recording languages contribute four
 /// records across three edges apiece. That surplus is the point: it is what
 /// `find_references` turns into more than one entry in `reference_lines`.
-const MEASURED_EVIDENCE_RECORDS_WITH_SPAN: usize = 12;
+/// FIR-2690 moved it from 12 to 13, in step with the relation count above: the
+/// one new span-backed relation is an entity-level import edge, and an import
+/// edge carries exactly one evidence record because a specifier binds once.
+/// The surplus of records over relations is unchanged, since it comes from
+/// repeat CALL sites and this edge adds none.
+const MEASURED_EVIDENCE_RECORDS_WITH_SPAN: usize = 13;
 
 #[test]
 fn relation_evidence_span_population_per_language() {

--- a/crates/kin-parser/src/extract.rs
+++ b/crates/kin-parser/src/extract.rs
@@ -320,6 +320,29 @@ pub struct FileImport {
     pub module_path: String,
     /// Individual names imported from this module.
     pub specifiers: Vec<ImportedName>,
+    /// Where the import statement sits in the file that wrote it.
+    ///
+    /// Required, not `Option`, and that is the whole design. An entity-level
+    /// import edge is sourced at the importing file's MODULE entity, whose span
+    /// is the entire file, so a rename planner searching the source entity's
+    /// span finds every mention of the name rather than the import site. Without
+    /// a span on the evidence, `kin rename` cannot edit an imported symbol at
+    /// all and refuses (`rename.rs`, "graph import evidence has no exact source
+    /// span").
+    ///
+    /// Thirteen language adapters build `FileImport`. An `Option` here would let
+    /// any one of them omit a span silently, and the symptom would be that
+    /// rename works for some languages and refuses for others with nothing in
+    /// any log. A required field moves that from a test someone has to remember
+    /// to write into a compile error nobody can skip: every adapter supplies a
+    /// site or the crate does not build. `adapter.rs::site_from_node` turns the
+    /// tree-sitter node each adapter already matched into one.
+    ///
+    /// A required field can still be satisfied with a lie, `(0, 0)` or a span
+    /// over the wrong bytes, so `import_span_coverage.rs` asserts every
+    /// language's span is real: non-empty, inside the file, and naming bytes
+    /// that actually contain the module path.
+    pub site: RelationSite,
 }
 
 /// A single imported name within an import declaration.
@@ -639,6 +662,22 @@ pub struct ParseOutput {
 
 #[cfg(test)]
 mod tests {
+
+    /// A well-formed but synthetic import site, for fixtures whose subject is
+    /// not the span. Tests whose subject IS the span parse real source; see
+    /// `tests/import_span_coverage.rs`.
+    fn synthetic_import_site() -> RelationSite {
+        RelationSite {
+            start_byte: 0,
+            end_byte: 1,
+            start_line: 1,
+            start_col: 0,
+            end_line: 1,
+            end_col: 1,
+            syntactic_role: None,
+        }
+    }
+
     use super::*;
 
     fn preview_for(text: &str) -> String {
@@ -728,6 +767,7 @@ mod tests {
         let file_id = FilePathId::new("packages/runtime-dom/src/index.ts");
         let mut entities = vec![test_entity(&file_id.to_string())];
         let imports = vec![FileImport {
+            site: synthetic_import_site(),
             module_path: "@vue/runtime-core".into(),
             specifiers: vec![ImportedName {
                 local_name: "createHydrationRenderer".into(),
@@ -756,6 +796,7 @@ mod tests {
 
     fn import(module_path: &str) -> FileImport {
         FileImport {
+            site: synthetic_import_site(),
             module_path: module_path.to_string(),
             specifiers: Vec::new(),
         }

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -514,6 +514,7 @@ fn extract_c_include(
                 .to_string();
 
             imports.push(FileImport {
+                site: crate::adapter::site_from_node(node),
                 module_path,
                 specifiers: vec![ImportedName {
                     local_name,

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -1308,6 +1308,7 @@ fn extract_include(node: &tree_sitter::Node, source: &[u8]) -> Option<FileImport
                 }
                 let local_name = path.rsplit('/').next().unwrap_or(&path).to_string();
                 return Some(FileImport {
+                    site: crate::adapter::site_from_node(node),
                     module_path: path,
                     specifiers: vec![ImportedName {
                         local_name,

--- a/crates/kin-parser/src/languages/go.rs
+++ b/crates/kin-parser/src/languages/go.rs
@@ -1180,6 +1180,7 @@ fn extract_go_import_spec(node: &tree_sitter::Node, source: &[u8]) -> Option<Fil
     };
 
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers: vec![ImportedName {
             local_name,

--- a/crates/kin-parser/src/languages/hcl.rs
+++ b/crates/kin-parser/src/languages/hcl.rs
@@ -202,6 +202,7 @@ fn extract_hcl_block(
                 // Extract source attribute as an import
                 if let Some(source_val) = extract_block_attr(node, source, "source") {
                     imports.push(FileImport {
+                        site: crate::adapter::site_from_node(node),
                         module_path: source_val.clone(),
                         specifiers: vec![ImportedName {
                             local_name: mod_name.clone(),

--- a/crates/kin-parser/src/languages/java.rs
+++ b/crates/kin-parser/src/languages/java.rs
@@ -474,6 +474,7 @@ fn extract_java_import(node: &tree_sitter::Node, source: &[u8]) -> Option<FileIm
                 let module_path = full_path[..dot_pos].to_string();
                 let local_name = full_path[dot_pos + 1..].to_string();
                 return Some(FileImport {
+                    site: crate::adapter::site_from_node(node),
                     module_path,
                     specifiers: vec![ImportedName {
                         local_name,
@@ -484,6 +485,7 @@ fn extract_java_import(node: &tree_sitter::Node, source: &[u8]) -> Option<FileIm
             } else {
                 // No dot — entire path is the name
                 return Some(FileImport {
+                    site: crate::adapter::site_from_node(node),
                     module_path: String::new(),
                     specifiers: vec![ImportedName {
                         local_name: full_path,

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -1547,6 +1547,7 @@ fn extract_js_import(node: &tree_sitter::Node, source: &[u8]) -> Option<FileImpo
     }
 
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers,
     })
@@ -1583,6 +1584,7 @@ fn extract_js_export_source(node: &tree_sitter::Node, source: &[u8]) -> Option<F
     }
 
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers,
     })
@@ -1804,6 +1806,7 @@ pub(super) fn collect_js_require_imports(
                 let specifiers = js_require_specifiers(&name, member.as_deref(), source);
                 if !specifiers.is_empty() {
                     imports.push(FileImport {
+                        site: crate::adapter::site_from_node(&declarator),
                         module_path,
                         specifiers,
                     });
@@ -1830,6 +1833,7 @@ pub(super) fn collect_js_require_imports(
                             continue;
                         }
                         imports.push(FileImport {
+                            site: crate::adapter::site_from_node(&child),
                             module_path,
                             specifiers: vec![ImportedName {
                                 local_name,
@@ -1843,6 +1847,7 @@ pub(super) fn collect_js_require_imports(
                     "call_expression" => {
                         if let Some((module_path, _)) = js_require_target(&child, source) {
                             imports.push(FileImport {
+                                site: crate::adapter::site_from_node(&child),
                                 module_path,
                                 specifiers: Vec::new(),
                             });

--- a/crates/kin-parser/src/languages/kotlin.rs
+++ b/crates/kin-parser/src/languages/kotlin.rs
@@ -734,6 +734,7 @@ fn extract_kotlin_import(node: &tree_sitter::Node, source: &[u8]) -> Option<File
 
     if is_wildcard {
         return Some(FileImport {
+            site: crate::adapter::site_from_node(node),
             module_path: full_path,
             specifiers: vec![ImportedName {
                 local_name: "*".to_string(),
@@ -750,6 +751,7 @@ fn extract_kotlin_import(node: &tree_sitter::Node, source: &[u8]) -> Option<File
         let has_alias = alias.is_some();
         let local_name = alias.unwrap_or_else(|| original_name.clone());
         Some(FileImport {
+            site: crate::adapter::site_from_node(node),
             module_path,
             specifiers: vec![ImportedName {
                 local_name,
@@ -760,6 +762,7 @@ fn extract_kotlin_import(node: &tree_sitter::Node, source: &[u8]) -> Option<File
     } else {
         let local_name = alias.unwrap_or_else(|| full_path.clone());
         Some(FileImport {
+            site: crate::adapter::site_from_node(node),
             module_path: String::new(),
             specifiers: vec![ImportedName {
                 local_name,

--- a/crates/kin-parser/src/languages/mod.rs
+++ b/crates/kin-parser/src/languages/mod.rs
@@ -33,6 +33,71 @@ use kin_model::LanguageId;
 
 use crate::adapter::LanguageAdapter;
 
+/// Every `LanguageId` this crate knows, as one list other code can iterate.
+///
+/// Rust cannot enumerate an enum without a macro, and this workspace has no
+/// `strum`, so a hand-written list is unavoidable. What IS avoidable is the
+/// list going stale silently, and that is what [`language_ordinal`] below is
+/// for: it matches every variant with no wildcard arm, so adding a variant to
+/// `LanguageId` fails to COMPILE there rather than quietly producing a shorter
+/// list here.
+///
+/// Be exact about what that does and does not close, because a guard whose
+/// name promises more than it detects is worse than no guard, which is the
+/// defect this constant exists to fix:
+///
+/// * Add a variant and forget everything else: **compile error**, at
+///   `language_ordinal`.
+/// * Add a variant and its ordinal arm, register no adapter: **test failure**,
+///   at `registry_covers_every_language_id`.
+/// * Add a variant, its ordinal arm and an adapter, and forget
+///   `adapter_conformance.rs`: **test failure**, at
+///   `conformance_list_covers_every_language_id`.
+/// * Add a variant, its ordinal arm, and forget THIS list: not caught. No
+///   hand-written list can catch its own omission. It is the one residual hole
+///   and it is stated rather than papered over.
+pub const ALL_LANGUAGE_IDS: &[LanguageId] = &[
+    LanguageId::TypeScript,
+    LanguageId::JavaScript,
+    LanguageId::Python,
+    LanguageId::Go,
+    LanguageId::Java,
+    LanguageId::Rust,
+    LanguageId::C,
+    LanguageId::Cpp,
+    LanguageId::CSharp,
+    LanguageId::Ruby,
+    LanguageId::Php,
+    LanguageId::Swift,
+    LanguageId::Kotlin,
+    LanguageId::Hcl,
+];
+
+/// A stable index per language, and the tripwire that makes the list above
+/// maintainable.
+///
+/// The body is an exhaustive match with **no wildcard arm**. That is the whole
+/// point: `_ => 0` would make this compile forever and turn every guard built
+/// on it into a guard that cannot fail. Do not add one.
+pub fn language_ordinal(id: LanguageId) -> usize {
+    match id {
+        LanguageId::TypeScript => 0,
+        LanguageId::JavaScript => 1,
+        LanguageId::Python => 2,
+        LanguageId::Go => 3,
+        LanguageId::Java => 4,
+        LanguageId::Rust => 5,
+        LanguageId::C => 6,
+        LanguageId::Cpp => 7,
+        LanguageId::CSharp => 8,
+        LanguageId::Ruby => 9,
+        LanguageId::Php => 10,
+        LanguageId::Swift => 11,
+        LanguageId::Kotlin => 12,
+        LanguageId::Hcl => 13,
+    }
+}
+
 /// Registry of all built-in language adapters.
 pub struct AdapterRegistry {
     adapters: Vec<Box<dyn LanguageAdapter>>,
@@ -212,25 +277,67 @@ fn cpp_class_declaration_present(source: &[u8]) -> bool {
 mod tests {
     use super::*;
 
+    /// The registry carries an adapter for every `LanguageId`, and nothing else.
+    ///
+    /// This replaces a guard that could not fail. The previous version read
+    /// `registry.supported_languages()`, asserted its length was 14, and then
+    /// asserted that same Vec contained each of 14 named variants.
+    /// `supported_languages()` is `self.adapters.iter().map(|a| a.language_id())`,
+    /// so **it compared the registry to itself**: add a fifteenth `LanguageId`
+    /// and register no adapter, and the Vec stays at fourteen, the length
+    /// assertion passes, all fourteen `contains` pass, green. A test named
+    /// "registry has all languages" could not detect a language the registry
+    /// lacked, which is the only thing it existed to catch. Filed as FIR-2704.
+    ///
+    /// The fix is to compare against something that is not the registry.
+    /// [`ALL_LANGUAGE_IDS`] is that something, and [`language_ordinal`] is what
+    /// keeps it honest: a new variant is a compile error there.
+    ///
+    /// Both directions are asserted, because either alone is half a guard. A
+    /// language with no adapter is a hole; an adapter for a language the
+    /// enumeration does not know means the two lists have drifted and the
+    /// coverage claims built on them are measuring different sets.
     #[test]
-    fn registry_has_all_languages() {
+    fn registry_covers_every_language_id() {
         let registry = AdapterRegistry::new();
-        let langs = registry.supported_languages();
-        assert_eq!(langs.len(), 14);
-        assert!(langs.contains(&LanguageId::TypeScript));
-        assert!(langs.contains(&LanguageId::JavaScript));
-        assert!(langs.contains(&LanguageId::Python));
-        assert!(langs.contains(&LanguageId::Go));
-        assert!(langs.contains(&LanguageId::Java));
-        assert!(langs.contains(&LanguageId::Rust));
-        assert!(langs.contains(&LanguageId::C));
-        assert!(langs.contains(&LanguageId::Cpp));
-        assert!(langs.contains(&LanguageId::CSharp));
-        assert!(langs.contains(&LanguageId::Ruby));
-        assert!(langs.contains(&LanguageId::Php));
-        assert!(langs.contains(&LanguageId::Swift));
-        assert!(langs.contains(&LanguageId::Kotlin));
-        assert!(langs.contains(&LanguageId::Hcl));
+        let mut registered: Vec<usize> = registry
+            .supported_languages()
+            .into_iter()
+            .map(language_ordinal)
+            .collect();
+        let mut expected: Vec<usize> = ALL_LANGUAGE_IDS
+            .iter()
+            .copied()
+            .map(language_ordinal)
+            .collect();
+        registered.sort_unstable();
+        expected.sort_unstable();
+
+        let missing: Vec<usize> = expected
+            .iter()
+            .copied()
+            .filter(|o| !registered.contains(o))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "these LanguageId ordinals have no registered adapter: {missing:?}"
+        );
+
+        let extra: Vec<usize> = registered
+            .iter()
+            .copied()
+            .filter(|o| !expected.contains(o))
+            .collect();
+        assert!(
+            extra.is_empty(),
+            "the registry holds adapters the enumeration does not know: {extra:?}"
+        );
+
+        assert_eq!(
+            registered.len(),
+            ALL_LANGUAGE_IDS.len(),
+            "one language must have exactly one adapter; duplicates hide a language behind another"
+        );
     }
 
     #[test]

--- a/crates/kin-parser/src/languages/php.rs
+++ b/crates/kin-parser/src/languages/php.rs
@@ -520,6 +520,7 @@ fn parse_php_use_declaration(node: &tree_sitter::Node, source: &[u8]) -> Option<
             };
 
             return Some(FileImport {
+                site: crate::adapter::site_from_node(node),
                 module_path: full_path,
                 specifiers: vec![ImportedName {
                     local_name,

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -2028,6 +2028,7 @@ fn extract_py_imports(node: &tree_sitter::Node, source: &[u8]) -> Vec<FileImport
             None => (module_path.clone(), None),
         };
         out.push(FileImport {
+            site: crate::adapter::site_from_node(node),
             module_path,
             specifiers: vec![ImportedName {
                 local_name,
@@ -2088,6 +2089,7 @@ fn extract_py_from_import(node: &tree_sitter::Node, source: &[u8]) -> Option<Fil
     }
 
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers,
     })

--- a/crates/kin-parser/src/languages/rust_lang.rs
+++ b/crates/kin-parser/src/languages/rust_lang.rs
@@ -791,6 +791,7 @@ fn extract_rust_use(node: &tree_sitter::Node, source: &[u8]) -> Option<FileImpor
                     .map(|node| node.utf8_text(source).unwrap_or("").to_string())
                     .unwrap_or_default();
                 return Some(FileImport {
+                    site: crate::adapter::site_from_node(node),
                     module_path,
                     specifiers: Vec::new(),
                 });
@@ -800,6 +801,7 @@ fn extract_rust_use(node: &tree_sitter::Node, source: &[u8]) -> Option<FileImpor
                 let name = child.utf8_text(source).unwrap_or("").to_string();
                 if !name.is_empty() {
                     return Some(FileImport {
+                        site: crate::adapter::site_from_node(node),
                         module_path: String::new(),
                         specifiers: vec![ImportedName {
                             local_name: name,
@@ -825,6 +827,7 @@ fn extract_scoped_identifier_import(node: &tree_sitter::Node, source: &[u8]) -> 
         return None;
     }
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers: vec![ImportedName {
             local_name,
@@ -857,6 +860,7 @@ fn extract_use_as_clause_import(node: &tree_sitter::Node, source: &[u8]) -> Opti
     }
 
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers: vec![ImportedName {
             local_name: alias,
@@ -922,6 +926,7 @@ fn extract_scoped_use_list_import(node: &tree_sitter::Node, source: &[u8]) -> Op
     }
 
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers,
     })

--- a/crates/kin-parser/src/languages/shallow_backed.rs
+++ b/crates/kin-parser/src/languages/shallow_backed.rs
@@ -373,6 +373,7 @@ fn extract_csharp_import(node: &Node, source: &[u8]) -> Option<FileImport> {
         .unwrap_or(module_path.as_str())
         .to_string();
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers: vec![ImportedName {
             local_name,
@@ -782,6 +783,7 @@ fn extract_ruby_require(node: &Node, source: &[u8]) -> Option<FileImport> {
         .unwrap_or(trimmed)
         .to_string();
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path: trimmed.to_string(),
         specifiers: vec![ImportedName {
             local_name,

--- a/crates/kin-parser/src/languages/swift.rs
+++ b/crates/kin-parser/src/languages/swift.rs
@@ -713,6 +713,7 @@ fn extract_swift_import(node: &tree_sitter::Node, source: &[u8]) -> Option<FileI
         .to_string();
 
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers: vec![ImportedName {
             local_name,

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -778,6 +778,7 @@ fn extract_ts_import(node: &tree_sitter::Node, source: &[u8]) -> Option<FileImpo
     }
 
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers,
     })
@@ -814,6 +815,7 @@ fn extract_ts_export_source(node: &tree_sitter::Node, source: &[u8]) -> Option<F
     }
 
     Some(FileImport {
+        site: crate::adapter::site_from_node(node),
         module_path,
         specifiers,
     })

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -58,10 +58,10 @@ pub use extract::{
     FILE_SURFACE_CONTEXT_KEY,
 };
 pub use languages::{
-    attach_go_command_effect_contract_metadata, is_python_builtin_name, AdapterRegistry, CAdapter,
-    CSharpAdapter, CppAdapter, GoAdapter, HclAdapter, JavaAdapter, JavaScriptAdapter,
-    KotlinAdapter, PhpAdapter, PythonAdapter, RubyAdapter, RustAdapter, SwiftAdapter,
-    TypeScriptAdapter, PYTHON_BUILTIN_NAMES,
+    attach_go_command_effect_contract_metadata, is_python_builtin_name, language_ordinal,
+    AdapterRegistry, CAdapter, CSharpAdapter, CppAdapter, GoAdapter, HclAdapter, JavaAdapter,
+    JavaScriptAdapter, KotlinAdapter, PhpAdapter, PythonAdapter, RubyAdapter, RustAdapter,
+    SwiftAdapter, TypeScriptAdapter, ALL_LANGUAGE_IDS, PYTHON_BUILTIN_NAMES,
 };
 pub use shallow::{
     extract_shallow, get_shallow_grammar, parse_shallow_file, ShallowDecl, ShallowDeclKind,

--- a/crates/kin-parser/tests/adapter_conformance.rs
+++ b/crates/kin-parser/tests/adapter_conformance.rs
@@ -20,6 +20,7 @@
 //! 10. Deterministic: same input produces same output
 
 use kin_model::{FilePathId, ParseState};
+use kin_parser::{language_ordinal, ALL_LANGUAGE_IDS};
 use kin_parser::{
     AdapterRegistry, CAdapter, CSharpAdapter, CppAdapter, GoAdapter, HclAdapter, JavaAdapter,
     JavaScriptAdapter, KotlinAdapter, LanguageAdapter, ParseOutput, PhpAdapter, PythonAdapter,
@@ -76,6 +77,63 @@ fn parse_fixture(adapter: &dyn LanguageAdapter, source: &[u8]) -> ParseOutput {
 }
 
 // ---- Conformance Requirement 1: language_id is valid ----
+
+/// `all_adapters()` covers every `LanguageId`, and nothing else.
+///
+/// Every conformance test in this file iterates `all_adapters()`, a list
+/// maintained by hand, and the module comment asks whoever adds an adapter to
+/// remember it. An adapter missing from that list is not tested by ANY of them,
+/// and the suite stays green while saying nothing about it. That is the same
+/// shape as the registry guard this lane replaced (FIR-2704): a list checked
+/// only against itself.
+///
+/// So the list is compared against `ALL_LANGUAGE_IDS`, whose companion
+/// `language_ordinal` is a wildcard-free match and therefore a compile error
+/// when a `LanguageId` variant is added. Both directions matter: a language
+/// with no entry here is untested, and an entry for a language the enumeration
+/// does not know means the two have drifted and every "all adapters" claim in
+/// this file is measuring a different set than it reads.
+#[test]
+fn conformance_list_covers_every_language_id() {
+    let mut listed: Vec<usize> = all_adapters()
+        .iter()
+        .map(|a| language_ordinal(a.language_id()))
+        .collect();
+    let mut expected: Vec<usize> = ALL_LANGUAGE_IDS
+        .iter()
+        .copied()
+        .map(language_ordinal)
+        .collect();
+    listed.sort_unstable();
+    expected.sort_unstable();
+
+    let missing: Vec<usize> = expected
+        .iter()
+        .copied()
+        .filter(|o| !listed.contains(o))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "these LanguageId ordinals are absent from all_adapters(), so every conformance test in \
+         this file silently skips them: {missing:?}"
+    );
+
+    let extra: Vec<usize> = listed
+        .iter()
+        .copied()
+        .filter(|o| !expected.contains(o))
+        .collect();
+    assert!(
+        extra.is_empty(),
+        "all_adapters() lists languages the enumeration does not know: {extra:?}"
+    );
+
+    assert_eq!(
+        listed.len(),
+        ALL_LANGUAGE_IDS.len(),
+        "one language, one adapter entry; a duplicate hides a language behind another"
+    );
+}
 
 #[test]
 fn conformance_language_id_is_set() {

--- a/crates/kin-parser/tests/import_span_coverage.rs
+++ b/crates/kin-parser/tests/import_span_coverage.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Every language's import carries a REAL span.
+//!
+//! `FileImport::site` is a required field, so no adapter can forget it: the
+//! compiler names every construction site that omits one. That closes the
+//! "forgot an adapter" case completely and closes nothing else, because a
+//! required field can still be satisfied with a lie. `(0, 0)` compiles. A span
+//! over the wrong bytes compiles. This suite is the half a compile error cannot
+//! reach.
+//!
+//! It is driven from `ALL_LANGUAGE_IDS` through a wildcard-free match, not from
+//! a hand-written list of cases. That matters here more than usual: the
+//! existing import fixture table in `adapter_conformance.rs` is such a list and
+//! it covers thirteen of fourteen languages, silently omitting HCL, so nothing
+//! asserted HCL carried a `FileImport` at all. A suite that enumerates its own
+//! subjects by hand cannot report the subject it forgot.
+
+use kin_model::{FilePathId, LanguageId};
+use kin_parser::{AdapterRegistry, ALL_LANGUAGE_IDS};
+
+/// Source that imports something, for every language.
+///
+/// The match has **no wildcard arm**. Adding a `LanguageId` variant fails to
+/// compile here, which is the point: a new language arrives with a fixture or
+/// it does not arrive. Do not add `_ => ...`; it would turn this suite into one
+/// that cannot fail.
+fn fixture_for(id: LanguageId) -> (&'static str, &'static [u8]) {
+    match id {
+        LanguageId::Python => ("py", b"import os\nfrom pathlib import Path\n"),
+        LanguageId::JavaScript => ("js", b"import util from './util.js';\n"),
+        LanguageId::TypeScript => ("ts", b"import { util } from './util';\n"),
+        LanguageId::Go => ("go", b"package main\nimport \"fmt\"\n"),
+        LanguageId::Rust => ("rs", b"use crate::util::run;\n"),
+        LanguageId::Java => ("java", b"import java.util.List;\npublic class Foo { }\n"),
+        LanguageId::C => ("c", b"#include <stdio.h>\nint main(void) { return 0; }\n"),
+        LanguageId::Cpp => ("cpp", b"#include <vector>\nint main() { return 0; }\n"),
+        LanguageId::CSharp => ("cs", b"using System;\npublic class Foo { }\n"),
+        LanguageId::Ruby => ("rb", b"require 'json'\nclass Foo\nend\n"),
+        // `use`, not `require`. PHP's `require`/`include` produces no
+        // FileImport at all, a known gap pinned by an ignored case in
+        // language_matrix_imports.rs; a fixture using it would fail here for a
+        // reason that has nothing to do with spans.
+        LanguageId::Php => ("php", b"<?php\nuse Foo\\Bar;\nclass Baz { }\n"),
+        LanguageId::Swift => ("swift", b"import Foundation\nclass Foo { }\n"),
+        LanguageId::Kotlin => ("kt", b"import foo.Bar\nclass Baz { }\n"),
+        // HCL's import is a module block's `source` attribute, and this is the
+        // language the hand-written table in adapter_conformance.rs omitted.
+        LanguageId::Hcl => ("tf", b"module \"vpc\" {\n  source = \"./modules/vpc\"\n}\n"),
+    }
+}
+
+/// The last identifier-ish segment of a module path, for checking the span
+/// points at bytes that actually mention what was imported.
+///
+/// Adapters normalise module paths differently (`./util.js` against `util`,
+/// `Foo\Bar` against `Bar`), so comparing the whole path would fail on
+/// normalisation rather than on a wrong span. The final segment survives every
+/// normalisation this workspace does and is still specific enough that a `(0,
+/// 0)` span or a span over the wrong statement does not contain it.
+fn tail_segment(module_path: &str) -> String {
+    module_path
+        .trim_matches(|c: char| c == '"' || c == '\'' || c == '<' || c == '>')
+        .rsplit(['/', '.', '\\', ':'])
+        .find(|part| !part.is_empty())
+        .unwrap_or(module_path)
+        .to_string()
+}
+
+#[test]
+fn every_language_carries_a_real_import_span() {
+    let registry = AdapterRegistry::new();
+    let mut checked = 0_usize;
+
+    for id in ALL_LANGUAGE_IDS.iter().copied() {
+        let (ext, source) = fixture_for(id);
+        let adapter = registry
+            .get_by_language(id)
+            .unwrap_or_else(|| panic!("{id}: no adapter registered"));
+        let tree = adapter
+            .parse(source)
+            .unwrap_or_else(|err| panic!("{id}: parse failed: {err}"));
+        let file_id = FilePathId(format!("test/import_span_fixture.{ext}"));
+        let output = adapter
+            .extract(&tree, source, &file_id)
+            .unwrap_or_else(|err| panic!("{id}: extract failed: {err}"));
+
+        assert!(
+            !output.imports.is_empty(),
+            "{id}: the fixture imports something but the adapter produced no FileImport, \
+             so this language's span cannot be checked at all"
+        );
+
+        for import in &output.imports {
+            let site = &import.site;
+
+            assert!(
+                site.end_byte > site.start_byte,
+                "{id}: import {:?} carries an empty span {}..{}; a required field satisfied \
+                 with (0, 0) is the lie this suite exists to catch",
+                import.module_path,
+                site.start_byte,
+                site.end_byte
+            );
+            assert!(
+                site.end_byte <= source.len(),
+                "{id}: import {:?} spans {}..{} but the file is {} bytes",
+                import.module_path,
+                site.start_byte,
+                site.end_byte,
+                source.len()
+            );
+            // Not "line >= 1". Both span builders in this crate write
+            // tree-sitter's `start_position().row` straight through, and that
+            // row is 0-based, so an import on the first line correctly reports
+            // 0. Asserting 1-based here failed on TypeScript and the assertion
+            // was wrong, not the code.
+            //
+            // What IS worth asserting is that the line agrees with the bytes.
+            // A fabricated span can carry any line number it likes; one derived
+            // from the same node cannot disagree with its own offset.
+            let newlines_before = source[..site.start_byte]
+                .iter()
+                .filter(|byte| **byte == b'\n')
+                .count() as u32;
+            assert_eq!(
+                site.start_line, newlines_before,
+                "{id}: import {:?} reports line {} but sits after {} newline(s); the line and \
+                 the byte offset come from one node and cannot disagree",
+                import.module_path, site.start_line, newlines_before
+            );
+
+            let text = String::from_utf8_lossy(&source[site.start_byte..site.end_byte]);
+            let tail = tail_segment(&import.module_path);
+            assert!(
+                text.contains(&tail),
+                "{id}: import {:?} points at {:?}, which does not mention {:?}; the span is \
+                 real but it is over the wrong bytes",
+                import.module_path,
+                text,
+                tail
+            );
+            checked += 1;
+        }
+    }
+
+    assert_eq!(
+        checked > 0,
+        true,
+        "no imports were checked at all, which is what this suite looks like when the fixtures \
+         stop producing imports"
+    );
+}


### PR DESCRIPTION
`kin rename` refused outright on any symbol another file imports. It now edits the import statement like any other reference site.

## Why it refused, read from the planner rather than the ticket

`rename.rs` groups every reference relation by its SOURCE ENTITY, sums `evidence.occurrence_count` into `group.expected`, finds occurrences of the name inside `group.entity.span`, and refuses unless the two are exactly equal.

An entity-level import edge is sourced at the importing file's **module entity, whose span is the whole file**. So the search found every mention of the name while the evidence counted only the import sites. The counts cannot match on any file that both imports a symbol and uses it, which is every real file. The `:472` guard refused early rather than let that surface as a confusing count mismatch, so the guard was a placeholder for semantics nobody had defined, not a bug on its own.

## The fix has two halves and the second is the real one

**The span.** `FileImport` gains a site; every adapter populates it; the linker carries it into `RelationEvidence.source_span`, a field kin-model has always had and no producer ever filled for an import.

**The semantics.** A span on the evidence is useless while the planner searches the source entity's span. The unit of search changes from one span per source ENTITY to one span per EVIDENCE RECORD, falling back to the entity span when the evidence names none.

- **Count** becomes per-span. A module entity with three import sites is three exact checks rather than one impossible whole-file check.
- **Overlap** is unchanged and stays global on `(file, start_byte, end_byte)`. Narrowing the search removes the false claims a whole-file search was making; it does not weaken the check.
- Evidence naming no span behaves exactly as before, so **no existing rename moves**.

The guard now asks whether the site survived into the graph rather than whether the file imports the target, so a store indexed before import spans existed still refuses loudly instead of renaming against evidence it does not have.

## The result, on the real-linker Python fixture

Four edits where there were three:

```
caller.py:17..23  graph-reference:imports     <- the site this ticket exists for
caller.py:50..56  graph-reference:calls
caller.py:61..67  graph-reference:calls
defs.py:4..10     declaration
```

## A required field, not a coverage test

Thirteen adapters build `FileImport`. An `Option<RelationSite>` would let any one omit a span silently, and the symptom is rename working for some languages and refusing for others with nothing in any log.

`site` is therefore **required**, and it did the work a coverage test would have had to do from memory: **the compiler named twenty-seven construction sites across all thirteen adapters on the first build.** Every one had a tree-sitter node already in scope, so every one calls `site_from_node`, the helper `ExtractedRelation`'s site already uses.

A required field still permits a lie, so `import_span_coverage.rs` asserts the span is REAL per language: non-empty, inside the file, over bytes that mention the module path's final segment, and on a line that agrees with the count of newlines before its own byte offset. Falsified against both available lies:

```
empty span (0,0)  -> "carries an empty span 0..0; a required field satisfied with
                      (0, 0) is the lie this suite exists to catch"
wrong bytes 0..3  -> "points at \"imp\", which does not mention \"os\"; the span is
                      real but it is over the wrong bytes"
```

Fixtures that hand-build `FileImport` get `synthetic_import_site()`. The name is the point: a helper called `default_site()` reads like something a production path could reach for, and nothing in production may invent a span.

## A guard that could not fail, replaced (FIR-2704)

`registry_has_all_languages` read `registry.supported_languages()`, asserted its length was 14, then asserted that same Vec contained each of 14 named variants. `supported_languages()` is `self.adapters.iter().map(|a| a.language_id()).collect()`, so **it compared the registry to itself**. Add a fifteenth `LanguageId` and register no adapter: the Vec stays at fourteen, every assertion passes, green. A test named "registry has all languages" could not detect a language the registry lacked.

Not a live defect when found, and filed as FIR-2704 for the guard rather than for a missing language. It is fixed here rather than noted, because a guard whose name promises what it cannot detect is worse than no guard: it stops anyone writing the one that would work.

`ALL_LANGUAGE_IDS` is now the one list, with `language_ordinal` beside it as a wildcard-free match, so adding a variant is a **compile error** rather than a quietly shorter list. Both the registry and `adapter_conformance.rs`'s `all_adapters()` are checked against it, in both directions. Falsified by **deleting** a known-good entry from each in turn, the mutation nobody writes because these lists are only ever maintained by addition:

```
registry entry deleted    -> "these LanguageId ordinals have no registered adapter: [12]"
conformance entry deleted -> "absent from all_adapters(), so every conformance test in
                              this file silently skips them: [12]"
```

The second arm also leaves the registry guard green, which is a free independence control.

The residual is stated in the constant's own doc comment rather than left to be discovered: add a variant, add its ordinal arm, and forget `ALL_LANGUAGE_IDS`, and nothing catches it. No hand-written list can catch its own omission and this workspace has no `strum`.

## Driving from the enumeration found a live hole

The existing import fixture table in `adapter_conformance.rs` is a hand-written list of cases and it covers **thirteen of fourteen** languages. HCL is absent, so nothing asserted HCL carried a `FileImport` at all. A suite that enumerates its own subjects by hand cannot report the subject it forgot.

## What this does NOT fix, asserted rather than skipped

**TypeScript and JavaScript still refuse**, and the suite says so out loud with the reason named.

Their cause is **FIR-2675, not this ticket**. Both adapters record import spans correctly, proven by `import_span_coverage.rs`. Neither emits a module entity for an ordinary source file, so there is no source entity to hang an entity-level import edge on, no edge, and therefore no evidence to carry the span however good it is.

The fixture flip was going to be uniform until the suite refused for TypeScript with a message about missing spans, which was true and misleading: the span exists, the edge does not. So the branch splits on the real cause. A suite that quietly skipped the languages it cannot serve would report coverage it does not have.

The hand-built fixture whose import evidence names no span also stays and still refuses, because that is the case the guard exists for.

## Measurement pins moved, with their reason

`relation_evidence_span_coverage.rs` went 9 to 10 relations and 12 to 13 evidence records. That suite is a tripwire doing its job and its failure message says exactly what to do. It is the FIR-1825 measurement, and this ticket is FIR-1825's residual.

Both doc comments now say why the number is one and not thirteen, because a later reader would otherwise take it for coverage: those are call-resolution fixtures holding a single cross-file import edge between them.

## What was run

- **`cargo test --workspace --no-fail-fast`: 148 suites, 7,325 tests, 0 failures.**
- **`bin/kin-precheck kin`: 16 gates enumerated from ci.yml's check job, 16 passed, 0 failed**, including the python and node guards. It names the three steps it deliberately skips and why.
- Falsifications above, each restoring on an EXIT/INT/TERM trap and asserting its mutant marker was in the tree before the arm ran.

One process note worth carrying: `cargo check -p <crate>` compiles the library target only, so a rename that breaks a `#[cfg(test)]` caller reports a clean check. Three green crate-scoped checks missed a third call site that the workspace suite then caught. The idiom is `cargo check --workspace --all-targets`.

Closes FIR-2690
Closes FIR-2704
