### PR TITLE
Classify colocated framework tests, and promote in-file tests on both pipeline paths

### DIFF
--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -300,13 +300,26 @@ impl IndexPipeline {
             parse_state,
         } = output;
 
-        // Convert extracted entities to model entities
+        // Convert extracted entities to model entities.
+        //
+        // The in-file test promotion below is the same one the full-parse path
+        // applies, and it is here because its absence made role path-dependent:
+        // a `#[test] fn` in `src/lib.rs` was Test after a full parse and Source
+        // after an incremental reconcile, so the same code changed role
+        // depending on which path last touched the file (FIR-1940). A promotion
+        // on one path only is the shape kin#1123 caught in a different consumer.
         let role = classify_file_role(&file_id.0);
+        let test_names: std::collections::HashSet<&str> =
+            tests.iter().map(|test| test.name.as_str()).collect();
         let mut entities: Vec<Entity> = extracted_entities
             .into_iter()
             .map(|e| {
                 let mut ent = e.into_entity_with_source(language, file_id, Some(&source));
-                ent.role = role;
+                ent.role = if role == EntityRole::Source && test_names.contains(ent.name.as_str()) {
+                    EntityRole::Test
+                } else {
+                    role
+                };
                 ent
             })
             .collect();
@@ -676,6 +689,53 @@ fn is_test_dir_component(component: &str) -> bool {
 /// signature/breaking changes on the contract surface. A repo's actual test tree
 /// (`tests/`, `__tests__/`, or any `test_*`/`*_test` file) still resolves to the
 /// test role.
+/// Whether a filename names a test by one of the conventions the ecosystems in
+/// this registry actually use.
+///
+/// This was eight literal extensions, which classified `Foo.test.tsx`,
+/// `FooTest.java`, `foo_spec.rb` and every other colocated framework test as
+/// production source. A React repository with colocated tests read 100% Source,
+/// and two linker gates that filter on `role != Test` then removed nothing,
+/// because nothing was Test (FIR-1940).
+///
+/// The rule is delimited rather than a bare suffix, and the delimiter is what
+/// makes it safe to widen. `latest.java` ends with the letters `test.java`, and
+/// a lowercased `ends_with` would call it a test; `release.rs` under a `latest/`
+/// directory is the same hazard one level up. So a marker counts only when a
+/// delimiter or a case boundary separates it from the rest of the stem:
+///
+/// - `test_foo.py`, delimited by the underscore that follows.
+/// - `foo_test.go`, `foo_spec.rb`, delimited by the underscore before.
+/// - `foo.test.tsx`, `foo.spec.js`, delimited by the dot before, which covers
+///   every extension the JS and TS adapters claim rather than four of them.
+/// - `FooTest.java`, `FooTests.cs`, `FooSpec.kt`, `FooTests.swift`, delimited by
+///   the capital. This is the one case that reads the ORIGINAL spelling: the
+///   lowercased form cannot tell `FooTest` from `latest`.
+///
+/// `original` is the filename as written; `lower` is the same string lowercased,
+/// passed in because the caller already has it.
+fn is_test_file_name(original: &str, lower: &str) -> bool {
+    let stem_lower = lower.rsplit_once('.').map_or(lower, |(stem, _)| stem);
+    if stem_lower.starts_with("test_")
+        || stem_lower.ends_with("_test")
+        || stem_lower.ends_with("_spec")
+        || stem_lower.ends_with(".test")
+        || stem_lower.ends_with(".spec")
+    {
+        return true;
+    }
+    // The capital is the delimiter. Matching on the original spelling is what
+    // separates `FooTest` from `latest`, and lowercasing first is what made the
+    // widened rule unsafe in the first place.
+    let stem = original.rsplit_once('.').map_or(original, |(stem, _)| stem);
+    for marker in ["Test", "Tests", "Spec", "Specs"] {
+        if stem.len() > marker.len() && stem.ends_with(marker) {
+            return true;
+        }
+    }
+    false
+}
+
 pub fn classify_file_role(path: &str) -> EntityRole {
     let lower = path.to_ascii_lowercase();
     let components: Vec<&str> = lower.split('/').filter(|c| !c.is_empty()).collect();
@@ -690,14 +750,10 @@ pub fn classify_file_role(path: &str) -> EntityRole {
         .iter()
         .take(dir_len)
         .any(|c| is_test_dir_component(c));
-    let is_test_file = file_name.starts_with("test_")
-        || file_name.ends_with("_test.py")
-        || file_name.ends_with("_test.rs")
-        || file_name.ends_with("_test.go")
-        || file_name.ends_with(".test.ts")
-        || file_name.ends_with(".test.js")
-        || file_name.ends_with(".spec.ts")
-        || file_name.ends_with(".spec.js");
+    // The ORIGINAL spelling, taken from `path` rather than from `lower`, because
+    // the capital in `FooTest` is a delimiter and lowercasing destroys it.
+    let original_file_name = path.rsplit('/').next().unwrap_or("");
+    let is_test_file = is_test_file_name(original_file_name, file_name);
     if in_test_dir || is_test_file {
         return EntityRole::Test;
     }
@@ -1128,6 +1184,66 @@ mod tests {
             classify_file_role("__tests__/App.test.ts"),
             EntityRole::Test
         );
+    }
+
+    /// Colocated framework tests, which the eight-literal rule read as product
+    /// source. A React repository with `Foo.test.tsx` beside `Foo.tsx`
+    /// classified 100% Source, and the two linker gates that filter on
+    /// `role != Test` then removed nothing, because nothing was Test
+    /// (FIR-1940).
+    ///
+    /// The controls are the point. Widening a suffix rule is only safe if it
+    /// stays delimited, and every name in the second group ends with the letters
+    /// of a marker without being a test.
+    #[test]
+    fn classify_colocated_framework_test_files() {
+        for path in [
+            // The dot-delimited family, across every extension the JS and TS
+            // adapters claim rather than the four the old rule listed.
+            "src/Foo.test.tsx",
+            "src/Foo.spec.tsx",
+            "src/foo.test.jsx",
+            "src/foo.test.mjs",
+            "src/foo.test.cjs",
+            // The underscore-delimited family, beyond py/rs/go.
+            "src/foo_test.ts",
+            "src/foo_test.js",
+            "spec/models/user_spec.rb",
+            // The capital-delimited family. Java, C#, Kotlin and Swift name the
+            // test after the type under test, with no separator but the case.
+            "src/main/java/com/example/FooTest.java",
+            "src/main/java/com/example/FooTests.java",
+            "tests/FooTests.cs",
+            "src/FooSpec.kt",
+            "Tests/FooTests.swift",
+        ] {
+            assert_eq!(
+                classify_file_role(path),
+                EntityRole::Test,
+                "{path} is a test by a convention this rule has to cover"
+            );
+        }
+
+        // Controls. Each ends with a marker's letters and is not a test, which
+        // is what a bare lowercased `ends_with` would get wrong.
+        for path in [
+            // `latest` ends with `test`. This is the name that makes a widened
+            // suffix rule unsafe without a delimiter.
+            "src/latest.java",
+            "src/Latest.java",
+            "latest/release.rs",
+            "src/contest.py",
+            "src/manifest.rs",
+            // And the case the previous fix bought: pytest's own product
+            // package must not be swept in by any widening.
+            "src/_pytest/python.py",
+        ] {
+            assert_eq!(
+                classify_file_role(path),
+                EntityRole::Source,
+                "{path} is product code and no marker is delimited in it"
+            );
+        }
     }
 
     /// A testing tool ships product code whose package name embeds "test"

--- a/crates/kin-index/tests/entity_role_survives_ingest.rs
+++ b/crates/kin-index/tests/entity_role_survives_ingest.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Role, read back out of the graph rather than off the in-memory parse.
+//!
+//! FIR-1940 item (b). Two gaps put the wrong role on real entities, and neither
+//! was visible to the unit tests beside the classifier, because those assert on
+//! `classify_file_role` and the defects live in what the pipeline does with its
+//! answer.
+//!
+//! Gap 1: the test-filename rule listed eight literal extensions, so every
+//! colocated framework test read as production source.
+//!
+//! Gap 2: the incremental path assigned the path role and skipped the in-file
+//! test promotion the full-parse path applies, so a `#[test] fn` in a product
+//! file was Test after a full parse and Source after an incremental reconcile.
+//! The same code, two roles, decided by which path last touched the file.
+//!
+//! Every assertion below reads the role back AFTER `apply_to_graph`, because a
+//! role that is correct in the `IndexedFile` and lost on the way to the store is
+//! the same defect one layer down, and an in-memory assertion cannot see it.
+
+use kin_blobs::BlobStore;
+use kin_db::InMemoryGraph;
+use kin_index::{apply_to_graph, IndexPipeline};
+use kin_model::graph::EntityStore;
+use kin_model::{
+    ArtifactId, EntityFilter, EntityRole, FilePathId, Hash256, LocatedEntry, RepoPath,
+    TransactionDelta, TreeDelta, TreeEntry,
+};
+
+fn zero() -> Hash256 {
+    Hash256::from_bytes([0; 32])
+}
+
+/// Admit `path` into the repository tree.
+///
+/// `apply_to_graph` refuses semantic enrichment for a path repository authority
+/// does not carry, which is the graph doing its job. The admission is keyed on
+/// the file id the indexer actually produced rather than on the string this test
+/// passed in, because the incremental path indexes a real file and carries the
+/// path it read.
+fn admit(graph: &InMemoryGraph, path: &str) {
+    let repo_path = RepoPath::from_utf8(path.to_string()).expect("a usable repository path");
+    if graph.artifact_id_at_path(&repo_path).is_some() {
+        return;
+    }
+    graph
+        .apply_transaction_delta(&TransactionDelta {
+            entity_deltas: Vec::new(),
+            relation_deltas: Vec::new(),
+            tree_deltas: vec![TreeDelta::Added {
+                artifact_id: ArtifactId::new(),
+                new: LocatedEntry::new(
+                    repo_path,
+                    TreeEntry::blob(Hash256::from_bytes([7; 32]), false),
+                ),
+            }],
+            admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
+        })
+        .expect("admission goes through the repository tree transaction");
+}
+
+/// Every role the graph holds for `path`, after the file has been applied.
+fn roles_in_graph(graph: &InMemoryGraph, path: &str) -> Vec<(String, EntityRole)> {
+    let mut rows: Vec<(String, EntityRole)> = graph
+        .query_entities(&EntityFilter::default())
+        .expect("the store answers")
+        .into_iter()
+        .filter(|entity| {
+            entity
+                .file_origin
+                .as_ref()
+                .is_some_and(|origin| origin.0 == path)
+        })
+        .map(|entity| (entity.name.clone(), entity.role))
+        .collect();
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+    rows
+}
+
+/// Index `source` at `path` through the FULL-PARSE path and apply it.
+fn ingest_batch(graph: &InMemoryGraph, path: &str, source: &str) {
+    let pipeline = IndexPipeline::new();
+    let file_id = FilePathId::new(path.to_string());
+    let indexed = pipeline
+        .index_file_content_with_tests(&file_id, source.as_bytes(), zero())
+        .expect("indexing succeeds")
+        .indexed_file;
+    admit(graph, &indexed.file_id.0);
+    apply_to_graph(graph, &indexed).expect("apply succeeds");
+}
+
+/// Index `source` at `path` through the INCREMENTAL path and apply it.
+///
+/// This is the path gap 2 lived on, and it needs a real file and a blob store,
+/// which is why it is not simply the call above with a flag.
+fn ingest_incremental(
+    graph: &InMemoryGraph,
+    root: &std::path::Path,
+    rel: &str,
+    source: &str,
+) -> String {
+    let pipeline = IndexPipeline::new();
+    let blob_store = BlobStore::new(root.join("cas")).expect("blob store");
+    // A RELATIVE path, because the file id is keyed on what the indexer read and
+    // repository authority refuses an absolute one. `root` is a tempdir created
+    // under the current directory, so its final component plus `rel` is a real
+    // path from here.
+    let file = std::path::PathBuf::from(root.file_name().expect("a tempdir name")).join(rel);
+    std::fs::create_dir_all(file.parent().expect("a parent")).expect("mkdir");
+    std::fs::write(&file, source).expect("write");
+    let (indexed, _tree) = pipeline
+        .index_file_with_hint(&file, &blob_store, None, None)
+        .expect("indexing succeeds");
+    admit(graph, &indexed.file_id.0);
+    apply_to_graph(graph, &indexed).expect("apply succeeds");
+    indexed.file_id.0.clone()
+}
+
+const PY_SOURCE: &str = "def add(a, b):\n    return a + b\n";
+const PY_TEST: &str = "def test_add():\n    assert True\n";
+const TS_TEST: &str = "export function renders() { return 1; }\n";
+const RS_MIXED: &str = r#"
+pub fn parse_note(text: &str) -> usize {
+    text.len()
+}
+
+#[test]
+fn parse_note_counts_bytes() {
+    assert_eq!(parse_note("ab"), 2);
+}
+"#;
+
+/// A path-classified test file, a product file, and the colocated framework test
+/// that gap 1 misread. All three read back from the graph.
+#[test]
+fn role_reaches_the_graph_for_every_path_convention() {
+    let graph = InMemoryGraph::new();
+    ingest_batch(&graph, "src/calc.py", PY_SOURCE);
+    ingest_batch(&graph, "tests/test_calc.py", PY_TEST);
+    // Gap 1: colocated, dot-delimited, and on an extension the old eight-literal
+    // rule never listed.
+    ingest_batch(&graph, "src/Widget.test.tsx", TS_TEST);
+
+    let product = roles_in_graph(&graph, "src/calc.py");
+    assert!(
+        !product.is_empty() && product.iter().all(|(_, role)| *role == EntityRole::Source),
+        "product code is Source: {product:?}"
+    );
+
+    let by_path = roles_in_graph(&graph, "tests/test_calc.py");
+    assert!(
+        !by_path.is_empty() && by_path.iter().all(|(_, role)| *role == EntityRole::Test),
+        "a test directory and a test_ prefix is Test: {by_path:?}"
+    );
+
+    let colocated = roles_in_graph(&graph, "src/Widget.test.tsx");
+    assert!(
+        !colocated.is_empty() && colocated.iter().all(|(_, role)| *role == EntityRole::Test),
+        "a colocated framework test is Test, which gap 1 got wrong: {colocated:?}"
+    );
+}
+
+/// Gap 2, and the reason this file exists rather than another classifier unit
+/// test: the role of the SAME source must not depend on which pipeline path
+/// touched it. A batch-only fix passes the first assertion and leaves the
+/// second, which is the shape kin#1123 caught in a different consumer.
+#[test]
+fn an_in_file_test_keeps_its_role_on_both_pipeline_paths() {
+    let batch_graph = InMemoryGraph::new();
+    ingest_batch(&batch_graph, "src/lib.rs", RS_MIXED);
+    let batch = roles_in_graph(&batch_graph, "src/lib.rs");
+
+    // Rooted under the current directory on purpose. The incremental entry
+    // takes a real path and keys the file id on what it read, and repository
+    // authority refuses an absolute path, so a relative root is what lets this
+    // arm reach `apply_to_graph` at all. It is cleaned up when `root` drops.
+    let root = tempfile::tempdir_in(".").expect("tempdir under the crate root");
+    let incr_graph = InMemoryGraph::new();
+    let incr_path = ingest_incremental(&incr_graph, root.path(), "src/lib.rs", RS_MIXED);
+    let incremental = roles_in_graph(&incr_graph, &incr_path);
+
+    let role_of = |rows: &[(String, EntityRole)], name: &str| -> Option<EntityRole> {
+        rows.iter()
+            .find(|(entity, _)| entity == name)
+            .map(|(_, role)| *role)
+    };
+
+    assert_eq!(
+        role_of(&batch, "parse_note_counts_bytes"),
+        Some(EntityRole::Test),
+        "the full-parse path promotes a #[test] fn in a product file: {batch:?}"
+    );
+    assert_eq!(
+        role_of(&incremental, "parse_note_counts_bytes"),
+        Some(EntityRole::Test),
+        "and so must the incremental path, or role is decided by which path ran \
+         last: {incremental:?}"
+    );
+
+    // The control that stops the promotion becoming "call everything in the file
+    // a test". The product function beside it stays Source on both paths.
+    assert_eq!(
+        role_of(&batch, "parse_note"),
+        Some(EntityRole::Source),
+        "{batch:?}"
+    );
+    assert_eq!(
+        role_of(&incremental, "parse_note"),
+        Some(EntityRole::Source),
+        "{incremental:?}"
+    );
+}


### PR DESCRIPTION
Two gaps put the wrong role on real entities. Colocated framework tests read as production source,
and a test declared inside a product file changed role depending on which pipeline path last touched
it.

**Gap 1: the test-filename rule listed eight literal extensions.** `Foo.test.tsx`, `FooTest.java`,
`foo_spec.rb`, `FooTests.cs`, `FooSpec.kt` and every other colocated framework test classified as
production source. A React repository with colocated tests read 100% Source, and the two linker gates
that filter on `role != Test` then removed nothing, because nothing was Test. Those gates exist to
stop a production call fanning out to a test double, so the failure is silent and it is on the
answer, not on a report.

The rule is now delimited rather than a bare suffix, and the delimiter is what makes widening safe.
`latest.java` ends with the letters `test.java`, so a lowercased `ends_with` would call it a test. A
marker counts only when an underscore, a dot, or a capital separates it from the rest of the stem.
The capital case reads the **original** spelling, because the lowercased form cannot tell `FooTest`
from `latest`.

**Gap 2: the incremental path skipped the in-file test promotion.** The full-parse path promotes an
entity the parser recognised as a test, by name, inside a product file. The incremental path assigned
the path role and stopped. So a `#[test] fn` in `src/lib.rs` was Test after a full parse and Source
after an incremental reconcile: the same code, two roles, decided by which path ran last. That is a
defect on its own, independent of whether any repository was ever observed reading all Source.

## Falsification

Five mutation and check pairings, each applied to the committed tree, each restored, with the tree
verified clean and no mutation marker left behind. The driver restores on an `EXIT`, `INT` and `TERM`
trap rather than at the end, because a killed run leaves a mutant that `git status` cannot tell from
a half-finished edit.

| Mutation | Check that went red |
|---|---|
| the marker is matched undelimited and lowercased, which is the naive widening | `classify_colocated_framework_test_files` |
| the rule goes back to the eight literals | `classify_colocated_framework_test_files` and `role_reaches_the_graph_for_every_path_convention` |
| the incremental path assigns the path role and nothing else | `an_in_file_test_keeps_its_role_on_both_pipeline_paths` |
| the promotion is made unconditional, so any file holding a test is all test | `an_in_file_test_keeps_its_role_on_both_pipeline_paths` |

The first is the one worth reading. It is not a broken version of the fix, it is the version a
reasonable person writes when asked to widen a suffix list, and the controls are what catch it:
`latest.java`, `Latest.java`, `latest/release.rs`, `contest.py`, `manifest.rs`, and pytest's own
`src/_pytest/python.py`, each of which ends with a marker's letters and is not a test.

The fourth is the control on the promotion itself. Without it, "promote in-file tests" is satisfied
by calling every entity in the file a test, and the product function beside the `#[test] fn` would go
with it.

**Every role assertion is read back after `apply_to_graph`, not off the in-memory `IndexedFile`,**
so a role that is correct at parse time and lost on the way to the store is caught too. The
incremental arm drives `index_file_with_hint` against a real file and a real blob store, because that
is the path the gap lived on, and a batch-only fix passes the first assertion and leaves the second.

## What I ran

`cargo test -p kin-index` (19 suites green, 361 lib tests plus the new integration file),
`cargo fmt --all -- --check`, and `bin/kin-precheck kin` against this tree: **16 gates ran, 16
passed, 0 failed**. It reports this tree 1 commit behind origin/main, which is kin#1134 landing
while this branch was under test; the queue builds its own merge, and the tool's own threshold is 20,
so this is a warning it prints rather than a state it refuses. Named here because the gate list this
run read is the one on this tree.

`bin/kin-parity` on `61e143ed2`, release profile, clean tree: **FINAL PASS-WITH-ALLOWANCES** in
769.2 s. magic 22 pass / 0 fail / 0 unreadable. brownfield 10 pass / 0 fail / 1 unreadable. firstrun
9 pass / 2 fail. All three non-passes are pre-existing and named in the allowance list, and **none is
from this branch**: brownfield 4 (FIR-2464, the truncated reference walk), firstrun 3 (FIR-2501, the
projection row under Kin's own shell hook) and firstrun 9 (FIR-2580, `kin daemon stop --all`).

Hosted CI is the gate of record and the Windows legs run only there.

## Tickets

Part of FIR-1940

The ticket carries two independent findings. Item 1 is the missing role field, and it is now whole:
the parity half landed in kin#1129 and this is the classifier half that makes the field mean
something, since a `role` that is always `Source` is a field with no information in it.

**Item 2 is untouched and this PR does not go near it.** The six MCP client registrations still
disagree on repo selection: Codex CLI is written with a `--repo` pin to the absolute path of whatever
repository `kin setup` ran in, while Claude Code, Cursor and Gemini CLI resolve from the agent's
working directory, and `kin setup doctor` reports all six equally `ok`. That is why this is `Part of`
rather than `Closes`.

Split from the parity half on purpose. That was a serializer change proved by a serializer test; this
is an ingest change proved by an ingest test that writes to a graph and reads back. Sharing a PR
would let a red run mean either.

## Claims not being made

That any repository was measured reading 100% Source. The ticket's own comment records that as
unverified at whole-graph scale; what is verified is that both gaps produce it on the right
repository shape, and both are now closed with checks that redden when restored. That the marker
list is complete: it covers the conventions the adapters in this registry actually serve, and a
language whose convention is neither delimiter nor capital would need its own arm. That role
classification is now correct everywhere; these are the two gaps the validation pass found in code,
not a proof that no third exists.
