### PR TITLE
Let a hosted daemon read repository authority from the backend it has

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9682,32 +9682,59 @@ async fn repository_authority_snapshot(
     state: &DaemonState,
     repo_id: &str,
 ) -> Result<kin_db::GraphSnapshot, (StatusCode, String)> {
+    // Capability decides which authority answers, never identity. A daemon with
+    // a storage backend reaches every repository it serves through that
+    // backend, the one it advertises included; a daemon without one has only
+    // the local binding it opened at startup. This is the selection
+    // [`repository_transfer_authority`] already makes, and the two now agree.
+    //
+    // Deciding by identity instead is what made these routes unservable on a
+    // hosted daemon. `DaemonState::open_with_backend` leaves
+    // `cached_workspace_id` and `local_repository_backend` unset, so routing
+    // the advertised repository into the local branch reached a binding that
+    // cannot exist there and answered "local daemon is missing its startup
+    // workspace binding" for the repository the daemon was built to serve.
+    //
+    // The other branch could not answer either. It read the envelope off
+    // `InMemoryGraph::to_snapshot()`, which sets `repository_authority` to
+    // `None` unconditionally because repository authority belongs to the
+    // immutable publication manager and never to the mutable graph. Asserting
+    // on a field the value's own type erases is a check that cannot pass, so
+    // that branch refused every sibling whatever storage held. Authority is
+    // read from the manager here for the same reason the local branch always
+    // did: it is the only thing that owns one.
+    if let Some(backend) = &state.storage_backend {
+        // Addressability and absence stay decided where they already were, and
+        // before authority is opened. An unserved id is a 404 naming the served
+        // identity, and a served id storage holds nothing for is a 404 too.
+        // Opening the manager first would answer both by minting a fresh empty
+        // authority, turning two distinct refusals into one 200 carrying no
+        // refs.
+        repo_scoped_graph(state, repo_id).await?;
+        let repository_id = RepositoryId::new(repo_id.to_string()).map_err(|error| {
+            (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                format!("invalid repository identity: {error}"),
+            )
+        })?;
+        // The manager's own open refuses a snapshot with no envelope and one
+        // whose envelope belongs to another repository, so neither check is
+        // repeated here; repeating them would assert over bytes that already
+        // passed the same validator.
+        let authority = RepositoryAuthorityManager::open(repository_id, Arc::clone(backend))
+            .map_err(repository_authority_error)?;
+        return Ok(authority.read_authority().snapshot().clone());
+    }
+
     if repo_id == state.cached_repo_id {
         let authority = ActiveApiRepositoryAuthority::open(state)?;
         return Ok(authority.manager.read_authority().snapshot().clone());
     }
 
-    let graph = repo_scoped_graph(state, repo_id).await?;
-    let snapshot = graph.to_snapshot();
-    let metadata = snapshot.repository_authority.as_ref().ok_or_else(|| {
-        (
-            StatusCode::FAILED_DEPENDENCY,
-            format!("repository {repo_id} has no repository-v6 authority envelope"),
-        )
-    })?;
-    if metadata.repository_id.as_str() != repo_id {
-        return Err((
-            StatusCode::FAILED_DEPENDENCY,
-            format!(
-                "requested repository {repo_id} but durable authority belongs to {}",
-                metadata.repository_id
-            ),
-        ));
-    }
-    metadata
-        .validate_against_snapshot(&snapshot)
-        .map_err(repository_authority_error)?;
-    Ok(snapshot)
+    Err((
+        StatusCode::NOT_FOUND,
+        format!("repository {repo_id} is unavailable in local daemon mode"),
+    ))
 }
 
 fn repository_metadata(
@@ -15611,6 +15638,110 @@ mod tests {
             .await
             .unwrap();
         (status, body.to_vec())
+    }
+
+    /// A hosted daemon answers for the repository it advertises out of its own
+    /// backend.
+    ///
+    /// This is the shape the hosted pod runs: `open_with_backend`, so
+    /// `cached_workspace_id` and `local_repository_backend` are both unset, and
+    /// the advertised repo id equal to the one being asked for. Selecting the
+    /// authority by identity sent exactly this request into the local branch
+    /// and answered "local daemon is missing its startup workspace binding" for
+    /// the repository the daemon exists to serve.
+    #[tokio::test]
+    async fn hosted_daemon_serves_the_advertised_repository_authority_from_its_backend() {
+        let repo_id = format!("hosted-advertised-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+        let (state, _working, storage) = replica_state(&repo_id);
+        seed_replica_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x8051,
+            "publish the advertised repository's head",
+        );
+
+        let snapshot = repository_authority_snapshot(&state, &repo_id)
+            .await
+            .expect("a hosted daemon must serve the authority its own backend holds");
+        let metadata = snapshot
+            .repository_authority
+            .as_ref()
+            .expect("the served snapshot carries the envelope the backend published");
+        assert_eq!(metadata.repository_id.as_str(), repo_id);
+        assert!(
+            !metadata.ref_state.refs.is_empty(),
+            "the published ref must be served, not an empty ref set"
+        );
+    }
+
+    /// The same daemon answers for a sibling it serves but does not advertise.
+    ///
+    /// This branch read the envelope off `InMemoryGraph::to_snapshot()`, which
+    /// sets `repository_authority` to `None` unconditionally, so it refused
+    /// every sibling with "has no repository-v6 authority envelope" no matter
+    /// what storage held. The assertion could not pass, which is why no amount
+    /// of republishing the backend ever changed the answer.
+    #[tokio::test]
+    async fn hosted_daemon_serves_a_sibling_repository_authority_from_its_backend() {
+        let advertised = format!("hosted-advertised-{}", Uuid::new_v4());
+        let sibling = format!("hosted-sibling-{}", Uuid::new_v4());
+        let sibling_id = RepositoryId::new(sibling.clone()).unwrap();
+        let (state, _working, storage) = replica_state(&advertised);
+        seed_replica_change(
+            storage.path(),
+            &sibling_id,
+            None,
+            0x8052,
+            "publish a sibling's head into the shared backend",
+        );
+
+        let snapshot = repository_authority_snapshot(&state, &sibling)
+            .await
+            .expect("a hosted daemon must serve a sibling it holds");
+        let metadata = snapshot
+            .repository_authority
+            .as_ref()
+            .expect("the served snapshot carries the sibling's envelope");
+        assert_eq!(metadata.repository_id.as_str(), sibling);
+        assert!(
+            !metadata.ref_state.refs.is_empty(),
+            "the sibling's published ref must be served"
+        );
+    }
+
+    /// A backend snapshot with no envelope is still refused, and loudly.
+    ///
+    /// This is the inverse of the two above and the half that matters: without
+    /// it, the checks they make would also pass against an authority minted
+    /// empty on the spot, which is a 200 carrying no refs where a refusal
+    /// belongs. It is also the exact state the hosted bucket is in, reached the
+    /// same way: a snapshot exported from the derived graph, which erases the
+    /// envelope by construction, then persisted as if it were a publication.
+    #[tokio::test]
+    async fn hosted_daemon_refuses_a_backend_snapshot_carrying_no_authority_envelope() {
+        let repo_id = format!("hosted-envelopeless-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+
+        let exported = kin_db::GraphSnapshot::empty();
+        assert!(
+            exported.repository_authority.is_none(),
+            "the fixture must reproduce an export, not a publication"
+        );
+        let backend = kin_db::LocalFileBackend::new(storage.path().to_path_buf());
+        backend
+            .save_snapshot(&repo_id, &exported.to_bytes().unwrap(), 0)
+            .expect("persisting a graph-only snapshot is what produced the hosted state");
+
+        let (status, detail) = repository_authority_snapshot(&state, &repo_id)
+            .await
+            .expect_err("a snapshot with no envelope has no authority to serve");
+        assert_eq!(status, StatusCode::FAILED_DEPENDENCY);
+        assert!(
+            detail.contains("authority envelope"),
+            "the refusal must name the missing envelope, got: {detail}"
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -15744,6 +15744,80 @@ mod tests {
         );
     }
 
+    /// The hosted publication loop, end to end.
+    ///
+    /// An empty hosted store admits a native transfer and then serves the head
+    /// it admitted. This is the operation that puts a repository into a hosted
+    /// bucket with an authority envelope, and it is the product's own route:
+    /// `kin push` drives exactly this `POST /repos/{id}/transfer/receive`.
+    ///
+    /// Worth its own test because the two halves were broken in different
+    /// places and only together do they make a hosted repository readable. The
+    /// receive half already worked; the read half answered 424 for everything,
+    /// so nothing that arrived this way could be seen afterwards. A test that
+    /// covered only one half would have gone green while the pair stayed
+    /// useless.
+    ///
+    /// It also pins the precondition the bucket currently violates. An empty
+    /// store mints genesis authority on open and admits this transfer; a store
+    /// holding a snapshot with no envelope refuses before the transfer starts,
+    /// which is why an export cannot be repaired in place and has to be moved
+    /// aside first.
+    #[tokio::test]
+    async fn a_hosted_store_admits_a_native_transfer_and_then_serves_the_head_it_admitted() {
+        let repo_id = format!("hosted-publish-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+        let pack = transfer_pack_for_unborn_destination(&repository_id);
+        let admitted_head = pack.source_head;
+        let (state, _working, _storage) = replica_state(&repo_id);
+        let destination_ref = kin_model::RefName::branch(b"main").unwrap();
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post(format!("/repos/{repo_id}/transfer/receive"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({
+                            "destination_ref": destination_ref,
+                            "pack": pack,
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 4 * 1024 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "an empty hosted store must admit a native transfer: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let snapshot = repository_authority_snapshot(&state, &repo_id)
+            .await
+            .expect("the head a hosted store admitted must be readable afterwards");
+        let metadata = snapshot
+            .repository_authority
+            .as_ref()
+            .expect("admitting a transfer publishes an envelope");
+        assert!(
+            metadata
+                .ref_state
+                .refs
+                .iter()
+                .any(|repository_ref| matches!(
+                    &repository_ref.target,
+                    kin_model::RefTarget::Change { change_id } if *change_id == admitted_head
+                )),
+            "the served refs must carry the change the transfer admitted"
+        );
+    }
+
     #[tokio::test]
     async fn native_push_and_pull_move_exact_history_between_two_daemons_over_http() {
         use kin_remote::repository_transfer_negotiation::{


### PR DESCRIPTION
Four routes were unservable on any daemon backed by storage: `/repos/{id}/refs`, `/files`, `/history` and `/archive/tar`. Both branches of `repository_authority_snapshot` refused, for different reasons, and neither refusal was about the data.

The advertised repository was routed by identity into the local branch, which opens authority through the startup workspace binding. `open_with_backend` never sets one, so the daemon answered `local daemon is missing its startup workspace binding` for the repository it exists to serve.

Every other repository took the branch that read the envelope off `InMemoryGraph::to_snapshot()`, which sets `repository_authority` to `None` unconditionally, because authority belongs to the immutable publication manager and never to the mutable graph. Asserting on a field the value's own type erases is a check that cannot pass, so that branch refused every sibling whatever storage held.

## The fix

Select by capability, which is what `repository_transfer_authority` in the same file already does: a backend answers for every repository it serves, and the local binding answers only when there is no backend. Authority comes from the manager either way, since that is the only thing that owns one. The two selections now agree instead of contradicting each other eight hundred lines apart.

Addressing and absence stay decided before authority is opened, so an unserved id and a served id storage holds nothing for both keep their 404s. Opening the manager first would answer both by minting an empty authority, which is a 200 carrying no refs where a refusal belongs.

The manager's own open already refuses a snapshot with no envelope and one whose envelope belongs to another repository, so neither check is repeated here.

## Falsification

Four tests, on the hosted fixture rather than a local one, each proven to go red under a named mutation on the committed tree. Baseline is all green.

| mutation | advertised | sibling | envelope-less | transfer loop |
| -- | -- | -- | -- | -- |
| `MUTANT-IDENTITY-FIRST`, put the identity branch back in front | FAILED | ok | FAILED | FAILED |
| `MUTANT-DERIVED-GRAPH`, read the envelope off `to_snapshot()` again | FAILED | FAILED | FAILED | FAILED |
| `MUTANT-FALLBACK-TO-DERIVED`, fall back to the derived snapshot when the manager refuses | ok | ok | FAILED | ok |

The third row is why the inverse test exists. A fix that quietly falls back instead of refusing passes both positive tests and is caught only by the one that requires the refusal to stand. Without it the suite could not tell a real fix from a weakened assertion.

The script restores on an EXIT, INT and TERM trap, asserts each mutant marker is in the tree before its build starts, and aborts the arm rather than running it unmutated. The tree was confirmed clean and marker free afterwards.

## What I ran

`bin/kin-precheck kin` through `bin/kin-lane run` on this worktree: 16 gates enumerated from ci.yml's own check job, 16 passed, 0 failed, on `245ca1789`. It caught a formatting slip in the second commit that would otherwise have cost a hosted round, which is the whole point of it. It also named the three check-job steps it deliberately does not run, and why, which is the part that makes the tally mean something. `cargo test -p kin-daemon --lib` on the rebased tree: 1042 passed, 0 failed. Rebased onto `origin/main` `5ee045f2a`.

## A cost this adds, named rather than hidden

The manager is opened per request, and on a hosted backend that is not free. kin's own comment at `state.rs:2148` says opening authority there re-downloads the snapshot `open_with_backend` already loaded and may replay the whole history to validate it. `/refs` is a hot route, the prod `kin` object is 69 MB, and `kin-db`'s GCS backend has no snapshot byte cache.

It is not fixed here on purpose. `ProjectionAuthorityCache` solves this for the local path, but it holds an `ActiveApiRepositoryAuthority` and labels it with a `LocalPublicationIdentity`, so it cannot take a hosted manager as is. An authority cache that serves one publication past its replacement is worse than a slow route, and getting the invalidation right needs its own falsification rather than a rider on a correctness fix. FIR-2709 carries it, including a cheaper option: the load path already decodes a snapshot with the envelope and throws it away, so capturing it there would cost a clone instead of a download.

## The other half, and why it needs no new code

This does not make the hosted smoke green on its own. The objects in the graph bucket carry no envelope, because they were exported from the derived graph rather than published through a repository transaction, so `RepositoryAuthorityManager::open` refuses them with `snapshot has no v13 authority envelope`.

The route that fixes that already exists and is the product's own. `kin push --url <daemon-base-url> --ref <ref>` publishes exact repository-v6 history to a native Kin remote, driving `POST /repos/{id}/transfer/receive`. That route resolves authority through `repository_transfer_authority`, which has always preferred `state.storage_backend`, so it was hosted-capable before this change. The receive commits a repository transaction, and `prepare_successor` stamps the envelope. A store with no object mints genesis authority on open, so the first push has something to advance.

The second commit proves it rather than asserting it: `a_hosted_store_admits_a_native_transfer_and_then_serves_the_head_it_admitted` admits a native transfer into an empty hosted-shaped store and reads the head back through `repository_authority_snapshot`. Both halves had to work and only one of them did, so a test covering either alone would have been green while the pair stayed useless.

It also pins the precondition the bucket violates. A store holding an envelope-free snapshot refuses at `RepositoryAuthorityManager::open`, which happens before the transfer is applied, so an exported object cannot be repaired in place and has to be moved aside first. Order: land this, deploy it, move the objects aside, then push. Nothing in that needs a kin-db change.

Closes FIR-2708
Part of FIR-2707
