### PR TITLE
Build the hosted daemon image on a machine with room for its fat-LTO link

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -86,7 +86,11 @@ substitutions:
   _KIN_DB_REF: 'main'
 
 options:
-  machineType: 'E2_HIGHCPU_8'
+  # E2_HIGHCPU_8 carries 8 GB, and rustc was SIGKILLed at the fat-LTO link of
+  # the kin-daemon binary on every push to main from 2026-08-25 19:33Z, with no
+  # log to say so until the deployer account could write one. E2_HIGHCPU_32
+  # carries 32 GB; the same Dockerfile builds green on kin's own 16 GB CI runner.
+  machineType: 'E2_HIGHCPU_32'
   logging: CLOUD_LOGGING_ONLY
 
 timeout: '1800s'


### PR DESCRIPTION
The `kin-build` Cloud Build trigger, which publishes `kin-daemon:<sha>` to Artifact Registry on every push to main, has failed on every run since 2026-08-25 19:33Z, thirteen in a row at about twenty-five minutes each, with no log because the deployer account could view logs and not write them. With `roles/logging.logWriter` granted and a diagnostic build writing to GCS (build 214d2b32 on main 5ee045f2a), the cause is on the record: `rustc ... --crate-name kin_daemon ... -C opt-level=3 -C lto=fat -C codegen-units=1` died with `(signal: 9, SIGKILL: kill)` at 889 s into the workspace compile, which is the fat-LTO link of the daemon binary running out of memory on an `E2_HIGHCPU_8` (8 GB). Kin's own `Docker Image Build (no push)` check builds the same Dockerfile green on a 16 GB runner, which is why nothing in the PR gate saw it.

This moves the trigger to `E2_HIGHCPU_32` (32 GB) and leaves the recipe otherwise untouched. Proof of the fix is a green trigger run for this PR's own squash with the image present in AR, which lands after the merge and is recorded on the ticket; the log-writer grant and a check that reads the trigger's last main run are the ticket's other two clauses.

Part of FIR-2710
