### PR TITLE
Resolve the home once per rc plan, so one plan cannot straddle two

### DIFF
--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1429,7 +1429,18 @@ fn fallback_shell() -> &'static str {
 }
 
 pub(crate) fn shell_rc(shell: &str) -> Result<PathBuf> {
-    let home = home_dir()?;
+    shell_rc_in(&home_dir()?, shell)
+}
+
+/// [`shell_rc`] against a home the caller already resolved.
+///
+/// The home is a parameter so that one plan cannot straddle two of them. Every
+/// path in an rc plan has to describe the same home, and the only way to
+/// guarantee that is to resolve it once and pass it down; resolving it again
+/// per path makes the plan's shape depend on whether anything moved `HOME` in
+/// between (FIR-2714).
+pub(crate) fn shell_rc_in(home: &Path, shell: &str) -> Result<PathBuf> {
+    let home = home.to_path_buf();
     match shell {
         "zsh" => Ok(home.join(".zshrc")),
         "bash" => Ok(home.join(".bashrc")),
@@ -1525,10 +1536,15 @@ fn bash_login_rc_in(home: &Path) -> PathBuf {
 /// them, and the arms below mirror that function's exactly, including its
 /// treatment of an unrecognized shell as zsh.
 pub(crate) fn shell_path_rcs(shell: &str) -> Result<Vec<PathBuf>> {
-    let home = home_dir()?;
+    shell_path_rcs_in(&home_dir()?, shell)
+}
+
+/// [`shell_path_rcs`] against a home the caller already resolved. Same reason as
+/// [`shell_rc_in`].
+pub(crate) fn shell_path_rcs_in(home: &Path, shell: &str) -> Result<Vec<PathBuf>> {
     Ok(match shell {
-        "bash" => vec![home.join(".bashrc"), bash_login_rc_in(&home)],
-        "fish" | "powershell" => vec![shell_rc(shell)?],
+        "bash" => vec![home.join(".bashrc"), bash_login_rc_in(home)],
+        "fish" | "powershell" => vec![shell_rc_in(home, shell)?],
         _ => vec![home.join(".zshenv")],
     })
 }
@@ -2529,13 +2545,24 @@ fn install_shell_hook(shell_name: &str) -> Result<(PathBuf, String)> {
 /// PATH line a second time, because bash reads one or the other and never both
 /// unless the login file says so.
 fn rc_write_plan(shell_name: &str) -> Result<Vec<RcTarget>> {
-    let hook_rc = shell_rc(shell_name)?;
+    // Resolved ONCE, and passed down. This function decides whether one file
+    // carries both blocks by comparing the hook path against each PATH path, and
+    // it used to resolve the home separately for each side. For fish and
+    // PowerShell those are the same expression, so they agreed and the plan was
+    // one target, until something moved `HOME` between the two reads: then the
+    // two sides described different homes, the comparison failed, and the plan
+    // grew a second target pointing at a home the caller never asked about. A
+    // plan that straddles two homes is wrong whatever produced the move, so the
+    // move is made impossible here rather than guarded against by its callers
+    // (FIR-2714).
+    let home = home_dir()?;
+    let hook_rc = shell_rc_in(&home, shell_name)?;
     let mut plan = vec![RcTarget {
         path: hook_rc.clone(),
         blocks: RcBlocks::HookOnly,
         seed_when_absent: None,
     }];
-    for path_rc in shell_path_rcs(shell_name)? {
+    for path_rc in shell_path_rcs_in(&home, shell_name)? {
         if path_rc == hook_rc {
             plan[0].blocks = RcBlocks::HookAndPath;
             continue;

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -18008,8 +18008,17 @@ printf 'LD=[%s]\n' "$LD_PRELOAD"
     /// while the defect was fully present, which makes it a falsification that
     /// cannot fail. This one cannot pass while the defect is present, and cannot
     /// be constructed once it is gone, because `rc_write_plan_in` takes one home.
+    ///
+    /// `PROFILE` is unset and the test is serial because the home is not the
+    /// only input to the PowerShell arm: `shell_rc_in` prefers `PROFILE` over
+    /// the home it is handed, so on a runner that sets it both homes would
+    /// answer the same path and the assertion below would fail for a reason
+    /// that is not the defect. Pinning it is what makes this a statement about
+    /// the home rather than about the machine.
     #[test]
+    #[serial]
     fn two_homes_would_have_produced_two_targets_for_a_one_file_shell() {
+        let _profile = EnvVarGuard::unset("PROFILE");
         let tmp = tempfile::tempdir().unwrap();
         let first = tmp.path().join("home-a");
         let second = tmp.path().join("home-b");
@@ -18071,8 +18080,15 @@ printf 'LD=[%s]\n' "$LD_PRELOAD"
     /// a one-file shell gets exactly one target and it is under that home. There
     /// is no second home to disagree with, which is the difference between a
     /// defect made unlikely and one made unrepresentable.
+    ///
+    /// `PROFILE` is unset for the same reason as its counterpart above: with it
+    /// set, the PowerShell arm correctly answers a path outside the home, and
+    /// "every path is under the home given" would be the wrong assertion rather
+    /// than a flaky one.
     #[test]
+    #[serial]
     fn a_plan_describes_the_one_home_it_was_given() {
+        let _profile = EnvVarGuard::unset("PROFILE");
         let tmp = tempfile::tempdir().unwrap();
         for name in ["home-a", "home-b"] {
             let home = tmp.path().join(name);

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1438,7 +1438,7 @@ pub(crate) fn shell_rc(shell: &str) -> Result<PathBuf> {
 /// path in an rc plan has to describe the same home, and the only way to
 /// guarantee that is to resolve it once and pass it down; resolving it again
 /// per path makes the plan's shape depend on whether anything moved `HOME` in
-/// between (FIR-2714).
+/// between.
 pub(crate) fn shell_rc_in(home: &Path, shell: &str) -> Result<PathBuf> {
     let home = home.to_path_buf();
     match shell {
@@ -2560,8 +2560,7 @@ fn rc_write_plan(shell_name: &str) -> Result<Vec<RcTarget>> {
 /// about.
 ///
 /// Taking the home as an argument makes that straddle unrepresentable rather
-/// than unlikely. A plan describes one home because it cannot describe two
-/// (FIR-2714).
+/// than unlikely. A plan describes one home because it cannot describe two.
 fn rc_write_plan_in(home: &Path, shell_name: &str) -> Result<Vec<RcTarget>> {
     let hook_rc = shell_rc_in(home, shell_name)?;
     let mut plan = vec![RcTarget {

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -17911,10 +17911,27 @@ printf 'LD=[%s]\n' "$LD_PRELOAD"
     /// interactive, so the two blocks go to two files: the PATH line where a
     /// script, a Makefile or an agent shelling out will read it, and the hook
     /// where it will not be injected into one.
+    /// Isolated and serial for the same reason as the fish case below it: this
+    /// resolves the home through `rc_write_plan`, which reads it twice, and a
+    /// sibling mutating `HOME` in between changes what the plan is about. zsh's
+    /// count survives that race because its two files differ by name whatever
+    /// the home is, so this was not the test that ejected anything; it is the
+    /// same read and it gets the same isolation rather than waiting to become
+    /// the next one.
     #[test]
+    #[serial]
     fn zsh_writes_its_path_line_where_a_non_interactive_shell_reads_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+
         let plan = rc_write_plan("zsh").unwrap();
         assert_eq!(plan.len(), 2, "{plan:?}");
+        assert!(
+            plan.iter().all(|target| target.path.starts_with(&home)),
+            "every target must be about the home under test: {plan:?}"
+        );
 
         let hook = plan
             .iter()
@@ -17945,14 +17962,56 @@ printf 'LD=[%s]\n' "$LD_PRELOAD"
 
     /// fish and PowerShell read one file for both, and splitting them there
     /// would write a second block nothing reads.
+    ///
+    /// Isolated from the machine's real home, and `#[serial]`, because both
+    /// mattered and neither was here. `rc_write_plan` resolves the home TWICE,
+    /// once for the hook file and once inside `shell_path_rcs`, and compares the
+    /// two paths to decide whether one file carries both blocks. So a sibling
+    /// test mutating `HOME` between those two reads makes the paths differ and
+    /// the plan grow to two, and on a runner whose real home already holds
+    /// `~/.config/fish/config.fish` the extra entry is that real file sitting
+    /// beside a temporary one. The count then depended on which runner image the
+    /// job landed on and on which tests happened to interleave, so this passed or
+    /// failed by environment rather than by the code, and it ejected two entries
+    /// from the merge queue before anyone read the merge-group log.
+    ///
+    /// `PROFILE` is unset because `shell_rc("powershell")` prefers it over the
+    /// home, and a runner that sets it would put the plan outside the home under
+    /// test.
     #[test]
+    #[serial]
     fn a_shell_that_reads_one_file_still_gets_one_plan() {
-        for shell in ["fish", "powershell"] {
-            let plan = rc_write_plan(shell).unwrap();
-            assert_eq!(plan.len(), 1, "{shell}: {plan:?}");
-            assert_eq!(plan[0].blocks, RcBlocks::HookAndPath, "{shell}");
-            assert_eq!(plan[0].path, shell_rc(shell).unwrap(), "{shell}");
-            assert!(plan[0].seed_when_absent.is_none(), "{shell}");
+        // Both arms, because the file's existence is the thing the runner
+        // differs on: a home that already carries the fish rc, and one that does
+        // not. Neither may change the count, and both must stay inside the home
+        // under test.
+        for rc_exists in [true, false] {
+            let tmp = tempfile::tempdir().unwrap();
+            let home = tmp.path().join("home");
+            fs::create_dir_all(&home).unwrap();
+            if rc_exists {
+                fs::create_dir_all(home.join(".config/fish")).unwrap();
+                fs::write(home.join(".config/fish/config.fish"), "# existing\n").unwrap();
+            }
+            let _home = EnvVarGuard::set("HOME", &home);
+            let _xdg = EnvVarGuard::unset("XDG_CONFIG_HOME");
+            let _profile = EnvVarGuard::unset("PROFILE");
+
+            for shell in ["fish", "powershell"] {
+                let plan = rc_write_plan(shell).unwrap();
+                assert_eq!(plan.len(), 1, "{shell} (rc_exists={rc_exists}): {plan:?}");
+                assert_eq!(plan[0].blocks, RcBlocks::HookAndPath, "{shell}");
+                assert_eq!(plan[0].path, shell_rc(shell).unwrap(), "{shell}");
+                assert!(plan[0].seed_when_absent.is_none(), "{shell}");
+                // The assertion that makes this runner-independent. Without it
+                // the three above hold against the machine's real home just as
+                // well as against this one.
+                assert!(
+                    plan[0].path.starts_with(&home),
+                    "{shell}: the plan must be about the home under test rather \
+                     than the machine's: {plan:?}"
+                );
+            }
         }
     }
 

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -2545,24 +2545,31 @@ fn install_shell_hook(shell_name: &str) -> Result<(PathBuf, String)> {
 /// PATH line a second time, because bash reads one or the other and never both
 /// unless the login file says so.
 fn rc_write_plan(shell_name: &str) -> Result<Vec<RcTarget>> {
-    // Resolved ONCE, and passed down. This function decides whether one file
-    // carries both blocks by comparing the hook path against each PATH path, and
-    // it used to resolve the home separately for each side. For fish and
-    // PowerShell those are the same expression, so they agreed and the plan was
-    // one target, until something moved `HOME` between the two reads: then the
-    // two sides described different homes, the comparison failed, and the plan
-    // grew a second target pointing at a home the caller never asked about. A
-    // plan that straddles two homes is wrong whatever produced the move, so the
-    // move is made impossible here rather than guarded against by its callers
-    // (FIR-2714).
-    let home = home_dir()?;
-    let hook_rc = shell_rc_in(&home, shell_name)?;
+    rc_write_plan_in(&home_dir()?, shell_name)
+}
+
+/// [`rc_write_plan`] against a home the caller already resolved.
+///
+/// The home is a PARAMETER, and that is the fix rather than a convenience. This
+/// function decides whether one file carries both blocks by comparing the hook
+/// path against each PATH path, and it used to resolve the home separately for
+/// each side. For fish and PowerShell those are the same expression, so they
+/// agreed and the plan was one target, until something moved `HOME` between the
+/// two reads: then the sides described different homes, the comparison failed,
+/// and the plan grew a second target pointing at a home the caller never asked
+/// about.
+///
+/// Taking the home as an argument makes that straddle unrepresentable rather
+/// than unlikely. A plan describes one home because it cannot describe two
+/// (FIR-2714).
+fn rc_write_plan_in(home: &Path, shell_name: &str) -> Result<Vec<RcTarget>> {
+    let hook_rc = shell_rc_in(home, shell_name)?;
     let mut plan = vec![RcTarget {
         path: hook_rc.clone(),
         blocks: RcBlocks::HookOnly,
         seed_when_absent: None,
     }];
-    for path_rc in shell_path_rcs_in(&home, shell_name)? {
+    for path_rc in shell_path_rcs_in(home, shell_name)? {
         if path_rc == hook_rc {
             plan[0].blocks = RcBlocks::HookAndPath;
             continue;
@@ -17985,6 +17992,108 @@ printf 'LD=[%s]\n' "$LD_PRELOAD"
             path.seed_when_absent.is_none(),
             "zsh's `.zshenv` needs nothing but Kin's own block: {path:?}"
         );
+    }
+
+    /// The defect, stated without a thread: two homes produce two targets.
+    ///
+    /// This is the shape `rc_write_plan` had. It resolved the home once for the
+    /// hook path and once for the PATH path, then folded them together when they
+    /// matched. For fish both sides were the same expression, so they matched,
+    /// unless the two reads saw different homes. Here the two homes are handed
+    /// in deliberately, so the failure is arithmetic rather than timing: the
+    /// paths differ, the fold does not happen, and a plan built that way carries
+    /// two entries for a shell that reads one file.
+    ///
+    /// Written this way on hostedauth's argument, and it replaced a ten-iteration
+    /// race loop at `--test-threads=16`. That loop could pass on a quiet machine
+    /// while the defect was fully present, which makes it a falsification that
+    /// cannot fail. This one cannot pass while the defect is present, and cannot
+    /// be constructed once it is gone, because `rc_write_plan_in` takes one home.
+    #[test]
+    fn two_homes_would_have_produced_two_targets_for_a_one_file_shell() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = tmp.path().join("home-a");
+        let second = tmp.path().join("home-b");
+
+        for shell in ["fish", "powershell"] {
+            let hook = shell_rc_in(&first, shell).unwrap();
+            let path = shell_rc_in(&second, shell).unwrap();
+            assert_ne!(
+                hook, path,
+                "{shell}: two homes must give two paths, or this proves nothing"
+            );
+            // The fold in `rc_write_plan_in` is exactly `path_rc == hook_rc`.
+            // With two homes it is false, so the second path becomes a second
+            // target: the plan the queue saw.
+            assert_eq!(
+                usize::from(hook != path) + 1,
+                2,
+                "{shell}: this is the count the merge-group runners reported"
+            );
+        }
+    }
+
+    /// The property the defect rested on: a home read is a read, every time.
+    ///
+    /// `home_dir` calls `resolve_home_dir` with a live `env::var_os` closure and
+    /// a freshly built `BaseDirs`, so it caches nothing and answers from the
+    /// environment as it stands at the call. Two reads can therefore see two
+    /// homes, which is what made the fold above fail. Asserted directly, because
+    /// the whole argument rests on it and a cached read would quietly make the
+    /// defect impossible for a reason nobody wrote down.
+    #[test]
+    #[serial]
+    fn a_home_read_answers_from_the_environment_at_the_time_of_the_call() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = tmp.path().join("first");
+        let second = tmp.path().join("second");
+        fs::create_dir_all(&first).unwrap();
+        fs::create_dir_all(&second).unwrap();
+
+        let seen_first = {
+            let _home = EnvVarGuard::set("HOME", &first);
+            home_dir().unwrap()
+        };
+        let seen_second = {
+            let _home = EnvVarGuard::set("HOME", &second);
+            home_dir().unwrap()
+        };
+        assert_ne!(
+            seen_first, seen_second,
+            "two reads across a moved HOME must differ, or the straddle this \
+             ticket is about could never have happened"
+        );
+        assert!(seen_first.starts_with(&first) && seen_second.starts_with(&second));
+    }
+
+    /// And the fix: one home in, one home throughout.
+    ///
+    /// The counterpart to the two-homes case above. Whatever home this is given,
+    /// a one-file shell gets exactly one target and it is under that home. There
+    /// is no second home to disagree with, which is the difference between a
+    /// defect made unlikely and one made unrepresentable.
+    #[test]
+    fn a_plan_describes_the_one_home_it_was_given() {
+        let tmp = tempfile::tempdir().unwrap();
+        for name in ["home-a", "home-b"] {
+            let home = tmp.path().join(name);
+            fs::create_dir_all(home.join(".config/fish")).unwrap();
+            fs::write(home.join(".config/fish/config.fish"), "# existing\n").unwrap();
+            for shell in ["fish", "powershell"] {
+                let plan = rc_write_plan_in(&home, shell).unwrap();
+                assert_eq!(plan.len(), 1, "{shell} in {name}: {plan:?}");
+                assert!(
+                    plan.iter().all(|target| target.path.starts_with(&home)),
+                    "{shell} in {name}: every path is about the home given: {plan:?}"
+                );
+            }
+            let zsh = rc_write_plan_in(&home, "zsh").unwrap();
+            assert_eq!(zsh.len(), 2, "zsh in {name}: {zsh:?}");
+            assert!(
+                zsh.iter().all(|target| target.path.starts_with(&home)),
+                "zsh in {name}: both files are about the home given: {zsh:?}"
+            );
+        }
     }
 
     /// fish and PowerShell read one file for both, and splitting them there


### PR DESCRIPTION
A unit test could resolve two different homes inside one call, so an rc plan straddled two of them
and grew a target the caller never asked about. It ejected two entries from the merge queue tonight,
and because the failure lived in a `merge_group` run, both pull requests showed every check green
while their entries were removed with nothing marking either one.

**The mechanism, corrected.** My first reading of this blamed the runner image, on the grounds that
`macos-latest` carries a real `~/.config/fish/config.fish` and the extra target was that file. That
is wrong, and the evidence against it is direct: a host that also carries a real fish rc runs this
test green, repeatedly. The file's presence is not sufficient.

What is sufficient is a move of `HOME` inside one call. `rc_write_plan` decides whether a single file
carries both blocks by comparing the hook path against each PATH path, and it resolved the home
separately for each side. For fish and PowerShell both sides are literally the same expression, so
they agreed and the plan was one target. When a concurrent test moved `HOME` between the two reads,
the sides described different homes, the comparison failed, and the plan grew a second entry. The
runner's real rc file is what made that second entry look plausible instead of obviously wrong.

The failing test carried no `#[serial]`, while 63 tests in the same module do and several point
`HOME` at a tempdir through `EnvVarGuard`. A serial test is only serialised against other serial
tests, so this one ran beside them. That is why it fires on a loaded merge-group runner and not on a
quiet laptop.

**The fix is a product fix, and that matters.** The home is now a parameter rather than something
each side looks up: `rc_write_plan_in`, `shell_rc_in` and `shell_path_rcs_in` take the home they are
to describe, and the existing functions keep their signatures and delegate after resolving it once. A
plan that straddles two homes is wrong whatever moved `HOME`, so the move is made impossible rather
than guarded against by callers.

The test isolation ships too, and is necessary, but on its own it would have been the wrong fix: the
test would still read whatever a concurrent sibling installed between the two reads, so it would pass
everywhere and flake again later on a loaded runner. `HOME` now points at a tempdir,
`XDG_CONFIG_HOME` and `PROFILE` are unset (`shell_rc("powershell")` prefers `PROFILE` over the home),
the test is `#[serial]`, and every planned path is asserted to be under the home the test created.
Two arms, a home carrying the fish rc and one without, and neither may change the count.

`zsh_writes_its_path_line_where_a_non_interactive_shell_reads_it` has the same unisolated read and
gets the same treatment. Its count survives the race because zsh's two files differ by name whatever
the home is, so it ejected nothing; it is fixed here rather than left to be the next one.

## The straddle is proved deterministically, not raced for

The obvious falsification is to restore the double read and run the suite at `--test-threads=16`
until it fails. I wrote that, ran it, and threw it away, because it is a check that cannot fail in
the direction that matters: on a quiet machine it comes back green with the defect fully present, and
a green result there says nothing at all. Nor does a red one say much, since it turns on the
scheduler rather than on the code. A falsification whose outcome is luck is not one.

Three checks replace it, none needing an interleaving.

**Two homes handed in deliberately produce two paths**, so the fold in `rc_write_plan_in` does not
happen and the plan carries two entries for a shell that reads one file. That is the exact count the
merge-group runners reported, reached by arithmetic instead of timing, and it cannot pass while the
defect is present.

**A home read answers from the environment at the time of the call.** That is the property the
straddle rested on, and it is worth pinning: a later change that cached the lookup would make the
defect impossible for a reason nobody wrote down, and the first check would keep passing while
meaning something different.

**A plan built from one home describes that home throughout**, for fish, PowerShell and zsh. This one
cannot even be constructed once the fix is in place, because `rc_write_plan_in` takes a single home.
That is the difference between a defect made unlikely and one made unrepresentable.

## Falsification

One run against the committed tree at head, seven gradings, each landing where the driver declared
it should before it ran. It was re-run on the final head after a comment-only commit rather than
left pointing at the sha it first passed on, because a table naming a sha that is not the one under
review invites the reader to assume the difference is nothing.

| Mutation | Check | Result |
|---|---|---|
| the home resolves somewhere other than the one the test created | `a_shell_that_reads_one_file_still_gets_one_plan` | RED |
| the same | `zsh_writes_its_path_line_where_a_non_interactive_shell_reads_it` | RED |
| the plan grows a second target when the rc file already exists on disk, which is what the runner's home looked like from outside | `a_shell_that_reads_one_file_still_gets_one_plan` | RED |
| the same | `zsh_writes_its_path_line_where_a_non_interactive_shell_reads_it` | GREEN, declared in advance, since zsh's count does not turn on that |
| the home stops being a parameter and the plan resolves its own | `a_plan_describes_the_one_home_it_was_given` | RED |
| `shell_rc_in` ignores the home it is handed | `two_homes_would_have_produced_two_targets_for_a_one_file_shell` | RED |
| the home read caches, so two reads across a moved `HOME` agree | `a_home_read_answers_from_the_environment_at_the_time_of_the_call` | RED |

Each was applied to the committed tree and restored, with the tree verified clean and no marker left
behind. The driver restores on an `EXIT`, `INT` and `TERM` trap, asserts each mutation's marker is
present before running anything, and separates a build failure from a red test, because `ran=0`
grades nothing and exits like neither.

It also grades any exit code of 128 or more as NOT RUN rather than RED, and prints no tally at all
when a run contains one. A shell reports a signalled child as 128 plus the signal number, so a
process someone killed is indistinguishable from a failing one by exit code alone. That rule is
falsified with a real SIGTERM sent to a live `cargo test` child, and the arm it lands on is the one
that makes the case: F1's declared expectation is RED, so without the rule a kill produces the red
the table wanted and the run tallies clean.

The danger is not that a kill looks like a failure. It is that a kill looks like a pass, whenever
the declared expectation for that arm is RED, and a falsification table is exactly where that holds
by construction, because half its arms expect red. The class is native to falsification drivers
rather than incidental to them.

**Two things I threw away, which are the useful part.**

The first version of the first mutation removed the environment closure from `home_dir`, on the
assumption that this would make the lookup ignore `HOME`. Both tests stayed green, and the reason is
that the `directories` fallback reads `HOME` itself, so the mutation never removed the sensitivity it
was written to remove. A mutation that does not do what you believe proves nothing, and a green
result from one reads exactly like a passing falsification.

The race loop went the same way, for a reason I could state before running it. It is not kept as
corroboration either. Its one reported failure was rc 143, which was my own `SIGTERM` when I killed
it, not the defect: a killed run and a failing one leave the same shape in a log, and reading the
first as the second would have been a fabricated result in a falsification table.

## The same defect, in my own new tests

Reviewing my own diff I found I had rebuilt the thing I was removing. Two of the three new checks
drive `powershell`, and `shell_rc_in` prefers `PROFILE` over the home it is handed, so neither was
a statement about the home alone.

On a runner with `PROFILE` set, `two_homes_would_have_produced_two_targets_for_a_one_file_shell`
gets one path from two homes and fails its `assert_ne`, and `a_plan_describes_the_one_home_it_was_given`
sees a plan pointing outside the home and fails its `starts_with`. Neither would have been flaky.
The first would have been wrong for a reason that is not the defect, and the second would have been
asserting something false, because a plan under an explicit `PROFILE` override is supposed to leave
the home.

Worth saying plainly, because it is counterintuitive: the second was asserting something **false**,
not something flaky. A plan built under an explicit `PROFILE` override is supposed to leave the home,
so a check demanding every path stay under the home is wrong there. A check that fails for a reason
that is not the defect is worse than no check, because someone eventually changes the product to
satisfy it.

They passed here only because no test in the module sets `PROFILE` and this host does not either.
That is luck, not construction, and it is the same shape as the defect this branch exists to remove:
a check whose answer comes from the machine. Both now unset `PROFILE` and are serial, matching the
sibling that already did. The checks that reach only fish and zsh are untouched, since neither arm
reads the environment.

Falsified in both directions, which is what makes the pin a claim rather than a precaution.

| Mutation | With `PROFILE` set | With `PROFILE` unset |
|---|---|---|
| the two-homes check loses its pin | RED | GREEN |
| the one-home check loses its pin | RED | GREEN |

The green half is the point. Without the pin these pass on any machine that happens not to set
`PROFILE`, which is every machine I would have tested on and not necessarily the one that runs them.

## An independent check on the fix's scope

While checking one of my own caveats I wrote a scanner that finds tests resolving a home through a
real call site without `#[serial]`. It is not part of this PR, and it turned into the best evidence
in it.

It carries two rules. Tests calling the `_in` variants take a home, so the home rule does not reach
them, and it would have said nothing about my own two new checks; they still read `PROFILE`. So the
second rule is that a test driving the PowerShell arm must pin `PROFILE`, and it applies to the
`_in` variants too.

Falsified against three trees with three different correct answers. On `origin/main` it names two
home offenders and one PowerShell offender and exits 1. On the commit after the isolation fix and
before the `PROFILE` pin it names exactly the two new checks and exits 1. On this head it finds
nothing and exits 0.

The middle case is the one worth having: it names the defect I put into my own tests, from a
direction I did not use to find it. The first confirms this PR's scope is neither short nor padded.

Three things make it answer correctly, and each was a mistake first. It blanks string literals as
well as comments, because a doc comment saying `shell_rc("powershell")` and an assertion message
naming `home_dir` both match a naive scan and a false regex hit is the same match as a real one. It
requires a boundary on both sides of a call site, so `resolve_home_dir(` is not `home_dir(`. And it
walks braces for a test's body, because slicing to the next `#[test]` swallows the following test's
doc comment, which is exactly how the mention got counted.

It also carries two controls that each caught a real error. The negative control was first a word
that also appears outside literals, so it failed the blanker for the wrong reason, and that wrong
failure is the only reason I looked again. The positive control was first `rc_write_plan_in`, a
function this PR introduces, so the scanner refused every unfixed tree: a positive control that
exists only after the fix cannot check a scan of the thing the fix removed.

Saved at `.kin-coord/reports/fishrc-home-reader-scan.py` and filed as **FIR-2720** with the wiring
it needs, since this PR removes one instance and nothing yet stops the next. Not in this PR's scope,
and deliberately not smuggled into it.

## What I ran

`cargo test -p kin-cli --no-default-features --lib --tests --locked`, which is the command CI runs:
exit 0, zero `FAILED` test lines, zero `test result: FAILED` lines, zero panics, against a negative
control string that appears nowhere. The suite is 2473 tests, taken from `-- --list` rather than by
summing the run's own `test result:` lines.

That distinction cost a detour and is worth one sentence. Summing those lines gave 2473 on
one run and 2472 on the next, from identical trees and the same command, and I went looking for the
missing test. Nothing was missing. Under the default thread count a `test result:` summary can
interleave with a test's own output line, so a field-position parse reads a test name where it
expects a count. Both runs ran all 2473. A total computed from interleaved output is not a
measurement, and the disagreement is the only reason I found that out. The three new checks are
confirmed present by name with a negative control, because a total cannot tell a test that ran from
one the filter never reached.

`cargo fmt --all -- --check` clean. `bin/kin-precheck kin --repo-dir kin=<worktree>` on the head
under review: 16 gates ran, 16 passed, 0 failed. It names three steps of the check job it
deliberately does not run, each needing a runner-supplied argument or event context this host cannot
supply truthfully, and it reports this tree behind origin/main, which the queue's own merge resolves.

Every gate and falsification in this body was re-run against the final head rather than left
pointing at the sha it first passed on, because a result naming a sha that is not the one under
review invites the reader to assume the difference is nothing.

Hosted CI is the gate of record and the Windows legs run only there.

## Tickets

Closes FIR-2714

## Claims not being made

That this is the only test in the tree reading the runner's home. The sweep covered this module.
After the fix, seven tests resolve a home through a real call site, six of them `#[serial]`, and the
one that is not is `unix_home_dir_still_resolves_exactly_what_base_dirs_reports`, which compares
against the real home deliberately as its contract. That count is worth one sentence of provenance,
because my first scan of it reported three non-serial readers and was wrong: it blanked comments but
kept string literals, so `shell_rc("powershell")` written inside a doc comment and `home_dir` named
inside an assertion message both counted as calls. The number above comes from a pass that blanks
literals too, with a control string that exists only inside a literal and must disappear, and a real
call site that must survive. That the interleaving is the only trigger: a runner
whose real home carries the fish rc can fail this on the image alone. That this makes the queue
ejections visible; it removes one cause, and an ejected entry still leaves no mark on the pull
request it hit. That the race loop found anything, since it was discarded before it could.
