### PR TITLE
Link the hosted daemon image under thin LTO on the machine the trigger can have

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,12 @@ ARG KIN_DB_REF=main
 ARG KIN_BUILD_GIT_SHA=""
 ARG KIN_BUILD_DIRTY=""
 ARG KIN_BUILD_BRANCH=""
+# The hosted image links its release profile with the LTO mode the build passes in,
+# because the fat link of kin-daemon exceeds the 8 GB the trigger's machine carries and
+# the only larger Cloud Build machine type is quota-blocked for this project. The
+# default stays fat so every other consumer of this Dockerfile is unchanged.
+ARG KIN_LTO=fat
+ENV CARGO_PROFILE_RELEASE_LTO=$KIN_LTO
 
 # Cargo will fetch the pinned kin-db dependency from Cargo.lock.
 WORKDIR /build

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,6 +46,7 @@ steps:
           --build-arg "KIN_BUILD_GIT_SHA=${COMMIT_SHA}" \
           --build-arg "KIN_BUILD_DIRTY=false" \
           --build-arg "KIN_BUILD_BRANCH=${build_branch}" \
+          --build-arg "KIN_LTO=${_KIN_LTO}" \
           -t "${_AR_REGISTRY}/kin-daemon:${COMMIT_SHA}" \
           -t "${_AR_REGISTRY}/kin-daemon:${branch_tag}" \
           --push \
@@ -84,13 +85,16 @@ steps:
 substitutions:
   _AR_REGISTRY: 'us-central1-docker.pkg.dev/kin-ecosystem/kin-ecosystem'
   _KIN_DB_REF: 'main'
+  _KIN_LTO: 'thin'
 
 options:
   # E2_HIGHCPU_8 carries 8 GB, and rustc was SIGKILLed at the fat-LTO link of
   # the kin-daemon binary on every push to main from 2026-08-25 19:33Z, with no
-  # log to say so until the deployer account could write one. E2_HIGHCPU_32
-  # carries 32 GB; the same Dockerfile builds green on kin's own 16 GB CI runner.
-  machineType: 'E2_HIGHCPU_32'
+  # log to say so until the deployer account could write one. E2_HIGHCPU_32 is
+  # quota-blocked for this project in this region, so the daemon links under
+  # thin LTO here (_KIN_LTO) and the 8 GB machine stays; the diagnostic build
+  # 879f04dc proved that shape on 2026-08-26.
+  machineType: 'E2_HIGHCPU_8'
   logging: CLOUD_LOGGING_ONLY
 
 timeout: '1800s'


### PR DESCRIPTION
#1143 moved the hosted daemon image build to `E2_HIGHCPU_32` and the first trigger run after it failed in seconds: that machine type is quota-blocked for this project in us-central1 (`gcloud builds describe b1e46e53`: "due to quota restrictions, Cloud Build cannot run builds of this machine type in this region"). The fat-LTO link of kin-daemon is what exceeds the 8 GB machine (`(signal: 9, SIGKILL: kill)` at the link in diagnostic build 214d2b32), and a thin-LTO link of the same source fits it: diagnostic build 879f04dc on main 5bedd597e compiled, linked, pushed `kin-daemon:5bedd597ee85e6cbcffda10f63c397143958dd50` to Artifact Registry and passed `scripts/verify-container-build-info.sh` against that sha.

This makes that shape the trigger's: the Dockerfile takes `KIN_LTO` as a build argument defaulting to `fat`, so the PR check and every other consumer are unchanged, and `cloudbuild.yaml` passes `thin` through `_KIN_LTO` and returns to `E2_HIGHCPU_8`. The hosted image therefore links under a different LTO mode from the release archives, which is recorded here and on the ticket rather than hidden; the durable alternatives (a private build pool, or building the image on kin's own 16 GB CI runner where it already passes) stay on FIR-2710.

Proof after landing: the trigger run for this PR's own squash green on the 8 GB machine with the image present in AR.

Part of FIR-2710
