### PR TITLE
Take kin-db 0.7.62 for write-time relation endpoint admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.60"
+version = "0.7.62"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "d968316efe650186062f10d97bc18de1a59169ad9e9d0aed739df9c12873834e"
+checksum = "5adaa50328a871716579ac3827bc04d4bf7cf3ce670d4c1d6f9c5e8c1dd11a77"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.60", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.62", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1651,9 +1651,52 @@ mod tests {
     use super::*;
     use kin_model::{
         ArtifactId, Entity, EntityMetadata, FilePathId, FingerprintAlgorithm, GraphNodeId, Hash256,
-        LanguageId, Relation, RelationId, RelationOrigin, RepoPath, ResolvedArtifact, ResolvedTree,
-        SemanticFingerprint, SourceSpan, TreeEntry, Visibility,
+        LanguageId, LocatedEntry, Relation, RelationId, RelationOrigin, RepoPath, ResolvedArtifact,
+        ResolvedTree, SemanticFingerprint, SourceSpan, TestCase, TestId, TestKind, TestRunner,
+        TransactionDelta, TreeDelta, TreeEntry, VerificationStore, Visibility,
     };
+
+    /// Admit a test case so a `Test` endpoint names something the store holds.
+    ///
+    /// These fixtures used to mint a `TestId` and relate it without ever
+    /// creating the case, which described coverage by a test the repository
+    /// does not have. `create_test_case` with no scopes admits the identity and
+    /// writes no relations of its own, so the fixture's own edge stays the only
+    /// one it asserts about.
+    fn admit_test_case(graph: &kin_db::InMemoryGraph, test_id: TestId) {
+        graph
+            .create_test_case(&TestCase {
+                test_id,
+                name: "fixture_case".into(),
+                language: "rust".into(),
+                kind: TestKind::Unit,
+                scopes: Vec::new(),
+                runner: TestRunner::Cargo,
+                file_origin: Some(FilePathId::new("tests/fixture.rs")),
+            })
+            .unwrap();
+    }
+
+    /// Admit an artifact at `path` so an `Artifact` endpoint names something the
+    /// resolved tree carries, through the transaction path the product uses.
+    fn admit_artifact(graph: &kin_db::InMemoryGraph, artifact_id: ArtifactId, path: &str) {
+        let mut seed = [0u8; 32];
+        for (slot, byte) in seed.iter_mut().zip(path.as_bytes()) {
+            *slot = *byte;
+        }
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id,
+                    new: LocatedEntry::new(
+                        RepoPath::from_utf8(path).unwrap(),
+                        TreeEntry::blob(Hash256::from_bytes(seed), false),
+                    ),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+    }
     use std::fs;
 
     /// The one-shot authority arm, which is what a test with no server around
@@ -3441,10 +3484,12 @@ mod tests {
         let (_temp, binding, graph) = graph_validation_fixture();
         let entity = test_entity("run_task");
         graph.upsert_entity(&entity).unwrap();
+        let test_id = kin_model::TestId::new();
+        admit_test_case(&graph, test_id);
         graph
             .upsert_relation(&graph_relation(
                 RelationKind::Covers,
-                GraphNodeId::Test(kin_model::TestId::new()),
+                GraphNodeId::Test(test_id),
                 GraphNodeId::Entity(entity.id),
             ))
             .unwrap();
@@ -3785,6 +3830,8 @@ mod tests {
 
         let test_id = kin_model::TestId::new();
         let artifact_id = ArtifactId::new();
+        admit_test_case(&graph, test_id);
+        admit_artifact(&graph, artifact_id, "src/dispatch.rs");
         graph
             .upsert_relation(&graph_relation(
                 RelationKind::Covers,

--- a/crates/kin-cli/tests/python_bare_builtin_call_resolution.rs
+++ b/crates/kin-cli/tests/python_bare_builtin_call_resolution.rs
@@ -26,8 +26,55 @@ use kin_cli::commands::trace_data_flow::{
 };
 use kin_db::InMemoryGraph;
 use kin_index::{link_cross_file, FileParseData};
-use kin_model::{ArtifactId, Entity, EntityStore, FilePathId};
+use std::collections::HashMap;
+
+use kin_model::{
+    ArtifactId, Entity, EntityStore, FilePathId, Hash256, LocatedEntry, RepoPath, TransactionDelta,
+    TreeDelta, TreeEntry,
+};
 use kin_parser::{LanguageAdapter, PythonAdapter};
+
+/// Admit one artifact per parsed file into the graph's repository tree, and
+/// return the identity map the linker takes.
+///
+/// This fixture used to mint an `ArtifactId` per file and admit none of them.
+/// That builds a store that could never exist: every persist gate refuses a
+/// relation whose artifact endpoint the resolved tree does not carry, so the
+/// graph these tests assembled was one no snapshot would have accepted, and
+/// kin-db now refuses the same edge at the write. Admitting through a
+/// transaction carrying a `TreeDelta::Added` is the path the product itself
+/// uses, so the fixture now describes a repository that could really hold what
+/// it is asserting about.
+fn admit_file_artifacts(
+    graph: &InMemoryGraph,
+    files: &[FileParseData],
+) -> HashMap<String, ArtifactId> {
+    let mut artifact_ids = HashMap::new();
+    for file in files {
+        let artifact_id = ArtifactId::new();
+        // Nothing here reads blob content; the artifact only has to exist at
+        // this path. Deriving the hash from the path keeps the fixture
+        // deterministic without pulling in a hasher.
+        let mut seed = [0u8; 32];
+        for (slot, byte) in seed.iter_mut().zip(file.file_path.as_bytes()) {
+            *slot = *byte;
+        }
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id,
+                    new: LocatedEntry::new(
+                        RepoPath::from_utf8(&file.file_path).expect("fixture path is utf-8"),
+                        TreeEntry::blob(Hash256::from_bytes(seed), false),
+                    ),
+                }],
+                ..TransactionDelta::default()
+            })
+            .expect("admit fixture artifact");
+        artifact_ids.insert(file.file_path.clone(), artifact_id);
+    }
+    artifact_ids
+}
 
 /// `parse_file` reads with the builtin `open` and imports nothing from storage.
 /// This is the call site the ticket names, verbatim in shape.
@@ -136,13 +183,10 @@ fn notekeeper_project() -> (InMemoryGraph, Vec<FileParseData>) {
         parse_py("parsing.py", PARSING_PY),
         parse_py("storage.py", STORAGE_PY),
     ];
-    let artifact_ids = files
-        .iter()
-        .map(|file| (file.file_path.clone(), ArtifactId::new()))
-        .collect();
+    let graph = InMemoryGraph::new();
+    let artifact_ids = admit_file_artifacts(&graph, &files);
     let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
 
-    let graph = InMemoryGraph::new();
     for entity in files.iter().flat_map(|file| file.entities.iter()) {
         graph.upsert_entity(entity).expect("upsert entity");
     }

--- a/crates/kin-cli/tests/python_impact_walk_agreement.rs
+++ b/crates/kin-cli/tests/python_impact_walk_agreement.rs
@@ -25,8 +25,55 @@
 use kin_cli::commands::impact::{build_impact_response, ImpactRequest};
 use kin_db::InMemoryGraph;
 use kin_index::{link_cross_file, FileParseData};
-use kin_model::{ArtifactId, Entity, EntityStore, FilePathId};
+use std::collections::HashMap;
+
+use kin_model::{
+    ArtifactId, Entity, EntityStore, FilePathId, Hash256, LocatedEntry, RepoPath, TransactionDelta,
+    TreeDelta, TreeEntry,
+};
 use kin_parser::{LanguageAdapter, PythonAdapter};
+
+/// Admit one artifact per parsed file into the graph's repository tree, and
+/// return the identity map the linker takes.
+///
+/// This fixture used to mint an `ArtifactId` per file and admit none of them.
+/// That builds a store that could never exist: every persist gate refuses a
+/// relation whose artifact endpoint the resolved tree does not carry, so the
+/// graph these tests assembled was one no snapshot would have accepted, and
+/// kin-db now refuses the same edge at the write. Admitting through a
+/// transaction carrying a `TreeDelta::Added` is the path the product itself
+/// uses, so the fixture now describes a repository that could really hold what
+/// it is asserting about.
+fn admit_file_artifacts(
+    graph: &InMemoryGraph,
+    files: &[FileParseData],
+) -> HashMap<String, ArtifactId> {
+    let mut artifact_ids = HashMap::new();
+    for file in files {
+        let artifact_id = ArtifactId::new();
+        // Nothing here reads blob content; the artifact only has to exist at
+        // this path. Deriving the hash from the path keeps the fixture
+        // deterministic without pulling in a hasher.
+        let mut seed = [0u8; 32];
+        for (slot, byte) in seed.iter_mut().zip(file.file_path.as_bytes()) {
+            *slot = *byte;
+        }
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id,
+                    new: LocatedEntry::new(
+                        RepoPath::from_utf8(&file.file_path).expect("fixture path is utf-8"),
+                        TreeEntry::blob(Hash256::from_bytes(seed), false),
+                    ),
+                }],
+                ..TransactionDelta::default()
+            })
+            .expect("admit fixture artifact");
+        artifact_ids.insert(file.file_path.clone(), artifact_id);
+    }
+    artifact_ids
+}
 
 const ADAPTERS_PY: &str = r#""""Transport adapters."""
 
@@ -158,12 +205,9 @@ fn project() -> (InMemoryGraph, Vec<FileParseData>) {
         parse_py("api.py", API_PY),
         parse_py("tests/test_adapters.py", TEST_ADAPTERS_PY),
     ];
-    let artifact_ids = files
-        .iter()
-        .map(|file| (file.file_path.clone(), ArtifactId::new()))
-        .collect();
-    let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
     let graph = InMemoryGraph::new();
+    let artifact_ids = admit_file_artifacts(&graph, &files);
+    let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
     for entity in files.iter().flat_map(|file| file.entities.iter()) {
         graph.upsert_entity(entity).expect("upsert entity");
     }

--- a/crates/kin-cli/tests/python_value_reference_dead_code.rs
+++ b/crates/kin-cli/tests/python_value_reference_dead_code.rs
@@ -21,8 +21,55 @@ use kin_cli::commands::dead_code::build_dead_code_response;
 use kin_cli::commands::refs::{build_bulk_refs_response, BulkRefsRequest};
 use kin_db::InMemoryGraph;
 use kin_index::{link_cross_file, FileParseData};
-use kin_model::{ArtifactId, Entity, EntityStore, FilePathId};
+use std::collections::HashMap;
+
+use kin_model::{
+    ArtifactId, Entity, EntityStore, FilePathId, Hash256, LocatedEntry, RepoPath, TransactionDelta,
+    TreeDelta, TreeEntry,
+};
 use kin_parser::{LanguageAdapter, PythonAdapter};
+
+/// Admit one artifact per parsed file into the graph's repository tree, and
+/// return the identity map the linker takes.
+///
+/// This fixture used to mint an `ArtifactId` per file and admit none of them.
+/// That builds a store that could never exist: every persist gate refuses a
+/// relation whose artifact endpoint the resolved tree does not carry, so the
+/// graph these tests assembled was one no snapshot would have accepted, and
+/// kin-db now refuses the same edge at the write. Admitting through a
+/// transaction carrying a `TreeDelta::Added` is the path the product itself
+/// uses, so the fixture now describes a repository that could really hold what
+/// it is asserting about.
+fn admit_file_artifacts(
+    graph: &InMemoryGraph,
+    files: &[FileParseData],
+) -> HashMap<String, ArtifactId> {
+    let mut artifact_ids = HashMap::new();
+    for file in files {
+        let artifact_id = ArtifactId::new();
+        // Nothing here reads blob content; the artifact only has to exist at
+        // this path. Deriving the hash from the path keeps the fixture
+        // deterministic without pulling in a hasher.
+        let mut seed = [0u8; 32];
+        for (slot, byte) in seed.iter_mut().zip(file.file_path.as_bytes()) {
+            *slot = *byte;
+        }
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id,
+                    new: LocatedEntry::new(
+                        RepoPath::from_utf8(&file.file_path).expect("fixture path is utf-8"),
+                        TreeEntry::blob(Hash256::from_bytes(seed), false),
+                    ),
+                }],
+                ..TransactionDelta::default()
+            })
+            .expect("admit fixture artifact");
+        artifact_ids.insert(file.file_path.clone(), artifact_id);
+    }
+    artifact_ids
+}
 
 const PARSING_PY: &str = r##""""Note parsing helpers."""
 
@@ -196,13 +243,10 @@ fn notes_project() -> (InMemoryGraph, Vec<FileParseData>) {
         parse_py("linkgraph.py", LINKGRAPH_PY),
         parse_py("tests/test_cli.py", TEST_CLI_PY),
     ];
-    let artifact_ids = files
-        .iter()
-        .map(|file| (file.file_path.clone(), ArtifactId::new()))
-        .collect();
+    let graph = InMemoryGraph::new();
+    let artifact_ids = admit_file_artifacts(&graph, &files);
     let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
 
-    let graph = InMemoryGraph::new();
     for entity in files.iter().flat_map(|file| file.entities.iter()) {
         graph.upsert_entity(entity).expect("upsert entity");
     }

--- a/crates/kin-cli/tests/reference_call_site_lines.rs
+++ b/crates/kin-cli/tests/reference_call_site_lines.rs
@@ -29,7 +29,10 @@ use kin_index::{
     link_cross_file_incremental_with_completeness, FileParseCompletenessMap, FileParseData,
     IndexPipeline,
 };
-use kin_model::{ArtifactId, Entity, EntityStore, FilePathId, Relation};
+use kin_model::{
+    ArtifactId, Entity, EntityStore, FilePathId, Hash256, LocatedEntry, Relation, RepoPath,
+    TransactionDelta, TreeDelta, TreeEntry,
+};
 
 /// A caller file that reaches `compute` twice, at lines the fixture states
 /// outright, plus a definition file. The two sites are on different lines so a
@@ -186,6 +189,29 @@ fn link_incremental(files: &[IndexedFixtureFile]) -> Vec<Relation> {
 /// never writes.
 fn graph_with(files: &[IndexedFixtureFile], linked: &[Relation]) -> InMemoryGraph {
     let graph = InMemoryGraph::new();
+    // Admit each fixture file's artifact before any relation names it. The
+    // linker roots reference edges at the file's artifact, so a graph that
+    // never admitted one holds edges no persist gate would accept, and kin-db
+    // refuses them at the write. A transaction carrying a `TreeDelta::Added`
+    // is the product's own admission path.
+    for file in files {
+        let mut seed = [0u8; 32];
+        for (slot, byte) in seed.iter_mut().zip(file.parse.file_path.as_bytes()) {
+            *slot = *byte;
+        }
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id: file.artifact_id,
+                    new: LocatedEntry::new(
+                        RepoPath::from_utf8(&file.parse.file_path).expect("fixture path is utf-8"),
+                        TreeEntry::blob(Hash256::from_bytes(seed), false),
+                    ),
+                }],
+                ..TransactionDelta::default()
+            })
+            .expect("admit fixture artifact");
+    }
     for file in files {
         for entity in &file.entities {
             let mut entity = entity.clone();

--- a/crates/kin-cli/tests/repository_rename_planner.rs
+++ b/crates/kin-cli/tests/repository_rename_planner.rs
@@ -55,7 +55,10 @@ impl PlannerHarness {
         artifact_id
     }
 
-    fn add_file(&mut self, path: &str, body: &str, completeness: ParseCompleteness) {
+    /// Returns the artifact this file was admitted as, so a test that needs
+    /// to name it in a relation uses the admitted identity rather than
+    /// minting a fresh one the tree does not carry.
+    fn add_file(&mut self, path: &str, body: &str, completeness: ParseCompleteness) -> ArtifactId {
         let artifact_id = self.add_tree_blob(path, body);
         let parser_rule = if completeness == ParseCompleteness::Full {
             kin_index::CALL_SHAPE_PARSE_COVERAGE_FULL_V1
@@ -91,6 +94,7 @@ impl PlannerHarness {
                 regions: Vec::new(),
             })
             .unwrap();
+        artifact_id
     }
 
     fn add_entity(&self, name: &str, path: &str, start_byte: usize, end_byte: usize) -> Entity {
@@ -485,8 +489,8 @@ fn extraction_incomplete_certificate_refuses_a_syntax_full_partial_refactor() {
     let target_body = "def target():\n    return 1\n";
     let caller_body =
         "def other():\n    return 2\n\ndef caller(flag):\n    return (target if flag else other)()\n";
-    harness.add_file("target.py", target_body, ParseCompleteness::Full);
-    harness.add_file("caller.py", caller_body, ParseCompleteness::Full);
+    let target_artifact = harness.add_file("target.py", target_body, ParseCompleteness::Full);
+    let caller_artifact = harness.add_file("caller.py", caller_body, ParseCompleteness::Full);
     harness.add_entity_at(
         "target",
         "target.py",
@@ -501,8 +505,12 @@ fn extraction_incomplete_certificate_refuses_a_syntax_full_partial_refactor() {
         .upsert_relation(&Relation {
             id: RelationId::new(),
             kind: RelationKind::DependsOn,
-            src: GraphNodeId::Artifact(ArtifactId::new()),
-            dst: GraphNodeId::Artifact(ArtifactId::new()),
+            // The certificate is about caller.py depending on target.py, so
+            // it names the artifacts the harness actually admitted. Minting
+            // fresh ids here described a dependency between two files the
+            // repository does not contain.
+            src: GraphNodeId::Artifact(caller_artifact),
+            dst: GraphNodeId::Artifact(target_artifact),
             confidence: 1.0,
             origin: RelationOrigin::Parsed,
             created_in: None,


### PR DESCRIPTION
kin-db now refuses, at the write, a relation naming an artifact, test, contract, work item, verification run or external reference the store does not carry, instead of admitting it and failing some later unrelated transaction over the strand. That is the asymmetry FIR-2613 is about: the transaction gate validated endpoints and a direct upsert did not, so a stranded edge got in first and the refusal fired later, on whichever commit happened to drop the endpoint. A deleted file could take an unrelated commit down that way.

Entity endpoints stay permissive on purpose. kin's own linker mints a canonical external-import placeholder whose destination entity is intentionally absent, and this repository's `graph validate` reports a graph carrying one as passing every integrity check. Judging that shape needs the predicate that recognizes it, which lives here in kin-index where kin-db cannot read it, so kin-db does not get to make that call yet. FIR-2715 carries the move that makes it possible.

The same release stops `remove_entities_for_file` keeping a cross-file edge with a dangling destination, makes the strand count readable, and fixes a `has_incoming_of_kinds` fallthrough that let an edge from nowhere keep an entity alive.

## Fifteen fixtures now admit what they always meant to have

The gate found fifteen fixtures relating an artifact or a test the store never admitted. That builds a repository that could not exist: every persist gate already refuses those edges, so these graphs were ones no snapshot would have accepted, independent of this pin. Admitting what a fixture always meant to have makes it more correct, not less; these tests now assert about a repository that could really hold what they claim.

Artifacts are admitted through a transaction carrying a `TreeDelta::Added`, the idiom `repository_rename_planner` already used for its own tree blobs. Tests are admitted through `create_test_case` with no scopes, so the identity exists and the fixture's own edge stays the only relation it asserts about.

| File | Tests | Refused on |
|---|---|---|
| `python_impact_walk_agreement` | 4 | source artifact |
| `python_value_reference_dead_code` | 4 | source artifact |
| `python_bare_builtin_call_resolution` | 3 | source artifact |
| `reference_call_site_lines` | 1 | source artifact |
| `repository_rename_planner` | 1 | source artifact |
| `commands::graph` unit tests | 2 | source test |

`repository_rename_planner` needed one more step. Its extraction-incomplete certificate named two freshly minted artifact ids, describing a dependency between two files the repository does not contain, so `add_file` now returns the identity it admitted and the test names those.

The three python harnesses each carry their own admission helper rather than sharing one. `tests/common/mod.rs` is bounded-subprocess support with a module doc that says so, and pulling kin-db graph types into a module every CLI test binary compiles would be a worse trade than three local copies of ten lines.

## The lock diff, and a stowaway

Two lines, the version and the checksum, keeping the `sparse+` registry source.

`cargo update -p kin-db --precise` also tried to downgrade `winapi-util`'s Windows-only dependency from `windows-sys 0.61.2` to `0.48.0`, which has nothing to do with this pin and is invisible on a host that cannot build that target. It is restored to main's resolution both times it appeared, on the 0.7.61 attempt and again here, so it is reproducible rather than a one-off. Both `windows-sys` versions already exist as packages in the lock, so the restore leaves it self-consistent, and `cargo metadata --locked` re-resolved kin-db 0.7.62 from the sparse registry afterwards without rewriting the lock.

## Gates

`cargo nextest run --workspace --locked --no-fail-fast`, run under the daemon lock because the featureless kin-cli suite spawns kin-daemons in temp directories: **7,349 tests run, 7,348 passed, 1 failed**. `cargo test --doc --locked` exit 0. `cargo fmt --all -- --check` clean.

`--no-fail-fast` is not decoration here. The first run of this gate stopped at its first failure, reporting 1 failed out of 316 with 7,018 never run, which is a symptom rather than a count and would have hidden the other thirty-six.

The one remaining failure is `kin-core::init_phase_ladder_contiguous the_admission_ladder_accounts_for_the_whole_of_init`, and it is not this change. It asserts that no wall-clock stretch of a real init runs with no admission span open, so its subject is scheduler behaviour, and it has now been read three times on this host at 7.1%, 8.4% and 3.1% against a 2.0% allowance while total init time stayed within 4% of itself. The gap tracks host contention and nothing else; this change adds one map lookup per relation write. It passes on CI, where the most recent successful run on `main` is green on every Check and Test job. Filed as FIR-2718 with all three readings and the fix direction.

Closes FIR-2613.
