### PR TITLE
Pin kin-db 0.7.63, which stops a workspace base carrying the change map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.62"
+version = "0.7.63"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "5adaa50328a871716579ac3827bc04d4bf7cf3ce670d4c1d6f9c5e8c1dd11a77"
+checksum = "19d9d31f834ca461ed9b61e26ba4b710f9ab6958a5cc40d38342c13b58773725"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.62", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.63", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
Takes kin-db 0.7.63, which stops a workspace comparison base carrying the repository's change map.

A full-history conversion's largest single term is the workspace preparation lap, measured at 2,922.2 MiB grown on psf/requests against a 5.67 GiB peak. Two of that lap's three internal holders were copies of the change map, one per base resolution, and the third was an entity revision timeline the graph built over the second copy derived across the whole history and then dropped. None of the three was read: a workspace mutation compares entities, relations, external references and the resolved tree, and reaches no change through its base. A resolved base now says whether it carries history, the daemon path that serves a workspace graph still does because queries read it, and the two resolutions inside `apply_workspace` do not.

kin-db 0.7.63 also ships one span per holder inside that lap, so the heap attribution probe reports `next_base`, `current_base`, the desired graph, the successor validation and the rematerialization separately instead of as one number. The kin-db side landed as kin-db#236, squash 527e445, with its guards and the full falsification matrix in that PR's body.

## The lock moves two lines

One version and one checksum, `19d9d31f834ca461...`, with the `sparse+` source intact. That checksum was read off the served registry index row, not off the publish workflow's status, with 0.7.62 as a positive control and a bogus version as a negative one.

Cargo's re-resolve also wanted to move `winapi-util`'s `windows-sys` edge from 0.61.2 to 0.48.0. That hunk is ambient: it appears on this manifest from any `cargo update` touch with no version change at all, which I checked before concluding it. It is a Windows-only edge, which is exactly the kind that ships unnoticed inside a small pin because the host cannot build the platform it affects. It is reverted here and left for whoever owns the divergence. `cargo metadata --locked` still resolves after the revert, and no tracked lock in this repo carries 0.7.62 any more, swept with a positive control on 0.7.63.

## What ran

`cargo nextest run --workspace --locked` and `cargo test --doc --locked`, which are the pair a registry pin needs, because the DEV-LOCAL gate replaces the crate under test with a local path and so cannot validate a pin at all.

One test fails locally under that gate and it is not this change. `kin-core::init_phase_ladder_contiguous the_admission_ladder_accounts_for_the_whole_of_init` reads 91.5 percent coverage against a 95 percent bar and a 3141 ms tail gap against a 2 percent bar. Run alone on the same tree it reads 98.9 percent with a 22 ms gap and passes.

That is not a diagnosis, so I ran the control: the base manifests, kin-db 0.7.62, through the same workspace-parallel gate on the same box.

| arm | ladder coverage | largest gap | workspace tally |
|---|---|---|---|
| base, kin-db 0.7.62 | 92.2% | 2959 ms | 7351 passed, 1 failed, 14 skipped |
| pinned, kin-db 0.7.63 | 92.9% | 2668 ms | 7351 passed, 1 failed, 14 skipped |

The same single test fails in both arms, and the pinned arm is marginally better on both numbers. The guard is wall-clock coverage over a real init, and the whole init takes 46 seconds inside the parallel run against 2.5 seconds alone. The gap it reports is the tail after `record_complete_admission`, a different part of the ladder from the `commit_bootstrap_transaction` this change lives inside. So the red belongs to running a wall-clock ladder guard beside 7,352 concurrent tests, not to the pin.

`bin/kin-parity` against this checkout returns 0: magic 22 pass 0 fail, brownfield 10 pass 0 fail 1 unreadable, firstrun 9 pass 2 fail with both failures allowed by name as pre-existing, FIR-2580 and FIR-2501. Doctests pass locked.

## What this does not claim

No number. The change is a mechanism fix and its size on a real corpus is unmeasured: both instrumented probe arms are built and preserved by sha256 but neither has run, because both need the daemon and quiet locks. The 2,922.2 and the 5.67 GiB above are a prior measurement, cited, not taken here. Nothing in this PR should be read as a conversion getting cheaper by any particular amount.

Part of FIR-2651
Part of FIR-2665
