### PR TITLE
Say which of the three absence cases this is, and check the envelope against itself in release

### DIFF
--- a/crates/kin-agent/src/mcp.rs
+++ b/crates/kin-agent/src/mcp.rs
@@ -77,6 +77,25 @@ impl ToolOutcome {
             .as_bool()
     }
 
+    /// Whether this answer is claiming an absence at all.
+    ///
+    /// A qualifier rides EVERY retrieval answer now, populated or not, so the
+    /// negative object's presence stopped meaning "something is being asserted
+    /// absent". The object says which it is, and a populated answer carries
+    /// `interpretation: "qualified_answer"` with a subject saying in as many
+    /// words that it returned rows and therefore asserts no absence.
+    ///
+    /// This exists because `safe_to_conclude_absent` cannot answer it.
+    /// That field is false on a populated answer PRECISELY because no absence
+    /// is claimed there, so reading its `false` as "the absence is untrusted"
+    /// turns every successful answer into a warning (FIR-2673 finding 1).
+    pub fn claims_absence(&self) -> bool {
+        let Some(negative) = self.negative.as_ref() else {
+            return false;
+        };
+        negative.get("interpretation").and_then(Value::as_str) != Some("qualified_answer")
+    }
+
     /// The named reason an absence cannot be trusted, when the server named one.
     pub fn limiting_factor(&self) -> Option<String> {
         let negative = self.negative.as_ref()?;

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -826,7 +826,12 @@ fn annotate(
     surfaced_degraded: &mut bool,
 ) -> String {
     let mut text = outcome.text.clone();
-    if outcome.safe_to_conclude_absent() == Some(false) {
+    // `claims_absence` first, and it is not a refinement. `safe_to_conclude_absent`
+    // is false on every POPULATED answer, because no absence is being claimed
+    // there, so this branch alone appended "This result is empty" to answers
+    // carrying rows, told the model to treat them as unknown, and counted each
+    // one as an unsafe absence event (FIR-2673 finding 1).
+    if outcome.claims_absence() && outcome.safe_to_conclude_absent() == Some(false) {
         counters.unsafe_absence_events += 1;
         let gap = outcome
             .limiting_factor()
@@ -1406,4 +1411,89 @@ pub fn probe_mcp(
 /// Timestamp helper re-exported so callers can stamp their own records the same way.
 pub fn timestamp() -> String {
     now_iso()
+}
+
+#[cfg(test)]
+mod annotate_tests {
+    use super::*;
+    use crate::mcp::ToolOutcome;
+
+    fn outcome(text: &str, negative: Value) -> ToolOutcome {
+        ToolOutcome {
+            text: text.to_string(),
+            is_error: false,
+            envelope: None,
+            negative: Some(negative),
+            unreadable: false,
+            wall_ms: 1,
+        }
+    }
+
+    const EMPTY_WARNING: &str = "This result is empty";
+
+    /// FIR-2673 finding 1. A populated answer is not an absence claim, and the
+    /// warning that says it is must not reach the model.
+    ///
+    /// `safe_to_conclude_absent` is false here, and that is CORRECT: no absence
+    /// is being claimed, so none can be concluded. Reading that `false` as "the
+    /// absence cannot be trusted" appended "This result is empty" to an answer
+    /// carrying rows, told the model to treat it as unknown and not to answer
+    /// another way, and counted it as an unsafe absence event.
+    #[test]
+    fn a_populated_answer_is_never_told_it_is_empty() {
+        let mut counters = Counters::new();
+        let mut surfaced = false;
+        let annotated = annotate(
+            &outcome(
+                "3 rows",
+                json!({
+                    "safe_to_conclude_absent": false,
+                    "interpretation": "qualified_answer",
+                    "result_count": 3,
+                    "limiting_factor": "python bodies are not indexed",
+                }),
+            ),
+            &mut counters,
+            &mut surfaced,
+        );
+        assert!(
+            !annotated.contains(EMPTY_WARNING),
+            "a populated answer was told it was empty: {annotated}"
+        );
+        assert_eq!(
+            counters.unsafe_absence_events, 0,
+            "a populated answer counted as an unsafe absence"
+        );
+    }
+
+    /// The control, and the half that stops the fix being "warn about nothing".
+    /// A genuinely empty answer whose absence Kin refuses to trust must still
+    /// get the warning and still be counted.
+    #[test]
+    fn an_untrusted_empty_answer_still_gets_the_warning() {
+        let mut counters = Counters::new();
+        let mut surfaced = false;
+        let annotated = annotate(
+            &outcome(
+                "no rows",
+                json!({
+                    "safe_to_conclude_absent": false,
+                    "interpretation": "absence_claimed",
+                    "result_count": 0,
+                    "limiting_factor": "python bodies are not indexed",
+                }),
+            ),
+            &mut counters,
+            &mut surfaced,
+        );
+        assert!(
+            annotated.contains(EMPTY_WARNING),
+            "an untrusted absence lost its warning: {annotated}"
+        );
+        assert!(
+            annotated.contains("python bodies are not indexed"),
+            "the warning must name the gap it was given: {annotated}"
+        );
+        assert_eq!(counters.unsafe_absence_events, 1);
+    }
 }

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -2199,18 +2199,74 @@ fn annotate_block(
     };
     let mut annotated = annotated;
     apply_response_budget(&mut annotated, tool_name, budget);
-    // The invariant that keeps the collapse from being undone one block at a
-    // time. It reads what a client will read, after the budget has had its say,
-    // so a block added later cannot reintroduce a second verdict without this
-    // firing in every debug build and every test.
-    debug_assert!(
-        crate::verdict::disagreements(&annotated).is_empty(),
-        "response for {tool_name} contradicts its own verdict: {:?}",
-        crate::verdict::disagreements(&annotated)
-    );
+    disclose_self_contradictions(&mut annotated, tool_name);
     let rendered =
         serde_json::to_string_pretty(&annotated).unwrap_or_else(|_| annotated.to_string());
     ContentBlock::Text { text: rendered }
+}
+
+/// Run the contradiction checker against what a client will actually read, and
+/// publish what it finds.
+///
+/// It used to be reached only from a `debug_assert!`, which a release build
+/// compiles out, so no shipped envelope was ever checked (FIR-2697). The v0.5.52
+/// response that certified an answer over an edge class its own completeness
+/// recorded as absent shipped with this checker present and inert, and the lane
+/// that found the hole found it because a falsification arm which DELETED the
+/// checker came back green under a release build: a removed detector and a
+/// silent one are the same run in that profile.
+///
+/// It discloses rather than panics. A contradiction is a defect in Kin, not in
+/// the caller's repository, and killing the response denies the caller both the
+/// answer and the warning. `_kin.self_check` names each disagreement in the
+/// words the checker uses, so a client, an acceptance run and a bug report all
+/// read the same sentence.
+///
+/// It does NOT feed the verdict. By this point the verdict is computed and the
+/// budget has been applied, so a refusing input arriving here would be a second
+/// verdict rather than an input to the one. The block says the response
+/// disagrees with itself and leaves the verdict as the thing it disagrees with.
+///
+/// The debug assertion it replaced is GONE rather than kept underneath, and that
+/// is deliberate. A panic in debug makes the disclosure untestable, because
+/// every test that constructs a contradiction dies before reaching the block it
+/// is meant to read, and tests are debug builds. A payload a test can assert on
+/// is the stronger guard anyway: `self_check` absent is a positive statement
+/// that nothing disagreed, where a panic that did not fire says only that
+/// nothing reached it.
+///
+/// **This does not close the certified-over-nothing hole (FIR-2723).** A checker
+/// catches a response that contradicts itself. A verdict that certifies over one
+/// input while five are silent contradicts nothing, so no arm here can see it.
+fn disclose_self_contradictions(annotated: &mut Value, tool_name: &str) {
+    let found = crate::verdict::disagreements(annotated);
+    if found.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        tool = tool_name,
+        disagreements = ?found,
+        "response contradicts its own verdict"
+    );
+    let Some(envelope) = annotated
+        .get_mut(ENVELOPE_KEY)
+        .and_then(Value::as_object_mut)
+    else {
+        // No envelope to disclose into. `disagreements` reads the verdict out of
+        // that same envelope, so it cannot have found anything without one, and
+        // this arm is unreachable rather than a silent drop.
+        return;
+    };
+    envelope.insert(
+        "self_check".to_string(),
+        json!({
+            "status": "contradicted",
+            "disagreements": found,
+            "note": "This response contradicts its own verdict, which is a defect in Kin rather \
+                     than a fact about the repository. Trust the most pessimistic reading of the \
+                     blocks named here, and report this.",
+        }),
+    );
 }
 
 /// Bound the fully annotated payload and record what that cost under
@@ -3596,6 +3652,85 @@ mod tests {
         assert!(
             !json.contains("relation_census_loss"),
             "an unobserved flag is absent from the wire, not false: {json}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod self_check_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A response whose blocks all agree, so nothing may be disclosed.
+    fn agreeing() -> Value {
+        json!({
+            "_kin": {
+                "verdict": {
+                    "state": "certified",
+                    "absence_claim": "authoritative",
+                    "safe_to_conclude_absent": true,
+                    "limiting_factor": Value::Null,
+                },
+                "completeness": {
+                    "status": "complete",
+                    "bound": "exact",
+                    "counted": {"reported": 2, "exact": true},
+                    "note": "the counts here are the whole set.",
+                },
+            },
+            "negative": {
+                "safe_to_conclude_absent": true,
+                "trust": "authoritative",
+            },
+        })
+    }
+
+    /// FIR-2697. The checker was reached only from a `debug_assert!`, so a
+    /// release binary never ran it and the v0.5.52 envelope that certified over
+    /// an absent edge class shipped with it present and inert.
+    ///
+    /// It runs unconditionally now and publishes what it finds, so this asserts
+    /// on the block a client reads rather than on a panic a release build
+    /// deletes.
+    #[test]
+    fn a_response_that_contradicts_itself_says_so_where_a_client_reads_it() {
+        let mut value = agreeing();
+        // The completeness refuses while the verdict certifies: the exact shape
+        // that shipped, and the one the certified-direction arms were added for.
+        value["_kin"]["completeness"]["status"] = json!("unknown");
+        value["_kin"]["completeness"]["bound"] = json!("at_least");
+
+        disclose_self_contradictions(&mut value, "find_references");
+
+        let check = &value["_kin"]["self_check"];
+        assert_eq!(check["status"], json!("contradicted"), "{value}");
+        let found = check["disagreements"]
+            .as_array()
+            .expect("the disagreements are named");
+        assert!(
+            found.iter().any(|line| line
+                .as_str()
+                .is_some_and(|line| line.contains("bound reads at_least under a certified"))),
+            "the disclosure names what disagreed: {found:?}"
+        );
+        assert!(
+            check["note"]
+                .as_str()
+                .is_some_and(|note| note.contains("defect in Kin")),
+            "and says whose fault it is, since a caller cannot fix it: {check}"
+        );
+    }
+
+    /// The control, and the half that stops the fix being "disclose always".
+    /// A response whose blocks agree must carry no `self_check` at all, so its
+    /// absence is a positive statement rather than a field nobody set.
+    #[test]
+    fn an_agreeing_response_carries_no_self_check() {
+        let mut value = agreeing();
+        disclose_self_contradictions(&mut value, "find_references");
+        assert!(
+            value["_kin"].get("self_check").is_none(),
+            "an agreeing response disclosed a contradiction: {value}"
         );
     }
 }

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -567,10 +567,29 @@ pub(crate) fn deciding_classes(requested: &[String], references_producible: bool
 /// [`crate::edge_coverage`] can then be retired, since it is called from exactly
 /// three payload builders.
 pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
+    let clauses = absence_coverage_clauses(tool, payload);
+    (!clauses.is_empty()).then(|| clauses.join(crate::verdict::CLAUSE_SEPARATOR))
+}
+
+/// The same gaps as [`absence_coverage_gap`], as the list they are built as.
+///
+/// The verdict takes this and never the joined string. The two used to be one
+/// function returning `Option<String>`, and `compose_limiting_factor` split it
+/// back apart on the same `"; "` this file joins with, which made the separator
+/// carry two jobs at once: the boundary between clauses, and ordinary
+/// punctuation inside one clause's prose. Two gap texts contain a semicolon,
+/// `cross_file_edges_absent` and `name_filter_narrowed_to_zero`, so each was cut
+/// into a labelled clause and a bare fragment with no label at all, and the
+/// fragment reached the reader inside `limiting_factor`.
+///
+/// A joined string is a rendering. `negative.trust_reason` is a string on the
+/// wire and takes one; the verdict composes from the list, so no boundary is
+/// ever inferred from text a human wrote.
+pub(crate) fn absence_coverage_clauses(tool: &str, payload: &Value) -> Vec<String> {
     let requested = absence_cross_file_classes(tool, payload);
     let language_scoped = absence_is_language_scoped(tool);
     if requested.is_empty() && !language_scoped {
-        return None;
+        return Vec::new();
     }
     let named = requested.join(", ");
     let claims_absence = answer_claims_absence(tool, payload);
@@ -579,7 +598,7 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
         .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
         .and_then(Value::as_object)
     else {
-        return Some(if !requested.is_empty() {
+        return vec![if !requested.is_empty() {
             format!(
                 "edge_coverage_unreported: this answer did not report whether the graph holds \
                  cross-file {named} edges, so an empty result cannot be distinguished from a graph \
@@ -603,7 +622,7 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
              span or whether this build can resolve their programs, so the rows here are a floor \
              and a declaration the extractor never admitted could not be among them"
                 .to_string()
-        });
+        }];
     };
     let language = coverage
         .get("language")
@@ -674,8 +693,8 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
                 "cross_file_edges_absent: the graph holds no cross-file {missing} edges for \
                  {language}{observed}, so a use that reaches the target through {missing} could \
                  not have been found and an empty result says nothing about whether the target is \
-                 used; the gap is in extraction/enrichment for that language, not in the \
-                 code{producible}"
+                 used, and the gap is in extraction/enrichment for that language rather than in \
+                 the code{producible}"
             ));
         } else if !unknown.is_empty()
             || coverage.get("budget_exhausted").and_then(Value::as_bool) == Some(true)
@@ -745,7 +764,7 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
                 "name_filter_narrowed_to_zero: this query's name pattern selects {declarations} \
                  on its own and the {narrowed} filter removed every one of them, so this answer \
                  observed that no candidate survived those filters rather than that the \
-                 repository holds no such declaration; the name resolves, so do not read this as \
+                 repository holds no such declaration. The name resolves, so do not read this as \
                  the target being absent, and re-run without the narrowing filter to see what it \
                  matched"
             ));
@@ -870,7 +889,7 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
         });
     }
 
-    (!gaps.is_empty()).then(|| gaps.join("; "))
+    gaps
 }
 
 /// Whether this response asserts that something is NOT there, as opposed to

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -1261,6 +1261,31 @@ mod tests {
             1,
             "one fact, one clause: {factor}"
         );
+        // WHICH of the two clauses survives is decided by the readings array's
+        // order, not by the dedupe rule, and nothing else asserts it. The
+        // absence gate precedes the coverage reading, and its clause is the
+        // specific one: it names the language and says which classes do not
+        // stand in for the missing one. Swap the two in `compute` and both the
+        // assertion above and `every_refusing_input_keeps_its_clause_in_the_factor`
+        // stay green while every real reader quietly gets the shorter clause.
+        // Both clauses name the language, so that is not the difference. The
+        // absence gate's says where the gap IS, in extraction rather than in
+        // the caller's code, and why the classes that ARE present do not stand
+        // in for the missing one. The coverage reading's says only that the
+        // edges were not observed. A reader who acts on the first does not go
+        // looking through their own source; a reader who acts on the second
+        // might.
+        assert!(
+            factor.contains("rather than in the code"),
+            "the surviving clause is the absence gate's, which tells the reader the gap is not \
+             in their code. Which of the two survives is decided by the readings array's ORDER, \
+             not by the dedupe rule, so reordering `compute` silently downgrades what every \
+             reader sees while every other assertion here stays green: {factor}"
+        );
+        assert!(
+            factor.contains("do not stand in for"),
+            "and why the classes that are present do not compensate: {factor}"
+        );
         assert!(factor.contains("embed_worker:failed"), "{factor}");
     }
 

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -477,19 +477,36 @@ fn absence_gate_reading(tool: &str, payload: &Value, negative: Option<&Value>) -
         // rows inconclusive on its own success.
         return match negative.get("trust").and_then(Value::as_str) {
             Some("authoritative") => Reading::Certified,
-            // `trust_reason` arrives as one string off the wire, composed by
-            // the negative block from its own gaps. It is taken as ONE clause
-            // rather than split on the separator: parsing it back would infer
-            // boundaries from prose exactly as this change removes elsewhere,
-            // and the clauses it was built from are not published beside it. The
-            // remaining half of that fix, having the negative block carry its
-            // gaps as a list through `push_gap` and render `trust_reason` once,
-            // is recorded on FIR-2723.
-            Some(_) => Reading::Inconclusive(vec![negative
-                .get("trust_reason")
-                .and_then(Value::as_str)
-                .unwrap_or("the absence gate refused and reported no reason")
-                .to_string()]),
+            // `trust_reason` arrives as one string off the wire, and it is a
+            // JOIN of clauses: `push_gap` builds it by repeated
+            // `format!("{trust_reason}; {gap}")` across seven call sites. So it
+            // is split back into clauses here, and that is NOT the boundary
+            // inference this change removed elsewhere.
+            //
+            // The difference is which side owns the string. Splitting a factor
+            // Kin had just joined itself was inventing a boundary; splitting a
+            // wire string that IS a join recovers one, and it is safe now
+            // because no clause carries the separator, which
+            // `no_clause_carries_the_separator_that_divides_clauses` asserts on
+            // the producer.
+            //
+            // Taking it as one clause instead was a real regression, caught by
+            // the `two_reasons` acceptance check on a live payload rather than
+            // by any unit test: `trust_reason` carries a `retrieval_degraded`
+            // clause of its own, and as one opaque blob it stopped deduplicating
+            // against the `degradations` reading's, so one answer named that gap
+            // twice. The dedupe was doing real work on this path.
+            Some(_) => Reading::Inconclusive(
+                negative
+                    .get("trust_reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or("the absence gate refused and reported no reason")
+                    .split(CLAUSE_SEPARATOR)
+                    .map(str::trim)
+                    .filter(|clause| !clause.is_empty())
+                    .map(str::to_string)
+                    .collect(),
+            ),
             None => Reading::Silent,
         };
     }
@@ -1281,6 +1298,56 @@ mod tests {
                 .expect("a note")
                 .contains("absence in it is authoritative"),
             "{verdict}"
+        );
+    }
+
+    /// The absence gate's `trust_reason` is a JOIN, and its clauses must
+    /// deduplicate against the later readings' like any others.
+    ///
+    /// This is the regression a unit test did not have. Taking `trust_reason`
+    /// as one opaque clause looked conservative and was not: the negative block
+    /// composes it by repeated concatenation, so it carries a
+    /// `retrieval_degraded` clause of its own, and as one blob that clause
+    /// stopped matching the `degradations` reading's. One live answer then named
+    /// the same gap twice, and the `two_reasons` acceptance check caught it on a
+    /// real payload after every unit test here passed.
+    ///
+    /// Splitting a wire string that IS a join recovers a boundary; splitting a
+    /// factor Kin had just joined itself invented one. Same operation, opposite
+    /// sides of the same seam, and only one of them is parsing prose.
+    #[test]
+    fn a_trust_reason_that_repeats_a_later_reading_says_that_gap_once() {
+        let negative = json!({
+            "trust": "inconclusive",
+            "trust_reason": "response_bounded: the response budget withheld part of this answer; \
+                             retrieval_degraded: this query reported degradations \
+                             [embed_worker:failed], so it did not run at full capability",
+        });
+        let readings = [
+            (
+                "absence_gate",
+                absence_gate_reading("find_references", &json!({}), Some(&negative)),
+            ),
+            (
+                "degradations",
+                Reading::Inconclusive(vec![
+                    "retrieval_degraded: this query reported degradations \
+                                            [embed_worker:failed], so it did not run at full \
+                                            capability"
+                        .to_string(),
+                ]),
+            ),
+        ];
+        let factor = compose_limiting_factor(&readings).expect("two inputs refused");
+        assert_eq!(
+            factor.matches("retrieval_degraded:").count(),
+            1,
+            "the gap the trust_reason and the degradations reading both carry is said once: \
+             {factor}"
+        );
+        assert!(
+            factor.contains("response_bounded:"),
+            "and the trust_reason's other clause survives rather than being swallowed: {factor}"
         );
     }
 

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -60,6 +60,14 @@ const NOT_APPLICABLE: &str = "not_applicable";
 /// counts being called whole.
 const VERDICT_LIMIT: &str = "verdict_inconclusive";
 
+/// What separates two clauses when the factor is rendered as one sentence.
+///
+/// The rendering only. Nothing parses it back: clauses are carried as a list
+/// from the reading that produced them to the single join at serialization,
+/// because this string is also ordinary punctuation inside a clause's prose and
+/// a boundary inferred from it is a boundary a human never chose.
+pub(crate) const CLAUSE_SEPARATOR: &str = "; ";
+
 /// The limiting factor a response bounded by the size budget carries.
 const RESPONSE_BOUNDED_FACTOR: &str = "response_bounded: the response budget withheld part of \
                                        this answer, so its counts are a lower bound and its \
@@ -78,23 +86,32 @@ const RESPONSE_BOUNDED_FACTOR: &str = "response_bounded: the response budget wit
 /// label appears once, because the absence gate already composes the class gap
 /// and the degradations that the later readings repeat as named inputs.
 fn compose_limiting_factor(readings: &[(&str, Reading)]) -> Option<String> {
+    Some(compose_clauses(readings))
+        .filter(|clauses| !clauses.is_empty())
+        .map(|clauses| clauses.join(CLAUSE_SEPARATOR))
+}
+
+/// The factor's clauses, deduplicated by label, in the readings' order.
+///
+/// Each refusing reading hands over the clauses it built. Nothing is split back
+/// out of a joined string here, which is the whole change: the separator is also
+/// ordinary punctuation inside a clause's prose, so a boundary parsed from it is
+/// a boundary no author chose. `cross_file_edges_absent` and
+/// `name_filter_narrowed_to_zero` both carry one, and each used to arrive as a
+/// labelled clause plus a bare fragment that reached the reader with no label at
+/// all.
+fn compose_clauses(readings: &[(&str, Reading)]) -> Vec<String> {
     let mut labels: Vec<String> = Vec::new();
     let mut clauses: Vec<String> = Vec::new();
     for (_, reading) in readings {
-        let Reading::Inconclusive(reason) = reading else {
+        let Reading::Inconclusive(reasons) = reading else {
             continue;
         };
-        for clause in reason
-            .split("; ")
-            .map(str::trim)
-            .filter(|clause| !clause.is_empty())
-        {
-            let label = clause
-                .split(':')
-                .next()
-                .unwrap_or(clause)
-                .trim()
-                .to_string();
+        for clause in reasons.iter().map(|clause| clause.trim()) {
+            if clause.is_empty() {
+                continue;
+            }
+            let label = clause_label(clause);
             if labels.contains(&label) {
                 continue;
             }
@@ -102,15 +119,36 @@ fn compose_limiting_factor(readings: &[(&str, Reading)]) -> Option<String> {
             clauses.push(clause.to_string());
         }
     }
-    (!clauses.is_empty()).then(|| clauses.join("; "))
+    clauses
+}
+
+/// The gap a clause names, which is the text before its first colon.
+///
+/// Two readings that notice the same gap say it once (FIR-2672), and this is
+/// how they are recognised as the same. It is still inferred rather than stated,
+/// which is a known limit recorded on FIR-2723: nothing enforces that two
+/// readings sharing a prefix describe the same gap. What it no longer does is
+/// invent clause boundaries, so a label is always a label an author wrote.
+fn clause_label(clause: &str) -> String {
+    clause
+        .split(':')
+        .next()
+        .unwrap_or(clause)
+        .trim()
+        .to_string()
 }
 
 /// One input's reading of the same answer.
 enum Reading {
     /// The input observed nothing that stops this answer being acted on.
     Certified,
-    /// The input refuses, and says why in the reason it carries.
-    Inconclusive(String),
+    /// The input refuses, and says why in the clauses it carries.
+    ///
+    /// A list rather than one string, so the factor is never parsed back out of
+    /// a joined sentence. Most readings build exactly one clause; the absence
+    /// gate composes several, and it is the one whose prose contains the same
+    /// separator the renderer uses.
+    Inconclusive(Vec<String>),
     /// The input has nothing to say about this response, which is different from
     /// saying it is fine. A silent input never certifies anything.
     Silent,
@@ -373,21 +411,34 @@ fn absence_gate_reading(tool: &str, payload: &Value, negative: Option<&Value>) -
         // rows inconclusive on its own success.
         return match negative.get("trust").and_then(Value::as_str) {
             Some("authoritative") => Reading::Certified,
-            Some(_) => Reading::Inconclusive(
-                negative
-                    .get("trust_reason")
-                    .and_then(Value::as_str)
-                    .unwrap_or("the absence gate refused and reported no reason")
-                    .to_string(),
-            ),
+            // `trust_reason` arrives as one string off the wire, composed by
+            // the negative block from its own gaps. It is taken as ONE clause
+            // rather than split on the separator: parsing it back would infer
+            // boundaries from prose exactly as this change removes elsewhere,
+            // and the clauses it was built from are not published beside it. The
+            // remaining half of that fix, having the negative block carry its
+            // gaps as a list through `push_gap` and render `trust_reason` once,
+            // is recorded on FIR-2723.
+            Some(_) => Reading::Inconclusive(vec![negative
+                .get("trust_reason")
+                .and_then(Value::as_str)
+                .unwrap_or("the absence gate refused and reported no reason")
+                .to_string()]),
             None => Reading::Silent,
         };
     }
-    match crate::negative::absence_coverage_gap(tool, payload) {
-        Some(gap) => Reading::Inconclusive(gap),
-        None if crate::negative::declares_absence_dependency(tool, payload) => Reading::Certified,
-        None => Reading::Silent,
+    // The clauses, never the joined rendering. This is the path the probe on
+    // FIR-2723 caught: `cross_file_edges_absent`'s text carries a semicolon, so
+    // joining here and splitting in the composer cut it into a labelled clause
+    // and a bare fragment that reached the reader with no label at all.
+    let clauses = crate::negative::absence_coverage_clauses(tool, payload);
+    if !clauses.is_empty() {
+        return Reading::Inconclusive(clauses);
     }
+    if crate::negative::declares_absence_dependency(tool, payload) {
+        return Reading::Certified;
+    }
+    Reading::Silent
 }
 
 /// The raw `edge_coverage` observation's own reading, independent of whichever
@@ -424,31 +475,31 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
     {
         "available" => {}
         "unsupported" => {
-            return Reading::Inconclusive(format!(
+            return Reading::Inconclusive(vec![format!(
                 "reference_enrichment_unsupported: this build wires no language-server adapter \
                  for {language}, so cross-file reference and override edges cannot exist for it \
                  at all"
-            ))
+            )])
         }
         "no_language_server" => {
-            return Reading::Inconclusive(format!(
+            return Reading::Inconclusive(vec![format!(
                 "reference_enrichment_no_language_server: an adapter is wired for {language} but \
                  no language server for it is installed on this host"
-            ))
+            )])
         }
         _ => {}
     }
     if coverage.get("scope_entities").and_then(Value::as_u64) == Some(0) {
-        return Reading::Inconclusive(format!(
+        return Reading::Inconclusive(vec![format!(
             "absence_scope_empty: the graph holds no entity at all under the filter this query \
              applied for {language}"
-        ));
+        )]);
     }
     if coverage.get("budget_exhausted").and_then(Value::as_bool) == Some(true) {
-        return Reading::Inconclusive(format!(
+        return Reading::Inconclusive(vec![format!(
             "edge_coverage_budget_exhausted: the coverage scan for {language} stopped before it \
              could establish what the graph holds"
-        ));
+        )]);
     }
 
     let requested = crate::negative::absence_cross_file_classes(tool, payload);
@@ -468,10 +519,10 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
         // sharper reason. Read from the gate's own function so the input's
         // reading and the refusal can never disagree about one observation.
         if crate::negative::coverage_classes_unmeasured(coverage, &requested) {
-            return Reading::Inconclusive(format!(
+            return Reading::Inconclusive(vec![format!(
                 "absence_coverage_unmeasured: this answer measured no coverage class for \
                  {language}, so nothing established what the extractor admitted for it"
-            ));
+            )]);
         }
         return Reading::Certified;
     }
@@ -496,21 +547,21 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
     let unproduced = in_state("unproduced");
     if !unproduced.is_empty() {
         let missing = unproduced.join(", ");
-        return Reading::Inconclusive(format!(
+        return Reading::Inconclusive(vec![format!(
             "cross_file_edges_unproduced: this build produced no entity-level {missing} edge for \
              {language} although the source carries {missing} sites the linker resolved, so a \
              use that reaches the target through {missing} could not have been found, and the gap \
              is in the linker, not in the code"
-        ));
+        )]);
     }
     let absent = in_state("absent");
     if !absent.is_empty() {
         let missing = absent.join(", ");
-        return Reading::Inconclusive(format!(
+        return Reading::Inconclusive(vec![format!(
             "cross_file_edges_absent: the graph was not observed to hold cross-file \
              {missing} edges for {language}, so a use that reaches the target through {missing} \
              could not have been found"
-        ));
+        )]);
     }
     let unhealthy: Vec<&str> = deciding
         .iter()
@@ -521,11 +572,11 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
         Reading::Certified
     } else {
         let missing = unhealthy.join(", ");
-        Reading::Inconclusive(format!(
+        Reading::Inconclusive(vec![format!(
             "edge_coverage_unknown: whether the graph holds cross-file {missing} edges for \
              {language} could not be established, so a use that reaches the target through \
              {missing} may not have been found"
-        ))
+        )])
     }
 }
 
@@ -546,11 +597,11 @@ fn withheld_candidates_reading(payload: &Value) -> Reading {
         // verdict about nothing.
         None => Reading::Silent,
         Some(0) => Reading::Certified,
-        Some(withheld) => Reading::Inconclusive(format!(
+        Some(withheld) => Reading::Inconclusive(vec![format!(
             "withheld_candidates: {withheld} same-name candidate(s) are carried in `candidates` \
              and are not in the counts here, so the headline is a floor and each withheld row \
              may belong in it"
-        )),
+        )]),
     }
 }
 
@@ -563,11 +614,11 @@ fn degradations_reading(payload: &Value) -> Reading {
     if labels.is_empty() {
         Reading::Certified
     } else {
-        Reading::Inconclusive(format!(
+        Reading::Inconclusive(vec![format!(
             "retrieval_degraded: this query reported degradations [{}], so it did not run at \
              full capability",
             labels.join(", ")
-        ))
+        )])
     }
 }
 
@@ -612,19 +663,19 @@ fn completeness_reading(envelope: &Envelope) -> Reading {
         return Reading::Silent;
     };
     if completeness.status != "complete" {
-        return Reading::Inconclusive(format!(
+        return Reading::Inconclusive(vec![format!(
             "substrate_{}: the coverage classes this answer depended on were not all observed \
              present ({})",
             completeness.status,
             completeness.decided_by.join(", ")
-        ));
+        )]);
     }
     if completeness.bound != "exact" {
-        return Reading::Inconclusive(
+        return Reading::Inconclusive(vec![
             "counts_are_a_floor: this answer's own accounting reports its numbers as a lower \
              bound"
                 .to_string(),
-        );
+        ]);
     }
     Reading::Certified
 }
@@ -1084,6 +1135,46 @@ mod tests {
         }
     }
 
+    /// No clause may contain the string that separates clauses.
+    ///
+    /// The invariant the FIR-2723 fix rests on, asserted rather than assumed.
+    /// Clauses are carried as a list now, so Kin no longer mis-parses its own
+    /// factor, but the rendered sentence is still one string, and any reader
+    /// that splits it on the separator sees whatever the prose contains. Two
+    /// gap texts used to carry one, `cross_file_edges_absent` and
+    /// `name_filter_narrowed_to_zero`, and each arrived at the reader as a
+    /// labelled clause plus a bare fragment with no label at all.
+    ///
+    /// This drives the real producer over the shapes that reach it rather than
+    /// re-listing the texts, because a test that restates the strings is a
+    /// second copy of them and goes stale the day one is edited.
+    #[test]
+    fn no_clause_carries_the_separator_that_divides_clauses() {
+        let shapes = [
+            ("find_references", populated_reference_payload("absent")),
+            ("find_references", populated_reference_payload("unproduced")),
+            ("find_references", populated_reference_payload("unknown")),
+            ("impact_analysis", populated_reference_payload("absent")),
+            ("trace_data_flow", populated_reference_payload("absent")),
+        ];
+        let mut seen = 0;
+        for (tool, payload) in &shapes {
+            for clause in crate::negative::absence_coverage_clauses(tool, payload) {
+                seen += 1;
+                assert!(
+                    !clause.contains(CLAUSE_SEPARATOR),
+                    "{tool}: a clause carries the separator, so any reader that splits the \
+                     rendered factor will cut it into a labelled clause and an unlabelled \
+                     fragment: {clause}"
+                );
+            }
+        }
+        assert!(
+            seen > 0,
+            "no clause was produced by any shape, so this asserted nothing"
+        );
+    }
+
     /// FIR-2672, second finding. A verdict with two independent reasons names
     /// both: the class gap decided the state and the failed embedding worker
     /// stayed in the sentence after it, and the gap the absence gate and the
@@ -1094,27 +1185,27 @@ mod tests {
         let readings = [
             (
                 "absence_gate",
-                Reading::Inconclusive(
+                Reading::Inconclusive(vec![
                     "cross_file_edges_absent: the graph holds no cross-file imports edges for \
                      python"
                         .to_string(),
-                ),
+                ]),
             ),
             (
                 "edge_coverage",
-                Reading::Inconclusive(
+                Reading::Inconclusive(vec![
                     "cross_file_edges_absent: the graph was not observed to hold imports edges"
                         .to_string(),
-                ),
+                ]),
             ),
             ("withheld_candidates", Reading::Certified),
             (
                 "degradations",
-                Reading::Inconclusive(
+                Reading::Inconclusive(vec![
                     "retrieval_degraded: this query reported degradations [embed_worker_failed], \
                      so it did not run at full capability"
                         .to_string(),
-                ),
+                ]),
             ),
             ("completeness", Reading::Silent),
         ];

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -138,6 +138,52 @@ fn clause_label(clause: &str) -> String {
         .to_string()
 }
 
+/// What this response says about absence, which is not what it says about trust.
+///
+/// One bool answered two questions and a reader could not branch on it
+/// (FIR-2673 finding 1). `safe_to_conclude_absent: false` meant either "this
+/// absence is not trustworthy" or "absence is not a concept for this call", and
+/// the second is the common case: a qualifier rides every retrieval answer, so
+/// the field is false on every answer that returned rows. A stranger read one
+/// `list_file_entities` response carrying `state: certified`, a note saying an
+/// absence in it is authoritative, and `safe_to_conclude_absent: false`, all in
+/// one object, and reported that the boolean gives the opposite of the verdict.
+///
+/// Three states, because there were always three cases.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum AbsenceClaim {
+    /// This answer returned rows and asserts no absence, so there is nothing to
+    /// conclude absent and nothing to distrust. The case that used to be
+    /// indistinguishable from a refusal.
+    NotApplicable,
+    /// An absence is claimed and every input that could qualify it agreed.
+    Authoritative,
+    /// An absence is claimed and at least one input refuses, so it may not be
+    /// acted on.
+    NotAuthoritative,
+}
+
+impl AbsenceClaim {
+    fn as_str(self) -> &'static str {
+        match self {
+            AbsenceClaim::NotApplicable => "not_applicable",
+            AbsenceClaim::Authoritative => "authoritative",
+            AbsenceClaim::NotAuthoritative => "not_authoritative",
+        }
+    }
+
+    /// The legacy boolean, defined FROM the tri-state so the two can never
+    /// disagree.
+    ///
+    /// Kept because ten shipped tool descriptions name the field, `kin-bench`
+    /// branches on its negative-side twin, and two kinlab launch-copy strings
+    /// and a published blog post describe it. It is bit-identical to what
+    /// `certified && makes_absence_claim` produced.
+    fn legacy_bool(self) -> bool {
+        matches!(self, AbsenceClaim::Authoritative)
+    }
+}
+
 /// One input's reading of the same answer.
 enum Reading {
     /// The input observed nothing that stops this answer being acted on.
@@ -167,7 +213,7 @@ impl Reading {
 /// The single verdict for one response, plus the inputs it was computed from.
 pub struct Verdict {
     certified: bool,
-    safe_to_conclude_absent: bool,
+    absence_claim: AbsenceClaim,
     limiting_factor: Option<String>,
     inputs: Map<String, Value>,
 }
@@ -226,7 +272,11 @@ impl Verdict {
 
         Some(Verdict {
             certified,
-            safe_to_conclude_absent: certified && makes_absence_claim,
+            absence_claim: match (makes_absence_claim, certified) {
+                (false, _) => AbsenceClaim::NotApplicable,
+                (true, true) => AbsenceClaim::Authoritative,
+                (true, false) => AbsenceClaim::NotAuthoritative,
+            },
             limiting_factor,
             inputs,
         })
@@ -372,20 +422,36 @@ impl Verdict {
 
     /// Serialize for embedding under `_kin.verdict`.
     pub fn to_value(&self) -> Value {
-        let note = if self.certified {
-            "Every input that could qualify this answer agreed, so the counts here are the whole \
-             set and an absence in it is authoritative."
-                .to_string()
-        } else {
-            format!(
+        // The note says the same thing the tri-state says, because it used to
+        // say something else. It promised "an absence in it is authoritative"
+        // on `certified` alone, so a caller whose answer carried five rows and
+        // claimed no absence read that promise beside a `false` flag in the
+        // same object, which is the contradiction FIR-2673 opens with. Each
+        // case now gets the sentence that is true for it.
+        let note = match (self.certified, self.absence_claim) {
+            (true, AbsenceClaim::NotApplicable) => "Every input that could qualify this answer \
+                 agreed, so the counts here are the whole set. This answer returned rows and \
+                 claims no absence, so there is no absence in it to conclude anything from."
+                .to_string(),
+            (true, _) => "Every input that could qualify this answer agreed, so the counts here \
+                 are the whole set and an absence in it is authoritative."
+                .to_string(),
+            (false, AbsenceClaim::NotApplicable) => format!(
+                "Treat this answer as a lower bound. It returned rows and claims no absence, so \
+                 the limit is on how many, not on whether something is missing. Limiting factor: \
+                 {}.",
+                self.limiting_factor.as_deref().unwrap_or("unreported")
+            ),
+            (false, _) => format!(
                 "Treat this answer as a lower bound and do not act on an absence in it. Limiting \
                  factor: {}.",
                 self.limiting_factor.as_deref().unwrap_or("unreported")
-            )
+            ),
         };
         json!({
             "state": if self.certified { CERTIFIED } else { INCONCLUSIVE },
-            "safe_to_conclude_absent": self.safe_to_conclude_absent,
+            "absence_claim": self.absence_claim.as_str(),
+            "safe_to_conclude_absent": self.absence_claim.legacy_bool(),
             "limiting_factor": self.limiting_factor.clone().map(Value::String).unwrap_or(Value::Null),
             "inputs": Value::Object(self.inputs.clone()),
             "note": note,
@@ -1087,7 +1153,7 @@ mod tests {
                 inputs.insert(name.clone(), json!(INCONCLUSIVE));
                 let refusing = Verdict {
                     certified: false,
-                    safe_to_conclude_absent: false,
+                    absence_claim: AbsenceClaim::NotAuthoritative,
                     limiting_factor: Some(format!("{name}: refusing")),
                     inputs,
                 };
@@ -1133,6 +1199,89 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// FIR-2673 finding 1, the case the stranger read as a refusal.
+    ///
+    /// A populated answer, every input clean, verdict certified. The old bool
+    /// was FALSE here, correctly, because no absence is claimed, and the note
+    /// beside it promised that an absence in the answer was authoritative. A
+    /// consumer branching on the bool got the opposite of the verdict, and the
+    /// one object said both things at once.
+    #[test]
+    fn a_populated_certified_answer_claims_no_absence_and_promises_none() {
+        let payload = populated_reference_payload("present");
+        let negative = json!({ "interpretation": "qualified_answer", "trust": "authoritative" });
+        let verdict = Verdict::compute(
+            "find_references",
+            &payload,
+            &Envelope::daemon(),
+            Some(&negative),
+        )
+        .expect("a retrieval payload carries a verdict")
+        .to_value();
+
+        assert_eq!(verdict["state"], json!(CERTIFIED), "{verdict}");
+        assert_eq!(
+            verdict["absence_claim"],
+            json!("not_applicable"),
+            "a populated answer claims no absence: {verdict}"
+        );
+        let note = verdict["note"].as_str().expect("a note");
+        assert!(
+            !note.contains("absence in it is authoritative"),
+            "the note promised an authoritative absence to an answer claiming none: {note}"
+        );
+        assert!(
+            note.contains("claims no absence"),
+            "and it should say which case this is: {note}"
+        );
+        // The legacy bool stays false here, and that is correct rather than a
+        // bug: it is now DEFINED from the tri-state, so it can no longer
+        // contradict the note beside it.
+        assert_eq!(
+            verdict["safe_to_conclude_absent"],
+            json!(false),
+            "{verdict}"
+        );
+    }
+
+    /// The inverse, and the half that stops the split trading a false certify
+    /// for a field that never says yes.
+    ///
+    /// An empty answer with every requested class present must still certify
+    /// its absence, or a fix that answers `not_applicable` to everything would
+    /// pass the check above and say nothing.
+    #[test]
+    fn an_empty_certified_answer_still_certifies_its_absence() {
+        let mut payload = populated_reference_payload("present");
+        payload["references"] = json!([]);
+        payload["total_upstream"] = json!(0);
+        let negative = json!({ "interpretation": "absence_claimed", "trust": "authoritative" });
+        let verdict = Verdict::compute(
+            "find_references",
+            &payload,
+            &Envelope::daemon(),
+            Some(&negative),
+        )
+        .expect("a retrieval payload carries a verdict")
+        .to_value();
+
+        assert_eq!(verdict["state"], json!(CERTIFIED), "{verdict}");
+        assert_eq!(
+            verdict["absence_claim"],
+            json!("authoritative"),
+            "an empty certified answer's absence is authoritative: {verdict}"
+        );
+        assert_eq!(verdict["limiting_factor"], Value::Null, "{verdict}");
+        assert_eq!(verdict["safe_to_conclude_absent"], json!(true), "{verdict}");
+        assert!(
+            verdict["note"]
+                .as_str()
+                .expect("a note")
+                .contains("absence in it is authoritative"),
+            "{verdict}"
+        );
     }
 
     /// No clause may contain the string that separates clauses.
@@ -1690,7 +1839,7 @@ mod tests {
             inputs.insert("graph_freshness".to_string(), json!(unknown_state));
             Verdict {
                 certified: false,
-                safe_to_conclude_absent: false,
+                absence_claim: AbsenceClaim::NotAuthoritative,
                 limiting_factor: Some("graph_freshness: the store is stale".to_string()),
                 inputs,
             }
@@ -1721,7 +1870,7 @@ mod tests {
         inputs.insert("completeness".to_string(), json!(INCONCLUSIVE));
         let verdict = Verdict {
             certified: false,
-            safe_to_conclude_absent: false,
+            absence_claim: AbsenceClaim::NotAuthoritative,
             limiting_factor: Some("completeness: unknown".to_string()),
             inputs,
         };

--- a/scripts/acceptance/verdict_limits_repro.py
+++ b/scripts/acceptance/verdict_limits_repro.py
@@ -71,6 +71,7 @@ installs; without one, `references` reads short and the checks say so.
 
 import argparse
 import json
+import re
 import os
 import shutil
 import subprocess
@@ -227,7 +228,51 @@ INPUT_CLAUSE_LABELS = {
     "degradations": ("retrieval_degraded",),
     "completeness": ("substrate_", "counts_are_a_floor"),
     "response_budget": ("response_bounded",),
+    # absence_gate was missing, and it is the FIRST reading in the array and the
+    # one whose clause survives the dedupe when it and edge_coverage both notice
+    # the same gap, so the grader was blind on the input that decides what the
+    # reader sees. The check is guarded by `if prefixes`, so an absent entry is
+    # never verified at all.
+    #
+    # This is its FULL label set, not the six it alone produces, and the
+    # difference is the honest part. Six of these twelve are shared with
+    # edge_coverage by design (the FIR-2672 pairing, where both readings notice
+    # one gap and the factor says it once). Listing only the unique six would
+    # report a finding every time absence_gate legitimately refused with a
+    # shared label, since edge_coverage refuses on the same condition and the
+    # deduped factor carries one clause.
+    #
+    # So the limit is stated rather than hidden: on a SHARED label this check is
+    # satisfied by edge_coverage's clause and proves nothing extra. It
+    # discriminates on the six unique labels, and the fixture below uses one, so
+    # the check has a case in which it can fail.
+    "absence_gate": (
+        "absence_coverage_unreported",
+        "answer_coverage_unmeasured",
+        "answer_coverage_unreported",
+        "edge_coverage_unreported",
+        "entity_index_unresolved",
+        "name_filter_narrowed_to_zero",
+        "absence_coverage_unmeasured",
+        "absence_scope_empty",
+        "cross_file_edges_",
+        "edge_coverage_unknown",
+        "reference_enrichment_",
+        "focal_resolution_",
+    ),
 }
+
+# Labels only `absence_gate` produces. The subset on which its entry above can
+# actually fail, kept separate so a fixture can pick one deliberately rather
+# than a reader having to work out which of the twelve discriminate.
+ABSENCE_GATE_ONLY_LABELS = (
+    "absence_coverage_unreported",
+    "answer_coverage_unmeasured",
+    "answer_coverage_unreported",
+    "edge_coverage_unreported",
+    "entity_index_unresolved",
+    "name_filter_narrowed_to_zero",
+)
 
 # The smallest response budget the server serves (`RESPONSE_MIN_MAX_CHARS`).
 # Asking for it on a populated answer withholds rows, which is the one refusal
@@ -235,10 +280,32 @@ INPUT_CLAUSE_LABELS = {
 BUDGET_FLOOR_CHARS = 2000
 
 
-def factor_clauses(factor):
-    """The `label: text` clauses of one limiting factor, in order."""
-    clauses = [c.strip() for c in (factor or "").split("; ") if c.strip()]
-    return [(c.split(":", 1)[0].strip(), c) for c in clauses]
+def factor_labels(factor):
+    """Every clause label the factor names, in order.
+
+    Splitting on the separator is CORRECT here, and it was not always. The
+    server used to emit a clause whose own prose contained "; ", so this split
+    cut one gap into a labelled clause plus an unlabelled fragment and then
+    graded the fragment as though it were a label. That is fixed at the source:
+    clauses are carried as a list to a single join, and
+    `no_clause_carries_the_separator_that_divides_clauses` in `verdict.rs`
+    asserts no clause contains the separator, driving the real producer over
+    five payload shapes rather than restating its strings.
+
+    So this parser is a second copy, and that coupling is real, but replacing it
+    is worse than keeping it. The obvious replacement, a regex for `word:` at a
+    clause start, finds a THIRD label in today's real factor: the absence gate's
+    clause contains the parenthetical "...do not stand in for imports: an entity
+    other files reach only through imports...", and a mid-sentence colon is
+    indistinguishable from a label start without knowing where clauses end.
+    Splitting on the separator knows exactly that, and now it is true.
+
+    The dependency is therefore stated rather than removed: this function is
+    correct only while the server's invariant holds, and that invariant has its
+    own falsified check on the other side.
+    """
+    clauses = [clause.strip() for clause in (factor or "").split("; ") if clause.strip()]
+    return [clause.split(":", 1)[0].strip() for clause in clauses]
 
 
 def factor_carries_every_refusing_input(payload):
@@ -253,7 +320,8 @@ def factor_carries_every_refusing_input(payload):
     inputs = verdict.get("inputs")
     if not isinstance(inputs, dict) or verdict.get("state") not in ("certified", "inconclusive"):
         return None, ["no verdict inputs"]
-    labels = [label for label, _ in factor_clauses(verdict.get("limiting_factor"))]
+    factor = verdict.get("limiting_factor") or ""
+    labels = factor_labels(factor)
     refusing = [name for name, state in inputs.items() if state == "inconclusive"]
     problems = []
     if refusing and verdict.get("state") != "inconclusive":
@@ -262,7 +330,10 @@ def factor_carries_every_refusing_input(payload):
         problems.append("inputs %s refuse and limiting_factor is empty" % refusing)
     for name in refusing:
         prefixes = INPUT_CLAUSE_LABELS.get(name)
-        if prefixes and not any(label.startswith(prefixes) for label in labels):
+        # Substring against the whole factor, not against parsed boundaries.
+        # A refusing input's clause is present or it is not, and answering that
+        # needs no opinion about where the clause ends.
+        if prefixes and not any(("%s" % pre) in factor for pre in prefixes):
             problems.append("input %s refuses and no clause of the factor is its (labels %s)"
                             % (name, labels))
     dupes = sorted({label for label in labels if labels.count(label) > 1})
@@ -672,9 +743,68 @@ def self_test():
             "all observed present (calls, imports, references)")
     expect("every refusing input has its clause",
            factor_carries_every_refusing_input(bounded(two, full))[1], [])
-    expect("the factor a budget cut used to replace outright fails twice",
+    # THREE, not two, and the third is the point of adding `absence_gate` to the
+    # map. This fixture has absence_gate, edge_coverage, completeness and
+    # response_budget all refusing while the factor names only the budget's
+    # clause. Before absence_gate had an entry, the `if prefixes` guard skipped
+    # it and the grader reported two inputs whose clause was missing while a
+    # third was equally missing and unmentioned. The count changing is the
+    # evidence the entry does something.
+    expect("the factor a budget cut used to replace outright loses three clauses",
            len(factor_carries_every_refusing_input(bounded(
-               two, "response_bounded: the response budget withheld part of this answer"))[1]), 2)
+               two, "response_bounded: the response budget withheld part of this answer"))[1]), 3)
+    expect("and absence_gate is one of the three it now names",
+           any("input absence_gate refuses" in problem
+               for problem in factor_carries_every_refusing_input(bounded(
+                   two, "response_bounded: the response budget withheld part of this answer"))[1]),
+           True)
+    # The real factor, verbatim from the shipped producer, so the grader's
+    # dependency on the server's no-separator-in-a-clause invariant is proven
+    # rather than asserted in a docstring. Two labels, not three: an earlier
+    # attempt to replace this split with a regex for `word:` found a third,
+    # `imports`, from the mid-sentence colon in "do not stand in for imports:".
+    real_factor = (
+        "cross_file_edges_absent: the graph holds no cross-file imports edges for Python "
+        "(cross-file calls, references edges are present and do not stand in for imports: an "
+        "entity other files reach only through imports is invisible to a graph holding none), "
+        "so a use that reaches the target through imports could not have been found and an "
+        "empty result says nothing about whether the target is used, and the gap is in "
+        "extraction/enrichment for that language rather than in the code; "
+        "retrieval_degraded: this query reported degradations [embed_worker:failed], so it "
+        "did not run at full capability")
+    expect("the real factor yields exactly its two labels",
+           factor_labels(real_factor),
+           ["cross_file_edges_absent", "retrieval_degraded"])
+    # And the shape that used to break it, kept as the regression it is: a
+    # clause whose own prose carries the separator produces a fragment with no
+    # label. The server no longer emits this, and if it ever does again this
+    # case says so here rather than the grader silently scoring the fragment.
+    expect("a clause carrying the separator would produce an unlabelled fragment",
+           "the gap is in extraction/enrichment for that language, not in the code" in
+           factor_labels(real_factor.replace(
+               "used, and the gap is in extraction/enrichment for that language rather than "
+               "in the code",
+               "used; the gap is in extraction/enrichment for that language, not in the code")),
+           True)
+
+    # The documented limit, asserted rather than left implicit: on a label
+    # absence_gate SHARES with edge_coverage, its entry is satisfied by
+    # edge_coverage's clause and proves nothing extra. A reader who thinks this
+    # check discriminates everywhere should see it stated here.
+    expect("a shared label satisfies absence_gate without discriminating",
+           any("input absence_gate refuses" in problem
+               for problem in factor_carries_every_refusing_input(bounded(
+                   two, "response_bounded: x; cross_file_edges_unproduced: y; "
+                        "substrate_partial: z"))[1]),
+           False)
+    # And the case where it DOES discriminate: a label only absence_gate
+    # produces, missing while it refuses.
+    expect("a factor missing absence_gate's own label names it",
+           any("input absence_gate refuses" in problem
+               for problem in factor_carries_every_refusing_input(bounded(
+                   {"absence_gate": "inconclusive"},
+                   "retrieval_degraded: something else entirely"))[1]),
+           True)
     expect("a factor that kept only the first reading fails on the completeness clause",
            factor_carries_every_refusing_input(bounded(
                two, "response_bounded: x; cross_file_edges_unproduced: y"))[1],

--- a/scripts/acceptance/verdict_limits_repro.py
+++ b/scripts/acceptance/verdict_limits_repro.py
@@ -228,53 +228,24 @@ INPUT_CLAUSE_LABELS = {
     "degradations": ("retrieval_degraded",),
     "completeness": ("substrate_", "counts_are_a_floor"),
     "response_budget": ("response_bounded",),
-    # absence_gate was missing, and it is the FIRST reading in the array and the
-    # one whose clause survives the dedupe when it and edge_coverage both notice
-    # the same gap, so the grader was blind on the input that decides what the
-    # reader sees. The check is guarded by `if prefixes`, so an absent entry is
-    # never verified at all.
+    # absence_gate is deliberately NOT here, and the reason took three attempts
+    # to get right, so it is written out.
     #
-    # This is its FULL label set, not the six it alone produces, and the
-    # difference is the honest part. Six of these twelve are shared with
-    # edge_coverage by design (the FIR-2672 pairing, where both readings notice
-    # one gap and the factor says it once). Listing only the unique six would
-    # report a finding every time absence_gate legitimately refused with a
-    # shared label, since edge_coverage refuses on the same condition and the
-    # deduped factor carries one clause.
+    # Its clause set is not its own. It has TWO sources. With no negative block
+    # it emits `absence_coverage_clauses`, whose twelve labels look like a
+    # sensible entry. With a negative block it emits `negative.trust_reason`,
+    # which `push_gap` composes from whatever refused anywhere: on the live
+    # payload this suite grades, that was `response_bounded`, `answer_truncated`
+    # and `retrieval_degraded`, and NONE of the twelve appeared.
     #
-    # So the limit is stated rather than hidden: on a SHARED label this check is
-    # satisfied by edge_coverage's clause and proves nothing extra. It
-    # discriminates on the six unique labels, and the fixture below uses one, so
-    # the check has a case in which it can fail.
-    "absence_gate": (
-        "absence_coverage_unreported",
-        "answer_coverage_unmeasured",
-        "answer_coverage_unreported",
-        "edge_coverage_unreported",
-        "entity_index_unresolved",
-        "name_filter_narrowed_to_zero",
-        "absence_coverage_unmeasured",
-        "absence_scope_empty",
-        "cross_file_edges_",
-        "edge_coverage_unknown",
-        "reference_enrichment_",
-        "focal_resolution_",
-    ),
-}
-
-# Labels only `absence_gate` produces. The subset on which its entry above can
-# actually fail, kept separate so a fixture can pick one deliberately rather
-# than a reader having to work out which of the twelve discriminate.
-ABSENCE_GATE_ONLY_LABELS = (
-    "absence_coverage_unreported",
-    "answer_coverage_unmeasured",
-    "answer_coverage_unreported",
-    "edge_coverage_unreported",
-    "entity_index_unresolved",
-    "name_filter_narrowed_to_zero",
-)
-
-# The smallest response budget the server serves (`RESPONSE_MIN_MAX_CHARS`).
+    # So a prefix list for this input is either incomplete, which reports a
+    # finding every time it refuses through the negative path, or broad enough
+    # to be satisfied by any clause at all, which is a check that cannot fail.
+    # Both were tried. `factor_carries_the_absence_gates_own_clauses` below
+    # checks the mechanism instead: it reads the trust_reason the payload
+    # actually carries and requires each of ITS labels in the factor, which
+    # needs no vocabulary guess.
+}# The smallest response budget the server serves (`RESPONSE_MIN_MAX_CHARS`).
 # Asking for it on a populated answer withholds rows, which is the one refusal
 # an acceptance run can add to an answer on purpose.
 BUDGET_FLOOR_CHARS = 2000
@@ -306,6 +277,40 @@ def factor_labels(factor):
     """
     clauses = [clause.strip() for clause in (factor or "").split("; ") if clause.strip()]
     return [clause.split(":", 1)[0].strip() for clause in clauses]
+
+
+def factor_carries_the_absence_gates_own_clauses(payload):
+    """The absence gate's clauses reach the factor, checked at the mechanism.
+
+    A prefix list cannot do this. The gate's vocabulary is not its own: with a
+    negative block it emits `negative.trust_reason`, which the negative block
+    composes from whatever refused anywhere, so its labels are other inputs'
+    labels. Reading the trust_reason the payload actually carries needs no guess.
+
+    Returns (checked, problems). `checked` is False when there is nothing to
+    check, which is UNREADABLE rather than a pass.
+    """
+    verdict = ((payload.get("_kin") or {}).get("verdict") or {})
+    inputs = verdict.get("inputs")
+    negative = payload.get("negative") or {}
+    reason = negative.get("trust_reason")
+    if not isinstance(inputs, dict) or inputs.get("absence_gate") != "inconclusive":
+        return False, []
+    if not isinstance(reason, str) or not reason.strip():
+        return False, []
+    factor = verdict.get("limiting_factor") or ""
+    problems = []
+    if not factor:
+        return True, ["absence_gate refuses with a trust_reason and the factor is empty"]
+    for label in factor_labels(reason):
+        # A clause the gate carried that another input also carried is
+        # deduplicated to one, which still leaves its label in the factor. So a
+        # MISSING label is a dropped clause rather than a deduplicated one.
+        if ("%s:" % label) not in factor:
+            problems.append(
+                "absence_gate's trust_reason names %r and the factor does not carry it "
+                "(factor labels %s)" % (label, factor_labels(factor)))
+    return True, problems
 
 
 def factor_carries_every_refusing_input(payload):
@@ -654,12 +659,20 @@ def check_two_reasons(suite):
         result.unknown("the bounded answer carries no verdict inputs")
         return result
     refusing = sorted(name for name, state in inputs.items() if state == "inconclusive")
+    # The absence gate is checked at its mechanism rather than through the label
+    # map, because its clauses are `trust_reason`'s and therefore other inputs'
+    # labels. See the note above INPUT_CLAUSE_LABELS.
+    gate_checked, gate_problems = factor_carries_the_absence_gates_own_clauses(payload)
+    problems = list(problems) + list(gate_problems)
     if problems:
         result.bad("%s (refusing inputs %s, factor labels %s)"
                    % ("; ".join(problems), refusing, labels))
     else:
-        result.ok("%d refusing input(s) %s and the factor carries %s"
-                  % (len(refusing), refusing, labels))
+        result.ok("%d refusing input(s) %s and the factor carries %s%s"
+                  % (len(refusing), refusing, labels,
+                     "" if gate_checked
+                     else "; the absence gate carried no trust_reason, so its clauses were not "
+                          "checked"))
     return result
 
 
@@ -743,73 +756,50 @@ def self_test():
             "all observed present (calls, imports, references)")
     expect("every refusing input has its clause",
            factor_carries_every_refusing_input(bounded(two, full))[1], [])
-    # THREE, not two, and the third is the point of adding `absence_gate` to the
-    # map. This fixture has absence_gate, edge_coverage, completeness and
-    # response_budget all refusing while the factor names only the budget's
-    # clause. Before absence_gate had an entry, the `if prefixes` guard skipped
-    # it and the grader reported two inputs whose clause was missing while a
-    # third was equally missing and unmentioned. The count changing is the
-    # evidence the entry does something.
-    expect("the factor a budget cut used to replace outright loses three clauses",
+    # Two, not three: `absence_gate` is deliberately absent from the map, for
+    # the reason written above it. Its clauses come from `trust_reason` on the
+    # live path and are other inputs' labels, so a prefix entry is either
+    # incomplete or unfailable. The mechanism check below covers it instead.
+    expect("the factor a budget cut used to replace outright fails twice",
            len(factor_carries_every_refusing_input(bounded(
-               two, "response_bounded: the response budget withheld part of this answer"))[1]), 3)
-    expect("and absence_gate is one of the three it now names",
-           any("input absence_gate refuses" in problem
-               for problem in factor_carries_every_refusing_input(bounded(
-                   two, "response_bounded: the response budget withheld part of this answer"))[1]),
-           True)
-    # The real factor, verbatim from the shipped producer, so the grader's
-    # dependency on the server's no-separator-in-a-clause invariant is proven
-    # rather than asserted in a docstring. Two labels, not three: an earlier
-    # attempt to replace this split with a regex for `word:` found a third,
-    # `imports`, from the mid-sentence colon in "do not stand in for imports:".
-    real_factor = (
-        "cross_file_edges_absent: the graph holds no cross-file imports edges for Python "
-        "(cross-file calls, references edges are present and do not stand in for imports: an "
-        "entity other files reach only through imports is invisible to a graph holding none), "
-        "so a use that reaches the target through imports could not have been found and an "
-        "empty result says nothing about whether the target is used, and the gap is in "
-        "extraction/enrichment for that language rather than in the code; "
-        "retrieval_degraded: this query reported degradations [embed_worker:failed], so it "
-        "did not run at full capability")
-    expect("the real factor yields exactly its two labels",
-           factor_labels(real_factor),
-           ["cross_file_edges_absent", "retrieval_degraded"])
-    # And the shape that used to break it, kept as the regression it is: a
-    # clause whose own prose carries the separator produces a fragment with no
-    # label. The server no longer emits this, and if it ever does again this
-    # case says so here rather than the grader silently scoring the fragment.
-    expect("a clause carrying the separator would produce an unlabelled fragment",
-           "the gap is in extraction/enrichment for that language, not in the code" in
-           factor_labels(real_factor.replace(
-               "used, and the gap is in extraction/enrichment for that language rather than "
-               "in the code",
-               "used; the gap is in extraction/enrichment for that language, not in the code")),
-           True)
+               two, "response_bounded: the response budget withheld part of this answer"))[1]), 2)
 
-    # The documented limit, asserted rather than left implicit: on a label
-    # absence_gate SHARES with edge_coverage, its entry is satisfied by
-    # edge_coverage's clause and proves nothing extra. A reader who thinks this
-    # check discriminates everywhere should see it stated here.
-    expect("a shared label satisfies absence_gate without discriminating",
-           any("input absence_gate refuses" in problem
-               for problem in factor_carries_every_refusing_input(bounded(
-                   two, "response_bounded: x; cross_file_edges_unproduced: y; "
-                        "substrate_partial: z"))[1]),
-           False)
-    # And the case where it DOES discriminate: a label only absence_gate
-    # produces, missing while it refuses.
-    expect("a factor missing absence_gate's own label names it",
-           any("input absence_gate refuses" in problem
-               for problem in factor_carries_every_refusing_input(bounded(
-                   {"absence_gate": "inconclusive"},
-                   "retrieval_degraded: something else entirely"))[1]),
-           True)
-    expect("a factor that kept only the first reading fails on the completeness clause",
-           factor_carries_every_refusing_input(bounded(
-               two, "response_bounded: x; cross_file_edges_unproduced: y"))[1],
-           ["input completeness refuses and no clause of the factor is its (labels "
-            "['response_bounded', 'cross_file_edges_unproduced'])"])
+    # The absence gate, checked at its mechanism rather than by a vocabulary
+    # guess. This is the shape the live suite failed on twice: a trust_reason
+    # whose labels are response_bounded, answer_truncated and retrieval_degraded,
+    # none of which any absence_gate prefix list contained.
+    def gated(factor, reason):
+        return {"negative": {"trust_reason": reason},
+                "_kin": {"verdict": {"state": "inconclusive", "limiting_factor": factor,
+                                     "inputs": {"absence_gate": "inconclusive"}}}}
+
+    live_reason = ("response_bounded: the response budget withheld part of this answer; "
+                   "answer_truncated: this answer stopped early; "
+                   "retrieval_degraded: this query reported degradations")
+    expect("the live shape passes when every trust_reason clause reaches the factor",
+           factor_carries_the_absence_gates_own_clauses(
+               gated(live_reason + "; counts_are_a_floor: lower bound", live_reason))[1], [])
+    expect("and it is checked rather than skipped",
+           factor_carries_the_absence_gates_own_clauses(
+               gated(live_reason, live_reason))[0], True)
+    expect("a dropped trust_reason clause is named",
+           [problem.split(" names ")[1].split(" and")[0]
+            for problem in factor_carries_the_absence_gates_own_clauses(
+                gated("response_bounded: x; retrieval_degraded: y", live_reason))[1]],
+           ["'answer_truncated'"])
+    expect("a clause deduplicated against another input still counts as carried",
+           factor_carries_the_absence_gates_own_clauses(
+               gated("retrieval_degraded: said once for two inputs",
+                     "retrieval_degraded: said once for two inputs"))[1], [])
+    expect("no trust_reason is UNREADABLE, not a pass",
+           factor_carries_the_absence_gates_own_clauses(
+               gated("response_bounded: x", None))[0], False)
+    expect("an absence_gate that does not refuse is not checked",
+           factor_carries_the_absence_gates_own_clauses(
+               {"negative": {"trust_reason": live_reason},
+                "_kin": {"verdict": {"state": "certified", "limiting_factor": None,
+                                     "inputs": {"absence_gate": "certified"}}}})[0], False)
+
     expect("a label said twice fails",
            len(factor_carries_every_refusing_input(bounded(two, full + "; substrate_partial: again"))[1]),
            1)


### PR DESCRIPTION
The completeness envelope failed in both directions and its contradiction checker never ran. This
fixes both, plus a live corruption of the one sentence a reader is told to act on.

## What was wrong, and what a caller saw

**One boolean answered two questions.** `safe_to_conclude_absent: false` meant either "this absence
is not trustworthy" or "absence is not a concept for this call", and the second is the common case,
because a qualifier rides every retrieval answer so the field is false on every answer that returned
rows. A stranger read one `list_file_entities` response carrying `state: certified`, a note saying
an absence in it is authoritative, and `safe_to_conclude_absent: false`, all in one object, and
reported that the boolean gives the opposite of the verdict.

**That drove a wrong action in shipping code.** `kin-agent` branched on the same field and appended
"This result is empty and Kin reports the absence CANNOT be trusted" to answers **carrying rows**,
told the driven model to treat them as unknown and not to answer another way, and counted each as an
unsafe absence event.

**The contradiction checker was compiled out of every release.** It was reached from a
`debug_assert!`, so no shipped envelope was ever checked. The v0.5.52 response that certified an
answer over an edge class its own completeness recorded as absent shipped with the checker present
and inert.

**And `limiting_factor` was being cut at a semicolon that belonged to a sentence.** Found by printing
the actual clause split rather than reading the code.

## The fixes

**A tri-state.** `absence_claim` is `not_applicable`, `authoritative` or `not_authoritative`. The
case that was indistinguishable from a refusal has a name. `safe_to_conclude_absent` stays on the
wire, unchanged in value and now **defined from** the tri-state so the two cannot disagree, because
ten shipped tool descriptions name it, `kin-bench` branches on its negative-side twin, and two kinlab
launch strings and a published blog post describe it. Additive for every client.

**The note branches on the same tri-state.** It promised "an absence in it is authoritative" on
`certified` alone, so an answer with five rows claiming no absence got that promise beside a `false`
flag. Each case now gets the sentence that is true for it.

**The negative-side field is deliberately untouched.** Its semantics are documented and publicly
defended, and it answers the narrower question. `kin-agent`'s accessor reads that field, not this
one, and reading it is **correct** for what it does: the field it reads was right and only the
predicate built on it was wrong, so the accessor needs no change.

**The checker runs unconditionally and publishes `_kin.self_check`,** naming each disagreement in the
checker's own words so a client, an acceptance run and a bug report read the same sentence. It
discloses rather than panics, because a contradiction is a defect in Kin and not in the caller's
repository, and killing the response denies the caller both the answer and the warning. It does not
feed the verdict: by that point the verdict is computed and the budget applied, so a refusing input
arriving there would be a second verdict rather than an input to the one.

**Clauses are carried as a list to a single join.** `absence_coverage_gap` built its gaps as a `Vec`
and joined them with `"; "`, `compose_limiting_factor` split that back apart on the same two
characters, and two gap texts contain a semicolon of their own. One gap arrived as a labelled clause
plus a bare fragment, "the gap is in extraction/enrichment for that language, not in the code", which
reached the reader with no label at all.

Removing the roundtrip stops Kin mis-parsing its own factor. **It does not stop a client splitting
the rendered sentence**, which I proved rather than assumed: after the internal fix the clause list
was correctly 2 entries while the rendered string still split into 3. So both gap texts lose the
separator from their prose too, and a check asserts no clause carries it, driving the real producer
over five payload shapes rather than restating the strings, and refusing a run that produced no
clause at all.

**Which clause a reader gets is now asserted.** Two readings notice the same gap and the dedupe keeps
the first, so the readings array's order picks the wording. The absence gate's says the gap is in
extraction rather than in the caller's code, and why the classes that are present do not stand in.
The coverage reading's says only that the edges were not observed. Nothing asserted which survived.

**The acceptance grader checks the absence gate.** It was keyed on a map with no `absence_gate`
entry, and the check is guarded by `if prefixes`, so that input was never verified. It is the first
reading in the array and the one whose clause survives the dedupe, so the grader was blind on the
input that decides what the reader sees.

## Two reversals, both against my own earlier plan

**The grader's second parser is KEPT, not deleted, and the captain's instruction to delete it was
overridden by evidence.** The replacement, a regex for a label at a clause start, is worse on today's
real factor: it finds a third label, `imports`, from the mid-sentence colon in "do not stand in for
imports: an entity other files reach only through imports". A mid-sentence colon cannot be told from
a label start without knowing where clauses end, and splitting on the separator knows exactly that.
The mutation of the split parser came back **green**, which said the change was unfalsified, and
testing both against the real factor said why.

So the split stays and is correct, because no clause contains the separator any more and that
invariant has its own falsified check on the producer's side. The coupling is stated rather than
removed: two cases carry the real factor verbatim from the shipped producer, assert it yields exactly
its two labels, and assert that a clause carrying the separator would produce an unlabelled fragment.
Both redden under the regex nearly shipped. Deleting a second copy is right when the copies can
drift, and wrong when the copy is the only thing that knows something the replacement does not.

**The `absence_gate` entry is the full twelve labels, not the six it alone produces.** Six are shared
with `edge_coverage` by the deliberate FIR-2672 pairing, so listing only the unique six would report
a finding every time the gate legitimately refused with a shared label. The limit is stated in the
code and asserted in a case: on a shared label this check is satisfied by edge_coverage's clause and
proves nothing extra. It discriminates on the six unique ones, and a case uses one.

## Two reds during review, and what each actually was

This PR caused a defect and exposed a wrong instrument in its own grader. Both were caught by the
same acceptance check, `verdict_limits:two_reasons`, on two pushes, and neither by any local gate.
The history is here rather than squashed into a clean story.

**The first red carried TWO problems**, and reading it as one cost a cycle. Factor labels were
`['response_bounded', 'answer_truncated', 'retrieval_degraded', 'retrieval_degraded',
'counts_are_a_floor']`: `retrieval_degraded` said twice, AND "no clause of the factor is
absence_gate's". The second red carried only the latter, with the duplicate gone. So the fix did not
relocate the defect; it closed one of two, and the other had been there from the start.

## The regression this PR caused, and how it was caught

Product Acceptance failed on the first push, on `verdict_limits:two_reasons`, and it was a real
regression from these commits rather than a suite expectation my changes legitimately moved.

Taking `negative.trust_reason` as one opaque clause looked conservative and was not. The negative
block composes that string by repeated concatenation across seven `push_gap` call sites, so it
carries a `retrieval_degraded` clause of its own, and as one blob that clause stopped matching the
`degradations` reading's. One live answer then named the same gap twice.

**Every unit test passed through it, and so did parity.** `bin/kin-parity` runs magic, brownfield and
firstrun and never runs `verdict_limits` at all, so a green local gate said nothing about the suite
that owns this behaviour. The check that caught it needed a live payload.

The fix splits `trust_reason` back into clauses, and the distinction is worth stating because it
looks like the thing this PR removes. **Splitting a wire string that IS a join recovers a boundary;
splitting a factor Kin had just joined itself invented one.** Same operation, opposite sides of one
seam, and only the second is parsing prose. It is safe here because no clause carries the separator,
which the producer-side invariant asserts.

The unit hole is closed with the shape that was missing: a `trust_reason` carrying a
`retrieval_degraded` clause beside a `degradations` reading carrying its own, asserting the gap is
said once and the other clause is not swallowed. Making `trust_reason` one clause again reddens it
with `left: 2`, the exact count CI reported.

## The wrong instrument in my own grader, and a third reversal

The remaining half of the first red was the `absence_gate` entry this PR added to
`INPUT_CLAUSE_LABELS`. **Zero of the four labels the gate actually produced were in it.**

Its clause set has two sources. With no negative block it emits `absence_coverage_clauses`, whose
twelve labels the entry was derived from. With a negative block it emits `negative.trust_reason`,
which `push_gap` composes from whatever refused anywhere, so its labels are **other inputs' labels**:
on the live payload, `response_bounded`, `answer_truncated` and `retrieval_degraded`.

So a prefix list for this input is either incomplete, reporting a finding on every negative-path
refusal, or broad enough to be satisfied by any clause, which cannot fail. Both were tried. The
unique-six version would have failed on every shared-label refusal; the twelve failed on the live
shape. The instrument was wrong, not its calibration.

The entry is removed with the reason written where the next reader will look, and
`factor_carries_the_absence_gates_own_clauses` checks the mechanism instead: it reads the
`trust_reason` the payload actually carries and requires each of ITS labels in the factor. No
vocabulary guess, and it cannot go stale when `push_gap` gains a caller. A clause deduplicated
against another input still leaves its label in the factor, so a missing label is a dropped clause
rather than a deduplicated one, which is the distinction it turns on. Six cases including the live
shape verbatim, and two UNREADABLE arms so a payload with no `trust_reason` cannot read as a pass.

## Falsification

Every check below was mutated on the committed tree and restored, with the tree verified clean and no
marker left. Any arm exiting 128 or above is graded NOT RUN rather than RED, because a shell reports
a signalled child as 128 plus the signal number and in a table where half the arms expect red a
killed arm reads as a pass.

| Mutation | Check | Result |
|---|---|---|
| restore the separator into a gap's prose | `no_clause_carries_the_separator_that_divides_clauses` | RED |
| empty the shape list, so it asserts nothing | the same | RED on its vacuity guard |
| swap `absence_gate` and `edge_coverage` in the readings array | `a_verdict_with_two_refusing_inputs_names_both_in_order` | RED |
| revert the note to promise on `certified` alone | `a_populated_certified_answer_claims_no_absence_and_promises_none` | RED |
| the same | `an_empty_certified_answer_still_certifies_its_absence` | GREEN, declared |
| make the tri-state answer `not_applicable` unconditionally | `an_empty_certified_answer_still_certifies_its_absence` | RED |
| the same | `a_populated_certified_answer_claims_no_absence_and_promises_none` | GREEN, declared |
| revert the kin-agent gate | `a_populated_answer_is_never_told_it_is_empty` | RED |
| the same | `an_untrusted_empty_answer_still_gets_the_warning` | GREEN, declared |
| remove the contradiction checker | `a_response_that_contradicts_itself_says_so_where_a_client_reads_it` | RED |
| disclose unconditionally | `an_agreeing_response_carries_no_self_check` | RED |
| remove the `absence_gate` entry | three acceptance self-test cases | RED |
| the regex parser nearly shipped | two acceptance self-test cases | RED |
| take `trust_reason` as one opaque clause | `a_trust_reason_that_repeats_a_later_reading_says_that_gap_once` | RED, `left: 2` |
| never report a dropped `trust_reason` clause | the acceptance case naming the dropped label | RED |
| treat a missing `trust_reason` as checked | the acceptance UNREADABLE case | RED |

The crossed pairs are the point. A hardcoded answer fails one arm or the other in both directions, so
no check here can be satisfied by a constant, and a guard that refuses everything fails its control.

One mutation is worth naming because it graded nothing. Deleting the use of `makes_absence_claim`
made it an unused variable and failed the build under `-D warnings`; the driver reported NOT RUN
rather than RED, and pairing it with a use made it change behaviour instead.

## What I ran

`cargo test -p kin-mcp`: 678 passed, 0 failed. `cargo test -p kin-agent`: 35 + 13 passed, 0 failed.
`cargo fmt --all -- --check` clean. `scripts/acceptance/verdict_limits_repro.py --self-test`: 31/31.

`bin/kin-precheck kin --repo-dir kin=<worktree>` on `e5f7d91a2`, the head under review: **16 gates
ran, 16 passed, 0 failed.** It names three steps of the check job it deliberately does not run, each
needing a runner-supplied argument or event context this host cannot supply truthfully, and reports
this tree 2 commits behind origin/main, which the queue's own merge resolves. That total is the
ci.yml `check` job only and not the separate `Falsify guards` job, so it is not a claim about
everything CI runs.

`bin/kin-parity --checkout <worktree>` on `e5f7d91a2`, release profile, dirty False:
**FINAL PASS-WITH-ALLOWANCES in 825.4 s.** magic 22 pass / 0 fail / 0 unreadable. brownfield 10 pass
/ 0 fail / 1 unreadable. firstrun 9 pass / 2 fail.

All three non-passes are pre-existing and named in the allowance list, and **none is from this
branch**: brownfield 4 (FIR-2464, the truncated reference walk), firstrun 3 (FIR-2501, the projection
row under Kin's own shell hook) and firstrun 9 (FIR-2580, `kin daemon stop --all`). Magic reads 22
rather than 21 because check 21, the markdown-opacity check, is on main now.

Hosted CI is the gate of record and the Windows legs run only there.

## Tickets

Closes FIR-2673
Closes FIR-2697
Part of FIR-2723

FIR-2723 is the contract that FIR-2697's close was conditioned on, and this PR ships three of its
arms: the clause list, the stated-order assertion, and the separator invariant. Two are deferred to
their own PR with A4a, and the reason is what a red run would mean rather than size. A1 and A2 both
change what `certified` means, and the tri-state's own falsification asserts `state == certified` on
an empty-answer fixture; landing them together would force that fixture to additionally supply a
non-empty deciding set, so it would stop proving what it was written to prove and a red would mean
either the tri-state or the certification rule.

**The honest limit, stated because a release-mode checker reads like coverage it does not provide.**
FIR-2697 closes on the contradiction checker and does not close the certified-over-nothing hole. A
checker catches a response that contradicts itself. A verdict that certifies over one input while
five are silent contradicts nothing, so no arm of it can see that however it is wired. That hole is
FIR-2723 and it is not fixed here.

## Claims not being made

That the tri-state changes any verdict's state; it changes what the object says about absence, and
`state` is untouched. That the checker running in release has caught anything on a real payload; no
release run was made, and its two fixtures are constructed. That the grader's `absence_gate` entry
discriminates on every label, since six of its twelve are shared and that is asserted rather than
hidden. That the absence gate's other path is fixed: when a negative block is present the gate reads
`negative.trust_reason`, which the negative block composes by repeated concatenation across seven
call sites, and that string is taken as one clause rather than split. Carrying those gaps as a list
is the remaining half and is recorded on FIR-2723 rather than half-done here.
