### PR TITLE
Give each Check & Test leg the cache it writes, the partition it can afford, and a guard against the next home reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1219,19 +1219,6 @@ jobs:
         if: matrix.shard == 1
         run: python3 scripts/test-private-repo-coupling.py
 
-      # A test that resolves a home through a real call site without
-      # `#[serial]` passes on a quiet laptop, lands green, and ejects a
-      # merge-queue entry weeks later from inside a `merge_group` run that
-      # marks no pull request. Two of the four ejections in the 2026-08-26
-      # window were one such test, and the pull requests it removed showed
-      # every check green. FIR-2714 removed that instance; this is what stops
-      # the next, and the guard carries its own blanker, recogniser and
-      # discovery controls so a scan that has stopped being able to say yes
-      # fails instead of reporting a clean tree.
-      - name: Check home-reading test isolation
-        if: matrix.shard == 1
-        run: python3 scripts/check-home-reader-tests.py
-
       # The committed Cargo.lock plus .cargo/config.toml pins kin-* dependencies
       # to public source until every crate is registry-published.
       - name: Build
@@ -1553,6 +1540,29 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt -- --check
+
+      # A test that resolves a home through a real call site without
+      # `#[serial]` passes on a quiet laptop, lands green, and ejects a
+      # merge-queue entry weeks later from inside a `merge_group` run that marks
+      # no pull request. Two of the four ejections in the 2026-08-26 window were
+      # one such test, and the pull requests it removed showed every check green.
+      # FIR-2714 removed that instance; this is what stops the next.
+      #
+      # It runs here rather than in `check` because it is a source read that
+      # resolves no dependencies, which is this job's whole admission rule, and
+      # because a script step in `check` is a gate `bin/kin-precheck` in the
+      # umbrella enumerates and must classify by name. Wiring it there without
+      # the matching umbrella entry makes precheck refuse with no tally, on this
+      # tree and on every lane still on an older base, which is measured rather
+      # than assumed: 16 of 17 gates passed and the run printed no tally.
+      # Promoting it later is this step moving one job and one name joining
+      # precheck's LOCAL list, which is FIR-2720's remaining half.
+      #
+      # The guard carries its own blanker, recogniser and discovery controls, so
+      # a scan that has stopped being able to say yes fails here instead of
+      # reporting a clean tree.
+      - name: Check home-reading test isolation
+        run: python3 scripts/check-home-reader-tests.py
 
       - name: Falsify Zero File-Search guards
         # Both guards still run on both platforms in Check & Test. Only this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,19 +843,38 @@ jobs:
       - name: Report the documentation-only fast path
         run: echo "documentation-only diff; build and test validation not applicable"
 
-  # The macOS half of this job moved to `check-macos` + `check-macos-aggregate`
-  # below, so this one now carries the ubuntu-latest context alone. The matrix
-  # stays, with one value, because it is what makes the display name expand to
-  # `Check & Test (ubuntu-latest)`, the exact required context name, and what
-  # keeps a SKIPPED job from expanding at all. The `runner.os == 'Linux'`
-  # conditions further down are now always true and are kept rather than
-  # deleted: they document which steps are Linux-only by intent, and they are
-  # what would keep this job honest if a platform were ever added back.
+  # The ubuntu half of Check & Test, sharded, and the job every source-reading
+  # gate in this repository runs in. The macOS half moved to `check-macos` +
+  # `check-macos-aggregate` below; this one carries the ubuntu-latest evidence
+  # and now splits its test step the same way, because `Test` was 14.98 min of
+  # a 21.8-minute job and was the last unpartitioned suite in the workflow.
+  #
+  # Within that set, shard 1 runs everything and shard 2 runs its own build and
+  # its own partition. The gates on shard 1 read source and cannot answer
+  # differently on a second runner, so running them twice would pay twice for
+  # one answer; the build is the one thing a partition genuinely needs of its
+  # own. Everything a partition consumes stays on both legs: the toolchain, the
+  # registry check, the cache, the build, nextest, and the language servers the
+  # enrichment proof needs, since which shard that test lands in is decided by
+  # the partitioner rather than by anything written here.
+  #
+  # The job id stays `check`. Two things read it and neither reads a display
+  # name: `bin/kin-precheck` in the umbrella enumerates this job's gate list out
+  # of this file by that id, and `rust-cache` composes its key from the job id
+  # when no shared key is given, so `feature-tests` reaches this job's warm
+  # dependency graph by asking for `check`. Renaming it would break the lane
+  # inner loop and silently cost the ubuntu permutations their cache, which is
+  # the same defect the macOS leg of that job carried until FIR-2722.
+  #
+  # This job publishes no required context. `check-aggregate` below does, and it
+  # fails unless every shard here succeeded. The `runner.os == 'Linux'`
+  # conditions further down are always true and are kept rather than deleted:
+  # they document which steps are Linux-only by intent.
   check:
-    name: Check & Test
+    name: Check & Test ubuntu shard
     needs: changes
     if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     # The all-features clippy/build/test sequence can otherwise retain more
     # than a hosted runner's available disk in incremental objects and debug
@@ -866,8 +885,13 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
     strategy:
+      # A shard that dies must not take its sibling with it. With fail-fast on,
+      # one red shard cancels the other, the aggregate reads `cancelled` for a
+      # partition that was passing, and the run reports one cause where there
+      # may be two.
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@v7
 
@@ -879,6 +903,7 @@ jobs:
       # crates/ is never classified documentation-only, so it never takes the
       # inert fast path.
       - name: Check the README language count against the adapter registry
+        if: matrix.shard == 1
         shell: bash
         run: |
           set -euo pipefail
@@ -957,6 +982,7 @@ jobs:
           echo "README and the adapter registry agree on $derived languages."
 
       - name: Install runtime guard tools
+        if: matrix.shard == 1
         shell: bash
         run: |
           if ! command -v rg >/dev/null 2>&1; then
@@ -995,6 +1021,7 @@ jobs:
           command -v rg
 
       - name: Validate installer checksum fixtures
+        if: matrix.shard == 1
         run: python3 scripts/test-install-checksum.py
 
       # A gate whose assertion lost its call site still exits 0, so passing the
@@ -1007,9 +1034,11 @@ jobs:
       # scripts/test-release-workflow-authority.py asserts this step exists, so
       # the pair cannot be half-removed.
       - name: Validate that every release gate assertion still runs
+        if: matrix.shard == 1
         run: python3 scripts/test-assertion-reachability.py
 
       - name: Validate mandatory Homebrew release outcome gate
+        if: matrix.shard == 1
         run: python3 scripts/test-homebrew-release-gate.py
 
       # Every validator below polices a repo-global invariant, so a break in one
@@ -1026,7 +1055,7 @@ jobs:
       # the gate because the assertion-reachability gate reads this file to
       # prove each suite still runs on pull requests.
       - name: Validate automatic release policy
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.shard == 1
         env:
           GH_TOKEN: ${{ github.token }}
           KIN_POLICY_EVENT: ${{ github.event_name }}
@@ -1060,7 +1089,7 @@ jobs:
       # success while the original moves, and release.yml is the one workflow
       # whose mistakes a later commit cannot repair.
       - name: Check the RC build mirrors the release build
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.shard == 1
         run: node scripts/check-rc-build-drift.mjs
 
       # release.yml refuses a release whose Kin lock resolves a different
@@ -1071,7 +1100,7 @@ jobs:
       # here, against the pin read out of release.yml, so the answer arrives
       # while a commit can still change it.
       - name: Verify Kin/kin-vfs compatibility at the pinned release input
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.shard == 1
         env:
           GH_TOKEN: ${{ github.token }}
         run: node scripts/check-kin-vfs-compat.mjs
@@ -1099,6 +1128,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check formatting
+        if: matrix.shard == 1
         run: cargo fmt -- --check
 
       # Two guards, two jobs. The Python checker walks every crate and carries
@@ -1107,9 +1137,11 @@ jobs:
       # kin-cli unit test drives. Both run, and the third step falsifies them,
       # because a guard that has never been shown to fail proves nothing.
       - name: Check Zero File-Search Invariant
+        if: matrix.shard == 1
         run: python3 scripts/verify-zero-file-search.py
 
       - name: Check Zero File-Search Invariant (answer modules)
+        if: matrix.shard == 1
         run: bash scripts/zero_file_search_guard.sh
 
       # Deep history is a PROJECTION re-authored at ingest, not a stored fact:
@@ -1120,9 +1152,11 @@ jobs:
       # releases that rewrote replay. This pins the replay surface by digest, so
       # an edit cannot ship without an explicit, reviewed manifest update.
       - name: Check Hydration Replay Semantics
+        if: matrix.shard == 1
         run: python3 scripts/verify-hydration-semantics.py
 
       - name: Falsify Hydration Replay Semantics guard
+        if: matrix.shard == 1
         run: |
           set -euo pipefail
           poisoned="$(mktemp -d)"
@@ -1142,7 +1176,7 @@ jobs:
       # deciding. Both run after the toolchain step because the leg helpers
       # resolve a compilation unit through cargo.
       - name: Falsify the release policy and Windows leg gates
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.shard == 1
         run: |
           bash scripts/test-release-policy-gate.sh
           bash scripts/test-windows-authority-legs.sh
@@ -1153,6 +1187,7 @@ jobs:
       # list would drift, and the drift would be invisible until the platform
       # whose copy lost an allow went red for a lint nobody meant to enforce.
       - name: Clippy
+        if: matrix.shard == 1
         shell: bash
         run: |
           set -euo pipefail
@@ -1170,16 +1205,32 @@ jobs:
           cargo clippy --all-targets --all-features -- $allows
 
       - name: Check Runtime Boundaries
+        if: matrix.shard == 1
         run: bash scripts/check_runtime_boundaries.sh
 
       - name: Check Private Repo Coupling
+        if: matrix.shard == 1
         run: bash scripts/check_private_repo_coupling.sh
 
       # The guard above is invoked from the repository root here and nowhere
       # else, which is the one working directory that hid a broken exclusion.
       # These tests run it from a foreign directory in both directions.
       - name: Test Private Repo Coupling Guard
+        if: matrix.shard == 1
         run: python3 scripts/test-private-repo-coupling.py
+
+      # A test that resolves a home through a real call site without
+      # `#[serial]` passes on a quiet laptop, lands green, and ejects a
+      # merge-queue entry weeks later from inside a `merge_group` run that
+      # marks no pull request. Two of the four ejections in the 2026-08-26
+      # window were one such test, and the pull requests it removed showed
+      # every check green. FIR-2714 removed that instance; this is what stops
+      # the next, and the guard carries its own blanker, recogniser and
+      # discovery controls so a scan that has stopped being able to say yes
+      # fails instead of reporting a clean tree.
+      - name: Check home-reading test isolation
+        if: matrix.shard == 1
+        run: python3 scripts/check-home-reader-tests.py
 
       # The committed Cargo.lock plus .cargo/config.toml pins kin-* dependencies
       # to public source until every crate is registry-published.
@@ -1198,7 +1249,7 @@ jobs:
       # One deliberate bound: it checks rather than builds, so it proves
       # compilation and name resolution and not linking.
       - name: Check the Linux release target (musl)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.shard == 1
         run: |
           set -euo pipefail
           rustup target add x86_64-unknown-linux-musl
@@ -1229,7 +1280,7 @@ jobs:
       # leg proves that natively on ubuntu-24.04-arm, where musl-tools does
       # supply an aarch64 musl-gcc, which is why nothing here is a cross build.
       - name: Check the aarch64 Linux release target (musl)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.shard == 1
         run: |
           set -euo pipefail
           rustup target add aarch64-unknown-linux-musl
@@ -1257,12 +1308,60 @@ jobs:
         if: runner.os == 'Linux'
         run: bash scripts/ci-install-language-servers.sh
 
+      # `--partition count:N/M` splits the suite by test, deterministically,
+      # so the two shards together run exactly the set one unpartitioned run
+      # ran. `check-aggregate` below is what makes "together" enforceable: a
+      # shard that never reported cannot leave its partition silently unrun.
       - name: Test
-        run: cargo nextest run --locked
+        run: cargo nextest run --locked --partition count:${{ matrix.shard }}/2
 
       - name: Doc tests
+        if: matrix.shard == 1
         # nextest does not run doctests; keep them covered explicitly.
         run: cargo test --doc --locked
+
+  # The required context for ubuntu. Its display name plus its one matrix value
+  # compose to `Check & Test (ubuntu-latest)`, byte for byte what ruleset
+  # 19746451, release-tag.yml's REQUIRED_CHECKS and expected_provenance tables,
+  # scripts/test-release-workflow-authority.py and docs/release-bot.md all name.
+  # Nothing about that string changes; only the job producing it does.
+  #
+  # The matrix is not decoration, for the same reason `check-macos-aggregate`
+  # carries one: a skipped matrix job never expands, so on a documentation-only
+  # diff this publishes the bare `Check & Test` name and leaves
+  # `check-docs-only` as the sole producer of the expanded one. Without the
+  # matrix, a skipped aggregate would publish `Check & Test (ubuntu-latest)` as
+  # `skipped` beside the stub's success, and two check runs under one required
+  # name is the ambiguity the release mint refuses on.
+  check-aggregate:
+    name: Check & Test
+    needs: [changes, check]
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      # `needs.<job>.result` for a matrix job is the roll-up of every leg, so
+      # this is `success` only when both shards succeeded. Requiring exactly
+      # `success` is what makes a SKIPPED or CANCELLED shard fail this check
+      # rather than pass it: a shard that never ran left half the ubuntu suite
+      # unexecuted, and a required context that goes green on that is worse than
+      # no context at all.
+      - name: Require every ubuntu shard to have succeeded
+        env:
+          SHARDS: ${{ needs.check.result }}
+        run: |
+          set -euo pipefail
+          if [ "$SHARDS" != "success" ]; then
+            echo "::error title=ubuntu shards did not pass::the sharded ubuntu Check & Test legs reported '$SHARDS'"
+            echo "Every partition of the ubuntu suite has to report success for this" >&2
+            echo "context to be evidence that the suite ran. 'skipped' and 'cancelled'" >&2
+            echo "mean a partition did not run at all." >&2
+            exit 1
+          fi
+          echo "every ubuntu Check & Test shard succeeded"
 
   # The macOS half of Check & Test, sharded.
   #
@@ -1614,19 +1713,32 @@ jobs:
           grep -q '^\[registries\.kin\]' .cargo/config.toml
           if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed. kin-* resolve from the Kin registry"; exit 1; fi
 
-      # `shared-key: check` is the key Check & Test's own cache already writes,
-      # so these permutations start from that warm third-party dependency graph
-      # instead of compiling it from nothing. Only the workspace crates rebuild
-      # for the changed feature set, which is what they cost inside Check & Test
-      # too. `save-if: false` because this job must never write that entry: it
-      # resolves a different feature set, and a save from here would hand
-      # Check & Test a target directory missing the artifacts its steps expect.
-      # A rename of the `check` job silently costs this job its warm start, so
-      # the cache-hit line in this step's log is the thing to read if it slows.
+      # These permutations start from the warm third-party dependency graph
+      # Check & Test's own cache already writes, instead of compiling it from
+      # nothing. Only the workspace crates rebuild for the changed feature set,
+      # which is what they cost inside Check & Test too. `save-if: false`
+      # because this job must never write that entry: it resolves a different
+      # feature set, and a save from here would hand Check & Test a target
+      # directory missing the artifacts its steps expect.
+      #
+      # Check & Test is two jobs, so one shared key cannot serve both legs of
+      # this matrix. `rust-cache` composes its key from the JOB ID when no
+      # shared key is given, so ubuntu's entry is written under `check` and
+      # macOS's under `check-macos`, and the expression below is which of the
+      # two this leg is entitled to read. Asking `check` on Darwin, which is
+      # what this step did until FIR-2722, requested
+      # `v0-rust-check-Darwin-arm64-*`, a key nothing in this workflow has ever
+      # written, so the macOS leg logged `No cache found.` on every run and
+      # compiled the dependency graph from nothing. The comment that used to
+      # sit here predicted exactly that and nobody read the line it named.
+      #
+      # Read the cache line in THIS step's log, on both legs, never the caches
+      # API listing, which is not an inventory and omitted every macOS entry
+      # while a job log showed a full match on one of them.
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: check
+          shared-key: ${{ matrix.os == 'macos-latest' && 'check-macos' || 'check' }}
           save-if: false
 
       - name: Install nextest

--- a/scripts/check-home-reader-tests.py
+++ b/scripts/check-home-reader-tests.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Refuse a test that decides by the runner's environment instead of by the code.
+
+FIR-2714 removed one instance. This is what stops the next, and the distinction
+between an alarm and a prevention is the whole point.
+
+A test that resolves a home through `home_dir`, `shell_rc`, `shell_path_rcs` or
+`rc_write_plan` without `#[serial]` passes on a quiet laptop, lands green, and
+ejects a merge-queue entry weeks later from inside a `merge_group` run that marks
+no pull request. That is what happened to kin#1141 and kin#1142 on 2026-08-26.
+A serial test is only serialised against other serial tests, so an unpinned one
+runs beside the sixty-odd siblings that point `HOME` at a tempdir, and reads
+whichever home the scheduler leaves in place between two calls.
+
+Two rules, and the second exists because the first alone would have shipped a
+guard carrying the exact gap that bit the lane writing it.
+
+RULE ONE. A test that resolves a home through a real call site is `#[serial]`.
+`unix_home_dir_still_resolves_exactly_what_base_dirs_reports` is allowlisted by
+name, because comparing against the real home is its contract.
+
+RULE TWO. A test that drives the PowerShell arm unsets `PROFILE`. Tests calling
+the parameterized `_in` variants take a home, so rule one does not reach them,
+and they still read `PROFILE`: `shell_rc_in` prefers it over the home it is
+handed. Taking a home as a parameter stops the home being the only input; it
+does not make it the only input. Both checks added in kin#1144 had this and
+passed anyway, because nothing in the module and nothing on that host sets it.
+
+## Scope
+
+The file set is DISCOVERED rather than pinned, because the class follows the
+call sites and a pinned list goes stale the day a test moves modules. Eight
+files under `crates/` reach these functions today and `git grep` finds them the
+same way this walk does. A pinned list would have been a check that stops being
+able to fail the moment somebody adds a ninth.
+
+## Three things make the scan answer correctly, and each was a mistake first
+
+It blanks string literals as well as comments. A doc comment saying
+`shell_rc("powershell")` and an assertion message naming `home_dir` both match a
+naive scan, and a false regex hit is the same match as a real one. The first
+version of this reported three non-serial readers when the answer was one.
+
+It requires a word boundary on both sides of a call site, so `resolve_home_dir(`
+is not `home_dir(` and `shell_rc_in(` is not `shell_rc(`.
+
+It walks braces for a test's body. Slicing to the next `#[test]` swallows the
+following test's doc comment, which is precisely how the mention got counted.
+
+## Controls, and why these ones
+
+Three run before any file is read, and all three can fail in both directions.
+
+The blanker self-test runs against a fixture carried here rather than against
+whatever the tree happens to contain. The scratch version of this guard drew its
+negative control from the file under test, which is fine for one file and
+vacuous for every file that does not happen to contain the chosen string: the
+check silently stops running rather than failing. A fixture cannot go vacuous.
+
+The recogniser self-test asserts the scan still reports a known offender and
+still stays quiet on its pinned twin. A guard that has lost the ability to say
+yes is green on every tree, and nothing else here would notice.
+
+The discovery control asserts the walk found files at all and found the module
+this class is known to live in. A walk that matches nothing reports a clean tree.
+
+A file that discovery selected and the parser found no test in is reported as
+unscannable rather than passing, because "no offenders" and "no tests parsed"
+are the same exit code otherwise.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+FNS = ("rc_write_plan", "shell_rc", "shell_path_rcs", "home_dir")
+PARAMETERIZED = ("rc_write_plan_in", "shell_rc_in", "shell_path_rcs_in")
+ALLOWED = {"unix_home_dir_still_resolves_exactly_what_base_dirs_reports"}
+ROOTS = ("crates",)
+# The module the class is known to live in. Discovery has to keep finding it, or
+# the walk has stopped reaching the code this guard exists for.
+DISCOVERY_ANCHOR = "crates/kin-cli/src/commands/setup.rs"
+
+# A fixture, not a needle drawn from the tree. Every line of it is load-bearing:
+# a comment mention, a literal mention, and one real call site, so the blanker
+# is proved to erase the first two and keep the third.
+BLANKER_FIXTURE = '''
+// a doc comment naming home_dir( and shell_rc("powershell")
+fn probe() {
+    let script = "#!/bin/sh\\nhome_dir(\\n";
+    let real = home_dir();
+    assert!(real.is_some(), "home_dir( failed");
+}
+'''
+BLANKER_MUST_VANISH = ("#!/bin/sh", 'shell_rc("powershell")')
+BLANKER_MUST_SURVIVE = "home_dir("
+
+# The recogniser self-test. The first must be reported under both rules and the
+# second under neither, from one pass of the same code that reads the tree.
+RECOGNISER_FIXTURE = '''
+    #[test]
+    fn an_offender_reads_the_home_and_drives_powershell() {
+        let plan = rc_write_plan("powershell").unwrap();
+        assert_eq!(plan.len(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn a_pinned_twin_reads_the_home_and_drives_powershell() {
+        let _profile = EnvVarGuard::unset("PROFILE");
+        let plan = rc_write_plan("powershell").unwrap();
+        assert_eq!(plan.len(), 1);
+    }
+'''
+RECOGNISER_OFFENDER = "an_offender_reads_the_home_and_drives_powershell"
+RECOGNISER_TWIN = "a_pinned_twin_reads_the_home_and_drives_powershell"
+
+
+def blank(text):
+    """Replace comment and string-literal bytes with spaces, preserving offsets."""
+    out, i, n = [], 0, len(text)
+    while i < n:
+        if text.startswith("//", i):
+            j = text.find("\n", i)
+            j = j if j > 0 else n
+            out.append(" " * (j - i))
+            i = j
+        elif text[i] == '"':
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == '"':
+                    break
+                j += 1
+            j = min(j, n - 1)
+            out.append(" " * (j - i + 1))
+            i = j + 1
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def body_after(text, idx):
+    """The brace-matched block that starts at the first { at or after idx."""
+    start = text.find("{", idx)
+    if start < 0:
+        return ""
+    depth, j = 0, start
+    while j < len(text):
+        if text[j] == "{":
+            depth += 1
+        elif text[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : j + 1]
+        j += 1
+    return text[start:]
+
+
+CALL = {fn: re.compile(r"(?<![A-Za-z0-9_])" + fn + r"\(") for fn in FNS}
+PARAM_CALL = {fn: re.compile(r"(?<![A-Za-z0-9_])" + fn + r"\(") for fn in PARAMETERIZED}
+TEST_FN = re.compile(r"((?:[ \t]*#\[[^\]]*\][ \t]*\n)+)[ \t]*fn (\w+)\(\)")
+
+
+def scan(raw):
+    """Return (home offenders, profile offenders, tests seen) for one source."""
+    code = blank(raw)
+    if len(code) != len(raw):
+        raise AssertionError("blanker changed the length; offsets are untrustworthy")
+
+    unpinned_home, unpinned_profile, seen = [], [], 0
+    for m in TEST_FN.finditer(code):
+        attrs, name = m.group(1), m.group(2)
+        if "#[test]" not in attrs:
+            continue
+        seen += 1
+        body = body_after(code, m.end())
+        raw_body = raw[m.end() : m.end() + len(body)]
+        serial = "#[serial]" in attrs
+
+        calls = [fn for fn, pat in CALL.items() if pat.search(body)]
+        if calls and not serial and name not in ALLOWED:
+            unpinned_home.append((name, calls))
+
+        reaches = calls or [fn for fn, pat in PARAM_CALL.items() if pat.search(body)]
+        if (
+            '"powershell"' in raw_body
+            and reaches
+            and 'EnvVarGuard::unset("PROFILE")' not in raw_body
+        ):
+            unpinned_profile.append(name)
+    return unpinned_home, unpinned_profile, seen
+
+
+def run_controls():
+    """Every control, before a single tree file is read. Raises on any failure."""
+    blanked = blank(BLANKER_FIXTURE)
+    if len(blanked) != len(BLANKER_FIXTURE):
+        raise AssertionError("blanker control: length changed, offsets are untrustworthy")
+    for needle in BLANKER_MUST_VANISH:
+        if needle in blanked:
+            raise AssertionError(
+                f"blanker control: {needle!r} survived blanking, so the scan would "
+                "count comments and string literals as call sites"
+            )
+    if not re.search(r"(?<![A-Za-z0-9_])home_dir\(", blanked):
+        raise AssertionError(
+            f"blanker control: {BLANKER_MUST_SURVIVE!r} did not survive blanking, so "
+            "the scan would count nothing and report every tree clean"
+        )
+
+    home, profile, seen = scan(RECOGNISER_FIXTURE)
+    if seen != 2:
+        raise AssertionError(
+            f"recogniser control: parsed {seen} of 2 fixture tests, so the walk has "
+            "stopped finding test bodies and would report every tree clean"
+        )
+    if [n for n, _ in home] != [RECOGNISER_OFFENDER]:
+        raise AssertionError(
+            "recogniser control: rule one no longer names exactly the known "
+            f"offender; it named {[n for n, _ in home]}"
+        )
+    if profile != [RECOGNISER_OFFENDER]:
+        raise AssertionError(
+            "recogniser control: rule two no longer names exactly the known "
+            f"offender; it named {profile}"
+        )
+    if RECOGNISER_TWIN in [n for n, _ in home] or RECOGNISER_TWIN in profile:
+        raise AssertionError(
+            "recogniser control: the pinned twin was reported, so this guard would "
+            "refuse a correctly isolated test"
+        )
+
+
+def discover(root):
+    """Every Rust source under ROOTS whose CODE reaches one of the call sites."""
+    found = []
+    for top in ROOTS:
+        for path in sorted((root / top).rglob("*.rs")):
+            code = blank(path.read_text(encoding="utf-8", errors="replace"))
+            if any(pat.search(code) for pat in CALL.values()):
+                found.append(path)
+    return found
+
+
+def main(argv):
+    root = Path(argv[1]) if len(argv) > 1 else Path.cwd()
+    run_controls()
+
+    files = discover(root)
+    relative = [str(p.relative_to(root)) for p in files]
+    if not files:
+        raise AssertionError(
+            "discovery control: no file under "
+            f"{'/, '.join(ROOTS)}/ reaches these call sites, so this run graded "
+            "nothing. Either the walk is broken or the functions were renamed; "
+            "fix this guard before trusting it"
+        )
+    if DISCOVERY_ANCHOR not in relative:
+        raise AssertionError(
+            f"discovery control: {DISCOVERY_ANCHOR} is not in the discovered set, so "
+            "the walk no longer reaches the module this class is known to live in"
+        )
+
+    home_hits, profile_hits, unscannable = [], [], []
+    for path, rel in zip(files, relative):
+        home, profile, seen = scan(path.read_text(encoding="utf-8", errors="replace"))
+        if seen == 0:
+            unscannable.append(rel)
+        home_hits.extend((rel, name, calls) for name, calls in home)
+        profile_hits.extend((rel, name) for name in profile)
+
+    for rel, name, calls in home_hits:
+        print(f"{rel}: {name} resolves a home via {', '.join(calls)} and is not #[serial]")
+    for rel, name in profile_hits:
+        print(f"{rel}: {name} drives the powershell arm without unsetting PROFILE")
+    for rel in unscannable:
+        print(f"{rel}: reaches these call sites and this guard parsed no #[test] in it")
+
+    if home_hits:
+        print(
+            f"\n{len(home_hits)} test(s) resolve a home without #[serial]. Such a test "
+            "passes on a quiet machine, lands, and ejects a merge-queue entry later "
+            "from inside a merge_group run that marks no pull request. Add #[serial] "
+            "and point HOME at a tempdir, or add the test to ALLOWED in this guard if "
+            "reading the real home is its contract."
+        )
+    if profile_hits:
+        print(
+            f"\n{len(profile_hits)} test(s) drive the powershell arm without pinning "
+            "PROFILE. shell_rc_in prefers PROFILE over the home it is handed, so on a "
+            "runner that sets it the plan correctly leaves the home and any assertion "
+            'about the home is wrong rather than flaky. Add EnvVarGuard::unset("PROFILE") '
+            "and #[serial]. Taking a home as a parameter does NOT exempt a test from "
+            "this: the home stops being the only input, it does not become the only one."
+        )
+    if unscannable:
+        print(
+            f"\n{len(unscannable)} file(s) reach these call sites and yielded no parsed "
+            "test. That is not a pass: it is this guard failing to read them. Either "
+            "the test shape changed or the parser broke; fix this guard."
+        )
+
+    if not (home_hits or profile_hits or unscannable):
+        print(
+            f"{len(files)} file(s) reach a home resolver; every test in them that does "
+            "is #[serial], and every one driving the powershell arm pins PROFILE"
+        )
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except AssertionError as error:
+        sys.exit(f"check-home-reader-tests: {error}")

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -574,7 +574,6 @@ UBUNTU_SHARD_ONE_ONLY_GATES = (
     "Check Runtime Boundaries",
     "Check Private Repo Coupling",
     "Test Private Repo Coupling Guard",
-    "Check home-reading test isolation",
     "Check the Linux release target (musl)",
     "Check the aarch64 Linux release target (musl)",
     "Doc tests",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -493,24 +493,103 @@ DOCS_ONLY_CHECK_JOB = textwrap.dedent(
           run: echo "documentation-only diff; build and test validation not applicable"
     """
 ).rstrip()
+# The ubuntu shards publish `Check & Test ubuntu shard (1)` and `(2)`, which no
+# ruleset requires, and `check-aggregate` is what publishes the required
+# `Check & Test (ubuntu-latest)`. The job id stays `check` rather than becoming
+# `check-ubuntu` for two reasons neither of which is visible from this file:
+# `bin/kin-precheck` in the umbrella enumerates this job's gate list by that id,
+# and `rust-cache` composes its key from the job id when no shared key is given,
+# so `feature-tests` reaches this job's warm dependency graph by asking for
+# `check`. Renaming it would cost the ubuntu permutations their cache exactly
+# the way the macOS leg lost its own.
 REAL_CHECK_JOB_AUTHORITY = textwrap.dedent(
     """\
     check:
-      name: Check & Test
+      name: Check & Test ubuntu shard
       needs: changes
       if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
-      runs-on: ${{ matrix.os }}
+      runs-on: ubuntu-latest
       timeout-minutes: 60
       env:
         CARGO_INCREMENTAL: "0"
         CARGO_PROFILE_DEV_DEBUG: "0"
         CARGO_PROFILE_TEST_DEBUG: "0"
       strategy:
+        fail-fast: false
+        matrix:
+          shard: [1, 2]
+      steps:
+    """
+).rstrip()
+# The ubuntu counterpart of MACOS_SHARD_AGGREGATE_AUTHORITY, pinned for the same
+# two reasons: the one-value matrix keeps a skipped aggregate from publishing the
+# expanded required name beside the documentation-only stub's, and admitting only
+# `success` from the shard roll-up keeps a skipped or cancelled shard from
+# leaving half the ubuntu suite unrun behind a green required context.
+UBUNTU_SHARD_AGGREGATE_AUTHORITY = textwrap.dedent(
+    """\
+    check-aggregate:
+      name: Check & Test
+      needs: [changes, check]
+      if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      strategy:
         matrix:
           os: [ubuntu-latest]
       steps:
     """
 ).rstrip()
+# Indented as `classifier_active_job_source` renders a dedented job block.
+UBUNTU_SHARD_RUNNER = "  runs-on: ubuntu-latest"
+UBUNTU_SHARD_INDEPENDENT_LEGS = "    fail-fast: false"
+UBUNTU_SHARD_MATRIX = "      shard: [1, 2]"
+UBUNTU_SHARD_PARTITION = (
+    "      run: cargo nextest run --locked --partition count:${{ matrix.shard }}/2"
+)
+UBUNTU_SHARD_DOCTESTS = "      run: cargo test --doc --locked"
+UBUNTU_SHARD_SUCCESS_GATE = 'if [ "$SHARDS" != "success" ]; then'
+# The gates this job runs and the macOS shards deliberately do not. Each reads
+# source and cannot answer differently on a second runner, so each is pinned to
+# shard 1 by an explicit condition. They are named individually rather than
+# counted: a bar set from a count is crossed by any twenty of them, and the one
+# that goes missing is the one nobody named. This is the ladder-coverage lesson
+# in docs/traps.md applied to a step list.
+UBUNTU_SHARD_ONE_ONLY_GATES = (
+    "Check the README language count against the adapter registry",
+    "Install runtime guard tools",
+    "Validate installer checksum fixtures",
+    "Validate that every release gate assertion still runs",
+    "Validate mandatory Homebrew release outcome gate",
+    "Validate automatic release policy",
+    "Check the RC build mirrors the release build",
+    "Verify Kin/kin-vfs compatibility at the pinned release input",
+    "Check formatting",
+    "Check Zero File-Search Invariant",
+    "Check Zero File-Search Invariant (answer modules)",
+    "Check Hydration Replay Semantics",
+    "Falsify Hydration Replay Semantics guard",
+    "Falsify the release policy and Windows leg gates",
+    "Clippy",
+    "Check Runtime Boundaries",
+    "Check Private Repo Coupling",
+    "Test Private Repo Coupling Guard",
+    "Check home-reading test isolation",
+    "Check the Linux release target (musl)",
+    "Check the aarch64 Linux release target (musl)",
+    "Doc tests",
+)
+# What a partition consumes, and therefore what neither shard may skip. A
+# partition that ran without one of these is not a partition of the suite.
+UBUNTU_SHARD_BOTH_LEGS_STEPS = (
+    "Install Rust toolchain",
+    "Verify kin cargo registry config",
+    "Cache cargo registry and build",
+    "Build",
+    "Install nextest",
+    "Install language servers for the enrichment proof",
+    "Test",
+)
 # The macOS shards publish `Check & Test macOS shard (1)` and `(2)`, which no
 # ruleset requires, and the aggregate is what publishes the required
 # `Check & Test (macos-latest)`. Two properties make that safe and both are
@@ -554,7 +633,15 @@ CI_JOB_DISPLAY_NAMES = {
     "windows-installer": "Windows installer + vector release build",
     "changes": "Classify diff scope",
     "check-docs-only": "Check & Test",
-    "check": "Check & Test",
+    # The ubuntu half of Check & Test, split so its 14.98-minute test step can
+    # run as two nextest partitions. The shard job keeps the id `check`, which
+    # bin/kin-precheck and rust-cache both key on, and publishes a name of its
+    # own that is required by nothing; `check-aggregate` publishes
+    # `Check & Test` with a one-value matrix, which expands to the
+    # release-required `Check & Test (ubuntu-latest)` and is what the ruleset
+    # names.
+    "check": "Check & Test ubuntu shard",
+    "check-aggregate": "Check & Test",
     # The macOS half of Check & Test, split so its 14.2-minute test step can run
     # as two nextest partitions. The shard job publishes a name of its own and
     # is required by nothing; the aggregate publishes `Check & Test` with a
@@ -747,14 +834,17 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
 }
 REQUIRED_CHECK_JOB_PRODUCERS = {
     # Three producers, one per required expansion plus the documentation-only
-    # stub. `check` carries ubuntu-latest, `check-macos-aggregate` carries
-    # macos-latest and is green only when every `check-macos` shard succeeded,
-    # and `check-docs-only` publishes both names on a documentation-only diff.
-    # The real jobs and the stub stay mutually exclusive by condition, so no two
-    # of them ever publish the same expanded name on one event.
+    # stub. `check-aggregate` carries ubuntu-latest and is green only when every
+    # `check` shard succeeded, `check-macos-aggregate` carries macos-latest on
+    # the same terms, and `check-docs-only` publishes both names on a
+    # documentation-only diff. `check` and `check-macos` publish names of their
+    # own that no ruleset requires, which is what keeps a shard from being a
+    # second check run under a required name. The real jobs and the stub stay
+    # mutually exclusive by condition, so no two of them ever publish the same
+    # expanded name on one event.
     "Check & Test": {
         (".github/workflows/ci.yml", "check-docs-only"),
-        (".github/workflows/ci.yml", "check"),
+        (".github/workflows/ci.yml", "check-aggregate"),
         (".github/workflows/ci.yml", "check-macos-aggregate"),
     },
     "Falsify guards": {
@@ -4679,6 +4769,104 @@ def assert_macos_shard_authority(workflow: str) -> None:
         MACOS_SHARD_SUCCESS_GATE,
         "macOS shard authority",
     )
+
+
+def shard_step_conditions(job: str) -> dict[str, str]:
+    """Map each named step of a job block to its `if:` condition, or "".
+
+    Read from the rendered active source rather than by regex over the raw file,
+    because a step's condition is decided by which step it sits under and a
+    line-oriented search cannot see that. A step that carries no condition maps
+    to the empty string, which is what makes "runs on both legs" an assertion
+    rather than the absence of one.
+    """
+
+    conditions: dict[str, str] = {}
+    name = None
+    for line in classifier_active_job_source(job).splitlines():
+        indent = len(line) - len(line.lstrip())
+        if line.startswith("    - "):
+            name = None
+            body = line[len("    - ") :]
+            if body.startswith("name: "):
+                name = body[len("name: ") :].strip()
+                conditions[name] = ""
+        elif name is not None and indent == 6 and line.lstrip().startswith("if: "):
+            conditions[name] = line.lstrip()[len("if: ") :].strip()
+        elif indent <= 4 and not line.startswith("    - "):
+            name = None
+    return conditions
+
+
+def assert_ubuntu_shard_authority(workflow: str) -> None:
+    """Pin the sharded ubuntu producer of `Check & Test (ubuntu-latest)`.
+
+    The macOS docstring above states why sharding a required context needs its
+    own authority, and every word of it applies here. What is different is that
+    the ubuntu job is also where every source-reading gate in this repository
+    runs, so splitting it can lose a gate as well as half a suite, and the two
+    failures look identical from outside: a faster green run.
+
+    So the gate list is pinned by NAME rather than by count. A count is crossed
+    by any twenty of twenty-one, and the one that goes missing is the one nobody
+    named. Each gate must carry an explicit shard-1 condition, and each step a
+    partition consumes must carry no shard condition at all, because a partition
+    that ran without its build or its nextest install is not a partition of the
+    suite.
+    """
+
+    blocks = workflow_job_blocks(workflow)
+    shards = blocks.get("check")
+    aggregate = blocks.get("check-aggregate")
+    if shards is None or aggregate is None:
+        raise AssertionError(
+            "ubuntu shard authority requires both the shard job and its aggregate"
+        )
+    if real_check_job_authority_source(aggregate) != UBUNTU_SHARD_AGGREGATE_AUTHORITY:
+        raise AssertionError(
+            "ubuntu shard authority requires the exact reviewed aggregate admission "
+            "and matrix contract"
+        )
+
+    active_shards = classifier_active_job_source(shards)
+    for policy in (
+        UBUNTU_SHARD_RUNNER,
+        UBUNTU_SHARD_INDEPENDENT_LEGS,
+        UBUNTU_SHARD_MATRIX,
+        UBUNTU_SHARD_PARTITION,
+        UBUNTU_SHARD_DOCTESTS,
+    ):
+        require(active_shards, policy, "ubuntu shard authority")
+    require(
+        classifier_active_job_source(aggregate),
+        UBUNTU_SHARD_SUCCESS_GATE,
+        "ubuntu shard authority",
+    )
+
+    conditions = shard_step_conditions(shards)
+    for gate in UBUNTU_SHARD_ONE_ONLY_GATES:
+        if gate not in conditions:
+            raise AssertionError(
+                f"ubuntu shard authority requires the gate {gate!r} to still run in "
+                "this job; a gate that left it is a gate nothing runs"
+            )
+        if "matrix.shard == 1" not in conditions[gate]:
+            raise AssertionError(
+                f"ubuntu shard authority requires {gate!r} to be pinned to shard 1; "
+                "a source-reading gate on both legs pays twice for one answer, and "
+                "one on neither is a gate nothing runs"
+            )
+    for step in UBUNTU_SHARD_BOTH_LEGS_STEPS:
+        if step not in conditions:
+            raise AssertionError(
+                f"ubuntu shard authority requires the step {step!r}, which a "
+                "partition consumes"
+            )
+        if "matrix.shard" in conditions[step]:
+            raise AssertionError(
+                f"ubuntu shard authority requires {step!r} on both legs; a shard "
+                "that ran without it did not run a partition of the suite"
+            )
 
 
 def execute_docs_only_classifier(
@@ -12526,6 +12714,7 @@ def main() -> None:
     )
     assert_check_consumer_authority(ci_workflow)
     assert_macos_shard_authority(ci_workflow)
+    assert_ubuntu_shard_authority(ci_workflow)
     consumer_blocks = workflow_job_blocks(ci_workflow)
     docs_only_check = consumer_blocks["check-docs-only"]
     real_check = consumer_blocks["check"]
@@ -12612,6 +12801,116 @@ def main() -> None:
             ),
         )
 
+    ubuntu_shards = consumer_blocks["check"]
+    ubuntu_aggregate = consumer_blocks["check-aggregate"]
+
+    for label, old, new in (
+        (
+            "the ubuntu aggregate accepts a shard result that is not success",
+            'if [ "$SHARDS" != "success" ]; then',
+            'if [ "$SHARDS" = "failure" ]; then',
+        ),
+        (
+            "the ubuntu aggregate loses the matrix that keeps a skip from expanding",
+            "        os: [ubuntu-latest]",
+            "        os: []",
+        ),
+        (
+            "the ubuntu aggregate stops waiting on the shards",
+            "    needs: [changes, check]",
+            "    needs: changes",
+        ),
+        (
+            "the ubuntu aggregate takes the display name of the shard job",
+            "    name: Check & Test",
+            "    name: Check & Test ubuntu aggregate",
+        ),
+    ):
+        if ubuntu_aggregate.count(old) != 1:
+            raise AssertionError(
+                f"ubuntu shard falsification could not identify {label}"
+            )
+        mutant_workflow = ci_workflow.replace(
+            ubuntu_aggregate, ubuntu_aggregate.replace(old, new, 1), 1
+        )
+        expect_assertion(
+            label,
+            "ubuntu shard authority",
+            lambda mutant_workflow=mutant_workflow: assert_ubuntu_shard_authority(
+                mutant_workflow
+            ),
+        )
+
+    for label, old, new in (
+        (
+            "a shard stops partitioning and both legs run the whole suite",
+            "        run: cargo nextest run --locked "
+            "--partition count:${{ matrix.shard }}/2",
+            "        run: cargo nextest run --locked",
+        ),
+        (
+            "the doctest pass nextest cannot run disappears",
+            "        run: cargo test --doc --locked",
+            "        run: echo doctests skipped",
+        ),
+        (
+            "one red ubuntu shard is allowed to cancel its passing sibling",
+            "      fail-fast: false",
+            "      fail-fast: true",
+        ),
+        (
+            "the ubuntu shards leave ubuntu",
+            "    runs-on: ubuntu-latest",
+            "    runs-on: macos-latest",
+        ),
+        (
+            "the ubuntu shard count changes without the partition denominator",
+            "        shard: [1, 2]",
+            "        shard: [1, 2, 3]",
+        ),
+        # The two that a count of steps cannot see, and the reason the gate list
+        # above is a list of names. A gate that loses its pin runs on both legs
+        # and pays macOS-shaped minutes twice for one source read; a gate that is
+        # renamed off the list runs nowhere, and both arrive as a faster green.
+        (
+            "a source-reading gate loses its shard pin and runs on both legs",
+            "      - name: Clippy\n        if: matrix.shard == 1\n",
+            "      - name: Clippy\n",
+        ),
+        (
+            "a source-reading gate is renamed off the pinned list",
+            "      - name: Check Runtime Boundaries\n",
+            "      - name: Check Runtime Boundaries (moved)\n",
+        ),
+        # The mirror image: a step a partition consumes is not optional on either
+        # leg, and a shard that skipped its own build never ran a partition.
+        (
+            "a step the partition consumes is pinned to one shard",
+            "      - name: Build\n        run: cargo build --all-targets --locked\n",
+            "      - name: Build\n        if: matrix.shard == 1\n"
+            "        run: cargo build --all-targets --locked\n",
+        ),
+        (
+            "a step the partition consumes leaves the job",
+            "      - name: Install nextest\n",
+            "      - name: Install nextest (moved)\n",
+        ),
+    ):
+        if ubuntu_shards.count(old) != 1:
+            raise AssertionError(
+                f"ubuntu shard falsification could not identify {label}"
+            )
+        mutant_workflow = ci_workflow.replace(
+            ubuntu_shards, ubuntu_shards.replace(old, new, 1), 1
+        )
+        expect_assertion(
+            label,
+            "ubuntu shard authority",
+            lambda mutant_workflow=mutant_workflow: assert_ubuntu_shard_authority(
+                mutant_workflow
+            ),
+        )
+
     docs_only_condition = (
         "    if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}"
     )
@@ -12692,9 +12991,13 @@ def main() -> None:
 
     for label, old, new in (
         (
+            # The sharp regression now that the aggregate owns the required
+            # name: a shard claiming `Check & Test` publishes
+            # `Check & Test (ubuntu-latest, 1)` and `(2)`, and its bare name
+            # collides with the aggregate's on a skip.
             "real Check & Test display name changed",
+            "    name: Check & Test ubuntu shard",
             "    name: Check & Test",
-            "    name: Check & Test trusted",
         ),
         (
             "real Check & Test dependency changed",
@@ -12702,17 +13005,17 @@ def main() -> None:
             "    needs: dco",
         ),
         (
-            "real Check & Test runner detached from its matrix",
-            "    runs-on: ${{ matrix.os }}",
+            "real Check & Test runner detached from its shard matrix",
             "    runs-on: ubuntu-latest",
+            "    runs-on: ${{ matrix.os }}",
         ),
         (
-            # Restoring the two-platform matrix is the specific regression to
-            # catch: `check` would publish `Check & Test (macos-latest)` again,
-            # beside the aggregate's, and put two check runs under one required
-            # context name.
+            # Restoring a platform matrix is the specific regression to catch:
+            # `check` would publish expanded platform names again, beside the
+            # aggregates', and put two check runs under one required context
+            # name.
             "real Check & Test matrix changed",
-            "        os: [ubuntu-latest]",
+            "        shard: [1, 2]",
             "        os: [ubuntu-latest, macos-latest]",
         ),
     ):


### PR DESCRIPTION
The CI latency audit's three tier-1 items, which are the ones that cost every landing and
weaken nothing. One is a cache key that asks for something nothing writes, one is the last
unpartitioned test suite in the workflow, and one turned out to be already fixed, so it
became the guard that stops the next instance instead.

## The macOS permutations asked for a cache nothing has ever written

`feature-tests` runs on a two-platform matrix and asked `shared-key: check` on both legs.
The comment directly above that line predicted what would happen and named the log line to
read, and nobody read it: the macOS leg logged `No cache found.` on every run and compiled
the third-party dependency graph from nothing.

The reason is not a rename, it is the key's shape, and the pinned action's own source says
it plainly:

```js
let key = getInput("prefix-key") || "v0-rust";
const sharedKey = getInput("shared-key");
if (sharedKey) { key += `-${sharedKey}`; }
else { const job = process.env.GITHUB_JOB;
       if (job && getInput("add-job-id-key")...) { key += `-${job}`; } }
key += `-${runnerOS}-${runnerArch}`;
```

`add-job-id-key` defaults to `"true"` in the same commit's `action.yml`. An unkeyed job
writes under its JOB ID, never its display name and never its matrix values. So `check`
writes `v0-rust-check-Linux-x64-*`, the macOS half writes
`v0-rust-check-macos-Darwin-arm64-*` because its job id is `check-macos`, and asking `check`
on Darwin requested `v0-rust-check-Darwin-arm64-*`, which nothing in this workflow has ever
produced. One shared key could not serve both legs. Now the expression picks the one the
leg is entitled to.

That reading is also why the second change below keeps the job id `check`.

**Falsification.** Read from the consuming job's own cache line, on both legs, never from
`GET /repos/{owner}/{repo}/actions/caches`, which is not an inventory: it returned
thirty-nine entries and none of the macOS ones, and a job log showed a full match on a key
the listing does not contain.

Before, from the audit's run: job 98067525025 logged `No cache found.` for
`v0-rust-check-Darwin-arm64-59113f08-998744a8`.

After, from this pull request's own run 32961965498, job 98156129152,
`Feature permutation tests (macos-latest)`:

```
Cache Key:  v0-rust-check-macos-Darwin-arm64-59113f08-433e5115
Cache hit for: v0-rust-check-macos-Darwin-arm64-59113f08-433e5115
Restored from cache key "v0-rust-check-macos-Darwin-arm64-59113f08-433e5115" full match: true.
```

That is byte for byte the key `check-macos` shard 1 hit in the same run (job 98156129211),
which is the positive control for the key being the right one rather than merely a
different one.

**The ubuntu leg of the same job missed, and it is worth saying plainly because it was
supposed to be the other control.** It asked
`v0-rust-check-Linux-x64-`**`6ea01539`**`-433e5115` and got `No cache found.`, while
`Check & Test ubuntu shard (1)` sixty-five seconds later hit
`v0-rust-check-Linux-x64-`**`8374e8ea`**`-433e5115`. Same prefix, same lockfile hash,
different environment hash, because rust-cache's `getRustVersions` hashes every toolchain
`rustup toolchain list` reports and the two jobs drew runner images carrying different
preinstalled Rust: 1.98.0 against 1.97.1. Nothing in this repository chose either. That is a
separate defect and it is filed as **FIR-2744** rather than fixed here.

It qualifies this change honestly: the shared key was wrong and is now right, and on macOS
that is sufficient because the macOS image carries a single toolchain, which is why
`59113f08` has been the macOS environment hash since the audit. On ubuntu a correct key is
necessary and not sufficient.

## The ubuntu Check & Test leg now shards, the way the macOS half already does

`Test` was `cargo nextest run --locked` unpartitioned, 14.98 min of a 21.8-min job and the
last unsharded suite in the workflow. `check-macos` solved this months ago and the ubuntu
leg never got the same treatment.

It now runs `--partition count:${{ matrix.shard }}/2` across a two-value shard matrix with
`fail-fast: false`, so one red shard cannot cancel a sibling that was passing.
`check-aggregate` publishes `Check & Test (ubuntu-latest)`, the required name, from a
one-value matrix, and admits only `success` from the shard roll-up, so a skipped or
cancelled shard fails it rather than passing it. No ruleset edit is needed, and no job in
any workflow references `check`.

Shard 1 runs everything. Shard 2 runs checkout, the toolchain, the registry check, the
cache, the build, nextest, the language servers the enrichment proof needs, and its own
partition. The twenty-one source-reading gates are pinned to shard 1: their answer cannot
differ on a second runner, so running them twice pays twice for one answer.

**The job id stays `check`, and that is load-bearing rather than incidental.** Two things
read it and neither reads a display name. `bin/kin-precheck` enumerates this job's gate list
out of this file by that id. And `rust-cache` keys on `GITHUB_JOB`, so `feature-tests`
reaches this job's warm dependency graph by asking for `check`. Renaming it to
`check-ubuntu` would have cost the ubuntu permutations their cache in exactly the way the
macOS leg lost its own, in the same pull request that fixes that.

Proved rather than argued: on run 32961965498 the renamed, sharded job still hit
`v0-rust-check-Linux-x64-8374e8ea-433e5115` (job 98156129321), the same job-id prefix it
wrote before. The display name moved and the key did not.

**The split executing, from the run rather than from the diff.** Shard 2 (job 98156129212)
reports `skipped` for all twenty-one source-reading gates and `success` for checkout,
toolchain, registry check and cache before going straight to its build. Shard 1 (job
98156129321) reports `success` for every one of them. `check-aggregate` published
`Check & Test (ubuntu-latest)` and it is green.

### The authority the split needed

`scripts/test-release-workflow-authority.py` pins the exact ci.yml job identity map, which
is why this split could not land quietly. Updated: `REAL_CHECK_JOB_AUTHORITY`, the
display-name census, `REQUIRED_CHECK_JOB_PRODUCERS` where `check-aggregate` replaces `check`
as the ubuntu producer, the three now-stale `check` consumer mutations, and a new
`assert_ubuntu_shard_authority` mirroring the macOS one.

The gate list is pinned by NAME rather than by count. A bar set from a count is crossed by
any twenty of twenty-one, and the one that goes missing is the one nobody named, which is
the ladder-coverage entry in `docs/traps.md` applied to a step list. The steps a partition
consumes are pinned the other way: each must carry no shard condition at all, because a
shard that ran without its own build never ran a partition of the suite.

Thirteen mutation arms drive it. Nine mirror the macOS set. Four are new, including the two
a step count cannot see: a gate that loses its shard pin and runs on both legs, and a gate
renamed off the pinned list. Both of those arrive as a faster green.
`scripts/test-assertion-reachability.py` passes, which is what proves the new assertion is
called rather than merely defined.

### Falsification: the suite size, from `--list` and not from a run's own summary

A total summed from a run's own `test result:` lines is a formatting artifact rather than a
measurement, so the size comes from `cargo nextest list --message-format json`, one read per
arm, on this branch's head.

```
unpartitioned  : 7352 selected, 7366 listed
shard 1 of 2   : 3708 selected
shard 2 of 2   : 3644 selected
union          : 7352      union == unpartitioned : True
intersection   : 0         shards disjoint        : True
```

The fourteen listed and not selected are `#[ignore]` tests, identical in all three reads.

The comparison carries both controls, because a loader that silently returned nothing would
report a perfect union of nothing. A name in no suite must appear in none of the three
reads, and a name known to be in the suite must appear in the union.

The comparison was then falsified against itself, six arms, each landing where declared
before it ran:

| Arm | Declared | Result |
|---|---|---|
| unmutated | PASS | PASS |
| shard 2 selects nothing | FAIL | FAIL |
| one binary missing from shard 2 | FAIL | FAIL |
| five tests run on both shards | FAIL | FAIL |
| the known-absent control appears | FAIL | FAIL |
| the unpartitioned listing selects nothing | FAIL | FAIL |

## The home-reading test, and a correction

The audit lists
`commands::setup::tests::a_shell_that_reads_one_file_still_gets_one_plan` as unfixed, two of
the window's four merge-queue ejections. Read against the tree that is no longer true.
kin#1144 fixed it and its sibling both, and on this base the test carries `#[serial]`, its
own `HOME` guard, `XDG_CONFIG_HOME` and `PROFILE` unset, both `rc_exists` arms and a
`starts_with(&home)` assertion, with the product fix at `setup.rs:2564`. The audit's
measurement window closed before that landing.

What is still missing is the part that stops the next one, so this ships FIR-2720's guard
instead. `scripts/check-home-reader-tests.py` refuses a test that resolves a home through
`home_dir`, `shell_rc`, `shell_path_rcs` or `rc_write_plan` without `#[serial]`, and a test
that drives the PowerShell arm without unsetting `PROFILE`, because `shell_rc_in` prefers
`PROFILE` over the home it is handed.

Four things separate it from the scratch scanner FIR-2720 filed.

**Its scope is discovered, not pinned.** Eight files under `crates/` reach these call sites
today and the walk finds them, so a test that moves module is still caught. A pinned list
stops being able to fail the day somebody adds a ninth. FIR-2720 left that question open and
this answers it with the measurement.

**Its negative control is a fixture rather than a string drawn from the file under test.**
The scratch version keyed on `#!/bin/sh` appearing in `setup.rs`, which is fine for one file
and silently vacuous for every file that does not contain it. On seven of the eight
discovered files that control would never have run at all. A fixture cannot go vacuous.

**It carries a recogniser control**, a known offender that must be reported under both rules
and a pinned twin that must not, from the same code path that reads the tree. A guard that
has lost the ability to say yes is green on every tree and nothing else here would notice.

**A file discovery selected and the parser found no test in is reported as unscannable**,
because "no offenders" and "no tests parsed" are otherwise the same exit code.

### Why it runs in `falsify-guards` and not in `check`

FIR-2720 asks for the step in `check` so `bin/kin-precheck` picks it up. I wired it there
first and measured rather than reasoned:

```
kin-precheck: 17 gates enumerated from the check job of .github/workflows/ci.yml
NOT RUN  guard:check-home-reader-tests.py  (UNCLASSIFIED: the 'check' job runs it and this
         tool has never heard of it. Read the script, then add it to LOCAL ... )
kin-precheck: NO TALLY. 1 gate(s) could not run
```

Sixteen of seventeen gates passed and the run printed no tally. Precheck reads its gate list
out of the check job and refuses on any script it cannot classify, so a step there needs
`scripts/check-home-reader-tests.py` in the LOCAL list of `bin/kin-precheck`, which lives in
the umbrella and not in this repository. Both orders break the other side in the gap: ci.yml
first gives UNCLASSIFIED to any lane that rebases, and precheck first gives the mirror-image
DROPPED to every lane still on an older base. The umbrella tree is shared, so that edit is
instant and global, while this one reaches a lane only on rebase.

So the step runs in `falsify-guards`, a required context that already carries
`cargo fmt -- --check` for source-reading guards and resolves no dependencies. The guard
blocks a landing that reintroduces the class, no lane's inner loop breaks, and precheck is
green again at sixteen gates. FIR-2720 stays open and its remaining half is exactly one
line plus moving this step one job, which have to land together.

### Falsification: eleven arms, all landing where declared

Every arm ran on a copy, so the lane tree was never mutated and there is no restore to get
wrong. Each mutation was asserted present in the file before its arm ran, and any exit of
128 or more would have graded NOT RUN with no tally printed.

| Arm | What moved | Declared | Result |
|---|---|---|---|
| `origin/main` before kin#1144 (`48fea9baf`) | nothing | RED | RED, two rule-one and one rule-two |
| `fd206fa43`, isolation fixed, `PROFILE` not yet pinned | nothing | RED | RED, exactly the two new checks |
| this branch head | nothing | GREEN | GREEN, eight files clean |
| the blanker stops erasing string literals | guard | RED, blanker control | RED |
| rule one stops firing | guard | RED, recogniser control | RED |
| rule two stops firing | guard | RED, recogniser control | RED |
| the brace walk stops finding test bodies | guard | RED, recogniser control | RED |
| the walk stops reaching the tree | guard | RED, discovery control | RED |
| the walk reaches files but not the module the class lives in | guard | RED, discovery control | RED |
| a real test loses `#[serial]` | tree | RED naming the test | RED |
| a real test stops unsetting `PROFILE` | tree | RED naming the test | RED |

The first three are FIR-2720's own acceptance table and this guard reproduces all three
answers, including the middle row that names a defect from a direction nobody used to find
it. The last two are the ones that matter most: they prove the guard can still go red on the
real tree rather than only on its own fixture, which is the distance between a mutation that
landed and a mutation that removed the property.

## What I ran

`bin/kin-precheck kin --repo-dir kin=<worktree>`:

```
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/citier1-kin sha=69e00993844e6f1d7b6ed68aa4b3a07de306fcaa branch=chore/lane-citier1-kin
kin-precheck: 16 gates ran, 16 passed, 0 failed
```

It names three steps of the check job it deliberately does not run, each needing a
runner-supplied argument or event context this host cannot supply truthfully.

`bin/kin-parity --checkout <worktree> --jobs 6`:

```
kin-parity: checkout  /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/citier1-kin
kin-parity: head      69e00993844e6f1d7b6ed68aa4b3a07de306fcaa
kin-parity: branch    chore/lane-citier1-kin
kin-parity: stamp     the binary reports the checkout's HEAD 69e00993844e
kin-parity: FINAL PASS-WITH-ALLOWANCES in 778.1s  (NON-CITABLE)  allowances: firstrun/9 FIR-2580, firstrun/3 FIR-2501, brownfield/4 FIR-2464
```

Three allowances, all of them the checked-in entries that stand on main today, and no new
failure. The preflight leg was not run and took no daemon lock, because this diff touches no
product code.

The guard also ran on the runner, in `Falsify guards` job 98156129242, and printed its own
clean line in 3.8 seconds:

```
8 file(s) reach a home resolver; every test in them that does is #[serial], and every one driving the powershell arm pins PROFILE
```

Run 32961965498 concluded green across every check, including the new
`Check & Test (ubuntu-latest)` from `check-aggregate`.

The workspace test gate is not run and is not claimed. This diff carries no product code:
two workflow changes, one CI guard script, and the authority pins that make the split
reviewable. Hosted CI is the gate of record and the Windows legs run only there.

## Tickets

Closes FIR-2743

Filed after the fact, because the CI latency audit lived in a scratchpad and had no ticket
of its own. The brief that sent this lane named FIR-2722, which is the `merge land --wait`
ticket and has nothing to do with this work; opening against it moved that ticket to In
Review over work nobody had done, and it has been put back.

FIR-2720 is deliberately NOT closed. Its guard ships here and its precheck half does not,
for the measured reason above.

FIR-2744 was found by this pull request's own falsification, when the control that was meant
to keep hitting did not. It is filed, not fixed here.

## Claims not being made

That the macOS cache saving is the audit's seven-minute ceiling. What is proved here is the
hit, not the minutes; the honest number comes from comparing this job's step times against a
run before the fix, and nobody has done that yet.

That the ubuntu permutations now start warm. They do not, for FIR-2744's reason, and this
change does not address it.

That the ubuntu partition halves the job. `Test` is 14.98 of 21.8 min, so the floor is what
shard 1's gates plus its build cost, and the saving is on the test step.

That the home-reader guard is the complete set of ways a test in these modules can decide by
the environment. It is the two rules that produced real ejections.

That FIR-2720 is closed. Its precheck half is named above and is deliberately not smuggled
into this pull request.

That `cargo nextest list` numbers predict runtime. They are a size, and the size is what the
union check needs.
