### PR TITLE
Emit a Module entity for every JavaScript and TypeScript file

### DIFF
--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -1020,7 +1020,7 @@ fn a_converted_store_reports_its_admission_rather_than_unknown_freshness() {
 fn graph_status_publishes_per_language_parse_coverage_without_a_verdict() {
     let root = tempdir().expect("temp root");
     let repo = root.path().join("repo");
-    seed_javascript_repository(&repo, 3);
+    seed_mixed_language_repository(&repo, 3);
     let admitted = admit_seeded(&repo);
     let graph = workspace_query_graph(&admitted.binding);
     let response = graph_status(&admitted.binding, &graph);
@@ -1030,19 +1030,35 @@ fn graph_status_publishes_per_language_parse_coverage_without_a_verdict() {
         lines.contains("Parse coverage (files that produced an entity / files admitted):"),
         "the section prints: {lines}"
     );
+    // The denominator assertion moves to the rust row, and it has to: every one
+    // of the four JavaScript files now produces an entity, so a javascript row
+    // reading 4/4 could not tell a correct denominator from one that had been
+    // subtracted down to the numerator. The rust row is 0 of 3, where the two
+    // counts differ and the subtraction bug this guards would show.
     let row = response
+        .lines
+        .iter()
+        .find(|line| line.trim_start().starts_with("rust:"))
+        .unwrap_or_else(|| panic!("no rust row in:\n{lines}"));
+    assert!(
+        row.contains("/3"),
+        "the denominator is every admitted rust file, not the ones that produced an \
+         entity: {row}"
+    );
+    assert!(
+        lines.contains("no_entity:") && lines.contains("unreadable0.rs"),
+        "the silent files are named so a reader can open them: {lines}"
+    );
+    // And the other half of what FIR-2675 changed, pinned rather than implied:
+    // JavaScript can no longer be silent, so its row is whole.
+    let js_row = response
         .lines
         .iter()
         .find(|line| line.trim_start().starts_with("javascript:"))
         .unwrap_or_else(|| panic!("no javascript row in:\n{lines}"));
     assert!(
-        row.contains("/7"),
-        "the denominator is every admitted javascript file, not the ones that produced an \
-         entity: {row}"
-    );
-    assert!(
-        lines.contains("no_entity:") && lines.contains("unreadable0.js"),
-        "the silent files are named so a reader can open them: {lines}"
+        js_row.contains("4/4"),
+        "every javascript file carries at least its module entity since FIR-2675: {js_row}"
     );
 
     // The control, and the half that can fail. A count is not a defect, so this
@@ -1073,7 +1089,7 @@ fn graph_status_publishes_per_language_parse_coverage_without_a_verdict() {
 
 /// A repository of four parseable JavaScript modules plus `silent` files that
 /// produce no entity.
-fn seed_javascript_repository(repo: &Path, silent: usize) {
+fn seed_mixed_language_repository(repo: &Path, silent: usize) {
     fs::create_dir_all(repo.join("lib")).expect("create lib directory");
     run_git(repo, &["init", "--initial-branch=main"]);
     run_git(repo, &["config", "user.email", "kin@example.invalid"]);
@@ -1086,13 +1102,22 @@ fn seed_javascript_repository(repo: &Path, silent: usize) {
         .expect("write a parseable module");
     }
     for index in 0..silent {
-        // Valid UTF-8 JavaScript that declares nothing. This is the honest
-        // shape: bytes an adapter is registered for, admitted as source, and
-        // holding no entity. NUL bytes would route the file to the opaque facet
-        // instead, which is a different state wearing the same numbers.
+        // The silent files are RUST, and they used to be JavaScript. FIR-2675
+        // made every JavaScript and TypeScript file emit a Module entity, so a
+        // comment-only `.js` file now produces one and is no longer silent:
+        // measured at 1 entity for exactly these bytes, against 0 before. That
+        // is the port working, and it deleted this fixture's silent case as a
+        // side effect, which is what this test caught.
+        //
+        // Rust carries no per-file module entity, so a comment-only `.rs` file
+        // still produces nothing: measured at 0. It is the same honest shape the
+        // old comment said, bytes an adapter is registered for, admitted as
+        // source, holding no entity. NUL bytes would route the file to the
+        // opaque facet instead, which is a different state wearing the same
+        // numbers.
         fs::write(
-            repo.join(format!("lib/unreadable{index}.js")),
-            b"require('./module0');\n// nothing is declared here\n" as &[u8],
+            repo.join(format!("lib/unreadable{index}.rs")),
+            b"// nothing is declared here\n" as &[u8],
         )
         .expect("write a silent module");
     }

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -1057,8 +1057,9 @@ fn graph_status_publishes_per_language_parse_coverage_without_a_verdict() {
         .find(|line| line.trim_start().starts_with("javascript:"))
         .unwrap_or_else(|| panic!("no javascript row in:\n{lines}"));
     assert!(
-        js_row.contains("4/4"),
-        "every javascript file carries at least its module entity since FIR-2675: {js_row}"
+        js_row.contains("5/5"),
+        "every javascript file carries at least its module entity since FIR-2675, including \
+         lib/quiet.js, which declares nothing and would have been silent before it: {js_row}"
     );
 
     // The control, and the half that can fail. A count is not a defect, so this
@@ -1101,6 +1102,17 @@ fn seed_mixed_language_repository(repo: &Path, silent: usize) {
         )
         .expect("write a parseable module");
     }
+    // A comment-only JavaScript file, which is the shape that used to be silent
+    // and no longer is. It exists so the javascript row below can tell the port
+    // working from the four parseable modules merely parsing: those four produce
+    // entities from their own functions with or without a module entity, so a
+    // row reading 4/4 says nothing about FIR-2675 at all. With this file the row
+    // is 5/5, and it falls to 4/5 the moment JavaScript stops emitting modules.
+    fs::write(
+        repo.join("lib/quiet.js"),
+        b"// nothing is declared here either\n" as &[u8],
+    )
+    .expect("write a formerly-silent javascript module");
     for index in 0..silent {
         // The silent files are RUST, and they used to be JavaScript. FIR-2675
         // made every JavaScript and TypeScript file emit a Module entity, so a

--- a/crates/kin-cli/tests/repository_rename_planner.rs
+++ b/crates/kin-cli/tests/repository_rename_planner.rs
@@ -621,7 +621,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "caller.ts",
         caller_source: "import { target } from './defs';\nexport function caller(): number { return target() + target(); }\n",
         has_named_import: true,
-        emits_module_entity_per_file: false,
+        emits_module_entity_per_file: true,
         records_call_sites: true,
     },
     LanguageFixture {
@@ -631,7 +631,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "caller.js",
         caller_source: "import { target } from './defs';\nexport function caller() { return target() + target(); }\n",
         has_named_import: true,
-        emits_module_entity_per_file: false,
+        emits_module_entity_per_file: true,
         records_call_sites: true,
     },
     LanguageFixture {
@@ -814,12 +814,14 @@ fn real_linker_spanless_relations_are_exact_or_refused_across_eight_languages() 
             },
         );
         if fixture.has_named_import && !fixture.emits_module_entity_per_file {
-            // FIR-2675, not FIR-2690. The parser records this language's import
-            // span correctly; there is simply no module entity to source the
-            // edge at, so no entity-level import edge exists and no evidence
-            // carries the span. The refusal is right and stays asserted, so
-            // this suite says out loud which languages the import fix does not
-            // reach yet.
+            // FIR-2675 emptied this branch. It held JavaScript and TypeScript,
+            // which recorded their import spans correctly and had no module
+            // entity to source the edge at, so the refusal was right and this
+            // suite said out loud which languages the import fix did not reach.
+            // Both now emit a module entity per file and have moved to the
+            // branch below. The branch stays rather than being deleted: it is
+            // the shape any language added without a per-file module falls into,
+            // and it is what would catch a regression that took one back out.
             let error = result.unwrap_err();
             assert!(
                 error

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -868,7 +868,23 @@ mod tests {
         let result = pipeline.index_file(&ts_file, &blob_store).unwrap();
         assert_eq!(result.language, LanguageId::TypeScript);
         assert!(!result.entities.is_empty());
-        assert_eq!(result.entities[0].name, "hello");
+        // By kind and name, the way `index_python_file` below already does it.
+        // Since FIR-2675 every TypeScript file carries a Module entity and it is
+        // emitted first, so `entities[0]` is the module: this assertion read
+        // "test" for the file stem rather than the function it names.
+        assert!(
+            result
+                .entities
+                .iter()
+                .any(|entity| entity.kind == kin_model::EntityKind::Function
+                    && entity.name == "hello"),
+            "expected the exported function, got {:?}",
+            result
+                .entities
+                .iter()
+                .map(|e| (e.kind, e.name.as_str()))
+                .collect::<Vec<_>>()
+        );
         assert!(matches!(result.parse_state, ParseState::Valid));
     }
 

--- a/crates/kin-index/tests/entity_level_import_edges.rs
+++ b/crates/kin-index/tests/entity_level_import_edges.rs
@@ -425,7 +425,10 @@ fn typescript_files_carry_module_entities_by_the_same_rule_as_javascript() {
     for (path, expected) in [
         ("lib/application.ts", Some("application")),
         ("components/Button.tsx", Some("Button")),
-        ("packages/mui-base/src/useSelect/index.ts", Some("useSelect")),
+        (
+            "packages/mui-base/src/useSelect/index.ts",
+            Some("useSelect"),
+        ),
         ("lib/index.ts", Some("lib")),
         ("index.ts", None),
     ] {
@@ -448,7 +451,10 @@ fn typescript_files_carry_module_entities_by_the_same_rule_as_javascript() {
 #[test]
 fn a_typescript_declaration_file_is_named_without_its_d_segment() {
     assert_eq!(
-        module_entity_name(&ts("types/express.d.ts", "export declare const x: number;\n")),
+        module_entity_name(&ts(
+            "types/express.d.ts",
+            "export declare const x: number;\n"
+        )),
         Some("express")
     );
 }
@@ -461,6 +467,12 @@ fn a_typescript_declaration_file_is_named_without_its_d_segment() {
 /// whole file and swallow every other entity in the region.
 #[test]
 fn an_extension_less_path_emits_no_module_entity() {
-    assert_eq!(module_entity_name(&js("some/fixture", "function a() {}\n")), None);
-    assert_eq!(module_entity_name(&ts("some/fixture", "function a() {}\n")), None);
+    assert_eq!(
+        module_entity_name(&js("some/fixture", "function a() {}\n")),
+        None
+    );
+    assert_eq!(
+        module_entity_name(&ts("some/fixture", "function a() {}\n")),
+        None
+    );
 }

--- a/crates/kin-index/tests/entity_level_import_edges.rs
+++ b/crates/kin-index/tests/entity_level_import_edges.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 use kin_index::{link_cross_file, FileParseData};
 use kin_model::{ArtifactId, Entity, EntityKind, FilePathId, GraphNodeId, RelationKind};
-use kin_parser::{JavaScriptAdapter, LanguageAdapter, PythonAdapter};
+use kin_parser::{JavaScriptAdapter, LanguageAdapter, PythonAdapter, TypeScriptAdapter};
 
 fn parse_with(adapter: &dyn LanguageAdapter, path: &str, src: &str) -> FileParseData {
     let file_id = FilePathId::new(path);
@@ -45,6 +45,22 @@ fn py(path: &str, src: &str) -> FileParseData {
 
 fn js(path: &str, src: &str) -> FileParseData {
     parse_with(&JavaScriptAdapter, path, src)
+}
+
+fn ts(path: &str, src: &str) -> FileParseData {
+    parse_with(&TypeScriptAdapter, path, src)
+}
+
+/// The module entity's name, or `None`.
+///
+/// The presence check alone would pass on a module named anything at all, and
+/// the name is half of what FIR-2675 decides: an index file takes its
+/// directory's name and every other file takes its own stem.
+fn module_entity_name(file: &FileParseData) -> Option<&str> {
+    file.entities
+        .iter()
+        .find(|e| e.kind == EntityKind::Module)
+        .map(|e| e.name.as_str())
 }
 
 fn link(files: &[FileParseData]) -> Vec<kin_model::Relation> {
@@ -213,12 +229,12 @@ fn python_import_of_an_undefined_name_produces_no_entity_edge() {
 /// A non-index JavaScript file carries no module entity, so it cannot source an
 /// entity-level import edge however well its specifier resolved.
 ///
-/// This test asserts the CURRENT limitation on purpose. It is the honest record
-/// that JavaScript is not fixed, and it is written to fail loudly the day the
-/// JavaScript adapter starts emitting module entities for ordinary files, so
-/// nobody has to remember to come back and check.
+/// FIR-2675 turned this from a limitation into the behaviour. It was written to
+/// fail the day the JavaScript adapter started emitting module entities for
+/// ordinary files, and that is this change; the assertion is inverted rather
+/// than deleted, so the record of what moved stays in the file.
 #[test]
-fn javascript_non_index_file_still_sources_no_entity_import_edge() {
+fn javascript_non_index_file_sources_an_entity_import_edge() {
     let files = vec![
         js("lib/router.js", "function Router() {}\nmodule.exports = Router;\n"),
         js(
@@ -226,16 +242,45 @@ fn javascript_non_index_file_still_sources_no_entity_import_edge() {
             "var Router = require('./router');\nfunction use() { return Router(); }\nmodule.exports = use;\n",
         ),
     ];
-    assert!(
-        !has_module_entity(&files[1]),
-        "lib/application.js now carries a module entity; the JavaScript adapter changed, \
-         so the entity-level import edge for non-index files is now buildable and this \
-         limitation test should be replaced by a positive assertion"
+    assert_eq!(
+        module_entity_name(&files[1]),
+        Some("application"),
+        "a non-index file takes its own stem, the way a Python module does"
     );
+    // The edge lands on the MODULE, not on the function inside it, and that is
+    // the right target rather than a near miss. `require('./router')` names the
+    // whole module; `module.exports = Router` is what makes the two the same
+    // object at runtime, and the graph should say what the source said. Python
+    // already behaves this way for `import routing`, which is why this port
+    // mirrors it rather than inventing a rule. Before this change `lib/router.js`
+    // had no module entity at all, so the edge existed for nothing to land on.
     let pairs = entity_import_pairs(&files);
     assert!(
-        pairs.is_empty(),
-        "a non-index JavaScript file sourced an entity-level import edge; got {pairs:?}"
+        pairs.contains(&("application".to_string(), "router".to_string())),
+        "lib/application.js must source an entity-level import edge to the router module; \
+         got {pairs:?}"
+    );
+}
+
+/// A NAMED import still reaches the named entity rather than the module.
+///
+/// The test above pins that a whole-module require names the module. This pins
+/// the other half, because a port that made every import land on a module would
+/// satisfy that one while destroying the specifier-level answer `find_references`
+/// is built on.
+#[test]
+fn a_named_javascript_import_binds_the_named_entity_not_the_module() {
+    let files = vec![
+        js("lib/router.js", "export function Router() {}\n"),
+        js(
+            "lib/application.js",
+            "import { Router } from './router';\nexport function use() { return Router(); }\n",
+        ),
+    ];
+    let pairs = entity_import_pairs(&files);
+    assert!(
+        pairs.contains(&("application".to_string(), "Router".to_string())),
+        "a named import must bind the named entity; got {pairs:?}"
     );
 }
 
@@ -340,24 +385,82 @@ fn javascript_index_file_in_a_named_directory_carries_a_module_entity() {
     );
 }
 
-/// An `index.js` sitting directly in `lib/` or `src/` carries NO module entity,
-/// because `extract_module_name_from_path` refuses those two directory names
-/// outright.
+/// An `index.js` directly in `lib/` or `src/` now carries a module entity too.
 ///
-/// This is the sharper half of the JavaScript gap and it is worth pinning
-/// separately: the exclusion lands on exactly the directories a real library
-/// keeps its code in, so express's own `lib/` is unreachable at entity level
-/// twice over, once for not being an index file and once for the directory
-/// name. Asserted as the current limitation, and written to fail the day the
-/// rule changes.
+/// The old rule refused those two directory names outright, which landed on
+/// exactly the directories a real library keeps its code in: express's own
+/// `lib/` was unreachable at entity level twice over, once for not being an
+/// index file and once for the directory name. Python carries no such blocklist
+/// and neither does this any more, so `lib/index.js` is named `lib`, which is
+/// what `require('./lib')` calls it.
 #[test]
-fn javascript_index_file_directly_under_lib_or_src_carries_no_module_entity() {
-    for path in ["lib/index.js", "src/index.js"] {
+fn javascript_index_file_directly_under_lib_or_src_carries_a_module_entity() {
+    for (path, expected) in [("lib/index.js", "lib"), ("src/index.js", "src")] {
         let file = js(path, "module.exports = require('./router');\n");
-        assert!(
-            !has_module_entity(&file),
-            "{path} now carries a module entity; the JavaScript adapter's src/lib \
-             exclusion changed and this limitation test should become a positive one"
+        assert_eq!(
+            module_entity_name(&file),
+            Some(expected),
+            "{path} must carry a module entity named after its directory"
         );
     }
+}
+
+/// A root-level `index.js` still carries nothing, and that is deliberate.
+///
+/// An index file is named after the directory it indexes, and a file at the
+/// repository root has no such directory. It produced nothing before this change
+/// and produces nothing after it, so the port did not quietly widen into a case
+/// with no sensible name.
+#[test]
+fn a_root_level_index_file_carries_no_module_entity() {
+    let file = js("index.js", "module.exports = require('./lib/router');\n");
+    assert_eq!(module_entity_name(&file), None);
+}
+
+/// TypeScript had NO module-entity test at all before this change, so this is
+/// added rather than converted. The two adapters carried byte-identical copies
+/// of the rule and drifted anyway, which is why they now share one helper.
+#[test]
+fn typescript_files_carry_module_entities_by_the_same_rule_as_javascript() {
+    for (path, expected) in [
+        ("lib/application.ts", Some("application")),
+        ("components/Button.tsx", Some("Button")),
+        ("packages/mui-base/src/useSelect/index.ts", Some("useSelect")),
+        ("lib/index.ts", Some("lib")),
+        ("index.ts", None),
+    ] {
+        let file = ts(path, "export function use() { return 1; }\n");
+        assert_eq!(
+            module_entity_name(&file),
+            expected,
+            "TypeScript module identity for {path}"
+        );
+    }
+}
+
+/// A `.d.ts` declaration file is named `foo`, not `foo.d`.
+///
+/// This is the drift the shared helper exists to stop: the old
+/// `is_ts_index_file` never matched `index.d.ts`, and stripping only `.ts` from
+/// `foo.d.ts` leaves a name no source ever writes. It is a separate test from
+/// the table above because it is the one case where suffix ORDER decides the
+/// answer.
+#[test]
+fn a_typescript_declaration_file_is_named_without_its_d_segment() {
+    assert_eq!(
+        module_entity_name(&ts("types/express.d.ts", "export declare const x: number;\n")),
+        Some("express")
+    );
+}
+
+/// A path carrying none of the language's suffixes emits nothing.
+///
+/// This mirrors `python_module_identity`'s `.strip_suffix(".py").unwrap_or("")`
+/// exactly, and it is the guard that matters most: `round_trip_fuzz.rs` passes
+/// an extension-less `FilePathId`, and a module entity there would span the
+/// whole file and swallow every other entity in the region.
+#[test]
+fn an_extension_less_path_emits_no_module_entity() {
+    assert_eq!(module_entity_name(&js("some/fixture", "function a() {}\n")), None);
+    assert_eq!(module_entity_name(&ts("some/fixture", "function a() {}\n")), None);
 }

--- a/crates/kin-index/tests/relation_evidence_span_coverage.rs
+++ b/crates/kin-index/tests/relation_evidence_span_coverage.rs
@@ -105,7 +105,7 @@ const FIXTURES: &[Fixture] = &[
     },
     Fixture {
         language: "TypeScript",
-        min_relations: 3,
+        min_relations: 4,
         min_calls: 1,
         min_calls_with_span: 1,
         files: &[
@@ -129,7 +129,7 @@ const FIXTURES: &[Fixture] = &[
     },
     Fixture {
         language: "JavaScript",
-        min_relations: 3,
+        min_relations: 4,
         min_calls: 1,
         min_calls_with_span: 1,
         files: &[
@@ -706,7 +706,7 @@ fn print_table(rows: &[(String, Counts)], title: &str) {
 /// offset. This constant proves something different and narrower: that the
 /// linker carries a site the parser recorded all the way onto persisted
 /// evidence.
-const MEASURED_RELATIONS_WITH_SPAN: usize = 10;
+const MEASURED_RELATIONS_WITH_SPAN: usize = 12;
 
 /// Span-backed evidence RECORDS, which exceed span-backed relations whenever one
 /// caller reaches one callee at more than one site. Each fixture calls `compute`
@@ -718,7 +718,7 @@ const MEASURED_RELATIONS_WITH_SPAN: usize = 10;
 /// edge carries exactly one evidence record because a specifier binds once.
 /// The surplus of records over relations is unchanged, since it comes from
 /// repeat CALL sites and this edge adds none.
-const MEASURED_EVIDENCE_RECORDS_WITH_SPAN: usize = 13;
+const MEASURED_EVIDENCE_RECORDS_WITH_SPAN: usize = 15;
 
 #[test]
 fn relation_evidence_span_population_per_language() {

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -51,21 +51,28 @@ impl LanguageAdapter for JavaScriptAdapter {
         let root = tree.root_node();
         let mut cursor = root.walk();
 
-        // Emit Module entity for index.js/index.jsx files (JS packages).
-        // This makes the module searchable by its directory name, e.g.,
-        // `src/plugin/customParseFormat/index.js` → entity "customParseFormat".
-        if is_js_index_file(&file_id.0) {
-            if let Some(module_name) = extract_module_name_from_path(&file_id.0) {
-                entities.push(ExtractedEntity {
-                    kind: EntityKind::Module,
-                    name: module_name,
-                    signature: format!("module {}", file_id.0),
-                    visibility: Visibility::Public,
-                    doc_summary: None,
-                    fingerprint: compute_fingerprint(&root, source),
-                    span: span_from_node(&root, file_id),
-                });
-            }
+        // Emit a Module entity for every JavaScript source file, as Python does.
+        // Previously only index files produced one, and only when their directory
+        // was not `src` or `lib`, so one of the 58 JS/TS files kin itself tracks
+        // carried a module entity. A file with no module entity cannot SOURCE an
+        // entity-level import edge, because the linker anchors those on the
+        // importing file's module, so every import in every other file stayed
+        // invisible to `find_references`.
+        let (module_name, is_package) = js_module_identity(&file_id.0, JS_SUFFIXES);
+        if !module_name.is_empty() {
+            entities.push(ExtractedEntity {
+                kind: EntityKind::Module,
+                name: module_name,
+                signature: if is_package {
+                    format!("package {}", file_id.0)
+                } else {
+                    format!("module {}", file_id.0)
+                },
+                visibility: Visibility::Public,
+                doc_summary: None,
+                fingerprint: compute_fingerprint(&root, source),
+                span: span_from_node(&root, file_id),
+            });
         }
 
         // Read the file's property-defining helpers before walking it.
@@ -1926,32 +1933,83 @@ fn extract_js_tests_from_node(
 }
 
 /// Check if a file is a JS index file (index.js, index.jsx, index.mjs, index.cjs).
-fn is_js_index_file(path: &str) -> bool {
-    let basename = path.rsplit('/').next().unwrap_or(path);
-    matches!(
-        basename,
-        "index.js" | "index.jsx" | "index.mjs" | "index.cjs"
-    )
-}
+/// The JavaScript file suffixes, longest first.
+///
+/// Order is load-bearing in `js_module_identity`, which strips the first suffix
+/// that matches. None of these is a suffix of another today, so the order costs
+/// nothing and stops a later addition from silently shadowing an existing one.
+pub(super) const JS_SUFFIXES: &[&str] = &[".jsx", ".mjs", ".cjs", ".js"];
 
-/// Extract the module name from a file path for index files.
-/// `src/plugin/customParseFormat/index.js` → `"customParseFormat"`
-/// `themes/index.js` → `"themes"`
-fn extract_module_name_from_path(path: &str) -> Option<String> {
-    let without_basename = path.rsplit_once('/')?.0;
-    let dir_name = without_basename
-        .rsplit('/')
-        .next()
-        .unwrap_or(without_basename);
-    if dir_name.is_empty() || dir_name == "src" || dir_name == "lib" {
-        return None;
+/// The TypeScript file suffixes, longest first.
+///
+/// `.d.ts` leads because it must: `foo.d.ts` stripped of `.ts` is `foo.d`, a
+/// name no source ever writes. The old `is_ts_index_file` never matched
+/// `index.d.ts` at all, which is the drift the shared helper exists to stop.
+pub(super) const TS_SUFFIXES: &[&str] = &[".d.ts", ".tsx", ".ts"];
+
+/// The module identity of a JavaScript or TypeScript source file: its name, and
+/// whether the file is a package index.
+///
+/// This mirrors `python_module_identity` deliberately, including the guard that
+/// decides nothing. Python emits a Module for every source file, names an
+/// ordinary module after its own stem and a package's `__init__.py` after the
+/// directory it marks, and carries no directory blocklist. An index file is the
+/// JS/TS `__init__.py`: `require('./customParseFormat')` names the directory, so
+/// the index takes the directory's name and every other file takes its own stem.
+///
+/// The empty return IS the guard, and it is the reason to mirror Python rather
+/// than invent a rule. A path carrying none of the language's suffixes yields an
+/// empty name and the caller emits nothing for it, which is what keeps an
+/// extension-less `FilePathId` from producing a whole-file module entity that
+/// would swallow every other entity in a round-trip region.
+///
+/// The old helper refused the directory names `src` and `lib` outright, which
+/// landed on exactly the directories a real library keeps its code in: express's
+/// own `lib/` was unreachable twice over, once for not being an index file and
+/// once for the directory name. Python has no such blocklist and neither does
+/// this. `lib/index.js` is named `lib`, because `require('./lib')` is what the
+/// source calls it.
+pub(super) fn js_module_identity(path: &str, suffixes: &[&str]) -> (String, bool) {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    let Some(stem) = suffixes
+        .iter()
+        .find_map(|suffix| basename.strip_suffix(suffix))
+    else {
+        return (String::new(), false);
+    };
+    if stem == "index" {
+        let directory = match path.rsplit_once('/') {
+            Some((head, _)) => head.rsplit('/').next().unwrap_or(head),
+            // A root-level `index.js` has no directory to be named after, so it
+            // has no identity, exactly as it had none before this change.
+            None => "",
+        };
+        return (directory.to_string(), true);
     }
-    Some(dir_name.to_string())
+    (stem.to_string(), false)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every entity except the file's own Module.
+    ///
+    /// Every JS/TS file now carries a Module entity, as every Python file has
+    /// since `python.rs:301`. A test whose subject is a class binding or an
+    /// export rule is not about that module, and asserting the whole list would
+    /// make every such test carry it. This drops exactly the file's own module
+    /// and nothing else, so an unexpected extra entity still fails the assertion
+    /// it was written for. The module entity has its own tests.
+    fn entities_besides_the_files_own_module(
+        entities: &[ExtractedEntity],
+    ) -> Vec<(EntityKind, &str)> {
+        entities
+            .iter()
+            .filter(|e| e.kind != EntityKind::Module)
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect()
+    }
 
     #[test]
     fn parse_javascript_function() {
@@ -2121,11 +2179,7 @@ mod tests {
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
 
-        let named: Vec<(EntityKind, &str)> = output
-            .entities
-            .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
+        let named = entities_besides_the_files_own_module(&output.entities);
         assert!(
             named.contains(&(EntityKind::Class, "View")),
             "a constructor carrying prototype methods is class-like, got {named:?}"
@@ -2213,7 +2267,7 @@ exports.static = require('serve-static');
         let output = adapter.extract(&tree, source, &file_id).unwrap();
 
         assert!(
-            output.entities.is_empty(),
+            entities_besides_the_files_own_module(&output.entities).is_empty(),
             "require bindings must not produce entities, got {:?}",
             output
                 .entities
@@ -2263,13 +2317,18 @@ exports.static = require('serve-static');
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let named: Vec<(EntityKind, &str)> = output
-            .entities
-            .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
+        let named = entities_besides_the_files_own_module(&output.entities);
         assert_eq!(named, vec![(EntityKind::Constant, "Router")]);
-        assert_eq!(output.entities[0].visibility, Visibility::Public);
+        // By name, for the same reason as the call-result test below.
+        assert_eq!(
+            output
+                .entities
+                .iter()
+                .find(|e| e.name == "Router")
+                .expect("the exported constant")
+                .visibility,
+            Visibility::Public
+        );
     }
 
     #[test]
@@ -2281,17 +2340,22 @@ exports.static = require('serve-static');
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let named: Vec<(EntityKind, &str)> = output
+        let named = entities_besides_the_files_own_module(&output.entities);
+        assert_eq!(named, vec![(EntityKind::Constant, "etag")]);
+        // Looked up by name, not by index. The file's own module entity is
+        // emitted first now, so `entities[0]` is the module: the visibility
+        // assertion below would have kept passing against it, because a module
+        // is Public too, while no longer testing the constant it names.
+        let etag = output
             .entities
             .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
-        assert_eq!(named, vec![(EntityKind::Constant, "etag")]);
-        assert_eq!(output.entities[0].visibility, Visibility::Public);
+            .find(|e| e.name == "etag")
+            .expect("the exported constant");
+        assert_eq!(etag.visibility, Visibility::Public);
         assert!(
-            output.entities[0].signature.contains("createETagGenerator"),
+            etag.signature.contains("createETagGenerator"),
             "the assignment is the body of a call-result export, got {:?}",
-            output.entities[0].signature
+            etag.signature
         );
         let calls: Vec<(&str, &str)> = output
             .relations
@@ -2311,11 +2375,7 @@ exports.static = require('serve-static');
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let named: Vec<(EntityKind, &str)> = output
-            .entities
-            .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
+        let named = entities_besides_the_files_own_module(&output.entities);
         assert_eq!(named, vec![(EntityKind::Constant, "wetag")]);
     }
 
@@ -2326,11 +2386,7 @@ exports.static = require('serve-static');
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let named: Vec<(EntityKind, &str)> = output
-            .entities
-            .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
+        let named = entities_besides_the_files_own_module(&output.entities);
         assert_eq!(named, vec![(EntityKind::Class, "Router")]);
     }
 
@@ -2346,7 +2402,7 @@ exports.static = require('serve-static');
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
         assert!(
-            output.entities.is_empty(),
+            entities_besides_the_files_own_module(&output.entities).is_empty(),
             "a require re-export is a dependency line, got {:?}",
             output
                 .entities
@@ -2379,7 +2435,7 @@ exports.static = require('serve-static');
             let file_id = FilePathId::new("test.js");
             let output = adapter.extract(&tree, source, &file_id).unwrap();
             assert!(
-                output.entities.is_empty(),
+                entities_besides_the_files_own_module(&output.entities).is_empty(),
                 "{:?} is not an exported property, got {:?}",
                 std::str::from_utf8(source).unwrap(),
                 output
@@ -2530,11 +2586,7 @@ exports.static = require('serve-static');
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
 
-        let named: Vec<(EntityKind, &str)> = output
-            .entities
-            .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
+        let named = entities_besides_the_files_own_module(&output.entities);
         assert_eq!(
             named,
             vec![
@@ -2717,11 +2769,7 @@ exports.static = require('serve-static');
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let named: Vec<(EntityKind, &str)> = output
-            .entities
-            .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
+        let named = entities_besides_the_files_own_module(&output.entities);
         assert_eq!(
             named,
             vec![
@@ -2810,6 +2858,9 @@ exports.static = require('serve-static');
         let file_id = FilePathId::new("lib/router/index.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
 
+        // The full list on purpose. This test's subject IS the module entity,
+        // so the helper that drops modules would strip exactly what is being
+        // asserted and the test would pass while measuring nothing.
         let named: Vec<(EntityKind, &str)> = output
             .entities
             .iter()

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -51,29 +51,6 @@ impl LanguageAdapter for JavaScriptAdapter {
         let root = tree.root_node();
         let mut cursor = root.walk();
 
-        // Emit a Module entity for every JavaScript source file, as Python does.
-        // Previously only index files produced one, and only when their directory
-        // was not `src` or `lib`, so one of the 58 JS/TS files kin itself tracks
-        // carried a module entity. A file with no module entity cannot SOURCE an
-        // entity-level import edge, because the linker anchors those on the
-        // importing file's module, so every import in every other file stayed
-        // invisible to `find_references`.
-        let (module_name, is_package) = js_module_identity(&file_id.0, JS_SUFFIXES);
-        if !module_name.is_empty() {
-            entities.push(ExtractedEntity {
-                kind: EntityKind::Module,
-                name: module_name,
-                signature: if is_package {
-                    format!("package {}", file_id.0)
-                } else {
-                    format!("module {}", file_id.0)
-                },
-                visibility: Visibility::Public,
-                doc_summary: None,
-                fingerprint: compute_fingerprint(&root, source),
-                span: span_from_node(&root, file_id),
-            });
-        }
 
         // Read the file's property-defining helpers before walking it.
         // Declaration order does not bind a helper to its uses: express
@@ -99,6 +76,45 @@ impl LanguageAdapter for JavaScriptAdapter {
             extract_js_tests_from_node(&child, source, &mut tests);
         }
 
+        // Emitted after the walk and BEFORE `owners.finish`, and both halves of
+        // that are load-bearing.
+        //
+        // After the walk, because Python emits its module last and every
+        // consumer that looks an entity up by name depends on it: with the
+        // module first, a `.find(|e| leaf(e.name) == "caller")` over `caller.ts`
+        // returns the MODULE rather than the function, which is how the rename
+        // planner's TypeScript case lost its call edge.
+        //
+        // Before `owners.finish`, because that function's collision guard reads
+        // the entity list to decide whether a receiver's owner already exists.
+        // Run after it, the module is invisible to the guard, which then
+        // synthesizes a Class under the same name and leaves one file holding
+        // two entities called `router` that the linker's (file, name) index
+        // cannot tell apart. That is the exact outcome its own comment warns
+        // about.
+        // Previously only index files produced one, and only when their directory
+        // was not `src` or `lib`, so one of the 58 JS/TS files kin itself tracks
+        // carried a module entity. A file with no module entity cannot SOURCE an
+        // entity-level import edge, because the linker anchors those on the
+        // importing file's module, so every import in every other file stayed
+        // invisible to `find_references`.
+        let (module_name, is_package) = js_module_identity(&file_id.0, JS_SUFFIXES);
+        if !module_name.is_empty() {
+            entities.push(ExtractedEntity {
+                kind: EntityKind::Module,
+                name: module_name,
+                signature: if is_package {
+                    format!("package {}", file_id.0)
+                } else {
+                    format!("module {}", file_id.0)
+                },
+                visibility: Visibility::Public,
+                doc_summary: None,
+                fingerprint: compute_fingerprint(&root, source),
+                span: span_from_node(&root, file_id),
+            });
+        }
+
         owners.finish(&mut entities);
 
         // Build import lookup: local_name -> module_path
@@ -122,6 +138,7 @@ impl LanguageAdapter for JavaScriptAdapter {
                 }
             }
         }
+
 
         Ok(ParseOutput {
             entities,
@@ -2868,9 +2885,14 @@ exports.static = require('serve-static');
             .collect();
         assert_eq!(
             named,
+            // The module comes LAST, as Python's does. What this test is about
+            // is that there is exactly one `router` and it is still a Module:
+            // the guard in `JsOwners::finish` reads the entity list to decide
+            // whether the owner already exists, so the module has to be in that
+            // list before it runs, and it is.
             vec![
-                (EntityKind::Module, "router"),
                 (EntityKind::Method, "router.handle"),
+                (EntityKind::Module, "router"),
             ],
             "the module keeps its kind and no second `router` is added"
         );

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -51,7 +51,6 @@ impl LanguageAdapter for JavaScriptAdapter {
         let root = tree.root_node();
         let mut cursor = root.walk();
 
-
         // Read the file's property-defining helpers before walking it.
         // Declaration order does not bind a helper to its uses: express
         // declares `defineGetter` below all twelve calls to it.
@@ -138,7 +137,6 @@ impl LanguageAdapter for JavaScriptAdapter {
                 }
             }
         }
-
 
         Ok(ParseOutput {
             entities,

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -19,7 +19,8 @@ use crate::extract::{
 use super::javascript::{
     collect_js_property_definers, collect_js_require_imports, extract_calls_from_context,
     extract_js_assignment_function, extract_js_object_methods, extract_js_property_definition,
-    js_heritage_name, js_require_target, JsOwners, JsPropertyDefiner,
+    js_heritage_name, js_module_identity, js_require_target, JsOwners, JsPropertyDefiner,
+    TS_SUFFIXES,
 };
 
 pub struct TypeScriptAdapter;
@@ -59,21 +60,26 @@ impl LanguageAdapter for TypeScriptAdapter {
         let root = tree.root_node();
         let mut cursor = root.walk();
 
-        // Emit Module entity for index.ts/index.tsx files (TS packages).
-        // This makes the module searchable by its directory name, e.g.,
-        // `packages/mui-base/src/useSelect/index.ts` → entity "useSelect".
-        if is_ts_index_file(&file_id.0) {
-            if let Some(module_name) = extract_module_name_from_path(&file_id.0) {
-                entities.push(ExtractedEntity {
-                    kind: EntityKind::Module,
-                    name: module_name,
-                    signature: format!("module {}", file_id.0),
-                    visibility: Visibility::Public,
-                    doc_summary: None,
-                    fingerprint: compute_fingerprint(&root, source),
-                    span: span_from_node(&root, file_id),
-                });
-            }
+        // Emit a Module entity for every TypeScript source file, through the
+        // same helper JavaScript uses. The two adapters carried byte-identical
+        // copies of this rule and drifted anyway: the TypeScript index predicate
+        // never matched `index.d.ts`. Sharing the helper is what the header
+        // comment above already says the shared surface exists for.
+        let (module_name, is_package) = js_module_identity(&file_id.0, TS_SUFFIXES);
+        if !module_name.is_empty() {
+            entities.push(ExtractedEntity {
+                kind: EntityKind::Module,
+                name: module_name,
+                signature: if is_package {
+                    format!("package {}", file_id.0)
+                } else {
+                    format!("module {}", file_id.0)
+                },
+                visibility: Visibility::Public,
+                doc_summary: None,
+                fingerprint: compute_fingerprint(&root, source),
+                span: span_from_node(&root, file_id),
+            });
         }
 
         // Read the file's property-defining helpers before walking it; a
@@ -994,28 +1000,27 @@ fn extract_js_tests(node: &tree_sitter::Node, source: &[u8], tests: &mut Vec<Ext
 }
 
 /// Check if a file is a TS index file (index.ts, index.tsx).
-fn is_ts_index_file(path: &str) -> bool {
-    let basename = path.rsplit('/').next().unwrap_or(path);
-    matches!(basename, "index.ts" | "index.tsx")
-}
-
-/// Extract the module name from a file path for index files.
-/// `packages/mui-base/src/useSelect/index.ts` → `"useSelect"`
-fn extract_module_name_from_path(path: &str) -> Option<String> {
-    let without_basename = path.rsplit_once('/')?.0;
-    let dir_name = without_basename
-        .rsplit('/')
-        .next()
-        .unwrap_or(without_basename);
-    if dir_name.is_empty() || dir_name == "src" || dir_name == "lib" {
-        return None;
-    }
-    Some(dir_name.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every entity except the file's own Module.
+    ///
+    /// Every JS/TS file now carries a Module entity, as every Python file has
+    /// since `python.rs:301`. A test whose subject is a class binding or an
+    /// export rule is not about that module, and asserting the whole list would
+    /// make every such test carry it. This drops exactly the file's own module
+    /// and nothing else, so an unexpected extra entity still fails the assertion
+    /// it was written for. The module entity has its own tests.
+    fn entities_besides_the_files_own_module(
+        entities: &[ExtractedEntity],
+    ) -> Vec<(EntityKind, &str)> {
+        entities
+            .iter()
+            .filter(|e| e.kind != EntityKind::Module)
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect()
+    }
 
     #[test]
     fn parse_typescript_function() {
@@ -1215,7 +1220,7 @@ const isAbsolute = require('node:path').isAbsolute;
         let file_id = FilePathId::new("test.ts");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
         assert!(
-            output.entities.is_empty(),
+            entities_besides_the_files_own_module(&output.entities).is_empty(),
             "require bindings must not produce entities, got {:?}",
             output
                 .entities
@@ -1240,11 +1245,7 @@ const isAbsolute = require('node:path').isAbsolute;
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.ts");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let named: Vec<(EntityKind, &str)> = output
-            .entities
-            .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
+        let named = entities_besides_the_files_own_module(&output.entities);
         assert!(named.contains(&(EntityKind::Class, "View")), "{named:?}");
         assert!(
             named.contains(&(EntityKind::Method, "View.lookup")),
@@ -1266,11 +1267,7 @@ const isAbsolute = require('node:path').isAbsolute;
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.ts");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let named: Vec<(EntityKind, &str)> = output
-            .entities
-            .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
+        let named = entities_besides_the_files_own_module(&output.entities);
         assert_eq!(
             named,
             vec![
@@ -1300,11 +1297,7 @@ const isAbsolute = require('node:path').isAbsolute;
         let file_id = FilePathId::new("test.ts");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
 
-        let named: Vec<(EntityKind, &str)> = output
-            .entities
-            .iter()
-            .map(|e| (e.kind, e.name.as_str()))
-            .collect();
+        let named = entities_besides_the_files_own_module(&output.entities);
         assert_eq!(
             named,
             vec![

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -60,27 +60,6 @@ impl LanguageAdapter for TypeScriptAdapter {
         let root = tree.root_node();
         let mut cursor = root.walk();
 
-        // Emit a Module entity for every TypeScript source file, through the
-        // same helper JavaScript uses. The two adapters carried byte-identical
-        // copies of this rule and drifted anyway: the TypeScript index predicate
-        // never matched `index.d.ts`. Sharing the helper is what the header
-        // comment above already says the shared surface exists for.
-        let (module_name, is_package) = js_module_identity(&file_id.0, TS_SUFFIXES);
-        if !module_name.is_empty() {
-            entities.push(ExtractedEntity {
-                kind: EntityKind::Module,
-                name: module_name,
-                signature: if is_package {
-                    format!("package {}", file_id.0)
-                } else {
-                    format!("module {}", file_id.0)
-                },
-                visibility: Visibility::Public,
-                doc_summary: None,
-                fingerprint: compute_fingerprint(&root, source),
-                span: span_from_node(&root, file_id),
-            });
-        }
 
         // Read the file's property-defining helpers before walking it; a
         // helper is not bound to its uses by declaration order.
@@ -103,6 +82,43 @@ impl LanguageAdapter for TypeScriptAdapter {
             collect_js_require_imports(&child, source, &mut imports);
             // Detect describe/it/test calls (Jest/Vitest/Mocha)
             extract_js_tests(&child, source, &mut tests);
+        }
+
+        // Emitted after the walk and BEFORE `owners.finish`, and both halves of
+        // that are load-bearing.
+        //
+        // After the walk, because Python emits its module last and every
+        // consumer that looks an entity up by name depends on it: with the
+        // module first, a `.find(|e| leaf(e.name) == "caller")` over `caller.ts`
+        // returns the MODULE rather than the function, which is how the rename
+        // planner's TypeScript case lost its call edge.
+        //
+        // Before `owners.finish`, because that function's collision guard reads
+        // the entity list to decide whether a receiver's owner already exists.
+        // Run after it, the module is invisible to the guard, which then
+        // synthesizes a Class under the same name and leaves one file holding
+        // two entities called `router` that the linker's (file, name) index
+        // cannot tell apart. That is the exact outcome its own comment warns
+        // about.
+        // same helper JavaScript uses. The two adapters carried byte-identical
+        // copies of this rule and drifted anyway: the TypeScript index predicate
+        // never matched `index.d.ts`. Sharing the helper is what the header
+        // comment above already says the shared surface exists for.
+        let (module_name, is_package) = js_module_identity(&file_id.0, TS_SUFFIXES);
+        if !module_name.is_empty() {
+            entities.push(ExtractedEntity {
+                kind: EntityKind::Module,
+                name: module_name,
+                signature: if is_package {
+                    format!("package {}", file_id.0)
+                } else {
+                    format!("module {}", file_id.0)
+                },
+                visibility: Visibility::Public,
+                doc_summary: None,
+                fingerprint: compute_fingerprint(&root, source),
+                span: span_from_node(&root, file_id),
+            });
         }
 
         owners.finish(&mut entities);
@@ -128,6 +144,7 @@ impl LanguageAdapter for TypeScriptAdapter {
                 }
             }
         }
+
 
         Ok(ParseOutput {
             entities,

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -60,7 +60,6 @@ impl LanguageAdapter for TypeScriptAdapter {
         let root = tree.root_node();
         let mut cursor = root.walk();
 
-
         // Read the file's property-defining helpers before walking it; a
         // helper is not bound to its uses by declaration order.
         let definers = collect_js_property_definers(&root, source);
@@ -144,7 +143,6 @@ impl LanguageAdapter for TypeScriptAdapter {
                 }
             }
         }
-
 
         Ok(ParseOutput {
             entities,

--- a/crates/kin-parser/tests/language_matrix_entities.rs
+++ b/crates/kin-parser/tests/language_matrix_entities.rs
@@ -586,13 +586,28 @@ fn assert_relational_shape(out: &ParseOutput, lang: &str) {
     // against Python's 2.64. Asserting the ratio is what makes a regression
     // that halves the edge count fail on a fixture that still contains every
     // expected name.
-    let density = out.relations.len() as f64 / out.entities.len() as f64;
+    //
+    // The file's own Module entity is excluded from the denominator, and the
+    // exclusion is the point rather than a convenience. Since FIR-2675 every
+    // JS/TS file carries one, and it is deliberately not a container: Python's
+    // module is not one either, and making it one would put every top-level
+    // entity inside it, which `top_level_entities` in the round-trip fuzz reads
+    // as one whole-file region and collapses. So the module is a node this
+    // fixture's relational shape says nothing about, and counting it in the
+    // denominator measured the port rather than the edges. Left in, it dropped
+    // this fixture from 2.07 to 1.94 while not one relation had changed.
+    let counted: Vec<_> = out
+        .entities
+        .iter()
+        .filter(|e| e.kind != EntityKind::Module)
+        .collect();
+    let density = out.relations.len() as f64 / counted.len() as f64;
     assert!(
         density >= 2.0,
-        "{lang}: {} relations over {} entities is {density:.2} per entity, \
+        "{lang}: {} relations over {} non-module entities is {density:.2} per entity, \
          below the 2.0 floor this fixture must clear",
         out.relations.len(),
-        out.entities.len()
+        counted.len()
     );
 }
 

--- a/crates/kin-projection/src/placement.rs
+++ b/crates/kin-projection/src/placement.rs
@@ -387,8 +387,7 @@ mod tests {
         let working_dir = tempfile::tempdir().unwrap();
         match decide_placement(&orphan, &graph, working_dir.path()).unwrap() {
             PlacementDecision::Ambiguous(candidates) => {
-                let mut names: Vec<String> =
-                    candidates.iter().map(|f| f.0.clone()).collect();
+                let mut names: Vec<String> = candidates.iter().map(|f| f.0.clone()).collect();
                 names.sort();
                 assert_eq!(names, vec!["lib/application.js", "lib/router.js"]);
             }

--- a/crates/kin-projection/src/placement.rs
+++ b/crates/kin-projection/src/placement.rs
@@ -328,6 +328,77 @@ mod tests {
         }
     }
 
+    /// A language whose every file carries a Module entity yields `Ambiguous`
+    /// with the candidate list, and that is the honest answer rather than a
+    /// regression.
+    ///
+    /// FIR-2675 made JavaScript and TypeScript emit a Module for every source
+    /// file, as Python has since `python.rs:301`. The fix design read the
+    /// resulting `Ambiguous` as a defect to be solved in the same pull request.
+    /// The sign is backwards. Step 3 has no `file_origin` and no
+    /// `lineage_parent` to go on; before the port it answered `ExistingFile`
+    /// whenever the language happened to have exactly one module file, which is
+    /// sparsity rather than evidence, and with two files it now says it cannot
+    /// decide and names what it could not decide between. A confidently wrong
+    /// answer is the defect; a correctly uncertain one is the honest state.
+    ///
+    /// Two facts bound how much this matters, and both are worth keeping beside
+    /// the assertion. Python has been in exactly this state since its own port,
+    /// so the condition is neither new nor language-specific. And
+    /// `decide_placement` has no caller: it is `pub` here and re-exported from
+    /// `lib.rs`, and a sweep of the workspace finds those two mentions and
+    /// nothing else, so no product surface observes either answer today. If it
+    /// ever gains a caller, what it should answer is that caller's ticket to
+    /// decide, not this one's.
+    ///
+    /// This test exists so the behaviour is asserted rather than incidental.
+    #[test]
+    fn a_per_file_module_language_yields_ambiguous_with_its_candidates() {
+        let graph = kin_db::InMemoryGraph::new();
+        let mut modules = Vec::new();
+        let mut tree = Vec::new();
+        for path in ["lib/application.js", "lib/router.js"] {
+            let mut module = make_entity(path, EntityKind::Module, LanguageId::JavaScript);
+            module.file_origin = Some(FilePathId::new(path));
+            modules.push(EntityDelta::Added { new: module });
+            // The graph refuses an entity whose repository path is not in the
+            // staged tree, so the files are staged beside their modules.
+            tree.push(TreeDelta::Added {
+                artifact_id: ArtifactId::new(),
+                new: LocatedEntry::new(
+                    RepoPath::from_utf8(path.to_string()).unwrap(),
+                    TreeEntry::blob(Hash256::from_bytes([0; 32]), false),
+                ),
+            });
+        }
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: modules,
+                relation_deltas: vec![],
+                tree_deltas: tree,
+                admission_policy_delta: None,
+                external_reference_deltas: vec![],
+            })
+            .unwrap();
+
+        // No file_origin and no lineage_parent, so steps 1 and 2 cannot answer
+        // and step 3 is the one under test.
+        let orphan = make_entity("handle", EntityKind::Function, LanguageId::JavaScript);
+        let working_dir = tempfile::tempdir().unwrap();
+        match decide_placement(&orphan, &graph, working_dir.path()).unwrap() {
+            PlacementDecision::Ambiguous(candidates) => {
+                let mut names: Vec<String> =
+                    candidates.iter().map(|f| f.0.clone()).collect();
+                names.sort();
+                assert_eq!(names, vec!["lib/application.js", "lib/router.js"]);
+            }
+            other => panic!(
+                "a per-file-module language must report ambiguity and name its \
+                 candidates, got {other:?}"
+            ),
+        }
+    }
+
     #[test]
     fn generate_file_path_rust() {
         let entity = make_entity("process", EntityKind::Function, LanguageId::Rust);

--- a/scripts/acceptance/parse_hole_repro.py
+++ b/scripts/acceptance/parse_hole_repro.py
@@ -155,7 +155,7 @@ def doctor_row_names_the_files(report):
         return None
     row = rows[0]
     detail = row.get("detail") or ""
-    return row.get("status") == "healthy" and ".js" in detail
+    return row.get("status") == "healthy" and ".rs" in detail
 
 
 GRADERS = {
@@ -224,13 +224,22 @@ class Suite(object):
                     "module.exports = handler%d;\n" % (following, index, index)
                 )
         for index in range(silent):
-            # Valid UTF-8 JavaScript that declares nothing. This is the honest
-            # shape: bytes an adapter is registered for, admitted as source, and
-            # holding no entity. NUL bytes would route the file to the opaque
-            # facet instead, which is a different state wearing the same
-            # numbers, and it is what an earlier version of this fixture used.
-            with open(os.path.join(repo, "lib", "silent%d.js" % index), "w") as handle:
-                handle.write("require('./module0');\n// nothing is declared here\n")
+            # The silent files are RUST, and they used to be JavaScript.
+            # FIR-2675 made every JavaScript and TypeScript file emit a Module
+            # entity, so a comment-only `.js` file now produces one and is no
+            # longer silent: measured at 1 entity for exactly these bytes against
+            # 0 before. That is the port working, and it emptied this fixture's
+            # hole as a side effect, which is what this suite caught.
+            #
+            # Rust carries no per-file module entity, so a comment-only `.rs`
+            # file still produces nothing: measured at 0. It is the same honest
+            # shape the old comment described, bytes an adapter is registered
+            # for, admitted as source, and holding no entity. NUL bytes would
+            # route the file to the opaque facet instead, which is a different
+            # state wearing the same numbers, and it is what an earlier version
+            # of this fixture used.
+            with open(os.path.join(repo, "lib", "silent%d.rs" % index), "w") as handle:
+                handle.write("// nothing is declared here\n")
         self.git(["add", "--all"], repo)
         rc, out = self.git(["commit", "-m", "a javascript library"], repo)
         if rc != 0:
@@ -322,15 +331,15 @@ def self_test():
     cases = [
         ("status_publishes_the_census", True,
          "Parse coverage (files that produced an entity / files admitted):\n"
-         "  javascript: 4/7 (57%)\n  no_entity: 3 of 7 admitted javascript files produced "
-         "no entity, including lib/silent0.js"),
+         "  javascript: 4/7 (57%)\n  no_entity: 3 of 7 admitted rust files produced "
+         "no entity, including lib/silent0.rs"),
         # The header alone is not the delta: a repository-grain count already
         # existed on that page, and the per-language row plus the named paths
         # are what this suite is about.
         ("status_publishes_the_census", False,
          "Parse coverage (files that produced an entity / files admitted):\n"
-         "  javascript: 7/7 (100%)"),
-        ("status_publishes_the_census", False, "no_entity: 3 of 7 admitted javascript files"),
+         "  rust: 3/3 (100%)"),
+        ("status_publishes_the_census", False, "no_entity: 3 of 3 admitted rust files"),
         ("status_publishes_the_census", False, "Entities: 4  |  Files: 4"),
     ]
     failures = []
@@ -342,13 +351,13 @@ def self_test():
     # The doctor grader reads a structure rather than a string.
     doctor_cases = [
         (True, {"checks": [{"id": "parse_coverage", "status": "healthy",
-                            "detail": "javascript 4/7; no_entity: 3 of 7, including lib/silent0.js"}]}),
+                            "detail": "rust 0/3; no_entity: 3 of 3, including lib/silent0.rs"}]}),
         # A row that went red on a count is the failure mode this suite exists
         # to prevent, so the grader must not accept one.
         (False, {"checks": [{"id": "parse_coverage", "status": "stale",
-                             "detail": "javascript 4/7, including lib/silent0.js"}]}),
+                             "detail": "rust 0/3, including lib/silent0.rs"}]}),
         (False, {"checks": [{"id": "parse_coverage", "status": "healthy",
-                             "detail": "javascript 7/7"}]}),
+                             "detail": "rust 3/3"}]}),
         (False, {"checks": [{"id": "parse_coverage", "status": "healthy"}]}),
         (None, {"checks": [{"id": "relation_census", "status": "healthy"}]}),
         (None, {"checks": []}),


### PR DESCRIPTION
Closes FIR-2675
Part of FIR-2679

Python fixed this for itself and the fix never travelled. JavaScript and TypeScript emitted a `Module` entity only for index files, and only when the directory was not `src` or `lib`, so one of the 58 JS/TS files kin itself tracks carried one. A file with no module entity cannot SOURCE an entity-level import edge, because the linker anchors those on the importing file's module, so every import in every other file stayed invisible to `find_references`.

## The rule, mirrored rather than invented

`js_module_identity` is a faithful mirror of `python_module_identity`. An index file is the JS/TS `__init__.py` and takes its directory's name, because `require('./customParseFormat')` is what the source calls it; every other file takes its own stem. The `src`/`lib` refusal is gone, since Python carries no such blocklist and the exclusion landed on exactly the directories a real library keeps its code in.

The guard is mirrored exactly too, and it is the part that matters most. Python's `.strip_suffix(".py").unwrap_or("")` yields an empty name for a path with no suffix, and the caller's non-empty check then emits nothing. `round_trip_fuzz` passes an extension-less `FilePathId`, and a module entity there would span the whole file and swallow every other entity in the region.

One helper serves both adapters now. They carried byte-identical copies and drifted anyway: the TypeScript index predicate never matched `index.d.ts`, so a declaration file was invisible, and stripping only `.ts` would have named it `foo.d`. Suffixes are ordered longest first for that reason.

## Measured, on both corpora the ticket names

Before is `origin/main`'s two adapter files swapped into the committed tree under a restore trap, marker-confirmed in both directions, ending `final dirty: 0`.

| counter | express before / after | drizzle-orm before / after |
|---|---|---|
| files with a module entity | **29 / 140** | **68 / 966** |
| entity-rooted import edges | **0 / 58** | **29 / 2358** |
| blocked for want of an importer module | **13 / 0** | **2295 / 0** |
| specifiers matching a target entity | 13 / 13 | 2324 / 2337 |
| resolved artifact pairs (the control) | **150 / 150** | **1848 / 1848** |

The plan's falsification was that entity-rooted import edges must move off zero with the artifact pair count unchanged byte for byte. Both hold on both corpora. Express reaches 140 of 141 rather than 141: the one file without a module entity is the root-level `index.js`, which has no directory to be named after and is asserted to emit nothing by its own test.

**The blocked column was a lower bound, not the upper bound the ticket expected.** The ticket warns that blocked is an upper bound because some specifiers may still fail to bind for unrelated reasons. On drizzle-orm it ran the other way: blocked was 2295 and the actual gain was 2329, thirty-four more than the column predicted. A module entity is both a source AND a target, and the blocked column counts only specifiers with no importer module to hang off; it cannot count the ones that now resolve TO a module entity that did not exist before, which is what a whole-module `require` or `import` names. The specifiers-matching-a-target row moves for the same reason. The ticket's caution was right in direction and wrong in sign, and only measuring could tell.

**My before-numbers for express differ from the ticket's** table, 13 and 13 against 36 and 34, while drizzle-orm's blocked matches exactly at 2295. The ticket measured when kin#1123 landed; this branch sits on `ca01b7ed`, which carries kin#1140 on top. I have not attributed the delta to a commit and am not claiming one. What the acceptance needs is a before and after measured on ONE base, which is what the table is, so the ticket's 2353 figure is reconciled against my own measured before rather than carried forward.

The per-language span census moves with it: JavaScript and TypeScript each gain one relation and one span-backed relation, and both rows land exactly on Python's, which is the ticket's claim in a line. Their `min_relations` floors rise with them, so the gained edge is pinned rather than tolerated.

## Part of FIR-2679: the layer is fixed, the residue is not, and the disclosure moved the wrong way

Re-running FIR-2679's own express reproduction on this branch, fixture copied so their store survives and all four of their controls re-verified: javascript files producing entities 66 of 141 to **140 of 141**, entity-to-entity relations 621 to **1679**, and the `Imports` row absent in BOTH their before and their after now reads **`Imports: 59`**. Their discriminator table flips exactly, `test/Route.js` and `test/exports.js` going 0 to 1 entity.

The four symbols still answer zero callers, tests and dependents. What changed is the confidence: they used to answer `verdict: inconclusive`, `imports: unproduced`, `safe_to_conclude_absent: false`, and now answer `imports: present`, unbounded, **`verdict: certified`**. For `Router` that is contradicted by FIR-2679's own grep ground truth of 32 uses across 9 tracked files. An honest inconclusive became a confident zero, and it did so because this change supplied the entities that let the gate certify. That is the being-present-versus-being-trustworthy trap, and it is filed on FIR-2679 with these numbers rather than left under this PR's green. `express.static` is untouched, an export-extraction gap this port cannot close.

## Falsification

Six mutations, each applied to the committed tree, marker-confirmed before its arm ran, restored on an EXIT/INT/TERM trap, tree clean after.

| Mutation | Case that must go red | Result |
|---|---|---|
| only index files emit, the pre-fix rule | `javascript_non_index_file_sources_an_entity_import_edge` | RED |
| the `src`/`lib` blocklist is back | `..._directly_under_lib_or_src_carries_a_module_entity` | RED |
| the suffix guard stops guarding | `an_extension_less_path_emits_no_module_entity` | RED |
| `.d.ts` loses its place at the front | `a_typescript_declaration_file_is_named_without_its_d_segment` | RED |
| an index file takes its stem | the index-naming assertions | RED |
| the placement ambiguity branch cannot fire | `a_per_file_module_language_yields_ambiguous_with_its_candidates` | RED |

The two limitation tests are inverted rather than deleted, so the record of what moved stays in the file. TypeScript had no module-entity test at all, so its coverage is added rather than converted.

## Findings beside the fix

**Two assertions were measuring the wrong entity** once a module was emitted first. `output.entities[0].visibility` reads the module, and a module is `Public` too, so it stayed green against the wrong subject; only its sibling `signature` assertion caught it. The same class bit the pipeline's TypeScript test, whose Python sibling was already written by kind and name. All look up by name now, with the reason at the site.

**The relational-density floor was measuring the port rather than the edges.** It counted the new module in its denominator and fell from 2.07 to 1.94 with not one relation changed. It excludes the file's own module now, because the module is deliberately not a container: Python's is not either, and putting every top-level entity inside it is what `top_level_entities` reads as one whole-file region.

**A module-dropping test helper nearly stripped the subject of the one test about modules.** `receiver_named_like_the_index_module_keeps_one_entity` asserts the module entity itself, so it keeps the full list, with a comment saying why the helper must not be used there.

**The plan's placement risk had the sign backwards.** It read `PlacementDecision::Ambiguous` as a defect to solve in this PR. Step 3 of `decide_placement` is reached only by an entity with no `file_origin` and no `lineage_parent`; before the port it answered `ExistingFile` whenever a language happened to have exactly one module file, which is sparsity rather than evidence. A confidently wrong answer is the defect and a correctly uncertain one is the honest state. No logic changed. Two facts bound it: Python has been in this state since its own port, and `decide_placement` has no caller, being `pub` and re-exported with no other mention in the workspace. The behaviour is now asserted rather than incidental.

**A whole-module require binds the module, and a named import still binds the named entity.** `var Router = require('./router')` now reaches the `router` module rather than the `Router` function, which is right because the require names the module and Python behaves the same way for `import routing`. The second half has its own test, because a port that made every import land on a module would have satisfied the first assertion while destroying the specifier-level answer `find_references` is built on.

## Two hosted reds, and the one line under both

This branch went red on hosted CI twice, and both times on a consumer of the port that no local gate ran. They belong in the record because the second one found the cause of the first.

**First red**, one leg: `graph_status_publishes_per_language_parse_coverage_without_a_verdict`. Its fixture seeded comment-only `.js` files as its silent case, and those now correctly produce a module entity, so coverage read 7 of 7 and "the silent files are named" had nothing to find. The silent files are Rust now, measured at 0 entities for the same shape rather than assumed, and the denominator assertion moved to the rust row with them, because a javascript row reading 4/4 cannot tell a correct denominator from one subtracted down to its numerator.

**Second red**, five legs including Product Acceptance. The root cause is one line and it is the part of Python this change had mirrored least carefully: **Python emits its module entity last and this emitted it first.** Every consumer that resolves an entity by name depends on that order. `.find(|e| leaf(e.name) == "caller")` over `caller.ts` returned the module rather than the function, which is how the rename planner's TypeScript case lost its call edge. It is also the common cause behind the `entities[0]` assertions this branch had been fixing one site at a time, and finding it retired that whole class rather than another instance of it.

Moving the push to the very end then broke something real, and a test caught it within a minute: `owners.finish` reads the entity list to decide whether a receiver's owner already exists, so with the module invisible it synthesized a `Class` under the same name and left one file holding two `router` entities the linker's `(file, name)` index cannot tell apart. That is exactly what its own comment warns about. The emission sits after the walk and BEFORE `owners.finish`, and both halves are written at the site with the failure each prevents.

Two consumers moved with the fact rather than being silenced. The rename planner already modelled it as data, a per-fixture `emits_module_entity_per_file` flag whose comment named FIR-2675 as the ticket that would flip it; JavaScript and TypeScript flip to true and move to the branch asserting the rename reaches the import site, and the emptied branch stays because it is the shape any language without a per-file module falls into. `scripts/acceptance/parse_hole_repro.py` seeded comment-only `.js` files as its holes, so its holed fixture had no holes and both graders failed against a store reading healthy; its silent files are Rust now, with the graders and their self-test fixtures moved to match.

**Why local gates missed both.** These live in kin-cli integration tests and the acceptance suites, behind feature permutations that neither the touched-crate suites nor `bin/kin-precheck`'s sixteen gates cover. And the CI leg itself reported one failure with `4917/7328 tests were not run due to test failure`, so nextest's fail-fast was hiding the rest: the fix pass ran every touched crate with `--no-fail-fast`, which is how both consumers surfaced together instead of as a third red.

## What I ran

`bin/kin-precheck kin` on `9ce94fd42`: **16 gates ran, 16 passed, 0 failed**, resolved against `.kin-coord/worktrees/fir2675-kin`. It caught three rustfmt failures on this branch before a push, two of them stray whitespace left by a mechanical block move; `cargo fmt -- --check` is the first step of the `falsify-guards` job. Its bound is FIR-2731: its positive control needle is a kin-only step, so it grades kin and refuses every other repo. This lane is kin.

`bin/kin-parity` on `0dd1b7368`: `FINAL PASS-WITH-ALLOWANCES` in 883.7s, magic PASS 22/0/0, brownfield PASS-WITH-ALLOWANCES 10 pass 0 fail 1 unreadable, firstrun PASS-WITH-ALLOWANCES 9 pass 2 fail. Three allowances, all pre-existing and tracked: FIR-2580, FIR-2501, FIR-2464. The only commit since is rustfmt output, proven identical once whitespace and commas are stripped, and `cargo test` is green on the new head for kin-parser, kin-index and kin-projection.
