### PR TITLE
Take the version to 0.6.0 across the lockstep set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.53] - 2026-08-25
+## [0.6.0] - 2026-08-25
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "kin-agent"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3075,14 +3075,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "age",
  "anyhow",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon-spawn"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "fs2",
  "libc",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "cap-std",
  "chrono",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.0",
  "hex",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notifier-macos"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "block2",
  "objc2 0.6.4",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notify"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "kin-model",
  "serde",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.0",
  "chrono",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.53"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -92,7 +92,7 @@ toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
 unicode-ident = "1"
-kin-spine = { version = "0.5.53", path = "../kin-spine" }
+kin-spine = { version = "0.6.0", path = "../kin-spine" }
 
 [dev-dependencies]
 kin-core = { workspace = true, features = ["test-support"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.5.53"
+version = "0.6.0"
 dependencies = [
  "kin-model",
  "serde",

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.5.53",
+  "version": "0.6.0",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.5.53",
+  "version": "0.6.0",
   "mcpName": "ai.kinlab/kin",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.5.53",
+  "version": "0.6.0",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
The founder confirmed the held release relabels as v0.6.0, so every tracked carrier of the version moves in one commit: the workspace and kin-cli manifests, Cargo.lock and fuzz/Cargo.lock (the multi-lockfile sweep, both verified to carry zero 0.5.53 rows afterward), the three npm package manifests, the changelog heading, and the release-version test's expectation. The lock diffs read as their own artifacts and carry only the workspace packages' own version rows; `cargo update -w --offline` locked zero external packages. This supersedes the 0.5.53 label; the release loop runs on main once the wave's last fixes land.
