### PR TITLE
Carry a payload into the transfer harness, and pin which bound refuses it

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17488,6 +17488,162 @@ mod tests {
         std::fs::remove_dir_all(&fixture.working).ok();
     }
 
+    /// What the transfer will say about these fixtures once the authority bound
+    /// moves, MEASURED rather than reasoned about.
+    ///
+    /// The push pin beside this cannot reach the size bound: the authority
+    /// comparison runs first and answers 409 for both arms. So the size bound's
+    /// behaviour would be an assertion nobody had ever run, written against a
+    /// route that does not exist, and the first time anyone saw its result
+    /// would be the day it mattered. That is the shape of an assertion that
+    /// turns out to have been wrong all along.
+    ///
+    /// This runs it today by removing the one thing that stops it. The
+    /// expectation is built from the SOURCE store's own transfer status, so its
+    /// `git_authority_hash` is the source's own and `TransferSourceContext::read`
+    /// agrees with itself; the destination is set unborn, which is what an empty
+    /// hosted store looks like. Everything downstream of the authority
+    /// comparison then runs for real against a real payload.
+    ///
+    /// What it establishes, and none of it was measured before:
+    ///
+    /// The under-cap arm assembles a pack. Its body closure covers every blob
+    /// the fixture wrote, verified by content hash against the source digests
+    /// rather than by counting bodies.
+    ///
+    /// The over-cap arm is refused, and refused by the INDIVISIBLE-STEP path
+    /// rather than by `validate_pack`. A one-commit history is one change, and
+    /// `Assembled::OverNegotiatedBound` is segmentation, so the builder has
+    /// nothing smaller to try. The sentence names `over negotiated limit`, which
+    /// is what the push pin's negative assertions are keyed on, so this is also
+    /// what proves those strings are the right ones to watch for.
+    #[cfg(unix)]
+    #[test]
+    fn the_size_bound_answers_for_real_once_the_authority_bound_is_out_of_the_way() {
+        let main = kin_model::RefName::branch(b"main").unwrap();
+
+        for (label, blobs, fits) in [
+            ("under", PAYLOAD_BLOBS_UNDER_CAP, true),
+            ("over", PAYLOAD_BLOBS_OVER_CAP, false),
+        ] {
+            let hosted_id = hosted_repository_id();
+            let hosted_repository = RepositoryId::new(hosted_id).unwrap();
+            let fixture = payload_fixture(label, blobs, &hosted_repository);
+            let authority =
+                ActiveApiRepositoryAuthority::open_layout_for_test(&fixture.layout).unwrap();
+
+            let status = kin_remote::repository_transfer::repository_transfer_status(
+                &authority.manager,
+                &hosted_repository,
+                &main,
+            )
+            .unwrap();
+            let mut expectation =
+                kin_remote::repository_transfer::RepositoryTransferExpectation::try_from(status)
+                    .unwrap();
+            // An empty hosted store's ref is unborn. Both fields move together
+            // because `validate_expectation` requires them both present or both
+            // absent, and a half-set destination would be refused for a reason
+            // that is not the one under test.
+            expectation.destination_target = None;
+            expectation.destination_head = None;
+
+            // The SEGMENT builder, because that is what a push calls
+            // (`push_to_remote` -> `build_repository_transfer_segment`). Its
+            // sibling `build_repository_transfer_pack` refuses the same
+            // condition with a shorter sentence, so probing that one would pin
+            // wording no push can produce. Measured, not read: the first draft
+            // of this test called the sibling and got
+            // `carries a 16777491 byte source body closure, over negotiated
+            // limit 16777216` with no mention of the indivisible step.
+            let built = kin_remote::repository_transfer::build_repository_transfer_segment(
+                &authority.manager,
+                &main,
+                &expectation,
+            );
+
+            if fits {
+                let pack = built
+                    .unwrap_or_else(|error| {
+                        panic!(
+                            "the {label} arm must assemble a segment once authority agrees: {error}"
+                        )
+                    })
+                    .pack;
+                let closure: u64 = pack.bodies.iter().map(|body| body.byte_len).sum();
+                assert!(
+                    closure >= fixture.payload_bytes,
+                    "the {label} arm's body closure must cover the payload it wrote: \
+                     {closure} against {}",
+                    fixture.payload_bytes
+                );
+                // By content hash, never by count. A pack carrying the right
+                // number of bodies with the wrong bytes passes any count.
+                let carried: std::collections::BTreeSet<String> = pack
+                    .bodies
+                    .iter()
+                    .map(|body| {
+                        hex::encode(Sha256::digest(
+                            &body
+                                .decode()
+                                .expect("a pack body decodes to its declared length"),
+                        ))
+                    })
+                    .collect();
+                for (path, want) in &fixture.source_digests {
+                    assert!(
+                        carried.contains(want),
+                        "the {label} arm's pack carries no body whose bytes hash to the \
+                         fixture's {path}"
+                    );
+                }
+            } else {
+                let error = built.err().unwrap_or_else(|| {
+                    panic!(
+                        "the over-cap arm must be refused once authority agrees, or the \
+                         cap FIR-2746 records does not bind"
+                    )
+                });
+                let message = error.to_string();
+                assert!(
+                    message.contains("over negotiated limit"),
+                    "the {label} arm must name the negotiated byte limit: {message}"
+                );
+                assert!(
+                    message.contains("cannot be split across continuation packs"),
+                    "a one-commit history is one change, so the refusal must be the \
+                     indivisible-step one rather than a segmentation retry: {message}"
+                );
+                // The number the refusal reports is a LOWER bound, not the
+                // payload. `assemble_segment_pack` returns the moment the
+                // running total crosses the limit, so it names the total at the
+                // crossing and stops counting. Asserting it equalled the
+                // fixture's 24 MiB would fail against a correct implementation.
+                assert!(
+                    message.contains(
+                        &kin_remote::repository_transfer::MAX_TRANSFER_DECODED_BODY_BYTES
+                            .to_string()
+                    ),
+                    "the refusal must name the limit it enforced, which is what makes \
+                     the number in it readable: {message}"
+                );
+                // The variant decides the HTTP status the push pin watches, so
+                // it is asserted here rather than left to be assumed there.
+                assert!(
+                    matches!(
+                        error,
+                        kin_remote::repository_transfer::RepositoryTransferError::Invalid(_)
+                    ),
+                    "the size bound must be Invalid, which maps to 422 and is what \
+                     separates it from the authority bound's 409: {message}"
+                );
+            }
+
+            drop(authority);
+            std::fs::remove_dir_all(&fixture.working).ok();
+        }
+    }
+
     /// Two replicas of ONE repository: a real local one with a graph-owned
     /// workspace projecting into a working directory, and a peer that forked
     /// from it and has since moved `refs/heads/main` ahead by one exact edit.

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17185,16 +17185,34 @@ mod tests {
     /// for bound one, because bound two would keep it failing. Pinning WHICH
     /// bound answered is what makes this go red at the right moment, and going
     /// red is what it is for: when Git-authority bootstrap lands, the under-cap
-    /// arm should publish and the over-cap arm should move to
-    /// `decoded body closure exceeds`, and both of those are this test failing.
+    /// arm should publish and the over-cap arm should refuse on size, and both
+    /// of those are this test failing.
     ///
-    /// It also establishes the ORDER, which nothing had measured. `validate_pack`
-    /// enforces the byte cap on the destination's side of a pack that the
-    /// source only builds after `TransferSourceContext::read` has already
-    /// compared the two replicas' Git authority, so the authority bound is
-    /// reached first and the size bound is unobservable end to end until it
-    /// moves. The over-cap arm proves that by observing the authority refusal
-    /// while being, on its own arithmetic, half again too large to ever fit.
+    /// **The tell is the STATUS, not a sentence, and the first draft of this
+    /// test got that wrong in a way that could not fail.** It asserted the
+    /// over-cap arm must not report `decoded body closure exceeds`, which is
+    /// `validate_pack`'s wording. A source-built pack never reaches that line.
+    /// The source's own byte check returns `Assembled::OverNegotiatedBound`
+    /// (`repository_transfer.rs:949`), which is SEGMENTATION rather than
+    /// refusal: the segment builder halves the change budget and rebuilds. It
+    /// only refuses when the step is indivisible, and a one-commit fixture is,
+    /// so it refuses at `:601` with a different sentence naming
+    /// `over negotiated limit`. The original assertion was keyed on a string
+    /// that can never appear, so it would have stayed green through exactly the
+    /// change it was written to catch.
+    ///
+    /// `RepositoryTransferError::Invalid` maps to 422 and `Conflict` to 409
+    /// (`repository_transfer_error`, `api.rs:10046`), so the status separates
+    /// the two bounds with nothing to spell: 409 today, 422 once authority
+    /// bootstrap lands. The message assertions are kept beside it as the
+    /// second, weaker reading.
+    ///
+    /// It also establishes the ORDER, which nothing had measured.
+    /// `build_repository_transfer_segment` reads the source context, and its
+    /// Git-authority comparison, before any byte is counted, so the authority
+    /// bound is reached first and the size bound is unobservable end to end
+    /// until it moves. The over-cap arm proves that by observing the authority
+    /// refusal while being, on its own arithmetic, half again too large to fit.
     #[cfg(unix)]
     #[tokio::test]
     async fn a_payload_bearing_push_meets_the_authority_bound_before_the_size_cap() {
@@ -17241,14 +17259,21 @@ mod tests {
                 "the {label} arm must name the authority bound: {message}"
             );
             // The half that makes this a pin rather than a restatement. The
-            // size cap refuses with a different variant and a different
-            // sentence, and an over-cap push that started reporting THAT would
-            // mean bound one had moved.
+            // size bound is a different error variant and therefore a different
+            // status, so the 409 above already excludes it; these name the two
+            // sentences the size bound can actually produce, so a reader who
+            // hits this failure is told which wording to look for.
             assert!(
-                !message.contains("decoded body closure exceeds"),
-                "the {label} arm must not be reporting the size cap yet; if it is, \
+                !message.contains("over negotiated limit"),
+                "the {label} arm must not be reporting the size bound yet; if it is, \
                  Git-authority bootstrap has landed and this pin has to be \
                  rewritten rather than relaxed: {message}"
+            );
+            assert!(
+                !message.contains("cannot be split across continuation packs"),
+                "the {label} arm must not be reporting the indivisible-step refusal \
+                 yet, which is how an over-cap one-commit history is refused once \
+                 the authority bound moves: {message}"
             );
             assert!(
                 !message.contains("does not match destination repository"),
@@ -17332,6 +17357,134 @@ mod tests {
              reports the authority bound then the pin beside it is measuring \
              refusal-in-general rather than that bound: {message}"
         );
+        std::fs::remove_dir_all(&fixture.working).ok();
+    }
+
+    /// Byte-verify a replica's admitted content against the bytes a fixture
+    /// wrote, by content hash and never by count.
+    ///
+    /// Counts survive every corruption that matters. A replica holding the
+    /// right number of artifacts with the wrong bytes in them, or the right
+    /// bytes under the wrong paths, passes any count and fails this.
+    ///
+    /// The comparison deliberately shares no machinery with the store. The
+    /// expected side is a SHA-256 taken of the bytes at the moment they were
+    /// written to the working tree; the actual side is a SHA-256 taken of what
+    /// `load_source_blob` hands back. Hashing both sides with Kin's own digest
+    /// function would compare the store to itself and hold under any error that
+    /// affected the digest and the content together.
+    ///
+    /// It is route-agnostic on purpose. It takes an authority and a digest map,
+    /// so the day a route lands the payload on a hosted replica this is pointed
+    /// at THAT authority with the same map and asserts the same thing. Until
+    /// then it runs against the source replica, which is what proves the
+    /// comparator can answer at all rather than being written and never run.
+    ///
+    /// Returns how many paths it verified, so a caller can refuse a run that
+    /// verified nothing.
+    #[cfg(unix)]
+    fn assert_payload_reassembles(
+        authority: &ActiveApiRepositoryAuthority,
+        expected: &std::collections::BTreeMap<String, String>,
+    ) -> usize {
+        assert!(
+            !expected.is_empty(),
+            "an empty expectation makes every assertion below vacuously true"
+        );
+        let lease = authority.manager.read_authority();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == authority.workspace_id)
+            .expect("the replica projects a workspace")
+            .clone();
+
+        let mut verified = 0_usize;
+        for (path, want) in expected {
+            let artifact = workspace
+                .tree
+                .artifacts_by_path()
+                .find(|artifact| artifact.path.as_bytes() == path.as_bytes())
+                .unwrap_or_else(|| {
+                    panic!("the replica projects no artifact at {path}, so its bytes cannot be compared")
+                });
+            let digest = artifact.entry.blob_identity().unwrap_or_else(|| {
+                panic!("the artifact at {path} carries no blob identity, so it has no bytes")
+            });
+            let bytes = authority
+                .manager
+                .load_source_blob(digest)
+                .unwrap_or_else(|error| panic!("reading {path} failed: {error}"))
+                .unwrap_or_else(|| panic!("the replica holds no body for {path}"));
+            let got = hex::encode(Sha256::digest(&bytes));
+            assert_eq!(
+                &got, want,
+                "the bytes the replica serves for {path} are not the bytes the fixture wrote"
+            );
+            verified += 1;
+        }
+        // The half that stops a silent pass. A loop that found nothing to
+        // compare exits exactly like one that compared everything.
+        assert_eq!(
+            verified,
+            expected.len(),
+            "every expected path must have been verified"
+        );
+        verified
+    }
+
+    /// The reassembly comparator, exercised today against the replica that
+    /// wrote the payload.
+    ///
+    /// The destination half cannot be written yet, because no route puts this
+    /// payload on a hosted replica. What CAN be established now is that the
+    /// comparator answers correctly at all: that the digest map is a true
+    /// record of the bytes, that `load_source_blob` reaches them by path, and
+    /// that a mismatch is detected rather than skipped. A comparator first run
+    /// on the day a route lands is a comparator whose first result nobody can
+    /// distinguish from a bug in the comparator.
+    ///
+    /// The negative half runs here too, in-process: a deliberately wrong
+    /// expectation must panic. Without it this test would pass on a comparator
+    /// that verified nothing.
+    #[cfg(unix)]
+    #[test]
+    fn the_reassembly_comparator_verifies_bytes_and_refuses_a_mismatch() {
+        let hosted_id = hosted_repository_id();
+        let hosted_repository = RepositoryId::new(hosted_id).unwrap();
+        let fixture = payload_fixture("reassembly", PAYLOAD_BLOBS_UNDER_CAP, &hosted_repository);
+        let authority =
+            ActiveApiRepositoryAuthority::open_layout_for_test(&fixture.layout).unwrap();
+
+        let verified = assert_payload_reassembles(&authority, &fixture.source_digests);
+        assert_eq!(
+            verified, PAYLOAD_BLOBS_UNDER_CAP,
+            "the comparator must have verified every blob the fixture wrote"
+        );
+
+        // A comparator that cannot fail is not a comparator. One byte of the
+        // expectation is flipped and the same call must panic, which is the
+        // control that the equality above is load-bearing.
+        let mut corrupted = fixture.source_digests.clone();
+        let (path, digest) = corrupted
+            .iter()
+            .next()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .unwrap();
+        let flipped = format!("{}0{}", &digest[..0], &digest[1..]);
+        assert_ne!(flipped, digest, "the corruption must change the digest");
+        corrupted.insert(path.clone(), flipped);
+        let refused = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assert_payload_reassembles(&authority, &corrupted)
+        }));
+        assert!(
+            refused.is_err(),
+            "a wrong expected digest for {path} must be refused, or every future \
+             byte-verification is vacuous"
+        );
+
+        drop(authority);
         std::fs::remove_dir_all(&fixture.working).ok();
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17165,10 +17165,16 @@ mod tests {
             "the over-cap arm must stay clear of the body-count cap: \
              {PAYLOAD_BLOBS_OVER_CAP} vs {max_bodies}"
         );
-        assert!(
-            PAYLOAD_BLOBS_UNDER_CAP < PAYLOAD_BLOBS_OVER_CAP,
-            "the two arms must differ in blob count and nothing else"
-        );
+        // A const block, because both sides are constants and clippy is right
+        // that a runtime assertion over them proves nothing at runtime. Moved
+        // rather than allowed: this way the two arms differing is a compile
+        // error the moment somebody edits them to agree.
+        const {
+            assert!(
+                PAYLOAD_BLOBS_UNDER_CAP < PAYLOAD_BLOBS_OVER_CAP,
+                "the two arms must differ in blob count and nothing else"
+            );
+        }
     }
 
     /// The pre-fix pin, carrying a payload, on both sides of the transfer cap.
@@ -17602,8 +17608,7 @@ mod tests {
                     .iter()
                     .map(|body| {
                         hex::encode(Sha256::digest(
-                            &body
-                                .decode()
+                            body.decode()
                                 .expect("a pack body decodes to its declared length"),
                         ))
                     })

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17049,6 +17049,22 @@ mod tests {
 
     #[cfg(unix)]
     fn payload_fixture(label: &str, blobs: usize, hosted: &RepositoryId) -> PayloadFixture {
+        payload_fixture_inner(label, blobs, Some(hosted))
+    }
+
+    /// The same fixture with the identity minted rather than adopted, which is
+    /// the one variable the identity control changes.
+    #[cfg(unix)]
+    fn payload_fixture_minting(label: &str, blobs: usize) -> PayloadFixture {
+        payload_fixture_inner(label, blobs, None)
+    }
+
+    #[cfg(unix)]
+    fn payload_fixture_inner(
+        label: &str,
+        blobs: usize,
+        hosted: Option<&RepositoryId>,
+    ) -> PayloadFixture {
         install_test_registry_override();
         let working =
             std::env::temp_dir().join(format!("kin-daemon-payload-{label}-{}", Uuid::new_v4()));
@@ -17087,16 +17103,23 @@ mod tests {
             ["commit", "-s", "-m", "one commit carrying a real payload"],
         );
 
-        let init = kin_core::init_from_git_adopting(&working, hosted)
-            .expect("a Git-admitted store may adopt a hosted repository identity");
-        assert_eq!(
-            kin_core::manifest::KinManifest::load(&init.layout.manifest_path())
-                .unwrap()
-                .repo_id,
-            hosted.as_str(),
-            "the fixture must carry the hosted identity, or the push it drives \
-             measures identity rather than payload"
-        );
+        let init = match hosted {
+            Some(hosted) => {
+                let init = kin_core::init_from_git_adopting(&working, hosted)
+                    .expect("a Git-admitted store may adopt a hosted repository identity");
+                assert_eq!(
+                    kin_core::manifest::KinManifest::load(&init.layout.manifest_path())
+                        .unwrap()
+                        .repo_id,
+                    hosted.as_str(),
+                    "the fixture must carry the hosted identity, or the push it drives \
+                     measures identity rather than payload"
+                );
+                init
+            }
+            None => kin_core::init_from_git(&working)
+                .expect("a Git-admitted store may mint its own identity"),
+        };
 
         PayloadFixture {
             layout: init.layout,
@@ -17242,6 +17265,74 @@ mod tests {
             );
             std::fs::remove_dir_all(&fixture.working).ok();
         }
+    }
+
+    /// The control that makes the pin above evidence rather than a restatement
+    /// of "pushes fail".
+    ///
+    /// A harness that observes a refusal proves nothing unless it can be shown
+    /// to distinguish refusals. This drives the same payload through the same
+    /// route with ONE property changed, the identity minted rather than
+    /// adopted, and requires a DIFFERENT answer: the identity refusal, named
+    /// with the minted id, and explicitly not the authority bound.
+    ///
+    /// If this and the pin above ever agreed, the pin would be measuring the
+    /// route's willingness to refuse anything, and both would stay green
+    /// through a fix for either bound.
+    ///
+    /// It uses the under-cap arm deliberately. A payload that could not fit
+    /// even if it were admitted would leave the refusal over-determined, and
+    /// the point here is that identity alone decides it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_payload_bearing_push_under_a_minted_identity_is_refused_on_identity_instead() {
+        let hosted_id = hosted_repository_id();
+        let (hosted_state, _hosted_working, _hosted_storage) = hosted_peer_state(&hosted_id);
+        let hosted_url = serve_replica(Arc::clone(&hosted_state)).await;
+
+        // Adopt nothing: mint, the way `kin init` does for an operator who
+        // never names a hosted repository.
+        let fixture = payload_fixture_minting("minted", PAYLOAD_BLOBS_UNDER_CAP);
+        let minted = kin_core::manifest::KinManifest::load(&fixture.layout.manifest_path())
+            .unwrap()
+            .repo_id;
+        assert_ne!(
+            minted, hosted_id,
+            "the control only means something if the two identities differ"
+        );
+
+        let source_state =
+            Arc::new(DaemonState::open_with_repo_id(fixture.layout.clone(), None).unwrap());
+        let request = kin_cli::commands::transfer::CommandTransferRequest {
+            remote_base_url: hosted_url,
+            remote_token: None,
+            // Left unset so the push sends what the store actually holds.
+            // Naming the hosted id here is refused locally before a byte
+            // crosses the wire, which measures the local daemon's repository
+            // scope rather than the remote's.
+            repository_id: None,
+            source_ref: None,
+            destination_ref: None,
+        };
+        let (status, body) = transfer_command(Arc::clone(&source_state), "push", &request).await;
+        let message = String::from_utf8_lossy(&body).to_string();
+
+        assert_ne!(
+            status,
+            StatusCode::OK,
+            "a minted identity must never reach a hosted repository that holds another: {message}"
+        );
+        assert!(
+            message.contains(minted.as_str()),
+            "the refusal must name the identity that was asked for: {message}"
+        );
+        assert!(
+            !message.contains("imported-Git authority"),
+            "this arm must be stopped by identity, not by the authority bound; if it \
+             reports the authority bound then the pin beside it is measuring \
+             refusal-in-general rather than that bound: {message}"
+        );
+        std::fs::remove_dir_all(&fixture.working).ok();
     }
 
     /// Two replicas of ONE repository: a real local one with a graph-owned

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -16983,22 +16983,41 @@ mod tests {
     #[cfg(unix)]
     const PAYLOAD_BLOB_BYTES: usize = 1024 * 1024;
 
-    /// Mirrors `kin`'s own tip tree, which FIR-2746 measured at 842 unique
-    /// blobs and 27.77 MiB decoded and which DOES NOT FIT. The property that
-    /// matters is the decoded total, not the blob count, so this carries the
-    /// total in far fewer blobs: 24 keeps it three orders of magnitude clear of
-    /// `MAX_TRANSFER_BODIES` (4096) and `MAX_TRANSFER_EXTERNAL_OBJECTS` (4096),
-    /// which is what makes a refusal here attributable to the byte cap alone.
+    /// How many of those blobs the decoded-closure ceiling holds.
+    ///
+    /// Derived from the product constant rather than written down, and the
+    /// history is the reason. These arms were originally sized to MIRROR real
+    /// repositories against a 16 MiB ceiling: the over arm carried kin's own
+    /// tip tree, which FIR-2746 measured at 27.77 MiB decoded and which did not
+    /// fit, and the under arm carried kin-db at 4.30 MiB, which did. Raising the
+    /// ceiling to 64 MiB made the first of those claims false, because kin's tip
+    /// now fits comfortably, and the straddle self-check below said so by
+    /// failing on every speculative merge. That is the harness working rather
+    /// than breaking: the bound moved and the pin noticed.
+    ///
+    /// The arms cannot mirror a repository any more, because the ceiling now
+    /// sits above every hosted repository's tip closure, which is exactly what
+    /// raising it bought. So they mirror the BOUND instead and follow it, and a
+    /// future change to the ceiling moves them rather than stranding them.
     #[cfg(unix)]
-    const PAYLOAD_BLOBS_OVER_CAP: usize = 24;
+    const CAP_BLOBS: usize = (kin_remote::repository_transfer::MAX_TRANSFER_DECODED_BODY_BYTES
+        / PAYLOAD_BLOB_BYTES as u64) as usize;
 
-    /// Mirrors the four hosted repositories FIR-2746 measured as fitting, the
-    /// largest of which is kin-db at 4.30 MiB. Same generator, same blob size,
-    /// same commit shape; the only variable between this and the fixture above
-    /// is how many blobs there are, which is what makes the pair a comparison
-    /// rather than two separate observations.
+    /// One blob past the ceiling, which is the smallest fixture that can exceed
+    /// it. Exceeding a decoded-byte cap means shipping that many bytes, so the
+    /// cost of this arm is the ceiling itself and no construction avoids it;
+    /// the minimum overshoot is what keeps it off the transport's own limit.
     #[cfg(unix)]
-    const PAYLOAD_BLOBS_UNDER_CAP: usize = 4;
+    const PAYLOAD_BLOBS_OVER_CAP: usize = CAP_BLOBS + 1;
+
+    /// Comfortably under the ceiling and deliberately cheap, since this arm has
+    /// to publish rather than be refused. Still derived, so a LOWERED ceiling
+    /// cannot leave it stranded above the bound it is supposed to sit under.
+    /// Same generator, same blob size, same commit shape as the arm above; the
+    /// only variable between them is how many blobs there are, which is what
+    /// makes the pair a comparison rather than two separate observations.
+    #[cfg(unix)]
+    const PAYLOAD_BLOBS_UNDER_CAP: usize = if CAP_BLOBS / 2 < 4 { CAP_BLOBS / 2 } else { 4 };
 
     /// Deterministic, distinct-per-blob, and not compressible into nothing.
     ///
@@ -17164,6 +17183,22 @@ mod tests {
             PAYLOAD_BLOBS_OVER_CAP < max_bodies,
             "the over-cap arm must stay clear of the body-count cap: \
              {PAYLOAD_BLOBS_OVER_CAP} vs {max_bodies}"
+        );
+        // The third isolation check, and the one nothing asserted until the
+        // ceiling moved. Bodies travel base64, so an over-cap arm can be large
+        // enough that the TRANSPORT refuses it with a 413 before the decoded
+        // closure check ever runs, and that refusal reads like a refusal this
+        // harness is about. It fits today with room to spare, and it is one
+        // legal edit from not fitting: raising PAYLOAD_BLOB_BYTES to 8 MiB is
+        // allowed by the per-body cap above and would put the over arm's wire
+        // size past this limit while every other assertion here still passed.
+        let wire = (over + 2) / 3 * 4;
+        let http_limit =
+            kin_remote::repository_transfer_http::REPOSITORY_TRANSFER_HTTP_BODY_LIMIT as u64;
+        assert!(
+            wire < http_limit,
+            "the over-cap arm must be refused by the decoded-closure cap, not by the \
+             transport: {wire} base64 bytes on the wire against a {http_limit} byte limit"
         );
         // A const block, because both sides are constants and clippy is right
         // that a runtime assertion over them proves nothing at runtime. Moved

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17192,7 +17192,10 @@ mod tests {
         // legal edit from not fitting: raising PAYLOAD_BLOB_BYTES to 8 MiB is
         // allowed by the per-body cap above and would put the over arm's wire
         // size past this limit while every other assertion here still passed.
-        let wire = (over + 2) / 3 * 4;
+        // Computed the way `http_body_limit_for` computes the limit it is
+        // compared against, so the two cannot drift into disagreeing about what
+        // base64 expansion costs.
+        let wire = over.div_ceil(3) * 4;
         let http_limit =
             kin_remote::repository_transfer_http::REPOSITORY_TRANSFER_HTTP_BODY_LIMIT as u64;
         assert!(

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17525,9 +17525,25 @@ mod tests {
     /// This runs it today by removing the one thing that stops it. The
     /// expectation is built from the SOURCE store's own transfer status, so its
     /// `git_authority_hash` is the source's own and `TransferSourceContext::read`
-    /// agrees with itself; the destination is set unborn, which is what an empty
-    /// hosted store looks like. Everything downstream of the authority
-    /// comparison then runs for real against a real payload.
+    /// agrees with itself, and the ref state is set unborn. Everything
+    /// downstream of the authority comparison then runs for real against a real
+    /// payload.
+    ///
+    /// **This is deliberately NOT an empty hosted replica, and the difference is
+    /// worth stating because it would be easy to read it as one.** An empty
+    /// replica's `repository_transfer_status` reports five things together
+    /// (`repository_transfer.rs:387`): `destination_target: None`,
+    /// `destination_head: None`, `default_ref: None`, `git_authority_hash: None`
+    /// and `roots.generation == 0`. This probe sets the first two and keeps the
+    /// last three from the source, because the authority hash agreeing is the
+    /// whole mechanism by which the bound in front of the size bound is removed.
+    /// So what runs here is an authority-agreeing replica with an unborn ref,
+    /// which is the smallest world in which the size bound answers, and not a
+    /// simulation of the hosted destination.
+    ///
+    /// The precondition is asserted rather than described, so the day the
+    /// bootstrap keys its compare-and-swap on all five, this test says which
+    /// ones it was holding fixed instead of quietly drifting.
     ///
     /// What it establishes, and none of it was measured before:
     ///
@@ -17565,10 +17581,24 @@ mod tests {
             let mut expectation =
                 kin_remote::repository_transfer::RepositoryTransferExpectation::try_from(status)
                     .unwrap();
-            // An empty hosted store's ref is unborn. Both fields move together
-            // because `validate_expectation` requires them both present or both
-            // absent, and a half-set destination would be refused for a reason
-            // that is not the one under test.
+            // Record what this probe holds fixed, against the five fields an
+            // empty replica reports together. Asserted rather than assumed:
+            // these are the source's own values, and the day the bootstrap keys
+            // its compare-and-swap on all five, a reader needs to know which
+            // ones this test was never varying.
+            assert!(
+                expectation.git_authority_hash.is_some(),
+                "the probe keeps the SOURCE's Git authority, which is how the bound \
+                 in front of the size bound is removed; an empty replica reports None"
+            );
+            assert_eq!(
+                expectation.repository_id, hosted_repository,
+                "the probe must be about the hosted identity it adopted"
+            );
+            // The ref state, and only the ref state, is moved to unborn. Both
+            // fields move together because `validate_expectation` requires them
+            // both present or both absent, and a half-set destination would be
+            // refused for a reason that is not the one under test.
             expectation.destination_target = None;
             expectation.destination_head = None;
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17351,7 +17351,14 @@ mod tests {
             // pointed at the source, the after-only check still passed, because
             // a Git-admitted store names its own bodies from the moment it is
             // created. Only an empty replica can name none and then name all.
-            let before = repository_authority_snapshot(&hosted_state, &hosted_id)
+            // ONE binding for both readings, deliberately. Falsification pointed
+            // the after-reading at the source while the before-reading stayed on
+            // the peer, and the pair passed: before from an empty replica, after
+            // from a full one, no single replica described. Naming the observed
+            // replica once means a change of target moves both halves, so the
+            // before assertion below refuses it. The join, not the endpoints.
+            let observed_replica = Arc::clone(&hosted_state);
+            let before = repository_authority_snapshot(&observed_replica, &hosted_id)
                 .await
                 .expect("an empty hosted replica is readable before anything is pushed");
             let named_before = before
@@ -17430,7 +17437,7 @@ mod tests {
                 let source_bodies =
                     source_payload_bodies(&source_authority, &fixture.source_digests);
                 drop(source_authority);
-                let snapshot = repository_authority_snapshot(&hosted_state, &hosted_id)
+                let snapshot = repository_authority_snapshot(&observed_replica, &hosted_id)
                     .await
                     .expect("the replica that admitted a bootstrap must be readable after it");
                 let named_after = snapshot

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17177,54 +17177,159 @@ mod tests {
         }
     }
 
-    /// The pre-fix pin, carrying a payload, on both sides of the transfer cap.
+    /// The source's own bodies for a fixture, keyed by Kin content address, with
+    /// each one byte-verified against the bytes the fixture wrote.
     ///
-    /// `a_git_admitted_store_adopting_a_hosted_identity_meets_the_git_authority_bound`
-    /// already records the Git-authority bound with a two-line commit. This
-    /// records it with 24 MiB and with 4 MiB, which is the pair FIR-2746 needs,
-    /// and it asserts something that test cannot: that the refusal is the
-    /// AUTHORITY bound and not the SIZE one.
+    /// This is the half that makes the destination check a byte claim rather
+    /// than a name comparison. A Kin body hash IS the content, so a destination
+    /// committing to hash H has committed to those bytes, but only if something
+    /// independent has established what H's bytes are. That is what the SHA-256
+    /// here does, and it deliberately uses a different hash function from the
+    /// one the address is, so the two sides cannot agree by construction.
+    #[cfg(unix)]
+    fn source_payload_bodies(
+        authority: &ActiveApiRepositoryAuthority,
+        expected: &std::collections::BTreeMap<String, String>,
+    ) -> std::collections::BTreeMap<String, (kin_model::Hash256, u64)> {
+        let lease = authority.manager.read_authority();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == authority.workspace_id)
+            .expect("the source replica projects a workspace")
+            .clone();
+
+        let mut bodies = std::collections::BTreeMap::new();
+        for (path, want) in expected {
+            let artifact = workspace
+                .tree
+                .artifacts_by_path()
+                .find(|artifact| artifact.path.as_bytes() == path.as_bytes())
+                .unwrap_or_else(|| panic!("the source projects no artifact at {path}"));
+            let digest = artifact
+                .entry
+                .blob_identity()
+                .unwrap_or_else(|| panic!("the artifact at {path} carries no blob identity"));
+            let bytes = authority
+                .manager
+                .load_source_blob(digest)
+                .unwrap_or_else(|error| panic!("reading {path} failed: {error}"))
+                .unwrap_or_else(|| panic!("the source holds no body for {path}"));
+            assert_eq!(
+                &hex::encode(Sha256::digest(&bytes)),
+                want,
+                "the source's bytes for {path} are not the bytes the fixture wrote, so \
+                 its content address cannot stand in for them"
+            );
+            bodies.insert(path.clone(), (digest, bytes.len() as u64));
+        }
+        assert_eq!(
+            bodies.len(),
+            expected.len(),
+            "every expected path must have produced a body"
+        );
+        bodies
+    }
+
+    /// Assert a hosted replica committed to the payload, read from its OWN
+    /// authority snapshot rather than from the sender's receipt.
     ///
-    /// That distinction is the whole point of writing this before a route
-    /// exists. Two independent bounds refuse a payload-bearing push today, and
-    /// a test asserting only "the push failed" would stay green through the fix
-    /// for bound one, because bound two would keep it failing. Pinning WHICH
-    /// bound answered is what makes this go red at the right moment, and going
-    /// red is what it is for: when Git-authority bootstrap lands, the under-cap
-    /// arm should publish and the over-cap arm should refuse on size, and both
-    /// of those are this test failing.
+    /// It cannot use the workspace-walking comparator: a bootstrapped hosted
+    /// replica commits with `workspace_mutation: null`, so it holds authority
+    /// without projecting a tree, and `ActiveApiRepositoryAuthority::open`
+    /// refuses it by name with "local daemon is missing its startup workspace
+    /// binding". That refusal is the replica behaving correctly, and reading it
+    /// as a failure would have been the easy mistake here.
     ///
-    /// **The tell is the STATUS, not a sentence, and the first draft of this
-    /// test got that wrong in a way that could not fail.** It asserted the
-    /// over-cap arm must not report `decoded body closure exceeds`, which is
-    /// `validate_pack`'s wording. A source-built pack never reaches that line.
-    /// The source's own byte check returns `Assembled::OverNegotiatedBound`
-    /// (`repository_transfer.rs:949`), which is SEGMENTATION rather than
-    /// refusal: the segment builder halves the change budget and rebuilds. It
-    /// only refuses when the step is indivisible, and a one-commit fixture is,
-    /// so it refuses at `:601` with a different sentence naming
-    /// `over negotiated limit`. The original assertion was keyed on a string
-    /// that can never appear, so it would have stayed green through exactly the
-    /// change it was written to catch.
+    /// So the destination is read through `repository_authority_snapshot`, which
+    /// is the reader that answers for a daemon serving a repository through a
+    /// backend rather than a startup binding.
     ///
-    /// `RepositoryTransferError::Invalid` maps to 422 and `Conflict` to 409
-    /// (`repository_transfer_error`, `api.rs:10046`), so the status separates
-    /// the two bounds with nothing to spell: 409 today, 422 once authority
-    /// bootstrap lands. The message assertions are kept beside it as the
-    /// second, weaker reading.
+    /// What this proves: the destination's committed authority names every one
+    /// of the source's payload bodies, by content address and with the same
+    /// declared length. Since `source_payload_bodies` has independently verified
+    /// what each of those addresses' bytes are, against a different hash
+    /// function, naming the address is a claim about the bytes.
     ///
-    /// It also establishes the ORDER, which nothing had measured.
-    /// `build_repository_transfer_segment` reads the source context, and its
-    /// Git-authority comparison, before any byte is counted, so the authority
-    /// bound is reached first and the size bound is unobservable end to end
-    /// until it moves. The over-cap arm proves that by observing the authority
-    /// refusal while being, on its own arithmetic, half again too large to fit.
+    /// What it does not prove: that the destination can SERVE those bytes on
+    /// demand. That is a body read against a hosted backend and it is not
+    /// reached here. Said plainly rather than left for a reader to assume.
+    #[cfg(unix)]
+    fn assert_destination_committed_payload(
+        snapshot: &kin_db::GraphSnapshot,
+        source_bodies: &std::collections::BTreeMap<String, (kin_model::Hash256, u64)>,
+    ) -> usize {
+        assert!(
+            !source_bodies.is_empty(),
+            "an empty expectation makes every assertion below vacuously true"
+        );
+        let authority = snapshot
+            .repository_authority
+            .as_ref()
+            .expect("admitting a bootstrap publishes an envelope");
+        let held: std::collections::BTreeMap<kin_model::Hash256, u64> = authority
+            .external_objects
+            .iter()
+            .map(|record| (record.body_hash, record.body_len))
+            .collect();
+        assert!(
+            !held.is_empty(),
+            "the destination's authority names no external object, so this verified \
+             nothing; a bootstrap that admitted no Git objects is what this would hide"
+        );
+
+        for (path, (digest, len)) in source_bodies {
+            let found = held.get(digest).unwrap_or_else(|| {
+                panic!(
+                    "the destination's authority does not name the body for {path}; it \
+                     names {} objects",
+                    held.len()
+                )
+            });
+            assert_eq!(
+                found, len,
+                "the destination declares a different length for {path}'s body"
+            );
+        }
+        source_bodies.len()
+    }
+
+    /// The payload pin, now that the bound in front of it has moved.
+    ///
+    /// This test was written before kin#1156 and asserted the 409 both arms then
+    /// got. It was built to go red the day Git-authority bootstrap landed,
+    /// keyed on the STATUS rather than on a sentence, and that is exactly how it
+    /// failed: `left: 422, right: 409` on the over-cap arm, with the message
+    /// naming the byte budget. The forward-looking half worked, so this is a
+    /// rewrite of what it pins rather than a relaxation of it.
+    ///
+    /// What it pins now is the DIVERGENCE, which is the whole content of the
+    /// change. The two arms differ in one variable, payload size, and now get
+    /// two different answers:
+    ///
+    /// The under-cap arm PUBLISHES. Not "does not fail": the receipt is read,
+    /// and it has to show a bootstrap rather than a fast-forward onto something
+    /// that already existed. `git_authority_delta.old` is null and `.new` is
+    /// present, which is authority being established on a replica that had
+    /// none, and the roots move from generation 0 to 1. Those are the two facts
+    /// that make it the thing kin#1156 built rather than an ordinary push.
+    ///
+    /// The over-cap arm is REFUSED BY NAME, 422, naming the negotiated byte
+    /// limit and the indivisible step. A bootstrap ships every Git object in one
+    /// pack because a pack is self-validating, so it cannot be segmented, and a
+    /// repository past the budget is refused rather than staged.
+    ///
+    /// Both halves are needed. An assertion that the under arm publishes would
+    /// pass on a build that had also stopped refusing the over arm, and an
+    /// assertion that the over arm refuses would pass on a build that refused
+    /// everything, which is what the 409 did yesterday.
     #[cfg(unix)]
     #[tokio::test]
-    async fn a_payload_bearing_push_meets_the_authority_bound_before_the_size_cap() {
-        for (label, blobs) in [
-            ("over", PAYLOAD_BLOBS_OVER_CAP),
-            ("under", PAYLOAD_BLOBS_UNDER_CAP),
+    async fn a_payload_bearing_push_bootstraps_under_the_cap_and_is_refused_over_it() {
+        for (label, blobs, fits) in [
+            ("over", PAYLOAD_BLOBS_OVER_CAP, false),
+            ("under", PAYLOAD_BLOBS_UNDER_CAP, true),
         ] {
             let hosted_id = hosted_repository_id();
             let hosted_repository = RepositoryId::new(hosted_id.clone()).unwrap();
@@ -17233,10 +17338,9 @@ mod tests {
 
             let fixture = payload_fixture(label, blobs, &hosted_repository);
             let cap = kin_remote::repository_transfer::MAX_TRANSFER_DECODED_BODY_BYTES;
-            let over_cap = fixture.payload_bytes > cap;
             assert_eq!(
-                over_cap,
-                label == "over",
+                fixture.payload_bytes > cap,
+                !fits,
                 "the {label} arm must sit on the side of the cap its name claims: \
                  {} bytes against {cap}",
                 fixture.payload_bytes
@@ -17255,45 +17359,91 @@ mod tests {
                 transfer_command(Arc::clone(&source_state), "push", &request).await;
             let message = String::from_utf8_lossy(&body).to_string();
 
-            assert_eq!(
-                status,
-                StatusCode::CONFLICT,
-                "the {label} arm must still be stopped by the Git-authority bound: {message}"
-            );
-            assert!(
-                message.contains("imported-Git authority"),
-                "the {label} arm must name the authority bound: {message}"
-            );
-            // The half that makes this a pin rather than a restatement. The
-            // size bound is a different error variant and therefore a different
-            // status, so the 409 above already excludes it; these name the two
-            // sentences the size bound can actually produce, so a reader who
-            // hits this failure is told which wording to look for.
-            assert!(
-                !message.contains("over negotiated limit"),
-                "the {label} arm must not be reporting the size bound yet; if it is, \
-                 Git-authority bootstrap has landed and this pin has to be \
-                 rewritten rather than relaxed: {message}"
-            );
-            assert!(
-                !message.contains("cannot be split across continuation packs"),
-                "the {label} arm must not be reporting the indivisible-step refusal \
-                 yet, which is how an over-cap one-commit history is refused once \
-                 the authority bound moves: {message}"
-            );
-            assert!(
-                !message.contains("does not match destination repository"),
-                "identity is not what stops a payload-bearing store: {message}"
-            );
+            if fits {
+                assert_eq!(
+                    status,
+                    StatusCode::OK,
+                    "the {label} arm must publish into the empty hosted replica: {message}"
+                );
+                // Read the receipt rather than the status. A 200 says the route
+                // answered; these say it BOOTSTRAPPED, which is the property
+                // kin#1156 added and the only one that distinguishes this from
+                // a push onto a replica that already had authority.
+                let receipt: serde_json::Value = serde_json::from_str(&message)
+                    .expect("a successful push answers with its receipt");
+                let delta = receipt
+                    .pointer("/outcome/receipts/0/authority_receipt/operation/git_authority_delta")
+                    .unwrap_or_else(|| {
+                        panic!("the receipt must carry a git authority delta: {message}")
+                    });
+                assert!(
+                    delta.get("old").is_some_and(|old| old.is_null()),
+                    "the destination must have held NO imported-Git authority before this \
+                     push, which is what makes it a bootstrap: {delta}"
+                );
+                assert!(
+                    delta.get("new").is_some_and(|new| !new.is_null()),
+                    "the push must have established imported-Git authority: {delta}"
+                );
+                let before = receipt
+                    .pointer("/outcome/receipts/0/authority_receipt/roots_before/generation");
+                let after =
+                    receipt.pointer("/outcome/receipts/0/authority_receipt/roots_after/generation");
+                assert_eq!(
+                    (
+                        before.and_then(|v| v.as_u64()),
+                        after.and_then(|v| v.as_u64())
+                    ),
+                    (Some(0), Some(1)),
+                    "an empty replica is generation zero and a bootstrap moves it to one: \
+                     {message}"
+                );
 
-            // The reassembly assertion's own input, checked here rather than
-            // where it will be used. A digest map that went empty would make
-            // every future byte-verification vacuously true.
-            assert_eq!(
-                fixture.source_digests.len(),
-                blobs,
-                "the {label} arm must carry one source digest per blob"
-            );
+                // The assertion this whole harness was built to be ready for,
+                // and the first day it can run. Until kin#1156 no route put a
+                // payload on a hosted replica, so the comparator ran against the
+                // source and proved only that it could answer. It now runs
+                // against the DESTINATION: every byte sequence the fixture wrote
+                // must be one the hosted replica can serve, by content hash
+                // against the bytes written, never by counting bodies.
+                let source_authority =
+                    ActiveApiRepositoryAuthority::open_layout_for_test(&fixture.layout).unwrap();
+                let source_bodies =
+                    source_payload_bodies(&source_authority, &fixture.source_digests);
+                drop(source_authority);
+                let snapshot = repository_authority_snapshot(&hosted_state, &hosted_id)
+                    .await
+                    .expect("the replica that admitted a bootstrap must be readable after it");
+                let verified = assert_destination_committed_payload(&snapshot, &source_bodies);
+                assert_eq!(
+                    verified, blobs,
+                    "every blob the {label} arm wrote must be verified on the destination"
+                );
+            } else {
+                assert_eq!(
+                    status,
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "the {label} arm must be refused on the byte budget, which is Invalid \
+                     rather than Conflict: {message}"
+                );
+                assert!(
+                    message.contains("over negotiated limit"),
+                    "the {label} arm must name the negotiated byte limit: {message}"
+                );
+                assert!(
+                    message.contains("cannot be split across continuation packs"),
+                    "a bootstrap ships every object in one pack, so the refusal must be the \
+                     indivisible-step one rather than a segmentation retry: {message}"
+                );
+                // The bound that MOVED. If this ever comes back, the bootstrap
+                // has regressed and the arm above would still be green, because
+                // both bounds refuse.
+                assert!(
+                    !message.contains("imported-Git authority"),
+                    "the Git-authority bound is closed for the push direction; seeing it \
+                     again is a regression rather than this test being out of date: {message}"
+                );
+            }
             std::fs::remove_dir_all(&fixture.working).ok();
         }
     }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -16960,6 +16960,290 @@ mod tests {
         );
     }
 
+    // ── FIR-2729 / FIR-2746: the payload-bearing transfer harness ──────────
+    //
+    // Everything above proves the transfer LOOP. `a_hosted_store_admits_a_
+    // native_transfer_and_then_serves_the_head_it_admitted` builds its pack
+    // from `seed_replica_change`, whose changes carry empty `tree_deltas` and
+    // empty `entity_deltas`, so it says nothing about whether a transfer can
+    // carry content. Every hosted repository IS content, so the loop passing
+    // is not evidence the republish can work.
+    //
+    // This harness carries a payload. It exists before the route that would
+    // let one through, so today its job is to pin the refusals precisely
+    // enough that the day a route lands, the right assertion moves and the
+    // wrong one does not.
+
+    /// One megabyte per blob: comfortably under `MAX_TRANSFER_BODY_BYTES`
+    /// (8 MiB, the PER-BODY cap), so a fixture built from these can only ever
+    /// cross the decoded-CLOSURE cap and never the per-body one. Isolating the
+    /// two matters: a fixture that tripped the per-body cap would refuse with a
+    /// different message for a different reason and read exactly like the cap
+    /// this harness is about.
+    #[cfg(unix)]
+    const PAYLOAD_BLOB_BYTES: usize = 1024 * 1024;
+
+    /// Mirrors `kin`'s own tip tree, which FIR-2746 measured at 842 unique
+    /// blobs and 27.77 MiB decoded and which DOES NOT FIT. The property that
+    /// matters is the decoded total, not the blob count, so this carries the
+    /// total in far fewer blobs: 24 keeps it three orders of magnitude clear of
+    /// `MAX_TRANSFER_BODIES` (4096) and `MAX_TRANSFER_EXTERNAL_OBJECTS` (4096),
+    /// which is what makes a refusal here attributable to the byte cap alone.
+    #[cfg(unix)]
+    const PAYLOAD_BLOBS_OVER_CAP: usize = 24;
+
+    /// Mirrors the four hosted repositories FIR-2746 measured as fitting, the
+    /// largest of which is kin-db at 4.30 MiB. Same generator, same blob size,
+    /// same commit shape; the only variable between this and the fixture above
+    /// is how many blobs there are, which is what makes the pair a comparison
+    /// rather than two separate observations.
+    #[cfg(unix)]
+    const PAYLOAD_BLOBS_UNDER_CAP: usize = 4;
+
+    /// Deterministic, distinct-per-blob, and not compressible into nothing.
+    ///
+    /// All three properties are load-bearing. Deterministic because a
+    /// reassembly assertion compares content hashes against the source tree and
+    /// a fixture that differs run to run cannot be compared to anything.
+    /// Distinct because `validate_pack` deduplicates bodies by hash
+    /// (`repository_transfer.rs:1222`), so a fixture of identical blobs would
+    /// collapse to ONE body and measure deduplication rather than size, while
+    /// still looking like a 24 MiB fixture on disk. Incompressible because the
+    /// cap is on DECODED bytes and a fixture of zeroes would prove nothing
+    /// about what a real tree costs.
+    #[cfg(unix)]
+    fn payload_blob_bytes(seed: u64, len: usize) -> Vec<u8> {
+        // SplitMix64. Chosen because it needs no dependency and is exactly
+        // reproducible from the seed, which is what makes the digests below a
+        // fixture property rather than a run property.
+        let mut out = Vec::with_capacity(len + 8);
+        let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+        while out.len() < len {
+            state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^= z >> 31;
+            out.extend_from_slice(&z.to_le_bytes());
+        }
+        out.truncate(len);
+        out
+    }
+
+    /// A Git-admitted store carrying real content, adopting a hosted identity,
+    /// built the way the hosted republish runbook stages its five stores:
+    /// `git init`, one commit, `kin init`.
+    #[cfg(unix)]
+    struct PayloadFixture {
+        layout: kin_core::KinLayout,
+        working: PathBuf,
+        /// Repository-relative path to the SHA-256 of the bytes written there.
+        /// This is the source of truth a reassembly assertion compares against,
+        /// and it is a content hash rather than a count on purpose: a count
+        /// survives every corruption that matters.
+        source_digests: std::collections::BTreeMap<String, String>,
+        /// What the fixture's payload actually costs, summed from the bytes
+        /// this function wrote rather than from anything the store reports.
+        payload_bytes: u64,
+    }
+
+    #[cfg(unix)]
+    fn payload_fixture(label: &str, blobs: usize, hosted: &RepositoryId) -> PayloadFixture {
+        install_test_registry_override();
+        let working =
+            std::env::temp_dir().join(format!("kin-daemon-payload-{label}-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(working.join("payload")).unwrap();
+        run_test_git(&working, ["init", "--initial-branch=main"]);
+        run_test_git(&working, ["config", "user.email", "kin@example.invalid"]);
+        run_test_git(&working, ["config", "user.name", "Kin Payload Harness"]);
+
+        let mut source_digests = std::collections::BTreeMap::new();
+        let mut payload_bytes = 0_u64;
+        for index in 0..blobs {
+            let path = format!("payload/blob-{index:04}.bin");
+            let bytes = payload_blob_bytes(index as u64 + 1, PAYLOAD_BLOB_BYTES);
+            std::fs::write(working.join(&path), &bytes).unwrap();
+            let digest = hex::encode(Sha256::digest(&bytes));
+            payload_bytes += bytes.len() as u64;
+            source_digests.insert(path, digest);
+        }
+        // The generator is only distinct if it is distinct. Asserting it here
+        // rather than trusting the seed is what stops a later edit to
+        // `payload_blob_bytes` from silently turning this fixture into one
+        // blob deduplicated `blobs` times.
+        assert_eq!(
+            source_digests
+                .values()
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            blobs,
+            "every payload blob must be distinct, or the pack deduplicates them \
+             and this fixture measures deduplication rather than size"
+        );
+
+        run_test_git(&working, ["add", "--all"]);
+        run_test_git(
+            &working,
+            ["commit", "-s", "-m", "one commit carrying a real payload"],
+        );
+
+        let init = kin_core::init_from_git_adopting(&working, hosted)
+            .expect("a Git-admitted store may adopt a hosted repository identity");
+        assert_eq!(
+            kin_core::manifest::KinManifest::load(&init.layout.manifest_path())
+                .unwrap()
+                .repo_id,
+            hosted.as_str(),
+            "the fixture must carry the hosted identity, or the push it drives \
+             measures identity rather than payload"
+        );
+
+        PayloadFixture {
+            layout: init.layout,
+            working,
+            source_digests,
+            payload_bytes,
+        }
+    }
+
+    /// The fixture pair is a comparison, so its two arms have to differ in
+    /// exactly one property and that property has to be the one under test.
+    ///
+    /// This asserts the arithmetic before any push depends on it. Without it
+    /// the pair could drift into measuring something else entirely and both
+    /// arms would still refuse, still for a reason, and still look right.
+    #[cfg(unix)]
+    #[test]
+    fn the_payload_fixtures_straddle_the_transfer_cap_and_nothing_else() {
+        let cap = kin_remote::repository_transfer::MAX_TRANSFER_DECODED_BODY_BYTES;
+        let per_body = kin_remote::repository_transfer::MAX_TRANSFER_BODY_BYTES;
+        let max_bodies = kin_remote::repository_transfer::MAX_TRANSFER_BODIES;
+
+        let over = (PAYLOAD_BLOBS_OVER_CAP * PAYLOAD_BLOB_BYTES) as u64;
+        let under = (PAYLOAD_BLOBS_UNDER_CAP * PAYLOAD_BLOB_BYTES) as u64;
+
+        assert!(
+            over > cap,
+            "the over-cap arm must exceed the decoded closure cap: {over} vs {cap}"
+        );
+        assert!(
+            under < cap,
+            "the under-cap arm must fit under the decoded closure cap: {under} vs {cap}"
+        );
+        // The isolation half. An arm that crossed one of the OTHER caps would
+        // be refused for a reason this harness is not about, and its refusal
+        // would read exactly like the one it is about.
+        assert!(
+            (PAYLOAD_BLOB_BYTES as u64) < per_body,
+            "no single blob may cross the per-body cap: {PAYLOAD_BLOB_BYTES} vs {per_body}"
+        );
+        assert!(
+            PAYLOAD_BLOBS_OVER_CAP < max_bodies,
+            "the over-cap arm must stay clear of the body-count cap: \
+             {PAYLOAD_BLOBS_OVER_CAP} vs {max_bodies}"
+        );
+        assert!(
+            PAYLOAD_BLOBS_UNDER_CAP < PAYLOAD_BLOBS_OVER_CAP,
+            "the two arms must differ in blob count and nothing else"
+        );
+    }
+
+    /// The pre-fix pin, carrying a payload, on both sides of the transfer cap.
+    ///
+    /// `a_git_admitted_store_adopting_a_hosted_identity_meets_the_git_authority_bound`
+    /// already records the Git-authority bound with a two-line commit. This
+    /// records it with 24 MiB and with 4 MiB, which is the pair FIR-2746 needs,
+    /// and it asserts something that test cannot: that the refusal is the
+    /// AUTHORITY bound and not the SIZE one.
+    ///
+    /// That distinction is the whole point of writing this before a route
+    /// exists. Two independent bounds refuse a payload-bearing push today, and
+    /// a test asserting only "the push failed" would stay green through the fix
+    /// for bound one, because bound two would keep it failing. Pinning WHICH
+    /// bound answered is what makes this go red at the right moment, and going
+    /// red is what it is for: when Git-authority bootstrap lands, the under-cap
+    /// arm should publish and the over-cap arm should move to
+    /// `decoded body closure exceeds`, and both of those are this test failing.
+    ///
+    /// It also establishes the ORDER, which nothing had measured. `validate_pack`
+    /// enforces the byte cap on the destination's side of a pack that the
+    /// source only builds after `TransferSourceContext::read` has already
+    /// compared the two replicas' Git authority, so the authority bound is
+    /// reached first and the size bound is unobservable end to end until it
+    /// moves. The over-cap arm proves that by observing the authority refusal
+    /// while being, on its own arithmetic, half again too large to ever fit.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_payload_bearing_push_meets_the_authority_bound_before_the_size_cap() {
+        for (label, blobs) in [
+            ("over", PAYLOAD_BLOBS_OVER_CAP),
+            ("under", PAYLOAD_BLOBS_UNDER_CAP),
+        ] {
+            let hosted_id = hosted_repository_id();
+            let hosted_repository = RepositoryId::new(hosted_id.clone()).unwrap();
+            let (hosted_state, _hosted_working, _hosted_storage) = hosted_peer_state(&hosted_id);
+            let hosted_url = serve_replica(Arc::clone(&hosted_state)).await;
+
+            let fixture = payload_fixture(label, blobs, &hosted_repository);
+            let cap = kin_remote::repository_transfer::MAX_TRANSFER_DECODED_BODY_BYTES;
+            let over_cap = fixture.payload_bytes > cap;
+            assert_eq!(
+                over_cap,
+                label == "over",
+                "the {label} arm must sit on the side of the cap its name claims: \
+                 {} bytes against {cap}",
+                fixture.payload_bytes
+            );
+
+            let source_state =
+                Arc::new(DaemonState::open_with_repo_id(fixture.layout.clone(), None).unwrap());
+            let request = kin_cli::commands::transfer::CommandTransferRequest {
+                remote_base_url: hosted_url,
+                remote_token: None,
+                repository_id: Some(hosted_id.clone()),
+                source_ref: None,
+                destination_ref: None,
+            };
+            let (status, body) =
+                transfer_command(Arc::clone(&source_state), "push", &request).await;
+            let message = String::from_utf8_lossy(&body).to_string();
+
+            assert_eq!(
+                status,
+                StatusCode::CONFLICT,
+                "the {label} arm must still be stopped by the Git-authority bound: {message}"
+            );
+            assert!(
+                message.contains("imported-Git authority"),
+                "the {label} arm must name the authority bound: {message}"
+            );
+            // The half that makes this a pin rather than a restatement. The
+            // size cap refuses with a different variant and a different
+            // sentence, and an over-cap push that started reporting THAT would
+            // mean bound one had moved.
+            assert!(
+                !message.contains("decoded body closure exceeds"),
+                "the {label} arm must not be reporting the size cap yet; if it is, \
+                 Git-authority bootstrap has landed and this pin has to be \
+                 rewritten rather than relaxed: {message}"
+            );
+            assert!(
+                !message.contains("does not match destination repository"),
+                "identity is not what stops a payload-bearing store: {message}"
+            );
+
+            // The reassembly assertion's own input, checked here rather than
+            // where it will be used. A digest map that went empty would make
+            // every future byte-verification vacuously true.
+            assert_eq!(
+                fixture.source_digests.len(),
+                blobs,
+                "the {label} arm must carry one source digest per blob"
+            );
+            std::fs::remove_dir_all(&fixture.working).ok();
+        }
+    }
+
     /// Two replicas of ONE repository: a real local one with a graph-owned
     /// workspace projecting into a working directory, and a peer that forked
     /// from it and has since moved `refs/heads/main` ahead by one exact edit.

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17346,17 +17346,23 @@ mod tests {
                 fixture.payload_bytes
             );
 
-            // The destination's BEFORE, which is the half that makes the after
-            // a statement about the destination. Falsification caught this:
-            // pointed at the source, the after-only check still passed, because
+            let source_state =
+                Arc::new(DaemonState::open_with_repo_id(fixture.layout.clone(), None).unwrap());
+
+            // The destination's BEFORE, which is the half that makes the after a
+            // statement about the destination. Falsification caught the
+            // after-only version: pointed at the source it still passed, because
             // a Git-admitted store names its own bodies from the moment it is
-            // created. Only an empty replica can name none and then name all.
-            // ONE binding for both readings, deliberately. Falsification pointed
-            // the after-reading at the source while the before-reading stayed on
-            // the peer, and the pair passed: before from an empty replica, after
-            // from a full one, no single replica described. Naming the observed
-            // replica once means a change of target moves both halves, so the
-            // before assertion below refuses it. The join, not the endpoints.
+            // created, so only an empty replica can name none and then name all.
+            //
+            // ONE binding for both readings, deliberately, and declared after
+            // the source so that swapping its target is a compiling mutation
+            // rather than an ordering error. Falsification caught that too: with
+            // only the after-reading retargeted, before came from an empty
+            // replica and after from a full one, and neither described a single
+            // replica. Two correct readings that jointly guarantee nothing,
+            // because the property lives in their agreement. The join, not the
+            // endpoints.
             let observed_replica = Arc::clone(&hosted_state);
             let before = repository_authority_snapshot(&observed_replica, &hosted_id)
                 .await
@@ -17372,8 +17378,6 @@ mod tests {
                  after-reading proves nothing about what crossed"
             );
 
-            let source_state =
-                Arc::new(DaemonState::open_with_repo_id(fixture.layout.clone(), None).unwrap());
             let request = kin_cli::commands::transfer::CommandTransferRequest {
                 remote_base_url: hosted_url,
                 remote_token: None,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17346,6 +17346,25 @@ mod tests {
                 fixture.payload_bytes
             );
 
+            // The destination's BEFORE, which is the half that makes the after
+            // a statement about the destination. Falsification caught this:
+            // pointed at the source, the after-only check still passed, because
+            // a Git-admitted store names its own bodies from the moment it is
+            // created. Only an empty replica can name none and then name all.
+            let before = repository_authority_snapshot(&hosted_state, &hosted_id)
+                .await
+                .expect("an empty hosted replica is readable before anything is pushed");
+            let named_before = before
+                .repository_authority
+                .as_ref()
+                .map(|authority| authority.external_objects.len())
+                .unwrap_or(0);
+            assert_eq!(
+                named_before, 0,
+                "the hosted replica must name no external object before the push, or the \
+                 after-reading proves nothing about what crossed"
+            );
+
             let source_state =
                 Arc::new(DaemonState::open_with_repo_id(fixture.layout.clone(), None).unwrap());
             let request = kin_cli::commands::transfer::CommandTransferRequest {
@@ -17414,6 +17433,17 @@ mod tests {
                 let snapshot = repository_authority_snapshot(&hosted_state, &hosted_id)
                     .await
                     .expect("the replica that admitted a bootstrap must be readable after it");
+                let named_after = snapshot
+                    .repository_authority
+                    .as_ref()
+                    .map(|authority| authority.external_objects.len())
+                    .unwrap_or(0);
+                assert!(
+                    named_after > named_before,
+                    "the destination must name MORE external objects after the push than \
+                     before it; naming the same set is what a snapshot of the SOURCE would \
+                     show, and that is the reading this pair exists to exclude"
+                );
                 let verified = assert_destination_committed_payload(&snapshot, &source_bodies);
                 assert_eq!(
                     verified, blobs,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17484,6 +17484,24 @@ mod tests {
              byte-verification is vacuous"
         );
 
+        // A path the fixture never wrote must be refused too, and this arm is
+        // here because falsification said so: without it, the missing-path
+        // guard was never reached, so a mutation removing it changed nothing
+        // and the guard could not be shown to do anything at all.
+        let mut absent = fixture.source_digests.clone();
+        absent.insert(
+            "payload/never-written.bin".to_string(),
+            hex::encode(Sha256::digest(b"a body no replica holds")),
+        );
+        let refused_absent = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assert_payload_reassembles(&authority, &absent)
+        }));
+        assert!(
+            refused_absent.is_err(),
+            "an expected path the replica does not project must be refused, or a \
+             reassembly that dropped a file entirely would verify clean"
+        );
+
         drop(authority);
         std::fs::remove_dir_all(&fixture.working).ok();
     }


### PR DESCRIPTION
**Rebased onto kin#1156 and flipped.** This branch was written before the Git-authority
bootstrap landed and pinned the 409 both arms then got. It was built to go red the day that
bound moved, keyed on the STATUS rather than on a sentence, and that is exactly how it failed:
`left: 422, right: 409` on the over-cap arm with the message naming the byte budget. What
follows describes the flipped shape; the falsification table below covers both.

Every transfer test in `api.rs` proves the LOOP. The one the hosted republish runbook cites,
`a_hosted_store_admits_a_native_transfer_and_then_serves_the_head_it_admitted`, builds its
pack from `seed_replica_change`, whose changes carry empty `tree_deltas` and empty
`entity_deltas`. Every hosted repository is content, so the loop passing was never evidence
the republish can work.

This is the harness that carries one. It exists before the route that would let a payload
through, so its job today is to pin the refusals precisely enough that the day something
moves, the right assertion goes red and the wrong one does not.

Tests only, one file, no product code, no kin-db, no version bump, no lock.

## The fixture pair, and why it is a pair

One builder parameterised by blob count, so the two arms differ in exactly one variable. Each
stages a Git worktree, writes N distinct megabyte blobs, commits once, and runs
`kin_core::init_from_git_adopting` against a hosted identity, which is how the republish
runbook stages its five stores.

24 MiB against 4 MiB, mirroring the shapes FIR-2746 measured as not fitting and fitting.

The arithmetic is asserted before any push depends on it, and so is the ISOLATION, which is
the half that matters. Each blob stays an order under `MAX_TRANSFER_BODY_BYTES` (8 MiB) and
the blob count three orders under `MAX_TRANSFER_BODIES` (4096), so a refusal is attributable
to the decoded-closure cap rather than to a neighbour. An arm that crossed a different cap
would refuse for a reason this harness is not about, and its refusal would read exactly like
the one it is about.

Content is deterministic and distinct per blob. Distinct because `validate_pack` deduplicates
bodies by hash, so a fixture of identical blobs would collapse to one body and measure
deduplication while still looking like 24 MiB on disk. Deterministic because the reassembly
comparator hashes against the bytes the fixture wrote, and a fixture that differs run to run
cannot be compared to anything.

## The pin, and what it pins

`a_payload_bearing_push_bootstraps_under_the_cap_and_is_refused_over_it` drives both arms over
a real socket at an empty hosted-shaped peer, and pins the DIVERGENCE kin#1156 created. Both
arms were measured before anything was pinned, by reporting rather than asserting:

```
MEASURE over:  status=422  invalid repository transfer: the next publishable step of this
               transfer is one exact change and it carries a 16777250 byte source body
               closure, over negotiated limit 16777216; a single change cannot be split
               across continuation packs
MEASURE under: status=200  {..."git_authority_delta":{"old":null,"new":{...}},
               "roots_before":{"generation":0},"roots_after":{"generation":1}...}
```

The under-cap arm PUBLISHES, and the receipt is read rather than the status.
`git_authority_delta.old == null` with `.new` present is authority being established on a
replica that had none; roots moving from generation 0 to 1 is the destination really having
been empty. A 200 alone says only that the route answered.

The over-cap arm is REFUSED BY NAME, 422, naming the negotiated byte limit and the indivisible
step, plus an assertion that the Git-authority bound does not come back.

Both halves are needed. Asserting only the publication would pass on a build that had also
stopped refusing the over arm; asserting only the refusal would pass on a build that refused
everything, which is what the 409 did the day before.

`a_payload_bearing_push_under_a_minted_identity_is_refused_on_identity_instead` is what makes
that evidence rather than a restatement of "pushes fail". Same payload, same route, one
property changed, and it requires a DIFFERENT answer: the identity refusal naming the minted
id, and explicitly not the authority bound. If the two ever agreed, the pin would be measuring
the route's willingness to refuse anything.

## Three things measured, two of which corrected readings

### The forward-looking assertion in the first draft could not fail

It asserted the over-cap arm must not report `decoded body closure exceeds`, and its doc
comment said the arm moving to that string is how the pin goes red once Git-authority
bootstrap lands. It would not have.

That wording is `validate_pack`'s and is unreachable from a source-built pack. The source's
own byte check returns `Assembled::OverNegotiatedBound` (`repository_transfer.rs:949`), which
is SEGMENTATION rather than refusal: the segment builder halves the change budget and
rebuilds. It refuses only when the step is indivisible, and a one-commit fixture is, so it
refuses with a different sentence. The assertion was keyed on a string that can never appear,
so it would have stayed green through exactly the change it was written to catch.

The tell is the STATUS. `RepositoryTransferError::Invalid` maps to 422 and `Conflict` to 409
(`repository_transfer_error`, `api.rs:10046`), so 409 today and 422 once the bound moves
separates them with nothing to spell. The two sentences the size bound can actually produce
are asserted beside it as the weaker reading, so whoever hits the failure is told which
wording to look for.

### The number in the refusal is a lower bound, not the payload

A 24 MiB fixture refuses at **16777491 bytes**, 275 over the cap. `assemble_segment_pack`
returns the moment the running total crosses, so it names the total at the crossing and stops
counting. An assertion that it equalled the payload would fail against correct code.

### Two public builders refuse the same condition with different sentences

`build_repository_transfer_pack` maps `OverNegotiatedBound` straight to `Err(invalid(reason))`
with the short reason. `build_repository_transfer_segment`, which is what `push_to_remote`
calls, adds the indivisible-step wording. The first draft of the size probe called the sibling
and got `carries a 16777491 byte source body closure, over negotiated limit 16777216` with no
mention of the indivisible step. Probing the wrong builder pins wording no push can produce,
which is the same class as the assertion above.

Through the push path the refusal is, captured verbatim by a temporary assertion flip whose
restore is proved by `git diff --quiet` rather than by the word restored:

```
invalid repository transfer: the next publishable step of this transfer is one exact change
and it carries a 16777491 byte source body closure, over negotiated limit 16777216;
a single change cannot be split across continuation packs
```

## The order, measured rather than inferred

Nothing had established which bound a payload-bearing push meets first. The over-cap arm
observes the AUTHORITY refusal while being, on its own arithmetic, half again too large to
ever fit. So the authority comparison runs first and the size bound is unobservable end to
end until it moves.

That is why `the_size_bound_answers_for_real_once_the_authority_bound_is_out_of_the_way`
exists. It builds the expectation from the source store's own transfer status, so the
authority hash agrees with itself, sets the destination unborn the way an empty hosted store
reads, and runs everything downstream for real against a real payload. Without it the size
bound's behaviour would have been an assertion nobody had ever run, first observed on the day
it mattered.

## The destination check, which this harness was built to be ready for

Until kin#1156 no route put a payload on a hosted replica, so the comparator ran against the
source and proved only that it could answer. It now reads the hosted replica's OWN authority
snapshot and requires it to name every payload body by content address with the same declared
length, while the source side independently verifies what those addresses' bytes are with
SHA-256, a different hash function from the address, so the two cannot agree by construction.

It cannot use the workspace-walking comparator. A bootstrapped hosted replica commits with
`workspace_mutation: null`, so `ActiveApiRepositoryAuthority::open` refuses it by name with
"local daemon is missing its startup workspace binding". That refusal is the replica behaving
correctly, and reading it as a failure was the easy mistake here.

### Three findings from falsifying it, all against my own work

**It passed when pointed at the source.** A Git-admitted store names its own bodies from
creation, so an after-only reading is satisfied by either replica. Fixed with a before-reading
requiring the hosted replica to name zero external objects first.

**Then it passed again with only the after-reading retargeted.** Before from an empty replica,
after from a full one, no single replica described by either. Two correct readings that
jointly guarantee nothing, because the property lives in their agreement and neither endpoint
can see it. Fixed by naming the observed replica once, so a change of target moves both halves.

**Then the arm could not compile,** because the binding sat above the source state, and a
build failure grades nothing. The driver refused to tally rather than counting it. Moving the
declaration below the source made the mutation compiling, and the arm lands red on the before
assertion.

A fourth arm came out as malformed rather than passing: it mutated the receipt ASSERTION to a
weaker one and the test then passed, which is what weakening an assertion always does. An arm
has to remove a property of the thing under test, not of the test.

## The reassembly comparator

Byte-verified by content hash against the bytes the fixture wrote, never by count, because a
replica holding the right number of artifacts with the wrong bytes passes any count. The
expected side is a SHA-256 taken when the bytes were written; the actual side is a SHA-256 of
what `load_source_blob` returns. Hashing both with Kin's own digest would compare the store to
itself.

It is route-agnostic on purpose: it takes an authority and a digest map, so the day a route
lands a payload on a hosted replica it is pointed at that authority with the same map. Until
then it runs against the source replica, because a comparator first run on the day a route
lands is one whose first result nobody can tell from a bug in the comparator.

The design lane's seam-surface note arrived after this branch was gated. Processing it
repoints the comparator and refines the empty-replica precondition; it changes where the
comparator points and not what it asserts, so it lands as a follow-up rather than holding this.

## Falsification: eighteen arms, eighteen where declared

Re-run against the final head rather than left pointing at the sha it first passed on. Driver
archived at `.kin-coord/reports/citier1-fir2729-falsify-20260826.py`.

It restores on EXIT, INT and TERM; asserts each mutation's marker is in the tree before the
build starts; asserts the test actually RAN rather than reading an exit code, because
`--exact` with a bare name selects nothing and cargo exits 0; and grades any exit of 128 or
more as NOT RUN with no tally printed. `git grep KIN_FALSIFY_P` over `crates/` returns zero
afterwards.

| arm | check | declared | result |
|---|---|---|---|
| baseline x5 | all five | GREEN | GREEN |
| the over-cap arm no longer exceeds the byte cap | fixtures straddle | RED | RED |
| the two arms are edited to agree | fixtures straddle | BUILD FAILS | BUILD FAILS |
| a single blob crosses the PER-BODY cap | fixtures straddle | RED | RED |
| every blob carries identical bytes | push pin | RED | RED |
| the fixture stops adopting the hosted identity | push pin | RED | RED |
| the arms swap sides of the cap | push pin | RED | RED |
| the identity control adopts the peer's own id | identity control | RED | RED |
| the destination check reads the SOURCE's snapshot | payload pin | RED | RED |
| the comparator stops comparing bytes | comparator | RED | RED |
| the comparator skips a path it cannot find | comparator | GREEN | GREEN |
| both producers of the missing-path refusal removed | comparator | RED | RED |
| the size probe leaves the destination born | size probe | RED | RED |
| the over arm carries the under arm's payload | size probe | RED | RED |

### The three arms that are the useful part

**One mutation did not do what I believed.** The identity control's first mutation swapped a
non-matching hosted identity for a DIFFERENT non-matching one, so the property survived and
the arm read GREEN. A green from a mutation that removed nothing is indistinguishable from a
passing falsification. It now adopts the peer's own id.

**One guard was unreachable, so it could not be falsified at all.** The comparator refuses a
path the replica does not project, and no arm ever asked for one, so a mutation deleting that
guard changed nothing. Enlarging the mutation could not fix that; the test needed an arm that
reaches the guard, and now has one.

**One arm is declared GREEN on purpose.** A missing path has TWO producers of the refusal:
the lookup panics, and the count check catches the shortfall. Removing either alone leaves
the property held, so GREEN is correct for each, and a separate arm removes both and is RED.
That is what makes the GREEN a claim rather than an excuse.

### A third grade the driver had to learn

The first sweep against the final head returned NO TALLY, correctly. Taking clippy's finding
on the blob-count comparison moved it into a `const` block, so the mutation setting the two
arms equal stopped producing a red test and started producing a compile error, which the
driver grades NOT RUN because a build that failed for an unnamed reason grades nothing.

That arm is now two. One sets the over arm to 8 blobs, still greater than the under arm's 4,
so the const block is satisfied and the RUNTIME assertion answers. The other sets it to 4 and
is declared `BUILD FAILS`, a grade awarded only when the compiler output names the const
assertion, so a build broken for any other reason still reads NOT RUN. A mutation that trips
two guards at once proves neither.

## What I ran

`bin/kin-precheck kin --repo-dir kin=<worktree>`:

```
kin-precheck: repo=kin tree=.kin-coord/worktrees/citier1-kin sha=b920617ebf484f8e5976aa26d910e27d084bf5be branch=chore/lane-citier1-fir2729harness-kin
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 16 gates ran, 16 passed, 0 failed
```

It failed first, on clippy, on two findings both mine: a runtime assertion over two constants,
and a needless borrow of an owned `Vec`. Caught before this pull request, which is what the
gate is for. The first is a const block now rather than an allow, which is stronger than the
assertion it replaces.

`cargo test -p kin-daemon --no-fail-fast`, exit 0. Read the way a total has to be read: SIZE
from `-- --list`, 1097 tests in the inventory; VERDICT from what interleaving cannot corrupt,
zero `... FAILED`, zero `test result: FAILED`, zero `panicked at`, zero `error[E`, against a
positive control of 7 `test result: ok` lines that must be and is nonzero and a never-emitted
string that must be and is zero. All five new checks confirmed present by name in the `--list`
inventory with a control name that must and does return zero, because a total cannot tell a
test that ran from one the filter never reached.

`bin/kin-parity` is not run and not claimed. This diff is tests in one crate and builds no
binary the acceptance suites exercise differently. Hosted CI is the gate of record and the
Windows legs run only there.

## Tickets

Part of FIR-2729
Part of FIR-2746

Closing neither, deliberately. This records the bounds precisely; it does not move them.

## Claims not being made

That any of this unblocks the hosted republish. It does not.

That the size bound is the last one. FIR-2729's native-route bound is untouched here, and the
fixture is Git-admitted, so the Native admission rule is out of its scope by construction.

That the fixtures mirror kin's tree in shape. They mirror it in the one property the cap
reads, the decoded total, and deliberately not in blob count, because matching 842 blobs would
have brought the count caps into a test that is about bytes.

That the destination can SERVE the payload bytes on demand. What is proved is that its
committed authority names every one of them by content address with the right length. A body
read against a hosted backend is not reached here.

That anything ran against prod. Nothing did. No bucket object, no hosted daemon, no gpu,
daemon or quiet lock.


---

## Rebased and the fixture sizes derived, 2026-08-26 (wedge lane)

This PR was ejected from the merge queue four times with `failed_checks`, and the
failing test named its own mechanism:
`the_payload_fixtures_straddle_the_transfer_cap_and_nothing_else`.

**The harness was right and the harness caught it.** The straddle self-check
already reads the cap from the product constant rather than a literal, and #1160
moved `MAX_TRANSFER_DECODED_BODY_BYTES` from 16 MiB to 64 MiB. So the over arm's
24 MiB stopped being over the cap and the check failed on every speculative merge
tree, exactly as it was built to. What went stale was the FIXTURE SIZES, not the
cap. A group ejection leaves its reason only on the `merge_group` timeline, which
is why nobody watching the PR surface saw it.

Both arms now derive from the ceiling:

```rust
const CAP_BLOBS: usize = (MAX_TRANSFER_DECODED_BODY_BYTES / PAYLOAD_BLOB_BYTES as u64) as usize;
const PAYLOAD_BLOBS_OVER_CAP: usize = CAP_BLOBS + 1;
const PAYLOAD_BLOBS_UNDER_CAP: usize = if CAP_BLOBS / 2 < 4 { CAP_BLOBS / 2 } else { 4 };
```

so the straddle holds across any future cap change by construction rather than by
a literal somebody remembers to edit. The over arm is the minimum overshoot, one
blob past the ceiling.

**The comments changed because a claim in them stopped being true.** The arms were
originally sized to mirror real repositories: the over arm carried kin's own tip
tree at 27.77 MiB, which did not fit at 16 MiB, and the under arm carried kin-db
at 4.30 MiB, which did. kin's tip now fits comfortably. The arms cannot mirror a
repository any more, because the raised ceiling sits above every hosted
repository's tip closure, which is exactly what raising it bought. They mirror the
BOUND instead, and the comments say so rather than repeating the old claim.

## A third isolation assertion

The test had two isolation checks, that no blob crosses the per-body cap and that
the over arm stays clear of the body-count cap, both so a refusal here is
attributable to the byte cap alone. There is a third bound and nothing asserted
it: bodies travel base64, so an over-cap arm can be large enough that the
TRANSPORT refuses it with a 413 before the decoded-closure check runs, and that
refusal reads like the one this harness is about.

It fits today with 6.7 MiB of margin, and it is one legal edit from not fitting.
The assertion computes the wire size the way `http_body_limit_for` computes the
limit it is compared against, so the two cannot drift apart on what base64 costs.

## Cost, measured rather than assumed

Exceeding a decoded-byte cap means shipping that many bytes, so the over arm goes
from 24 MiB to 65 MiB and no construction avoids it.

**`a_payload_bearing_push_bootstraps_under_the_cap_and_is_refused_over_it` runs in
55.83 s**, and both payload tests together in 56.34 s. That is inside the bar, so
this ships plain rather than reaching for `#[ignore]`, because an ignored test on
hosted CI is a guard that never runs.

Shrinking the ceiling for the test was considered and rejected on evidence:
`configured_transfer_limits()` reads `std::env::var` at call time, so setting
`KIN_TRANSFER_MAX_DECODED_BODY_BYTES` in a test mutates process-global state
shared with every other test in the binary. That is a known race class and saving
test minutes is not worth introducing it.

## Falsification

Four mutations against the committed tree, each red at its own named assertion,
tree restored after every arm with zero markers and `git diff HEAD --quiet` clean.

| mutation | verdict | which assertion answered |
|---|---|---|
| the over arm reverts to the stale literal 24 | RED | `the over-cap arm must exceed the decoded closure cap: 25165824 vs 67108864` |
| the under arm is pushed past the over arm | **COMPILE-RED** | `the two arms must differ in blob count and nothing else` |
| the under arm lands exactly on the ceiling | RED | `the under-cap arm must fit under the decoded closure cap: 67108864 vs 67108864` |
| the blob grows to one byte under the per-body cap | RED | `refused by the decoded-closure cap, not by the transport: 100663284 base64 bytes against a 97867096 byte limit` |

Two of those are worth reading. The second does not fail at runtime at all: it
fails to COMPILE, because that pair is guarded by a `const` block the original
author added deliberately with a comment saying it makes the two arms agreeing a
compile error. That is a stronger guard than a runtime assertion, and the third
mutation exists because of it, landing the under arm exactly ON the ceiling so the
const block stays happy and the runtime assertion answers instead. Both guards are
now shown to work.

The fourth proves the new assertion is load-bearing rather than decorative.
Growing the blob to one byte under the per-body cap is legal against every other
check in the test, and only the new one catches it.

## Gates

`bin/kin-precheck kin` through `bin/kin-lane run` against the lane worktree:
**16 gates ran, 16 passed, 0 failed**. The first run was 15 of 16 with clippy
denying `manual_div_ceil` on the new assertion; fixed by using `div_ceil`, which
is what the product's own `http_body_limit_for` already uses.

`cargo test -p kin-daemon --lib api::tests::a_payload_bearing_push`: 2 passed,
0 failed, zero `test result: FAILED`, zero `... FAILED`, zero `panicked at`.

One note on running these locally: the leaf test name alone matches nothing under
`--exact`, and a filter that selects nothing exits 0 and prints `test result: ok`,
which reads exactly like a pass. The full path is
`api::tests::the_payload_fixtures_straddle_the_transfer_cap_and_nothing_else`.
