### PR TITLE
Stop hashing the runner's incidental toolchains into the cargo cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,30 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # FIR-2744. `rust-cache` hashes EVERY toolchain `rustup toolchain
+          # list` reports, not the one this repository pins, so two jobs in one
+          # run that drew runner images with different preinstalled Rust
+          # produce different keys and cannot share an entry. Measured on run
+          # 32961965498: `check` saw 1.96.0/1.97.1 and hit
+          # `v0-rust-check-Linux-x64-8374e8ea-433e5115`, while
+          # `feature-tests` saw 1.96.0/1.98.0 sixty-five seconds later, asked
+          # `...-6ea01539-...` and logged `No cache found.` Same prefix, same
+          # lockfile hash, nothing in this repository chose either image.
+          #
+          # What this drops, stated rather than assumed. The hash covers the
+          # toolchain versions AND every CARGO, CC, CFLAGS, CXX, CMAKE and RUST
+          # environment variable. Toolchain sensitivity survives, because
+          # `rust-toolchain.toml` and `.github/actions/rust-toolchain/action.yml`
+          # are both in the key's lockfiles half, which the job log's
+          # "Lockfiles considered" list shows. Environment sensitivity does not,
+          # and that only matters where a key is SHARED between jobs, which is
+          # `check`, `check-macos` and `feature-tests`. They declare an
+          # identical cargo env today and
+          # `assert_shared_cache_key_jobs_declare_one_environment` in
+          # scripts/test-release-workflow-authority.py is what keeps them that
+          # way, because a divergence would otherwise be a silent cache
+          # collision rather than a failure.
+          add-rust-environment-hash-key: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
 
@@ -448,6 +472,8 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # FIR-2744, and see the note on the first cache step in this file.
+          add-rust-environment-hash-key: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
 
@@ -515,6 +541,8 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # FIR-2744, and see the note on the first cache step in this file.
+          add-rust-environment-hash-key: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
 
@@ -1509,6 +1537,8 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # FIR-2744, and see the note on the first cache step in this file.
+          add-rust-environment-hash-key: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check formatting
@@ -1802,6 +1832,8 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # FIR-2744, and see the note on the first cache step in this file.
+          add-rust-environment-hash-key: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # See .github/clippy-allowed-lints.txt. This is the only clippy pass over
@@ -2164,6 +2196,8 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # FIR-2744, and see the note on the first cache step in this file.
+          add-rust-environment-hash-key: false
           shared-key: ${{ matrix.os == 'macos-latest' && 'check-macos' || 'check' }}
           save-if: false
 
@@ -2335,6 +2369,8 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # FIR-2744, and see the note on the first cache step in this file.
+          add-rust-environment-hash-key: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The build stamps its own source identity, and `kin bench-meta` reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -904,6 +904,15 @@ jobs:
     name: Fast gate lint and policy
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # FIR-2744. This job shares `check`'s cargo cache key, and with
+    # `add-rust-environment-hash-key` off nothing else would notice the two
+    # declaring different cargo profiles, so they must declare the same one or
+    # they are sharing a cache built under settings neither agreed to. Added on
+    # rebase: this job arrived on main after the change was written.
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
     permissions:
       actions: read
       contents: read
@@ -940,6 +949,13 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # FIR-2744. These two jobs share `check`'s cache key, which is exactly
+          # the case this setting exists for: without it `rust-cache` hashes
+          # every toolchain the runner happens to carry, so two jobs in one run
+          # that drew different images ask for different keys and share nothing.
+          # Added on rebase, because both jobs arrived on main after this change
+          # was written and its own guard refuses any cache step that omits it.
+          add-rust-environment-hash-key: false
           shared-key: check
           save-if: false
 
@@ -1117,6 +1133,13 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # FIR-2744. These two jobs share `check`'s cache key, which is exactly
+          # the case this setting exists for: without it `rust-cache` hashes
+          # every toolchain the runner happens to carry, so two jobs in one run
+          # that drew different images ask for different keys and share nothing.
+          # Added on rebase, because both jobs arrived on main after this change
+          # was written and its own guard refuses any cache step that omits it.
+          add-rust-environment-hash-key: false
           shared-key: check
           save-if: false
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -5488,6 +5488,122 @@ def assert_ubuntu_shard_authority(workflow: str) -> None:
             )
 
 
+def cached_job_cache_inputs(workflow: str) -> dict[str, dict[str, str]]:
+    """Map every job running `rust-cache` to that step's `with:` inputs."""
+
+    inputs: dict[str, dict[str, str]] = {}
+    for job, block in workflow_job_blocks(workflow).items():
+        lines = classifier_active_job_source(block).splitlines()
+        for index, line in enumerate(lines):
+            if "uses: Swatinem/rust-cache@" not in line:
+                continue
+            found: dict[str, str] = {}
+            for follow in lines[index + 1 :]:
+                indent = len(follow) - len(follow.lstrip())
+                stripped = follow.strip()
+                if stripped == "with:":
+                    continue
+                # A new step, or a shallower key, ends this step's inputs.
+                if stripped.startswith("- ") or indent <= 4:
+                    break
+                if ": " in stripped:
+                    key, value = stripped.split(": ", 1)
+                    found[key.strip()] = value.strip()
+            inputs[job] = found
+            break
+    return inputs
+
+
+def job_cargo_environment(block: str) -> dict[str, str]:
+    """The job-level `env:` mapping, which rust-cache would otherwise hash."""
+
+    lines = classifier_active_job_source(block).splitlines()
+    try:
+        start = lines.index("  env:")
+    except ValueError:
+        return {}
+    environment: dict[str, str] = {}
+    for line in lines[start + 1 :]:
+        indent = len(line) - len(line.lstrip())
+        if indent <= 2:
+            break
+        if ": " in line:
+            key, value = line.strip().split(": ", 1)
+            environment[key.strip()] = value.strip()
+    return environment
+
+
+def assert_shared_cache_key_jobs_declare_one_environment(workflow: str) -> None:
+    """Keep the jobs that SHARE a cargo cache key on one declared environment.
+
+    FIR-2744 turned `add-rust-environment-hash-key` off, because the hash it
+    computes includes every toolchain the runner image happens to carry, so two
+    jobs in one run drew different keys off the same prefix and could not share
+    an entry. That fix is only safe because of what the hash's other half
+    covered.
+
+    The hash covers the toolchain versions AND every CARGO, CC, CFLAGS, CXX,
+    CMAKE and RUST environment variable. Toolchain sensitivity survives the
+    change, because the pin lives in `rust-toolchain.toml` and the toolchain
+    action, both of which are in the key's lockfiles half. Environment
+    sensitivity does not survive it.
+
+    That loss is harmless for a job keyed on its own job id, which shares with
+    nothing. It is not harmless where a `shared-key` deliberately points one
+    job at another's entry: those jobs now agree on a key while declaring
+    whatever environment they like, and a divergence would be a silent cache
+    collision rather than a failure. Nothing else in this repository would
+    notice, which is why it is asserted here.
+
+    The check is the JOIN rather than the endpoints: it reads which jobs
+    actually share a key out of the workflow and requires each such group to
+    declare one environment, so a new sharer is covered the day it is added
+    rather than the day someone remembers to list it.
+    """
+
+    inputs = cached_job_cache_inputs(workflow)
+    if not inputs:
+        raise AssertionError(
+            "shared cache-key authority found no job running rust-cache, so it "
+            "graded nothing; the extraction is broken or the action was renamed"
+        )
+    for job, found in inputs.items():
+        if found.get("add-rust-environment-hash-key") != "false":
+            raise AssertionError(
+                "shared cache-key authority requires every rust-cache step to set "
+                f"add-rust-environment-hash-key: false (FIR-2744); {job} does not"
+            )
+
+    blocks = workflow_job_blocks(workflow)
+    # Which jobs share which key, read from the workflow rather than listed.
+    # A `shared-key` naming another job's id joins that job's group; an
+    # expression naming several joins all of them.
+    groups: dict[str, set[str]] = {}
+    for job, found in inputs.items():
+        shared = found.get("shared-key")
+        if shared is None:
+            continue
+        for other in inputs:
+            if f"'{other}'" in shared or shared == other:
+                groups.setdefault(other, {other}).add(job)
+    if not groups:
+        raise AssertionError(
+            "shared cache-key authority found no shared-key at all, so it graded "
+            "nothing; if sharing was removed on purpose, remove this check with it"
+        )
+
+    for owner, members in sorted(groups.items()):
+        environments = {job: job_cargo_environment(blocks[job]) for job in sorted(members)}
+        distinct = {tuple(sorted(env.items())) for env in environments.values()}
+        if len(distinct) != 1:
+            raise AssertionError(
+                "shared cache-key authority requires every job sharing the "
+                f"{owner!r} cargo cache key to declare one environment, because "
+                "add-rust-environment-hash-key is off and nothing else would "
+                f"notice a divergence: {environments}"
+            )
+
+
 def execute_docs_only_classifier(
     classifier: str,
     *,
@@ -13605,7 +13721,7 @@ def main() -> None:
             expected,
             lambda mutant=mutant_workflow: assert_fast_gate_authority(mutant),
         )
-
+    assert_shared_cache_key_jobs_declare_one_environment(ci_workflow)
     consumer_blocks = workflow_job_blocks(ci_workflow)
     stub_check = consumer_blocks["check-pr-fast-path"]
     real_check = consumer_blocks["check"]
@@ -13801,6 +13917,58 @@ def main() -> None:
                 mutant_workflow
             ),
         )
+
+    # FIR-2744's guard, driven in every direction it can fail.
+    for label, old, new in (
+        (
+            "a cache step lets the runner's toolchain set back into the key",
+            "          add-rust-environment-hash-key: false",
+            "          add-rust-environment-hash-key: true",
+        ),
+        (
+            "the shared-key expression stops naming a job, so nothing shares",
+            "          shared-key: ${{ matrix.os == 'macos-latest' "
+            "&& 'check-macos' || 'check' }}",
+            "          shared-key: unshared-by-anything",
+        ),
+        (
+            "the action is renamed, so the extraction silently finds no cache step",
+            "uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4",
+            "uses: Renamed/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4",
+        ),
+    ):
+        if ci_workflow.count(old) < 1:
+            raise AssertionError(
+                f"shared cache-key falsification could not identify {label}"
+            )
+        expect_assertion(
+            label,
+            "shared cache-key authority",
+            lambda mutant=ci_workflow.replace(
+                old, new
+            ): assert_shared_cache_key_jobs_declare_one_environment(mutant),
+        )
+
+    # The one that matters most, because it is the collision the guard exists
+    # for and the only one nothing else in this repository would notice.
+    feature_tests = consumer_blocks["feature-tests"]
+    diverged_env = feature_tests.replace(
+        '      CARGO_PROFILE_TEST_DEBUG: "0"',
+        '      CARGO_PROFILE_TEST_DEBUG: "2"',
+        1,
+    )
+    if diverged_env == feature_tests:
+        raise AssertionError(
+            "shared cache-key falsification could not diverge a sharing job's "
+            "environment"
+        )
+    expect_assertion(
+        "a job sharing the cargo cache key declares a different environment",
+        "shared cache-key authority",
+        lambda mutant=ci_workflow.replace(
+            feature_tests, diverged_env, 1
+        ): assert_shared_cache_key_jobs_declare_one_environment(mutant),
+    )
 
     stub_condition = (
         "    if: ${{ !cancelled() && github.event_name == 'pull_request' }}"

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -13926,10 +13926,17 @@ def main() -> None:
             "          add-rust-environment-hash-key: true",
         ),
         (
+            # Target the `shared-key` line itself rather than one job's
+            # expression. Unsharing a SINGLE job stopped falsifying this the day
+            # main added a second and third job keyed on `check`: the group was
+            # no longer emptied, the survivors still agreed, and the guard
+            # correctly stayed green while the arm expected red. Commenting out
+            # every shared-key leaves nothing sharing at all, which is what the
+            # label claims and what the refusal above is for, and it cannot be
+            # broken again by a new sharer arriving.
             "the shared-key expression stops naming a job, so nothing shares",
-            "          shared-key: ${{ matrix.os == 'macos-latest' "
-            "&& 'check-macos' || 'check' }}",
-            "          shared-key: unshared-by-anything",
+            "          shared-key: ",
+            "          # falsification removed shared-key: ",
         ),
         (
             "the action is renamed, so the extraction silently finds no cache step",


### PR DESCRIPTION
Stops `rust-cache` hashing the runner's incidental toolchain set into the cargo cache key, and adds a guard that keeps jobs sharing a key on one declared environment. FIR-2744. Written 2026-08-26 by lane citier1cache, rebased onto current main on 2026-08-30 by lane railfix after sitting DIRTY.

## The defect

`rust-cache` hashes EVERY toolchain `rustup toolchain list` reports, not the one this repository pins, so two jobs in one run that drew runner images with different preinstalled Rust produce different keys and cannot share an entry. Measured on run 32961965498: `check` saw 1.96.0/1.97.1 and hit `v0-rust-check-Linux-x64-8374e8ea-433e5115`, while `feature-tests` saw 1.96.0/1.98.0 sixty-five seconds later, asked for `...-6ea01539-...` and logged `No cache found.` Same prefix, same lockfile hash, and nothing in this repository chose either image.

Turning `add-rust-environment-hash-key` off fixes that, and the guard is what makes it safe. The hash covered toolchain versions AND every CARGO, CC, CFLAGS, CXX, CMAKE and RUST variable. Toolchain sensitivity survives, because the pin lives in `rust-toolchain.toml`. Environment sensitivity does not, so jobs pointed at another's entry by `shared-key` could agree on a key while declaring whatever environment they liked, and a divergence would be a silent cache collision rather than a failure. The guard reads which jobs actually share a key out of the workflow and requires each group to declare one environment, so a new sharer is covered the day it is added.

## The rebase, in a separate commit

Kept as its own commit so a reviewer can see what the rebase needed rather than what was written in August. It found a live defect on main.

Main gained two `rust-cache` steps since this was written, `fast-gate-lint` and `fast-gate-tests`, both keyed on `check`. Both needed `add-rust-environment-hash-key: false`, which is the guard covering new sharers exactly as designed.

**`fast-gate-lint` declared no cargo environment at all while sharing `check`'s key.** Filed as FIR-2987, and the ordering constraint is written down there: the environment fix must land with or before the hash-key change, never after, because landing FIR-2744 without it is what opens the collision. `check` and `fast-gate-tests` both declare `CARGO_INCREMENTAL`, `CARGO_PROFILE_DEV_DEBUG` and `CARGO_PROFILE_TEST_DEBUG` at `"0"`; `fast-gate-lint` declared none. With `add-rust-environment-hash-key` off, nothing else in the repository would notice two jobs agreeing on a key while compiling under different profiles, which is the collision this guard exists for. It is latent rather than live today: `add-rust-environment-hash-key` appears 0 times across main's 9 cache steps, so the default applies, the environment is still in the hash, and the two currently draw DIFFERENT keys rather than colliding. The present cost is a wasted entry. This change is what turns that hash off, so it is also what would open the collision, which is why the fix rides here rather than following later.

**One falsification arm needed repair rather than adaptation.** It unshared a single job and expected the guard to red, which worked only because that job was then the sole sharer, so the group emptied and the guard refused on having nothing to check. With three jobs now keyed on `check`, unsharing one leaves the survivors agreeing and the guard correctly stays green while the arm expects red. The arm now comments out every `shared-key` line, so nothing shares at all, which is what its label claims and what the refusal it targets is for, and it cannot be broken again by a new sharer arriving.

## Verification

`scripts/test-release-workflow-authority.py` passes. Nine of nine `rust-cache` steps now set the key. The falsification arms remain load-bearing: `expect_assertion` requires each mutant to fail the assertion, so a green suite is proof the arms still catch.

## Status

Do not land until the v0.6.2 tag is minted. This changes the CI that grades the release candidate and the mint's required contexts run on it, so it waits behind the tag by the captain's instruction. Held green and rebased; it will be re-rebased if main moves.

Closes FIR-2987
