### PR TITLE
Stop the derived flush from erasing a hosted authority envelope

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -15936,6 +15936,182 @@ mod tests {
         );
     }
 
+    /// Read the authority envelope straight off the persisted object.
+    ///
+    /// Deliberately not through the daemon. The question these tests ask is
+    /// what the NEXT open would find, and a served answer can be perfectly
+    /// right while the object underneath it has already been overwritten.
+    fn persisted_authority(storage: &FsPath, repo_id: &str) -> (bool, usize, u64) {
+        let backend = kin_db::LocalFileBackend::new(storage.to_path_buf());
+        match kin_db::load_recovered_snapshot(&backend, repo_id)
+            .expect("reading the persisted authority object must not fail")
+        {
+            Some(recovered) => {
+                let generation = recovered.generation;
+                match recovered.snapshot.repository_authority.as_ref() {
+                    Some(authority) => (true, authority.ref_state.refs.len(), generation),
+                    None => (false, 0, generation),
+                }
+            }
+            None => (false, 0, 0),
+        }
+    }
+
+    /// Open a second daemon over a backend that already holds a publication.
+    ///
+    /// This is the restart, and the restart is the trigger. A daemon that was
+    /// already running when the envelope was published keeps a stale cursor, so
+    /// its next flush CAS-fails and the envelope survives by accident. A daemon
+    /// that opens afterwards loads the current generation, so its CAS succeeds
+    /// and the erasure lands. Any fixture that reuses the seeding daemon tests
+    /// the accident instead of the defect.
+    ///
+    /// Returns the working directory beside the state because dropping it
+    /// deletes the layout out from under a live daemon.
+    fn reopen_hosted_daemon(
+        storage: &FsPath,
+        repo_id: &str,
+    ) -> (Arc<DaemonState>, tempfile::TempDir) {
+        let working = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(working.path()).unwrap().layout;
+        let state = Arc::new(
+            DaemonState::open_with_backend(
+                layout,
+                Box::new(kin_db::LocalFileBackend::new(storage.to_path_buf())),
+                repo_id,
+                None,
+            )
+            .unwrap(),
+        );
+        (state, working)
+    }
+
+    /// A derived flush must not erase the envelope the backend published.
+    ///
+    /// The daemon serializes its in-place mutable graph, which does not own the
+    /// authority envelope and writes an explicit null where one belongs, then
+    /// hands those bytes to the write that IS the authority object. Refs,
+    /// receipts, workspaces, aliases and admission state go with it.
+    ///
+    /// Driven through `save_snapshot_full` and `save_snapshot`, which are the
+    /// two entry points every one of the four flush callers reaches: the
+    /// periodic loop, the shutdown flush, the pre-idle flush and the LSP sweep
+    /// all arrive through `save_snapshot_blocking`. Guarding the wall-clock
+    /// trigger rather than the write would leave the other three erasing.
+    #[tokio::test]
+    async fn a_hosted_flush_leaves_the_authority_envelope_the_backend_published() {
+        let repo_id = format!("hosted-flush-keeps-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        let (_seeded, _seed_working, storage) = replica_state(&repo_id);
+        seed_replica_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x8060,
+            "publish the head a derived flush must not erase",
+        );
+
+        let (present, refs, generation) = persisted_authority(storage.path(), &repo_id);
+        assert!(
+            present && refs > 0,
+            "the fixture must publish a real envelope carrying refs, or this test grades nothing"
+        );
+
+        let (state, _reopened_working) = reopen_hosted_daemon(storage.path(), &repo_id);
+        state
+            .save_snapshot_full()
+            .expect("a hosted flush must not fail");
+        state.save_snapshot().expect("a hosted flush must not fail");
+
+        let (still_present, still_refs, still_generation) =
+            persisted_authority(storage.path(), &repo_id);
+        assert!(
+            still_present,
+            "the flush erased the authority envelope the backend published"
+        );
+        assert_eq!(
+            still_refs, refs,
+            "the flush changed the published ref set it had no authority to touch"
+        );
+        assert_eq!(
+            still_generation, generation,
+            "the flush advanced the authority generation without committing authority"
+        );
+    }
+
+    /// The guard is keyed on the envelope, not on having a backend at all.
+    ///
+    /// Without this arm the fix could be "a hosted daemon never persists
+    /// anything", which passes the test above perfectly and breaks every
+    /// envelope-free hosted store, including the one in the bucket today. The
+    /// write must still happen where there is no publication to destroy.
+    #[tokio::test]
+    async fn a_hosted_flush_still_persists_where_the_backend_holds_no_envelope() {
+        let repo_id = format!("hosted-flush-writes-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+
+        let (present, _, before) = persisted_authority(storage.path(), &repo_id);
+        assert!(
+            !present,
+            "the fixture must start with no envelope, or this arm proves nothing"
+        );
+
+        state
+            .save_snapshot_full()
+            .expect("an envelope-free hosted store must still persist");
+
+        let (_, _, after) = persisted_authority(storage.path(), &repo_id);
+        assert!(
+            after > before,
+            "the flush was suppressed on a store with no envelope to protect: {before} -> {after}"
+        );
+    }
+
+    /// The periodic loop fires forever, so one safe flush is not the claim.
+    ///
+    /// A guard that holds once and then lets a later flush through, because it
+    /// consumed a flag or keyed on some first-pass state, would pass the arm
+    /// above and still erase the envelope on the second tick of a thirty-second
+    /// timer. The loop gets no fewer chances than this.
+    #[tokio::test]
+    async fn repeated_hosted_flushes_never_erode_the_published_envelope() {
+        let repo_id = format!("hosted-flush-repeat-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        let (_seeded, _seed_working, storage) = replica_state(&repo_id);
+        seed_replica_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x8061,
+            "publish a head many flushes must not erase",
+        );
+        let (present, refs, generation) = persisted_authority(storage.path(), &repo_id);
+        assert!(
+            present && refs > 0,
+            "the fixture must publish a real envelope"
+        );
+
+        let (state, _reopened_working) = reopen_hosted_daemon(storage.path(), &repo_id);
+        for tick in 0..8 {
+            state
+                .save_snapshot()
+                .unwrap_or_else(|error| panic!("flush {tick} failed: {error}"));
+            state
+                .save_snapshot_full()
+                .unwrap_or_else(|error| panic!("full flush {tick} failed: {error}"));
+            let (still_present, still_refs, still_generation) =
+                persisted_authority(storage.path(), &repo_id);
+            assert!(still_present, "flush {tick} erased the envelope");
+            assert_eq!(still_refs, refs, "flush {tick} changed the ref set");
+            assert_eq!(
+                still_generation, generation,
+                "flush {tick} advanced the authority generation"
+            );
+        }
+    }
+
     /// The hosted publication loop, end to end.
     ///
     /// An empty hosted store admits a native transfer and then serves the head

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -16112,6 +16112,242 @@ mod tests {
         }
     }
 
+    /// The production-shaped chain, end to end.
+    ///
+    /// `POST /graph/mutations` reaches no save of its own; what it does is
+    /// `mark_dirty`, and the periodic loop refuses to flush at all unless
+    /// `is_dirty`. So the real sequence is a mutation ARMING the gate and the
+    /// wall clock firing it. An earlier reading of this ticket called the route
+    /// a third write path, which it is not, and an arm written that way would
+    /// have asserted something false.
+    ///
+    /// The batch is deliberately empty. The arming step is `mark_dirty`, which
+    /// the handler runs unconditionally after applying whatever it was given,
+    /// so an empty batch isolates exactly the step under test.
+    #[tokio::test]
+    async fn a_graph_mutation_arms_the_flush_that_must_not_erase_the_envelope() {
+        let repo_id = format!("hosted-flush-armed-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        let (_seeded, _seed_working, storage) = replica_state(&repo_id);
+        seed_replica_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x8062,
+            "publish a head an armed flush must not erase",
+        );
+        let (present, refs, generation) = persisted_authority(storage.path(), &repo_id);
+        assert!(
+            present && refs > 0,
+            "the fixture must publish a real envelope"
+        );
+
+        let (state, _reopened_working) = reopen_hosted_daemon(storage.path(), &repo_id);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/mutations")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "the arming route must succeed, or this arm never reaches the flush"
+        );
+        assert!(
+            state.is_dirty(),
+            "the mutation must arm the dirty gate, or the periodic loop would skip the flush entirely"
+        );
+
+        state
+            .save_snapshot()
+            .expect("the armed flush must not fail");
+
+        let (still_present, still_refs, still_generation) =
+            persisted_authority(storage.path(), &repo_id);
+        assert!(still_present, "the armed flush erased the envelope");
+        assert_eq!(still_refs, refs, "the armed flush changed the ref set");
+        assert_eq!(
+            still_generation, generation,
+            "the armed flush advanced the authority generation"
+        );
+        assert!(
+            state.hosted_authority_flush_refusals() >= 1,
+            "the flush must have been refused the authority write, not merely found nothing to do"
+        );
+    }
+
+    /// Today's accidental protection, pinned so the fix is not credited with it.
+    ///
+    /// A daemon that was already running when the envelope was published keeps
+    /// the cursor it opened with, so its flush CAS-fails and the envelope
+    /// survives for a reason that has nothing to do with this guard. Without
+    /// this arm the fix could look like it protects a case that was already
+    /// safe, and the restart arm beside it would lose its meaning.
+    ///
+    /// The refusal counter reading zero is the whole point: the CAS did this.
+    #[tokio::test]
+    async fn a_live_daemons_stale_cursor_already_refuses_by_cas_not_by_the_guard() {
+        let repo_id = format!("hosted-flush-stale-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        // Opened against an empty store, so its cursor is the empty one.
+        let (state, _working, storage) = replica_state(&repo_id);
+        seed_replica_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x8063,
+            "publish a head under a daemon that is already running",
+        );
+        let (present, refs, generation) = persisted_authority(storage.path(), &repo_id);
+        assert!(
+            present && refs > 0,
+            "the fixture must publish a real envelope"
+        );
+
+        let outcome = state.save_snapshot_full();
+        assert!(
+            outcome.is_err(),
+            "a stale cursor must lose the compare-and-swap rather than overwrite"
+        );
+        assert_eq!(
+            state.hosted_authority_flush_refusals(),
+            0,
+            "this daemon opened before the publication, so the guard must not be what stopped it"
+        );
+
+        let (still_present, still_refs, still_generation) =
+            persisted_authority(storage.path(), &repo_id);
+        assert!(
+            still_present,
+            "the CAS failure must leave the envelope intact"
+        );
+        assert_eq!(still_refs, refs, "the ref set must be untouched");
+        assert_eq!(
+            still_generation, generation,
+            "the generation must be untouched"
+        );
+    }
+
+    /// A refusal is normal, so it must not be reported as a fault.
+    ///
+    /// The periodic loop calls `mark_clean` only when the flush returns `Ok`,
+    /// and backs off with a climbing `consecutive_failures` and a "persistence
+    /// unhealthy" error when it does not. A guard that refused by returning an
+    /// error would therefore turn a correctly-behaving hosted daemon into one
+    /// that logs an escalating fault every tick and never settles.
+    ///
+    /// So the claim is behavioural, not cosmetic: `Ok`, the dirty flag clears,
+    /// and the counter proves the refusal really happened rather than the flush
+    /// having found nothing to do.
+    #[tokio::test]
+    async fn a_refused_hosted_flush_reports_success_so_the_persist_loop_settles() {
+        let repo_id = format!("hosted-flush-settle-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        let (_seeded, _seed_working, storage) = replica_state(&repo_id);
+        seed_replica_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x8064,
+            "publish a head a settling loop must not erase",
+        );
+        let (state, _reopened_working) = reopen_hosted_daemon(storage.path(), &repo_id);
+
+        for tick in 1..=5u64 {
+            state.mark_dirty();
+            assert!(state.is_dirty(), "tick {tick} did not arm the gate");
+            state
+                .save_snapshot()
+                .unwrap_or_else(|error| panic!("tick {tick} reported a fault: {error}"));
+            assert_eq!(
+                state.hosted_authority_flush_refusals(),
+                tick,
+                "tick {tick} did not refuse exactly once"
+            );
+        }
+    }
+
+    /// The same guard, reached through a second caller.
+    ///
+    /// Four callers reach `save_snapshot_impl`, and the invariant is stated
+    /// regardless of caller. Every arm above drives the periodic entry points,
+    /// which leaves "the other three are also covered" resting on the guard's
+    /// position in the source rather than on anything observed. This drives the
+    /// shutdown path, which is a different function with its own dirty check
+    /// and its own wipe guard in front of the same write.
+    #[tokio::test]
+    async fn the_shutdown_flush_refuses_the_authority_write_too() {
+        let repo_id = format!("hosted-flush-shutdown-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        let (_seeded, _seed_working, storage) = replica_state(&repo_id);
+        seed_replica_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x8065,
+            "publish a head the shutdown flush must not erase",
+        );
+        let (present, refs, generation) = persisted_authority(storage.path(), &repo_id);
+        assert!(
+            present && refs > 0,
+            "the fixture must publish a real envelope"
+        );
+
+        let (state, _reopened_working) = reopen_hosted_daemon(storage.path(), &repo_id);
+        state.mark_dirty();
+        crate::daemon::run_shutdown_persistence(&state).await;
+
+        let (still_present, still_refs, still_generation) =
+            persisted_authority(storage.path(), &repo_id);
+        assert!(still_present, "the shutdown flush erased the envelope");
+        assert_eq!(still_refs, refs, "the shutdown flush changed the ref set");
+        assert_eq!(
+            still_generation, generation,
+            "the shutdown flush advanced the authority generation"
+        );
+        assert!(
+            state.hosted_authority_flush_refusals() >= 1,
+            "the shutdown flush must reach the same guard, not skip the write for some other reason"
+        );
+    }
+
+    /// Durability control: the guard is inert where there is no backend.
+    ///
+    /// A local daemon owns its own authority and must keep writing exactly as
+    /// before. The counter reading zero is what makes this a control rather
+    /// than a restatement: a flush that silently refused and a flush that had
+    /// nothing to do both return `Ok` and both leave the caller unable to tell
+    /// which happened.
+    #[tokio::test]
+    async fn a_daemon_with_no_backend_persists_and_never_refuses() {
+        let working = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(working.path()).unwrap().layout;
+        let state = Arc::new(DaemonState::open(layout).unwrap());
+
+        state.mark_dirty();
+        state
+            .save_snapshot()
+            .expect("a local daemon must still persist");
+        state
+            .save_snapshot_full()
+            .expect("a local daemon must still persist a full snapshot");
+
+        assert_eq!(
+            state.hosted_authority_flush_refusals(),
+            0,
+            "the authority-envelope guard must never fire on a daemon that owns its own authority"
+        );
+    }
+
     /// The hosted publication loop, end to end.
     ///
     /// An empty hosted store admits a native transfer and then serves the head

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -650,7 +650,12 @@ const DEFERRED_CHECKPOINT_RETRY_MAX: Duration = Duration::from_secs(300);
 /// Runs under the persistence task's own shutdown budget
 /// (`KIN_DAEMON_SHUTDOWN_FLUSH_SECS`, five minutes by default), which exists
 /// because the graph flush here can need minutes on a real store.
-async fn run_shutdown_persistence(state: &Arc<DaemonState>) {
+/// Visible to the crate so the authority-envelope guard can be exercised
+/// through this caller as well as the periodic one. The invariant it protects
+/// is stated regardless of caller, and four callers reach the same write, so a
+/// test that only ever drives the periodic path proves the guard is positioned
+/// correctly by inspection rather than by behaviour.
+pub(crate) async fn run_shutdown_persistence(state: &Arc<DaemonState>) {
     if state.is_dirty() {
         if state.shutdown_flush_would_wipe_graph() {
             // The in-memory graph collapsed to a small fraction of the last

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1187,6 +1187,18 @@ pub struct DaemonState {
     /// `None` = local repository-v6 authority.
     /// `Some` = hosted StorageBackend (GCS or an isolated backend fixture).
     pub storage_backend: Option<Arc<dyn StorageBackend>>,
+    /// Whether the backend this daemon opened against already holds a
+    /// repository-authority envelope.
+    ///
+    /// Captured at open from the loaded snapshot, because it cannot be read
+    /// back cheaply later: `load_snapshot_authority` defaults to pulling the
+    /// whole object, and the periodic flush is not a place to download the
+    /// graph. Captured rather than recomputed is also correct rather than
+    /// merely cheap: nothing this daemon can do creates an envelope, since
+    /// `record_repository_authority_commit` refuses a storage-backend daemon
+    /// outright, so the only way one appears is a transfer, and a transfer
+    /// advances the generation the daemon's CAS is pinned to.
+    hosted_authority_envelope: bool,
     /// Startup-opened local storage capability. Reusing this exact backend
     /// preserves KinDB's device/inode root pin across every local authority
     /// request; constructing a new backend from the mutable path would bless a
@@ -2537,6 +2549,7 @@ impl DaemonState {
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
             storage_backend: None,
+            hosted_authority_envelope: false,
             local_repository_backend: Some(local_repository_backend),
             projection_authority: crate::api::ProjectionAuthorityCache::default(),
             registered_local_repository_authorities,
@@ -2668,11 +2681,19 @@ impl DaemonState {
         allowed_repo_ids: Option<HashSet<String>>,
     ) -> Result<Self> {
         let text_index_path = layout.text_index_dir();
-        let (graph, generation, loaded_snapshot) =
+        let (graph, generation, loaded_snapshot, hosted_authority_envelope) =
             match kin_db::load_recovered_snapshot(backend.as_ref(), repo_id)
                 .map_err(DaemonError::from)?
             {
                 Some(recovered) => {
+                    // Read before the move: `from_snapshot_with_text_index`
+                    // discards this field by design, because the envelope is
+                    // owned by the publication manager and never by the
+                    // in-place mutable graph. This is the last point at which
+                    // the daemon can see whether the object it opened is one
+                    // an envelope-free write would erase.
+                    let hosted_authority_envelope =
+                        recovered.snapshot.repository_authority.is_some();
                     let g = kin_db::InMemoryGraph::from_snapshot_with_text_index(
                         recovered.snapshot,
                         text_index_path.clone(),
@@ -2682,9 +2703,15 @@ impl DaemonState {
                         repo_id,
                         generation = recovered.generation,
                         deltas_replayed = recovered.deltas_applied,
+                        hosted_authority_envelope,
                         "loaded graph from storage backend"
                     );
-                    (Arc::new(g), recovered.generation, true)
+                    (
+                        Arc::new(g),
+                        recovered.generation,
+                        true,
+                        hosted_authority_envelope,
+                    )
                 }
                 None => {
                     info!(repo_id, "no snapshot found, starting with empty graph");
@@ -2696,6 +2723,7 @@ impl DaemonState {
                         )),
                         0,
                         true,
+                        false,
                     )
                 }
             };
@@ -2773,6 +2801,7 @@ impl DaemonState {
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
             storage_backend: Some(backend),
+            hosted_authority_envelope,
             local_repository_backend: None,
             projection_authority: crate::api::ProjectionAuthorityCache::default(),
             registered_local_repository_authorities: Vec::new(),
@@ -4750,7 +4779,44 @@ impl DaemonState {
         let mut committed = false;
 
         let new_gen = if let Some(backend) = &self.storage_backend {
-            if force_full
+            if self.hosted_authority_envelope {
+                // The derived flush must never write this backend's authority
+                // object, and this is the one place all four callers reach:
+                // the periodic loop, the shutdown flush, the pre-idle flush and
+                // the LSP sweep. Guarding the wall-clock trigger instead would
+                // leave the other three writing.
+                //
+                // Both backend writes are barred here, for two different
+                // reasons that happen to land on the same branch. A full
+                // snapshot is serialized from the in-place mutable graph, which
+                // does not own the authority envelope and writes an explicit
+                // null in its place, so committing one erases refs, receipts,
+                // workspaces, aliases and admission state. An incremental delta
+                // is barred by the format's own rule: once the envelope is
+                // present, every root moves only through a full repository
+                // transaction, and a storage-backend daemon cannot run one
+                // because `record_repository_authority_commit` refuses it.
+                //
+                // So there is nothing here this daemon is entitled to commit,
+                // and the honest flush is the local half. The text index is
+                // derived from the live graph and rebuildable from it, which is
+                // why it can be made durable without an authority commit
+                // behind it.
+                //
+                // Deliberately not a graph-persistence epoch. Detaching a batch
+                // and completing it would acknowledge work no durable object
+                // holds, and the next open would come back without it. That is
+                // the exact failure the local arm below documents having made
+                // once already, and it is worse than not flushing, because it
+                // is silent.
+                self.graph.flush_text_index().map_err(DaemonError::from)?;
+                debug!(
+                    repo_id,
+                    generation = expected_gen,
+                    "flushed derived text index only; the backend authority envelope is not this daemon's to rewrite"
+                );
+                expected_gen
+            } else if force_full
                 || expected_gen == kin_db::GENERATION_INIT
                 || self.graph.full_snapshot_required()
                 || !backend.supports_incremental_deltas()

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1199,6 +1199,13 @@ pub struct DaemonState {
     /// outright, so the only way one appears is a transfer, and a transfer
     /// advances the generation the daemon's CAS is pinned to.
     hosted_authority_envelope: bool,
+    /// How many flushes have been refused the backend authority write.
+    ///
+    /// Exists so the healthy path can assert zero rather than merely not
+    /// asserting anything: a guard that fires where it should not is invisible
+    /// from the outside, because a refused flush and a flush with nothing to do
+    /// both return `Ok` and both leave the object alone.
+    hosted_authority_flush_refusals: AtomicU64,
     /// Startup-opened local storage capability. Reusing this exact backend
     /// preserves KinDB's device/inode root pin across every local authority
     /// request; constructing a new backend from the mutable path would bless a
@@ -2550,6 +2557,7 @@ impl DaemonState {
             reconciliation_status: AtomicU8::new(RECON_IDLE),
             storage_backend: None,
             hosted_authority_envelope: false,
+            hosted_authority_flush_refusals: AtomicU64::new(0),
             local_repository_backend: Some(local_repository_backend),
             projection_authority: crate::api::ProjectionAuthorityCache::default(),
             registered_local_repository_authorities,
@@ -2802,6 +2810,7 @@ impl DaemonState {
             reconciliation_status: AtomicU8::new(RECON_IDLE),
             storage_backend: Some(backend),
             hosted_authority_envelope,
+            hosted_authority_flush_refusals: AtomicU64::new(0),
             local_repository_backend: None,
             projection_authority: crate::api::ProjectionAuthorityCache::default(),
             registered_local_repository_authorities: Vec::new(),
@@ -4241,6 +4250,13 @@ impl DaemonState {
         self.save_snapshot_impl(SnapshotSaveMode::Incremental)
     }
 
+    /// How many flushes this daemon has refused the backend authority write.
+    ///
+    /// Zero is the assertion that matters on a healthy path.
+    pub fn hosted_authority_flush_refusals(&self) -> u64 {
+        self.hosted_authority_flush_refusals.load(Ordering::SeqCst)
+    }
+
     pub fn save_snapshot_full(&self) -> Result<()> {
         self.save_snapshot_impl(SnapshotSaveMode::Full)
     }
@@ -4810,11 +4826,22 @@ impl DaemonState {
                 // once already, and it is worse than not flushing, because it
                 // is silent.
                 self.graph.flush_text_index().map_err(DaemonError::from)?;
+                let refusals = self
+                    .hosted_authority_flush_refusals
+                    .fetch_add(1, Ordering::SeqCst)
+                    + 1;
                 debug!(
                     repo_id,
                     generation = expected_gen,
+                    refusals,
                     "flushed derived text index only; the backend authority envelope is not this daemon's to rewrite"
                 );
+                // Deliberately `Ok`, not an error. The periodic loop marks the
+                // state clean on success and only then stops flushing until the
+                // next mutation; an error would instead climb
+                // `consecutive_failures`, back off, and log "persistence
+                // unhealthy" on a daemon behaving exactly as designed. A
+                // refusal that is normal must not be reported as a fault.
                 expected_gen
             } else if force_full
                 || expected_gen == kin_db::GENERATION_INIT


### PR DESCRIPTION
A hosted daemon's periodic flush was writing its derived graph over the object that IS the repository authority, and that write erases the authority envelope by construction. Refs, operation receipts, workspaces, aliases and admission state went with it.

## Why the write is lossy, and why carrying the envelope through is not the fix

The obvious reading is that a field got dropped and should be threaded back. It cannot be. The in-place mutable graph is *defined* as not owning the envelope, and says so where it discards it (kin-db `engine/graph.rs:2620`):

```rust
// Repository authority is owned by the immutable publication
// manager, never by this in-place mutable graph.
repository_authority: _,
```

so `to_snapshot()` writes an explicit `None` because there is nothing to write. The daemon does not have the envelope to carry. This is a category error, not a missing field: bytes from a graph that owns no authority were handed to the write that is the authority.

## The guard is at the write, because the invariant says regardless of caller

Four callers reach `save_snapshot_impl` through `save_snapshot_blocking`:

| caller | line |
|---|---|
| shutdown | `daemon.rs:672` |
| pre-idle | `daemon.rs:1638` |
| periodic loop | `daemon.rs:3840` |
| LSP cold sweep | `daemon.rs:5154` |

A guard on the wall-clock trigger would satisfy "the flush is guarded" and leave the other three erasing. One branch at the write covers all four.

**Both** backend writes are barred when an envelope is present, for two different reasons landing on one branch. A full snapshot erases it by construction. An incremental delta is barred by the persisted format's own rule, that once the envelope is present every root moves only through a full repository transaction, which a storage-backend daemon cannot run because `record_repository_authority_commit` refuses it by name.

## What it does instead

Its local half. `flush_text_index` is derived from the live graph and rebuildable from it, so it can be made durable with no authority commit behind it. The derived-index durability this loop exists for was already local: `persist_snapshot_sidecars_for_epoch` targets `self.layout.kindb_snapshot_path()`, and only the `backend.save_snapshot` line after it touched authority. Nothing needed a new home.

**Deliberately not a graph-persistence epoch.** Detaching a batch and completing it would acknowledge work no durable object holds, and the next open would come back without it. The local arm twenty lines below already documents making exactly that mistake once. It is worse than not flushing, because it is silent.

## Envelope presence is captured at open

It cannot be read back cheaply later: `load_snapshot_authority` defaults to pulling the whole object, and a thirty-second flush is no place to download a graph. Capture is also correct rather than merely cheap. Nothing this daemon can do creates an envelope, so the only way one appears is a transfer, and a transfer advances the generation the daemon's CAS is pinned to. The CAS is the second layer, and the ticket verified it by reading.

## Falsification

Eight arms, three mutations, each marker-asserted and restored on an EXIT, INT and TERM trap.

| arm | M1 removed | M2 unconditional | M3 leaks to local |
|---|---|---|---|
| 1 envelope survives a flush | **red** | ok | ok |
| 2 envelope-free store still persists | ok | **red** | ok |
| 3 eight flush pairs never erode it | **red** | ok | ok |
| 4 a mutation arms the flush | **red** | ok | ok |
| 5 stale cursor loses the CAS | ok | **red** | ok |
| 6 shutdown reaches the same guard | **red** | ok | ok |
| 7 refusal reports success and settles | **red** | ok | ok |
| 8 no-backend daemon never refuses | ok | ok | **red** |

**M3 exists because of what the first matrix showed.** Under M1 and M2 alone, arm 8 stayed green under both, since the guard sits inside `if let Some(backend)` and a local daemon never reaches it. An arm no mutation can kill is a check that cannot fail, so M3 leaks the refusal onto the local arm and arm 8 goes red there and only there. Every arm now dies to at least one mutation.

Three of these deserve a word.

**Arm 2** is what stops the fix being "a hosted daemon never persists anything", which passes arm 1 perfectly and breaks every envelope-free hosted store, the one in the bucket today included.

**Arm 5** pins today's accidental protection so this change is not credited with it. A daemon already running when the envelope was published keeps its cursor, so its flush loses the compare-and-swap and the envelope survives for reasons unrelated to this guard. The refusal counter reading **zero** there is the whole point. The ticket marked this nuance "verified read, not observed"; this arm observes it.

**Arm 6** drives the shutdown path, so regardless-of-caller is behavioural rather than a claim about where the branch sits in the source.

The fixture seeds through `RepositoryAuthorityManager`, then **reopens** the daemon. That is not incidental: only a daemon that opened after the publication has a cursor whose CAS succeeds, so a fixture reusing the seeding daemon would test the accident and stay green with the guard removed. Every assertion reads the persisted object directly, because a served answer can be right while the object underneath it is gone.

## A refusal returns Ok, and that is load-bearing

The periodic loop calls `mark_clean` only on success, and otherwise climbs `consecutive_failures`, backs off and logs "persistence unhealthy". Refusing by error would turn a correctly-behaving hosted daemon into one reporting an escalating fault every tick and never settling. There is no hot spin, and the reason is structural rather than a matter of tuning. Arm 7 pins it.

A refusal counter exists so the healthy path can assert **zero**. A refused flush and a flush that found nothing to do both return `Ok` and both leave the object alone, so without a counter a guard firing where it should not is unobservable.

## What was run

- `bin/kin-precheck kin` through the lane: **16 gates enumerated from ci.yml, 16 passed, 0 failed**
- `cargo test -p kin-daemon --lib`: **1058 passed, 0 failed** on the rebased head
- Tree confirmed clean after each falsification arm

## What this does not claim

It does not prove the bootstrap that publishes an envelope, which is FIR-2729 route (a). It removes the erasure that would have made that bootstrap survive only until the next restart, which is why the ticket asks for this first.

One risk stated rather than assumed: a hosted daemon still accepts `POST /graph/mutations` and marks dirty, and under this guard those mutations do not reach the backend. That follows from the format rule above, since a daemon that cannot run a repository transaction is mutating derived state. Arm 2 pins that envelope-free stores are untouched, so nothing in the bucket today changes behavior.

Two things worth stating for anyone reading this later. Vector sidecar persistence on a hosted daemon was **already** refused before this change, by `reject_remote_backend_embed_persistence` (`state.rs:4990`) and pinned by a test at `state.rs:9461`, so the refusal branch not writing sidecars is not a regression. And the escape hatch was checked: the only non-obvious `backend.save_snapshot` outside the flush is `gcs_endpoint.rs:483`, which sits under a `#[test]`. There is no production site where a storage-backend daemon authors.

Closes FIR-2748
