### PR TITLE
Land an in-place edit as a commit, and stamp the daemon-loss shape a kill produces

### DIFF
--- a/crates/kin-agent/src/belt.rs
+++ b/crates/kin-agent/src/belt.rs
@@ -336,6 +336,14 @@ pub struct LocalOutcome {
     pub is_error: bool,
     /// The repository-relative path that changed, when one did.
     pub changed: Option<String>,
+    /// The file's complete new text, as this tool left it.
+    ///
+    /// Repository authority admits a source change from the whole file, so the harness
+    /// has to hand it those bytes. It carries them out of the tool that produced them
+    /// rather than reading the file back: the text is already in hand here, a read would
+    /// put a filesystem access on the runtime path, and between the write and the read
+    /// the file could be something else.
+    pub body: Option<String>,
 }
 
 /// Resolve a model-supplied path inside the repository, refusing every escape.
@@ -482,6 +490,7 @@ pub fn run_edit(repo: &Path, arguments: &Value) -> LocalOutcome {
         ),
         is_error: false,
         changed: Some(raw_path.to_string()),
+        body: Some(updated),
     }
 }
 
@@ -513,6 +522,7 @@ pub fn run_write(repo: &Path, arguments: &Value) -> LocalOutcome {
         ),
         is_error: false,
         changed: Some(raw_path.to_string()),
+        body: Some(content.to_string()),
     }
 }
 
@@ -534,6 +544,7 @@ pub fn published_create(arguments: &Value) -> LocalOutcome {
         ),
         is_error: false,
         changed: Some(raw_path.to_string()),
+        body: Some(content.to_string()),
     }
 }
 
@@ -545,6 +556,7 @@ impl LocalOutcome {
             text: message,
             is_error: true,
             changed: None,
+            body: None,
         }
     }
 }

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -41,8 +41,8 @@ for byte. You never open, stage or commit a transaction yourself, and those tool
 on your belt on purpose. The harness does it around every call you make: a file you create \
 with write_file is staged as Kin's create operation, carrying the repository-relative path \
 and the full body, and committed with provenance naming this agent. An edit to a file Kin \
-already tracks lands in the working tree and is recorded in this run's trace, and the \
-harness does not yet admit that edit to the graph in the same step.
+already tracks is staged as Kin's replace operation, carrying that path and the file's \
+complete new text as your edit left it, and committed the same way.
 
 Your tools are the mcp__kin__ ones named above plus edit_file and write_file. You have no \
 others.
@@ -675,6 +675,7 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                                     &mut bracket,
                                                     session.as_deref(),
                                                     &plan,
+                                                    None,
                                                     &mut writer,
                                                 )?;
                                                 let provenance = close_transaction(
@@ -729,6 +730,7 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                                         &mut bracket,
                                                         session.as_deref(),
                                                         &plan,
+                                                        outcome.body.as_deref(),
                                                         &mut writer,
                                                     )?
                                                 };
@@ -1015,18 +1017,25 @@ fn end_kin_session(server: &mut Server, writer: &mut TranscriptWriter) -> anyhow
 
 /// What the harness will stage inside the bracket for one local tool call.
 ///
-/// `kin_transaction_stage` admits five disjoint shapes (`crates/kin-mcp/src/tools.rs`),
-/// and exactly one of them is keyed on a repository-relative path plus a body: the new
-/// source file, verb `create`. The in-place edit shape resolves its target against
-/// repository authority as an entity uuid or an exact entity name
+/// `kin_transaction_stage` admits several disjoint shapes (`crates/kin-mcp/src/tools.rs`),
+/// and two of them are keyed on a repository-relative path plus the file's whole text: the
+/// new source file, verb `create`, and the rewritten one, verb `replace`. Between them they
+/// cover both local tools, because a path and a complete body is exactly what a local write
+/// or edit leaves the harness holding. The entity-keyed `update` shape resolves its target
+/// against repository authority as an entity uuid or an exact entity name
 /// (`kin_mcp::handlers::sessions::resolve_target_entity`), which a text splice does not
-/// know, so the harness plans nothing for an edit rather than staging a shape the daemon
-/// would refuse at commit. A transaction with nothing in it is refused too, by design, so
-/// an unstageable call opens no transaction at all and the trace says why.
+/// know, so the harness never plans that one. A transaction with nothing in it is refused
+/// by design, so an unstageable call opens no transaction at all and the trace says why.
 enum StagePlan {
     /// Admit the file at this repository-relative path with this body. Repository
     /// authority refuses it by name if it already tracks the path.
     Create { target: String, body: String },
+    /// Rewrite the tracked file at this repository-relative path from its complete new
+    /// text. The body is deliberately not carried here: an edit's new text does not exist
+    /// until the edit has run, and this plan is made before it, so the body is read from
+    /// the file the harness just wrote. Repository authority refuses the operation by name
+    /// if it does not already track the path.
+    Replace { target: String },
     /// Nothing the stage surface admits fits this call, and this is the reason.
     Unstageable { reason: String },
 }
@@ -1035,18 +1044,25 @@ enum StagePlan {
 ///
 /// Whether the path is new is repository authority's question, not the filesystem's, and
 /// the two answers differ: a path can sit on disk untracked, or be tracked with nothing on
-/// disk yet. So the harness plans the create and lets the daemon refuse it by name if the
-/// graph already holds that path, which is the rule `create` documents. Probing the disk
-/// here would put a filesystem heuristic on the runtime path to answer a question the
-/// graph owns.
+/// disk yet. So the harness plans the create for a write and the replace for an edit, and
+/// lets the daemon refuse either by name when the graph disagrees about whether it holds
+/// that path, which is the rule both verbs document. Probing the disk here would put a
+/// filesystem heuristic on the runtime path to answer a question the graph owns.
 fn plan_stage(repo: &Path, tool: LocalTool, arguments: &Value) -> StagePlan {
     let raw_path = arguments.get("path").and_then(Value::as_str).unwrap_or("");
     match tool {
-        LocalTool::Edit => StagePlan::Unstageable {
-            reason: "an in-place edit has no stage shape keyed on a path; the update \
-                     operation names an entity uuid or an exact entity name"
-                .into(),
-        },
+        LocalTool::Edit => {
+            let path = match belt::resolve_in_repo(repo, raw_path) {
+                Ok(path) => path,
+                Err(problem) => return StagePlan::Unstageable { reason: problem },
+            };
+            match repository_relative(repo, &path) {
+                Some(target) => StagePlan::Replace { target },
+                None => StagePlan::Unstageable {
+                    reason: "the path did not reduce to a repository-relative target".into(),
+                },
+            }
+        }
         LocalTool::Write => {
             let content = arguments
                 .get("content")
@@ -1186,19 +1202,56 @@ fn stage_planned_operation(
     bracket: &mut Bracket,
     session: Option<&str>,
     plan: &StagePlan,
+    produced: Option<&str>,
     writer: &mut TranscriptWriter,
 ) -> anyhow::Result<bool> {
     let server_name = server.name();
-    let (Some(transaction_id), StagePlan::Create { target, body }) =
-        (bracket.transaction_id.clone(), plan)
-    else {
+    let Some(transaction_id) = bracket.transaction_id.clone() else {
         return Ok(false);
     };
+    // A create carries the body the model sent, because the file does not exist yet and
+    // repository authority is what writes it. A replace carries the file's complete new
+    // text, which only exists once the edit has run, so it comes from the tool that just
+    // ran rather than from the plan that was made before it.
+    let (verb, target, body) = match plan {
+        StagePlan::Create { target, body } => ("create", target.clone(), body.clone()),
+        StagePlan::Replace { target } => match produced {
+            Some(body) if !body.is_empty() => ("replace", target.clone(), body.to_string()),
+            _ => {
+                // Nothing is staged, so the bracket aborts rather than committing an empty
+                // transaction, and the provenance says so instead of going quiet.
+                let detail = format!("the edit of {target} produced no text to admit to the graph");
+                writer.trace(json!({
+                    "surface": "kin",
+                    "server": server_name,
+                    "tool": "kin_transaction_stage",
+                    "policy": "allowed",
+                    "event": "transaction_stage",
+                    "transaction_id": transaction_id,
+                    "verb": "replace",
+                    "target": target,
+                    "is_error": true,
+                    "detail": detail.clone(),
+                }))?;
+                bracket.staged = Some(json!({
+                    "verb": "replace",
+                    "target": target,
+                    "accepted": false,
+                    "detail": detail,
+                }));
+                return Ok(false);
+            }
+        },
+        StagePlan::Unstageable { .. } => return Ok(false),
+    };
     let operation = json!({
-        "verb": "create",
+        "verb": verb,
         "target": target,
         "body": body,
-        "description": format!("kin agent created {target}"),
+        "description": match verb {
+            "replace" => format!("kin agent rewrote {target}"),
+            _ => format!("kin agent created {target}"),
+        },
     });
     let mut arguments = json!({
         "transaction_id": transaction_id,
@@ -1219,14 +1272,14 @@ fn stage_planned_operation(
         "policy": "allowed",
         "event": "transaction_stage",
         "transaction_id": transaction_id,
-        "verb": "create",
+        "verb": verb,
         "target": target,
         "body_bytes": body.len(),
         "is_error": is_error,
         "detail": detail,
     }))?;
     bracket.staged = Some(json!({
-        "verb": "create",
+        "verb": verb,
         "target": target,
         "body_bytes": body.len(),
         "accepted": !is_error,

--- a/crates/kin-agent/tests/loop_integration.rs
+++ b/crates/kin-agent/tests/loop_integration.rs
@@ -181,13 +181,22 @@ def call(name, args):
     if name == "kin_transaction_begin":
         return payload({"transaction_id": "txn-fixture-1", "_kin": ENVELOPE})
     if name == "kin_transaction_stage":
-        # The daemon refuses a create whose path repository authority already tracks.
-        # TRACKED stands for the fixture graph's contents, so the refusal is the graph's
-        # answer rather than a look at the working tree.
+        # The daemon refuses a create whose path repository authority already tracks, and
+        # the mirror of it: a replace whose path authority does not track. TRACKED stands
+        # for the fixture graph's contents, so both refusals are the graph's answer rather
+        # than a look at the working tree.
         TRACKED = ("src/greet.py", "README.md")
         for op in args.get("operations", []):
-            if op.get("target") in TRACKED:
-                return payload({"error": "path " + op.get("target") + " is already tracked",
+            verb = op.get("verb")
+            target = op.get("target")
+            if verb in ("replace", "overwrite"):
+                if target not in TRACKED:
+                    return payload({"error": "path " + str(target) + " is not tracked by "
+                                             "repository authority, so there is nothing to "
+                                             "replace", "_kin": ENVELOPE}, is_error=True)
+                continue
+            if target in TRACKED:
+                return payload({"error": "path " + str(target) + " is already tracked",
                                 "_kin": ENVELOPE}, is_error=True)
         STAGED.setdefault(args.get("transaction_id"), []).extend(args.get("operations", []))
         return payload({"staged": len(args.get("operations", [])),
@@ -208,7 +217,7 @@ def call(name, args):
                                 "_kin": ENVELOPE}, is_error=True)
         for op in operations:
             target = op.get("target")
-            if op.get("verb") in ("create", "add", "insert"):
+            if op.get("verb") in ("create", "add", "insert", "replace", "overwrite"):
                 parent = os.path.dirname(target)
                 if parent:
                     os.makedirs(parent, exist_ok=True)
@@ -394,7 +403,7 @@ fn mcp_log(path: &Path) -> Vec<Value> {
 }
 
 #[test]
-fn a_tool_call_reaches_kin_and_an_in_place_edit_records_why_it_stages_nothing() {
+fn a_tool_call_reaches_kin_and_an_in_place_edit_is_staged_as_a_replace() {
     let dir = tempfile::tempdir().unwrap();
     let repo = fixture_repo(dir.path());
     let out = dir.path().join("out");
@@ -445,9 +454,9 @@ fn a_tool_call_reaches_kin_and_an_in_place_edit_records_why_it_stages_nothing() 
         "the docstring must be in the file: {edited}"
     );
 
-    // The call reached the graph server. The edit itself opens no transaction: the stage
-    // surface has no shape keyed on a path for an in-place edit, and a transaction with
-    // nothing staged in it can only end in the daemon's refusal of an empty commit.
+    // The call reached the graph server, and the edit was bracketed and published: the
+    // stage surface's `replace` shape is keyed on a repository-relative path plus the
+    // file's complete new text, which is exactly what an edit leaves the harness holding.
     let calls = mcp_log(&log);
     let names: Vec<&str> = calls
         .iter()
@@ -455,10 +464,39 @@ fn a_tool_call_reaches_kin_and_an_in_place_edit_records_why_it_stages_nothing() 
         .collect();
     assert_eq!(
         names,
-        vec!["kin_session_start", "semantic_locate", "kin_session_end"],
-        "an unstageable edit must not open a transaction it cannot stage into"
+        vec![
+            "kin_session_start",
+            "semantic_locate",
+            "kin_transaction_begin",
+            "kin_transaction_stage",
+            "kin_transaction_commit",
+            "kin_session_end"
+        ],
+        "an edit must be staged as a replace and committed, not left unbracketed"
     );
     assert_eq!(calls[1]["args"]["query"], "greet");
+
+    // The staged operation carries the file's WHOLE new text, not the fragment the model
+    // sent as `replace`. A body built from the fragment would satisfy every assertion
+    // above and destroy the file at commit, so the untouched line is asserted too.
+    let staged_op = &calls
+        .iter()
+        .find(|call| call["tool"] == "kin_transaction_stage")
+        .expect("the edit is staged")["args"]["operations"][0];
+    assert_eq!(staged_op["verb"], "replace");
+    assert_eq!(staged_op["target"], "src/greet.py");
+    let staged_body = staged_op["body"]
+        .as_str()
+        .expect("the replace carries a body");
+    assert!(
+        staged_body.contains("\"\"\"Return a greeting for name.\"\"\""),
+        "the staged body must carry the edit: {staged_body}"
+    );
+    assert!(
+        staged_body.contains("return f\"hello {name}\""),
+        "the staged body must be the file's complete new text, keeping the lines the edit \
+         did not touch: {staged_body}"
+    );
 
     // The transcript records it in the shape the analyzers read.
     let records = read_jsonl(&outcome.transcript_path);
@@ -512,13 +550,24 @@ fn a_tool_call_reaches_kin_and_an_in_place_edit_records_why_it_stages_nothing() 
         .iter()
         .find(|row| row["surface"] == "local" && row["tool"] == "edit_file")
         .expect("the local edit is traced");
-    assert_eq!(edit["provenance"]["bracketed"], false);
-    assert_eq!(edit["provenance"]["staged"], Value::Null);
-    let reason = edit["provenance"]["reason"].as_str().unwrap();
-    assert!(
-        reason.contains("entity uuid or an exact entity name"),
-        "the provenance must name why the edit could not be staged: {reason}"
+    assert_eq!(edit["provenance"]["bracketed"], true);
+    assert_eq!(edit["provenance"]["staged"]["verb"], "replace");
+    assert_eq!(edit["provenance"]["staged"]["target"], "src/greet.py");
+    assert_eq!(edit["provenance"]["staged"]["accepted"], true);
+    assert_eq!(
+        edit["provenance"]["closed_with"], "kin_transaction_commit",
+        "a staged edit is committed, never aborted"
     );
+    assert_eq!(edit["provenance"]["closed_cleanly"], true);
+    // The stage row is in the sidecar under the verb it actually used.
+    let staged_row = trace
+        .iter()
+        .find(|row| row["tool"] == "kin_transaction_stage")
+        .expect("the stage call is traced");
+    assert_eq!(staged_row["verb"], "replace");
+    assert_eq!(staged_row["target"], "src/greet.py");
+    assert_eq!(staged_row["is_error"], false);
+    assert!(staged_row["body_bytes"].as_u64().unwrap() > 0);
     // The whole written body stays out of the trace row; the transcript already has it.
     assert!(edit["args"]["replace"]
         .as_str()

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -535,6 +535,14 @@ fn mcp_spawn_plan(
 /// needs a corrected call.
 pub const DAEMON_EXITED_RESTART_REQUIRED: &str = "repo daemon exited; restart required";
 
+/// The prefix for a daemon that stopped answering in the middle of a call.
+///
+/// It exists for the same reason the one above does: the envelope boundary has only the
+/// message to go on, and it has to be able to tell daemon loss from a live daemon refusing
+/// a call. The text it replaces opened `daemon <operation> failed:` and then handed the
+/// caller a bare transport URL, which named neither the daemon nor the cause.
+pub const DAEMON_STOPPED_MID_REQUEST: &str = "repo daemon stopped answering mid-request";
+
 /// Marker inside a revival error meaning the replacement daemon is alive and
 /// still loading, rather than dead.
 ///
@@ -635,7 +643,7 @@ fn daemon_gone_advice(record: Option<&kin_daemon_spawn::DaemonKillRecord>) -> St
 }
 
 /// The message for a daemon that stopped answering and could not be replaced.
-fn revival_failed_message(
+pub(crate) fn revival_failed_message(
     operation: &str,
     daemon_url: &str,
     first_err: &str,
@@ -650,7 +658,7 @@ fn revival_failed_message(
 }
 
 /// The message for a replacement daemon that started and still could not answer.
-fn revived_retry_failed_message(
+pub(crate) fn revived_retry_failed_message(
     operation: &str,
     new_url: &str,
     detail: &str,
@@ -664,13 +672,13 @@ fn revived_retry_failed_message(
 }
 
 /// The message for a connection that broke while it was carrying a request.
-fn transport_dropped_message(
+pub(crate) fn transport_dropped_message(
     operation: &str,
     error: &str,
     record: Option<&kin_daemon_spawn::DaemonKillRecord>,
 ) -> String {
     format!(
-        "daemon {operation} failed: {error}{}",
+        "{DAEMON_STOPPED_MID_REQUEST}: {operation}: {error}{}",
         recorded_kill_detail(record)
     )
 }
@@ -683,6 +691,19 @@ fn transport_dropped_message(
 /// over an ordinary tool error is wasted work.
 pub fn is_daemon_exited_error(message: &str) -> bool {
     message.starts_with(DAEMON_EXITED_RESTART_REQUIRED)
+}
+
+/// Did this delegate error mean the daemon stopped answering, by any of the routes?
+///
+/// [`is_daemon_exited_error`] answers a narrower question, the one a caller deciding
+/// whether to restart wants: the revival was attempted and is spent. The envelope wants
+/// the wider one, because `daemon_unreachable` absent reads to a client as a live daemon,
+/// and a connection that broke while it was carrying the request is not a live daemon. It
+/// is what a daemon killed mid-answer looks like from here, it is the first error a caller
+/// meets when the kernel takes the daemon out, and keying the flag on the narrow predicate
+/// sent exactly that shape out looking healthy.
+pub fn is_daemon_loss_error(message: &str) -> bool {
+    is_daemon_exited_error(message) || message.starts_with(DAEMON_STOPPED_MID_REQUEST)
 }
 
 /// Bearer token the daemon expects on non-public routes.
@@ -4551,8 +4572,8 @@ mod tests {
                 "error sending request for url (http://127.0.0.1:42231/mcp/tools/call)",
                 None,
             ),
-            "daemon MCP tool call failed: error sending request for url \
-             (http://127.0.0.1:42231/mcp/tools/call)"
+            "repo daemon stopped answering mid-request: MCP tool call: error sending \
+             request for url (http://127.0.0.1:42231/mcp/tools/call)"
         );
     }
 

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -1328,7 +1328,7 @@ fn envelope_for_delegate_error(
     error: &str,
     record: Option<&kin_daemon_spawn::DaemonKillRecord>,
 ) -> Envelope {
-    if daemon_delegate::is_daemon_exited_error(error) {
+    if daemon_delegate::is_daemon_loss_error(error) {
         Envelope::daemon_unreachable().with_recorded_daemon_kill(record)
     } else {
         Envelope::daemon()
@@ -3043,6 +3043,71 @@ mod tests {
             calls.lock().unwrap().is_empty(),
             "the binder must not run while the startup binding already bound"
         );
+    }
+
+    /// Every daemon-loss message the delegate mints must go out stamped unreachable.
+    ///
+    /// The endpoints were each guarded and the join between them was not. The delegate
+    /// mints three messages for a daemon that stopped answering; the classifier keyed on
+    /// one prefix; and the third, a connection that broke while it was carrying the
+    /// request, went out with an empty `degraded` object, which a client reads as a live
+    /// daemon. That shape is what an OOM kill mid-answer looks like from here and it is
+    /// the first error a caller meets.
+    ///
+    /// So the cases are BUILT from the delegate's own constructors rather than written out
+    /// again as strings. A fourth shape, or a reworded prefix, has to be handled here
+    /// rather than merely matched, which is the whole difference between this test and two
+    /// correct tests that jointly guard nothing.
+    #[test]
+    fn every_daemon_loss_message_the_delegate_mints_is_stamped_unreachable() {
+        let record = kin_daemon_spawn::DaemonKillRecord {
+            kills: 4,
+            memory_kills: 4,
+            first_unix: 4_320,
+            last_unix: 4_800,
+            last_pid: Some(41),
+            last_cause: kin_daemon_spawn::DaemonKillCause::MemoryLimit {
+                kernel_oom_kills: 1,
+            },
+            limit_bytes: Some(12 * 1024 * 1024 * 1024),
+            last_rss_bytes: None,
+        };
+        for record in [None, Some(&record)] {
+            let minted = [
+                daemon_delegate::revival_failed_message(
+                    "tool semantic_locate",
+                    "http://127.0.0.1:42231",
+                    "error sending request",
+                    "daemon exited during startup with status signal: 9 (SIGKILL)",
+                    record,
+                ),
+                daemon_delegate::revived_retry_failed_message(
+                    "tool semantic_locate",
+                    "http://127.0.0.1:42232",
+                    "timed out",
+                    record,
+                ),
+                daemon_delegate::transport_dropped_message(
+                    "MCP tool call",
+                    "error sending request for url (http://127.0.0.1:42231/mcp/tools/call)",
+                    record,
+                ),
+            ];
+            for message in minted {
+                assert_eq!(
+                    envelope_for_delegate_error(&message, record)
+                        .degraded
+                        .daemon_unreachable,
+                    Some(true),
+                    "a daemon-loss message went out reading as a live daemon: {message}"
+                );
+            }
+        }
+
+        // The control that has to stay silent. A live daemon refusing a call has not
+        // become unreachable, and a flag set on everything says nothing.
+        let ordinary = envelope_for_delegate_error("no entity named `HTTPAdapter.send`", None);
+        assert_eq!(ordinary.degraded.daemon_unreachable, None);
     }
 
     /// The dead-daemon error is the shape that never set a degraded flag, and a


### PR DESCRIPTION
Two defects a first-day developer hits, each fixed at its root, each with a scripted check that goes red under a named mutation.

## An in-place edit now lands a commit

kin agent brackets every local edit in a transaction and staged nothing into it for an `edit_file` call, so the daemon refused the empty commit by design and the run landed nothing. An agent asked to change an existing file did the edit on disk and left the graph untouched. The stage surface grew a path-keyed rewrite, verb `replace`, in this same wave under kin#1052, and the harness never reached for it. Its own comment still said no such shape existed.

`plan_stage` now plans a `replace` for an edit. The body is the file's complete new text, carried out of the tool that produced it on `LocalOutcome` rather than read back off disk. The text is already in hand there, a read would put a filesystem access on the runtime path that the zero-file-search guard rightly refuses, and between the write and the read the file could be something else. The system prompt no longer tells the model an edit is not admitted to the graph.

The check is the integration test that used to assert the opposite. It now asserts the exact call sequence the graph server sees, that the staged operation is a `replace` on the edited path, and that the staged body carries the line the edit did not touch. That last assertion is what stops the class coming back as a body built from the model's fragment, which would destroy the file at commit while satisfying everything else. The fake graph server learned the verb the way the daemon holds it: a `replace` naming a path authority does not track is refused, and a commit projects the working copy from the body.

## The daemon-loss shape an OOM kill actually produces is stamped

A repo daemon killed mid-answer reaches the MCP boundary as a connection that broke while it was carrying the request. The delegate mints three messages for a daemon that stopped answering, the envelope classifier keyed on one prefix, and that third shape went out with an empty `degraded` object, which a client reads as a live daemon. It is the first error a caller meets when the kernel takes the daemon out, and it was the one shape reading healthy. FIR-2498's own leading evidence is that message.

`is_daemon_loss_error` is the question the envelope wants: did the daemon stop answering, by any route. `is_daemon_exited_error` keeps the narrower meaning a caller deciding whether to restart needs. The message itself no longer opens with a bare transport string; it opens with `repo daemon stopped answering mid-request`, so the prefix names the daemon and the cause before the URL, and the recorded kill still closes it.

The check builds every daemon-loss message from the delegate's own constructors rather than writing the strings out a second time, so a fourth shape or a reworded prefix has to be handled rather than merely matched. Two tests that each hardcode the same string are two correct tests that jointly guard nothing, which is how this shipped. An ordinary tool error is the control that must stay unstamped.

## Falsification

Every mutation confirmed present by its marker before its arm ran, restored on an EXIT, INT and TERM trap, with the restored blob printed as a value.

| Mutation | Expected | Result |
|---|---|---|
| `plan_stage`'s Edit arm reverted to `Unstageable` | call-sequence assertion red | FAILED loop_integration.rs:465 |
| staged body truncated, dropping the untouched line | complete-new-text assertion red | FAILED loop_integration.rs:495 |
| classifier reverted to `is_daemon_exited_error` | join check red on the mid-request shape | FAILED server.rs:3098 |
| the mid-request message loses its named prefix | join check red, proving it mints rather than repeats | FAILED server.rs:3097 |

Baseline green before each, tree clean after, zero mutation markers left.

## What ran

`bin/kin-precheck kin --repo-dir kin=<lane worktree>` on `32b8500bb`: 16 gates enumerated from ci.yml's own check job, 16 passed, 0 failed. `cargo test -p kin-agent`: 35 lib, 13 integration, 1 ignored because it starts a real daemon. `cargo test -p kin-mcp`: 680 lib tests.

## Not claiming

Not that this makes a local model use Kin well. That is the open half of FIR-2586 and needs a real local-model run to answer; this closes the harness half, so an edit can land a commit at all.

Not that FIR-2498 is finished. Its first ask, answering from durable authority when the daemon is gone rather than only reporting the loss, has not landed: the MCP path still returns an error where `kin status` would answer from durable authority. This PR closes the second ask, the envelope, on the shape that was missing it, and part of the third by naming the cause in the message.

Part of FIR-2586.
Part of FIR-2498.
