### PR TITLE
Quote the embed memory floor only to a machine that is under it

### DIFF
--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -406,7 +406,7 @@ fn embed_resource_exhaustion(
     let cause = match (observed_kills, observed_ceiling_hits, under_recommendation) {
         (Some(count), _, _) => format!(
             "the daemon was lost during this embed pass and this container's kernel recorded \
-             {count} out-of-memory kill(s) while it ran, so the embed ran out of memory"
+             {count} out-of-memory kill(s) while it ran, so this container ran out of memory"
         ),
         // No byte figure in this sentence, deliberately. The ceiling count and
         // `limit_bytes` are resolved by two separate walks up the cgroup tree,
@@ -416,7 +416,8 @@ fn embed_resource_exhaustion(
         // worth aiming at is named in the guidance below.
         (None, Some(hits), _) => format!(
             "the daemon was lost during this embed pass and this container's memory charge was \
-             held at its ceiling {hits} time(s) while it ran, so it most likely ran out of memory"
+             held at its ceiling {hits} time(s) while it ran, so this container most likely ran \
+             out of memory"
         ),
         (None, None, true) => format!(
             "the daemon was lost during this embed pass and only {} of memory is available to \
@@ -425,15 +426,37 @@ fn embed_resource_exhaustion(
         ),
         (None, None, false) => return None,
     };
+    // The floor is advice only for a machine that is under it. Quoting it
+    // unconditionally is what FIR-2493 caught: a 12 GiB container that had
+    // recorded 27 kills was told to "give this machine at least 2.0 GiB", six
+    // times what it already had, and a setup session spent a whole debugging
+    // pass on batch sizes and resource profiles on the strength of it. A
+    // machine already above the floor did not die for want of the model's
+    // working set, so it is pointed at the other heavy resident instead of at
+    // a number it already clears.
+    let guidance = if under_recommendation {
+        format!(
+            "`kin embed` loads the {EMBED_MODEL_DOWNLOAD} {EMBED_MODEL_ID} model and a real \
+             repository peaks well above that, so give this machine at least {}.",
+            human_bytes(RECOMMENDED_EMBED_MEMORY_BYTES),
+        )
+    } else {
+        format!(
+            "This machine already clears the {} the {EMBED_MODEL_DOWNLOAD} {EMBED_MODEL_ID} \
+             model needs, so more memory is not the first thing to reach for. The other heavy \
+             resident in this daemon is the language-server enrichment sweep, measured taking a \
+             daemon from 15 MB to 11.5 GB on a store of about one gigabyte. Set \
+             `KIN_DAEMON_DISABLE_LSP=1` and re-run to take it out of the picture.",
+            human_bytes(RECOMMENDED_EMBED_MEMORY_BYTES),
+        )
+    };
     Some(format!(
         "{cause}.\n\
-         `kin embed` loads the {EMBED_MODEL_DOWNLOAD} {EMBED_MODEL_ID} model and a real \
-         repository peaks well above that, so give this machine at least {}.\n\
-         Coverage already embedded is persisted, so re-running `kin embed` under a higher limit \
-         resumes rather than starting over.\n\
+         {guidance}\n\
+         Coverage already embedded is persisted, so re-running `kin embed` resumes rather than \
+         starting over.\n\
          Lexical and graph retrieval need no model: `kin locate` and `kin search` keep answering \
-         without vectors.",
-        human_bytes(RECOMMENDED_EMBED_MEMORY_BYTES),
+         without vectors."
     ))
 }
 
@@ -1344,7 +1367,8 @@ mod tests {
             "the count reported must be the pass's one, not the container's four: {guidance}"
         );
         assert!(
-            guidance.contains("so the embed ran out of memory"),
+            guidance.contains("so this container ran out of memory")
+                && !guidance.contains("most likely"),
             "a kill during the pass is reported as observed, not hedged: {guidance}"
         );
     }
@@ -1407,6 +1431,47 @@ mod tests {
             embed_resource_exhaustion(OOM_KILLED_MID_PASS, &untouched),
             None,
             "6344 ceiling hits that all predate the pass say nothing about the pass"
+        );
+    }
+
+    /// FIR-2493: a machine already above the model's floor is not told to reach
+    /// it, and a container-wide kill counter does not name the embed.
+    ///
+    /// The stranger's container had 12 GiB and 27 recorded kills and was told
+    /// to "give this machine at least 2.0 GiB". The advice was off by six
+    /// times, and it named the embedder on evidence that names no process at
+    /// all: the same run measured 23 of those 27 kills landing while the
+    /// language-server sweep ran, and none in the eleven minutes after it was
+    /// disabled.
+    ///
+    /// Two arms, because below the floor the floor is still the right advice. A
+    /// fix that simply deleted the sentence would pass the first arm alone.
+    #[test]
+    fn a_machine_above_the_model_floor_is_not_told_to_reach_it() {
+        let roomy = embed_resource_exhaustion(OOM_KILLED_MID_PASS, &evidence(12 << 30, Some(27)))
+            .expect("a kill during the pass is a memory diagnosis");
+        assert!(
+            !roomy.contains("give this machine at least"),
+            "a 12 GiB machine must not be told to reach 2.0 GiB: {roomy}"
+        );
+        assert!(
+            roomy.contains("KIN_DAEMON_DISABLE_LSP=1"),
+            "a machine above the floor is pointed at the other heavy resident: {roomy}"
+        );
+        assert!(
+            !roomy.contains("so the embed ran out of memory"),
+            "a container-wide kill counter does not say the embed was the consumer: {roomy}"
+        );
+
+        let cramped = embed_resource_exhaustion(OOM_KILLED_MID_PASS, &evidence(512 << 20, Some(1)))
+            .expect("a kill under the floor is a memory diagnosis too");
+        assert!(
+            cramped.contains("give this machine at least 2.0 GiB"),
+            "below the floor the floor is exactly the right advice: {cramped}"
+        );
+        assert!(
+            !cramped.contains("KIN_DAEMON_DISABLE_LSP=1"),
+            "a machine that cannot hold the model at all is not a sweep problem: {cramped}"
         );
     }
 

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -1444,35 +1444,58 @@ mod tests {
     /// language-server sweep ran, and none in the eleven minutes after it was
     /// disabled.
     ///
-    /// Two arms, because below the floor the floor is still the right advice. A
-    /// fix that simply deleted the sentence would pass the first arm alone.
+    /// Five checks, and every one reports independently rather than aborting
+    /// the test at the first that fires. An `assert!` chain hides every later
+    /// arm behind the first failure, so a falsification grid built on one reads
+    /// whole rows as green that were never reached. Collecting the failures is
+    /// what makes each arm's status its own fact.
+    ///
+    /// The cramped arms are the control: below the floor the floor is still
+    /// exactly the right advice, so a fix that simply deleted the sentence
+    /// fails here rather than passing everything.
     #[test]
     fn a_machine_above_the_model_floor_is_not_told_to_reach_it() {
         let roomy = embed_resource_exhaustion(OOM_KILLED_MID_PASS, &evidence(12 << 30, Some(27)))
             .expect("a kill during the pass is a memory diagnosis");
-        assert!(
-            !roomy.contains("give this machine at least"),
-            "a 12 GiB machine must not be told to reach 2.0 GiB: {roomy}"
-        );
-        assert!(
-            roomy.contains("KIN_DAEMON_DISABLE_LSP=1"),
-            "a machine above the floor is pointed at the other heavy resident: {roomy}"
-        );
-        assert!(
-            !roomy.contains("so the embed ran out of memory"),
-            "a container-wide kill counter does not say the embed was the consumer: {roomy}"
-        );
-
         let cramped = embed_resource_exhaustion(OOM_KILLED_MID_PASS, &evidence(512 << 20, Some(1)))
             .expect("a kill under the floor is a memory diagnosis too");
-        assert!(
+
+        let mut failed: Vec<String> = Vec::new();
+        let mut check = |ok: bool, arm: &str, why: String| {
+            if !ok {
+                failed.push(format!("[{arm}] {why}"));
+            }
+        };
+
+        check(
+            !roomy.contains("give this machine at least"),
+            "roomy-no-floor",
+            format!("a 12 GiB machine must not be told to reach 2.0 GiB: {roomy}"),
+        );
+        check(
+            roomy.contains("KIN_DAEMON_DISABLE_LSP=1"),
+            "roomy-names-sweep",
+            format!("a machine above the floor is pointed at the other heavy resident: {roomy}"),
+        );
+        check(
+            !roomy.contains("so the embed ran out of memory"),
+            "cause-not-the-embed",
+            format!("a container-wide kill counter does not name the embed: {roomy}"),
+        );
+        check(
             cramped.contains("give this machine at least 2.0 GiB"),
-            "below the floor the floor is exactly the right advice: {cramped}"
+            "cramped-keeps-floor",
+            format!("below the floor the floor is exactly the right advice: {cramped}"),
         );
-        assert!(
+        check(
             !cramped.contains("KIN_DAEMON_DISABLE_LSP=1"),
-            "a machine that cannot hold the model at all is not a sweep problem: {cramped}"
+            "cramped-not-a-sweep-problem",
+            format!(
+                "a machine that cannot hold the model at all is not a sweep problem: {cramped}"
+            ),
         );
+
+        assert!(failed.is_empty(), "{}", failed.join("\n"));
     }
 
     #[test]


### PR DESCRIPTION
A container with 12 GiB and 27 recorded out-of-memory kills was told to give the
machine at least 2.0 GiB, six times what it already had, and the cause sentence
read a container-wide kill counter as proof the embed was the consumer. Both
halves were wrong, and a stranger's setup session spent a full debugging pass on
batch sizes and resource profiles on the strength of them.

The mechanism is small and exact. The guidance line was appended to all three
cause arms, while it is only true in the arm where the ceiling is below the
model's floor. So a machine already above the floor was handed a number it had
long cleared, phrased as the fix.

The floor now prints only when the ceiling is under it. Above the floor the
diagnosis says the machine already clears it, points at the language-server
enrichment sweep as the other heavy resident, and names KIN_DAEMON_DISABLE_LSP=1,
the lever that is already a supported doctor check and status remediation. The
same run that recorded the 27 kills measured 23 of them landing while that sweep
ran and none in the eleven minutes after it was disabled. The cause sentence now
says this container ran out of memory rather than that the embed did, because a
cgroup counter names no process. The resume line drops "under a higher limit",
which was the same raise-the-ceiling nudge in a third place.

The second commit is about the test rather than the product. An assert chain
stops at the first arm that fires, so the arms behind it are never reached and a
falsification grid reads their rows as green. Running the grid showed exactly
that, three rows green under every mutation, two of them only because an earlier
assert had already aborted the test. The checks now collect failures and assert
once, so each arm's status is its own fact.

Falsification, three mutations, each marker-asserted before the build and
restored on an EXIT, INT and TERM trap, tree verified clean after every arm:

| arm | M1 always-floor | M2 never-floor | M3 blame-embed |
|---|---|---|---|
| roomy-no-floor | RED | ok | ok |
| roomy-names-sweep | RED | ok | ok |
| cause-not-the-embed | ok | ok | RED |
| cramped-keeps-floor | ok | RED | ok |
| cramped-not-a-sweep-problem | ok | RED | ok |
| A3-observed-not-hedged | ok | ok | RED |

Every arm dies to at least one mutation and no row is green all the way across.
The cramped arms are the control: below the floor the floor is still exactly the
right advice, so a fix that simply deleted the sentence fails here.

Ran: bin/kin-precheck kin through the lane worktree, 16 gates enumerated from
ci.yml, 16 passed, 0 failed, on cb8e5e44e. cargo test -p kin-cli --lib, 1810
passed, 0 failed. The falsification matrix above on that same committed tree.

bin/kin-parity was waived for this diff by the captain, and the reasoning is the
waiver: this is a CLI diagnostic string builder on the embed failure path, so it
cannot move daemon runtime behaviour, and the hosted acceptance gate runs the
release's own suites against this build regardless. The daemon lock was held by
another lane's live heap measurement at the time, so taking the queue for it
would have cost several lanes time to prove nothing.

Part of FIR-2493. This closes its ask 3, the diagnostic. Asks 1, 2 and 4 landed
earlier in kin#1015, kin#989, kin#1050 and the doctor and status surfaces; this
lane verified they are present on main but did not re-measure the sweep's memory
profile on a live store, so it does not claim the ticket closed.
