### PR TITLE
Report a daemon that can no longer sample itself live

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -795,6 +795,16 @@ pub struct HealthResponse {
     /// admits nothing. These are the outcomes.
     #[serde(default)]
     pub reconcile: kin_cli::commands::resources::ReconcileHealth,
+    /// Consecutive `kin_graph_status` calls that could not sample this daemon
+    /// live, reset by the first that does. Past
+    /// [`GRAPH_STATUS_UNANSWERABLE_STREAK`] it drives `status: "attention"`.
+    ///
+    /// FIR-2136: a daemon can stop being able to answer a live question about
+    /// itself while every other term here stays healthy, and the surface that
+    /// exists to report ill health was the one that could not see it. Additive
+    /// and defaulted, so a client on either side of this change still parses.
+    #[serde(default)]
+    pub status_live_sample_failures: u64,
     pub build: BuildResponse,
 }
 
@@ -1024,6 +1034,21 @@ pub struct RepoHealthResponse {
     /// refresh then failed; absent means they match.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub derived_views_stale: Option<String>,
+    /// Consecutive status calls that could not sample this repo's graph live.
+    /// FIR-2136; the same tally `/health` grades, carried here because this is
+    /// the repo-scoped surface the ticket names.
+    #[serde(default)]
+    pub status_live_sample_failures: u64,
+    /// Whether this daemon can still answer a live question about itself.
+    /// False is the wedged reading, and it is the one a supervisor acts on.
+    #[serde(default = "default_true")]
+    pub status_answerable: bool,
+}
+
+/// Serde default for a boolean whose healthy value is `true`, so a payload from
+/// a daemon that predates the field does not read as the unhealthy case.
+fn default_true() -> bool {
+    true
 }
 
 /// Repo entities search response.
@@ -2049,6 +2074,28 @@ const GRAPH_STATUS_WRITER_SETTLE_FLOOR: Duration = Duration::from_millis(50);
 /// so a backoff there would buy the writer no time and cost the caller 100 ms.
 const GRAPH_STATUS_ATTEMPT_BACKOFF: Duration = Duration::from_millis(25);
 
+/// How many consecutive status calls must fail to sample live before this
+/// daemon reports itself unable to answer a live question about itself.
+///
+/// FIR-2136. A judgement rather than a measurement, so it is written here where
+/// a reader can find and argue with it, the way the derived memory budget's
+/// ceiling is.
+///
+/// One failed CALL already means three revalidations were lost inside it,
+/// across 75 ms of backoff, so five consecutive means fifteen lost across five
+/// separate asks. A store mid-embed can lose a few: the embedding fence is held
+/// for the length of a batch and a caller polling through one legitimately gets
+/// replays. A store that has lost fifteen in a row is not merely busy. The
+/// wedge this exists to catch failed eleven consecutive calls over hours.
+///
+/// Duration was considered as the second axis and deliberately left out. It
+/// would separate a long embed from a wedge more sharply, but the streak is
+/// already driven by how often a caller asks rather than by a poll, since
+/// `kin_graph_status` is a user and agent tool and `/health` is what supervisors
+/// poll. Adding a clock here would buy specificity this signal does not need
+/// and cost every test a time source.
+pub(crate) const GRAPH_STATUS_UNANSWERABLE_STREAK: u64 = 5;
+
 /// The last settled `kin_graph_status` observation of one selected graph.
 ///
 /// The graph is held as a [`std::sync::Weak`] for two reasons: a temporal
@@ -2236,12 +2283,32 @@ async fn mcp_graph_status_with_stable_authority(
         state
             .graph_status_settled
             .record(scope, selected_graph, observation);
+        // Same event as the record above, deliberately at the same site: a
+        // reading that survived revalidation IS this daemon answering a live
+        // question about itself, so the streak clears exactly when that is true
+        // and never on a replay that merely looked like an answer.
+        state.graph_status_live_sample_settled();
         return kin_mcp::handlers::entities::handle_daemon_graph_status_observation(
             scope,
             observation,
         );
     }
 
+    // Reaching here is the failure, whichever of the two answers follows. Both
+    // the no-settled-reading error below and the stale replay after it are a
+    // call that could not sample this daemon live, so the streak advances once
+    // here rather than twice in two arms that could drift apart.
+    let streak = state.graph_status_live_sample_abandoned();
+    if streak == GRAPH_STATUS_UNANSWERABLE_STREAK {
+        // Once, on the crossing, rather than on every call past it. A daemon in
+        // this state is asked repeatedly and a line per call would bury the
+        // transition that matters.
+        tracing::warn!(
+            streak,
+            "this daemon has not completed a live status sample in {streak} consecutive \
+             calls; its repo health surface reports attention until one succeeds"
+        );
+    }
     let attempts = u32::try_from(GRAPH_STATUS_STABLE_READ_ATTEMPTS).unwrap_or(u32::MAX);
     let observed_authority_epoch = state.stable_graph_authority_epoch();
     let Some((observation, age)) = state.graph_status_settled.get(scope, selected_graph) else {
@@ -3098,6 +3165,16 @@ async fn health(
     let background_pass_stopped = state.background_work.any_stopped();
     let reconcile = state.background_work.reconcile_report(sampled_at);
     let reconcile_degraded = reconcile.degraded();
+    // FIR-2136. The term that was missing entirely: whether this daemon can
+    // still answer a live question about itself. Every other term here reports
+    // some subsystem's outcome, and a daemon can be healthy by all of them
+    // while the tool that exists to report ill health has stopped answering.
+    // The wedge that produced this failed eleven consecutive status calls over
+    // hours and reported `ok` throughout.
+    let status_live_sample_failures = state
+        .graph_status_live_sample_failures
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let status_unanswerable = !state.graph_status_is_answerable();
     // Surface graph-safety + derived-index health in the top-level status so an
     // operator or client polling /health sees a non-"ok" signal when the daemon
     // is withholding a suspected mass-deletion wipe OR the embedding worker has
@@ -3128,6 +3205,7 @@ async fn health(
         || coordination_event_persist_failures > 0
         || background_pass_stopped
         || reconcile_degraded
+        || status_unanswerable
     {
         "attention"
     } else {
@@ -3178,6 +3256,7 @@ async fn health(
         daemon_cpu_seconds: state.background_work.daemon_cpu_seconds(),
         background_passes,
         reconcile,
+        status_live_sample_failures,
         build: current_build_response(),
     }))
 }
@@ -10815,6 +10894,10 @@ async fn repo_health(
         embed_persistence_unavailable: !state.can_persist_embed_progress_locally(),
         filesystem_reconcile_disabled: state.filesystem_reconcile_disabled(),
         derived_views_stale: state.derived_views_stale.read().await.clone(),
+        status_live_sample_failures: state
+            .graph_status_live_sample_failures
+            .load(std::sync::atomic::Ordering::Relaxed),
+        status_answerable: state.graph_status_is_answerable(),
     }))
 }
 
@@ -25701,6 +25784,115 @@ mod tests {
         )
         .await
         .unwrap()
+    }
+
+    /// FIR-2136: a daemon that can no longer answer a live question about
+    /// itself says so on the surface supervisors poll.
+    ///
+    /// The wedge that produced this ticket failed every status call for hours
+    /// while `/health` reported `ok` throughout, because health graded eight
+    /// subsystem outcomes and none of them was "can I still answer". The cure
+    /// was a restart nobody knew to perform.
+    ///
+    /// Three arms, and the first is the one that decides the SHAPE of the
+    /// signal rather than merely testing it. A daemon nobody has queried holds
+    /// no settled reading, exactly like a wedged one, so an age-of-last-settled
+    /// probe cannot tell them apart and would report every idle daemon as sick.
+    /// A lifetime failure total cannot tell a store that recovered from one
+    /// that never did. Only a consecutive count reset on success separates all
+    /// three, which is why the counter has that shape and why arm one is not
+    /// decoration.
+    ///
+    /// Every arm reports independently rather than aborting at the first, so a
+    /// falsification grid cannot read a row as green that was never reached.
+    #[tokio::test]
+    async fn a_daemon_that_cannot_sample_itself_live_reports_attention() {
+        let state = test_state();
+        let graph = Arc::clone(&state.graph);
+        state
+            .graph
+            .upsert_entity(&test_entity("handler", "src/lib.py"))
+            .unwrap();
+
+        let mut failed: Vec<String> = Vec::new();
+        let mut check = |ok: bool, arm: &str, why: String| {
+            if !ok {
+                failed.push(format!("[{arm}] {why}"));
+            }
+        };
+
+        // Arm 1. Nobody has asked. Healthy, and it must stay healthy.
+        let quiet = health_json(Arc::clone(&state)).await;
+        check(
+            quiet.status == "ok",
+            "nobody-asked-is-ok",
+            format!(
+                "a daemon nobody has queried is not wedged: {}",
+                quiet.status
+            ),
+        );
+        check(
+            quiet.status_live_sample_failures == 0,
+            "nobody-asked-counts-zero",
+            format!(
+                "no call, no failures: {}",
+                quiet.status_live_sample_failures
+            ),
+        );
+
+        // Arm 2. Asked, and every call loses its live sample. Holding the
+        // embedding fence is what a real embed pass does to this path.
+        {
+            let _wedge = state
+                .embedding_work
+                .lock()
+                .expect("the fixture takes the embedding fence");
+            for _ in 0..GRAPH_STATUS_UNANSWERABLE_STREAK {
+                let _ = head_graph_status(&state, &graph).await;
+            }
+            let wedged = health_json(Arc::clone(&state)).await;
+            check(
+                wedged.status == "attention",
+                "wedged-is-attention",
+                format!(
+                    "{GRAPH_STATUS_UNANSWERABLE_STREAK} consecutive failed live samples must \
+                     reach the surface: status={} failures={}",
+                    wedged.status, wedged.status_live_sample_failures
+                ),
+            );
+            check(
+                wedged.status_live_sample_failures >= GRAPH_STATUS_UNANSWERABLE_STREAK,
+                "wedged-counts-the-streak",
+                format!(
+                    "the streak is what the verdict rests on: {}",
+                    wedged.status_live_sample_failures
+                ),
+            );
+        }
+
+        // Arm 3. The fence is released and one call samples live again. The
+        // reset lives at the record site, so recovery is the same event as the
+        // reading that proves it.
+        let _ = head_graph_status(&state, &graph).await;
+        let recovered = health_json(Arc::clone(&state)).await;
+        check(
+            recovered.status == "ok",
+            "recovery-clears-attention",
+            format!(
+                "one successful live sample ends the condition: {}",
+                recovered.status
+            ),
+        );
+        check(
+            recovered.status_live_sample_failures == 0,
+            "recovery-clears-the-streak",
+            format!(
+                "a streak that survived its own recovery would wedge forever: {}",
+                recovered.status_live_sample_failures
+            ),
+        );
+
+        assert!(failed.is_empty(), "{}", failed.join("\n"));
     }
 
     fn parse_graph_status(

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1329,6 +1329,22 @@ pub struct DaemonState {
     /// each; it costs no lock the embed path needs and no work proportional to
     /// the graph, which is the constraint FIR-2416 put on this surface.
     pub(crate) graph_status_settled: crate::api::GraphStatusSettledCache,
+    /// Consecutive `kin_graph_status` calls that could not complete a live
+    /// sample of the selected graph, reset by the first one that does.
+    ///
+    /// FIR-2136. A daemon can enter a state where the tool that exists to
+    /// report ill health is the one that stops answering, and before this the
+    /// health surface could not see it: a daemon serving nothing but stale
+    /// replays for hours reported `status: "ok"`.
+    ///
+    /// Consecutive, rather than a lifetime total or the age of the last settled
+    /// reading, because only a consecutive count reset on success separates the
+    /// three states that matter. A daemon nobody has asked reads zero, which is
+    /// the same as a daemon whose samples all succeed, and both are healthy. A
+    /// lifetime total cannot tell a store that recovered from one that never
+    /// did, and an age-of-last-settled cannot tell a wedged daemon from one no
+    /// caller has ever queried, since neither holds a settled reading.
+    pub graph_status_live_sample_failures: AtomicU64,
     /// Serializes derived-index and hosted snapshot persistence so the
     /// persistence loop, idle-shutdown flush, and embedding worker can never
     /// interleave writes. Local repository-v6 authority is committed before
@@ -1793,6 +1809,33 @@ impl DaemonState {
             .saturating_add(1);
         self.coordination_events.persist_failure_count(count);
         warn!(reason = %reason, "coordination evidence is incomplete; stream is not claim-eligible");
+    }
+
+    /// Record that a status call completed a live sample, clearing any streak.
+    ///
+    /// Called at the one site that records a settled reading, so the reset and
+    /// the success are the same event and cannot drift apart.
+    pub(crate) fn graph_status_live_sample_settled(&self) {
+        self.graph_status_live_sample_failures
+            .store(0, Ordering::Relaxed);
+    }
+
+    /// Record that a status call gave up on a live sample, and return the
+    /// streak length including this one.
+    pub(crate) fn graph_status_live_sample_abandoned(&self) -> u64 {
+        self.graph_status_live_sample_failures
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1)
+    }
+
+    /// Whether this daemon can still answer a live question about itself.
+    ///
+    /// False once the streak crosses the bound, which is what puts the repo
+    /// health surface into `attention` while the condition lasts.
+    pub fn graph_status_is_answerable(&self) -> bool {
+        self.graph_status_live_sample_failures
+            .load(Ordering::Relaxed)
+            < crate::api::GRAPH_STATUS_UNANSWERABLE_STREAK
     }
 
     /// Load a persisted vector-index sidecar into a graph that was NOT built
@@ -2595,6 +2638,7 @@ impl DaemonState {
             embedding_work: Mutex::new(()),
             embed_batch_size: AtomicUsize::new(0),
             graph_status_settled: crate::api::GraphStatusSettledCache::default(),
+            graph_status_live_sample_failures: AtomicU64::new(0),
             persist_lock: Mutex::new(()),
             #[cfg(feature = "embeddings")]
             vector_checkpoint_authority_match: VectorCheckpointAuthorityMatch::default(),
@@ -2848,6 +2892,7 @@ impl DaemonState {
             embedding_work: Mutex::new(()),
             embed_batch_size: AtomicUsize::new(0),
             graph_status_settled: crate::api::GraphStatusSettledCache::default(),
+            graph_status_live_sample_failures: AtomicU64::new(0),
             persist_lock: Mutex::new(()),
             #[cfg(feature = "embeddings")]
             vector_checkpoint_authority_match: VectorCheckpointAuthorityMatch::default(),


### PR DESCRIPTION
A daemon can stop being able to answer a live question about itself while every
other health term stays healthy, and the surface that exists to report ill health
is then the one that cannot see it. The wedge behind FIR-2136 failed every status
call for hours while /health reported ok throughout, and the only cure was a
restart nobody knew to perform.

Health grades a ninth term now: consecutive status calls that could not sample the
selected graph live, reset by the first one that does. Past the bound it drives
attention. The bound is a judgement rather than a measurement, so it is written
where a reader can find and argue with it, next to the constant.

Consecutive is the only shape that separates silence from a wedge. Three states
have to stay distinguishable and only this shape gets all three right. A daemon
nobody has queried holds no settled reading, exactly like a wedged one, so an
age-of-last-settled probe cannot tell them apart and would report every idle
daemon as sick. A lifetime failure total cannot tell a store that recovered from
one that never did. A consecutive count reset on success separates all three, and
the arm that pins the quiet case is therefore load-bearing rather than decoration.

The status path has exactly two exits, which is what makes this small. The counter
resets at the single site that records a settled reading, so recovery and the
reading that proves it are the same event and cannot drift apart. It increments
once after the attempt loop, covering both failure answers, the no-settled-reading
error and the stale replay, rather than in two arms that could diverge.

Both health fields are additive and defaulted, so a client parses on either side
of this change. The repo-scoped surface the ticket names carries the same tally
plus a boolean, whose serde default is the healthy value so a payload from an
older daemon does not read as the unhealthy case.

Falsification, five mutations, each marker-asserted before the build and restored
on an EXIT, INT and TERM trap, tree verified clean after every arm:

| arm | N1 no-term | N2 no-reset | N3 streak-0 | N4 no-increment | N5 init-nonzero |
|---|---|---|---|---|---|
| nobody-asked-is-ok | ok | ok | RED | ok | ok |
| nobody-asked-counts-zero | ok | ok | ok | ok | RED |
| wedged-is-attention | RED | ok | ok | RED | ok |
| wedged-counts-the-streak | ok | ok | ok | RED | ok |
| recovery-clears-attention | ok | RED | RED | ok | ok |
| recovery-clears-the-streak | ok | RED | ok | ok | ok |

Every arm dies to at least one mutation and no row is green all the way across.
N3 is the one worth reading: setting the bound to zero makes an unqueried daemon
report wedged, which is precisely the failure an age-based probe would ship, and
the quiet arm is what catches it.

The six checks report independently rather than aborting at the first, because an
assert chain leaves later arms unevaluated and a grid then prints their rows green
for a run that never reached them.

Ran: bin/kin-precheck kin through the lane worktree, 16 gates enumerated from
ci.yml, 16 passed, 0 failed, on 827a729c1. cargo test -p kin-daemon --lib, 1062
passed, 0 failed. The matrix above on that same committed tree.

Part of FIR-2136. This closes its status-answerable probe; reconcile-backlog age
landed earlier in kin#722.

The third probe, a bounded self-query latency check, is deliberately not here and
is tracked as FIR-2760 rather than dropped. An absolute millisecond bound
false-positives on a large store and on a merely loaded box, so it needs a
baseline design rather than a constant, and a health term that cries wolf is
worse than the gap it fills: it trains an operator to ignore the surface that
exists to tell them something is wrong, which is the very failure FIR-2136 was
filed about. FIR-2760 carries the design, including the hole that makes it
non-trivial, a daemon already wedged when it takes its first reading sets its own
high baseline and the ratio never trips, which is why that design needs an
absolute ceiling underneath the ratio and a wedged-from-boot falsification arm.

Note for reviewers on the ticket text: FIR-2136's stated repro no longer
reproduces, because FIR-2131 was fixed by kin#710, and its stated symptom was
replaced by FIR-2135's stale-reading replay. The defect it describes survives both
in the form this PR fixes, which is why the fixture injects the wedge by holding
the embedding fence rather than following the ticket's repro.
