### PR TITLE
Make the cargo cache key a function of this repository, not of the runner image

### DIFF
--- a/.github/actions/rust-toolchain/action.yml
+++ b/.github/actions/rust-toolchain/action.yml
@@ -25,6 +25,11 @@ outputs:
   toolchain:
     description: The resolved toolchain name, suitable for `cargo +<name>`.
     value: ${{ steps.resolve.outputs.toolchain }}
+  repo_pin:
+    description: >
+      The channel in rust-toolchain.toml, which may differ from the resolved toolchain when
+      a caller passes one of its own. Kept installed alongside it.
+    value: ${{ steps.resolve.outputs.repo_pin }}
 
 runs:
   using: composite
@@ -40,16 +45,18 @@ runs:
       run: |
         set -euo pipefail
         toolchain="$INPUT_TOOLCHAIN"
+        # Resolved unconditionally, because the prune step needs the repository's own channel
+        # whether or not the caller passed a toolchain of its own.
+        pin="$GITHUB_ACTION_PATH/../../../rust-toolchain.toml"
+        if [ ! -f "$pin" ]; then
+          pin="$GITHUB_WORKSPACE/rust-toolchain.toml"
+        fi
         if [ -z "$toolchain" ]; then
-          # This action lives at <repo>/.github/actions/rust-toolchain, so the
-          # repository root is three levels above it. Deriving the root from the
-          # action's own location keeps this correct when a job checks the
-          # repository out under a `path:` instead of at the workspace root,
-          # where $GITHUB_WORKSPACE would point at the wrong tree.
-          pin="$GITHUB_ACTION_PATH/../../../rust-toolchain.toml"
-          if [ ! -f "$pin" ]; then
-            pin="$GITHUB_WORKSPACE/rust-toolchain.toml"
-          fi
+          # `pin` is resolved above. This action lives at
+          # <repo>/.github/actions/rust-toolchain, so the repository root is three levels
+          # above it. Deriving the root from the action's own location keeps this correct
+          # when a job checks the repository out under a `path:` instead of at the workspace
+          # root, where $GITHUB_WORKSPACE would point at the wrong tree.
           if [ -f "$pin" ]; then
             toolchain=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p;' "$pin" | sed -n '1p')
           fi
@@ -62,6 +69,16 @@ runs:
         fi
         echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
         echo "resolved toolchain: $toolchain"
+        # Published separately from the resolved toolchain because the two differ whenever a
+        # caller passes `toolchain:` explicitly, and the prune below keeps both: fuzz.yml
+        # installs a pinned nightly and still runs a bare `cargo install`, which
+        # rust-toolchain.toml resolves to this channel.
+        repo_pin=""
+        if [ -f "$pin" ]; then
+          repo_pin=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p;' "$pin" | sed -n '1p')
+        fi
+        echo "repo_pin=$repo_pin" >> "$GITHUB_OUTPUT"
+        echo "rust-toolchain.toml channel: ${repo_pin:-<none>}"
 
     - name: Pin CARGO_HOME for later steps
       shell: bash
@@ -104,6 +121,17 @@ runs:
           echo "${CARGO_HOME:-$USERPROFILE\\.cargo}\\bin" >> "$GITHUB_PATH"
         fi
 
+    # Captured BEFORE the install, because afterwards nothing can tell a toolchain the
+    # image shipped from the one this action just added, and the difference is the whole
+    # input the cache key was varying on.
+    - name: Record the toolchains the runner image shipped
+      shell: bash
+      run: |
+        set -euo pipefail
+        rustup toolchain list > "$RUNNER_TEMP/kin-preinstalled-toolchains.txt" || true
+        echo "image toolchains:"
+        cat "$RUNNER_TEMP/kin-preinstalled-toolchains.txt"
+
     # The flag lists are built as strings and expanded unquoted on purpose:
     # that is the word split that turns "clippy, rustfmt" into two --component
     # flags. An empty string expands to no argument at all, which is why this
@@ -138,6 +166,21 @@ runs:
       env:
         TOOLCHAIN: ${{ steps.resolve.outputs.toolchain }}
       run: rustup default "$TOOLCHAIN"
+
+    # `Swatinem/rust-cache` hashes every entry of `rustup toolchain list` into half its key,
+    # so a runner image's own preinstalled toolchain decided whether two jobs could share a
+    # cache. Removing what the image shipped makes that list a function of this repository's
+    # files. The mechanism, the measurement and why the obvious flag is the wrong fix are in
+    # prune-image-toolchains.sh.
+    - name: Prune toolchains this repository never named
+      shell: bash
+      env:
+        TOOLCHAIN: ${{ steps.resolve.outputs.toolchain }}
+        REPO_PIN: ${{ steps.resolve.outputs.repo_pin }}
+      run: |
+        set -euo pipefail
+        bash "$GITHUB_ACTION_PATH/prune-image-toolchains.sh" \
+          "$TOOLCHAIN" "$RUNNER_TEMP/kin-preinstalled-toolchains.txt" "$REPO_PIN"
 
     - name: Set the Cargo defaults CI expects
       shell: bash

--- a/.github/actions/rust-toolchain/prune-image-toolchains.sh
+++ b/.github/actions/rust-toolchain/prune-image-toolchains.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Remove the toolchains the runner image shipped, keeping only the ones this repository
+# names, so the set of installed toolchains is a function of files we control.
+#
+# Why this exists. `Swatinem/rust-cache` builds half its key from `getRustVersions`, which
+# hashes EVERY entry of `rustup toolchain list`, not the one the repository pins. Two
+# ubuntu-latest jobs sixty-five seconds apart in run 32961965498 drew images carrying
+# 1.97.1 and 1.98.0, hashed to 8374e8ea and 6ea01539 against the same Cargo.lock, and could
+# not restore each other's cache. Nothing in this repository chose either version, and a
+# restore key cannot fall back past that segment because it is a prefix of it. macOS was
+# immune only because its image happened to carry one toolchain.
+#
+# The fix is not to drop the segment. `add-rust-environment-hash-key: false` gates BOTH
+# halves of the key in that action's source, so turning it off left `Lockfiles considered`
+# empty and the key frozen at its bare prefix, which is a worse defect than the one being
+# fixed. That was measured on run 32976932775 and is why kin#1158 is a draft.
+#
+# So the unstable INPUT is removed instead. After this runs, every installed toolchain is
+# one this repository named: the one the action was asked to install, and the channel in
+# rust-toolchain.toml. Both come from files in the tree, so the hash comes from the tree.
+#
+# Usage: prune-image-toolchains.sh <resolved-toolchain> <preinstalled-list-file> [repo-pin]
+#
+# The preinstalled list must be captured BEFORE the install, because afterwards nothing can
+# tell an image's toolchain from the one we just added. The repo pin is kept as well as the
+# resolved toolchain because a job may install one and still shell out to the other:
+# fuzz.yml installs a pinned nightly and then runs a bare `cargo install`, which
+# rust-toolchain.toml resolves to the stable pin. Pruning that would trade a cache-key bug
+# for a toolchain download on every fuzz run.
+set -euo pipefail
+
+resolved="${1:?resolved toolchain required}"
+before_file="${2:?preinstalled list file required}"
+repo_pin="${3:-}"
+
+# A `rustup toolchain list` line is a name, optionally followed by ` (default)` or
+# ` (override)`. Take the name and nothing else.
+toolchain_names() { # <file> -> one bare name per line
+  sed -e 's/[[:space:]]*(.*)$//' -e 's/[[:space:]]*$//' "$1" | grep -v '^$' || true
+}
+
+# A channel matches an installed name when the name IS the channel or is the channel plus a
+# host triple. Substring matching would be wrong in both directions: `1.9` must not keep
+# `1.96.0`, and `nightly` must not keep `nightly-2026-06-17` when only the dated one is
+# named.
+matches_channel() { # <installed-name> <channel>
+  [ -n "$2" ] || return 1
+  [ "$1" = "$2" ] || case "$1" in "$2"-*) return 0 ;; *) return 1 ;; esac
+}
+
+kept_by_this_repo() { # <installed-name>
+  matches_channel "$1" "$resolved" && return 0
+  matches_channel "$1" "$repo_pin" && return 0
+  return 1
+}
+
+echo "resolved toolchain: $resolved"
+echo "rust-toolchain.toml channel: ${repo_pin:-<none>}"
+echo "preinstalled on this image:"
+toolchain_names "$before_file" | sed 's/^/  /'
+
+started=$SECONDS
+removed=0
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  if kept_by_this_repo "$name"; then
+    echo "keeping $name, named by this repository"
+    continue
+  fi
+  echo "removing $name, shipped by the runner image"
+  # Loud on purpose. A failed uninstall that is swallowed leaves a third toolchain in the
+  # list, which reintroduces exactly this defect under a green run, and the next person
+  # measures a cache miss with no cause in the log.
+  if ! rustup toolchain uninstall "$name"; then
+    echo "::error::could not uninstall $name; the cache key would carry a toolchain this repository never chose" >&2
+    exit 1
+  fi
+  removed=$((removed + 1))
+done < <(toolchain_names "$before_file")
+
+# The assertion is the whole point, and it is what makes this a check rather than a hope.
+# The original falsification was "wait for two jobs to draw different images and compare",
+# which is luck, not a check. This holds on every run on every image: if what remains is a
+# function of this repository's files, then two jobs on the same platform agree by
+# construction and there is nothing left to wait for.
+after_file="$(mktemp)"
+trap 'rm -f "$after_file"' EXIT
+rustup toolchain list > "$after_file"
+echo "installed after pruning:"
+toolchain_names "$after_file" | sed 's/^/  /'
+
+straggler=""
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  kept_by_this_repo "$name" || straggler="$straggler $name"
+done < <(toolchain_names "$after_file")
+
+if [ -n "$straggler" ]; then
+  echo "::error::toolchains this repository never named survived the prune:$straggler" >&2
+  exit 1
+fi
+
+if ! toolchain_names "$after_file" | grep -q .; then
+  echo "::error::pruning left no toolchain installed at all" >&2
+  exit 1
+fi
+
+echo "pruned $removed image toolchain(s) in $((SECONDS - started))s; every remaining toolchain is named by this repository"

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -35,6 +35,10 @@ HOLD_ALARM_POLICY = "scripts/release-hold-alarm.mjs"
 PROOF_GATE = ROOT / "scripts" / "check-release-proof-artifacts.mjs"
 PROOF_GATE_POLICY = "scripts/check-release-proof-artifacts.mjs"
 INSTALL_PROOF_CANARY = WORKFLOWS / "install-proof-canary.yml"
+RUST_TOOLCHAIN_ACTION = ROOT / ".github" / "actions" / "rust-toolchain" / "action.yml"
+TOOLCHAIN_PRUNE = (
+    ROOT / ".github" / "actions" / "rust-toolchain" / "prune-image-toolchains.sh"
+)
 CAPABILITY_CONTRACT = ROOT / "scripts" / "verify-capability-proof.mjs"
 CAPABILITY_CONTRACT_POLICY = "scripts/verify-capability-proof.mjs"
 RELEASE_BOT_DOC = ROOT / "docs" / "release-bot.md"
@@ -3547,6 +3551,251 @@ def assert_install_proof_status_contract(
         'kin status --json | tee "$captures/kin-embedded-status.json"',
         "post-embedding repository status capture",
     )
+
+
+def assert_toolchain_prune_is_wired(action: str) -> None:
+    """Keep the cache key a function of this repository, not of the runner image.
+
+    `Swatinem/rust-cache` hashes every entry of `rustup toolchain list` into half its key.
+    Two ubuntu-latest jobs sixty-five seconds apart drew images carrying 1.97.1 and 1.98.0,
+    hashed to 8374e8ea and 6ea01539 against one `Cargo.lock`, and could not restore each
+    other's cache. Nothing in this repository chose either version.
+
+    The obvious fix is the wrong one and has its own arm below: turning off
+    `add-rust-environment-hash-key` gates BOTH halves of the key in that action's source,
+    so the key freezes at its bare prefix and stops varying on `Cargo.lock` at all.
+
+    Order is the load-bearing part here. The image's set has to be recorded BEFORE the
+    install, because afterwards nothing can tell an image toolchain from the one this action
+    added, and a prune that reads the list after the install would remove the toolchain it
+    just installed or nothing at all.
+    """
+
+    for step in (
+        "Record the toolchains the runner image shipped",
+        "Prune toolchains this repository never named",
+    ):
+        if action.count(f"- name: {step}\n") != 1:
+            raise AssertionError(
+                f"the rust-toolchain action must declare exactly one step named {step!r}; "
+                "without it the cargo cache key carries whatever toolchain the runner "
+                "image happened to ship"
+            )
+    record = action.index("- name: Record the toolchains the runner image shipped")
+    install = action.index("- name: Install the toolchain")
+    prune = action.index("- name: Prune toolchains this repository never named")
+    if not record < install < prune:
+        raise AssertionError(
+            "the image toolchain set must be recorded before the install and pruned after "
+            "it; recorded after the install it cannot tell the image's toolchains from ours"
+        )
+    # The needle is the INVOCATION, never the name. The step's own comment names the
+    # script, so a needle of `prune-image-toolchains.sh` matches a step that calls nothing
+    # and this assertion could not fail. That is how it read on the first run of the
+    # mutation below, which is the only reason it is written this way.
+    if 'bash "$GITHUB_ACTION_PATH/prune-image-toolchains.sh"' not in action:
+        raise AssertionError(
+            "the prune step must call prune-image-toolchains.sh, which is the copy the "
+            "behavioral cases below drive"
+        )
+    if "repo_pin=$repo_pin" not in action and 'repo_pin=$repo_pin' not in action:
+        raise AssertionError(
+            "the resolve step must publish repo_pin, because the prune keeps the channel "
+            "rust-toolchain.toml names as well as the toolchain the caller asked for"
+        )
+
+
+def run_prune(
+    tmp: Path,
+    resolved: str,
+    preinstalled: list[str],
+    repo_pin: str = "",
+    uninstall_fails: str = "",
+    uninstall_fails_after: str = "",
+    after: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Drive the prune script against a stub rustup, so its logic is testable off CI.
+
+    The stub is the whole point. Asserting the script's TEXT would pass on a script that
+    removes the wrong toolchain, and a check that cannot fail is not evidence. `after` lets
+    a case model a rustup that reports something the prune did not achieve, which is the
+    straggler the assertion exists to catch.
+    """
+
+    bindir = tmp / "bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    state = tmp / "installed.txt"
+    state.write_text("\n".join(preinstalled) + "\n", encoding="utf-8")
+    forced = tmp / "forced-after.txt"
+    if after is not None:
+        forced.write_text("\n".join(after) + "\n", encoding="utf-8")
+    stub = bindir / "rustup"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f'STATE="{state}"\n'
+        f'FORCED="{forced}"\n'
+        f'FAILS="{uninstall_fails}"\n'
+        f'FAILS_AFTER="{uninstall_fails_after}"\n'
+        'if [ "$1" = "toolchain" ] && [ "$2" = "list" ]; then\n'
+        '  if [ -f "$FORCED" ]; then cat "$FORCED"; else cat "$STATE"; fi\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "toolchain" ] && [ "$2" = "uninstall" ]; then\n'
+        '  if [ -n "$FAILS" ] && [ "$3" = "$FAILS" ]; then echo "stub refuses $3" >&2; exit 1; fi\n'
+        '  grep -v "^$3\\( \\|$\\)" "$STATE" > "$STATE.new" || true\n'
+        '  mv "$STATE.new" "$STATE"\n'
+        '  if [ -n "$FAILS_AFTER" ] && [ "$3" = "$FAILS_AFTER" ]; then echo "stub errored after removing $3" >&2; exit 1; fi\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    before = tmp / "before.txt"
+    before.write_text("\n".join(preinstalled) + "\n", encoding="utf-8")
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}{os.pathsep}{env['PATH']}"
+    return subprocess.run(
+        ["bash", str(TOOLCHAIN_PRUNE), resolved, str(before), repo_pin],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def assert_toolchain_prune_behavior() -> None:
+    """The prune keeps what this repository names and removes what the image shipped."""
+
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+
+        # The measured case: the image shipped a second stable nobody here chose.
+        run = run_prune(
+            tmp / "image-extra",
+            "1.96.0",
+            [
+                "1.96.0-x86_64-unknown-linux-gnu (default)",
+                "1.98.0-x86_64-unknown-linux-gnu",
+            ],
+            repo_pin="1.96.0",
+        )
+        if run.returncode != 0:
+            raise AssertionError(f"the prune refused an ordinary image: {run.stderr}")
+        if "removing 1.98.0-x86_64-unknown-linux-gnu" not in run.stdout:
+            raise AssertionError(
+                f"the prune left the image's own toolchain installed: {run.stdout}"
+            )
+        if "keeping 1.96.0-x86_64-unknown-linux-gnu" not in run.stdout:
+            raise AssertionError(
+                f"the prune removed the toolchain this repository pins: {run.stdout}"
+            )
+
+        # fuzz.yml's shape: a caller-supplied nightly, and a bare `cargo` that
+        # rust-toolchain.toml resolves to the stable pin. Both survive.
+        run = run_prune(
+            tmp / "two-named",
+            "nightly-2026-06-17",
+            [
+                "1.96.0-x86_64-unknown-linux-gnu",
+                "1.98.0-x86_64-unknown-linux-gnu",
+                "nightly-2026-06-17-x86_64-unknown-linux-gnu",
+            ],
+            repo_pin="1.96.0",
+        )
+        if run.returncode != 0:
+            raise AssertionError(f"the prune refused the fuzz shape: {run.stderr}")
+        for kept in ("1.96.0-x86_64", "nightly-2026-06-17-x86_64"):
+            if f"keeping {kept}" not in run.stdout:
+                raise AssertionError(
+                    f"the prune removed {kept}, which this repository names: {run.stdout}"
+                )
+        if "removing 1.98.0-x86_64-unknown-linux-gnu" not in run.stdout:
+            raise AssertionError(
+                f"the prune kept a toolchain nobody named: {run.stdout}"
+            )
+
+        # A prefix must not be read as a match in either direction.
+        run = run_prune(
+            tmp / "prefix",
+            "1.9",
+            ["1.96.0-x86_64-unknown-linux-gnu"],
+        )
+        if run.returncode == 0:
+            raise AssertionError(
+                "channel 1.9 matched toolchain 1.96.0, so a prefix is being read as a "
+                "match and the wrong toolchain can be kept"
+            )
+
+        # A refused uninstall must stop the job. Swallowed, it leaves a third toolchain in
+        # the list under a green run, which is exactly the defect being fixed.
+        run = run_prune(
+            tmp / "refused",
+            "1.96.0",
+            [
+                "1.96.0-x86_64-unknown-linux-gnu",
+                "1.98.0-x86_64-unknown-linux-gnu",
+            ],
+            repo_pin="1.96.0",
+            uninstall_fails="1.98.0-x86_64-unknown-linux-gnu",
+        )
+        if run.returncode == 0:
+            raise AssertionError(
+                "a refused uninstall exited zero, so a toolchain this repository never "
+                "chose survives into the cache key under a green run"
+            )
+        if "could not uninstall" not in run.stderr:
+            raise AssertionError(
+                f"a refused uninstall did not name itself: {run.stderr}"
+            )
+
+        # The same refusal from a rustup that removed the toolchain and THEN errored. It
+        # leaves no straggler, so the assertion below cannot shield it, and the loud
+        # failure is the only thing that can stop the job. Without this case the
+        # "could not uninstall" assertion is unreachable: every refusal the other stub mode
+        # produces is caught by the straggler check first, and an assertion nothing can
+        # reach is not evidence.
+        run = run_prune(
+            tmp / "refused-after",
+            "1.96.0",
+            [
+                "1.96.0-x86_64-unknown-linux-gnu",
+                "1.98.0-x86_64-unknown-linux-gnu",
+            ],
+            repo_pin="1.96.0",
+            uninstall_fails_after="1.98.0-x86_64-unknown-linux-gnu",
+        )
+        if run.returncode == 0:
+            raise AssertionError(
+                "an uninstall that errored after doing the work exited zero, so nothing "
+                "stops a job whose toolchain removal is only half trustworthy"
+            )
+        if "could not uninstall" not in run.stderr:
+            raise AssertionError(
+                f"a refusal that left no straggler was not named: {run.stderr}"
+            )
+
+        # And the straggler assertion, which is what turns this from a hope into a check:
+        # a rustup that reports an unnamed toolchain still installed must fail the step,
+        # however it got there.
+        run = run_prune(
+            tmp / "straggler",
+            "1.96.0",
+            ["1.96.0-x86_64-unknown-linux-gnu"],
+            repo_pin="1.96.0",
+            after=[
+                "1.96.0-x86_64-unknown-linux-gnu",
+                "1.99.0-x86_64-unknown-linux-gnu",
+            ],
+        )
+        if run.returncode == 0:
+            raise AssertionError(
+                "a toolchain this repository never named survived the prune and the step "
+                "still passed, so the invariant is asserted nowhere"
+            )
+        if "survived the prune" not in run.stderr:
+            raise AssertionError(f"the straggler was not named: {run.stderr}")
 
 
 def assert_docs_only_classifier_guard(workflow: str) -> None:
@@ -12361,6 +12610,35 @@ def main() -> None:
     classifier = ci_workflow[classifier_start:classifier_end]
     assert_docs_only_classifier_guard(ci_workflow)
     assert_assertion_reachability_gate_wired(ci_workflow)
+    toolchain_action = RUST_TOOLCHAIN_ACTION.read_text(encoding="utf-8")
+    assert_toolchain_prune_is_wired(toolchain_action)
+    assert_toolchain_prune_behavior()
+    for label, original, replacement, expected in (
+        (
+            "the prune step is dropped, so the image decides the cache key",
+            "    - name: Prune toolchains this repository never named",
+            "    - name: Prune nothing at all",
+            "must declare exactly one step named",
+        ),
+        (
+            "the image set is recorded after the install, where it cannot tell them apart",
+            "    - name: Record the toolchains the runner image shipped",
+            "    - name: Recorded too late",
+            "must declare exactly one step named",
+        ),
+        (
+            "the prune stops calling the script the behavioral cases drive",
+            'bash "$GITHUB_ACTION_PATH/prune-image-toolchains.sh" \\',
+            "true \\",
+            "must call prune-image-toolchains.sh",
+        ),
+    ):
+        mutant = replace_exactly_once(toolchain_action, original, replacement, label)
+        expect_assertion(
+            label,
+            expected,
+            lambda mutant=mutant: assert_toolchain_prune_is_wired(mutant),
+        )
     assert_cargo_deny_reads_every_advisory(sast)
     assert_advisory_sweep_authority(advisory_sweep, release_train)
     for label, source, original, replacement, expected, check in (


### PR DESCRIPTION
`Swatinem/rust-cache` hashes every entry of `rustup toolchain list` into half its key. Two `ubuntu-latest` jobs sixty-five seconds apart in run 32961965498 drew images carrying 1.97.1 and 1.98.0, hashed to `8374e8ea` and `6ea01539` against the same `Cargo.lock` `433e5115`, and could not restore each other's cache. Nothing in this repository chose either version, and a restore key cannot fall back past that segment because it is a prefix of it. macOS was immune only because its image happened to ship one toolchain.

The measurement and the mechanism are lane citier1cache's, in `.kin-coord/reports/citier1cache-fir2744-20260826.md`. This is the root-cause fix that handoff asked for.

## The obvious fix is worse than the defect

`add-rust-environment-hash-key: false` was the approved fix and it should not land. That flag gates BOTH halves of the key in the action's own source, so turning it off left `Lockfiles considered` empty and the key frozen at its bare prefix, never varying on `Cargo.lock` again. Measured on run 32976932775. kin#1158 is a draft for that reason.

## So the unstable input is removed instead

The action records what the image shipped before it installs anything, then removes every toolchain this repository did not name. It keeps two: the toolchain the caller asked for, and the channel in `rust-toolchain.toml`. Both come from files in the tree, so the hash comes from the tree.

Keeping both matters. `fuzz.yml` installs a pinned nightly and still runs a bare `cargo install cargo-fuzz`, which `rust-toolchain.toml` resolves to the stable pin. Pruning that would trade a cache-key bug for a toolchain download on every fuzz run. The rule is "remove what the image shipped", captured before the install, never "keep only the pin".

The step fails loud when an uninstall is refused, because a swallowed one leaves a third toolchain in the list and reintroduces this exact defect under a green run, with no cause in the log for whoever measures the miss.

## The falsification is deterministic, not a wait

The original plan was to wait for two jobs to draw different images and compare. That is luck, not a check, and the handoff says so.

The step asserts instead, after pruning, that every remaining toolchain is one this repository named. That holds on every run on every image. If what remains is a function of this repository's files, two jobs on one platform agree by construction and there is nothing left to wait for.

## The logic is a script so it can be driven off CI

`prune-image-toolchains.sh` rather than embedded YAML, so `scripts/test-release-workflow-authority.py` can run it against a stub `rustup`. Asserting the step's TEXT would pass on a step that removes the wrong toolchain, and a check that cannot fail is not evidence.

Six behavioral cases, each running on every `check` job:

- the measured shape: an image that shipped a second stable nobody here chose
- the fuzz shape: a caller-supplied nightly plus the repo pin, both kept
- a prefix that must not be read as a match, so `1.9` cannot keep `1.96.0`
- a refused uninstall that must stop the job
- a refusal from a rustup that removed the toolchain and THEN errored, which leaves no straggler, so only the loud failure can catch it
- a straggler that must fail the step however it arrived

That fifth case exists because without it the "could not uninstall" assertion is unreachable: every refusal the other stub mode produces is caught by the straggler check first, and an assertion nothing can reach is not evidence.

## Falsification

| Mutation | Expected | Result |
|---|---|---|
| the prune step is dropped | structural check red | raised, right reason |
| the image set is recorded after the install | structural check red | raised, right reason |
| the prune stops calling the script | structural check red | raised, right reason |
| channel matching becomes a substring test | prefix case red | `channel 1.9 matched toolchain 1.96.0` |
| the uninstall is short-circuited away | straggler case red | `toolchains this repository never named survived the prune` |
| the straggler assertion is removed | straggler case red | `the invariant is asserted nowhere` |
| the uninstall runs and its error is swallowed | loud-failure case red | `a refused uninstall did not name itself` |

The three structural arms run inside the guard on every CI run through `expect_assertion`, which also requires each to raise for the RIGHT reason. The four behavioral arms were driven by an external driver with markers and an EXIT/INT/TERM restore, on the committed tree, restored clean.

One of the structural arms first read green because the needle was the script's NAME, which the step's own comment carries. The needle is now the invocation. That is trap 57 and it is why the arm exists.

## What ran

`bin/kin-precheck kin --repo-dir kin=<lane worktree>` on `55e2fdedb`: 16 gates enumerated from ci.yml's own check job, 16 passed, 0 failed.

## Measured on real runners

This PR's own CI answered requirement three and confirmed the mechanism, read from the consuming job's own log rather than from `GET /actions/caches`, which is not an inventory.

`Check & Test ubuntu shard (2)`, job 98292172037:

```
preinstalled on this image:
  stable-x86_64-unknown-linux-gnu
removing stable-x86_64-unknown-linux-gnu, shipped by the runner image
info: toolchain stable-x86_64-unknown-linux-gnu uninstalled
installed after pruning:
  1.96.0-x86_64-unknown-linux-gnu
pruned 1 image toolchain(s) in 0s; every remaining toolchain is named by this repository
```

Requirement three's answer is **75 ms**, the step's own recorded duration. It does not need a budget.

The image shipped `stable-x86_64-unknown-linux-gnu`, the channel alias rather than a pinned version. Whatever `stable` resolved to on a given image is what varied, which is the mechanism, and the channel matcher correctly treats it as unnamed by this repository.

The before and after is a same-run split becoming a same-run agreement, which is sharper than the measurement this fix was built on. That one needed two jobs sixty-five seconds apart in different runs.

Control, the unmodified action, run 33000218960, three jobs that share one key:

| job | Rust Versions considered | key |
|---|---|---|
| `Check & Test ubuntu shard (1)` | 1.96.0, **1.97.1**, 1.96.0 | `v0-rust-check-Linux-x64-`**`8374e8ea`**`-29254e45` |
| `Check & Test ubuntu shard (2)` | 1.96.0, **1.98.0**, 1.96.0 | `v0-rust-check-Linux-x64-`**`6ea01539`**`-29254e45` |
| `Feature permutation tests (ubuntu-latest)` | 1.96.0, **1.97.1**, 1.96.0 | `v0-rust-check-Linux-x64-`**`8374e8ea`**`-29254e45` |

Three jobs sharing a key, one run, split across two environment hashes. Both values are the exact pair lane citier1cache recorded from run 32961965498, so the defect reproduced independently on a run not designed to catch it.

This PR, run 33003800808, the same three jobs:

| job | Rust Versions considered | key |
|---|---|---|
| `Check & Test ubuntu shard (1)` | 1.96.0, 1.96.0 | `v0-rust-check-Linux-x64-d01c1248-876dc3da` |
| `Check & Test ubuntu shard (2)` | 1.96.0, 1.96.0 | `v0-rust-check-Linux-x64-d01c1248-876dc3da` |
| `Feature permutation tests (ubuntu-latest)` | 1.96.0, 1.96.0 | `v0-rust-check-Linux-x64-d01c1248-876dc3da` |

Byte-identical, and the prune cost 0 to 1 second per job.

One thing to state precisely rather than let the table imply it: all three control jobs reported `Cache hit`. The defect is not that the cache never works. It is that the population splits into two hash families that cannot restore each other, and whether either side hits depends on what `main` last saved under that family.

The half that `add-rust-environment-hash-key: false` destroyed is intact: `Lockfiles considered` lists 24 `Cargo.toml` entries in BOTH the control and this PR, plus `.cargo/config.toml` and `Cargo.lock`.

One observation with its own control so it is not read as new: `Lockfiles considered` includes `.github/actions/rust-toolchain/action.yml` in the control as well as here, because rust-cache's `rust-toolchain` glob matches the directory. It was already there. The new script joins it, so editing the action busts the cache, which is correct rather than a defect.

## Two red checks on this PR, and what they are

`Install Proof (PR) / ubuntu-latest` failed, and `Install Proof (PR) Gate` is the aggregator reporting it. The failure:

```
daemon embed failed: kin embed refused (HTTP 500): embed build failed:
index error: failed to download model weights: request error: http status: 429
```

A remote rate limit on the model-weights download. There is no causal path from a rustup toolchain prune to a 429 from a weights host, and in the same window `ci.yml` also failed on `main` and on three `gh-readonly-queue` runs for other PRs, on two different remote services.

That reasoning is not proof, and the proof is a same-code re-run holding the code fixed while varying only the run. This PR is held, its one needed measurement is already taken, and spending runners on it during a live release loop is the thing the hold exists to avoid. So the re-run happens with the post-tag landing rather than now, and this section stands rather than a reader discovering two red checks under a body that reads clean.

## Why this is a draft

The handoff's approved disposition is the root-cause fix post-tag, and the v0.6.0 loop is live. This touches an action under every Rust job, which is a different blast radius from a cache flag. Held until the captain says go, which is after v0.6.0 promotes to Latest.

## Not claiming

Not that this is the whole gap between a warm and a cold ubuntu job. It is one cause with direct evidence and a mechanism read from the action's source.

Not that kin#1158's shared-key environment guard is folded in. It is not on main, and the handoff asks for it to be re-judged against this shape. My read: under this fix the environment hash survives and is repo-determined, so two jobs sharing a key agree unless they declare different cargo env vars, which is a cache miss rather than a correctness bug and is now visible in the hash. That guard is a separate call and a separate PR.

Not the macOS arm, which was still running. Not any figure for how much wall clock this recovers: the control jobs hit their own family's cache, so this is about the population splitting, not about a cache that never works.

Part of FIR-2744.
