### PR TITLE
Exclude a declaring parent from its own member's impact, whatever edge joins them

### DIFF
--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -504,14 +504,21 @@ fn empty_impact_context(
 /// listing disagreeing with the count printed above it.
 ///
 /// The edge set is entity-to-entity relations pointing at the entity being
-/// expanded, with the relation's source as the dependent, kept only when
-/// [`kin_review::is_impact_relation`] says the edge carries impact. That
-/// predicate is the ranked report's own, imported rather than restated, so the
-/// two walks this command runs over one target cannot answer differently
-/// (FIR-2478). `impact_hop_walk_reaches_what_the_ranked_report_ranks` pins the
-/// agreement, and `impact_hop_walk_matches_the_impact_filtered_graph_walk` pins
-/// the remaining equivalence with `GraphStore::get_downstream_impact`, which
-/// applies no such filter and so is the wider set.
+/// expanded, with the relation's source as the dependent, selected by
+/// [`kin_review::inbound_impact_relations`]. That function is the ranked
+/// report's own, called rather than restated, so the two walks this command runs
+/// over one target cannot answer differently (FIR-2478). Sharing a whole
+/// selection rather than a per-kind predicate is deliberate: while each side
+/// applied `is_impact_relation` for itself they still diverged, because the rule
+/// that matters needs the `Contains` edge to identify a declaring parent and
+/// that edge is not itself an impact relation.
+///
+/// `both_impact_walks_name_the_same_entities_on_one_graph` pins the agreement by
+/// reading what each walk actually returned and requiring the sets to match,
+/// rather than checking each against its own expectation.
+/// `impact_hop_walk_matches_the_impact_filtered_graph_walk` pins the remaining
+/// equivalence with `GraphStore::get_downstream_impact`, which applies no such
+/// filter and so is the wider set.
 /// The two graph reads the hop walk performs, named so a test can count them.
 trait ImpactWalkGraph {
     /// Entity-to-entity relations that point at `id`.
@@ -546,14 +553,13 @@ fn downstream_impact_by_hop<G: ImpactWalkGraph>(
     for hop in 1..=depth {
         let mut next = Vec::new();
         for current in frontier {
-            for relation in graph.inbound_relations(&current)? {
-                // One policy, both walks. Containment is the edge this exists to
-                // drop: without it a method's own containing class is reached at
-                // hop 1 and printed under "direct callers", and every sibling
-                // member the class contains follows at hop 2.
-                if !kin_review::is_impact_relation(relation.kind) {
-                    continue;
-                }
+            // One policy, both walks, and one function rather than one predicate
+            // each side applies for itself. Dropping the `Contains` KIND was not
+            // enough on a real graph: a declaring class carries a `UsesType` edge
+            // to the same member as well, so the pair is joined twice and the
+            // class kept printing under "direct callers".
+            let inbound = graph.inbound_relations(&current)?;
+            for relation in kin_review::inbound_impact_relations(&inbound, &current) {
                 let Some(dependent) = relation.src.as_entity() else {
                     continue;
                 };
@@ -1904,6 +1910,203 @@ mod tests {
                 "  2 hops:".to_string(),
                 "    - indirect_caller (Function) @ src/indirect.rs:31".to_string(),
             ]
+        );
+    }
+
+    /// The same member, with the edge a real graph actually delivers.
+    ///
+    /// A declaring class carries TWO edges to its own member, not one:
+    /// `Contains`, which states the declaration, and `UsesType`, which
+    /// [`kin_review::is_impact_relation`] admits because it carries impact for
+    /// every other pair. Measured on psf/requests, `BaseAdapter.send` holds both
+    /// from `BaseAdapter`, and a four-file Python fixture reproduces it, so this
+    /// is the shape a corpus delivers rather than an exotic one.
+    ///
+    /// The sibling test above builds only the `Contains` edge. It passed while
+    /// the class kept printing under "1 hop (direct callers)" on every real
+    /// repository, because dropping a kind does not drop a row when the pair is
+    /// joined twice.
+    #[tokio::test]
+    async fn a_declaring_class_is_not_a_direct_caller_through_its_uses_type_edge() {
+        let graph = kin_db::InMemoryGraph::new();
+        let holder = entity("Holder", "src/holder.rs");
+        let member = entity("Holder.send", "src/holder.rs");
+        let sibling = entity("Holder.close", "src/holder.rs");
+        for e in [&holder, &member, &sibling] {
+            graph.upsert_entity(e).unwrap();
+        }
+        // Both edges on both pairs, which is what the linker and the enrichment
+        // sweep produce together.
+        relate(&graph, &holder, &member, RelationKind::Contains);
+        relate(&graph, &holder, &member, RelationKind::UsesType);
+        relate(&graph, &holder, &sibling, RelationKind::Contains);
+        relate(&graph, &holder, &sibling, RelationKind::UsesType);
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "Holder.send".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: true,
+            },
+            &healthy_test_envelope(),
+        )
+        .await
+        .unwrap();
+
+        let rendered = response.lines.join("\n");
+        assert!(
+            !rendered.contains("1 hop (direct callers)"),
+            "a class is not a caller of its own method, whatever second edge kind \
+             also joins the pair: {rendered}"
+        );
+        assert!(
+            listed_names(&response.lines).is_empty(),
+            "no entity may be listed as impacted through a declaring parent: {rendered}"
+        );
+        assert_eq!(
+            response
+                .ranked
+                .as_ref()
+                .expect("structured callers get a ranked report")
+                .candidates
+                .len(),
+            0,
+            "the ranked walk applies the same rule: {rendered}"
+        );
+    }
+
+    /// A module that CALLS its own function is a real caller and stays.
+    ///
+    /// The declaring-source rule drops a parent's structural edges, and a
+    /// blanket exclusion would cost real recall: a Python module really does
+    /// call its own function at import time, and that caller is one a developer
+    /// means. `Calls` is therefore the exception, and this is the guard that
+    /// stops the rule from over-suppressing.
+    #[tokio::test]
+    async fn a_declaring_module_that_calls_its_own_function_stays_a_direct_caller() {
+        let graph = kin_db::InMemoryGraph::new();
+        let module = entity("search", "src/search.py");
+        let func = entity("run_search", "src/search.py");
+        for e in [&module, &func] {
+            graph.upsert_entity(e).unwrap();
+        }
+        relate(&graph, &module, &func, RelationKind::Contains);
+        relate(&graph, &module, &func, RelationKind::UsesType);
+        // The import-time call. This is the edge the exception exists for.
+        relate(&graph, &module, &func, RelationKind::Calls);
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "run_search".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: true,
+            },
+            &healthy_test_envelope(),
+        )
+        .await
+        .unwrap();
+
+        let rendered = response.lines.join("\n");
+        assert!(
+            listed_names(&response.lines).contains(&"search".to_string()),
+            "a module-level call is a real caller and the structural rule must not \
+             swallow it: {rendered}"
+        );
+        assert_eq!(
+            response
+                .ranked
+                .as_ref()
+                .expect("structured callers get a ranked report")
+                .candidates
+                .len(),
+            1,
+            "exactly the calling module, once, not once per edge kind: {rendered}"
+        );
+    }
+
+    /// The two walks agree, asserted over what they actually returned.
+    ///
+    /// Each walk being correct against its own fixture is not the property that
+    /// matters. The property lives in their agreement, and neither endpoint can
+    /// see it: two tests can each pin a real behavior and jointly guard nothing.
+    /// So this reads the human listing's names back out of the rendered lines
+    /// and requires the ranked report to name exactly that set, rather than
+    /// checking each against a hardcoded expectation that would drift together.
+    ///
+    /// The fixture deliberately mixes all three cases the policy separates: a
+    /// real cross-file caller, a declaring parent joined twice, and a declaring
+    /// module that also calls.
+    #[tokio::test]
+    async fn both_impact_walks_name_the_same_entities_on_one_graph() {
+        let graph = kin_db::InMemoryGraph::new();
+        let holder = entity("Holder", "src/holder.rs");
+        let member = entity("Holder.send", "src/holder.rs");
+        let caller = entity("real_caller", "src/caller.rs");
+        let module = entity("holder", "src/holder.rs");
+        for e in [&holder, &member, &caller, &module] {
+            graph.upsert_entity(e).unwrap();
+        }
+        relate(&graph, &holder, &member, RelationKind::Contains);
+        relate(&graph, &holder, &member, RelationKind::UsesType);
+        relate(&graph, &module, &member, RelationKind::Contains);
+        relate(&graph, &module, &member, RelationKind::Calls);
+        relate(&graph, &caller, &member, RelationKind::Calls);
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "Holder.send".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: true,
+            },
+            &healthy_test_envelope(),
+        )
+        .await
+        .unwrap();
+
+        let listed: std::collections::BTreeSet<String> =
+            listed_names(&response.lines).into_iter().collect();
+        let ranked: std::collections::BTreeSet<String> = response
+            .ranked
+            .as_ref()
+            .expect("structured callers get a ranked report")
+            .candidates
+            .iter()
+            .map(|candidate| candidate.identity.name.clone())
+            .collect();
+
+        // Two empty sets agree vacuously, so the join proves nothing unless the
+        // walks actually returned something. This is the half that makes the
+        // assertion able to fail.
+        assert!(
+            !listed.is_empty(),
+            "a fixture where both walks return nothing cannot demonstrate agreement: {:?}",
+            response.lines
+        );
+        assert_eq!(
+            listed, ranked,
+            "one relation policy, two walks: the human listing and the ranked report \
+             must name the same entities, read from what each actually returned"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -39,12 +39,15 @@ relation graph to find every entity that could be affected. Target it four ways 
 a time): base/head change IDs, entity_ids, file paths, or a list of change_ids to \
 combine. Optionally include active agent traffic on the impacted entities so you can see \
 who else is working nearby. Reach for it before merging or refactoring to gauge blast \
-radius — \"if I change this, what else might break?\" — answered from the graph in one \
+radius, answering \"if I change this, what else might break?\", from the graph in one \
 call instead of hand-tracing callers. Pair it with semantic_diff (what changed) or use \
 semantic_review when you want diff + impact + risk together in a single report. \
 Per-entity counts separate `consumer_count` (every inbound edge) from \
-`proven_consumer_count` (only edges resolved above `name_only`), and each ranked path \
-step carries its own `resolution`. Read a used/unused claim against the proven count: a \
+`proven_consumer_count` (only edges resolved above `name_only`). This response carries \
+counts and buckets rather than ranked paths: the per-hop ranked report, where every step \
+carries its own `resolution` and a confidence score, is produced only by \
+`kin impact --json` on the CLI and is not reachable from here. Read a used/unused claim \
+against the proven count: a \
 call edge matched by bare method name is a candidate, not a fact. The response also \
 carries an additive `negative` object whose `safe_to_conclude_absent` flag says whether \
 this graph could have seen the impact it reports missing: the verdicts are read off \

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -35,9 +35,10 @@ pub use inline::{
     CONSUMER_FANOUT_THRESHOLD,
 };
 pub use ranked_impact::{
-    is_impact_relation, rank_impact, rank_impact_at, CandidateLocation, ImpactBucket,
-    PriorityScoreComponents, RankedImpactCandidate, RankedImpactReport, RelationPathStep,
-    StableEntityIdentity, IMPACT_MAX_DEPTH, PRIORITY_SCORE_FORMULA, RANKED_IMPACT_SCHEMA_VERSION,
+    inbound_impact_relations, is_impact_relation, rank_impact, rank_impact_at, CandidateLocation,
+    ImpactBucket, PriorityScoreComponents, RankedImpactCandidate, RankedImpactReport,
+    RelationPathStep, StableEntityIdentity, IMPACT_MAX_DEPTH, PRIORITY_SCORE_FORMULA,
+    RANKED_IMPACT_SCHEMA_VERSION,
 };
 pub use ref_graph::GraphAtRef;
 pub use release_gate::{

--- a/crates/kin-review/src/ranked_impact.rs
+++ b/crates/kin-review/src/ranked_impact.rs
@@ -8,7 +8,7 @@
 //! and captured source evidence. The existing [`crate::impact::ImpactReport`]
 //! remains the compatibility surface for review policy; this module is additive.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use kin_index::RelationResolution;
 use kin_model::entity::{Entity, EntityRole};
@@ -213,8 +213,8 @@ pub fn rank_impact_at<I: ImpactGraph>(
         if frontier.hop >= bounded_depth {
             continue;
         }
-        let mut relations = graph.get_all_relations_for_entity(&frontier.entity_id)?;
-        relations.retain(|relation| is_impact_relation(relation.kind));
+        let all_relations = graph.get_all_relations_for_entity(&frontier.entity_id)?;
+        let mut relations = inbound_impact_relations(&all_relations, &frontier.entity_id);
         relations.sort_by_key(relation_sort_key);
 
         for relation in relations {
@@ -369,6 +369,49 @@ pub fn is_impact_relation(kind: RelationKind) -> bool {
             | RelationKind::Covers
             | RelationKind::DerivedFrom
     )
+}
+
+/// Inbound impact edges into `id`, with its declaring parent's non-call edges
+/// removed.
+///
+/// [`is_impact_relation`] drops the `Contains` edge a declaration carries to its
+/// members, and on a real graph that is not enough. The declaring parent carries
+/// a SECOND edge to the same member, `UsesType`, which does carry impact for
+/// every other pair, so the pair is joined twice and dropping one kind leaves the
+/// row standing. Measured on psf/requests: `BaseAdapter.send` holds both
+/// `<- Contains BaseAdapter` and `<- UsesType BaseAdapter`, and the class kept
+/// printing under a header that reads "direct callers" after the containment
+/// exclusion landed. A four-file Python fixture reproduces it, so this is the
+/// shape a graph actually delivers rather than an exotic one.
+///
+/// A `Calls` edge from a declaring parent is KEPT. A module really does call its
+/// own function at import time, and that caller is one a developer means.
+///
+/// `all` must be every relation touching `id`, not a pre-filtered set. The
+/// `Contains` edge that identifies the declaring parent is itself not an impact
+/// relation, so filtering by kind first destroys the evidence this needs.
+///
+/// Both walks call this, rather than each applying the per-kind predicate
+/// separately, so their agreement is structural instead of conventional.
+pub fn inbound_impact_relations(all: &[Relation], id: &EntityId) -> Vec<Relation> {
+    let node = GraphNodeId::Entity(*id);
+    let declaring: HashSet<EntityId> = all
+        .iter()
+        .filter(|relation| relation.dst == node && relation.kind == RelationKind::Contains)
+        .filter_map(|relation| relation.src.as_entity())
+        .collect();
+    all.iter()
+        .filter(|relation| relation.dst == node)
+        .filter(|relation| is_impact_relation(relation.kind))
+        .filter(|relation| {
+            relation.kind == RelationKind::Calls
+                || relation
+                    .src
+                    .as_entity()
+                    .is_none_or(|src| !declaring.contains(&src))
+        })
+        .cloned()
+        .collect()
 }
 
 fn impact_bucket(entity: &Entity, relation: RelationKind) -> ImpactBucket {


### PR DESCRIPTION
A class is not a caller of its own method, and dropping the containment edge did not stop it saying so.

FIR-2478's containment exclusion landed and the symptom survived on every real repository. `kin impact BaseAdapter.send` on psf/requests still printed `BaseAdapter (Class)` under a header reading "1 hop (direct callers)", beside the two modules that enclose it. The reason is that the pair is joined twice. `kin graph inspect BaseAdapter.send` shows both `<- Contains BaseAdapter` and `<- UsesType BaseAdapter`, same source entity, same target, two kinds. `is_impact_relation` drops the first and admits the second, so removing the kind removed nothing. A four-file Python fixture with thirteen entities reproduces it, so this is the shape a graph actually delivers rather than an exotic one.

The rule is now a whole selection rather than a per-kind predicate. `kin_review::inbound_impact_relations` takes every relation touching an entity, identifies its declaring parents from the inbound `Contains` edges, and returns the inbound impact-carrying edges minus the ones from a declaring parent. It has to take the unfiltered set, because the `Contains` edge that names the parent is itself not an impact relation, so filtering by kind first destroys the evidence the rule needs. That is also why sharing the predicate was never going to be enough.

`Calls` from a declaring parent is kept. A Python module really does call its own function at import time, and that caller is one a developer means.

Both walks call the new function, so their agreement is structural instead of conventional. That mattered more than expected: the doc comment on `downstream_impact_by_hop` said `impact_hop_walk_reaches_what_the_ranked_report_ranks` pins the agreement, and that identifier appears exactly once in the repository, in that sentence. No such test exists. The one agreement test that does exist compares the hop walk against the graph's unfiltered downstream walk, on a fixture built entirely from `Calls` edges, and never calls `rank_impact`. So nothing asserted the two walks agree. `both_impact_walks_name_the_same_entities_on_one_graph` now does, by reading what each walk actually returned and requiring the sets to match, and by asserting the listed set is non-empty first, because two empty sets agree vacuously. The doc comment now names tests that exist.

This also stops the tool description promising a field the response has never carried. `IMPACT_ANALYSIS_DESC` told agents that "each ranked path step carries its own `resolution`", while `handle_impact_analysis` serializes `ImpactReport`, which has no ranked path step and no `resolution` field at all. It now says the response carries counts and buckets, and names `kin impact --json` as where the per-hop ranked report lives. Wiring the ranked report into MCP is filed rather than done here, because it needs a merge policy across a diff's several roots, a response-shape decision, and budget work on a payload that already serializes to 422,778 characters against a 60,000 ceiling. While editing that string I also removed an em dash it carried, which is house style and is named here so it does not read as a silent edit.

Guards, falsified on the committed tree with every test in the class run under every mutation and per-test lines read rather than a summary. The driver prints HEAD, counts a symbol only this change adds and refuses to grade when it reads zero, and refuses outright if the files it restores carry uncommitted work.

| mutation | Contains-only | Contains+UsesType | Calls exception | the join |
| --- | --- | --- | --- | --- |
| drop the declaring-source rule | ok | FAILED | ok | ok |
| drop the `Calls` exception | ok | ok | FAILED | ok |
| put the two walks back on separate rules | ok | FAILED | ok | FAILED |

Every guard reds under the mutation that removes its own mechanism, and none reds under a mutation that leaves its mechanism intact. The pre-existing Contains-only test stays green throughout, correctly: `is_impact_relation` still drops the `Contains` kind, so on a fixture holding only that edge there is nothing for the new rule to exclude. It is pinned by the kind filter, which reds when that filter is mutated directly. The two tests pin two different mechanisms and reading them as one would be wrong in both directions.

The four guards are `a_containing_declaration_is_not_a_direct_caller_of_its_own_member` (pre-existing, unchanged), `a_declaring_class_is_not_a_direct_caller_through_its_uses_type_edge` (the corpus shape the first cannot see), `a_declaring_module_that_calls_its_own_function_stays_a_direct_caller` (the exception, so the rule cannot over-suppress a real import-time call), and `both_impact_walks_name_the_same_entities_on_one_graph` (the join).

Also run: `cargo test -p kin-review -p kin-cli --lib` at 1812 and 256 passed, zero failed, which sums to the 2068 the suite reports from `--list`. `cargo fmt --all -- --check` clean.

Measured before any of this was written, on origin/main, psf/requests replayed at tree 19e4272a9f1e9048c27fb6daa1b4916497a70193: `lines` and `ranked.candidates` both read 80 on `BaseAdapter.send`, `kin impact send --json` returns `ambiguous` with `match_count: 12` and narrows to 2 under `--file`, and `kin impact HTTPAdapter.send --json` keeps returning its candidates as the positive control.

Closes FIR-2478
Part of FIR-2761
