### PR TITLE
Weigh cross-repo authority in the verdict, not only when an absence is claimed

### DIFF
--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -2844,11 +2844,16 @@ mod tests {
                 // cross-repo authority is not the fully-resolved answer these
                 // cases are about: it would read as a floor for a reason the
                 // test never meant to exercise.
+                "focal_entity": { "id": "0195f2a1-0000-7000-8000-00000000f0ca" },
                 "cross_repo": {
                     "status": "available",
                     "authority_complete": true,
                     "authority_revision": "sha256:complete",
                     "authority_roots": { "local": "local-root" },
+                    "authority_anchor": {
+                        "repo_id": "local",
+                        "entity_id": "0195f2a1-0000-7000-8000-00000000f0ca",
+                    },
                 },
                 // Every class but the one the case varies is present, and the
                 // host can produce reference edges. Since FIR-2672 every
@@ -2902,11 +2907,16 @@ mod tests {
                 "references": vec![json!({"name": "extract_tags"}); 5],
                 "relation_kinds": ["calls", "imports", "references"],
                 "degradations": [],
+                "focal_entity": { "id": "0195f2a1-0000-7000-8000-00000000f0ca" },
                 "cross_repo": {
                     "status": "available",
                     "authority_complete": true,
                     "authority_revision": "sha256:complete",
                     "authority_roots": { "local": "local-root" },
+                    "authority_anchor": {
+                        "repo_id": "local",
+                        "entity_id": "0195f2a1-0000-7000-8000-00000000f0ca",
+                    },
                 },
                 "edge_coverage": {
                     "scope": "language",

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1856,7 +1856,7 @@ fn focal_is_method(payload: &Value) -> bool {
 /// cannot act on, describing a state the response already reports in full under
 /// `cross_repo`, teaches the reader to discount every limit including the real
 /// ones.
-enum CrossRepoQualifier {
+pub(crate) enum CrossRepoQualifier {
     /// The spine answered completely. Nothing to report.
     Complete,
     /// A configured spine failed, went stale, or answered incompletely. The
@@ -1921,6 +1921,28 @@ fn apply_cross_repo_qualifier(
         CrossRepoQualifier::Gap(reason) => push_gap(trustworthy, trust_reason, reason),
         CrossRepoQualifier::Note(note) => notes.push(note),
         CrossRepoQualifier::Complete => {}
+    }
+}
+
+/// The cross-repo qualifier this response earns, for the callers that need it
+/// outside this gate.
+///
+/// Exposed because [`crate::verdict`] must weigh the same fact, and a second
+/// implementation of "is cross-repo authority a gap" would drift from this one.
+/// The rule lives here once; the verdict maps it onto a reading.
+///
+/// `None` means the payload carries no cross-repo accounting at all, which is
+/// not the same as reporting that nothing was missed. This gate treats an absent
+/// block as a gap when an absence is being claimed, because an answer that says
+/// "nothing references this" while silently reporting no cross-repo authority is
+/// the exact shape it exists to refuse. A populated answer claims no absence, so
+/// there the honest reading is that the concept is not carried.
+pub(crate) fn cross_repo_qualifier(tool: &str, payload: &Value) -> Option<CrossRepoQualifier> {
+    payload.get("cross_repo")?;
+    match tool {
+        "find_references" => Some(cross_repo_references_qualifier(payload)),
+        "bulk_check_references" => Some(cross_repo_bulk_qualifier(payload)),
+        _ => None,
     }
 }
 

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -731,12 +731,10 @@ fn withheld_candidates_reading(payload: &Value) -> Reading {
 /// and a populated answer asserts no such thing.
 fn cross_repo_reading(tool: &str, payload: &Value) -> Reading {
     use crate::negative::CrossRepoQualifier;
-    let unbound_caller = payload
-        .get("cross_repo")
-        .is_some_and(|cross_repo| {
-            cross_repo.get("status").and_then(Value::as_str) == Some("unavailable")
-                && cross_repo.get("code").and_then(Value::as_str).is_none()
-        });
+    let unbound_caller = payload.get("cross_repo").is_some_and(|cross_repo| {
+        cross_repo.get("status").and_then(Value::as_str) == Some("unavailable")
+            && cross_repo.get("code").and_then(Value::as_str).is_none()
+    });
     if unbound_caller {
         return Reading::Silent;
     }
@@ -1886,7 +1884,6 @@ mod tests {
         })
     }
 
-
     /// FIR-2764. A populated answer whose configured spine answered incompletely
     /// is a lower bound, and the verdict has to say so.
     ///
@@ -1915,7 +1912,11 @@ mod tests {
             json!(INCONCLUSIVE),
             "a set presented as whole while the spine could not answer: {verdict}"
         );
-        assert_eq!(verdict["inputs"]["cross_repo"], json!(INCONCLUSIVE), "{verdict}");
+        assert_eq!(
+            verdict["inputs"]["cross_repo"],
+            json!(INCONCLUSIVE),
+            "{verdict}"
+        );
         let factor = verdict["limiting_factor"].as_str().expect("a factor");
         assert!(
             factor.contains("cross_repo_authority_incomplete"),
@@ -1963,10 +1964,7 @@ mod tests {
     fn the_ordinary_states_of_a_healthy_install_limit_nothing() {
         let mut broken: Vec<String> = Vec::new();
         for (case, cross_repo) in [
-            (
-                "no spine configured",
-                json!({ "status": "not_configured" }),
-            ),
+            ("no spine configured", json!({ "status": "not_configured" })),
             (
                 "a repository the spine has not registered",
                 json!({
@@ -2039,7 +2037,11 @@ mod tests {
         .to_value();
 
         assert_eq!(verdict["state"], json!(CERTIFIED), "{verdict}");
-        assert_eq!(verdict["inputs"]["cross_repo"], json!(CERTIFIED), "{verdict}");
+        assert_eq!(
+            verdict["inputs"]["cross_repo"],
+            json!(CERTIFIED),
+            "{verdict}"
+        );
         assert_eq!(verdict["limiting_factor"], Value::Null, "{verdict}");
     }
 

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -2080,6 +2080,64 @@ mod tests {
         );
     }
 
+    /// The other tool that carries a cross-repo block reaches the same input.
+    ///
+    /// The dispatch names two tools, and the absence gate names the same two, so
+    /// the strings are written twice in one file. A rename that moved one and not
+    /// the other would leave this arm matching nothing, and nothing about a
+    /// find_references test can see that: the verdict would simply stop weighing
+    /// cross-repo authority on bulk answers and no assertion anywhere would go
+    /// red.
+    ///
+    /// So the arm gets its own case, with the healthy direction beside the
+    /// refusing one. A dispatch that stopped matching would certify both.
+    #[test]
+    fn the_bulk_tool_reaches_the_same_cross_repo_input() {
+        let complete = json!({
+            "status": "available",
+            "authority_complete": true,
+            "authority_revision": "sha256:complete",
+            "authority_roots": {"local": "local-root"},
+            "relation_subtype_complete": true,
+            "verdicts_complete": true,
+        });
+        let mut incomplete = complete.clone();
+        incomplete["authority_complete"] = json!(false);
+
+        for (case, cross_repo, expected_state, expected_input) in [
+            ("a complete bulk authority", complete, CERTIFIED, CERTIFIED),
+            (
+                "a bulk authority that answered incompletely",
+                incomplete,
+                INCONCLUSIVE,
+                INCONCLUSIVE,
+            ),
+        ] {
+            let payload = json!({
+                "results": [{"name": "index_note", "has_references": true}],
+                "degradations": [],
+                "cross_repo": cross_repo,
+            });
+            let negative =
+                json!({ "interpretation": "qualified_answer", "trust": "authoritative" });
+            let verdict = Verdict::compute(
+                "bulk_check_references",
+                &payload,
+                &Envelope::daemon(),
+                Some(&negative),
+            )
+            .expect("a retrieval payload carries a verdict")
+            .to_value();
+
+            assert_eq!(
+                verdict["inputs"]["cross_repo"],
+                json!(expected_input),
+                "{case}: the bulk dispatch arm must be reached: {verdict}"
+            );
+            assert_eq!(verdict["state"], json!(expected_state), "{case}: {verdict}");
+        }
+    }
+
     /// FIR-2672, the sole-cause case. Every input is clean except one requested
     /// class the answer could not read, and that alone makes the verdict
     /// inconclusive and names the class, for each of the three states a class

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -252,6 +252,7 @@ impl Verdict {
             ("edge_coverage", edge_coverage_reading(tool, payload)),
             ("withheld_candidates", withheld_candidates_reading(payload)),
             ("degradations", degradations_reading(payload)),
+            ("cross_repo", cross_repo_reading(tool, payload)),
             ("completeness", completeness_reading(envelope)),
             ("graph_freshness", graph_freshness_reading(envelope)),
         ];
@@ -685,6 +686,65 @@ fn withheld_candidates_reading(payload: &Value) -> Reading {
              and are not in the counts here, so the headline is a floor and each withheld row \
              may belong in it"
         )]),
+    }
+}
+
+/// Whether the configured cross-repo authority could answer for this response.
+///
+/// The absence gate already weighs this, and weighs it well, but only on an
+/// answer that CLAIMS an absence. That scoping is deliberate and it is right for
+/// what it was written for: a populated answer claims nothing is missing, so
+/// refusing there on a store with no spine would put a floor under every answer
+/// forever.
+///
+/// What it leaves uncovered is the case this input exists for. A populated
+/// answer is presented as the reference set, and when a configured spine went
+/// stale or answered incompletely, every cross-repo row is missing from a set
+/// nothing marks as partial. That is `find_references` certifying an answer as
+/// the whole set while recording that a class is absent, one level up: the class
+/// here is every other repository. The gap belongs in the verdict on both
+/// shapes of answer, and only the absence claim differs.
+///
+/// The rule itself is not restated here. [`crate::negative::cross_repo_qualifier`]
+/// owns it, so this reading and the absence gate can never disagree about what
+/// counts as a gap, and the clause text is identical, which is what makes the
+/// composer's label dedupe collapse them to one on an answer where both speak.
+///
+/// Silent, never refusing, in the states that are facts about an install rather
+/// than limits on an answer: no spine configured, and a repository the spine has
+/// not registered. Both already travel as notes on the absence path, and both
+/// are the ordinary state of a healthy single-repo store, so refusing on either
+/// is the "mark everything uncertain" regression arriving by a side door.
+///
+/// Silent on a third, which the absence path does treat as a gap and this one
+/// deliberately does not. An `unavailable` carrying no `code` is a caller that
+/// never bound to a repository at all, not a spine that failed:
+/// the absence gate's own unavailable-qualifier states the principle
+/// itself, that every code "describes a spine that IS configured and did not
+/// answer", and an uncoded reason reaches the gap branch only through the
+/// catch-all label. `kin refs` is such a caller on every invocation, since it
+/// resolves its binding from `KIN_REPO_ID` and that is an override rather than
+/// something an install sets, so weighing it here would mark every CLI reference
+/// answer on every machine a lower bound. The absence path keeps its stricter
+/// reading, because an answer asserting that nothing references a symbol while
+/// reporting no cross-repo authority is exactly what that gate exists to refuse,
+/// and a populated answer asserts no such thing.
+fn cross_repo_reading(tool: &str, payload: &Value) -> Reading {
+    use crate::negative::CrossRepoQualifier;
+    let unbound_caller = payload
+        .get("cross_repo")
+        .is_some_and(|cross_repo| {
+            cross_repo.get("status").and_then(Value::as_str) == Some("unavailable")
+                && cross_repo.get("code").and_then(Value::as_str).is_none()
+        });
+    if unbound_caller {
+        return Reading::Silent;
+    }
+    match crate::negative::cross_repo_qualifier(tool, payload) {
+        None => Reading::Silent,
+        Some(CrossRepoQualifier::Complete) => Reading::Certified,
+        Some(CrossRepoQualifier::Note(_)) => Reading::Silent,
+        Some(CrossRepoQualifier::Gap(reason)) => Reading::Inconclusive(vec![reason]),
     }
 }
 
@@ -1784,6 +1844,11 @@ mod tests {
 
     /// A populated reference answer whose every other input is clean, with one
     /// requested class in the state given.
+    /// One focal id for the fixture, named once so the payload's `focal_entity`
+    /// and the cross-repo anchor cannot drift apart into a response that would
+    /// never be produced.
+    const FIXTURE_FOCAL_ID: &str = "0195f2a1-0000-7000-8000-00000000f0ca";
+
     fn populated_reference_payload(imports: &str) -> Value {
         json!({
             "references": [{"name": "index_note"}, {"name": "test_blank_code_masks_fences"}],
@@ -1791,11 +1856,18 @@ mod tests {
             "relation_kinds": ["calls", "imports", "references"],
             "counts": {"receiver_name_candidates": 0},
             "degradations": [],
+            // Complete the way a real answer is complete. The producer always
+            // writes an anchor beside the roots and always writes `focal_entity`,
+            // and the absence gate has always required the anchor to name the
+            // focal this query asked about. A fixture carrying roots and no
+            // anchor describes a response the handler cannot emit.
+            "focal_entity": {"id": FIXTURE_FOCAL_ID},
             "cross_repo": {
                 "status": "available",
                 "authority_complete": true,
                 "authority_revision": "sha256:complete",
                 "authority_roots": {"local": "local-root"},
+                "authority_anchor": {"repo_id": "local", "entity_id": FIXTURE_FOCAL_ID},
             },
             "focal_resolution": {
                 "addressed_by": "entity_id",
@@ -1812,6 +1884,189 @@ mod tests {
                 "budget_exhausted": false,
             },
         })
+    }
+
+
+    /// FIR-2764. A populated answer whose configured spine answered incompletely
+    /// is a lower bound, and the verdict has to say so.
+    ///
+    /// The absence gate already weighs cross-repo authority, and weighs it well,
+    /// but only on an answer that claims an absence. A populated answer is
+    /// presented as the reference set, so a spine that could not answer means
+    /// every cross-repo row is missing from a set nothing marks as partial.
+    /// Before this input the verdict read six other blocks, none of which can
+    /// see the spine, and certified.
+    #[test]
+    fn a_populated_answer_over_an_incomplete_spine_is_a_lower_bound() {
+        let mut payload = populated_reference_payload("present");
+        payload["cross_repo"]["authority_complete"] = json!(false);
+        let negative = json!({ "interpretation": "qualified_answer", "trust": "authoritative" });
+        let verdict = Verdict::compute(
+            "find_references",
+            &payload,
+            &Envelope::daemon(),
+            Some(&negative),
+        )
+        .expect("a retrieval payload carries a verdict")
+        .to_value();
+
+        assert_eq!(
+            verdict["state"],
+            json!(INCONCLUSIVE),
+            "a set presented as whole while the spine could not answer: {verdict}"
+        );
+        assert_eq!(verdict["inputs"]["cross_repo"], json!(INCONCLUSIVE), "{verdict}");
+        let factor = verdict["limiting_factor"].as_str().expect("a factor");
+        assert!(
+            factor.contains("cross_repo_authority_incomplete"),
+            "the factor must name the spine rather than something else: {factor}"
+        );
+    }
+
+    /// The same shape with an `unavailable` spine that named its condition.
+    #[test]
+    fn a_populated_answer_over_a_stale_spine_is_a_lower_bound() {
+        let mut payload = populated_reference_payload("present");
+        payload["cross_repo"] = json!({
+            "status": "unavailable",
+            "code": "spine_root_stale",
+            "reason": "spine root mismatch for repository local",
+        });
+        let negative = json!({ "interpretation": "qualified_answer", "trust": "authoritative" });
+        let verdict = Verdict::compute(
+            "find_references",
+            &payload,
+            &Envelope::daemon(),
+            Some(&negative),
+        )
+        .expect("a retrieval payload carries a verdict")
+        .to_value();
+
+        assert_eq!(verdict["state"], json!(INCONCLUSIVE), "{verdict}");
+        let factor = verdict["limiting_factor"].as_str().expect("a factor");
+        assert!(
+            factor.contains("spine_root_stale"),
+            "the producer's own code names the condition: {factor}"
+        );
+    }
+
+    /// The controls that keep this input from becoming a floor under every
+    /// answer, which is the regression the absence gate's own scoping comment
+    /// warns about. Each of these is an ordinary state of a healthy install, and
+    /// each must leave the verdict certified with no factor at all.
+    ///
+    /// `unavailable` with no code is `kin refs` on every invocation: it resolves
+    /// its binding from `KIN_REPO_ID`, which is an override rather than
+    /// something an install sets. Weighing it would mark every CLI reference
+    /// answer on every machine a lower bound.
+    #[test]
+    fn the_ordinary_states_of_a_healthy_install_limit_nothing() {
+        for (case, cross_repo) in [
+            (
+                "no spine configured",
+                json!({ "status": "not_configured" }),
+            ),
+            (
+                "a repository the spine has not registered",
+                json!({
+                    "status": "unavailable",
+                    "code": "spine_repo_unregistered",
+                    "reason": "repository local has no registered spine authority",
+                }),
+            ),
+            (
+                "a caller that never bound to a repository",
+                json!({
+                    "status": "unavailable",
+                    "reason": "KIN_REPO_ID is missing or blank; cross-repo authority cannot \
+                               bind this graph to a repository",
+                }),
+            ),
+        ] {
+            let mut payload = populated_reference_payload("present");
+            payload["cross_repo"] = cross_repo;
+            let negative =
+                json!({ "interpretation": "qualified_answer", "trust": "authoritative" });
+            let verdict = Verdict::compute(
+                "find_references",
+                &payload,
+                &Envelope::daemon(),
+                Some(&negative),
+            )
+            .expect("a retrieval payload carries a verdict")
+            .to_value();
+
+            assert_eq!(
+                verdict["state"],
+                json!(CERTIFIED),
+                "{case} is a fact about the install, not a limit on the answer: {verdict}"
+            );
+            assert_eq!(
+                verdict["limiting_factor"],
+                Value::Null,
+                "{case} must contribute no clause: {verdict}"
+            );
+            assert_eq!(
+                verdict["inputs"]["cross_repo"],
+                json!(NOT_APPLICABLE),
+                "{case} must read silent rather than certifying: {verdict}"
+            );
+        }
+    }
+
+    /// A complete spine certifies rather than staying silent, so the input
+    /// contributes agreement on the healthy path instead of merely not refusing.
+    #[test]
+    fn a_complete_spine_certifies_as_its_own_named_input() {
+        let payload = populated_reference_payload("present");
+        let negative = json!({ "interpretation": "qualified_answer", "trust": "authoritative" });
+        let verdict = Verdict::compute(
+            "find_references",
+            &payload,
+            &Envelope::daemon(),
+            Some(&negative),
+        )
+        .expect("a retrieval payload carries a verdict")
+        .to_value();
+
+        assert_eq!(verdict["state"], json!(CERTIFIED), "{verdict}");
+        assert_eq!(verdict["inputs"]["cross_repo"], json!(CERTIFIED), "{verdict}");
+        assert_eq!(verdict["limiting_factor"], Value::Null, "{verdict}");
+    }
+
+    /// The same gap seen by two readings is named once.
+    ///
+    /// On an answer that claims an absence, the gate puts the cross-repo clause
+    /// in `trust_reason` and the absence-gate reading splits it back out, while
+    /// this input builds the same clause directly. Both speak, and the composer
+    /// dedupes by label, so the reader gets one clause rather than the same
+    /// sentence twice. That is the FIR-2672 rule this input has to obey rather
+    /// than re-break.
+    #[test]
+    fn one_gap_seen_by_two_readings_is_named_once() {
+        let mut payload = populated_reference_payload("present");
+        payload["cross_repo"]["authority_complete"] = json!(false);
+        let negative = json!({
+            "interpretation": "absence_claim",
+            "trust": "inconclusive",
+            "trust_reason": "cross_repo_authority_incomplete: spine topology or requested \
+                             relation subtype is incomplete at revision sha256:complete",
+        });
+        let verdict = Verdict::compute(
+            "find_references",
+            &payload,
+            &Envelope::daemon(),
+            Some(&negative),
+        )
+        .expect("a retrieval payload carries a verdict")
+        .to_value();
+
+        let factor = verdict["limiting_factor"].as_str().expect("a factor");
+        assert_eq!(
+            factor.matches("cross_repo_authority_incomplete").count(),
+            1,
+            "the gap is one gap however many readings noticed it: {factor}"
+        );
     }
 
     /// FIR-2672, the sole-cause case. Every input is clean except one requested

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -1961,6 +1961,7 @@ mod tests {
     /// answer on every machine a lower bound.
     #[test]
     fn the_ordinary_states_of_a_healthy_install_limit_nothing() {
+        let mut broken: Vec<String> = Vec::new();
         for (case, cross_repo) in [
             (
                 "no spine configured",
@@ -1996,22 +1997,30 @@ mod tests {
             .expect("a retrieval payload carries a verdict")
             .to_value();
 
-            assert_eq!(
-                verdict["state"],
-                json!(CERTIFIED),
-                "{case} is a fact about the install, not a limit on the answer: {verdict}"
-            );
-            assert_eq!(
-                verdict["limiting_factor"],
-                Value::Null,
-                "{case} must contribute no clause: {verdict}"
-            );
-            assert_eq!(
-                verdict["inputs"]["cross_repo"],
-                json!(NOT_APPLICABLE),
-                "{case} must read silent rather than certifying: {verdict}"
-            );
+            // Collected rather than asserted in place. A bare assert aborts the
+            // loop on the first case, so a break confined to a later one is
+            // invisible behind an earlier one failing first, and the mutation
+            // written for it reads as covered while proving nothing.
+            if verdict["state"] != json!(CERTIFIED) {
+                broken.push(format!(
+                    "{case} is a fact about the install, not a limit on the answer: {verdict}"
+                ));
+            }
+            if verdict["limiting_factor"] != Value::Null {
+                broken.push(format!("{case} must contribute no clause: {verdict}"));
+            }
+            if verdict["inputs"]["cross_repo"] != json!(NOT_APPLICABLE) {
+                broken.push(format!(
+                    "{case} must read silent rather than certifying: {verdict}"
+                ));
+            }
         }
+        assert!(
+            broken.is_empty(),
+            "{} of the ordinary install states limited an answer:\n{}",
+            broken.len(),
+            broken.join("\n")
+        );
     }
 
     /// A complete spine certifies rather than staying silent, so the input


### PR DESCRIPTION
A find_references answer that returned rows is presented as the reference set. When the configured cross-repo spine went stale or answered incompletely, every cross-repo row is missing from that set and nothing marked it partial. The verdict read six inputs and none of them can see the spine, so the answer came back certified. That is find_references certifying an answer as the whole set while recording that a class is absent, one level up, where the class is every other repository.

The absence gate already weighs cross-repo authority, and weighs it well, but it is scoped to answers that claim an absence, and that scoping is right for what it was written for. This adds cross_repo as its own named verdict input so the fact reaches a populated answer too. The rule is not restated anywhere: negative.rs owns it and now exposes it, so the gate and the verdict can never disagree about what counts as a gap, and because the clause text is identical the composer's label dedupe collapses them to one clause on an answer where both speak.

Three states stay silent, because they are facts about an install rather than limits on an answer: no spine configured, a repository the spine has not registered, and a caller that never bound to a repository. The third is the one worth naming. kin refs resolves its binding from KIN_REPO_ID, which is an override rather than something an install sets, so every CLI reference answer on every machine reports an uncoded unavailable. Weighing that would mark all of them a lower bound, which is exactly the regression the gate's own scoping comment warns about. The gate keeps its stricter reading on the absence path, where an answer asserting that nothing references a symbol while reporting no cross-repo authority is what it exists to refuse.

Three test fixtures gain the anchor a real answer always carries. The producer always writes authority_anchor beside the roots and always writes focal_entity, and the gate has always required the anchor to name the focal the query asked about, so a fixture carrying roots and no anchor described a response the handler cannot emit. One of those fixtures says in its own comment that it means to be complete.

## Falsification

Seven mutations against all five tests in the class, on the committed tree, each proven applied by finding its marker before the build, each restored from an explicit source under an EXIT, INT and TERM trap that prints the sha it restored to and the marker count, which read zero every time. No row is green across.

| mutation | tests it turns red |
|---|---|
| the gap reading goes silent | both lower-bound tests |
| the input is unwired from the readings | both lower-bound tests, the healthy-states control, the certifying control |
| a note refuses instead of staying silent | the healthy-states control, on the first two states |
| the unbound-caller carve-out is removed | the healthy-states control, on the third state alone |
| a note certifies instead of staying silent | the healthy-states control, on its silent-input assertion alone |
| the gap clause takes a different label | the dedupe test |
| the unregistered carve-out is removed | the healthy-states control, on the second state alone |

The healthy-states control asserted in place inside its loop at first, so the first case failing ended the test and the two after it never ran. Two mutations both fired on the first case and stopped there, which left the middle state defended by nothing. It now collects and reports every state, and the last three rows above are what that bought: each names a different state or a different assertion, so no arm is covered only by an earlier arm failing sooner.

The driver's own marker guard was falsified too. A no-op mutation makes it abort that arm and exit nonzero rather than running the arm green. It needed the check: with two files under mutation, grep -c prints a per-file count, so the guard had been erroring and falling through.

## The sixth test, added after the matrix

The dispatch names two tools and the absence gate names the same two, so those strings are written twice in one file. A rename that moved one and not the other would leave the `bulk_check_references` arm matching nothing, and no `find_references` test can see that: the verdict would simply stop weighing cross-repo authority on bulk answers, silently, with every assertion still green. That arm shipped with no coverage until this.

It now has its own case in both directions. Falsified by renaming the dispatch arm, which turns it red while the `find_references` lower-bound test stays green under the same mutation, so the two arms are independently covered rather than one riding on the other.

## What was run

kin-precheck against the lane worktree at 1440dbdd5, which enumerated 16 gates from ci.yml's own check job and reported 16 passed, 0 failed, 0 commits behind origin/main. cargo test -p kin-mcp: 685 passed, 0 failed. cargo test -p kin-daemon as the consumer. Hosted CI is the gate of record.

## What this does not do

It does not report cross-repo coverage on kin doctor or graph status, which is the other half of the ticket's acceptance. It does not touch the identity defect that leaves the spine empty in the first place, which is FIR-2763 and is held pending a decision on which side owns repository identity.

Part of FIR-2764
