### PR TITLE
Report why the cross-repo edge count is what it is, beside the count

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -30110,6 +30110,71 @@ mod tests {
         );
     }
 
+    /// The alarming value, actually produced.
+    ///
+    /// The two tests above run on a daemon that pinned everything, so both read
+    /// `startup_authority_complete: true`, and a mutation hardcoding the field to
+    /// `true` left them both green. An assertion comparing the route's answer to
+    /// the state's answer cannot catch that when the two agree on `true` anyway,
+    /// which made it decoration rather than a control.
+    ///
+    /// This builds a daemon whose startup pass cannot bind a repository the
+    /// registry names, which is the condition the field exists to report, and
+    /// requires the route to say so. Hardcoding either value now fails one of
+    /// the two directions.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn spine_health_reports_a_startup_authority_it_could_not_bind() {
+        // A registry row pointing at a directory that carries a `.kin` but no
+        // readable manifest. Binding it fails, which is what leaves the startup
+        // authority set short.
+        let sibling_parent = tempfile::tempdir().unwrap();
+        let sibling_root = sibling_parent.path().join("unbindable-sibling");
+        std::fs::create_dir_all(sibling_root.join(".kin")).unwrap();
+
+        let registry_dir = tempfile::tempdir().unwrap();
+        let registry_path = registry_dir.path().join("registry.toml");
+        kin_core::registry::KinRegistry {
+            repos: vec![kin_core::registry::RegisteredRepo {
+                id: "unbindable-sibling".to_string(),
+                path: sibling_root.clone(),
+                entities: 1,
+                last_commit: String::new(),
+                dependencies: vec![],
+            }],
+        }
+        .save_to(&registry_path)
+        .unwrap();
+        let _registry_env =
+            kin_core::test_env::EnvVarGuard::set("KIN_REGISTRY_PATH", &registry_path);
+
+        let primary_dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(primary_dir.path()).unwrap().layout;
+        let state = Arc::new(DaemonState::open(layout).unwrap());
+        assert!(
+            !state.startup_authority_complete(),
+            "the fixture must actually produce a short startup authority, or this \
+             test proves nothing about reporting one"
+        );
+
+        let app = router(state);
+        let response = app
+            .oneshot(Request::get("/spine/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            json["startup_authority_complete"],
+            serde_json::json!(false),
+            "a registry row the daemon could not bind must reach the reader: {json}"
+        );
+    }
+
     #[tokio::test]
     async fn spine_repos_returns_list() {
         let state = test_state();

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -11872,11 +11872,25 @@ async fn spine_health(
         )
     })?;
 
+    // Two completeness readings, never one. `cross_repo_edges: 0` beside nothing
+    // else is a bare zero: it reads as "this install has no cross-repo edges"
+    // whether the authority was built and found none or was never built at all.
+    //
+    // They answer different questions and both are needed to tell those apart.
+    // `authority_complete` is the spine's own edge authority, which goes false
+    // for a refresh in flight as readily as for an authority that is short.
+    // `startup_authority_complete` is false only when the startup pass could not
+    // bind a repository the registry named, which is the condition that leaves
+    // cross-repo answers empty for the rest of the process's life. Collapsing
+    // them into one boolean would make a transient refresh indistinguishable
+    // from a permanently short authority.
     Ok(Json(json!({
         "status": "ok",
         "repos": spine.repo_count(),
         "entities": spine.entity_count(),
         "cross_repo_edges": spine.edge_count(),
+        "authority_complete": spine.authority_complete(),
+        "startup_authority_complete": state.startup_authority_complete(),
     })))
 }
 
@@ -30008,6 +30022,92 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["status"], "ok");
+    }
+
+    /// A zero edge count says nothing on its own, so the health route reports
+    /// what produced it.
+    ///
+    /// `cross_repo_edges: 0` beside nothing else is the bare zero this ticket is
+    /// about: an authority that was built and found no edges and an authority
+    /// that was never built read identically. The two completeness fields are
+    /// what separate them, and this asserts both are present and typed, on a
+    /// healthy single-repo daemon where the answer is a real zero.
+    #[tokio::test]
+    async fn spine_health_reports_both_completeness_readings_beside_the_edge_count() {
+        let state = test_state();
+        let startup_complete = state.startup_authority_complete();
+        let app = router(state);
+        let response = app
+            .oneshot(Request::get("/spine/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(
+            json["cross_repo_edges"].is_u64(),
+            "the count this qualifies must still be reported: {json}"
+        );
+        assert!(
+            json["authority_complete"].is_boolean(),
+            "the spine's own edge-authority reading must be reported: {json}"
+        );
+        assert!(
+            json["startup_authority_complete"].is_boolean(),
+            "the startup pin's reading must be reported beside it: {json}"
+        );
+        // Healthy control: a single-repo daemon that pinned everything the
+        // registry named reports a complete startup authority, so the field
+        // cannot be hardcoded to the alarming value and read as working.
+        assert_eq!(
+            json["startup_authority_complete"],
+            serde_json::json!(startup_complete),
+            "the route must report the state's own reading, not a constant: {json}"
+        );
+        assert_eq!(
+            json["startup_authority_complete"],
+            serde_json::json!(true),
+            "a daemon whose registry named nothing it could not pin is complete: {json}"
+        );
+    }
+
+    /// The two readings are not the same reading, and the route must not
+    /// collapse them.
+    ///
+    /// A refresh in flight turns the spine's own authority incomplete while the
+    /// startup pin stays complete. If one field were derived from the other, or
+    /// both from one source, this case would report the startup pass as short
+    /// and send a reader hunting a registry problem that does not exist.
+    #[tokio::test]
+    async fn a_dirty_edge_authority_does_not_report_the_startup_pin_as_short() {
+        let state = test_state();
+        let spine = state.ensure_spine().expect("spine enabled in test");
+        for repo in spine.registered_repo_ids() {
+            spine.invalidate_cross_repo_edges(&repo);
+        }
+        let app = router(state);
+        let response = app
+            .oneshot(Request::get("/spine/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            json["authority_complete"],
+            serde_json::json!(false),
+            "a dirtied edge authority must read incomplete: {json}"
+        );
+        assert_eq!(
+            json["startup_authority_complete"],
+            serde_json::json!(true),
+            "dirtying edges says nothing about what the startup pass could bind: {json}"
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2254,6 +2254,19 @@ impl DaemonState {
         Ok(true)
     }
 
+    /// Whether every registry row naming a live local repository was pinned at
+    /// startup.
+    ///
+    /// A distinct question from the spine's own edge-authority completeness, and
+    /// the two must be reported side by side rather than collapsed. The spine's
+    /// reading goes false for a refresh in flight as readily as for an authority
+    /// that is short; this one is false only when the startup pass could not
+    /// bind a repository the registry named, which is the condition that leaves
+    /// cross-repo answers empty for the rest of the process's life.
+    pub fn startup_authority_complete(&self) -> bool {
+        !self.registered_local_repository_authority_incomplete
+    }
+
     /// Freeze local sibling authority capabilities before the daemon becomes
     /// externally visible.
     ///

--- a/crates/kin-spine/src/backend.rs
+++ b/crates/kin-spine/src/backend.rs
@@ -110,6 +110,17 @@ pub trait SpineBackend: Send + Sync {
     /// ignoring a failed refresh.
     fn invalidate_cross_repo_edges(&self, repo_id: &str);
 
+    /// Whether the cross-repo edge authority this backend is serving is
+    /// complete.
+    ///
+    /// The default derives it from the snapshot, which is correct for any
+    /// backend and costs a full materialization; a backend that can answer
+    /// cheaply should override. Reported so an empty cross-repo answer can say
+    /// whether it is an observed zero or an unbuilt authority.
+    fn authority_complete(&self) -> bool {
+        self.cross_repo_edges_snapshot().complete
+    }
+
     /// Acquire one all-repo refresh lease against an exact registered root set.
     /// While active, per-source refreshes cannot advertise completeness.
     fn begin_cross_repo_refresh_pass(
@@ -163,6 +174,10 @@ impl Default for InMemorySpineBackend {
 }
 
 impl SpineBackend for InMemorySpineBackend {
+    fn authority_complete(&self) -> bool {
+        self.index.authority_is_complete()
+    }
+
     fn register_repo(&self, repo_id: &str, entries: Vec<EntityEntry>, root_hash: &str) {
         self.index.register_repo(repo_id, entries, root_hash);
     }

--- a/crates/kin-spine/src/firestore.rs
+++ b/crates/kin-spine/src/firestore.rs
@@ -176,6 +176,16 @@ impl SpineBackend for FirestoreSpineBackend {
         self.cache.cross_repo_edges_for(repo_id, entity_id)
     }
 
+    fn authority_complete(&self) -> bool {
+        // The same fail-closed rule the snapshot below applies, said directly.
+        // The trait's default derives this by materializing the whole snapshot,
+        // which for this backend clones every cached edge and entity to arrive
+        // at a constant. Stating it here keeps the policy in one readable place
+        // per backend rather than emergent from what the default happens to
+        // read, and a health probe stops paying a full clone for one boolean.
+        false
+    }
+
     fn cross_repo_edges_snapshot(&self) -> CrossRepoEdgesSnapshot {
         // Durable rows and this pod's graph refreshes are useful advisory
         // positives, but neither can prove that every other pod observed the

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -593,6 +593,28 @@ impl SpineIndex {
         inner.authority_revision = cross_repo_snapshot_revision(&roots, &canonical_edges);
     }
 
+    /// This index's own cross-repo authority completeness, read without
+    /// materializing the edge set.
+    ///
+    /// `cross_repo_edges_snapshot().complete` answers the same question and
+    /// clones every edge and entity to do it, which is the wrong price for a
+    /// health endpoint that wants one boolean.
+    ///
+    /// What it means is narrow on purpose: the edge authority this index is
+    /// currently serving is closed and nothing is dirty. It goes false for a
+    /// refresh in flight as readily as for an authority that is genuinely short,
+    /// so a caller reporting WHY cross-repo answers are empty needs the startup
+    /// pin's own reading beside it, not this alone.
+    pub fn authority_is_complete(&self) -> bool {
+        let inner = self.inner.read();
+        let roots = inner
+            .root_hashes
+            .iter()
+            .map(|(repo, root)| (repo.clone(), root.clone()))
+            .collect::<BTreeMap<_, _>>();
+        Self::authority_complete(&inner, &roots)
+    }
+
     fn authority_complete(inner: &SpineInner, roots: &BTreeMap<RepoId, String>) -> bool {
         inner.active_edge_refreshes == 0
             && inner.active_full_refresh_epoch.is_none()


### PR DESCRIPTION
`GET /spine/health` answered `cross_repo_edges` with a bare number. Zero there reads as "this install has no cross-repo edges" whether the authority was built and found none or was never built at all, and on this fleet it has been the second one since July while reading like the first.

It now reports two completeness readings beside the count, and two rather than one because they answer different questions. `authority_complete` is the spine's own edge authority, and it goes false for a refresh in flight as readily as for an authority that is genuinely short. `startup_authority_complete` is false only when the startup pass could not bind a repository the registry named, which is the condition that leaves cross-repo answers empty for the rest of the process's life. Collapsing them into one boolean would make a transient refresh indistinguishable from a permanently short authority, and would send a reader hunting a registry problem that does not exist.

The spine gains a cheap read of its own completeness. `cross_repo_edges_snapshot` already answers that question and clones every edge and entity to do it, which is the wrong price for a health endpoint that wants one boolean. The trait carries the expensive derivation as its default so no backend is forced to change, and the in-memory backend overrides it.

## Falsification

Five mutations against four tests, on the committed tree, markers proven present before each build, restore from an explicit source under an EXIT, INT and TERM trap.

| mutation | turns red |
|---|---|
| drop the startup reading | all three tests that assert on the new fields |
| drop the spine reading | the two that read it |
| hardcode the startup reading true | the short-authority test alone |
| derive the spine reading from the startup one | the dirty-edge test alone |
| make the startup reading always alarm | both healthy-path tests |

`spine_health_returns_ok` is in the list and green under every arm. It asserts only that the route answers `status: ok` and predates this change, so it is a bystander rather than coverage, and it is listed rather than quietly dropped.

The third row is the one that cost a round. Two tests shipped first and both ran on a daemon that pinned everything, so both read the field as true, and hardcoding it to true left them green. One of them compares the route's answer to the state's own answer, which reads like a control and is not one when the two agree on true anyway. The fourth test builds the condition the field exists for, a registry row pointing at a directory carrying a `.kin` and no readable manifest, and asserts the fixture actually produced a short authority before asserting anything about reporting one.

The driver's test list was itself wrong on the first pass: the new test existed and the driver did not enumerate it, so the hardcode arm still came back green. A matrix is only as good as the list it runs.

## What was run

`kin-precheck` against the lane worktree at 9445aed93, 16 gates enumerated from ci.yml's own check job, 16 passed, 0 failed, 0 commits behind origin/main. `cargo test -p kin-daemon -p kin-spine`, read from cargo's own exit code: 1065 lib tests plus eight suites, zero `FAILED` lines, zero `test result: FAILED`, zero panics. Hosted CI is the gate of record.

## Scope, stated precisely

This is a disclosure surface, and it is **not** the one FIR-2764's acceptance names. That clause reads "kin doctor or graph status states cross-repo authority coverage". `GET /spine/health` is a daemon HTTP route, which is what a hosted operator reads; `kin graph status` is a separate CLI command that mentions spine and cross-repo zero times today, and there is no `kin doctor` in the tree at all beyond a `kin setup doctor` string in an update path.

So this PR closes a real gap and does not close that clause. Saying otherwise would be probing the convenient surface instead of the one the claim is about. Wiring the CLI needs a parameter added to `execute_graph_command_for_store`, whose signature kin-daemon shares at `api.rs:4134`, and that is worth doing on its own rather than appended here.

The verdict-envelope half of the acceptance is PR 1168. Neither PR touches the identity defect that empties the spine in the first place, which is FIR-2763 and is held pending a decision on which side owns repository identity.

Part of FIR-2764
