### PR TITLE
Serialize the spine-health test its sibling was racing

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -30032,7 +30032,20 @@ mod tests {
     /// that was never built read identically. The two completeness fields are
     /// what separate them, and this asserts both are present and typed, on a
     /// healthy single-repo daemon where the answer is a real zero.
+    ///
+    /// Serialized because the sibling below sets `KIN_REGISTRY_PATH`, which is
+    /// process-global, and `serial_test::serial` only serializes a test against
+    /// OTHER serial tests. That sibling carries the attribute; without it here
+    /// the two run concurrently, the sibling installs its deliberately
+    /// unbindable registry while this test's daemon is opening, and this test
+    /// reads the other one's world: `startup_authority_complete` comes back
+    /// false and the assertion below fails for a reason unrelated to the code
+    /// under test.
+    ///
+    /// It passes alone and fails in company, so a solo run is not a control for
+    /// it. `cargo test -p kin-daemon --lib -- spine_health` is.
     #[tokio::test]
+    #[serial_test::serial]
     async fn spine_health_reports_both_completeness_readings_beside_the_edge_count() {
         let state = test_state();
         let startup_complete = state.startup_authority_complete();


### PR DESCRIPTION
One attribute. The kin merge queue has been ejecting groups on a race, and this is
the fix.

## The race

`spine_health_reports_both_completeness_readings_beside_the_edge_count` asserts
`startup_authority_complete == true` on a healthy single-repo daemon.

Its sibling `spine_health_reports_a_startup_authority_it_could_not_bind` builds a
deliberately unbindable registry and installs it by setting `KIN_REGISTRY_PATH`,
which is process-global.

**That sibling is marked `#[serial_test::serial]`. This one was not.** `serial`
only serializes a test against OTHER serial tests, so the two run concurrently:
the sibling installs its unbindable registry while this test's daemon is opening,
and this test reads the other one's world. The sibling carrying the attribute is
itself evidence that somebody already knew the state was shared.

## What it cost

Every recent kin `merge_group` failure died on this test: **PR 1164 at 22:02, PR
1168 at 22:03, PR 1157 at 22:06**, all on the `Test featureless kin-daemon` step,
all ejected. A group ejection leaves its reason only on the `merge_group`
timeline, so all three read green on their own surfaces while the queue silently
refused to drain. The solo group for its own PR passed, which is the same schedule
luck that made this hard to see.

Featureless is where it surfaced because a different feature set changes timing,
not because anything here is feature-dependent.

## Falsification, supplied by main

No mutation driver, because `origin/main` IS the removed-attribute arm.

On unmodified `origin/main` at `d1253729e`, `cargo test -p kin-daemon --lib --
spine_health` fails:

```
assertion `left == right` failed: a daemon whose registry named nothing it could not pin is complete:
{"authority_complete":false,"cross_repo_edges":0,"entities":0,"repos":1,
 "startup_authority_complete":false,"status":"ok"}
  left: Bool(false)
 right: Bool(true)
```

With the attribute, the same command passes all of them together.

**It passes alone and fails in company**, which is why a solo `--exact` run has
always been green and can never be a control for it. That is the whole reason this
survived review.

## The class this belongs to

A sweep for kin-daemon tests that MUTATE process-global state without `serial`
found three more of the same shape, and the reader half of the class is not
enumerated at all. That audit is **FIR-2774**, filed separately.

It is separate on an evidence bar rather than for tidiness. This PR has a
reproduction on unmodified main; those three have a code reading. Serializing
tests costs wall clock on every future run, and letting an unproven change ride a
proven one would confuse the record of which was which.

One thing FIR-2774 carries that is easy to lose: **a mutator-only sweep finds half
the class.** The test fixed here mutates nothing. It reads a default that a
concurrent mutator destroys, so a clean mutator sweep can sit over a suite that
still races.

Closes FIR-2773
