### PR TITLE
Move the four compile-heavy CI jobs to the kin-16core larger runner

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -104,7 +104,7 @@ jobs:
     # mint refuses a sha whose required checks are not green, so what this
     # proves still has to be true before a tag, only later than it used to be.
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: kin-16core
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1258,7 +1258,7 @@ jobs:
       ${{ !cancelled()
       && needs.changes.outputs.docs_only != 'true'
       && github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: kin-16core
     timeout-minutes: 60
     # The all-features clippy/build/test sequence can otherwise retain more
     # than a hosted runner's available disk in incremental objects and debug
@@ -2254,7 +2254,7 @@ jobs:
     # sha release-tag.yml sweeps, where a non-required failure is terminal even
     # though nothing gated on it. A job that never starts cannot conclude.
     if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
-    runs-on: ubuntu-latest
+    runs-on: kin-16core
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
@@ -2315,7 +2315,7 @@ jobs:
       ${{ !cancelled()
       && needs.changes.outputs.docs_only != 'true'
       && github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: kin-16core
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -524,7 +524,7 @@ REAL_CHECK_JOB_AUTHORITY = textwrap.dedent(
         ${{ !cancelled()
         && needs.changes.outputs.docs_only != 'true'
         && github.event_name != 'pull_request' }}
-      runs-on: ubuntu-latest
+      runs-on: kin-16core
       timeout-minutes: 60
       env:
         CARGO_INCREMENTAL: "0"
@@ -560,7 +560,13 @@ UBUNTU_SHARD_AGGREGATE_AUTHORITY = textwrap.dedent(
     """
 ).rstrip()
 # Indented as `classifier_active_job_source` renders a dedented job block.
-UBUNTU_SHARD_RUNNER = "  runs-on: ubuntu-latest"
+# The `check` job runner, pinned here as well as inside
+# REAL_CHECK_JOB_AUTHORITY, because `shards` binds to blocks.get("check"),
+# so one job is pinned in two places and both have to move together.
+# Moved to the larger runner under the founder's 2026-08-26 ruling. The
+# aggregate is deliberately NOT moved: it compiles nothing and runs in
+# seconds, so it stays on ubuntu-latest.
+UBUNTU_SHARD_RUNNER = "  runs-on: kin-16core"
 UBUNTU_SHARD_INDEPENDENT_LEGS = "    fail-fast: false"
 UBUNTU_SHARD_MATRIX = "      shard: [1, 2]"
 UBUNTU_SHARD_PARTITION = (
@@ -13750,8 +13756,12 @@ def main() -> None:
             "      fail-fast: true",
         ),
         (
-            "the ubuntu shards leave ubuntu",
-            "    runs-on: ubuntu-latest",
+            # The shards no longer run on ubuntu-latest, so mutating away from it
+            # stopped identifying anything the day the runner moved. What the arm
+            # has always meant is "the shards leave their pinned runner", so it
+            # names the pinned value rather than the historical one.
+            "the ubuntu shards leave their pinned runner",
+            "    runs-on: kin-16core",
             "    runs-on: macos-latest",
         ),
         (
@@ -13909,8 +13919,11 @@ def main() -> None:
             "    needs: dco",
         ),
         (
+            # The real check job moved to the larger runner; the pull-request
+            # stub above did not, which is why only this arm changes and the
+            # stub's two arms still name ubuntu-latest.
             "real Check & Test runner detached from its shard matrix",
-            "    runs-on: ubuntu-latest",
+            "    runs-on: kin-16core",
             "    runs-on: ${{ matrix.os }}",
         ),
         (


### PR DESCRIPTION
Moves the four compile-heavy CI jobs onto the `kin-16core` larger runner. Written 2026-08-26 by lane runnersflip, rebased onto current main on 2026-08-30 by lane railfix after sitting DIRTY.

## What it changes

Four `runs-on:` lines and nothing else. Three in `.github/workflows/ci.yml`, one in `.github/workflows/acceptance.yml`. The diff against main is exactly:

```
-    runs-on: ubuntu-latest
+    runs-on: kin-16core
```

four times, with no other line touched.

## The rebase, and the one thing worth checking

Three conflicts, all the same shape: main had since added `&& github.event_name != 'pull_request'` to the `if` on two of these jobs, and a comment above the third explaining why Acceptance reports `skipped` on pull requests.

Each was resolved by keeping MAIN's `if` and comments and taking only this change's `runs-on`. Taking the incoming `if` wholesale would have silently reverted main's newer gating, which is the failure mode worth naming: the jobs would have started running on pull requests again after main decided they should not, and nothing in this diff would have said so. Main's condition survives, with 14 occurrences of `github.event_name != 'pull_request'` still in `ci.yml`.

## The release-authority pin moved with it, and it was pinned twice

The workflow change alone leaves the guard pinning a runner the workflow no longer uses, so `scripts/test-release-workflow-authority.py` moves in this PR rather than after it. The captain ruled this under the founder's 2026-08-26 larger-runner decision.

**The `check` job's runner is pinned in TWO places**, which is worth knowing before anyone touches it again:

- inside `REAL_CHECK_JOB_AUTHORITY`, as part of the job's literal header, and
- again as `UBUNTU_SHARD_RUNNER`, because the ubuntu shard authority binds `shards = blocks.get("check")`.

One job, two pins, and both had to move. `check-aggregate` is deliberately left on `ubuntu-latest`: it compiles nothing and runs in seconds.

Two falsification arms moved with them, because both keyed on the old runner string. The ubuntu-shard arm mutated away from `ubuntu-latest`, which stopped identifying anything the moment the runner changed; what it has always meant is that the shards leave their pinned runner, so it now names the pinned value. The consumer arm needed the same. The pull-request stub's two arms still name `ubuntu-latest`, because the stub did not move.

## Falsified in three arms, and the third is the one nobody asked for

```
M0  unmutated                                   rc 0   guard passes with check on kin-16core
F1  revert ONLY the check job's runner          rc 1   reds on consumer authority
F2  move a job the pin does NOT cover           rc 0   stays green
```

F1 is the arm that proves the pin still guards. F2 moves `fast-gate-lint`, which the pin does not cover, and matters more than it looks: without it, F1's red is equally consistent with a guard that fires on any runner change anywhere, which would be worse than no pin at all. The tree was restored from a saved copy with its `kin-16core` lines intact and zero mutation markers left.

## The runner label

`kin-16core` is a GitHub-hosted larger runner, status `Ready`, `runner_group_id=5`. Group 5 is `kin-16core-public`, `visibility=selected`, and its repositories endpoint returns exactly one entry, `firelock-ai/kin`. So the group grants this repository. That group's `/runners` endpoint is empty, which is correct rather than a gap: it lists self-hosted runners, and this is a hosted one.

That is a configuration claim. Whether a job has ever actually started on the label is a separate claim, and it is now settled twice.

**A job ran on `kin-16core` on 2026-08-26 and passed.** Run `33024788399`, this branch's own `pull_request` Acceptance at head `f023edf57`, runner `kin-16core-1000107238`, 43 steps, conclusion success. That job skips on `pull_request` today, because main gained the `github.event_name != 'pull_request'` condition afterwards, which is why the label looked unexercised on a later reading.

**And again on current main's tree.** `gh workflow run acceptance.yml --ref chore/lane-runnersflip-kin` produced run `33295810206`: runner `kin-16core-1000120913`, `labels=kin-16core`, queued 05:57:32Z and running by 05:59:00Z, 60 steps of which 59 succeeded including the release build.

That run concluded failure on step 58, the acceptance verdict, and the runner is not why. Main's own run `33295456256` sits at head `670561923`, exactly the base this branch is rebased onto, so the two trees differ by these four lines and no product source:

```
                     this branch, kin-16core      main, ubuntu-latest
run                  33295810206                  33295456256
head                 d988c66b2 (base + 4 lines)   670561923
CHECK verdicts       141 PASS 1 FAIL 1 UNREADABLE 141 PASS 1 FAIL 1 UNREADABLE
failed step          58 Acceptance verdict        58 Acceptance verdict
the FAIL             content FIR-2961             content FIR-2961
the UNREADABLE       4 FIR-2464                   4 FIR-2464
```

Identical verdict shape across two runners under two labels. Both findings are main's, tracked separately.

## Cost, and the size of the claim being made

Cost: no measured difference. On base 670561923, Product Acceptance ran 36.47 min on kin-16core (run 33295810206) against 36.43 min on ubuntu-latest (run 33295456256), both grading 62 steps. Main's ten full runs that morning span 34.92 to 43.05 min, median 40.2.

Run 33024788399 (2026-08-26T23:51Z, runner kin-16core-1000107238, 43 steps, success) is the first proof that the label resolves and runs a job to conclusion, and today's dispatch is that proof on the current 62-step tree.

Do not compare that against older sub-30-minute readings. The suite has been growing all week and duration tracks step count: 43 steps on 08-26, 49 to 52 on 08-28 and 08-29, 62 now. The 29.17 and 29.85 minute runs are real (`33227618366` at 51 steps, `33211759780` at 49) and they are a smaller suite, so setting them beside a 62-step run reports more work as a slower machine.

Acceptance is dominated by daemon runs and waits rather than parallel compilation, so a wider machine has little to bite on here. **The three jobs where this move can pay are `check`, `coverage` and `install-proof-pr-build`, and none of them has run on the label**, because they execute only on `main` and `merge_group`. There is no honest way to measure them before this lands.

**So the measurement happens right after, and this PR is reversible on it.** Compare the first three main runs after this lands against the last three before, per job. If the compile-heavy three do not move, this reverts as a measured no-gain.

## Status

Do not land until the v0.6.2 tag is minted. This changes the CI that grades the release candidate and the mint's required contexts run on it, so it waits behind the tag by the captain's instruction. Held green and rebased; it will be re-rebased if main moves.


