### PR TITLE
Stop certifying an enumeration and an absence the extractor never accounted for

### DIFF
--- a/crates/kin-index/tests/certified_answers_account_for_the_file.rs
+++ b/crates/kin-index/tests/certified_answers_account_for_the_file.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The scripted check for the two certified-wrong findings of the v0.6.0 npm
+//! stranger run (FIR-2786, FIR-2775).
+//!
+//! Both are one class on two languages: an extractor or linker gap becomes a
+//! certified, authoritative, wrong answer, because the certification is asserted
+//! rather than gated on whether the file was accounted for. The class gets its
+//! check here before its fix merges, so it is never rediscovered a release
+//! later.
+//!
+//! ## Why these run through the real pipeline rather than against a fixture
+//!
+//! Each half of both chains is already unit-tested somewhere. That is exactly
+//! the arrangement the trap catalogue warns about: two tests can each be
+//! correct, each guard a real property, and jointly guard nothing, because the
+//! property that matters lives in the agreement between them. `list_file_entities`
+//! proves a hand-built `ParseCompleteness::Partial` does not certify; nothing
+//! proved a real file with a broken top-level statement ever reaches `Partial`.
+//! `caller_arrival` proves an absent `file_parsed_call_sites` key makes an
+//! absence unaccounted; nothing proved the Python adapter actually withholds
+//! that key on the shape the stranger hit. These drive the real adapters through
+//! the real `IndexPipeline` and assert the join.
+
+use kin_index::IndexPipeline;
+use kin_model::{FilePathId, ParseCompleteness};
+
+fn blob_hash() -> kin_blobs::Hash256 {
+    kin_blobs::Hash256::from_bytes([7; 32])
+}
+
+fn index(path: &str, source: &str) -> kin_index::IndexedFile {
+    IndexPipeline::new()
+        .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash())
+        .unwrap_or_else(|error| panic!("indexing {path} failed: {error}"))
+        .indexed_file
+}
+
+/// express's `lib/express.js`, trimmed to the statements that decide the
+/// finding. Line 79 of the real file is `exports.static = require('serve-static')`.
+const EXPRESS_EXPORT_SURFACE: &str = r#"'use strict';
+
+var bodyParser = require('body-parser');
+var Router = require('router');
+
+function createApplication() {
+  return {};
+}
+
+exports = module.exports = createApplication;
+
+exports.Router = Router;
+exports.json = bodyParser.json
+exports.raw = bodyParser.raw
+exports.static = require('serve-static');
+exports.text = bodyParser.text
+exports.urlencoded = bodyParser.urlencoded
+"#;
+
+/// FIR-2786. `list_file_entities("lib/express.js")` returned eleven entities
+/// with `bound: exact`, `status: complete`, `verdict: certified`,
+/// `negative.trust: authoritative` and `certifies_enumeration: true`, and did
+/// not hold `exports.static`, one of the most-used names in the Express API.
+///
+/// The enumeration reads the entity set. An import specifier is not in it, so
+/// the extractor's decision to leave the re-export as an import alone made the
+/// symbol invisible to this tool, to `find_references`, and to every dead-code
+/// answer over the file, with no envelope and no degradation to warn about it.
+#[test]
+fn a_require_re_export_is_in_the_files_entity_set() {
+    let indexed = index("lib/express.js", EXPRESS_EXPORT_SURFACE);
+    let names: Vec<&str> = indexed
+        .entities
+        .iter()
+        .map(|entity| entity.name.as_str())
+        .collect();
+
+    assert!(
+        names.contains(&"static"),
+        "the enumeration a caller certifies must hold the re-exported symbol; have {names:?}"
+    );
+    // The controls, so this cannot pass by admitting everything. The member
+    // expression exports around it were never the defect and must be unchanged,
+    // and the local `require` bindings above them must stay out: readmitting
+    // those is the 451-constant bloat that bought the exclusion in the first
+    // place, and it would bury the file's functions again.
+    for present in [
+        "Router",
+        "json",
+        "raw",
+        "text",
+        "urlencoded",
+        "createApplication",
+    ] {
+        assert!(
+            names.contains(&present),
+            "control: {present} must still be an entity; have {names:?}"
+        );
+    }
+    for absent in ["bodyParser", "require", "serve-static"] {
+        assert!(
+            !names.contains(&absent),
+            "control: {absent} is a local dependency binding, not an export; have {names:?}"
+        );
+    }
+    // The import side is unchanged. The entity is not a replacement for the
+    // specifier, and a fix that moved the symbol from one surface to the other
+    // rather than putting it on both would pass the assertion above.
+    let specifiers: Vec<&str> = indexed
+        .imports
+        .iter()
+        .filter(|import| import.module_path == "serve-static")
+        .flat_map(|import| {
+            import
+                .specifiers
+                .iter()
+                .map(|spec| spec.local_name.as_str())
+        })
+        .collect();
+    assert_eq!(
+        specifiers,
+        vec!["static"],
+        "serve-static must still bind its specifier"
+    );
+}
+
+/// FIR-2786, the structural half of the acceptance: the certification gate holds
+/// on a file the adapter could not fully parse.
+///
+/// This is the join nothing was asserting. `list_file_entities` gates
+/// `certifies_enumeration` on `ParseCompleteness::Full` and proves that against
+/// a `Partial` built by hand; the chain from a genuinely broken top-level
+/// statement to `Partial` runs through `collect_error_ranges`,
+/// `ParseState::Incomplete` and `ParseCompleteness::from_parse_state`, and was
+/// pinned nowhere. A rename anywhere along it would have left both ends green
+/// while a broken file certified its enumeration as exact.
+#[test]
+fn a_file_with_a_broken_top_level_statement_cannot_certify_its_enumeration() {
+    let broken = index(
+        "lib/broken.js",
+        "function ok() { return 1; }\nexports.torn = function( {\n",
+    );
+    assert_ne!(
+        broken.file_layout.parse_completeness,
+        ParseCompleteness::Full,
+        "a file the adapter could not parse through must not report a full parse, because that \
+         is the one state that licenses certifying its enumeration as the whole set"
+    );
+    assert_eq!(
+        broken.file_layout.parse_completeness.bucket(),
+        "partial",
+        "the broken file must reach the exact wire word `list_file_entities` reads back as \
+         `file_coverage.parsed`, since that string and not the enum is what the gate matches on"
+    );
+
+    // The control, and it is what keeps the gate from becoming a blanket
+    // downgrade: the same file, whole, still reports a full parse and so still
+    // certifies. A fix that floored every enumeration passes the assertion above
+    // and fails right here.
+    let whole = index(
+        "lib/whole.js",
+        "function ok() { return 1; }\nexports.torn = function() { return 2; };\n",
+    );
+    assert_eq!(
+        whole.file_layout.parse_completeness,
+        ParseCompleteness::Full,
+        "an intact file must still license certification"
+    );
+}
+
+/// FIR-2775. The exact shape from the stranger's five-symbol probe: a package
+/// under `src/`, a test that reaches the module through an absolute
+/// `from package import module`, and an attribute call through that binding.
+///
+/// Two things are asserted and they are different claims. The first is the
+/// finding itself: the call produces no entity-level `Calls` edge, so
+/// `find_references("note_body")` sees nothing. The second is the one the
+/// certification gate rests on: the parser withholds the file's call-site count
+/// when it could not represent a call, and that withheld count is the signal
+/// `kin_mcp::caller_arrival` reads to decline authority. Without this second
+/// assertion the gate is tested only against a hand-built store and could be
+/// keyed on a signal the real path never emits.
+#[test]
+fn an_absolute_module_import_attribute_call_leaves_the_files_call_count_withheld() {
+    let caller = index(
+        "tests/test_storage.py",
+        "from notekeeper import storage\n\n\ndef test_bodies_round_trip(db, note):\n    assert \"x\" in storage.note_body(db, note.id)\n",
+    );
+
+    // The parse side read the call: it is not that the extractor missed it.
+    assert!(
+        caller
+            .extracted_relations
+            .iter()
+            .any(|relation| relation.dst_name == "note_body"),
+        "the parser must read the attribute call, or this fixture is testing the wrong thing"
+    );
+    // And it recorded a receiver, which is what sends it down the linker tier
+    // that resolves the binding to the package rather than to the module.
+    assert!(
+        caller.extracted_relations.iter().any(|relation| {
+            relation.dst_name == "note_body" && relation.receiver.as_deref() == Some("storage")
+        }),
+        "the call must carry its receiver; the receiver is what the failing tier keys on"
+    );
+
+    // The signal the certification gate reads. The extractor removes this key
+    // from every entity of a file whose call extraction it could not represent,
+    // and a reader treats an absent count as unmeasured rather than as zero.
+    // `kin_mcp::caller_arrival` reads exactly this absence.
+    assert!(
+        !caller.entities.is_empty(),
+        "the fixture must produce entities, or the count would be absent for the wrong reason"
+    );
+    for entity in &caller.entities {
+        assert!(
+            !entity
+                .metadata
+                .extra
+                .contains_key(kin_parser::FILE_PARSED_CALL_SITES_KEY),
+            "a file whose call extraction was incomplete must withhold its call-site count, \
+             because a zero there reads as a fully accounted file: {} carries {:?}",
+            entity.name,
+            entity
+                .metadata
+                .extra
+                .get(kin_parser::FILE_PARSED_CALL_SITES_KEY)
+        );
+    }
+
+    // The control, and it is the one the ticket demands: a file whose calls the
+    // extractor CAN represent still reports its count, so the gate cannot become
+    // a blanket downgrade over every Python file. A direct-name import with a
+    // bare call is the shape the stranger's probe found resolves.
+    let resolved = index(
+        "tests/test_parsing.py",
+        "from notekeeper.parsing import extract_tags\n\n\ndef test_tags():\n    assert extract_tags(\"#a\") == [\"a\"]\n",
+    );
+    let counted = resolved
+        .entities
+        .iter()
+        .filter_map(|entity| {
+            entity
+                .metadata
+                .extra
+                .get(kin_parser::FILE_PARSED_CALL_SITES_KEY)
+        })
+        .count();
+    assert!(
+        counted > 0,
+        "control: a file whose calls the extractor could represent must still report its \
+         call-site count, or every Python absence goes inconclusive"
+    );
+}

--- a/crates/kin-mcp/src/caller_arrival.rs
+++ b/crates/kin-mcp/src/caller_arrival.rs
@@ -221,6 +221,14 @@ impl CallerArrival {
                         ),
                     })
                     .collect();
+                // Joined with ", " and never with "; ", which is
+                // `crate::verdict::CLAUSE_SEPARATOR`. The rendered limiting
+                // factor is one string that a reader splits back into clauses on
+                // that separator, so a clause carrying it arrives as a labelled
+                // clause plus a bare fragment with no label at all. Two gap texts
+                // shipped that defect before; this one would have been the third,
+                // and the guard that asserts the invariant drives one producer by
+                // name and cannot see a new one.
                 let more = self.unaccounted.len().saturating_sub(named.len());
                 let tail = if more > 0 {
                     format!(" and {more} more")
@@ -234,7 +242,7 @@ impl CallerArrival {
                      set: {}{tail}",
                     self.unaccounted.len(),
                     self.family_files,
-                    named.join("; ")
+                    named.join(", ")
                 ))
             }
         }
@@ -530,7 +538,7 @@ pub fn arrival_gap(payload: &serde_json::Value) -> Option<String> {
                  this focal may be among them and an empty reference list here is a floor rather \
                  than proof of disuse: {}",
                 files.len(),
-                files.join("; ")
+                files.join(", ")
             ))
         }
         "unmeasured" => {
@@ -957,6 +965,90 @@ mod tests {
             1
         );
         assert_eq!(small_block["unaccounted_files_truncated"], json!(false));
+    }
+
+    #[test]
+    fn no_factor_this_module_produces_carries_the_clause_separator() {
+        // `crate::verdict` renders the one limiting factor as a single string and
+        // a reader splits it back into clauses on "; ". A clause carrying that
+        // separator arrives as a labelled clause plus a bare fragment with no
+        // label at all, and the reader handed `limiting_factor` gets the
+        // fragment. Two gap texts shipped that defect before this module existed.
+        //
+        // Mine would have been the third: both producers joined their file list
+        // with "; ", and the guard that asserts this invariant drives
+        // `negative::absence_coverage_clauses` by name, so it could not see a new
+        // producer at all. This drives MY producers over the shapes that reach
+        // them rather than restating their text, for the same reason that one
+        // does: a test that restates the strings is a second copy of them.
+        let mut seen = 0;
+        for (label, arrival) in arrival_shapes() {
+            if let Some(factor) = arrival.limiting_factor() {
+                seen += 1;
+                assert!(
+                    !factor.contains(crate::verdict::CLAUSE_SEPARATOR),
+                    "{label}: limiting_factor carries the clause separator, so any reader that \
+                     splits the rendered factor cuts it into a labelled clause and an unlabelled \
+                     fragment: {factor}"
+                );
+            }
+            if let Some(gap) = arrival_gap(&json!({ CALLER_ARRIVAL_KEY: arrival.to_json() })) {
+                seen += 1;
+                assert!(
+                    !gap.contains(crate::verdict::CLAUSE_SEPARATOR),
+                    "{label}: arrival_gap carries the clause separator: {gap}"
+                );
+            }
+        }
+        assert!(
+            seen > 0,
+            "no factor was produced by any shape, so this asserted nothing"
+        );
+    }
+
+    /// Every shape whose factor a reader can end up splitting, including the
+    /// multi-file ones, which are the only ones that join anything at all and so
+    /// the only ones that can carry a separator.
+    fn arrival_shapes() -> Vec<(&'static str, CallerArrival)> {
+        let one = UnaccountedFile {
+            file: "tests/test_storage.py".to_string(),
+            parsed_call_sites: Some(3),
+            resolved_call_edges: 2,
+            unaccounted_call_sites: Some(1),
+        };
+        let withheld = UnaccountedFile {
+            file: "tests/test_linkgraph.py".to_string(),
+            parsed_call_sites: None,
+            resolved_call_edges: 4,
+            unaccounted_call_sites: None,
+        };
+        let many: Vec<UnaccountedFile> = (0..8)
+            .map(|index| UnaccountedFile {
+                file: format!("tests/test_{index}.py"),
+                parsed_call_sites: Some(index + 2),
+                resolved_call_edges: 1,
+                unaccounted_call_sites: Some(index + 1),
+            })
+            .collect();
+        let build = |unaccounted: Vec<UnaccountedFile>| CallerArrival {
+            state: ArrivalState::Unaccounted,
+            family_files: unaccounted.len().max(1),
+            family_measured: 0,
+            unaccounted,
+            unmeasured_reason: None,
+        };
+        vec![
+            ("one shortfall file", build(vec![one.clone()])),
+            ("one withheld-count file", build(vec![withheld.clone()])),
+            ("both kinds joined", build(vec![one, withheld])),
+            ("more files than the factor names", build(many)),
+            (
+                "unmeasured",
+                CallerArrival::unmeasured(
+                    "this language links no imports across files in this graph",
+                ),
+            ),
+        ]
     }
 
     #[test]

--- a/crates/kin-mcp/src/caller_arrival.rs
+++ b/crates/kin-mcp/src/caller_arrival.rs
@@ -1,0 +1,770 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Whether a caller could have arrived at the focal through a call the linker
+//! never recorded (FIR-2775).
+//!
+//! `find_references` answers from the `Calls` edges the graph holds. That is the
+//! whole answer only when every call site the parser read in the files that can
+//! reach the focal became an edge. Where it did not, the missing edges are
+//! invisible to the query, so an empty answer and a genuinely uncalled function
+//! produce the identical response, and the envelope stamps the first one
+//! `certified` / `safe_to_conclude_absent: true`.
+//!
+//! That is not hypothetical. On the v0.6.0 stranger run a Python package under
+//! `src/` called `storage.note_body(db, note.id)` from a test that reached the
+//! module through `from notekeeper import storage`. The parser read the call.
+//! The linker declined to bind it, because binding a member whose leaf name the
+//! repository already defines would be a guess rather than a resolution. Nothing
+//! recorded the decline, so `find_references("note_body")` reported no incoming
+//! relations of any kind and certified that absence as authoritative. A
+//! dead-code sweep run on the envelope's word would have deleted a live
+//! function.
+//!
+//! ## What this measures, and what it deliberately does not
+//!
+//! Two numbers per file, both already graph-owned:
+//!
+//! - how many call sites the parser read there
+//!   ([`kin_parser::FILE_PARSED_CALL_SITES_KEY`], stamped on every entity of the
+//!   file at extraction),
+//! - how many `Calls` edges the graph holds whose source is one of that file's
+//!   entities.
+//!
+//! A file whose parse side exceeds its edge side holds calls that reached no
+//! destination. That is not by itself a defect: a call into a third-party
+//! package cannot resolve to an in-repo entity either. The linker records those
+//! as unresolved-receiver placeholders, which ARE `Calls` edges and so are
+//! counted here, which is what keeps an ordinary dependency call from reading as
+//! a gap. What remains in the shortfall is calls the linker dropped without a
+//! placeholder, and that is exactly the ambiguity class the focal could be
+//! hiding in.
+//!
+//! ## Why it is scoped to a family rather than to the store
+//!
+//! Flooring every absence on store-wide health is the substitution this module
+//! exists to avoid, in the other direction: an envelope that never certifies
+//! teaches a caller to ignore it, and the ticket that filed this is explicit
+//! that a genuinely uncalled function reached through a resolved shape must
+//! still read as an authoritative absence. So the reading is taken over the
+//! files that can actually reach the focal: those holding an `Imports` or
+//! `Includes` edge into an entity of the focal's own file. A shortfall in an
+//! unrelated corner of the repository says nothing about this focal and is not
+//! reported as if it did.
+//!
+//! The family is established from import edges rather than from the focal's own
+//! call edges, and that split is the point: import resolution and call
+//! resolution are separate tiers, and this gate exists precisely for the case
+//! where the second one failed while the first one held. Where the language
+//! holds no import edges at all, the family cannot be established and the state
+//! is `unmeasured` rather than empty, because "nobody imports this file" and "I
+//! cannot see who imports anything" are opposite facts and only the first is
+//! evidence about the focal.
+
+use std::collections::{HashMap, HashSet};
+
+use kin_model::graph::{EntityFilter, GraphStore};
+use kin_model::{entity::Entity, EntityId, FilePathId, RelationKind};
+use serde::Serialize;
+use serde_json::json;
+
+/// Key under which `find_references` publishes this reading.
+pub const CALLER_ARRIVAL_KEY: &str = "caller_arrival";
+
+/// Limiting-factor id the negative envelope reports when arrival is incomplete.
+/// Spelled once so the gate, the advice and any test key on one string.
+pub const UNRESOLVED_ARRIVAL_LIMITING_FACTOR: &str = "caller_arrival_unresolved";
+
+/// Limiting-factor id for a family that could not be established at all.
+pub const UNMEASURED_ARRIVAL_LIMITING_FACTOR: &str = "caller_arrival_unmeasured";
+
+/// Entities scanned before the reading gives up and reports `unmeasured`.
+///
+/// The walk costs one relation read per entity of the focal's file plus one per
+/// entity of each family file. A repository large enough to make that expensive
+/// gets an honest refusal rather than a query nobody asked for, and `unmeasured`
+/// is a real answer here: it declines to certify rather than certifying on a
+/// scan that did not finish.
+const ARRIVAL_SCAN_CAP: usize = 4_000;
+
+/// How completely this reading could account for the ways a caller reaches the
+/// focal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArrivalState {
+    /// Every file that can reach the focal had every call site it parsed become
+    /// an edge. An absence answered over these edges is the whole set.
+    Accounted,
+    /// At least one file that can reach the focal holds call sites that became
+    /// no edge, so a caller of the focal may be among them.
+    Unaccounted,
+    /// The reading could not be taken. Not the same as `Accounted`, and never
+    /// collapsed into it.
+    Unmeasured,
+}
+
+impl ArrivalState {
+    pub fn wire(self) -> &'static str {
+        match self {
+            Self::Accounted => "accounted",
+            Self::Unaccounted => "unaccounted",
+            Self::Unmeasured => "unmeasured",
+        }
+    }
+
+    /// Whether this state licenses reading an empty reference list as the whole
+    /// truth about the focal. Only a complete accounting does.
+    pub fn certifies_absence(self) -> bool {
+        matches!(self, Self::Accounted)
+    }
+}
+
+/// One family file whose call sites did not all become edges.
+#[derive(Debug, Clone, Serialize)]
+pub struct UnaccountedFile {
+    pub file: String,
+    /// `None` when the file carries no parse-side count, which the parser omits
+    /// on any file whose call extraction it could not represent. Absent, not
+    /// zero, and it is its own kind of gap.
+    pub parsed_call_sites: Option<u64>,
+    pub resolved_call_edges: u64,
+    /// `parsed - resolved`, floored at zero. `None` when the parse side was not
+    /// measured.
+    pub unaccounted_call_sites: Option<u64>,
+}
+
+/// The reading itself.
+#[derive(Debug, Clone)]
+pub struct CallerArrival {
+    pub state: ArrivalState,
+    /// Files holding an import edge into the focal's file.
+    pub family_files: usize,
+    /// Of those, how many carry a parse-side call count.
+    pub family_measured: usize,
+    pub unaccounted: Vec<UnaccountedFile>,
+    /// Why the state is `unmeasured`, when it is.
+    pub unmeasured_reason: Option<String>,
+}
+
+impl CallerArrival {
+    fn unmeasured(reason: impl Into<String>) -> Self {
+        Self {
+            state: ArrivalState::Unmeasured,
+            family_files: 0,
+            family_measured: 0,
+            unaccounted: Vec::new(),
+            unmeasured_reason: Some(reason.into()),
+        }
+    }
+
+    /// The block `find_references` publishes, and the one the negative envelope
+    /// reads back. Published on every answer, populated or empty, so a reader
+    /// never has to tell "checked and fine" from "not reported".
+    pub fn to_json(&self) -> serde_json::Value {
+        json!({
+            "state": self.state.wire(),
+            "family_files": self.family_files,
+            "family_measured": self.family_measured,
+            "unaccounted_files": self.unaccounted,
+            "unmeasured_reason": self.unmeasured_reason,
+        })
+    }
+
+    /// The one sentence the verdict prints when this reading limits the answer,
+    /// or `None` when it does not.
+    pub fn limiting_factor(&self) -> Option<String> {
+        match self.state {
+            ArrivalState::Accounted => None,
+            ArrivalState::Unmeasured => Some(format!(
+                "{UNMEASURED_ARRIVAL_LIMITING_FACTOR}: this answer could not establish which files \
+                 can reach the focal ({}), so an empty reference list is not evidence that nothing \
+                 calls it",
+                self.unmeasured_reason.as_deref().unwrap_or("no reason recorded")
+            )),
+            ArrivalState::Unaccounted => {
+                let named: Vec<String> = self
+                    .unaccounted
+                    .iter()
+                    .take(5)
+                    .map(|file| match file.unaccounted_call_sites {
+                        Some(missing) => format!(
+                            "{} ({missing} of {} parsed call sites became no edge)",
+                            file.file,
+                            file.parsed_call_sites.unwrap_or(0)
+                        ),
+                        None => format!(
+                            "{} (call extraction was incomplete, so its call sites were never \
+                             counted)",
+                            file.file
+                        ),
+                    })
+                    .collect();
+                let more = self.unaccounted.len().saturating_sub(named.len());
+                let tail = if more > 0 {
+                    format!(" and {more} more")
+                } else {
+                    String::new()
+                };
+                Some(format!(
+                    "{UNRESOLVED_ARRIVAL_LIMITING_FACTOR}: {} of {} file(s) that import the \
+                     focal's file hold call sites the linker recorded no edge for, so a caller of \
+                     this focal may be among them and this list is a floor rather than the whole \
+                     set: {}{tail}",
+                    self.unaccounted.len(),
+                    self.family_files,
+                    named.join("; ")
+                ))
+            }
+        }
+    }
+}
+
+/// Relation classes that put a file in the focal's family: it named the focal's
+/// file in its own source, so a call from it could have reached the focal.
+const FAMILY_KINDS: [RelationKind; 2] = [RelationKind::Imports, RelationKind::Includes];
+
+/// Read the per-file parse-side call count the extractor stamped on every
+/// entity of the file. `None` means unmeasured, never zero.
+fn parsed_call_sites(entity: &Entity) -> Option<u64> {
+    entity
+        .metadata
+        .extra
+        .get(kin_parser::FILE_PARSED_CALL_SITES_KEY)
+        .and_then(serde_json::Value::as_u64)
+}
+
+/// Entities examined before the language-wide import witness gives up.
+///
+/// It stops at the first import edge it sees, so on any graph that links imports
+/// this costs a handful of reads. The budget bounds the other case, where the
+/// answer is that there are none: a completed scan that found nothing and a scan
+/// that ran out of budget both mean the same thing here, which is that the
+/// control could not witness import linking, and both decline.
+const IMPORT_WITNESS_BUDGET: usize = 500;
+
+/// Whether this language links imports across files anywhere in this graph.
+///
+/// The control for an empty family. It answers a question about the LANGUAGE,
+/// never about the focal's file, because a file nothing imports holds no import
+/// edge by construction and reading the control off that file would make every
+/// such file unmeasurable.
+fn language_links_imports<G: GraphStore>(store: &G, language_entities: &[Entity]) -> bool {
+    for entity in language_entities.iter().take(IMPORT_WITNESS_BUDGET) {
+        let Ok(relations) = store.get_all_relations_for_entity(&entity.id) else {
+            continue;
+        };
+        if relations
+            .iter()
+            .any(|relation| FAMILY_KINDS.contains(&relation.kind))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether a caller could reach `focal` through a call this graph does not hold.
+///
+/// Never fails the request: any error or budget exhaustion becomes `Unmeasured`,
+/// which declines to certify rather than certifying on an unfinished scan.
+pub fn observe_caller_arrival<G: GraphStore>(store: &G, focal: &Entity) -> CallerArrival {
+    let Some(focal_file) = focal.file_origin.clone() else {
+        return CallerArrival::unmeasured("the focal entity carries no file of origin");
+    };
+
+    let Ok(language_entities) = store.query_entities(&EntityFilter {
+        languages: Some(vec![focal.language]),
+        ..EntityFilter::default()
+    }) else {
+        return CallerArrival::unmeasured("the entity index could not be read for this language");
+    };
+    if language_entities.len() > ARRIVAL_SCAN_CAP {
+        return CallerArrival::unmeasured(format!(
+            "this language holds {} entities, above the {ARRIVAL_SCAN_CAP} this reading walks",
+            language_entities.len()
+        ));
+    }
+
+    // One pass builds every index the walk needs: which file each entity sits
+    // in, which entities each file owns, and the file's parse-side call count.
+    // The count is stamped identically on every entity of the file, so the first
+    // one carrying it settles the file.
+    let mut file_of: HashMap<EntityId, FilePathId> = HashMap::new();
+    let mut entities_by_file: HashMap<FilePathId, Vec<EntityId>> = HashMap::new();
+    let mut parsed_by_file: HashMap<FilePathId, u64> = HashMap::new();
+    for entity in &language_entities {
+        let Some(file) = entity.file_origin.clone() else {
+            continue;
+        };
+        file_of.insert(entity.id, file.clone());
+        entities_by_file
+            .entry(file.clone())
+            .or_default()
+            .push(entity.id);
+        if let Some(count) = parsed_call_sites(entity) {
+            parsed_by_file.entry(file).or_insert(count);
+        }
+    }
+
+    // The family: files holding an import edge into an entity of the focal's
+    // file. Walked from the focal's file outward, because the focal's file owns
+    // few entities while the language owns many.
+    let mut family: HashSet<FilePathId> = HashSet::new();
+    let focal_file_entities = entities_by_file
+        .get(&focal_file)
+        .cloned()
+        .unwrap_or_default();
+    for entity_id in &focal_file_entities {
+        let Ok(relations) = store.get_all_relations_for_entity(entity_id) else {
+            return CallerArrival::unmeasured(
+                "the relation index could not be read for the focal's file",
+            );
+        };
+        for relation in relations {
+            if !FAMILY_KINDS.contains(&relation.kind) {
+                continue;
+            }
+            let Some(source) = relation.src.as_entity() else {
+                continue;
+            };
+            let Some(source_file) = file_of.get(&source) else {
+                continue;
+            };
+            // An import edge whose destination is not this file says nothing
+            // about who can reach it, and a file never imports itself.
+            if relation.dst.as_entity().and_then(|dst| file_of.get(&dst)) != Some(&focal_file) {
+                continue;
+            }
+            if source_file != &focal_file {
+                family.insert(source_file.clone());
+            }
+        }
+    }
+
+    if family.is_empty() {
+        // Nothing imports this file. Whether that is a fact about the repository
+        // or about the graph depends on whether this language links imports at
+        // all, and only one of those licenses certifying an absence.
+        //
+        // The control is taken over the LANGUAGE and not over the focal's own
+        // file, and that distinction is load-bearing rather than pedantic: a
+        // file nothing imports holds no import edge by definition, so reading
+        // the control off the walk above would report every such file as
+        // unmeasured and put a floor under every absence in the store. Four
+        // handler fixtures went inconclusive on exactly that mistake, including
+        // the one built to prove a graph linking every class across files still
+        // earns its absence.
+        if language_links_imports(store, &language_entities) {
+            return CallerArrival {
+                state: ArrivalState::Accounted,
+                family_files: 0,
+                family_measured: 0,
+                unaccounted: Vec::new(),
+                unmeasured_reason: None,
+            };
+        }
+        return CallerArrival::unmeasured(
+            "this language links no imports across files in this graph, so the set of files that \
+             can reach the focal could not be established",
+        );
+    }
+
+    let mut unaccounted = Vec::new();
+    let mut family_measured = 0usize;
+    let mut family_files: Vec<&FilePathId> = family.iter().collect();
+    family_files.sort_by(|left, right| left.0.cmp(&right.0));
+    for file in &family_files {
+        let parsed = parsed_by_file.get(*file).copied();
+        if parsed.is_some() {
+            family_measured += 1;
+        }
+        let mut resolved = 0u64;
+        for entity_id in entities_by_file.get(*file).into_iter().flatten() {
+            let Ok(relations) = store.get_all_relations_for_entity(entity_id) else {
+                return CallerArrival::unmeasured(
+                    "the relation index could not be read for a file in the focal's family",
+                );
+            };
+            resolved += relations
+                .iter()
+                .filter(|relation| {
+                    relation.kind == RelationKind::Calls
+                        && relation.src.as_entity() == Some(*entity_id)
+                })
+                .count() as u64;
+        }
+        // A call site can fan out to several same-named destinations, so the
+        // resolved side can exceed the parsed side; the shortfall floors at
+        // zero rather than wrapping, which is the same cap `call_percent` puts
+        // on the ratio for the same reason.
+        let missing = parsed.map(|parsed| parsed.saturating_sub(resolved));
+        // Two distinct gaps and both count. A positive shortfall is call sites
+        // that reached no destination. An absent count is a file whose call
+        // extraction the parser could not represent at all, which it signals by
+        // withholding the number rather than by reporting zero.
+        if missing.is_none_or(|missing| missing > 0) {
+            unaccounted.push(UnaccountedFile {
+                file: file.0.clone(),
+                parsed_call_sites: parsed,
+                resolved_call_edges: resolved,
+                unaccounted_call_sites: missing,
+            });
+        }
+    }
+
+    CallerArrival {
+        state: if unaccounted.is_empty() {
+            ArrivalState::Accounted
+        } else {
+            ArrivalState::Unaccounted
+        },
+        family_files: family_files.len(),
+        family_measured,
+        unaccounted,
+        unmeasured_reason: None,
+    }
+}
+
+/// The gate the negative envelope applies, read back off the published block so
+/// the verdict and the evidence a reader audits it against are the same object.
+///
+/// Returns the limiting factor when the answer's own `caller_arrival` block says
+/// a caller could have arrived through an edge the graph does not hold, and
+/// `None` when it says the arrival paths are accounted for.
+pub fn arrival_gap(payload: &serde_json::Value) -> Option<String> {
+    let block = payload.get(CALLER_ARRIVAL_KEY)?;
+    let state = block.get("state").and_then(serde_json::Value::as_str)?;
+    match state {
+        "accounted" => None,
+        "unaccounted" => {
+            let files: Vec<String> = block
+                .get("unaccounted_files")
+                .and_then(serde_json::Value::as_array)
+                .map(|files| {
+                    files
+                        .iter()
+                        .take(5)
+                        .filter_map(|file| {
+                            let path = file.get("file").and_then(serde_json::Value::as_str)?;
+                            Some(
+                                match file
+                                    .get("unaccounted_call_sites")
+                                    .and_then(serde_json::Value::as_u64)
+                                {
+                                    Some(missing) => format!("{path} ({missing} unaccounted)"),
+                                    None => format!("{path} (call extraction incomplete)"),
+                                },
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let family = block
+                .get("family_files")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            Some(format!(
+                "{UNRESOLVED_ARRIVAL_LIMITING_FACTOR}: of the {family} file(s) that import the \
+                 focal's file, {} hold call sites the linker recorded no edge for, so a caller of \
+                 this focal may be among them and an empty reference list here is a floor rather \
+                 than proof of disuse: {}",
+                files.len(),
+                files.join("; ")
+            ))
+        }
+        "unmeasured" => {
+            let reason = block
+                .get("unmeasured_reason")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("no reason recorded");
+            Some(format!(
+                "{UNMEASURED_ARRIVAL_LIMITING_FACTOR}: this answer could not establish which files \
+                 can reach the focal ({reason}), so an empty reference list is not evidence that \
+                 nothing calls it"
+            ))
+        }
+        other => Some(format!(
+            "caller_arrival_state_unknown: this answer reported the arrival state as {other:?}, \
+             which is not a state that licenses reading an empty reference list as whole"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use kin_db::InMemoryGraph;
+    use kin_model::graph::EntityStore;
+    use kin_model::{
+        EntityKind, EntityMetadata, FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId,
+        Relation, RelationId, RelationOrigin, SemanticFingerprint, SourceSpan, Visibility,
+    };
+
+    const FOCAL_FILE: &str = "src/notekeeper/storage.py";
+    const CALLER_FILE: &str = "tests/test_storage.py";
+
+    /// One entity in a file, carrying the file-level parse-side call count the
+    /// extractor stamps on every entity of the file. `None` reproduces a file
+    /// whose call extraction the parser could not represent, which it signals by
+    /// withholding the number rather than by reporting zero.
+    fn entity_in(name: &str, file: &str, parsed_calls: Option<u64>) -> Entity {
+        let mut metadata = EntityMetadata::default();
+        if let Some(count) = parsed_calls {
+            metadata.extra.insert(
+                kin_parser::FILE_PARSED_CALL_SITES_KEY.into(),
+                serde_json::Value::from(count),
+            );
+        }
+        Entity {
+            id: EntityId::from_content(file, name, "Function", 0),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Python,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file)),
+            span: Some(SourceSpan {
+                file: FilePathId::new(file),
+                start_byte: 0,
+                end_byte: 10,
+                start_line: 1,
+                start_col: 0,
+                end_line: 2,
+                end_col: 0,
+            }),
+            signature: format!("def {name}()"),
+            visibility: Visibility::Public,
+            role: kin_model::EntityRole::Source,
+            doc_summary: None,
+            metadata,
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn edge(kind: RelationKind, src: &Entity, dst: &Entity) -> Relation {
+        Relation {
+            id: RelationId::from_content(
+                &src.id.0.to_string(),
+                &dst.id.0.to_string(),
+                &format!("{kind:?}"),
+            ),
+            kind,
+            src: GraphNodeId::Entity(src.id),
+            dst: GraphNodeId::Entity(dst.id),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        }
+    }
+
+    /// The stranger's shape: a module under `src/`, a test file that imports it
+    /// and calls into it, and a linker that bound some of that test's calls and
+    /// not others.
+    ///
+    /// `caller_parsed_calls` is what the parser read in the test file and
+    /// `caller_resolved_calls` is how many of them became edges. The gap between
+    /// them is the whole subject.
+    fn store_with(
+        caller_parsed_calls: Option<u64>,
+        caller_resolved_calls: usize,
+        import_edge: bool,
+    ) -> (InMemoryGraph, Entity) {
+        let store = InMemoryGraph::new();
+        let focal = entity_in("note_body", FOCAL_FILE, Some(2));
+        let focal_module = entity_in("storage", FOCAL_FILE, Some(2));
+        let find_note = entity_in("find_note", FOCAL_FILE, Some(2));
+        let caller_module = entity_in("test_storage", CALLER_FILE, caller_parsed_calls);
+        let caller = entity_in("test_bodies_round_trip", CALLER_FILE, caller_parsed_calls);
+        for entity in [&focal, &focal_module, &find_note, &caller_module, &caller] {
+            store.upsert_entity(entity).unwrap();
+        }
+        if import_edge {
+            store
+                .upsert_relation(&edge(RelationKind::Imports, &caller_module, &focal_module))
+                .unwrap();
+        }
+        // Whatever the linker did bind from the test file. `find_note` stands in
+        // for the calls that resolved; `note_body` is the one that did not, so
+        // the focal has no incoming edge in any arm.
+        for index in 0..caller_resolved_calls {
+            let target = if index == 0 {
+                &find_note
+            } else {
+                &focal_module
+            };
+            store
+                .upsert_relation(&Relation {
+                    id: RelationId::from_content(
+                        &caller.id.0.to_string(),
+                        &target.id.0.to_string(),
+                        &format!("Calls{index}"),
+                    ),
+                    ..edge(RelationKind::Calls, &caller, target)
+                })
+                .unwrap();
+        }
+        (store, focal)
+    }
+
+    #[test]
+    fn a_call_site_that_became_no_edge_makes_the_absence_unaccounted() {
+        // Three call sites read in the test file, two edges recorded. The third
+        // is `storage.note_body(db, note.id)`, and it is the focal.
+        let (store, focal) = store_with(Some(3), 2, true);
+        let arrival = observe_caller_arrival(&store, &focal);
+
+        assert_eq!(arrival.state, ArrivalState::Unaccounted);
+        assert_eq!(arrival.family_files, 1);
+        assert_eq!(arrival.family_measured, 1);
+        assert_eq!(arrival.unaccounted.len(), 1);
+        assert_eq!(arrival.unaccounted[0].file, CALLER_FILE);
+        assert_eq!(arrival.unaccounted[0].parsed_call_sites, Some(3));
+        assert_eq!(arrival.unaccounted[0].resolved_call_edges, 2);
+        assert_eq!(arrival.unaccounted[0].unaccounted_call_sites, Some(1));
+
+        let factor = arrival
+            .limiting_factor()
+            .expect("an unaccounted arrival limits the answer");
+        assert!(
+            factor.starts_with(UNRESOLVED_ARRIVAL_LIMITING_FACTOR),
+            "the limiting factor must lead with its id: {factor}"
+        );
+        assert!(
+            factor.contains(CALLER_FILE),
+            "the limiting factor must name the file that holds the unaccounted calls: {factor}"
+        );
+        // And the published block says the same thing, so the gate a reader sees
+        // and the evidence they audit it against cannot disagree.
+        let gap = arrival_gap(&json!({ CALLER_ARRIVAL_KEY: arrival.to_json() }))
+            .expect("the published block must reproduce the gap");
+        assert!(gap.starts_with(UNRESOLVED_ARRIVAL_LIMITING_FACTOR), "{gap}");
+        assert!(gap.contains(CALLER_FILE), "{gap}");
+    }
+
+    #[test]
+    fn every_call_site_accounted_still_certifies_the_absence() {
+        // The control the ticket demands. Flooring every absence would destroy
+        // the envelope's value in the other direction, so a family whose call
+        // sites all became edges must still license an authoritative absence,
+        // on a store built the same way as the failing arm.
+        let (store, focal) = store_with(Some(2), 2, true);
+        let arrival = observe_caller_arrival(&store, &focal);
+
+        assert_eq!(arrival.state, ArrivalState::Accounted);
+        assert_eq!(arrival.family_files, 1);
+        assert!(arrival.unaccounted.is_empty());
+        assert_eq!(arrival.limiting_factor(), None);
+        assert_eq!(
+            arrival_gap(&json!({ CALLER_ARRIVAL_KEY: arrival.to_json() })),
+            None
+        );
+    }
+
+    #[test]
+    fn fan_out_past_the_parsed_count_is_not_a_shortfall() {
+        // One call site can bind several same-named destinations, so the edge
+        // side can exceed the parse side. Subtracting the other way round would
+        // wrap and report a gap on a graph that resolved everything.
+        let (store, focal) = store_with(Some(1), 3, true);
+        let arrival = observe_caller_arrival(&store, &focal);
+        assert_eq!(arrival.state, ArrivalState::Accounted);
+    }
+
+    #[test]
+    fn a_file_whose_call_extraction_was_incomplete_is_its_own_gap() {
+        // The parser withholds the count rather than reporting zero when it
+        // could not represent a file's calls. An absent count read as zero would
+        // make that file look perfectly resolved, which is the reading this
+        // whole module exists to refuse.
+        let (store, focal) = store_with(None, 2, true);
+        let arrival = observe_caller_arrival(&store, &focal);
+
+        assert_eq!(arrival.state, ArrivalState::Unaccounted);
+        assert_eq!(arrival.family_measured, 0);
+        assert_eq!(arrival.unaccounted[0].parsed_call_sites, None);
+        assert_eq!(arrival.unaccounted[0].unaccounted_call_sites, None);
+        let factor = arrival
+            .limiting_factor()
+            .expect("an unmeasured file limits the answer");
+        assert!(
+            factor.contains("call extraction was incomplete"),
+            "the reason must say the count is absent rather than zero: {factor}"
+        );
+    }
+
+    #[test]
+    fn no_import_edge_anywhere_is_unmeasured_not_empty() {
+        // "Nobody imports this file" and "I cannot see who imports anything" are
+        // opposite facts and only the first licenses certifying an absence. With
+        // no import edge in the language the family cannot be established, so
+        // the state declines rather than reading as an empty family.
+        let (store, focal) = store_with(Some(3), 2, false);
+        let arrival = observe_caller_arrival(&store, &focal);
+
+        assert_eq!(arrival.state, ArrivalState::Unmeasured);
+        assert!(!arrival.state.certifies_absence());
+        let factor = arrival
+            .limiting_factor()
+            .expect("unmeasured limits the answer");
+        assert!(
+            factor.starts_with(UNMEASURED_ARRIVAL_LIMITING_FACTOR),
+            "{factor}"
+        );
+    }
+
+    #[test]
+    fn a_file_nothing_imports_still_certifies_when_the_language_links_imports() {
+        // The other half of the control above, and the reason the two cannot be
+        // collapsed. Here the graph demonstrably resolves imports and this file
+        // simply has none pointing at it, so an empty family is a real reading
+        // about the repository rather than a blind spot.
+        //
+        // The focal's own file is deliberately left with NO incident import edge
+        // of any kind. That is what makes this a falsification of the mistake it
+        // was written for: taking the control off the focal's file rather than
+        // off the language reports every unimported file as unmeasured and puts
+        // a floor under every absence in the store. Four handler fixtures went
+        // red on it, this one goes red on it, and no arm above can see it.
+        let store = InMemoryGraph::new();
+        let focal = entity_in("private_helper", "src/notekeeper/internal.py", Some(0));
+        let other = entity_in("elsewhere", "src/notekeeper/other.py", Some(1));
+        let third = entity_in("third", "src/notekeeper/third.py", Some(1));
+        for entity in [&focal, &other, &third] {
+            store.upsert_entity(entity).unwrap();
+        }
+        store
+            .upsert_relation(&edge(RelationKind::Imports, &other, &third))
+            .unwrap();
+
+        let arrival = observe_caller_arrival(&store, &focal);
+        assert_eq!(
+            arrival.state,
+            ArrivalState::Accounted,
+            "a language that links imports elsewhere makes an unimported file a real empty family"
+        );
+        assert_eq!(arrival.family_files, 0);
+        assert_eq!(arrival.limiting_factor(), None);
+    }
+
+    #[test]
+    fn an_unreported_block_is_not_read_as_accounted() {
+        // A payload carrying no block at all yields no gap, because there is
+        // nothing to read; the tool always publishes one, and this pins that the
+        // reader never invents an "accounted" from silence.
+        assert_eq!(arrival_gap(&json!({})), None);
+        // An unknown state is refused rather than treated as whole.
+        let gap = arrival_gap(&json!({ CALLER_ARRIVAL_KEY: { "state": "probably_fine" } }))
+            .expect("an unrecognized state cannot license an absence");
+        assert!(gap.starts_with("caller_arrival_state_unknown"), "{gap}");
+    }
+}

--- a/crates/kin-mcp/src/caller_arrival.rs
+++ b/crates/kin-mcp/src/caller_arrival.rs
@@ -61,7 +61,7 @@
 //! cannot see who imports anything" are opposite facts and only the first is
 //! evidence about the focal.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use kin_model::graph::{EntityFilter, GraphStore};
 use kin_model::{entity::Entity, EntityId, FilePathId, RelationKind};
@@ -78,14 +78,13 @@ pub const UNRESOLVED_ARRIVAL_LIMITING_FACTOR: &str = "caller_arrival_unresolved"
 /// Limiting-factor id for a family that could not be established at all.
 pub const UNMEASURED_ARRIVAL_LIMITING_FACTOR: &str = "caller_arrival_unmeasured";
 
-/// Entities scanned before the reading gives up and reports `unmeasured`.
+/// Importing files examined before the reading declines.
 ///
-/// The walk costs one relation read per entity of the focal's file plus one per
-/// entity of each family file. A repository large enough to make that expensive
-/// gets an honest refusal rather than a query nobody asked for, and `unmeasured`
-/// is a real answer here: it declines to certify rather than certifying on a
-/// scan that did not finish.
-const ARRIVAL_SCAN_CAP: usize = 4_000;
+/// Each costs one entity query plus one relation read per entity of that file.
+/// A hub imported by more files than this gets an honest `unmeasured` rather
+/// than a verdict drawn from a truncated set, because truncating and reporting
+/// `accounted` is the silent cap this module exists to refuse.
+const FAMILY_FILE_CAP: usize = 200;
 
 /// How completely this reading could account for the ways a caller reaches the
 /// focal.
@@ -241,14 +240,27 @@ fn parsed_call_sites(entity: &Entity) -> Option<u64> {
 /// control could not witness import linking, and both decline.
 const IMPORT_WITNESS_BUDGET: usize = 500;
 
-/// Whether this language links imports across files anywhere in this graph.
+/// Whether this graph links imports across files at all, for this language.
 ///
-/// The control for an empty family. It answers a question about the LANGUAGE,
-/// never about the focal's file, because a file nothing imports holds no import
-/// edge by construction and reading the control off that file would make every
-/// such file unmeasurable.
-fn language_links_imports<G: GraphStore>(store: &G, language_entities: &[Entity]) -> bool {
-    for entity in language_entities.iter().take(IMPORT_WITNESS_BUDGET) {
+/// The last-resort control for an empty family, and it is reached only when the
+/// focal's own file holds no import edge in EITHER direction, which on a real
+/// repository is rare. It answers a question about the LANGUAGE and never about
+/// the focal's file: a file nothing imports holds no incoming import edge by
+/// construction, and reading the control off that alone would make every such
+/// file unmeasurable.
+///
+/// This is the only path here that reads the whole language, and it declines
+/// rather than truncating when the language is larger than the walk: a sample
+/// that finds no import edge and a store that holds none are the same answer
+/// from this function, and only one of them is evidence.
+fn language_links_imports<G: GraphStore>(store: &G, language: kin_model::LanguageId) -> bool {
+    let Ok(entities) = store.query_entities(&EntityFilter {
+        languages: Some(vec![language]),
+        ..EntityFilter::default()
+    }) else {
+        return false;
+    };
+    for entity in entities.iter().take(IMPORT_WITNESS_BUDGET) {
         let Ok(relations) = store.get_all_relations_for_entity(&entity.id) else {
             continue;
         };
@@ -262,57 +274,60 @@ fn language_links_imports<G: GraphStore>(store: &G, language_entities: &[Entity]
     false
 }
 
+/// Entities of one file, and the parse-side call count the extractor stamped on
+/// every one of them. The count is identical across a file's entities, so the
+/// first entity carrying it settles the file, and `None` means unmeasured.
+fn file_entities<G: GraphStore>(
+    store: &G,
+    file: &FilePathId,
+) -> Option<(Vec<EntityId>, Option<u64>)> {
+    let entities = store
+        .query_entities(&EntityFilter {
+            file_path: Some(file.clone()),
+            ..EntityFilter::default()
+        })
+        .ok()?;
+    let parsed = entities.iter().find_map(parsed_call_sites);
+    Some((
+        entities.into_iter().map(|entity| entity.id).collect(),
+        parsed,
+    ))
+}
+
 /// Whether a caller could reach `focal` through a call this graph does not hold.
 ///
-/// Never fails the request: any error or budget exhaustion becomes `Unmeasured`,
-/// which declines to certify rather than certifying on an unfinished scan.
+/// Never fails the request: any error, an oversized family or an unreadable
+/// index becomes `Unmeasured`, which declines to certify rather than certifying
+/// on a walk that did not finish.
+///
+/// Every read here is scoped to one file. An earlier version loaded the whole
+/// language to build a file index and refused above a cap, which on any real
+/// repository is every query: kin's own Rust alone declares more than seven
+/// thousand functions, so the gate would have reported `unmeasured` for every
+/// focal in the store and put a floor under every absence in it. The cost now
+/// scales with the focal's file and its importers, not with the repository.
 pub fn observe_caller_arrival<G: GraphStore>(store: &G, focal: &Entity) -> CallerArrival {
     let Some(focal_file) = focal.file_origin.clone() else {
         return CallerArrival::unmeasured("the focal entity carries no file of origin");
     };
 
-    let Ok(language_entities) = store.query_entities(&EntityFilter {
-        languages: Some(vec![focal.language]),
-        ..EntityFilter::default()
-    }) else {
-        return CallerArrival::unmeasured("the entity index could not be read for this language");
+    let Some((focal_file_entities, _)) = file_entities(store, &focal_file) else {
+        return CallerArrival::unmeasured(
+            "the entity index could not be read for the focal's file",
+        );
     };
-    if language_entities.len() > ARRIVAL_SCAN_CAP {
-        return CallerArrival::unmeasured(format!(
-            "this language holds {} entities, above the {ARRIVAL_SCAN_CAP} this reading walks",
-            language_entities.len()
-        ));
-    }
-
-    // One pass builds every index the walk needs: which file each entity sits
-    // in, which entities each file owns, and the file's parse-side call count.
-    // The count is stamped identically on every entity of the file, so the first
-    // one carrying it settles the file.
-    let mut file_of: HashMap<EntityId, FilePathId> = HashMap::new();
-    let mut entities_by_file: HashMap<FilePathId, Vec<EntityId>> = HashMap::new();
-    let mut parsed_by_file: HashMap<FilePathId, u64> = HashMap::new();
-    for entity in &language_entities {
-        let Some(file) = entity.file_origin.clone() else {
-            continue;
-        };
-        file_of.insert(entity.id, file.clone());
-        entities_by_file
-            .entry(file.clone())
-            .or_default()
-            .push(entity.id);
-        if let Some(count) = parsed_call_sites(entity) {
-            parsed_by_file.entry(file).or_insert(count);
-        }
-    }
+    let focal_owned: HashSet<EntityId> = focal_file_entities.iter().copied().collect();
 
     // The family: files holding an import edge into an entity of the focal's
     // file. Walked from the focal's file outward, because the focal's file owns
-    // few entities while the language owns many.
+    // few entities and the repository owns many.
+    //
+    // `focal_file_imports_something` rides along as the cheap half of the
+    // empty-family control: if this file's own imports resolved to edges, then
+    // import linking demonstrably works here, and no language-wide read is
+    // needed to establish it.
     let mut family: HashSet<FilePathId> = HashSet::new();
-    let focal_file_entities = entities_by_file
-        .get(&focal_file)
-        .cloned()
-        .unwrap_or_default();
+    let mut focal_file_imports_something = false;
     for entity_id in &focal_file_entities {
         let Ok(relations) = store.get_all_relations_for_entity(entity_id) else {
             return CallerArrival::unmeasured(
@@ -323,37 +338,44 @@ pub fn observe_caller_arrival<G: GraphStore>(store: &G, focal: &Entity) -> Calle
             if !FAMILY_KINDS.contains(&relation.kind) {
                 continue;
             }
-            let Some(source) = relation.src.as_entity() else {
+            let (Some(source), Some(destination)) =
+                (relation.src.as_entity(), relation.dst.as_entity())
+            else {
                 continue;
             };
-            let Some(source_file) = file_of.get(&source) else {
-                continue;
-            };
-            // An import edge whose destination is not this file says nothing
-            // about who can reach it, and a file never imports itself.
-            if relation.dst.as_entity().and_then(|dst| file_of.get(&dst)) != Some(&focal_file) {
+            if focal_owned.contains(&source) {
+                focal_file_imports_something = true;
+            }
+            // An import edge out of this file says nothing about who can reach
+            // it. Only one INTO it puts the importer in the family.
+            if !focal_owned.contains(&destination) || focal_owned.contains(&source) {
                 continue;
             }
-            if source_file != &focal_file {
-                family.insert(source_file.clone());
+            let Ok(Some(importer)) = store.get_entity(&source) else {
+                continue;
+            };
+            if let Some(importer_file) = importer.file_origin {
+                if importer_file != focal_file {
+                    family.insert(importer_file);
+                }
             }
         }
     }
 
     if family.is_empty() {
         // Nothing imports this file. Whether that is a fact about the repository
-        // or about the graph depends on whether this language links imports at
-        // all, and only one of those licenses certifying an absence.
+        // or about the graph depends on whether imports link here at all, and
+        // only one of those licenses certifying an absence.
         //
         // The control is taken over the LANGUAGE and not over the focal's own
-        // file, and that distinction is load-bearing rather than pedantic: a
-        // file nothing imports holds no import edge by definition, so reading
-        // the control off the walk above would report every such file as
-        // unmeasured and put a floor under every absence in the store. Four
+        // incoming edges, and that distinction is load-bearing rather than
+        // pedantic: a file nothing imports holds no incoming import edge by
+        // definition, so reading the control there would report every such file
+        // as unmeasured and put a floor under every absence in the store. Four
         // handler fixtures went inconclusive on exactly that mistake, including
         // the one built to prove a graph linking every class across files still
         // earns its absence.
-        if language_links_imports(store, &language_entities) {
+        if focal_file_imports_something || language_links_imports(store, focal.language) {
             return CallerArrival {
                 state: ArrivalState::Accounted,
                 family_files: 0,
@@ -368,17 +390,33 @@ pub fn observe_caller_arrival<G: GraphStore>(store: &G, focal: &Entity) -> Calle
         );
     }
 
+    let mut family_files: Vec<FilePathId> = family.into_iter().collect();
+    family_files.sort_by(|left, right| left.0.cmp(&right.0));
+    // A hub file can be imported by hundreds of others, and reading them all is
+    // work nobody asked for. Truncating and reporting `accounted` would be the
+    // silent cap this whole module exists to refuse, so an oversized family
+    // declines instead: it is the honest word for a set that was not examined.
+    if family_files.len() > FAMILY_FILE_CAP {
+        return CallerArrival::unmeasured(format!(
+            "{} files import the focal's file, above the {FAMILY_FILE_CAP} this reading examines, \
+             so their call sites were not accounted for",
+            family_files.len()
+        ));
+    }
+
     let mut unaccounted = Vec::new();
     let mut family_measured = 0usize;
-    let mut family_files: Vec<&FilePathId> = family.iter().collect();
-    family_files.sort_by(|left, right| left.0.cmp(&right.0));
     for file in &family_files {
-        let parsed = parsed_by_file.get(*file).copied();
+        let Some((entity_ids, parsed)) = file_entities(store, file) else {
+            return CallerArrival::unmeasured(
+                "the entity index could not be read for a file in the focal's family",
+            );
+        };
         if parsed.is_some() {
             family_measured += 1;
         }
         let mut resolved = 0u64;
-        for entity_id in entities_by_file.get(*file).into_iter().flatten() {
+        for entity_id in &entity_ids {
             let Ok(relations) = store.get_all_relations_for_entity(entity_id) else {
                 return CallerArrival::unmeasured(
                     "the relation index could not be read for a file in the focal's family",
@@ -754,6 +792,83 @@ mod tests {
         );
         assert_eq!(arrival.family_files, 0);
         assert_eq!(arrival.limiting_factor(), None);
+    }
+
+    #[test]
+    fn a_repository_larger_than_any_scan_cap_is_still_measured() {
+        // The regression this guards shipped in the first draft of this module
+        // and would have been invisible in every arm above: the reading built a
+        // file index by loading the whole language and refused above a cap. On
+        // any real repository that is every query. Kin's own Rust declares more
+        // than seven thousand functions, so the gate would have reported
+        // `unmeasured` for every focal in the store and put a floor under every
+        // absence in it, which is the exact over-correction the ticket names.
+        //
+        // Five thousand entities in unrelated files, well past any cap a future
+        // edit is likely to reintroduce. The verdict must still be the real one.
+        let (store, focal) = store_with(Some(3), 2, true);
+        for index in 0..5_000 {
+            store
+                .upsert_entity(&entity_in(
+                    &format!("unrelated{index}"),
+                    &format!("src/notekeeper/bulk{}.py", index % 250),
+                    Some(1),
+                ))
+                .unwrap();
+        }
+
+        let arrival = observe_caller_arrival(&store, &focal);
+        assert_eq!(
+            arrival.state,
+            ArrivalState::Unaccounted,
+            "the reading must scale with the focal's file and its importers, never with the \
+             repository; a cap on the language turns this into `unmeasured`"
+        );
+        assert_eq!(arrival.family_files, 1, "the family is unchanged by bulk");
+        assert_eq!(arrival.unaccounted[0].file, CALLER_FILE);
+    }
+
+    #[test]
+    fn a_family_too_large_to_examine_declines_rather_than_truncating() {
+        // A hub imported by more files than the reading examines. Truncating and
+        // reporting `accounted` would be the silent cap this module exists to
+        // refuse, so the verdict is `unmeasured` and the reason carries the
+        // number, which is the one word that does not overstate what was read.
+        let store = InMemoryGraph::new();
+        let focal = entity_in("note_body", FOCAL_FILE, Some(2));
+        let focal_module = entity_in("storage", FOCAL_FILE, Some(2));
+        store.upsert_entity(&focal).unwrap();
+        store.upsert_entity(&focal_module).unwrap();
+        for index in 0..(FAMILY_FILE_CAP + 1) {
+            let importer = entity_in(
+                &format!("importer{index}"),
+                &format!("tests/test_{index}.py"),
+                Some(1),
+            );
+            store.upsert_entity(&importer).unwrap();
+            store
+                .upsert_relation(&edge(RelationKind::Imports, &importer, &focal_module))
+                .unwrap();
+        }
+
+        let arrival = observe_caller_arrival(&store, &focal);
+        assert_eq!(arrival.state, ArrivalState::Unmeasured);
+        let reason = arrival
+            .unmeasured_reason
+            .as_deref()
+            .expect("an oversized family names its own size");
+        assert!(
+            reason.contains(&(FAMILY_FILE_CAP + 1).to_string()),
+            "the reason must say how many files it did not examine: {reason}"
+        );
+
+        // The control that keeps the cap from being a blanket refusal: one file
+        // under the cap is examined normally.
+        let (small, small_focal) = store_with(Some(2), 2, true);
+        assert_eq!(
+            observe_caller_arrival(&small, &small_focal).state,
+            ArrivalState::Accounted
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/caller_arrival.rs
+++ b/crates/kin-mcp/src/caller_arrival.rs
@@ -86,6 +86,14 @@ pub const UNMEASURED_ARRIVAL_LIMITING_FACTOR: &str = "caller_arrival_unmeasured"
 /// `accounted` is the silent cap this module exists to refuse.
 const FAMILY_FILE_CAP: usize = 200;
 
+/// Evidence rows the published block carries, at most.
+///
+/// The verdict rests on `unaccounted_file_count`, which is never truncated. These
+/// rows are what a reader audits it with, and they are capped because this block
+/// must not become the reason the answer gets evicted from the response budget.
+/// The block says when it truncated, so a short list is never read as a whole one.
+const EVIDENCE_ROW_CAP: usize = 10;
+
 /// How completely this reading could account for the ways a caller reaches the
 /// focal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -163,7 +171,23 @@ impl CallerArrival {
             "state": self.state.wire(),
             "family_files": self.family_files,
             "family_measured": self.family_measured,
-            "unaccounted_files": self.unaccounted,
+            // How many family files hold unaccounted calls, beside the rows.
+            // The count is the fact the verdict rests on and it is never
+            // truncated; the rows below are evidence a reader can audit it with,
+            // and those are capped.
+            "unaccounted_file_count": self.unaccounted.len(),
+            // Capped, and the cap is named rather than silent. The one response
+            // shape this module adds must not become the reason the answer gets
+            // evicted: a `find_references` returning two rows already carried
+            // close to eight kilobytes of envelope on the run that filed this,
+            // and a hub with two hundred importers would put two hundred more
+            // objects in front of the references a caller asked for.
+            "unaccounted_files": self
+                .unaccounted
+                .iter()
+                .take(EVIDENCE_ROW_CAP)
+                .collect::<Vec<_>>(),
+            "unaccounted_files_truncated": self.unaccounted.len() > EVIDENCE_ROW_CAP,
             "unmeasured_reason": self.unmeasured_reason,
         })
     }
@@ -869,6 +893,70 @@ mod tests {
             observe_caller_arrival(&small, &small_focal).state,
             ArrivalState::Accounted
         );
+    }
+
+    #[test]
+    fn the_published_block_caps_its_evidence_and_says_so() {
+        // The count the verdict rests on is never truncated; the rows a reader
+        // audits it with are. The stranger's second recommendation was that the
+        // envelope is eating the answer, with a two-row `find_references`
+        // carrying close to eight kilobytes of it, so the block this module adds
+        // must not be the reason the references get evicted. A silent cap would
+        // be the same defect wearing this module's name.
+        let store = InMemoryGraph::new();
+        let focal = entity_in("note_body", FOCAL_FILE, Some(2));
+        let focal_module = entity_in("storage", FOCAL_FILE, Some(2));
+        store.upsert_entity(&focal).unwrap();
+        store.upsert_entity(&focal_module).unwrap();
+        let importers = EVIDENCE_ROW_CAP + 5;
+        for index in 0..importers {
+            // No parse-side count, so every one of them is unaccounted.
+            let importer = entity_in(
+                &format!("importer{index}"),
+                &format!("tests/test_{index:03}.py"),
+                None,
+            );
+            store.upsert_entity(&importer).unwrap();
+            store
+                .upsert_relation(&edge(RelationKind::Imports, &importer, &focal_module))
+                .unwrap();
+        }
+
+        let arrival = observe_caller_arrival(&store, &focal);
+        assert_eq!(arrival.state, ArrivalState::Unaccounted);
+        assert_eq!(arrival.unaccounted.len(), importers);
+
+        let block = arrival.to_json();
+        assert_eq!(
+            block["unaccounted_file_count"],
+            json!(importers),
+            "the count the verdict rests on is never truncated"
+        );
+        assert_eq!(
+            block["unaccounted_files"].as_array().unwrap().len(),
+            EVIDENCE_ROW_CAP,
+            "the evidence rows are capped"
+        );
+        assert_eq!(
+            block["unaccounted_files_truncated"],
+            json!(true),
+            "a capped list must say so, or a short list reads as a whole one"
+        );
+        // And the gate still fires off the capped block, because it keys on the
+        // state and not on the row count.
+        assert!(arrival_gap(&json!({ CALLER_ARRIVAL_KEY: block }))
+            .is_some_and(|gap| gap.starts_with(UNRESOLVED_ARRIVAL_LIMITING_FACTOR)));
+
+        // The control: a family under the cap publishes every row and says it
+        // did not truncate, so the flag cannot become decoration.
+        let (small, small_focal) = store_with(Some(3), 2, true);
+        let small_block = observe_caller_arrival(&small, &small_focal).to_json();
+        assert_eq!(small_block["unaccounted_file_count"], json!(1));
+        assert_eq!(
+            small_block["unaccounted_files"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(small_block["unaccounted_files_truncated"], json!(false));
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -2035,6 +2035,21 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         "cross_repo": cross_repo,
     });
     result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
+    // Whether a caller could have reached this focal through a call site the
+    // linker recorded no edge for (FIR-2775). `edge_coverage` above answers
+    // whether the graph holds the CLASS of edge this query reads; this answers
+    // whether the files that can reach this focal had their own call sites
+    // accounted for. A graph can pass the first and fail the second, and that is
+    // the state in which an empty reference list came back certified for a
+    // function a test calls.
+    //
+    // Published on every answer rather than only on empty ones, for the reason
+    // stated above `edge_coverage`: an answer that returned rows proved nothing
+    // about the caller it missed. The gate in `crate::negative` reads it back
+    // from here so the verdict and the evidence a reader audits it against are
+    // the same object.
+    result[crate::caller_arrival::CALLER_ARRIVAL_KEY] =
+        crate::caller_arrival::observe_caller_arrival(store, &target).to_json();
     disclose_withheld_candidates(&mut result);
 
     // Say that a bare name was resolved, and to how many candidates.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -943,6 +943,22 @@ pub fn handle_get_context_pack<G: GraphStore>(
         ),
         None => serde_json::Value::Null,
     };
+    // Whether a caller could have reached this focal through a call the linker
+    // recorded no edge for (FIR-2775), read exactly as `find_references` reads
+    // it and published under the same key.
+    //
+    // A pack's `dependents` group is built by the same collector over the same
+    // edges, so it inherits the same gap and has to report it the same way. The
+    // method gate beside this one is shared for precisely that reason: gating a
+    // shared gap on the tool name alone was how two surfaces over one graph came
+    // to answer opposite things about one entity, the tool that refused to
+    // certify and the tool that published `[]` reading the identical incomplete
+    // call graph. Adding a new gap to one surface and not the other would
+    // rebuild that disagreement from scratch.
+    let caller_arrival = match &focal_entity {
+        Some(entity) => crate::caller_arrival::observe_caller_arrival(store, entity).to_json(),
+        None => serde_json::Value::Null,
+    };
 
     // The dependency section carries both directions, so it is served as two
     // groups named for what they are. Serving it as one list called
@@ -1061,6 +1077,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
         // language rather than as a bare fact. Computed by the same observer
         // `find_references` uses, from the same witnesses.
         crate::edge_coverage::EDGE_COVERAGE_KEY: edge_coverage,
+        crate::caller_arrival::CALLER_ARRIVAL_KEY: caller_arrival,
         "token_budget": budget.max_tokens(),
         "tokens_used": pack.actual_tokens,
     });

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -9860,6 +9860,64 @@ mod tests {
         );
     }
 
+    /// FIR-2775. Both reference surfaces must actually EMIT the arrival reading,
+    /// not merely be able to read one.
+    ///
+    /// This exists because the falsification of the shared gate stayed green
+    /// under the mutation that deletes the pack's publication. The envelope test
+    /// injects the block into both payloads by hand, so it proves the gate reads
+    /// a block and proves nothing about whether either handler produces one. Two
+    /// tests, each correct, jointly guarding nothing: the property that matters
+    /// lives in the agreement between what one side emits and what the other
+    /// reads, and only this end asserts the emitting half.
+    #[tokio::test]
+    async fn both_reference_surfaces_publish_the_arrival_reading() {
+        let (store, focal_id) = wide_store(3);
+        let sessions = SessionRegistry::empty_for_test();
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(focal_id.to_string()),
+        )]);
+
+        let pack = parsed_response(&crate::finalize_with_envelope(
+            handle_get_context_pack(&args, &store, &sessions, None).unwrap(),
+            structurally_ready_envelope(),
+            "get_context_pack",
+        ));
+        let references = parsed_response(&crate::finalize_with_envelope(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+
+        for (label, response) in [
+            ("get_context_pack", &pack),
+            ("find_references", &references),
+        ] {
+            let block = &response[crate::caller_arrival::CALLER_ARRIVAL_KEY];
+            assert!(
+                block.is_object(),
+                "{label} must publish the arrival reading the negative envelope gates on; got \
+                 {block}"
+            );
+            // A state the gate recognizes, so the block cannot be present and
+            // inert. `caller_arrival_state_unknown` is what an unrecognized one
+            // produces, and it would read as a gap for the wrong reason.
+            let state = block["state"].as_str().unwrap_or_default();
+            assert!(
+                matches!(state, "accounted" | "unaccounted" | "unmeasured"),
+                "{label} published an arrival state the gate does not recognize: {state:?}"
+            );
+            // The count the verdict rests on rides beside the rows on every
+            // answer, populated or not, so a reader never has to tell "checked
+            // and fine" from "not reported".
+            assert!(
+                block["unaccounted_file_count"].is_u64(),
+                "{label} must publish the unaccounted count beside the rows; got {block}"
+            );
+        }
+    }
+
     #[test]
     fn get_context_pack_response_fits_the_budget() {
         let (store, focal_id) = wide_store(0);

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 pub mod budget;
+pub mod caller_arrival;
 pub mod daemon_delegate;
 pub mod edge_coverage;
 pub mod envelope;

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -2217,7 +2217,13 @@ pub fn negative_for(
     // The file that called it had produced 15 entities, so the
     // file-produced-nothing warning did not apply, and no other signal in the
     // envelope could see a call site that became no edge.
-    if tool == "find_references" && claims_absence {
+    // Shared with `get_context_pack` on purpose, exactly like the method gate
+    // below. A pack's `dependents` group is built by the same collector over the
+    // same edges, so it inherits the same gap; gating this on `find_references`
+    // alone would let the tool that refuses to certify and the tool that
+    // publishes `[]` read one incomplete call graph and answer opposite things,
+    // which is the disagreement the method gate was widened to end.
+    if matches!(tool, "find_references" | "get_context_pack") && claims_absence {
         if let Some(gap) = crate::caller_arrival::arrival_gap(payload) {
             push_gap(&mut trustworthy, &mut trust_reason, gap);
         }
@@ -4124,6 +4130,76 @@ mod tests {
             },
             "edge_coverage": coverage,
         })
+    }
+
+    /// FIR-2775's two-surface arm. The gate that refuses to certify a reference
+    /// absence a dropped call could be hiding in has to reach `get_context_pack`
+    /// too, because a pack's `dependents` group is built by the same collector
+    /// over the same edges. Gating a shared gap on the tool name alone is how
+    /// two surfaces over one graph came to answer opposite things about one
+    /// entity: the tool that refused to certify and the tool that published `[]`
+    /// were reading the identical incomplete call graph.
+    ///
+    /// So this asserts the AGREEMENT rather than each end separately. One block,
+    /// both tools, one verdict, and the healthy control beside it in the same
+    /// test so a fix that floors both surfaces cannot pass either.
+    #[test]
+    fn both_reference_surfaces_reach_one_verdict_on_one_arrival_reading() {
+        let unaccounted = json!({
+            "state": "unaccounted",
+            "family_files": 1,
+            "family_measured": 0,
+            "unaccounted_file_count": 1,
+            "unaccounted_files": [{
+                "file": "tests/test_storage.py",
+                "parsed_call_sites": null,
+                "resolved_call_edges": 2,
+                "unaccounted_call_sites": null,
+            }],
+            "unaccounted_files_truncated": false,
+            "unmeasured_reason": null,
+        });
+        let accounted = json!({
+            "state": "accounted",
+            "family_files": 2,
+            "family_measured": 2,
+            "unaccounted_file_count": 0,
+            "unaccounted_files": [],
+            "unaccounted_files_truncated": false,
+            "unmeasured_reason": null,
+        });
+
+        for (block, expected, label) in [
+            (&unaccounted, false, "an unaccounted arrival"),
+            (&accounted, true, "an accounted arrival"),
+        ] {
+            let mut references = authoritative_empty_references("function");
+            references[crate::caller_arrival::CALLER_ARRIVAL_KEY] = block.clone();
+            let mut pack = empty_pack_dependents("function", cross_file_edges_observed());
+            pack[crate::caller_arrival::CALLER_ARRIVAL_KEY] = block.clone();
+
+            let from_references =
+                negative_for("find_references", &references, &structural_ready_envelope())
+                    .expect("empty references yields a negative");
+            let from_pack = negative_for("get_context_pack", &pack, &structural_ready_envelope())
+                .expect("an empty dependents group yields a negative");
+
+            assert_eq!(
+                from_references["safe_to_conclude_absent"],
+                json!(expected),
+                "{label}: find_references answered the wrong way"
+            );
+            assert_eq!(
+                from_pack["safe_to_conclude_absent"],
+                json!(expected),
+                "{label}: get_context_pack answered the wrong way"
+            );
+            assert_eq!(
+                from_references["safe_to_conclude_absent"], from_pack["safe_to_conclude_absent"],
+                "{label}: the two surfaces disagreed over one reading, which is the exact \
+                 failure this gate is shared to prevent"
+            );
+        }
     }
 
     /// FIR-2474, the half an agent acts on. `get_context_pack` published

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -2202,6 +2202,27 @@ pub fn negative_for(
         }
     }
 
+    // Whether a caller could have arrived through a call the graph does not hold
+    // (FIR-2775). Scoped to answers that claim an absence, like the cross-repo
+    // gate below and for the same reason: a shortfall in the arrival paths
+    // bounds what "nothing calls this" can mean, and says nothing about whether
+    // the rows a populated answer did return are real.
+    //
+    // This is the gap that had no input at all. `storage.note_body` was called
+    // once, from a test that reached the module through `from notekeeper import
+    // storage`, and the linker declined to bind the call. Every other gate here
+    // read a healthy store and agreed, so the answer certified: state
+    // `certified`, `absence_claim: authoritative`, `safe_to_conclude_absent:
+    // true`, `limiting_factor: null`, about a function one grep proves is used.
+    // The file that called it had produced 15 entities, so the
+    // file-produced-nothing warning did not apply, and no other signal in the
+    // envelope could see a call site that became no edge.
+    if tool == "find_references" && claims_absence {
+        if let Some(gap) = crate::caller_arrival::arrival_gap(payload) {
+            push_gap(&mut trustworthy, &mut trust_reason, gap);
+        }
+    }
+
     // The enumeration's own gate, and the only one that can certify it. Every
     // other signal here describes the store; this describes the file, and a
     // file no adapter parsed holds no entities in a graph of any health at all.
@@ -2843,7 +2864,138 @@ mod tests {
                 "matched": "exact_focal_name",
                 "other_candidates": [],
             },
+            // Every real answer carries this block too (FIR-2775), for the same
+            // reason the resolution block above is here: a fixture without one
+            // is not a smaller response, it is a shape the handler cannot
+            // produce, and leaving it out would exercise the absence gates
+            // against a payload that never says whether a caller could have
+            // arrived through an edge the graph does not hold.
+            //
+            // Healthy by default, which is what makes this fixture a control:
+            // the gate below has to leave an accounted arrival alone, or every
+            // absence in this module goes inconclusive and the envelope stops
+            // meaning anything.
+            crate::caller_arrival::CALLER_ARRIVAL_KEY: {
+                "state": "accounted",
+                "family_files": 2,
+                "family_measured": 2,
+                "unaccounted_files": [],
+                "unmeasured_reason": null,
+            },
         })
+    }
+
+    /// FIR-2775, the reproduction. A Python package under `src/` whose test
+    /// reached a module through `from notekeeper import storage` and called
+    /// `storage.note_body(db, note.id)`. The parser read the call, the linker
+    /// declined to bind it, and nothing recorded the decline, so this answer
+    /// came back `certified` / `safe_to_conclude_absent: true` about a function
+    /// one grep proves is used. Every other gate in this module read a healthy
+    /// store and agreed, which is why the reading had to be added rather than
+    /// tightened.
+    #[test]
+    fn find_references_absence_is_inconclusive_when_a_caller_could_arrive_unaccounted() {
+        let mut payload = authoritative_empty_references("function");
+        payload[crate::caller_arrival::CALLER_ARRIVAL_KEY] = json!({
+            "state": "unaccounted",
+            "family_files": 1,
+            "family_measured": 0,
+            "unaccounted_files": [{
+                "file": "tests/test_storage.py",
+                "parsed_call_sites": null,
+                "resolved_call_edges": 2,
+                "unaccounted_call_sites": null,
+            }],
+            "unmeasured_reason": null,
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("empty references yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with(crate::caller_arrival::UNRESOLVED_ARRIVAL_LIMITING_FACTOR),
+            "the limiting factor must lead the reason: {reason}"
+        );
+        assert!(
+            reason.contains("tests/test_storage.py"),
+            "the reason names the file whose calls became no edge: {reason}"
+        );
+    }
+
+    /// The control the ticket demands beside it. Flooring every absence destroys
+    /// the envelope's value in the other direction, so the accounted arrival the
+    /// shared fixture carries must leave an authoritative absence alone.
+    #[test]
+    fn find_references_absence_stays_authoritative_when_every_arrival_is_accounted() {
+        let payload = authoritative_empty_references("function");
+        assert_eq!(
+            payload[crate::caller_arrival::CALLER_ARRIVAL_KEY]["state"],
+            json!("accounted"),
+            "the control is only a control while the fixture is healthy"
+        );
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("empty references yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+        assert_eq!(negative["trust"], json!("authoritative"));
+    }
+
+    /// An arrival the reading could not take is not an arrival it cleared. The
+    /// two states are one word apart in the payload and opposite in consequence,
+    /// so each gets its own arm.
+    #[test]
+    fn find_references_absence_is_inconclusive_when_arrival_could_not_be_measured() {
+        let mut payload = authoritative_empty_references("function");
+        payload[crate::caller_arrival::CALLER_ARRIVAL_KEY] = json!({
+            "state": "unmeasured",
+            "family_files": 0,
+            "family_measured": 0,
+            "unaccounted_files": [],
+            "unmeasured_reason": "the graph holds no import or include edge into this file",
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("empty references yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with(crate::caller_arrival::UNMEASURED_ARRIVAL_LIMITING_FACTOR),
+            "an unmeasured arrival names itself rather than borrowing the unresolved id: {reason}"
+        );
+    }
+
+    /// The gate is scoped to answers that claim an absence, like the cross-repo
+    /// one below it. An answer holding rows asserts nothing about what is not
+    /// there, and putting a floor under it would report every populated answer
+    /// on every repository with one unresolvable call as limited.
+    #[test]
+    fn an_answer_with_rows_is_not_limited_by_an_unaccounted_arrival() {
+        let mut payload = authoritative_empty_references("function");
+        payload["total_upstream"] = json!(1);
+        payload["references"] = json!([{ "name": "caller", "file_path": "app.py" }]);
+        payload[crate::caller_arrival::CALLER_ARRIVAL_KEY] = json!({
+            "state": "unaccounted",
+            "family_files": 1,
+            "family_measured": 1,
+            "unaccounted_files": [{
+                "file": "tests/test_storage.py",
+                "parsed_call_sites": 3,
+                "resolved_call_edges": 2,
+                "unaccounted_call_sites": 1,
+            }],
+            "unmeasured_reason": null,
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("a populated reference answer is still qualified");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "no absence is claimed by an answer with rows"
+        );
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            !reason.contains(crate::caller_arrival::UNRESOLVED_ARRIVAL_LIMITING_FACTOR),
+            "the arrival gate must not fire on an answer that claims no absence: {reason}"
+        );
     }
 
     /// FIR-2475, the verdict half. `find_references` published a

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -1035,14 +1035,20 @@ fn extract_js_assignment_target(
         // than an unresolved reference: an export sweep run from the graph over
         // `lib/utils.js` returns six of its nine exports and reports nothing
         // missing, because from the graph's side there is nothing to hedge about.
+        // A `require(...)` re-export is an export of this module, and the import
+        // specifier it also produces is not a substitute for the entity. The two
+        // live on different surfaces: `list_file_entities`, `find_references` and
+        // every dead-code sweep read the entity set, and none of them can see an
+        // import specifier, so `exports.static = require('serve-static')` reached
+        // an agent as a file whose enumeration certified itself complete without
+        // holding one of express's most-used exports. The 451-constant bloat that
+        // bought the exclusion came from LOCAL bindings (`var etag = require(..)`)
+        // and those stay filtered where they are declared; the export namespace is
+        // a different and much smaller set, one statement in the whole of express.
+        let reexported_dependency = js_require_target(value, source).is_some();
         if matches!(receiver_path.as_str(), "exports" | "module.exports")
             && !property.is_empty()
             && !is_js_function_like_node(value)
-            // A `require(...)` re-export already reaches the graph as a
-            // `FileImport` specifier under this same name. Emitting a constant
-            // beside it would double every re-exported dependency, which is the
-            // shape that buried express's functions under 451 constants.
-            && js_require_target(value, source).is_none()
         {
             entities.push(ExtractedEntity {
                 kind: if value.kind() == "class" {
@@ -1061,7 +1067,16 @@ fn extract_js_assignment_target(
             // it reachable: `exports.etag` calls `createETagGenerator`. The
             // statement is what gets walked rather than the value, because the
             // walk tests a node's children and the value here IS the call.
-            extract_calls_from_context(stmt, source, property, None, relations);
+            //
+            // Skipped for a re-exported dependency, where the only call in the
+            // statement is `require` itself. That is a module load rather than a
+            // call to anything this repository owns, it can never resolve to an
+            // entity, and counting it would charge the file a parsed call site
+            // that no resolver could ever satisfy, which is the denominator
+            // `edge_coverage` reports call resolution against.
+            if !reexported_dependency {
+                extract_calls_from_context(stmt, source, property, None, relations);
+            }
         }
 
         // `module.exports = { parse() {}, print() {} }` is the CommonJS way of
@@ -2264,10 +2279,17 @@ mod tests {
 
     #[test]
     fn parse_js_require_binding_is_an_import_not_a_constant() {
-        // A `require(...)` binding is a dependency line, already carried as a
-        // FileImport. Emitting a Constant beside it doubled every dependency
+        // A LOCAL `require(...)` binding is a dependency line, already carried as
+        // a FileImport. Emitting a Constant beside it doubled every dependency
         // into the entity set: on express those bindings were the bulk of the
         // 451 constants that buried 133 functions.
+        //
+        // The export namespace is the exception and it rides in this fixture on
+        // purpose, because the distinction is the whole rule and a test that only
+        // showed the local side would pass just as well if the export side were
+        // filtered too. That is what shipped: five local bindings and one export
+        // all filtered together, and `express.static` absent from a certified
+        // enumeration as a result.
         let adapter = JavaScriptAdapter;
         let source = br#"
 var contentDisposition = require('content-disposition');
@@ -2281,13 +2303,30 @@ exports.static = require('serve-static');
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
 
-        assert!(
-            entities_besides_the_files_own_module(&output.entities).is_empty(),
-            "require bindings must not produce entities, got {:?}",
+        assert_eq!(
+            entities_besides_the_files_own_module(&output.entities),
+            vec![(EntityKind::Constant, "static")],
+            "five local require bindings produce no entity and the one export \
+             produces exactly one, got {:?}",
             output
                 .entities
                 .iter()
                 .map(|e| (e.kind, e.name.as_str()))
+                .collect::<Vec<_>>()
+        );
+        // The module load is not a call this repository could ever resolve, so it
+        // must not be charged to the file as a parsed call site.
+        assert!(
+            !output
+                .relations
+                .iter()
+                .any(|r| r.kind == kin_model::RelationKind::Calls && r.dst_name == "require"),
+            "a re-export must not record a Calls edge to `require`, got {:?}",
+            output
+                .relations
+                .iter()
+                .filter(|r| r.kind == kin_model::RelationKind::Calls)
+                .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
                 .collect::<Vec<_>>()
         );
 
@@ -2406,25 +2445,32 @@ exports.static = require('serve-static');
     }
 
     #[test]
-    fn parse_js_exports_require_reexport_stays_an_import() {
-        // `exports.static = require('serve-static')` already reaches the graph
-        // as an import specifier named `static`. A constant beside it would
-        // double every re-exported dependency, which is the shape that buried
-        // express's functions under 451 constants.
+    fn parse_js_exports_require_reexport_is_an_export_and_an_import() {
+        // `exports.static = require('serve-static')` is express's line 79 and it
+        // is both things at once: an import of `serve-static` and an export of
+        // this module named `static`. It has to reach BOTH surfaces, because an
+        // import specifier is invisible to every surface that reads the entity
+        // set. Answering only the import side is how `list_file_entities` came to
+        // certify `lib/express.js` as an exact and complete enumeration of eleven
+        // entities that did not include one of the Express API's most-used names,
+        // and how `find_references("express.static")` had no focal to resolve.
         let adapter = JavaScriptAdapter;
         let source = b"exports.static = require('serve-static');";
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        assert!(
-            entities_besides_the_files_own_module(&output.entities).is_empty(),
-            "a require re-export is a dependency line, got {:?}",
+        assert_eq!(
+            entities_besides_the_files_own_module(&output.entities),
+            vec![(EntityKind::Constant, "static")],
+            "a re-export is an export of this module, got {:?}",
             output
                 .entities
                 .iter()
                 .map(|e| (e.kind, e.name.as_str()))
                 .collect::<Vec<_>>()
         );
+        // The import side is unchanged. Both readings are true and the entity is
+        // not a replacement for the specifier.
         let specifiers: Vec<&str> = output
             .imports
             .iter()

--- a/crates/kin-parser/tests/language_matrix_entities.rs
+++ b/crates/kin-parser/tests/language_matrix_entities.rs
@@ -713,12 +713,13 @@ fn assert_export_surface(out: &ParseOutput, lang: &str) {
         );
     }
 
-    // `exports.static = require('serve-static')` is a re-exported dependency.
-    // It reaches the graph as an import specifier under that name, so a
-    // constant beside it would count the same dependency line twice.
+    // `exports.static = require('serve-static')` is a re-exported dependency AND
+    // an export of this module. It has to reach both surfaces, because the
+    // enumeration, the reference index and every dead-code sweep read the entity
+    // set and none of them can see an import specifier.
     assert!(
-        !named.iter().any(|(_, n)| *n == "static"),
-        "{lang}: a require re-export must stay an import; have {named:?}"
+        named.contains(&(EntityKind::Constant, "static")),
+        "{lang}: a require re-export is still an export of this module; have {named:?}"
     );
     let static_specifiers: Vec<&str> = out
         .imports
@@ -751,8 +752,14 @@ fn assert_export_surface(out: &ParseOutput, lang: &str) {
         );
     }
 
-    // Nine exports in, nine reachable out. Reverting the rule that admits a
-    // non-function right-hand side drops this to six.
+    // Nine exports in, nine ENTITIES out. Reverting the rule that admits a
+    // non-function right-hand side drops this to six; reverting the rule that
+    // admits a re-export drops it to eight.
+    //
+    // The reachability test used to accept an import specifier in place of an
+    // entity, which is why `static` could vanish from the entity set with this
+    // assertion still green: the specifier stood in for the entity it was not.
+    // An enumeration reads entities, so this counts entities.
     let exported = [
         "methods",
         "etag",
@@ -764,20 +771,15 @@ fn assert_export_surface(out: &ParseOutput, lang: &str) {
         "compileETag",
         "compileQueryParser",
     ];
-    let reachable = exported
+    let missing: Vec<&str> = exported
         .iter()
-        .filter(|name| {
-            named.iter().any(|(_, n)| n == *name)
-                || out
-                    .imports
-                    .iter()
-                    .any(|i| i.specifiers.iter().any(|s| s.local_name == **name))
-        })
-        .count();
-    assert_eq!(
-        reachable,
-        exported.len(),
-        "{lang}: {reachable} of {} exports reachable; have {named:?}",
+        .copied()
+        .filter(|name| !named.iter().any(|(_, n)| n == name))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "{lang}: {} of {} exports have no entity ({missing:?}); have {named:?}",
+        missing.len(),
         exported.len()
     );
 }


### PR DESCRIPTION
Both findings are one class on two languages: an extractor or linker gap becomes a certified,
authoritative, wrong answer, because the certification is asserted rather than gated on whether the
file was accounted for. This attacks both halves: it removes the gap where that was cheap and safe,
and it makes the envelope able to see the gaps that remain.

## The JavaScript enumeration

`list_file_entities("lib/express.js")` returned eleven entities with `bound: exact`,
`status: complete`, `verdict: certified`, `negative.trust: authoritative` and
`certifies_enumeration: true`, and did not hold `exports.static`, one of the most-used names in the
Express API. The extractor admitted every `exports.X = <anything>` except a `require(...)`
initializer, on the ground that the re-export already reaches the graph as an import specifier. That
is true and it answers the wrong question. The enumeration surface, `find_references` and every
dead-code sweep read the entity set, and an import specifier is not in it.

The 451-constant bloat that bought the exclusion came from LOCAL bindings, and those stay filtered
where they are declared. The export namespace is a different and far smaller set: one statement in
the whole of expressjs/express, and zero in kin's own JS and TS. The module load itself is not
charged to the file as a parsed call site, because no resolver could satisfy a call to `require` and
`edge_coverage` reports call resolution against that denominator.

The matrix test's reachability check counted an export as reachable if it had an entity **or** an
import specifier, so it could not fail for `static` under either behaviour: the specifier stood in
for the entity it was not. It counts entities now.

## The Python reference absence

The ticket calls this an extractor gap. It is a linker gap, and that changes the fix. The extractor
does read `storage.note_body(db, note.id)` and records its receiver. Because the receiver is
present, the linker takes tier (a0), `classify_receiver` looks `storage` up and finds
`("notekeeper", "storage")`, since `extract_py_from_import` stores the package as the module path
and the submodule as a specifier and never joins them. That resolves to `notekeeper/__init__.py`,
both lookups miss, and the tier `continue`s past every lower tier. The external-reference path
declines for want of an `import_source`, and the unresolved-receiver placeholder is never reached at
all. The call is dropped with no edge and no record. The rule in one line: the receiver's binding
must map to the module path of the file that defines the callee, and `from pkg import mod` maps it
one level too high.

Fixing that resolution changes behaviour for every Python repository in the fleet and cannot be
falsified against a real converted store inside this window, so this PR takes the second branch of
the ticket's acceptance: the envelope stops certifying what it cannot see.

`crates/kin-mcp/src/caller_arrival.rs` compares two numbers the graph already owns, per file, over
the files holding an import edge into the focal's file: how many call sites the parser read there,
and how many `Calls` edges the graph holds from that file's entities. Unresolved-receiver
placeholders are edges and are counted, so an ordinary call into a dependency is not a gap. A file
whose parse-side count is absent entirely is its own gap, because the extractor withholds that
number on any file whose calls it could not represent, and Python withholds it on exactly the shape
this ticket is about.

It is scoped to answers that claim an absence, and to a family rather than to the store, because an
envelope that never certifies teaches a caller to ignore it. The control that separates an empty
family from an unreadable one is taken over the language and never over the focal's own file: a file
nothing imports holds no import edge by construction, and reading the control there put four
existing fixtures inconclusive, including the one built to prove that a graph linking every class
across files still earns its absence.

## Three things found by asking what the gate costs, not by a test failing

The reading first built its file index by loading every entity of the focal's language and refused
above a four-thousand cap. Every fixture is small, so all nine tests passed, and on any real
repository that cap is every query: kin's own Rust declares more than seven thousand functions, so
the gate would have reported `unmeasured` for every focal in the store and floored every absence in
it. Every read is scoped to one file now, and a hub imported by more files than the reading examines
declines rather than truncating.

The block emitted one object per unaccounted importing file, uncapped, which on a hub would have put
hundreds of them in front of the references a caller asked for. The count the verdict rests on is
published whole and the evidence rows are capped at ten with the truncation disclosed.

And the gate reached only `find_references`, which is a known failure in this file: the method gate
beside it carries the note that gating a shared gap on the tool name alone is how two surfaces over
one graph came to answer opposite things about one entity, the tool that refused to certify and the
tool that published an empty array reading the identical incomplete call graph. `get_context_pack`
publishes the same block under the same key now, and the test asserts the agreement rather than each
end separately.

## The scripted checks

`crates/kin-index/tests/certified_answers_account_for_the_file.rs` pins both fixture shapes end to
end through the real pipeline, because each half of both chains was already unit-tested and the
joins were not. `list_file_entities` proves a hand-built `ParseCompleteness::Partial` does not
certify, and nothing proved a real file with a broken top-level statement ever reaches `Partial`.
`caller_arrival` proves an absent call count makes an absence unaccounted, and nothing proved the
Python adapter actually withholds that key on the shape the stranger hit.

Every check was falsified by breaking the behaviour it guards, reading which assertion fired rather
than only that the suite went red. Seventeen mutations, each landing on its own arm. Deleting the
envelope gate turns both inconclusive arms red and leaves the accounted control green, which is what
proves the control is a control and not a floor. Stamping the call count unconditionally turns the
Python arm red; never stamping it turns the CONTROL red.

One of those mutations found a hole nothing else could see. Deleting the pack's publication of the
block left the two-surface agreement test green, because that test injects the block into both
payloads by hand: it proves the gate reads a block and proves nothing about whether either handler
produces one. Two tests, each correct, jointly guarding nothing. A second test now drives both
handlers and asserts each response actually carries the reading, and deleting either publication
fails it by name.

## What this does not do

The Python linker resolution is unfixed, so `from pkg import mod` then `mod.f()` still produces no
`Calls` edge and `kin trace` and `kin refs` still disagree about `note_body`. What changed is that
`find_references` no longer certifies the resulting absence. FIR-2786's byte-range accounting is not
built either; the extractor fix removes the express gap outright, so the ticket's first acceptance
branch is met without it, but a general accounting remains unbuilt and both carriers I considered
are wrong (`ParseCompleteness::Partial` has real blast radius, since `kin rename` refuses on any
non-`Full` parse, and entity metadata dies on a zero-entity file). The gate's real-world firing rate
is unmeasured against a converted repository. The full lane report, with the design notes and the
remaining work named, is at `.kin-coord/reports/certgate-20260826.md`.

`bin/kin-precheck kin --repo-dir kin=<lane worktree>` ran 16 of 16 gates green on this branch, and
the `kin-parser`, `kin-index` and `kin-mcp` suites are green. The express arm was also spot-checked
against the real `lib/express.js`, including the copy the stranger ran against: it indexes to twelve
entities including `Constant:static` where the run saw eleven without it, with nothing else added and
nothing lost.

Part of FIR-2775
Part of FIR-2786
