### PR TITLE
State the memory this machine affords before a conversion starts, and stop two surfaces claiming a graph they did not build

### DIFF
--- a/crates/kin-cli/src/capability.rs
+++ b/crates/kin-cli/src/capability.rs
@@ -44,6 +44,17 @@
 //! reason out to the caller so a tier chosen from a stand-in is never presented
 //! as a reading.
 
+/// Effective cores a machine needs before locate runs its full multihop budget.
+///
+/// Public because `kin doctor` states this line before a conversion starts, and
+/// a reader deciding which machine to convert on needs the number rather than
+/// the word "performance". [`LocateProfile::score`] is its only other reader,
+/// so the line a user is told and the line that is scored are one value.
+pub const PERFORMANCE_TIER_MIN_CORES: usize = 8;
+
+/// GiB a machine needs alongside those cores, on the same terms.
+pub const PERFORMANCE_TIER_MIN_RAM_GB: f64 = 16.0;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocateProfile {
     /// ≤2 cores OR ≤4GB RAM
@@ -63,8 +74,14 @@ impl LocateProfile {
     ///
     /// Pure, so the thresholds are testable without a host to run on and
     /// without the env override in the way.
+    ///
+    /// The `Performance` arm reads its two numbers from the constants beside
+    /// this enum rather than writing them here, because `kin doctor` states
+    /// that line to a reader deciding where to run, and a threshold written
+    /// twice is a threshold that can move in one place. The row quotes the
+    /// same constants.
     fn score(cores: usize, ram_gb: f64) -> Self {
-        if cores >= 8 && ram_gb >= 16.0 {
+        if cores >= PERFORMANCE_TIER_MIN_CORES && ram_gb >= PERFORMANCE_TIER_MIN_RAM_GB {
             Self::Performance
         } else if cores >= 4 && ram_gb >= 8.0 {
             Self::Standard

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -47,7 +47,7 @@ pub async fn run(message: String, quiet: bool) -> Result<()> {
 async fn pending_enrichment(layout: &kin_core::KinLayout) -> Option<String> {
     let url = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await?;
     let client = crate::daemon_client::DaemonClient::from_base_url_for_layout(url, layout).ok()?;
-    let status = client.lsp_sweep_status().await.ok()?;
+    let status = probe_sweep_status(&client).await?;
     let field = |name: &str| status.get(name).and_then(|value| value.as_u64());
     let done = field("files_done")?;
     let total = field("files_total")?;
@@ -56,6 +56,27 @@ async fn pending_enrichment(layout: &kin_core::KinLayout) -> Option<String> {
         .and_then(|value| value.as_bool())
         .unwrap_or(false);
     pending_enrichment_line(running, done, total)
+}
+
+/// Ask the daemon how its sweep is going, under a bound of this command's own.
+///
+/// A function rather than an inline `timeout`, so a test can drive the real
+/// call against a real socket that never answers. Asserting the bound by
+/// wrapping the client in the test would pin the constant and nothing else, and
+/// would keep passing on the day this call site stopped using it.
+///
+/// The client's own ceiling is 300 s. The endpoint is an atomics read and
+/// answers instantly on a daemon that is well, but the daemon this line is
+/// ABOUT is a busy one, and five minutes of silence after a commit that already
+/// landed is a worse surface than no line at all. An answer that does not
+/// arrive in the window is treated exactly like one that could not be read.
+async fn probe_sweep_status(
+    client: &crate::daemon_client::DaemonClient,
+) -> Option<serde_json::Value> {
+    tokio::time::timeout(PENDING_ENRICHMENT_PROBE, client.lsp_sweep_status())
+        .await
+        .ok()?
+        .ok()
 }
 
 /// The sentence, split from the probe so both branches are testable without a
@@ -153,6 +174,13 @@ struct DaemonCommitResult {
     relation_count: usize,
     file_count: usize,
 }
+
+/// How long the post-commit enrichment probe is allowed to take.
+///
+/// Short on purpose. The commit has landed by the time this runs, so every
+/// second here is a second a user waits to be told their write succeeded, and
+/// the sentence it buys is an advisory one.
+const PENDING_ENRICHMENT_PROBE: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// How often the phase tail is read while the commit request is outstanding.
 const PHASE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(400);
@@ -977,6 +1005,45 @@ mod tests {
             noisy.ends_with("Cross-file enrichment is behind."),
             "{noisy}"
         );
+    }
+
+    /// A landed commit is never held hostage by the probe that annotates it.
+    ///
+    /// The daemon client's own ceiling is 300 s, and `/lsp/sweep/status` is an
+    /// atomics read that answers instantly on a daemon that is well. The daemon
+    /// this line is about is a busy one, so the well case is not the one to
+    /// size for: five minutes of silence after a write that already succeeded
+    /// is worse than no line at all.
+    ///
+    /// Driven against a socket that accepts and then says nothing, which is the
+    /// shape a wedged daemon presents, so the bound is proved by a hang rather
+    /// than asserted about a constant.
+    #[tokio::test]
+    async fn a_probe_that_never_answers_gives_up_long_before_the_client_would() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let silent = tokio::spawn(async move {
+            // Accept and hold. Never reply.
+            let _held = listener.accept().await;
+            tokio::time::sleep(std::time::Duration::from_secs(600)).await;
+        });
+
+        let client =
+            crate::daemon_client::DaemonClient::from_base_url(format!("http://{addr}")).unwrap();
+        let started = std::time::Instant::now();
+        let answered = probe_sweep_status(&client).await;
+        let waited = started.elapsed();
+
+        assert!(
+            answered.is_none(),
+            "a socket that never replies must trip the bound, not return a reading"
+        );
+        assert!(
+            waited < std::time::Duration::from_secs(30),
+            "the probe waited {waited:?}; the client's own ceiling is 300s and this line is not \
+             worth any of it"
+        );
+        silent.abort();
     }
 
     /// The announcement this command publishes before it does anything else,

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -973,7 +973,10 @@ mod tests {
             noisy.lines().take(2).collect::<Vec<_>>(),
             "the summary and the git-status note are unchanged by the third line"
         );
-        assert!(noisy.ends_with("Cross-file enrichment is behind."), "{noisy}");
+        assert!(
+            noisy.ends_with("Cross-file enrichment is behind."),
+            "{noisy}"
+        );
     }
 
     /// The announcement this command publishes before it does anything else,

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -864,13 +864,16 @@ mod tests {
     /// stayed dirty forever afterward.
     #[test]
     fn a_successful_commit_says_the_change_is_in_kin_authority_and_not_in_git() {
-        let summary = render_commit_summary(&DaemonCommitResult {
-            change_id: "9ade4452cd80".to_string(),
-            branch: "refs/heads/main".to_string(),
-            entity_count: 0,
-            relation_count: 0,
-            file_count: 1,
-        });
+        let summary = render_commit_summary(
+            &DaemonCommitResult {
+                change_id: "9ade4452cd80".to_string(),
+                branch: "refs/heads/main".to_string(),
+                entity_count: 0,
+                relation_count: 0,
+                file_count: 1,
+            },
+            None,
+        );
         assert!(
             summary.contains("Created semantic change 9ade4452cd80"),
             "{summary}"
@@ -881,6 +884,96 @@ mod tests {
             "the note must name the surface that keeps disagreeing: {summary}"
         );
         assert!(summary.contains("kin eject"), "{summary}");
+    }
+
+    /// The measured FIR-2776 commit, and the store that must stay quiet.
+    ///
+    /// A fully parseable new module landed as `(0 entities, 0 relations, 2
+    /// artifacts)` because the counts are the change's own deltas and the sweep
+    /// deriving its cross-file edges had not reached the file. The next `kin
+    /// diff` then reported `Relations: +123` on a tree nobody had touched. Both
+    /// numbers were right; neither surface said the word "yet".
+    ///
+    /// The caught-up arm is the load-bearing half. A line printed under every
+    /// commit is a line a user stops reading by the third one, and then it is
+    /// worth nothing on the commit that needed it.
+    #[test]
+    fn a_commit_taken_while_the_sweep_is_behind_says_so_and_a_caught_up_one_says_nothing() {
+        let behind = pending_enrichment_line(true, 312, 480)
+            .expect("a sweep with files left to walk is work this commit did not record");
+        assert!(
+            behind.contains("312 of 480 files"),
+            "the reader needs the distance, not the fact: {behind}"
+        );
+        assert!(
+            behind.contains("deltas"),
+            "the sentence has to say why the counts above look empty: {behind}"
+        );
+        assert!(
+            behind.contains("next commit"),
+            "and when the missing edges arrive: {behind}"
+        );
+        assert!(
+            behind.contains("exits"),
+            "and what happens if the daemon goes first: {behind}"
+        );
+
+        assert!(
+            pending_enrichment_line(false, 480, 480).is_none(),
+            "a store whose sweep has walked everything it has is not behind, and a warning it \
+             always prints is a warning nobody reads"
+        );
+    }
+
+    /// The two shapes a single condition would have missed.
+    ///
+    /// Keying on `running` alone goes quiet over a sweep that was cut short and
+    /// is not coming back, which is precisely a store with outstanding work and
+    /// nothing in flight to finish it. Keying on the file counts alone goes
+    /// quiet in the window between a sweep being queued and its first file
+    /// landing, and a commit taken in that window is the one this exists for.
+    #[test]
+    fn a_sweep_that_stopped_early_is_still_behind_and_an_empty_walk_is_not() {
+        assert!(
+            pending_enrichment_line(false, 12, 480).is_some(),
+            "nothing is running and 468 files are unwalked; that is outstanding work"
+        );
+        assert!(
+            pending_enrichment_line(true, 0, 0).is_none(),
+            "a queued sweep with nothing to walk owes nothing"
+        );
+        assert!(
+            pending_enrichment_line(false, 0, 0).is_none(),
+            "and neither does a store that has never had a file to walk"
+        );
+    }
+
+    /// The line is appended, and nothing else about the summary moves.
+    ///
+    /// Two lines when the sweep has caught up, three when it has not, and the
+    /// first two byte-identical either way. The note about `git status` is the
+    /// one sentence this command exists to keep saying, and an enrichment line
+    /// that displaced it would trade one confusion for another.
+    #[test]
+    fn the_pending_line_is_added_beneath_the_summary_and_replaces_none_of_it() {
+        let result = DaemonCommitResult {
+            change_id: "9ade4452cd80".to_string(),
+            branch: "refs/heads/main".to_string(),
+            entity_count: 0,
+            relation_count: 0,
+            file_count: 2,
+        };
+        let quiet = render_commit_summary(&result, None);
+        let noisy = render_commit_summary(&result, Some("Cross-file enrichment is behind."));
+
+        assert_eq!(quiet.lines().count(), 2, "{quiet}");
+        assert_eq!(noisy.lines().count(), 3, "{noisy}");
+        assert_eq!(
+            quiet.lines().take(2).collect::<Vec<_>>(),
+            noisy.lines().take(2).collect::<Vec<_>>(),
+            "the summary and the git-status note are unchanged by the third line"
+        );
+        assert!(noisy.ends_with("Cross-file enrichment is behind."), "{noisy}");
     }
 
     /// The announcement this command publishes before it does anything else,

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -21,9 +21,69 @@ pub async fn run(message: String, quiet: bool) -> Result<()> {
 
     let result = run_daemon_commit(&layout, &message, quiet).await?;
     if !quiet {
-        println!("{}", render_commit_summary(&result));
+        println!(
+            "{}",
+            render_commit_summary(&result, pending_enrichment(&layout).await.as_deref())
+        );
     }
     Ok(())
+}
+
+/// What this store's cross-file sweep still owes, when it owes anything.
+///
+/// `kin commit` printed `(0 entities, 0 relations, 2 artifacts)` for a fully
+/// parseable new module, because the counts are the change's own deltas and the
+/// sweep that derives cross-file edges had not reached the file yet. The next
+/// `kin diff` then showed `Relations: +123` on a tree with no file change. Both
+/// readings are correct and neither one says the word "yet", so the surface
+/// that reports success is the surface that leaves out the part that is still
+/// moving. FIR-2776.
+///
+/// Read after the commit and not before it, because the question is what is
+/// outstanding for the store the reader now has. Every failure answers `None`:
+/// an enrichment probe must never be able to turn a landed commit into an
+/// error, and a commit that already succeeded is not made wrong by a daemon
+/// that would not say how its sweep is going.
+async fn pending_enrichment(layout: &kin_core::KinLayout) -> Option<String> {
+    let url = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await?;
+    let client = crate::daemon_client::DaemonClient::from_base_url_for_layout(url, layout).ok()?;
+    let status = client.lsp_sweep_status().await.ok()?;
+    let field = |name: &str| status.get(name).and_then(|value| value.as_u64());
+    let done = field("files_done")?;
+    let total = field("files_total")?;
+    let running = status
+        .get("running")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    pending_enrichment_line(running, done, total)
+}
+
+/// The sentence, split from the probe so both branches are testable without a
+/// daemon.
+///
+/// Two conditions, not one. `running` alone goes quiet on a sweep that was cut
+/// short and never resumed, which is a store with work outstanding and nothing
+/// in flight to finish it. An unwalked file count alone goes quiet in the
+/// window between a sweep being queued and its first file landing.
+///
+/// A store whose sweep has walked everything it has prints nothing, and a store
+/// that has never had a file to walk prints nothing either, because both
+/// counters are zero and zero is not behind zero. That silence is the point: a
+/// line under every commit is a line nobody reads by the third one.
+fn pending_enrichment_line(running: bool, done: u64, total: u64) -> Option<String> {
+    if !running && done >= total {
+        return None;
+    }
+    if total == 0 {
+        return None;
+    }
+    Some(format!(
+        "Cross-file enrichment is still catching up ({done} of {total} files). The counts above \
+         are this change's own deltas, so edges the sweep has not reached are not in it; they \
+         reach durable authority at your next commit. Until then they live only in this daemon, \
+         and a daemon that exits loses them from its live graph; its next start resumes the sweep \
+         from where it stopped."
+    ))
 }
 
 /// The announcement this command publishes for as long as it runs.
@@ -63,8 +123,8 @@ impl Drop for CommitAnnouncement {
 /// working tree this change came from stays dirty and `git log` never moves.
 /// Without it a brownfield user commits all day and reads `git status` as proof
 /// that nothing happened.
-fn render_commit_summary(result: &DaemonCommitResult) -> String {
-    format!(
+fn render_commit_summary(result: &DaemonCommitResult, pending: Option<&str>) -> String {
+    let summary = format!(
         "Created semantic change {} on branch '{}' ({} entities, {} relations, {} artifacts)\n{}",
         result.change_id,
         result.branch,
@@ -72,7 +132,11 @@ fn render_commit_summary(result: &DaemonCommitResult) -> String {
         result.relation_count,
         result.file_count,
         AUTHORITY_NOT_GIT_NOTE,
-    )
+    );
+    match pending {
+        Some(pending) => format!("{summary}\n{pending}"),
+        None => summary,
+    }
 }
 
 /// Result from the daemon-owned native commit transaction.
@@ -693,7 +757,7 @@ mod tests {
             .expect("a commit with no reply deadline waits for the daemon");
         let result: DaemonCommitResult = response.json().await.unwrap();
         assert_eq!(result.change_id, "5b8ca7b7");
-        assert_eq!(render_commit_summary(&result).lines().count(), 2);
+        assert_eq!(render_commit_summary(&result, None).lines().count(), 2);
 
         serving.abort();
     }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -8306,6 +8306,11 @@ mod tests {
         assert!(json.contains("\"platform\""));
         assert!(json.contains("\"healthy\""));
         assert!(json.contains("\"retrieval_profile\""));
+        // The row FIR-2787 is about answers with no repository in sight, so a
+        // run outside one is exactly where it has to appear. Every unit test
+        // above calls its core directly and would stay green if nobody ever
+        // registered it, which is the shape of a check that cannot fail.
+        assert!(json.contains("\"memory_floor\""));
     }
 
     #[cfg(unix)]

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -4034,14 +4034,23 @@ fn memory_floor_check_for(
 
     let available = format_health_bytes(evidence.limit_bytes);
     let ceiling_source = evidence.limit_source.describe();
-    let budget = kin_core::memory_pressure::FootprintBudget::derived_from(evidence.limit_bytes);
+    // Resolved rather than derived, so an operator who named a budget is told
+    // their own number. `kin doctor` runs before the conversion, so the daemon
+    // this row is describing is one this shell has not started yet and will
+    // start with this environment.
+    let budget = kin_core::memory_pressure::FootprintBudget::resolve(Some(evidence.limit_bytes))
+        .unwrap_or(kin_core::memory_pressure::FootprintBudget {
+            bytes: kin_core::memory_pressure::FootprintBudget::derived_from(evidence.limit_bytes),
+            source: kin_core::memory_pressure::BudgetSource::Derived,
+        });
     let daemon_clause = format!(
-        "one repository daemon is allowed {} of that, half the ceiling, and its background \
-         embedding is the first work held back once that is spent; a second repository gets its \
-         own daemon and its own {}, so two of them are allowed {} here",
-        format_health_bytes(budget),
-        format_health_bytes(budget),
-        format_health_bytes(budget.saturating_mul(2)),
+        "one repository daemon is allowed {} of that, {}, and its background embedding is the \
+         first work held back once that is spent; a second repository gets its own daemon and \
+         its own {}, so two of them are allowed {} here",
+        format_health_bytes(budget.bytes),
+        describe_daemon_budget(&budget, evidence.limit_bytes),
+        format_health_bytes(budget.bytes),
+        format_health_bytes(budget.bytes.saturating_mul(2)),
     );
 
     let (tier_clause, tier_is_full) = memory_floor_tier_clause(detection);
@@ -4057,7 +4066,10 @@ fn memory_floor_check_for(
         None => (None, true),
         Some(point) => {
             let comfortable = point.peak_bytes.saturating_add(
-                point.peak_bytes.saturating_mul(COMMIT_PEAK_COMFORT_MARGIN_PERCENT) / 100,
+                point
+                    .peak_bytes
+                    .saturating_mul(COMMIT_PEAK_COMFORT_MARGIN_PERCENT)
+                    / 100,
             );
             let clears = evidence.limit_bytes >= comfortable;
             let clause = if clears {
@@ -4088,7 +4100,8 @@ fn memory_floor_check_for(
         }
     };
 
-    let mut detail = format!("{available} of memory here ({ceiling_source}); {daemon_clause}. {tier_clause}");
+    let mut detail =
+        format!("{available} of memory here ({ceiling_source}); {daemon_clause}. {tier_clause}");
     if let Some(commit_clause) = commit_clause {
         detail.push_str(". ");
         detail.push_str(&commit_clause);
@@ -4115,7 +4128,10 @@ fn memory_floor_check_for(
             format_health_bytes(
                 cheapest
                     .map(|point| point.peak_bytes.saturating_add(
-                        point.peak_bytes.saturating_mul(COMMIT_PEAK_COMFORT_MARGIN_PERCENT) / 100,
+                        point
+                            .peak_bytes
+                            .saturating_mul(COMMIT_PEAK_COMFORT_MARGIN_PERCENT)
+                            / 100,
                     ))
                     .unwrap_or(evidence.limit_bytes)
             )
@@ -4133,6 +4149,42 @@ fn memory_floor_check_for(
         "Before converting a repository here: {}.",
         moves.join(", or ")
     ))
+}
+
+/// Where a daemon's budget came from, in the four shapes it can take.
+///
+/// "Half the ceiling" is true of a 12 GiB container and false of a 128 GiB
+/// workstation, where half is 64 and the derived budget is capped at 8. The row
+/// printed the half sentence over both, which is a claim eight times the size of
+/// the fact on the second machine, and a reader who trusted it would size their
+/// host for a daemon Kin will never let grow that large.
+fn describe_daemon_budget(
+    budget: &kin_core::memory_pressure::FootprintBudget,
+    ceiling_bytes: u64,
+) -> String {
+    if budget.source == kin_core::memory_pressure::BudgetSource::Operator {
+        return format!(
+            "the figure {} names rather than anything derived from this ceiling",
+            kin_core::memory_pressure::FOOTPRINT_BUDGET_ENV
+        );
+    }
+    let half = ceiling_bytes / 2;
+    if budget.bytes >= kin_core::memory_pressure::DERIVED_BUDGET_CEILING_BYTES
+        && half > budget.bytes
+    {
+        return format!(
+            "the most a derived budget ever allows one daemon rather than half of {}, because a \
+             repository daemon holding more than that is pathological whatever the host has spare",
+            format_health_bytes(ceiling_bytes)
+        );
+    }
+    if budget.bytes <= kin_core::memory_pressure::DERIVED_BUDGET_FLOOR_BYTES && half < budget.bytes
+    {
+        return "the least a derived budget ever allows, because a smaller one would back off \
+                before it could do anything useful"
+            .to_string();
+    }
+    "half the ceiling".to_string()
 }
 
 /// The tier half of the row, and whether this machine is over the line.
@@ -4792,7 +4844,6 @@ mod tests {
         }
     }
 
-
     /// Build a detection the way the host probe would have, so a row's numbers
     /// come from a shape the real reader produces rather than from a literal.
     fn detected(
@@ -4808,6 +4859,84 @@ mod tests {
         }
     }
 
+    /// "Half the ceiling" is true of a small container and false of a big host.
+    ///
+    /// The first draft of this row said it over both. On the 128 GiB machine it
+    /// was written on, half is 64 GiB and the budget a daemon actually gets is
+    /// 8, so the sentence was eight times the size of the fact and pointed a
+    /// reader at a host they would never need. Caught by printing the row rather
+    /// than by reading it, which is why this arm exists.
+    ///
+    /// Falsify by restoring the unconditional "half the ceiling": the clamped
+    /// arm goes red and the container arm stays green, which is exactly how the
+    /// defect read.
+    #[test]
+    #[serial]
+    fn the_budget_clause_says_half_only_where_the_budget_really_is_half() {
+        let container = memory_floor_check_for(
+            &capped_memory(12288 * MIB),
+            &detected(crate::capability::LocateProfile::Standard, 5, 12.0),
+        );
+        assert!(
+            container
+                .detail
+                .contains("6.0 GiB of that, half the ceiling"),
+            "on a 12 GiB box the derived budget really is half of it: {}",
+            container.detail
+        );
+
+        let workstation = memory_floor_check_for(
+            &memory(128 * 1024 * MIB),
+            &detected(crate::capability::LocateProfile::Performance, 18, 128.0),
+        );
+        assert!(
+            !workstation.detail.contains("half the ceiling"),
+            "half of 128 GiB is 64 and the cap holds a daemon to 8, so this machine is not \
+             getting half of anything: {}",
+            workstation.detail
+        );
+        assert!(
+            workstation.detail.contains("8.0 GiB of that")
+                && workstation
+                    .detail
+                    .contains("the most a derived budget ever allows"),
+            "and the row names the cap that decided it: {}",
+            workstation.detail
+        );
+    }
+
+    /// A budget an operator named is theirs, not a number this row derived.
+    ///
+    /// Doctor runs before the conversion, so the daemon being described is one
+    /// this shell has not started and will start with this environment. Quoting
+    /// a derived figure over an operator's own would misreport the machine they
+    /// configured.
+    #[test]
+    #[serial]
+    fn a_budget_an_operator_named_is_reported_as_theirs() {
+        let _guard = EnvVarGuard::set(
+            kin_core::memory_pressure::FOOTPRINT_BUDGET_ENV,
+            (3 * 1024 * MIB).to_string(),
+        );
+        let check = memory_floor_check_for(
+            &memory(128 * 1024 * MIB),
+            &detected(crate::capability::LocateProfile::Performance, 18, 128.0),
+        );
+        assert!(
+            check.detail.contains("3.0 GiB of that")
+                && check
+                    .detail
+                    .contains(kin_core::memory_pressure::FOOTPRINT_BUDGET_ENV),
+            "the row quotes the operator's number and names where it came from: {}",
+            check.detail
+        );
+        assert!(
+            !check.detail.contains("half the ceiling"),
+            "and never calls it a fraction of anything: {}",
+            check.detail
+        );
+    }
+
     /// The stranger's own box, and the reading nobody was given until after an
     /// eleven-minute conversion had spent itself.
     ///
@@ -4820,6 +4949,7 @@ mod tests {
     /// registration: the constrained arm goes quiet, which is the state this
     /// row exists to end.
     #[test]
+    #[serial]
     fn the_memory_floor_row_reads_a_constrained_container_before_any_repository_exists() {
         let check = memory_floor_check_for(
             &capped_memory(12288 * MIB),
@@ -4854,6 +4984,7 @@ mod tests {
     /// are allowed the whole machine, which is the sentence the stranger
     /// assembled for themselves out of four surfaces over several hours.
     #[test]
+    #[serial]
     fn the_row_states_what_two_repository_daemons_come_to_against_this_ceiling() {
         let check = memory_floor_check_for(
             &capped_memory(12288 * MIB),
@@ -4872,12 +5003,17 @@ mod tests {
     /// A warning that fires on every machine is wallpaper by the second run.
     /// This is a developer host clear of both lines, and it has to be silent.
     #[test]
+    #[serial]
     fn a_machine_over_both_lines_keeps_a_quiet_row_and_offers_no_repair() {
         let check = memory_floor_check_for(
             &memory(64 * 1024 * MIB),
             &detected(crate::capability::LocateProfile::Performance, 10, 64.0),
         );
-        assert!(matches!(check.status, HealthStatus::Healthy), "{}", check.detail);
+        assert!(
+            matches!(check.status, HealthStatus::Healthy),
+            "{}",
+            check.detail
+        );
         assert!(
             check.manual_fix.is_none(),
             "there is nothing to repair on a machine that clears both lines: {check:?}"
@@ -4899,6 +5035,7 @@ mod tests {
     /// for. The two arms are asserted against each other so neither can quietly
     /// become the other's text.
     #[test]
+    #[serial]
     fn the_fix_line_names_the_shortfall_this_machine_has_and_not_the_other_one() {
         let tier_only = memory_floor_check_for(
             &memory(32 * 1024 * MIB),
@@ -4950,6 +5087,7 @@ mod tests {
     /// Falsify by hardcoding the pair in `memory_floor_tier_clause` and then
     /// changing either constant: this goes red and nothing else does.
     #[test]
+    #[serial]
     fn the_tier_line_the_row_quotes_is_the_one_the_scorer_uses() {
         let check = memory_floor_check_for(
             &memory(64 * 1024 * MIB),
@@ -4974,6 +5112,7 @@ mod tests {
     /// forced arm is the same rule from the other side: an operator who named
     /// the tier was not measured either.
     #[test]
+    #[serial]
     fn a_tier_from_an_unread_host_or_an_operator_says_so_instead_of_quoting_numbers() {
         let misread = memory_floor_check_for(
             &memory(64 * 1024 * MIB),

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -196,6 +196,7 @@ pub async fn run_health_checks() -> HealthReport {
     checks.push(check_parse_coverage(&graph_status).await);
     checks.push(check_background_work().await);
     checks.push(check_embedding_model().await);
+    checks.push(check_memory_floor());
     checks.push(check_commit_memory_headroom());
     checks.push(check_daemon_kill_record());
     checks.push(check_interrupted_init());
@@ -3991,6 +3992,222 @@ fn check_commit_memory_headroom() -> HealthCheck {
     };
     let footprint = crate::commands::store_footprint::StoreFootprint::measure(&layout);
     commit_memory_headroom_check_for(&footprint, &crate::capability::memory_evidence())
+}
+
+/// What this machine affords Kin, stated before a conversion starts rather than
+/// after one has already cost something.
+///
+/// Every other memory row on this page needs a store to talk about, so on a
+/// fresh box, before `kin init`, all of them read n/a and the page says nothing
+/// at all about whether Kin fits here. FIR-2787 is what that costs: four
+/// separate disclosures reached one reader, each of them true, each on a
+/// different surface, and each after the work it described had been paid for.
+/// This row needs no repository, so it is the one that arrives first.
+///
+/// It states three things a reader can act on before an import runs for eleven
+/// minutes: the ceiling this process actually runs under, what one repository
+/// daemon will be allowed to hold inside it, and whether this machine is over
+/// the line where locate runs its full multihop budget. It forecasts nothing
+/// about a particular store, which is the neighbouring row's job and needs one
+/// to exist.
+///
+/// Advisory by construction, like every memory row here. `Degraded` never
+/// blocks readiness, because a machine smaller than Kin wants is a fact about
+/// the machine, and a check that failed on it would fail every correct install
+/// on a small host.
+fn check_memory_floor() -> HealthCheck {
+    memory_floor_check_for(
+        &crate::capability::memory_evidence(),
+        &crate::capability::CapabilityDetection::detect(),
+    )
+}
+
+/// Core of [`check_memory_floor`] with both readings as inputs, so every branch
+/// is testable on any host, including the small container no developer here
+/// runs on.
+fn memory_floor_check_for(
+    evidence: &crate::capability::MemoryEvidence,
+    detection: &crate::capability::CapabilityDetection,
+) -> HealthCheck {
+    const ID: &str = "memory_floor";
+    const LABEL: &str = "Memory floor";
+
+    let available = format_health_bytes(evidence.limit_bytes);
+    let ceiling_source = evidence.limit_source.describe();
+    let budget = kin_core::memory_pressure::FootprintBudget::derived_from(evidence.limit_bytes);
+    let daemon_clause = format!(
+        "one repository daemon is allowed {} of that, half the ceiling, and its background \
+         embedding is the first work held back once that is spent; a second repository gets its \
+         own daemon and its own {}, so two of them are allowed {} here",
+        format_health_bytes(budget),
+        format_health_bytes(budget),
+        format_health_bytes(budget.saturating_mul(2)),
+    );
+
+    let (tier_clause, tier_is_full) = memory_floor_tier_clause(detection);
+
+    // The cheapest commit anybody has measured, so a ceiling under it is under
+    // every row in the table. A reader with no store cannot pick a row by store
+    // size the way `Commit memory headroom` does, so this quotes the floor of
+    // the table and names the repository it came from.
+    let cheapest = MEASURED_COMMIT_PEAKS
+        .iter()
+        .min_by_key(|point| point.peak_bytes);
+    let (commit_clause, ceiling_clears) = match cheapest {
+        None => (None, true),
+        Some(point) => {
+            let comfortable = point.peak_bytes.saturating_add(
+                point.peak_bytes.saturating_mul(COMMIT_PEAK_COMFORT_MARGIN_PERCENT) / 100,
+            );
+            let clears = evidence.limit_bytes >= comfortable;
+            let clause = if clears {
+                format!(
+                    "The cheapest commit Kin has measured drove a {} machine to {} in total on \
+                     {} ({} store), and this ceiling clears that by at least {}%",
+                    format_health_bytes(point.observed_ceiling_bytes),
+                    format_health_bytes(point.peak_bytes),
+                    point.repository,
+                    format_health_bytes(point.store_bytes),
+                    COMMIT_PEAK_COMFORT_MARGIN_PERCENT,
+                )
+            } else {
+                format!(
+                    "The cheapest commit Kin has measured drove a {} machine to {} in total on \
+                     {} ({} store), and {available} is not {}% clear of that, so a commit here \
+                     has no measured room. That total is a whole-machine reading with everything \
+                     else resident inside it rather than a commit's own demand, so this compares \
+                     a ceiling against an observation and forecasts nothing about a write here",
+                    format_health_bytes(point.observed_ceiling_bytes),
+                    format_health_bytes(point.peak_bytes),
+                    point.repository,
+                    format_health_bytes(point.store_bytes),
+                    COMMIT_PEAK_COMFORT_MARGIN_PERCENT,
+                )
+            };
+            (Some(clause), clears)
+        }
+    };
+
+    let mut detail = format!("{available} of memory here ({ceiling_source}); {daemon_clause}. {tier_clause}");
+    if let Some(commit_clause) = commit_clause {
+        detail.push_str(". ");
+        detail.push_str(&commit_clause);
+    }
+    detail.push('.');
+
+    if ceiling_clears && tier_is_full {
+        return HealthCheck::new(ID, LABEL, HealthStatus::Healthy, detail);
+    }
+
+    // One fix line, carrying only the moves that apply. A fix that listed a
+    // larger machine under a shortfall the machine does not have is the kind of
+    // advice that sends a reader to buy hardware they already own, which is the
+    // defect `disabled_signals` was corrected for.
+    let mut moves: Vec<String> = Vec::new();
+    if !ceiling_clears {
+        moves.push(
+            "convert one repository at a time here, and run `kin daemon stop` in a repository you \
+             are not working in"
+                .to_string(),
+        );
+        moves.push(format!(
+            "raise this ceiling above {}",
+            format_health_bytes(
+                cheapest
+                    .map(|point| point.peak_bytes.saturating_add(
+                        point.peak_bytes.saturating_mul(COMMIT_PEAK_COMFORT_MARGIN_PERCENT) / 100,
+                    ))
+                    .unwrap_or(evidence.limit_bytes)
+            )
+        ));
+    }
+    if !tier_is_full {
+        moves.push(format!(
+            "run locate work on a machine with {} cores and {:.0} GB to get the full multihop \
+             budget",
+            crate::capability::PERFORMANCE_TIER_MIN_CORES,
+            crate::capability::PERFORMANCE_TIER_MIN_RAM_GB,
+        ));
+    }
+    HealthCheck::new(ID, LABEL, HealthStatus::Degraded, detail).with_manual_fix(format!(
+        "Before converting a repository here: {}.",
+        moves.join(", or ")
+    ))
+}
+
+/// The tier half of the row, and whether this machine is over the line.
+///
+/// Split out because it has four shapes and the row has two, and because the
+/// case that matters most is the one nobody can reach on a developer host: a
+/// tier scored against a stand-in after the memory probe failed. That tier must
+/// never be reported as a reading, since "run on a bigger host" is actively
+/// wrong advice for a host that was never read.
+fn memory_floor_tier_clause(detection: &crate::capability::CapabilityDetection) -> (String, bool) {
+    let full = detection.profile == crate::capability::LocateProfile::Performance;
+    let line = format!(
+        "the {} core / {:.0} GB line",
+        crate::capability::PERFORMANCE_TIER_MIN_CORES,
+        crate::capability::PERFORMANCE_TIER_MIN_RAM_GB,
+    );
+    let narrowing = format!(
+        "multihop depth {} of {}, frontier {} of {}, timeout {}ms of {}ms",
+        detection.profile.multihop_max_depth(),
+        crate::capability::LocateProfile::Performance.multihop_max_depth(),
+        detection.profile.multihop_frontier_limit(),
+        crate::capability::LocateProfile::Performance.multihop_frontier_limit(),
+        detection.profile.multihop_timeout_ms(),
+        crate::capability::LocateProfile::Performance.multihop_timeout_ms(),
+    );
+
+    if detection.forced_by_env {
+        let clause = if full {
+            format!(
+                "KIN_LOCATE_PROFILE pins locate to the {} tier, so no reading of this host decided \
+                 it and it runs the full multihop budget",
+                detection.profile.name()
+            )
+        } else {
+            format!(
+                "KIN_LOCATE_PROFILE pins locate to the {} tier, so no reading of this host decided \
+                 it: {narrowing}",
+                detection.profile.name()
+            )
+        };
+        return (clause, full);
+    }
+
+    // A probe that could not answer is scored against a stand-in, and the
+    // stand-in is 4 GB, so this arm is always below the line. Saying which
+    // numbers were read is the whole point: the remediation differs.
+    if let Some(reason) = detection.misread_host() {
+        return (
+            format!(
+                "this host's memory could not be read ({reason}), so locate was scored against a \
+                 stand-in rather than a measurement and sits on the {} tier: {narrowing}",
+                detection.profile.name()
+            ),
+            false,
+        );
+    }
+
+    let cores = detection.cores.unwrap_or(0);
+    let ram = detection
+        .memory
+        .as_ref()
+        .map(|memory| memory.gb_or_stand_in())
+        .unwrap_or(0.0);
+    let clause = if full {
+        format!(
+            "{cores} cores and {ram:.1} GB put this machine at or over {line}, so locate runs its \
+             full multihop budget"
+        )
+    } else {
+        format!(
+            "{cores} cores and {ram:.1} GB put locate on the {} tier, under {line}: {narrowing}",
+            detection.profile.name()
+        )
+    };
+    (clause, full)
 }
 
 /// Whether a daemon serving this store was killed, and what killed it.

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -4792,6 +4792,233 @@ mod tests {
         }
     }
 
+
+    /// Build a detection the way the host probe would have, so a row's numbers
+    /// come from a shape the real reader produces rather than from a literal.
+    fn detected(
+        profile: crate::capability::LocateProfile,
+        cores: usize,
+        ram_gb: f64,
+    ) -> crate::capability::CapabilityDetection {
+        crate::capability::CapabilityDetection {
+            profile,
+            forced_by_env: false,
+            cores: Some(cores),
+            memory: Some(crate::capability::HostMemory::Detected(ram_gb)),
+        }
+    }
+
+    /// The stranger's own box, and the reading nobody was given until after an
+    /// eleven-minute conversion had spent itself.
+    ///
+    /// Five schedulable CPUs and a 12 GiB container cap. Every memory row on
+    /// this page reads n/a there before `kin init`, because every one of them
+    /// needs a store, so the page said nothing at all about a machine two
+    /// converted repositories would not fit on.
+    ///
+    /// Falsify by returning `Healthy` unconditionally, or by deleting the
+    /// registration: the constrained arm goes quiet, which is the state this
+    /// row exists to end.
+    #[test]
+    fn the_memory_floor_row_reads_a_constrained_container_before_any_repository_exists() {
+        let check = memory_floor_check_for(
+            &capped_memory(12288 * MIB),
+            &detected(crate::capability::LocateProfile::Standard, 5, 12.0),
+        );
+
+        assert!(
+            matches!(check.status, HealthStatus::Degraded),
+            "a container two daemons do not fit in is not a quiet row: {}",
+            check.detail
+        );
+        assert!(
+            check.detail.contains("12.0 GiB") && check.detail.contains("container"),
+            "the ceiling and which reading it came from are the whole point: {}",
+            check.detail
+        );
+        assert!(
+            check.detail.contains("6.0 GiB"),
+            "the per-daemon budget is what the reader is about to spend: {}",
+            check.detail
+        );
+        assert!(
+            check.manual_fix.is_some(),
+            "every non-green row on this page carries the fix it needs: {check:?}"
+        );
+    }
+
+    /// The arithmetic that makes a 12 GiB box a bad place for two repositories,
+    /// stated before the second conversion rather than after it.
+    ///
+    /// One daemon per repository, each deriving half the ceiling. Two of them
+    /// are allowed the whole machine, which is the sentence the stranger
+    /// assembled for themselves out of four surfaces over several hours.
+    #[test]
+    fn the_row_states_what_two_repository_daemons_come_to_against_this_ceiling() {
+        let check = memory_floor_check_for(
+            &capped_memory(12288 * MIB),
+            &detected(crate::capability::LocateProfile::Standard, 5, 12.0),
+        );
+        assert!(
+            check.detail.contains("two of them are allowed 12.0 GiB"),
+            "one daemon at 6.0 GiB is unremarkable and two are the whole box; the row has to do \
+             that multiplication for the reader: {}",
+            check.detail
+        );
+    }
+
+    /// The control, and the reason the row is worth having at all.
+    ///
+    /// A warning that fires on every machine is wallpaper by the second run.
+    /// This is a developer host clear of both lines, and it has to be silent.
+    #[test]
+    fn a_machine_over_both_lines_keeps_a_quiet_row_and_offers_no_repair() {
+        let check = memory_floor_check_for(
+            &memory(64 * 1024 * MIB),
+            &detected(crate::capability::LocateProfile::Performance, 10, 64.0),
+        );
+        assert!(matches!(check.status, HealthStatus::Healthy), "{}", check.detail);
+        assert!(
+            check.manual_fix.is_none(),
+            "there is nothing to repair on a machine that clears both lines: {check:?}"
+        );
+        assert!(
+            check.detail.contains("full multihop budget"),
+            "and it says so, because a reader deciding where to convert wants the positive \
+             answer too: {}",
+            check.detail
+        );
+    }
+
+    /// A fix line names only the moves this machine needs.
+    ///
+    /// A 32 GiB box with four cores clears every measured commit and is still
+    /// under the tier line. Telling that reader to raise a memory limit is the
+    /// shape of advice that sent an earlier operator off to buy hardware they
+    /// were already running, which is what `disabled_signals` was corrected
+    /// for. The two arms are asserted against each other so neither can quietly
+    /// become the other's text.
+    #[test]
+    fn the_fix_line_names_the_shortfall_this_machine_has_and_not_the_other_one() {
+        let tier_only = memory_floor_check_for(
+            &memory(32 * 1024 * MIB),
+            &detected(crate::capability::LocateProfile::Standard, 4, 32.0),
+        );
+        assert!(
+            matches!(tier_only.status, HealthStatus::Degraded),
+            "{}",
+            tier_only.detail
+        );
+        let fix = tier_only
+            .manual_fix
+            .clone()
+            .expect("a row needing attention carries its fix");
+        assert!(
+            fix.contains("multihop"),
+            "the shortfall this machine has is the tier: {fix}"
+        );
+        assert!(
+            !fix.contains("raise this ceiling"),
+            "and a machine with memory to spare must not be told to buy more: {fix}"
+        );
+
+        let ceiling_only = memory_floor_check_for(
+            &capped_memory(8 * 1024 * MIB),
+            &detected(crate::capability::LocateProfile::Performance, 16, 8.0),
+        );
+        let fix = ceiling_only
+            .manual_fix
+            .clone()
+            .expect("a ceiling under every measured commit carries its fix");
+        assert!(
+            fix.contains("raise this ceiling"),
+            "the shortfall here is the ceiling: {fix}"
+        );
+        assert!(
+            !fix.contains("multihop"),
+            "and locate is already running at full budget on it: {fix}"
+        );
+    }
+
+    /// The line a reader is told is the line that is scored.
+    ///
+    /// Two constants, read by the tier scorer and by this row, so the sentence
+    /// cannot drift from the threshold. Asserting a literal "8 core / 16 GB"
+    /// here would write the number twice and let the row keep quoting a line
+    /// the scorer had moved off.
+    ///
+    /// Falsify by hardcoding the pair in `memory_floor_tier_clause` and then
+    /// changing either constant: this goes red and nothing else does.
+    #[test]
+    fn the_tier_line_the_row_quotes_is_the_one_the_scorer_uses() {
+        let check = memory_floor_check_for(
+            &memory(64 * 1024 * MIB),
+            &detected(crate::capability::LocateProfile::Performance, 10, 64.0),
+        );
+        let line = format!(
+            "{} core / {:.0} GB",
+            crate::capability::PERFORMANCE_TIER_MIN_CORES,
+            crate::capability::PERFORMANCE_TIER_MIN_RAM_GB,
+        );
+        assert!(
+            check.detail.contains(&line),
+            "the row has to quote the scorer's own threshold: wanted {line} in {}",
+            check.detail
+        );
+    }
+
+    /// A tier scored from a probe that failed is never reported as a reading.
+    ///
+    /// The stand-in is 4 GB, so this arm always lands below the line, and "run
+    /// on a bigger host" is actively wrong advice for a host nothing read. The
+    /// forced arm is the same rule from the other side: an operator who named
+    /// the tier was not measured either.
+    #[test]
+    fn a_tier_from_an_unread_host_or_an_operator_says_so_instead_of_quoting_numbers() {
+        let misread = memory_floor_check_for(
+            &memory(64 * 1024 * MIB),
+            &crate::capability::CapabilityDetection {
+                profile: crate::capability::LocateProfile::Minimal,
+                forced_by_env: false,
+                cores: Some(10),
+                memory: Some(crate::capability::HostMemory::Undetected(
+                    "sysctl hw.memsize refused".to_string(),
+                )),
+            },
+        );
+        assert!(
+            misread.detail.contains("could not be read")
+                && misread.detail.contains("sysctl hw.memsize refused"),
+            "the row says the host was not read, and quotes the probe's own reason: {}",
+            misread.detail
+        );
+        assert!(
+            matches!(misread.status, HealthStatus::Degraded),
+            "an unmeasured host is not a machine this row has cleared: {}",
+            misread.detail
+        );
+
+        let forced = memory_floor_check_for(
+            &memory(64 * 1024 * MIB),
+            &crate::capability::CapabilityDetection {
+                profile: crate::capability::LocateProfile::Performance,
+                forced_by_env: true,
+                cores: None,
+                memory: None,
+            },
+        );
+        assert!(
+            forced.detail.contains("KIN_LOCATE_PROFILE"),
+            "a tier an operator named says who named it: {}",
+            forced.detail
+        );
+        assert!(
+            matches!(forced.status, HealthStatus::Healthy),
+            "a forced performance tier runs the full budget, whoever chose it: {}",
+            forced.detail
+        );
+    }
+
     /// The reading a user needed BEFORE the commit that killed their daemon.
     ///
     /// A ceiling under a peak already measured for a store no larger than this

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1512,6 +1512,103 @@ mod tests {
         }
     }
 
+
+    /// What the word over the counts is allowed to claim.
+    ///
+    /// The measured FIR-2787 run: entities and relations both nonzero, no
+    /// cross-file reference edge anywhere in the graph, and a summary reading
+    /// "present". Every number under that word was correct. The word was the
+    /// claim, and the reader took it, converted a second repository, and found
+    /// out on a different surface hours later.
+    ///
+    /// The produced arm is half of this test and not a formality. A build that
+    /// said "partial" whenever the counts were nonzero would pass the withheld
+    /// arm and downgrade every healthy conversion Kin has ever done.
+    mod cross_file_enrichment_wording {
+        use super::super::{
+            cross_file_pending_notice, render_semantic_enrichment, CrossFileEnrichment,
+        };
+        use super::enrichment;
+        use crate::commands::status::SemanticEnrichmentPresence;
+
+        fn withheld() -> CrossFileEnrichment {
+            CrossFileEnrichment::Withheld {
+                pending: "no language-server sweep ran for this repository".to_string(),
+            }
+        }
+
+        #[test]
+        fn a_run_that_built_no_cross_file_graph_says_partial_and_names_what_is_pending() {
+            let status = enrichment(SemanticEnrichmentPresence::Present, 1058);
+            let line = render_semantic_enrichment(&status, None, &withheld());
+            assert!(
+                line.starts_with("partial"),
+                "a run that produced no cross-file edge has not produced a present graph: {line}"
+            );
+            assert!(
+                !line.contains("present"),
+                "the word this replaced must be gone, not merely joined: {line}"
+            );
+            assert!(
+                line.contains("1058 entities"),
+                "the counts were never wrong and are still printed: {line}"
+            );
+
+            let notice = cross_file_pending_notice(&status, &withheld())
+                .expect("a partial graph names what is pending beneath the counts");
+            assert!(
+                notice.contains("no language-server sweep ran"),
+                "the notice carries the phase's own reason, not a guess: {notice}"
+            );
+        }
+
+        #[test]
+        fn a_run_that_produced_cross_file_edges_keeps_present_and_prints_no_second_line() {
+            let status = enrichment(SemanticEnrichmentPresence::Present, 1058);
+            let line = render_semantic_enrichment(&status, None, &CrossFileEnrichment::Produced);
+            assert!(
+                line.starts_with("present"),
+                "a conversion that swept its files is present, and a build that could not say so \
+                 would downgrade every healthy repository: {line}"
+            );
+            assert!(
+                cross_file_pending_notice(&status, &CrossFileEnrichment::Produced).is_none(),
+                "and it carries no notice at all"
+            );
+        }
+
+        /// A store with no entity and no relation is not partially anything.
+        ///
+        /// It already carries `semantic_absence_notice`, which says more than
+        /// this one would and says it about the right absence. Two notices
+        /// under one line would each be read as qualifying the other.
+        #[test]
+        fn an_absent_store_keeps_its_own_word_and_gets_no_second_notice() {
+            let status = enrichment(SemanticEnrichmentPresence::Absent, 0);
+            let line = render_semantic_enrichment(&status, None, &withheld());
+            assert!(line.starts_with("absent"), "{line}");
+            assert!(cross_file_pending_notice(&status, &withheld()).is_none());
+        }
+
+        /// A sweep nobody could read supports no claim, so it makes none.
+        ///
+        /// The tempting shape is to treat an unreadable probe as success and
+        /// keep the confident word. That is the exact trade this ticket exists
+        /// to undo, one layer down.
+        #[test]
+        fn a_sweep_this_run_could_not_read_is_withheld_rather_than_produced() {
+            let unreadable = CrossFileEnrichment::unreadable();
+            assert_ne!(unreadable, CrossFileEnrichment::Produced);
+            let pending = unreadable
+                .pending()
+                .expect("an unread sweep is not a produced graph");
+            assert!(
+                pending.contains("unknown"),
+                "and it says it does not know, rather than picking a side: {pending}"
+            );
+        }
+    }
+
     /// The measured FIR-2650 summary, and the two stores it could not tell
     /// apart.
     ///
@@ -1528,7 +1625,7 @@ mod tests {
     fn a_killed_daemon_changes_the_enrichment_summary_and_nothing_else_does() {
         let status = enrichment(SemanticEnrichmentPresence::Present, 1058);
 
-        let quiet = render_semantic_enrichment(&status, None);
+        let quiet = render_semantic_enrichment(&status, None, &CrossFileEnrichment::Produced);
         assert!(
             quiet.contains("completion not attested"),
             "the caveat is true of every store and stays: {quiet}"
@@ -1554,7 +1651,8 @@ mod tests {
             limit_bytes: Some(12 * 1024 * 1024 * 1024),
             last_rss_bytes: Some(11 * 1024 * 1024 * 1024),
         };
-        let killed = render_semantic_enrichment(&status, Some(&record));
+        let killed =
+            render_semantic_enrichment(&status, Some(&record), &CrossFileEnrichment::Produced);
         assert!(
             killed.contains("1058 entities"),
             "the counts are still true and still printed: {killed}"

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1512,7 +1512,6 @@ mod tests {
         }
     }
 
-
     /// What the word over the counts is allowed to claim.
     ///
     /// The measured FIR-2787 run: entities and relations both nonzero, no

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -201,7 +201,7 @@ pub async fn run(
     //
     // Runs before the result is printed so what a reader is told about their
     // repository is true of the repository they now have.
-    if !no_enrich {
+    let cross_file = if !no_enrich {
         // Isolated on its own task so a panic inside it cannot decide init's
         // exit status. `kin init 2>&1 | head -1` closes both streams after one
         // line and every advisory write after that panics; init's contract is
@@ -211,15 +211,25 @@ pub async fn run(
         // forever is a worse guarantee than making the phase structurally unable
         // to matter.
         let kin_root = result.layout.root().to_path_buf();
-        if let Err(error) = tokio::spawn(async move { enrich_after_init(&kin_root).await }).await {
-            note!("note: the cross-file enrichment phase did not finish cleanly: {error}");
+        match tokio::spawn(async move { enrich_after_init(&kin_root).await }).await {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                note!("note: the cross-file enrichment phase did not finish cleanly: {error}");
+                CrossFileEnrichment::unreadable()
+            }
         }
-    }
+    } else {
+        CrossFileEnrichment::Withheld {
+            pending: "`--no-enrich` skipped the language-server sweep, so cross-file reference \
+                      and override edges are not in this graph; `kin daemon sweep` runs it"
+                .to_string(),
+        }
+    };
 
     if json {
         print_json_result(&result, boundary, enrichment)?;
     } else {
-        print_human_result(&result, boundary, &enrichment)?;
+        print_human_result(&result, boundary, &enrichment, &cross_file)?;
     }
     Ok(())
 }
@@ -289,6 +299,61 @@ async fn stop_conversion_daemon(borrowed_existing: bool, kin_root: &Path) {
 /// there and fails with a version error naming a layout nothing wrote, which is
 /// exactly how this read as "no daemon could be started" on a repository whose
 /// store had just been created successfully.
+/// What the conversion's enrichment phase produced, as the summary has to
+/// describe it.
+///
+/// `kin init` reported "Semantic enrichment: present" on a repository whose
+/// graph held no cross-file reference edge at all, because presence is scored
+/// from entity and relation counts and a single-file parse fills both. The
+/// containment edges are real, so the counts are right; the word over them is
+/// what claimed a graph the run did not build. FIR-2787 is the reader who was
+/// told four separate times, on four surfaces, what this one word had already
+/// said wrongly.
+///
+/// The phase already knows the answer at no extra cost. It watches the sweep it
+/// started, so it sees a daemon that could not sweep, a sweep that walked files
+/// and enriched none, and a sweep cut short by its own budget, and each of the
+/// three is a run that produced no complete cross-file graph. Nothing here
+/// re-reads the store to find that out, which matters on the repository this
+/// ticket came from, where a `graph status` costs half a minute.
+///
+/// The claim is deliberately about THIS RUN and not about the store. The phase
+/// watched one sweep; it did not count the graph's edges, and saying it had
+/// would be the same overreach in the other direction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CrossFileEnrichment {
+    /// A sweep finished having enriched files, so this run produced cross-file
+    /// edges.
+    Produced,
+    /// This run produced no complete cross-file graph, with what is pending and
+    /// what would finish it.
+    Withheld { pending: String },
+}
+
+impl CrossFileEnrichment {
+    /// The phase reached the daemon and could not learn what the sweep did.
+    ///
+    /// Withheld rather than `Produced`, because the summary's word is a claim
+    /// and an unread sweep supports no claim. It says so plainly instead of
+    /// borrowing the confident word from a run nobody watched.
+    fn unreadable() -> Self {
+        Self::Withheld {
+            pending: "this run could not read what the cross-file sweep did, so whether it \
+                      produced any cross-file edge is unknown; run `kin doctor` to read this \
+                      store's reference-edge coverage"
+                .to_string(),
+        }
+    }
+
+    /// What is still owed, when something is.
+    fn pending(&self) -> Option<&str> {
+        match self {
+            Self::Withheld { pending } => Some(pending),
+            Self::Produced => None,
+        }
+    }
+}
+
 /// Run the conversion phase and ALWAYS clean up after it.
 ///
 /// The cleanup used to sit after the happy-path wait, so every early return
@@ -301,10 +366,10 @@ async fn stop_conversion_daemon(borrowed_existing: bool, kin_root: &Path) {
 ///
 /// The phase runs on its own task and the cleanup runs after the join, so it is
 /// reached on success, on refusal, on timeout and on panic alike.
-async fn enrich_after_init(kin_root: &Path) {
+async fn enrich_after_init(kin_root: &Path) -> CrossFileEnrichment {
     let Some(layout) = kin_core::KinLayout::discover(kin_root) else {
         note!("note: cross-file reference enrichment was skipped: no Kin layout at this path");
-        return;
+        return CrossFileEnrichment::unreadable();
     };
 
     // Whether a daemon was already serving this repository. If not, anything
@@ -317,11 +382,16 @@ async fn enrich_after_init(kin_root: &Path) {
     let root = kin_root.to_path_buf();
     let phase_layout = layout.clone();
     let phase = tokio::spawn(async move { enrich_phase(&root, &phase_layout).await });
-    if let Err(error) = phase.await {
-        note!("note: the cross-file enrichment phase did not finish cleanly: {error}");
-    }
+    let outcome = match phase.await {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            note!("note: the cross-file enrichment phase did not finish cleanly: {error}");
+            CrossFileEnrichment::unreadable()
+        }
+    };
 
     stop_conversion_daemon(borrowed_existing, kin_root).await;
+    outcome
 }
 
 /// The sentence `kin init` prints when a run produced no cross-file edges.
@@ -388,7 +458,7 @@ fn enrichment_unavailable_note(reason: &str, detail: Option<&str>) -> String {
     }
 }
 
-async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
+async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) -> CrossFileEnrichment {
     let url = match crate::daemon_client::ensure_daemon_running(kin_root).await {
         Ok(url) => url,
         Err(error) => {
@@ -396,7 +466,7 @@ async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
                 "note: cross-file reference enrichment was skipped because no daemon could be \
                  started ({error}); run `kin doctor` to see what is missing"
             );
-            return;
+            return CrossFileEnrichment::unreadable();
         }
     };
     // FOR_LAYOUT, not the plain constructor. The plain one resolves the
@@ -410,7 +480,7 @@ async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
         Ok(client) => client,
         Err(error) => {
             note!("note: cross-file reference enrichment was skipped: {error:#}");
-            return;
+            return CrossFileEnrichment::unreadable();
         }
     };
 
@@ -418,7 +488,7 @@ async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
         Ok(value) => value,
         Err(error) => {
             note!("note: cross-file reference enrichment could not be started: {error:#}");
-            return;
+            return CrossFileEnrichment::unreadable();
         }
     };
     // A daemon with no language server never sweeps. Saying so, with the
@@ -440,7 +510,12 @@ async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
             .and_then(|value| value.get("detail"))
             .and_then(|value| value.as_str());
         note!("{}", enrichment_unavailable_note(reason, detail));
-        return;
+        return CrossFileEnrichment::Withheld {
+            pending: "no language-server sweep ran for this repository, so cross-file reference \
+                      and override edges are not in this graph; the note above names what would \
+                      let it run"
+                .to_string(),
+        };
     }
     let baseline = queued
         .get("sweeps_completed")
@@ -456,7 +531,7 @@ async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
             Ok(status) => status,
             Err(error) => {
                 note!("note: enrichment progress could not be read: {error:#}");
-                return;
+                return CrossFileEnrichment::unreadable();
             }
         };
         let done = status
@@ -501,10 +576,16 @@ async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
                      files it walked ({blocked} blocked); reference and import edges will be \
                      missing until it can run"
                 );
-            } else {
-                note!("  cross-file enrichment complete ({done}/{total} files)");
+                return CrossFileEnrichment::Withheld {
+                    pending: format!(
+                        "the sweep walked {total} files and enriched none of them, so cross-file \
+                         reference and override edges are not in this graph; `kin daemon sweep` \
+                         retries it"
+                    ),
+                };
             }
-            return;
+            note!("  cross-file enrichment complete ({done}/{total} files)");
+            return CrossFileEnrichment::Produced;
         }
         if std::time::Instant::now() >= deadline {
             note!(
@@ -512,7 +593,14 @@ async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) {
                  resumes from where it stopped on the next daemon start",
                 ENRICH_BUDGET.as_secs()
             );
-            return;
+            return CrossFileEnrichment::Withheld {
+                pending: format!(
+                    "the sweep reached {last_reported} files and did not finish within {}s, so \
+                     the cross-file edges it has not got to are not in this graph; it resumes on \
+                     the next daemon start",
+                    ENRICH_BUDGET.as_secs()
+                ),
+            };
         }
     }
 }
@@ -825,8 +913,14 @@ fn print_human_result(
     result: &kin_core::InitResult,
     boundary: InitBoundary,
     semantic_enrichment: &SemanticEnrichmentStatus,
+    cross_file: &CrossFileEnrichment,
 ) -> Result<()> {
-    emit(&render_human_result(result, boundary, semantic_enrichment)?)
+    emit(&render_human_result(
+        result,
+        boundary,
+        semantic_enrichment,
+        cross_file,
+    )?)
 }
 
 /// Hand a finished result to stdout, tolerating a reader that already left.
@@ -852,6 +946,7 @@ fn render_human_result(
     result: &kin_core::InitResult,
     boundary: InitBoundary,
     semantic_enrichment: &SemanticEnrichmentStatus,
+    cross_file: &CrossFileEnrichment,
 ) -> Result<String> {
     let default_ref = initialized_default_ref(result);
     let mut out = String::new();
@@ -904,10 +999,13 @@ fn render_human_result(
     writeln!(
         out,
         "  Semantic enrichment: {}",
-        render_semantic_enrichment(semantic_enrichment, daemon_death.as_ref())
+        render_semantic_enrichment(semantic_enrichment, daemon_death.as_ref(), cross_file)
     )?;
     if let Some(warning) = enrichment_kill_warning(daemon_death.as_ref()) {
         writeln!(out, "{warning}")?;
+    }
+    if let Some(notice) = cross_file_pending_notice(semantic_enrichment, cross_file) {
+        writeln!(out, "{notice}")?;
     }
     if let Some(notice) = semantic_absence_notice(semantic_enrichment) {
         writeln!(out, "{notice}")?;
@@ -1084,10 +1182,20 @@ fn semantic_absence_notice(enrichment: &SemanticEnrichmentStatus) -> Option<Stri
 fn render_semantic_enrichment(
     enrichment: &SemanticEnrichmentStatus,
     death: Option<&kin_daemon_spawn::DaemonKillRecord>,
+    cross_file: &CrossFileEnrichment,
 ) -> String {
-    let presence = match enrichment.presence {
-        SemanticEnrichmentPresence::Absent => "absent",
-        SemanticEnrichmentPresence::Present => "present",
+    // "partial" and not "present", on a run that built the within-file half of
+    // the graph and not the cross-file half. The counts under the word are
+    // unchanged and still exact; only the word moves, because the word is the
+    // part that was claiming a graph this run did not build.
+    //
+    // `absent` is left alone. A store with no entity and no relation is not
+    // partially enriched, and downgrading a word that is already the weakest
+    // one would say less than the truth rather than more.
+    let presence = match (&enrichment.presence, cross_file.pending().is_some()) {
+        (SemanticEnrichmentPresence::Absent, _) => "absent",
+        (SemanticEnrichmentPresence::Present, true) => "partial",
+        (SemanticEnrichmentPresence::Present, false) => "present",
     };
     format!(
         "{presence} ({} entities, {} relations, {} changes in durable authority generation {}; {})",
@@ -1097,6 +1205,25 @@ fn render_semantic_enrichment(
         enrichment.authority_generation,
         crate::daemon_death::enrichment_clause(death)
     )
+}
+
+/// What the word "partial" is short for, on the line beneath it.
+///
+/// Beneath rather than inside, matching every other qualifier on this summary,
+/// and because the sentence names a next action and the counts line does not.
+/// It is emitted only when the counts line actually said `partial`, so the two
+/// can never disagree: an `absent` store keeps its own notice and gets no
+/// second one, and a run that produced cross-file edges prints nothing here at
+/// all. A line that appeared after every conversion would be read once and
+/// skipped forever.
+fn cross_file_pending_notice(
+    enrichment: &SemanticEnrichmentStatus,
+    cross_file: &CrossFileEnrichment,
+) -> Option<String> {
+    if matches!(enrichment.presence, SemanticEnrichmentPresence::Absent) {
+        return None;
+    }
+    Some(format!("  ⚠ {}", cross_file.pending()?))
 }
 
 /// The warning line a store whose daemon was killed carries beneath its

--- a/scripts/acceptance/first_contact_honesty.py
+++ b/scripts/acceptance/first_contact_honesty.py
@@ -4,9 +4,10 @@
 
 """First-contact honesty: what a stranger meets before the graph answers anything.
 
-Three defects the npm0549 green stranger hit on shipped 0.5.49, each on a surface
-that runs before any semantic question is asked, and none of them visible to the
-suites that grade answers:
+Four defects strangers hit on shipped builds, each on a surface that runs before
+any semantic question is asked, and none of them visible to the suites that grade
+answers. Checks 0 to 2 come from the npm0549 green stranger on 0.5.49; check 3
+comes from the rc060n brown stranger on 0.6.0:
 
   CHECK 0 (FIR-2627)  `kin commit --help` never said a Kin commit is not a git
                       commit, so the write-through assumption formed at help and
@@ -23,6 +24,12 @@ suites that grade answers:
                       Probed through `kin setup --install-language-servers`,
                       which reaches the same installer without needing a store;
                       check 2's own docstring says why and what pins the rest.
+  CHECK 3 (FIR-2787)  `kin doctor` said nothing about memory until a repository
+                      existed, so a stranger on a 12 GiB container learned what
+                      the machine could not do only after an eleven-minute
+                      conversion had already spent itself. Graded outside a
+                      repository, which is the only place the question is asked
+                      in time.
 
 A new suite rather than three rows bolted onto the graph suites, for one reason:
 none of these needs a store, a daemon or a corpus, and all three are minutes
@@ -536,7 +543,136 @@ def check_2(suite):
     return res
 
 
-CHECKS = [("0", check_0), ("1", check_1), ("2", check_2)]
+def doctor_rows(suite, extra_env=None):
+    """(rows_by_id, detail) from one `kin doctor --json` run outside a repository.
+
+    Outside, deliberately. The row this check grades is the one FIR-2787 says
+    has to answer before `kin init` runs, and every other memory row on that
+    page reads n/a there, so a run inside a repository would grade a different
+    question entirely.
+    """
+    env = suite.base_env()
+    if extra_env:
+        env.update(extra_env)
+    work = os.path.join(suite.workdir, "no-repository")
+    if not os.path.isdir(work):
+        os.makedirs(work)
+    rc, out, err = run([suite.kin, "doctor", "--json"], cwd=work, env=env, timeout=600)
+    if not out.strip():
+        return None, "`kin doctor --json` exited %d and printed nothing: %s" % (
+            rc, flatten(err)[:200])
+    try:
+        report = json.loads(strip_ansi(out))
+    except ValueError as exc:
+        return None, "`kin doctor --json` did not print JSON: %s" % exc
+    return {row.get("id"): row for row in report.get("checks", [])}, ""
+
+
+def check_3(suite):
+    """FIR-2787: the memory this box affords is on the page before `kin init` runs.
+
+    The stranger converting two mid-sized repositories inside a 12 GiB container
+    was told four separate things, on four surfaces, after each had already cost
+    them something. `kin doctor` on that box flagged two rows and neither was
+    that the daemons would not fit, because every memory row there needs a store
+    and no store existed yet.
+
+    What this grades, and what it does not. The row's shape and its presence
+    outside a repository are graded here, on whatever host runs the suite. The
+    MEMORY band, the one that separates a 12 GiB container from a 32 GiB laptop,
+    is not: nothing on this host can move the ceiling `MemoryEvidence` reads, and
+    a check that pretended to constrain it would be grading its own stand-in. The
+    bands are pinned instead by the unit tests in
+    `crates/kin-cli/src/commands/health.rs`, against the container's exact
+    readings, and this check exists to prove the wiring those tests cannot see.
+
+    The tier band IS constrained here, because `KIN_LOCATE_PROFILE` is a real
+    lever a reader can set, and it moves the row for a reason a reader can act
+    on. Its control is the same command with the tier forced the other way: a
+    row that warned under both would be wallpaper, which is the failure mode
+    this ticket is about in the first place.
+    """
+    res = Result("3", "FIR-2787",
+                 "kin doctor states this machine's memory floor before any repository exists")
+
+    rows, detail = doctor_rows(suite)
+    if rows is None:
+        res.unknown(detail)
+        return res
+    row = rows.get("memory_floor")
+    if row is None:
+        res.bad("`kin doctor` outside a repository carries no memory_floor row; the page still "
+                "says nothing about memory until a store exists, which is FIR-2787 itself")
+        return res
+    res.ok("the row answers outside a repository, where every other memory row reads n/a")
+
+    flat = flatten(row.get("detail", ""))
+    for wanted, why in (
+            ("of memory here", "the ceiling this process runs under"),
+            ("repository daemon is allowed", "what one daemon will hold inside it"),
+            ("two of them are allowed", "what a second converted repository comes to"),
+            ("multihop", "what the capability tier does to retrieval"),
+    ):
+        if wanted in flat:
+            res.ok("the row states %s" % why)
+        else:
+            res.bad("the row does not state %s (looked for %r in: %s)" % (why, wanted, flat[:400]))
+
+    # Every non-green row on this page carries the fix it needs, and every green
+    # one offers none. That pairing is the doctor's own register, and a row that
+    # broke it in either direction would read as a defect in the page rather
+    # than in the machine.
+    green = row.get("status") == "healthy"
+    has_fix = bool(row.get("manual_fix"))
+    if green and has_fix:
+        res.bad("a green row offers a repair for a machine that needs none: %r"
+                % row.get("manual_fix"))
+    elif not green and not has_fix:
+        res.bad("the row needs attention (%s) and carries no fix: %s"
+                % (row.get("status"), flat[:300]))
+    else:
+        res.ok("the row holds the page's register: %s, fix %s"
+               % (row.get("status"), "present" if has_fix else "absent"))
+
+    # The constrained fixture, and its control. `minimal` narrows the multihop
+    # budget for real, so the row has to say so and hand back a move; forcing
+    # the full tier removes exactly that reason to warn.
+    narrowed, detail = doctor_rows(suite, {"KIN_LOCATE_PROFILE": "minimal"})
+    if narrowed is None:
+        res.unknown("the constrained arm could not be read: %s" % detail)
+        return res
+    row = narrowed.get("memory_floor") or {}
+    fix = flatten(row.get("manual_fix") or "")
+    if row.get("status") == "healthy":
+        res.bad("a machine pinned to the minimal tier reads green, so the row cannot report a "
+                "narrowed retrieval budget at all: %s" % flatten(row.get("detail", ""))[:300])
+    elif "multihop" not in fix:
+        res.bad("the constrained row's fix does not name the narrowed budget: %r" % fix)
+    else:
+        res.ok("a tier pinned below the line reads %s and its fix names the multihop budget"
+               % row.get("status"))
+
+    full, detail = doctor_rows(suite, {"KIN_LOCATE_PROFILE": "performance"})
+    if full is None:
+        res.unknown("the control arm could not be read: %s" % detail)
+        return res
+    row = full.get("memory_floor") or {}
+    fix = flatten(row.get("manual_fix") or "")
+    if "multihop" in fix:
+        res.bad("the row still asks for a bigger machine after the tier reason is gone, so it "
+                "warns whatever the host is: %r" % fix)
+    elif row.get("status") == "healthy":
+        res.ok("with the tier at full budget this host's row is green and silent")
+    else:
+        # Honest rather than green: this host's own ceiling is under a measured
+        # commit total. That is the row working, not failing, and saying so
+        # beats grading the suite on which laptop ran it.
+        res.ok("the tier reason is gone and this host's remaining reason is its own ceiling: %s"
+               % flatten(row.get("detail", ""))[:200])
+    return res
+
+
+CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3)]
 
 
 # ----------------------------------------------------------------------- suite


### PR DESCRIPTION
A stranger's first hour with Kin ends with them knowing four things nobody told them in
time. This is three of those four, on the surfaces where the question is actually asked.

`kin doctor` said nothing about memory until a repository existed. Every memory row on that
page needs a store, so on a fresh box all of them read n/a and the page was silent about
whether Kin fits here at all. The reader on a 12 GiB container found out in four separate
places, each after the work it described had already been paid for. A new row answers with
no repository in sight: the ceiling this process runs under and which reading gave it, what
one repository daemon will be allowed to hold inside it, what two of them come to against
the same ceiling, whether this machine is over the line where locate runs its full multihop
budget, and how the ceiling stands against the cheapest commit Kin has measured. It is
advisory and never blocks readiness, like every memory row beside it, and a non-green row
carries the fix it needs.

The tier line is now two constants that both the scorer and the row read, so the number a
user is told cannot drift from the number that is scored. The daemon budget names whichever
of four things set it, because "half the ceiling" is true of a 12 GiB container and false on
a 128 GiB workstation, where half is 64 and a derived budget is capped at 8.

`kin init` reported enrichment present on a repository holding no cross-file reference edge,
because presence is scored from entity and relation counts and a single-file parse fills
both. Every number under that word was right; the word was the claim. The enrichment phase
already watches the sweep it starts, so it now returns what it saw and the summary follows:
partial, with a line beneath naming what is pending and what finishes it. Nothing re-reads
the store to find that out.

`kin commit` printed its change's own deltas with nothing to say about a sweep still
deriving edges for the same files, so a fully parseable module landed as 0 entities and 0
relations and the next diff showed 123 relations on an unchanged tree. A commit taken while
the sweep is behind now says how far behind, says the counts are deltas, and says what
happens if the daemon exits first. A store whose sweep has caught up prints the two lines it
always did.

Every new surface is falsified by its own mechanism: fourteen mutations, fourteen reds, each
on the assertion written for it. The one worth naming is the fourteenth. Unregistering the
doctor row leaves every unit test green, because they all call the check's core directly, so
the registration has an assertion of its own.

`scripts/acceptance/first_contact_honesty.py` gains CHECK 3, which grades the row outside a
repository with a constrained fixture and its control. Its docstring says what it does not
grade: nothing on a developer host can move the memory ceiling, so the bands stay pinned by
unit tests against the container's own readings.

Not claimed, and left open on purpose. The embedding pass has no separate memory producer in
this tree; the row says it runs inside the daemon budget and is the first work held back,
which is checkable, rather than inventing a number. `kin init` withholds the word "present"
on what this run produced rather than on a count of the graph's edges. And FIR-2776 and the
init half are pinned by unit tests rather than by acceptance-suite checks, which is why
neither ticket carries a Closes here.

Refs FIR-2787
Refs FIR-2776
