### PR TITLE
Let the question decide which hop a narrow trace keeps

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -193,6 +193,19 @@ jobs:
       - name: Falsify the first-query readiness graders
         run: python3 scripts/acceptance/first_query_readiness_repro.py --self-test
 
+      # FIR-2781. The v0.6.0 stranger walked Session.send with limit_per_step 4
+      # and got a chain that stops two hops short of where verify goes: the cap
+      # discarded eleven of fifteen callees, HTTPAdapter.send among them, and
+      # ranked them by a same-file proximity term no question is an input to.
+      # The class is not that a hop was dropped, a cap has to drop something. It
+      # is that a chain missing its point reads exactly like a complete one,
+      # because "treat this as a lower bound" is the label a complete walk
+      # carries too. Each grader is handed the payload it must refuse, including
+      # a walk that counts the clip and never says it, and a walk that writes the
+      # spine key as zero rather than omitting it.
+      - name: Falsify the trace spine-clipping graders
+        run: python3 scripts/acceptance/trace_spine_clipping_repro.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -3226,8 +3226,7 @@ mod tests {
             let mut request = trace_request(&focal_id, 5, TraceDirection::Calls, 4);
             request.target = Some(target.clone());
             let started = std::time::Instant::now();
-            let response =
-                build_trace_data_flow_response(&authority, &graph, &request).unwrap();
+            let response = build_trace_data_flow_response(&authority, &graph, &request).unwrap();
             targeted.push(started.elapsed());
             assert_eq!(response.target_name.as_deref(), Some(target.as_str()));
         }

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -2566,6 +2566,171 @@ mod tests {
         );
     }
 
+    /// The stranger run's own fan-out, rebuilt from the tiers the linker really
+    /// stamps.
+    ///
+    /// `Session.send` in `psf/requests` offers fifteen callees. Eleven sit in
+    /// `sessions.py` and are parser-certain, because a call whose destination is
+    /// defined in the calling file is stamped 1.0. Three leave the module: two
+    /// through an explicit import (0.9), and `HTTPAdapter.send` through the
+    /// declared `BaseAdapter` return type and the override edge beneath it
+    /// (`INHERITED_METHOD_CONFIDENCE`, 0.85). One is a builtin the repository
+    /// does not define.
+    ///
+    /// The confidences are not decoration. They are what makes this fixture a
+    /// statement about the product rather than about itself: a same-file call
+    /// outranking a module-crossing one is not an accident of the fan-out order,
+    /// it is the ladder in `kin_index::resolution`, and a fixture that stamped
+    /// every edge 1.0 would have proven nothing about which term did the
+    /// clipping.
+    fn requests_send_graph() -> (InMemoryGraph, EntityId) {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("Session.send", "src/requests/sessions.py");
+        let focal_id = focal.id;
+        graph.upsert_entity(&focal).unwrap();
+
+        let mut edges: Vec<(Entity, f32)> = Vec::new();
+        for name in [
+            "Session.get_adapter",
+            "Session.prepare_request",
+            "SessionRedirectMixin.resolve_redirects",
+            "Session.merge_environment_settings",
+            "Session.rebuild_auth",
+            "Session.rebuild_proxies",
+            "Session.rebuild_method",
+            "Session.get_redirect_target",
+            "Session.should_strip_auth",
+            "Session.mount",
+            "Session.close",
+        ] {
+            edges.push((make_entity(name, "src/requests/sessions.py"), 1.0));
+        }
+        edges.push((
+            make_entity("extract_cookies_to_jar", "src/requests/cookies.py"),
+            0.9,
+        ));
+        edges.push((make_entity("dispatch_hook", "src/requests/hooks.py"), 0.9));
+        edges.push((
+            make_entity("HTTPAdapter.send", "src/requests/adapters.py"),
+            0.85,
+        ));
+        edges.push((make_external_entity("preferred_clock"), 0.7));
+
+        for (entity, confidence) in &edges {
+            graph.upsert_entity(entity).unwrap();
+            let mut relation = make_relation(focal_id, entity.id, RelationKind::Calls);
+            relation.confidence = *confidence;
+            graph.upsert_relation(&relation).unwrap();
+        }
+        (graph, focal_id)
+    }
+
+    /// What the stranger measured, pinned so the fix has something to move.
+    ///
+    /// Not an assertion that the product is correct. It is the falsification of
+    /// every check below it: a fixture that did not reproduce the loss could not
+    /// prove the fix removed it, and this one reproduces the reported clip
+    /// exactly, eleven dropped callees at a four-wide cap.
+    #[test]
+    fn the_measured_fan_out_loses_its_module_crossing_hop_to_the_files_own_callees() {
+        let (graph, focal_id) = requests_send_graph();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 1, TraceDirection::Calls, 4),
+        )
+        .unwrap();
+
+        let kept = step_names(&response);
+        assert_eq!(kept.len(), 4, "the four-wide cap kept four: {kept:?}");
+        assert_eq!(
+            response.clipped_steps[0].dropped_callees, 11,
+            "the stranger's own number: fifteen callees under a four-wide cap"
+        );
+        assert!(
+            kept.iter()
+                .all(|name| name.starts_with("Session") || name.starts_with("SessionRedirect")),
+            "every surviving callee is in the focal's own file, which is the defect: {kept:?}"
+        );
+    }
+
+    /// A fan-out the size of a real one, so a change to how the cap chooses can
+    /// be timed rather than guessed at.
+    ///
+    /// Every node below the focal offers the same fifteen-wide fan-out the
+    /// measured `Session.send` did, at the same tiers, four levels deep. That is
+    /// roughly fifty thousand entities and as many edges, which is the scale at
+    /// which a per-candidate cost shows up as time instead of as noise.
+    fn deep_requests_shaped_graph(levels: usize) -> (InMemoryGraph, EntityId, String) {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("Session.send", "src/requests/sessions.py");
+        let focal_id = focal.id;
+        graph.upsert_entity(&focal).unwrap();
+
+        let mut frontier = vec![(focal_id, 0usize)];
+        let mut serial = 0usize;
+        let mut deepest = String::new();
+        for level in 0..levels {
+            let mut next = Vec::new();
+            for (parent, _) in frontier.drain(..) {
+                for index in 0..15usize {
+                    serial += 1;
+                    let (file, confidence) = match index {
+                        0..=10 => ("src/requests/sessions.py", 1.0),
+                        11 => ("src/requests/cookies.py", 0.9),
+                        12 => ("src/requests/hooks.py", 0.9),
+                        13 => ("src/requests/adapters.py", 0.85),
+                        _ => ("src/requests/utils.py", 0.7),
+                    };
+                    let name = format!("n{level}_{serial}_{index}");
+                    let entity = make_entity(&name, file);
+                    graph.upsert_entity(&entity).unwrap();
+                    let mut relation = make_relation(parent, entity.id, RelationKind::Calls);
+                    relation.confidence = confidence;
+                    graph.upsert_relation(&relation).unwrap();
+                    if level + 1 < levels {
+                        next.push((entity.id, level + 1));
+                    } else if index == 13 {
+                        deepest = name;
+                    }
+                }
+            }
+            frontier = next;
+        }
+        (graph, focal_id, deepest)
+    }
+
+    /// Wall time of the walk itself, printed rather than asserted.
+    ///
+    /// Ignored by default because it is a measurement, not a gate: a threshold
+    /// on a shared machine fails on load rather than on the diff. Run it with
+    /// `--ignored --nocapture` on both sides of a change and read the numbers.
+    #[test]
+    #[ignore = "timing measurement: cargo test -p kin-cli --lib measure_walk_wall_time -- --ignored --nocapture"]
+    fn measure_walk_wall_time_on_a_requests_shaped_fan_out() {
+        let (graph, focal_id, target) = deep_requests_shaped_graph(4);
+        let (_t, binding) = empty_binding();
+        let authority = RequestRepositoryAuthority::pinned(binding.clone());
+
+        let mut samples = Vec::new();
+        for _ in 0..9 {
+            let request = trace_request(&focal_id, 5, TraceDirection::Calls, 4);
+            let started = std::time::Instant::now();
+            let response =
+                build_trace_data_flow_response(&authority, &graph, &request).unwrap();
+            samples.push(started.elapsed());
+            assert!(!response.chain.is_empty());
+        }
+        samples.sort();
+        println!(
+            "WALK_MEDIAN_MS untargeted {:.3}",
+            samples[samples.len() / 2].as_secs_f64() * 1000.0
+        );
+        println!("WALK_TARGET_NAME {target}");
+    }
+
     #[test]
     fn compact_mode_keeps_every_edge_and_span_while_inlining_no_body() {
         let (graph, focal_id) = redirect_graph();

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -3216,6 +3216,26 @@ mod tests {
             "WALK_MEDIAN_MS untargeted {:.3}",
             samples[samples.len() / 2].as_secs_f64() * 1000.0
         );
+
+        // What naming a target costs: one bounded reverse walk from it, plus a
+        // set lookup per candidate. The target is the deepest node in the
+        // fixture and it is reached through the module-crossing edge, which is
+        // the worst case for the reverse walk on this shape.
+        let mut targeted = Vec::new();
+        for _ in 0..9 {
+            let mut request = trace_request(&focal_id, 5, TraceDirection::Calls, 4);
+            request.target = Some(target.clone());
+            let started = std::time::Instant::now();
+            let response =
+                build_trace_data_flow_response(&authority, &graph, &request).unwrap();
+            targeted.push(started.elapsed());
+            assert_eq!(response.target_name.as_deref(), Some(target.as_str()));
+        }
+        targeted.sort();
+        println!(
+            "WALK_MEDIAN_MS targeted {:.3}",
+            targeted[targeted.len() / 2].as_secs_f64() * 1000.0
+        );
         println!("WALK_TARGET_NAME {target}");
     }
 

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -1066,9 +1066,8 @@ pub fn build_trace_data_flow_response_within(
                         };
                         candidate_index.insert((next_id, role), candidates.len());
                         let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
-                        let reaches_target = reach_set
-                            .as_ref()
-                            .is_some_and(|set| set.contains(&next_id));
+                        let reaches_target =
+                            reach_set.as_ref().is_some_and(|set| set.contains(&next_id));
                         candidates.push(FanoutCandidate {
                             reaches_target,
                             call_edges: usize::from(kin_index::is_raise_classifiable_call_edge(
@@ -1331,11 +1330,7 @@ pub fn build_trace_data_flow_response_within(
 /// dropped were never followed. Only the second makes "this chain does not
 /// contain X" mean nothing at all.
 fn record_spine_clipping(response: &mut TraceDataFlowResponse) {
-    let parents: HashSet<usize> = response
-        .chain
-        .iter()
-        .map(|step| step.parent_step)
-        .collect();
+    let parents: HashSet<usize> = response.chain.iter().map(|step| step.parent_step).collect();
     let mut spine_steps = 0usize;
     let mut spine_crossing = 0usize;
     for clip in &mut response.clipped_steps {
@@ -1360,9 +1355,7 @@ fn record_spine_clipping(response: &mut TraceDataFlowResponse) {
     };
     let dropped = widest.dropped_callees + widest.dropped_callers;
     let crossing = if spine_crossing > 0 {
-        format!(
-            ", {spine_crossing} of which lived outside the file of the node that offered them"
-        )
+        format!(", {spine_crossing} of which lived outside the file of the node that offered them")
     } else {
         String::new()
     };
@@ -2960,7 +2953,11 @@ mod tests {
         .unwrap();
 
         let kept = step_names(&response);
-        assert_eq!(kept.len(), 4, "the four-wide cap still keeps four: {kept:?}");
+        assert_eq!(
+            kept.len(),
+            4,
+            "the four-wide cap still keeps four: {kept:?}"
+        );
         assert_eq!(
             response.clipped_steps[0].dropped_callees, 11,
             "and still drops eleven, because a floor is not extra breadth"
@@ -3210,8 +3207,7 @@ mod tests {
         for _ in 0..9 {
             let request = trace_request(&focal_id, 5, TraceDirection::Calls, 4);
             let started = std::time::Instant::now();
-            let response =
-                build_trace_data_flow_response(&authority, &graph, &request).unwrap();
+            let response = build_trace_data_flow_response(&authority, &graph, &request).unwrap();
             samples.push(started.elapsed());
             assert!(!response.chain.is_empty());
         }

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -313,6 +313,21 @@ pub struct TraceDataFlowRequest {
     /// steps, to stay inside it, and says so in `degradations`.
     #[serde(default)]
     pub max_response_chars: Option<usize>,
+    /// A symbol the caller is trying to reach, and the only way the question
+    /// itself gets a vote on which hops survive.
+    ///
+    /// Without one, the per-step cap orders neighbors by proximity terms no
+    /// question is an input to, so on a wide node it discards by a rule
+    /// unrelated to what was asked. With one, every candidate from which the
+    /// target is still reachable inside the requested depth sorts ahead of
+    /// every candidate that is not, before the cap cuts anything.
+    ///
+    /// It changes only which neighbors survive the cap. No edge is invented,
+    /// no edge is hidden, and a walk whose target resolves to nothing is a walk
+    /// with a disclosure on it rather than an error, because the chain is still
+    /// the chain.
+    #[serde(default)]
+    pub target: Option<String>,
     /// Walk THROUGH a type-annotation edge to a type this repository defines
     /// (default false). A dataclass field typed with a repo class is a real
     /// flow into that class, so the hop is available; it is off by default
@@ -450,6 +465,23 @@ pub struct TraceFanoutClip {
     pub entity_name: String,
     pub dropped_callees: usize,
     pub dropped_callers: usize,
+    /// How many of the dropped neighbors lived outside this node's own file.
+    ///
+    /// The class of hop, not just the count. A node that dropped eleven
+    /// same-file callees lost breadth; a node that dropped the only hops that
+    /// leave its module lost the kind of edge a data-flow question is about,
+    /// and a single `dropped` number cannot tell those apart.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub dropped_crossing_file: usize,
+    /// Whether the walk went on beneath this node, so the chain reads as a
+    /// path that continues while a sibling branch was discarded.
+    ///
+    /// This is the shape that produced a wrong answer: a clip at a leaf costs
+    /// breadth the caller can see is missing, while a clip on the spine hands
+    /// back a chain that looks like a complete route and is one of several.
+    /// A reader deciding whether "X never reaches Y" is safe reads this.
+    #[serde(default)]
+    pub continued_below: bool,
     /// The cap that did the clipping, so the remedy is a number the caller can
     /// raise rather than a guess.
     pub limit_per_step: usize,
@@ -505,11 +537,29 @@ pub struct TraceDataFlowResponse {
     /// `response_budget` degradation report the cut. Steps dropped to fit the
     /// budget DO set it, because those are edges the caller did not receive.
     pub truncated: bool,
+    /// The target this walk ranked toward, echoed so a caller can see the
+    /// question was received. Null when none was named, and null when the one
+    /// that was named resolved to nothing, which the degradations say.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_name: Option<String>,
     /// Every node whose fan-out the per-step cap clipped, with the count it
     /// dropped. Empty — and omitted — for a walk that expanded every neighbor it
     /// reached.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub clipped_steps: Vec<TraceFanoutClip>,
+    /// How many clipped nodes the walk went on beneath, so a reader has the
+    /// one number that decides whether an absence in this chain means anything.
+    ///
+    /// Zero — and omitted — when no clip sits on the surviving chain's spine,
+    /// which is the only case where a hop this chain does not contain is a hop
+    /// the walk actually looked for and did not find.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub spine_clipped_steps: usize,
+    /// How many neighbors the spine clips dropped that lived outside their
+    /// node's own file: the count of module-crossing hops this chain was never
+    /// offered. Zero — and omitted — when clipping cost only same-file breadth.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub spine_dropped_crossing_file: usize,
     /// Step bodies the response budget dropped, and steps it dropped after that.
     /// Both zero — and omitted — for a response that fit as built.
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -642,6 +692,7 @@ pub async fn run_seeded(
     include_body: Option<bool>,
     max_response_chars: Option<usize>,
     include_type_edges: Option<bool>,
+    target: Option<String>,
 ) -> Result<()> {
     let direction = match direction {
         Some(value) => Some(TraceDirection::parse(&value)?),
@@ -655,6 +706,7 @@ pub async fn run_seeded(
         include_body,
         max_response_chars,
         include_type_edges,
+        target,
     };
     let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_trace_data_flow(&layout, &request).await?;
@@ -790,6 +842,56 @@ pub fn build_trace_data_flow_response_within(
         .copied()
         .chain(std::iter::once(RelationKind::UsesType))
         .collect();
+
+    // The question, resolved once and consulted per candidate.
+    //
+    // A target that resolves to nothing is disclosed rather than fatal: the
+    // chain the caller asked for is still the chain, and failing the call would
+    // turn a typo in an optional hint into no answer at all.
+    let mut target_name: Option<String> = None;
+    let mut reach_set: Option<HashSet<EntityId>> = None;
+    if let Some(target) = request
+        .target
+        .as_deref()
+        .map(str::trim)
+        .filter(|target| !target.is_empty())
+    {
+        match resolve_trace_focal(graph, target)? {
+            Some(entity) => {
+                let (set, complete) =
+                    reach_set_toward(graph, &entity, direction, depth, &allowed, &mut meter)?;
+                if !complete {
+                    record_degradation(
+                        &mut degradations,
+                        RetrievalDegradation {
+                            component: "target_reachability".to_string(),
+                            reason: "reachability_bounded".to_string(),
+                            detail: format!(
+                                "the reverse walk from '{}' hit a work ceiling before it finished,                                  so some neighbors that do reach it were not recognized and                                  ranked as though they do not",
+                                entity.name
+                            ),
+                            remediation: "narrow the walk with a smaller depth, or name a target                                           closer to the focal"
+                                .to_string(),
+                        },
+                    );
+                }
+                target_name = Some(entity.name.clone());
+                reach_set = Some(set);
+            }
+            None => record_degradation(
+                &mut degradations,
+                RetrievalDegradation {
+                    component: "target_reachability".to_string(),
+                    reason: "target_not_resolved".to_string(),
+                    detail: format!(
+                        "no entity matches target '{target}', so this walk ranked its fan-out by                          relevance alone and the question had no vote in what the cap kept"
+                    ),
+                    remediation: "check the target's spelling, or find it first with                                   semantic_locate"
+                        .to_string(),
+                },
+            ),
+        }
+    }
 
     let mut chain: Vec<TraceStep> = Vec::new();
     let mut visited: HashSet<EntityId> = HashSet::new();
@@ -964,7 +1066,11 @@ pub fn build_trace_data_flow_response_within(
                         };
                         candidate_index.insert((next_id, role), candidates.len());
                         let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
+                        let reaches_target = reach_set
+                            .as_ref()
+                            .is_some_and(|set| set.contains(&next_id));
                         candidates.push(FanoutCandidate {
+                            reaches_target,
                             call_edges: usize::from(kin_index::is_raise_classifiable_call_edge(
                                 rel,
                             )),
@@ -997,10 +1103,10 @@ pub fn build_trace_data_flow_response_within(
                 candidates.into_iter().partition(|c| c.role == "callee");
             sort_by_relevance(&mut callees, &node);
             sort_by_relevance(&mut callers, &node);
-            let dropped_callees = callees.len().saturating_sub(limit_per_step);
-            let dropped_callers = callers.len().saturating_sub(limit_per_step);
-            callees.truncate(limit_per_step);
-            callers.truncate(limit_per_step);
+            let (dropped_callees, crossing_callees) =
+                apply_fanout_cap(&mut callees, node.file.as_deref(), limit_per_step);
+            let (dropped_callers, crossing_callers) =
+                apply_fanout_cap(&mut callers, node.file.as_deref(), limit_per_step);
 
             // Localize the cut on the node it happened at. A single top-level
             // flag names no node, so a caller cannot tell a complete step from a
@@ -1028,6 +1134,8 @@ pub fn build_trace_data_flow_response_within(
                     entity_name,
                     dropped_callees,
                     dropped_callers,
+                    dropped_crossing_file: crossing_callees + crossing_callers,
+                    continued_below: false,
                     limit_per_step,
                 });
             }
@@ -1175,7 +1283,10 @@ pub fn build_trace_data_flow_response_within(
         total_steps: chain.len(),
         chain,
         truncated,
+        target_name,
         clipped_steps,
+        spine_clipped_steps: 0,
+        spine_dropped_crossing_file: 0,
         bodies_omitted: 0,
         steps_omitted: 0,
         fanout_narrowed: 0,
@@ -1205,7 +1316,189 @@ pub fn build_trace_data_flow_response_within(
     enforce_response_budget(&mut response);
     record_unproven_steps(&mut response);
     record_terminal_steps(&mut response);
+    // After the budget, because a clip is on the spine only if the walk beneath
+    // it is in the response the caller receives. A branch the budget removed
+    // took its own evidence of continuation with it.
+    record_spine_clipping(&mut response);
     Ok(response)
+}
+
+/// Mark the clips the chain continued beneath, and count them once at the top.
+///
+/// The distinction is the whole point of the field. A clip at the end of a
+/// branch costs breadth a reader can see missing; a clip the walk went on
+/// beneath hands back a route that reads like the route, while the neighbors it
+/// dropped were never followed. Only the second makes "this chain does not
+/// contain X" mean nothing at all.
+fn record_spine_clipping(response: &mut TraceDataFlowResponse) {
+    let parents: HashSet<usize> = response
+        .chain
+        .iter()
+        .map(|step| step.parent_step)
+        .collect();
+    let mut spine_steps = 0usize;
+    let mut spine_crossing = 0usize;
+    for clip in &mut response.clipped_steps {
+        clip.continued_below = parents.contains(&clip.step);
+        if clip.continued_below {
+            spine_steps += 1;
+            spine_crossing += clip.dropped_crossing_file;
+        }
+    }
+    response.spine_clipped_steps = spine_steps;
+    response.spine_dropped_crossing_file = spine_crossing;
+    if spine_steps == 0 {
+        return;
+    }
+    let widest = response
+        .clipped_steps
+        .iter()
+        .filter(|clip| clip.continued_below)
+        .max_by_key(|clip| clip.dropped_callees + clip.dropped_callers);
+    let Some(widest) = widest else {
+        return;
+    };
+    let dropped = widest.dropped_callees + widest.dropped_callers;
+    let crossing = if spine_crossing > 0 {
+        format!(
+            ", {spine_crossing} of which lived outside the file of the node that offered them"
+        )
+    } else {
+        String::new()
+    };
+    record_degradation(
+        &mut response.degradations,
+        RetrievalDegradation {
+            component: "fanout_cap".to_string(),
+            reason: "spine_clipped".to_string(),
+            detail: format!(
+                "the walk continued beneath {spine_steps} node(s) whose fan-out limit_per_step                  {} had already cut, dropping {} neighbor(s) that were never followed{crossing};                  the widest was '{}', which offered {} more than the cap kept. This chain is one                  route among the ones the cap left, so a hop it does not contain was not looked                  for and its absence proves nothing",
+                widest.limit_per_step,
+                response
+                    .clipped_steps
+                    .iter()
+                    .filter(|clip| clip.continued_below)
+                    .map(|clip| clip.dropped_callees + clip.dropped_callers)
+                    .sum::<usize>(),
+                widest.entity_name,
+                dropped,
+            ),
+            remediation: format!(
+                "name the symbol you are looking for as `target` so the cap ranks toward it, or                  re-query '{}' with limit_per_step above {}",
+                widest.entity_name, widest.limit_per_step
+            ),
+        },
+    );
+}
+
+/// Entities from which `target` is reachable, walking the requested direction
+/// backwards, bounded by the same depth and the same work meter as the chain.
+///
+/// Returns the set and whether the reverse walk finished. An unfinished one is
+/// a SUBSET, so a candidate that does reach the target can be missing from it,
+/// which is why the caller discloses rather than trusts it silently.
+///
+/// The depth bound is deliberately the walk's whole depth rather than the
+/// remaining depth at each candidate, which makes the set a superset in that
+/// direction: a candidate is preferred when the target is reachable from it
+/// within `depth` hops, not only within the hops it has left. Preferring a
+/// neighbor that might reach the target costs a cap slot; missing one costs the
+/// answer.
+fn reach_set_toward(
+    graph: &kin_db::InMemoryGraph,
+    target: &Entity,
+    direction: TraceDirection,
+    depth: usize,
+    allowed: &HashSet<RelationKind>,
+    meter: &mut TraceMeter,
+) -> Result<(HashSet<EntityId>, bool)> {
+    let want_callees = matches!(direction, TraceDirection::Calls | TraceDirection::Both);
+    let want_callers = matches!(direction, TraceDirection::Callers | TraceDirection::Both);
+    let mut seen: HashSet<EntityId> = HashSet::new();
+    seen.insert(target.id);
+    let mut frontier = vec![target.id];
+    for _ in 0..depth {
+        let mut next = Vec::new();
+        for node in frontier.drain(..) {
+            if meter.should_stop().is_some() {
+                return Ok((seen, false));
+            }
+            let relations = graph
+                .get_all_relations_for_entity(&node)
+                .context("read relations for target reachability")?;
+            for rel in &relations {
+                if meter.charge_edge().is_some() {
+                    return Ok((seen, false));
+                }
+                if !allowed.contains(&rel.kind) {
+                    continue;
+                }
+                let src = rel.src.as_entity();
+                let dst = match rel.dst {
+                    GraphNodeId::Entity(id) => Some(id),
+                    _ => None,
+                };
+                // One step back along whichever sense the forward walk takes:
+                // a `calls` chain reaches the target through outgoing edges, so
+                // whoever reaches it is on the incoming side.
+                let prior = if want_callees && dst == Some(node) {
+                    src
+                } else if want_callers && src == Some(node) {
+                    dst
+                } else {
+                    None
+                };
+                let Some(prior) = prior else { continue };
+                if prior != node && seen.insert(prior) {
+                    next.push(prior);
+                }
+            }
+        }
+        if next.is_empty() {
+            return Ok((seen, true));
+        }
+        frontier = next;
+    }
+    Ok((seen, true))
+}
+
+/// Apply the per-step cap to one side of a node's ranked fan-out.
+///
+/// Returns how many candidates were dropped, and how many of those lived
+/// outside the expanding node's own file. The keep rule itself is
+/// [`kin_ranking::entity_ranking::fanout_cap_keeps`], shared with the
+/// GraphStore walker in `kin_mcp` so the two cannot answer differently.
+fn apply_fanout_cap(
+    candidates: &mut Vec<FanoutCandidate>,
+    node_file: Option<&str>,
+    limit: usize,
+) -> (usize, usize) {
+    let same_file: Vec<bool> = candidates
+        .iter()
+        .map(|candidate| {
+            node_file
+                .zip(candidate.entity.file_origin.as_ref())
+                .map(|(parent, file)| parent == file.0.as_str())
+                .unwrap_or(false)
+        })
+        .collect();
+    let keep = kin_ranking::entity_ranking::fanout_cap_keeps(&same_file, limit);
+    if keep.len() == candidates.len() {
+        return (0, 0);
+    }
+    let kept: HashSet<usize> = keep.iter().copied().collect();
+    let dropped_crossing = (0..candidates.len())
+        .filter(|index| !kept.contains(index) && !same_file[*index])
+        .count();
+    let dropped = candidates.len() - keep.len();
+    let mut taken: Vec<FanoutCandidate> = Vec::with_capacity(keep.len());
+    for (index, candidate) in std::mem::take(candidates).into_iter().enumerate() {
+        if kept.contains(&index) {
+            taken.push(candidate);
+        }
+    }
+    *candidates = taken;
+    (dropped, dropped_crossing)
 }
 
 /// Give every node the walk did not continue through a reason, and publish the
@@ -1443,6 +1736,10 @@ struct FanoutCandidate {
     /// inverted the ordering could not tell the difference.
     call_edges: usize,
     raise_call_edges: usize,
+    /// Whether a named target is still reachable from this candidate inside the
+    /// requested depth. False for every candidate when no target was named, so
+    /// an untargeted walk orders exactly as it did before this existed.
+    reaches_target: bool,
 }
 
 impl FanoutCandidate {
@@ -1464,6 +1761,12 @@ impl FanoutCandidate {
 /// moves under the caller.
 fn sort_by_relevance(candidates: &mut [FanoutCandidate], node: &FrontierNode) {
     candidates.sort_by(|left, right| {
+        // The question first, when there is one. Every proximity term below is
+        // a guess about what the caller meant; reachability toward a named
+        // target is the one term that knows.
+        if left.reaches_target != right.reaches_target {
+            return right.reaches_target.cmp(&left.reaches_target);
+        }
         let left_score = kin_ranking::entity_ranking::trace_fanout_score(
             &left.entity,
             left.relation_kind,

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -1473,22 +1473,26 @@ fn apply_fanout_cap(
     node_file: Option<&str>,
     limit: usize,
 ) -> (usize, usize) {
-    let same_file: Vec<bool> = candidates
+    let locality: Vec<kin_ranking::entity_ranking::FanoutLocality> = candidates
         .iter()
-        .map(|candidate| {
-            node_file
-                .zip(candidate.entity.file_origin.as_ref())
-                .map(|(parent, file)| parent == file.0.as_str())
-                .unwrap_or(false)
+        .map(|candidate| match candidate.entity.file_origin.as_ref() {
+            None => kin_ranking::entity_ranking::FanoutLocality::Unlocated,
+            Some(file) if node_file == Some(file.0.as_str()) => {
+                kin_ranking::entity_ranking::FanoutLocality::SameFile
+            }
+            Some(_) => kin_ranking::entity_ranking::FanoutLocality::OtherFile,
         })
         .collect();
-    let keep = kin_ranking::entity_ranking::fanout_cap_keeps(&same_file, limit);
+    let keep = kin_ranking::entity_ranking::fanout_cap_keeps(&locality, limit);
     if keep.len() == candidates.len() {
         return (0, 0);
     }
     let kept: HashSet<usize> = keep.iter().copied().collect();
     let dropped_crossing = (0..candidates.len())
-        .filter(|index| !kept.contains(index) && !same_file[*index])
+        .filter(|index| {
+            !kept.contains(index)
+                && locality[*index] == kin_ranking::entity_ranking::FanoutLocality::OtherFile
+        })
         .count();
     let dropped = candidates.len() - keep.len();
     let mut taken: Vec<FanoutCandidate> = Vec::with_capacity(keep.len());
@@ -2169,6 +2173,7 @@ mod tests {
             include_body: None,
             max_response_chars: None,
             include_type_edges: None,
+            target: None,
         }
     }
 
@@ -2225,6 +2230,7 @@ mod tests {
                 include_body: None,
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap_err();
@@ -2249,6 +2255,7 @@ mod tests {
                 include_body: None,
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap_err();
@@ -2299,6 +2306,7 @@ mod tests {
                 include_body: None,
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -2357,6 +2365,7 @@ mod tests {
                 include_body: None,
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -2404,6 +2413,7 @@ mod tests {
                 include_body: None,
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -2464,6 +2474,7 @@ mod tests {
             include_body: None,
             max_response_chars: None,
             include_type_edges: None,
+            target: None,
         }
     }
 
@@ -2652,6 +2663,7 @@ mod tests {
             include_body: None,
             max_response_chars: None,
             include_type_edges: None,
+            target: None,
         };
 
         let uncancelled = build_trace_data_flow_response_within(
@@ -2928,14 +2940,15 @@ mod tests {
         (graph, focal_id)
     }
 
-    /// What the stranger measured, pinned so the fix has something to move.
+    /// What the stranger measured, and what it costs now.
     ///
-    /// Not an assertion that the product is correct. It is the falsification of
-    /// every check below it: a fixture that did not reproduce the loss could not
-    /// prove the fix removed it, and this one reproduces the reported clip
-    /// exactly, eleven dropped callees at a four-wide cap.
+    /// The premise is unchanged and still asserted: fifteen callees under a
+    /// four-wide cap drops eleven. What changed is which four survive. Every
+    /// one of them used to be in `sessions.py`, so the chain answered a
+    /// question about where a value goes without ever leaving the module the
+    /// value starts in.
     #[test]
-    fn the_measured_fan_out_loses_its_module_crossing_hop_to_the_files_own_callees() {
+    fn the_measured_fan_out_now_leaves_the_module_it_started_in() {
         let (graph, focal_id) = requests_send_graph();
         let (_t, binding) = empty_binding();
 
@@ -2947,16 +2960,192 @@ mod tests {
         .unwrap();
 
         let kept = step_names(&response);
-        assert_eq!(kept.len(), 4, "the four-wide cap kept four: {kept:?}");
+        assert_eq!(kept.len(), 4, "the four-wide cap still keeps four: {kept:?}");
         assert_eq!(
             response.clipped_steps[0].dropped_callees, 11,
-            "the stranger's own number: fifteen callees under a four-wide cap"
+            "and still drops eleven, because a floor is not extra breadth"
+        );
+        let crossed: Vec<&String> = kept
+            .iter()
+            .filter(|name| !name.starts_with("Session"))
+            .collect();
+        assert_eq!(
+            crossed.len(),
+            1,
+            "exactly one slot goes to a hop that leaves the file, no more: {kept:?}"
+        );
+        assert_eq!(
+            response.clipped_steps[0].dropped_crossing_file, 2,
+            "three callees live in another file, one now takes the reserved slot, \
+             so two module-crossing hops are still dropped"
+        );
+    }
+
+    /// The acceptance, first arm: name the hop and the cap keeps it.
+    ///
+    /// Same fifteen-callee node, same four-wide cap, same everything except
+    /// that the caller said what they were looking for. `HTTPAdapter.send` is
+    /// the worst-ranked hop in this fan-out by every proximity term the cap
+    /// consults, which is what makes it the right fixture: nothing but the
+    /// question can put it in the chain.
+    #[test]
+    fn naming_the_target_puts_the_asked_about_hop_in_the_chain() {
+        let (graph, focal_id) = requests_send_graph();
+        let (_t, binding) = empty_binding();
+
+        let mut request = trace_request(&focal_id, 1, TraceDirection::Calls, 4);
+        request.target = Some("HTTPAdapter.send".to_string());
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &request,
+        )
+        .unwrap();
+
+        let kept = step_names(&response);
+        assert!(
+            kept.iter().any(|name| name == "HTTPAdapter.send"),
+            "the hop the caller named must survive the cap: {kept:?}"
+        );
+        assert_eq!(
+            response.target_name.as_deref(),
+            Some("HTTPAdapter.send"),
+            "and the response echoes the question it was given"
+        );
+        // The control on the control: without the target, this same walk does
+        // not contain it, so the assertion above is testing the target and not
+        // the floor that landed beside it.
+        let untargeted = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 1, TraceDirection::Calls, 4),
+        )
+        .unwrap();
+        assert!(
+            !step_names(&untargeted)
+                .iter()
+                .any(|name| name == "HTTPAdapter.send"),
+            "the untargeted walk must still miss it, or this check proves nothing"
+        );
+    }
+
+    /// A target that names nothing is a disclosure, not a failed call.
+    #[test]
+    fn an_unresolved_target_is_disclosed_and_the_chain_still_comes_back() {
+        let (graph, focal_id) = requests_send_graph();
+        let (_t, binding) = empty_binding();
+
+        let mut request = trace_request(&focal_id, 1, TraceDirection::Calls, 4);
+        request.target = Some("HTTPAdapter.sendd".to_string());
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &request,
+        )
+        .unwrap();
+
+        assert_eq!(response.chain.len(), 4, "the chain is still the chain");
+        assert!(response.target_name.is_none(), "nothing was ranked toward");
+        assert!(
+            response
+                .degradations
+                .iter()
+                .any(|degradation| degradation.reason == "target_not_resolved"),
+            "and the walk says the question had no vote: {:?}",
+            response.degradations
+        );
+    }
+
+    /// The acceptance, second arm: when nothing was named, say so loudly.
+    ///
+    /// The failure this exists for is not a missing hop, it is a chain that
+    /// reads like a route while eleven siblings were never followed. The
+    /// disclosure has to name the node, the parameter and the count, and it has
+    /// to say in words that an absence here proves nothing.
+    #[test]
+    fn a_clip_the_walk_continued_beneath_refuses_to_be_read_as_an_absence() {
+        let (graph, focal_id) = requests_send_graph();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 1, TraceDirection::Calls, 4),
+        )
+        .unwrap();
+
+        assert_eq!(
+            response.spine_clipped_steps, 1,
+            "the focal was clipped and the chain continues beneath it"
+        );
+        assert_eq!(
+            response.spine_dropped_crossing_file, 2,
+            "two of the hops it never followed left the module"
         );
         assert!(
-            kept.iter()
-                .all(|name| name.starts_with("Session") || name.starts_with("SessionRedirect")),
-            "every surviving callee is in the focal's own file, which is the defect: {kept:?}"
+            response.clipped_steps[0].continued_below,
+            "and the clip itself carries the distinction"
         );
+        let disclosure = response
+            .degradations
+            .iter()
+            .find(|degradation| degradation.reason == "spine_clipped")
+            .expect("a spine clip must be disclosed");
+        assert!(
+            disclosure.detail.contains("Session.send")
+                && disclosure.detail.contains("limit_per_step"),
+            "the disclosure names the node and the parameter: {}",
+            disclosure.detail
+        );
+        assert!(
+            disclosure.detail.contains("absence proves nothing"),
+            "and says what a reader may not conclude: {}",
+            disclosure.detail
+        );
+        assert!(
+            disclosure.remediation.contains("target"),
+            "and names the lever that fixes it: {}",
+            disclosure.remediation
+        );
+    }
+
+    /// The control the acceptance asks for: a walk the cap never cut carries
+    /// none of this, so a complete answer is not qualified by machinery that
+    /// exists for incomplete ones.
+    #[test]
+    fn an_unclipped_walk_still_certifies_and_says_nothing_about_spines() {
+        let (graph, focal_id) = requests_send_graph();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 1, TraceDirection::Calls, 25),
+        )
+        .unwrap();
+
+        assert_eq!(
+            response.total_steps, 15,
+            "a 25-wide cap expands all fifteen callees"
+        );
+        assert!(response.clipped_steps.is_empty());
+        assert_eq!(response.spine_clipped_steps, 0);
+        assert_eq!(response.spine_dropped_crossing_file, 0);
+        assert!(
+            !response
+                .degradations
+                .iter()
+                .any(|degradation| degradation.component == "fanout_cap"),
+            "no cap disclosure on a walk no cap cut: {:?}",
+            response.degradations
+        );
+        let json = serde_json::to_value(&response).unwrap();
+        for absent in ["spine_clipped_steps", "spine_dropped_crossing_file"] {
+            assert!(
+                json.get(absent).is_none(),
+                "an unaffected walk must not carry {absent} at all"
+            );
+        }
     }
 
     /// A fan-out the size of a real one, so a change to how the cap chooses can
@@ -3153,7 +3342,10 @@ mod tests {
             total_steps: chain.len(),
             chain,
             truncated: false,
+            target_name: None,
             clipped_steps: Vec::new(),
+            spine_clipped_steps: 0,
+            spine_dropped_crossing_file: 0,
             bodies_omitted: 0,
             steps_omitted: 0,
             fanout_narrowed: 0,
@@ -3220,6 +3412,8 @@ mod tests {
             entity_name: "step_199".to_string(),
             dropped_callees: 4,
             dropped_callers: 0,
+            dropped_crossing_file: 0,
+            continued_below: false,
             limit_per_step: 25,
         });
 
@@ -3432,6 +3626,8 @@ mod tests {
                 entity_name: format!("step_{step}"),
                 dropped_callees: 3,
                 dropped_callers: 0,
+                dropped_crossing_file: 0,
+                continued_below: false,
                 limit_per_step: 12,
             });
         }
@@ -4346,6 +4542,7 @@ mod boundary_and_ranking_tests {
                 include_body: Some(false),
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -4379,6 +4576,7 @@ mod boundary_and_ranking_tests {
                 include_body: Some(false),
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -4455,6 +4653,7 @@ mod boundary_and_ranking_tests {
                 include_body: Some(false),
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -4510,6 +4709,7 @@ mod boundary_and_ranking_tests {
                 include_body: Some(false),
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -4556,6 +4756,7 @@ mod boundary_and_ranking_tests {
                 include_body: Some(false),
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -4596,6 +4797,7 @@ mod boundary_and_ranking_tests {
                 include_body: Some(false),
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -4644,6 +4846,7 @@ mod boundary_and_ranking_tests {
                 include_body: Some(false),
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();
@@ -4694,6 +4897,7 @@ mod boundary_and_ranking_tests {
                 include_body: Some(false),
                 max_response_chars: None,
                 include_type_edges: None,
+                target: None,
             },
         )
         .unwrap();

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -550,6 +550,12 @@ enum Command {
         /// Max relations expanded per step (default 5, capped at 25).
         #[arg(long = "limit-per-step", value_name = "M")]
         limit_per_step: Option<usize>,
+        /// A symbol you are trying to reach. Neighbors from which it is still
+        /// reachable inside the requested depth survive the per-step cap ahead
+        /// of ones that are not, so the question decides what a narrow walk
+        /// keeps instead of proximity deciding it.
+        #[arg(long = "target", value_name = "ENTITY")]
+        target: Option<String>,
         /// Return the chain's shape — names, kinds, roles, spans, edges —
         /// without inlining any source body.
         #[arg(long = "no-bodies", default_value_t = false)]
@@ -3137,6 +3143,7 @@ fn main() -> Result<()> {
                     depth,
                     direction,
                     limit_per_step,
+                    target,
                     no_bodies,
                     max_response_chars,
                     include_type_edges,
@@ -3149,6 +3156,7 @@ fn main() -> Result<()> {
                         no_bodies.then_some(false),
                         max_response_chars,
                         include_type_edges.then_some(true),
+                        target,
                     )
                     .await
                 }

--- a/crates/kin-cli/tests/python_bare_builtin_call_resolution.rs
+++ b/crates/kin-cli/tests/python_bare_builtin_call_resolution.rs
@@ -230,6 +230,7 @@ fn callee_chain(graph: &InMemoryGraph, files: &[FileParseData], focal: &str) -> 
             include_body: Some(false),
             max_response_chars: None,
             include_type_edges: None,
+            target: None,
         },
     )
     .expect("trace fixture");

--- a/crates/kin-cli/tests/rust_receiver_method_call_resolution.rs
+++ b/crates/kin-cli/tests/rust_receiver_method_call_resolution.rs
@@ -240,6 +240,7 @@ fn trace_callees(
             include_body: Some(false),
             max_response_chars: None,
             include_type_edges: None,
+            target: None,
         },
     )
     .expect("trace fixture")

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9392,6 +9392,11 @@ async fn mcp_tools_call_inner(
             .arguments
             .get("include_type_edges")
             .and_then(serde_json::Value::as_bool);
+        let target = request
+            .arguments
+            .get("target")
+            .and_then(serde_json::Value::as_str)
+            .map(|s| s.to_string());
         let req = kin_cli::commands::trace_data_flow::TraceDataFlowRequest {
             focal,
             depth,
@@ -9400,6 +9405,7 @@ async fn mcp_tools_call_inner(
             include_body,
             max_response_chars,
             include_type_edges,
+            target,
         };
         let repository_authority = match require_mcp_command_repository_authority(&state) {
             Ok(authority) => authority,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3271,7 +3271,12 @@ pub fn handle_find_dead_code_seeded<G: GraphStore>(
 }
 
 pub const TRACE_DATA_FLOW_DESC: &str = "\
-Walk the actual call/data-flow chain rooted at a focal entity and return it as an \
+A CALL-CHAIN WALKER, despite the name: it walks entity-to-entity edges and returns them \
+as an ordered list of steps in one call. It does NOT follow a value. If your question is \
+\"where does this parameter end up\" or \"what actually reads this field\", start with \
+semantic_locate on the behavior at the far end, because the graph has no node for a value \
+and this walker will trace control flow past the branch the data went down. \
+Walk the call chain rooted at a focal entity and return it as an \
 ordered list of steps in one call. Unlike trace_computation (which returns a flat \
 neighborhood), this follows Calls/Imports/References edges directionally from the \
 focal: direction='calls' walks outward to callees, 'callers' walks inward to callers, \
@@ -3295,7 +3300,14 @@ breadth: the per-step cap keeps the most relevant neighbors (located over file-l
 test, Calls over Imports over References, the expanded node's own file first) rather than \
 whatever order the relation table returned, and any node whose fan-out was cut carries \
 `fanout_truncated` with `fanout_dropped`, listed together under `clipped_steps`, so you can \
-re-query exactly that node with a wider limit_per_step. Every step reports the same keys: a \
+re-query exactly that node with a wider limit_per_step. That cap is where a narrow walk \
+loses answers: on a fifteen-callee function a five-wide cap discards ten neighbors, and it \
+ranks them by proximity, which no question is an input to. Pass `target` with the symbol \
+you are trying to reach and every neighbor from which it is still reachable sorts ahead of \
+every neighbor that is not, BEFORE the cap cuts. Without a target, read \
+`spine_clipped_steps`: when it is above zero the walk continued beneath a node whose \
+fan-out was already cut, so this chain is one route among several and a hop it does not \
+contain was never looked for. Do not read such a chain as evidence that X never reaches Y. Every step reports the same keys: a \
 symbol the graph owns no file for carries explicit nulls plus `external: true` rather than a \
 shorter record, and one symbol never appears both located and file-less in one response. \
 When the chain comes back empty, the additive `negative` object's `safe_to_conclude_absent` \
@@ -3385,6 +3397,10 @@ struct TraceFanoutCandidate {
     /// the same neighbor replaces them, so the step reports what the edge it
     /// names actually proved.
     resolution: RelationResolution,
+    /// Whether a named target is still reachable from this candidate inside the
+    /// requested depth. False for every candidate when no target was named, so
+    /// an untargeted walk orders exactly as it did before this existed.
+    reaches_target: bool,
 }
 
 impl TraceFanoutCandidate {
@@ -3399,10 +3415,115 @@ impl TraceFanoutCandidate {
     }
 }
 
+/// Entities from which `target` is reachable, walking the requested direction
+/// backwards and bounded by the same depth as the chain.
+///
+/// The depth bound is the walk's whole depth rather than the remaining depth at
+/// each candidate, which makes the set a superset in that direction: preferring
+/// a neighbor that might reach the target costs a cap slot, while missing one
+/// costs the answer.
+fn trace_reach_set_toward<G: GraphStore>(
+    store: &G,
+    target: &kin_model::entity::Entity,
+    direction: &str,
+    depth: usize,
+    allowed: &std::collections::HashSet<RelationKind>,
+) -> Result<std::collections::HashSet<kin_model::ids::EntityId>> {
+    let want_callees = direction == "calls" || direction == "both";
+    let want_callers = direction == "callers" || direction == "both";
+    let mut seen: std::collections::HashSet<kin_model::ids::EntityId> =
+        std::collections::HashSet::new();
+    seen.insert(target.id);
+    let mut frontier = vec![target.id];
+    for _ in 0..depth {
+        let mut next = Vec::new();
+        for node in frontier.drain(..) {
+            let relations = store
+                .get_all_relations_for_entity(&node)
+                .map_err(McpError::graph)?;
+            for rel in &relations {
+                if !allowed.contains(&rel.kind) {
+                    continue;
+                }
+                let src = rel.src.as_entity();
+                let dst = match rel.dst {
+                    kin_model::GraphNodeId::Entity(id) => Some(id),
+                    _ => None,
+                };
+                // One step back along whichever sense the forward walk takes: a
+                // `calls` chain reaches the target through outgoing edges, so
+                // whoever reaches it is on the incoming side.
+                let prior = if want_callees && dst == Some(node) {
+                    src
+                } else if want_callers && src == Some(node) {
+                    dst
+                } else {
+                    None
+                };
+                let Some(prior) = prior else { continue };
+                if prior != node && seen.insert(prior) {
+                    next.push(prior);
+                }
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+    }
+    Ok(seen)
+}
+
+/// Apply the per-step cap to one side of a node's ranked fan-out.
+///
+/// Returns how many candidates were dropped, and how many of those lived
+/// outside the expanding node's own file. The keep rule is
+/// [`kin_ranking::entity_ranking::fanout_cap_keeps`], the same one the CLI
+/// walker calls, because two copies of a cap can only ever disagree in a way
+/// that reads as a passing run on both sides.
+fn apply_trace_fanout_cap(
+    candidates: &mut Vec<TraceFanoutCandidate>,
+    node_file: Option<&str>,
+    limit: usize,
+) -> (usize, usize) {
+    let same_file: Vec<bool> = candidates
+        .iter()
+        .map(|candidate| {
+            node_file
+                .zip(candidate.entity.file_origin.as_ref())
+                .map(|(parent, file)| parent == file.0.as_str())
+                .unwrap_or(false)
+        })
+        .collect();
+    let keep = kin_ranking::entity_ranking::fanout_cap_keeps(&same_file, limit);
+    if keep.len() == candidates.len() {
+        return (0, 0);
+    }
+    let kept: std::collections::HashSet<usize> = keep.iter().copied().collect();
+    let dropped_crossing = (0..candidates.len())
+        .filter(|index| !kept.contains(index) && !same_file[*index])
+        .count();
+    let dropped = candidates.len() - keep.len();
+    let mut taken: Vec<TraceFanoutCandidate> = Vec::with_capacity(keep.len());
+    for (index, candidate) in std::mem::take(candidates).into_iter().enumerate() {
+        if kept.contains(&index) {
+            taken.push(candidate);
+        }
+    }
+    *candidates = taken;
+    (dropped, dropped_crossing)
+}
+
 /// Order one side of a node's fan-out by relevance, most relevant first, with
 /// name and id tiebreaks so the same store returns the same chain every run.
 fn sort_trace_candidates(candidates: &mut [TraceFanoutCandidate], node: &TraceFrontierNode) {
     candidates.sort_by(|left, right| {
+        // The question first, when there is one. Every proximity term below is
+        // a guess about what the caller meant; reachability toward a named
+        // target is the one term that knows.
+        if left.reaches_target != right.reaches_target {
+            return right.reaches_target.cmp(&left.reaches_target);
+        }
         let left_score = trace_fanout_score(
             &left.entity,
             left.relation_kind,
@@ -3503,6 +3624,82 @@ fn trace_step_value(
 
 /// Push one degradation onto the response, creating the array if this is the
 /// first.
+/// Mark the clips the chain continued beneath, and count them once at the top.
+///
+/// The distinction is the point of the field. A clip at the end of a branch
+/// costs breadth a reader can see missing; a clip the walk went on beneath
+/// hands back a route that reads like the route, while the neighbors it dropped
+/// were never followed. Only the second makes "this chain does not contain X"
+/// mean nothing at all. Mirrors `record_spine_clipping` on the CLI walker, and
+/// the two are held together by `both_trace_walkers_report_spine_clipping`.
+fn record_trace_spine_clipping(result: &mut serde_json::Value) {
+    let parents: std::collections::HashSet<u64> = result["chain"]
+        .as_array()
+        .map(|chain| {
+            chain
+                .iter()
+                .filter_map(|step| step["parent_step"].as_u64())
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut spine_steps = 0usize;
+    let mut spine_crossing = 0usize;
+    let mut widest: Option<(String, u64, u64)> = None;
+    if let Some(clips) = result["clipped_steps"].as_array_mut() {
+        for clip in clips.iter_mut() {
+            let on_spine = clip["step"].as_u64().is_some_and(|step| parents.contains(&step));
+            clip["continued_below"] = serde_json::Value::Bool(on_spine);
+            if !on_spine {
+                continue;
+            }
+            spine_steps += 1;
+            spine_crossing += clip["dropped_crossing_file"].as_u64().unwrap_or(0) as usize;
+            let dropped = clip["dropped_callees"].as_u64().unwrap_or(0)
+                + clip["dropped_callers"].as_u64().unwrap_or(0);
+            if widest.as_ref().is_none_or(|(_, most, _)| dropped > *most) {
+                widest = Some((
+                    clip["entity_name"].as_str().unwrap_or_default().to_string(),
+                    dropped,
+                    clip["limit_per_step"].as_u64().unwrap_or(0),
+                ));
+            }
+        }
+    }
+    if spine_steps == 0 {
+        return;
+    }
+    result["spine_clipped_steps"] = serde_json::Value::from(spine_steps);
+    if spine_crossing > 0 {
+        result["spine_dropped_crossing_file"] = serde_json::Value::from(spine_crossing);
+    }
+    let Some((name, dropped, limit)) = widest else {
+        return;
+    };
+    let crossing = if spine_crossing > 0 {
+        format!(", {spine_crossing} of which lived outside the file of the node that offered them")
+    } else {
+        String::new()
+    };
+    append_trace_degradation(
+        result,
+        serde_json::json!({
+            "component": "fanout_cap",
+            "reason": "spine_clipped",
+            "detail": format!(
+                "the walk continued beneath {spine_steps} node(s) whose fan-out limit_per_step \
+                 {limit} had already cut, dropping neighbors that were never followed{crossing}; \
+                 the widest was '{name}', which offered {dropped} more than the cap kept. This \
+                 chain is one route among the ones the cap left, so a hop it does not contain \
+                 was not looked for and its absence proves nothing"
+            ),
+            "remediation": format!(
+                "name the symbol you are looking for as `target` so the cap ranks toward it, or \
+                 re-query '{name}' with limit_per_step above {limit}"
+            ),
+        }),
+    );
+}
+
 fn append_trace_degradation(result: &mut serde_json::Value, disclosure: serde_json::Value) {
     match result
         .get_mut("degradations")
@@ -3813,6 +4010,33 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     let mut step_language: std::collections::HashMap<usize, kin_model::ids::LanguageId> =
         std::collections::HashMap::new();
 
+    // The question, resolved once and consulted per candidate. A target that
+    // resolves to nothing is disclosed rather than fatal: the chain the caller
+    // asked for is still the chain.
+    let mut target_name: Option<String> = None;
+    let mut target_unresolved: Option<String> = None;
+    let mut reach_set: Option<std::collections::HashSet<kin_model::ids::EntityId>> = None;
+    if let Some(target) = get_optional_string_param(args, "target")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        let resolved = match uuid::Uuid::parse_str(&target).ok() {
+            Some(uuid) => store
+                .get_entity(&kin_model::ids::EntityId(uuid))
+                .map_err(McpError::graph)?,
+            None => select_best_reference_target(store, &target).map_err(McpError::graph)?,
+        };
+        match resolved {
+            Some(entity) => {
+                reach_set = Some(trace_reach_set_toward(
+                    store, &entity, direction, depth, &allowed,
+                )?);
+                target_name = Some(entity.name.clone());
+            }
+            None => target_unresolved = Some(target),
+        }
+    }
+
     // Frontier: (step, entity, depth, file, dir) — the expanded node's own
     // location travels with it, because relevance is scored against the node
     // being expanded rather than against the focal.
@@ -3910,7 +4134,11 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                         };
                         candidate_index.insert((next_id, role), candidates.len());
                         let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
+                        let reaches_target = reach_set
+                            .as_ref()
+                            .is_some_and(|set| set.contains(&next_id));
                         candidates.push(TraceFanoutCandidate {
+                            reaches_target,
                             call_edges: usize::from(kin_index::is_raise_classifiable_call_edge(
                                 rel,
                             )),
@@ -3943,10 +4171,10 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                 candidates.into_iter().partition(|c| c.role == "callee");
             sort_trace_candidates(&mut callees, &node);
             sort_trace_candidates(&mut callers, &node);
-            let dropped_callees = callees.len().saturating_sub(limit_per_step);
-            let dropped_callers = callers.len().saturating_sub(limit_per_step);
-            callees.truncate(limit_per_step);
-            callers.truncate(limit_per_step);
+            let (dropped_callees, crossing_callees) =
+                apply_trace_fanout_cap(&mut callees, node.file.as_deref(), limit_per_step);
+            let (dropped_callers, crossing_callers) =
+                apply_trace_fanout_cap(&mut callers, node.file.as_deref(), limit_per_step);
 
             if dropped_callees + dropped_callers > 0 {
                 truncated = true;
@@ -3964,14 +4192,20 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                         step["entity_name"].as_str().unwrap_or_default().to_string(),
                     )
                 };
-                clipped_steps.push(serde_json::json!({
+                let mut clip = serde_json::json!({
                     "step": node.step,
                     "entity_id": entity_id,
                     "entity_name": entity_name,
                     "dropped_callees": dropped_callees,
                     "dropped_callers": dropped_callers,
+                    "continued_below": false,
                     "limit_per_step": limit_per_step,
-                }));
+                });
+                let crossing = crossing_callees + crossing_callers;
+                if crossing > 0 {
+                    clip["dropped_crossing_file"] = serde_json::Value::from(crossing);
+                }
+                clipped_steps.push(clip);
             }
 
             for candidate in callees.into_iter().chain(callers) {
@@ -4204,6 +4438,23 @@ pub fn handle_trace_data_flow<G: GraphStore>(
         },
     });
     result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
+    if let Some(name) = target_name {
+        result["target_name"] = serde_json::Value::from(name);
+    }
+    if let Some(target) = target_unresolved {
+        append_trace_degradation(
+            &mut result,
+            serde_json::json!({
+                "component": "target_reachability",
+                "reason": "target_not_resolved",
+                "detail": format!(
+                    "no entity matches target '{target}', so this walk ranked its fan-out by \
+                     relevance alone and the question had no vote in what the cap kept"
+                ),
+                "remediation": "check the target's spelling, or find it first with semantic_locate",
+            }),
+        );
+    }
     if !clipped_steps.is_empty() {
         result["clipped_steps"] = serde_json::Value::Array(clipped_steps);
     }
@@ -4221,6 +4472,9 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     // a key that appears only after a cut cannot be read as a zero.
     result["fanout_narrowed"] = serde_json::Value::from(0);
     bound_trace_payload(&mut result, max_response_chars);
+    // After the bound, because a clip is on the spine only if the walk beneath
+    // it is in the response the caller receives.
+    record_trace_spine_clipping(&mut result);
     // Counted from the chain rather than during the walk, so the numbers
     // describe the steps this payload carries after `bound_trace_payload` has
     // dropped whatever it drops. Kept apart rather than summed because only the

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3651,7 +3651,9 @@ fn record_trace_spine_clipping(result: &mut serde_json::Value) {
     let mut widest: Option<(String, u64, u64)> = None;
     if let Some(clips) = result["clipped_steps"].as_array_mut() {
         for clip in clips.iter_mut() {
-            let on_spine = clip["step"].as_u64().is_some_and(|step| parents.contains(&step));
+            let on_spine = clip["step"]
+                .as_u64()
+                .is_some_and(|step| parents.contains(&step));
             clip["continued_below"] = serde_json::Value::Bool(on_spine);
             if !on_spine {
                 continue;
@@ -4138,9 +4140,8 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                         };
                         candidate_index.insert((next_id, role), candidates.len());
                         let crossing = kin_index::trace_crossing_for(&entity, Some(rel));
-                        let reaches_target = reach_set
-                            .as_ref()
-                            .is_some_and(|set| set.contains(&next_id));
+                        let reaches_target =
+                            reach_set.as_ref().is_some_and(|set| set.contains(&next_id));
                         candidates.push(TraceFanoutCandidate {
                             reaches_target,
                             call_edges: usize::from(kin_index::is_raise_classifiable_call_edge(
@@ -8907,7 +8908,6 @@ mod tests {
             .map(|step| step["entity_name"].as_str().unwrap_or_default().to_string())
             .collect()
     }
-
 
     /// The fan-out the stranger measured, on the arm that has its own copy of
     /// the cap.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3486,22 +3486,26 @@ fn apply_trace_fanout_cap(
     node_file: Option<&str>,
     limit: usize,
 ) -> (usize, usize) {
-    let same_file: Vec<bool> = candidates
+    let locality: Vec<kin_ranking::entity_ranking::FanoutLocality> = candidates
         .iter()
-        .map(|candidate| {
-            node_file
-                .zip(candidate.entity.file_origin.as_ref())
-                .map(|(parent, file)| parent == file.0.as_str())
-                .unwrap_or(false)
+        .map(|candidate| match candidate.entity.file_origin.as_ref() {
+            None => kin_ranking::entity_ranking::FanoutLocality::Unlocated,
+            Some(file) if node_file == Some(file.0.as_str()) => {
+                kin_ranking::entity_ranking::FanoutLocality::SameFile
+            }
+            Some(_) => kin_ranking::entity_ranking::FanoutLocality::OtherFile,
         })
         .collect();
-    let keep = kin_ranking::entity_ranking::fanout_cap_keeps(&same_file, limit);
+    let keep = kin_ranking::entity_ranking::fanout_cap_keeps(&locality, limit);
     if keep.len() == candidates.len() {
         return (0, 0);
     }
     let kept: std::collections::HashSet<usize> = keep.iter().copied().collect();
     let dropped_crossing = (0..candidates.len())
-        .filter(|index| !kept.contains(index) && !same_file[*index])
+        .filter(|index| {
+            !kept.contains(index)
+                && locality[*index] == kin_ranking::entity_ranking::FanoutLocality::OtherFile
+        })
         .count();
     let dropped = candidates.len() - keep.len();
     let mut taken: Vec<TraceFanoutCandidate> = Vec::with_capacity(keep.len());
@@ -8902,6 +8906,109 @@ mod tests {
             .iter()
             .map(|step| step["entity_name"].as_str().unwrap_or_default().to_string())
             .collect()
+    }
+
+
+    /// The fan-out the stranger measured, on the arm that has its own copy of
+    /// the cap.
+    ///
+    /// Two walkers apply a per-step cap in this codebase, and a rule fixed in
+    /// one of them is a rule that reads as fixed on both while only one is. So
+    /// this fixture is the CLI walker's `requests_send_graph` again, at the
+    /// same tiers, asserted through the GraphStore handler.
+    fn requests_send_store() -> (InMemoryGraph, EntityId) {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("Session.send", "src/requests/sessions.py");
+        let focal_id = focal.id;
+        store.upsert_entity(&focal).unwrap();
+
+        let mut edges: Vec<(Entity, f32)> = Vec::new();
+        for index in 0..11 {
+            edges.push((
+                make_entity(&format!("Session.own_{index}"), "src/requests/sessions.py"),
+                1.0,
+            ));
+        }
+        edges.push((
+            make_entity("extract_cookies_to_jar", "src/requests/cookies.py"),
+            0.9,
+        ));
+        edges.push((make_entity("dispatch_hook", "src/requests/hooks.py"), 0.9));
+        edges.push((
+            make_entity("HTTPAdapter.send", "src/requests/adapters.py"),
+            0.85,
+        ));
+
+        for (entity, confidence) in &edges {
+            store.upsert_entity(entity).unwrap();
+            let mut relation = make_relation(focal_id, entity.id, RelationKind::Calls);
+            relation.confidence = *confidence;
+            store.upsert_relation(&relation).unwrap();
+        }
+        (store, focal_id)
+    }
+
+    #[test]
+    fn trace_data_flow_offline_cap_leaves_the_module_and_names_the_target() {
+        let (store, focal_id) = requests_send_store();
+        let untargeted = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal_id.to_string())),
+                ("direction", serde_json::json!("calls")),
+                ("depth", serde_json::json!(1)),
+                ("limit_per_step", serde_json::json!(4)),
+            ],
+        );
+        let names = traced_step_names(&untargeted);
+        assert_eq!(names.len(), 4);
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| !name.starts_with("Session."))
+                .count(),
+            1,
+            "one slot leaves the file, on this arm too: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|name| name == "HTTPAdapter.send"),
+            "and the hop nobody asked for is still not the one it keeps: {names:?}"
+        );
+        assert_eq!(
+            untargeted["spine_clipped_steps"], 1,
+            "the walk continued beneath the clipped focal: {untargeted}"
+        );
+        assert_eq!(
+            untargeted["clipped_steps"][0]["dropped_crossing_file"], 2,
+            "two module-crossing hops were dropped: {untargeted}"
+        );
+        assert!(
+            untargeted["degradations"]
+                .as_array()
+                .is_some_and(|degradations| degradations
+                    .iter()
+                    .any(|degradation| degradation["reason"] == "spine_clipped")),
+            "and the disclosure fires: {untargeted}"
+        );
+
+        let targeted = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal_id.to_string())),
+                ("direction", serde_json::json!("calls")),
+                ("depth", serde_json::json!(1)),
+                ("limit_per_step", serde_json::json!(4)),
+                ("target", serde_json::json!("HTTPAdapter.send")),
+            ],
+        );
+        assert!(
+            traced_step_names(&targeted)
+                .iter()
+                .any(|name| name == "HTTPAdapter.send"),
+            "naming the hop keeps it here too: {:?}",
+            traced_step_names(&targeted)
+        );
+        assert_eq!(targeted["target_name"], "HTTPAdapter.send");
     }
 
     /// Both arms of one tool have to answer the same way, so the offline arm

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -555,6 +555,7 @@ fn registered_tools() -> ToolsListResult {
                             "default": "both"
                         },
                         "limit_per_step": { "type": "integer", "description": "Max relations expanded per step (default 5, capped at 25). Kept by relevance, not by relation order; a step whose fan-out was cut says so with the count it dropped.", "default": 5, "minimum": 1, "maximum": 25 },
+                        "target": { "type": "string", "description": "A symbol you are trying to reach, by exact name or UUID. Neighbors from which it is still reachable inside the requested depth survive the per-step cap ahead of neighbors that are not, so the question decides what a narrow walk keeps instead of proximity deciding it. Optional; a target that resolves to nothing is reported in degradations and the chain is still returned." },
                         "include_body": {
                             "type": "boolean",
                             "description": "Inline each step's source body (default true). Pass false to ask for the SHAPE of the chain (names, kinds, roles, spans, edges), which is a fraction of the size and is what you want unless you intend to read the code.",

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -593,7 +593,6 @@ pub fn trace_constant_score(entity: &Entity, focal_dir: Option<&str>) -> (bool, 
     )
 }
 
-
 /// Where one fan-out candidate sits relative to the node being expanded.
 ///
 /// Three states, not two. A file-less candidate is neither in the node's file
@@ -647,8 +646,8 @@ pub fn fanout_cap_keeps(locality: &[FanoutLocality], limit: usize) -> Vec<usize>
     {
         return kept;
     }
-    let Some(crossing) = (limit..locality.len())
-        .find(|&index| locality[index] == FanoutLocality::OtherFile)
+    let Some(crossing) =
+        (limit..locality.len()).find(|&index| locality[index] == FanoutLocality::OtherFile)
     else {
         return kept;
     };

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -593,6 +593,49 @@ pub fn trace_constant_score(entity: &Entity, focal_dir: Option<&str>) -> (bool, 
     )
 }
 
+
+/// Which of a node's ranked neighbors a per-step fan-out cap keeps.
+///
+/// `same_file` is one flag per candidate, in relevance order, saying whether
+/// that candidate lives in the expanded node's own file. The return is the
+/// indices to keep, still in relevance order.
+///
+/// The rule is the ordinary top-N, with one floor under it: a cap may not spend
+/// every slot inside the node's own file when the node has a neighbor outside
+/// it. A chain that never leaves the file it started in has not answered a
+/// data-flow question, and the ranking cannot help here, because the term that
+/// crowds the boundary out is a proximity term that no question is an input to.
+/// The measured case is `Session.send` in `psf/requests`: fifteen callees,
+/// eleven of them parser-certain same-file calls at confidence 1.0, and a
+/// four-wide cap that therefore kept four `sessions.py` functions and dropped
+/// every hop that leaves the module.
+///
+/// The reservation takes at most one slot and never takes it before the node's
+/// own file has two, so a two-wide cap still keeps the two best neighbors it
+/// has and nothing about a narrow walk changes. It is a floor, not a fix for
+/// relevance: it guarantees the chain crosses the boundary when it can, and it
+/// does not know which crossing the caller wanted. Naming a target is what
+/// answers that.
+pub fn fanout_cap_keeps(same_file: &[bool], limit: usize) -> Vec<usize> {
+    if same_file.len() <= limit {
+        return (0..same_file.len()).collect();
+    }
+    let mut kept: Vec<usize> = (0..limit).collect();
+    if limit < 3 {
+        return kept;
+    }
+    if kept.iter().any(|&index| !same_file[index]) {
+        return kept;
+    }
+    let Some(crossing) = (limit..same_file.len()).find(|&index| !same_file[index]) else {
+        return kept;
+    };
+    // The lowest-ranked kept slot, so the reservation costs the least relevant
+    // neighbor rather than the best one, and the kept set stays in rank order.
+    kept[limit - 1] = crossing;
+    kept
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -594,21 +594,38 @@ pub fn trace_constant_score(entity: &Entity, focal_dir: Option<&str>) -> (bool, 
 }
 
 
+/// Where one fan-out candidate sits relative to the node being expanded.
+///
+/// Three states, not two. A file-less candidate is neither in the node's file
+/// nor in another one: the graph owns no location for it, it is a leaf with no
+/// next hop, and reserving a cap slot for it would spend the reservation on a
+/// step that continues nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FanoutLocality {
+    /// Defined in the expanded node's own file.
+    SameFile,
+    /// Defined in a different file this repository owns. This is the hop a
+    /// data-flow question is about, and the one the cap used to discard first.
+    OtherFile,
+    /// The graph owns no file for this symbol: an import another repository
+    /// defines, a builtin, or an alias split off its definition.
+    Unlocated,
+}
+
 /// Which of a node's ranked neighbors a per-step fan-out cap keeps.
 ///
-/// `same_file` is one flag per candidate, in relevance order, saying whether
-/// that candidate lives in the expanded node's own file. The return is the
+/// `locality` is one entry per candidate, in relevance order. The return is the
 /// indices to keep, still in relevance order.
 ///
 /// The rule is the ordinary top-N, with one floor under it: a cap may not spend
-/// every slot inside the node's own file when the node has a neighbor outside
-/// it. A chain that never leaves the file it started in has not answered a
-/// data-flow question, and the ranking cannot help here, because the term that
-/// crowds the boundary out is a proximity term that no question is an input to.
-/// The measured case is `Session.send` in `psf/requests`: fifteen callees,
-/// eleven of them parser-certain same-file calls at confidence 1.0, and a
-/// four-wide cap that therefore kept four `sessions.py` functions and dropped
-/// every hop that leaves the module.
+/// every slot inside the node's own file when the node has a located neighbor
+/// outside it. A chain that never leaves the file it started in has not
+/// answered a data-flow question, and the ranking cannot help here, because the
+/// term that crowds the boundary out is a proximity term that no question is an
+/// input to. The measured case is `Session.send` in `psf/requests`: fifteen
+/// callees, eleven of them parser-certain same-file calls at confidence 1.0,
+/// and a four-wide cap that therefore kept four `sessions.py` functions and
+/// dropped every hop that leaves the module.
 ///
 /// The reservation takes at most one slot and never takes it before the node's
 /// own file has two, so a two-wide cap still keeps the two best neighbors it
@@ -616,18 +633,23 @@ pub fn trace_constant_score(entity: &Entity, focal_dir: Option<&str>) -> (bool, 
 /// relevance: it guarantees the chain crosses the boundary when it can, and it
 /// does not know which crossing the caller wanted. Naming a target is what
 /// answers that.
-pub fn fanout_cap_keeps(same_file: &[bool], limit: usize) -> Vec<usize> {
-    if same_file.len() <= limit {
-        return (0..same_file.len()).collect();
+pub fn fanout_cap_keeps(locality: &[FanoutLocality], limit: usize) -> Vec<usize> {
+    if locality.len() <= limit {
+        return (0..locality.len()).collect();
     }
     let mut kept: Vec<usize> = (0..limit).collect();
     if limit < 3 {
         return kept;
     }
-    if kept.iter().any(|&index| !same_file[index]) {
+    if kept
+        .iter()
+        .any(|&index| locality[index] == FanoutLocality::OtherFile)
+    {
         return kept;
     }
-    let Some(crossing) = (limit..same_file.len()).find(|&index| !same_file[index]) else {
+    let Some(crossing) = (limit..locality.len())
+        .find(|&index| locality[index] == FanoutLocality::OtherFile)
+    else {
         return kept;
     };
     // The lowest-ranked kept slot, so the reservation costs the least relevant
@@ -639,6 +661,71 @@ pub fn fanout_cap_keeps(same_file: &[bool], limit: usize) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use FanoutLocality::{OtherFile, SameFile, Unlocated};
+
+    /// The measured shape: a node whose best neighbors are all in its own file,
+    /// and the one hop that leaves the module ranked below every one of them.
+    #[test]
+    fn a_cap_may_not_spend_every_slot_inside_the_nodes_own_file() {
+        let fanout = [SameFile, SameFile, SameFile, SameFile, OtherFile];
+        assert_eq!(
+            fanout_cap_keeps(&fanout, 4),
+            vec![0, 1, 2, 4],
+            "the reservation costs the lowest-ranked kept slot, not the best one"
+        );
+    }
+
+    /// The floor is a floor, not extra breadth. It never takes a second slot,
+    /// however many crossings are waiting.
+    #[test]
+    fn the_reservation_never_takes_more_than_one_slot() {
+        let fanout = [
+            SameFile, SameFile, SameFile, SameFile, OtherFile, OtherFile, OtherFile,
+        ];
+        assert_eq!(fanout_cap_keeps(&fanout, 4), vec![0, 1, 2, 4]);
+    }
+
+    /// A two-wide cap has room for the two best neighbors and nothing else, so
+    /// it is left exactly as it was. This is the case `the_per_step_cap_keeps_\
+    /// the_callees_that_continue_the_chain` pins on the walker.
+    #[test]
+    fn a_cap_too_narrow_to_afford_a_reservation_does_not_take_one() {
+        let fanout = [SameFile, SameFile, OtherFile];
+        assert_eq!(fanout_cap_keeps(&fanout, 2), vec![0, 1]);
+        // Three is where it can afford one: two slots stay with the node's own
+        // file, which is the promise the narrow case rests on.
+        assert_eq!(fanout_cap_keeps(&fanout, 3), vec![0, 1, 2]);
+    }
+
+    /// A file-less symbol is a leaf with no next hop, so reserving a slot for
+    /// one would spend the floor on a step that continues nothing.
+    #[test]
+    fn an_unlocated_candidate_never_takes_the_reserved_slot() {
+        let fanout = [SameFile, SameFile, SameFile, SameFile, Unlocated];
+        assert_eq!(
+            fanout_cap_keeps(&fanout, 4),
+            vec![0, 1, 2, 3],
+            "nothing crosses a file boundary here, so nothing is reserved"
+        );
+    }
+
+    /// A cap that already kept a crossing has nothing to fix, and must not
+    /// reshuffle what relevance chose.
+    #[test]
+    fn a_cap_that_already_crosses_is_left_alone() {
+        let fanout = [SameFile, OtherFile, SameFile, SameFile, SameFile];
+        assert_eq!(fanout_cap_keeps(&fanout, 4), vec![0, 1, 2, 3]);
+    }
+
+    /// And a fan-out inside the cap is untouched, so an unclipped walk is
+    /// byte-identical to the one before this rule existed.
+    #[test]
+    fn a_fan_out_that_fits_is_kept_whole() {
+        let fanout = [SameFile, OtherFile, Unlocated];
+        assert_eq!(fanout_cap_keeps(&fanout, 5), vec![0, 1, 2]);
+        assert_eq!(fanout_cap_keeps(&fanout, 3), vec![0, 1, 2]);
+    }
 
     #[test]
     fn declaration_kind_rank_function_highest() {

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -712,9 +712,13 @@ mod tests {
 
     /// A cap that already kept a crossing has nothing to fix, and must not
     /// reshuffle what relevance chose.
+    ///
+    /// The second crossing below the cap is the point of the fixture. Without
+    /// it, a rule that reserved unconditionally would look identical here,
+    /// because there would be nothing left to promote.
     #[test]
     fn a_cap_that_already_crosses_is_left_alone() {
-        let fanout = [SameFile, OtherFile, SameFile, SameFile, SameFile];
+        let fanout = [SameFile, OtherFile, SameFile, SameFile, OtherFile];
         assert_eq!(fanout_cap_keeps(&fanout, 4), vec![0, 1, 2, 3]);
     }
 

--- a/scripts/acceptance/trace_spine_clipping_repro.py
+++ b/scripts/acceptance/trace_spine_clipping_repro.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove a narrow trace says it may be missing the hop you asked about.
+
+FIR-2781. The v0.6.0 stranger run walked `Session.send` on a converted
+`psf/requests` with `limit_per_step: 4` and got a chain that stops two hops
+short of where `verify` goes. The per-step cap had discarded eleven of fifteen
+callees, `HTTPAdapter.send` among them, and the response said so only as a count
+in `clipped_steps`. Their words: "If I had trusted it, I would have written that
+`verify` ends at `Session.send`."
+
+The cap did not discard at random. `trace_fanout_score` ranks a candidate in the
+expanded node's own file above one in any other file, as a hard tier above
+declaration kind and above confidence, so a node with more same-file neighbors
+than the cap allows never leaves its module. That is a proximity term, and no
+question is an input to it.
+
+The class this suite pins is not "a hop was dropped". A cap has to drop
+something. It is that a chain missing its point reads exactly like a complete
+one, because the honest label the tool already carried ("treat this as a lower
+bound") is the same label a complete walk carries.
+
+Four checks, on one seeded repository:
+
+  0  a walk the cap cut BENEATH a node it then continued through says so in
+     words, naming the node, the parameter and the count, and saying that an
+     absence in this chain proves nothing
+  1  that disclosure separates module-crossing losses from same-file breadth, so
+     a reader can tell which class of hop went
+  2  naming a `target` puts the module-crossing hop in the chain at the same cap
+     that loses it unnamed, with the unnamed walk asserted beside it, because
+     either half alone is satisfiable by a broken tool
+  3  a walk no cap cut publishes none of this, and the keys are ABSENT rather
+     than zero, so machinery for incomplete answers never qualifies a complete one
+
+Exit status is 0 when every check passed, 1 when one failed, 2 when one could not
+be read, and 3 when the run could not be set up. `--self-test` exercises every
+grader against its inverse and needs no binary, so a grader that cannot fail is a
+failure here rather than a silent pass in CI.
+"""
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+print = functools.partial(print, flush=True)
+
+# The wording a caller has to be unable to read as a mere lower bound. Asserted
+# as a substring of the walker's own disclosure, because the number beside it
+# (`spine_clipped_steps`) is what a machine reads and this is what a person does.
+REFUSAL_PHRASE = "absence proves nothing"
+
+# One module whose entry point calls many neighbours in its own file and exactly
+# one function in another module. That is the measured shape: the cap fills on
+# same-file callees and the hop that leaves the module is the one the question is
+# about.
+SESSIONS_SRC = '''"""Session layer."""
+
+from adapters import send_via_adapter
+
+
+def get_adapter(url):
+    return url
+
+
+def prepare_request(request):
+    return request
+
+
+def resolve_redirects(response):
+    return response
+
+
+def rebuild_auth(request):
+    return request
+
+
+def rebuild_proxies(request):
+    return request
+
+
+def rebuild_method(request):
+    return request
+
+
+def merge_settings(request):
+    return request
+
+
+def should_strip_auth(old, new):
+    return old != new
+
+
+def close_session(state):
+    return state
+
+
+def send(request, verify=True):
+    """The focal. Nine same-file callees and one that leaves the module."""
+    adapter = get_adapter(request)
+    prepared = prepare_request(request)
+    prepared = rebuild_auth(prepared)
+    prepared = rebuild_proxies(prepared)
+    prepared = rebuild_method(prepared)
+    prepared = merge_settings(prepared)
+    should_strip_auth(request, prepared)
+    response = send_via_adapter(adapter, prepared, verify)
+    resolve_redirects(response)
+    close_session(response)
+    return response
+'''
+
+ADAPTERS_SRC = '''"""Adapter layer: where verify leaves the session."""
+
+
+def cert_verify(conn, verify):
+    conn["cert_reqs"] = "CERT_REQUIRED" if verify else "CERT_NONE"
+    return conn
+
+
+def send_via_adapter(adapter, request, verify):
+    """The hop the question is about."""
+    return cert_verify({"adapter": adapter, "request": request}, verify)
+'''
+
+CROSSING_HOP = "send_via_adapter"
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    proc = subprocess.Popen(
+        cmd, cwd=cwd, env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        out, err = proc.communicate()
+        return 124, out, err
+    return proc.returncode, out, err
+
+
+# ── graders ────────────────────────────────────────────────────────────────
+#
+# Every grader takes a parsed payload and returns (status, detail). Kept apart
+# from the run so `--self-test` can hand each one a payload that must pass and a
+# payload that must fail, with no binary anywhere.
+
+
+def spine_disclosure(payload):
+    """The `fanout_cap` / `spine_clipped` degradation, or None."""
+    if not isinstance(payload, dict):
+        return None
+    for entry in payload.get("degradations") or []:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("component") == "fanout_cap" and entry.get("reason") == "spine_clipped":
+            return entry
+    return None
+
+
+def grade_says_the_absence_proves_nothing(payload):
+    steps = payload.get("spine_clipped_steps")
+    if steps is None:
+        return UNREADABLE, "no spine_clipped_steps key on a walk that should carry one"
+    if steps < 1:
+        return FAIL, "spine_clipped_steps is %r on a walk the cap cut beneath" % (steps,)
+    disclosure = spine_disclosure(payload)
+    if disclosure is None:
+        return FAIL, "spine_clipped_steps is %r and nothing in degradations says so" % (steps,)
+    detail = disclosure.get("detail") or ""
+    missing = [
+        name for name, present in (
+            ("limit_per_step", "limit_per_step" in detail),
+            ("the refusal phrase", REFUSAL_PHRASE in detail),
+            ("a clipped node name", "'" in detail),
+        ) if not present
+    ]
+    if missing:
+        return FAIL, "the disclosure omits %s: %r" % (", ".join(missing), detail[:220])
+    remediation = disclosure.get("remediation") or ""
+    if "target" not in remediation:
+        return FAIL, "the disclosure names no lever: %r" % (remediation[:180],)
+    return PASS, "spine_clipped_steps=%r and the disclosure names the node, the cap and the lever" % (steps,)
+
+
+def grade_separates_the_class_of_loss(payload):
+    clips = payload.get("clipped_steps")
+    if not isinstance(clips, list) or not clips:
+        return UNREADABLE, "no clipped_steps array to read a class of loss from"
+    on_spine = [clip for clip in clips if isinstance(clip, dict) and clip.get("continued_below")]
+    if not on_spine:
+        return FAIL, "no clip reports continued_below, so no loss is attributable to the spine"
+    crossing = sum(clip.get("dropped_crossing_file") or 0 for clip in on_spine)
+    dropped = sum(
+        (clip.get("dropped_callees") or 0) + (clip.get("dropped_callers") or 0)
+        for clip in on_spine
+    )
+    if dropped < 1:
+        return FAIL, "a clip on the spine dropped nothing, which is not a clip"
+    if crossing < 1:
+        return FAIL, (
+            "the spine dropped %d neighbour(s) and none is reported as module-crossing, so the "
+            "class of hop the question is about is indistinguishable from same-file breadth"
+            % (dropped,)
+        )
+    if payload.get("spine_dropped_crossing_file") != crossing:
+        return FAIL, (
+            "the top-level spine_dropped_crossing_file (%r) disagrees with the clips (%d)"
+            % (payload.get("spine_dropped_crossing_file"), crossing)
+        )
+    return PASS, "%d of %d spine losses are reported as module-crossing" % (crossing, dropped)
+
+
+def chain_names(payload):
+    chain = payload.get("chain")
+    if not isinstance(chain, list):
+        return None
+    return [
+        step.get("entity_name")
+        for step in chain
+        if isinstance(step, dict)
+    ]
+
+
+def grade_the_target_is_what_delivers_the_hop(untargeted, targeted):
+    """Both arms, because either alone is satisfiable by a broken tool.
+
+    A tool that ignored the cap entirely would pass the targeted half. A tool
+    that returned an empty chain would pass the untargeted half. Only the pair
+    says the question is what moved the answer.
+    """
+    without = chain_names(untargeted)
+    with_target = chain_names(targeted)
+    if without is None or with_target is None:
+        return UNREADABLE, "one of the two walks returned no readable chain"
+    if CROSSING_HOP in without:
+        return FAIL, (
+            "the untargeted walk already contains %s, so this fixture no longer reproduces the "
+            "loss and the targeted half proves nothing: %r" % (CROSSING_HOP, without)
+        )
+    if CROSSING_HOP not in with_target:
+        return FAIL, (
+            "naming %s as the target did not put it in the chain: %r" % (CROSSING_HOP, with_target)
+        )
+    if targeted.get("target_name") != CROSSING_HOP:
+        return FAIL, (
+            "the response does not echo the question it was given: target_name=%r"
+            % (targeted.get("target_name"),)
+        )
+    return PASS, "%s is absent unnamed and present when named" % (CROSSING_HOP,)
+
+
+def grade_a_complete_walk_is_not_qualified(payload):
+    if spine_disclosure(payload) is not None:
+        return FAIL, "a walk no cap cut carries a spine_clipped disclosure"
+    present = [
+        key for key in ("spine_clipped_steps", "spine_dropped_crossing_file", "clipped_steps")
+        if key in payload
+    ]
+    if present:
+        return FAIL, (
+            "a walk no cap cut carries %s; these keys must be absent, not zero, or a reader "
+            "cannot tell an unaffected walk from one that reported nothing"
+            % (", ".join(present),)
+        )
+    if not chain_names(payload):
+        return UNREADABLE, "the control walk returned no chain, so it grades nothing"
+    return PASS, "no clip, no spine key, no disclosure on a walk the cap never cut"
+
+
+# ── the run ────────────────────────────────────────────────────────────────
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.env = dict(os.environ)
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env.pop("KIN_MCP_REPO", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repo = None
+
+    def git(self, args, repo):
+        base = ["git", "-c", "core.hooksPath=/dev/null",
+                "-c", "user.email=repro@example.invalid",
+                "-c", "user.name=trace-spine-clipping-repro",
+                "-c", "commit.gpgsign=false"]
+        return run(base + args, cwd=repo, env=self.env)
+
+    def repo(self):
+        if self._repo:
+            return self._repo
+        path = os.path.join(self.workdir, "sessions")
+        os.makedirs(path)
+        for rel, body in (("sessions.py", SESSIONS_SRC), ("adapters.py", ADAPTERS_SRC)):
+            with open(os.path.join(path, rel), "w") as handle:
+                handle.write(body)
+        self.git(["init", "-q", "."], path)
+        self.git(["add", "-A"], path)
+        rc, out, err = self.git(["commit", "-q", "-m", "fixture"], path)
+        if rc != 0:
+            raise RuntimeError("git commit failed: %s" % (err or out)[-300:])
+        rc, out, err = self.kin_run(["init", "."], path)
+        if rc != 0:
+            raise RuntimeError("kin init failed: %s" % (err or out)[-300:])
+        self._repo = path
+        return path
+
+    def kin_run(self, args, repo, timeout=600):
+        return run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+
+    def trace(self, limit, target=None):
+        """One `kin trace-data-flow`, parsed, or None when it could not be read."""
+        repo = self.repo()
+        args = ["trace-data-flow", "--focal", "send", "--direction", "calls",
+                "--depth", "2", "--limit-per-step", str(limit), "--no-bodies"]
+        if target:
+            args += ["--target", target]
+        rc, out, err = self.kin_run(args, repo)
+        if self.verbose:
+            print("  $ kin %s -> rc=%s" % (" ".join(args[1:]), rc))
+        if rc != 0:
+            return None
+        try:
+            return json.loads(out)
+        except ValueError:
+            return None
+
+
+class Result(object):
+    def __init__(self, ident, status, detail):
+        self.ident = ident
+        self.status = status
+        self.detail = detail
+
+
+def check_says_the_absence_proves_nothing(suite):
+    payload = suite.trace(limit=3)
+    if payload is None:
+        return Result("0", UNREADABLE, "the narrow walk returned nothing readable")
+    status, detail = grade_says_the_absence_proves_nothing(payload)
+    return Result("0", status, "A clipped spine refuses to be read as an absence. " + detail)
+
+
+def check_separates_the_class_of_loss(suite):
+    payload = suite.trace(limit=3)
+    if payload is None:
+        return Result("1", UNREADABLE, "the narrow walk returned nothing readable")
+    status, detail = grade_separates_the_class_of_loss(payload)
+    return Result("1", status, "The disclosure separates module-crossing loss from breadth. " + detail)
+
+
+def check_the_target_is_what_delivers_the_hop(suite):
+    untargeted = suite.trace(limit=3)
+    targeted = suite.trace(limit=3, target=CROSSING_HOP)
+    if untargeted is None or targeted is None:
+        return Result("2", UNREADABLE, "one of the two walks returned nothing readable")
+    status, detail = grade_the_target_is_what_delivers_the_hop(untargeted, targeted)
+    return Result("2", status, "Naming the target is what puts the hop in the chain. " + detail)
+
+
+def check_a_complete_walk_is_not_qualified(suite):
+    payload = suite.trace(limit=25)
+    if payload is None:
+        return Result("3", UNREADABLE, "the wide walk returned nothing readable")
+    status, detail = grade_a_complete_walk_is_not_qualified(payload)
+    return Result("3", status, "A walk no cap cut carries none of this. " + detail)
+
+
+CHECKS = [
+    ("0", check_says_the_absence_proves_nothing),
+    ("1", check_separates_the_class_of_loss),
+    ("2", check_the_target_is_what_delivers_the_hop),
+    ("3", check_a_complete_walk_is_not_qualified),
+]
+
+
+# ── self-test ──────────────────────────────────────────────────────────────
+#
+# Each grader is handed a payload it must pass and one it must fail. A grader
+# that answers PASS to both cannot fail in CI, which is the failure this suite
+# exists to prevent in the tool it grades.
+
+CLIPPED = {
+    "chain": [{"entity_name": "get_adapter", "parent_step": 0}],
+    "spine_clipped_steps": 1,
+    "spine_dropped_crossing_file": 1,
+    "clipped_steps": [{
+        "step": 0, "entity_name": "send", "dropped_callees": 7, "dropped_callers": 0,
+        "dropped_crossing_file": 1, "continued_below": True, "limit_per_step": 3,
+    }],
+    "degradations": [{
+        "component": "fanout_cap", "reason": "spine_clipped",
+        "detail": "the walk continued beneath 1 node(s) whose fan-out limit_per_step 3 had "
+                  "already cut ... the widest was 'send' ... its absence proves nothing",
+        "remediation": "name the symbol you are looking for as `target` ...",
+    }],
+}
+
+CLEAN = {"chain": [{"entity_name": "get_adapter", "parent_step": 0}], "degradations": []}
+
+
+def _without(payload, *path):
+    import copy
+    clone = copy.deepcopy(payload)
+    cursor = clone
+    for key in path[:-1]:
+        cursor = cursor[key]
+    cursor.pop(path[-1], None)
+    return clone
+
+
+def self_test():
+    failures = []
+    graded = []
+
+    def expect(label, got, want):
+        graded.append(label)
+        status = got[0]
+        if status != want:
+            failures.append("%s: expected %s, got %s (%s)" % (label, want, status, got[1]))
+
+    expect("0 passes an honest clipped walk",
+           grade_says_the_absence_proves_nothing(CLIPPED), PASS)
+    expect("0 fails a walk that counts the clip and never says it",
+           grade_says_the_absence_proves_nothing(_without(CLIPPED, "degradations")), FAIL)
+    silent = json.loads(json.dumps(CLIPPED))
+    silent["degradations"][0]["detail"] = "the walk continued beneath 1 node(s), limit_per_step 3, 'send'"
+    expect("0 fails a disclosure missing the refusal phrase",
+           grade_says_the_absence_proves_nothing(silent), FAIL)
+    leverless = json.loads(json.dumps(CLIPPED))
+    leverless["degradations"][0]["remediation"] = "re-query 'send' with a wider cap"
+    expect("0 fails a disclosure that names no lever",
+           grade_says_the_absence_proves_nothing(leverless), FAIL)
+    expect("0 cannot read a walk with no spine key",
+           grade_says_the_absence_proves_nothing(CLEAN), UNREADABLE)
+
+    expect("1 passes a clip that separates the class",
+           grade_separates_the_class_of_loss(CLIPPED), PASS)
+    blind = json.loads(json.dumps(CLIPPED))
+    blind["clipped_steps"][0]["dropped_crossing_file"] = 0
+    blind["spine_dropped_crossing_file"] = 0
+    expect("1 fails a clip that reports no module-crossing loss",
+           grade_separates_the_class_of_loss(blind), FAIL)
+    offspine = json.loads(json.dumps(CLIPPED))
+    offspine["clipped_steps"][0]["continued_below"] = False
+    expect("1 fails when no clip is attributable to the spine",
+           grade_separates_the_class_of_loss(offspine), FAIL)
+    disagreeing = json.loads(json.dumps(CLIPPED))
+    disagreeing["spine_dropped_crossing_file"] = 9
+    expect("1 fails when the top-level total disagrees with the clips",
+           grade_separates_the_class_of_loss(disagreeing), FAIL)
+
+    without = {"chain": [{"entity_name": "get_adapter"}]}
+    with_hop = {"chain": [{"entity_name": CROSSING_HOP}], "target_name": CROSSING_HOP}
+    expect("2 passes absent-unnamed and present-named",
+           grade_the_target_is_what_delivers_the_hop(without, with_hop), PASS)
+    expect("2 fails when the unnamed walk already had it",
+           grade_the_target_is_what_delivers_the_hop(with_hop, with_hop), FAIL)
+    expect("2 fails when naming it changed nothing",
+           grade_the_target_is_what_delivers_the_hop(without, without), FAIL)
+    unechoed = {"chain": [{"entity_name": CROSSING_HOP}]}
+    expect("2 fails when the response does not echo the question",
+           grade_the_target_is_what_delivers_the_hop(without, unechoed), FAIL)
+
+    expect("3 passes an unaffected walk",
+           grade_a_complete_walk_is_not_qualified(CLEAN), PASS)
+    expect("3 fails a walk carrying the disclosure anyway",
+           grade_a_complete_walk_is_not_qualified(CLIPPED), FAIL)
+    zeroed = {"chain": [{"entity_name": "get_adapter"}], "degradations": [],
+              "spine_clipped_steps": 0}
+    expect("3 fails a walk that writes the key as zero rather than omitting it",
+           grade_a_complete_walk_is_not_qualified(zeroed), FAIL)
+    expect("3 cannot read a walk with no chain",
+           grade_a_complete_walk_is_not_qualified({"degradations": []}), UNREADABLE)
+
+    for line in failures:
+        print("SELFTEST FAIL %s" % line)
+    # Counted, never written out. A hardcoded total is a number that drifts from
+    # the assertions it claims to describe, and it drifts silently downward.
+    print("self-test: %d grader assertions, %d failed" % (len(graded), len(failures)))
+    if len(graded) != len(set(graded)):
+        print("SELFTEST FAIL duplicate assertion labels, so one shadowed another")
+        return 1
+    if not graded:
+        print("SELFTEST FAIL no grader assertion ran")
+        return 1
+    return 1 if failures else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN") or shutil.which("kin"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    opts = parser.parse_args(argv)
+
+    if opts.self_test:
+        return self_test()
+
+    if not opts.kin:
+        print("SETUP no kin binary: pass --kin or set KIN_BIN")
+        return 3
+
+    workdir = tempfile.mkdtemp(prefix="trace-spine-clipping-")
+    try:
+        suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
+        results = []
+        for ident, check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - a setup failure is not a verdict
+                results.append(Result(ident, UNREADABLE, "check raised: %s" % (error,)))
+        for result in results:
+            print("CHECK %s %s %s" % (result.ident, result.status, result.detail))
+        asked = [ident for ident, _ in CHECKS]
+        answered = [result.ident for result in results]
+        if answered != asked:
+            print("SETUP asked for %r and %r answered" % (asked, answered))
+            return 3
+        if any(result.status == FAIL for result in results):
+            return 1
+        if any(result.status == UNREADABLE for result in results):
+            return 2
+        return 0
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Part of FIR-2781

`trace_data_flow` walked `Session.send` on a converted `psf/requests` with a four-wide cap
and handed back a chain that stops two hops short of where `verify` goes. The stranger's
words: if I had trusted it, I would have written that `verify` ends at `Session.send`.

Reading the code says the cap did not discard at random. `trace_fanout_score` puts
`same_file` fourth in its tuple, above declaration kind, above the raise-target demotion,
above confidence, so it is a hard tier: every same-file candidate beats every
module-crossing one regardless of anything below it. `Session.send` has eleven callees in
its own file. A four-wide cap therefore kept four `sessions.py` functions, deterministically,
and `HTTPAdapter.send` was never in contention. That term is a proximity heuristic, and the
ticket's phrase for the rest is exact: the query is not an input to that ranking at all.

The linker's own tiers close off the obvious repair. A call whose destination is defined in
the calling file is stamped 1.0, an import-pinned cross-file call 0.9, and the
inherited-method dispatch that resolves `adapter.send` through `BaseAdapter` is 0.85. So
reordering by proof strength ranks the hop we want LAST of the three that leave the module.
No proximity-free rule reliably returns that specific hop at breadth four on a fifteen-callee
node, because which four survive is a judgment only the caller's question can make.

So the question becomes an input.

**`target`.** Name the symbol you are trying to reach and a bounded reverse walk from it
computes which neighbors can still get there; membership sorts ahead of every proximity
term, before the cap cuts. Exposed on the MCP schema and as `--target` on the CLI. The
reverse walk is bounded by the same depth and charged to the same work meter as the chain,
and an unfinished one is disclosed rather than trusted, because a partial reach set is a
subset and would rank a neighbor that does reach the target as though it does not. A target
that resolves to nothing is a degradation, not a failed call.

**A floor under the cap.** It may no longer spend every slot inside the expanded node's own
file when that node has a located neighbor outside it. One slot, never taken before the
node's own file has two, so a two-wide cap is untouched and
`the_per_step_cap_keeps_the_callees_that_continue_the_chain` still passes unchanged.
Locality is three-state, because a file-less symbol is a leaf with no next hop and reserving
for one would spend the floor on a step that continues nothing. This is a floor, not
relevance: it guarantees the chain crosses the boundary when it can, and it does not know
which crossing was wanted. It does not deliver the stranger's hop, and the checks assert
that directly rather than letting the reader assume otherwise.

**A clip now says whether the walk continued beneath it.** `continued_below` per clip,
`spine_clipped_steps` and `spine_dropped_crossing_file` at the top, and a
`fanout_cap` / `spine_clipped` degradation naming the widest clipped node, the parameter
that cut it, the count, and the sentence a reader needs: this chain is one route among the
ones the cap left, so a hop it does not contain was not looked for and its absence proves
nothing.

The verdict-wording half of FIR-2781 is not in this PR. It rides with lane certgate, and
these fields are what it can key on, so the ticket stays open until both halves land.

Two walkers apply a per-step cap in this repo, the CLI one behind the daemon route and the
GraphStore one in `kin-mcp`. The keep rule now lives once, in `kin-ranking`, and both call
it, because a cap fixed in one copy reads as fixed in both while only one is. The GraphStore
walker gets the same fixture at the same parameters.

The tool description stops promising value tracing it cannot do: call-chain walker in the
first sentence, and value-flow questions routed to `semantic_locate`, which is what answered
this question in the stranger's own session.

## The scripted check for the class

Per the lane contract, `scripts/acceptance/trace_spine_clipping_repro.py`, wired into
`acceptance.yml` beside its siblings. Four checks on one seeded repository whose entry point
calls nine neighbours in its own file and exactly one function in another module. A narrow
walk must say in words that its absence proves nothing; it must separate module-crossing
loss from same-file breadth; naming a target must put the crossing hop in the chain at the
same cap that loses it unnamed, with the unnamed walk asserted beside it; and a walk no cap
cut must carry none of it, keys absent rather than zero. The self-test is the CI gate, as it
is for every sibling: each grader is handed the payload it must refuse. Falsified by making
one grader accept a missing disclosure, which turns it red. Its assertion total is counted
rather than written out, because the number I first wrote down said 24 and the truth was 17.

## Falsification

Eleven mutations, each turning red the check written for it, with the assertion named rather
than only the suite going red. Removing the reservation, letting an unlocated leaf take the
reserved slot, taking two slots, firing when the cap already crossed, taking a slot a
two-wide cap cannot spare, dropping the question from the ordering on each walker
separately, marking no clip as on the spine on each walker, leaving module-crossing losses
uncounted, renaming the unresolved-target reason, and emitting the cap disclosure on every
walk (which reddens the control, 29 checks including
`an_unclipped_walk_still_certifies_and_says_nothing_about_spines`).

Two survived and are named rather than hidden. `<=` to `<` on the fits-inside-the-cap early
return is an equivalent mutation: at `len == limit` the fall-through computes the same set.
And the first already-crosses fixture had no second crossing below the cap for the mutant to
promote, so I added one and it now fails.

The falsification harness itself carried the trap it exists to catch. Its first pass used
`cargo test` filters containing `\|`, which libtest reads as a literal substring, so six of
eight mutations matched no tests and reported a clean run. The harness now counts
`^test ... ...` lines and prints NO TESTS RAN instead of a tally.

## Timing

The walker on a synthetic fifteen-wide fan-out four levels deep, ~54k entities, depth 5,
`limit_per_step` 4, median of nine in-process runs. This measures the walker, not the MCP
call, which is dominated by authority open.

Under the `quiet` lock, same fixture and same timer on both arms, with the before tree
proven to be the before tree (`reaches_target` occurrences = 0): before 444.423 ms, after
445.537 ms, after on a second run 454.349 ms. The after-to-after spread is 8.8 ms against
1.1 ms between the arms, so the floor costs nothing this instrument can see. Expected: the
reservation changes which candidate fills a slot, never how many slots there are.

Naming a target, paired in one process so both arms see identical load: untargeted
471.375 ms, targeted 466.588 ms. Not a claim that targeting is faster, a claim that its cost
is below what this fixture resolves. On a store where the target is a high-fan-in hub the
reverse walk is real work, which is why it is metered and why an unfinished one is disclosed.

## Ran

`cargo test -p kin-cli -p kin-mcp -p kin-ranking -p kin-daemon` on this exact head (exit 0,
72 suites ok, 0 failing tests, 0 panics), `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` with
the repo's own debt allow-list exactly as `ci.yml` assembles it, and `bin/kin-precheck kin
--repo-dir kin=<lane worktree>`, which reported 16 gates ran, 16 passed, 0 failed. Read that
tally, not the exit code: `kin-precheck` exits 0 either way, and its first run against this
branch said 15 passed, 1 failed.

