### PR TITLE
Take kin-db 0.7.67 for the conversion persist cut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.65"
+version = "0.7.67"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "82aeb8e23d98d55e8d98fe4c3aac9fb76c0776385bdab7df927a1465dade9941"
+checksum = "1b11a925682d8fe6114ae50bb96a1b55eb19babe7520f2efb77402f39cc344ca"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.65", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.67", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.14", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
kin pinned `=0.7.65`. kin-db 0.7.67 is published and carries FIR-2683's cut to
the snapshot persist.

**The persist-side effect is fir2651's measurement, not mine:** that lane
measured `kindb.commit.persist_successor` at 1260.8 MiB grown and called it the
largest single remaining term in a conversion. My own FIR-2782 attribution
prices the plan path and never runs a commit, so it says nothing about persist
either way, and I am not the evidence for this pin.

The case for taking it is conversion-side. The stranger container that OOM-killed
a one-file commit under FIR-2782 had converted first, with `memory.peak` sitting
exactly at its 12 GiB cap and 1861 reclaim events during setup alone, before the
commit that died. That is where this headroom is spent.

What 0.7.67 does **not** fix, so nobody reads more into this than it carries: the
planner's two whole-store clone sites are untouched. On kin-db main the `Carried`
site is still at `repository.rs:5068` with the clones at `:5380` and `:5384`,
substantively identical to 0.7.65's `:5014`, `:5326` and `:5330`, and the only
commit touching that file between the two versions is #240, a gitlink change.
Those clones are FIR-2808.

## The pin move, and the two traps it walked into

**An exact requirement refuses `--precise`.** The catalogue's sequence, run
`cargo update -p kin-db --precise <ver>` while the manifest still carries the old
requirement, is for a loose requirement. Against `=0.7.65` cargo refuses with
"candidate versions found which didn't match: 0.7.67" and leaves the lock
untouched, which I verified rather than assumed. So the manifest moved first, and
the exactness is also what removes the hazard that sequence exists to avoid,
since a one-member range has no maximum to land on by accident.

**A stray hunk rode along and was removed.** The re-resolve opportunistically
moved `winapi-util 0.1.11`'s edge from `windows-sys 0.48.0` to `0.61.2`, a
Windows-only change this host cannot build, inside what should be a two-line pin.
It was reverted, and `cargo metadata --locked` then accepts the lock, which
proves the bump did not require it.

## The lock diff, as its own artifact

```
 [[package]]
 name = "kin-db"
-version = "0.7.65"
+version = "0.7.67"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "82aeb8e23d98d55e8d98fe4c3aac9fb76c0776385bdab7df927a1465dade9941"
+checksum = "1b11a925682d8fe6114ae50bb96a1b55eb19babe7520f2efb77402f39cc344ca"
```

`git diff --numstat -- Cargo.lock` is `2 2`. Two versions, two checksums, nothing
else. The entry keeps its `sparse+` source and a checksum.

**Both tracked lockfiles swept.** This workspace carries two, `Cargo.lock` and
`fuzz/Cargo.lock`, and a root re-lock alone would ship fuzz targets on the old
version. Both read zero occurrences of `0.7.65`, with the new version present in
the root lock as the positive control. `fuzz/Cargo.lock` carries no kin-db entry
at all, so it needed nothing.

Every workspace crate takes `kin-db = { workspace = true }`, so the requirement
has exactly one manifest home, `Cargo.toml:158`, which the sweep confirms.

## Gates

Gated with `--locked` on purpose: the DEV-LOCAL gate replaces the crate under
test with a local path and therefore cannot validate a registry pin at all.

Part of FIR-2782. Part of FIR-2651.
