### PR TITLE
Say what a killed conversion's stranded stages cost, instead of reaping them in silence

### DIFF
--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -262,7 +262,13 @@ fn init_from_git_with_hooks(
     // at their own phase eight, so the disk comes back before the minutes are
     // spent instead of after.
     let capture_dir = crate::init_staging::GitCaptureStaging::claim(source_parent)?;
-    let _ = crate::init::recover_orphaned_repository_stages(source_parent, &final_kin_dir);
+    // The count this used to drop. `report_reclaimed` beneath reads the capture
+    // list, which only ever holds `.kin-git-capture-*` directories with an
+    // abandonable lease, so a repository stage with no readable capture record
+    // was reaped here and named nowhere.
+    let reclaimed = crate::init::recover_orphaned_repository_stages(source_parent, &final_kin_dir)
+        .unwrap_or_default();
+    crate::init_attempt::report_reclaimed_stages(reclaimed.recovered, reclaimed.retained);
     crate::init_attempt::report_reclaimed(&leftovers);
 
     // The ladder now stamps every phase it opens into the capture directory, so

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -3383,8 +3383,8 @@ mod tests {
 
             assert_eq!(
                 recover_orphaned_repository_stages(&parent, &final_kin)
-                .unwrap()
-                .recovered,
+                    .unwrap()
+                    .recovered,
                 1,
                 "an abandoned {label} stage must be reclaimed, not walked past"
             );
@@ -3397,6 +3397,73 @@ mod tests {
                 "the {label} owner record must be gone after recovery"
             );
         }
+    }
+
+    /// The two tallies, joined to the sentence an operator actually reads.
+    ///
+    /// Both numbers were already computed and neither left this function: the
+    /// return value was dropped at both call sites and the retained count went
+    /// to an `info!`. So a stage came off somebody's disk and appeared in no
+    /// sentence anywhere, which is the silence FIR-2639 removed from the
+    /// capture side and left standing here.
+    ///
+    /// The counts are read out of the pass and handed straight to the renderer
+    /// rather than being written twice. A test that asserted `recovered == 1`
+    /// here and `"reclaimed 1"` in the wording test would leave both green on
+    /// the day the two stopped meaning the same thing.
+    ///
+    /// Unix-only for the reason its neighbours are: off Unix the pass returns
+    /// zero unconditionally, so a nonzero count there would measure the
+    /// platform.
+    #[cfg(unix)]
+    #[test]
+    fn a_reclaimed_stage_reaches_the_operator_and_a_clean_parent_stays_silent() {
+        let directory = tempfile::tempdir().unwrap();
+        let parent = directory.path().canonicalize().unwrap();
+        let final_kin = parent.join(".kin");
+
+        // The control first, and on the same parent, so the silence is a fact
+        // about having nothing to report rather than about a different
+        // directory. A line printed here would print under every conversion.
+        let quiet = recover_orphaned_repository_stages(&parent, &final_kin).unwrap();
+        assert_eq!(quiet, ReclaimedStages::default(), "nothing is stranded yet");
+        assert!(
+            crate::init_attempt::reclaimed_stage_lines(quiet.recovered, quiet.retained).is_empty(),
+            "an ordinary conversion reclaims nothing and must say nothing"
+        );
+
+        // Now strand one the way a kill does: nothing runs on the way out, and
+        // what is on disk is all the next pass has to go on.
+        let mut prepared = prepare_repository_layout_with_origin(
+            &parent.join(format!(".kin.init-{}", uuid::Uuid::new_v4())),
+            &final_kin,
+            KinConfig::default(),
+            KinManifest::new(),
+            RepositoryIdentityOrigin::Minted,
+        )
+        .unwrap();
+        let stage_root = prepared.layout.root().to_path_buf();
+        prepared.cleanup_armed = false;
+        drop(prepared);
+        assert!(stage_root.is_dir(), "the stage must exist to be reclaimed");
+
+        let reclaimed = recover_orphaned_repository_stages(&parent, &final_kin).unwrap();
+        assert!(
+            reclaimed.recovered > 0,
+            "the pass took a stage back: {reclaimed:?}"
+        );
+        assert!(!stage_root.exists(), "and its disk is gone");
+
+        let lines =
+            crate::init_attempt::reclaimed_stage_lines(reclaimed.recovered, reclaimed.retained);
+        assert!(
+            !lines.is_empty(),
+            "a stage that came off this disk has to appear in a sentence: {reclaimed:?}"
+        );
+        assert!(
+            lines[0].contains(&format!("reclaimed {}", reclaimed.recovered)),
+            "the sentence carries the count the pass actually returned, not a literal: {lines:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -775,7 +775,11 @@ pub fn prepare_repository_layout_with_origin(
     let staging_parent = staging_root
         .parent()
         .expect("canonical repository stage always has a parent");
-    recover_orphaned_repository_stages(staging_parent, &final_kin_dir)?;
+    // Reported rather than dropped. This is the native path, where a killed
+    // conversion's stranded stages were reclaimed with nothing said at all,
+    // while the Git path at least named the capture directories beside them.
+    let reclaimed = recover_orphaned_repository_stages(staging_parent, &final_kin_dir)?;
+    crate::init_attempt::report_reclaimed_stages(reclaimed.recovered, reclaimed.retained);
 
     create_private_staging_root(&staging_root)?;
     let layout = KinLayout::new(staging_root);
@@ -2328,14 +2332,30 @@ fn filesystem_entry_exists(path: &Path) -> Result<bool> {
 /// Invalid, ambiguous, replaced, or active candidates are retained. Automatic
 /// orphan recovery is disabled when the platform cannot expose a stable file
 /// identity and current-user ownership.
+/// What one reclaim pass over abandoned repository stages did.
+///
+/// Two numbers rather than one, because an operator's question after a killed
+/// conversion is not only what came back but what is still sitting on their
+/// disk. Both tallies existed already and neither left this function: the
+/// return value was dropped at both call sites and the retained count reached
+/// an `info!` and nothing a person running `kin init` would ever see. FIR-2792.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ReclaimedStages {
+    /// Stages whose owner was proven gone, whose disk this pass took back.
+    pub recovered: usize,
+    /// Stages this pass declined to touch, because it could not prove them
+    /// unused.
+    pub retained: usize,
+}
+
 pub(crate) fn recover_orphaned_repository_stages(
     staging_parent: &Path,
     final_kin_dir: &Path,
-) -> Result<usize> {
+) -> Result<ReclaimedStages> {
     #[cfg(not(unix))]
     {
         let _ = (staging_parent, final_kin_dir);
-        return Ok(0);
+        return Ok(ReclaimedStages::default());
     }
 
     #[cfg(unix)]
@@ -2529,7 +2549,10 @@ pub(crate) fn recover_orphaned_repository_stages(
                 staging_parent.display()
             );
         }
-        Ok(recovered)
+        Ok(ReclaimedStages {
+            recovered,
+            retained,
+        })
     }
 }
 
@@ -2882,7 +2905,9 @@ mod tests {
         drop(prepared);
 
         assert_eq!(
-            recover_orphaned_repository_stages(&parent, &final_kin).unwrap(),
+            recover_orphaned_repository_stages(&parent, &final_kin)
+                .unwrap()
+                .recovered,
             0,
             "recovery must reap nothing where it cannot prove ownership"
         );
@@ -3256,7 +3281,9 @@ mod tests {
         let staging_parent = staging_root.parent().unwrap();
 
         assert_eq!(
-            recover_orphaned_repository_stages(staging_parent, &final_kin).unwrap(),
+            recover_orphaned_repository_stages(staging_parent, &final_kin)
+                .unwrap()
+                .recovered,
             0
         );
         assert!(staging_root.is_dir());
@@ -3290,7 +3317,9 @@ mod tests {
         assert!(staging_root.is_dir());
         assert!(owner_path.is_file());
         assert_eq!(
-            recover_orphaned_repository_stages(&staging_parent, &final_kin).unwrap(),
+            recover_orphaned_repository_stages(&staging_parent, &final_kin)
+                .unwrap()
+                .recovered,
             1
         );
         assert!(!staging_root.exists());
@@ -3353,7 +3382,9 @@ mod tests {
             assert!(stage_root.is_dir(), "{label} stage must exist to be reaped");
 
             assert_eq!(
-                recover_orphaned_repository_stages(&parent, &final_kin).unwrap(),
+                recover_orphaned_repository_stages(&parent, &final_kin)
+                .unwrap()
+                .recovered,
                 1,
                 "an abandoned {label} stage must be reclaimed, not walked past"
             );
@@ -3377,7 +3408,9 @@ mod tests {
         let unproved = parent.join(format!(".kin.init-{}", uuid::Uuid::new_v4()));
         create_private_staging_root(&unproved).unwrap();
         assert_eq!(
-            recover_orphaned_repository_stages(&parent, &final_kin).unwrap(),
+            recover_orphaned_repository_stages(&parent, &final_kin)
+                .unwrap()
+                .recovered,
             0
         );
         assert!(unproved.is_dir());
@@ -3392,7 +3425,9 @@ mod tests {
         create_private_staging_root(&replaced).unwrap();
 
         assert_eq!(
-            recover_orphaned_repository_stages(&parent, &final_kin).unwrap(),
+            recover_orphaned_repository_stages(&parent, &final_kin)
+                .unwrap()
+                .recovered,
             0
         );
         assert!(replaced.is_dir());
@@ -3418,7 +3453,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            recover_orphaned_repository_stages(&parent, &final_kin).unwrap(),
+            recover_orphaned_repository_stages(&parent, &final_kin)
+                .unwrap()
+                .recovered,
             0
         );
         assert!(non_private_stage.is_dir());
@@ -3430,7 +3467,9 @@ mod tests {
         std::fs::hard_link(&non_private_owner, &hard_link).unwrap();
 
         assert_eq!(
-            recover_orphaned_repository_stages(&parent, &final_kin).unwrap(),
+            recover_orphaned_repository_stages(&parent, &final_kin)
+                .unwrap()
+                .recovered,
             0
         );
         assert!(non_private_stage.is_dir());
@@ -3462,12 +3501,16 @@ mod tests {
         drop(prepared);
 
         assert_eq!(
-            recover_orphaned_repository_stages(&parent, &other_final_kin).unwrap(),
+            recover_orphaned_repository_stages(&parent, &other_final_kin)
+                .unwrap()
+                .recovered,
             0
         );
         assert!(staging_root.is_dir());
         assert_eq!(
-            recover_orphaned_repository_stages(&parent, &final_kin).unwrap(),
+            recover_orphaned_repository_stages(&parent, &final_kin)
+                .unwrap()
+                .recovered,
             1
         );
         assert!(!staging_root.exists());

--- a/crates/kin-core/src/init_attempt.rs
+++ b/crates/kin-core/src/init_attempt.rs
@@ -785,7 +785,9 @@ pub fn reclaimed_stage_lines(recovered: usize, retained: usize) -> Vec<String> {
             ("directories", "are", "them")
         };
         lines.push(format!(
-            "  {retained} more repository staging {noun} {verb} still on disk and this run left              {pronoun} alone, because it could not prove {pronoun} unused; delete {pronoun} by              hand once no `kin init` is running here"
+            "  {retained} more repository staging {noun} {verb} still on disk and this run left \
+             {pronoun} alone, because it could not prove {pronoun} unused; delete {pronoun} by \
+             hand once no `kin init` is running here"
         ));
     }
     lines
@@ -858,6 +860,88 @@ fn human_seconds(seconds: u64) -> String {
 mod tests {
     use super::*;
     use crate::memory_pressure::PressureSource;
+
+    /// A pass that touched nothing says nothing.
+    ///
+    /// The load-bearing half. Every ordinary `kin init` reclaims no stage, so a
+    /// line here would print under every conversion anyone ever runs and be
+    /// skipped by the third one. It has to be readable on the first conversion
+    /// after a kill, which means it cannot appear on the others.
+    ///
+    /// Falsify by dropping either `> 0` guard: this goes red and the two arms
+    /// below stay green, which is exactly how a warning becomes wallpaper.
+    #[test]
+    fn a_reclaim_pass_that_touched_nothing_prints_nothing() {
+        assert!(
+            reclaimed_stage_lines(0, 0).is_empty(),
+            "an ordinary conversion reclaims nothing and must say nothing"
+        );
+    }
+
+    /// What was taken back, and what is still costing the operator disk.
+    ///
+    /// Two separate lines because they call for opposite actions: one is news
+    /// about disk that came back on its own, the other is a directory the
+    /// operator has to decide about. Folding them into one total would report
+    /// the second as though this run had handled it.
+    #[test]
+    fn a_reclaim_says_what_it_took_back_and_names_what_it_left_with_the_reason() {
+        let took = reclaimed_stage_lines(1, 0);
+        assert_eq!(took.len(), 1, "{took:?}");
+        assert!(
+            took[0].contains("reclaimed 1 repository staging directory"),
+            "the count and what it counts are both the point: {}",
+            took[0]
+        );
+
+        let left = reclaimed_stage_lines(0, 2);
+        assert_eq!(left.len(), 1, "{left:?}");
+        assert!(
+            left[0].contains("2 more repository staging directories are still on disk"),
+            "a directory this run declined to touch is still costing disk: {}",
+            left[0]
+        );
+        assert!(
+            left[0].contains("could not prove them unused"),
+            "and the reason it was left is what makes deleting it safe: {}",
+            left[0]
+        );
+        assert!(
+            left[0].contains("delete them by hand"),
+            "every non-quiet line here carries what to do about it: {}",
+            left[0]
+        );
+
+        // Printed, not read. A Rust line continuation drops the newline and the
+        // indentation after it, and a literal assembled by anything that ate
+        // the backslash first keeps the indentation as a run of spaces inside
+        // the sentence. The source looks right either way, so the only reading
+        // that settles it is the rendered line. This caught exactly that on the
+        // line above.
+        for line in [&took[0], &left[0]] {
+            let body = line.trim_start();
+            assert!(
+                !body.contains("  "),
+                "a rendered line carries a run of spaces, so its continuation was assembled \
+                 wrong: {line:?}"
+            );
+        }
+
+        let both = reclaimed_stage_lines(3, 1);
+        assert_eq!(
+            both.len(),
+            2,
+            "what came back and what stayed are never one line: {both:?}"
+        );
+        assert!(
+            both[0].contains("reclaimed 3 repository staging directories"),
+            "{both:?}"
+        );
+        assert!(
+            both[1].contains("1 more repository staging directory is still on disk"),
+            "{both:?}"
+        );
+    }
 
     fn record() -> InitAttemptRecord {
         InitAttemptRecord {

--- a/crates/kin-core/src/init_attempt.rs
+++ b/crates/kin-core/src/init_attempt.rs
@@ -739,6 +739,58 @@ pub fn reclaim_lines(before: &[AbandonedInit]) -> Vec<String> {
     lines
 }
 
+/// Say what a reclaim pass over abandoned repository stages did.
+///
+/// The sibling of [`report_reclaimed`], for the half of the reap that list
+/// cannot see. `reclaim_lines` measures the `.kin-git-capture-*` directories
+/// this run scanned, and a killed conversion also strands a repository STAGE,
+/// reclaimed by owner record rather than by capture lease. Those were reaped on
+/// both paths with the count thrown away, so a stage whose capture record was
+/// unreadable came off an operator's disk and appeared in no sentence anywhere.
+pub fn report_reclaimed_stages(recovered: usize, retained: usize) {
+    for line in reclaimed_stage_lines(recovered, retained) {
+        disclose(&line);
+    }
+}
+
+/// What that pass leaves an operator to read, as lines.
+///
+/// Split from the writing so the wording is pinned by a test rather than by
+/// running a conversion and killing it, exactly as [`reclaim_lines`] is.
+///
+/// Silent when the pass touched nothing, which is every ordinary `kin init`.
+/// That silence is load-bearing: a line printed under every conversion is a line
+/// nobody reads by the third one, and this one has to be read on the first
+/// conversion after a kill.
+pub fn reclaimed_stage_lines(recovered: usize, retained: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    if recovered > 0 {
+        lines.push(format!(
+            "  reclaimed {recovered} repository staging {} an earlier `kin init` left behind here",
+            if recovered == 1 {
+                "directory"
+            } else {
+                "directories"
+            }
+        ));
+    }
+    if retained > 0 {
+        // Named rather than folded into the line above, and never counted as
+        // reclaimed. A directory this run declined to touch is still costing
+        // the operator disk, and the reason it was left is the reason they can
+        // act on it safely.
+        let (noun, verb, pronoun) = if retained == 1 {
+            ("directory", "is", "it")
+        } else {
+            ("directories", "are", "them")
+        };
+        lines.push(format!(
+            "  {retained} more repository staging {noun} {verb} still on disk and this run left              {pronoun} alone, because it could not prove {pronoun} unused; delete {pronoun} by              hand once no `kin init` is running here"
+        ));
+    }
+    lines
+}
+
 /// The `kin doctor` row's detail and fix lines for whatever staging is sitting
 /// beside `parent`, or `None` when there is none.
 ///


### PR DESCRIPTION
A killed `kin init` left staging on somebody's disk, the next run took it back, and nothing
anywhere said so.

`recover_orphaned_repository_stages` counted two things and told nobody either of them. Its
return value was dropped at both call sites, with a `let _ =` on the Git path and discarded
through `?` on the native one, and the tally of what it declined to touch reached an `info!`
that no person running `kin init` ever reads. So a repository stage whose capture record was
unreadable came off a disk and appeared in no sentence. That is the silence FIR-2639 removed
from the capture side and left standing on this one. The native path was the worse half: it
reclaimed with no scan and no report at all, while the Git path at least named the capture
directories beside what it reaped.

Both tallies now come back from one pass and both are said. They get two lines rather than one
total, because they call for opposite actions: what came back is news, and what was left is a
directory still costing disk that the operator has to decide about, so it carries the reason it
was left, which is what makes deleting it safe. A pass that touched nothing still says nothing,
and that silence is load-bearing. Every ordinary conversion reclaims no stage, so a line here
would print under all of them and be skipped by the third.

Six mutations, six reds, each on the assertion written for it. Dropping either line, printing
either unconditionally, folding the retained count into the reclaimed one, and returning
`default()` from the pass instead of its counts all go red, and the two wording mutations fire
on different assertion lines rather than on each other's.

One of those checks came out of a defect in this change. A string rendered as `this run left
              them alone`: a Rust line continuation drops the newline and the indentation after
it, so the source read correctly while the sentence a terminal would print carried a run of
spaces. Reading the source could not see it and rendering the line could. Every rendered line
is now asserted to carry no such run, falsified by re-mangling the literal.

The remainder is stated rather than glossed. This does not land the scripted check that drives
the native path with a stranded stage, because a native `kin init` on an empty tree runs in
about 700 ms and a mid-run kill is not reproducible the way one is against a seventeen-phase
Git conversion, and planting a stage by hand needs an owner record whose stage identity is a
filesystem identity rather than a value a fixture can write. A check built on a kill that only
sometimes strands a repository stage would be an absence measuring completion rather than
behaviour. What is landed instead is deterministic: the kin-core fixtures strand a stage on
demand, and the test reads the counts out of the pass and hands them to the renderer rather
than writing the number on both sides.

Refs FIR-2792
