### PR TITLE
Follow the one re-export hop a receiver's own import names

### DIFF
--- a/crates/kin-core/env_var_allowlist.txt
+++ b/crates/kin-core/env_var_allowlist.txt
@@ -68,3 +68,10 @@ KIN_UPDATE_TEST_WORKER_HOME
 KIN_UPDATE_TEST_WORKER_RECOVER
 KIN_UPDATE_TEST_WORKER_SPEC
 KIN_UPDATE_TEST_WORKER_STAGE
+# Name the repository the receiver-hop corpus arm parses, and the symbol it
+# reports incoming callers for. That arm is #[ignore]d and reports rather than
+# asserting a ceiling, so nothing runs without a path here, and it drives a test
+# harness rather than the product: no runtime behaviour keys on either, and
+# nothing an operator sets.
+KIN_RECEIVER_HOP_CORPUS
+KIN_RECEIVER_HOP_FOCAL

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -929,7 +929,10 @@ fn resolve_one_file(
                         target_file.as_str(),
                         receiver_root,
                         rel.dst_name.as_str(),
-                        &ctx.entity_by_file_name,
+                        ctx.import_map.get(file.file_path.as_str()),
+                        &ctx.import_map,
+                        &ctx.known_files,
+                        |target, name| ctx.entity_by_file_name.get(&(target, name)).copied(),
                     ) {
                         accumulate_relation(
                             &mut resolved,
@@ -3905,23 +3908,152 @@ fn settle_receiver_method_owner<'a>(
 /// the parser-pinned and namespace-member tiers.
 const RECEIVER_MODULE_CONFIDENCE: f32 = 0.9;
 
+/// The local name a whole-module re-export binds its source module under.
+///
+/// `extract_assignment_lhs_name` keeps the `module.exports` receiver whole
+/// rather than reducing it to the `exports` property, so a file that does
+/// nothing but hand its exports on names the real module under this key in its
+/// own import map.
+const WHOLE_MODULE_REEXPORT_LOCAL_NAME: &str = "module.exports";
+
+/// The sibling module a package-root receiver's own import specifier names.
+///
+/// `from pkg import mod` records `pkg` as the module path and `mod` as a
+/// specifier and never joins the two, so the receiver resolves to
+/// `pkg/__init__.py` while the callee is defined in the sibling `pkg/mod.py`.
+/// The specifier is already in the calling file's import map, one element over
+/// from the module path the receiver was classified through.
+///
+/// Only a receiver that landed on a package index is eligible, and only the one
+/// sibling the import statement actually names is offered. A module file wins
+/// over a subpackage of the same name, matching [`python_module_file`]'s order.
+fn receiver_package_sibling<S>(
+    target_file: &str,
+    receiver_root: &str,
+    caller_imports: Option<&HashMap<&str, (&str, &str)>>,
+    known_files: &HashSet<S>,
+) -> Option<String>
+where
+    S: std::borrow::Borrow<str> + std::hash::Hash + Eq,
+{
+    let base_name = target_file
+        .rsplit_once('/')
+        .map(|(_, name)| name)
+        .unwrap_or(target_file);
+    if !PACKAGE_INDEX_FILENAMES.contains(&base_name) {
+        return None;
+    }
+    let specifier = caller_imports?.get(receiver_root)?.1.trim();
+    if specifier.is_empty() || !is_path_identifier(specifier) {
+        return None;
+    }
+    let dir = parent_dir(target_file);
+    let prefix = if dir.is_empty() {
+        specifier.to_string()
+    } else {
+        format!("{dir}/{specifier}")
+    };
+    for ext in MODULE_EXTENSIONS {
+        let candidate = format!("{prefix}.{ext}");
+        if known_files.contains(candidate.as_str()) {
+            return Some(candidate);
+        }
+    }
+    for index in PACKAGE_INDEX_FILENAMES {
+        let candidate = format!("{prefix}/{index}");
+        if known_files.contains(candidate.as_str()) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// The module a file re-exports wholesale.
+///
+/// `module.exports = require('./lib/express')` makes the package entry point the
+/// receiver's file while every export lives one hop away, which is why
+/// `express.static(...)` reached nothing even once `lib/express.js` carried the
+/// entity. The re-export is already recorded as an import of this file, so the
+/// destination is read rather than guessed. A re-export that resolves back to
+/// its own file is refused: a self-loop is not a hop.
+fn whole_module_reexport_target<S>(
+    target_file: &str,
+    import_map: &HashMap<&str, HashMap<&str, (&str, &str)>>,
+    known_files: &HashSet<S>,
+) -> Option<String>
+where
+    S: std::borrow::Borrow<str> + std::hash::Hash + Eq,
+{
+    let (module_path, _) = import_map
+        .get(target_file)?
+        .get(WHOLE_MODULE_REEXPORT_LOCAL_NAME)?;
+    let resolved = resolve_module_path(target_file, module_path, known_files)?;
+    (resolved != target_file).then_some(resolved)
+}
+
+/// The single file a receiver's module hands its callee off to, when the
+/// receiver's own file does not define it.
+///
+/// Tier (a0) binds a receiver to the file its import names, and that file is
+/// frequently one hop short of where the callee lives. Two shapes produce that
+/// gap and each names its own destination in source, so neither needs a guess:
+/// a Python package index standing in for a submodule, and a JavaScript entry
+/// point that re-exports another module wholesale.
+///
+/// Exactly one candidate is returned, chosen by a statement the source actually
+/// wrote. Handing the call to the name-matching tiers instead would bind the
+/// bare leaf to any same-named symbol in the repository, which is the false
+/// consumer the caller's `continue` exists to prevent.
+fn resolve_receiver_module_hop<S>(
+    target_file: &str,
+    receiver_root: &str,
+    caller_imports: Option<&HashMap<&str, (&str, &str)>>,
+    import_map: &HashMap<&str, HashMap<&str, (&str, &str)>>,
+    known_files: &HashSet<S>,
+) -> Option<String>
+where
+    S: std::borrow::Borrow<str> + std::hash::Hash + Eq,
+{
+    receiver_package_sibling(target_file, receiver_root, caller_imports, known_files)
+        .or_else(|| whole_module_reexport_target(target_file, import_map, known_files))
+}
+
 /// Resolve an attribute call whose receiver names a repo-local module. The
 /// callee is looked up as a plain member of that module first, then as a member
 /// of a type the receiver's own root names (`Session.get` for `Session.get(...)`
-/// where `Session` was imported).
-fn resolve_receiver_module_target(
+/// where `Session` was imported). When neither name is in that file, one
+/// re-export hop the source itself names is followed and both lookups are tried
+/// again there.
+///
+/// `lookup` is the caller's own entity index, passed as a closure because the
+/// batch and incremental linkers key theirs differently and this tier has to
+/// answer identically in both: a cold, incremental and reopened graph resolving
+/// one call to different destinations is drift, not a difference.
+fn resolve_receiver_module_target<S>(
     target_file: &str,
     receiver_root: &str,
     method: &str,
-    entity_by_file_name: &HashMap<(&str, &str), EntityId>,
-) -> Option<EntityId> {
-    if let Some(&dst_id) = entity_by_file_name.get(&(target_file, method)) {
+    caller_imports: Option<&HashMap<&str, (&str, &str)>>,
+    import_map: &HashMap<&str, HashMap<&str, (&str, &str)>>,
+    known_files: &HashSet<S>,
+    lookup: impl Fn(&str, &str) -> Option<EntityId>,
+) -> Option<EntityId>
+where
+    S: std::borrow::Borrow<str> + std::hash::Hash + Eq,
+{
+    let qualified = format!("{receiver_root}.{method}");
+    let in_file = |file: &str| lookup(file, method).or_else(|| lookup(file, qualified.as_str()));
+    if let Some(dst_id) = in_file(target_file) {
         return Some(dst_id);
     }
-    let qualified = format!("{receiver_root}.{method}");
-    entity_by_file_name
-        .get(&(target_file, qualified.as_str()))
-        .copied()
+    let hop = resolve_receiver_module_hop(
+        target_file,
+        receiver_root,
+        caller_imports,
+        import_map,
+        known_files,
+    )?;
+    in_file(&hop)
 }
 
 /// Outcome of resolving a relation through its parser-recorded import source.
@@ -6364,16 +6496,24 @@ fn resolve_one_file_incremental(
             let receiver_root = receiver.split('.').next().unwrap_or(receiver);
             match scope {
                 ReceiverScope::Module(target_file) => {
-                    let in_module = linker.entity_by_file_name.get(target_file.as_str());
-                    let dst_id = in_module
-                        .and_then(|names| names.get(rel.dst_name.as_str()))
-                        .copied()
-                        .or_else(|| {
-                            let qualified = format!("{receiver_root}.{}", rel.dst_name);
-                            in_module
-                                .and_then(|names| names.get(qualified.as_str()))
+                    // Shares the batch linker's resolver rather than repeating
+                    // its lookup order, so the re-export hop cannot land on one
+                    // path and be missing from the other.
+                    let dst_id = resolve_receiver_module_target(
+                        target_file.as_str(),
+                        receiver_root,
+                        rel.dst_name.as_str(),
+                        import_map.get(file.file_path.as_str()),
+                        import_map,
+                        &linker.known_files,
+                        |target, name| {
+                            linker
+                                .entity_by_file_name
+                                .get(target)
+                                .and_then(|names| names.get(name))
                                 .copied()
-                        });
+                        },
+                    );
                     if let Some(dst_id) = dst_id {
                         accumulate_relation(
                             &mut resolved,

--- a/crates/kin-index/tests/receiver_module_hop.rs
+++ b/crates/kin-index/tests/receiver_module_hop.rs
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! A call whose receiver is bound to a module one hop short of the callee.
+//!
+//! Tier (a0) binds an attribute call's receiver to the file its import names,
+//! and two shapes put that file one hop away from where the callee is defined:
+//!
+//! - `from pkg import mod` records `pkg` as the module path and `mod` as a
+//!   separate specifier, so the receiver lands on `pkg/__init__.py` while the
+//!   callee lives in the sibling `pkg/mod.py`.
+//! - `module.exports = require('./lib/express')` makes the package entry point
+//!   the receiver's file while every export lives one module away.
+//!
+//! Before the hop existed, tier (a0) missed and `continue`d past every lower
+//! tier, so the call produced no edge and no placeholder at all: on the shipped
+//! 0.6.0 bytes `kin refs note_body` answered "no incoming relations" and the
+//! envelope certified that absence as authoritative, while the test that calls
+//! it sat one grep away.
+//!
+//! The controls matter as much as the arms. The hop offers exactly one
+//! candidate, named by a statement the source actually wrote; handing the call
+//! to the name-matching tiers instead would bind the bare leaf to any same-named
+//! symbol in the repository, which is a false consumer nothing downstream can
+//! catch. `a_submodule_that_does_not_define_the_callee_reaches_nothing` is that
+//! property, and it is the arm that fails if anyone reaches for a fallthrough.
+
+use std::collections::HashMap;
+
+use kin_index::{
+    link_cross_file as link_cross_file_with_identities, link_cross_file_incremental,
+    FileParseData, IncrementalLinker,
+};
+use kin_model::{ArtifactId, Entity, EntityId, FilePathId, GraphNodeId, Relation, RelationKind};
+use kin_parser::{JavaScriptAdapter, LanguageAdapter, PythonAdapter};
+
+fn parse_with(adapter: &dyn LanguageAdapter, file_path: &str, source: &str) -> FileParseData {
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn py(file_path: &str, source: &str) -> FileParseData {
+    parse_with(&PythonAdapter, file_path, source)
+}
+
+fn js(file_path: &str, source: &str) -> FileParseData {
+    parse_with(&JavaScriptAdapter, file_path, source)
+}
+
+fn entity_id(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+        .unwrap_or_else(|| panic!("entity `{name}` in `{file}` not found"))
+        .id
+}
+
+fn link(files: &[FileParseData]) -> Vec<Relation> {
+    let artifact_ids: HashMap<String, ArtifactId> = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    link_cross_file_with_identities(files, &artifact_ids)
+        .expect("every fixture file has an explicitly assigned artifact identity")
+}
+
+fn link_incremental(files: &[FileParseData]) -> Vec<Relation> {
+    let mut linker = IncrementalLinker::new();
+    for file in files {
+        linker.add_file(&file.file_path, ArtifactId::new(), &file.entities);
+    }
+    linker.record_class_bases(files);
+    link_cross_file_incremental(files, &linker)
+        .expect("every fixture file has an explicitly assigned artifact identity")
+}
+
+fn has_call(relations: &[Relation], src: EntityId, dst: EntityId) -> bool {
+    relations.iter().any(|r| {
+        r.kind == RelationKind::Calls
+            && r.src == GraphNodeId::Entity(src)
+            && r.dst == GraphNodeId::Entity(dst)
+    })
+}
+
+/// Every `Calls` destination this source reaches, resolved or not.
+///
+/// Read rather than `has_call` wherever an arm has to say that NOTHING was
+/// produced: an unresolved-receiver placeholder is a `Calls` edge to a
+/// synthesized destination, so "no edge to the right target" and "no edge at
+/// all" are different findings and only this separates them.
+fn call_destinations(relations: &[Relation], src: EntityId) -> Vec<GraphNodeId> {
+    relations
+        .iter()
+        .filter(|r| r.kind == RelationKind::Calls && r.src == GraphNodeId::Entity(src))
+        .map(|r| r.dst.clone())
+        .collect()
+}
+
+/// The stranger's own shape, trimmed: `from notekeeper import storage` in a
+/// test, then `storage.note_body(...)`. The package index defines nothing the
+/// call names, exactly as the real `src/notekeeper/__init__.py` defines only a
+/// docstring and `__version__`.
+fn notekeeper_shape() -> Vec<FileParseData> {
+    vec![
+        py(
+            "src/notekeeper/__init__.py",
+            "\"\"\"notekeeper: a local markdown knowledge base.\"\"\"\n\n__version__ = \"0.1.0\"\n",
+        ),
+        py(
+            "src/notekeeper/storage.py",
+            "def note_body(conn, note_id):\n    return \"\"\n",
+        ),
+        py(
+            "tests/test_storage.py",
+            "from notekeeper import storage\n\n\ndef test_bodies_round_trip(db):\n    assert storage.note_body(db, 1)\n",
+        ),
+    ]
+}
+
+#[test]
+fn a_submodule_receiver_resolves_through_the_package_index() {
+    let files = notekeeper_shape();
+    let caller = entity_id(&files, "tests/test_storage.py", "test_bodies_round_trip");
+    let target = entity_id(&files, "src/notekeeper/storage.py", "note_body");
+
+    let relations = link(&files);
+    assert!(
+        has_call(&relations, caller, target),
+        "`from notekeeper import storage` then `storage.note_body(...)` must reach \
+         src/notekeeper/storage.py::note_body; the receiver resolves to the package \
+         __init__, which defines nothing the call names, and before the hop existed \
+         tier (a0) dropped the call whole"
+    );
+}
+
+#[test]
+fn an_incremental_submodule_receiver_resolves_with_batch_parity() {
+    // The incremental linker carries its own copy of tier (a0). A hop that
+    // lands only in the batch path means the live-edit graph and the cold graph
+    // answer one call differently, which is drift no other arm here can see.
+    let files = notekeeper_shape();
+    let caller = entity_id(&files, "tests/test_storage.py", "test_bodies_round_trip");
+    let target = entity_id(&files, "src/notekeeper/storage.py", "note_body");
+
+    let relations = link_incremental(&files);
+    assert!(
+        has_call(&relations, caller, target),
+        "the incremental linker must resolve the submodule receiver exactly as the \
+         batch linker does"
+    );
+}
+
+#[test]
+fn a_relative_submodule_receiver_resolves_through_the_package_index() {
+    // `from . import storage` inside the package, the real shape at
+    // src/notekeeper/cli.py:19. It takes the same path to the same __init__.
+    let files = vec![
+        py("src/notekeeper/__init__.py", "__version__ = \"0.1.0\"\n"),
+        py(
+            "src/notekeeper/storage.py",
+            "def ingest_directory(path):\n    return 0\n",
+        ),
+        py(
+            "src/notekeeper/cli.py",
+            "from . import storage\n\n\ndef main(path):\n    return storage.ingest_directory(path)\n",
+        ),
+    ];
+    let caller = entity_id(&files, "src/notekeeper/cli.py", "main");
+    let target = entity_id(&files, "src/notekeeper/storage.py", "ingest_directory");
+
+    let relations = link(&files);
+    assert!(
+        has_call(&relations, caller, target),
+        "`from . import storage` then `storage.ingest_directory(...)` must reach the \
+         sibling module, not stop at the package __init__"
+    );
+}
+
+#[test]
+fn an_aliased_submodule_receiver_resolves_through_its_original_name() {
+    // `from notekeeper import storage as st` binds the receiver root to `st`
+    // while the module is still `storage`. The import map records the pair, and
+    // only the ORIGINAL half names a file. A hop that joined the receiver root
+    // instead would look for notekeeper/st.py, find nothing, and be silently
+    // right on every unaliased call in the fleet.
+    let files = vec![
+        py("src/notekeeper/__init__.py", "__version__ = \"0.1.0\"\n"),
+        py(
+            "src/notekeeper/storage.py",
+            "def note_body(conn, note_id):\n    return \"\"\n",
+        ),
+        py(
+            "tests/test_alias.py",
+            "from notekeeper import storage as st\n\n\ndef test_alias(db):\n    assert st.note_body(db, 1)\n",
+        ),
+    ];
+    let caller = entity_id(&files, "tests/test_alias.py", "test_alias");
+    let target = entity_id(&files, "src/notekeeper/storage.py", "note_body");
+
+    let relations = link(&files);
+    assert!(
+        has_call(&relations, caller, target),
+        "`from notekeeper import storage as st` then `st.note_body(...)` must reach \
+         storage.py: the hop names the module by the import's original name, not by \
+         the local name the receiver was written with"
+    );
+}
+
+#[test]
+fn a_submodule_that_does_not_define_the_callee_reaches_nothing() {
+    // THE CONTROL THAT SEPARATES THIS FIX FROM A TIER FALLTHROUGH.
+    //
+    // The hop lands on pkg/mod.py, which does not define `note_body`. A same
+    // named function exists in a file this caller never imports. Letting the
+    // call fall through to the name-matching tiers would bind it there and mint
+    // a consumer the source never had, which is the whole reason tier (a0)
+    // `continue`s. Nothing downstream can catch that, so it is caught here.
+    let files = vec![
+        py("pkg/__init__.py", "__version__ = \"1\"\n"),
+        py("pkg/mod.py", "def unrelated_helper():\n    return 1\n"),
+        py("elsewhere.py", "def note_body(conn, note_id):\n    return \"\"\n"),
+        py(
+            "caller.py",
+            "from pkg import mod\n\n\ndef run(db):\n    return mod.note_body(db, 1)\n",
+        ),
+    ];
+    let caller = entity_id(&files, "caller.py", "run");
+    let decoy = entity_id(&files, "elsewhere.py", "note_body");
+
+    let relations = link(&files);
+    assert!(
+        !has_call(&relations, caller, decoy),
+        "`mod.note_body(...)` must not bind to a same-named function in a file this \
+         caller never imports; the receiver names pkg/mod.py and that is the only \
+         file that can answer"
+    );
+}
+
+#[test]
+fn a_receiver_naming_a_class_rather_than_a_submodule_is_unchanged() {
+    // CONTROL THAT MUST STAY GREEN UNDER EVERY MUTATION OF THE HOP.
+    //
+    // `from pkg import Session` names a class the package index defines, and no
+    // pkg/Session.py exists. The hop must not fire, and the pre-existing
+    // resolution through the package index must be untouched.
+    let files = vec![
+        py(
+            "pkg/__init__.py",
+            "class Session:\n    def send(self, request):\n        return request\n",
+        ),
+        py(
+            "caller.py",
+            "from pkg import Session\n\n\ndef run(session):\n    return Session.send(session, 1)\n",
+        ),
+    ];
+    let caller = entity_id(&files, "caller.py", "run");
+    let target = entity_id(&files, "pkg/__init__.py", "Session.send");
+
+    let relations = link(&files);
+    assert!(
+        has_call(&relations, caller, target),
+        "a receiver bound to a class the package index itself defines must keep \
+         resolving there; the hop is additive and must not displace it"
+    );
+}
+
+#[test]
+fn a_whole_module_reexport_receiver_reaches_the_real_export() {
+    // The express shape. `require('..')` resolves to the repo-root index.js,
+    // which is `module.exports = require('./lib/express')` and defines nothing,
+    // so every `express.static(...)` call site reached nothing even once
+    // lib/express.js carried the entity.
+    let files = vec![
+        js("index.js", "module.exports = require('./lib/express');\n"),
+        js(
+            "lib/express.js",
+            "exports.static = require('serve-static');\nexports.json = function json() { return 1; };\n",
+        ),
+        js(
+            "test/app.js",
+            "var express = require('..');\n\nfunction mount(app) {\n  return app.use(express.json());\n}\n",
+        ),
+    ];
+    let caller = entity_id(&files, "test/app.js", "mount");
+    let target = entity_id(&files, "lib/express.js", "json");
+
+    let relations = link(&files);
+    assert!(
+        has_call(&relations, caller, target),
+        "`var express = require('..')` then `express.json()` must reach \
+         lib/express.js::json through the root index's whole-module re-export"
+    );
+}
+
+#[test]
+fn the_hop_resolves_the_call_rather_than_minting_a_placeholder() {
+    // An unresolved-receiver placeholder is itself a `Calls` edge, and the
+    // arrival gate counts them to decide whether a file's calls were accounted
+    // for. Minting one here would move the file from unaccounted to accounted
+    // and re-certify exactly the absences that gate exists to refuse, so this
+    // arm reads the destination set rather than asking whether the right edge
+    // is somewhere in it.
+    let files = notekeeper_shape();
+    let caller = entity_id(&files, "tests/test_storage.py", "test_bodies_round_trip");
+    let target = entity_id(&files, "src/notekeeper/storage.py", "note_body");
+
+    let relations = link(&files);
+    let destinations = call_destinations(&relations, caller);
+    assert_eq!(
+        destinations,
+        vec![GraphNodeId::Entity(target)],
+        "the call must resolve to exactly the real target: no second edge, and no \
+         unresolved-receiver placeholder beside it"
+    );
+}
+
+/// The same class against a real repository rather than a trimmed fixture.
+///
+/// Ignored by default and driven by `KIN_RECEIVER_HOP_CORPUS`, because the
+/// corpora that carry this shape are not in the tree. A fixture written by the
+/// same hand as the fix cannot say what the real adapters emit over real source,
+/// so this runs the real parser over every `.py` file under the named root and
+/// reports how many calls through a package-index receiver the hop recovered.
+///
+///     KIN_RECEIVER_HOP_CORPUS=/path/to/repo cargo test -p kin-index \
+///         --test receiver_module_hop -- --ignored --nocapture
+#[test]
+#[ignore]
+fn a_real_repository_recovers_calls_through_a_package_index_receiver() {
+    let root = std::env::var("KIN_RECEIVER_HOP_CORPUS")
+        .expect("KIN_RECEIVER_HOP_CORPUS must name a repository root");
+    let root = std::path::PathBuf::from(root);
+
+    let mut sources: Vec<std::path::PathBuf> = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if path.is_dir() {
+                if name != ".kin" && name != ".git" && name != "node_modules" && name != "__pycache__"
+                {
+                    stack.push(path);
+                }
+            } else if path.extension().and_then(|e| e.to_str()) == Some("py") {
+                sources.push(path);
+            }
+        }
+    }
+    sources.sort();
+    assert!(
+        !sources.is_empty(),
+        "corpus {} holds no .py files, so this arm measured nothing",
+        root.display()
+    );
+
+    let files: Vec<FileParseData> = sources
+        .iter()
+        .filter_map(|path| {
+            let rel = path.strip_prefix(&root).ok()?.to_string_lossy().to_string();
+            let source = std::fs::read_to_string(path).ok()?;
+            Some(py(&rel, &source))
+        })
+        .collect();
+
+    let relations = link(&files);
+    let entity_files: HashMap<EntityId, String> = files
+        .iter()
+        .flat_map(|f| f.entities.iter().map(|e| (e.id, f.file_path.clone())))
+        .collect();
+
+    // Every call whose destination is an entity in a file OTHER than the one
+    // the caller's receiver import named. Reported, not asserted on a number:
+    // the count is corpus-specific and a hardcoded one would be a check that
+    // passes for the wrong reason on the next corpus.
+    let mut cross_file = 0usize;
+    for relation in &relations {
+        if relation.kind != RelationKind::Calls {
+            continue;
+        }
+        let (GraphNodeId::Entity(src), GraphNodeId::Entity(dst)) =
+            (&relation.src, &relation.dst)
+        else {
+            continue;
+        };
+        match (entity_files.get(src), entity_files.get(dst)) {
+            (Some(src_file), Some(dst_file)) if src_file != dst_file => cross_file += 1,
+            _ => {}
+        }
+    }
+
+    println!("RECEIVER_HOP_CORPUS {}", root.display());
+    println!("RECEIVER_HOP_FILES {}", files.len());
+    println!("RECEIVER_HOP_CROSS_FILE_CALLS {cross_file}");
+    assert!(
+        cross_file > 0,
+        "a real Python repository must produce at least one cross-file call edge; \
+         zero means the run parsed nothing rather than that the hop found nothing"
+    );
+}

--- a/crates/kin-index/tests/receiver_module_hop.rs
+++ b/crates/kin-index/tests/receiver_module_hop.rs
@@ -28,8 +28,8 @@
 use std::collections::HashMap;
 
 use kin_index::{
-    link_cross_file as link_cross_file_with_identities, link_cross_file_incremental,
-    FileParseData, IncrementalLinker,
+    link_cross_file as link_cross_file_with_identities, link_cross_file_incremental, FileParseData,
+    IncrementalLinker,
 };
 use kin_model::{ArtifactId, Entity, EntityId, FilePathId, GraphNodeId, Relation, RelationKind};
 use kin_parser::{JavaScriptAdapter, LanguageAdapter, PythonAdapter};
@@ -232,7 +232,10 @@ fn a_submodule_that_does_not_define_the_callee_reaches_nothing() {
     let files = vec![
         py("pkg/__init__.py", "__version__ = \"1\"\n"),
         py("pkg/mod.py", "def unrelated_helper():\n    return 1\n"),
-        py("elsewhere.py", "def note_body(conn, note_id):\n    return \"\"\n"),
+        py(
+            "elsewhere.py",
+            "def note_body(conn, note_id):\n    return \"\"\n",
+        ),
         py(
             "caller.py",
             "from pkg import mod\n\n\ndef run(db):\n    return mod.note_body(db, 1)\n",
@@ -356,7 +359,10 @@ fn a_real_repository_recovers_calls_through_a_package_index_receiver() {
             let name = entry.file_name();
             let name = name.to_string_lossy();
             if path.is_dir() {
-                if name != ".kin" && name != ".git" && name != "node_modules" && name != "__pycache__"
+                if name != ".kin"
+                    && name != ".git"
+                    && name != "node_modules"
+                    && name != "__pycache__"
                 {
                     stack.push(path);
                 }
@@ -396,8 +402,7 @@ fn a_real_repository_recovers_calls_through_a_package_index_receiver() {
         if relation.kind != RelationKind::Calls {
             continue;
         }
-        let (GraphNodeId::Entity(src), GraphNodeId::Entity(dst)) =
-            (&relation.src, &relation.dst)
+        let (GraphNodeId::Entity(src), GraphNodeId::Entity(dst)) = (&relation.src, &relation.dst)
         else {
             continue;
         };
@@ -426,9 +431,7 @@ fn a_real_repository_recovers_calls_through_a_package_index_receiver() {
             .iter()
             .filter(|r| r.kind == RelationKind::Calls)
             .filter_map(|r| match (&r.src, &r.dst) {
-                (GraphNodeId::Entity(src), GraphNodeId::Entity(dst))
-                    if targets.contains(dst) =>
-                {
+                (GraphNodeId::Entity(src), GraphNodeId::Entity(dst)) if targets.contains(dst) => {
                     entity_files.get(src).cloned()
                 }
                 _ => None,

--- a/crates/kin-index/tests/receiver_module_hop.rs
+++ b/crates/kin-index/tests/receiver_module_hop.rs
@@ -410,6 +410,37 @@ fn a_real_repository_recovers_calls_through_a_package_index_receiver() {
     println!("RECEIVER_HOP_CORPUS {}", root.display());
     println!("RECEIVER_HOP_FILES {}", files.len());
     println!("RECEIVER_HOP_CROSS_FILE_CALLS {cross_file}");
+
+    // The ticket's own question, asked of whatever symbol the caller names:
+    // how many callers does the graph hold for it, and from which files. A
+    // count of zero here is the shape that certified a false absence.
+    if let Ok(focal) = std::env::var("KIN_RECEIVER_HOP_FOCAL") {
+        let targets: Vec<EntityId> = files
+            .iter()
+            .flat_map(|f| f.entities.iter())
+            .filter(|e| e.name == focal)
+            .map(|e| e.id)
+            .collect();
+        println!("RECEIVER_HOP_FOCAL {focal} declarations={}", targets.len());
+        let mut callers: Vec<String> = relations
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .filter_map(|r| match (&r.src, &r.dst) {
+                (GraphNodeId::Entity(src), GraphNodeId::Entity(dst))
+                    if targets.contains(dst) =>
+                {
+                    entity_files.get(src).cloned()
+                }
+                _ => None,
+            })
+            .collect();
+        callers.sort();
+        callers.dedup();
+        println!("RECEIVER_HOP_FOCAL_INCOMING {}", callers.len());
+        for caller in &callers {
+            println!("RECEIVER_HOP_FOCAL_CALLER {caller}");
+        }
+    }
     assert!(
         cross_file > 0,
         "a real Python repository must produce at least one cross-file call edge; \


### PR DESCRIPTION
A call whose receiver is bound to a repo-local module resolved only against that
module's own file. Two shapes put the callee one hop further on, and both name
their destination in the source that produced them.

`from pkg import mod` records `pkg` as the module path and `mod` as a separate
specifier and never joins the two, so the receiver landed on `pkg/__init__.py`
while the callee was defined in the sibling `pkg/mod.py`.
`module.exports = require('./lib/express')` made the package entry point the
receiver's file while every export lived one module away.

On a miss, tier (a0) continues past every lower tier, and neither fallback
catches it: the external-reference builder needs an `import_source` that no
receiver call carries, and the unresolved-receiver placeholder is never reached.
So the call produced no edge and no placeholder at all. That is the shape behind
`kin refs note_body` answering "no incoming relations" on the shipped 0.6.0
bytes, with the envelope certifying that absence as authoritative while the test
that calls it sat one grep away.

Tier (a0) now retries its two lookups once, in the single file the source's own
import statement names. Strictly additive: the first lookup is unchanged, so
every edge that resolved before resolves identically at the same confidence, and
only calls that produced nothing at all can change. The batch and incremental
linkers now share one resolver through a lookup closure, the idiom
`resolve_import_pinned_target` already uses, so the hop cannot land on one path
and be missing from the other.

## Measured on the corpus the stranger ran

Real adapters over the real source of the v0.6.0 stranger run's own green-arm
corpus, through the ignored `KIN_RECEIVER_HOP_CORPUS` arm, with and without the
hop and nothing else changed:

| | hop reverted | hop present |
|---|---|---|
| cross-file call edges | 36 | 115 |
| `note_body` incoming callers | 0 | 1, `tests/test_storage.py` |

## Falsification

Six mutations, each removing a property of the code under test rather than
weakening an assertion, every one built and graded by WHICH arm went red.

| mutation | arms that went red |
|---|---|
| no hop at all | the six hop arms; both controls stayed GREEN, which is what proves they are controls |
| hop in the batch copy only | the incremental parity arm, ALONE |
| Python sibling hop removed only | the five Python arms; the JavaScript arm stayed green |
| JavaScript re-export hop removed only | the JavaScript arm, ALONE |
| sibling named by the receiver root, not the import's original name | the aliased-import arm, ALONE |
| miss mints an unresolved-receiver placeholder | the placeholder arm, on the destination set |

The last two are worth reading. The alias mutation is silently correct on every
unaliased call in the fleet and only the `as` form catches it. The placeholder
mutation and the no-hop mutation both redden the same arm, so the arm was read
one level deeper: no-hop gives `left: []` and placeholder gives
`left: [Entity(f4ef8a47…)]`, so it genuinely separates "produced nothing" from
"produced a placeholder". That distinction is load-bearing, because an
unresolved-receiver placeholder is itself a `Calls` edge and the arrival gate
counts them, so minting one here would move a file from unaccounted to accounted
and re-certify the absences that gate exists to refuse.

## Gates

`bin/kin-precheck kin --repo-dir kin=<lane worktree>`: 16 gates ran, 16 passed,
0 failed, on `513f4b7772beda8315a30557c529f443670b1e23`. Those 16 are fmt,
clippy and the guard scripts; precheck runs no test gate, so the suites are
reported separately. `cargo test -p kin-index -p kin-mcp` at the same head: exit
0, zero `FAILED` lines, zero panics, 1205 passed and 3 ignored (that total is
summed from the run's own rows and is derived; the verdict is the exit code and
the zero counts).

## Measured on express, and it corrects this PR's own first reading

The JavaScript hop was expected to be what makes `impact_analysis` on `express.static` name its
consumers. It is not. On a real converted express store, with kin#1175's extractor half applied
locally so the entity exists at all, `impact_analysis` names `lib/express.js:79` and all seven
consumer files **with the hop reverted just as well as with it**: same 59 entities, same eight direct
callers. Those surfaces answer through `References` edges from module entities, and every consumer
use except one sits at module top level.

What the hop actually adds on express is one row. `kin refs static` differs in exactly one place:

| | `createApp @ test/express.static.js:804` |
|---|---|
| hop present | `[Calls, References] (type_resolved) sites 808` |
| hop reverted | `[References] (type_resolved) sites 808` |

That is `app.use(express.static(root, options))` at line 808, the one consumer call inside a
function rather than at module scope. One `Calls` edge, not twenty-five. Kept because it is the same
code path as the Python hop and costs nothing extra, not because this corpus proved it valuable.

## What is NOT claimed

Nothing here was measured through a daemon, a store, or the MCP envelope. The
corpus arm runs the real parser and the real linker over real source; it does not
build a graph, so it says nothing about what `kin refs` answers end to end, and
it cannot see LSP enrichment, which is a second producer of this exact edge in a
daemon-backed store. On express the hop's contribution is one `Calls` edge, measured;
the surfaces that answer FIR-2757 do so without it. The 79-edge recovery is one 14-file
repository, not a fleet figure.

Part of FIR-2775
Part of FIR-2757
Closes FIR-2812
