### PR TITLE
Carry the spine-clipping refusal into the verdict a caller actually reads

### DIFF
--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1438,6 +1438,12 @@ fn focal_resolution_gap(payload: &Value, subject: &str) -> Option<String> {
     }
 }
 
+/// The limiting-factor id a spine-clipped trace reports under.
+///
+/// Spelled once so the gate, the clause and every test key on one string, the
+/// way `caller_arrival` spells its own.
+pub(crate) const TRACE_SPINE_CLIPPED_LIMITING_FACTOR: &str = "trace_spine_clipped";
+
 fn trace_flow_gaps(payload: &Value) -> Vec<String> {
     let mut gaps = Vec::new();
 
@@ -1459,6 +1465,32 @@ fn trace_flow_gaps(payload: &Value) -> Vec<String> {
     // twin a question that was asked of one.
     if let Some(gap) = focal_resolution_gap(payload, "an empty chain") {
         gaps.push(gap);
+    }
+
+    // Spine clipping supersedes the two general cap clauses below, and this is
+    // the whole subject of FIR-2781. A cap at the end of a branch costs breadth
+    // a reader can see missing; a cap the walk went on BENEATH hands back a route
+    // that reads like the route while the neighbours it dropped were never
+    // followed. Only the second makes "this chain does not contain X" mean
+    // nothing at all, and it is the state in which a stranger walked `verify`
+    // from `requests.get`, never reached `HTTPAdapter.send`, and would have
+    // written that `verify` ends at `Session.send` had they trusted the answer.
+    //
+    // The walker already discloses this precisely, as a `fanout_cap` /
+    // `spine_clipped` degradation whose detail says the absence proves nothing.
+    // That sentence never reached the verdict: `trace_data_flow` is excluded by
+    // name from the `retrieval_degraded` gap, on the correct ground that it
+    // states its gaps in walk vocabulary here instead, and this function had no
+    // spine clause. So the right sentence existed in a channel the verdict does
+    // not read for this tool, and what a caller saw in `limiting_factor` was a
+    // cap notice they could reasonably hear as a lower bound.
+    let spine_clipped = payload
+        .get("spine_clipped_steps")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if spine_clipped > 0 {
+        gaps.push(spine_clipping_gap(payload, spine_clipped));
+        return gaps;
     }
 
     // A walk cut short by its own caps or work ceilings stopped before it could
@@ -1483,6 +1515,70 @@ fn trace_flow_gaps(payload: &Value) -> Vec<String> {
     }
 
     gaps
+}
+
+/// The limiting factor for a chain the walk continued beneath a clipped node.
+///
+/// It ABSORBS the two clauses it supersedes rather than replacing them away: the
+/// cap numbers `trace_walk_truncated` would have carried and the fact that the
+/// walk ran degraded are both stated here, so no information dies with them. It
+/// then adds the part neither could say, which is that the dropped set is drawn
+/// from the same neighbourhood the question is about, so this chain not
+/// containing a hop is not evidence that no such hop exists.
+///
+/// One clause, never several. Three sentences about one cap teach a reader to
+/// skim all three, which is the flooring argument moved down to the clause
+/// level: a caller reading one precise sentence acts on it, and a caller reading
+/// two hedges tunes both out.
+///
+/// Every list inside this clause joins on ", " and never on "; ", which is
+/// [`crate::verdict::CLAUSE_SEPARATOR`]. The vec this returns into is joined on
+/// the separator by its caller, and that is correct, because those elements ARE
+/// clauses; a separator INSIDE one clause is what reaches a reader as a labelled
+/// clause plus an unlabelled fragment.
+fn spine_clipping_gap(payload: &Value, spine_clipped: u64) -> String {
+    let nodes = if spine_clipped == 1 { "node" } else { "nodes" };
+    // The two facts the superseded clauses carried, absorbed rather than lost.
+    let mut absorbed: Vec<String> = Vec::new();
+    if let Some(dropped) = payload.get("steps_omitted").and_then(Value::as_u64) {
+        if dropped > 0 {
+            absorbed.push(format!("{dropped} step(s) were omitted from the response"));
+        }
+    }
+    if payload.get("truncated").and_then(Value::as_bool) == Some(true) {
+        absorbed.push("the walk hit a per-step or total cap".to_string());
+    }
+    if payload
+        .get("degradations")
+        .and_then(Value::as_array)
+        .is_some_and(|degradations| !degradations.is_empty())
+    {
+        absorbed.push("the walk ran degraded under its own work bounds".to_string());
+    }
+    let carried = if absorbed.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", absorbed.join(", "))
+    };
+    let crossing = match payload
+        .get("spine_dropped_crossing_file")
+        .and_then(Value::as_u64)
+    {
+        Some(count) if count > 0 => {
+            format!(", {count} of the dropped neighbours lived outside the file that offered them")
+        }
+        _ => String::new(),
+    };
+    format!(
+        "{TRACE_SPINE_CLIPPED_LIMITING_FACTOR}: the walk continued beneath {spine_clipped} \
+         {nodes} whose fan-out the per-step cap had already cut{carried}{crossing}, so the \
+         neighbours it dropped were never followed and this chain is one route among the ones \
+         the cap happened to keep. It is NOT a lower bound on a complete search: a hop missing \
+         from it was not looked for, so its absence is no evidence that the focal cannot reach \
+         it, and no conclusion of the form \"X never reaches Y\" may be drawn from this answer. \
+         Name the symbol you are after as `target` so the cap ranks toward it, or re-query the \
+         clipped node with a larger `limit_per_step`"
+    )
 }
 
 /// The component and reason a retrieval payload files its corpus-scale
@@ -5713,6 +5809,246 @@ mod tests {
             json!(true),
             "an outgoing-only walk never read the under-resolved edges: {negative}"
         );
+    }
+
+    /// The requests-shaped fixture, FIR-2781's own case. A POPULATED chain whose
+    /// spine was clipped: the stranger walked `verify` from `requests.get`,
+    /// `limit_per_step` threw away 11 of `Session.send`'s 15 callees before
+    /// relevance was consulted, `HTTPAdapter.send` never appeared, and the
+    /// answer read as a lower bound. Had they trusted it they would have written
+    /// that `verify` ends at `Session.send`.
+    fn spine_clipped_trace() -> Value {
+        let mut payload = clean_empty_trace("calls");
+        // Populated, which is the point: this defect does not need an empty
+        // answer, and the gate must fire on a chain that returned rows.
+        payload["chain"] = json!([
+            { "entity_name": "get", "parent_step": null, "step": 0 },
+            { "entity_name": "request", "parent_step": 0, "step": 1 },
+            { "entity_name": "Session.request", "parent_step": 1, "step": 2 },
+            { "entity_name": "Session.send", "parent_step": 2, "step": 3 },
+            { "entity_name": "resolve_redirects", "parent_step": 3, "step": 4 },
+        ]);
+        payload["total_steps"] = json!(5);
+        payload["truncated"] = json!(true);
+        payload["steps_omitted"] = json!(126);
+        payload["spine_clipped_steps"] = json!(1);
+        payload["spine_dropped_crossing_file"] = json!(11);
+        payload["degradations"] = json!([
+            { "component": "fanout_cap", "reason": "spine_clipped" }
+        ]);
+        payload
+    }
+
+    /// The refusal itself: a spine-clipped answer may not be read as evidence
+    /// that the focal cannot reach something, and the sentence has to say so in
+    /// words a caller cannot hear as a mere lower bound.
+    #[test]
+    fn a_spine_clipped_chain_refuses_the_never_reaches_conclusion() {
+        let negative = negative_for(
+            "trace_data_flow",
+            &spine_clipped_trace(),
+            &structural_ready_envelope(),
+        )
+        .expect("a qualified trace answer yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains(TRACE_SPINE_CLIPPED_LIMITING_FACTOR),
+            "the spine clause must be in the factor: {reason}"
+        );
+        // The three things the acceptance asks the sentence to say, each checked
+        // rather than assumed from the id being present.
+        assert!(
+            reason.contains("NOT a lower bound"),
+            "the sentence must refuse the lower-bound reading outright: {reason}"
+        );
+        assert!(
+            reason.contains("was not looked for"),
+            "it must say the missing hop was never searched, not merely not found: {reason}"
+        );
+        assert!(
+            reason.contains("X never reaches Y"),
+            "it must name the conclusion it forbids: {reason}"
+        );
+    }
+
+    /// The captain's first condition: the specific clause ABSORBS the two it
+    /// supersedes rather than replacing them away, so no information dies with
+    /// them.
+    #[test]
+    fn the_spine_clause_carries_what_the_clauses_it_supersedes_would_have_said() {
+        let negative = negative_for(
+            "trace_data_flow",
+            &spine_clipped_trace(),
+            &structural_ready_envelope(),
+        )
+        .unwrap();
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("126 step(s) were omitted"),
+            "the omitted count trace_walk_truncated would have implied must survive: {reason}"
+        );
+        assert!(
+            reason.contains("hit a per-step or total cap"),
+            "the cap fact must survive: {reason}"
+        );
+        assert!(
+            reason.contains("ran degraded"),
+            "the degraded fact trace_walk_degraded carried must survive: {reason}"
+        );
+        assert!(
+            reason.contains("11 of the dropped neighbours lived outside the file"),
+            "the cross-file count must survive: {reason}"
+        );
+    }
+
+    /// The captain's second condition, pinned as a property rather than left an
+    /// implementation detail: a spine-clipped answer carries EXACTLY ONE cap
+    /// clause. Goes red if anyone re-adds a general clause beside the specific
+    /// one, or breaks the supersession so both fire.
+    ///
+    /// Its controls sit in the same test, because a supersession assertion with
+    /// no control is satisfied by a gate that emits nothing at all: a non-spine
+    /// truncation must still get `trace_walk_truncated`, and a non-spine
+    /// degradation must still get `trace_walk_degraded`, each untouched.
+    #[test]
+    fn a_spine_clipped_answer_carries_exactly_one_cap_clause() {
+        let negative = negative_for(
+            "trace_data_flow",
+            &spine_clipped_trace(),
+            &structural_ready_envelope(),
+        )
+        .unwrap();
+        let reason = negative["trust_reason"].as_str().unwrap();
+        let cap_clauses = [
+            TRACE_SPINE_CLIPPED_LIMITING_FACTOR,
+            "trace_walk_truncated",
+            "trace_walk_degraded",
+        ]
+        .iter()
+        .filter(|id| reason.contains(**id))
+        .count();
+        assert_eq!(
+            cap_clauses, 1,
+            "one cap, one sentence: three sentences about one cap teach a reader to skim all \
+             three. Got {cap_clauses} in: {reason}"
+        );
+        assert!(reason.contains(TRACE_SPINE_CLIPPED_LIMITING_FACTOR));
+
+        // Control one: truncation that did NOT clip the spine keeps the general
+        // clause, untouched.
+        let mut truncated = clean_empty_trace("both");
+        truncated["truncated"] = json!(true);
+        let general =
+            negative_for("trace_data_flow", &truncated, &structural_ready_envelope()).unwrap();
+        let general_reason = general["trust_reason"].as_str().unwrap();
+        assert!(
+            general_reason.contains("trace_walk_truncated"),
+            "a non-spine truncation must still get the general clause: {general_reason}"
+        );
+        assert!(
+            !general_reason.contains(TRACE_SPINE_CLIPPED_LIMITING_FACTOR),
+            "and must not get the spine clause: {general_reason}"
+        );
+
+        // Control two: a degradation that did NOT clip the spine likewise.
+        let mut degraded = clean_empty_trace("both");
+        degraded["degradations"] = json!([{ "component": "entity_bodies", "reason": "budget" }]);
+        let general =
+            negative_for("trace_data_flow", &degraded, &structural_ready_envelope()).unwrap();
+        let general_reason = general["trust_reason"].as_str().unwrap();
+        assert!(
+            general_reason.contains("trace_walk_degraded"),
+            "a non-spine degradation must still get the general clause: {general_reason}"
+        );
+        assert!(
+            !general_reason.contains(TRACE_SPINE_CLIPPED_LIMITING_FACTOR),
+            "and must not get the spine clause: {general_reason}"
+        );
+    }
+
+    /// The other half of the control the ticket demands: an unclipped trace
+    /// still certifies. A gate that refused every trace would pass every
+    /// assertion above and be worthless.
+    #[test]
+    fn an_unclipped_trace_still_certifies() {
+        let negative = negative_for(
+            "trace_data_flow",
+            &clean_empty_trace("both"),
+            &structural_ready_envelope(),
+        )
+        .unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            !reason.contains(TRACE_SPINE_CLIPPED_LIMITING_FACTOR),
+            "{reason}"
+        );
+
+        // And clipping that is NOT on the spine is not spine clipping. A clip at
+        // the end of a branch costs breadth a reader can see missing; only a clip
+        // the walk continued BENEATH makes the chain read like the route while
+        // hiding the hop. This is the sharper control, because a gate keyed on
+        // `clipped_steps` rather than on `spine_clipped_steps` passes every other
+        // arm here and fails this one.
+        let mut off_spine = clean_empty_trace("both");
+        off_spine["clipped_steps"] = json!([
+            { "entity_name": "leaf", "step": 9, "continued_below": false, "dropped_callees": 4 }
+        ]);
+        let negative =
+            negative_for("trace_data_flow", &off_spine, &structural_ready_envelope()).unwrap();
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            !reason.contains(TRACE_SPINE_CLIPPED_LIMITING_FACTOR),
+            "a clip the walk did not continue beneath is not spine clipping: {reason}"
+        );
+    }
+
+    /// The join rule, asserted on this producer rather than trusted to the guard
+    /// that drives a different one by name.
+    ///
+    /// The clause names a list of absorbed facts, and the vec it returns into is
+    /// joined on `CLAUSE_SEPARATOR` by its caller. Joining CLAUSES on the
+    /// separator is correct; a separator INSIDE one clause reaches a reader as a
+    /// labelled clause plus an unlabelled fragment.
+    #[test]
+    fn the_spine_clause_never_carries_the_clause_separator() {
+        let mut seen = 0;
+        for (label, payload) in [
+            ("all facts absorbed", spine_clipped_trace()),
+            ("no cross-file drops", {
+                let mut p = spine_clipped_trace();
+                p.as_object_mut()
+                    .unwrap()
+                    .remove("spine_dropped_crossing_file");
+                p
+            }),
+            ("clipped but neither truncated nor degraded", {
+                let mut p = spine_clipped_trace();
+                p["truncated"] = json!(false);
+                p.as_object_mut().unwrap().remove("steps_omitted");
+                p["degradations"] = json!([]);
+                p
+            }),
+            ("several spine nodes", {
+                let mut p = spine_clipped_trace();
+                p["spine_clipped_steps"] = json!(4);
+                p
+            }),
+        ] {
+            let clause = spine_clipping_gap(
+                &payload,
+                payload["spine_clipped_steps"].as_u64().unwrap_or(1),
+            );
+            seen += 1;
+            assert!(
+                !clause.contains(crate::verdict::CLAUSE_SEPARATOR),
+                "{label}: the clause carries the separator, so any reader that splits the \
+                 rendered factor cuts it into a labelled clause and an unlabelled fragment: \
+                 {clause}"
+            );
+        }
+        assert!(seen > 0, "no clause was produced, so this asserted nothing");
     }
 
     /// A walk stopped by its own caps or work bounds did not examine what an


### PR DESCRIPTION
kin#1178 already discloses spine clipping precisely. It appends a `fanout_cap` / `spine_clipped`
degradation whose detail says a hop the chain does not contain was not looked for and its absence
proves nothing. That is very close to the sentence this ticket asks for.

The defect is where it lives. `negative.rs` excludes `trace_data_flow` by name from the
`retrieval_degraded` gap, on the correct ground that the tool states its gaps in walk vocabulary
through `trace_flow_gaps` instead, and that function had no spine clause. So the right sentence sat
in `payload.degradations` and never reached `_kin.verdict.limiting_factor`. What a caller actually
saw was `trace_walk_truncated`, a cap notice they could reasonably hear as a lower bound. On the run
that filed this, a walk of `verify` from `requests.get` never reached `HTTPAdapter.send`, and a
reader who trusted the answer would have written that `verify` ends at `Session.send`.

So the acceptance clause's phrase, "in words a caller cannot read as a mere lower bound", is not
decoration. It is the entire defect, and this is a change that sharpens one gate rather than adding
one.

## Supersede, and what that costs

Two general clauses fire on a spine-clipped answer today, not one: `trace_walk_truncated` because the
walk truncated, and `trace_walk_degraded` because the spine-clipped disclosure is itself a
degradation. Adding a third sentence about one cap would teach a reader to skim all three, which is
the flooring argument moved down to the clause level: a caller reading one precise sentence acts on
it, and a caller reading two hedges tunes both out.

So the new clause supersedes both, and absorbs what they carried rather than replacing them away. The
omitted-step count, the cap fact, the degraded fact and the cross-file drop count are all stated
inside it. Then it adds what neither could say: the dropped neighbours were never followed, so this
chain is one route among the ones the cap kept, it is not a lower bound on a complete search, and no
conclusion of the form "X never reaches Y" may be drawn from it.

## The supersession is pinned as a property

A spine-clipped answer must carry exactly one cap clause. That assertion goes red if a general clause
is re-added beside the specific one, or if the supersession breaks so both fire.

Its controls sit in the same test, because a supersession assertion with no control is satisfied by a
gate that emits nothing at all: a non-spine truncation still gets `trace_walk_truncated` and a
non-spine degradation still gets `trace_walk_degraded`, each untouched. A separate arm proves a clip
the walk did NOT continue beneath is not spine clipping, which is the arm that fails any gate keyed
on `clipped_steps` rather than `spine_clipped_steps`.

## Falsification

Five mutations, each landing on its own assertion. Removing the gate reddens the refusal, the
absorption and the exactly-one property. Breaking only the supersession reddens only the exactly-one
property, at three clauses. Dropping only the absorption reddens only the absorption arm. Keying on
`clipped_steps` reddens four arms including the off-spine control. Joining the absorbed list on the
clause separator reddens only the separator guard.

The pre-existing `trace_cut_short_by_its_own_bounds_is_inconclusive` stayed green under every
mutation, which is the control that matters most and one this change did not write for itself: the
supersede does not break the general path.

`bin/kin-precheck kin --repo-dir kin=<lane worktree>` ran 16 of 16 gates green on this head, and the
kin-mcp suite is green at 709.

## What this does not do

Parts two and three of the ticket are not here. The default breadth was addressed by kin#1178, and
the tool's name and description still promise value-level tracing; that half is unclaimed.

Part of FIR-2781
