### PR TITLE
Give the package-root guard a mutation that can kill it, and the corpus arm both languages

### DIFF
--- a/crates/kin-index/tests/receiver_module_hop.rs
+++ b/crates/kin-index/tests/receiver_module_hop.rs
@@ -254,6 +254,42 @@ fn a_submodule_that_does_not_define_the_callee_reaches_nothing() {
 }
 
 #[test]
+fn a_receiver_bound_to_a_plain_module_does_not_reach_a_same_named_sibling() {
+    // THE ARM THAT KILLS THE PACKAGE-ROOT GUARD, which nothing else here can.
+    //
+    // `from pkg.mod import helper` binds the receiver to a name defined INSIDE
+    // `pkg/mod.py`, so the resolved receiver file is a plain module rather than a
+    // package index. A sibling `pkg/helper.py` exists and does define `run`, so
+    // the hop would happily bind there if it fired. It must not: the source said
+    // `helper` comes out of `pkg.mod`, and `pkg/helper.py` is a different thing
+    // that merely shares a name.
+    //
+    // Without the `PACKAGE_INDEX_FILENAMES` guard this test goes red, which is
+    // the mutation the first round of arms could not construct: with those
+    // fixtures the unguarded lookup landed back on the receiver's own file and
+    // changed nothing, so the guard read as covered while being unfalsifiable.
+    let files = vec![
+        py("pkg/__init__.py", "__version__ = \"1\"\n"),
+        py("pkg/mod.py", "helper = object()\n"),
+        py("pkg/helper.py", "def run():\n    return 1\n"),
+        py(
+            "caller.py",
+            "from pkg.mod import helper\n\n\ndef go():\n    return helper.run()\n",
+        ),
+    ];
+    let caller = entity_id(&files, "caller.py", "go");
+    let decoy = entity_id(&files, "pkg/helper.py", "run");
+
+    let relations = link(&files);
+    assert!(
+        !has_call(&relations, caller, decoy),
+        "`helper` is a name inside pkg/mod.py, not the module pkg/helper.py, so \
+         `helper.run()` must not bind to the same-named sibling; the hop is for a \
+         receiver that resolved to a PACKAGE INDEX standing in for a submodule"
+    );
+}
+
+#[test]
 fn a_receiver_naming_a_class_rather_than_a_submodule_is_unchanged() {
     // CONTROL THAT MUST STAY GREEN UNDER EVERY MUTATION OF THE HOP.
     //
@@ -366,7 +402,10 @@ fn a_real_repository_recovers_calls_through_a_package_index_receiver() {
                 {
                     stack.push(path);
                 }
-            } else if path.extension().and_then(|e| e.to_str()) == Some("py") {
+            } else if matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("py" | "js" | "mjs" | "cjs")
+            ) {
                 sources.push(path);
             }
         }
@@ -374,7 +413,7 @@ fn a_real_repository_recovers_calls_through_a_package_index_receiver() {
     sources.sort();
     assert!(
         !sources.is_empty(),
-        "corpus {} holds no .py files, so this arm measured nothing",
+        "corpus {} holds no source files this census can parse, so it measured nothing",
         root.display()
     );
 
@@ -383,7 +422,13 @@ fn a_real_repository_recovers_calls_through_a_package_index_receiver() {
         .filter_map(|path| {
             let rel = path.strip_prefix(&root).ok()?.to_string_lossy().to_string();
             let source = std::fs::read_to_string(path).ok()?;
-            Some(py(&rel, &source))
+            // Pick the adapter by extension so one census covers both hop shapes:
+            // a Python package index standing in for a submodule, and a JavaScript
+            // entry point re-exporting another module wholesale.
+            match path.extension().and_then(|e| e.to_str()) {
+                Some("py") => Some(py(&rel, &source)),
+                _ => Some(js(&rel, &source)),
+            }
         })
         .collect();
 


### PR DESCRIPTION
Two test-only additions closing gaps kin#1181 named in its own report rather than
left for someone to find later. No production code changes.

## The package-root guard had no mutation that could kill it

kin#1181's `receiver_package_sibling` only fires when the receiver's resolved file
is a package index. That guard is what keeps the hop from binding a call to a
same-named sibling the source never referred to, and it was untested: with #1181's
fixtures a mutation removing it landed the sibling lookup back on the receiver's
own file and changed nothing, so it read as covered while being unfalsifiable.

The new arm builds the one input only that guard refuses. `from pkg.mod import
helper` binds the receiver to a name defined INSIDE `pkg/mod.py`, so the resolved
file is a plain module rather than a package index, while a sibling
`pkg/helper.py` exists and does define the callee. If the hop fired there it
would bind `helper.run()` to a file the source never named.

Falsified against this branch's own tree, on the merged linker: removing the
guard turns that arm red **alone**, on its own assertion.

```
a_receiver_bound_to_a_plain_module_does_not_reach_a_same_named_sibling
  panicked at crates/kin-index/tests/receiver_module_hop.rs:284:5:
  `helper` is a name inside pkg/mod.py, not the module pkg/helper.py ...
```

The driver refuses a dirty `linker.rs` at entry, above its restore trap, and
printed `guard_lines_back=1 markers=0 linker_dirty=0` on exit.

## The corpus arm could only measure one of the two hop shapes

It picked its adapter by assuming Python, so the JavaScript half of the hop was
unmeasurable on any real repository. It picks by extension now, which is what
makes a census over a mixed corpus possible rather than a Python one.

Run on both corpora, no daemon and no lock:

| corpus | files | cross-file calls | focal | incoming |
|---|---|---|---|---|
| express | 141 | 101 | `static` | declarations=0 |
| notekeeper | 14 | 115 | `note_body` | 1, `tests/test_storage.py` |

`declarations=0` on express is the arm reporting that the entity is absent rather
than printing a silent zero incoming count, which is the distinction a reader
needs: "nothing references it" and "it is not there" are different findings.

## Gates

`bin/kin-precheck kin --repo-dir kin=<lane worktree>`: 16 gates ran, 16 passed, 0
failed, on `625d7119eebf7bad248c55863a7e7bac1593631b`. Those 16 are fmt, clippy
and the guard scripts; precheck runs no test gate, so the suite is separate:
`cargo test -p kin-index` at the same head, exit 0, zero `FAILED` lines, zero
`test result: FAILED`, zero panics.

## What is NOT claimed

That a fleet census has been run. This makes one possible over mixed corpora; 101
and 115 are still two repositories. Nothing here changes product behaviour, so no
claim about edges, coverage or performance follows from it.

Part of FIR-2812
