### PR TITLE
Stop minting an entity out of the receiver a call was written through

### DIFF
--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -25,9 +25,8 @@ use sha2::{Digest, Sha256};
 use crate::classifier::{FileClassification, FileClassifier};
 use crate::error::{IndexError, Result};
 use crate::linker::{
-    is_external_import_placeholder, is_unresolved_receiver_placeholder,
-    link_cross_file_borrowed_with_completeness, split_unresolved_receiver_token,
-    unresolved_receiver_display_name, ArtifactIdentityMap, FileParseCompletenessMap, FileParseData,
+    is_external_import_placeholder, link_cross_file_borrowed_with_completeness,
+    ArtifactIdentityMap, FileParseCompletenessMap, FileParseData,
 };
 use crate::pipeline::IndexPipeline;
 
@@ -50,7 +49,7 @@ use crate::pipeline::IndexPipeline;
 /// authored to contain until it is admitted again, and reports nothing about
 /// which version authored it. Coupling the dial to graph authority so a
 /// version gap can be detected and refused is open follow-up work.
-pub const HYDRATION_SEMANTICS_VERSION: u32 = 9;
+pub const HYDRATION_SEMANTICS_VERSION: u32 = 10;
 
 /// Semantic graph delta derived for one pre-enrichment change identity.
 ///
@@ -456,59 +455,7 @@ fn external_reference_targets(
             .push(source.language);
     }
 
-    // The second placeholder class: a member call whose receiver resolves to
-    // nothing this repository defines. It carries no import source, because
-    // there is no module to name, so its identity and its display name come
-    // from the member expression the evidence recorded as written.
-    let mut receivers: BTreeMap<EntityId, (String, Vec<LanguageId>)> = BTreeMap::new();
-    for relation in linked {
-        if !is_unresolved_receiver_placeholder(relation) {
-            continue;
-        }
-        let Some(destination) = relation.dst.as_entity() else {
-            continue;
-        };
-        if entities.contains_key(&destination) {
-            continue;
-        }
-        let (Some(source), Some(token)) = (
-            relation.src.as_entity().and_then(|id| entities.get(&id)),
-            relation
-                .evidence
-                .first()
-                .and_then(|evidence| evidence.token.as_deref()),
-        ) else {
-            continue;
-        };
-        let Some((receiver, symbol)) = split_unresolved_receiver_token(token) else {
-            continue;
-        };
-        receivers
-            .entry(destination)
-            .or_insert_with(|| {
-                (
-                    unresolved_receiver_display_name(receiver, symbol),
-                    Vec::new(),
-                )
-            })
-            .1
-            .push(source.language);
-    }
-
     let mut targets = BTreeMap::new();
-    for (destination, (display_name, languages)) in receivers {
-        let fingerprint = fingerprints
-            .entry(destination)
-            .or_insert_with(|| external_reference_fingerprint("", &display_name))
-            .clone();
-        let Some(language) = lowest_language(&languages) else {
-            continue;
-        };
-        targets.insert(
-            destination,
-            external_reference_entity(destination, &display_name, language, fingerprint),
-        );
-    }
     for (destination, (import_source, symbol, languages)) in importers {
         let fingerprint = fingerprints
             .entry(destination)
@@ -558,12 +505,13 @@ pub fn is_external_reference_target(entity: &Entity) -> bool {
 /// The placeholder entity one placeholder relation's destination stands for,
 /// or `None` when the relation is not a placeholder.
 ///
-/// Both placeholder classes are handled here so a caller cannot learn one and
-/// miss the other. That is not hypothetical: the historical ref view re-links
-/// source and inserts the result straight into a snapshot, and admission fails
-/// closed on an endpoint no entity backs, so a synthesis that knew only the
-/// cross-repo class turned a new class of edge into a hard error the moment one
-/// appeared.
+/// One class reaches here, and it is the one whose destination a resolver can
+/// bind: a cross-repo import, which names its module in `import_source` and its
+/// symbol in evidence. Admission fails closed on an endpoint no entity backs,
+/// so the historical ref view calls this before inserting a re-linked relation
+/// into a snapshot, and a placeholder class this does not know is a hard error
+/// rather than a silent drop. That is the contract every placeholder class has
+/// to satisfy to exist at all, and it is why there is exactly one.
 ///
 /// The language comes from the caller because a target defined elsewhere has
 /// none of its own; the importing side is the only thing that observed it.
@@ -576,17 +524,6 @@ pub fn placeholder_target_entity(relation: &Relation, language: LanguageId) -> O
         return Some(external_reference_entity(
             destination,
             token,
-            language,
-            fingerprint,
-        ));
-    }
-    if is_unresolved_receiver_placeholder(relation) {
-        let (receiver, symbol) = split_unresolved_receiver_token(token)?;
-        let name = unresolved_receiver_display_name(receiver, symbol);
-        let fingerprint = external_reference_fingerprint("", &name);
-        return Some(external_reference_entity(
-            destination,
-            &name,
             language,
             fingerprint,
         ));

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -64,9 +64,7 @@ pub use linker::{
 };
 pub use linker::{
     is_external_import_placeholder, is_raise_classifiable_call_edge, is_raise_target_edge,
-    is_unresolved_receiver_placeholder, split_unresolved_receiver_token, trace_crossing_for,
-    unresolved_receiver_display_name, TraceCrossing, EXTERNAL_IMPORT_REFERENCE_RULE,
-    RAISE_TARGET_CALL_RULE, UNRESOLVED_RECEIVER_CALL_RULE,
+    trace_crossing_for, TraceCrossing, EXTERNAL_IMPORT_REFERENCE_RULE, RAISE_TARGET_CALL_RULE,
 };
 pub use overlay::{apply_file_removal, apply_to_graph, ApplyResult};
 pub use pipeline::{

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -1562,24 +1562,6 @@ fn resolve_one_file(
             continue;
         }
 
-        // (e) Unresolvable receiver. A member call whose receiver names neither
-        // a module this repository owns nor an object whose type any tier
-        // settled has no destination to bind, but it is still a call the source
-        // makes and the reader needs. Recording it as the weakest edge the
-        // linker emits keeps it visible without claiming a resolution; dropping
-        // it made an unresolvable call and an absent one look the same.
-        let repository_defines_symbol = repository_defines_symbol_elsewhere(
-            ctx.entity_by_name.get(dst_lookup),
-            ctx.entity_by_bare_name.get(dst_lookup),
-            src_id,
-        );
-        if let Some(unresolved) =
-            make_unresolved_receiver_relation(rel, src_id, repository_defines_symbol)
-        {
-            accumulate_relation(&mut resolved, &mut relation_indices, unresolved);
-            continue;
-        }
-
         debug!(
             src = %rel.src_name,
             dst = %rel.dst_name,
@@ -4293,26 +4275,6 @@ const EXTERNAL_REFERENCE_KIND_TAG: &str = "ExternalReference";
 /// Calls/References relation also has a non-empty import source and this rule.
 pub const EXTERNAL_IMPORT_REFERENCE_RULE: &str = "external_import_reference";
 
-/// Confidence the unresolved-receiver placeholder tier persists.
-///
-/// Below every tier that settles anything, so `RelationResolution::of` reads it
-/// as `name_only` and nothing that counts by resolution can mistake it for an
-/// edge the linker resolved. It is deliberately the weakest thing the linker
-/// emits: the edge asserts that a call happened and that this repository cannot
-/// say what it reached, which is strictly more than the silence it replaces.
-const UNRESOLVED_RECEIVER_CONFIDENCE: f32 = 0.1;
-
-/// Synthetic tag used to derive a deterministic id for the destination of a
-/// member call whose receiver this repository cannot resolve. Never a real
-/// `EntityKind`, so the id cannot collide with a locally indexed entity, and
-/// distinct from the cross-repo tag so the two placeholder classes never share
-/// a node.
-const UNRESOLVED_RECEIVER_KIND_TAG: &str = "UnresolvedReceiver";
-
-/// Linker evidence rule identifying a member call whose receiver resolves to
-/// nothing this repository defines.
-pub const UNRESOLVED_RECEIVER_CALL_RULE: &str = "unresolved_receiver_call";
-
 /// Evidence marker for a call the parser read as the operand of a `raise`.
 ///
 /// `raise SSLError(...)` in an `except` block is a call edge like any other and
@@ -4350,8 +4312,14 @@ pub struct TraceCrossing {
     #[serde(default)]
     pub specifier: Option<String>,
     /// The receiver the call was written through, when the edge recorded one
-    /// and no specifier is available. `this.router` says more than nothing
-    /// about where to look without claiming to name a package.
+    /// and no specifier is available.
+    ///
+    /// Always `None` since the unresolved-receiver placeholder tier was removed:
+    /// the only edge class that ever recorded a receiver here was the one that
+    /// minted a destination entity out of the receiver's own spelling, and a
+    /// resolver-bound specifier is the only provenance left. The key stays in
+    /// the payload because the object's keys are uniform across both statuses,
+    /// for the same reason the step's are.
     #[serde(default)]
     pub receiver: Option<String>,
     /// Why the status reads the way it does, in a sentence a caller can act on.
@@ -4391,10 +4359,9 @@ pub fn is_raise_target_edge(rel: &Relation) -> bool {
 /// The crossing record for a step, built from the edge that reached it.
 ///
 /// Reads only what the graph already persisted: `import_source`, set by the
-/// cross-repo tier when the parser pinned the module a symbol came from, and
-/// the unresolved-receiver evidence token, which carries the receiver as source
-/// spells it. Nothing is inferred from a name, so a symbol the graph cannot
-/// place reports `unknown` rather than a guess.
+/// cross-repo tier when the parser pinned the module a symbol came from.
+/// Nothing is inferred from a name, so a symbol the graph cannot place reports
+/// `unknown` rather than a guess.
 pub fn trace_crossing_for(entity: &Entity, reached_by: Option<&Relation>) -> Option<TraceCrossing> {
     if entity.file_origin.is_some() {
         return None;
@@ -4414,27 +4381,11 @@ pub fn trace_crossing_for(entity: &Entity, reached_by: Option<&Relation>) -> Opt
             receiver: None,
         });
     }
-    let receiver = reached_by
-        .and_then(|rel| {
-            rel.evidence
-                .iter()
-                .find(|e| e.parser_rule.as_deref() == Some(UNRESOLVED_RECEIVER_CALL_RULE))
-        })
-        .and_then(|e| e.token.as_deref())
-        .and_then(|token| token.rsplit_once('.').map(|(receiver, _)| receiver))
-        .filter(|receiver| !receiver.is_empty())
-        .map(str::to_string);
-    let note = match receiver.as_deref() {
-        Some(receiver) => format!(
-            "the call was written through `{receiver}` and no edge records which module it comes from, so this symbol could be a package, a builtin or a typo"
-        ),
-        None => "no edge into this symbol records a module, so this symbol could be a package, a builtin or a typo".to_string(),
-    };
     Some(TraceCrossing {
         status: "unknown".to_string(),
         specifier: None,
-        receiver,
-        note,
+        receiver: None,
+        note: "no edge into this symbol records a module, so this symbol could be a package, a builtin or a typo".to_string(),
     })
 }
 
@@ -4507,160 +4458,6 @@ pub fn is_external_import_placeholder(relation: &Relation) -> bool {
 /// import, not a cross-repo reference: a symbol that fails local resolution
 /// there (e.g. a moved or deleted local definition) must not be mis-attributed
 /// as an external edge. Only module sources that do not resolve locally qualify.
-/// Whether this repository defines the called member on something other than
-/// the caller itself.
-///
-/// The caller is excluded deliberately. `app.handle` in express calls
-/// `this.router.handle`, and the two share a leaf name, so counting the caller
-/// would have the function's own definition stand as proof that the repository
-/// answers to `handle` and suppress the placeholder for the one call it exists
-/// to record. A member whose only local namesake is the caller has still found
-/// no destination here; recursion through an unresolvable receiver is not a
-/// self-call.
-///
-/// Generic over the key type because the batch index borrows its file paths and
-/// the incremental one owns them; the answer depends on neither.
-fn repository_defines_symbol_elsewhere<P>(
-    exact: Option<&Vec<(P, EntityId)>>,
-    bare: Option<&Vec<(P, EntityId)>>,
-    caller: EntityId,
-) -> bool {
-    [exact, bare]
-        .into_iter()
-        .flatten()
-        .any(|candidates| candidates.iter().any(|(_, candidate)| *candidate != caller))
-}
-
-/// Split the member expression an unresolved-receiver placeholder records back
-/// into the receiver it was written on and the member it named.
-///
-/// The evidence carries the expression as written, `this.router.handle`, which
-/// is one lexical token at the evidence site and needs no field used against
-/// its documented meaning to hold it. The receiver is everything before the
-/// final separator and the member is what follows.
-pub fn split_unresolved_receiver_token(token: &str) -> Option<(&str, &str)> {
-    let (receiver, symbol) = token.rsplit_once('.')?;
-    if receiver.is_empty() || symbol.is_empty() {
-        return None;
-    }
-    Some((receiver, symbol))
-}
-
-/// How an unresolved-receiver target is named where a reader will see it.
-///
-/// The full expression is `this.router.handle`, but `this` is the calling
-/// object and says nothing about the destination, so the name keeps the last
-/// receiver segment and the member: `router.handle`. That is what a reader
-/// recognizes in a walk, and it is derived rather than stored so one rule
-/// governs every display of it.
-pub fn unresolved_receiver_display_name(receiver: &str, symbol: &str) -> String {
-    let leaf = receiver.rsplit('.').next().unwrap_or(receiver);
-    let leaf = if leaf.is_empty() { receiver } else { leaf };
-    format!("{leaf}.{symbol}")
-}
-
-/// Whether a relation exactly matches the unresolved-receiver placeholder
-/// contract. Like the cross-repo predicate beside it, this does not inspect
-/// graph membership; a caller establishes separately that the destination is
-/// absent from the local entity set.
-pub fn is_unresolved_receiver_placeholder(relation: &Relation) -> bool {
-    if relation.kind != RelationKind::Calls
-        || relation.origin != RelationOrigin::Inferred
-        || relation.confidence.to_bits() != UNRESOLVED_RECEIVER_CONFIDENCE.to_bits()
-        || relation.import_source.is_some()
-    {
-        return false;
-    }
-    let Some(src) = relation.src.as_entity() else {
-        return false;
-    };
-    let Some(dst) = relation.dst.as_entity() else {
-        return false;
-    };
-    let [evidence] = relation.evidence.as_slice() else {
-        return false;
-    };
-    if evidence.parser_rule.as_deref() != Some(UNRESOLVED_RECEIVER_CALL_RULE)
-        || evidence.source_path.is_some()
-        || evidence.resolved_path.is_some()
-        || evidence.source_span.is_some()
-        || evidence.call_shape.is_some()
-        || evidence.occurrence_count == 0
-    {
-        return false;
-    }
-    let Some(token) = evidence.token.as_deref() else {
-        return false;
-    };
-    if token != token.trim() {
-        return false;
-    }
-    let Some((receiver, symbol)) = split_unresolved_receiver_token(token) else {
-        return false;
-    };
-    let expected_dst = EntityId::from_content(receiver, symbol, UNRESOLVED_RECEIVER_KIND_TAG, 0);
-    dst == expected_dst && relation.id == stable_relation_id(&src, &expected_dst, &relation.kind)
-}
-
-/// Record a member call whose receiver resolves to nothing this repository
-/// defines, instead of dropping it.
-///
-/// `app.handle` in express ends in `this.router.handle(req, res, done)`, the
-/// line the function exists for. `this.router` is a property bound to a package
-/// outside the tree, so no tier above can name a destination, and the call used
-/// to disappear: a reader got every minor callee and missed the hand-off, with
-/// nothing disclosing the omission. An absent call and an unresolvable one were
-/// indistinguishable, which is the failure this repairs.
-///
-/// The placeholder states only what was observed. A call happened, it was
-/// written on this receiver, it named this member, and the destination is not
-/// here. It carries the weakest confidence the linker emits, so it reads as
-/// `name_only` and is excluded from every count that keys on resolution, which
-/// is what keeps presence from becoming fabrication.
-///
-/// `repository_defines_symbol` is what keeps the claim true. When this
-/// repository defines something by that name, the tiers above declined to pick
-/// among the candidates on purpose, and saying the destination is elsewhere
-/// would be a second guess dressed as a fact: `req.copy()` against three local
-/// `copy` methods stays unbound, exactly as before. Only a member this tree
-/// defines nowhere can honestly be called external, which is the express case,
-/// where no `handle` exists outside the `app.handle` that makes the call.
-fn make_unresolved_receiver_relation(
-    rel: &ExtractedRelation,
-    src: EntityId,
-    repository_defines_symbol: bool,
-) -> Option<Relation> {
-    if rel.kind != RelationKind::Calls || repository_defines_symbol {
-        return None;
-    }
-    let receiver = rel
-        .receiver
-        .as_deref()
-        .map(str::trim)
-        .filter(|receiver| !receiver.is_empty() && !receiver.contains(char::is_whitespace))?;
-    let symbol = rel.dst_name.trim();
-    if symbol.is_empty() || symbol.contains('.') {
-        return None;
-    }
-    let dst = EntityId::from_content(receiver, symbol, UNRESOLVED_RECEIVER_KIND_TAG, 0);
-    let id = stable_relation_id(&src, &dst, &rel.kind);
-    Some(Relation {
-        id,
-        kind: rel.kind,
-        src: GraphNodeId::Entity(src),
-        dst: GraphNodeId::Entity(dst),
-        confidence: UNRESOLVED_RECEIVER_CONFIDENCE,
-        origin: RelationOrigin::Inferred,
-        created_in: None,
-        import_source: None,
-        evidence: vec![RelationEvidence {
-            token: Some(format!("{receiver}.{symbol}")),
-            parser_rule: Some(UNRESOLVED_RECEIVER_CALL_RULE.to_string()),
-            ..RelationEvidence::default()
-        }],
-    })
-}
-
 fn make_external_reference_relation<S>(
     rel: &ExtractedRelation,
     src: EntityId,
@@ -7097,21 +6894,6 @@ fn resolve_one_file_incremental(
             make_external_reference_relation(rel, src_id, &file.file_path, &linker.known_files)
         {
             accumulate_relation(&mut resolved, &mut relation_indices, external);
-            continue;
-        }
-
-        // (e) Unresolvable receiver, mirroring the batch resolver. The two
-        // chains must end the same way or an incremental reparse would silently
-        // retract every placeholder the batch pass recorded.
-        let repository_defines_symbol = repository_defines_symbol_elsewhere(
-            linker.entity_by_name.get(dst_lookup),
-            linker.entity_by_bare_name.get(dst_lookup),
-            src_id,
-        );
-        if let Some(unresolved) =
-            make_unresolved_receiver_relation(rel, src_id, repository_defines_symbol)
-        {
-            accumulate_relation(&mut resolved, &mut relation_indices, unresolved);
             continue;
         }
     }
@@ -12487,15 +12269,19 @@ void f();
         }
     }
 
-    // ── An unresolvable member call is recorded, not dropped ──────────────
+    // ── An unresolvable member call names no node ─────────────────────────
     //
-    // `app.handle` in express ends in `this.router.handle(...)`, the line the
-    // function exists for, and the receiver is bound to a package outside the
-    // tree. Every tier declines, and the call used to vanish with nothing
-    // disclosing it, so a reader got every minor callee and missed the hand-off.
+    // The tier that used to answer here minted a destination entity out of the
+    // receiver's own spelling, so `sig_str.join` and `"a.rs".into` became
+    // `Module` entities carrying no file. Half of every repository's entity
+    // count was that class. `kin-model`'s external-reference module states the
+    // rule it broke: parser spelling stays relation evidence until a resolver
+    // can bind it, and only a resolver-issued coordinate earns a persisted
+    // identity. A receiver this repository cannot resolve has no coordinate, so
+    // it gets no node, and with no node it can carry no edge.
 
     #[test]
-    fn a_member_call_this_repository_cannot_resolve_is_recorded_as_unproven() {
+    fn a_member_call_this_repository_cannot_resolve_names_no_node() {
         let caller = py_method("app.handle", "lib/application.js", EntityRole::Source);
         let files = vec![FileParseData {
             file_path: "lib/application.js".to_string(),
@@ -12505,38 +12291,28 @@ void f();
         }];
 
         let result = link_cross_file(&files);
-        let edges = calls_edges_from(&result, &caller);
 
-        assert_eq!(edges.len(), 1, "the call must be recorded: {result:#?}");
-        let edge = edges[0];
         assert!(
-            is_unresolved_receiver_placeholder(edge),
-            "and recorded as the unresolved-receiver placeholder: {edge:#?}"
-        );
-        assert_eq!(
-            crate::resolution::RelationResolution::of(edge),
-            crate::resolution::RelationResolution::NameOnly,
-            "an unresolvable call must never read as something the linker settled"
-        );
-        assert_ne!(
-            edge.dst,
-            GraphNodeId::Entity(caller.id),
-            "the placeholder destination is not a local entity"
-        );
-        assert_eq!(
-            edge.evidence[0].token.as_deref(),
-            Some("this.router.handle"),
-            "the evidence carries the member expression as written"
+            calls_edges_from(&result, &caller).is_empty(),
+            "a receiver nothing here resolves must produce no edge, because the only \
+             destination available is the receiver's own spelling: {result:#?}"
         );
     }
 
-    /// The claim has to be true, so it is only made when nothing here answers
-    /// to the name. This is the same shape as the case above and must produce
-    /// nothing, because the repository does define a `handle`.
+    /// The other half of the same claim, and the one that fails if the removal
+    /// went too far: a call whose destination this repository really does
+    /// define still resolves, to that definition.
+    ///
+    /// This is the control the entity fix is worth nothing without. Removing
+    /// the tier that answered when nothing was found must not touch a call that
+    /// had a real answer, so this asserts the edge exists AND that its
+    /// destination is the local definition, rather than merely that some edge
+    /// appeared.
     #[test]
-    fn a_member_call_whose_name_this_repository_defines_is_left_alone() {
+    fn a_call_this_repository_defines_still_resolves_to_that_definition() {
         let caller = py_method("app.handle", "lib/application.js", EntityRole::Source);
-        let local = py_method("Router.handle", "lib/router.js", EntityRole::Source);
+        let local = py_method("route", "lib/router.js", EntityRole::Source);
+        let local_id = local.id;
         let files = vec![
             FileParseData {
                 file_path: "lib/router.js".to_string(),
@@ -12547,26 +12323,41 @@ void f();
             FileParseData {
                 file_path: "lib/application.js".to_string(),
                 entities: vec![caller.clone()],
-                relations: vec![py_receiver_call("app.handle", "this.router", "handle")],
+                relations: vec![ExtractedRelation {
+                    site: None,
+                    receiver: None,
+                    call_shape: None,
+                    kind: RelationKind::Calls,
+                    src_name: "app.handle".to_string(),
+                    dst_name: "route".to_string(),
+                    import_source: None,
+                }],
                 imports: vec![],
             },
         ];
 
         let result = link_cross_file(&files);
 
-        assert!(
-            !calls_edges_from(&result, &caller)
+        assert_eq!(
+            calls_edges_from(&result, &caller)
                 .iter()
-                .any(|edge| is_unresolved_receiver_placeholder(edge)),
-            "calling a member this repository defines is not evidence it is elsewhere: {result:#?}"
+                .map(|edge| edge.dst)
+                .collect::<Vec<_>>(),
+            vec![GraphNodeId::Entity(local_id)],
+            "the call must reach the definition this repository holds, and reach \
+             nothing beside it: {result:#?}"
         );
     }
 
-    /// The negative control the fix is worth nothing without: a function that
-    /// makes no such call gains no step. Presence has to come from the source,
-    /// not from the tier existing.
+    /// The negative control: a function that writes no call gains no edge.
+    /// Presence has to come from the source, not from a tier existing.
+    ///
+    /// It shares its assertion with the unresolvable case above and is not
+    /// redundant with it, because the two separate under the mutation that
+    /// matters: restoring the placeholder tier turns that one red and leaves
+    /// this one green, since there is no call here for a tier to answer.
     #[test]
-    fn a_function_that_makes_no_unresolvable_call_gains_no_placeholder() {
+    fn a_function_that_makes_no_call_gains_no_edge() {
         let caller = py_method("app.listen", "lib/application.js", EntityRole::Source);
         let files = vec![FileParseData {
             file_path: "lib/application.js".to_string(),

--- a/crates/kin-index/tests/module_entities_are_declarations.rs
+++ b/crates/kin-index/tests/module_entities_are_declarations.rs
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! A method call contributes no entity, and every `Module` entity is a
+//! declaration with a file origin.
+//!
+//! FIR-2819. Measured on production, `Module` was the most common entity kind
+//! in the graph and most of it was not modules: 30,240 of 63,356 entities
+//! across five repositories, of which 29,422 carried no file path and 29,201
+//! had a `.` or a `(` in the name. The verbatim samples were `sig_str.join`,
+//! `std::io::stdin().read_to_string`, `Math.random` and `"structured".into`,
+//! which are the receiver expressions of method calls. The discriminator was
+//! exact: of `kin`'s 21,526 `Module` entities, the 664 carrying a file path all
+//! had clean names and read as real `mod` declarations.
+//!
+//! The producer was one tier. A member call whose receiver no tier could settle
+//! was recorded as a placeholder edge whose destination id was derived from the
+//! receiver STRING, and the entity synthesized to back that destination was
+//! named `{receiver_leaf}.{symbol}` with `EntityKind::Module` and no file
+//! origin. `"a.rs".into()` reached it as receiver `"a.rs"`, whose leaf after
+//! the final dot is `rs"`, which is where the 101 first segments spelled `rs"`
+//! came from.
+//!
+//! `kin-model`'s external-reference module already states the rule that tier
+//! broke: parser spelling stays relation evidence until a resolver can bind it,
+//! and only a resolver-issued coordinate earns a persisted identity. The tier
+//! took unresolved parser spelling and gave it one, through the entity door.
+//!
+//! Every fixture here goes through the real git admission path, because that is
+//! the path that synthesizes these entities. The live reconcile path drops the
+//! edge instead, so a fixture built that way could not see the class at all.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use kin_blobs::BlobStore;
+use kin_git::{
+    admit_semantic_git_import, capture_lossless_git_repository, plan_semantic_git_import,
+};
+use kin_index::derive_historical_semantic_deltas;
+use kin_model::{
+    ChangeStore, Entity, EntityDelta, EntityKind, Relation, RelationDelta, RelationKind,
+    RepositoryId, SemanticChange,
+};
+
+/// One admitted repository, reduced to the entity and relation state its
+/// first-parent history replays to.
+struct AdmittedRepository {
+    entities: Vec<Entity>,
+    relations: Vec<Relation>,
+}
+
+impl AdmittedRepository {
+    fn modules(&self) -> Vec<&Entity> {
+        self.entities
+            .iter()
+            .filter(|entity| entity.kind == EntityKind::Module)
+            .collect()
+    }
+
+    fn describe(&self) -> String {
+        let mut rows: Vec<String> = self
+            .entities
+            .iter()
+            .map(|entity| {
+                format!(
+                    "  {:?} {:?} file={:?}",
+                    entity.kind,
+                    entity.name,
+                    entity.file_origin.as_ref().map(|file| file.0.clone())
+                )
+            })
+            .collect();
+        rows.sort();
+        rows.join("\n")
+    }
+}
+
+/// Two module declarations, and eleven method calls whose receivers are locals
+/// this repository does not define a method for.
+///
+/// Every call here took the removed tier on the tree this fixture is written
+/// against: `parts.join`, `raw.trim`, `text.split`, `seen.insert`, and the
+/// three string-literal receivers that produced the name fragments the ticket
+/// samples. `"a.rs".into()` is the one that made `rs"`.
+const RUST_LIB: &str = r#"mod alpha;
+mod beta;
+
+use std::collections::BTreeSet;
+
+pub fn run(raw: &str) -> String {
+    let text = raw.trim();
+    let parts: Vec<&str> = text.split(',').collect();
+    let mut seen = BTreeSet::new();
+    for part in &parts {
+        seen.insert(part.to_string());
+    }
+    let joined = parts.join("-");
+    let owned: String = "structured".into();
+    let suffixed: String = "a.rs".into();
+    let padded = joined.to_uppercase();
+    format!("{padded}{owned}{suffixed}{}", seen.len())
+}
+"#;
+
+/// The first control: module declarations and no method calls at all. Its
+/// `Module` count must not move, because nothing here ever reached the tier.
+const RUST_DECLARATIONS_ONLY: &str = r#"mod gamma;
+mod delta;
+
+pub const LIMIT: usize = 7;
+"#;
+
+const RUST_ALPHA: &str = "pub fn alpha_helper() -> usize {\n    1\n}\n";
+const RUST_BETA: &str = "pub fn beta_helper() -> usize {\n    2\n}\n";
+const RUST_GAMMA: &str = "pub fn gamma_helper() -> usize {\n    3\n}\n";
+const RUST_DELTA: &str = "pub fn delta_helper() -> usize {\n    4\n}\n";
+
+/// The second control, and the one that fails if the removal went too far: a
+/// call whose destination this repository really does define must keep its
+/// edge. `caller` calls `alpha_helper`, which `src/alpha.rs` declares.
+const RUST_CALLER: &str = r#"use crate::alpha::alpha_helper;
+
+pub fn caller() -> usize {
+    alpha_helper()
+}
+"#;
+
+#[test]
+fn a_method_call_contributes_no_module_entity() {
+    let root = tempfile::tempdir().unwrap();
+    let repo = admit_repository(
+        &root.path().join("rust"),
+        "frag-rust",
+        &[
+            ("src/lib.rs", RUST_LIB),
+            ("src/alpha.rs", RUST_ALPHA),
+            ("src/beta.rs", RUST_BETA),
+            ("src/caller.rs", RUST_CALLER),
+        ],
+    );
+
+    let modules = repo.modules();
+
+    // The fragment tell, asserted first and on its own, because it is the claim
+    // that is exactly about this defect: the removed tier named its targets
+    // `{receiver_leaf}.{symbol}`, so a `.` or a `(` in a Module name is the
+    // signature of a call expression whatever else is true of the row.
+    let fragments: Vec<String> = modules
+        .iter()
+        .filter(|entity| entity.name.contains('.') || entity.name.contains('('))
+        .map(|entity| entity.name.clone())
+        .collect();
+    assert!(
+        fragments.is_empty(),
+        "no Module name may carry a `.` or a `(`, which is what a method-call \
+         receiver looks like: {fragments:?}\nall entities:\n{}",
+        repo.describe()
+    );
+
+    // The second claim, and it is NOT the first one restated. Production showed
+    // 20,862 pathless Module entities against 20,761 carrying a `.`, so the two
+    // populations differ by about a hundred rows: the cross-repo import class,
+    // which is pathless too and is named by a real imported symbol rather than
+    // by an expression. That class stays, so the claim here is not that every
+    // Module has a file, it is that a pathless one is backed by an import this
+    // repository actually wrote. A Module with neither is a fabrication.
+    let unbacked: Vec<String> = modules
+        .iter()
+        .filter(|entity| entity.file_origin.is_none())
+        .filter(|entity| !is_import_backed(&repo, entity))
+        .map(|entity| entity.name.clone())
+        .collect();
+    assert!(
+        unbacked.is_empty(),
+        "a Module entity carries a file it is declared in, or an import naming \
+         the module it came from; these carry neither: {unbacked:?}\nall \
+         entities:\n{}",
+        repo.describe()
+    );
+
+    // The call the repository really does define keeps its edge, so the fix is
+    // a removal of fabrication and not a removal of resolution.
+    let caller = repo
+        .entities
+        .iter()
+        .find(|entity| entity.name == "caller")
+        .unwrap_or_else(|| panic!("the fixture declares `caller`:\n{}", repo.describe()));
+    let target = repo
+        .entities
+        .iter()
+        .find(|entity| entity.name == "alpha_helper")
+        .unwrap_or_else(|| panic!("the fixture declares `alpha_helper`:\n{}", repo.describe()));
+    assert!(
+        repo.relations.iter().any(|relation| {
+            relation.kind == RelationKind::Calls
+                && relation.src.as_entity() == Some(caller.id)
+                && relation.dst.as_entity() == Some(target.id)
+        }),
+        "the call to a function this repository declares must survive; \
+         relations from `caller`: {:?}",
+        repo.relations
+            .iter()
+            .filter(|relation| relation.src.as_entity() == Some(caller.id))
+            .map(|relation| (relation.kind, relation.dst))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn a_repository_of_declarations_and_no_method_calls_is_unaffected() {
+    let root = tempfile::tempdir().unwrap();
+    let repo = admit_repository(
+        &root.path().join("control"),
+        "frag-control",
+        &[
+            ("src/lib.rs", RUST_DECLARATIONS_ONLY),
+            ("src/gamma.rs", RUST_GAMMA),
+            ("src/delta.rs", RUST_DELTA),
+        ],
+    );
+
+    let names: BTreeSet<String> = repo
+        .modules()
+        .iter()
+        .map(|entity| entity.name.clone())
+        .collect();
+
+    assert_eq!(
+        names,
+        ["delta", "gamma"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<BTreeSet<_>>(),
+        "a file that declares two modules and calls no method contributes \
+         exactly those two module entities and nothing else:\n{}",
+        repo.describe()
+    );
+}
+
+/// The class that stays, asserted present rather than assumed absent.
+///
+/// Without this the pathless claim above is vacuous: a fixture that mints no
+/// placeholder of either class satisfies it by producing nothing. This one
+/// imports a symbol no file here defines, which is the shape the cross-repo
+/// tier answers, and pins that what comes back is named by the symbol the
+/// source wrote and carries the module it came from.
+#[test]
+fn a_cross_repo_import_still_earns_its_pathless_module_and_names_a_symbol() {
+    let root = tempfile::tempdir().unwrap();
+    let repo = admit_repository(
+        &root.path().join("consumer"),
+        "frag-consumer",
+        &[(
+            "src/app.rs",
+            "use provider::do_work;\n\npub fn run_task() -> u32 {\n    do_work()\n}\n",
+        )],
+    );
+
+    let modules = repo.modules();
+    let pathless: Vec<&&Entity> = modules
+        .iter()
+        .filter(|entity| entity.file_origin.is_none())
+        .collect();
+
+    assert_eq!(
+        pathless.len(),
+        1,
+        "an import of a symbol nothing here defines must produce exactly one \
+         cross-repo target:\n{}",
+        repo.describe()
+    );
+    let target = pathless[0];
+    assert_eq!(
+        target.name,
+        "do_work",
+        "and it is named by the symbol the source imported, not by an \
+         expression:\n{}",
+        repo.describe()
+    );
+    assert!(
+        is_import_backed(&repo, target),
+        "and it carries the module it came from, which is the coordinate the \
+         spine resolves it by: {:?}",
+        repo.relations
+            .iter()
+            .filter(|relation| relation.dst.as_entity() == Some(target.id))
+            .map(|relation| relation.import_source.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Whether a pathless entity is the destination of a relation naming the module
+/// it came from.
+///
+/// This is what separates the class that stays from the class that went. A
+/// cross-repo import placeholder carries a non-empty `import_source`, which is
+/// the resolver coordinate the spine binds it by. The receiver placeholder
+/// carried none, because there was no module to name, which is exactly why its
+/// identity had to be invented out of the receiver's spelling.
+fn is_import_backed(repo: &AdmittedRepository, entity: &Entity) -> bool {
+    repo.relations.iter().any(|relation| {
+        relation.dst.as_entity() == Some(entity.id)
+            && relation
+                .import_source
+                .as_deref()
+                .is_some_and(|source| !source.trim().is_empty())
+    })
+}
+
+/// Build a Git repository from `files`, admit it exactly as `kin init` does,
+/// and replay its first-parent history into entity and relation state.
+fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> AdmittedRepository {
+    std::fs::create_dir_all(dir).unwrap();
+    git_ok(dir, ["init", "--quiet", "--initial-branch", "main"]);
+    git_ok(dir, ["config", "user.name", "Fixture"]);
+    git_ok(dir, ["config", "user.email", "fixture@example.invalid"]);
+    for (path, body) in files {
+        let file = dir.join(path);
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, body).unwrap();
+    }
+    git_ok(dir, ["add", "--all"]);
+    git_ok(dir, ["commit", "--quiet", "--message", "seed"]);
+
+    let blob_store = BlobStore::new(dir.join(".fixture-cas")).unwrap();
+    let snapshot = capture_lossless_git_repository(
+        dir,
+        RepositoryId::new(repository_id).unwrap(),
+        &blob_store,
+    )
+    .unwrap();
+    let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+    let trees = plan
+        .aliases
+        .iter()
+        .map(|alias| {
+            (
+                alias.change_id,
+                plan.commit_trees
+                    .get(&alias.oid)
+                    .expect("every imported commit has an exact resolved tree")
+                    .clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let bindings = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store)
+        .unwrap()
+        .into_iter()
+        .map(|delta| {
+            kin_git::HistoricalSemanticBinding::owned(
+                delta.change_id,
+                delta.entity_deltas,
+                delta.relation_deltas,
+            )
+        })
+        .collect::<Vec<_>>();
+    let admitted = admit_semantic_git_import(
+        &plan
+            .with_historical_semantics(&blob_store, bindings)
+            .unwrap(),
+        &blob_store,
+    )
+    .unwrap();
+    admitted.validate(&blob_store).unwrap();
+
+    // Admission fails closed on a relation naming a destination entity the tree
+    // does not define, so this replay is also the assertion that removing the
+    // synthesized targets removed the edges that named them. A surviving
+    // placeholder edge makes `derive_historical_semantic_deltas` return an
+    // error above rather than reaching here.
+    let graph = kin_db::InMemoryGraph::new();
+    for change in &admitted.changes {
+        graph.create_change(change).unwrap();
+    }
+    let head = admitted
+        .changes
+        .iter()
+        .map(|change| change.id)
+        .find(|candidate| {
+            !admitted
+                .changes
+                .iter()
+                .any(|change| change.parents.contains(candidate))
+        })
+        .expect("history must have a head");
+    graph
+        .resolve_graph_at(&head)
+        .expect("admitted history must replay");
+
+    replay_first_parent(&admitted.changes)
+}
+
+/// Apply every change's deltas in parent-first order, the way durable authority
+/// replay derives the state a workspace reports.
+fn replay_first_parent(changes: &[SemanticChange]) -> AdmittedRepository {
+    let known: BTreeSet<_> = changes.iter().map(|change| change.id).collect();
+    let mut applied = BTreeSet::new();
+    let mut ordered = Vec::with_capacity(changes.len());
+    while ordered.len() < changes.len() {
+        let next = changes
+            .iter()
+            .find(|change| {
+                !applied.contains(&change.id)
+                    && change
+                        .parents
+                        .iter()
+                        .all(|parent| !known.contains(parent) || applied.contains(parent))
+            })
+            .expect("the admitted change set must be a DAG rooted in this history");
+        applied.insert(next.id);
+        ordered.push(next);
+    }
+
+    let mut entities = BTreeMap::new();
+    let mut relations = BTreeMap::new();
+    for change in ordered {
+        for delta in &change.entity_deltas {
+            match delta {
+                EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => {
+                    entities.insert(new.id, new.clone());
+                }
+                EntityDelta::Removed { old } => {
+                    entities.remove(&old.id);
+                }
+            }
+        }
+        for delta in &change.relation_deltas {
+            match delta {
+                RelationDelta::Added { new } | RelationDelta::Modified { new, .. } => {
+                    relations.insert(new.id, new.clone());
+                }
+                RelationDelta::Removed { old } => {
+                    relations.remove(&old.id);
+                }
+            }
+        }
+    }
+
+    AdmittedRepository {
+        entities: entities.into_values().collect(),
+        relations: relations.into_values().collect(),
+    }
+}
+
+fn git_ok<I, S>(repo: &Path, args: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = git_output(repo, args);
+    assert!(
+        output.status.success(),
+        "git failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_output<I, S>(repo: &Path, args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("git runs")
+}

--- a/crates/kin-index/tests/python_two_hop_receiver_resolution.rs
+++ b/crates/kin-index/tests/python_two_hop_receiver_resolution.rs
@@ -702,13 +702,25 @@ class Session:
 }
 
 #[test]
-fn a_declined_two_hop_call_keeps_the_edge_the_bare_leaf_would_have_had() {
-    // The hand-back invariant, on the shape that exposed it. The parser writes
-    // the owner half from declarations, so a call whose join fails carries a
-    // name the source never spelled. Tier (d) mints its cross-repo placeholder
-    // from `dst_name`, and a dotted name there produced no edge at all: four
-    // real unresolved-receiver edges vanished from the requests measurement
-    // until a declining tier handed the call back unchanged.
+fn a_declined_two_hop_call_hands_back_cleanly_and_names_nothing() {
+    // The hand-back invariant, on the shape that exposed it, restated against
+    // the contract FIR-2819 left behind.
+    //
+    // The parser writes the owner half from declarations, so a call whose join
+    // fails carries a name the source never spelled. Tier (d) mints its
+    // cross-repo placeholder from `dst_name`, and a dotted name there produces
+    // no edge, which is what a declining tier handing the call back unchanged
+    // exists to keep from mattering.
+    //
+    // What that hand-back used to reach was a tier that minted a destination
+    // entity out of the receiver's own spelling: `transport.dispatch`, a
+    // `Module` carrying no file. That tier is gone, because it was half of
+    // every repository's entity count and named expression fragments as
+    // symbols. So a declined two-hop call now names nothing, and the assertion
+    // is that it names nothing rather than something wrong: a future declining
+    // tier that hands back a MANGLED call and resolves it against some
+    // unrelated local `dispatch` turns this red, which is the regression the
+    // original test was written to catch.
     let files = vec![parse_py(
         "client.py",
         r#"
@@ -732,17 +744,10 @@ def run(session: Session, payload):
         .filter(|r| r.kind == RelationKind::Calls && r.src.as_entity() == Some(caller))
         .collect();
 
-    // Tier (e) builds its token as `{receiver}.{symbol}` and refuses a symbol
-    // that carries a dot of its own, so the parser's `Session.transport.dispatch`
-    // reached it as a symbol it could not use and no edge was recorded at all.
     assert!(
-        outgoing.iter().any(|r| r
-            .evidence
-            .iter()
-            .any(|e| e.token.as_deref() == Some("session.transport.dispatch"))),
-        "a two-hop call the repository cannot settle must still record the \
-         call it makes, through the receiver the source wrote and the bare \
-         symbol it read; got {outgoing:?}"
+        outgoing.is_empty(),
+        "a two-hop call through a type this repository does not own has no \
+         destination here, so it must name none: got {outgoing:?}"
     );
 }
 

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,6 +1,6 @@
 {
   "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what a repository's past is said to contain the next time that repository is admitted. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together. Bumping the version records the decision; it does not migrate, invalidate, or re-enrich a repository that was already admitted, because nothing persists the version beside a graph or compares it when one is opened.",
-  "hydration_semantics_version": 9,
+  "hydration_semantics_version": 10,
   "guarded": [
     {
       "file": "crates/kin-index/src/history.rs",
@@ -19,7 +19,7 @@
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "external_reference_targets",
-      "digest": "sha256:71a383d53839a3ca68a109671b91508d2c2a7ff640a34a44f6f643880bd068c1",
+      "digest": "sha256:9542f2e28f43ed31d8f66c229992457570c3fc18f07fe2ed5f3d729d8ccf574a",
       "reason": "Decides which cross-repo destinations a tree binds an external target for, and derives every field of that target from the importers it collects. Its output is persisted entity state, so a change here restates what a repository's past says about the symbols it reaches through another repository.",
       "owner": "kin-index"
     },


### PR DESCRIPTION
Half of every repository's entity count was one linker tier, and the thing it counted was the receiver a call was written through.

`Module` was the most common entity kind in the graph and most of it was not modules. Measured on production across five repositories: 30,240 of 63,356 entities were `Module`, 29,422 of those carried no file path, and 29,201 had a `.` or a `(` in the name. Verbatim: `sig_str.join`, `std::io::stdin().read_to_string`, `Math.random`, `"structured".into`.

## The mechanism

Tier (e) of the resolver, `make_unresolved_receiver_relation`, recorded a member call no tier could settle as a `Calls` relation whose destination id came from the receiver **string**:

```rust
let dst = EntityId::from_content(receiver, symbol, UNRESOLVED_RECEIVER_KIND_TAG, 0);
```

`external_reference_targets` then minted an entity to back that destination, hardcoding `kind: EntityKind::Module`, `file_origin: None`, `role: External`. So the missing file path is by construction, not by accident, which is why "has a file origin" separated the two populations perfectly in the production sample: they come from different producers and only one of them ever saw a file.

The name is `format!("{leaf}.{symbol}")` over `receiver.rsplit('.')`, so **every** entity of this class carries a `.` by construction. It also explains the strangest sample: `"a.rs".into()` arrives with receiver `"a.rs"`, whose leaf after the final dot is `rs"`, giving `rs".into`. That is where the 101 first segments spelled `rs"` came from.

`kin-model/src/external_reference.rs:4-11` already stated the rule this broke: *"Parser spelling ... remains relation evidence until a resolver can bind it"*, and the constructor beside it says *"Unresolved parser spelling must not enter this constructor."* The tier took unresolved parser spelling, which is what "unresolved receiver" means, and gave it a persisted identity through the entity door instead.

**No shape filter fixes it.** The paren-bearing receivers are the smaller half: the first-segment tally over `kin` is led by `std` (449), `iter()` (424), `serde_json` (298), `fs` (246). The tier's only guard fired whenever the repository defined no method of that name, which in Rust is essentially every standard-library call. The class is wrong, not its inputs.

## What changed

Removed at the source, both resolver copies, with everything that became dead. The entity and the edge had to move together: `history.rs` returns `InvalidHistoricalSemantics("linked relation ... names destination entity ... that the tree does not define")` and `kin-git` maps that to a failed `kin init`, so removing the synthesis alone breaks every import. Arm M2 below is that mutation and it fails exactly there.

**The cross-repo import placeholder class is untouched.** It carries a non-empty `import_source`, its name is the imported symbol rather than an expression, and the spine resolver binds it. That is a coordinate; the receiver class had none, which is why its identity had to be invented.

## One correction to the ticket's acceptance, please read

The ticket asks for "a second control asserting every `Module` entity carries a file origin". **That assertion is false, and testing found it.** The cross-repo import class legitimately produces a pathless `Module`, which is the ~100-row gap between production's 20,862 pathless and 20,761 dotted. My first fixture asserted the strict version and passed only because it happened to mint no import placeholder.

The claim is now two claims: no `Module` name carries a `.` or a `(`, and a pathless `Module` is backed by a relation naming the module it came from. A third test mints exactly one such target and pins its name and provenance, so the second claim is exercised rather than vacuous.

`Closes` is on this PR because the headline defect is fully removed and the acceptance is met on substance. If the intent was that the import class should stop being `Module` too, this should be reopened and that is a separate change.

## Migration

- **A fresh import is already clean**, proved by the fixture rather than assumed: it admits through the real capture, plan, derive, admit path and asserts the resulting entity set.
- **An existing store cannot be cleaned by relinking.** These entered as `EntityDelta::Added` inside admitted changes, which are immutable. Re-import is the migration and there is no partial one.
- **The live path never had them.** `cross_file.rs:456` skips only the import placeholder and the receiver edge dies at `reconciler.rs:1063`, so a store's fragments all came from its initial import.
- **The hosted graph needs a re-ingest**, the same procedure that ran v8 to v13. What it must carry is the expectation: the count roughly halves, and that is the defect leaving, not data.
- **`HYDRATION_SEMANTICS_VERSION` goes 9 to 10** with the manifest, because re-deriving the same commits now produces a different entity set. Its own doc is explicit that the constant is a declaration and not an enforcement point, so the bump records the decision and migrates nothing. Nothing will tell an operator their graph is stale.

## Two consequences that move published numbers

Recorded here, edited nowhere; these are the captain's and the founder's to communicate.

**Entity counts fall by roughly the pathless-`Module` population.** Fleet 63,356 to about 34,000, a drop of roughly 29,200; `kin` 43,225 to about 22,400. Derived from the ticket's table by subtracting the dotted-or-paren column, so it is an estimate of this class, not a measured post-fix count.

**`kin-mcp`'s caller-arrival gate counted these edges with no filter.** `caller_arrival.rs:456-463` counts every `Calls` relation sourced by a family-file entity, testing neither confidence nor placeholder-ness, and its own module doc at line 36 says so. `reference_coverage.rs:855` does the same into `resolved_call_edges`, the numerator of `call_percent`. So files will report `unaccounted` where they reported `accounted`. **That is the gate reading truthfully and it extends #1175 rather than regressing it**: a placeholder never pointed at the focal, so it never contributed a real caller, it only suppressed a warning that was true. The magnitude is **not measured** and I am not claiming one; the lane report names the measurement that settles it and the follow-up that would let the gate say "accounted" without fabricating anything.

## Falsification

Six arms, re-run on this exact sha after the rebase onto #1181. Every arm removes a property of the code; none weakens an assertion.

| Arm | Mutation | Verdict | Which assertion fired |
|---|---|---|---|
| A0 | none | GREEN | 39 targets, zero failures |
| M1 | tier and synthesis both restored | RED | fixture:156 fragment names; the unit test; the two-hop test |
| M2 | tier restored WITHOUT the synthesis | RED | fixture:350, the admission error instead |
| M3 | import-class synthesis deleted | RED | an existing history guard, plus the import control at fixture:350 |
| M4 | bare-name resolution broken | RED | linker unit control, plus 26 lib and 3 two-hop |
| M5 | a resolved call emits no `Calls` edge | RED | fixture:196, the surviving-edge claim |

**M1 and M2 fire different assertions in the same test**, so the two failure modes separate rather than collapsing into one red. Under M1 the declarations-only and import-class controls stayed green; under M3 the fragment claim and the whole two-hop suite stayed green. No row is green all the way across.

**M5 exists because M4 exposed an assertion nothing could fire.** M4 turns 30 tests red but left the end-to-end fixture green, because its own call resolves at the import-declared tier, which never reads `dst_lookup`. An assertion no arm can fire is not evidence, so M5 removes the property that assertion is actually about.

The first driver reported DID-NOT-COMPILE on every red arm: its classifier matched cargo's own `error: test failed` line. Nothing had failed to compile. It also ran at the default thread count, so assertion text interleaved and could not be attributed by position. Both are fixed in the driver that produced the grid above.

## A test rewritten rather than deleted

`a_declined_two_hop_call_keeps_the_edge_the_bare_leaf_would_have_had` asserted the placeholder edge survives a declined two-hop call. It was written for a real bug where a mangled hand-back produced no edge at all. That invariant is still real; only its observable is gone, because a declined call now correctly names nothing. The rewrite keeps the shape and the history and asserts the call names **nothing rather than something wrong**, so a future declining tier that resolves a mangled call against an unrelated local still turns it red. Recording it so nobody later reads this as the silent deletion the anti-revert rule exists to catch.

## Gates

`bin/kin-precheck kin`: **16 gates ran, 16 passed, 0 failed** on `6465d86ab`, 0 behind `origin/main`. `cargo test -p kin-mcp -p kin-core -p kin-reconcile -p kin-index --no-fail-fast`: green, 39 targets, zero failures. `cargo check --workspace --all-targets`: exit 0.

`fmt` and `verify-hydration-semantics.py` both failed on the first pass and both were real. The hydration guard asked the migration question above before I had written it down, which is the guard working.

Rebased onto #1181 (`a0fa21e64`) and fully re-graded there, because a green earned against the old base says nothing about a squash onto a main that moved. The subject was proved before grading: `crates/kin-index/tests/receiver_module_hop.rs`, which only #1181 adds, is present in the graded tree. The two compose in the right direction, since #1181 resolves more receivers to real entities before the removed tier would ever be reached.

Lane report: `.kin-coord/reports/frag2819-20260827.md`.

Closes FIR-2819
