### PR TITLE
Count a daemon's memory once per process, not once per thread

### DIFF
--- a/crates/kin-cli/src/commands/commit_progress.rs
+++ b/crates/kin-cli/src/commands/commit_progress.rs
@@ -463,6 +463,16 @@ pub fn other_resident_daemons(dead_pid: u32) -> Vec<ResidentDaemon> {
             if pid == dead_pid || pid == std::process::id() {
                 return None;
             }
+            // A thread is not a daemon. Linux lists a process's threads under
+            // `/proc/<pid>/task` and `sysinfo` returns them from `processes()`
+            // beside real processes, each carrying its owning process's
+            // executable and argv, so an unfiltered census reports one daemon
+            // once per thread and sums a resident set they all share. That is
+            // what showed the v0.6.1 stranger "13 kin daemons serving
+            // /work/express, 473 MiB each" for a single daemon (FIR-2823).
+            if process.thread_kind().is_some() {
+                return None;
+            }
             let name = process.exe()?.file_name()?.to_str()?.to_owned();
             if name != crate::daemon_client::DAEMON_BINARY_FILE_NAME {
                 return None;

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -1641,6 +1641,14 @@ fn managed_daemon_processes(install_root: &Path) -> Vec<ManagedDaemonProcess> {
         if pid == std::process::id() {
             continue;
         }
+        // A thread carries its owning process's executable, so an unfiltered
+        // scan finds one managed daemon once per thread. Here that is not only
+        // a wrong count: the uninstall quiescence fence refuses on a non-empty
+        // result, so a daemon's own threads would report it as "processes
+        // appeared after shutdown" and block a clean uninstall (FIR-2823).
+        if process.thread_kind().is_some() {
+            continue;
+        }
         let args = process
             .cmd()
             .iter()

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -11268,6 +11268,14 @@ fn collect_active_managed_runtime_pids(
     let mut pids = Vec::new();
     for (pid, process) in system.processes() {
         let pid = pid.as_u32();
+        // A thread carries its owning process's executable and argv, so an
+        // unfiltered scan returns one serving process once per thread. This
+        // matcher feeds a fail-closed preflight and a drain scan, so the extra
+        // pids refuse an update that should proceed and send the drain after
+        // tids that were never processes (FIR-2823).
+        if process.thread_kind().is_some() {
+            continue;
+        }
         let command = process_command(process);
         let matched =
             process.exe().is_some_and(|executable| {

--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -1842,6 +1842,10 @@ fn owned_process_ids(owner_env: &'static str, owner_token: &str) -> Vec<u32> {
     let mut pids = system
         .processes()
         .values()
+        // A thread inherits its owning process's environment, so an unfiltered
+        // scan reports one owned process once per thread and every failure
+        // message counts tids as strays (FIR-2823).
+        .filter(|process| process.thread_kind().is_none())
         .filter(|process| process_has_owner_token(process, owner_env, owner_token))
         .map(|process| process.pid().as_u32())
         .collect::<Vec<_>>();

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -8147,10 +8147,18 @@ mod memory_pressure_tests {
 
         // Half the join: the marking is live. Without this, the fold's rule
         // could be unreachable and nothing here would say so.
+        //
+        // An absolute floor rather than a delta, because a delta is only sound
+        // when this test owns the process. `cargo nextest` gives it one, plain
+        // `cargo test --workspace` does not, and there a sibling test's threads
+        // exiting between the two readings subtracts from the delta and fails a
+        // correct build. The floor cannot be gamed the same way: the SPAWNED
+        // threads are alive at the second reading by construction, so anything
+        // that marks threads at all must report at least that many.
         assert!(
-            threads_after >= threads_before + SPAWNED,
-            "starting {SPAWNED} threads must show up as thread rows: {threads_before} before, \
-             {threads_after} after"
+            threads_after >= SPAWNED,
+            "starting {SPAWNED} threads must show up as thread rows parented to this process: \
+             {threads_before} before, {threads_after} after"
         );
 
         // The other half, over that same reading. Bounded by the number of

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1836,11 +1836,22 @@ fn embed_batch_under_pressure(
     }
 }
 
-/// One row of the host's process table, in the three fields a footprint needs.
+/// One row of the host's process table, in the four fields a footprint needs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ProcessRow {
     pub(crate) pid: u32,
     pub(crate) parent: Option<u32>,
+    /// Whether the host reported this row as a THREAD of `parent` rather than
+    /// as a process of its own.
+    ///
+    /// Linux lists a process's threads under `/proc/<pid>/task` and `sysinfo`
+    /// returns them from `processes()` beside real processes, each with its own
+    /// tid as a pid and its owning process as its parent. Nothing in the shape
+    /// of such a row says it is not a process, which is the whole of FIR-2823:
+    /// a thread shares its process's address space, so `/proc/<tid>/smaps_rollup`
+    /// answers with the WHOLE process's proportional set, and charging one row
+    /// per thread multiplies a daemon's footprint by its thread count.
+    pub(crate) is_thread: bool,
     /// What this process contributes to what the container is charged: a
     /// proportional or private figure, never a resident set. See
     /// [`kin_daemon_spawn::process_footprint_bytes`] for what each platform
@@ -1872,6 +1883,17 @@ pub(crate) struct ProcessRow {
 /// refusing to answer, because the descendants are still real and a caller that
 /// got nothing would fall back to the pre-budget behaviour on a reading that
 /// mostly succeeded.
+///
+/// A row the host reported as a THREAD is not a descendant and is never
+/// charged, which is FIR-2823. Threads share one address space, so every one of
+/// them reads back the whole process's proportional set, and counting them as
+/// children multiplies the process by its thread count rather than measuring
+/// anything: the v0.6.1 stranger measured a 1.41 GiB daemon reporting 10.35
+/// GiB, its own figure repeated once per thread, which refused background
+/// embedding on a repository that had room and left it at 0 of 2116 vectors for
+/// the life of the container. Skipping the row outright loses nothing a real
+/// child would have contributed, because Linux parents a process forked from a
+/// thread to the thread's PROCESS, so no real descendant ever hangs off a tid.
 pub(crate) fn tree_footprint_from(
     root: u32,
     rows: &[ProcessRow],
@@ -1890,6 +1912,9 @@ pub(crate) fn tree_footprint_from(
         }
         for row in rows.iter().filter(|row| row.parent == Some(pid)) {
             if !visited.insert(row.pid) {
+                continue;
+            }
+            if row.is_thread {
                 continue;
             }
             children_bytes = children_bytes.saturating_add(row.footprint_bytes);
@@ -1946,22 +1971,7 @@ fn sample_tree_footprint() -> Option<kin_core::memory_pressure::TreeFootprint> {
 /// accessor states the intent without arguing with a guard that is right to be
 /// blunt.
 fn walk_process_table() -> Option<kin_core::memory_pressure::TreeFootprint> {
-    let me = sysinfo::get_current_pid().ok()?;
-    let mut system = sysinfo::System::new();
-    system.refresh_processes_specifics(
-        sysinfo::ProcessesToUpdate::All,
-        true,
-        sysinfo::ProcessRefreshKind::nothing().with_memory(),
-    );
-    let rows = system
-        .processes()
-        .iter()
-        .map(|(pid, process)| ProcessRow {
-            pid: pid.as_u32(),
-            parent: process.parent().map(|parent| parent.as_u32()),
-            footprint_bytes: row_footprint_bytes(pid.as_u32(), process),
-        })
-        .collect::<Vec<_>>();
+    let (me, rows) = current_process_rows()?;
     if rows.is_empty() {
         return None;
     }
@@ -1972,15 +1982,61 @@ fn walk_process_table() -> Option<kin_core::memory_pressure::TreeFootprint> {
     // a figure nobody could take.
     if !rows
         .iter()
-        .any(|row| row.pid == me.as_u32() && row.footprint_bytes > 0)
+        .any(|row| row.pid == me && row.footprint_bytes > 0)
     {
         return None;
     }
-    let folded = tree_footprint_from(me.as_u32(), &rows);
+    let folded = tree_footprint_from(me, &rows);
     // Held to what the kernel says this container is charged, so the figure a
     // reader sees beside a cap can never exceed it. Off a cgroup there is no
     // such ceiling and the reading stands as measured.
     Some(folded.clamped_to(kin_daemon_spawn::cgroup_memory().current_bytes))
+}
+
+/// This process's pid and the host's process table as rows the fold can take.
+///
+/// Split from the fold above it so the marking can be checked against a real
+/// host. The fold's refusal to charge a thread is only worth anything if
+/// something actually marks one, and that join cannot be seen from either side
+/// alone: a `thread_kind()` that never answered `Some` would leave the fold's
+/// rule dead and every synthetic test still green, which is exactly how
+/// FIR-2823 would come back.
+fn current_process_rows() -> Option<(u32, Vec<ProcessRow>)> {
+    let me = sysinfo::get_current_pid().ok()?.as_u32();
+    let mut system = sysinfo::System::new();
+    system.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::All,
+        true,
+        sysinfo::ProcessRefreshKind::nothing().with_memory(),
+    );
+    let rows = system
+        .processes()
+        .iter()
+        .map(|(pid, process)| {
+            // `thread_kind()` is `Some` exactly for the `/proc/<pid>/task`
+            // entries Linux publishes beside real processes, and `None` for a
+            // process on every platform. A thread is marked rather than dropped
+            // here so the rule that refuses to charge it lives in the fold,
+            // where the budget rests on it and a synthetic table can exercise
+            // it.
+            let is_thread = process.thread_kind().is_some();
+            ProcessRow {
+                pid: pid.as_u32(),
+                parent: process.parent().map(|parent| parent.as_u32()),
+                is_thread,
+                // Not read for a thread: `/proc/<tid>/smaps_rollup` answers
+                // with the whole owning process's proportional set, so the
+                // figure would be both wrong and, on a large address space,
+                // expensive to be wrong with.
+                footprint_bytes: if is_thread {
+                    0
+                } else {
+                    row_footprint_bytes(pid.as_u32(), process)
+                },
+            }
+        })
+        .collect::<Vec<_>>();
+    Some((me, rows))
 }
 
 /// What one row of the process table contributes, in bytes.
@@ -7593,6 +7649,20 @@ mod memory_pressure_tests {
         ProcessRow {
             pid,
             parent,
+            is_thread: false,
+            footprint_bytes,
+        }
+    }
+
+    /// One `/proc/<pid>/task` row as Linux publishes it: its own tid, its
+    /// owning process as its parent, and, because a thread shares that
+    /// process's address space, that process's whole proportional set as its
+    /// reading. FIR-2823.
+    fn thread_of(tid: u32, owner: u32, footprint_bytes: u64) -> ProcessRow {
+        ProcessRow {
+            pid: tid,
+            parent: Some(owner),
+            is_thread: true,
             footprint_bytes,
         }
     }
@@ -7641,6 +7711,7 @@ mod memory_pressure_tests {
             .map(|(pid, parent, body)| ProcessRow {
                 pid: *pid,
                 parent: *parent,
+                is_thread: false,
                 footprint_bytes: kin_daemon_spawn::resolve_process_footprint(
                     Some(body),
                     None,
@@ -7745,6 +7816,193 @@ mod memory_pressure_tests {
         );
     }
 
+    /// FIR-2823, over the process table Linux publishes for a threaded daemon.
+    ///
+    /// The shape is the v0.6.1 stranger's express reading: one daemon whose
+    /// eleven threads `sysinfo` returns from `processes()` beside real
+    /// processes, each with its own tid and the daemon as its parent. Every
+    /// thread row carries the daemon's rollup VERBATIM, because that is what
+    /// `/proc/<tid>/smaps_rollup` answers with: threads share one address
+    /// space, so each reads back the whole process's proportional set.
+    ///
+    /// Two real descendants sit beside the threads, a language server and its
+    /// worker, so the test separates the fix from an over-deletion. A fold that
+    /// stopped counting children at all would satisfy "the number got smaller"
+    /// and fails here on `child_count` and on the children's own bytes.
+    ///
+    /// The pre-fix figure is computed from the same fixture rather than written
+    /// down, so the control and the experiment cannot drift apart.
+    #[test]
+    fn a_daemons_threads_are_not_children_and_are_counted_once() {
+        const KB: u64 = 1024;
+        const GIB: u64 = 1024 * 1024 * 1024;
+        // The measured express daemon: 1.41 GiB resident, 0.863 GiB
+        // proportional, eleven threads, and Kin reporting 10.35 GiB.
+        const DAEMON_RSS_KB: u64 = 1_478_656;
+        const DAEMON_PSS_KB: u64 = 905_216;
+        const THREADS: u64 = 11;
+        const SERVER_PSS_KB: u64 = 512 * KB;
+        const WORKER_PSS_KB: u64 = 128 * KB;
+
+        fn rollup(rss_kb: u64, pss_kb: u64) -> String {
+            format!(
+                "Rss:            {rss_kb} kB\nPss:            {pss_kb} kB\n\
+                 Shared_Clean:   {} kB\nPrivate_Clean:  {pss_kb} kB\n",
+                rss_kb.saturating_sub(pss_kb),
+            )
+        }
+        let read = |body: &str| {
+            kin_daemon_spawn::resolve_process_footprint(Some(body), None, None, 4096)
+                .expect("a rollup carrying a Pss line is readable")
+        };
+
+        let daemon_body = rollup(DAEMON_RSS_KB, DAEMON_PSS_KB);
+        let daemon_bytes = read(&daemon_body);
+        let server_bytes = read(&rollup(SERVER_PSS_KB * 2, SERVER_PSS_KB));
+        let worker_bytes = read(&rollup(WORKER_PSS_KB * 2, WORKER_PSS_KB));
+
+        // The fixture's central claim, asserted rather than assumed: a thread's
+        // rollup IS its process's, so a thread row's reading is the daemon's
+        // own figure over again.
+        let thread_bytes = read(&daemon_body);
+        assert_eq!(
+            thread_bytes, daemon_bytes,
+            "a thread reads back the whole address space it shares, which is why summing \
+             threads multiplies rather than measures"
+        );
+
+        let table = |threads: u64| {
+            let mut rows = vec![
+                row(100, Some(1), daemon_bytes),
+                row(200, Some(100), server_bytes),
+                row(201, Some(200), worker_bytes),
+            ];
+            rows.extend((0..threads).map(|n| {
+                thread_of(
+                    u32::try_from(300 + n).expect("fixture tids fit in a u32"),
+                    100,
+                    thread_bytes,
+                )
+            }));
+            rows
+        };
+
+        let tree = tree_footprint_from(100, &table(THREADS));
+
+        assert_eq!(
+            tree.child_count, 2,
+            "the language server and its worker are the daemon's only children; the eleven \
+             threads are the daemon itself"
+        );
+        assert_eq!(
+            tree.own_bytes, daemon_bytes,
+            "the daemon's own proportional set, counted once"
+        );
+        assert_eq!(
+            tree.children_bytes,
+            server_bytes + worker_bytes,
+            "every real descendant still charged, so this cannot be satisfied by counting none"
+        );
+        assert_eq!(
+            tree.total_bytes(),
+            daemon_bytes + server_bytes + worker_bytes,
+            "one reading per process, threads folded into the process that owns them"
+        );
+
+        // The acceptance criterion, stated the way it was written: thread count
+        // must not move the answer.
+        assert_eq!(
+            tree_footprint_from(100, &table(1)),
+            tree_footprint_from(100, &table(64)),
+            "a daemon with 64 threads reports what the same daemon with one thread reports"
+        );
+
+        // The pre-fix arithmetic, from the same fixture: the daemon's own
+        // figure once per thread plus itself.
+        let pre_fix_bytes = daemon_bytes * (THREADS + 1) + server_bytes + worker_bytes;
+        assert!(
+            pre_fix_bytes > 10 * GIB,
+            "the pre-fix reading of this fixture is {pre_fix_bytes} bytes, the 10.35 GiB the \
+             stranger was shown, and this test exists to be able to see it"
+        );
+        assert!(
+            tree.total_bytes() < 2 * GIB,
+            "roughly 1.5 GiB, against the 10.35 GiB reported"
+        );
+
+        // What that costs is not a label on a dial. Under the stranger's 12 GiB
+        // container the derived budget is 6 GiB, and the two readings give
+        // opposite answers to "may background embedding start", which is why
+        // one repository sat at 0 of 2116 vectors.
+        let bars = kin_core::memory_pressure::Thresholds::default();
+        let host = kin_core::memory_pressure::MemoryPressure::Known(
+            kin_core::memory_pressure::MemoryReading {
+                source: kin_core::memory_pressure::PressureSource::Cgroup,
+                limit_bytes: 12 * GIB,
+                used_bytes: 3 * GIB,
+                swap_used_bytes: None,
+                swap_total_bytes: None,
+                oom_kills: Some(0),
+                peak_bytes: None,
+            },
+        );
+        // Derived by hand rather than through `resolve`, for the reason the
+        // FIR-2653 test above gives: a sibling test pins an operator budget,
+        // and a check another test can switch off is a check that cannot fail.
+        let budget = kin_core::memory_pressure::FootprintBudget {
+            bytes: kin_core::memory_pressure::FootprintBudget::derived_from(12 * GIB),
+            source: kin_core::memory_pressure::BudgetSource::Derived,
+        };
+        assert_eq!(budget.bytes, 6 * GIB, "half of a 12 GiB container");
+        let stand = |footprint| kin_core::memory_pressure::BudgetStanding { footprint, budget };
+        assert_eq!(
+            kin_core::memory_pressure::Verdict::decide(
+                kin_core::memory_pressure::HeavyWork::EmbedBatch,
+                &host,
+                Some(&stand(tree)),
+                &bars,
+            ),
+            kin_core::memory_pressure::Verdict::Proceed,
+            "counted once, the daemon has room and embedding starts"
+        );
+        let pre_fix = kin_core::memory_pressure::TreeFootprint {
+            own_bytes: daemon_bytes,
+            children_bytes: pre_fix_bytes - daemon_bytes,
+            child_count: usize::try_from(THREADS).expect("fixture thread count fits") + 2,
+            kernel_capped: false,
+        };
+        assert!(
+            kin_core::memory_pressure::Verdict::decide(
+                kin_core::memory_pressure::HeavyWork::EmbedBatch,
+                &host,
+                Some(&stand(pre_fix)),
+                &bars,
+            )
+            .refused(),
+            "and the pre-fix reading refuses it, which is the defect this fixes"
+        );
+    }
+
+    /// A thread that is somehow reported as owning a process must not smuggle
+    /// that process back into the count through the walk, and a thread of a
+    /// CHILD is the daemon's memory exactly once, through the child.
+    #[test]
+    fn threads_are_skipped_at_every_depth() {
+        let table = [
+            row(100, Some(1), 1024),
+            row(200, Some(100), 2048),
+            thread_of(300, 100, 1024),
+            thread_of(301, 200, 2048),
+        ];
+        let tree = tree_footprint_from(100, &table);
+        assert_eq!(
+            tree.child_count, 1,
+            "one real child, whose own threads are itself"
+        );
+        assert_eq!(tree.children_bytes, 2048, "the child charged once");
+        assert_eq!(tree.total_bytes(), 1024 + 2048);
+    }
+
     /// The shape the measured failure had: a daemon, a language server it
     /// started, and an unrelated process that must not be counted.
     #[test]
@@ -7829,6 +8087,88 @@ mod memory_pressure_tests {
             "a running process holds more than nothing"
         );
         assert!(sampled.total_bytes() >= sampled.own_bytes);
+    }
+
+    /// FIR-2823 on the LIVE path: the seam between marking a thread and
+    /// refusing to charge it.
+    ///
+    /// The fold test proves the fold skips a row marked as a thread. It cannot
+    /// prove anything marks one, and a `thread_kind()` that never answered
+    /// `Some` would leave that rule dead with every synthetic test still green.
+    /// That is the join, so it is asserted over the real process table rather
+    /// than at either end of it: threads this test starts itself must appear as
+    /// thread rows, and the fold over the same reading must not have grown
+    /// children by them.
+    ///
+    /// Linux only, because Linux is the platform that publishes
+    /// `/proc/<pid>/task` and the only one where `sysinfo` returns threads from
+    /// `processes()` at all. On macOS and Windows the reading contains no
+    /// thread rows to find, so this would pass without exercising anything, and
+    /// a check that cannot fail is worse than an absent one.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn threads_this_process_starts_are_marked_and_never_become_children() {
+        use super::current_process_rows;
+
+        const SPAWNED: usize = 64;
+
+        let own_threads = |rows: &[ProcessRow], me: u32| {
+            rows.iter()
+                .filter(|row| row.parent == Some(me) && row.is_thread)
+                .count()
+        };
+
+        let (me, before) = current_process_rows().expect("Linux publishes a process table");
+        let threads_before = own_threads(&before, me);
+
+        // Parked rather than spinning, so the threads are alive for the second
+        // reading and cost the box nothing while they wait.
+        let (release, wait) = std::sync::mpsc::channel::<()>();
+        let wait = std::sync::Arc::new(std::sync::Mutex::new(wait));
+        let started = std::sync::Arc::new(std::sync::Barrier::new(SPAWNED + 1));
+        let handles = (0..SPAWNED)
+            .map(|_| {
+                let wait = std::sync::Arc::clone(&wait);
+                let started = std::sync::Arc::clone(&started);
+                std::thread::spawn(move || {
+                    started.wait();
+                    let _ = wait
+                        .lock()
+                        .expect("the park channel is not poisoned")
+                        .recv();
+                })
+            })
+            .collect::<Vec<_>>();
+        started.wait();
+
+        let (me_again, after) = current_process_rows().expect("Linux publishes a process table");
+        assert_eq!(me_again, me, "the same process across both readings");
+        let threads_after = own_threads(&after, me);
+
+        // Half the join: the marking is live. Without this, the fold's rule
+        // could be unreachable and nothing here would say so.
+        assert!(
+            threads_after >= threads_before + SPAWNED,
+            "starting {SPAWNED} threads must show up as thread rows: {threads_before} before, \
+             {threads_after} after"
+        );
+
+        // The other half, over that same reading. Bounded by the number of
+        // threads started rather than by an exact count, because other tests in
+        // this binary run concurrently and may hold real child processes; the
+        // pre-fix reading would be at least SPAWNED and this is well under it.
+        let tree = tree_footprint_from(me, &after);
+        assert!(
+            tree.child_count < SPAWNED,
+            "the {SPAWNED} threads this test started are not children of it, yet the fold \
+             counted {} of them",
+            tree.child_count
+        );
+
+        drop(release);
+        for handle in handles {
+            handle.join().expect("a parked thread exits when released");
+        }
     }
 
     /// FIR-2653, on the LIVE path rather than over a fixture.

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -2161,6 +2161,13 @@ fn enumerate_repo_daemons(sys: &mut sysinfo::System, self_pid: u32) -> Vec<Disco
         if pid == self_pid {
             continue;
         }
+        // A thread carries its owning process's name and argv, `--repo`
+        // included, so an unfiltered scan adopts one repo daemon into the
+        // registry once per thread and then heartbeats tids that are not
+        // processes (FIR-2823).
+        if process.thread_kind().is_some() {
+            continue;
+        }
         let args: Vec<&str> = process
             .cmd()
             .iter()

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -165,11 +165,31 @@ above it. Both checks are Linux, and both say so off it: the macOS reader
 `kin-daemon-spawn` and no end-to-end arm here, because there is no second kernel
 figure to grade it against without root.
 
-Those two run twice in CI, and the second run is the one that can fail. A runner
-has no memory cap, so check 10's cgroup arm has nothing to hold a published
-figure under and check 11's derived budget is gigabytes; the workflow therefore
-runs `--only 10 --only 11` again inside `docker run --memory=2g`, which is the
-shape the defect was found in. Against shipped 0.5.51 bytes in exactly that
+Check 12 grades the TREE that reading was taken over (FIR-2823). Linux lists a
+process's threads under `/proc/<pid>/task` and `sysinfo` returns them from
+`processes()` beside real processes, each with its own tid as a pid and its
+owning process as its parent, so a walk that does not exclude them counts one
+daemon once per thread. Threads share an address space, so each reads back the
+whole process's proportional set, and the v0.6.1 stranger was shown a 1.41 GiB
+daemon published at 10.35 GiB with `child_count: 11` against zero child
+processes. Check 11 could not catch it: when the published `child_count`
+disagrees with the descendants it reads, it declines to grade on the reasoning
+that the two readings are of different trees, and a daemon counting its threads
+produces that disagreement on every run, so the arm skipped and the suite passed.
+Check 12 grades that number, reading the descendant set before and after the
+standing is published and grading only where the two agree, so a short-lived
+child during init is an unreadable tree rather than a defect. Its control is the
+reason it can fail at all and is asserted rather than assumed: a single-threaded
+process counts its threads and its child processes to the same number, so a
+one-thread daemon is reported UNREADABLE and never banked as a pass. Linux, and
+it says so off it, for the same reason as the two above.
+
+Checks 10 and 11 run twice in CI, and the second run is the one that can fail. A
+runner has no memory cap, so check 10's cgroup arm has nothing to hold a
+published figure under and check 11's derived budget is gigabytes; the workflow
+therefore runs `--only 10 --only 11` again inside `docker run --memory=2g`, which
+is the shape the defect was found in. Check 12 needs no cap, because a thread
+count is not a budget, so it runs once with the rest. Against shipped 0.5.51 bytes in exactly that
 setup both checks FAIL, quoting a daemon and twenty-three children published as
 holding 1.45 GiB inside a container the kernel charged 283 MiB, and a rung of
 `critical` against a derived budget of 1 GiB while the tree held 62 MiB.

--- a/scripts/acceptance/memory_pressure_refusal.py
+++ b/scripts/acceptance/memory_pressure_refusal.py
@@ -286,6 +286,26 @@ def descendants_of(pid):
     return sorted(found)
 
 
+def settle_descendants(read, attempts=20, gap=0.5, sleep_fn=time.sleep):
+    """The descendant set once two consecutive reads agree, else None.
+
+    Pure over the injected `read`, so the agreement rule is falsifiable
+    without a daemon. A freshly initialized daemon holds short-lived children,
+    and a single before/after pair taken half a second apart lands exactly in
+    that churn: the first hosted run of check 12 read 4 then 1 and refused.
+    Two consecutive equal reads bound the claim to a quiet tree; a tree that
+    never quiets inside `attempts` reads returns None and the caller refuses.
+    """
+    previous = read()
+    for _ in range(max(attempts - 1, 1)):
+        sleep_fn(gap)
+        current = read()
+        if current == previous:
+            return current
+        previous = current
+    return None
+
+
 def thread_count(pid):
     """How many threads `pid` runs, out of `/proc/<pid>/status`.
 
@@ -314,12 +334,24 @@ def footprint_child_verdict(child_count, real_children, threads):
     accountings apart, because counting its threads and counting its child
     processes give the same answer, so a match there is evidence of nothing and
     the caller must say so rather than bank it.
+
+    `over` requires the thread-counting shape, `child_count >= threads - 1`,
+    because the defect this grades sums the task rows and those exclude the
+    main thread. A smaller disagreement is `drifted`: the record was minted at
+    a different instant than the tree reading, which a daemon holding
+    short-lived children produces honestly, and grading it as `over` is how
+    this check false-alarmed on its first hosted run (child_count 4 against a
+    settled tree of 1 under 12 threads). Drifted is refused, never banked.
     """
     if child_count is None or real_children is None or threads is None:
         return "cannot-grade"
     if threads < 2:
         return "cannot-grade"
-    return "matches" if child_count == real_children else "over"
+    if child_count == real_children:
+        return "matches"
+    if child_count >= threads - 1:
+        return "over"
+    return "drifted"
 
 
 def binding_cgroup_dir(pid):
@@ -1865,10 +1897,12 @@ def check_12(suite):
     UNREADABLE unless the daemon it measured was actually running more than one
     thread.
 
-    The kernel tree is read twice, before and after the published standing, and
-    graded only where the two agree. A daemon holds short-lived children during
-    `kin init`, and one exiting between the readings is a different tree rather
-    than a defect.
+    The kernel tree is read until it settles, two consecutive equal reads
+    inside a bound, and graded only then. A daemon holds short-lived children
+    during `kin init`, and the record is minted on the daemon's own cadence, so
+    a sub-thread disagreement between the record and the settled tree is the
+    two instants differing rather than the defect; only the thread-counting
+    shape, `child_count >= threads - 1`, grades as over.
     """
     result = Result(
         "12", TICKET_THREADS,
@@ -1901,17 +1935,20 @@ def check_12(suite):
     child_count = footprint.get("child_count")
     threads = thread_count(pid)
 
-    # Twice, because a daemon holds short-lived children during a sweep and one
-    # exiting between the record and this read is a different tree rather than a
-    # defect. Disagreement is reported, never averaged away.
-    before = descendants_of(pid)
-    time.sleep(0.5)
-    after = descendants_of(pid)
-    if before != after:
+    # Settled, because a daemon holds short-lived children during a sweep and a
+    # single pair taken half a second apart lands exactly in that churn, which
+    # is how this check refused on its first hosted run (4 then 1). The claim
+    # is bound to a quiet tree: two consecutive equal reads, bounded, and a
+    # tree that never quiets is reported, never averaged away.
+    trail = []
+    after = settle_descendants(
+        lambda: trail.append(descendants_of(pid)) or trail[-1]
+    )
+    if after is None:
         result.unknown(
-            "the daemon's child processes changed under the reading (%d then %d), so the "
+            "the daemon's child processes changed under the reading (%s), so the "
             "published count and this one describe different trees"
-            % (len(before), len(after))
+            % " then ".join(str(len(t)) for t in trail)
         )
         return result
     if threads is None or child_count is None:
@@ -1922,6 +1959,15 @@ def check_12(suite):
         return result
 
     verdict = footprint_child_verdict(child_count, len(after), threads)
+    if verdict == "drifted":
+        result.unknown(
+            "the record's child_count %d disagrees with the settled tree's %d by less than "
+            "its %d threads, which is the shape of a record minted while short-lived "
+            "children came or went, not of thread-counting; a record and a tree from "
+            "different instants are not graded against each other"
+            % (child_count, len(after), threads)
+        )
+        return result
     if verdict == "cannot-grade":
         result.unknown(
             "this daemon ran %s thread(s), and a process with one thread counts its threads "
@@ -2293,12 +2339,44 @@ def self_test():
         ("cannot-grade", (0, 0, None)),
         ("cannot-grade", (None, 0, 12)),
         ("cannot-grade", (5, None, 12)),
+        # the first hosted run: a record minted while four short-lived children
+        # lived, read against a settled tree of one, under twelve threads. The
+        # disagreement is smaller than the thread count, so it is two instants,
+        # not thread-counting, and it must refuse rather than false-alarm.
+        ("drifted", (4, 1, 12)),
+        # a record minted before a child spawned drifts the other way.
+        ("drifted", (0, 2, 12)),
+        # the boundary: task rows exclude the main thread, so the defect's
+        # smallest shape is threads minus one.
+        ("over", (11, 0, 12)),
+        ("drifted", (10, 0, 12)),
     ]
     for want, (child_count, real_children, threads) in child_cases:
         got = footprint_child_verdict(child_count, real_children, threads)
         if got != want:
             failures.append("footprint_child_verdict(%s, %s, %s) = %s, wanted %s"
                             % (child_count, real_children, threads, got, want))
+
+    # FIR-2823, the reading protocol. Pure over an injected reader, so the
+    # agreement rule is falsifiable here: a settle that returned its first
+    # read, or one that never gave up, fails these in seconds.
+    def scripted_reader(sequence):
+        reads = list(sequence)
+        return lambda: reads.pop(0) if len(reads) > 1 else reads[0]
+    settle_cases = [
+        # a quiet tree settles on the second read.
+        ([1], [[1], [1]], "stable"),
+        # churn first, then quiet: the first hosted run's shape, 4 then 1.
+        ([1], [[1, 2, 3, 4], [1], [1]], "late"),
+        # a tree that never quiets returns None inside the bound.
+        (None, [[1], [2], [1], [2], [1], [2]], "never"),
+    ]
+    for want, sequence, name in settle_cases:
+        got = settle_descendants(scripted_reader(sequence),
+                                 attempts=5, gap=0, sleep_fn=lambda _: None)
+        if got != want:
+            failures.append("settle_descendants(%s case) = %s, wanted %s"
+                            % (name, got, want))
 
     grade_cases = [
         (PASS, [(PASS, "a")]),
@@ -2322,7 +2400,8 @@ def self_test():
              + len(memory_cases) + len(idle_cases) + len(enrichment_cases)
              + len(kill_row_cases) + len(warning_cases) + len(line_cases)
              + len(tail_cases) + len(grade_cases)
-             + len(proportional_cases) + len(charge_cases))
+             + len(proportional_cases) + len(charge_cases)
+             + len(child_cases) + len(settle_cases))
     print("kin-memory-pressure-repro: self-test %d/%d cases"
           % (total - len(failures), total))
     return 1 if failures else 0

--- a/scripts/acceptance/memory_pressure_refusal.py
+++ b/scripts/acceptance/memory_pressure_refusal.py
@@ -116,6 +116,9 @@ TICKET_DEATH = "FIR-2650"
 # The footprint READING is a third ticket in the same class: the back-off was
 # right and the number it read was impossible.
 TICKET_FOOTPRINT = "FIR-2653"
+# A fourth, and the same reading again: the tree the daemon measured was its own
+# threads, so the figure was itself repeated once per thread.
+TICKET_THREADS = "FIR-2823"
 
 # The doctor row and the durable record this suite is about.
 ROW_ID = "host_memory_pressure"
@@ -281,6 +284,42 @@ def descendants_of(pid):
                 found.add(child)
                 frontier.append(child)
     return sorted(found)
+
+
+def thread_count(pid):
+    """How many threads `pid` runs, out of `/proc/<pid>/status`.
+
+    The other half of FIR-2823's arithmetic. Linux lists these under
+    `/proc/<pid>/task` and they are not processes: they share one address
+    space, so each reads back the whole process's proportional set. A published
+    child count that tracks this number rather than the descendant count is the
+    thread count wearing a child count's name.
+    """
+    try:
+        with open("/proc/%d/status" % pid) as handle:
+            for line in handle:
+                if line.startswith("Threads:"):
+                    return int(line.split()[1])
+    except (IOError, OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def footprint_child_verdict(child_count, real_children, threads):
+    """Grade a published child count against the kernel's own two numbers.
+
+    Pure, so both cases are falsifiable without a daemon.
+
+    `cannot-grade` is not a pass. A single-threaded process cannot tell the two
+    accountings apart, because counting its threads and counting its child
+    processes give the same answer, so a match there is evidence of nothing and
+    the caller must say so rather than bank it.
+    """
+    if child_count is None or real_children is None or threads is None:
+        return "cannot-grade"
+    if threads < 2:
+        return "cannot-grade"
+    return "matches" if child_count == real_children else "over"
 
 
 def binding_cgroup_dir(pid):
@@ -561,6 +600,7 @@ GRADERS = {
     "offers_the_idle_window": offers_the_idle_window,
     "enrichment_names_a_kill": enrichment_names_a_kill,
     "row_reports_a_kill": row_reports_a_kill,
+    "footprint_child_verdict": footprint_child_verdict,
 }
 
 
@@ -1802,9 +1842,132 @@ def check_11(suite):
     return result
 
 
+def check_12(suite):
+    """FIR-2823: the published child count is processes, never threads.
+
+    Check 11 grades the published total against the tree's two summed readings,
+    but it declines to grade at all when the record's `child_count` disagrees
+    with the descendants this reads, on the reasoning that the two readings must
+    then be of different trees. A daemon counting its own threads as children
+    produces exactly that disagreement on every run, so the arm that would have
+    caught this one skipped instead and the suite reported a pass. This check is
+    the one that grades that number.
+
+    What the v0.6.1 stranger measured: a daemon holding 1.41 GiB published
+    itself at 10.35 GiB, `child_count: 11` against zero child processes, and the
+    same figure repeated once per thread. Background embedding refused on that
+    reading and psf/requests sat at 0 of 2116 vectors for the life of the
+    container, on a box with room the whole time.
+
+    The control is the reason this can fail at all, and it is asserted rather
+    than assumed: a single-threaded daemon counts its threads and its children
+    to the same number, so a match would prove nothing. The check reports
+    UNREADABLE unless the daemon it measured was actually running more than one
+    thread.
+
+    The kernel tree is read twice, before and after the published standing, and
+    graded only where the two agree. A daemon holds short-lived children during
+    `kin init`, and one exiting between the readings is a different tree rather
+    than a defect.
+    """
+    result = Result(
+        "12", TICKET_THREADS,
+        "the published child count counts processes, and a thread is not one",
+    )
+    if not sys.platform.startswith("linux"):
+        result.unknown(
+            "no /proc on %s, and this is the one platform that publishes /proc/<pid>/task, "
+            "so there are no thread rows here to miscount. The same accounting is asserted "
+            "over a synthetic process table in kin_daemon::daemon, where eleven threads "
+            "carry one address space" % sys.platform
+        )
+        return result
+
+    repo = suite.fixture("threads-are-not-children")
+    rc, out = suite.restart_daemon(repo, pressure="nominal")
+    if rc != 0:
+        result.unknown("could not start a daemon, exit %d: %s" % (rc, tail(out)))
+        return result
+    pid = suite.daemon_pid(repo)
+    if pid is None:
+        result.unknown("no daemon pid for %s" % repo)
+        return result
+
+    before = descendants_of(pid)
+    published = suite.publish_standing(repo)
+    after = descendants_of(pid)
+    footprint = published.get("footprint") or {}
+    child_count = footprint.get("child_count")
+    threads = thread_count(pid)
+
+    if before != after:
+        result.unknown(
+            "the daemon's child processes changed under the reading (%d before, %d after), "
+            "so the published count and this one describe different trees"
+            % (len(before), len(after))
+        )
+        return result
+    if threads is None or child_count is None:
+        result.unknown(
+            "could not read both numbers: threads=%s published child_count=%s standing=%s"
+            % (threads, child_count, json.dumps(published))
+        )
+        return result
+
+    verdict = footprint_child_verdict(child_count, len(after), threads)
+    if verdict == "cannot-grade":
+        result.unknown(
+            "this daemon ran %s thread(s), and a process with one thread counts its threads "
+            "and its children to the same number, so this arm could not have failed and is "
+            "not reported as a pass" % threads
+        )
+        return result
+
+    result.ok(
+        "control: the daemon ran %d threads, so counting threads and counting child "
+        "processes are distinguishable here" % threads
+    )
+    if verdict == "over":
+        result.bad(
+            "the daemon publishes child_count %d against %d real child process(es) while "
+            "running %d threads. Threads share one address space, so each reads back the "
+            "whole process's proportional set and the total is the daemon repeated once per "
+            "thread: this is what published a 1.41 GiB daemon at 10.35 GiB and refused the "
+            "background embedding that left a repository at 0 of 2116 vectors"
+            % (child_count, len(after), threads)
+        )
+        return result
+    result.ok(
+        "child_count %d is the %d child process(es) this reads from /proc, not the %d "
+        "threads beside them" % (child_count, len(after), threads)
+    )
+
+    # The consequence, on the surface it had one. A daemon counted once per
+    # process fits its own derived budget; counted once per thread it does not,
+    # which is the whole of what this ticket cost.
+    own = _published_own_bytes(published)
+    total = (own or 0) + (footprint.get("children_bytes") or 0)
+    mine = proportional_bytes(pid)
+    if own is None or mine is None:
+        result.unknown("no published own figure or no /proc reading for pid %d" % pid)
+    elif threads >= 2 and total >= mine * threads:
+        result.bad(
+            "the published total of %d bytes is at least this daemon's own %d bytes times "
+            "its %d threads, which is the summing this check exists to catch"
+            % (total, mine, threads)
+        )
+    else:
+        result.ok(
+            "the published total of %d bytes stays under one reading per thread of the "
+            "daemon's own %d bytes across %d threads" % (total, mine, threads)
+        )
+    return result
+
+
 CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3),
           ("4", check_4), ("5", check_5), ("6", check_6), ("7", check_7),
-          ("8", check_8), ("9", check_9), ("10", check_10), ("11", check_11)]
+          ("8", check_8), ("9", check_9), ("10", check_10), ("11", check_11),
+          ("12", check_12)]
 
 
 # ------------------------------------------------------------------ self-test
@@ -2091,6 +2254,32 @@ def self_test():
         if total_fits_the_kernel_charge(total, charged, cap) != want:
             failures.append("total_fits_the_kernel_charge(%s, %s, %s) != %s"
                             % (total, charged, cap, want))
+
+    # FIR-2823. The two shapes that matter are the measured ones, and they must
+    # give opposite verdicts: a threaded daemon with no child processes, and the
+    # same daemon publishing its thread count as a child count.
+    child_cases = [
+        # the measured defect: eleven threads, no child processes, eleven
+        # children published.
+        ("over", (11, 0, 12)),
+        # the same daemon counted correctly.
+        ("matches", (0, 0, 12)),
+        # a daemon that really did start a language server, counted correctly.
+        ("matches", (1, 1, 12)),
+        # and the same one with its threads added on top.
+        ("over", (12, 1, 12)),
+        # a single-threaded process counts its threads and its children to the
+        # same number, so this arm cannot fail and must not be banked as a pass.
+        ("cannot-grade", (0, 0, 1)),
+        ("cannot-grade", (0, 0, None)),
+        ("cannot-grade", (None, 0, 12)),
+        ("cannot-grade", (5, None, 12)),
+    ]
+    for want, (child_count, real_children, threads) in child_cases:
+        got = footprint_child_verdict(child_count, real_children, threads)
+        if got != want:
+            failures.append("footprint_child_verdict(%s, %s, %s) = %s, wanted %s"
+                            % (child_count, real_children, threads, got, want))
 
     grade_cases = [
         (PASS, [(PASS, "a")]),

--- a/scripts/acceptance/memory_pressure_refusal.py
+++ b/scripts/acceptance/memory_pressure_refusal.py
@@ -1888,22 +1888,29 @@ def check_12(suite):
     if rc != 0:
         result.unknown("could not start a daemon, exit %d: %s" % (rc, tail(out)))
         return result
-    pid = suite.daemon_pid(repo)
+    published = suite.publish_standing(repo)
+    # The record names its own pid, and `publish_standing` will not return one
+    # that names a predecessor. Taking the pid from the record rather than
+    # asking again is what makes this read and that count the same process.
+    pid = published.get("pid") or suite.daemon_pid(repo)
     if pid is None:
-        result.unknown("no daemon pid for %s" % repo)
+        result.unknown("no daemon pid for %s: standing=%s" % (repo, json.dumps(published)))
         return result
 
-    before = descendants_of(pid)
-    published = suite.publish_standing(repo)
-    after = descendants_of(pid)
     footprint = published.get("footprint") or {}
     child_count = footprint.get("child_count")
     threads = thread_count(pid)
 
+    # Twice, because a daemon holds short-lived children during a sweep and one
+    # exiting between the record and this read is a different tree rather than a
+    # defect. Disagreement is reported, never averaged away.
+    before = descendants_of(pid)
+    time.sleep(0.5)
+    after = descendants_of(pid)
     if before != after:
         result.unknown(
-            "the daemon's child processes changed under the reading (%d before, %d after), "
-            "so the published count and this one describe different trees"
+            "the daemon's child processes changed under the reading (%d then %d), so the "
+            "published count and this one describe different trees"
             % (len(before), len(after))
         )
         return result
@@ -1948,18 +1955,30 @@ def check_12(suite):
     own = _published_own_bytes(published)
     total = (own or 0) + (footprint.get("children_bytes") or 0)
     mine = proportional_bytes(pid)
-    if own is None or mine is None:
-        result.unknown("no published own figure or no /proc reading for pid %d" % pid)
-    elif threads >= 2 and total >= mine * threads:
+    if after:
+        # A real child holds real bytes, and separating them from a per-thread
+        # sum needs a per-process reading this arm does not take. Check 11
+        # already grades the tree total against its two summed readings, so the
+        # honest thing is to say which arm ran rather than to grade a number
+        # this one cannot attribute.
+        result.ok(
+            "bytes arm: not run, the daemon holds %d real child process(es) whose bytes this "
+            "arm cannot separate from a per-thread sum; check 11 grades that total" % len(after)
+        )
+    elif own is None or mine is None:
+        result.unknown("no published own figure or no /proc reading for pid %s" % pid)
+    elif total >= mine * 2:
         result.bad(
-            "the published total of %d bytes is at least this daemon's own %d bytes times "
-            "its %d threads, which is the summing this check exists to catch"
-            % (total, mine, threads)
+            "the daemon has no child processes and %d threads, yet publishes %d bytes against "
+            "its own /proc reading of %d. With nothing else in the tree the published total is "
+            "this process counted more than once, which is the summing this check exists to "
+            "catch" % (threads, total, mine)
         )
     else:
         result.ok(
-            "the published total of %d bytes stays under one reading per thread of the "
-            "daemon's own %d bytes across %d threads" % (total, mine, threads)
+            "with no child processes and %d threads, the published total of %d bytes stays "
+            "beside the daemon's own /proc reading of %d rather than a multiple of it"
+            % (threads, total, mine)
         )
     return result
 


### PR DESCRIPTION
Linux lists a process's threads under `/proc/<pid>/task`, and `sysinfo` returns them from `processes()` beside real processes, each carrying its own tid as a pid and its owning process as its parent. Nothing in the shape of such a row says it is not a process. A thread shares its process's address space, so `/proc/<tid>/smaps_rollup` answers with the whole process's proportional set, and charging one row per thread multiplies a daemon's footprint by its thread count.

The v0.6.1 stranger measured what that costs. A daemon holding 1.41 GiB reported 10.35 GiB, its own figure repeated once per thread, against a 6.0 GiB budget derived from a 12 GiB container. Background embedding refused on that reading and one repository sat at 0 of 2116 vectors for the life of the container, on a box that had room the whole time.

## What the code actually does

`walk_process_table` at `crates/kin-daemon/src/daemon.rs:1973` mapped every `sysinfo` entry into a `ProcessRow` with no thread filter, and `tree_footprint_from` deduplicated by pid, which a thread's tid satisfies. `row_footprint_bytes` then read that tid's `smaps_rollup`.

One detail differs from the ticket, and the code wins: the rows carry PSS, not RSS, because FIR-2653 already moved off resident sets. The stranger's own arithmetic confirms it. Express published `own 0.86 GiB + children 9.49 GiB across 11`, which is 0.863 GiB twelve times, while its resident set was 1.41 GiB. So this is PSS summed once per thread, and the two defects are separate.

## The fix

The fold refuses to charge a row the host reported as a thread, and the walk marks one rather than dropping it, so the rule lives where the budget rests on it and a synthetic table can exercise it. A thread's rollup is not read at all, because the figure would be both wrong and expensive to be wrong with.

Five other scans shared the mechanism, since a thread also carries its process's executable, argv and environment. The commit-failure census reported one daemon once per thread, which is the "13 kin daemons serving /work/express, 473 MiB each" the stranger was shown. The uninstall quiescence fence would have read a daemon's own threads as processes that appeared after shutdown and refused a clean uninstall. The update preflight counted tids as serving processes and sent its drain after them. The supervisor adopted one repo daemon into its registry once per thread. The test harness counted tids as strays.

## The scripted check

Acceptance check 11 already read the daemon's descendants out of `/proc`, but when the published `child_count` disagreed with them it declined to grade, on the reasoning that the two readings must be of different trees. A daemon counting its own threads produces that disagreement on every run, so the arm that would have caught this skipped and the suite reported a pass. New check 12 grades that number, reading the descendant set twice and grading only where the two agree. Its control is asserted rather than assumed, because it is the only reason the check can fail: a single-threaded process counts its threads and its children to the same number, so a one-thread daemon is reported UNREADABLE and never banked as a pass.

## What was run

- `cargo test -p kin-daemon --lib memory_pressure_tests`, 21 passed. The listing was asserted first and a fabricated name graded zero, so the filter is real.
- Falsification, restored clean between each arm, driver refusing a dirty tree above its own trap. Control green. Deleting the fold's thread skip turns the new test red on `child_count left: 13 right: 2` and fails only the two thread tests. Charging no children at all turns the same assertion red on `left: 0 right: 2` and fails eight tests, which is what proves the test is not satisfied by the number merely getting smaller.
- The marking half cannot be mutated on macOS, where `thread_kind()` never answers `Some`, so it was graded by varying the platform instead: running the Linux test here with its `cfg` lifted goes red on "starting 64 threads must show up as thread rows: 0 before, 0 after", which is the same condition the mutation creates. That run also proves the Linux-only body compiles.
- A minimal `sysinfo` 0.39 probe in a Debian container, which is the Linux half this host cannot answer: eight spawned threads produced eight rows marked `thread_kind() == Some`, parented to the process, and `/proc/<tid>/smaps_rollup` read 1364 kB against the process's own 1364 kB, for exactly 9.00x inflation at nine readings of one address space.
- `python3 scripts/acceptance/memory_pressure_refusal.py --self-test`, 82 cases, up from 74. Falsified twice: making the grader always answer "matches" turns the two over-counted cases red, and dropping the single-thread guard turns the degenerate case red.
- `bin/kin-parity --checkout <lane worktree>`: FINAL PASS-WITH-ALLOWANCES in 761.7s. magic 22 pass 0 fail, brownfield 11 pass 0 fail 1 unreadable, firstrun 9 pass 2 fail. All three allowances are the checked-in pre-existing ones, FIR-2580, FIR-2501 and FIR-2464, none touching this change. It graded `f7d46cad3`, and `git diff f7d46cad3 HEAD -- '*.rs' '*.toml' Cargo.lock` is empty, so its verdict stands for this head's product code.
- `bin/kin-precheck kin`: 16 gates ran, 16 passed, 0 failed, on `d3ec64423fb293c55c36af022f66e87697b6a625`. fmt, clippy with the repo's 45-lint allow list, and all 14 guard scripts the check job names, including `verify-zero-file-search.py` and `check_runtime_boundaries.sh`.

Closes FIR-2823

Check 12 hardened after its own first hosted run refused itself: a single before/after descendant pair taken half a second after a fresh init landed in short-lived-children churn (4 then 1) and the gate failed on the new UNREADABLE. The reading now settles (two consecutive equal reads inside a bound, pure over an injected reader, refusal kept when the tree never quiets), and the grader is three-way: over requires the thread-counting shape, child_count at least threads minus one since task rows exclude the main thread, while a smaller disagreement refuses as drifted, a record and a tree from different instants. Self-test 97 cases; three mutation arms each red on the assertion aimed at.
