### PR TITLE
Make admission a fast gate instead of a second run of the full suite

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+# Flake quarantine, and the two verdicts one execution produces.
+#
+# A job-level retry restarts the check clock, which is what a merge-queue
+# ejection costs: four ejections in the 2026-08-26 window, roughly thirty
+# minutes each, none of them a code change. A test-level retry costs seconds
+# and restarts nothing. This file is where that difference is declared.
+#
+# Every value below was verified against cargo-nextest 0.9.140 by running it,
+# not by reading its help text. The controls are in the report for FIR-2815 and
+# in scripts/check-quarantine.py, and the four that matter are:
+#
+#   retries = 2 + flaky-result = "pass"  -> exit 0, "2 passed (1 flaky)"
+#   flaky-result = "fail", same test     -> exit 100, "FLKY-FL"
+#   no override at all, same test        -> exit 100, plain FAIL
+#   an unknown key anywhere in this file -> a WARNING and exit 0
+#
+# The last one decides the shape of this file. nextest IGNORES keys it does not
+# know, so quarantine bookkeeping cannot live in this table as extra fields: a
+# typo would be silently dropped and the row would still read complete. The
+# bookkeeping is therefore a comment line in a fixed format above each override,
+# and scripts/check-quarantine.py refuses the file unless every override carries
+# one and the comment and the filter name the same test.
+#
+# The blocking verdict is this profile: a quarantined test that passes on retry
+# does not fail the run, so it stops ejecting queue entries and stops reddening
+# main tips. The reporting verdict is the same execution read the other way,
+# out of the JUnit file below, which records every retry as a `flakyFailure`
+# element whatever `flaky-result` says. `check-quarantine.py --report-junit`
+# is that read. Without it quarantine is a place where flakes go quiet, which is
+# the one outcome that would make this file worse than no file.
+#
+# Entering quarantine takes evidence and nothing else does: the test failed at a
+# sha, a SAME-CODE re-run of that job at that exact sha passed, and both run ids
+# are on the ticket. A test that fails deterministically cannot enter, because
+# its re-run is red too.
+
+[profile.default]
+# The blocking verdict. Explicit rather than inherited, because the whole point
+# of this file is that a reader can see which way a flake is being graded.
+flaky-result = "pass"
+
+# The record. Written on every nextest run, including a lane's local one, so the
+# reporting verdict never depends on having remembered a flag. Lands at
+# target/nextest/default/junit.xml.
+[profile.default.junit]
+path = "junit.xml"
+
+# ─── Quarantine rows ────────────────────────────────────────────────────────
+#
+# Format, enforced by scripts/check-quarantine.py:
+#
+#   # quarantine: ticket=FIR-NNNN since=YYYY-MM-DD last-flake=YYYY-MM-DD source=<path>
+#   [[profile.default.overrides]]
+#   filter = 'binary_id(=<pkg>::<target>) & test(=<test path>)'
+#   retries = 2
+#
+# `since` starts the fourteen-day clock. `last-flake` is the most recent run in
+# which this test actually needed a retry, read off nextest's own `(N flaky)`
+# summary; a row whose last flake is seven days old is a promotion candidate and
+# the guard says so. `source` is the file the test lives in, and the guard joins
+# it against the filter so a renamed or deleted test cannot leave a row behind
+# that applies to nothing.
+
+# quarantine: ticket=FIR-2809 since=2026-08-27 last-flake=2026-08-27 source=crates/kin-core/tests/init_phase_ladder_contiguous.rs
+#
+# Day-one intake, and the only row. It ejected pull request 1141 for a measured
+# 34 minutes on 2026-08-26. It has the evidence quarantine demands: the guard was
+# confirmed LOAD-SENSITIVE by the control that counts, same bytes, round one red
+# at 2.6% against a 2.0% bar and round two green. Note what that entry did and
+# copy it: the bar was NOT loosened, and the breached-ladder control that must
+# stay red was re-run to prove the guard still catches a real breach. Parking a
+# test here is never a licence to weaken the assertion it makes.
+[[profile.default.overrides]]
+filter = 'binary_id(=kin-core::init_phase_ladder_contiguous) & test(=the_admission_ladder_accounts_for_the_whole_of_init)'
+retries = 2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -25,9 +25,26 @@
 # (FIR-2593). An acceptance suite whose result depends on a profile nobody
 # releases is answering a question nobody asked.
 #
-# This workflow publishes no required context yet. It becomes one on main after
-# it has been green on five consecutive pull requests, which is a separate,
-# deliberate step (FIR-2591).
+# `Product Acceptance` IS a required context on main. It is one of the eleven on
+# ruleset 19746451, "Require status checks on main", read live from
+# `GET /repos/firelock-ai/kin/rules/branches/main` on 2026-08-27. The header
+# here used to say the opposite, that it "publishes no required context yet"
+# and would become one after five green pull requests under FIR-2591. That step
+# happened and the comment did not move.
+#
+# The correction matters beyond tidiness, because the required list is live
+# GitHub configuration no test in this repository can read, which is why the
+# release mint keeps a reviewed mirror of it. A comment claiming a context is
+# advisory when a ruleset is blocking on it is the kind of thing somebody reads
+# right before deciding a job is safe to skip.
+#
+# The job below is off the pull-request path as of FIR-2815, and that is a
+# separate question from whether the context is required. It still reports on a
+# pull request, as `skipped`, which satisfies the required context the same way
+# the Windows installer leg has satisfied it since before this file existed. It
+# runs for real in the merge queue and on every commit that reaches main, where
+# the concurrency group below gives each commit its own run and cancels
+# nothing, so acceptance is graded per commit rather than per window.
 
 name: Acceptance
 
@@ -68,6 +85,12 @@ env:
 jobs:
   acceptance:
     name: Product Acceptance
+    # Measured at 29.0 minutes on a pull request, the single largest required
+    # context, against a ten-minute open-to-merge bar. It reports `skipped` here
+    # and runs in full on the merge queue and on every main commit; the release
+    # mint refuses a sha whose required checks are not green, so what this
+    # proves still has to be true before a tag, only later than it used to be.
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,16 +189,26 @@ jobs:
 
   windows-authority-tests:
     name: Windows authority tests
+    if: ${{ github.event_name != 'pull_request' }}
     # Split out of the installer job: the debug test compile and the release
     # build share no artifacts (separate target profiles), so serialising them
     # only added wall clock. They run concurrently now.
     #
-    # This job and the two Windows authority jobs below stay on every event on
-    # purpose, and the authority test enforces that none of them carries a
-    # job-level `if:`. Together they are the merge group's only proof of the
-    # native Windows admission contract, so taking them off the queue to reclaim
-    # runner minutes would trade a reviewable pre-landing signal for a required
-    # context that first fails on main.
+    # This job and the two Windows authority jobs below stay on the merge queue
+    # and on every commit that reaches main. Together they are the merge group's
+    # only proof of the native Windows admission contract, so taking them off
+    # the queue to reclaim runner minutes would trade a reviewable pre-landing
+    # signal for a required context that first fails on main. The authority test
+    # enforces that, and it now admits exactly one job-level condition, the
+    # pull-request filter below, and refuses any other.
+    #
+    # They came off pull requests with the rest of the heavy set. The longest of
+    # the three measured 11.7 minutes, which no admission gate can carry against
+    # a ten-minute open-to-merge bar, and they gate nothing on a pull request
+    # anyway: `merge_pr_ready` in the umbrella refuses while ANY check is still
+    # pending, required or not, so an advisory leg sets the lane's clock exactly
+    # as a required one does. The proof itself did not move. It runs in the
+    # queue, which is what the release mint reads.
     #
     # The legs were split three ways by compilation unit because one job could
     # not finish inside any cap worth setting. Across 119 sampled runs, 32 of
@@ -408,6 +418,7 @@ jobs:
 
   windows-authority-cli-tests:
     name: Windows authority CLI tests
+    if: ${{ github.event_name != 'pull_request' }}
     # Every leg here is `-p kin-cli --no-default-features --lib`, which is one
     # compilation unit and the single most expensive one in the Windows set.
     # Splitting on that boundary is why the three jobs do not duplicate each
@@ -480,6 +491,7 @@ jobs:
 
   windows-authority-runtime-tests:
     name: Windows authority runtime tests
+    if: ${{ github.event_name != 'pull_request' }}
     # The integration-test binaries: real daemons, real process trees, real
     # containment. These are the legs that spend their time running rather than
     # compiling, which is why they belong away from the unit legs instead of
@@ -826,22 +838,303 @@ jobs:
           fi
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
 
-  # A skipped matrix job never expands, so the required per-platform contexts
-  # would go missing instead of reporting skipped. This stub carries the same
-  # display name and matrix as the real job and succeeds instantly on
-  # documentation-only diffs, producing the exact required context names. The
-  # two jobs' conditions are mutually exclusive.
-  check-docs-only:
-    name: Check & Test
+  # ─── The admission core ─────────────────────────────────────────────────────
+  #
+  # Two jobs, both running on every event, and between them the whole of what
+  # blocks a pull request from landing. FIR-2815, on the founder's ruling that a
+  # serialized all-green-admission queue is the wrong shape for a ten-minute
+  # open-to-merge bar.
+  #
+  # The measurement that decided the split, over the 2026-08-23 to 2026-08-26
+  # window: a landing spent a measured 31.9 minutes of pull-request CI and a
+  # measured 32.5 minutes in the queue, and in 16 of 17 landings the tree the
+  # queue built was NOT the tree the pull request tested, because main moved
+  # under it while its checks ran. So the pull-request suite was proving a base
+  # that had already been replaced by the time it went green. That is the half
+  # whose result nothing downstream depends on, and it is the half that moved.
+  #
+  # What these two catch, measured over the same window: 31 of 64 distinct
+  # pull-request failures, 48 percent, were formatting, clippy or a policy
+  # script. The other 52 percent now arrive as a red main tip instead. That is
+  # the trade, it is deliberate, and it is safe for one reason: release-tag.yml
+  # refuses to mint a sha lacking either its proof records or its nine green
+  # required checks, per sha and failing closed, so an unproven main tip cannot
+  # be tagged. It can only be inconvenient.
+  #
+  # Neither job may be skipped on any event. A required context nobody reports
+  # blocks a merge forever with every visible check green, which is a silent
+  # hang rather than a failure, so the sharded test job publishes its required
+  # name from an aggregate that always runs and names which case it passed on.
+  # The three display names below carry no colon on purpose. A YAML scalar
+  # containing ": " has to be quoted, and the job-name census in
+  # scripts/test-release-workflow-authority.py reads the exact scalar text, so a
+  # quoted name would be registered with its quotes and would no longer be the
+  # string GitHub publishes or the string a ruleset has to name.
+  fast-gate-lint:
+    name: Fast gate lint and policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+        with:
+          components: rustfmt, clippy
+
+      # `save-if: false` and a shared key, for the same reason `feature-tests`
+      # carries them: this job must never write the entry `check` owns. `check`
+      # still runs on every main commit, so the entry keeps being written by the
+      # branch that is allowed to write it. Read the cache line in THIS step's
+      # log rather than the caches API listing, which is not an inventory.
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: check
+          save-if: false
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      # The quarantine's clock. `.config/nextest.toml` buys a flaky test two
+      # retries so it stops ejecting queue entries; this is what stops that
+      # becoming a place to park a real bug. It reads source and resolves no
+      # dependencies, and it lives here rather than in `check` because a script
+      # step in `check` is a gate `bin/kin-precheck` in the umbrella enumerates
+      # and must classify by name, and wiring one there without the matching
+      # umbrella entry makes precheck refuse with no tally, on this tree and on
+      # every lane still on an older base. Promoting it is this step moving one
+      # job and one name joining precheck's LOCAL list.
+      - name: Check the flake quarantine
+        run: python3 scripts/check-quarantine.py
+
+      # Byte-identical to the `check` job's clippy step, deliberately. The two
+      # run on different events now and there is no event on which neither runs,
+      # so the workspace is linted exactly once per event rather than twice.
+      - name: Clippy
+        shell: bash
+        run: |
+          set -euo pipefail
+          allows="$(grep -Ev '^(#|$)' .github/clippy-allowed-lints.txt | tr '\n' ' ')"
+          words="$(printf '%s\n' "$allows" | wc -w | tr -d ' ')"
+          if [ "$words" -lt 2 ]; then
+            echo "::error title=Empty clippy debt list::.github/clippy-allowed-lints.txt carries no allows"
+            echo "Clippy would run with the RUSTFLAGS -D warnings group and nothing" >&2
+            echo "overriding it, so every entry on the debt list would go red at once." >&2
+            exit 1
+          fi
+          echo "clippy debt allow-list: $((words / 2)) lints"
+          # The allow list is a word list, and splitting it is the point.
+          # shellcheck disable=SC2086
+          cargo clippy --all-targets --all-features -- $allows
+
+      # Nine of the window's 64 failures were release ordering and npm
+      # provenance policy and eight more were this gate, so a fifth of what a
+      # pull request used to learn in thirty minutes is learned here in under
+      # one. The wrapper routes its own failures by event: hard for anything
+      # reaching release machinery, for the release pull request, for a push and
+      # for a diff it cannot read, and a warning annotation otherwise.
+      - name: Validate automatic release policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KIN_POLICY_EVENT: ${{ github.event_name }}
+          KIN_POLICY_HEAD_REF: ${{ github.head_ref }}
+          KIN_POLICY_REPOSITORY: ${{ github.repository }}
+          KIN_POLICY_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          KIN_POLICY_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: |
+          bash scripts/release-policy-gate.sh <<'RELEASE_POLICY'
+          python3 scripts/test-release-workflow-authority.py
+          node --test \
+            scripts/check-glibc-floor.test.mjs \
+            scripts/check-kin-vfs-compat.test.mjs \
+            scripts/check-rc-build-drift.test.mjs \
+            scripts/check-release-proof-artifacts.test.mjs \
+            scripts/release-train-body.test.mjs \
+            scripts/check-release-version.test.mjs \
+            scripts/release-intent.test.mjs \
+            scripts/extract-release-notes.test.mjs \
+            scripts/prepare-release.test.mjs \
+            scripts/release-archive-shape.test.cjs \
+            scripts/write-release-archive-docs.test.mjs
+          node --check scripts/check-release-version.mjs
+          node --check scripts/prepare-release.mjs
+          node --check scripts/release-intent.mjs
+          RELEASE_POLICY
+
+  # The build-and-test half of admission, sharded three ways over the packages
+  # the diff can have broken.
+  #
+  # Three shards each pay their own build, about ten runner minutes of
+  # duplicated compile. Building once and passing an artifact is cheaper in
+  # runner minutes and MORE expensive in wall clock, and the founder's ruling on
+  # 2026-08-26 was spend over the coverage trade, so the clock wins.
+  #
+  # The scope is the changed packages plus their reverse-dependency closure, and
+  # it widens to the whole workspace on anything it is unsure of. A selector
+  # that narrows too far exits 0 having graded nothing, which reads exactly like
+  # a clean pass, so the listing is asserted non-empty before the run: nextest
+  # over a filter matching nothing prints the summary a clean pass prints.
+  fast-gate-tests:
+    name: Fast gate test shard
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    strategy:
+      # A shard that dies must not take its siblings with it, for the reason
+      # `check` sets this: one red shard cancelling the others makes the
+      # aggregate report one cause where there may be three.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      # The scope read diffs a base against a head, so it needs both.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+
+      - name: Verify kin cargo registry config
+        run: |
+          test -f .cargo/config.toml
+          grep -q '^\[registries\.kin\]' .cargo/config.toml
+          if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed. kin-* resolve from the Kin registry"; exit 1; fi
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: check
+          save-if: false
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      # An event with no readable base produces no changed paths, and the
+      # selector widens on that rather than guessing, which is the same answer a
+      # failed diff gets. Those two must not be told apart.
+      - name: Choose the packages this diff can have broken
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+          cargo metadata --no-deps --format-version 1 > "$RUNNER_TEMP/metadata.json"
+          : > "$RUNNER_TEMP/changed.txt"
+          if [ -n "${BASE_SHA:-}" ] && [ -n "${HEAD_SHA:-}" ]; then
+            git diff --name-only "$BASE_SHA...$HEAD_SHA" -- > "$RUNNER_TEMP/changed.txt" || {
+              echo "::warning::could not diff $BASE_SHA...$HEAD_SHA; testing the whole workspace"
+              : > "$RUNNER_TEMP/changed.txt"
+            }
+          fi
+          python3 scripts/changed-crate-scope.py "$RUNNER_TEMP/metadata.json" \
+            < "$RUNNER_TEMP/changed.txt" > "$RUNNER_TEMP/scope.args"
+          if [ ! -s "$RUNNER_TEMP/scope.args" ]; then
+            echo "::error title=Empty test scope::the selector printed no arguments"
+            echo "An empty selection would run the whole suite or none of it, and" >&2
+            echo "cargo cannot tell you which. Refusing rather than guessing." >&2
+            exit 1
+          fi
+          echo "scope: $(tr '\n' ' ' < "$RUNNER_TEMP/scope.args")"
+
+      # A filter that matches nothing grades nothing and exits 0, printing the
+      # same summary a clean pass prints. Assert the listing before the run.
+      - name: Assert the selection lists tests before running any
+        run: |
+          set -euo pipefail
+          readarray -t SCOPE < "$RUNNER_TEMP/scope.args"
+          cargo nextest list --locked "${SCOPE[@]}" --message-format json \
+            > "$RUNNER_TEMP/listing.json"
+          python3 - "$RUNNER_TEMP/listing.json" <<'LISTING'
+          import json, sys
+          listing = json.load(open(sys.argv[1], encoding="utf-8"))
+          suites = listing.get("rust-suites", {})
+          total = sum(len(suite.get("testcases", {})) for suite in suites.values())
+          print(f"{total} test(s) across {len(suites)} binaries in the selection")
+          if total == 0:
+              print("::error title=Empty test selection::the scope lists zero tests")
+              raise SystemExit(1)
+          LISTING
+
+      - name: Test
+        run: |
+          set -euo pipefail
+          readarray -t SCOPE < "$RUNNER_TEMP/scope.args"
+          cargo nextest run --locked "${SCOPE[@]}" --partition count:${{ matrix.shard }}/3
+
+      # The reporting verdict. The run above graded a quarantined flake as
+      # passing, which is what keeps it off the critical path; this reads the
+      # same execution's JUnit record for what `--flaky-result fail` would have
+      # said, so a retry stays visible instead of going quiet.
+      - name: Report quarantined flakes
+        run: python3 scripts/check-quarantine.py --report-junit target/nextest/default/junit.xml
+
+  # The required context, and the only job that publishes it. It always runs, on
+  # every event, because a required context that is never reported is a silent
+  # hang. It names which case it passed on rather than passing quietly, and it
+  # admits `success` from the shards and nothing else: a skipped or cancelled
+  # shard left part of the selection unrun, and a required context that goes
+  # green on that is worse than no context at all.
+  fast-gate-tests-aggregate:
+    name: Fast gate build and tests
+    needs: [changes, fast-gate-tests]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every fast-gate shard to have succeeded
+        env:
+          DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          SHARDS: ${{ needs.fast-gate-tests.result }}
+        run: |
+          set -euo pipefail
+          if [ "$DOCS_ONLY" = "true" ]; then
+            echo "documentation-only diff: no package changed, so there is nothing to build"
+            exit 0
+          fi
+          if [ "$SHARDS" != "success" ]; then
+            echo "::error title=fast gate shards did not pass::the sharded fast-gate legs reported '$SHARDS'"
+            echo "Every shard of the selection has to report success for this" >&2
+            echo "context to be evidence that the selection ran. 'skipped' and" >&2
+            echo "'cancelled' mean a shard did not run at all." >&2
+            exit 1
+          fi
+          echo "every fast-gate shard succeeded"
+
+  # A skipped matrix job never expands, so the required per-platform contexts
+  # would go missing instead of reporting skipped, and a required context nobody
+  # reports is a silent hang rather than a failure. This stub carries the same
+  # display name and matrix as the real job and produces the exact required
+  # context names instantly. Its condition and the real jobs' are mutually
+  # exclusive, so no two of them ever publish one expanded name on one event.
+  #
+  # It used to cover documentation-only diffs alone. It now covers every pull
+  # request, because the ubuntu and macOS suites moved off the pull-request path
+  # entirely: what admits a change is the fast gate below, and the full suite
+  # runs on the merge queue and on every commit that reaches main, where it is
+  # graded per commit and nothing cancels it. `release-tag.yml` still refuses to
+  # mint a sha whose nine required checks are not green, so the proof did not
+  # move, only the moment it is paid for.
+  check-pr-fast-path:
+    name: Check & Test
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - name: Report the documentation-only fast path
-        run: echo "documentation-only diff; build and test validation not applicable"
+      - name: Report the pull-request fast path
+        run: |
+          echo "Check & Test runs in the merge queue and on every main commit."
+          echo "Admission is the fast gate; see .github/workflows/ci.yml."
 
   # The ubuntu half of Check & Test, sharded, and the job every source-reading
   # gate in this repository runs in. The macOS half moved to `check-macos` +
@@ -873,7 +1166,10 @@ jobs:
   check:
     name: Check & Test ubuntu shard
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    if: >-
+      ${{ !cancelled()
+      && needs.changes.outputs.docs_only != 'true'
+      && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     # The all-features clippy/build/test sequence can otherwise retain more
@@ -1316,14 +1612,17 @@ jobs:
   # The matrix is not decoration, for the same reason `check-macos-aggregate`
   # carries one: a skipped matrix job never expands, so on a documentation-only
   # diff this publishes the bare `Check & Test` name and leaves
-  # `check-docs-only` as the sole producer of the expanded one. Without the
+  # `check-pr-fast-path` as the sole producer of the expanded one. Without the
   # matrix, a skipped aggregate would publish `Check & Test (ubuntu-latest)` as
   # `skipped` beside the stub's success, and two check runs under one required
   # name is the ambiguity the release mint refuses on.
   check-aggregate:
     name: Check & Test
     needs: [changes, check]
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    if: >-
+      ${{ !cancelled()
+      && needs.changes.outputs.docs_only != 'true'
+      && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
@@ -1377,7 +1676,10 @@ jobs:
   check-macos:
     name: Check & Test macOS shard
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    if: >-
+      ${{ !cancelled()
+      && needs.changes.outputs.docs_only != 'true'
+      && github.event_name != 'pull_request' }}
     runs-on: macos-latest
     timeout-minutes: 60
     env:
@@ -1465,7 +1767,7 @@ jobs:
   #
   # The matrix is not decoration. A skipped matrix job never expands, so on a
   # documentation-only diff this publishes the bare `Check & Test` name and
-  # leaves `check-docs-only` as the sole producer of the expanded one, exactly
+  # leaves `check-pr-fast-path` as the sole producer of the expanded one, exactly
   # as the real and stub `check` jobs already behave. Without the matrix, a
   # skipped aggregate would publish `Check & Test (macos-latest)` as `skipped`
   # beside the stub's success, and two check runs under one required name is the
@@ -1477,7 +1779,10 @@ jobs:
   check-macos-aggregate:
     name: Check & Test
     needs: [changes, check-macos]
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    if: >-
+      ${{ !cancelled()
+      && needs.changes.outputs.docs_only != 'true'
+      && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
@@ -1517,7 +1822,10 @@ jobs:
   falsify-guards:
     name: Falsify guards
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    if: >-
+      ${{ !cancelled()
+      && needs.changes.outputs.docs_only != 'true'
+      && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1677,28 +1985,32 @@ jobs:
       - name: Falsify the release version guards
         run: python3 ./scripts/falsify-release-version-guards.py
   # A skipped matrix job never expands, so its per-leg context names do not
-  # appear at all rather than appearing skipped. `check-docs-only` exists for
+  # appear at all rather than appearing skipped. `check-pr-fast-path` exists for
   # exactly that reason and this is its counterpart: once the branch ruleset
   # requires `Feature permutation tests (ubuntu-latest)` and its macOS leg, a
   # documentation-only diff would otherwise wait forever for two contexts that
   # were never going to be created. Both legs run here on one ubuntu runner
   # because the point is the name, not the work.
-  feature-tests-docs-only:
+  feature-tests-pr-fast-path:
     name: Feature permutation tests
-    needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - name: Report the documentation-only fast path
-        run: echo "documentation-only diff; feature permutation tests not applicable"
+      - name: Report the pull-request fast path
+        run: |
+          echo "The feature permutations run in the merge queue and on every"
+          echo "main commit. Admission is the fast gate."
 
   feature-tests:
     name: Feature permutation tests
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    if: >-
+      ${{ !cancelled()
+      && needs.changes.outputs.docs_only != 'true'
+      && github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     # Same bounds as Check & Test: the feature permutations compile the same
@@ -1872,7 +2184,10 @@ jobs:
   install-proof-pr-build:
     name: Install Proof (PR) Build
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    if: >-
+      ${{ !cancelled()
+      && needs.changes.outputs.docs_only != 'true'
+      && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -1975,6 +2290,7 @@ jobs:
     if: >-
       ${{ !cancelled()
       && needs.changes.outputs.docs_only != 'true'
+      && github.event_name != 'pull_request'
       && needs.install-proof-pr-build.result == 'success' }}
     uses: ./.github/workflows/install-proof.yml
     with:
@@ -1999,11 +2315,18 @@ jobs:
     steps:
       - name: Require the pull request install proof
         env:
+          EVENT_NAME: ${{ github.event_name }}
           DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
           BUILD_RESULT: ${{ needs.install-proof-pr-build.result }}
           PROOF_RESULT: ${{ needs.install-proof-pr.result }}
         run: |
           set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "the install proof runs in the merge queue and on every main commit;"
+            echo "admission is the fast gate, and release-tag.yml still refuses a sha"
+            echo "whose required checks are not green"
+            exit 0
+          fi
           if [ "$DOCS_ONLY" = "true" ]; then
             echo "documentation-only diff: no binaries changed, so the install proof has nothing to install"
             exit 0

--- a/.github/workflows/daemon-smoke.yml
+++ b/.github/workflows/daemon-smoke.yml
@@ -31,6 +31,14 @@ env:
 jobs:
   daemon-smoke:
     name: Linux Daemon Smoke + MCP Headless
+    # Off the pull-request path as of FIR-2815. This job gates nothing on a pull
+    # request and never did, but `merge_pr_ready` in the umbrella refuses while
+    # ANY check is still pending, required or not, so an advisory leg sets the
+    # lane's clock exactly as a required one does. Moving only the required legs
+    # would have left the pull-request clock at this job's measured 3.4 minutes
+    # and read like the idea did not work. The `push: branches: [main]` trigger
+    # above is untouched, so every commit that reaches main still runs it.
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     # BLOCKING gate. The experimental allow-failure was dropped after a real
     # end-to-end green run was observed on main (run 27318898667 / af14579:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,14 @@ permissions:
 jobs:
   build-image:
     name: Docker Image Build (no push)
+    # Off the pull-request path as of FIR-2815. This job gates nothing on a pull
+    # request and never did, but `merge_pr_ready` in the umbrella refuses while
+    # ANY check is still pending, required or not, so an advisory leg sets the
+    # lane's clock exactly as a required one does. Moving only the required legs
+    # would have left the pull-request clock at this job's measured 20.1 minutes
+    # and read like the idea did not work. The `push: branches: [main]` trigger
+    # above is untouched, so every commit that reaches main still runs it.
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -922,6 +922,15 @@ jobs:
           # green, which is a silent hang rather than a failure. Reading the
           # mirror against the check-runs the sha carries turns that hang into
           # a named refusal here.
+          #
+          # DO NOT SHRINK THIS LIST TO MATCH A THINNED LIVE RULESET. It is a
+          # superset of REQUIRED_CHECKS by contract, and `missing_from_ruleset`
+          # below refuses when the mint requires a context this list does not
+          # gate, on every sha, unconditionally. FIR-2815 thinned ruleset
+          # 19746451 to a short admission list, which makes syncing this down
+          # the obvious tidy-up and makes it fatal: drop one of the nine and
+          # every release refuses, with no pull request to blame it on.
+          # scripts/test-release-workflow-authority.py enforces the superset.
           RULESET_REQUIRED_CHECKS: |
             Check & Test (ubuntu-latest)
             Check & Test (macos-latest)

--- a/scripts/changed-crate-scope.py
+++ b/scripts/changed-crate-scope.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Decide which workspace packages a diff can possibly have broken.
+
+The admission core builds and tests on the pull request's own clock, so it
+cannot afford the whole workspace on every diff and it cannot afford to be
+clever about it either. A test selector that narrows too far is the worst kind
+of check: it exits 0 having graded nothing, and it reads exactly like a clean
+pass. Everything below is arranged so that the failure mode is running too much
+rather than running too little.
+
+## What it prints
+
+Either the single argument `--workspace`, or one `-p <package>` argument per
+line for the changed packages and everything in the workspace that depends on
+them. Nothing else goes to stdout; the reasoning goes to stderr so a caller can
+read the decision without parsing it.
+
+## When it refuses to narrow
+
+Every one of these prints `--workspace`, and each is a case where narrowing
+would be a guess:
+
+  no changed paths at all      a push or a merge-group build, where there is no
+                               base to diff against. Also the shape a failed
+                               diff produces, and those two must not be told
+                               apart by guessing.
+  a path outside every crate   Cargo.lock, the root manifest, .cargo/, .config/,
+                               .github/, scripts/. A lockfile move can change
+                               any crate's dependency versions, so no closure
+                               over source ownership can bound it.
+  a path in no known package   a new crate directory the metadata does not yet
+                               carry, or a layout this script does not model.
+  a closure covering most of   narrowing to nine tenths of the workspace costs
+  the workspace                a longer command line and buys nothing.
+
+## The reverse closure, and why it is the point
+
+Changing a leaf crate can only break that leaf. Changing a crate other crates
+depend on breaks them, and they are where the failure shows up. So the selected
+set is the changed packages plus their reverse-dependency closure over workspace
+members, computed from `cargo metadata`, which is the same graph cargo builds
+from rather than a directory-name heuristic.
+
+## What the caller still owes
+
+This script chooses a set. It cannot tell whether the set ran. The caller has to
+assert the test LISTING is non-empty before the run, because a filter matching
+nothing prints the same `test result: ok` a clean pass prints, with `running 0
+tests` the only tell. That assertion lives in the workflow beside the run, not
+here, because only the caller knows which run it just made.
+
+## Usage
+
+  cargo metadata --no-deps --format-version 1 > meta.json
+  scripts/changed-crate-scope.py meta.json < changed-paths.txt
+  scripts/changed-crate-scope.py --self-test
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import PurePosixPath
+
+# Above this share of the workspace, narrowing is not worth the command line.
+WHOLE_WORKSPACE_SHARE = 0.6
+
+# Paths that can reach any crate, so no closure over source ownership bounds
+# them. A lockfile move is the sharp one: it changes resolved dependency
+# versions for packages whose own files never moved.
+UNBOUNDED_PREFIXES = (
+    "Cargo.lock",
+    "Cargo.toml",
+    ".cargo/",
+    ".config/",
+    ".github/",
+    "rust-toolchain",
+    "scripts/",
+)
+
+WORKSPACE = ["--workspace"]
+
+
+def load_members(metadata, root):
+    """Map each workspace member to its directory and its workspace deps."""
+
+    members = {}
+    ids = {package["id"]: package["name"] for package in metadata["packages"]}
+    wanted = {ids[member] for member in metadata["workspace_members"] if member in ids}
+    for package in metadata["packages"]:
+        name = package["name"]
+        if name not in wanted:
+            continue
+        manifest = PurePosixPath(package["manifest_path"].replace(os.sep, "/"))
+        try:
+            directory = manifest.parent.relative_to(root)
+        except ValueError:
+            # A member outside the workspace root is a shape this script does
+            # not model, and modelling it wrongly is worse than declining to.
+            return None
+        members[name] = {
+            "dir": str(directory),
+            "deps": {dep["name"] for dep in package.get("dependencies", [])},
+        }
+    for entry in members.values():
+        entry["deps"] &= set(members)
+    return members
+
+
+def owning_package(path, members):
+    """Longest directory prefix wins, so a nested crate beats its parent."""
+
+    best = None
+    for name, entry in members.items():
+        directory = entry["dir"]
+        if path == directory or path.startswith(directory + "/"):
+            if best is None or len(directory) > len(members[best]["dir"]):
+                best = name
+    return best
+
+
+def reverse_closure(seeds, members):
+    """Everything that depends on a seed, transitively."""
+
+    selected = set(seeds)
+    changed = True
+    while changed:
+        changed = False
+        for name, entry in members.items():
+            if name in selected:
+                continue
+            if entry["deps"] & selected:
+                selected.add(name)
+                changed = True
+    return selected
+
+
+def scope(paths, members, note=lambda _: None):
+    """Return (arguments, rule). The rule name is not decoration.
+
+    Several rules widen to the whole workspace, and more than one of them
+    accepts the same input: with `Cargo.lock` removed from UNBOUNDED_PREFIXES
+    the unknown-path rule still widens it, so deleting that entry left the
+    behaviour correct and every control green. Two rules that can both catch one
+    input hide each other's absence, so the caller and the controls read WHICH
+    rule fired rather than only what it returned.
+    """
+
+    if members is None:
+        note("workspace layout is not one this script models")
+        return WORKSPACE, "unmodelled"
+    paths = [path.strip() for path in paths if path.strip()]
+    if not paths:
+        note("no changed paths, which is a push, a merge group, or a failed diff")
+        return WORKSPACE, "no-paths"
+
+    seeds = set()
+    for path in paths:
+        if any(path == prefix or path.startswith(prefix) for prefix in UNBOUNDED_PREFIXES):
+            note(f"{path} can reach any crate")
+            return WORKSPACE, "unbounded"
+        owner = owning_package(path, members)
+        if owner is None:
+            note(f"{path} belongs to no known package")
+            return WORKSPACE, "unknown-path"
+        seeds.add(owner)
+
+    selected = reverse_closure(seeds, members)
+    if len(selected) >= max(1, int(len(members) * WHOLE_WORKSPACE_SHARE)):
+        note(
+            f"{len(selected)} of {len(members)} packages selected, which is most "
+            "of the workspace"
+        )
+        return WORKSPACE, "most-of-workspace"
+
+    note(
+        f"changed {sorted(seeds)}; with reverse dependents that is "
+        f"{len(selected)} of {len(members)} packages"
+    )
+    args = [argument for name in sorted(selected) for argument in ("-p", name)]
+    return args, "narrowed"
+
+
+# ─── Controls ───────────────────────────────────────────────────────────────
+
+FIXTURE = {
+    "leaf": {"dir": "crates/leaf", "deps": set()},
+    "middle": {"dir": "crates/middle", "deps": {"leaf"}},
+    "top": {"dir": "crates/top", "deps": {"middle"}},
+    "aside": {"dir": "crates/aside", "deps": set()},
+    "nested": {"dir": "crates/leaf/nested", "deps": set()},
+    "spare1": {"dir": "crates/spare1", "deps": set()},
+    "spare2": {"dir": "crates/spare2", "deps": set()},
+    "spare3": {"dir": "crates/spare3", "deps": set()},
+}
+
+
+def run_controls():
+    """Each rule, and the case that must NOT trigger it.
+
+    A selector is only ever wrong in a way that looks like a passing run, so
+    every arm below is paired: the input that must widen to the workspace, and
+    the input that must not. Without the second half a selector that always
+    answers `--workspace` passes every one of these.
+    """
+
+    def check(label, paths, expected, rule):
+        got, fired = scope(paths, FIXTURE)
+        if got != expected:
+            raise AssertionError(f"{label}: expected {expected}, got {got}")
+        if fired != rule:
+            raise AssertionError(
+                f"{label}: widened by rule '{fired}', expected '{rule}'. A rule "
+                "another rule already covers is a defence whose removal nothing "
+                "would notice"
+            )
+
+    # Widening, one case per rule.
+    check("empty diff widens", [], WORKSPACE, "no-paths")
+    check("lockfile widens", ["Cargo.lock"], WORKSPACE, "unbounded")
+    check("workflow widens", [".github/workflows/ci.yml"], WORKSPACE, "unbounded")
+    check("quarantine config widens", [".config/nextest.toml"], WORKSPACE, "unbounded")
+    check("unknown path widens", ["docs/thing.md"], WORKSPACE, "unknown-path")
+
+    # A closure covering most of the workspace widens. Its own control is the
+    # transitive case further down, where the identical change over a bigger
+    # workspace narrows instead, so this rule is shown to key on the SHARE
+    # rather than on the change.
+    small = {
+        "leaf": {"dir": "crates/leaf", "deps": set()},
+        "middle": {"dir": "crates/middle", "deps": {"leaf"}},
+        "top": {"dir": "crates/top", "deps": {"middle"}},
+    }
+    if scope(["crates/leaf/src/a.rs"], small) != (WORKSPACE, "most-of-workspace"):
+        raise AssertionError("a closure covering the whole workspace must widen")
+
+    # Every unbounded path, written out rather than iterated. Two attempts got
+    # this wrong before it worked. Controlling only `Cargo.lock` and `.github/`
+    # left the rest free, because the unknown-path rule widened them anyway.
+    # Looping over UNBOUNDED_PREFIXES was worse: deleting an entry deletes the
+    # control with it, so the self-test passed with one fewer element every
+    # time. The list below is the ratchet, deliberately a second copy, and a
+    # prefix leaving the tuple has to be a deliberate edit here too.
+    for probe in (
+        "Cargo.lock",
+        "Cargo.toml",
+        ".cargo/config.toml",
+        ".config/nextest.toml",
+        ".github/workflows/ci.yml",
+        "rust-toolchain.toml",
+        "scripts/check-quarantine.py",
+    ):
+        got, fired = scope([probe], FIXTURE)
+        if (got, fired) != (WORKSPACE, "unbounded"):
+            raise AssertionError(
+                f"{probe} must widen by the unbounded rule, got {got} by "
+                f"'{fired}'. Its prefix left UNBOUNDED_PREFIXES, and the "
+                "unknown-path rule widening it anyway is luck, not a defence"
+            )
+
+    # Not widening. Without these, a selector that always widens passes above.
+    check(
+        "a leaf change selects only its own package",
+        ["crates/aside/src/a.rs"],
+        ["-p", "aside"],
+        "narrowed",
+    )
+    check(
+        "a middle change selects its reverse dependents",
+        ["crates/middle/src/a.rs"],
+        ["-p", "middle", "-p", "top"],
+        "narrowed",
+    )
+    check(
+        "a nested crate is not attributed to its parent directory",
+        ["crates/leaf/nested/src/a.rs"],
+        ["-p", "nested"],
+        "narrowed",
+    )
+    check(
+        "two changes union rather than replace",
+        ["crates/aside/src/a.rs", "crates/spare1/src/b.rs"],
+        ["-p", "aside", "-p", "spare1"],
+        "narrowed",
+    )
+
+    # The closure must be transitive, not one hop. leaf -> middle -> top, and
+    # `leaf` is only kept out of the widening rule by a workspace large enough.
+    big = dict(FIXTURE)
+    for extra in range(9):
+        big[f"filler{extra}"] = {"dir": f"crates/filler{extra}", "deps": set()}
+    got, _ = scope(["crates/leaf/src/a.rs"], big)
+    if got != ["-p", "leaf", "-p", "middle", "-p", "top"]:
+        raise AssertionError(f"transitive closure is not transitive: {got}")
+
+    # A member the metadata cannot place must widen rather than be guessed at.
+    if scope(["crates/aside/src/a.rs"], None) != (WORKSPACE, "unmodelled"):
+        raise AssertionError("an unmodelled layout must widen to the workspace")
+
+    print(
+        f"changed-crate-scope: {12 + 7} controls passed, "
+        "each naming the rule that fired"
+    )
+
+
+def main(argv):
+    if len(argv) > 1 and argv[1] == "--self-test":
+        run_controls()
+        return 0
+    run_controls_quietly()
+    if len(argv) < 2:
+        raise AssertionError("usage: changed-crate-scope.py <cargo-metadata.json>")
+    metadata = json.loads(open(argv[1], encoding="utf-8").read())
+    root = PurePosixPath(metadata["workspace_root"].replace(os.sep, "/"))
+    members = load_members(metadata, root)
+    selection, rule = scope(
+        sys.stdin.read().splitlines(),
+        members,
+        note=lambda why: print(f"changed-crate-scope: {why}", file=sys.stderr),
+    )
+    print(f"changed-crate-scope: rule={rule}", file=sys.stderr)
+    for argument in selection:
+        print(argument)
+    return 0
+
+
+def run_controls_quietly():
+    import contextlib
+    import io
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        run_controls()
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except AssertionError as error:
+        sys.exit(f"changed-crate-scope: {error}")

--- a/scripts/check-quarantine.py
+++ b/scripts/check-quarantine.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Refuse a flake quarantine that has become a graveyard.
+
+`.config/nextest.toml` buys a quarantined test two retries so a flake costs
+seconds instead of a merge-queue ejection. The cost of that is obvious and it is
+the reason this guard exists: a quarantine with no clock is a place to park a
+real bug where nobody has to look at it again. Every rule below is a way of
+saying the same thing, that a row has to keep earning its place.
+
+## What it refuses
+
+  no-ticket       an override with no `ticket=FIR-NNNN` in its quarantine
+                  comment. A row nobody has to close is a row nobody closes.
+  no-date         no `since=`, or a `since` that is not a date. The clock is
+                  the point, so a row without one is not a quarantine row.
+  expired         `since` older than QUARANTINE_MAX_DAYS. Fourteen days is long
+                  enough to fix a flake and short enough that forgetting shows.
+  too-many        more than QUARANTINE_MAX_ROWS rows. A cap turns "one more
+                  test is misbehaving" into a decision instead of a habit.
+  stale-row       a row naming a test that is no longer there, or a row whose
+                  comment and filter disagree about which test it is.
+  loose-filter    a filter with no `binary_id(=...)`. A bare `test(=name)`
+                  matches that name in EVERY binary, so a row meant for one
+                  test can silently buy retries for a namesake elsewhere.
+  no-retries      an override with no `retries`, or `retries = 0`. Measured:
+                  with retries at 0 a failing test is a plain FAIL, so such a
+                  row is quarantine bookkeeping over a test nothing retries.
+
+And one thing it only warns about, because it is good news:
+
+  promotion       `last-flake` older than QUARANTINE_PROMOTION_DAYS. The test
+                  has not needed a retry in a week and is a candidate to leave.
+
+## The division of labour with nextest, measured rather than assumed
+
+cargo-nextest 0.9.140 was run against each shape before this guard was written:
+
+  binary_id(=...) matching no binary  -> config parse ERROR, exit 96
+  test(=...) matching no test         -> accepted silently, exit 0
+  an unknown key anywhere in the file -> a warning, exit 0
+
+So nextest already owns the binary half of "this row still applies to
+something", loudly, on every run. The test-name half is unowned, which is the
+half this guard covers, and it covers it by reading the source file the row
+names rather than by grepping the config, because a config the tool never
+matched is a lie about coverage a text search cannot see.
+
+The unknown-key result is why the bookkeeping is a comment. Extra fields in the
+override table would be dropped with a warning nobody reads, and the row would
+still look complete.
+
+## What `cargo nextest show-config` does not do
+
+Its help says it "shows configuration information about nextest, including
+overrides applied to individual tests". On 0.9.140 it has exactly two
+subcommands, `version` and `test-groups`, and `show-config version` accepts a
+config carrying a malformed filter expression and exits 0. It is not a
+validator, and there is no subcommand that dumps resolved per-test overrides.
+Reading the help and stopping there would have produced a check that cannot
+fail. Measured, and recorded here so the next reader does not pay for it twice.
+
+## The controls, and why these ones
+
+`run_controls()` runs before a single repository file is read, against carried
+fixtures rather than against the tree, because a control drawn from the file
+under test only proves self-consistency.
+
+Every refusal has its own mutation and each is asserted to fire BY NAME. A
+mutation that turns the guard red for the wrong reason is a guard with an arm
+nothing reaches, which is how two assertions come to hide each other's absence.
+The clean fixture is the negative control and must stay silent. The absent
+needle is assembled from parts so this file cannot be what satisfies it.
+
+## Usage
+
+  python3 scripts/check-quarantine.py [root]
+  python3 scripts/check-quarantine.py --report-junit <path> [root]
+
+The second mode is the reporting verdict. `.config/nextest.toml` grades a
+quarantined flake as passing so it blocks nothing, and writes a JUnit file that
+records the retry either way. This mode reads that file and reports what the
+same execution would have been graded under `--flaky-result fail`, so the
+retries stay visible instead of going quiet. A missing or empty JUnit file is
+UNREADABLE and refuses; it is not zero flakes.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+import xml.etree.ElementTree as ElementTree
+from datetime import date, timedelta
+from pathlib import Path
+
+CONFIG = Path(".config") / "nextest.toml"
+
+QUARANTINE_MAX_DAYS = 14
+QUARANTINE_MAX_ROWS = 5
+QUARANTINE_PROMOTION_DAYS = 7
+
+# The bookkeeping comment that must sit above every override. Keys are matched
+# individually rather than as one line pattern, so a row missing exactly one of
+# them is refused by the arm that owns that key instead of by a shapeless
+# "malformed comment".
+#
+# The colon is load-bearing and was bought by this guard's first run against the
+# real file. With the marker written as `# quarantine ` a line of ordinary prose
+# reading "# quarantine row is not a licence to weaken an assertion" satisfied
+# it, the walk-back stopped there, and a correctly filled row was reported as
+# having no ticket. A marker also has to fail to match the prose around it, so
+# the walk-back below keeps going unless the line it stops on carries keys.
+COMMENT_MARKER = "# quarantine:"
+KEY = re.compile(r"\b(ticket|since|last-flake|source)=(\S+)")
+TICKET = re.compile(r"^FIR-[0-9]+$")
+ISO_DATE = re.compile(r"^([0-9]{4})-([0-9]{2})-([0-9]{2})$")
+
+BINARY_ID = re.compile(r"binary_id\(=([^)]+)\)")
+TEST_NAME = re.compile(r"test\(=([^)]+)\)")
+
+
+class Row:
+    """One override plus the comment block immediately above it."""
+
+    def __init__(self, index, line, filter_expr, retries, meta):
+        self.index = index
+        self.line = line
+        self.filter_expr = filter_expr
+        self.retries = retries
+        self.meta = meta
+
+    def label(self):
+        return f"row {self.index} (line {self.line})"
+
+
+def parse_rows(text):
+    """Pair each `[[profile.default.overrides]]` with the comment above it.
+
+    Textual on purpose. tomllib discards comments, and the comment is where the
+    bookkeeping lives, so a TOML-only read would report every row as having no
+    ticket. tomllib still runs, in `load_config`, to prove the file is valid
+    TOML and to read the values; this pass only supplies what tomllib throws
+    away.
+    """
+
+    rows = []
+    lines = text.splitlines()
+    index = 0
+    for number, line in enumerate(lines, start=1):
+        if line.strip() != "[[profile.default.overrides]]":
+            continue
+        meta = {}
+        # Walk back over the contiguous comment block above the table header.
+        for above in range(number - 2, -1, -1):
+            candidate = lines[above]
+            if not candidate.startswith("#"):
+                break
+            if candidate.startswith(COMMENT_MARKER):
+                found = dict(KEY.findall(candidate))
+                if found:
+                    meta = found
+                    break
+        filter_expr = None
+        retries = None
+        for below in range(number, len(lines)):
+            body = lines[below]
+            if body.startswith("[") or body.strip() == "[[profile.default.overrides]]":
+                break
+            stripped = body.strip()
+            if stripped.startswith("filter"):
+                filter_expr = stripped.split("=", 1)[1].strip().strip("'\"")
+            elif stripped.startswith("retries"):
+                retries = stripped.split("=", 1)[1].strip()
+        rows.append(Row(index, number, filter_expr, retries, meta))
+        index += 1
+    return rows
+
+
+def load_config(path):
+    """Prove the file is TOML before anything reads meaning out of it."""
+
+    raw = path.read_bytes()
+    try:
+        tomllib.loads(raw.decode("utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as error:
+        raise AssertionError(f"{path} is not readable as TOML: {error}")
+    return raw.decode("utf-8")
+
+
+def parse_date(value):
+    match = ISO_DATE.match(value or "")
+    if not match:
+        return None
+    try:
+        return date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    except ValueError:
+        return None
+
+
+def check_rows(rows, root, today):
+    """Return (findings, warnings). A finding is a refusal; a warning is news."""
+
+    findings = []
+    warnings = []
+
+    if len(rows) > QUARANTINE_MAX_ROWS:
+        findings.append(
+            f"too-many: {len(rows)} quarantine rows, the cap is "
+            f"{QUARANTINE_MAX_ROWS}. Fix one before adding another, or say on "
+            "the record why the cap should move"
+        )
+
+    for row in rows:
+        meta = row.meta
+        where = row.label()
+
+        ticket = meta.get("ticket")
+        if not ticket or not TICKET.match(ticket):
+            findings.append(
+                f"no-ticket: {where} carries no `ticket=FIR-NNNN`. A row nobody "
+                "has to close is a row nobody closes"
+            )
+
+        since = parse_date(meta.get("since"))
+        if since is None:
+            findings.append(
+                f"no-date: {where} carries no readable `since=YYYY-MM-DD`. The "
+                "clock is what separates a quarantine from a hiding place"
+            )
+        else:
+            age = (today - since).days
+            if age > QUARANTINE_MAX_DAYS:
+                findings.append(
+                    f"expired: {where} has been quarantined {age} days, the "
+                    f"limit is {QUARANTINE_MAX_DAYS}. Fix the test and delete "
+                    "the row, naming the run where it passed without retries"
+                )
+
+        last_flake = parse_date(meta.get("last-flake"))
+        if last_flake is None:
+            findings.append(
+                f"no-date: {where} carries no readable `last-flake=YYYY-MM-DD`. "
+                "Without it nothing can tell a live flake from a fixed one"
+            )
+        elif (today - last_flake).days >= QUARANTINE_PROMOTION_DAYS:
+            warnings.append(
+                f"promotion: {where} has not needed a retry in "
+                f"{(today - last_flake).days} days. Delete the row and let the "
+                "test stand on its own, or record a newer flake"
+            )
+
+        if row.retries is None or row.retries.strip() in ("0", ""):
+            findings.append(
+                f"no-retries: {where} sets no `retries` above zero, so nothing "
+                "retries this test and the row buys it nothing. Measured: at "
+                "retries 0 a failing test is a plain FAIL, never flaky"
+            )
+
+        findings.extend(check_filter_join(row, root, where))
+
+    return findings, warnings
+
+
+def check_filter_join(row, root, where):
+    """Join the filter, the comment's source path, and the file on disk.
+
+    Three facts that must agree. Asserting any one of them alone is the shape
+    where two checks each hold and jointly guarantee nothing: the filter can
+    name a test the file no longer defines, and the comment can name a file the
+    filter is not about.
+    """
+
+    findings = []
+    expr = row.filter_expr or ""
+
+    binary = BINARY_ID.search(expr)
+    if not binary:
+        findings.append(
+            f"loose-filter: {where} has no `binary_id(=...)`, so `test(=...)` "
+            "matches that name in every binary in the workspace. Scope it"
+        )
+
+    test = TEST_NAME.search(expr)
+    if not test:
+        findings.append(
+            f"stale-row: {where} has no `test(=...)`, so it names no test at all"
+        )
+        return findings
+
+    source = row.meta.get("source")
+    if not source:
+        findings.append(
+            f"stale-row: {where} carries no `source=<path>`, so nothing can "
+            "check that the test it names still exists"
+        )
+        return findings
+
+    path = root / source
+    if not path.is_file():
+        findings.append(
+            f"stale-row: {where} names source {source}, which is not a file. "
+            "The test moved or went; delete the row or repoint it"
+        )
+        return findings
+
+    function = test.group(1).rsplit("::", 1)[-1]
+    body = path.read_text(encoding="utf-8", errors="replace")
+    if not re.search(rf"\bfn\s+{re.escape(function)}\s*\(", body):
+        findings.append(
+            f"stale-row: {where} names test {function}, which {source} no "
+            "longer defines. A row that applies to nothing is a row claiming "
+            "coverage it does not have"
+        )
+
+    if binary:
+        target = binary.group(1).rsplit("::", 1)[-1]
+        if path.stem != target:
+            findings.append(
+                f"stale-row: {where} filters binary target {target} while its "
+                f"source is {source}. The comment and the filter disagree "
+                "about which test this row is for"
+            )
+
+    return findings
+
+
+# ─── The reporting verdict ──────────────────────────────────────────────────
+
+
+def report_junit(junit_path, quarantined):
+    """Grade one execution the other way, out of its own JUnit record.
+
+    `.config/nextest.toml` grades a quarantined flake as passing. That is what
+    keeps it off the critical path, and it is also how quarantine goes quiet, so
+    the same run is read here for what `--flaky-result fail` would have said.
+    """
+
+    if not junit_path.is_file():
+        raise AssertionError(
+            f"UNREADABLE: no JUnit file at {junit_path}. That is a fact about "
+            "this read, not about the run: absent is not zero flakes"
+        )
+    raw = junit_path.read_text(encoding="utf-8", errors="replace")
+    # nextest writes this file on the same runner that just ran the tests, so it
+    # is not foreign input. Refusing a DOCTYPE anyway costs one line and removes
+    # the entity-expansion class outright, which is cheaper than taking a
+    # third-party parser as a dependency for one guard.
+    if "<!DOCTYPE" in raw or "<!ENTITY" in raw:
+        raise AssertionError(
+            f"UNREADABLE: {junit_path} declares a DTD. nextest writes none, so "
+            "this file did not come from the run it claims to describe"
+        )
+    try:
+        tree = ElementTree.fromstring(raw)
+    except ElementTree.ParseError as error:
+        raise AssertionError(f"UNREADABLE: {junit_path} did not parse: {error}")
+
+    cases = tree.iter("testcase")
+    total = 0
+    flaky = []
+    for case in cases:
+        total += 1
+        retried = list(case.iter("flakyFailure")) + list(case.iter("flakyError"))
+        if retried:
+            name = f"{case.get('classname', '?')} {case.get('name', '?')}"
+            flaky.append((name, len(retried)))
+
+    if total == 0:
+        raise AssertionError(
+            f"UNREADABLE: {junit_path} records no test case at all, so it is "
+            "evidence about nothing. A run that graded zero tests is a finding"
+        )
+
+    if not flaky:
+        print(f"{total} test(s) recorded, none needed a retry")
+        return 0
+
+    unquarantined = []
+    for name, tries in flaky:
+        print(f"::notice title=Quarantined flake::{name} needed {tries} retry(ies)")
+        print(f"flaky under --flaky-result fail: {name}, {tries} retry(ies)")
+        if not any(test in name for test in quarantined):
+            unquarantined.append(name)
+
+    if unquarantined:
+        print(
+            "these tests were retried and no quarantine row names them: "
+            + ", ".join(unquarantined)
+        )
+        print(
+            "A retry nobody declared is a flake nobody ticketed. Add the row "
+            "with its evidence, or find out why something is retrying it."
+        )
+        return 1
+
+    print(
+        f"{len(flaky)} quarantined test(s) needed a retry. The run passed under "
+        "the blocking verdict and this is the reporting one; update `last-flake` "
+        "on the rows above"
+    )
+    return 0
+
+
+# ─── Controls ───────────────────────────────────────────────────────────────
+
+CLEAN_FIXTURE = """
+[profile.default]
+flaky-result = "pass"
+
+# quarantine: ticket=FIR-1 since={since} last-flake={flake} source={source}
+[[profile.default.overrides]]
+filter = 'binary_id(=pkg::target) & test(=a_test_that_is_defined)'
+retries = 2
+"""
+
+EXTRA_ROW = """
+# quarantine: ticket=FIR-2 since={since} last-flake={flake} source=target.rs
+[[profile.default.overrides]]
+filter = 'binary_id(=pkg::target) & test(=a_test_that_is_defined)'
+retries = 2
+"""
+
+# Assembled rather than written out, so this file cannot be the thing that
+# satisfies a search for it. The guard's own source sits in the tree it reads.
+ABSENT_FUNCTION = "a_function_" + "no_fixture_defines"
+
+FIXTURE_SOURCE = """
+#[test]
+fn a_test_that_is_defined() { assert!(true); }
+"""
+
+
+def run_controls():
+    """Every arm, one mutation each, asserted by NAME.
+
+    Asserting only that the guard went red would let one arm cover another's
+    absence. The clean fixture is the negative control: if it ever produces a
+    finding, every mutation below is red for a reason that has nothing to do
+    with what it mutated.
+    """
+
+    import tempfile
+
+    today = date(2026, 8, 27)
+    fresh = (today - timedelta(days=1)).isoformat()
+
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        (tmp / "target.rs").write_text(FIXTURE_SOURCE, encoding="utf-8")
+
+        def grade(text):
+            findings, warnings = check_rows(parse_rows(text), tmp, today)
+            return findings, warnings
+
+        clean = CLEAN_FIXTURE.format(since=fresh, flake=fresh, source="target.rs")
+        findings, warnings = grade(clean)
+        if findings or warnings:
+            raise AssertionError(
+                "control failed: the clean fixture produced "
+                f"{findings + warnings}, so every mutation below would be red "
+                "for the wrong reason"
+            )
+
+        mutations = {
+            "no-ticket": clean.replace("ticket=FIR-1 ", ""),
+            "no-date": clean.replace(f"since={fresh} ", ""),
+            "expired": clean.replace(
+                f"since={fresh}",
+                "since=" + (today - timedelta(days=QUARANTINE_MAX_DAYS + 1)).isoformat(),
+            ),
+            "too-many": clean + EXTRA_ROW.format(since=fresh, flake=fresh)
+            * QUARANTINE_MAX_ROWS,
+            "stale-row": clean.replace(
+                "test(=a_test_that_is_defined)", f"test(={ABSENT_FUNCTION})"
+            ),
+            "loose-filter": clean.replace("binary_id(=pkg::target) & ", ""),
+            "no-retries": clean.replace("retries = 2", "retries = 0"),
+        }
+
+        for arm, text in mutations.items():
+            findings, _ = grade(text)
+            if not findings:
+                raise AssertionError(
+                    f"control failed: the {arm} mutation produced no finding, "
+                    "so that refusal cannot fire"
+                )
+            if not any(finding.startswith(arm + ":") for finding in findings):
+                raise AssertionError(
+                    f"control failed: the {arm} mutation was caught by "
+                    f"{[f.split(':', 1)[0] for f in findings]} rather than by "
+                    f"{arm}. A mutation caught by the wrong arm proves the "
+                    "wrong arm works and says nothing about this one"
+                )
+
+        # The promotion arm is a warning, not a refusal, so it needs its own
+        # assertion in both directions: it must fire, and it must not refuse.
+        aged = clean.replace(
+            f"last-flake={fresh}",
+            "last-flake="
+            + (today - timedelta(days=QUARANTINE_PROMOTION_DAYS)).isoformat(),
+        )
+        findings, warnings = grade(aged)
+        if findings:
+            raise AssertionError(
+                f"control failed: an old last-flake refused ({findings}); it is "
+                "good news and must warn rather than block a landing"
+            )
+        if not any(warning.startswith("promotion:") for warning in warnings):
+            raise AssertionError(
+                "control failed: an old last-flake produced no promotion warning"
+            )
+
+        # The stale-row arm must also catch a source path that no longer exists,
+        # which is a different producer of the same finding.
+        missing = clean.replace("source=target.rs", "source=gone.rs")
+        findings, _ = grade(missing)
+        if not any(finding.startswith("stale-row:") for finding in findings):
+            raise AssertionError(
+                "control failed: a row naming a missing source file was not "
+                "caught as stale-row"
+            )
+
+
+def run_junit_controls():
+    """The reporting verdict, both directions, on carried XML."""
+
+    import contextlib
+    import io
+    import tempfile
+
+    quiet = """<testsuites><testsuite name="s">
+      <testcase name="a" classname="pkg::t"/>
+    </testsuite></testsuites>"""
+    noisy = """<testsuites><testsuite name="s">
+      <testcase name="a" classname="pkg::t"><flakyFailure/></testcase>
+    </testsuite></testsuites>"""
+    empty = """<testsuites></testsuites>"""
+
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        for name, body in (("quiet", quiet), ("noisy", noisy), ("empty", empty)):
+            (tmp / f"{name}.xml").write_text(body, encoding="utf-8")
+
+        def graded(path, quarantined):
+            with contextlib.redirect_stdout(io.StringIO()):
+                return report_junit(path, quarantined)
+
+        if graded(tmp / "quiet.xml", ["a"]) != 0:
+            raise AssertionError("control failed: a clean JUnit file refused")
+        if graded(tmp / "noisy.xml", ["a"]) != 0:
+            raise AssertionError(
+                "control failed: a declared quarantined flake refused; it is "
+                "reported, not blocked"
+            )
+        if graded(tmp / "noisy.xml", ["something_else"]) != 1:
+            raise AssertionError(
+                "control failed: a flake no quarantine row names was accepted"
+            )
+        for name in ("empty", "absent"):
+            try:
+                graded(tmp / f"{name}.xml", [])
+            except AssertionError:
+                continue
+            raise AssertionError(
+                f"control failed: an {name} JUnit file read as zero flakes "
+                "rather than as UNREADABLE"
+            )
+
+
+def main(argv):
+    argv = list(argv[1:])
+    junit = None
+    if argv and argv[0] == "--report-junit":
+        if len(argv) < 2:
+            raise AssertionError("--report-junit needs a path")
+        junit = Path(argv[1])
+        argv = argv[2:]
+    root = Path(argv[0]) if argv else Path.cwd()
+
+    run_controls()
+    run_junit_controls()
+
+    config = root / CONFIG
+    if not config.is_file():
+        if junit is not None:
+            raise AssertionError(
+                f"no {CONFIG} under {root}, so nothing declares which retries "
+                "are expected; this read cannot grade the run"
+            )
+        print(f"no {CONFIG}: nothing is quarantined, which is the goal state")
+        return 0
+
+    text = load_config(config)
+    rows = parse_rows(text)
+
+    if junit is not None:
+        quarantined = []
+        for row in rows:
+            named = TEST_NAME.search(row.filter_expr or "")
+            if named:
+                quarantined.append(named.group(1).rsplit("::", 1)[-1])
+        return report_junit(junit, quarantined)
+
+    findings, warnings = check_rows(rows, root, date.today())
+
+    for warning in warnings:
+        print(f"::warning title=Quarantine promotion candidate::{warning}")
+        print(warning)
+
+    if findings:
+        for finding in findings:
+            print(finding)
+        print(
+            f"\n{len(findings)} quarantine finding(s). A quarantine row is a "
+            "promise to fix a test, with a clock on it. Fix the test and delete "
+            "the row, or correct the row."
+        )
+        return 1
+
+    print(
+        f"{len(rows)} quarantine row(s), every one ticketed, dated, inside "
+        f"{QUARANTINE_MAX_DAYS} days, and naming a test that still exists"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except AssertionError as error:
+        sys.exit(f"check-quarantine: {error}")

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -482,19 +482,26 @@ DOCS_ONLY_CLASSIFIER_JOB = textwrap.dedent(
             echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
     """
 ).rstrip()
-DOCS_ONLY_CHECK_JOB = textwrap.dedent(
+# The inert pull-request producer of both expanded `Check & Test` names. It
+# covered documentation-only diffs alone until FIR-2815 took the ubuntu and
+# macOS suites off the pull-request path; it now covers every pull request, and
+# it carries no `needs:` so it reports without waiting on the classifier. Its
+# condition and the two aggregates' are mutually exclusive on every event, which
+# is what keeps one required name from having two check runs behind it.
+PULL_REQUEST_CHECK_STUB = textwrap.dedent(
     """\
-    check-docs-only:
+    check-pr-fast-path:
       name: Check & Test
-      needs: changes
-      if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}
+      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
       runs-on: ubuntu-latest
       strategy:
         matrix:
           os: [ubuntu-latest, macos-latest]
       steps:
-        - name: Report the documentation-only fast path
-          run: echo "documentation-only diff; build and test validation not applicable"
+        - name: Report the pull-request fast path
+          run: |
+            echo "Check & Test runs in the merge queue and on every main commit."
+            echo "Admission is the fast gate; see .github/workflows/ci.yml."
     """
 ).rstrip()
 # The ubuntu shards publish `Check & Test ubuntu shard (1)` and `(2)`, which no
@@ -511,7 +518,10 @@ REAL_CHECK_JOB_AUTHORITY = textwrap.dedent(
     check:
       name: Check & Test ubuntu shard
       needs: changes
-      if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+      if: >-
+        ${{ !cancelled()
+        && needs.changes.outputs.docs_only != 'true'
+        && github.event_name != 'pull_request' }}
       runs-on: ubuntu-latest
       timeout-minutes: 60
       env:
@@ -535,7 +545,10 @@ UBUNTU_SHARD_AGGREGATE_AUTHORITY = textwrap.dedent(
     check-aggregate:
       name: Check & Test
       needs: [changes, check]
-      if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+      if: >-
+        ${{ !cancelled()
+        && needs.changes.outputs.docs_only != 'true'
+        && github.event_name != 'pull_request' }}
       runs-on: ubuntu-latest
       timeout-minutes: 5
       strategy:
@@ -607,7 +620,10 @@ MACOS_SHARD_AGGREGATE_AUTHORITY = textwrap.dedent(
     check-macos-aggregate:
       name: Check & Test
       needs: [changes, check-macos]
-      if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+      if: >-
+        ${{ !cancelled()
+        && needs.changes.outputs.docs_only != 'true'
+        && github.event_name != 'pull_request' }}
       runs-on: ubuntu-latest
       timeout-minutes: 5
       strategy:
@@ -635,7 +651,18 @@ CI_JOB_DISPLAY_NAMES = {
     "windows-authority-runtime-tests": "Windows authority runtime tests",
     "windows-installer": "Windows installer + vector release build",
     "changes": "Classify diff scope",
-    "check-docs-only": "Check & Test",
+    # The admission core (FIR-2815). Both run on every event and between them
+    # they are the whole of what blocks a pull request. `fast-gate-tests`
+    # publishes a shard name no ruleset requires; `fast-gate-tests-aggregate`
+    # publishes the required name and is green only when every shard succeeded.
+    "fast-gate-lint": "Fast gate lint and policy",
+    "fast-gate-tests": "Fast gate test shard",
+    "fast-gate-tests-aggregate": "Fast gate build and tests",
+    # The inert pull-request producer of the two expanded `Check & Test` names.
+    # It covered documentation-only diffs alone until FIR-2815 moved the ubuntu
+    # and macOS suites off the pull-request path; it now covers every pull
+    # request, which is why the id no longer says docs.
+    "check-pr-fast-path": "Check & Test",
     # The ubuntu half of Check & Test, split so its 14.98-minute test step can
     # run as two nextest partitions. The shard job keeps the id `check`, which
     # bin/kin-precheck and rust-cache both key on, and publishes a name of its
@@ -657,7 +684,7 @@ CI_JOB_DISPLAY_NAMES = {
     # branch ruleset names it, so each is listed here to be reviewed as a
     # producer, and the ruleset is what makes it block.
     "falsify-guards": "Falsify guards",
-    "feature-tests-docs-only": "Feature permutation tests",
+    "feature-tests-pr-fast-path": "Feature permutation tests",
     "feature-tests": "Feature permutation tests",
     "coverage": "Code Coverage",
     "install-proof-pr-build": "Install Proof (PR) Build",
@@ -846,15 +873,30 @@ REQUIRED_CHECK_JOB_PRODUCERS = {
     # mutually exclusive by condition, so no two of them ever publish the same
     # expanded name on one event.
     "Check & Test": {
-        (".github/workflows/ci.yml", "check-docs-only"),
+        (".github/workflows/ci.yml", "check-pr-fast-path"),
         (".github/workflows/ci.yml", "check-aggregate"),
         (".github/workflows/ci.yml", "check-macos-aggregate"),
     },
     "Falsify guards": {
         (".github/workflows/ci.yml", "falsify-guards"),
     },
+    # The admission core (FIR-2815). Neither is required by a ruleset at the
+    # moment this lands; the captain adds them, and the shape of that change is
+    # in the report. They are registered here for the reason `Install Proof (PR)
+    # Gate` is: this map is what stops a second job appearing under a name a
+    # ruleset is about to block on, and a name is easiest to steal in the window
+    # before anything requires it.
+    "Fast gate lint and policy": {
+        (".github/workflows/ci.yml", "fast-gate-lint"),
+    },
+    "Fast gate build and tests": {
+        (".github/workflows/ci.yml", "fast-gate-tests-aggregate"),
+    },
+    "Fast gate test shard": {
+        (".github/workflows/ci.yml", "fast-gate-tests"),
+    },
     "Feature permutation tests": {
-        (".github/workflows/ci.yml", "feature-tests-docs-only"),
+        (".github/workflows/ci.yml", "feature-tests-pr-fast-path"),
         (".github/workflows/ci.yml", "feature-tests"),
     },
     "DCO Sign-off": {
@@ -3050,6 +3092,21 @@ INSTALL_PROOF_PULL_REQUEST_JOBS = (
 )
 
 
+# The only event filters the pull-request install proof jobs may carry, matched
+# on the whole stripped line. A set rather than a substring test, because
+# `event_name != 'pull_request'` is a substring of every filter that also
+# excludes something else, and the thing this assertion exists to catch is a
+# heavy leg quietly leaving the merge queue. `install-proof-pr-gate` carries no
+# job-level filter at all: it always reports, and decides inside its own step.
+INSTALL_PROOF_ADMITTED_EVENT_FILTERS = frozenset(
+    {"&& github.event_name != 'pull_request'"}
+)
+# The gate is exempt from even that. It always reports, under one stable name,
+# and decides inside its own step, so any job-level event filter here publishes
+# no check rather than a skipped one.
+INSTALL_PROOF_PULL_REQUEST_GATE = "install-proof-pr-gate"
+
+
 def assert_install_proof_runs_on_pull_requests(ci: str, install_proof: str) -> None:
     """Require the release install proof to run before a tag exists.
 
@@ -3065,11 +3122,23 @@ def assert_install_proof_runs_on_pull_requests(ci: str, install_proof: str) -> N
     falsifiable. The proof must reach the reviewed reusable workflow rather
     than a lookalike; the binaries it installs must be the ones the pull
     request compiled and packaged in the release archive layout; and none of
-    the three jobs may exclude the pull request or the merge queue, which is
-    exactly how a heavy leg gets quietly moved back to main and how this class
-    of break returns. The semantic-coverage assertion itself is pinned last:
-    the step producing its capture stays on the ordinary Unix path, so a
-    pull-request run reaches it rather than skipping it as an optional extra.
+    the three jobs may exclude the MERGE QUEUE, which is what the release mint
+    reads. The semantic-coverage assertion itself is pinned last: the step
+    producing its capture stays on the ordinary Unix path, so a run reaches it
+    rather than skipping it as an optional extra.
+
+    The pull-request exclusion used to be barred too, and FIR-2815 admits
+    exactly one form of it and no other. The reason it was barred has not
+    changed and is not weakened: a heavy leg quietly moved back to main is how
+    this class of break returns. What changed is where "before a tag" is paid.
+    The proof measured 9.4 minutes on a pull request against a ten-minute
+    open-to-merge bar, and it now runs in the merge queue and on every commit
+    that reaches main, both of which are before any tag. `release-tag.yml`
+    still refuses to mint a sha whose required checks are not green.
+
+    The admitted form is the exact expression below and nothing else, so an
+    event filter that excluded the merge queue, or excluded a push, or was
+    written differently enough to mean something else, still fails here.
     """
 
     jobs = workflow_job_blocks(ci)
@@ -3107,11 +3176,33 @@ def assert_install_proof_runs_on_pull_requests(ci: str, install_proof: str) -> N
 
     for job_id, job in zip(INSTALL_PROOF_PULL_REQUEST_JOBS, (build, call, gate)):
         for line in active_lines(job):
-            if "event_name" in line:
+            clause = line.strip()
+            is_condition = clause.startswith(("&&", "||", "if:"))
+            if not is_condition or "event_name" not in clause:
+                continue
+            # A folded `if:` puts the closing `}}` on whichever clause happens
+            # to be last, so one reviewed filter reads two ways depending on
+            # clause order. Normalise that and nothing else.
+            clause = clause.removesuffix("}}").strip()
+            if job_id == INSTALL_PROOF_PULL_REQUEST_GATE:
                 raise AssertionError(
-                    f"{job_id} must not exclude an event: the install proof "
-                    "exists to run on pull requests and merge groups, and a "
-                    f"job-level event filter silently returns it to the tag: {line}"
+                    f"{job_id} must not exclude an event. It is the job that "
+                    "always reports, under one stable name, and is the context "
+                    "to require; a filter here publishes no check at all rather "
+                    f"than a skipped one: {line}"
+                )
+            if clause not in INSTALL_PROOF_ADMITTED_EVENT_FILTERS:
+                raise AssertionError(
+                    f"{job_id} carries an event filter that is not the one "
+                    "reviewed under FIR-2815. The install proof runs in the "
+                    "merge queue and on every main commit, and a filter written "
+                    f"any other way silently returns it to the tag: {line}"
+                )
+            if "merge_group" in line or "push" in line:
+                raise AssertionError(
+                    f"{job_id} must run inside the merge queue and on main: "
+                    "the release mint keys off the queue-proven sha and "
+                    f"refuses a build that skipped this proof: {line}"
                 )
 
     gate_lines = active_lines(gate)
@@ -4076,6 +4167,11 @@ WINDOWS_AUTHORITY_JOBS = (
     "windows-authority-runtime-tests",
 )
 WINDOWS_AUTHORITY_LEG_HELPERS = "source ./scripts/windows-authority-legs.sh"
+# The one job-level condition these three may carry, matched whole. Whole rather
+# than by substring, because `github.event_name != 'pull_request'` is a
+# substring of every condition that also excludes the merge queue or the push,
+# and that is the thing this rule exists to catch.
+WINDOWS_AUTHORITY_ADMITTED_IF = "${{ github.event_name != 'pull_request' }}"
 # Every native Windows leg, wherever it runs. The set is what the three jobs
 # owe between them, so splitting or rebalancing them stays a free choice while
 # dropping one does not: a leg that leaves this file has to leave it visibly.
@@ -4107,6 +4203,116 @@ WINDOWS_AUTHORITY_LEGS = (
 )
 
 
+# The admission core, FIR-2815. Two jobs decide whether a pull request may land
+# and a third publishes the required name for the sharded one. Everything about
+# that arrangement is invisible from the context name, which is why it is pinned
+# here the way the Check & Test aggregates are: a required context that goes
+# green on a shard that never ran is worse than no context at all, and an
+# admission gate is the one place where that is cheapest to introduce and
+# hardest to notice.
+FAST_GATE_LINT_STEPS = (
+    "run: cargo fmt -- --check",
+    "run: python3 scripts/check-quarantine.py",
+    "cargo clippy --all-targets --all-features -- $allows",
+    "bash scripts/release-policy-gate.sh <<'RELEASE_POLICY'",
+)
+# What the sharded half owes. The listing assertion is the load-bearing one: the
+# scope selector narrows the run to the packages a diff can have broken, and a
+# nextest filter matching nothing grades nothing and exits 0, printing the same
+# summary a clean pass prints. Without a listing count the whole job is a check
+# that cannot fail.
+FAST_GATE_SHARD_STEPS = (
+    "python3 scripts/changed-crate-scope.py",
+    "cargo nextest list --locked",
+    'print("::error title=Empty test selection::the scope lists zero tests")',
+    "cargo nextest run --locked",
+    "run: python3 scripts/check-quarantine.py --report-junit",
+)
+FAST_GATE_SHARD_MATRIX = "shard: [1, 2, 3]"
+FAST_GATE_SHARD_INDEPENDENT_LEGS = "fail-fast: false"
+FAST_GATE_AGGREGATE_ALWAYS_RUNS = "if: ${{ !cancelled() }}"
+FAST_GATE_AGGREGATE_NEEDS = "needs: [changes, fast-gate-tests]"
+FAST_GATE_AGGREGATE_SUCCESS_GATE = 'if [ "$SHARDS" != "success" ]; then'
+
+
+def assert_fast_gate_authority(workflow: str) -> None:
+    """Pin the admission core so it cannot go green having graded nothing.
+
+    Three properties, none of them observable from the required context's name.
+
+    The aggregate ALWAYS runs. It is the only producer of the required name, and
+    a required context nobody reports blocks a merge forever with every visible
+    check green, which is a silent hang rather than a failure. So its condition
+    is `!cancelled()` and nothing narrower, and it decides inside its own step.
+
+    The aggregate admits `success` from the shards and nothing else. `skipped`
+    and `cancelled` mean part of the selection never ran, and a required context
+    green on that is worse than no context at all. The documentation-only case
+    is the one exemption and it is spelled out in the step rather than inferred
+    from a job condition, so a reader can see which case is being passed.
+
+    The shards assert their LISTING before they run. The scope selector narrows
+    to the packages a diff can have broken, and a nextest filter matching
+    nothing grades nothing and exits 0 with the same summary a clean pass
+    prints. The count is what separates the two, and it is the only thing that
+    can, so it is required here rather than left to a reviewer to notice.
+    """
+
+    jobs = workflow_job_blocks(workflow)
+    for job_id in ("fast-gate-lint", "fast-gate-tests", "fast-gate-tests-aggregate"):
+        if job_id not in jobs:
+            raise AssertionError(
+                f"the admission core lost {job_id}; what blocks a pull request "
+                "from landing is not something to remove quietly"
+            )
+
+    lint = active_lines(jobs["fast-gate-lint"])
+    for policy in FAST_GATE_LINT_STEPS:
+        if not any(policy in line for line in lint):
+            raise AssertionError(
+                "the admission core's lint and policy half must keep running "
+                f"`{policy}`: 31 of 64 measured pull-request failures were "
+                "formatting, clippy or a policy script"
+            )
+
+    shard = jobs["fast-gate-tests"]
+    shard_lines = active_lines(shard)
+    for policy in FAST_GATE_SHARD_STEPS:
+        if not any(policy in line for line in shard_lines):
+            raise AssertionError(
+                f"the admission core's sharded half must keep running `{policy}`"
+            )
+    for policy in (FAST_GATE_SHARD_MATRIX, FAST_GATE_SHARD_INDEPENDENT_LEGS):
+        if policy not in shard_lines:
+            raise AssertionError(
+                f"the admission core's shards must keep `{policy}`: one red "
+                "shard cancelling its siblings makes the aggregate report one "
+                "cause where there may be three"
+            )
+
+    aggregate = jobs["fast-gate-tests-aggregate"]
+    aggregate_lines = active_lines(aggregate)
+    conditions = [line for line in aggregate_lines if line.startswith("if:")]
+    if conditions != [FAST_GATE_AGGREGATE_ALWAYS_RUNS]:
+        raise AssertionError(
+            "the admission core's aggregate publishes the required name and "
+            f"must run on every event, with `{FAST_GATE_AGGREGATE_ALWAYS_RUNS}` "
+            f"and nothing narrower; it carries {conditions}. A required context "
+            "nobody reports is a silent hang, not a failure"
+        )
+    if FAST_GATE_AGGREGATE_NEEDS not in aggregate_lines:
+        raise AssertionError(
+            "the admission core's aggregate must wait on the shards it grades; "
+            f"missing `{FAST_GATE_AGGREGATE_NEEDS}`"
+        )
+    if FAST_GATE_AGGREGATE_SUCCESS_GATE not in aggregate_lines:
+        raise AssertionError(
+            "the admission core's aggregate must admit only `success` from the "
+            "shards: `skipped` and `cancelled` mean part of the selection never "
+            "ran, and a required context green on that is worse than none"
+        )
+
+
 def assert_windows_authority_split(ci_jobs: dict[str, str]) -> None:
     """Hold the three native Windows jobs to what one job used to owe.
 
@@ -4120,9 +4326,17 @@ def assert_windows_authority_split(ci_jobs: dict[str, str]) -> None:
     drop a test, because the leg simply is not in the job you are reading and
     the other job looks complete on its own.
 
-    No job takes a job-level `if:`. These jobs are the merge group's only proof
+    No job takes a job-level `if:` other than the one reviewed under FIR-2815,
+    which takes them off pull requests and leaves them on the merge queue and on
+    every commit that reaches main. These jobs are the merge group's only proof
     of the native Windows admission contract, and that reasoning did not change
-    when one job became three.
+    when one job became three, nor when the pull-request half of CI was thinned:
+    a filter excluding the queue or the push is still what would quietly move
+    this proof to the tag, and is still refused. The longest of the three
+    measured 11.7 minutes, which no admission gate carries against a ten-minute
+    open-to-merge bar, and `merge_pr_ready` refuses while any check is pending,
+    so leaving them on pull requests set the lane's clock whether or not any
+    ruleset named them.
 
     The step budgets sum to less than the job cap. GitHub CANCELS a job that
     hits its own timeout, and a cancelled job is silent on a check no ruleset
@@ -4146,11 +4360,14 @@ def assert_windows_authority_split(ci_jobs: dict[str, str]) -> None:
 
     for job_id in WINDOWS_AUTHORITY_JOBS:
         block = ci_jobs[job_id]
-        if re.search(r"(?m)^    if:", block) is not None:
+        conditions = re.findall(r"(?m)^    if: (.*)$", block)
+        if conditions != [] and conditions != [WINDOWS_AUTHORITY_ADMITTED_IF]:
             raise AssertionError(
-                "the Windows authority jobs must stay on every event, so "
-                "admission behavior is asserted before a release commit can "
-                f"carry it: {job_id}"
+                "the Windows authority jobs must stay on the merge queue and "
+                "on every main commit, so admission behavior is asserted "
+                "before a release commit can carry it. The only reviewed "
+                f"condition is `{WINDOWS_AUTHORITY_ADMITTED_IF}`, and "
+                f"{job_id} carries {conditions}"
             )
         require(block, WINDOWS_AUTHORITY_LEG_HELPERS, f"shared leg helpers in {job_id}")
         job_cap = re.search(r"(?m)^    timeout-minutes: (?P<cap>\d+)$", block)
@@ -4952,14 +5169,12 @@ def assert_check_consumer_authority(workflow: str) -> None:
             "identity and display-name map"
         )
 
-    docs_only = blocks.get("check-docs-only")
+    stub = blocks.get("check-pr-fast-path")
     real = blocks.get("check")
-    if (
-        docs_only is None
-        or classifier_active_job_source(docs_only) != DOCS_ONLY_CHECK_JOB
-    ):
+    if stub is None or classifier_active_job_source(stub) != PULL_REQUEST_CHECK_STUB:
         raise AssertionError(
-            "Check & Test consumer authority requires the exact inert docs-only job"
+            "Check & Test consumer authority requires the exact inert "
+            "pull-request job"
         )
     if (
         real is None
@@ -11725,14 +11940,33 @@ def main() -> None:
             "exactly once",
         ),
         (
-            "a Windows authority job takes a job-level condition",
+            "a Windows authority job is taken off the merge queue",
             "windows-authority-runtime-tests",
             ci_jobs["windows-authority-runtime-tests"].replace(
                 "    runs-on: windows-latest",
                 "    if: github.event_name != 'merge_group'\n    runs-on: windows-latest",
                 1,
             ),
-            "must stay on every event",
+            "must stay on the merge queue",
+        ),
+        (
+            "a Windows authority job takes an unreviewed job-level condition",
+            "windows-authority-runtime-tests",
+            ci_jobs["windows-authority-runtime-tests"].replace(
+                f"    if: {WINDOWS_AUTHORITY_ADMITTED_IF}\n", "    if: ${{ false }}\n", 1
+            ),
+            "The only reviewed condition is",
+        ),
+        (
+            "the reviewed condition is widened to exclude the push as well",
+            "windows-authority-runtime-tests",
+            ci_jobs["windows-authority-runtime-tests"].replace(
+                f"    if: {WINDOWS_AUTHORITY_ADMITTED_IF}\n",
+                "    if: ${{ github.event_name != 'pull_request'"
+                " && github.event_name != 'push' }}\n",
+                1,
+            ),
+            "The only reviewed condition is",
         ),
         (
             "a Windows authority job stops sourcing the shared leg helpers",
@@ -12605,9 +12839,18 @@ def main() -> None:
     # reviewed shell is meaningless without its checkout, output, id, event,
     # SHA, shell, and startup-environment bindings, so those are one authority
     # contract rather than independently mutable text.
+    # The span ends at the next job header rather than at a named sibling. It
+    # used to name `check-docs-only`, which put this reader one job rename or
+    # one inserted job away from a ValueError that reads like a missing
+    # classifier rather than like a moved neighbour.
     classifier_start = ci_workflow.index("  changes:")
-    classifier_end = ci_workflow.index("\n  check-docs-only:", classifier_start)
-    classifier = ci_workflow[classifier_start:classifier_end]
+    next_job = re.search(
+        r"(?m)^  [A-Za-z0-9_.-]+:$", ci_workflow[classifier_start + len("  changes:") :]
+    )
+    if next_job is None:
+        raise AssertionError("the classifier job must be followed by another job")
+    classifier_end = classifier_start + len("  changes:") + next_job.start()
+    classifier = ci_workflow[classifier_start:classifier_end].rstrip("\n")
     assert_docs_only_classifier_guard(ci_workflow)
     assert_assertion_reachability_gate_wired(ci_workflow)
     toolchain_action = RUST_TOOLCHAIN_ACTION.read_text(encoding="utf-8")
@@ -12992,8 +13235,77 @@ def main() -> None:
     assert_check_consumer_authority(ci_workflow)
     assert_macos_shard_authority(ci_workflow)
     assert_ubuntu_shard_authority(ci_workflow)
+    assert_fast_gate_authority(ci_workflow)
+    fast_gate_blocks = workflow_job_blocks(ci_workflow)
+    for label, owner, old, new, expected in (
+        (
+            "the aggregate stops always running, so a pull request waits on a "
+            "context nothing will report",
+            "fast-gate-tests-aggregate",
+            f"    {FAST_GATE_AGGREGATE_ALWAYS_RUNS}",
+            "    if: ${{ !cancelled() && github.event_name != 'pull_request' }}",
+            "must run on every event",
+        ),
+        (
+            "the aggregate accepts a shard result that is not success",
+            "fast-gate-tests-aggregate",
+            FAST_GATE_AGGREGATE_SUCCESS_GATE,
+            'if [ "$SHARDS" = "failure" ]; then',
+            "admit only `success`",
+        ),
+        (
+            "the aggregate stops waiting on the shards it grades",
+            "fast-gate-tests-aggregate",
+            f"    {FAST_GATE_AGGREGATE_NEEDS}",
+            "    needs: changes",
+            "must wait on the shards",
+        ),
+        (
+            "the shards stop asserting the selection lists any test",
+            "fast-gate-tests",
+            'print("::error title=Empty test selection::the scope lists zero tests")',
+            "pass",
+            "sharded half must keep running",
+        ),
+        (
+            "the scope selector is dropped and the shards test whatever is left",
+            "fast-gate-tests",
+            "python3 scripts/changed-crate-scope.py",
+            "true scripts/changed-crate-scope-disabled.py",
+            "sharded half must keep running",
+        ),
+        (
+            "one red shard is allowed to cancel its passing siblings",
+            "fast-gate-tests",
+            f"      {FAST_GATE_SHARD_INDEPENDENT_LEGS}",
+            "      fail-fast: true",
+            "shards must keep",
+        ),
+        (
+            "the quarantine clock stops running in the admission core",
+            "fast-gate-lint",
+            "        run: python3 scripts/check-quarantine.py\n",
+            "        run: true\n",
+            "lint and policy half must keep running",
+        ),
+    ):
+        # Scoped to the owning job block rather than the whole file: two jobs
+        # carry `if: ${{ !cancelled() }}`, and a whole-file replace would mutate
+        # whichever came first and grade a job this assertion is not about.
+        block = fast_gate_blocks[owner]
+        if block.count(old) != 1:
+            raise AssertionError(
+                f"admission core falsification could not identify {label}"
+            )
+        mutant_workflow = ci_workflow.replace(block, block.replace(old, new, 1), 1)
+        expect_assertion(
+            label,
+            expected,
+            lambda mutant=mutant_workflow: assert_fast_gate_authority(mutant),
+        )
+
     consumer_blocks = workflow_job_blocks(ci_workflow)
-    docs_only_check = consumer_blocks["check-docs-only"]
+    stub_check = consumer_blocks["check-pr-fast-path"]
     real_check = consumer_blocks["check"]
     macos_shards = consumer_blocks["check-macos"]
     macos_aggregate = consumer_blocks["check-macos-aggregate"]
@@ -13188,25 +13500,28 @@ def main() -> None:
             ),
         )
 
-    docs_only_condition = (
-        "    if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}"
+    stub_condition = (
+        "    if: ${{ !cancelled() && github.event_name == 'pull_request' }}"
     )
     real_check_condition = (
-        "    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}"
+        "    if: >-\n"
+        "      ${{ !cancelled()\n"
+        "      && needs.changes.outputs.docs_only != 'true'\n"
+        "      && github.event_name != 'pull_request' }}"
     )
-    swapped_docs_only_check = docs_only_check.replace(
-        docs_only_condition,
+    swapped_stub_check = stub_check.replace(
+        stub_condition,
         real_check_condition,
         1,
     )
     swapped_real_check = real_check.replace(
         real_check_condition,
-        docs_only_condition,
+        stub_condition,
         1,
     )
     swapped_consumers = ci_workflow.replace(
-        docs_only_check,
-        swapped_docs_only_check,
+        stub_check,
+        swapped_stub_check,
         1,
     ).replace(
         real_check,
@@ -13221,43 +13536,53 @@ def main() -> None:
 
     for label, old, new in (
         (
-            "docs-only Check & Test job identity changed",
-            "  check-docs-only:",
+            "pull-request Check & Test job identity changed",
+            "  check-pr-fast-path:",
             "  check-context-spoof:",
         ),
         (
-            "docs-only Check & Test display name changed",
+            "pull-request Check & Test display name changed",
             "    name: Check & Test",
             "    name: Documentation shortcut",
         ),
         (
-            "docs-only Check & Test dependency changed",
-            "    needs: changes",
-            "    needs: dco",
+            "pull-request Check & Test gained a dependency it must not wait on",
+            "    runs-on: ubuntu-latest",
+            "    needs: changes\n    runs-on: ubuntu-latest",
         ),
         (
-            "docs-only Check & Test runner changed",
+            "pull-request Check & Test runner changed",
             "    runs-on: ubuntu-latest",
             "    runs-on: ${{ matrix.os }}",
         ),
         (
-            "docs-only Check & Test matrix changed",
+            "pull-request Check & Test matrix changed",
             "        os: [ubuntu-latest, macos-latest]",
             "        os: [ubuntu-latest]",
         ),
         (
-            "docs-only Check & Test inert step changed",
-            '      run: echo "documentation-only diff; '
-            'build and test validation not applicable"',
-            '      run: echo "unreviewed shortcut"',
+            "pull-request Check & Test inert step changed",
+            '          echo "Admission is the fast gate; '
+            'see .github/workflows/ci.yml."',
+            '          echo "unreviewed shortcut"',
+        ),
+        (
+            # The one that matters most after FIR-2815: narrowing this back to
+            # documentation-only diffs leaves every ordinary pull request with
+            # no producer of either expanded `Check & Test` name at all, which
+            # is a silent hang rather than a failure.
+            "pull-request Check & Test narrowed back to documentation diffs",
+            "    if: ${{ !cancelled() && github.event_name == 'pull_request' }}",
+            "    if: ${{ !cancelled() && "
+            "needs.changes.outputs.docs_only == 'true' }}",
         ),
     ):
-        if docs_only_check.count(old) != 1:
+        if stub_check.count(old) != 1:
             raise AssertionError(
                 f"Check & Test consumer falsification could not identify {label}"
             )
-        mutant_job = docs_only_check.replace(old, new, 1)
-        mutant_workflow = ci_workflow.replace(docs_only_check, mutant_job, 1)
+        mutant_job = stub_check.replace(old, new, 1)
+        mutant_workflow = ci_workflow.replace(stub_check, mutant_job, 1)
         expect_assertion(
             label,
             "Check & Test consumer authority",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -7530,6 +7530,50 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
         )
 
 
+def assert_ruleset_mirror_stays_a_superset(release_tag: str) -> None:
+    """The reviewed mirror must never shrink below what the mint vetoes on.
+
+    `missing_from_ruleset` runs unconditionally in the mint and refuses when the
+    mint requires a context the reviewed mirror does not gate. `REQUIRED_CHECKS`
+    is the veto set and `RULESET_REQUIRED_CHECKS` is the mirror of live ruleset
+    19746451, so the mirror has to stay a superset of the veto set forever, and
+    the day it stops being one EVERY release refuses.
+
+    That is not a theoretical edit. FIR-2815 thins the live ruleset to a short
+    admission list, which makes "sync the mirror to the ruleset" the obvious
+    next tidy-up and makes it fatal. Nothing caught it before this: the mint's
+    own refusal is driven here only against a synthetic environment, so the
+    file's actual mirror content was unread, and a shrunken mirror landed green
+    and failed at the next mint with no pull request to blame.
+
+    The mirror may hold MORE than the veto set. That is its purpose: a context a
+    ruleset gates and the mint does not veto on still has to be published by an
+    admitted build, or the queue waits on a name nobody produces.
+    """
+
+    def block(key: str) -> tuple[str, ...]:
+        found = re.search(
+            rf"\n          {key}: \|\n((?:            \S.*\n)+)", release_tag
+        )
+        if found is None:
+            raise AssertionError(
+                f"release-tag.yml no longer declares {key} as a block scalar"
+            )
+        return tuple(
+            line.strip() for line in found.group(1).splitlines() if line.strip()
+        )
+
+    veto = block("REQUIRED_CHECKS")
+    mirror = block("RULESET_REQUIRED_CHECKS")
+    dropped = sorted(set(veto) - set(mirror))
+    if dropped:
+        raise AssertionError(
+            "the reviewed ruleset mirror must stay a superset of the checks the "
+            f"mint vetoes on; it no longer gates {dropped}, which makes "
+            "missing_from_ruleset non-empty and refuses EVERY release"
+        )
+
+
 def assert_required_check_set_is_single_sourced(release_tag: str) -> None:
     """The env list and the provenance table must name the same contexts.
 
@@ -14994,6 +15038,32 @@ def main() -> None:
     assert_required_context_action_pins(workflow_sources)
     assert_tag_readback_retries(release_tag)
     assert_required_check_set_is_single_sourced(release_tag)
+    assert_ruleset_mirror_stays_a_superset(release_tag)
+    for label, old_name, new_name in (
+        (
+            "the mirror is synced down to a thinned live ruleset",
+            "            Falsify guards\n            Feature permutation tests (ubuntu-latest)\n",
+            "",
+        ),
+        (
+            "one name is dropped from the mirror alone",
+            "            Windows installer + vector release build\n            PR text hygiene\n",
+            "            PR text hygiene\n",
+        ),
+    ):
+        mirror_start = release_tag.index("          RULESET_REQUIRED_CHECKS: |")
+        head, mirror = release_tag[:mirror_start], release_tag[mirror_start:]
+        if mirror.count(old_name) != 1:
+            raise AssertionError(
+                f"ruleset mirror falsification could not identify {label}"
+            )
+        expect_assertion(
+            label,
+            "must stay a superset",
+            lambda mutant=head + mirror.replace(old_name, new_name, 1): (
+                assert_ruleset_mirror_stays_a_superset(mutant)
+            ),
+        )
     assert_soft_decline_is_legible(release_tag)
     assert_recovery_escalation_classifies(
         RELEASE_RECOVERY.read_text(encoding="utf-8")


### PR DESCRIPTION
The founder ruled that a serialized all-green-admission merge queue is the wrong
shape for a ten-minute open-to-merge bar. This is the workflow half of the new
shape. The ruleset half is the captain's and is deliberately not in this PR.

## Why this half is the half that moves

Measured over 2026-08-23 to 2026-08-26, a landing spent 31.9 minutes of
pull-request CI and 32.5 minutes in the queue, so about 95 percent of a
single-push lane's wall clock was two runs of one suite. The second run is not
rework: in 16 of 17 landings the tree the queue built was not the tree the pull
request tested, because main moved under it while its checks ran. So the
pull-request suite was proving a base that had already been replaced by the time
it went green, and it is the half whose result nothing downstream depends on.

## What moves off the pull request

Both Check & Test aggregates and their shards, both feature permutation legs,
Falsify guards, Product Acceptance, the three Windows authority legs, the
pull-request install proof, Docker Image Build and the Linux daemon smoke. Every
one still runs on the merge queue and on every commit that reaches main, where
ci.yml's concurrency group already gives each commit its own run and cancels
nothing, so grading stays per commit and attribution stays exact.

The advisory jobs move for a reason that is easy to miss. `merge_pr_ready`
refuses while any check is still pending, required or not, so an advisory leg
sets the lane's clock exactly as a required one does. Moving only the required
legs would have left the clock at Docker's measured 20.1 minutes and read like
the idea did not work.

The mechanism is the `github.event_name != 'pull_request'` skip that
`windows-installer` has carried on main since before this change, and a skip
satisfies a required context.

## What arrives in their place

Two jobs, on every event, and a third that publishes the required name for the
sharded one.

`Fast gate lint and policy` runs formatting, the flake-quarantine clock, clippy
with the same allow list `check` uses, and the release policy validators.
`Fast gate build and tests` builds and tests the packages the diff can have
broken, three shards over a reverse-dependency closure taken from cargo
metadata. It asserts the test listing is non-empty before running anything,
because a nextest filter matching nothing grades nothing and exits 0 with the
same summary a clean pass prints.

Measured over the same window those catch 31 of 64 distinct pull-request
failures. The other 52 percent become red main tips. That is the trade, it is
deliberate, and it is safe for one reason: release-tag.yml refuses to mint a sha
lacking either its proof records or its nine green required checks, per sha and
failing closed, so an unproven main tip cannot be tagged. It can only be
inconvenient.

## Flake quarantine

A job-level retry restarts the whole check clock, which is what a merge-queue
ejection costs: four ejections in the window, roughly thirty minutes each, none
of them a code change. A test-level retry costs seconds. `.config/nextest.toml`
is new and starts with one row, FIR-2809's admission-ladder test, which ejected
PR 1141 for a measured 34 minutes. The row does not fix that test and does not
close its ticket. It buys two retries and starts a fourteen-day clock, and
`scripts/check-quarantine.py` is what makes the clock real: no ticket, no date,
past fourteen days, more than five rows, a row naming a test that no longer
exists, a filter loose enough to catch a namesake, or retries a zero setting
never grants, and every one of those is refused.

Every value in that config was verified by running cargo-nextest 0.9.140 rather
than by reading its help. Retries plus flaky-result pass exits 0 and reports one
flaky; the same test under flaky-result fail exits 100; with no override it is a
plain FAIL; and an unknown key anywhere in the file is a warning and exit 0,
which is why the bookkeeping is a comment rather than fields nextest would drop.
`cargo nextest show-config` does not report per-test overrides on 0.9.140 and
accepts a malformed config with exit 0, so the guard reads the source file the
row names instead, and says so in its own header.

## Authority

Two rules were relaxed and both were narrowed rather than dropped. The Windows
authority jobs admit exactly one job-level condition and no other, so a filter
excluding the queue or the push still fails. The install proof admits the same
one clause on its build and call jobs and none at all on its gate, which is the
job that always reports.

Three assertions are new. The admission core gets its own authority with seven
falsification arms, because an aggregate that goes green on a shard that never
ran is the cheapest possible way to lose a required context. And the mint's
reviewed ruleset mirror must stay a superset of the checks the mint vetoes on:
nothing enforced that before, the mirror's content was unread by any test, and
thinning the live ruleset makes syncing the mirror down the obvious next tidy-up
and the one edit that refuses every release.

## A stale comment corrected

acceptance.yml's header claimed Product Acceptance publishes no required context
yet, pending five green pull requests under FIR-2591. It is one of the eleven on
ruleset 19746451, read live on 2026-08-27. That step happened and the comment
did not move.

## What ran

`bin/kin-precheck kin` from the lane worktree: 16 gates enumerated, 16 ran, 16
passed, 0 failed, on b3d86315b. The same sixteen as before this change, which is
the tell that no gate left the `check` job. `actionlint` 1.7.12 clean on every
workflow touched, with a positive control that reddened it. The two new guards
were falsified arm by arm against the real tree, reading which assertion fired
under each mutation, and so were the new workflow assertions, both inside the
suite and against the real ci.yml. Three arms read SURVIVED first and each is
written up rather than quietly fixed.

Workflow YAML has no unit tests, so the admission core's real wall clock and the
cache warmth of its shared key are claims this PR asserts and hosted CI decides.
The full grid, the prepared ruleset commands with their read-backs, and what
could only be verified by CI running are in
`.kin-coord/reports/queue2815-20260827.md` in the umbrella.

## What remains

The ruleset half. Thinning the eleven required contexts to six, setting
`strict_required_status_checks_policy` to false, and disabling the merge-queue
ruleset are the captain's, executed after this merges, and until then the eleven
still block and the queue still serializes.

Part of FIR-2815
