### PR TITLE
Keep the named target through the trim and carry every step's call site

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -418,6 +418,34 @@ jobs:
             echo "::warning title=Response budget elision suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: Trace spine clipping suite (verdict comes from the gate step)
+        id: trace_spine
+        if: always()
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/trace_spine_clipping_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/trace_spine.json \
+            --label "$KIN_ACCEPTANCE_LABEL" \
+            --verbose >acceptance/trace_spine.log 2>&1 || rc=$?
+          cat acceptance/trace_spine.log
+          {
+            echo "### Trace spine clipping suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/trace_spine.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Trace spine clipping suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
       - name: Parse-hole acceptance suite (verdict comes from the gate step)
         id: parsehole
         if: always()
@@ -768,6 +796,7 @@ jobs:
             --report magic=acceptance/magic.json \
             --report brownfield=acceptance/brownfield.json \
             --report response_budget=acceptance/response_budget.json \
+            --report trace_spine=acceptance/trace_spine.json \
             --report parsehole=acceptance/parsehole.json \
             --report sameowner=acceptance/sameowner.json \
             --report memory_pressure=acceptance/memory_pressure.json \

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -3419,7 +3419,22 @@ mod tests {
         let caller = make_entity("caller", "src/caller.rs");
         let missing = make_entity("missing_site", "src/missing.rs");
         let outside = make_entity("outside_site", "src/outside.rs");
-        for entity in [&focal, &callee, &caller, &missing, &outside] {
+        // An incoming edge whose span names a THIRD file, which is what makes the
+        // caller arm's filter falsifiable. Every other incoming span already
+        // sits in the caller's own file, so passing `None` for the filter and
+        // passing the caller's file admit the same set, and the mutation that
+        // disables the filter outright produces identical output. Only a span
+        // the filter must reject separates "admitted because it matched" from
+        // "admitted because nothing filtered".
+        let caller_outside = make_entity("caller_outside_site", "src/caller-outside.rs");
+        for entity in [
+            &focal,
+            &callee,
+            &caller,
+            &missing,
+            &outside,
+            &caller_outside,
+        ] {
             graph.upsert_entity(entity).unwrap();
         }
 
@@ -3476,6 +3491,15 @@ mod tests {
                 19,
             ))
             .unwrap();
+        graph
+            .upsert_relation(&make_relation_with_site(
+                caller_outside.id,
+                focal.id,
+                RelationKind::Calls,
+                "src/third-party.rs",
+                19,
+            ))
+            .unwrap();
 
         let mut request = trace_request(&focal.id, 1, TraceDirection::Both, 25);
         request.include_body = Some(false);
@@ -3502,6 +3526,16 @@ mod tests {
         assert!(step("outside_site").reference_lines.is_empty());
         assert_eq!(
             step("outside_site")
+                .reference_lines_absent_reason
+                .as_deref(),
+            Some("span_outside_caller_file")
+        );
+        // The caller arm filters against the CHILD's own file, not the focal's.
+        // This span names neither, so a row that carries lines here means the
+        // filter is not running rather than that it chose the wrong file.
+        assert!(step("caller_outside_site").reference_lines.is_empty());
+        assert_eq!(
+            step("caller_outside_site")
                 .reference_lines_absent_reason
                 .as_deref(),
             Some("span_outside_caller_file")

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -1115,15 +1115,28 @@ pub fn build_trace_data_flow_response_within(
                 // A candidate can collect several edges, so the lines collect
                 // beside them rather than moving with whichever edge is ranked
                 // strongest for display.
-                let caller_file = if role == "callee" {
-                    node.file_origin.as_ref()
-                } else {
-                    candidates[candidate_at].entity.file_origin.as_ref()
-                };
-                let tally = relation_reference_lines(rel, caller_file);
-                candidates[candidate_at].reference_lines.extend(tally.lines);
-                candidates[candidate_at].reference_spans_outside_caller_file +=
-                    tally.outside_caller_file;
+                //
+                // Only from a REFERENCE edge, though. `allowed` carries
+                // `UsesType` as well, so an annotation target is a named leaf
+                // rather than a symbol the walk never mentions, and the graph
+                // holds a `UsesType` edge beside the `Calls` edge for the same
+                // pair. Its span is the annotation's target, which is the
+                // callee's own definition, not a site where the caller calls
+                // anything. Accumulating it published `[def_line, call_line]`
+                // on every row and a reader could not tell which was which.
+                // `reference_kinds` is the set the reference surface reads, so
+                // gating on it is what keeps the two answers the same.
+                if reference_kinds.contains(&rel.kind) {
+                    let caller_file = if role == "callee" {
+                        node.file_origin.as_ref()
+                    } else {
+                        candidates[candidate_at].entity.file_origin.as_ref()
+                    };
+                    let tally = relation_reference_lines(rel, caller_file);
+                    candidates[candidate_at].reference_lines.extend(tally.lines);
+                    candidates[candidate_at].reference_spans_outside_caller_file +=
+                        tally.outside_caller_file;
+                }
             }
 
             // This node's relations were read to the end, so what the graph

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -3394,7 +3394,7 @@ mod tests {
         );
     }
 
-    /// FIR-2824's second half. A chain is only actionable when each hop names
+    /// A chain is only actionable when each hop names
     /// the syntax site that created it, not only the callee's definition.
     /// Outgoing and incoming steps have different callers, duplicate edges must
     /// accumulate, and an empty list must explain which absence occurred.
@@ -3849,7 +3849,7 @@ mod tests {
         );
     }
 
-    /// FIR-2824 at the typed response arm. The target is a shallow leaf that
+    /// At the typed response arm, the target is a shallow leaf that
     /// ordinary depth-first preservation gives up before the deeper branch, so
     /// target-aware walk ordering alone cannot make this pass. At one explicit
     /// response cut the unnamed arm loses it and the named arm keeps it.
@@ -3874,6 +3874,8 @@ mod tests {
                 let targeted_names = step_names(&targeted);
                 (unnamed.steps_omitted > 0
                     && targeted.steps_omitted > 0
+                    && unnamed.fanout_narrowed > 0
+                    && targeted.fanout_narrowed > 0
                     && !unnamed_names.iter().any(|name| name == target)
                     && targeted_names.iter().any(|name| name == target))
                 .then_some((budget, unnamed, targeted))

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -3523,6 +3523,66 @@ mod tests {
                 && step.reference_lines_absent_reason.as_deref() == Some("unreported_by_daemon")));
     }
 
+    /// An annotation edge's span is not a call site, on this arm too.
+    ///
+    /// The generic GraphStore arm has a test for exactly this. The CLI arm
+    /// carried the same edge-class gate with nothing grading it, so restoring
+    /// the old accumulation here went unnoticed on this surface while the other
+    /// surface caught it, which is a guard that cannot fail. The graph holds a
+    /// `UsesType` edge beside the `Calls` edge for the same pair, and its span
+    /// is the annotation's target, which is the callee's own definition rather
+    /// than anywhere the caller calls it.
+    #[test]
+    fn an_annotation_span_is_not_a_call_site() {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("focal", "src/focal.rs");
+        let callee = make_entity("callee", "src/callee.rs");
+        for entity in [&focal, &callee] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        graph
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::Calls,
+                "src/focal.rs",
+                11,
+            ))
+            .unwrap();
+        graph
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::UsesType,
+                "src/focal.rs",
+                4,
+            ))
+            .unwrap();
+
+        let mut request = trace_request(&focal.id, 1, TraceDirection::Calls, 25);
+        request.include_body = Some(false);
+        let response = traced(&graph, &request);
+        let row = response
+            .chain
+            .iter()
+            .find(|step| step.entity.entity_name == "callee")
+            .unwrap_or_else(|| {
+                panic!(
+                    "the annotation edge must still reach the leaf: {:?}",
+                    step_names(&response)
+                )
+            });
+
+        // The premise: the leaf is here at all, which is what `UsesType` being
+        // in the allowed set buys and what this gate must not take away.
+        assert_eq!(
+            row.reference_lines,
+            vec![12],
+            "only the call site belongs here, not the annotation's target: {row:?}"
+        );
+        assert_eq!(row.reference_lines_absent_reason, None);
+    }
+
     /// The regression a character count is the only guard against: a change that
     /// re-inlines bodies on a shape query is invisible to every assertion about
     /// chain contents.

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -1903,10 +1903,21 @@ fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
         // Narrow first. Every candidate the shared rule offers is measured the
         // way this response will be sent, so the arithmetic is the budget's own
         // rather than an estimate of it.
+        // The question this walk was given. A step standing for the named target
+        // is never offered up as "least relevant", and neither is any step
+        // between it and the focal; a walk that named nothing, or named
+        // something it never reached, protects nothing and narrows as before.
+        let named = response.target_name.clone();
+        let must_keep = |step: &TraceStep| {
+            named
+                .as_deref()
+                .is_some_and(|name| step.entity.entity_name == name)
+        };
         let narrowed = kin_mcp::budget::narrow_fanout_to_fit(
             &full,
             &|step: &TraceStep| step.step as u64,
             &|step: &TraceStep| Some(step.parent_step as u64),
+            &must_keep,
             &mut |kept: &[TraceStep]| {
                 response.chain = kept.to_vec();
                 response.total_steps = kept.len();

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -3539,10 +3539,29 @@ mod tests {
             !json.contains("\"body\": \""),
             "a shape query must carry no inlined body"
         );
+        // Keep the original compact-shape tripwire load-bearing rather than
+        // weakening it for the two uniform site-contract fields. Measure the
+        // old shape with exactly those fields removed, then bound their own
+        // incremental cost separately. A future unrelated per-step expansion
+        // still trips the original 20k ceiling, while the call-site contract
+        // gets a named allowance rather than silently consuming its margin.
+        let mut without_site_contract = serde_json::to_value(&response).unwrap();
+        for step in without_site_contract["chain"].as_array_mut().unwrap() {
+            let row = step.as_object_mut().unwrap();
+            row.remove("reference_lines");
+            row.remove("reference_lines_absent_reason");
+        }
+        let compact_shape = serde_json::to_string_pretty(&without_site_contract).unwrap();
         assert!(
-            json.len() < 20_000,
-            "25 steps of shape are small; {} chars means bodies or per-step bloat crept back in",
-            json.len()
+            compact_shape.len() < 20_000,
+            "25 steps without the site contract are small; {} chars means bodies or unrelated \
+             per-step bloat crept back in",
+            compact_shape.len()
+        );
+        let site_contract_chars = json.len().saturating_sub(compact_shape.len());
+        assert!(
+            site_contract_chars < 3_000,
+            "the two uniform site fields added {site_contract_chars} chars across 25 steps"
         );
     }
 

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -47,7 +47,10 @@ use kin_mcp::budget::Elision;
 /// neither the chain nor a way to ask for less, which is why the number exists at
 /// all — see the definition for what it was measured against.
 pub use kin_mcp::handlers::common::TRACE_DEFAULT_MAX_RESPONSE_CHARS as DEFAULT_MAX_RESPONSE_CHARS;
-use kin_mcp::handlers::common::{trace_response_budget, TRACE_DISCLOSURE_RESERVE_CHARS};
+use kin_mcp::handlers::common::{
+    relation_reference_lines, trace_response_budget, ReferenceLinesAbsent,
+    TRACE_DISCLOSURE_RESERVE_CHARS,
+};
 
 /// Wall-clock ceiling for one trace walk.
 ///
@@ -405,6 +408,10 @@ pub struct TraceEntityRecord {
 }
 
 /// One step in the data-flow chain.
+fn legacy_trace_reference_lines_absent_reason() -> Option<String> {
+    Some("unreported_by_daemon".to_string())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceStep {
     /// 1-based step index (0 is reserved for the focal entity).
@@ -428,6 +435,20 @@ pub struct TraceStep {
     /// Depth from the focal (1 = direct neighbor of focal, 2 = neighbor of
     /// neighbor, etc.).
     pub depth: usize,
+    /// 1-based source lines of the edge that introduced this step, accumulated
+    /// across every contributing relation and deduplicated.
+    ///
+    /// These are call/reference sites, not this entity's definition lines. For
+    /// a `callee` step they live in its parent's file; for a `caller` step they
+    /// live in this step's own `entity_file`. The role and `parent_step` make
+    /// that file explicit without repeating a path on every row.
+    #[serde(default)]
+    pub reference_lines: Vec<u32>,
+    /// Why `reference_lines` is empty, and null when at least one line is
+    /// present. Uses the same vocabulary as `find_references` so an absent
+    /// parser span and an unusable cross-file span never collapse together.
+    #[serde(default = "legacy_trace_reference_lines_absent_reason")]
+    pub reference_lines_absent_reason: Option<String>,
     /// This step's identity, location, and (when served) body.
     #[serde(flatten)]
     pub entity: TraceEntityRecord,
@@ -1018,7 +1039,7 @@ pub fn build_trace_data_flow_response_within(
                     continue;
                 }
 
-                match candidate_index.get(&(next_id, role)) {
+                let candidate_at = match candidate_index.get(&(next_id, role)) {
                     // The same neighbor reached twice, by two edges of different
                     // kinds or confidences. One step, described by the stronger
                     // edge, rather than one candidate per edge.
@@ -1056,6 +1077,7 @@ pub fn build_trace_data_flow_response_within(
                                 candidate.crossing = Some(named);
                             }
                         }
+                        existing
                     }
                     None => {
                         let Some(entity) = graph
@@ -1080,9 +1102,28 @@ pub fn build_trace_data_flow_response_within(
                             confidence: rel.confidence,
                             resolution: RelationResolution::of(rel),
                             crossing,
+                            reference_lines: Vec::new(),
+                            reference_spans_outside_caller_file: 0,
                         });
+                        candidates.len() - 1
                     }
-                }
+                };
+
+                // The syntax site belongs to the referencing entity. Walking
+                // out to a callee means the caller is the parent node; walking
+                // in to a caller means the caller is the child step itself.
+                // A candidate can collect several edges, so the lines collect
+                // beside them rather than moving with whichever edge is ranked
+                // strongest for display.
+                let caller_file = if role == "callee" {
+                    node.file_origin.as_ref()
+                } else {
+                    candidates[candidate_at].entity.file_origin.as_ref()
+                };
+                let tally = relation_reference_lines(rel, caller_file);
+                candidates[candidate_at].reference_lines.extend(tally.lines);
+                candidates[candidate_at].reference_spans_outside_caller_file +=
+                    tally.outside_caller_file;
             }
 
             // This node's relations were read to the end, so what the graph
@@ -1139,7 +1180,7 @@ pub fn build_trace_data_flow_response_within(
                 });
             }
 
-            for candidate in callees.into_iter().chain(callers) {
+            for mut candidate in callees.into_iter().chain(callers) {
                 if chain.len() >= MAX_TOTAL_STEPS {
                     truncated = true;
                     break;
@@ -1222,6 +1263,8 @@ pub fn build_trace_data_flow_response_within(
                     candidate.relation_kind,
                     include_type_edges,
                 );
+                candidate.normalize_reference_lines();
+                let reference_lines_absent_reason = candidate.reference_lines_absent_reason();
                 chain.push(TraceStep {
                     step: step_index,
                     role: candidate.role.to_string(),
@@ -1229,6 +1272,8 @@ pub fn build_trace_data_flow_response_within(
                     resolution: candidate.resolution.as_str().to_string(),
                     parent_step: node.step,
                     depth: next_depth,
+                    reference_lines: candidate.reference_lines,
+                    reference_lines_absent_reason,
                     entity: entity_record(
                         &candidate.entity,
                         source.as_ref(),
@@ -1683,6 +1728,10 @@ struct FrontierNode {
     id: EntityId,
     depth: usize,
     file: Option<String>,
+    /// The same file as `file`, retained in its graph identity type so relation
+    /// evidence can be checked against the caller file without reconstructing
+    /// one from presentation text.
+    file_origin: Option<kin_model::ids::FilePathId>,
     dir: Option<String>,
 }
 
@@ -1693,6 +1742,7 @@ impl FrontierNode {
             id: entity.id,
             depth,
             file: entity.file_origin.as_ref().map(|path| path.0.clone()),
+            file_origin: entity.file_origin.clone(),
             dir: kin_ranking::entity_ranking::entity_directory(entity),
         }
     }
@@ -1737,6 +1787,14 @@ struct FanoutCandidate {
     /// requested depth. False for every candidate when no target was named, so
     /// an untargeted walk orders exactly as it did before this existed.
     reaches_target: bool,
+    /// Every source site carried by every edge that reaches this one step.
+    /// These accumulate even when a different, stronger edge supplies the
+    /// displayed relation kind.
+    reference_lines: Vec<u32>,
+    /// Evidence spans that could not be reported because they named a file
+    /// other than the caller's. Counted so an empty list can say whether the
+    /// parser recorded no span or recorded an unusable one.
+    reference_spans_outside_caller_file: usize,
 }
 
 impl FanoutCandidate {
@@ -1748,6 +1806,25 @@ impl FanoutCandidate {
     /// repository with a language server installed.
     fn is_raise_target(&self) -> bool {
         self.call_edges > 0 && self.raise_call_edges == self.call_edges
+    }
+
+    fn normalize_reference_lines(&mut self) {
+        self.reference_lines.sort_unstable();
+        self.reference_lines.dedup();
+    }
+
+    fn reference_lines_absent_reason(&self) -> Option<String> {
+        if !self.reference_lines.is_empty() {
+            None
+        } else if self.reference_spans_outside_caller_file > 0 {
+            Some(
+                ReferenceLinesAbsent::SpanOutsideCallerFile
+                    .as_str()
+                    .to_string(),
+            )
+        } else {
+            Some(ReferenceLinesAbsent::NoEvidenceSpan.as_str().to_string())
+        }
     }
 }
 
@@ -2112,7 +2189,7 @@ mod tests {
         Visibility,
     };
     use kin_model::ids::{FilePathId, Hash256, LanguageId, RelationId, RepositoryId, WorkspaceId};
-    use kin_model::relation::{Relation, RelationOrigin};
+    use kin_model::relation::{Relation, RelationEvidence, RelationOrigin};
     use std::sync::Arc;
 
     pub(super) fn make_entity(name: &str, file: &str) -> Entity {
@@ -2201,6 +2278,29 @@ mod tests {
             import_source: None,
             evidence: vec![],
         }
+    }
+
+    fn make_relation_with_site(
+        src: EntityId,
+        dst: EntityId,
+        kind: RelationKind,
+        file: &str,
+        row: u32,
+    ) -> Relation {
+        let mut relation = make_relation(src, dst, kind);
+        relation.evidence = vec![RelationEvidence {
+            source_span: Some(kin_model::entity::SourceSpan {
+                file: FilePathId::new(file),
+                start_byte: 0,
+                end_byte: 1,
+                start_line: row,
+                start_col: 0,
+                end_line: row,
+                end_col: 1,
+            }),
+            ..RelationEvidence::default()
+        }];
+        relation
     }
 
     /// Synthesize an absent repository authority. The body itself isn't
@@ -3294,6 +3394,122 @@ mod tests {
         );
     }
 
+    /// FIR-2824's second half. A chain is only actionable when each hop names
+    /// the syntax site that created it, not only the callee's definition.
+    /// Outgoing and incoming steps have different callers, duplicate edges must
+    /// accumulate, and an empty list must explain which absence occurred.
+    #[test]
+    fn every_chain_step_carries_its_call_site_lines_or_an_explicit_reason() {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("focal", "src/focal.rs");
+        let callee = make_entity("callee", "src/callee.rs");
+        let caller = make_entity("caller", "src/caller.rs");
+        let missing = make_entity("missing_site", "src/missing.rs");
+        let outside = make_entity("outside_site", "src/outside.rs");
+        for entity in [&focal, &callee, &caller, &missing, &outside] {
+            graph.upsert_entity(entity).unwrap();
+        }
+
+        // Two sites on two edges into one callee. They must union even though
+        // one displayed step can name only one strongest relation.
+        graph
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::Calls,
+                "src/focal.rs",
+                11,
+            ))
+            .unwrap();
+        graph
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::References,
+                "src/focal.rs",
+                41,
+            ))
+            .unwrap();
+        graph
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::Imports,
+                "src/focal.rs",
+                41,
+            ))
+            .unwrap();
+        // An incoming step's call site lives in the CHILD/caller's file.
+        graph
+            .upsert_relation(&make_relation_with_site(
+                caller.id,
+                focal.id,
+                RelationKind::Calls,
+                "src/caller.rs",
+                7,
+            ))
+            .unwrap();
+        // One parser edge carried no span; one carried a span in the wrong
+        // file. The reasons have to stay distinguishable.
+        graph
+            .upsert_relation(&make_relation(focal.id, missing.id, RelationKind::Calls))
+            .unwrap();
+        graph
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                outside.id,
+                RelationKind::Calls,
+                "src/not-the-caller.rs",
+                19,
+            ))
+            .unwrap();
+
+        let mut request = trace_request(&focal.id, 1, TraceDirection::Both, 25);
+        request.include_body = Some(false);
+        let response = traced(&graph, &request);
+        let step = |name: &str| {
+            response
+                .chain
+                .iter()
+                .find(|step| step.entity.entity_name == name)
+                .unwrap_or_else(|| panic!("missing {name} in {:?}", step_names(&response)))
+        };
+
+        assert_eq!(step("callee").reference_lines, vec![12, 42]);
+        assert_eq!(step("callee").reference_lines_absent_reason, None);
+        assert_eq!(step("caller").reference_lines, vec![8]);
+        assert_eq!(step("caller").reference_lines_absent_reason, None);
+        assert!(step("missing_site").reference_lines.is_empty());
+        assert_eq!(
+            step("missing_site")
+                .reference_lines_absent_reason
+                .as_deref(),
+            Some("no_evidence_span")
+        );
+        assert!(step("outside_site").reference_lines.is_empty());
+        assert_eq!(
+            step("outside_site")
+                .reference_lines_absent_reason
+                .as_deref(),
+            Some("span_outside_caller_file")
+        );
+
+        let mut old_payload = serde_json::to_value(&response).unwrap();
+        for item in old_payload["chain"].as_array_mut().unwrap() {
+            item.as_object_mut().unwrap().remove("reference_lines");
+            item.as_object_mut()
+                .unwrap()
+                .remove("reference_lines_absent_reason");
+        }
+        let parsed: TraceDataFlowResponse = serde_json::from_value(old_payload)
+            .expect("a daemon predating call-site fields must remain readable");
+        assert!(parsed
+            .chain
+            .iter()
+            .all(|step| step.reference_lines.is_empty()
+                && step.reference_lines_absent_reason.as_deref() == Some("unreported_by_daemon")));
+    }
+
     /// The regression a character count is the only guard against: a change that
     /// re-inlines bodies on a shape query is invisible to every assertion about
     /// chain contents.
@@ -3347,6 +3563,10 @@ mod tests {
                 resolution: RelationResolution::TypeResolved.as_str().to_string(),
                 parent_step: index.saturating_sub(1),
                 depth: 1,
+                reference_lines: Vec::new(),
+                reference_lines_absent_reason: Some(
+                    ReferenceLinesAbsent::NoEvidenceSpan.as_str().to_string(),
+                ),
                 entity: record,
                 fanout_truncated: false,
                 fanout_dropped: 0,
@@ -3503,6 +3723,10 @@ mod tests {
                 resolution: RelationResolution::TypeResolved.as_str().to_string(),
                 parent_step: parent,
                 depth,
+                reference_lines: Vec::new(),
+                reference_lines_absent_reason: Some(
+                    ReferenceLinesAbsent::NoEvidenceSpan.as_str().to_string(),
+                ),
                 entity: record,
                 fanout_truncated: false,
                 fanout_dropped: 0,
@@ -3603,6 +3827,61 @@ mod tests {
         assert!(
             serde_json::to_string_pretty(&response).unwrap().len() <= response.max_response_chars,
             "the payload must end up inside the budget it reports"
+        );
+    }
+
+    /// FIR-2824 at the typed response arm. The target is a shallow leaf that
+    /// ordinary depth-first preservation gives up before the deeper branch, so
+    /// target-aware walk ordering alone cannot make this pass. At one explicit
+    /// response cut the unnamed arm loses it and the named arm keeps it.
+    #[test]
+    fn a_named_target_survives_the_cli_response_budget_that_drops_it_unnamed() {
+        let fixture = wide_then_deep_response(12, 2, 900);
+        let target = "neighbour_12";
+        let found = (kin_mcp::handlers::common::TRACE_MIN_MAX_RESPONSE_CHARS
+            ..=kin_mcp::handlers::common::TRACE_MAX_MAX_RESPONSE_CHARS)
+            .step_by(250)
+            .find_map(|budget| {
+                let mut unnamed = fixture.clone();
+                unnamed.max_response_chars = budget;
+                enforce_response_budget(&mut unnamed);
+
+                let mut targeted = fixture.clone();
+                targeted.target_name = Some(target.to_string());
+                targeted.max_response_chars = budget;
+                enforce_response_budget(&mut targeted);
+
+                let unnamed_names = step_names(&unnamed);
+                let targeted_names = step_names(&targeted);
+                (unnamed.steps_omitted > 0
+                    && targeted.steps_omitted > 0
+                    && !unnamed_names.iter().any(|name| name == target)
+                    && targeted_names.iter().any(|name| name == target))
+                .then_some((budget, unnamed, targeted))
+            })
+            .expect(
+                "no accepted response budget separated the unnamed and targeted arms; either the \
+                 fixture no longer reaches branch narrowing or the named branch is not protected",
+            );
+
+        let (budget, unnamed, targeted) = found;
+        assert!(
+            unnamed.fanout_narrowed > 0 && targeted.fanout_narrowed > 0,
+            "both arms must exercise branch narrowing at budget {budget}"
+        );
+        let target_step = targeted
+            .chain
+            .iter()
+            .find(|step| step.entity.entity_name == target)
+            .expect("the protected target survives");
+        assert_eq!(
+            target_step.parent_step, 0,
+            "the target must not survive with a missing parent"
+        );
+        assert!(
+            !step_names(&unnamed).iter().any(|name| name == target),
+            "the unnamed control kept {target} at budget {budget}: {:?}",
+            step_names(&unnamed)
         );
     }
 
@@ -3917,6 +4196,8 @@ mod tests {
             "relation_kind",
             "parent_step",
             "depth",
+            "reference_lines",
+            "reference_lines_absent_reason",
             "entity_id",
             "entity_name",
             "entity_kind",

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -35593,7 +35593,7 @@ mod tests {
     /// receives.
     #[tokio::test]
     async fn a_trace_over_its_budget_drops_bodies_and_keeps_every_edge() {
-        const BUDGET: usize = 6_000;
+        const ORIGINAL_BUDGET: usize = 6_000;
         let state = test_state();
         let ids = install_trace_chain(&state, 6);
         // The chain links only its calls. Every requested class decides
@@ -35616,8 +35616,48 @@ mod tests {
             json!({ "focal": ids[0].to_string(), "depth": 5, "direction": "calls" }),
         )
         .await;
+
+        // Keep the original 6k fixture load-bearing after the trace step gained
+        // its two uniform call-site fields. The old shape still has to fit the
+        // exact target this ladder used before the call-site contract. Only the serialized
+        // cost of those two fields is added back to the exercised budget, and
+        // that increment has its own ceiling, so unrelated per-step growth
+        // cannot hide inside a raised magic number.
+        let compact = call_mcp_tool_text(
+            app.clone(),
+            "trace_data_flow",
+            json!({
+                "focal": ids[0].to_string(),
+                "depth": 5,
+                "direction": "calls",
+                "include_body": false,
+            }),
+        )
+        .await;
+        let mut without_site_contract: serde_json::Value = serde_json::from_str(&compact).unwrap();
+        for step in without_site_contract["chain"].as_array_mut().unwrap() {
+            let row = step.as_object_mut().unwrap();
+            row.remove("reference_lines");
+            row.remove("reference_lines_absent_reason");
+        }
+        let old_shape_chars = serde_json::to_string_pretty(&without_site_contract)
+            .unwrap()
+            .len();
+        let original_target =
+            ORIGINAL_BUDGET.saturating_sub(kin_mcp::budget::RESPONSE_DISCLOSURE_RESERVE_CHARS);
         assert!(
-            unbounded.len() > BUDGET,
+            old_shape_chars <= original_target,
+            "the pre-call-site shape must still fit the original ladder target: {old_shape_chars} \
+             chars against {original_target}"
+        );
+        let site_contract_chars = compact.len().saturating_sub(old_shape_chars);
+        assert!(
+            (1..1_000).contains(&site_contract_chars),
+            "the two uniform site fields added {site_contract_chars} chars to this five-step chain"
+        );
+        let budget = ORIGINAL_BUDGET + site_contract_chars;
+        assert!(
+            unbounded.len() > budget,
             "the fixture must exceed the budget under test or this proves nothing: {} chars",
             unbounded.len()
         );
@@ -35630,15 +35670,15 @@ mod tests {
                 "focal": ids[0].to_string(),
                 "depth": 5,
                 "direction": "calls",
-                "max_response_chars": BUDGET,
+                "max_response_chars": budget,
             }),
         )
         .await;
         let cut: serde_json::Value = serde_json::from_str(&bounded).unwrap();
 
         assert!(
-            bounded.len() <= BUDGET,
-            "the tool must return what it promised to fit: {} chars against {BUDGET}",
+            bounded.len() <= budget,
+            "the tool must return what it promised to fit: {} chars against {budget}",
             bounded.len()
         );
         assert_eq!(

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1727,7 +1727,7 @@ mod tests {
         );
     }
 
-    /// FIR-2824, the defect itself. A branch the caller named survives the trim
+    /// A branch the caller named survives the trim
     /// that gives up "least relevant" branches, and the arm beside it is what
     /// makes that mean anything: the SAME walk at the SAME budget loses that
     /// branch when nothing names it.
@@ -2004,7 +2004,7 @@ mod tests {
         })
     }
 
-    /// FIR-2824 at the surface a caller reads. The sentence is COMPOSED from
+    /// At the surface a caller reads, the sentence is COMPOSED from
     /// clauses and joined, so it is probed rather than reasoned about: reading
     /// the code says what each clause holds, and only printing the join says
     /// what a caller receives.

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -419,6 +419,33 @@ pub fn measure(value: &Value) -> usize {
 /// class this codebase keeps paying for, so the rule is written once, generically
 /// over the step type, and both arms call it.
 ///
+/// ## Why the question outranks relevance
+///
+/// Relevance orders the children of a node. It does not know what was asked.
+/// `trace_data_flow` takes a `target`, and before this the target governed the
+/// per-step fan-out cap and nothing else, so a branch could be walked BECAUSE
+/// the caller named it and then given up here as "least relevant", which is the
+/// worst of both: the work was done and the result was thrown away.
+///
+/// Measured on the converted `psf/requests` by the rc061y stranger, focal
+/// `Session.send`, `depth: 3`, `limit_per_step: 25`, `target: "cert_verify"`:
+/// `HTTPAdapter.send` was walked and continued beneath, and the answer came back
+/// holding `RequestsCookieJar.items` and `Response.iter_content` with the named
+/// branch gone. Their words: "the relevance ordering used for elision does not
+/// appear to consult `target` at all, even though the fan-out cap's own
+/// remediation text tells you to set `target` for exactly this purpose."
+///
+/// So `must_keep` names the steps the question asked for, and neither they nor
+/// any step between them and the root is ever offered up. Everything else sheds
+/// first, in the same order as before. When the caller names nothing, or names
+/// something the walk never reached, no step is protected and this behaves
+/// exactly as it did: a rule that could never drop anything would be no rule.
+///
+/// The protection is a preference, not a refusal. If holding the named branch
+/// leaves nothing that fits, the drop order is rebuilt without it and the
+/// narrowing runs again, because a shorter answer that loses the target still
+/// beats falling through to the suffix cut that loses the depth of every branch.
+///
 /// `fits` is called on candidate survivor sets, bisected over the drop order, so
 /// a caller pays a handful of serializations rather than one per branch. It may
 /// mutate whatever it needs to measure and is not required to leave it restored:
@@ -432,17 +459,20 @@ pub fn narrow_fanout_to_fit<T: Clone>(
     steps: &[T],
     id_of: &dyn Fn(&T) -> u64,
     parent_of: &dyn Fn(&T) -> Option<u64>,
+    must_keep: &dyn Fn(&T) -> bool,
     fits: &mut dyn FnMut(&[T]) -> bool,
 ) -> Option<Vec<T>> {
     // Children in the order they were discovered, which is the order relevance
     // put them in. A step that names itself as its own parent is skipped rather
     // than trusted: it would make the descendant walk below cyclic.
     let mut children: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
+    let mut parent_of_id: BTreeMap<u64, u64> = BTreeMap::new();
     for step in steps {
         if let Some(parent) = parent_of(step) {
             let id = id_of(step);
             if id != parent {
                 children.entry(parent).or_default().push(id);
+                parent_of_id.insert(id, parent);
             }
         }
     }
@@ -477,15 +507,58 @@ pub fn narrow_fanout_to_fit<T: Clone>(
         }
     }
 
-    // The drop order: within a node, shallowest branch first and least relevant
-    // among equals, so the branch it keeps is the one that reaches deepest.
-    // Across nodes, widest first, so the budget is reclaimed where it was spent.
-    // Ties broken by parent id so the order is deterministic.
+    // The steps the question named, and every step between each of them and the
+    // root. Ancestors are protected too because a dropped branch takes its
+    // descendants with it: protecting the target alone and then giving up the
+    // node above it would drop the target anyway, silently, one level up.
+    //
+    // The insert-or-break walk is what makes this cycle-safe. A chain is a tree
+    // by construction, and a malformed one must not hang the bounder.
+    let mut protected: BTreeSet<u64> = BTreeSet::new();
+    for step in steps.iter().filter(|step| must_keep(step)) {
+        let mut at = Some(id_of(step));
+        while let Some(id) = at {
+            if !protected.insert(id) {
+                break;
+            }
+            at = parent_of_id.get(&id).copied();
+        }
+    }
+
+    let mut drop_order = fanout_drop_order(&children, &reach, &protected);
+    let mut chosen = bisect_narrowing(steps, id_of, &children, &drop_order, fits);
+    if chosen.is_none() && !protected.is_empty() {
+        // Holding the named branch left nothing that fits. Give it up rather
+        // than fall through to the suffix cut, which would amputate the far end
+        // of every branch including this one.
+        drop_order = fanout_drop_order(&children, &reach, &BTreeSet::new());
+        chosen = bisect_narrowing(steps, id_of, &children, &drop_order, fits);
+    }
+    chosen
+}
+
+/// Which branches to give up, in the order to give them up.
+///
+/// Within a node, shallowest branch first and least relevant among equals, so
+/// the branch it keeps is the one that reaches deepest. Across nodes, widest
+/// first, so the budget is reclaimed where it was spent. Ties broken by parent
+/// id so the order is deterministic.
+///
+/// A protected child is never offered, and it also satisfies the keep-one-child
+/// floor on its own: a node with a protected child among six may give up the
+/// other five, because the protection is already keeping one. A node with no
+/// protected child keeps its deepest, exactly as before, which is why an
+/// unprotected walk narrows identically to how it did before protection existed
+/// (`giveups.len()` is then `kids.len() - 1` for every node, and subtracting one
+/// from every width leaves the widest-first order unchanged).
+fn fanout_drop_order(
+    children: &BTreeMap<u64, Vec<u64>>,
+    reach: &BTreeMap<u64, usize>,
+    protected: &BTreeSet<u64>,
+) -> Vec<u64> {
     let mut by_width: Vec<(u64, Vec<u64>)> = children
         .iter()
-        .filter(|(_, kids)| kids.len() > 1)
-        .map(|(parent, kids)| {
-            let mut ordered: Vec<u64> = kids.clone();
+        .filter_map(|(parent, kids)| {
             // Sorted into GIVE-UP order: shallowest first, and among equally
             // deep branches the one relevance put last.
             let rank: BTreeMap<u64, usize> = kids
@@ -493,6 +566,7 @@ pub fn narrow_fanout_to_fit<T: Clone>(
                 .enumerate()
                 .map(|(at, kid)| (*kid, at))
                 .collect();
+            let mut ordered: Vec<u64> = kids.clone();
             ordered.sort_by(|left, right| {
                 reach
                     .get(left)
@@ -501,7 +575,16 @@ pub fn narrow_fanout_to_fit<T: Clone>(
                     .cmp(&reach.get(right).copied().unwrap_or(0))
                     .then_with(|| rank[right].cmp(&rank[left]))
             });
-            (*parent, ordered)
+            let mut giveups: Vec<u64> = ordered
+                .into_iter()
+                .filter(|kid| !protected.contains(kid))
+                .collect();
+            if giveups.len() == kids.len() {
+                // Nothing here is protected, so one child still has to survive,
+                // and it is the last in give-up order: the deepest.
+                giveups.pop();
+            }
+            (!giveups.is_empty()).then_some((*parent, giveups))
         })
         .collect();
     by_width.sort_by(|left, right| {
@@ -515,10 +598,9 @@ pub fn narrow_fanout_to_fit<T: Clone>(
     let mut round = 0usize;
     loop {
         let mut moved = false;
-        for (_parent, kids) in &by_width {
-            // Keep one child always; peel from the give-up end inward.
-            if kids.len() > 1 + round {
-                drop_order.push(kids[round]);
+        for (_parent, giveups) in &by_width {
+            if round < giveups.len() {
+                drop_order.push(giveups[round]);
                 moved = true;
             }
         }
@@ -527,10 +609,24 @@ pub fn narrow_fanout_to_fit<T: Clone>(
         }
         round += 1;
     }
+    drop_order
+}
+
+/// The fewest drops off the front of `drop_order` that fit, or `None` when no
+/// prefix of it does.
+///
+/// One drop is the floor: zero drops is the input, and the input is why this was
+/// called.
+fn bisect_narrowing<T: Clone>(
+    steps: &[T],
+    id_of: &dyn Fn(&T) -> u64,
+    children: &BTreeMap<u64, Vec<u64>>,
+    drop_order: &[u64],
+    fits: &mut dyn FnMut(&[T]) -> bool,
+) -> Option<Vec<T>> {
     if drop_order.is_empty() {
         return None;
     }
-
     let retained = |dropped: usize| -> Vec<T> {
         let mut condemned: BTreeSet<u64> = drop_order[..dropped].iter().copied().collect();
         // Breadth-first over the children map rather than one pass over
@@ -551,8 +647,6 @@ pub fn narrow_fanout_to_fit<T: Clone>(
             .collect()
     };
 
-    // Bisected for the FEWEST drops that fit. One drop is the floor: zero drops
-    // is the input, and the input is why this was called.
     let mut low = 1usize;
     let mut high = drop_order.len();
     let mut chosen: Option<Vec<T>> = None;
@@ -966,19 +1060,17 @@ fn run_ladder(
             .get(*key)
             .and_then(Value::as_array)
             .map_or(0, Vec::len);
-        let (withheld, narrowed) = trim_collection(payload, key, target, 1);
+        let (withheld, shape) = trim_collection(payload, key, target, 1);
         if withheld > 0 {
             accounting.bounded = true;
             withheld_any = true;
             // Which cut, not just how much. A list narrowed by branch still
             // reaches as deep as the walk did; one cut from the end does not,
             // and a reader who cannot tell them apart cannot tell whether the
-            // far end of the answer is missing.
-            let how = if narrowed {
-                "as whole branches, least relevant first"
-            } else {
-                "from the end of the list"
-            };
+            // far end of the answer is missing. A cut that held the named target
+            // says so too, because "the branch you asked for is still here" is
+            // the one thing a caller who named a target needs to read.
+            let how = shape.phrase();
             cuts.push(format!(
                 "{withheld} of {found} entries withheld from `{key}`, {how}"
             ));
@@ -1226,13 +1318,21 @@ fn remove_present(map: &mut Map<String, Value>, key: &str) -> bool {
 /// Every entry must carry both keys before this fires. A collection where only
 /// some do is one this rule cannot reason about, and guessing at the rest would
 /// be a cut nobody could predict.
+///
+/// The question the response echoes is what the narrowing protects. A walk that
+/// resolved a `target` reports it as `target_name`, and an entry standing for
+/// that symbol carries the same string in `entity_name` (verified against the
+/// rc061y transcript, where a surviving target read
+/// `"SessionRedirectMixin.resolve_redirects"` in both fields). A payload with no
+/// `target_name`, or one no entry matches, protects nothing and narrows exactly
+/// as it did before.
 fn trim_parented_collection(
     payload: &mut Value,
     key: &str,
     target: usize,
     min_keep: usize,
     full: &[Value],
-) -> Option<usize> {
+) -> Option<(usize, bool)> {
     let parented = full.iter().all(|entry| {
         entry.get("step").and_then(Value::as_u64).is_some()
             && entry.get("parent_step").and_then(Value::as_u64).is_some()
@@ -1240,10 +1340,25 @@ fn trim_parented_collection(
     if !parented {
         return None;
     }
+    // Read before the `fits` closure borrows the payload, and owned because that
+    // closure rewrites the very array these names came from.
+    let named = payload
+        .get("target_name")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let reached = named.as_deref().is_some_and(|name| {
+        full.iter()
+            .any(|entry| entry.get("entity_name").and_then(Value::as_str) == Some(name))
+    });
     let kept = narrow_fanout_to_fit(
         full,
         &|entry: &Value| entry["step"].as_u64().unwrap_or(0),
         &|entry: &Value| entry["parent_step"].as_u64(),
+        &|entry: &Value| {
+            named
+                .as_deref()
+                .is_some_and(|name| entry.get("entity_name").and_then(Value::as_str) == Some(name))
+        },
         &mut |candidate: &[Value]| {
             payload[key] = Value::Array(candidate.to_vec());
             measure(payload) <= target
@@ -1252,6 +1367,13 @@ fn trim_parented_collection(
     if kept.len() < min_keep {
         return None;
     }
+    // Claimed only when the target is still there. Protection is a preference
+    // the second pass gives up, and a sentence saying the named branch was kept
+    // must not outlive the branch it describes.
+    let held = reached
+        && kept
+            .iter()
+            .any(|entry| entry.get("entity_name").and_then(Value::as_str) == named.as_deref());
     let withheld = full.len() - kept.len();
     payload[key] = Value::Array(kept);
     if withheld > 0 {
@@ -1261,7 +1383,38 @@ fn trim_parented_collection(
             .unwrap_or(0) as usize;
         payload[format!("{key}_withheld")] = Value::from(prior.saturating_add(withheld));
     }
-    Some(withheld)
+    Some((withheld, held))
+}
+
+/// Which cut a reader of a bounded collection actually received.
+///
+/// Reported rather than inferred because the three read differently and a reader
+/// who cannot tell them apart cannot tell what is missing: a suffix cut has lost
+/// the far end of every branch, a branch cut has not, and a branch cut that held
+/// the named target has not lost the thing that was asked for.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum CutShape {
+    Suffix,
+    Branches,
+    BranchesKeepingTarget,
+}
+
+impl CutShape {
+    /// How this cut describes itself inside the disclosure sentence.
+    ///
+    /// No semicolons: these clauses are joined with `"; "` downstream, and a
+    /// clause carrying the separator its own join uses is the composed-string
+    /// defect this codebase has already paid for once.
+    fn phrase(self) -> &'static str {
+        match self {
+            CutShape::Suffix => "from the end of the list",
+            CutShape::Branches => "as whole branches, least relevant first",
+            CutShape::BranchesKeepingTarget => {
+                "as whole branches, least relevant first, keeping the branch that reaches the \
+                 named target"
+            }
+        }
+    }
 }
 
 /// Withhold entries from one collection until the payload fits, returning how
@@ -1293,15 +1446,23 @@ fn trim_collection(
     key: &str,
     target: usize,
     min_keep: usize,
-) -> (usize, bool) {
+) -> (usize, CutShape) {
     let Some(full) = payload.get(key).and_then(Value::as_array).cloned() else {
-        return (0, false);
+        return (0, CutShape::Suffix);
     };
     if full.len() <= min_keep || measure(payload) <= target {
-        return (0, false);
+        return (0, CutShape::Suffix);
     }
-    if let Some(withheld) = trim_parented_collection(payload, key, target, min_keep, &full) {
-        return (withheld, true);
+    if let Some((withheld, held)) = trim_parented_collection(payload, key, target, min_keep, &full)
+    {
+        return (
+            withheld,
+            if held {
+                CutShape::BranchesKeepingTarget
+            } else {
+                CutShape::Branches
+            },
+        );
     }
     let mut kept = min_keep;
     let mut low = min_keep;
@@ -1332,7 +1493,7 @@ fn trim_collection(
             .unwrap_or(0) as usize;
         payload[format!("{key}_withheld")] = Value::from(prior.saturating_add(withheld));
     }
-    (withheld, false)
+    (withheld, CutShape::Suffix)
 }
 
 /// Append the cuts to the `degradations` channel the retrieval tools already
@@ -1433,6 +1594,18 @@ mod tests {
             steps,
             &|step: &(u64, u64)| step.0,
             &|step: &(u64, u64)| Some(step.1),
+            &|_step: &(u64, u64)| false,
+            &mut |kept: &[(u64, u64)]| kept.len() <= budget,
+        )
+    }
+
+    /// The same narrowing with one step named as the question's answer.
+    fn narrowed_keeping(steps: &[(u64, u64)], keep: u64, budget: usize) -> Option<Vec<(u64, u64)>> {
+        narrow_fanout_to_fit(
+            steps,
+            &|step: &(u64, u64)| step.0,
+            &|step: &(u64, u64)| Some(step.1),
+            &|step: &(u64, u64)| step.0 == keep,
             &mut |kept: &[(u64, u64)]| kept.len() <= budget,
         )
     }
@@ -1546,10 +1719,77 @@ mod tests {
                 &steps,
                 &|step: &(u64, u64)| step.0,
                 &|step: &(u64, u64)| Some(step.1),
+                &|_step: &(u64, u64)| false,
                 &mut |_kept: &[(u64, u64)]| false,
             )
             .is_none(),
             "a spine has no branch to give up"
+        );
+    }
+
+    /// FIR-2824, the defect itself. A branch the caller named survives the trim
+    /// that gives up "least relevant" branches, and the arm beside it is what
+    /// makes that mean anything: the SAME walk at the SAME budget loses that
+    /// branch when nothing names it.
+    ///
+    /// Two branches off the focal, the second reaching deeper, so relevance
+    /// order and depth order disagree and the give-up rule has a real choice to
+    /// make.
+    #[test]
+    fn a_named_branch_survives_a_trim_that_drops_it_unnamed() {
+        // Focal 0 with three children; the FIRST is a leaf, so the give-up rule
+        // sheds it first, and the target hangs under it.
+        let steps: Vec<(u64, u64)> = vec![
+            (1, 0),
+            (2, 0),
+            (3, 0),
+            (4, 1), // the target, under the shallowest child
+            (5, 2),
+            (6, 5),
+            (7, 3),
+            (8, 7),
+        ];
+
+        // The premise, asserted rather than assumed: unnamed, this budget loses
+        // the step. A fixture that never lost it would make the named half pass
+        // against a tool that does nothing.
+        let unnamed = narrowed(&steps, 5).expect("the unnamed walk narrows");
+        let unnamed_ids: Vec<u64> = unnamed.iter().map(|step| step.0).collect();
+        assert!(
+            !unnamed_ids.contains(&4),
+            "the fixture no longer drops step 4 unnamed, so naming it proves nothing: \
+             {unnamed_ids:?}"
+        );
+
+        let named = narrowed_keeping(&steps, 4, 5).expect("the named walk narrows");
+        let named_ids: Vec<u64> = named.iter().map(|step| step.0).collect();
+        assert!(
+            named_ids.contains(&4),
+            "the named step was given up as least relevant: {named_ids:?}"
+        );
+        assert!(
+            named_ids.contains(&1),
+            "the named step survived without the step that introduced it, so its \
+             parent_step names a step the caller no longer has: {named_ids:?}"
+        );
+        assert!(
+            named.len() < steps.len(),
+            "protecting one branch stopped the trim from cutting anything at all, \
+             which is an elision that can never fire: {named_ids:?}"
+        );
+    }
+
+    /// Protection is a preference, not a refusal. A budget too small to hold the
+    /// named branch still gets an answer rather than falling through to the
+    /// suffix cut, which loses the far end of every branch including that one.
+    #[test]
+    fn a_budget_too_small_for_the_named_branch_still_narrows() {
+        let steps: Vec<(u64, u64)> = vec![(1, 0), (2, 0), (3, 0), (4, 1), (5, 2), (6, 5)];
+        let named = narrowed_keeping(&steps, 4, 2)
+            .expect("a budget that cannot hold the named branch must still narrow, not refuse");
+        assert!(
+            named.len() <= 2,
+            "the second pass did not give the protection up: {named:?}"
         );
     }
 
@@ -1584,9 +1824,13 @@ mod tests {
         let mut payload = json!({"chain": entries});
         let target = measure(&payload) / 2;
 
-        let (withheld, narrowed) = trim_collection(&mut payload, "chain", target, 1);
+        let (withheld, shape) = trim_collection(&mut payload, "chain", target, 1);
 
-        assert!(narrowed, "a parented collection must be narrowed, not cut");
+        assert_eq!(
+            shape,
+            CutShape::Branches,
+            "a parented collection must be narrowed, not cut"
+        );
         assert!(withheld > 0, "the fixture must reach the cut");
         let kept: Vec<u64> = payload["chain"]
             .as_array()
@@ -1613,11 +1857,12 @@ mod tests {
         let mut payload = json!({"entities": entries});
         let target = measure(&payload) / 2;
 
-        let (withheld, narrowed) = trim_collection(&mut payload, "entities", target, 1);
+        let (withheld, shape) = trim_collection(&mut payload, "entities", target, 1);
 
         assert!(withheld > 0, "the fixture must reach the cut");
-        assert!(
-            !narrowed,
+        assert_eq!(
+            shape,
+            CutShape::Suffix,
             "a collection with no parents cannot be narrowed by branch"
         );
         let kept = payload["entities"].as_array().expect("entities survive");
@@ -1728,6 +1973,161 @@ mod tests {
         assert!(cuts
             .iter()
             .all(|cut| cut["component"] == json!("response_budget")));
+    }
+
+    /// One `trace_data_flow` chain, wide and shallow, with `target_name` echoing
+    /// a step the walk reached. Named after the shape the rc061y stranger hit.
+    fn targeted_chain_payload(width: usize, target_step: usize) -> Value {
+        let chain: Vec<Value> = (1..=width)
+            .map(|step| {
+                json!({
+                    "step": step,
+                    "parent_step": 0,
+                    "depth": 1,
+                    "entity_id": format!("id-{step}"),
+                    "entity_name": format!("Neighbour.call_{step}"),
+                    "relation_kind": "Calls",
+                    "resolution": "type_resolved",
+                    "file_path": format!("src/module_{step}.py"),
+                    "signature": "def call(self, request, stream=False, timeout=None): ...",
+                    "fanout_truncated": false,
+                    "fanout_dropped": 0,
+                    "terminal": null,
+                })
+            })
+            .collect();
+        json!({
+            "focal_name": "Session.send",
+            "target_name": format!("Neighbour.call_{target_step}"),
+            "total_steps": width,
+            "chain": chain,
+        })
+    }
+
+    /// FIR-2824 at the surface a caller reads. The sentence is COMPOSED from
+    /// clauses and joined, so it is probed rather than reasoned about: reading
+    /// the code says what each clause holds, and only printing the join says
+    /// what a caller receives.
+    #[test]
+    fn a_bounded_trace_says_it_kept_the_branch_the_caller_named() {
+        const BUDGET: usize = 4_000;
+        // The target sits LAST, which is where relevance order puts the branch
+        // it is most willing to give up.
+        let mut payload = targeted_chain_payload(40, 40);
+        assert!(
+            measure(&payload) > BUDGET,
+            "the fixture must overflow or nothing is trimmed"
+        );
+        let budget = ResponseBudget {
+            max_chars: BUDGET,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "trace_data_flow", &budget).expect("trace_data_flow is budgeted");
+
+        let kept: Vec<String> = payload["chain"]
+            .as_array()
+            .expect("chain survives")
+            .iter()
+            .filter_map(|entry| entry["entity_name"].as_str().map(str::to_string))
+            .collect();
+        assert!(
+            kept.contains(&"Neighbour.call_40".to_string()),
+            "the trim gave up the branch the caller named: {kept:?}"
+        );
+        assert!(
+            kept.len() < 40,
+            "nothing was trimmed, so this grades an elision that never fired: {kept:?}"
+        );
+
+        let detail = payload["degradations"]
+            .as_array()
+            .expect("a cut is disclosed")
+            .iter()
+            .filter(|cut| cut["reason"] == json!(BOUNDED_REASON))
+            .filter_map(|cut| cut["detail"].as_str())
+            .next()
+            .expect("the bounded cut carries a detail")
+            .to_string();
+        // Printed, not merely asserted: the composed sentence is the artifact.
+        println!("composed disclosure: {detail}");
+        assert!(
+            detail.contains("keeping the branch that reaches the named target"),
+            "the disclosure does not say the named branch was held: {detail}"
+        );
+        assert!(
+            !CutShape::BranchesKeepingTarget.phrase().contains("; "),
+            "a clause carrying the separator its own join uses splits itself apart"
+        );
+    }
+
+    /// The control, and the half that makes the test above mean anything. The
+    /// same chain at the same budget, with no target named, still gives up its
+    /// last branch and says so in the words it always did. An elision that can
+    /// never drop anything is a check that cannot fail.
+    #[test]
+    fn an_unnamed_trace_still_elides_least_relevant_first() {
+        const BUDGET: usize = 4_000;
+        let mut payload = targeted_chain_payload(40, 40);
+        payload
+            .as_object_mut()
+            .expect("payload is an object")
+            .remove("target_name");
+        let budget = ResponseBudget {
+            max_chars: BUDGET,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "trace_data_flow", &budget).expect("trace_data_flow is budgeted");
+
+        let kept: Vec<String> = payload["chain"]
+            .as_array()
+            .expect("chain survives")
+            .iter()
+            .filter_map(|entry| entry["entity_name"].as_str().map(str::to_string))
+            .collect();
+        assert!(
+            !kept.contains(&"Neighbour.call_40".to_string()),
+            "the unnamed walk kept the last branch anyway, so the named half above \
+             proves nothing: {kept:?}"
+        );
+        let detail = payload["degradations"]
+            .as_array()
+            .expect("a cut is disclosed")
+            .iter()
+            .filter(|cut| cut["reason"] == json!(BOUNDED_REASON))
+            .filter_map(|cut| cut["detail"].as_str())
+            .next()
+            .expect("the bounded cut carries a detail")
+            .to_string();
+        assert!(
+            !detail.contains("keeping the branch that reaches the named target"),
+            "a walk that named no target claims to have held one: {detail}"
+        );
+    }
+
+    /// A target the walk never reached protects nothing, which is the case that
+    /// separates "the question steered the trim" from "the trim stopped
+    /// trimming". Named but absent, the chain sheds exactly as the unnamed one
+    /// does.
+    #[test]
+    fn a_target_the_walk_never_reached_protects_nothing() {
+        const BUDGET: usize = 4_000;
+        let mut payload = targeted_chain_payload(40, 40);
+        payload["target_name"] = json!("HTTPAdapter.never_walked");
+        let budget = ResponseBudget {
+            max_chars: BUDGET,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "trace_data_flow", &budget).expect("trace_data_flow is budgeted");
+        let kept: Vec<String> = payload["chain"]
+            .as_array()
+            .expect("chain survives")
+            .iter()
+            .filter_map(|entry| entry["entity_name"].as_str().map(str::to_string))
+            .collect();
+        assert!(
+            !kept.contains(&"Neighbour.call_40".to_string()),
+            "an unreached target changed what the trim kept: {kept:?}"
+        );
     }
 
     /// At the floor of the clamp the disclosure is a large fraction of the whole

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1789,7 +1789,76 @@ mod tests {
             .expect("a budget that cannot hold the named branch must still narrow, not refuse");
         assert!(
             named.len() <= 2,
-            "the second pass did not give the protection up: {named:?}"
+            "protecting the named branch still left an answer inside the budget: {named:?}"
+        );
+    }
+
+    /// The give-up fallback, on the only shape that reaches it.
+    ///
+    /// The test above cannot reach it, and its old message claimed otherwise.
+    /// Protecting a target protects its ancestry, and when what fits is counted
+    /// in STEPS that ancestry is never larger than the deepest spine the
+    /// keep-one-child floor would hold anyway, so the first pass always has an
+    /// answer and the second pass is unreachable. Deleting the fallback leaves
+    /// every count-based test green.
+    ///
+    /// A real budget is not a count. It is serialized size, and a shallow
+    /// branch of fat steps can cost more than a deeper branch of thin ones. So
+    /// depth decides which branch the floor holds and cost decides what fits,
+    /// and here the two disagree on purpose: the named target sits in the
+    /// shallow expensive branch, and holding it cannot fit at any price the
+    /// first pass can pay.
+    #[test]
+    fn a_protected_branch_too_expensive_to_hold_is_given_up_rather_than_refused() {
+        // Two branches under the focal: `1 -> 2` is shallow and expensive and
+        // holds the target, `5 -> 6 -> 7` is deeper and cheap.
+        let steps: Vec<(u64, u64)> = vec![(1, 0), (2, 1), (5, 0), (6, 5), (7, 6)];
+        const TARGET: u64 = 2;
+        const BUDGET: usize = 5;
+        let weight = |id: u64| -> usize {
+            if id == 1 || id == TARGET {
+                10
+            } else {
+                1
+            }
+        };
+        let cost = |kept: &[(u64, u64)]| -> usize { kept.iter().map(|step| weight(step.0)).sum() };
+
+        // The premise, asserted rather than assumed: the protected branch alone
+        // is already over budget, so the first pass has nothing it can return.
+        // Without this the test would pass on a fixture that never reached the
+        // second pass at all, which is exactly how the sibling above read as
+        // covered.
+        assert!(
+            weight(1) + weight(TARGET) > BUDGET,
+            "the protected branch must not fit, or the first pass answers and this grades nothing"
+        );
+
+        let narrowed = narrow_fanout_to_fit(
+            &steps,
+            &|step: &(u64, u64)| step.0,
+            &|step: &(u64, u64)| Some(step.1),
+            &|step: &(u64, u64)| step.0 == TARGET,
+            &mut |kept: &[(u64, u64)]| cost(kept) <= BUDGET,
+        );
+
+        // Read as an assertion rather than an expect, so deleting the fallback
+        // fails HERE by name instead of panicking somewhere downstream.
+        assert!(
+            narrowed.is_some(),
+            "protection is a preference, not a refusal: a budget too small to hold the named \
+             branch must still come back with a narrowed answer"
+        );
+        let kept = narrowed.expect("asserted present above");
+        let ids: Vec<u64> = kept.iter().map(|step| step.0).collect();
+        assert!(
+            cost(&kept) <= BUDGET,
+            "the answer must fit the budget it was given: {ids:?} costs {}",
+            cost(&kept)
+        );
+        assert!(
+            !ids.contains(&TARGET),
+            "the second pass gives the protection up, so the target cannot still be here: {ids:?}"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -9506,7 +9506,22 @@ mod tests {
         let caller = make_entity("caller", "src/caller.rs");
         let missing = make_entity("missing_site", "src/missing.rs");
         let outside = make_entity("outside_site", "src/outside.rs");
-        for entity in [&focal, &callee, &caller, &missing, &outside] {
+        // An incoming edge whose span names a THIRD file, which is what makes the
+        // caller arm's filter falsifiable. Every other incoming span already
+        // sits in the caller's own file, so passing `None` for the filter and
+        // passing the caller's file admit the same set, and the mutation that
+        // disables the filter outright produces identical output. Only a span
+        // the filter must reject separates "admitted because it matched" from
+        // "admitted because nothing filtered".
+        let caller_outside = make_entity("caller_outside_site", "src/caller-outside.rs");
+        for entity in [
+            &focal,
+            &callee,
+            &caller,
+            &missing,
+            &outside,
+            &caller_outside,
+        ] {
             store.upsert_entity(entity).unwrap();
         }
         store
@@ -9557,6 +9572,15 @@ mod tests {
                 19,
             ))
             .unwrap();
+        store
+            .upsert_relation(&make_relation_with_site(
+                caller_outside.id,
+                focal.id,
+                RelationKind::Calls,
+                "src/third-party.rs",
+                19,
+            ))
+            .unwrap();
 
         let response = traced_payload(
             &store,
@@ -9595,6 +9619,17 @@ mod tests {
         );
         assert_eq!(
             step("outside_site")["reference_lines_absent_reason"],
+            "span_outside_caller_file"
+        );
+        // The caller arm filters against the CHILD's own file, not the focal's.
+        // This span names neither, so a row that carries lines here means the
+        // filter is not running rather than that it chose the wrong file.
+        assert_eq!(
+            step("caller_outside_site")["reference_lines"],
+            serde_json::json!([])
+        );
+        assert_eq!(
+            step("caller_outside_site")["reference_lines_absent_reason"],
             "span_outside_caller_file"
         );
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3763,10 +3763,24 @@ fn narrow_trace_fanout_to_fit(
 ) -> usize {
     let step_of = |value: &serde_json::Value| value["step"].as_u64().unwrap_or(0);
     let parent_of = |value: &serde_json::Value| value["parent_step"].as_u64();
+    // The question this walk was given, so the branch that answers it is not
+    // offered up as "least relevant". Read off the result rather than passed in
+    // because this is the same string the response echoes to the caller, and a
+    // rule keyed on a second copy is a rule that can drift from the answer.
+    let named = result
+        .get("target_name")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let must_keep = |value: &serde_json::Value| {
+        named.as_deref().is_some_and(|name| {
+            value.get("entity_name").and_then(serde_json::Value::as_str) == Some(name)
+        })
+    };
     let narrowed = crate::budget::narrow_fanout_to_fit(
         discovered,
         &step_of,
         &parent_of,
+        &must_keep,
         &mut |kept: &[serde_json::Value]| {
             result["chain"] = serde_json::Value::Array(kept.to_vec());
             result["total_steps"] = serde_json::Value::from(kept.len());

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3339,9 +3339,12 @@ you are trying to reach and every neighbor from which it is still reachable sort
 every neighbor that is not, BEFORE the cap cuts. Without a target, read \
 `spine_clipped_steps`: when it is above zero the walk continued beneath a node whose \
 fan-out was already cut, so this chain is one route among several and a hop it does not \
-contain was never looked for. Do not read such a chain as evidence that X never reaches Y. Every step reports the same keys: a \
-symbol the graph owns no file for carries explicit nulls plus `external: true` rather than a \
-shorter record, and one symbol never appears both located and file-less in one response. \
+contain was never looked for. Do not read such a chain as evidence that X never reaches Y. Every step reports the same keys, \
+including `reference_lines` for the 1-based syntax sites that introduced the hop and \
+`reference_lines_absent_reason` when the parser recorded no usable site. For a `callee` step \
+those lines live in its parent's file; for a `caller` step they live in the step's own \
+`entity_file`. A symbol the graph owns no file for carries explicit nulls plus `external: true` \
+rather than a shorter record, and one symbol never appears both located and file-less in one response. \
 When the chain comes back empty, the additive `negative` object's `safe_to_conclude_absent` \
 flag says whether \"no flow from here\" is authoritative or merely \"not indexed yet\", and its \
 `subject` scopes the absence to the direction that was walked, so an empty 'callers' result is \
@@ -3389,6 +3392,9 @@ struct TraceFrontierNode {
     id: kin_model::ids::EntityId,
     depth: usize,
     file: Option<String>,
+    /// The same file in graph identity form, for checking relation evidence
+    /// against the referencing entity without rebuilding it from display text.
+    file_origin: Option<kin_model::ids::FilePathId>,
     dir: Option<String>,
 }
 
@@ -3399,6 +3405,7 @@ impl TraceFrontierNode {
             id: entity.id,
             depth,
             file: entity.file_origin.as_ref().map(|path| path.0.clone()),
+            file_origin: entity.file_origin.clone(),
             dir: kin_ranking::entity_ranking::entity_directory(entity),
         }
     }
@@ -3433,6 +3440,12 @@ struct TraceFanoutCandidate {
     /// requested depth. False for every candidate when no target was named, so
     /// an untargeted walk orders exactly as it did before this existed.
     reaches_target: bool,
+    /// Call/reference sites accumulated across every edge that reaches this
+    /// step, independent of which edge supplies the displayed relation kind.
+    reference_lines: Vec<u32>,
+    /// Evidence spans naming a file other than the caller's. This distinguishes
+    /// unusable evidence from an edge whose parser recorded no span at all.
+    reference_spans_outside_caller_file: usize,
 }
 
 impl TraceFanoutCandidate {
@@ -3444,6 +3457,21 @@ impl TraceFanoutCandidate {
     /// repository with a language server installed.
     fn is_raise_target(&self) -> bool {
         self.call_edges > 0 && self.raise_call_edges == self.call_edges
+    }
+
+    fn normalize_reference_lines(&mut self) {
+        self.reference_lines.sort_unstable();
+        self.reference_lines.dedup();
+    }
+
+    fn reference_lines_absent_reason(&self) -> Option<&'static str> {
+        if !self.reference_lines.is_empty() {
+            None
+        } else if self.reference_spans_outside_caller_file > 0 {
+            Some(ReferenceLinesAbsent::SpanOutsideCallerFile.as_str())
+        } else {
+            Some(ReferenceLinesAbsent::NoEvidenceSpan.as_str())
+        }
     }
 }
 
@@ -3627,6 +3655,8 @@ fn trace_step_value(
     resolution: &str,
     parent_step: usize,
     depth: usize,
+    reference_lines: Vec<u32>,
+    reference_lines_absent_reason: Option<&str>,
     entity: &kin_model::entity::Entity,
     terminal: Option<TraceTerminal>,
     crossing: Option<&kin_index::TraceCrossing>,
@@ -3641,6 +3671,13 @@ fn trace_step_value(
         "resolution": resolution,
         "parent_step": parent_step,
         "depth": depth,
+        // The edge's 1-based source sites, not the entity definition line. A
+        // callee's sites live in its parent file; a caller's sites live in its
+        // own entity_file. The role plus parent_step identifies which.
+        "reference_lines": reference_lines,
+        // Explicit null when lines exist, and the same two reason strings
+        // `find_references` uses when they do not.
+        "reference_lines_absent_reason": reference_lines_absent_reason,
         "fanout_truncated": false,
         "fanout_dropped": 0,
         // Why the walk stopped here, or null for an ordinary step. Written on
@@ -4148,7 +4185,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                     continue;
                 }
 
-                match candidate_index.get(&(next_id, role)) {
+                let candidate_at = match candidate_index.get(&(next_id, role)) {
                     Some(&existing) => {
                         let candidate: &mut TraceFanoutCandidate = &mut candidates[existing];
                         let stronger = trace_relation_rank(rel.kind)
@@ -4178,6 +4215,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                                 candidate.crossing = Some(named);
                             }
                         }
+                        existing
                     }
                     None => {
                         let Some(entity) = store.get_entity(&next_id).map_err(McpError::graph)?
@@ -4200,9 +4238,26 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                             confidence: rel.confidence,
                             resolution: RelationResolution::of(rel),
                             crossing,
+                            reference_lines: Vec::new(),
+                            reference_spans_outside_caller_file: 0,
                         });
+                        candidates.len() - 1
                     }
-                }
+                };
+
+                // The source site belongs to the referencing entity. An
+                // outgoing step's caller is the parent node; an incoming
+                // step's caller is the candidate itself. Keep every edge's
+                // site even when another edge ranks stronger for display.
+                let caller_file = if role == "callee" {
+                    node.file_origin.as_ref()
+                } else {
+                    candidates[candidate_at].entity.file_origin.as_ref()
+                };
+                let tally = relation_reference_lines(rel, caller_file);
+                candidates[candidate_at].reference_lines.extend(tally.lines);
+                candidates[candidate_at].reference_spans_outside_caller_file +=
+                    tally.outside_caller_file;
             }
 
             // This node's relations were read to the end, so what the graph held
@@ -4259,7 +4314,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                 clipped_steps.push(clip);
             }
 
-            for candidate in callees.into_iter().chain(callers) {
+            for mut candidate in callees.into_iter().chain(callers) {
                 if chain.len() >= MAX_TOTAL_STEPS {
                     truncated = true;
                     break;
@@ -4298,6 +4353,16 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                                 .unwrap_or_else(|| RelationResolution::NameOnly.as_str()),
                             chain[existing - 1]["parent_step"].as_u64().unwrap_or(0) as usize,
                             promoted_depth,
+                            chain[existing - 1]["reference_lines"]
+                                .as_array()
+                                .cloned()
+                                .unwrap_or_default()
+                                .into_iter()
+                                .filter_map(|line| {
+                                    line.as_u64().and_then(|line| u32::try_from(line).ok())
+                                })
+                                .collect(),
+                            chain[existing - 1]["reference_lines_absent_reason"].as_str(),
                             &candidate.entity,
                             promoted_terminal,
                             candidate.crossing.as_ref(),
@@ -4334,6 +4399,8 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                     candidate.relation_kind,
                     include_type_edges,
                 );
+                candidate.normalize_reference_lines();
+                let reference_lines_absent_reason = candidate.reference_lines_absent_reason();
                 chain.push(trace_step_value(
                     step_index,
                     candidate.role,
@@ -4341,6 +4408,8 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                     candidate.resolution.as_str(),
                     node.step,
                     next_depth,
+                    candidate.reference_lines,
+                    reference_lines_absent_reason,
                     &candidate.entity,
                     terminal,
                     candidate.crossing.as_ref(),
@@ -5832,6 +5901,29 @@ mod tests {
             import_source: None,
             evidence: Vec::new(),
         }
+    }
+
+    fn make_relation_with_site(
+        src: EntityId,
+        dst: EntityId,
+        kind: RelationKind,
+        file: &str,
+        row: u32,
+    ) -> Relation {
+        let mut relation = make_relation(src, dst, kind);
+        relation.evidence = vec![RelationEvidence {
+            source_span: Some(kin_model::entity::SourceSpan {
+                file: FilePathId::new(file),
+                start_byte: 0,
+                end_byte: 1,
+                start_line: row,
+                start_col: 0,
+                end_line: row,
+                end_col: 1,
+            }),
+            ..RelationEvidence::default()
+        }];
+        relation
     }
 
     fn graph_root(graph: &InMemoryGraph) -> String {
@@ -9233,6 +9325,117 @@ mod tests {
         assert_eq!(targeted["target_name"], "HTTPAdapter.send");
     }
 
+    /// FIR-2824's call-site contract on the generic GraphStore arm. The line
+    /// belongs to the referencing entity, which is the parent for a callee and
+    /// the child for a caller. Duplicate edges contribute every site, and an
+    /// empty list states whether evidence was missing or unusable.
+    #[test]
+    fn trace_data_flow_offline_carries_call_sites_for_every_chain_step() {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("focal", "src/focal.rs");
+        let callee = make_entity("callee", "src/callee.rs");
+        let caller = make_entity("caller", "src/caller.rs");
+        let missing = make_entity("missing_site", "src/missing.rs");
+        let outside = make_entity("outside_site", "src/outside.rs");
+        for entity in [&focal, &callee, &caller, &missing, &outside] {
+            store.upsert_entity(entity).unwrap();
+        }
+        store
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::Calls,
+                "src/focal.rs",
+                11,
+            ))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::References,
+                "src/focal.rs",
+                41,
+            ))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::Imports,
+                "src/focal.rs",
+                41,
+            ))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation_with_site(
+                caller.id,
+                focal.id,
+                RelationKind::Calls,
+                "src/caller.rs",
+                7,
+            ))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation(focal.id, missing.id, RelationKind::Calls))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                outside.id,
+                RelationKind::Calls,
+                "src/not-the-caller.rs",
+                19,
+            ))
+            .unwrap();
+
+        let response = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal.id.to_string())),
+                ("direction", serde_json::json!("both")),
+                ("depth", serde_json::json!(1)),
+                ("limit_per_step", serde_json::json!(25)),
+            ],
+        );
+        let steps = response["chain"].as_array().unwrap();
+        let step = |name: &str| {
+            steps
+                .iter()
+                .find(|step| step["entity_name"] == name)
+                .unwrap_or_else(|| panic!("missing {name}: {response:#}"))
+        };
+        assert_eq!(
+            step("callee")["reference_lines"],
+            serde_json::json!([12, 42])
+        );
+        assert!(step("callee")["reference_lines_absent_reason"].is_null());
+        assert_eq!(step("caller")["reference_lines"], serde_json::json!([8]));
+        assert!(step("caller")["reference_lines_absent_reason"].is_null());
+        assert_eq!(
+            step("missing_site")["reference_lines"],
+            serde_json::json!([])
+        );
+        assert_eq!(
+            step("missing_site")["reference_lines_absent_reason"],
+            "no_evidence_span"
+        );
+        assert_eq!(
+            step("outside_site")["reference_lines"],
+            serde_json::json!([])
+        );
+        assert_eq!(
+            step("outside_site")["reference_lines_absent_reason"],
+            "span_outside_caller_file"
+        );
+
+        let expected: Vec<String> = steps[0].as_object().unwrap().keys().cloned().collect();
+        for item in steps {
+            let keys: Vec<String> = item.as_object().unwrap().keys().cloned().collect();
+            assert_eq!(keys, expected, "every step carries one key set: {item}");
+        }
+    }
+
     /// Both arms of one tool have to answer the same way, so the offline arm
     /// gets the same fixture at the same reported parameters.
     #[test]
@@ -9562,6 +9765,71 @@ mod tests {
         }
     }
 
+    /// A located record can arrive one depth after its file-less placeholder.
+    /// Promotion replaces identity and location, but the edge into the existing
+    /// step does not change, so its call-site evidence must not be reset to the
+    /// later edge's site.
+    #[test]
+    fn trace_data_flow_offline_promotion_preserves_the_original_edge_site() {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("focal", "src/focal.rs");
+        let bridge = make_entity("bridge", "src/bridge.rs");
+        let admitted = make_entity("shared", "src/shared.rs");
+        let mut placeholder = make_entity("shared", "unused");
+        placeholder.kind = EntityKind::Module;
+        placeholder.file_origin = None;
+        placeholder.span = None;
+        for entity in [&focal, &bridge, &admitted, &placeholder] {
+            store.upsert_entity(entity).unwrap();
+        }
+        store
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                placeholder.id,
+                RelationKind::Calls,
+                "src/focal.rs",
+                4,
+            ))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation(focal.id, bridge.id, RelationKind::Calls))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation_with_site(
+                bridge.id,
+                admitted.id,
+                RelationKind::Calls,
+                "src/bridge.rs",
+                9,
+            ))
+            .unwrap();
+
+        let response = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal.id.to_string())),
+                ("direction", serde_json::json!("calls")),
+                ("depth", serde_json::json!(2)),
+                ("limit_per_step", serde_json::json!(25)),
+            ],
+        );
+        let shared = response["chain"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|step| step["entity_name"] == "shared")
+            .unwrap_or_else(|| panic!("missing promoted step: {response:#}"));
+        assert_eq!(shared["entity_id"], admitted.id.to_string());
+        assert_eq!(shared["entity_file"], "src/shared.rs");
+        assert_eq!(shared["reference_lines"], serde_json::json!([5]));
+        assert!(shared["reference_lines_absent_reason"].is_null());
+        assert_ne!(
+            shared["reference_lines"],
+            serde_json::json!([10]),
+            "the promoting edge's line does not replace the edge already in the chain"
+        );
+    }
+
     /// This arm inlines no bodies, so what it can shed is steps — and it must,
     /// because 200 steps of identity and signature is a six-figure character
     /// count on its own.
@@ -9633,6 +9901,95 @@ mod tests {
             .find(|entry| entry["component"] == serde_json::json!("response_budget"))
             .expect("the cut must name itself");
         assert_eq!(disclosure["reason"], serde_json::json!("steps_omitted"));
+    }
+
+    /// FIR-2824 at the GraphStore arm's first response-boundary stage. The
+    /// target branch is shallower than the distractor, so ordinary deep-branch
+    /// preservation gives it up. Reading `target_name` is the only thing that
+    /// can make the named and unnamed arms choose differently.
+    #[test]
+    fn trace_data_flow_offline_response_narrowing_keeps_the_named_branch() {
+        let discovered = vec![
+            serde_json::json!({
+                "step": 1, "parent_step": 0, "entity_name": "target_parent", "pad": "p".repeat(300),
+            }),
+            serde_json::json!({
+                "step": 2, "parent_step": 0, "entity_name": "distractor", "pad": "p".repeat(300),
+            }),
+            serde_json::json!({
+                "step": 3, "parent_step": 1, "entity_name": "cert_verify", "pad": "p".repeat(300),
+            }),
+            serde_json::json!({
+                "step": 4, "parent_step": 2, "entity_name": "deeper", "pad": "p".repeat(300),
+            }),
+            serde_json::json!({
+                "step": 5, "parent_step": 4, "entity_name": "deepest", "pad": "p".repeat(300),
+            }),
+        ];
+        let payload = |target_name: Option<&str>, chain: Vec<serde_json::Value>| {
+            let mut value = serde_json::json!({
+                "chain": chain,
+                "total_steps": 5,
+            });
+            if let Some(name) = target_name {
+                value["target_name"] = serde_json::json!(name);
+            }
+            value
+        };
+        let measure =
+            |value: &serde_json::Value| serde_json::to_string_pretty(value).unwrap().len();
+        let protected_shape = payload(
+            Some("cert_verify"),
+            vec![discovered[0].clone(), discovered[2].clone()],
+        );
+        let deep_shape = payload(
+            None,
+            vec![
+                discovered[1].clone(),
+                discovered[3].clone(),
+                discovered[4].clone(),
+            ],
+        );
+        let target_chars = measure(&protected_shape).max(measure(&deep_shape));
+        let full = payload(Some("cert_verify"), discovered.clone());
+        assert!(measure(&full) > target_chars, "the fixture must need a cut");
+
+        let mut unnamed = payload(None, discovered.clone());
+        let unnamed_dropped =
+            narrow_trace_fanout_to_fit(&mut unnamed, &discovered, target_chars, measure);
+        assert!(unnamed_dropped > 0, "the unnamed control must narrow");
+        assert!(
+            !traced_step_names(&unnamed)
+                .iter()
+                .any(|name| name == "cert_verify"),
+            "the unnamed control kept the shallow target branch: {unnamed}"
+        );
+
+        let mut named = payload(Some("cert_verify"), discovered.clone());
+        let named_dropped =
+            narrow_trace_fanout_to_fit(&mut named, &discovered, target_chars, measure);
+        assert!(named_dropped > 0, "the named arm must still narrow");
+        let named_steps = named["chain"].as_array().unwrap();
+        let names: std::collections::BTreeSet<&str> = named_steps
+            .iter()
+            .filter_map(|step| step["entity_name"].as_str())
+            .collect();
+        assert!(
+            names.contains("cert_verify"),
+            "the first response bounder dropped the named branch: {named}"
+        );
+        assert!(
+            names.contains("target_parent"),
+            "the target survived without the parent that introduced it: {named}"
+        );
+        let present: std::collections::BTreeSet<u64> = named_steps
+            .iter()
+            .filter_map(|step| step["step"].as_u64())
+            .collect();
+        assert!(named_steps.iter().all(|step| {
+            let parent = step["parent_step"].as_u64().unwrap_or(0);
+            parent == 0 || present.contains(&parent)
+        }));
     }
 
     /// The authoritative side of the trace absence: a focal that is in the

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4249,15 +4249,27 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                 // outgoing step's caller is the parent node; an incoming
                 // step's caller is the candidate itself. Keep every edge's
                 // site even when another edge ranks stronger for display.
-                let caller_file = if role == "callee" {
-                    node.file_origin.as_ref()
-                } else {
-                    candidates[candidate_at].entity.file_origin.as_ref()
-                };
-                let tally = relation_reference_lines(rel, caller_file);
-                candidates[candidate_at].reference_lines.extend(tally.lines);
-                candidates[candidate_at].reference_spans_outside_caller_file +=
-                    tally.outside_caller_file;
+                //
+                // Every REFERENCE edge, that is. `allowed` also carries
+                // `UsesType` so an annotation target is a named leaf, and the
+                // graph holds one beside the `Calls` edge for the same pair.
+                // Its span is the annotation's target, which is the callee's
+                // own definition rather than a site where the caller calls it,
+                // so accumulating it published `[def_line, call_line]` on every
+                // row with nothing to tell them apart. `reference_kinds` is
+                // what the reference surface reads, so gating on it keeps the
+                // two answers the same.
+                if reference_kinds.contains(&rel.kind) {
+                    let caller_file = if role == "callee" {
+                        node.file_origin.as_ref()
+                    } else {
+                        candidates[candidate_at].entity.file_origin.as_ref()
+                    };
+                    let tally = relation_reference_lines(rel, caller_file);
+                    candidates[candidate_at].reference_lines.extend(tally.lines);
+                    candidates[candidate_at].reference_spans_outside_caller_file +=
+                        tally.outside_caller_file;
+                }
             }
 
             // This node's relations were read to the end, so what the graph held
@@ -9323,6 +9335,73 @@ mod tests {
             traced_step_names(&targeted)
         );
         assert_eq!(targeted["target_name"], "HTTPAdapter.send");
+    }
+
+    /// An annotation edge's span is not a call site.
+    ///
+    /// The graph holds a `UsesType` edge beside the `Calls` edge for the same
+    /// pair, and its span is the annotation's target, which is the callee's own
+    /// definition rather than anywhere the caller calls it. `allowed` admits
+    /// `UsesType` so an annotation target is a named leaf, and the reference
+    /// surface deliberately does not read it, so publishing its span here made
+    /// this tool disagree with `kin refs` about the same pair and gave every row
+    /// a definition line beside its call line with nothing to tell them apart.
+    ///
+    /// Both spans are in the CALLER's file on purpose. The caller-file filter
+    /// can never separate them, so passing this can only mean the edge class
+    /// was consulted.
+    #[test]
+    fn trace_data_flow_offline_leaves_annotation_spans_out_of_call_sites() {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("focal", "src/focal.rs");
+        let callee = make_entity("callee", "src/callee.rs");
+        for entity in [&focal, &callee] {
+            store.upsert_entity(entity).unwrap();
+        }
+        store
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::Calls,
+                "src/focal.rs",
+                11,
+            ))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation_with_site(
+                focal.id,
+                callee.id,
+                RelationKind::UsesType,
+                "src/focal.rs",
+                4,
+            ))
+            .unwrap();
+
+        let response = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal.id.to_string())),
+                ("direction", serde_json::json!("calls")),
+                ("depth", serde_json::json!(1)),
+                ("limit_per_step", serde_json::json!(25)),
+            ],
+        );
+        let steps = response["chain"].as_array().unwrap();
+        let row = steps
+            .iter()
+            .find(|step| step["entity_name"] == "callee")
+            .unwrap_or_else(|| {
+                panic!("the annotation edge must still reach the leaf: {response:#}")
+            });
+
+        // The premise: the leaf is here at all, which is what `UsesType` being
+        // in `allowed` buys and what this fix must not take away.
+        assert_eq!(
+            row["reference_lines"],
+            serde_json::json!([12]),
+            "only the call site belongs here, not the annotation's target: {row}"
+        );
+        assert!(row["reference_lines_absent_reason"].is_null());
     }
 
     /// The call-site contract on the generic GraphStore arm. The line

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -9325,7 +9325,7 @@ mod tests {
         assert_eq!(targeted["target_name"], "HTTPAdapter.send");
     }
 
-    /// FIR-2824's call-site contract on the generic GraphStore arm. The line
+    /// The call-site contract on the generic GraphStore arm. The line
     /// belongs to the referencing entity, which is the parent for a callee and
     /// the child for a caller. Duplicate edges contribute every site, and an
     /// empty list states whether evidence was missing or unusable.
@@ -9903,7 +9903,7 @@ mod tests {
         assert_eq!(disclosure["reason"], serde_json::json!("steps_omitted"));
     }
 
-    /// FIR-2824 at the GraphStore arm's first response-boundary stage. The
+    /// At the GraphStore arm's first response-boundary stage, the
     /// target branch is shallower than the distractor, so ordinary deep-branch
     /// preservation gives it up. Reading `target_name` is the only thing that
     /// can make the named and unnamed arms choose differently.

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -58,6 +58,11 @@ EXPECTED_SUITES = (
         "acceptance/response_budget.json",
     ),
     ExpectedSuite(
+        "scripts/acceptance/trace_spine_clipping_repro.py",
+        "trace_spine",
+        "acceptance/trace_spine.json",
+    ),
+    ExpectedSuite(
         "scripts/acceptance/parse_hole_repro.py",
         "parsehole",
         "acceptance/parsehole.json",
@@ -1003,7 +1008,8 @@ def main() -> int:
     if problems:
         return 1
     print(
-        "workflow authority holds: 13 suite reports reach one always-running verdict in order"
+        "workflow authority holds: %d suite reports reach one always-running verdict in order"
+        % len(EXPECTED_SUITES)
     )
     return 0
 

--- a/scripts/acceptance/trace_spine_clipping_repro.py
+++ b/scripts/acceptance/trace_spine_clipping_repro.py
@@ -4,7 +4,7 @@
 
 """Prove trace cuts preserve and explain the branch the caller asked for.
 
-FIR-2781 established checks 0 through 3. The v0.6.0 stranger run walked `Session.send` on a converted
+The original suite established checks 0 through 3. The v0.6.0 stranger run walked `Session.send` on a converted
 `psf/requests` with `limit_per_step: 4` and got a chain that stops two hops
 short of where `verify` goes. The per-step cap had discarded eleven of fifteen
 callees, `HTTPAdapter.send` among them, and the response said so only as a count
@@ -162,7 +162,13 @@ SESSIONS_FILE = "sessions.py"
 ADAPTERS_FILE = "adapters.py"
 # Small enough to force branch narrowing on this body-free fixture, while still
 # leaving room for the protected two-hop branch plus the bounder's disclosure.
-RESPONSE_BUDGET = 4000
+# Calibrated against the built binaries on 2026-08-28 by sweeping 3000 to 11000: below 4500
+# nothing separates the arms, at 7000 and above both keep the target, and 5500 to 6500 is the
+# plateau where the named arm keeps it by branch narrowing and the unnamed arm loses it.
+RESPONSE_BUDGET = 6000
+# The synthetic graders run against small payloads, so they get their own budget. The real
+# constant above is the one the product is judged on.
+SELFTEST_RESPONSE_BUDGET = 1300
 WIDE_RESPONSE_BUDGET = 60000
 ELISION_DEPTH = 3
 ELISION_LIMIT = 25
@@ -321,8 +327,17 @@ def grade_a_complete_walk_is_not_qualified(payload):
             "cannot tell an unaffected walk from one that reported nothing"
             % (", ".join(present),)
         )
-    if not chain_names(payload):
+    names = chain_names(payload)
+    if not names:
         return UNREADABLE, "the control walk returned no chain, so it grades nothing"
+    # Absence of the qualifying keys is only good news on a walk that actually reached the
+    # crossing hop. A walk that returned one same-file callee and silently dropped the hop
+    # carries none of these keys either, and that is the loss this suite exists to catch.
+    if CROSSING_HOP not in names:
+        return FAIL, (
+            "the uncapped walk does not contain %s, so an unqualified answer here is the "
+            "silent loss rather than a complete walk: %r" % (CROSSING_HOP, names)
+        )
     return PASS, "no clip, no spine key, no disclosure on a walk the cap never cut"
 
 
@@ -464,7 +479,8 @@ def bounded_subset_problem(payload, wide):
         source = wide_by_identity.get(identity)
         if source is None:
             return "bounded entity_id %s was not discovered by the wide arm" % identity
-        for key in ("entity_name", "role"):
+        for key in ("entity_name", "role", "reference_lines",
+                    "reference_lines_absent_reason"):
             if row.get(key) != source.get(key):
                 return "bounded entity %s changed %s from %r to %r" % (
                     identity, key, source.get(key), row.get(key),
@@ -514,14 +530,23 @@ def wide_premise_problem(payload):
     return problem
 
 
-def bounded_elision_problem(payload, wide):
-    bounds = graph_bounds_problem(payload, RESPONSE_BUDGET)
+def bounded_elision_problem(payload, wide, budget):
+    bounds = graph_bounds_problem(payload, budget)
     if bounds:
         return "bounded bounds drifted: " + bounds
     rendered_chars = pretty_serialized_bytes(payload)
-    if rendered_chars > RESPONSE_BUDGET:
+    if rendered_chars > budget:
         return "the bounded response serializes to %d bytes, above its %d-byte budget" % (
-            rendered_chars, RESPONSE_BUDGET,
+            rendered_chars, budget,
+        )
+    # The cut has to be attributable to the budget. A discovery universe that already
+    # fits cannot overflow it, so a response that trims anyway trimmed for some other
+    # reason and labelled it response_budget.
+    wide_chars = pretty_serialized_bytes(wide)
+    if wide_chars <= budget:
+        return (
+            "the wide discovery serializes to %d bytes, inside the %d-byte budget, so nothing "
+            "here can be attributed to the response budget" % (wide_chars, budget)
         )
     clips = fanout_clip_problem(payload)
     if clips:
@@ -529,6 +554,8 @@ def bounded_elision_problem(payload, wide):
     chain = payload.get("chain")
     if not isinstance(chain, list):
         return "the response carries no chain array"
+    if not chain:
+        return "the bounded arm returned no steps at all, so it answers nothing"
     wide_chain = wide.get("chain")
     if not isinstance(wide_chain, list):
         return "the wide response carries no chain array"
@@ -573,10 +600,15 @@ def bounded_elision_problem(payload, wide):
     problem = parentage_problem(payload, require_target=False)
     if problem:
         return problem
+    # The suite claims each SURVIVING step carries its call sites. Grading that only on
+    # the wide arm proves it on a response nothing cut, which is the opposite of the claim.
+    problem = reference_line_contract_problem(payload)
+    if problem:
+        return problem
     return bounded_subset_problem(payload, wide)
 
 
-def grade_named_target_survives_response_budget(wide, bounded):
+def grade_named_target_survives_response_budget(wide, bounded, budget):
     if not isinstance(wide, dict) or not isinstance(bounded, dict):
         return UNREADABLE, "the wide or bounded response is not an object"
     if not isinstance(wide.get("chain"), list) or not isinstance(bounded.get("chain"), list):
@@ -584,7 +616,7 @@ def grade_named_target_survives_response_budget(wide, bounded):
     problem = wide_premise_problem(wide)
     if problem:
         return FAIL, "the wide discovery premise is not sound: " + problem
-    problem = bounded_elision_problem(bounded, wide)
+    problem = bounded_elision_problem(bounded, wide, budget)
     if problem:
         return FAIL, "the targeted bounded arm is not a coherent response cut: " + problem
     if bounded.get("target_name") != ELISION_TARGET:
@@ -600,15 +632,16 @@ def grade_named_target_survives_response_budget(wide, bounded):
     )
 
 
-def grade_unnamed_response_budget_drops_the_target(wide, targeted, unnamed):
+def grade_unnamed_response_budget_drops_the_target(wide, targeted, unnamed, budget):
     if not all(isinstance(payload, dict) for payload in (wide, targeted, unnamed)):
         return UNREADABLE, "one of the three response arms is not an object"
     if not all(isinstance(payload.get("chain"), list) for payload in (wide, targeted, unnamed)):
         return UNREADABLE, "one of the three response arms carries no readable chain"
-    target_status, target_detail = grade_named_target_survives_response_budget(wide, targeted)
+    target_status, target_detail = grade_named_target_survives_response_budget(
+        wide, targeted, budget)
     if target_status != PASS:
         return FAIL, "the paired targeted arm is not a valid control: " + target_detail
-    problem = bounded_elision_problem(unnamed, wide)
+    problem = bounded_elision_problem(unnamed, wide, budget)
     if problem:
         return FAIL, "the unnamed bounded arm is not a coherent response cut: " + problem
     names = chain_names(unnamed)
@@ -930,7 +963,8 @@ def check_the_named_target_survives_response_elision(suite):
     wide, targeted, _ = suite.elision_arms()
     if wide is None or targeted is None:
         return Result("4", UNREADABLE, "the wide or targeted bounded walk returned nothing readable")
-    status, detail = grade_named_target_survives_response_budget(wide, targeted)
+    status, detail = grade_named_target_survives_response_budget(
+        wide, targeted, RESPONSE_BUDGET)
     return Result("4", status, "The named branch survives response elision. " + detail)
 
 
@@ -938,7 +972,8 @@ def check_the_unnamed_budget_drops_the_same_target(suite):
     wide, targeted, unnamed = suite.elision_arms()
     if wide is None or targeted is None or unnamed is None:
         return Result("5", UNREADABLE, "one of the three response-budget arms returned nothing readable")
-    status, detail = grade_unnamed_response_budget_drops_the_target(wide, targeted, unnamed)
+    status, detail = grade_unnamed_response_budget_drops_the_target(
+        wide, targeted, unnamed, RESPONSE_BUDGET)
     return Result("5", status, "The unnamed control loses the same branch. " + detail)
 
 
@@ -992,7 +1027,20 @@ CLIPPED = {
     }],
 }
 
+# One same-file callee, no crossing hop, and nothing said about it. This is the silent
+# loss the suite exists to catch, so it is a must-FAIL arm for check 3 rather than the
+# unaffected walk it used to stand in for.
 CLEAN = {"chain": [{"entity_name": "get_adapter", "parent_step": 0}], "degradations": []}
+# A walk the cap never cut: it reached the crossing hop and carries none of the
+# qualifying keys, which is the only shape that earns an unqualified answer.
+COMPLETE = {
+    "chain": [
+        {"entity_name": "get_adapter", "parent_step": 0},
+        {"entity_name": CROSSING_HOP, "parent_step": 0},
+        {"entity_name": ELISION_TARGET, "parent_step": 2},
+    ],
+    "degradations": [],
+}
 WIDE_ELISION = {
     "depth": ELISION_DEPTH,
     "direction": "calls",
@@ -1023,13 +1071,15 @@ TARGETED_ELISION = {
     "depth": ELISION_DEPTH,
     "direction": "calls",
     "limit_per_step": ELISION_LIMIT,
-    "max_response_chars": RESPONSE_BUDGET,
+    "max_response_chars": SELFTEST_RESPONSE_BUDGET,
     "bodies_included": False,
     "chain": [
         {"step": 2, "parent_step": 0, "entity_id": "entity-send-via-adapter",
-         "entity_name": CROSSING_HOP, "role": "callee"},
+         "entity_name": CROSSING_HOP, "role": "callee",
+         "reference_lines": [SESSION_ADAPTER_CALL_LINE], "reference_lines_absent_reason": None},
         {"step": 4, "parent_step": 2, "entity_id": "entity-cert-verify",
-         "entity_name": ELISION_TARGET, "role": "callee"},
+         "entity_name": ELISION_TARGET, "role": "callee",
+         "reference_lines": [ADAPTER_CERT_CALL_LINE], "reference_lines_absent_reason": None},
     ],
     "total_steps": 2,
     "target_name": ELISION_TARGET,
@@ -1046,15 +1096,18 @@ UNNAMED_ELISION = {
     "depth": ELISION_DEPTH,
     "direction": "calls",
     "limit_per_step": ELISION_LIMIT,
-    "max_response_chars": RESPONSE_BUDGET,
+    "max_response_chars": SELFTEST_RESPONSE_BUDGET,
     "bodies_included": False,
     "chain": [
         {"step": 1, "parent_step": 0, "entity_id": "entity-get-adapter",
-         "entity_name": "get_adapter", "role": "callee"},
+         "entity_name": "get_adapter", "role": "callee",
+         "reference_lines": [1], "reference_lines_absent_reason": None},
         {"step": 3, "parent_step": 1, "entity_id": "entity-normalize-adapter",
-         "entity_name": "normalize_adapter", "role": "callee"},
+         "entity_name": "normalize_adapter", "role": "callee",
+         "reference_lines": [2], "reference_lines_absent_reason": None},
         {"step": 5, "parent_step": 3, "entity_id": "entity-record-adapter",
-         "entity_name": "record_adapter", "role": "callee"},
+         "entity_name": "record_adapter", "role": "callee",
+         "reference_lines": [3], "reference_lines_absent_reason": None},
     ],
     "total_steps": 3,
     "steps_omitted": 2,
@@ -1104,11 +1157,17 @@ def self_test():
     failures = []
     graded = []
 
-    def expect(label, got, want):
+    def expect(label, got, want, want_detail=None):
         graded.append(label)
         status = got[0]
         if status != want:
             failures.append("%s: expected %s, got %s (%s)" % (label, want, status, got[1]))
+            return
+        # Status alone cannot separate two branches that both report a failure, so an arm
+        # may name the assertion it means to provoke and is graded on that too.
+        if want_detail is not None and want_detail not in (got[1] or ""):
+            failures.append("%s: %s for the wrong reason, wanted %r in %r" % (
+                label, status, want_detail, got[1]))
 
     expect("0 passes an honest clipped walk",
            grade_says_the_absence_proves_nothing(CLIPPED), PASS)
@@ -1154,7 +1213,10 @@ def self_test():
            grade_the_target_is_what_delivers_the_hop(without, unechoed), FAIL)
 
     expect("3 passes an unaffected walk",
-           grade_a_complete_walk_is_not_qualified(CLEAN), PASS)
+           grade_a_complete_walk_is_not_qualified(COMPLETE), PASS)
+    expect("3 fails a walk that never reached the crossing hop and said nothing",
+           grade_a_complete_walk_is_not_qualified(CLEAN), FAIL,
+           "does not contain %s" % (CROSSING_HOP,))
     expect("3 fails a walk carrying the disclosure anyway",
            grade_a_complete_walk_is_not_qualified(CLIPPED), FAIL)
     zeroed = {"chain": [{"entity_name": "get_adapter"}], "degradations": [],
@@ -1165,26 +1227,79 @@ def self_test():
            grade_a_complete_walk_is_not_qualified({"degradations": []}), UNREADABLE)
 
     expect("4 passes a discovered named branch that survives a real cut",
-           grade_named_target_survives_response_budget(WIDE_ELISION, TARGETED_ELISION), PASS)
+           grade_named_target_survives_response_budget(WIDE_ELISION, TARGETED_ELISION, SELFTEST_RESPONSE_BUDGET), PASS)
     renumbered_targeted = json.loads(json.dumps(TARGETED_ELISION))
     renumbered_targeted["chain"][0]["step"] = 20
     renumbered_targeted["chain"][1]["step"] = 40
     renumbered_targeted["chain"][1]["parent_step"] = 20
     expect("4 accepts renumbering when canonical entity and parent identities are unchanged",
            grade_named_target_survives_response_budget(
-               WIDE_ELISION, renumbered_targeted), PASS)
+               WIDE_ELISION, renumbered_targeted, SELFTEST_RESPONSE_BUDGET), PASS)
     no_cut_targeted = json.loads(json.dumps(TARGETED_ELISION))
     no_cut_targeted["steps_omitted"] = 0
     expect("4 fails a targeted arm whose response budget never bit",
-           grade_named_target_survives_response_budget(WIDE_ELISION, no_cut_targeted), FAIL)
+           grade_named_target_survives_response_budget(WIDE_ELISION, no_cut_targeted, SELFTEST_RESPONSE_BUDGET), FAIL)
+    # Renaming the row leaves its entity_id in place, and the wide-versus-bounded identity
+    # check catches that one step earlier and for a different reason. Dropping the row is
+    # the mutation that actually removes the property this check is named for.
     lost_targeted = json.loads(json.dumps(TARGETED_ELISION))
-    lost_targeted["chain"][1]["entity_name"] = "other_target"
+    lost_targeted["chain"] = [
+        row for row in lost_targeted["chain"] if row["entity_name"] != ELISION_TARGET
+    ]
+    lost_targeted["total_steps"] = len(lost_targeted["chain"])
+    lost_targeted["steps_omitted"] = 4
+    lost_targeted["fanout_narrowed"] = 4
+    lost_targeted["elisions"]["chain"] = {
+        "kept": 1, "elided": 4, "total": 5, "reason": "response_budget",
+    }
+    # A discovery universe that already fits the budget cannot overflow it, so a response
+    # that trimmed anyway trimmed for some other reason and labelled it response_budget.
+    # The universe still has to be a sound wide premise and still has to be larger than
+    # the bounded arm, or an earlier check answers instead of this one.
+    small_universe = json.loads(json.dumps(WIDE_ELISION))
+    small_universe["chain"] = [
+        row for row in small_universe["chain"]
+        if row["entity_name"] in ("get_adapter", CROSSING_HOP, ELISION_TARGET)
+    ]
+    small_universe["total_steps"] = len(small_universe["chain"])
+    small_cut = json.loads(json.dumps(TARGETED_ELISION))
+    small_cut["steps_omitted"] = 1
+    small_cut["fanout_narrowed"] = 1
+    small_cut["elisions"]["chain"] = {
+        "kept": 2, "elided": 1, "total": 3, "reason": "response_budget",
+    }
+    expect("4 fails when the wide universe already fits the bounded budget",
+           grade_named_target_survives_response_budget(
+               small_universe, small_cut, SELFTEST_RESPONSE_BUDGET), FAIL,
+           "inside the %d-byte budget" % (SELFTEST_RESPONSE_BUDGET,))
+
+    # The suite's own claim is that each SURVIVING step carries its call sites. These two
+    # arms are the ones that make that claim gradeable on a trimmed response: a fabricated
+    # line the wide arm never reported, and an absence reason outside the vocabulary. They
+    # answer at two different assertions on purpose.
+    fabricated_lines = json.loads(json.dumps(TARGETED_ELISION))
+    for row in fabricated_lines["chain"]:
+        row["reference_lines"] = [999]
+        row["reference_lines_absent_reason"] = None
+    expect("4 fails a trimmed row carrying a call site the wide arm never reported",
+           grade_named_target_survives_response_budget(
+               WIDE_ELISION, fabricated_lines, SELFTEST_RESPONSE_BUDGET), FAIL,
+           "changed reference_lines")
+    invented_absence = json.loads(json.dumps(TARGETED_ELISION))
+    for row in invented_absence["chain"]:
+        row["reference_lines"] = []
+        row["reference_lines_absent_reason"] = "garbage_reason"
+    expect("4 fails a trimmed row whose absence reason is outside the vocabulary",
+           grade_named_target_survives_response_budget(
+               WIDE_ELISION, invented_absence, SELFTEST_RESPONSE_BUDGET), FAIL,
+           "unknown reference_lines_absent_reason")
     expect("4 fails when the named branch was still elided",
-           grade_named_target_survives_response_budget(WIDE_ELISION, lost_targeted), FAIL)
+           grade_named_target_survives_response_budget(WIDE_ELISION, lost_targeted, SELFTEST_RESPONSE_BUDGET), FAIL,
+           "the named target path did not survive intact")
     unechoed_targeted = json.loads(json.dumps(TARGETED_ELISION))
     unechoed_targeted.pop("target_name")
     expect("4 fails when the bounded arm does not echo the target",
-           grade_named_target_survives_response_budget(WIDE_ELISION, unechoed_targeted), FAIL)
+           grade_named_target_survives_response_budget(WIDE_ELISION, unechoed_targeted, SELFTEST_RESPONSE_BUDGET), FAIL)
     wide_without_target = json.loads(json.dumps(WIDE_ELISION))
     wide_without_target["chain"] = [
         row for row in wide_without_target["chain"]
@@ -1192,43 +1307,68 @@ def self_test():
     ]
     wide_without_target["total_steps"] = len(wide_without_target["chain"])
     expect("4 fails a readable wide premise that never discovered the target",
-           grade_named_target_survives_response_budget(wide_without_target, TARGETED_ELISION), FAIL)
-    missing_parent = json.loads(json.dumps(TARGETED_ELISION))
-    missing_parent["chain"][1]["parent_step"] = 0
+           grade_named_target_survives_response_budget(wide_without_target, TARGETED_ELISION, SELFTEST_RESPONSE_BUDGET), FAIL)
+    # Moving the bounded parent alone disagrees with the wide arm, and the identity check
+    # answers first. Moving it in both arms keeps them consistent, so the only thing left
+    # to object is that the target no longer hangs off the surviving crossing hop.
+    reparented_wide = json.loads(json.dumps(WIDE_ELISION))
+    for row in reparented_wide["chain"]:
+        if row["entity_name"] == ELISION_TARGET:
+            row["parent_step"] = 1
+    wrong_parent = json.loads(json.dumps(TARGETED_ELISION))
+    wrong_parent["chain"] = [
+        {"step": 1, "parent_step": 0, "entity_id": "entity-get-adapter",
+         "entity_name": "get_adapter", "role": "callee",
+         "reference_lines": [1], "reference_lines_absent_reason": None},
+        {"step": 2, "parent_step": 0, "entity_id": "entity-send-via-adapter",
+         "entity_name": CROSSING_HOP, "role": "callee",
+         "reference_lines": [SESSION_ADAPTER_CALL_LINE], "reference_lines_absent_reason": None},
+        {"step": 4, "parent_step": 1, "entity_id": "entity-cert-verify",
+         "entity_name": ELISION_TARGET, "role": "callee",
+         "reference_lines": [ADAPTER_CERT_CALL_LINE], "reference_lines_absent_reason": None},
+    ]
+    wrong_parent["total_steps"] = 3
+    wrong_parent["steps_omitted"] = 2
+    wrong_parent["fanout_narrowed"] = 2
+    wrong_parent["elisions"]["chain"] = {
+        "kept": 3, "elided": 2, "total": 5, "reason": "response_budget",
+    }
     expect("4 fails a target row attached to the surviving wrong parent",
-           grade_named_target_survives_response_budget(WIDE_ELISION, missing_parent), FAIL)
+           grade_named_target_survives_response_budget(
+               reparented_wide, wrong_parent, SELFTEST_RESPONSE_BUDGET), FAIL,
+           "does not name surviving %s" % (CROSSING_HOP,))
     orphaned_target = json.loads(json.dumps(TARGETED_ELISION))
     orphaned_target["chain"][1]["parent_step"] = 99
     expect("4 fails a target row that points at a missing parent step",
-           grade_named_target_survives_response_budget(WIDE_ELISION, orphaned_target), FAIL)
+           grade_named_target_survives_response_budget(WIDE_ELISION, orphaned_target, SELFTEST_RESPONSE_BUDGET), FAIL)
     evidence_free = _without(TARGETED_ELISION, "elisions")
     expect("4 fails a cut with no elisions accounting",
-           grade_named_target_survives_response_budget(WIDE_ELISION, evidence_free), FAIL)
+           grade_named_target_survives_response_budget(WIDE_ELISION, evidence_free, SELFTEST_RESPONSE_BUDGET), FAIL)
     no_disclosure = _without(TARGETED_ELISION, "degradations")
     expect("4 fails a cut with no response-budget degradation",
-           grade_named_target_survives_response_budget(WIDE_ELISION, no_disclosure), FAIL)
+           grade_named_target_survives_response_budget(WIDE_ELISION, no_disclosure, SELFTEST_RESPONSE_BUDGET), FAIL)
     cut_wide = json.loads(json.dumps(WIDE_ELISION))
     cut_wide["steps_omitted"] = 1
     expect("4 fails when the wide discovery premise was already cut",
-           grade_named_target_survives_response_budget(cut_wide, TARGETED_ELISION), FAIL)
+           grade_named_target_survives_response_budget(cut_wide, TARGETED_ELISION, SELFTEST_RESPONSE_BUDGET), FAIL)
     oversized_wide = json.loads(json.dumps(WIDE_ELISION))
     oversized_wide["untrimmed_payload"] = "x" * WIDE_RESPONSE_BUDGET
     expect("4 fails a wide premise whose shipped JSON exceeds its budget",
            grade_named_target_survives_response_budget(
-               oversized_wide, TARGETED_ELISION), FAIL)
+               oversized_wide, TARGETED_ELISION, SELFTEST_RESPONSE_BUDGET), FAIL)
     clipped_targeted = json.loads(json.dumps(TARGETED_ELISION))
     clipped_targeted["clipped_steps"] = [{"step": 2}]
     expect("4 fails when fanout clipping can explain the loss",
-           grade_named_target_survives_response_budget(WIDE_ELISION, clipped_targeted), FAIL)
+           grade_named_target_survives_response_budget(WIDE_ELISION, clipped_targeted, SELFTEST_RESPONSE_BUDGET), FAIL)
     wrong_budget = json.loads(json.dumps(TARGETED_ELISION))
-    wrong_budget["max_response_chars"] = RESPONSE_BUDGET + 1
+    wrong_budget["max_response_chars"] = SELFTEST_RESPONSE_BUDGET + 1
     expect("4 fails a bounded arm that echoes a different budget",
-           grade_named_target_survives_response_budget(WIDE_ELISION, wrong_budget), FAIL)
+           grade_named_target_survives_response_budget(WIDE_ELISION, wrong_budget, SELFTEST_RESPONSE_BUDGET), FAIL)
     oversized_targeted = json.loads(json.dumps(TARGETED_ELISION))
-    oversized_targeted["untrimmed_payload"] = "x" * RESPONSE_BUDGET
+    oversized_targeted["untrimmed_payload"] = "x" * SELFTEST_RESPONSE_BUDGET
     expect("4 fails a response whose shipped JSON exceeds the echoed budget",
            grade_named_target_survives_response_budget(
-               WIDE_ELISION, oversized_targeted), FAIL)
+               WIDE_ELISION, oversized_targeted, SELFTEST_RESPONSE_BUDGET), FAIL)
     short_targeted_universe = json.loads(json.dumps(TARGETED_ELISION))
     short_targeted_universe["steps_omitted"] = 2
     short_targeted_universe["fanout_narrowed"] = 2
@@ -1240,48 +1380,83 @@ def self_test():
     }
     expect("4 fails internally coherent accounting for a smaller source universe",
            grade_named_target_survives_response_budget(
-               WIDE_ELISION, short_targeted_universe), FAIL)
+               WIDE_ELISION, short_targeted_universe, SELFTEST_RESPONSE_BUDGET), FAIL)
     invented_target_identity = json.loads(json.dumps(TARGETED_ELISION))
     invented_target_identity["chain"][1]["entity_id"] = "entity-not-in-wide"
     expect("4 fails a coherent target row the wide discovery never returned",
            grade_named_target_survives_response_budget(
-               WIDE_ELISION, invented_target_identity), FAIL)
+               WIDE_ELISION, invented_target_identity, SELFTEST_RESPONSE_BUDGET), FAIL)
 
     expect("5 passes when the unnamed cut loses the widely discovered target",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, TARGETED_ELISION, UNNAMED_ELISION), PASS)
+               WIDE_ELISION, TARGETED_ELISION, UNNAMED_ELISION, SELFTEST_RESPONSE_BUDGET), PASS)
     no_cut_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
     no_cut_unnamed["steps_omitted"] = 0
     expect("5 fails an unnamed arm whose response budget never bit",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, TARGETED_ELISION, no_cut_unnamed), FAIL)
+               WIDE_ELISION, TARGETED_ELISION, no_cut_unnamed, SELFTEST_RESPONSE_BUDGET), FAIL)
+    # Renaming a surviving row to the target leaves the original entity_id, which the
+    # identity check answers first. The honest mutation is an unnamed arm that keeps the
+    # target branch with the wide arm's own identities and parentage, which nothing but
+    # the target-absence assertion can object to.
     kept_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
-    kept_unnamed["chain"][-1]["entity_name"] = ELISION_TARGET
+    kept_unnamed["chain"] = [
+        {"step": 1, "parent_step": 0, "entity_id": "entity-get-adapter",
+         "entity_name": "get_adapter", "role": "callee",
+         "reference_lines": [1], "reference_lines_absent_reason": None},
+        {"step": 2, "parent_step": 0, "entity_id": "entity-send-via-adapter",
+         "entity_name": CROSSING_HOP, "role": "callee",
+         "reference_lines": [SESSION_ADAPTER_CALL_LINE], "reference_lines_absent_reason": None},
+        {"step": 4, "parent_step": 2, "entity_id": "entity-cert-verify",
+         "entity_name": ELISION_TARGET, "role": "callee",
+         "reference_lines": [ADAPTER_CERT_CALL_LINE], "reference_lines_absent_reason": None},
+    ]
+    kept_unnamed["total_steps"] = 3
+    kept_unnamed["steps_omitted"] = 2
+    kept_unnamed["fanout_narrowed"] = 2
+    kept_unnamed["elisions"]["chain"] = {
+        "kept": 3, "elided": 2, "total": 5, "reason": "response_budget",
+    }
     expect("5 fails when the unnamed arm already keeps the target",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, TARGETED_ELISION, kept_unnamed), FAIL)
+               WIDE_ELISION, TARGETED_ELISION, kept_unnamed, SELFTEST_RESPONSE_BUDGET), FAIL,
+           "the unnamed arm still contains")
+    # An arm that returned nothing contains no target either, and the conservation
+    # arithmetic is satisfiable at kept=0, so the absence check passes on it vacuously.
+    empty_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
+    empty_unnamed["chain"] = []
+    empty_unnamed["total_steps"] = 0
+    empty_unnamed["steps_omitted"] = 5
+    empty_unnamed["fanout_narrowed"] = 5
+    empty_unnamed["elisions"]["chain"] = {
+        "kept": 0, "elided": 5, "total": 5, "reason": "response_budget",
+    }
+    expect("5 fails an unnamed arm that returned no steps at all",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, empty_unnamed, SELFTEST_RESPONSE_BUDGET), FAIL,
+           "returned no steps at all")
     lost_target_control = json.loads(json.dumps(TARGETED_ELISION))
     lost_target_control["chain"][1]["entity_name"] = "other_target"
     expect("5 fails when both bounded arms lose the target",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, lost_target_control, UNNAMED_ELISION), FAIL)
+               WIDE_ELISION, lost_target_control, UNNAMED_ELISION, SELFTEST_RESPONSE_BUDGET), FAIL)
     named_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
     named_unnamed["target_name"] = ELISION_TARGET
     expect("5 fails when the unnamed arm claims a target",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, TARGETED_ELISION, named_unnamed), FAIL)
+               WIDE_ELISION, TARGETED_ELISION, named_unnamed, SELFTEST_RESPONSE_BUDGET), FAIL)
     claiming_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
     claiming_unnamed["degradations"][0]["detail"] = (
         "cut as whole branches, keeping the branch that reaches the named target"
     )
     expect("5 fails when the unnamed disclosure claims it kept a named target",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, TARGETED_ELISION, claiming_unnamed), FAIL)
+               WIDE_ELISION, TARGETED_ELISION, claiming_unnamed, SELFTEST_RESPONSE_BUDGET), FAIL)
     clipped_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
     clipped_unnamed["chain"][0]["fanout_truncated"] = True
     expect("5 fails when the unnamed arm has a per-step fanout cut",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, TARGETED_ELISION, clipped_unnamed), FAIL)
+               WIDE_ELISION, TARGETED_ELISION, clipped_unnamed, SELFTEST_RESPONSE_BUDGET), FAIL)
     short_unnamed_universe = json.loads(json.dumps(UNNAMED_ELISION))
     short_unnamed_universe["steps_omitted"] = 1
     short_unnamed_universe["fanout_narrowed"] = 1
@@ -1293,16 +1468,16 @@ def self_test():
     }
     expect("5 fails internally coherent accounting for a smaller source universe",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, TARGETED_ELISION, short_unnamed_universe), FAIL)
+               WIDE_ELISION, TARGETED_ELISION, short_unnamed_universe, SELFTEST_RESPONSE_BUDGET), FAIL)
     invented_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
     for index, row in enumerate(invented_unnamed["chain"]):
         row["entity_name"] = "invented_%d" % index
     expect("5 fails bounded rows whose identities changed from the wide discovery",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, TARGETED_ELISION, invented_unnamed), FAIL)
+               WIDE_ELISION, TARGETED_ELISION, invented_unnamed, SELFTEST_RESPONSE_BUDGET), FAIL)
     expect("5 cannot read a non-object response arm",
            grade_unnamed_response_budget_drops_the_target(
-               WIDE_ELISION, TARGETED_ELISION, None), UNREADABLE)
+               WIDE_ELISION, TARGETED_ELISION, None, SELFTEST_RESPONSE_BUDGET), UNREADABLE)
 
     expect("6 passes exact callee sites from both parent files",
            grade_callee_call_sites(WIDE_ELISION), PASS)

--- a/scripts/acceptance/trace_spine_clipping_repro.py
+++ b/scripts/acceptance/trace_spine_clipping_repro.py
@@ -22,7 +22,7 @@ something. It is that a chain missing its point reads exactly like a complete
 one, because the honest label the tool already carried ("treat this as a lower
 bound") is the same label a complete walk carries.
 
-FIR-2824 adds checks 4 through 7. A target that steers discovery must also
+The extension adds checks 4 through 7. A target that steers discovery must also
 survive both response-budget decisions, and each surviving step must carry the
 exact graph-owned call-site lines that make the hop actionable.
 

--- a/scripts/acceptance/trace_spine_clipping_repro.py
+++ b/scripts/acceptance/trace_spine_clipping_repro.py
@@ -172,6 +172,15 @@ SELFTEST_RESPONSE_BUDGET = 1300
 WIDE_RESPONSE_BUDGET = 60000
 ELISION_DEPTH = 3
 ELISION_LIMIT = 25
+# The cap the spine checks run under. Measured against built binaries on
+# 2026-08-28: the fan-out ranking promotes one cross-file candidate into the
+# last kept slot, so at a cap of 3 or more send_via_adapter always survives, the
+# walk reports no module-crossing loss at all, and checks 1 and 2 have no loss
+# to classify or recover. At 1 and 2 the crossing hop is genuinely dropped and
+# spine_dropped_crossing_file reads 1. Two is chosen over one because it leaves
+# a three-step chain rather than a two-step one, and it sits one step from the
+# promotion boundary, so a ranking drift shows up here first.
+SPINE_CLIP_LIMIT = 2
 
 
 def fixture_line(source, needle):
@@ -927,7 +936,7 @@ class Result(object):
 
 
 def check_says_the_absence_proves_nothing(suite):
-    payload = suite.trace(limit=3)
+    payload = suite.trace(limit=SPINE_CLIP_LIMIT)
     if payload is None:
         return Result("0", UNREADABLE, "the narrow walk returned nothing readable")
     status, detail = grade_says_the_absence_proves_nothing(payload)
@@ -935,7 +944,7 @@ def check_says_the_absence_proves_nothing(suite):
 
 
 def check_separates_the_class_of_loss(suite):
-    payload = suite.trace(limit=3)
+    payload = suite.trace(limit=SPINE_CLIP_LIMIT)
     if payload is None:
         return Result("1", UNREADABLE, "the narrow walk returned nothing readable")
     status, detail = grade_separates_the_class_of_loss(payload)
@@ -943,8 +952,8 @@ def check_separates_the_class_of_loss(suite):
 
 
 def check_the_target_is_what_delivers_the_hop(suite):
-    untargeted = suite.trace(limit=3)
-    targeted = suite.trace(limit=3, target=CROSSING_HOP)
+    untargeted = suite.trace(limit=SPINE_CLIP_LIMIT)
+    targeted = suite.trace(limit=SPINE_CLIP_LIMIT, target=CROSSING_HOP)
     if untargeted is None or targeted is None:
         return Result("2", UNREADABLE, "one of the two walks returned nothing readable")
     status, detail = grade_the_target_is_what_delivers_the_hop(untargeted, targeted)
@@ -959,10 +968,42 @@ def check_a_complete_walk_is_not_qualified(suite):
     return Result("3", status, "A walk no cap cut carries none of this. " + detail)
 
 
+def elision_premise_not_run(targeted):
+    """Why checks 4 and 5 graded nothing, or None when the mechanism was exercised.
+
+    The budget these two run at is calibrated, and calibration rots. If the
+    response collapses to a single step, or the cut was the suffix fallback
+    rather than branch narrowing, then whether the target came back says nothing
+    about target-governed narrowing: at a small enough budget the arm keeps one
+    step and it is either the target or it is not. That is a coin flip, and a
+    coin flip that lands right reads exactly like a passing check. So these
+    report UNREADABLE, which the gate treats as graded-nothing rather than as
+    a pass or a failure, and which exits 2 rather than 0.
+    """
+    if not isinstance(targeted, dict) or not isinstance(targeted.get("chain"), list):
+        return "the targeted arm carries no readable chain"
+    kept = len(targeted["chain"])
+    if kept <= 1:
+        return (
+            "the targeted arm came back with %d step(s), so keeping the target is a coin flip "
+            "rather than a narrowing decision; recalibrate RESPONSE_BUDGET" % kept
+        )
+    narrowed = targeted.get("fanout_narrowed")
+    if not isinstance(narrowed, int) or narrowed <= 0:
+        return (
+            "the targeted arm reports fanout_narrowed=%r, so its cut was the suffix fallback "
+            "rather than branch narrowing; recalibrate RESPONSE_BUDGET" % (narrowed,)
+        )
+    return None
+
+
 def check_the_named_target_survives_response_elision(suite):
     wide, targeted, _ = suite.elision_arms()
     if wide is None or targeted is None:
         return Result("4", UNREADABLE, "the wide or targeted bounded walk returned nothing readable")
+    not_run = elision_premise_not_run(targeted)
+    if not_run:
+        return Result("4", UNREADABLE, "The named branch survives response elision. " + not_run)
     status, detail = grade_named_target_survives_response_budget(
         wide, targeted, RESPONSE_BUDGET)
     return Result("4", status, "The named branch survives response elision. " + detail)
@@ -972,6 +1013,9 @@ def check_the_unnamed_budget_drops_the_same_target(suite):
     wide, targeted, unnamed = suite.elision_arms()
     if wide is None or targeted is None or unnamed is None:
         return Result("5", UNREADABLE, "one of the three response-budget arms returned nothing readable")
+    not_run = elision_premise_not_run(targeted)
+    if not_run:
+        return Result("5", UNREADABLE, "The unnamed control loses the same branch. " + not_run)
     status, detail = grade_unnamed_response_budget_drops_the_target(
         wide, targeted, unnamed, RESPONSE_BUDGET)
     return Result("5", status, "The unnamed control loses the same branch. " + detail)
@@ -1252,6 +1296,23 @@ def self_test():
     lost_targeted["elisions"]["chain"] = {
         "kept": 1, "elided": 4, "total": 5, "reason": "response_budget",
     }
+    # The plateau guard. These two report graded-nothing rather than a verdict when the
+    # calibrated budget has drifted far enough that the arm is no longer narrowing.
+    expect_none = elision_premise_not_run(TARGETED_ELISION)
+    if expect_none is not None:
+        failures.append("plateau guard: a healthy targeted arm was refused (%s)" % expect_none)
+    graded.append("plateau guard passes a healthy targeted arm")
+    one_step = json.loads(json.dumps(TARGETED_ELISION))
+    one_step["chain"] = one_step["chain"][:1]
+    if elision_premise_not_run(one_step) is None:
+        failures.append("plateau guard: a one-step targeted arm was graded rather than refused")
+    graded.append("plateau guard refuses a one-step targeted arm")
+    suffix_cut = json.loads(json.dumps(TARGETED_ELISION))
+    suffix_cut["fanout_narrowed"] = 0
+    if elision_premise_not_run(suffix_cut) is None:
+        failures.append("plateau guard: a suffix-cut targeted arm was graded rather than refused")
+    graded.append("plateau guard refuses a suffix-cut targeted arm")
+
     # A discovery universe that already fits the budget cannot overflow it, so a response
     # that trimmed anyway trimmed for some other reason and labelled it response_budget.
     # The universe still has to be a sound wide premise and still has to be larger than

--- a/scripts/acceptance/trace_spine_clipping_repro.py
+++ b/scripts/acceptance/trace_spine_clipping_repro.py
@@ -1285,13 +1285,18 @@ def self_test():
            grade_named_target_survives_response_budget(
                WIDE_ELISION, fabricated_lines, SELFTEST_RESPONSE_BUDGET), FAIL,
            "changed reference_lines")
+    # Both arms have to carry the bad reason. Mutating only the bounded arm disagrees
+    # with the wide one, and the identity comparison answers first, which would leave the
+    # contract check green on a tree that had removed it.
     invented_absence = json.loads(json.dumps(TARGETED_ELISION))
-    for row in invented_absence["chain"]:
-        row["reference_lines"] = []
-        row["reference_lines_absent_reason"] = "garbage_reason"
+    invented_wide = json.loads(json.dumps(WIDE_ELISION))
+    for payload in (invented_absence, invented_wide):
+        for row in payload["chain"]:
+            row["reference_lines"] = []
+            row["reference_lines_absent_reason"] = "garbage_reason"
     expect("4 fails a trimmed row whose absence reason is outside the vocabulary",
            grade_named_target_survives_response_budget(
-               WIDE_ELISION, invented_absence, SELFTEST_RESPONSE_BUDGET), FAIL,
+               invented_wide, invented_absence, SELFTEST_RESPONSE_BUDGET), FAIL,
            "unknown reference_lines_absent_reason")
     expect("4 fails when the named branch was still elided",
            grade_named_target_survives_response_budget(WIDE_ELISION, lost_targeted, SELFTEST_RESPONSE_BUDGET), FAIL,

--- a/scripts/acceptance/trace_spine_clipping_repro.py
+++ b/scripts/acceptance/trace_spine_clipping_repro.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Firelock, LLC
 
-"""Prove a narrow trace says it may be missing the hop you asked about.
+"""Prove trace cuts preserve and explain the branch the caller asked for.
 
-FIR-2781. The v0.6.0 stranger run walked `Session.send` on a converted
+FIR-2781 established checks 0 through 3. The v0.6.0 stranger run walked `Session.send` on a converted
 `psf/requests` with `limit_per_step: 4` and got a chain that stops two hops
 short of where `verify` goes. The per-step cap had discarded eleven of fifteen
 callees, `HTTPAdapter.send` among them, and the response said so only as a count
@@ -22,7 +22,11 @@ something. It is that a chain missing its point reads exactly like a complete
 one, because the honest label the tool already carried ("treat this as a lower
 bound") is the same label a complete walk carries.
 
-Four checks, on one seeded repository:
+FIR-2824 adds checks 4 through 7. A target that steers discovery must also
+survive both response-budget decisions, and each surviving step must carry the
+exact graph-owned call-site lines that make the hop actionable.
+
+Eight checks, on one seeded repository:
 
   0  a walk the cap cut BENEATH a node it then continued through says so in
      words, naming the node, the parameter and the count, and saying that an
@@ -34,6 +38,14 @@ Four checks, on one seeded repository:
      either half alone is satisfiable by a broken tool
   3  a walk no cap cut publishes none of this, and the keys are ABSENT rather
      than zero, so machinery for incomplete answers never qualifies a complete one
+  4  a wide walk proves `cert_verify` was discovered, then a response-budget
+     cut with that target keeps it and proves the budget actually bit
+  5  the same response budget without a target drops `cert_verify`, beside the
+     targeted arm, so the named question rather than the fixture delivers it
+  6  callee steps carry the exact 1-based call sites from their parent files,
+     including the cross-module hop and the next step beyond it
+  7  the cross-file `send_via_adapter` edge walked backwards reports `send` as
+     a caller and carries that caller's exact site from `sessions.py`
 
 Exit status is 0 when every check passed, 1 when one failed, 2 when one could not
 be read, and 3 when the run could not be set up. `--self-test` exercises every
@@ -71,8 +83,16 @@ SESSIONS_SRC = '''"""Session layer."""
 from adapters import send_via_adapter
 
 
-def get_adapter(url):
+def record_adapter(url):
     return url
+
+
+def normalize_adapter(url):
+    return record_adapter(url)
+
+
+def get_adapter(url):
+    return normalize_adapter(url)
 
 
 def prepare_request(request):
@@ -136,6 +156,30 @@ def send_via_adapter(adapter, request, verify):
 '''
 
 CROSSING_HOP = "send_via_adapter"
+ELISION_TARGET = "cert_verify"
+CALLER_ENTITY = "send"
+SESSIONS_FILE = "sessions.py"
+ADAPTERS_FILE = "adapters.py"
+# Small enough to force branch narrowing on this body-free fixture, while still
+# leaving room for the protected two-hop branch plus the bounder's disclosure.
+RESPONSE_BUDGET = 4000
+WIDE_RESPONSE_BUDGET = 60000
+ELISION_DEPTH = 3
+ELISION_LIMIT = 25
+
+
+def fixture_line(source, needle):
+    matches = [
+        number for number, line in enumerate(source.splitlines(), 1)
+        if needle in line
+    ]
+    if len(matches) != 1:
+        raise AssertionError("fixture line %r matched %d times" % (needle, len(matches)))
+    return matches[0]
+
+
+SESSION_ADAPTER_CALL_LINE = fixture_line(SESSIONS_SRC, "response = send_via_adapter(")
+ADAPTER_CERT_CALL_LINE = fixture_line(ADAPTERS_SRC, "return cert_verify(")
 
 
 def run(cmd, cwd=None, env=None, timeout=600):
@@ -282,6 +326,446 @@ def grade_a_complete_walk_is_not_qualified(payload):
     return PASS, "no clip, no spine key, no disclosure on a walk the cap never cut"
 
 
+def response_budget_degradations(payload, reason):
+    return [
+        item for item in payload.get("degradations") or []
+        if isinstance(item, dict)
+        and item.get("component") == "response_budget"
+        and item.get("reason") == reason
+    ]
+
+
+def graph_bounds_problem(payload, budget):
+    expected = {
+        "depth": ELISION_DEPTH,
+        "direction": "calls",
+        "limit_per_step": ELISION_LIMIT,
+        "max_response_chars": budget,
+        "bodies_included": False,
+    }
+    mismatches = [
+        "%s=%r (wanted %r)" % (key, payload.get(key), value)
+        for key, value in expected.items()
+        if payload.get(key) != value
+    ]
+    return ", ".join(mismatches) if mismatches else None
+
+
+def pretty_serialized_bytes(payload):
+    """Match serde_json::to_string_pretty(...).len() for the ASCII fixture."""
+    return len(json.dumps(payload, indent=2, ensure_ascii=False).encode("utf-8"))
+
+
+def fanout_clip_problem(payload):
+    clips = payload.get("clipped_steps")
+    if clips:
+        return "clipped_steps is nonempty, so per-step fanout loss can masquerade as response elision"
+    if payload.get("spine_clipped_steps"):
+        return "spine_clipped_steps is nonzero, so the walk itself was clipped"
+    chain = payload.get("chain") or []
+    truncated = [
+        step.get("entity_name")
+        for step in chain
+        if isinstance(step, dict) and step.get("fanout_truncated")
+    ]
+    if truncated:
+        return "chain rows report fanout_truncated: %r" % (truncated,)
+    return None
+
+
+def parentage_problem(payload, require_target):
+    chain = payload.get("chain")
+    if not isinstance(chain, list):
+        return "the response carries no chain array"
+    rows = [step for step in chain if isinstance(step, dict)]
+    if len(rows) != len(chain):
+        return "the chain carries a non-object step"
+    by_step = {}
+    for row in rows:
+        step = row.get("step")
+        parent = row.get("parent_step")
+        if not isinstance(step, int) or not isinstance(parent, int):
+            return "a chain row carries a non-integer step or parent_step"
+        if step in by_step:
+            return "step %r appears more than once" % (step,)
+        by_step[step] = row
+    for row in rows:
+        parent = row["parent_step"]
+        if parent != 0 and parent not in by_step:
+            return "%s points at missing parent step %r" % (
+                row.get("entity_name"), parent,
+            )
+    if not require_target:
+        return None
+    hops = [row for row in rows if row.get("entity_name") == CROSSING_HOP]
+    targets = [row for row in rows if row.get("entity_name") == ELISION_TARGET]
+    if len(hops) != 1 or len(targets) != 1:
+        return "the target path needs exactly one %s and one %s, found %d and %d" % (
+            CROSSING_HOP, ELISION_TARGET, len(hops), len(targets),
+        )
+    if targets[0]["parent_step"] != hops[0]["step"]:
+        return "%s parent_step=%r does not name surviving %s step=%r" % (
+            ELISION_TARGET, targets[0]["parent_step"], CROSSING_HOP, hops[0]["step"],
+        )
+    return None
+
+
+def indexed_chain(payload, label):
+    """Index one chain by local step and canonical entity identity."""
+    chain = payload.get("chain")
+    if not isinstance(chain, list):
+        return None, "%s response carries no chain array" % label
+    by_step = {}
+    by_identity = {}
+    for row in chain:
+        if not isinstance(row, dict):
+            return None, "%s chain carries a non-object step" % label
+        step = row.get("step")
+        identity = row.get("entity_id")
+        name = row.get("entity_name")
+        if not isinstance(step, int):
+            return None, "%s row carries non-integer step=%r" % (label, step)
+        if not isinstance(identity, str) or not identity:
+            return None, "%s step %r carries no canonical entity_id" % (label, step)
+        if not isinstance(name, str) or not name:
+            return None, "%s entity %s carries no entity_name" % (label, identity)
+        if step in by_step:
+            return None, "%s step %r appears more than once" % (label, step)
+        if identity in by_identity:
+            return None, "%s entity_id %s appears more than once" % (label, identity)
+        by_step[step] = row
+        by_identity[identity] = row
+    return (by_step, by_identity), None
+
+
+def bounded_subset_problem(payload, wide):
+    """Every bounded row and parent edge must come from the wide discovery."""
+    wide_index, problem = indexed_chain(wide, "wide")
+    if problem:
+        return problem
+    bounded_index, problem = indexed_chain(payload, "bounded")
+    if problem:
+        return problem
+    wide_by_step, wide_by_identity = wide_index
+    bounded_by_step, bounded_by_identity = bounded_index
+
+    def parent_identity(row, by_step, label):
+        parent = row.get("parent_step")
+        if parent == 0:
+            return "<focal>", None
+        parent_row = by_step.get(parent)
+        if parent_row is None:
+            return None, "%s step %r points at missing parent step %r" % (
+                label, row.get("step"), parent,
+            )
+        return parent_row.get("entity_id"), None
+
+    for identity, row in bounded_by_identity.items():
+        source = wide_by_identity.get(identity)
+        if source is None:
+            return "bounded entity_id %s was not discovered by the wide arm" % identity
+        for key in ("entity_name", "role"):
+            if row.get(key) != source.get(key):
+                return "bounded entity %s changed %s from %r to %r" % (
+                    identity, key, source.get(key), row.get(key),
+                )
+        bounded_parent, problem = parent_identity(row, bounded_by_step, "bounded")
+        if problem:
+            return problem
+        wide_parent, problem = parent_identity(source, wide_by_step, "wide")
+        if problem:
+            return problem
+        if bounded_parent != wide_parent:
+            return "bounded edge into %s changed parent identity from %r to %r" % (
+                identity, wide_parent, bounded_parent,
+            )
+    return None
+
+
+def wide_premise_problem(payload):
+    bounds = graph_bounds_problem(payload, WIDE_RESPONSE_BUDGET)
+    if bounds:
+        return "wide bounds drifted: " + bounds
+    rendered_chars = pretty_serialized_bytes(payload)
+    if rendered_chars > WIDE_RESPONSE_BUDGET:
+        return "the wide response serializes to %d bytes, above its %d-byte budget" % (
+            rendered_chars, WIDE_RESPONSE_BUDGET,
+        )
+    clips = fanout_clip_problem(payload)
+    if clips:
+        return clips
+    if payload.get("steps_omitted") or payload.get("fanout_narrowed") \
+            or payload.get("chain_withheld"):
+        return "the wide premise reports response step loss"
+    if (payload.get("elisions") or {}).get("chain"):
+        return "the wide premise carries an elisions.chain cut"
+    if response_budget_degradations(payload, "steps_omitted") \
+            or response_budget_degradations(payload, "response_bounded"):
+        return "the wide premise carries a response-budget step-loss degradation"
+    chain = payload.get("chain")
+    if isinstance(chain, list) and payload.get("total_steps") != len(chain):
+        return "wide total_steps=%r disagrees with chain length %d" % (
+            payload.get("total_steps"), len(chain),
+        )
+    problem = parentage_problem(payload, require_target=True)
+    if problem:
+        return problem
+    _, problem = indexed_chain(payload, "wide")
+    return problem
+
+
+def bounded_elision_problem(payload, wide):
+    bounds = graph_bounds_problem(payload, RESPONSE_BUDGET)
+    if bounds:
+        return "bounded bounds drifted: " + bounds
+    rendered_chars = pretty_serialized_bytes(payload)
+    if rendered_chars > RESPONSE_BUDGET:
+        return "the bounded response serializes to %d bytes, above its %d-byte budget" % (
+            rendered_chars, RESPONSE_BUDGET,
+        )
+    clips = fanout_clip_problem(payload)
+    if clips:
+        return clips
+    chain = payload.get("chain")
+    if not isinstance(chain, list):
+        return "the response carries no chain array"
+    wide_chain = wide.get("chain")
+    if not isinstance(wide_chain, list):
+        return "the wide response carries no chain array"
+    if len(chain) >= len(wide_chain):
+        return "the bounded chain kept %d of %d steps, so the budget cut nothing" % (
+            len(chain), len(wide_chain),
+        )
+    omitted = payload.get("steps_omitted")
+    narrowed = payload.get("fanout_narrowed")
+    if not isinstance(omitted, int) or omitted <= 0:
+        return "steps_omitted=%r does not prove a response cut" % (omitted,)
+    if not isinstance(narrowed, int) or narrowed <= 0 or narrowed > omitted:
+        return "fanout_narrowed=%r is not a positive subset of steps_omitted=%r" % (
+            narrowed, omitted,
+        )
+    if len(chain) + omitted != len(wide_chain):
+        return "bounded kept plus omitted is %d, but the wide premise discovered %d steps" % (
+            len(chain) + omitted, len(wide_chain),
+        )
+    if payload.get("total_steps") != len(chain):
+        return "total_steps=%r disagrees with bounded chain length %d" % (
+            payload.get("total_steps"), len(chain),
+        )
+    elision = (payload.get("elisions") or {}).get("chain")
+    if not isinstance(elision, dict):
+        return "the cut carries no elisions.chain object"
+    expected = {
+        "kept": len(chain),
+        "elided": omitted,
+        "total": len(wide_chain),
+        "reason": "response_budget",
+    }
+    mismatches = [
+        "%s=%r (wanted %r)" % (key, elision.get(key), value)
+        for key, value in expected.items()
+        if elision.get(key) != value
+    ]
+    if mismatches:
+        return "elisions.chain disagrees: " + ", ".join(mismatches)
+    if len(response_budget_degradations(payload, "steps_omitted")) != 1:
+        return "the cut needs exactly one response_budget/steps_omitted degradation"
+    problem = parentage_problem(payload, require_target=False)
+    if problem:
+        return problem
+    return bounded_subset_problem(payload, wide)
+
+
+def grade_named_target_survives_response_budget(wide, bounded):
+    if not isinstance(wide, dict) or not isinstance(bounded, dict):
+        return UNREADABLE, "the wide or bounded response is not an object"
+    if not isinstance(wide.get("chain"), list) or not isinstance(bounded.get("chain"), list):
+        return UNREADABLE, "the wide or bounded response carries no readable chain"
+    problem = wide_premise_problem(wide)
+    if problem:
+        return FAIL, "the wide discovery premise is not sound: " + problem
+    problem = bounded_elision_problem(bounded, wide)
+    if problem:
+        return FAIL, "the targeted bounded arm is not a coherent response cut: " + problem
+    if bounded.get("target_name") != ELISION_TARGET:
+        return FAIL, "the bounded response does not echo target_name=%s" % (ELISION_TARGET,)
+    problem = parentage_problem(bounded, require_target=True)
+    if problem:
+        return FAIL, "the named target path did not survive intact: " + problem
+    return PASS, "%s and its %s parent survived; steps_omitted=%d, fanout_narrowed=%d" % (
+        ELISION_TARGET,
+        CROSSING_HOP,
+        bounded["steps_omitted"],
+        bounded["fanout_narrowed"],
+    )
+
+
+def grade_unnamed_response_budget_drops_the_target(wide, targeted, unnamed):
+    if not all(isinstance(payload, dict) for payload in (wide, targeted, unnamed)):
+        return UNREADABLE, "one of the three response arms is not an object"
+    if not all(isinstance(payload.get("chain"), list) for payload in (wide, targeted, unnamed)):
+        return UNREADABLE, "one of the three response arms carries no readable chain"
+    target_status, target_detail = grade_named_target_survives_response_budget(wide, targeted)
+    if target_status != PASS:
+        return FAIL, "the paired targeted arm is not a valid control: " + target_detail
+    problem = bounded_elision_problem(unnamed, wide)
+    if problem:
+        return FAIL, "the unnamed bounded arm is not a coherent response cut: " + problem
+    names = chain_names(unnamed)
+    if ELISION_TARGET in names:
+        return FAIL, "the unnamed arm still contains %s: %r" % (ELISION_TARGET, names)
+    if unnamed.get("target_name") is not None:
+        return FAIL, "the unnamed arm reports target_name=%r" % (unnamed.get("target_name"),)
+    for entry in unnamed.get("degradations") or []:
+        if isinstance(entry, dict) and "named target" in (entry.get("detail") or ""):
+            return FAIL, "the unnamed arm claims a named target branch was kept"
+    return PASS, "%s survives only in the paired targeted cut; unnamed steps_omitted=%d" % (
+        ELISION_TARGET, unnamed["steps_omitted"],
+    )
+
+
+def reference_line_contract_problem(payload):
+    chain = payload.get("chain")
+    if not isinstance(chain, list):
+        return "the response carries no chain array"
+    for index, step in enumerate(chain):
+        if not isinstance(step, dict):
+            return "chain row %d is not an object" % index
+        for key in ("reference_lines", "reference_lines_absent_reason"):
+            if key not in step:
+                return "%s omits required key %s" % (step.get("entity_name"), key)
+        lines = step["reference_lines"]
+        reason = step["reference_lines_absent_reason"]
+        if not isinstance(lines, list) or any(
+                not isinstance(line, int) or line < 1 for line in lines):
+            return "%s carries invalid 1-based reference_lines=%r" % (
+                step.get("entity_name"), lines,
+            )
+        if lines != sorted(set(lines)):
+            return "%s reference_lines are not sorted and deduplicated: %r" % (
+                step.get("entity_name"), lines,
+            )
+        if lines and reason is not None:
+            return "%s has site lines but also absent reason %r" % (
+                step.get("entity_name"), reason,
+            )
+        if not lines and (not isinstance(reason, str) or not reason):
+            return "%s has no site lines and no explicit absent reason" % (
+                step.get("entity_name"),
+            )
+        allowed_reasons = {
+            "no_evidence_span",
+            "span_outside_caller_file",
+            "federated_xref",
+            "unreported_by_daemon",
+        }
+        if not lines and reason not in allowed_reasons:
+            return "%s has unknown reference_lines_absent_reason=%r" % (
+                step.get("entity_name"), reason,
+            )
+    return None
+
+
+def one_step(payload, name):
+    matches = [
+        step for step in payload.get("chain") or []
+        if isinstance(step, dict) and step.get("entity_name") == name
+    ]
+    if len(matches) != 1:
+        return None, "%s appears %d times" % (name, len(matches))
+    return matches[0], None
+
+
+def grade_callee_call_sites(payload):
+    if not isinstance(payload, dict) or not isinstance(payload.get("chain"), list):
+        return UNREADABLE, "the callee walk carries no readable chain"
+    problem = wide_premise_problem(payload)
+    if problem:
+        return FAIL, "the callee walk is not a complete wide premise: " + problem
+    problem = reference_line_contract_problem(payload)
+    if problem:
+        return FAIL, problem
+    expected = (
+        (CROSSING_HOP, SESSION_ADAPTER_CALL_LINE),
+        (ELISION_TARGET, ADAPTER_CERT_CALL_LINE),
+    )
+    for name, line in expected:
+        step, problem = one_step(payload, name)
+        if problem:
+            return FAIL, problem
+        if step.get("role") != "callee":
+            return FAIL, "%s role=%r, wanted callee" % (name, step.get("role"))
+        if step["reference_lines"] != [line]:
+            return FAIL, "%s reference_lines=%r, wanted [%d]" % (
+                name, step["reference_lines"], line,
+            )
+        if step["reference_lines_absent_reason"] is not None:
+            return FAIL, "%s carries an absent reason beside a known site" % name
+    return PASS, "%s line %d and %s line %d come from their parent files" % (
+        CROSSING_HOP,
+        SESSION_ADAPTER_CALL_LINE,
+        ELISION_TARGET,
+        ADAPTER_CERT_CALL_LINE,
+    )
+
+
+def grade_caller_call_site(payload):
+    if not isinstance(payload, dict) or not isinstance(payload.get("chain"), list):
+        return UNREADABLE, "the caller walk carries no readable chain"
+    expected_bounds = {
+        "depth": 1,
+        "direction": "callers",
+        "limit_per_step": ELISION_LIMIT,
+        "max_response_chars": WIDE_RESPONSE_BUDGET,
+        "bodies_included": False,
+    }
+    mismatches = [
+        "%s=%r (wanted %r)" % (key, payload.get(key), value)
+        for key, value in expected_bounds.items()
+        if payload.get(key) != value
+    ]
+    if mismatches:
+        return FAIL, "caller bounds drifted: " + ", ".join(mismatches)
+    problem = fanout_clip_problem(payload)
+    if problem:
+        return FAIL, problem
+    if payload.get("steps_omitted") or payload.get("fanout_narrowed") \
+            or payload.get("chain_withheld") or (payload.get("elisions") or {}).get("chain"):
+        return FAIL, "the caller walk was response-bounded, so it is not a complete premise"
+    if payload.get("total_steps") != len(payload["chain"]):
+        return FAIL, "caller total_steps disagrees with its chain length"
+    problem = parentage_problem(payload, require_target=False)
+    if problem:
+        return FAIL, problem
+    problem = reference_line_contract_problem(payload)
+    if problem:
+        return FAIL, problem
+    step, problem = one_step(payload, CALLER_ENTITY)
+    if problem:
+        return FAIL, problem
+    if step.get("role") != "caller":
+        return FAIL, "%s role=%r, wanted caller" % (CALLER_ENTITY, step.get("role"))
+    if payload.get("focal_file") != ADAPTERS_FILE:
+        return FAIL, "caller focal_file=%r, wanted %s" % (
+            payload.get("focal_file"), ADAPTERS_FILE,
+        )
+    if step.get("entity_file") != SESSIONS_FILE:
+        return FAIL, "%s entity_file=%r, wanted %s" % (
+            CALLER_ENTITY, step.get("entity_file"), SESSIONS_FILE,
+        )
+    if step.get("entity_file") == payload.get("focal_file"):
+        return FAIL, "the caller and focal are in one file, so role-based file selection is untested"
+    if step["reference_lines"] != [SESSION_ADAPTER_CALL_LINE]:
+        return FAIL, "%s caller reference_lines=%r, wanted [%d]" % (
+            CALLER_ENTITY, step["reference_lines"], SESSION_ADAPTER_CALL_LINE,
+        )
+    if step["reference_lines_absent_reason"] is not None:
+        return FAIL, "%s carries an absent reason beside a known caller site" % CALLER_ENTITY
+    return PASS, "%s walked as caller reports sessions.py line %d from a different file" % (
+        CALLER_ENTITY, SESSION_ADAPTER_CALL_LINE,
+    )
+
+
 # ── the run ────────────────────────────────────────────────────────────────
 
 
@@ -291,12 +775,17 @@ class Suite(object):
         self.workdir = workdir
         self.verbose = verbose
         self.env = dict(os.environ)
+        self.env["KIN_HOME"] = os.path.join(workdir, "kin-home")
         self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
         self.env["KIN_VFS_DISABLE"] = "1"
         self.env.pop("KIN_MCP_REPO", None)
         if daemon:
             self.env["KIN_DAEMON_BIN"] = daemon
+        os.makedirs(self.env["KIN_HOME"])
         self._repo = None
+        self._elision_arms = None
+        self._caller_trace = None
 
     def git(self, args, repo):
         base = ["git", "-c", "core.hooksPath=/dev/null",
@@ -327,13 +816,17 @@ class Suite(object):
     def kin_run(self, args, repo, timeout=600):
         return run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
 
-    def trace(self, limit, target=None):
+    def trace(
+            self, limit, target=None, max_response_chars=None, depth=2,
+            focal="send", direction="calls"):
         """One `kin trace-data-flow`, parsed, or None when it could not be read."""
         repo = self.repo()
-        args = ["trace-data-flow", "--focal", "send", "--direction", "calls",
-                "--depth", "2", "--limit-per-step", str(limit), "--no-bodies"]
+        args = ["trace-data-flow", "--focal", focal, "--direction", direction,
+                "--depth", str(depth), "--limit-per-step", str(limit), "--no-bodies"]
         if target:
             args += ["--target", target]
+        if max_response_chars:
+            args += ["--max-response-chars", str(max_response_chars)]
         rc, out, err = self.kin_run(args, repo)
         if self.verbose:
             print("  $ kin %s -> rc=%s" % (" ".join(args[1:]), rc))
@@ -344,12 +837,60 @@ class Suite(object):
         except ValueError:
             return None
 
+    def elision_arms(self):
+        """One wide premise and a paired target/no-target response cut."""
+        if self._elision_arms is None:
+            wide = self.trace(
+                limit=ELISION_LIMIT,
+                max_response_chars=WIDE_RESPONSE_BUDGET,
+                depth=ELISION_DEPTH,
+            )
+            targeted = self.trace(
+                limit=ELISION_LIMIT,
+                target=ELISION_TARGET,
+                max_response_chars=RESPONSE_BUDGET,
+                depth=ELISION_DEPTH,
+            )
+            unnamed = self.trace(
+                limit=ELISION_LIMIT,
+                max_response_chars=RESPONSE_BUDGET,
+                depth=ELISION_DEPTH,
+            )
+            self._elision_arms = (wide, targeted, unnamed)
+        return self._elision_arms
+
+    def caller_trace(self):
+        if self._caller_trace is None:
+            self._caller_trace = self.trace(
+                limit=ELISION_LIMIT,
+                max_response_chars=WIDE_RESPONSE_BUDGET,
+                depth=1,
+                focal=CROSSING_HOP,
+                direction="callers",
+            )
+        return self._caller_trace
+
+    def close(self):
+        if self._repo is None:
+            return
+        rc, out, err = self.kin_run(["daemon", "stop", "--json"], self._repo, timeout=60)
+        if self.verbose and rc != 0:
+            print("  daemon stop returned rc=%s: %s" % (rc, (err or out)[-300:]))
+
 
 class Result(object):
     def __init__(self, ident, status, detail):
         self.ident = ident
         self.status = status
         self.detail = detail
+
+    def row(self):
+        return {
+            "id": self.ident,
+            "ticket": "FIR-2824",
+            "status": self.status,
+            "detail": self.detail,
+        }
 
 
 def check_says_the_absence_proves_nothing(suite):
@@ -385,11 +926,47 @@ def check_a_complete_walk_is_not_qualified(suite):
     return Result("3", status, "A walk no cap cut carries none of this. " + detail)
 
 
+def check_the_named_target_survives_response_elision(suite):
+    wide, targeted, _ = suite.elision_arms()
+    if wide is None or targeted is None:
+        return Result("4", UNREADABLE, "the wide or targeted bounded walk returned nothing readable")
+    status, detail = grade_named_target_survives_response_budget(wide, targeted)
+    return Result("4", status, "The named branch survives response elision. " + detail)
+
+
+def check_the_unnamed_budget_drops_the_same_target(suite):
+    wide, targeted, unnamed = suite.elision_arms()
+    if wide is None or targeted is None or unnamed is None:
+        return Result("5", UNREADABLE, "one of the three response-budget arms returned nothing readable")
+    status, detail = grade_unnamed_response_budget_drops_the_target(wide, targeted, unnamed)
+    return Result("5", status, "The unnamed control loses the same branch. " + detail)
+
+
+def check_callee_steps_carry_their_parent_file_sites(suite):
+    wide, _, _ = suite.elision_arms()
+    if wide is None:
+        return Result("6", UNREADABLE, "the wide callee walk returned nothing readable")
+    status, detail = grade_callee_call_sites(wide)
+    return Result("6", status, "Callee steps carry their parent-file call sites. " + detail)
+
+
+def check_caller_steps_carry_their_own_file_sites(suite):
+    payload = suite.caller_trace()
+    if payload is None:
+        return Result("7", UNREADABLE, "the caller walk returned nothing readable")
+    status, detail = grade_caller_call_site(payload)
+    return Result("7", status, "Caller steps carry their own-file call sites. " + detail)
+
+
 CHECKS = [
     ("0", check_says_the_absence_proves_nothing),
     ("1", check_separates_the_class_of_loss),
     ("2", check_the_target_is_what_delivers_the_hop),
     ("3", check_a_complete_walk_is_not_qualified),
+    ("4", check_the_named_target_survives_response_elision),
+    ("5", check_the_unnamed_budget_drops_the_same_target),
+    ("6", check_callee_steps_carry_their_parent_file_sites),
+    ("7", check_caller_steps_carry_their_own_file_sites),
 ]
 
 
@@ -416,6 +993,101 @@ CLIPPED = {
 }
 
 CLEAN = {"chain": [{"entity_name": "get_adapter", "parent_step": 0}], "degradations": []}
+WIDE_ELISION = {
+    "depth": ELISION_DEPTH,
+    "direction": "calls",
+    "limit_per_step": ELISION_LIMIT,
+    "max_response_chars": WIDE_RESPONSE_BUDGET,
+    "bodies_included": False,
+    "chain": [
+        {"step": 1, "parent_step": 0, "entity_id": "entity-get-adapter",
+         "entity_name": "get_adapter", "role": "callee",
+         "reference_lines": [1], "reference_lines_absent_reason": None},
+        {"step": 2, "parent_step": 0, "entity_id": "entity-send-via-adapter",
+         "entity_name": CROSSING_HOP, "role": "callee",
+         "reference_lines": [SESSION_ADAPTER_CALL_LINE], "reference_lines_absent_reason": None},
+        {"step": 3, "parent_step": 1, "entity_id": "entity-normalize-adapter",
+         "entity_name": "normalize_adapter", "role": "callee",
+         "reference_lines": [2], "reference_lines_absent_reason": None},
+        {"step": 4, "parent_step": 2, "entity_id": "entity-cert-verify",
+         "entity_name": ELISION_TARGET, "role": "callee",
+         "reference_lines": [ADAPTER_CERT_CALL_LINE], "reference_lines_absent_reason": None},
+        {"step": 5, "parent_step": 3, "entity_id": "entity-record-adapter",
+         "entity_name": "record_adapter", "role": "callee",
+         "reference_lines": [3], "reference_lines_absent_reason": None},
+    ],
+    "total_steps": 5,
+    "degradations": [],
+}
+TARGETED_ELISION = {
+    "depth": ELISION_DEPTH,
+    "direction": "calls",
+    "limit_per_step": ELISION_LIMIT,
+    "max_response_chars": RESPONSE_BUDGET,
+    "bodies_included": False,
+    "chain": [
+        {"step": 2, "parent_step": 0, "entity_id": "entity-send-via-adapter",
+         "entity_name": CROSSING_HOP, "role": "callee"},
+        {"step": 4, "parent_step": 2, "entity_id": "entity-cert-verify",
+         "entity_name": ELISION_TARGET, "role": "callee"},
+    ],
+    "total_steps": 2,
+    "target_name": ELISION_TARGET,
+    "steps_omitted": 3,
+    "fanout_narrowed": 3,
+    "elisions": {
+        "chain": {"kept": 2, "elided": 3, "total": 5, "reason": "response_budget"},
+    },
+    "degradations": [
+        {"component": "response_budget", "reason": "steps_omitted", "detail": "cut"},
+    ],
+}
+UNNAMED_ELISION = {
+    "depth": ELISION_DEPTH,
+    "direction": "calls",
+    "limit_per_step": ELISION_LIMIT,
+    "max_response_chars": RESPONSE_BUDGET,
+    "bodies_included": False,
+    "chain": [
+        {"step": 1, "parent_step": 0, "entity_id": "entity-get-adapter",
+         "entity_name": "get_adapter", "role": "callee"},
+        {"step": 3, "parent_step": 1, "entity_id": "entity-normalize-adapter",
+         "entity_name": "normalize_adapter", "role": "callee"},
+        {"step": 5, "parent_step": 3, "entity_id": "entity-record-adapter",
+         "entity_name": "record_adapter", "role": "callee"},
+    ],
+    "total_steps": 3,
+    "steps_omitted": 2,
+    "fanout_narrowed": 2,
+    "elisions": {
+        "chain": {"kept": 3, "elided": 2, "total": 5, "reason": "response_budget"},
+    },
+    "degradations": [
+        {"component": "response_budget", "reason": "steps_omitted", "detail": "cut"},
+    ],
+}
+CALLER_SITE = {
+    "depth": 1,
+    "direction": "callers",
+    "limit_per_step": ELISION_LIMIT,
+    "max_response_chars": WIDE_RESPONSE_BUDGET,
+    "bodies_included": False,
+    "focal_file": ADAPTERS_FILE,
+    "chain": [
+        {
+            "step": 1,
+            "parent_step": 0,
+            "entity_id": "entity-send",
+            "entity_name": CALLER_ENTITY,
+            "entity_file": SESSIONS_FILE,
+            "role": "caller",
+            "reference_lines": [SESSION_ADAPTER_CALL_LINE],
+            "reference_lines_absent_reason": None,
+        },
+    ],
+    "total_steps": 1,
+    "degradations": [],
+}
 
 
 def _without(payload, *path):
@@ -492,6 +1164,191 @@ def self_test():
     expect("3 cannot read a walk with no chain",
            grade_a_complete_walk_is_not_qualified({"degradations": []}), UNREADABLE)
 
+    expect("4 passes a discovered named branch that survives a real cut",
+           grade_named_target_survives_response_budget(WIDE_ELISION, TARGETED_ELISION), PASS)
+    renumbered_targeted = json.loads(json.dumps(TARGETED_ELISION))
+    renumbered_targeted["chain"][0]["step"] = 20
+    renumbered_targeted["chain"][1]["step"] = 40
+    renumbered_targeted["chain"][1]["parent_step"] = 20
+    expect("4 accepts renumbering when canonical entity and parent identities are unchanged",
+           grade_named_target_survives_response_budget(
+               WIDE_ELISION, renumbered_targeted), PASS)
+    no_cut_targeted = json.loads(json.dumps(TARGETED_ELISION))
+    no_cut_targeted["steps_omitted"] = 0
+    expect("4 fails a targeted arm whose response budget never bit",
+           grade_named_target_survives_response_budget(WIDE_ELISION, no_cut_targeted), FAIL)
+    lost_targeted = json.loads(json.dumps(TARGETED_ELISION))
+    lost_targeted["chain"][1]["entity_name"] = "other_target"
+    expect("4 fails when the named branch was still elided",
+           grade_named_target_survives_response_budget(WIDE_ELISION, lost_targeted), FAIL)
+    unechoed_targeted = json.loads(json.dumps(TARGETED_ELISION))
+    unechoed_targeted.pop("target_name")
+    expect("4 fails when the bounded arm does not echo the target",
+           grade_named_target_survives_response_budget(WIDE_ELISION, unechoed_targeted), FAIL)
+    wide_without_target = json.loads(json.dumps(WIDE_ELISION))
+    wide_without_target["chain"] = [
+        row for row in wide_without_target["chain"]
+        if row["entity_name"] not in (CROSSING_HOP, ELISION_TARGET)
+    ]
+    wide_without_target["total_steps"] = len(wide_without_target["chain"])
+    expect("4 fails a readable wide premise that never discovered the target",
+           grade_named_target_survives_response_budget(wide_without_target, TARGETED_ELISION), FAIL)
+    missing_parent = json.loads(json.dumps(TARGETED_ELISION))
+    missing_parent["chain"][1]["parent_step"] = 0
+    expect("4 fails a target row attached to the surviving wrong parent",
+           grade_named_target_survives_response_budget(WIDE_ELISION, missing_parent), FAIL)
+    orphaned_target = json.loads(json.dumps(TARGETED_ELISION))
+    orphaned_target["chain"][1]["parent_step"] = 99
+    expect("4 fails a target row that points at a missing parent step",
+           grade_named_target_survives_response_budget(WIDE_ELISION, orphaned_target), FAIL)
+    evidence_free = _without(TARGETED_ELISION, "elisions")
+    expect("4 fails a cut with no elisions accounting",
+           grade_named_target_survives_response_budget(WIDE_ELISION, evidence_free), FAIL)
+    no_disclosure = _without(TARGETED_ELISION, "degradations")
+    expect("4 fails a cut with no response-budget degradation",
+           grade_named_target_survives_response_budget(WIDE_ELISION, no_disclosure), FAIL)
+    cut_wide = json.loads(json.dumps(WIDE_ELISION))
+    cut_wide["steps_omitted"] = 1
+    expect("4 fails when the wide discovery premise was already cut",
+           grade_named_target_survives_response_budget(cut_wide, TARGETED_ELISION), FAIL)
+    oversized_wide = json.loads(json.dumps(WIDE_ELISION))
+    oversized_wide["untrimmed_payload"] = "x" * WIDE_RESPONSE_BUDGET
+    expect("4 fails a wide premise whose shipped JSON exceeds its budget",
+           grade_named_target_survives_response_budget(
+               oversized_wide, TARGETED_ELISION), FAIL)
+    clipped_targeted = json.loads(json.dumps(TARGETED_ELISION))
+    clipped_targeted["clipped_steps"] = [{"step": 2}]
+    expect("4 fails when fanout clipping can explain the loss",
+           grade_named_target_survives_response_budget(WIDE_ELISION, clipped_targeted), FAIL)
+    wrong_budget = json.loads(json.dumps(TARGETED_ELISION))
+    wrong_budget["max_response_chars"] = RESPONSE_BUDGET + 1
+    expect("4 fails a bounded arm that echoes a different budget",
+           grade_named_target_survives_response_budget(WIDE_ELISION, wrong_budget), FAIL)
+    oversized_targeted = json.loads(json.dumps(TARGETED_ELISION))
+    oversized_targeted["untrimmed_payload"] = "x" * RESPONSE_BUDGET
+    expect("4 fails a response whose shipped JSON exceeds the echoed budget",
+           grade_named_target_survives_response_budget(
+               WIDE_ELISION, oversized_targeted), FAIL)
+    short_targeted_universe = json.loads(json.dumps(TARGETED_ELISION))
+    short_targeted_universe["steps_omitted"] = 2
+    short_targeted_universe["fanout_narrowed"] = 2
+    short_targeted_universe["elisions"]["chain"] = {
+        "kept": 2,
+        "elided": 2,
+        "total": 4,
+        "reason": "response_budget",
+    }
+    expect("4 fails internally coherent accounting for a smaller source universe",
+           grade_named_target_survives_response_budget(
+               WIDE_ELISION, short_targeted_universe), FAIL)
+    invented_target_identity = json.loads(json.dumps(TARGETED_ELISION))
+    invented_target_identity["chain"][1]["entity_id"] = "entity-not-in-wide"
+    expect("4 fails a coherent target row the wide discovery never returned",
+           grade_named_target_survives_response_budget(
+               WIDE_ELISION, invented_target_identity), FAIL)
+
+    expect("5 passes when the unnamed cut loses the widely discovered target",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, UNNAMED_ELISION), PASS)
+    no_cut_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
+    no_cut_unnamed["steps_omitted"] = 0
+    expect("5 fails an unnamed arm whose response budget never bit",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, no_cut_unnamed), FAIL)
+    kept_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
+    kept_unnamed["chain"][-1]["entity_name"] = ELISION_TARGET
+    expect("5 fails when the unnamed arm already keeps the target",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, kept_unnamed), FAIL)
+    lost_target_control = json.loads(json.dumps(TARGETED_ELISION))
+    lost_target_control["chain"][1]["entity_name"] = "other_target"
+    expect("5 fails when both bounded arms lose the target",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, lost_target_control, UNNAMED_ELISION), FAIL)
+    named_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
+    named_unnamed["target_name"] = ELISION_TARGET
+    expect("5 fails when the unnamed arm claims a target",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, named_unnamed), FAIL)
+    claiming_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
+    claiming_unnamed["degradations"][0]["detail"] = (
+        "cut as whole branches, keeping the branch that reaches the named target"
+    )
+    expect("5 fails when the unnamed disclosure claims it kept a named target",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, claiming_unnamed), FAIL)
+    clipped_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
+    clipped_unnamed["chain"][0]["fanout_truncated"] = True
+    expect("5 fails when the unnamed arm has a per-step fanout cut",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, clipped_unnamed), FAIL)
+    short_unnamed_universe = json.loads(json.dumps(UNNAMED_ELISION))
+    short_unnamed_universe["steps_omitted"] = 1
+    short_unnamed_universe["fanout_narrowed"] = 1
+    short_unnamed_universe["elisions"]["chain"] = {
+        "kept": 3,
+        "elided": 1,
+        "total": 4,
+        "reason": "response_budget",
+    }
+    expect("5 fails internally coherent accounting for a smaller source universe",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, short_unnamed_universe), FAIL)
+    invented_unnamed = json.loads(json.dumps(UNNAMED_ELISION))
+    for index, row in enumerate(invented_unnamed["chain"]):
+        row["entity_name"] = "invented_%d" % index
+    expect("5 fails bounded rows whose identities changed from the wide discovery",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, invented_unnamed), FAIL)
+    expect("5 cannot read a non-object response arm",
+           grade_unnamed_response_budget_drops_the_target(
+               WIDE_ELISION, TARGETED_ELISION, None), UNREADABLE)
+
+    expect("6 passes exact callee sites from both parent files",
+           grade_callee_call_sites(WIDE_ELISION), PASS)
+    wrong_callee_line = json.loads(json.dumps(WIDE_ELISION))
+    wrong_callee_line["chain"][1]["reference_lines"] = [SESSION_ADAPTER_CALL_LINE + 1]
+    expect("6 fails a callee line from the wrong source row",
+           grade_callee_call_sites(wrong_callee_line), FAIL)
+    wrong_callee_role = json.loads(json.dumps(WIDE_ELISION))
+    wrong_callee_role["chain"][3]["role"] = "caller"
+    expect("6 fails when the forward step reports the wrong role",
+           grade_callee_call_sites(wrong_callee_role), FAIL)
+    unexplained_step = json.loads(json.dumps(WIDE_ELISION))
+    unexplained_step["chain"][0]["reference_lines"] = []
+    expect("6 fails any step with no lines and no absent reason",
+           grade_callee_call_sites(unexplained_step), FAIL)
+    invented_reason = json.loads(json.dumps(WIDE_ELISION))
+    invented_reason["chain"][0]["reference_lines"] = []
+    invented_reason["chain"][0]["reference_lines_absent_reason"] = "made_up_reason"
+    expect("6 fails an empty-line row with an unknown absent-reason value",
+           grade_callee_call_sites(invented_reason), FAIL)
+    missing_line_key = json.loads(json.dumps(WIDE_ELISION))
+    missing_line_key["chain"][0].pop("reference_lines_absent_reason")
+    expect("6 fails a chain row that omits one uniform site key",
+           grade_callee_call_sites(missing_line_key), FAIL)
+
+    expect("7 passes the exact caller site in the caller's own file",
+           grade_caller_call_site(CALLER_SITE), PASS)
+    wrong_caller_line = json.loads(json.dumps(CALLER_SITE))
+    wrong_caller_line["chain"][0]["reference_lines"] = [ADAPTER_CERT_CALL_LINE]
+    expect("7 fails when the caller receives a line from the focal file",
+           grade_caller_call_site(wrong_caller_line), FAIL)
+    same_file_caller = json.loads(json.dumps(CALLER_SITE))
+    same_file_caller["chain"][0]["entity_file"] = ADAPTERS_FILE
+    expect("7 fails a fixture whose caller does not cross away from the focal file",
+           grade_caller_call_site(same_file_caller), FAIL)
+    wrong_caller_role = json.loads(json.dumps(CALLER_SITE))
+    wrong_caller_role["chain"][0]["role"] = "callee"
+    expect("7 fails when the reverse step reports the wrong role",
+           grade_caller_call_site(wrong_caller_role), FAIL)
+    reason_beside_line = json.loads(json.dumps(CALLER_SITE))
+    reason_beside_line["chain"][0]["reference_lines_absent_reason"] = "no_evidence_span"
+    expect("7 fails an absent reason beside a known caller site",
+           grade_caller_call_site(reason_beside_line), FAIL)
+    expect("7 cannot read a non-object caller response",
+           grade_caller_call_site(None), UNREADABLE)
+
     for line in failures:
         print("SELFTEST FAIL %s" % line)
     # Counted, never written out. A hardcoded total is a number that drifts from
@@ -510,6 +1367,8 @@ def main(argv):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--kin", default=os.environ.get("KIN_BIN") or shutil.which("kin"))
     parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", default=None, help="write the machine-readable report here")
+    parser.add_argument("--label", default=os.environ.get("KIN_ACCEPTANCE_LABEL") or "")
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument("--self-test", action="store_true")
     opts = parser.parse_args(argv)
@@ -520,10 +1379,22 @@ def main(argv):
     if not opts.kin:
         print("SETUP no kin binary: pass --kin or set KIN_BIN")
         return 3
+    kin = os.path.abspath(os.path.expanduser(opts.kin))
+    if not os.path.isfile(kin) or not os.access(kin, os.X_OK):
+        print("SETUP kin binary is missing or not executable: %s" % kin)
+        return 3
+    daemon = opts.daemon and os.path.abspath(os.path.expanduser(opts.daemon))
+    if daemon is None:
+        sibling = os.path.join(os.path.dirname(kin), "kin-daemon")
+        daemon = sibling if os.path.isfile(sibling) else None
+    if daemon is not None and (not os.path.isfile(daemon) or not os.access(daemon, os.X_OK)):
+        print("SETUP kin-daemon binary is missing or not executable: %s" % daemon)
+        return 3
 
     workdir = tempfile.mkdtemp(prefix="trace-spine-clipping-")
+    suite = None
     try:
-        suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
+        suite = Suite(kin, workdir, daemon=daemon, verbose=opts.verbose)
         results = []
         for ident, check in CHECKS:
             try:
@@ -537,12 +1408,33 @@ def main(argv):
         if answered != asked:
             print("SETUP asked for %r and %r answered" % (asked, answered))
             return 3
+        if opts.json:
+            report_path = os.path.abspath(opts.json)
+            directory = os.path.dirname(report_path)
+            if directory and not os.path.isdir(directory):
+                os.makedirs(directory)
+            with open(report_path, "w") as handle:
+                json.dump(
+                    {
+                        "suite": "trace_spine_clipping_repro",
+                        "ticket": "FIR-2824",
+                        "label": opts.label,
+                        "kin": kin,
+                        "results": [result.row() for result in results],
+                    },
+                    handle,
+                    indent=2,
+                    sort_keys=True,
+                )
+                handle.write("\n")
         if any(result.status == FAIL for result in results):
             return 1
         if any(result.status == UNREADABLE for result in results):
             return 2
         return 0
     finally:
+        if suite is not None:
+            suite.close()
         shutil.rmtree(workdir, ignore_errors=True)
 
 


### PR DESCRIPTION
A trace answer now keeps the thing you asked about. When a caller names a target, that step and every step between it and the focal survive both response-budget cuts instead of being given up as "least relevant". Every chain step also carries the source lines where the call actually happens, or an explicit reason it cannot.

The defect had two stages, not one, and both ignored the target. The trace handler narrows the fan-out first, then the generic MCP ladder narrows again. A fix aimed at either alone would have moved the number and not the answer. Both call the same shared rule, so one predicate threaded through `narrow_fanout_to_fit` reaches both. Ancestors are protected alongside the named step, because a dropped branch takes its descendants with it. Protection is a preference and not a refusal: when nothing fits with the branch held, the drop order is rebuilt without it and the response still narrows. A walk that names nothing, or names something it never reached, narrows exactly as it did before, and a new `CutShape` tells the reader which of the three cuts they received.

Call sites accumulate across duplicate edges, sort and deduplicate, take the parent's file for a callee edge and the child's file for a caller edge, and survive promotion. Payloads from an older daemon stay readable and label the absence `unreported_by_daemon`.

## The annotation span that was not a call site

Running the acceptance suite against real binaries showed `cert_verify` coming back with `reference_lines: [4, 11]`, where 4 is its own definition line and only 11 is a call. The cause is that the walk accumulated a span from every allowed edge, and `allowed` carries `UsesType` so an annotation target is still reached as a named leaf. The graph holds a `UsesType` edge beside the `Calls` edge for the same pair, and its span is the annotation's target, which is the callee's own definition rather than anywhere the caller calls it.

Spans are now accumulated only from the edge classes the reference surface itself reads, on both walks, so the two answers agree. `kin refs` reported one site for these pairs all along, and the trace arm now reports the same one. The leaf is still reached, because that is what admitting `UsesType` buys and this must not take it away.

That is FIR-2834, and it is what turned acceptance checks 6 and 7 from red to green.

## Merged with main twice rather than rebased

Main moved under this branch while it was in review, so it is merged in with merge commits and the review ranges survive.

The first merge took #1204, #1208 and #1198. One conflict, in `crates/kin-mcp/src/budget.rs`, where main renamed the `trim_collection` call's second binding and this branch had changed that function to return a `CutShape` rather than a `bool`. Main's comment is kept verbatim, this branch's return type is kept, and the binding is named `cut_shape` so it no longer shadows the `shape: &ResponseShape` parameter whose scope it sits inside. `ResponseShape` has no `phrase` method, so a missed rename is a compile error rather than a silent rebind.

Where the two overlap, #1208's rule wins. The skip that let a cursorless final locate page keep its primary rows is gone, every collection is cut to `max_chars` under the one-entry floor, and the remedy names `max_chars` rather than a `next_cursor` the page does not have. Its renamed ceiling test came with it.

The two rules govern disjoint collection shapes and do not collide. `trim_collection` tries the parented path first and falls back to main's suffix bisection whenever an entry lacks `step` or `parent_step`, which every locate page does, so locate pages take main's path untouched and trace chains take this branch's. The one-entry floor holds on both.

The second merge took #1205, #1206, #1207 and #1210, with no conflict. Two of them touch files this branch also changes and both reconcile. `.github/workflows/acceptance.yml` gains #1205's two steps beside this branch's `trace_spine` step, and `EXPECTED_SUITES` now lists fifteen suites including both `trace_spine` and `working_copy_freshness`. That file's line counts are the one place the merge arithmetic does not match, and the reason is convergence rather than loss: both sides independently replaced the hardcoded "13 suite reports" summary with `len(EXPECTED_SUITES)`, so relative to this branch the merge needs only main's three-line comment above it.

Both merges were reconciled against each parent before being committed, per file rather than only in total, and every count is explained.

## Acceptance, graded against real binaries

`scripts/acceptance/trace_spine_clipping_repro.py` grades eight checks against a running daemon and real binaries. Four are this ticket's. Hosted CI cannot grade it on a pull request: the step sits in the `acceptance` job, which is gated `if: github.event_name != 'pull_request'`, and with the queue ruleset disabled there is no `merge_group` event either. So a local run against release binaries is the only grading it gets before landing, and this is it.

Against binaries `kin-parity` built from this branch at `2bc98f87840019b3047dbf92316e264becc11d1b`, whose version string names that head rather than a neighbouring commit:

```
CHECK 0 PASS A clipped spine refuses to be read as an absence
CHECK 1 PASS The disclosure separates module-crossing loss from breadth
CHECK 2 PASS Naming the target is what puts the hop in the chain
CHECK 3 PASS A walk no cap cut carries none of this
CHECK 4 PASS The named branch survives response elision; steps_omitted=11, fanout_narrowed=11
CHECK 5 PASS The unnamed control loses the same branch; unnamed steps_omitted=10
CHECK 6 PASS Callee steps carry their parent-file call sites; send_via_adapter line 59 and cert_verify line 11
CHECK 7 PASS Caller steps carry their own-file call sites; sessions.py line 59 from a different file
```

The suite had never run against a built binary before this branch, so its first real run was its own first grading, and that run was red. The repairs are here rather than deferred. The response budget the checks used was never calibrated: at 4000 characters the real response collapsed to a single step, both arms took the suffix fallback, and no product could have passed. A sweep across 3000 to 11000 in steps of 500 found the plateau where the mechanism actually fires, and the constant is now 6000, the middle of it. Checks 4 and 5 now report UNREADABLE rather than PASS or FAIL when the targeted arm comes back with one step or no branch narrowing, so a collapsed response can never read as a pass.

Six graders that could pass on payloads proving nothing were repaired. An arm returning no steps contains no target either and satisfied the conservation arithmetic at zero kept, so the unnamed control must now be a real answer. A discovery universe already inside the budget cannot have been cut by it, so the attribution is checked rather than assumed. The call-site half of the suite's own claim was graded only on the wide arm, which a 60000 budget leaves untrimmed by construction, so the trimmed rows now carry the contract. Check 3 certified a walk that silently dropped the crossing hop, so its must-pass fixture is now its must-fail one. The self-test went from 56 grader assertions to 64.

Each of the five new graders was then falsified on its own. Removing one guard at a time gives `64 grader assertions, 1 failed` five times over, and the one failure is the arm written for that guard: five mutations, five distinct arms.

## Falsification of the change itself

Nine arms, every mutation removing a property of the product rather than weakening an assertion. Each anchor had to match exactly once, each mutation was proven to have removed its property before the build started, and the restore is an explicit `git checkout HEAD --` on a trap armed after a dirty-tree refusal.

| arm | what was removed | assertion that fired |
|---|---|---|
| M1 | the ancestor walk in `narrow_fanout_to_fit` | `budget.rs:1872` "the named step was given up as least relevant" |
| M2 | the `must_keep` selection that seeds the protected set | the same assertion |
| M3 | the CLI caller arm's own-file ownership | `trace_data_flow.rs:3493`, left `[]` against right `[8]` |
| M4 | the GraphStore caller arm's own-file ownership | `entities.rs:9496`, left `[]` against right `[8]` |
| M5 | promotion carrying the original edge's site fields | `entities.rs:9899`, left `[]` against right `[5]` |
| M6 | the MCP handler's named-entity predicate | `entities.rs:10055` "the named arm must still narrow" |
| M7 | the CLI's named-entity predicate | `trace_data_flow.rs:3957` "no accepted response budget separated the unnamed and targeted arms" |
| M8 | the annotation edge-class gate, GraphStore arm | `entities.rs:9401`, left `[5, 12]` against right `[12]` |
| M9 | the annotation edge-class gate, CLI arm | `trace_data_flow.rs:3576`, left `[5, 12]` against right `[12]` |
| M10 | the caller arm's file filter, disabled outright | `trace_data_flow.rs:3536` and `entities.rs:9627`, the new third-file row |

Nine red, no survivors, none grading nothing. `an_unnamed_trace_still_elides_least_relevant_first` and `a_target_the_walk_never_reached_protects_nothing` stay green under both M1 and M2, which separates target recognition from ordinary branch narrowing. M1 and M2 fire the same assertion because they disable target protection by two routes and one guard covers the property both attack.

M10 is new here too, and it is the one the review asked for. The caller arm compares an evidence span's
file against the referencing entity's own file, and nothing could tell whether that comparison ran:
every incoming edge in both fixtures carried a span in the caller's own file, so disabling the filter
by passing `None` admitted exactly the same set. M3 and M4 point the arm at the parent's file, which
makes it reject everything, so they falsify which file it compares against rather than that it
compares at all. Each fixture now carries one more incoming edge whose span names a third file
belonging to neither the caller nor the focal, which the filter must reject. The two mutations answer
on different assertions on both surfaces: `3536` and `9627` are the new row, `3517` and `9606` are the
older `caller` one.

M9 is new here. The annotation fix gates both surfaces, and the commit that wrote it added one test, on the GraphStore arm. The CLI arm carried the identical gate with nothing grading it, so the mutation that removes the gate from both files went red on one surface and unnoticed on the other. A guard with no check is not evidence, so the CLI arm now has the mirrored test, `commands::trace_data_flow::tests::an_annotation_span_is_not_a_call_site`, and it goes red.

## Gates

Two heads were gated in full, because main moved under the branch twice. `2bc98f878` is the head after
the first merge and `eed47b76f` the head after the second. `b832dde10` adds one fixture row per
call-site test and nothing else, so it carries its own targeted falsification and hosted CI rather
than a third full local pass. Every line below names the sha it graded, taken
from that gate's own printed resolution line rather than from the shell that launched it.

| gate | sha graded | result |
|---|---|---|
| `cargo check --workspace --all-targets` | `2bc98f878` | `RC cargo_check=0` |
| `cargo check --workspace --all-targets` | `eed47b76f` | `RC cargo_check=0` |
| five crate suites | `2bc98f878` | 4362 passed, 0 failed, 3 ignored |
| five crate suites | `eed47b76f` | 4382 passed, 0 failed, 3 ignored |
| doctests, `kin-cli` and `kin-mcp` | `2bc98f878` | both `RC=0` |
| doctests, `kin-cli` and `kin-mcp` | `eed47b76f` | both `RC=0` |
| `bin/kin-precheck kin` | `2bc98f878` | `16 gates ran, 16 passed, 0 failed` |
| `bin/kin-precheck kin` | `eed47b76f` | `16 gates ran, 16 passed, 0 failed` |
| `bin/kin-parity` | `2bc98f878` | `FINAL PASS-WITH-ALLOWANCES in 1316.7s` |
| `bin/kin-parity` | `eed47b76f` | `FINAL PASS-WITH-ALLOWANCES in 1083.5s` |
| acceptance suite vs those binaries | `2bc98f878` | CHECK 0 to 7 PASS, `TRACE_SPINE_RC=0` |
| acceptance suite vs those binaries | `eed47b76f` | CHECK 0 to 7 PASS, `TRACE_SPINE_RC=0` |
| nine-arm falsification grid | `2bc98f878` | 9 red, 4 controls green, 0 survivors, 0 not-run |
| five acceptance-guard mutations | `2d8fa9388` | each red on its own named arm |
| caller-filter falsification, both directions | `b832dde10` | 4 arms red on 4 distinct assertions, both intact arms green |

The crate suites are `kin-cli`, `kin-mcp`, `kin-index`, `kin-parser` and `kin-daemon`. Every listing
was asserted before its run and reconciles against it, and a fabricated test name lists zero, which is
what makes the other counts mean anything. The totals differ between the two heads because main's
second batch brought its own tests, most visibly `kin-mcp` going from 747 to 759.

Parity's three allowances are the same pre-existing ones on both heads and nothing new appeared:
`firstrun/9` FIR-2580, `firstrun/3` FIR-2501, `brownfield/4` FIR-2464. Both runs proved the bytes they
graded: `stamp the binary reports the checkout's HEAD 2bc98f878400` and `eed47b76fb37`. Parity's own
record says NON-CITABLE, and it is not the release-clean gate.

`cargo fmt --all -- --check` is one of precheck's sixteen, so it carries those shas. Run standalone it
is also clean, and that green was falsified rather than trusted: mis-indenting one line inside the new
CLI test makes the same command exit 1 and name that file.

The acceptance suite's JSON reports carry all eight check ids, 0 through 7, every one PASS, labelled
with the head each graded. The suite returns 3 on any mismatch between the ids it asked for and the
ids that answered, and it did not.

## The re-grade, and why it was run

The second head was gated in full rather than assumed, because main's #1206 changes how the Python
parser records call sites and this suite's fixture is `sessions.py` and `adapters.py`. The two meet for
the first time on this tree, and the first place they would otherwise meet is main, after the merge,
which is the class #1208's own commit message recorded as uncatchable by a local parity gate.

They compose. Check 6 reads `send_via_adapter line 59 and cert_verify line 11 come from their parent
files` on both heads, so #1206 does not move this fixture's call sites.

The falsification grid is the one thing not repeated on `eed47b76f`. It grades this branch's own code,
which neither merge touched, and its fixtures build relations by hand through `InMemoryGraph` rather
than through the parser #1206 changed.

## Found and not fixed here

The real store run surfaced a pre-existing overrun on the CLI arm that this change neither causes nor fixes. `enforce_response_budget` narrows to the ceiling less a fixed 1500 character disclosure reserve, then adds the disclosures. Measured at a 60000 ceiling, the ladder honored its target exactly at 58424 characters, the three disclosures cost 1660, and the printed response came to 60084, which is 84 over what the caller asked for. The overshoot is a function of disclosure cost against a fixed reserve and is independent of what the steps contain. This branch adds no disclosure text on the CLI arm. It needs its own ticket.

The same-file case of the call-site defect is fixed by the edge-class gate above. What remains is that a partial cross-file evidence drop is still undisclosed: a step with three same-file sites and five dropped cross-file ones ships the three with a null absence reason, because the reason is gated on the list being empty. Only the all-or-nothing case is disclosed. Also its own ticket.

## The re-grade on the current head

The figures above were taken after the first merge. Everything was then run again on the current head,
so #1206's parser change and this branch's Python acceptance fixture are graded on one tree rather than
on two.

`cargo check --workspace --all-targets` exits 0. Crate suites 4382 passed, 0 failed, 3 ignored, with
every listing reconciling against its run and a fabricated name listing zero. Both doctest legs 0.
`kin-precheck` 16 of 16, naming this head. `kin-parity` `PASS-WITH-ALLOWANCES` in 1083.5s from a binary
whose stamp names this head, with the same three pre-existing allowances and nothing new. And the
acceptance suite against those binaries is CHECK 0 through 7 PASS again, with the same readings:
`send_via_adapter line 59 and cert_verify line 11 come from their parent files`.

So #1206 does not move this fixture's call sites, and the two changes compose.

The falsification grid is not repeated. It grades this branch's own code, which neither merge touched,
and its fixtures build relations by hand through `InMemoryGraph` rather than through the parser #1206
changed.

Closes FIR-2824
Closes FIR-2834
