### PR TITLE
Fix deterministic repository transfer validation

### DIFF
--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -79,7 +79,13 @@ pub const REPOSITORY_TRANSFER_PROTOCOL: &str = "kin-repository-v6-fast-forward";
 /// between replicas whose imported-Git authority already matches, and no push
 /// could establish one, so a repository that came from Git had no route into a
 /// hosted store at all. A version 2 peer is refused by name, same as version 1.
-pub const REPOSITORY_TRANSFER_SCHEMA_VERSION: u32 = 3;
+///
+/// Version 4 makes the transfer identity a deterministic manifest over the
+/// content-addressed identities the receiver independently verifies. Version
+/// 3 hashed raw JSON for the whole pack, including unordered entity metadata
+/// maps. A receiver reconstructing one of those maps could therefore reject a
+/// semantically identical pack under a different byte order.
+pub const REPOSITORY_TRANSFER_SCHEMA_VERSION: u32 = 4;
 pub const FEATURE_EXACT_TREES: &str = "exact-trees-v1";
 pub const FEATURE_IMMUTABLE_SOURCE_CAS: &str = "immutable-source-cas-v1";
 pub const FEATURE_REF_CAS: &str = "ref-cas-v1";
@@ -1954,12 +1960,78 @@ fn transfer_receipt(
     }
 }
 
+#[derive(Serialize)]
+struct RepositoryTransferIdentity<'a> {
+    schema_version: u32,
+    protocol: &'a str,
+    operation_id: &'a OperationId,
+    repository_id: &'a RepositoryId,
+    source_ref: &'a RefName,
+    destination_ref: &'a RefName,
+    source_head: SemanticChangeId,
+    transfer_target_head: SemanticChangeId,
+    source_tree_hash: Hash256,
+    expected_destination_target: &'a Option<RefTarget>,
+    expected_destination_head: Option<SemanticChangeId>,
+    expected_destination_roots: &'a RootBundle,
+    expected_destination_default_ref: &'a Option<RefName>,
+    source_git_authority_hash: Option<Hash256>,
+    expected_destination_git_authority_hash: Option<Hash256>,
+    git_authority_bootstrap_hash: Option<Hash256>,
+    required_features: &'a [String],
+    changes: Vec<SemanticChangeId>,
+    trees: &'a [RepositoryTransferTreeIdentity],
+    external_objects: &'a [ExternalObjectRecord],
+    aliases: &'a [ExternalChangeAlias],
+    bodies: Vec<RepositoryTransferBodyIdentity>,
+}
+
+#[derive(Serialize)]
+struct RepositoryTransferBodyIdentity {
+    hash: Hash256,
+    byte_len: u64,
+}
+
 fn compute_transfer_id(pack: &RepositoryTransferPack) -> Result<Hash256> {
-    let mut canonical = pack.clone();
-    canonical.transfer_id = Hash256::from_bytes([0; 32]);
-    let payload = serde_json::to_vec(&canonical)
+    // Semantic changes and bodies are already content-addressed objects. Their
+    // declared identities are recomputed below by `validate_pack`, so carrying
+    // those identities here binds the exact content without serializing an
+    // unordered metadata map or copying every base64 body into a second large
+    // allocation. The remaining envelope fields are ordered model values.
+    let identity = RepositoryTransferIdentity {
+        schema_version: pack.schema_version,
+        protocol: &pack.protocol,
+        operation_id: &pack.operation_id,
+        repository_id: &pack.repository_id,
+        source_ref: &pack.source_ref,
+        destination_ref: &pack.destination_ref,
+        source_head: pack.source_head,
+        transfer_target_head: pack.transfer_target_head,
+        source_tree_hash: pack.source_tree_hash,
+        expected_destination_target: &pack.expected_destination_target,
+        expected_destination_head: pack.expected_destination_head,
+        expected_destination_roots: &pack.expected_destination_roots,
+        expected_destination_default_ref: &pack.expected_destination_default_ref,
+        source_git_authority_hash: pack.source_git_authority_hash,
+        expected_destination_git_authority_hash: pack.expected_destination_git_authority_hash,
+        git_authority_bootstrap_hash: hash_git_authority(pack.git_authority_bootstrap.as_ref())?,
+        required_features: &pack.required_features,
+        changes: pack.changes.iter().map(|change| change.id).collect(),
+        trees: &pack.trees,
+        external_objects: &pack.external_objects,
+        aliases: &pack.aliases,
+        bodies: pack
+            .bodies
+            .iter()
+            .map(|body| RepositoryTransferBodyIdentity {
+                hash: body.hash,
+                byte_len: body.byte_len,
+            })
+            .collect(),
+    };
+    let payload = serde_json::to_vec(&identity)
         .map_err(|error| invalid(format!("serialize transfer identity: {error}")))?;
-    Ok(domain_hash(b"kin-repository-transfer-v1\0", &payload))
+    Ok(domain_hash(b"kin-repository-transfer-v2\0", &payload))
 }
 
 fn hash_git_authority(authority: Option<&GitExternalAuthority>) -> Result<Option<Hash256>> {
@@ -2092,14 +2164,16 @@ impl ChangeStore for TransferChangeStore {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::sync::Arc;
 
     use kin_db::LocalFileBackend;
     use kin_model::{
-        compute_semantic_change_id, ArtifactId, ExternalObjectKind, GitExternalAuthorityDelta,
-        GitObjectBodyLoader, GitObjectFormat, GitObjectId, GitRawRef, GitRawTarget, LocatedEntry,
-        RepoPath, Timestamp, TreeDelta,
+        compute_semantic_change_id, ArtifactId, Entity, EntityDelta, EntityId, EntityKind,
+        EntityMetadata, EntityRole, ExternalObjectKind, FingerprintAlgorithm,
+        GitExternalAuthorityDelta, GitObjectBodyLoader, GitObjectFormat, GitObjectId, GitRawRef,
+        GitRawTarget, LanguageId, LocatedEntry, RepoPath, SemanticFingerprint, Timestamp,
+        TreeDelta, Visibility,
     };
     use sha1::{Digest as _, Sha1};
     use tempfile::TempDir;
@@ -2130,6 +2204,57 @@ mod tests {
 
     fn digest(bytes: &[u8]) -> Hash256 {
         Hash256::from_bytes(Sha256::digest(bytes).into())
+    }
+
+    fn entity_with_metadata(extra: HashMap<String, serde_json::Value>) -> Entity {
+        Entity {
+            id: EntityId(Uuid::from_u128(9_001)),
+            kind: EntityKind::Function,
+            name: "metadata_order_probe".to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0x11; 32]),
+                signature_hash: Hash256::from_bytes([0x22; 32]),
+                behavior_hash: Hash256::from_bytes([0x33; 32]),
+                equivalence_hash: Hash256::from_bytes([0x44; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: None,
+            span: None,
+            signature: "fn metadata_order_probe()".to_string(),
+            visibility: Visibility::Private,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata { extra },
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn pack_with_metadata(
+        base: &RepositoryTransferPack,
+        extra: HashMap<String, serde_json::Value>,
+    ) -> RepositoryTransferPack {
+        let mut pack = base.clone();
+        assert_eq!(pack.changes.len(), 1);
+        assert_eq!(pack.trees.len(), 1);
+        assert!(pack.aliases.is_empty());
+
+        let old_change_id = pack.changes[0].id;
+        pack.changes[0].entity_deltas.push(EntityDelta::Added {
+            new: entity_with_metadata(extra),
+        });
+        let new_change_id = compute_semantic_change_id(&pack.changes[0]).unwrap();
+        pack.changes[0].id = new_change_id;
+        pack.source_head = new_change_id;
+        pack.transfer_target_head = new_change_id;
+        assert_eq!(pack.trees[0].change_id, old_change_id);
+        pack.trees[0].change_id = new_change_id;
+        pack.transfer_id = Hash256::from_bytes([0; 32]);
+        pack.transfer_id = compute_transfer_id(&pack).unwrap();
+        pack
     }
 
     fn manager(
@@ -3863,6 +3988,67 @@ mod tests {
         duplicate.transfer_id = compute_transfer_id(&duplicate).unwrap();
         let error = validate_pack(&duplicate, &RepositoryTransferLimits::default()).unwrap_err();
         assert!(error.to_string().contains("duplicate source body"));
+    }
+
+    #[test]
+    fn transfer_identity_survives_metadata_map_reconstruction() {
+        let fixture = fixture();
+
+        // Entity metadata is intentionally extensible and therefore uses a
+        // HashMap. Find two maps with the same values and observably different
+        // iteration orders, as happens when a receiver deserializes a pack.
+        let entries = (0..16)
+            .map(|index| {
+                (
+                    format!("metadata_key_{index:02}"),
+                    serde_json::json!({ "index": index, "stable": true }),
+                )
+            })
+            .collect::<Vec<_>>();
+        let first = entries.iter().cloned().collect::<HashMap<_, _>>();
+        let first_bytes = serde_json::to_vec(&EntityMetadata {
+            extra: first.clone(),
+        })
+        .unwrap();
+        let second = (0..256)
+            .map(|rotation| {
+                entries
+                    .iter()
+                    .cycle()
+                    .skip(rotation % entries.len())
+                    .take(entries.len())
+                    .cloned()
+                    .collect::<HashMap<_, _>>()
+            })
+            .find(|candidate| {
+                serde_json::to_vec(&EntityMetadata {
+                    extra: candidate.clone(),
+                })
+                .unwrap()
+                    != first_bytes
+            })
+            .expect("independent HashMaps expose a different JSON key order");
+        assert_eq!(first, second);
+
+        let first_pack = pack_with_metadata(&fixture.pack, first);
+        let second_pack = pack_with_metadata(&fixture.pack, second);
+
+        // The semantic change contract already canonicalizes metadata keys, so
+        // both spellings declare one exact change and differ only in map order.
+        assert_eq!(first_pack.changes[0].id, second_pack.changes[0].id);
+        assert_ne!(
+            serde_json::to_vec(&first_pack).unwrap(),
+            serde_json::to_vec(&second_pack).unwrap(),
+            "the control must exercise different raw pack bytes"
+        );
+        assert_eq!(
+            first_pack.transfer_id, second_pack.transfer_id,
+            "reconstructing an unordered metadata map must not change transfer identity"
+        );
+
+        let reconstructed: RepositoryTransferPack =
+            serde_json::from_slice(&serde_json::to_vec(&first_pack).unwrap()).unwrap();
+        validate_pack(&reconstructed, &RepositoryTransferLimits::default()).unwrap();
     }
 
     #[test]

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -36,6 +36,11 @@ use crate::repository_transfer_negotiation::RepositoryTransferTransport;
 pub const REPOSITORY_TRANSFER_HTTP_BODY_LIMIT: usize =
     http_body_limit_for(crate::repository_transfer::MAX_TRANSFER_DECODED_BODY_BYTES);
 
+/// Error prose is diagnostic, not a second transfer envelope. Bound it
+/// separately so a refusing peer cannot make the client allocate the normal
+/// pack ceiling merely to explain one status code.
+const REPOSITORY_TRANSFER_HTTP_ERROR_BODY_LIMIT: usize = 64 * 1024;
+
 /// Room for everything in a pack envelope that is not a body.
 ///
 /// Changes, trees, external-object records, aliases, refs, roots and the JSON
@@ -128,6 +133,11 @@ impl HttpRepositoryTransferTransport {
     pub fn new(endpoint: RepositoryTransferEndpoint) -> Self {
         let agent: Agent = Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(endpoint.timeout_secs)))
+            // A repository-v6 refusal carries the violated invariant in its
+            // response body. Keep the response available so this layer can
+            // preserve that reason while mapping the status to the right
+            // transfer error class.
+            .http_status_as_error(false)
             .build()
             .into();
         Self { endpoint, agent }
@@ -158,7 +168,7 @@ impl HttpRepositoryTransferTransport {
         let response = request
             .call()
             .map_err(|error| peer_error(error, what, repository_id))?;
-        read_json(response, what)
+        read_json(response, what, repository_id)
     }
 
     fn post_json<T: serde::Serialize, R: serde::de::DeserializeOwned>(
@@ -175,14 +185,37 @@ impl HttpRepositoryTransferTransport {
         let response = request
             .send_json(body)
             .map_err(|error| peer_error(error, what, repository_id))?;
-        read_json(response, what)
+        read_json(response, what, repository_id)
     }
 }
 
 fn read_json<R: serde::de::DeserializeOwned>(
     response: ureq::http::Response<ureq::Body>,
     what: &str,
+    repository_id: &RepositoryId,
 ) -> Result<R> {
+    let status = response.status().as_u16();
+    if !(200..300).contains(&status) {
+        let body = response
+            .into_body()
+            .into_with_config()
+            .limit(REPOSITORY_TRANSFER_HTTP_ERROR_BODY_LIMIT as u64 + 1)
+            .read_to_string();
+        return Err(match body {
+            Ok(body) => peer_status_error(status, &body, what, repository_id),
+            Err(ureq::Error::BodyExceedsLimit(_)) => peer_status_error(
+                status,
+                &format!(
+                    "response body exceeds the {REPOSITORY_TRANSFER_HTTP_ERROR_BODY_LIMIT} byte diagnostic limit"
+                ),
+                what,
+                repository_id,
+            ),
+            Err(error) => RepositoryTransferError::Storage(format!(
+                "failed to read remote {what} refusal body (HTTP {status}): {error}"
+            )),
+        });
+    }
     let body = response
         .into_body()
         .into_with_config()
@@ -229,38 +262,58 @@ fn body_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
 /// team usage, and "this repository" gives the caller nothing to compare their
 /// spelling against. Every other class is the peer refusing on the state of a
 /// repository it does serve, where the id is not what the caller would correct.
+fn peer_status_error(
+    code: u16,
+    body: &str,
+    what: &str,
+    repository_id: &RepositoryId,
+) -> RepositoryTransferError {
+    let detail = body.trim();
+    let with_detail = |message: String| {
+        if detail.is_empty() {
+            message
+        } else {
+            format!("{message}: {detail}")
+        }
+    };
+    match code {
+        409 => RepositoryTransferError::Conflict(with_detail(format!(
+            "remote refused {what} with a repository-v6 conflict (HTTP 409)"
+        ))),
+        422 => RepositoryTransferError::Invalid(with_detail(format!(
+            "remote rejected {what} as an invalid repository-v6 envelope (HTTP 422)"
+        ))),
+        424 => RepositoryTransferError::Storage(with_detail(format!(
+            "remote {what} failed on storage (HTTP 424)"
+        ))),
+        404 => RepositoryTransferError::Invalid(with_detail(format!(
+            "remote does not serve {what} for repository {:?} (HTTP 404); check the \
+             repository id, or that the peer serves it",
+            repository_id.as_str()
+        ))),
+        // The peer is intact and answered; the envelope is too large for
+        // the bound both sides declare. That is the same refusal the
+        // client raises on an oversized body it reads, not a peer failure.
+        413 => RepositoryTransferError::Invalid(with_detail(format!(
+            "remote refused {what} as larger than the \
+             {REPOSITORY_TRANSFER_HTTP_BODY_LIMIT} byte repository-v6 transfer body limit (HTTP 413)"
+        ))),
+        other => RepositoryTransferError::Storage(with_detail(format!(
+            "remote {what} failed with HTTP {other}"
+        ))),
+    }
+}
+
 fn peer_error(
     error: ureq::Error,
     what: &str,
     repository_id: &RepositoryId,
 ) -> RepositoryTransferError {
     match error {
-        ureq::Error::StatusCode(code) => match code {
-            409 => RepositoryTransferError::Conflict(format!(
-                "remote refused {what} with a repository-v6 conflict (HTTP 409)"
-            )),
-            422 => RepositoryTransferError::Invalid(format!(
-                "remote rejected {what} as an invalid repository-v6 envelope (HTTP 422)"
-            )),
-            424 => RepositoryTransferError::Storage(format!(
-                "remote {what} failed on storage (HTTP 424)"
-            )),
-            404 => RepositoryTransferError::Invalid(format!(
-                "remote does not serve {what} for repository {:?} (HTTP 404); check the \
-                 repository id, or that the peer serves it",
-                repository_id.as_str()
-            )),
-            // The peer is intact and answered; the envelope is too large for
-            // the bound both sides declare. That is the same refusal the
-            // client raises on an oversized body it reads, not a peer failure.
-            413 => RepositoryTransferError::Invalid(format!(
-                "remote refused {what} as larger than the \
-                 {REPOSITORY_TRANSFER_HTTP_BODY_LIMIT} byte repository-v6 transfer body limit (HTTP 413)"
-            )),
-            other => {
-                RepositoryTransferError::Storage(format!("remote {what} failed with HTTP {other}"))
-            }
-        },
+        // Defensive fallback for an Agent supplied by a future constructor
+        // that restores status-as-error. The standard constructor above keeps
+        // the body and routes statuses through `read_json`.
+        ureq::Error::StatusCode(code) => peer_status_error(code, "", what, repository_id),
         other => {
             RepositoryTransferError::Storage(format!("remote {what} transport failed: {other}"))
         }
@@ -332,15 +385,19 @@ mod tests {
         HttpRepositoryTransferTransport::new(RepositoryTransferEndpoint::new(base_url))
     }
 
-    fn json_response(payload: String) -> ureq::http::Response<ureq::Body> {
+    fn response(status: u16, payload: String) -> ureq::http::Response<ureq::Body> {
         ureq::http::Response::builder()
-            .status(200)
+            .status(status)
             .body(
                 ureq::Body::builder()
                     .mime_type("application/json")
                     .data(payload),
             )
             .unwrap()
+    }
+
+    fn json_response(payload: String) -> ureq::http::Response<ureq::Body> {
+        response(200, payload)
     }
 
     #[test]
@@ -373,25 +430,43 @@ mod tests {
     fn peer_status_codes_keep_their_refusal_class() {
         let asked_for = asked_for();
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(409), "transfer receive", &asked_for),
+            peer_status_error(409, "", "transfer receive", &asked_for),
             RepositoryTransferError::Conflict(_)
         ));
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(422), "transfer receive", &asked_for),
+            peer_status_error(422, "", "transfer receive", &asked_for),
             RepositoryTransferError::Invalid(_)
         ));
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(424), "transfer receive", &asked_for),
+            peer_status_error(424, "", "transfer receive", &asked_for),
             RepositoryTransferError::Storage(_)
         ));
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(413), "transfer receive", &asked_for),
+            peer_status_error(413, "", "transfer receive", &asked_for),
             RepositoryTransferError::Invalid(_)
         ));
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(500), "transfer receive", &asked_for),
+            peer_status_error(500, "", "transfer receive", &asked_for),
             RepositoryTransferError::Storage(_)
         ));
+    }
+
+    #[test]
+    fn peer_refusal_preserves_the_receivers_exact_reason() {
+        let reason = "invalid repository transfer: transfer identity declared recomputes to actual";
+        let error = read_json::<serde_json::Value>(
+            response(422, reason.to_string()),
+            "transfer receive",
+            &asked_for(),
+        )
+        .expect_err("the receiver refused the pack");
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("an HTTP 422 is an invalid envelope, not a storage failure");
+        };
+        assert!(
+            message.contains(reason),
+            "the caller must see the invariant the receiver named: {message}"
+        );
     }
 
     #[test]
@@ -407,7 +482,7 @@ mod tests {
             "transfer export",
             "transfer receive",
         ] {
-            let error = peer_error(ureq::Error::StatusCode(404), what, &asked_for);
+            let error = peer_status_error(404, "", what, &asked_for);
             let RepositoryTransferError::Invalid(message) = error else {
                 panic!("a repository the peer does not serve is not a storage failure");
             };
@@ -432,7 +507,8 @@ mod tests {
         assert!(payload.len() > 10 * 1024 * 1024);
 
         let value: serde_json::Value =
-            read_json(json_response(payload), "transfer export").expect("a body under the bound");
+            read_json(json_response(payload), "transfer export", &asked_for())
+                .expect("a body under the bound");
         assert_eq!(value["value"].as_str().unwrap().len(), 11 * 1024 * 1024);
     }
 
@@ -471,13 +547,15 @@ mod tests {
         let payload = format!(r#"{{"value":"{}"}}"#, "a".repeat(filler));
         assert_eq!(payload.len(), REPOSITORY_TRANSFER_HTTP_BODY_LIMIT);
         let value: serde_json::Value =
-            read_json(json_response(payload), "transfer export").expect("a body at the bound");
+            read_json(json_response(payload), "transfer export", &asked_for())
+                .expect("a body at the bound");
         assert_eq!(value["value"].as_str().unwrap().len(), filler);
 
         let payload = format!(r#"{{"value":"{}"}}"#, "a".repeat(filler + 1));
         assert_eq!(payload.len(), REPOSITORY_TRANSFER_HTTP_BODY_LIMIT + 1);
-        let error = read_json::<serde_json::Value>(json_response(payload), "transfer export")
-            .expect_err("a body one byte past the bound is refused");
+        let error =
+            read_json::<serde_json::Value>(json_response(payload), "transfer export", &asked_for())
+                .expect_err("a body one byte past the bound is refused");
         let RepositoryTransferError::Invalid(message) = error else {
             panic!("a local read bound is not a remote storage failure");
         };


### PR DESCRIPTION
## What

Make repository-v6 transfer identity deterministic across serialization boundaries and preserve a receiver's exact bounded refusal reason in the HTTP client.

## Why

A real staged `kin-db` push into an empty receiver reproduced the production HTTP 422. The receiver reported that the transfer identity recomputed to a different value. The transfer ID hashed raw JSON for the whole pack, including `EntityMetadata.extra`, which is a `HashMap`. Deserializing the same semantic map can change key iteration order and therefore change the raw JSON hash.

The client also discarded the receiver's response body for every non-success status, hiding the invariant that failed.

## How

Repository transfer schema 4 hashes a compact manifest over fields with deterministic representation. Semantic changes, source bodies and imported Git authority stay bound by their content identities, which the receiver independently recomputes before admitting the pack.

The HTTP transport retains non-success responses, reads diagnostic prose under a separate 64 KiB limit, and maps the same status classes while appending the receiver's exact reason.

## Testing

- [x] Pre-fix metadata reconstruction regression failed with equal semantic change IDs and unequal transfer IDs.
- [x] Post-fix metadata reconstruction regression passed.
- [x] The identity regression was falsified by temporarily restoring full semantic-change JSON to the manifest. Its guarded assertion failed, then the fixed form was restored.
- [x] Pre-fix refusal-body regression failed because the receiver reason was absent.
- [x] Post-fix refusal-body regression passed.
- [x] The refusal-body regression was falsified by temporarily dropping the body. Its guarded assertion failed, then the fixed form was restored.
- [x] `cargo test -p kin-remote --all-features`: 119 passed, 0 failed. Doctests: 0 failed.
- [x] `bin/kin-precheck kin`: 16 gates ran, 16 passed, 0 failed, including fmt, clippy and the current CI guard set.
- [x] Release build of `kin` and `kin-daemon` from the exact lane completed.
- [x] A fresh disposable hosted-style receiver accepted the real staged `kin-db` push at schema 4, published `refs/heads/main`, returned `up_to_date` on the immediate second push, and retained generation, head, default ref and imported Git authority after restart.
- [ ] Full local parity did not clear. Magic was 22 pass, 0 fail, 0 unreadable. First Run was pass-with-allowances with two existing named failures. Brownfield was 6 pass, 0 fail, 6 unreadable because fixture logs recorded no completed sweep. A second patched-byte run and a clean-base control at `1b775962bc501e73ce2b8f8b05d05dde459cf5e1` reproduced the same Brownfield result. Hosted CI remains the gate of record.
- [x] Every commit carries a `Signed-off-by` trailer.

Production was not written after rollback. Re-ingest remains blocked until this exact change lands, a controlled deployment advertises schema 4, and live proof clears.
