### PR TITLE
Align transfer boundary types with schema 4

### DIFF
--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -499,7 +499,7 @@ export interface RepositoryTransferLimits {
 }
 
 export interface RepositoryTransferStatus {
-  schema_version: 3;
+  schema_version: 4;
   protocol: "kin-repository-v6-fast-forward";
   repository_id: string;
   destination_ref: RepositoryTransferRefName;
@@ -523,7 +523,7 @@ export interface RepositoryTransferBody {
 }
 
 export interface RepositoryTransferPack {
-  schema_version: 3;
+  schema_version: 4;
   protocol: "kin-repository-v6-fast-forward";
   transfer_id: string;
   operation_id: string;
@@ -561,7 +561,7 @@ export interface RepositoryTransferPack {
 }
 
 export interface RepositoryTransferReceipt {
-  schema_version: 3;
+  schema_version: 4;
   protocol: "kin-repository-v6-fast-forward";
   transfer_id: string;
   repository_id: string;

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -3,8 +3,14 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { assertContract, loadAllSchemas, validateContract } from '../src/index.js';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repositoryRoot = path.resolve(packageRoot, '../..');
 
 test('all schemas load', async () => {
   const schemas = await loadAllSchemas();
@@ -14,6 +20,36 @@ test('all schemas load', async () => {
   assert.ok(schemas.scmResourceGroups);
   assert.ok(schemas.mcpArtifactReadInput);
   assert.ok(schemas.shadowGateReport);
+});
+
+test('repository transfer declarations match the Rust schema authority', async () => {
+  const [declarations, transferSource] = await Promise.all([
+    fs.readFile(path.join(packageRoot, 'src/index.d.ts'), 'utf8'),
+    fs.readFile(
+      path.join(repositoryRoot, 'crates/kin-remote/src/repository_transfer.rs'),
+      'utf8'
+    )
+  ]);
+  const versionMatch = transferSource.match(
+    /pub const REPOSITORY_TRANSFER_SCHEMA_VERSION: u32 = (\d+);/
+  );
+
+  assert.ok(versionMatch, 'Rust transfer schema authority must remain readable');
+  const schemaVersion = Number(versionMatch[1]);
+  assert.equal(schemaVersion, 4, 'update the shared declarations for each schema revision');
+
+  for (const contract of [
+    'RepositoryTransferStatus',
+    'RepositoryTransferPack',
+    'RepositoryTransferReceipt'
+  ]) {
+    assert.ok(
+      declarations.includes(
+        `export interface ${contract} {\n  schema_version: ${schemaVersion};`
+      ),
+      `${contract} must declare repository transfer schema ${schemaVersion}`
+    );
+  }
 });
 
 test('exact MCP artifact reads accept lossless paths and reject lossy selectors', async () => {


### PR DESCRIPTION
## Outcome

Aligns the shared TypeScript repository-transfer declarations with the Rust schema-4 authority for status, pack, and receipt envelopes. Adds a regression that reads the Rust schema constant and requires all three public declarations to match it.

This unblocks KinLab from accepting the schema-4 daemon wire contract without casts or a permissive compatibility window.

## Verification

- `npm --prefix packages/boundary-contracts test`
- `npm --prefix packages/boundary-contracts run lint`
- `npm pack --dry-run --json`
- `bin/kin-precheck kin`: 16/16 gates passed
- Falsification against the pre-fix schema-3 declaration failed on the intended parity assertion

No manifest, package version, lockfile, runtime, release, or production state changes.