### PR TITLE
Materialize hosted repository refs for queries

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -10029,84 +10029,13 @@ fn resolve_repository_ref_target(
     target: &kin_model::RefTarget,
 ) -> Result<kin_model::SemanticChangeId, (StatusCode, String)> {
     let metadata = repository_metadata(snapshot)?;
-    let mut target = target.clone();
-    let mut seen = HashSet::new();
-    loop {
-        match target {
-            kin_model::RefTarget::Change { change_id } => return Ok(change_id),
-            kin_model::RefTarget::ExternalObject { object }
-                if object.kind == kin_model::ExternalObjectKind::Commit =>
-            {
-                return metadata
-                    .aliases
-                    .iter()
-                    .find(|alias| alias.oid == object.oid)
-                    .map(|alias| alias.change_id)
-                    .ok_or_else(|| {
-                        (
-                            StatusCode::FAILED_DEPENDENCY,
-                            format!(
-                                "external commit {} has no repository-v6 semantic alias",
-                                object.oid
-                            ),
-                        )
-                    });
-            }
-            kin_model::RefTarget::ExternalObject { object } => {
-                return Err((
-                    StatusCode::FAILED_DEPENDENCY,
-                    format!(
-                        "repository ref targets external {:?} {}; exact history requires a materializable commit target",
-                        object.kind, object.oid
-                    ),
-                ));
-            }
-            kin_model::RefTarget::Symbolic { target: name } => {
-                if !seen.insert(name.clone()) {
-                    return Err((
-                        StatusCode::FAILED_DEPENDENCY,
-                        format!("repository ref cycle reaches {name}"),
-                    ));
-                }
-                target = metadata
-                    .ref_state
-                    .refs
-                    .iter()
-                    .find(|repository_ref| repository_ref.name == name)
-                    .map(|repository_ref| repository_ref.target.clone())
-                    .ok_or_else(|| {
-                        (
-                            StatusCode::FAILED_DEPENDENCY,
-                            format!("symbolic repository ref target {name} is missing"),
-                        )
-                    })?;
-            }
-        }
-    }
+    crate::state::resolve_repository_target(metadata, target).map_err(repository_authority_error)
 }
 
 fn default_repository_ref(
     metadata: &kin_db::PersistedRepositoryAuthority,
-) -> Option<&kin_model::RepositoryRef> {
-    metadata
-        .ref_state
-        .default_ref
-        .as_ref()
-        .and_then(|name| {
-            metadata
-                .ref_state
-                .refs
-                .iter()
-                .find(|repository_ref| &repository_ref.name == name)
-        })
-        .or_else(|| {
-            metadata
-                .ref_state
-                .refs
-                .iter()
-                .find(|repository_ref| repository_ref.name.is_branch())
-        })
-        .or_else(|| metadata.ref_state.refs.first())
+) -> Result<Option<&kin_model::RepositoryRef>, (StatusCode, String)> {
+    crate::state::select_repository_default_ref(metadata).map_err(repository_authority_error)
 }
 
 fn repository_tree_at(
@@ -10945,7 +10874,7 @@ async fn repo_files(
 ) -> std::result::Result<impl IntoResponse, (StatusCode, String)> {
     let snapshot = repository_authority_snapshot(&state, &repo_id).await?;
     let metadata = repository_metadata(&snapshot)?;
-    let files = if let Some(repository_ref) = default_repository_ref(metadata) {
+    let files = if let Some(repository_ref) = default_repository_ref(metadata)? {
         let change_id = resolve_repository_ref_target(&snapshot, &repository_ref.target)?;
         repository_tree_at(snapshot, &change_id)?
             .into_artifacts()
@@ -10975,7 +10904,7 @@ async fn repo_refs(
             None
         }
     });
-    let selected = default_repository_ref(metadata);
+    let selected = default_repository_ref(metadata)?;
     let selected_head = selected.map(|repository_ref| match &repository_ref.target {
         kin_model::RefTarget::Change { change_id } => change_id.to_string(),
         kin_model::RefTarget::ExternalObject { object } => object.oid.to_string(),
@@ -11034,7 +10963,7 @@ async fn repo_history(
 ) -> std::result::Result<impl IntoResponse, (StatusCode, String)> {
     let snapshot = repository_authority_snapshot(&state, &repo_id).await?;
     let metadata = repository_metadata(&snapshot)?;
-    let Some(repository_ref) = default_repository_ref(metadata) else {
+    let Some(repository_ref) = default_repository_ref(metadata)? else {
         return Ok(Json(RepoHistoryResponse {
             repo_id,
             branch_name: metadata.ref_state.default_ref.as_ref().map(short_ref_name),
@@ -16992,6 +16921,311 @@ mod tests {
                 .is_some_and(|authority| !authority.ref_state.refs.is_empty()),
             "the hosted replica must publish the ref the bootstrap established"
         );
+    }
+
+    /// A schema-4 Git bootstrap persists repository authority, whose top-level
+    /// graph domains are empty by construction. Hosted entity and provenance
+    /// routes must resolve the default ref rather than mistake those empty
+    /// authority caches for the graph the ref names.
+    ///
+    /// Both hosted load paths are pinned here. The first query after receive is
+    /// a lazy reload because receive evicts the repository cache. The second is
+    /// a fresh daemon open against the exact persisted bytes. A restart cannot
+    /// be allowed to change the answer.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn hosted_authority_materialization_survives_schema_four_receive_and_reopen() {
+        let repo_id = format!("hosted-materialize-{}", Uuid::new_v4().simple());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        install_test_registry_override();
+        let source_working = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(source_working.path().join("src")).unwrap();
+        run_test_git(source_working.path(), ["init", "--initial-branch=main"]);
+        run_test_git(
+            source_working.path(),
+            ["config", "user.email", "kin@example.invalid"],
+        );
+        run_test_git(
+            source_working.path(),
+            ["config", "user.name", "Kin Materialization Test"],
+        );
+        std::fs::write(
+            source_working.path().join("src/lib.rs"),
+            b"pub fn greeting(name: &str) -> String { format!(\"hello {name}\") }\n\
+              pub fn greet_world() -> String { greeting(\"world\") }\n",
+        )
+        .unwrap();
+        run_test_git(source_working.path(), ["add", "--all"]);
+        run_test_git(
+            source_working.path(),
+            ["commit", "-s", "-m", "import semantic fixture"],
+        );
+
+        let initialized = kin_core::init_from_git_adopting(source_working.path(), &repository_id)
+            .expect("the source fixture must be admitted through the real Git import");
+        let source_backend = Arc::new(kin_db::LocalFileBackend::new(
+            initialized.layout.kindb_dir(),
+        ));
+        let source_authority =
+            RepositoryAuthorityManager::open(repository_id.clone(), Arc::clone(&source_backend))
+                .unwrap();
+        let source_state = Arc::new(
+            DaemonState::open_with_repo_id(initialized.layout, None)
+                .expect("the imported source daemon must open"),
+        );
+
+        let (status, body) = repo_route(
+            Arc::clone(&source_state),
+            &format!("/repos/{repo_id}/entities"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let source_entities: RepoEntitiesResponse = serde_json::from_slice(&body).unwrap();
+        assert!(
+            !source_entities.entities.is_empty(),
+            "the real Git import must bind semantic entities into its change"
+        );
+        let source_entity_facts = source_entities
+            .entities
+            .iter()
+            .map(|entity| {
+                (
+                    entity.id.clone(),
+                    (
+                        entity.name.clone(),
+                        entity.kind.clone(),
+                        entity.file_path.clone(),
+                    ),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let (status, body) = repo_route(
+            Arc::clone(&source_state),
+            &format!("/repos/{repo_id}/provenance/verify"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let source_provenance: RepoProvenanceVerifyResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert!(source_provenance.valid);
+        assert_eq!(
+            source_provenance.checked_entities,
+            source_entity_facts.len()
+        );
+
+        let (destination_state, _destination_working, destination_storage) =
+            replica_state(&repo_id);
+        let destination_ref = kin_model::RefName::branch(b"main").unwrap();
+        let destination_authority = RepositoryAuthorityManager::open(
+            repository_id.clone(),
+            Arc::new(kin_db::LocalFileBackend::new(
+                destination_storage.path().to_path_buf(),
+            )),
+        )
+        .unwrap();
+        let status = kin_remote::repository_transfer::repository_transfer_status(
+            &destination_authority,
+            &repository_id,
+            &destination_ref,
+        )
+        .unwrap();
+        let expectation =
+            kin_remote::repository_transfer::RepositoryTransferExpectation::try_from(status)
+                .unwrap();
+        let segment = kin_remote::repository_transfer::build_repository_transfer_segment(
+            &source_authority,
+            &destination_ref,
+            &expectation,
+        )
+        .unwrap();
+        assert!(
+            segment.is_final(),
+            "the one-file fixture must fit one segment"
+        );
+        assert_eq!(
+            segment.pack.schema_version,
+            kin_remote::repository_transfer::REPOSITORY_TRANSFER_SCHEMA_VERSION
+        );
+        assert_eq!(segment.pack.schema_version, 4);
+        assert!(
+            segment
+                .pack
+                .changes
+                .iter()
+                .any(|change| !change.entity_deltas.is_empty()),
+            "schema 4 must carry the imported semantic entity deltas"
+        );
+
+        let response = router(Arc::clone(&destination_state))
+            .oneshot(
+                Request::post(format!("/repos/{repo_id}/transfer/receive"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({
+                            "destination_ref": destination_ref,
+                            "pack": segment.pack,
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let receive_status = response.status();
+        let receive_body = axum::body::to_bytes(response.into_body(), 4 * 1024 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            receive_status,
+            StatusCode::OK,
+            "schema-4 receive must commit: {}",
+            String::from_utf8_lossy(&receive_body)
+        );
+        assert!(
+            !destination_state
+                .list_loaded_repos()
+                .await
+                .iter()
+                .any(|loaded| loaded == &repo_id),
+            "receive must evict the old graph so the next route is a lazy reload"
+        );
+
+        // This is the negative control for the incident. Repository-v6 stores
+        // the semantics in immutable changes and deliberately leaves the raw
+        // authority graph empty. Loading these top-level fields directly is
+        // therefore guaranteed to return the production symptom.
+        let recovered = kin_db::load_recovered_snapshot(
+            &kin_db::LocalFileBackend::new(destination_storage.path().to_path_buf()),
+            &repo_id,
+        )
+        .unwrap()
+        .expect("receive must persist repository authority");
+        assert!(
+            recovered.snapshot.entities.is_empty(),
+            "the regression must retain the raw-authority shape that falsifies direct loading"
+        );
+        assert!(
+            recovered
+                .snapshot
+                .changes
+                .values()
+                .any(|change| !change.entity_deltas.is_empty()),
+            "the raw authority must still carry the semantic graph in history"
+        );
+
+        // Post-commit finalization reopens authority independently of both
+        // query-load paths. Its durable read index must be built from the same
+        // materialized ref, not from repository-v6's empty top-level caches.
+        destination_state
+            .finalize_committed_generation_for_test(recovered.generation)
+            .expect("post-commit finalization must materialize the admitted default ref");
+        let read_index = kin_db::ReadIndex::load(
+            &destination_state
+                .layout
+                .kindb_snapshot_path()
+                .with_extension("kidx"),
+        )
+        .expect("finalization must publish the read index");
+        assert_eq!(
+            u64::from(read_index.entity_count),
+            source_provenance.checked_entities as u64,
+            "post-commit finalization must index the transferred entity set"
+        );
+
+        let (status, body) = repo_route(
+            Arc::clone(&destination_state),
+            &format!("/repos/{repo_id}/entities"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let received_entities: RepoEntitiesResponse = serde_json::from_slice(&body).unwrap();
+        let received_entity_facts = received_entities
+            .entities
+            .iter()
+            .map(|entity| {
+                (
+                    entity.id.clone(),
+                    (
+                        entity.name.clone(),
+                        entity.kind.clone(),
+                        entity.file_path.clone(),
+                    ),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_eq!(
+            received_entity_facts, source_entity_facts,
+            "the immediate lazy reload must serve the exact source entity set"
+        );
+        let (status, body) = repo_route(
+            Arc::clone(&destination_state),
+            &format!("/repos/{repo_id}/provenance/verify"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let received_provenance: RepoProvenanceVerifyResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            received_provenance.checked_entities,
+            source_provenance.checked_entities
+        );
+        assert_eq!(
+            received_provenance.verified_entities,
+            source_provenance.verified_entities
+        );
+        assert_eq!(
+            received_provenance.graph_root_hash,
+            source_provenance.graph_root_hash
+        );
+        assert_eq!(received_provenance.valid, source_provenance.valid);
+
+        drop(destination_state);
+        let (reopened, _reopened_working) =
+            reopen_hosted_daemon(destination_storage.path(), &repo_id);
+        let (status, body) =
+            repo_route(Arc::clone(&reopened), &format!("/repos/{repo_id}/entities")).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let reopened_entities: RepoEntitiesResponse = serde_json::from_slice(&body).unwrap();
+        let reopened_entity_facts = reopened_entities
+            .entities
+            .iter()
+            .map(|entity| {
+                (
+                    entity.id.clone(),
+                    (
+                        entity.name.clone(),
+                        entity.kind.clone(),
+                        entity.file_path.clone(),
+                    ),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_eq!(
+            reopened_entity_facts, source_entity_facts,
+            "a full hosted reopen must serve the exact source entity set"
+        );
+        let (status, body) = repo_route(
+            Arc::clone(&reopened),
+            &format!("/repos/{repo_id}/provenance/verify"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let reopened_provenance: RepoProvenanceVerifyResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            reopened_provenance.checked_entities,
+            source_provenance.checked_entities
+        );
+        assert_eq!(
+            reopened_provenance.verified_entities,
+            source_provenance.verified_entities
+        );
+        assert_eq!(
+            reopened_provenance.graph_root_hash,
+            source_provenance.graph_root_hash
+        );
+        assert_eq!(reopened_provenance.valid, source_provenance.valid);
     }
 
     // ── FIR-2729 / FIR-2746: the payload-bearing transfer harness ──────────

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -12,7 +12,6 @@ use kin_core::KinLayout;
 use kin_db::{
     LocalFileBackend, LocalRepositoryAuthorityFreeze, RepositoryAuthorityManager, StorageBackend,
 };
-#[cfg(test)]
 use kin_model::ChangeStore;
 use kin_model::{
     EntityId, EntityStore, FilePathId, Hash256, OperationId, RepoPath, RepositoryCommitReceipt,
@@ -26,6 +25,252 @@ use tracing::{debug, error, info, warn};
 
 use crate::error::{DaemonError, Result};
 use crate::session_registry::SessionCoordinator;
+
+/// Borrowed immutable history used to materialize a hosted repository ref.
+///
+/// Repository-v6 snapshots intentionally leave their top-level graph domains
+/// empty. `ChangeStore::resolve_graph_at` needs only `get_change`, so borrowing
+/// the admitted change map avoids cloning the payload-heavy history into a
+/// throwaway graph before every hosted load.
+struct HostedAuthorityHistory<'a> {
+    changes: &'a HashMap<SemanticChangeId, SemanticChange>,
+}
+
+impl HostedAuthorityHistory<'_> {
+    fn unsupported(operation: &str) -> kin_db::KinDbError {
+        kin_db::KinDbError::StorageError(format!(
+            "{operation} is unavailable through a hosted authority materialization view"
+        ))
+    }
+}
+
+impl ChangeStore for HostedAuthorityHistory<'_> {
+    type Error = kin_db::KinDbError;
+
+    fn get_change(
+        &self,
+        id: &SemanticChangeId,
+    ) -> std::result::Result<Option<SemanticChange>, Self::Error> {
+        Ok(self.changes.get(id).cloned())
+    }
+
+    fn get_entity_history(
+        &self,
+        _id: &EntityId,
+    ) -> std::result::Result<Vec<SemanticChange>, Self::Error> {
+        Err(Self::unsupported("entity history"))
+    }
+
+    fn find_merge_bases(
+        &self,
+        _a: &SemanticChangeId,
+        _b: &SemanticChangeId,
+    ) -> std::result::Result<Vec<SemanticChangeId>, Self::Error> {
+        Err(Self::unsupported("merge-base search"))
+    }
+
+    fn create_change(&self, _change: &SemanticChange) -> std::result::Result<(), Self::Error> {
+        Err(Self::unsupported("change creation"))
+    }
+
+    fn get_changes_since(
+        &self,
+        _base: &SemanticChangeId,
+        _head: &SemanticChangeId,
+    ) -> std::result::Result<Vec<SemanticChange>, Self::Error> {
+        Err(Self::unsupported("change-range listing"))
+    }
+}
+
+fn hosted_materialization_error(detail: impl Into<String>) -> kin_db::KinDbError {
+    kin_db::KinDbError::StorageError(detail.into())
+}
+
+/// Choose the replicated query view for a hosted repository.
+///
+/// Hosted replicas do not transfer a source workspace. The explicit default
+/// ref is the one repository-scoped view every replica does share. An unborn
+/// repository has no refs and materializes empty; once any ref exists, missing
+/// or dangling default-ref authority is refused rather than replaced with an
+/// invented branch choice.
+pub(crate) fn select_repository_default_ref(
+    metadata: &kin_db::PersistedRepositoryAuthority,
+) -> std::result::Result<Option<&kin_model::RepositoryRef>, kin_db::KinDbError> {
+    if metadata.ref_state.refs.is_empty() {
+        return Ok(None);
+    }
+    let default_ref = metadata.ref_state.default_ref.as_ref().ok_or_else(|| {
+        hosted_materialization_error(format!(
+            "repository {} has refs but no persisted default ref",
+            metadata.repository_id
+        ))
+    })?;
+    metadata
+        .ref_state
+        .refs
+        .iter()
+        .find(|repository_ref| &repository_ref.name == default_ref)
+        .map(Some)
+        .ok_or_else(|| {
+            hosted_materialization_error(format!(
+                "repository {} default ref {} is absent from persisted refs",
+                metadata.repository_id, default_ref
+            ))
+        })
+}
+
+/// Resolve a persisted ref target using only the authority envelope admitted
+/// with the snapshot. No Git checkout, object directory, or file projection is
+/// consulted.
+pub(crate) fn resolve_repository_target(
+    metadata: &kin_db::PersistedRepositoryAuthority,
+    target: &kin_model::RefTarget,
+) -> std::result::Result<SemanticChangeId, kin_db::KinDbError> {
+    let mut target = target.clone();
+    let mut seen_refs = HashSet::new();
+    loop {
+        match target {
+            kin_model::RefTarget::Change { change_id } => return Ok(change_id),
+            kin_model::RefTarget::Symbolic { target: name } => {
+                if !seen_refs.insert(name.clone()) {
+                    return Err(hosted_materialization_error(format!(
+                        "hosted repository ref cycle reaches {name}"
+                    )));
+                }
+                target = metadata
+                    .ref_state
+                    .refs
+                    .iter()
+                    .find(|repository_ref| repository_ref.name == name)
+                    .map(|repository_ref| repository_ref.target.clone())
+                    .ok_or_else(|| {
+                        hosted_materialization_error(format!(
+                            "hosted symbolic repository ref target {name} is missing"
+                        ))
+                    })?;
+            }
+            kin_model::RefTarget::ExternalObject { object } => {
+                let mut current = object;
+                let mut seen_objects = HashSet::new();
+                while current.kind == kin_model::ExternalObjectKind::Tag {
+                    if !seen_objects.insert(current) {
+                        return Err(hosted_materialization_error(format!(
+                            "hosted Git authority contains an annotated-tag cycle through {}",
+                            current.oid
+                        )));
+                    }
+                    let authority = metadata.git_external_authority.as_ref().ok_or_else(|| {
+                        hosted_materialization_error(format!(
+                            "hosted external tag {} has no persisted Git authority for exact peeling",
+                            current.oid
+                        ))
+                    })?;
+                    let entry = authority
+                        .closure
+                        .objects
+                        .iter()
+                        .find(|entry| entry.record.object == current)
+                        .ok_or_else(|| {
+                            hosted_materialization_error(format!(
+                                "hosted external tag {} is absent from persisted Git authority",
+                                current.oid
+                            ))
+                        })?;
+                    let mut targets = entry.dependencies.iter().filter_map(|dependency| {
+                        (dependency.kind == kin_model::GitObjectDependencyKind::TagTarget)
+                            .then_some(dependency.target)
+                    });
+                    current = targets.next().ok_or_else(|| {
+                        hosted_materialization_error(format!(
+                            "hosted external tag {} has no exact target",
+                            entry.record.object.oid
+                        ))
+                    })?;
+                    if targets.next().is_some() {
+                        return Err(hosted_materialization_error(format!(
+                            "hosted external tag {} has multiple exact targets",
+                            entry.record.object.oid
+                        )));
+                    }
+                }
+                if current.kind != kin_model::ExternalObjectKind::Commit {
+                    return Err(hosted_materialization_error(format!(
+                        "hosted repository ref target {:?} {} does not peel to a commit",
+                        current.kind, current.oid
+                    )));
+                }
+                return metadata
+                    .aliases
+                    .iter()
+                    .find(|alias| alias.oid == current.oid)
+                    .map(|alias| alias.change_id)
+                    .ok_or_else(|| {
+                        hosted_materialization_error(format!(
+                            "hosted external commit {} has no semantic change alias",
+                            current.oid
+                        ))
+                    });
+            }
+        }
+    }
+}
+
+/// Convert one raw repository-v6 authority snapshot into the non-authoritative
+/// graph its default ref names.
+///
+/// The durable authority keeps immutable semantic history and deliberately
+/// requires its top-level entity, relation, tree, and revision caches to be
+/// empty. Every hosted authority-to-query conversion must pass through this
+/// helper, or a valid transfer presents as a zero-entity repository.
+fn materialize_hosted_repository_snapshot(
+    mut snapshot: kin_db::GraphSnapshot,
+) -> Result<(kin_db::GraphSnapshot, Option<SemanticChangeId>)> {
+    let Some(metadata) = snapshot.repository_authority.as_ref() else {
+        // Envelope-free hosted snapshots predate repository-v6 and own their
+        // top-level graph directly. Preserve that compatibility path exactly.
+        return Ok((snapshot, None));
+    };
+
+    let selected = select_repository_default_ref(metadata)
+        .map_err(DaemonError::Graph)?
+        .cloned();
+    let (resolved, head) = match selected {
+        Some(repository_ref) => {
+            let head = resolve_repository_target(metadata, &repository_ref.target)
+                .map_err(DaemonError::Graph)?;
+            let resolved = HostedAuthorityHistory {
+                changes: &snapshot.changes,
+            }
+            .resolve_graph_at(&head)
+            .map_err(DaemonError::Graph)?;
+            (Some(resolved), Some(head))
+        }
+        None => (None, None),
+    };
+
+    match resolved {
+        Some(resolved) => {
+            snapshot.entities = resolved.entities;
+            snapshot.relations = resolved.relations;
+            snapshot.entity_revisions = resolved.entity_revisions;
+            snapshot.resolved_tree = resolved.tree;
+            snapshot.external_references = resolved.external_references;
+        }
+        None => {
+            snapshot.entities.clear();
+            snapshot.relations.clear();
+            snapshot.entity_revisions.clear();
+            snapshot.resolved_tree = ResolvedTree::default();
+            snapshot.external_references.clear();
+        }
+    }
+    snapshot.outgoing.clear();
+    snapshot.incoming.clear();
+    // This is a derived ref view. Publication authority remains owned by the
+    // storage manager and must never be serialized back out of the query graph.
+    snapshot.repository_authority = None;
+    Ok((snapshot, head))
+}
 
 /// Read-only overlay used to resolve the complete source tree an incoming
 /// change would create without first inserting that change into graph
@@ -2842,8 +3087,10 @@ impl DaemonState {
                     // an envelope-free write would erase.
                     let hosted_authority_envelope =
                         recovered.snapshot.repository_authority.is_some();
+                    let (query_snapshot, materialized_head) =
+                        materialize_hosted_repository_snapshot(recovered.snapshot)?;
                     let g = kin_db::InMemoryGraph::from_snapshot_with_text_index(
-                        recovered.snapshot,
+                        query_snapshot,
                         text_index_path.clone(),
                     )
                     .map_err(DaemonError::from)?;
@@ -2852,6 +3099,7 @@ impl DaemonState {
                         generation = recovered.generation,
                         deltas_replayed = recovered.deltas_applied,
                         hosted_authority_envelope,
+                        materialized_head = ?materialized_head,
                         "loaded graph from storage backend"
                     );
                     (
@@ -4104,9 +4352,11 @@ impl DaemonState {
         {
             Some(recovered) => {
                 let text_index_path = self.layout.text_index_dir();
+                let (query_snapshot, materialized_head) =
+                    materialize_hosted_repository_snapshot(recovered.snapshot)?;
                 let graph = Arc::new(
                     kin_db::InMemoryGraph::from_snapshot_with_text_index(
-                        recovered.snapshot,
+                        query_snapshot,
                         text_index_path,
                     )
                     .map_err(DaemonError::from)?,
@@ -4115,6 +4365,7 @@ impl DaemonState {
                     repo_id,
                     generation = recovered.generation,
                     deltas_replayed = recovered.deltas_applied,
+                    materialized_head = ?materialized_head,
                     "loaded repo graph from storage backend"
                 );
                 Ok(graph)
@@ -5437,6 +5688,11 @@ impl DaemonState {
         Ok(())
     }
 
+    #[cfg(test)]
+    pub(crate) fn finalize_committed_generation_for_test(&self, generation: u64) -> Result<()> {
+        self.finalize_committed_generation(generation)
+    }
+
     /// Finish startup artifacts from the graph that was just loaded and
     /// validated before the state is exposed to any request or mutator.
     /// Reopening the same authority here doubles graph memory and repeats
@@ -5714,8 +5970,10 @@ impl DaemonState {
                             ),
                         )));
                     }
+                    let (query_snapshot, _) =
+                        materialize_hosted_repository_snapshot(recovered.snapshot)?;
                     Arc::new(
-                        kin_db::InMemoryGraph::from_snapshot(recovered.snapshot)
+                        kin_db::InMemoryGraph::from_snapshot(query_snapshot)
                             .map_err(DaemonError::from)?,
                     )
                 }
@@ -6345,6 +6603,80 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         sync_directory_metadata(directory.path())
             .expect("directory metadata sync must not reject a valid host directory");
+    }
+
+    fn empty_repository_metadata(label: &str) -> kin_db::PersistedRepositoryAuthority {
+        let storage = tempfile::tempdir().unwrap();
+        let repository_id =
+            RepositoryId::new(format!("{label}-{}", uuid::Uuid::new_v4().simple())).unwrap();
+        let authority = RepositoryAuthorityManager::open(
+            repository_id,
+            Arc::new(LocalFileBackend::new(storage.path().to_path_buf())),
+        )
+        .unwrap();
+        authority.read_authority().metadata().clone()
+    }
+
+    #[test]
+    fn hosted_authority_materialization_accepts_only_a_valid_unborn_repository() {
+        let mut metadata = empty_repository_metadata("unborn-default");
+        metadata.ref_state.default_ref = Some(kin_model::RefName::branch(b"main").unwrap());
+        assert!(
+            select_repository_default_ref(&metadata).unwrap().is_none(),
+            "an unborn default names no graph and materializes empty"
+        );
+    }
+
+    #[test]
+    fn hosted_authority_materialization_refuses_missing_or_dangling_default_ref() {
+        let mut metadata = empty_repository_metadata("invalid-default");
+        let repository_id = metadata.repository_id.clone();
+        let main = kin_model::RefName::branch(b"main").unwrap();
+        let head = SemanticChangeId::from_hash(Hash256::from_bytes([7; 32]));
+        metadata.ref_state.refs.push(kin_model::RepositoryRef {
+            repository_id,
+            name: main.clone(),
+            target: kin_model::RefTarget::change(head),
+        });
+
+        let missing = select_repository_default_ref(&metadata)
+            .expect_err("refs without an explicit default must fail closed");
+        assert!(missing.to_string().contains("no persisted default ref"));
+
+        metadata.ref_state.default_ref = Some(kin_model::RefName::branch(b"absent").unwrap());
+        let dangling = select_repository_default_ref(&metadata)
+            .expect_err("a default name absent from the ref set must fail closed");
+        assert!(dangling.to_string().contains("absent from persisted refs"));
+    }
+
+    #[test]
+    fn hosted_authority_materialization_resolves_a_symbolic_chain_exactly() {
+        let mut metadata = empty_repository_metadata("symbolic-default");
+        let repository_id = metadata.repository_id.clone();
+        let main = kin_model::RefName::branch(b"main").unwrap();
+        let selected = kin_model::RefName::branch(b"selected").unwrap();
+        let head = SemanticChangeId::from_hash(Hash256::from_bytes([9; 32]));
+        metadata.ref_state.refs = vec![
+            kin_model::RepositoryRef {
+                repository_id: repository_id.clone(),
+                name: main.clone(),
+                target: kin_model::RefTarget::symbolic(selected.clone()),
+            },
+            kin_model::RepositoryRef {
+                repository_id,
+                name: selected,
+                target: kin_model::RefTarget::change(head),
+            },
+        ];
+        metadata.ref_state.default_ref = Some(main);
+
+        let repository_ref = select_repository_default_ref(&metadata)
+            .unwrap()
+            .expect("the explicit default ref must be selected");
+        assert_eq!(
+            resolve_repository_target(&metadata, &repository_ref.target).unwrap(),
+            head
+        );
     }
 
     /// Both sides at the resolution layer. A client whose session outlasts the


### PR DESCRIPTION
## Problem

Hosted `load_repo_graph` fed raw schema 4 authority directly to `InMemoryGraph`, unlike
local ref materialization. Schema 4 source semantics live in immutable `SemanticChange`
history while the repository authority top-level entity map is intentionally empty. A
correct hosted graph appeared empty on queries because no default ref was materialized.

The attempted five-repository schema 4 cutover was stopped after only `kin-db` when
`/entities` returned empty immediately after load. The other four repositories were not
changed. The `kin-db` objects were restored from versioned backups.

## Fix

Resolve the exact persisted default ref and materialize through shared hosted authority
logic on initial open, lazy open, and post-commit finalization. Handle symbolic chains
and external annotated tags through persisted Git authority only. Fail closed on missing
default refs, dangling refs, and cycles. Use no filesystem or Git checkout as runtime
answer authority.

## Evidence

- Pre-fix regression reproduced two exact source Function entities becoming an empty
  hosted destination.
- Repaired focused suite passed 4/4: immediate visibility, reopen visibility, exact
  provenance, and post-commit read-index visibility.
- Independent focused review returned GO with no P0 or P1 finding.
- Magic parity: 22/22 passed.
- Brownfield parity (corrected `RUST_LOG=info`): 11 pass, 0 fail, 1 unreadable
  (check 4, FIR-2464 trace truncation, tracked and being repaired separately).
- First run: 9 pass, 2 fail (FIR-2501 and FIR-2580, existing named allowances).
- Precheck: 16 gates ran, 16 passed, 0 failed on `67ddc013c800e95a07a3c170a985f09df925a01d`.

Brownfield unreadable root cause: the shell carried `RUST_LOG=warn`, the suite inherited
it, and `sweep_gate` requires the INFO-level `LSP cold sweep complete` line. The gate
suppressed its own evidence and declared checks unreadable. The corrected run with
`RUST_LOG=info` reduced 6 unreadables to 1 tracked allowance.

Parity evidence: `.kin-coord/parity/20260827T160832Z/parity.json`
Audit: `.kin-coord/reports/postpushvis-parity-unreadable-audit-20260827.md`