### PR TITLE
Restore the kin-registry-release dispatch receiver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Test release ordering and npm provenance policy
         run: |
           python3 ./scripts/test-release-workflow-authority.py
+          python3 ./scripts/test-kin-registry-release-receiver.py
           python3 ./scripts/test_install_optional_vfs.py
           python3 ./scripts/test_installer_parity.py
           # Every install surface builds a release asset name; the release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened]
   merge_group:
   repository_dispatch:
     types: [dependency-updated]
@@ -875,8 +876,28 @@ jobs:
     name: Fast gate lint and policy
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Verify registry dependency-wave admission
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/verify-kin-registry-wave-head.py \
+            --event-file "$GITHUB_EVENT_PATH" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --repository "$GITHUB_REPOSITORY" \
+            --ref "$GITHUB_REF" \
+            --workflow-sha "$GITHUB_SHA" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --attestation-wait-seconds 300
 
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain

--- a/.github/workflows/kin-registry-release-attest.yml
+++ b/.github/workflows/kin-registry-release-attest.yml
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Kin Registry Release Admission Attester
+
+on:
+  workflow_run:
+    workflows: [Kin Registry Release Receiver]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  attest-completed-receiver:
+    name: Attest completed Kin registry receiver
+    if: >-
+      github.event.workflow_run.status == 'completed' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'repository_dispatch' ||
+       github.event.workflow_run.event == 'schedule') &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    concurrency:
+      group: kin-registry-admission-${{ github.repository }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release-tag
+    env:
+      SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+      SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+      SOURCE_POLICY_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Checkout the exact completed receiver policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ env.SOURCE_POLICY_SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download the exact completed-run admission
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: kin-registry-result-${{ env.SOURCE_RUN_ID }}-${{ env.SOURCE_RUN_ATTEMPT }}
+          path: ${{ runner.temp }}/kin-registry-result
+          github-token: ${{ github.token }}
+          run-id: ${{ env.SOURCE_RUN_ID }}
+
+      - name: Validate terminal server authority and live admitted head
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          result="$(python3 scripts/attest-kin-registry-wave.py validate \
+            --event-file "$GITHUB_EVENT_PATH" \
+            --admission-file "$RUNNER_TEMP/kin-registry-result/result.json" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --repository "$GITHUB_REPOSITORY")"
+          echo "changed=$(jq -r .changed <<<"$result")" >> "$GITHUB_OUTPUT"
+          echo "needs_attestation=$(jq -r .needs_attestation <<<"$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Mint repository-scoped attestation token
+        id: app-token
+        if: steps.validate.outputs.changed == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: firelock-ai
+          repositories: kin
+          permission-contents: read
+          permission-pull-requests: write
+          permission-issues: write
+
+      - name: Verify exact attestation App identity and scope
+        if: steps.validate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-kin-release-app-token.py \
+            --app-slug "$APP_SLUG" \
+            --repository "$GITHUB_REPOSITORY"
+
+      - name: Persist exact post-completion admission attestation
+        if: >-
+          steps.validate.outputs.changed == 'true' &&
+          steps.validate.outputs.needs_attestation == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/attest-kin-registry-wave.py post \
+            --admission-file "$RUNNER_TEMP/kin-registry-result/result.json" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --repository "$GITHUB_REPOSITORY"
+
+      - name: Inspect exact-head CI after the persisted attestation
+        id: recheck
+        if: steps.validate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          result="$(python3 scripts/attest-kin-registry-wave.py recheck-status \
+            --admission-file "$RUNNER_TEMP/kin-registry-result/result.json" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --repository "$GITHUB_REPOSITORY")"
+          echo "needs_retrigger=$(jq -r .needs_retrigger <<<"$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Retrigger exact-head CI when the attestation arrived late
+        if: >-
+          steps.validate.outputs.changed == 'true' &&
+          steps.recheck.outputs.needs_retrigger == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/attest-kin-registry-wave.py retrigger \
+            --admission-file "$RUNNER_TEMP/kin-registry-result/result.json" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --repository "$GITHUB_REPOSITORY"
+
+      - name: Verify a required exact-head CI recheck materialized
+        if: steps.validate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/attest-kin-registry-wave.py recheck-status \
+            --admission-file "$RUNNER_TEMP/kin-registry-result/result.json" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --repository "$GITHUB_REPOSITORY" \
+            --wait-seconds 120 \
+            --require-recheck

--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Kin Registry Release Receiver
+
+# repository_dispatch resolves this workflow from the default branch. The
+# sender uses one exact event type, and the validation job below refuses any
+# payload that does not bind an allowed crate to its owning source repository.
+on:
+  repository_dispatch:
+    types: [kin-registry-release]
+
+permissions:
+  contents: read
+
+# GitHub keeps at most one pending run per concurrency group. Every surviving
+# run refreshes the complete allowed pin set, so replacing an older pending
+# event cannot strand that event's crate on its old registry version.
+concurrency:
+  group: kin-registry-release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  validate-dispatch:
+    name: Validate Kin registry release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted receiver policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Validate event and package authority
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          python3 scripts/validate-kin-registry-release.py \
+            --event-file "$GITHUB_EVENT_PATH" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --event-action "$EVENT_ACTION" \
+            --actor "$GITHUB_ACTOR" \
+            --repository "$GITHUB_REPOSITORY" \
+            --default-branch "$DEFAULT_BRANCH" \
+            --ref "$GITHUB_REF" \
+            --workflow-sha "$GITHUB_SHA"
+
+  dependency-wave:
+    name: Refresh Kin registry pins
+    needs: validate-dispatch
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: release-tag
+    permissions:
+      contents: read
+    env:
+      KIN_ACTIONS_SHA: 398595fa14ba1eaebca6eb176facd8a57ce9db05 # v0.1.33
+      WAVE_BRANCH: automation/kin-registry-dependency-wave
+    steps:
+      - name: Mint repository-scoped dependency-wave token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: firelock-ai
+          repositories: kin
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
+      - name: Checkout exact trusted Kin main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact Kin dependency updater
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: firelock-ai/kin-actions
+          ref: ${{ env.KIN_ACTIONS_SHA }}
+          path: .kin-actions
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+
+      - name: Configure Kin registry
+        run: |
+          set -euo pipefail
+          cargo_home="$RUNNER_TEMP/kin-cargo-home"
+          echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
+          mkdir -p "$cargo_home"
+          cat > "$cargo_home/config.toml" <<'TOML'
+          [registries.kin]
+          index = "sparse+https://kinlab.ai/registry/cargo/"
+          TOML
+
+      - name: Update the allowed root-manifest pins
+        id: update
+        env:
+          EVENT_CRATE: ${{ github.event.client_payload.crate_name }}
+          EVENT_VERSION: ${{ github.event.client_payload.crate_version }}
+        run: |
+          set -uo pipefail
+          set +e
+          output="$(python3 .kin-actions/scripts/update-cargo-registry-deps.py \
+            --manifest Cargo.toml \
+            --crate kin-blobs \
+            --crate kin-model \
+            --crate kin-db \
+            --crate kin-lsp \
+            --crate kin-vfs-core \
+            --crate "$EVENT_CRATE" \
+            --event-crate "$EVENT_CRATE" \
+            --version "$EVENT_VERSION" 2>&1)"
+          code=$?
+          set -e
+          printf '%s\n' "$output"
+          case "$code" in
+            0)
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            2)
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+              ;;
+            3)
+              reason="$(printf '%s\n' "$output" \
+                | sed -n 's/^dependency wave blocked: //p' | head -1)"
+              if [ -z "$reason" ]; then
+                echo "::error::dependency updater reported a blocked roll without a reason"
+                exit 1
+              fi
+              echo "::error title=Kin dependency wave blocked::$reason"
+              exit 3
+              ;;
+            *)
+              echo "::error::dependency updater failed with exit code $code"
+              exit "$code"
+              ;;
+          esac
+          echo "title=refresh Kin registry pins after ${EVENT_CRATE}@${EVENT_VERSION}" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Snapshot the exact generated dependency delta
+        id: generated
+        if: steps.update.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          validator="$RUNNER_TEMP/validate-dependency-wave-generated.py"
+          git -C .kin-actions show \
+            "${KIN_ACTIONS_SHA}:scripts/validate-dependency-wave.py" \
+            > "$validator"
+          generated="$(python3 "$validator" \
+            --manifest Cargo.toml \
+            --version-mode manual \
+            --bump-own-version false \
+            --ephemeral-path .kin-actions)"
+          echo "expected_tree=$(jq -r .tree <<<"$generated")" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Verify the updated Kin consumers
+        if: steps.update.outputs.changed == 'true'
+        run: cargo check -p kin-core -p kin-cli -p kin-daemon -p kin-mcp
+
+      - name: Admit the exact verified dependency delta
+        id: admission
+        if: steps.update.outputs.changed == 'true'
+        env:
+          EXPECTED_TREE: ${{ steps.generated.outputs.expected_tree }}
+        run: |
+          set -euo pipefail
+          validator="$RUNNER_TEMP/validate-dependency-wave.py"
+          git -C .kin-actions show \
+            "${KIN_ACTIONS_SHA}:scripts/validate-dependency-wave.py" \
+            > "$validator"
+          admission="$(python3 "$validator" \
+            --manifest Cargo.toml \
+            --version-mode manual \
+            --bump-own-version false \
+            --expected-tree "$EXPECTED_TREE" \
+            --ephemeral-path .kin-actions)"
+          {
+            echo "expected_tree=$(jq -r .tree <<<"$admission")"
+            echo "add_paths<<KIN_PATHS"
+            jq -r '.paths[]' <<<"$admission"
+            echo "KIN_PATHS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Clean helper checkout
+        if: always()
+        run: rm -rf .kin-actions
+
+      - name: Ensure dependency-wave labels exist
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh label create release:consumer-bump --force \
+            --color ededed --description "Kin release automation"
+          gh label create proof-impacting --force \
+            --color ededed --description "Kin release automation"
+
+      - name: Open or update the dependency bump PR
+        id: open-pr
+        if: steps.update.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ env.WAVE_BRANCH }}
+          base: ${{ github.event.repository.default_branch }}
+          add-paths: ${{ steps.admission.outputs.add_paths }}
+          delete-branch: true
+          signoff: true
+          labels: release:consumer-bump,proof-impacting
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          commit-message: "chore(deps): ${{ steps.update.outputs.title }}"
+          title: "chore(deps): ${{ steps.update.outputs.title }}"
+          body: |
+            Automated Kin registry dependency wave.
+
+            This PR updates the allowed root-manifest registry pins after a validated Kin registry publish and verifies the affected Kin consumers before opening or updating the fixed automation branch.
+
+      - name: Verify exact first-party generated PR
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.open-pr.outputs.pull-request-number }}
+          ACTION_HEAD: ${{ steps.open-pr.outputs.pull-request-head-sha }}
+          EXPECTED_TREE: ${{ steps.admission.outputs.expected_tree }}
+          EXPECTED_BASE: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$PR" =~ ^[1-9][0-9]*$ ||
+                ! "$ACTION_HEAD" =~ ^[0-9a-f]{40}$ ||
+                ! "$EXPECTED_TREE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::dependency action returned invalid PR identity"
+            exit 1
+          fi
+          pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}")"
+          api_head="$(jq -r .head.sha <<<"$pull")"
+          if [ "$(jq -r .state <<<"$pull")" != open ] ||
+             [ "$(jq -r .head.repo.full_name <<<"$pull")" != "$GITHUB_REPOSITORY" ] ||
+             [ "$(jq -r .head.ref <<<"$pull")" != "$WAVE_BRANCH" ] ||
+             [ "$(jq -r .base.ref <<<"$pull")" != "$EXPECTED_BASE" ] ||
+             [ "$api_head" != "$ACTION_HEAD" ]; then
+            echo "::error::dependency PR is not the exact first-party automation branch"
+            exit 1
+          fi
+          api_tree="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/commits/${api_head}" --jq .tree.sha)"
+          if [ "$api_tree" != "$EXPECTED_TREE" ]; then
+            echo "::error::dependency PR tree $api_tree differs from admitted $EXPECTED_TREE"
+            exit 1
+          fi

--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -3,22 +3,17 @@
 
 name: Kin Registry Release Receiver
 
-# repository_dispatch resolves this workflow from the default branch. The
-# sender uses one exact event type, and the validation job below refuses any
-# payload that does not bind an allowed crate to its owning source repository.
+# Both events resolve this workflow from the default branch. Dispatch validates
+# the exact package boundary. The hourly eventless arm reconciles the full pin
+# set when a notification was missed or safely coalesced.
 on:
   repository_dispatch:
     types: [kin-registry-release]
+  schedule:
+    - cron: "17 * * * *"
 
 permissions:
   contents: read
-
-# GitHub keeps at most one pending run per concurrency group. Every surviving
-# run refreshes the complete allowed pin set, so replacing an older pending
-# event cannot strand that event's crate on its old registry version.
-concurrency:
-  group: kin-registry-release-${{ github.repository }}
-  cancel-in-progress: false
 
 jobs:
   validate-dispatch:
@@ -47,19 +42,57 @@ jobs:
             --ref "$GITHUB_REF" \
             --workflow-sha "$GITHUB_SHA"
 
-  dependency-wave:
-    name: Refresh Kin registry pins
+  disarm-wave:
+    name: Disarm inherited Kin registry landing state
     needs: validate-dispatch
+    concurrency:
+      group: kin-registry-release-disarm-${{ github.repository }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10
     environment: release-tag
     permissions:
       contents: read
     env:
-      KIN_ACTIONS_SHA: 398595fa14ba1eaebca6eb176facd8a57ce9db05 # v0.1.33
+      BASE_BRANCH: main
       WAVE_BRANCH: automation/kin-registry-dependency-wave
     steps:
-      - name: Mint repository-scoped dependency-wave token
+      - name: Bind early disarm to the queued workflow policy
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          base_sha="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
+            --jq .object.sha)"
+          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]] ||
+             [ "$base_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::early disarm is not bound to exact queued protected main"
+            exit 1
+          fi
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact policy for early disarm
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.base.outputs.base_sha }}
+          persist-credentials: false
+
+      - name: Refuse protected-main movement before early-disarm token mint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current_base="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
+            --jq .object.sha)"
+          if [ "$current_base" != "$GITHUB_SHA" ]; then
+            echo "::error::protected main moved before early disarm"
+            exit 1
+          fi
+
+      - name: Mint repository-scoped early-disarm token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -67,14 +100,71 @@ jobs:
           private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
           owner: firelock-ai
           repositories: kin
-          permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
 
-      - name: Checkout exact trusted Kin main
+      - name: Verify exact early-disarm App identity and scope
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-kin-release-app-token.py \
+            --app-slug "$APP_SLUG" \
+            --repository "$GITHUB_REPOSITORY"
+
+      - name: Clear inherited landing state before dependency preparation
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ensure-kin-registry-wave-no-automerge.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --branch "$WAVE_BRANCH" \
+            --base "$BASE_BRANCH"
+
+  prepare-wave:
+    name: Prepare and compile Kin registry pins
+    needs: [validate-dispatch, disarm-wave]
+    # Invalid dispatches never enter this queue. Every admitted run reconciles
+    # the complete dependency set, so GitHub's pending-run coalescing is safe.
+    concurrency:
+      group: kin-registry-release-prepare-${{ github.repository }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.update.outputs.changed }}
+      title: ${{ steps.update.outputs.title }}
+      base_sha: ${{ steps.base.outputs.base_sha }}
+    env:
+      KIN_ACTIONS_SHA: 398595fa14ba1eaebca6eb176facd8a57ce9db05 # v0.1.33
+      BASE_BRANCH: main
+    steps:
+      - name: Bind preparation to the queued workflow policy
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          base_sha="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
+            --jq .object.sha)"
+          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::protected main returned invalid object id $base_sha"
+            exit 1
+          fi
+          if [ "$base_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::queued receiver policy $GITHUB_SHA is not protected main $base_sha"
+            exit 1
+          fi
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact queued protected main
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ steps.base.outputs.base_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -95,10 +185,10 @@ jobs:
           cargo_home="$RUNNER_TEMP/kin-cargo-home"
           echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
           mkdir -p "$cargo_home"
-          cat > "$cargo_home/config.toml" <<'TOML'
-          [registries.kin]
-          index = "sparse+https://kinlab.ai/registry/cargo/"
-          TOML
+          printf '%s\n' \
+            '[registries.kin]' \
+            'index = "sparse+https://kinlab.ai/registry/cargo/"' \
+            > "$cargo_home/config.toml"
 
       - name: Update the allowed root-manifest pins
         id: update
@@ -107,27 +197,42 @@ jobs:
           EVENT_VERSION: ${{ github.event.client_payload.crate_version }}
         run: |
           set -uo pipefail
+          crate_args=(
+            --crate kin-blobs
+            --crate kin-model
+            --crate kin-db
+            --crate kin-lsp
+            --crate kin-vfs-core
+          )
+          title="refresh Kin registry dependency pins"
+          case "$GITHUB_EVENT_NAME" in
+            repository_dispatch)
+              if [ -z "$EVENT_CRATE" ] || [ -z "$EVENT_VERSION" ]; then
+                echo "::error::validated dispatch lost its crate or version"
+                exit 1
+              fi
+              crate_args+=(
+                --event-crate "$EVENT_CRATE"
+                --version "$EVENT_VERSION"
+              )
+              title="refresh Kin registry pins after ${EVENT_CRATE}@${EVENT_VERSION}"
+              ;;
+            schedule) ;;
+            *)
+              echo "::error::unsupported dependency-wave event $GITHUB_EVENT_NAME"
+              exit 1
+              ;;
+          esac
           set +e
           output="$(python3 .kin-actions/scripts/update-cargo-registry-deps.py \
             --manifest Cargo.toml \
-            --crate kin-blobs \
-            --crate kin-model \
-            --crate kin-db \
-            --crate kin-lsp \
-            --crate kin-vfs-core \
-            --crate "$EVENT_CRATE" \
-            --event-crate "$EVENT_CRATE" \
-            --version "$EVENT_VERSION" 2>&1)"
+            "${crate_args[@]}" 2>&1)"
           code=$?
           set -e
           printf '%s\n' "$output"
           case "$code" in
-            0)
-              echo "changed=true" >> "$GITHUB_OUTPUT"
-              ;;
-            2)
-              echo "changed=false" >> "$GITHUB_OUTPUT"
-              ;;
+            0) echo "changed=true" >> "$GITHUB_OUTPUT" ;;
+            2) echo "changed=false" >> "$GITHUB_OUTPUT" ;;
             3)
               reason="$(printf '%s\n' "$output" \
                 | sed -n 's/^dependency wave blocked: //p' | head -1)"
@@ -143,8 +248,7 @@ jobs:
               exit "$code"
               ;;
           esac
-          echo "title=refresh Kin registry pins after ${EVENT_CRATE}@${EVENT_VERSION}" \
-            >> "$GITHUB_OUTPUT"
+          echo "title=$title" >> "$GITHUB_OUTPUT"
 
       - name: Snapshot the exact generated dependency delta
         id: generated
@@ -163,11 +267,7 @@ jobs:
           echo "expected_tree=$(jq -r .tree <<<"$generated")" \
             >> "$GITHUB_OUTPUT"
 
-      - name: Verify the updated Kin consumers
-        if: steps.update.outputs.changed == 'true'
-        run: cargo check -p kin-core -p kin-cli -p kin-daemon -p kin-mcp
-
-      - name: Admit the exact verified dependency delta
+      - name: Admit the generated dependency delta before compilation
         id: admission
         if: steps.update.outputs.changed == 'true'
         env:
@@ -184,19 +284,176 @@ jobs:
             --bump-own-version false \
             --expected-tree "$EXPECTED_TREE" \
             --ephemeral-path .kin-actions)"
+          echo "expected_tree=$(jq -r .tree <<<"$admission")" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Clean trusted updater checkout before the handoff
+        if: steps.update.outputs.changed == 'true'
+        run: rm -rf -- .kin-actions
+
+      - name: Build the hash-bound data-only candidate handoff
+        if: steps.update.outputs.changed == 'true'
+        env:
+          ADMITTED_BASE: ${{ steps.base.outputs.base_sha }}
+          EXPECTED_TREE: ${{ steps.admission.outputs.expected_tree }}
+        run: |
+          set -euo pipefail
+          candidate_dir="$RUNNER_TEMP/kin-registry-candidate"
+          python3 scripts/kin-registry-wave-artifact.py prepare \
+            --workspace "$GITHUB_WORKSPACE" \
+            --output-dir "$candidate_dir" \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --base "$ADMITTED_BASE" \
+            --expected-tree "$EXPECTED_TREE"
+
+      - name: Upload the exact candidate before dependency code executes
+        if: steps.update.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kin-registry-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/kin-registry-candidate
+          if-no-files-found: error
+          retention-days: 7
+
+      # This must remain the final step. Newly resolved registry code can run
+      # build scripts and proc macros, so nothing on this runner may consume a
+      # credential, PATH, GITHUB_ENV, or artifact after compilation begins.
+      - name: Verify the updated Kin consumers on the credential-free runner
+        if: steps.update.outputs.changed == 'true'
+        run: cargo check --locked -p kin-core -p kin-cli -p kin-daemon -p kin-mcp
+
+  mutate-wave:
+    name: Update the fixed Kin registry PR
+    needs: [validate-dispatch, prepare-wave]
+    concurrency:
+      group: kin-registry-release-mutate-${{ github.repository }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: release-tag
+    permissions:
+      actions: read
+      contents: read
+    env:
+      KIN_RELEASE_APP_API_ID: "4370197"
+      KIN_RELEASE_APP_OWNER_ID: "69090636"
+      KIN_RELEASE_BOT_USER_ID: "308181894"
+      BASE_BRANCH: main
+      WAVE_BRANCH: automation/kin-registry-dependency-wave
+      ADMITTED_BASE: ${{ needs.prepare-wave.outputs.base_sha }}
+    steps:
+      - name: Rebind the fresh mutation runner to queued policy
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          base_sha="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
+            --jq .object.sha)"
+          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]] ||
+             [ "$base_sha" != "$GITHUB_SHA" ] ||
+             [ "$base_sha" != "$ADMITTED_BASE" ]; then
+            echo "::error::fresh mutation runner is not bound to exact queued protected main"
+            exit 1
+          fi
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact protected main for trusted mutation code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.base.outputs.base_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Refuse protected-main movement immediately before token mint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current_base="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
+            --jq .object.sha)"
+          if [ "$current_base" != "$GITHUB_SHA" ] ||
+             [ "$current_base" != "$ADMITTED_BASE" ]; then
+            echo "::error::protected main moved before dependency-wave token mint"
+            exit 1
+          fi
+
+      - name: Mint repository-scoped dependency-wave token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: firelock-ai
+          repositories: kin
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
+      - name: Verify exact App installation identity and scope
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-kin-release-app-token.py \
+            --app-slug "$APP_SLUG" \
+            --repository "$GITHUB_REPOSITORY"
+
+      - name: Clear inherited landing state before candidate handling
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ensure-kin-registry-wave-no-automerge.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --branch "$WAVE_BRANCH" \
+            --base "$BASE_BRANCH"
+
+      - name: Download the compiled data-only candidate
+        if: needs.prepare-wave.outputs.changed == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: kin-registry-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/kin-registry-candidate
+
+      - name: Revalidate and apply only the admitted manifest bytes
+        id: admission
+        if: needs.prepare-wave.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          candidate="$(python3 scripts/kin-registry-wave-artifact.py apply \
+            --workspace "$GITHUB_WORKSPACE" \
+            --artifact-dir "$RUNNER_TEMP/kin-registry-candidate" \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --base "$ADMITTED_BASE")"
           {
-            echo "expected_tree=$(jq -r .tree <<<"$admission")"
-            echo "add_paths<<KIN_PATHS"
-            jq -r '.paths[]' <<<"$admission"
-            echo "KIN_PATHS"
+            echo "expected_tree=$(jq -r .tree <<<"$candidate")"
+            echo "delta_sha256=$(jq -r .delta_sha256 <<<"$candidate")"
+            echo "package_version=$(jq -r .package_version <<<"$candidate")"
+            echo "workspace_version=$(jq -r .workspace_version <<<"$candidate")"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Clean helper checkout
-        if: always()
-        run: rm -rf .kin-actions
+      - name: Refuse protected-main movement before repository mutation
+        if: needs.prepare-wave.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          current_base="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
+            --jq .object.sha)"
+          if [ "$current_base" != "$ADMITTED_BASE" ]; then
+            echo "::error::protected main moved before the fixed PR write"
+            exit 1
+          fi
 
       - name: Ensure dependency-wave labels exist
-        if: steps.update.outputs.changed == 'true'
+        if: needs.prepare-wave.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -208,33 +465,65 @@ jobs:
 
       - name: Open or update the dependency bump PR
         id: open-pr
-        if: steps.update.outputs.changed == 'true'
+        if: needs.prepare-wave.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ env.WAVE_BRANCH }}
-          base: ${{ github.event.repository.default_branch }}
-          add-paths: ${{ steps.admission.outputs.add_paths }}
+          base: ${{ env.BASE_BRANCH }}
+          add-paths: |
+            Cargo.lock
+            Cargo.toml
           delete-branch: true
           signoff: true
           labels: release:consumer-bump,proof-impacting
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          commit-message: "chore(deps): ${{ steps.update.outputs.title }}"
-          title: "chore(deps): ${{ steps.update.outputs.title }}"
+          commit-message: |
+            chore(deps): ${{ needs.prepare-wave.outputs.title }}
+
+            Kin-Registry-Dependency-Wave: v1
+          title: "chore(deps): ${{ needs.prepare-wave.outputs.title }}"
           body: |
             Automated Kin registry dependency wave.
 
-            This PR updates the allowed root-manifest registry pins after a validated Kin registry publish and verifies the affected Kin consumers before opening or updating the fixed automation branch.
+            This PR updates the allowed root-manifest registry pins from registry authority after a validated notification or hourly recovery run, then verifies the affected Kin consumers before updating the fixed automation branch.
+
+            Dispatch source_sha and delivery_id values are sender-supplied correlation metadata. They are not treated as source provenance.
+
+      - name: Clear and verify landing state on the generated PR
+        if: needs.prepare-wave.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.open-pr.outputs.pull-request-number }}
+          ACTION_HEAD: ${{ steps.open-pr.outputs.pull-request-head-sha }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ensure-kin-registry-wave-no-automerge.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --branch "$WAVE_BRANCH" \
+            --base "$BASE_BRANCH" \
+            --expected-number "$PR" \
+            --expected-head "$ACTION_HEAD"
+
+      - name: Verify no-change reconciliation left no landing state
+        if: needs.prepare-wave.outputs.changed == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ensure-kin-registry-wave-no-automerge.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --branch "$WAVE_BRANCH" \
+            --base "$BASE_BRANCH"
 
       - name: Verify exact first-party generated PR
-        if: steps.update.outputs.changed == 'true'
+        if: needs.prepare-wave.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.open-pr.outputs.pull-request-number }}
           ACTION_HEAD: ${{ steps.open-pr.outputs.pull-request-head-sha }}
           EXPECTED_TREE: ${{ steps.admission.outputs.expected_tree }}
-          EXPECTED_BASE: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           if [[ ! "$PR" =~ ^[1-9][0-9]*$ ||
@@ -248,7 +537,9 @@ jobs:
           if [ "$(jq -r .state <<<"$pull")" != open ] ||
              [ "$(jq -r .head.repo.full_name <<<"$pull")" != "$GITHUB_REPOSITORY" ] ||
              [ "$(jq -r .head.ref <<<"$pull")" != "$WAVE_BRANCH" ] ||
-             [ "$(jq -r .base.ref <<<"$pull")" != "$EXPECTED_BASE" ] ||
+             [ "$(jq -r .base.ref <<<"$pull")" != "$BASE_BRANCH" ] ||
+             [ "$(jq -r .base.sha <<<"$pull")" != "$ADMITTED_BASE" ] ||
+             ! jq -e '.auto_merge == null' >/dev/null <<<"$pull" ||
              [ "$api_head" != "$ACTION_HEAD" ]; then
             echo "::error::dependency PR is not the exact first-party automation branch"
             exit 1
@@ -259,3 +550,43 @@ jobs:
             echo "::error::dependency PR tree $api_tree differs from admitted $EXPECTED_TREE"
             exit 1
           fi
+
+      - name: Build the post-completion admission record
+        if: needs.prepare-wave.outputs.changed == 'true'
+        env:
+          PR: ${{ steps.open-pr.outputs.pull-request-number }}
+          PR_HEAD: ${{ steps.open-pr.outputs.pull-request-head-sha }}
+        run: |
+          set -euo pipefail
+          python3 scripts/kin-registry-wave-artifact.py finalize \
+            --artifact-dir "$RUNNER_TEMP/kin-registry-candidate" \
+            --output-file "$RUNNER_TEMP/kin-registry-result/result.json" \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --base "$ADMITTED_BASE" \
+            --pull "$PR" \
+            --head "$PR_HEAD" \
+            --workflow-path .github/workflows/kin-registry-release.yml \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT"
+
+      - name: Build the post-completion no-change record
+        if: needs.prepare-wave.outputs.changed == 'false'
+        run: |
+          set -euo pipefail
+          python3 scripts/kin-registry-wave-artifact.py finalize-no-change \
+            --output-file "$RUNNER_TEMP/kin-registry-result/result.json" \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --base "$ADMITTED_BASE" \
+            --workflow-path .github/workflows/kin-registry-release.yml \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT"
+
+      - name: Upload exact result for the post-completion attester
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kin-registry-result-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/kin-registry-result/result.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -73,10 +73,17 @@ jobs:
           fi
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
 
+      # github.sha, not steps.base.outputs.base_sha: the step above already
+      # refuses unless that computed value equals github.sha, so the checkout
+      # ref and the assertion target are the same commit either way. A
+      # step-output expression reads as attacker-influenceable to a static
+      # checker with no view of the shell assertion that pins it, so this
+      # checkout uses the literal trusted context value instead. CodeQL rule
+      # actions/cache-poisoning/poisonable-step named this exact expression.
       - name: Checkout exact policy for early disarm
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.base.outputs.base_sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Refuse protected-main movement before early-disarm token mint
@@ -161,10 +168,14 @@ jobs:
           fi
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
 
+      # github.sha, not steps.base.outputs.base_sha: see the comment on the
+      # same substitution in disarm-wave above. The step directly above this
+      # one already refuses the job unless the computed value equals
+      # github.sha, so this checks out the same commit either way.
       - name: Checkout exact queued protected main
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.base.outputs.base_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -360,10 +371,15 @@ jobs:
           fi
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
 
+      # github.sha, not steps.base.outputs.base_sha: see the comment on the
+      # same substitution in disarm-wave above. The step directly above this
+      # one already refuses the job unless the computed value equals both
+      # github.sha and prepare-wave's admitted base, so this checks out the
+      # same commit either way.
       - name: Checkout exact protected main for trusted mutation code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.base.outputs.base_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/scripts/attest-kin-registry-wave.py
+++ b/scripts/attest-kin-registry-wave.py
@@ -1,0 +1,1061 @@
+#!/usr/bin/env python3
+"""Validate a completed receiver run, then persist its exact App attestation."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Sequence
+
+
+EXPECTED_REPOSITORY = "firelock-ai/kin"
+CI_WORKFLOW_NAME = "CI"
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+CI_REQUIRED_JOB = "Fast gate lint and policy"
+RECHECK_STATUSES = frozenset(
+    {"queued", "in_progress", "completed", "waiting", "pending", "requested"}
+)
+
+
+class AttesterError(RuntimeError):
+    """The completed receiver or its live pull request is not attestable."""
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise AttesterError(f"cannot load trusted helper {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+artifact = _load(
+    "kin_registry_wave_attester_artifact",
+    SCRIPT_DIR / "kin-registry-wave-artifact.py",
+)
+guard = _load(
+    "kin_registry_wave_attester_guard",
+    SCRIPT_DIR / "verify-kin-registry-wave-head.py",
+)
+landing = _load(
+    "kin_registry_wave_attester_landing",
+    SCRIPT_DIR / "ensure-kin-registry-wave-no-automerge.py",
+)
+
+
+def run_gh(arguments: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["gh", *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise AttesterError(f"gh {' '.join(arguments)} failed: {detail}")
+    return result.stdout
+
+
+def gh_json(arguments: Sequence[str]) -> Any:
+    try:
+        return json.loads(run_gh(arguments))
+    except json.JSONDecodeError as exc:
+        raise AttesterError("GitHub returned malformed JSON") from exc
+
+
+def _event(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AttesterError(f"cannot read workflow_run event: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AttesterError("workflow_run event is not an object")
+    return value
+
+
+def validate_completed_run(
+    *,
+    event_file: Path,
+    repository: str,
+) -> dict[str, Any]:
+    event = _event(event_file)
+    workflow_run = event.get("workflow_run")
+    if event.get("action") != "completed" or not isinstance(workflow_run, dict):
+        raise AttesterError("event is not a completed workflow_run")
+    run_id = workflow_run.get("id")
+    run_attempt = workflow_run.get("run_attempt")
+    policy_sha = workflow_run.get("head_sha")
+    evidence = {
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "workflow_path": workflow_run.get("path"),
+        "policy_sha": policy_sha,
+        "base": policy_sha,
+    }
+    live_run = gh_json(
+        [
+            "api",
+            f"repos/{repository}/actions/runs/{run_id}/attempts/{run_attempt}",
+        ]
+    )
+    try:
+        guard.validate_workflow_run(repository, evidence, live_run)
+    except guard.AdmissionError as exc:
+        raise AttesterError(str(exc)) from exc
+    for field in (
+        "id",
+        "run_attempt",
+        "name",
+        "path",
+        "status",
+        "conclusion",
+        "event",
+        "head_branch",
+        "head_sha",
+    ):
+        if workflow_run.get(field) != live_run.get(field):
+            raise AttesterError(
+                f"workflow_run event field {field} differs from the Actions API"
+            )
+    return live_run
+
+
+def _load_admission(
+    *,
+    admission_file: Path,
+    repository: str,
+    policy_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, Any]:
+    if admission_file.parent.is_symlink():
+        raise AttesterError("admission artifact directory is a symlink")
+    entries = frozenset(item.name for item in admission_file.parent.iterdir())
+    if entries != {"result.json"}:
+        raise AttesterError("receiver result contains entries outside its allowlist")
+    try:
+        return artifact.validate_result(
+            result_file=admission_file,
+            repository=repository,
+            workflow_path=guard.RECEIVER_WORKFLOW_PATH,
+            policy_sha=policy_sha,
+            run_id=run_id,
+            run_attempt=run_attempt,
+        )
+    except artifact.ArtifactError as exc:
+        raise AttesterError(str(exc)) from exc
+
+
+def _load_changed_admission(
+    *,
+    admission_file: Path,
+    repository: str,
+) -> dict[str, Any]:
+    try:
+        raw = artifact._read_json(admission_file)
+        return artifact.validate_admission(
+            admission_file=admission_file,
+            repository=repository,
+            workflow_path=guard.RECEIVER_WORKFLOW_PATH,
+            policy_sha=str(raw.get("policy_sha")),
+            run_id=int(raw.get("run_id")),
+            run_attempt=int(raw.get("run_attempt")),
+        )
+    except (artifact.ArtifactError, TypeError, ValueError) as exc:
+        raise AttesterError(str(exc)) from exc
+
+
+def _paginated_items(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise AttesterError(f"{label} response is not an array")
+    if value and all(isinstance(page, list) for page in value):
+        return [item for page in value for item in page]
+    return value
+
+
+def _attestation_documents(
+    repository: str,
+    pull_number: int,
+) -> tuple[list[Any], list[Any]]:
+    reviews = _paginated_items(
+        gh_json(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{repository}/pulls/{pull_number}/reviews?per_page=100",
+            ]
+        ),
+        "pull review",
+    )
+    comments = _paginated_items(
+        gh_json(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{repository}/issues/{pull_number}/comments?per_page=100",
+            ]
+        ),
+        "pull comment",
+    )
+    return reviews, comments
+
+
+def _existing_attestation(
+    *,
+    workspace: Path,
+    repository: str,
+    admission: dict[str, Any],
+    verify_server_run: bool,
+) -> dict[str, Any] | None:
+    pull_number = int(admission["pull"])
+    head = str(admission["head"])
+    reviews, comments = _attestation_documents(repository, pull_number)
+    try:
+        guard.validate_attestation(
+            workspace,
+            repository,
+            pull_number,
+            head,
+            reviews,
+            comments,
+            expected_base=str(admission["base"]),
+            verify_server_run=verify_server_run,
+        )
+    except guard.PendingAttestation:
+        return None
+    except guard.AdmissionError as exc:
+        raise AttesterError(str(exc)) from exc
+
+    current: list[tuple[dict[str, Any], dict[str, str | int]]] = []
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        body = comment.get("body")
+        if not isinstance(body, str) or not body.startswith(guard.ATTESTATION_MARKER):
+            continue
+        evidence = guard._parse_comment_body(body)
+        if evidence["head"] == head:
+            current.append((comment, evidence))
+    if not current:
+        raise AttesterError("validated dependency attestation disappeared")
+    comment, evidence = max(current, key=lambda item: int(item[0]["id"]))
+    candidate_fields = (
+        "repository",
+        "pull",
+        "head",
+        "tree",
+        "base",
+        "delta_sha256",
+        "package_version",
+        "workspace_version",
+        "workflow_path",
+        "policy_sha",
+    )
+    expected = {
+        "repository": repository,
+        "pull": pull_number,
+        **{field: admission[field] for field in candidate_fields if field not in {"repository", "pull"}},
+    }
+    observed = {field: evidence[field] for field in candidate_fields}
+    if observed != expected:
+        raise AttesterError(
+            "existing App attestation differs from the immutable admission candidate"
+        )
+    created_at = comment.get("created_at")
+    if not isinstance(created_at, str):
+        raise AttesterError("existing App attestation has no creation timestamp")
+    _timestamp(created_at, "attestation comment creation")
+    return {
+        "review_id": int(evidence["review_id"]),
+        "comment_id": int(comment["id"]),
+        "comment_created_at": created_at,
+        "run_id": int(evidence["run_id"]),
+        "run_attempt": int(evidence["run_attempt"]),
+    }
+
+
+def _timestamp(value: Any, label: str) -> datetime:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise AttesterError(f"{label} is not a UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise AttesterError(f"{label} is malformed") from exc
+    if parsed.utcoffset() is None:
+        raise AttesterError(f"{label} has no timezone")
+    return parsed
+
+
+def validate_live_admission(
+    *,
+    workspace: Path,
+    repository: str,
+    admission: dict[str, Any],
+) -> None:
+    pull_number = int(admission["pull"])
+    head = str(admission["head"])
+    policy_sha = str(admission["policy_sha"])
+    current_ref = gh_json(
+        ["api", f"repos/{repository}/git/ref/heads/{guard.EXPECTED_BASE}"]
+    )
+    ref_object = current_ref.get("object") if isinstance(current_ref, dict) else None
+    if not isinstance(ref_object, dict) or ref_object.get("sha") != policy_sha:
+        raise AttesterError("protected main moved after the completed receiver")
+
+    pull = gh_json(["api", f"repos/{repository}/pulls/{pull_number}"])
+    try:
+        pull_evidence = guard.validate_pull(
+            pull,
+            repository=repository,
+            expected_head=head,
+            require_open=True,
+        )
+    except guard.AdmissionError as exc:
+        raise AttesterError(str(exc)) from exc
+    if pull_evidence.base != admission["base"]:
+        raise AttesterError("live pull base differs from the completed admission")
+
+    graphql_pull = landing._graphql_pull(repository, pull_number)
+    try:
+        _, auto_armed, queue_armed = landing._validate_graphql_pull(
+            graphql_pull,
+            repository=repository,
+            branch=guard.WAVE_BRANCH,
+            base=guard.EXPECTED_BASE,
+            expected_number=pull_number,
+            expected_head=head,
+        )
+    except landing.LandingStateError as exc:
+        raise AttesterError(str(exc)) from exc
+    if auto_armed or queue_armed:
+        raise AttesterError("live dependency pull still has server-owned landing state")
+
+    try:
+        guard.ensure_pull_head(workspace, pull_number, head)
+        evidence = guard.validate_delta(
+            workspace,
+            str(admission["base"]),
+            head,
+            require_marker=True,
+        )
+    except guard.AdmissionError as exc:
+        raise AttesterError(str(exc)) from exc
+    observed = {
+        "tree": evidence.tree,
+        "delta_sha256": evidence.delta_sha256,
+        "package_version": evidence.package_version,
+        "workspace_version": evidence.workspace_version,
+    }
+    expected = {key: admission[key] for key in observed}
+    if observed != expected:
+        raise AttesterError("live dependency pull differs from the completed admission")
+
+
+def validate_for_attestation(
+    *,
+    event_file: Path,
+    admission_file: Path,
+    workspace: Path,
+    repository: str,
+) -> dict[str, Any]:
+    run = validate_completed_run(event_file=event_file, repository=repository)
+    admission = _load_admission(
+        admission_file=admission_file,
+        repository=repository,
+        policy_sha=str(run["head_sha"]),
+        run_id=int(run["id"]),
+        run_attempt=int(run["run_attempt"]),
+    )
+    result = dict(admission)
+    result["needs_attestation"] = False
+    if admission["changed"] is True:
+        validate_live_admission(
+            workspace=workspace,
+            repository=repository,
+            admission=admission,
+        )
+        result["needs_attestation"] = (
+            _existing_attestation(
+                workspace=workspace,
+                repository=repository,
+                admission=admission,
+                verify_server_run=True,
+            )
+            is None
+        )
+    return result
+
+
+def _exact_review(review: Any, *, head: str, body: str) -> int:
+    if not isinstance(review, dict):
+        raise AttesterError("review creation response is not an object")
+    review_id = review.get("id")
+    user = review.get("user")
+    if (
+        not isinstance(review_id, int)
+        or isinstance(review_id, bool)
+        or review_id < 1
+        or review.get("state") != "COMMENTED"
+        or review.get("commit_id") != head
+        or review.get("body") != body
+        or not isinstance(user, dict)
+        or user.get("id") != guard.ATTESTATION_CREATOR_ID
+        or user.get("login") != guard.ATTESTATION_CREATOR
+        or user.get("type") != "Bot"
+    ):
+        raise AttesterError("release App review did not bind the exact admitted head")
+    return review_id
+
+
+def _exact_comment(
+    comment: Any,
+    *,
+    repository: str,
+    pull_number: int,
+    body: str,
+) -> int:
+    if not isinstance(comment, dict):
+        raise AttesterError("comment creation response is not an object")
+    comment_id = comment.get("id")
+    app = comment.get("performed_via_github_app")
+    owner = app.get("owner") if isinstance(app, dict) else None
+    user = comment.get("user")
+    if (
+        not isinstance(comment_id, int)
+        or isinstance(comment_id, bool)
+        or comment_id < 1
+        or comment.get("body") != body
+        or comment.get("created_at") != comment.get("updated_at")
+        or comment.get("issue_url")
+        != f"https://api.github.com/repos/{repository}/issues/{pull_number}"
+        or comment.get("html_url")
+        != (
+            f"https://github.com/{repository}/pull/{pull_number}"
+            f"#issuecomment-{comment_id}"
+        )
+        or not isinstance(app, dict)
+        or app.get("id") != guard.ATTESTATION_APP_ID
+        or app.get("slug") != guard.ATTESTATION_APP_SLUG
+        or not isinstance(owner, dict)
+        or owner.get("id") != guard.ATTESTATION_APP_OWNER_ID
+        or owner.get("login") != guard.ATTESTATION_APP_OWNER
+        or not isinstance(user, dict)
+        or user.get("id") != guard.ATTESTATION_CREATOR_ID
+        or user.get("login") != guard.ATTESTATION_CREATOR
+        or user.get("type") != "Bot"
+    ):
+        raise AttesterError("release App identity did not persist on the attestation")
+    return comment_id
+
+
+def post_attestation(
+    *,
+    admission_file: Path,
+    workspace: Path,
+    repository: str,
+) -> dict[str, Any]:
+    admission = _load_changed_admission(
+        admission_file=admission_file,
+        repository=repository,
+    )
+    validate_live_admission(
+        workspace=workspace,
+        repository=repository,
+        admission=admission,
+    )
+
+    existing = _existing_attestation(
+        workspace=workspace,
+        repository=repository,
+        admission=admission,
+        verify_server_run=False,
+    )
+    if existing is not None:
+        return {"created": False, **existing}
+
+    pull_number = int(admission["pull"])
+    head = str(admission["head"])
+    body_args = (
+        repository,
+        pull_number,
+        head,
+        str(admission["tree"]),
+        str(admission["base"]),
+        str(admission["delta_sha256"]),
+        str(admission["package_version"]),
+        str(admission["workspace_version"]),
+        str(admission["workflow_path"]),
+        str(admission["policy_sha"]),
+        int(admission["run_id"]),
+        int(admission["run_attempt"]),
+    )
+    review_body = guard._review_body(*body_args)
+    review = gh_json(
+        [
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repository}/pulls/{pull_number}/reviews",
+            "-f",
+            "event=COMMENT",
+            "-f",
+            f"commit_id={head}",
+            "-f",
+            f"body={review_body}",
+        ]
+    )
+    review_id = _exact_review(review, head=head, body=review_body)
+    comment_body = guard._comment_body(
+        repository,
+        pull_number,
+        review_id,
+        head,
+        str(admission["tree"]),
+        str(admission["base"]),
+        str(admission["delta_sha256"]),
+        str(admission["package_version"]),
+        str(admission["workspace_version"]),
+        str(admission["workflow_path"]),
+        str(admission["policy_sha"]),
+        int(admission["run_id"]),
+        int(admission["run_attempt"]),
+    )
+    comment = gh_json(
+        [
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repository}/issues/{pull_number}/comments",
+            "-f",
+            f"body={comment_body}",
+        ]
+    )
+    comment_id = _exact_comment(
+        comment,
+        repository=repository,
+        pull_number=pull_number,
+        body=comment_body,
+    )
+    persisted_review = gh_json(
+        ["api", f"repos/{repository}/pulls/{pull_number}/reviews/{review_id}"]
+    )
+    persisted_comment = gh_json(
+        ["api", f"repos/{repository}/issues/comments/{comment_id}"]
+    )
+    _exact_review(persisted_review, head=head, body=review_body)
+    _exact_comment(
+        persisted_comment,
+        repository=repository,
+        pull_number=pull_number,
+        body=comment_body,
+    )
+    validate_live_admission(
+        workspace=workspace,
+        repository=repository,
+        admission=admission,
+    )
+    created_at = persisted_comment.get("created_at")
+    if not isinstance(created_at, str):
+        raise AttesterError("persisted App attestation has no creation timestamp")
+    _timestamp(created_at, "persisted App attestation creation")
+    return {
+        "created": True,
+        "review_id": review_id,
+        "comment_id": comment_id,
+        "comment_created_at": created_at,
+        "run_id": int(admission["run_id"]),
+        "run_attempt": int(admission["run_attempt"]),
+    }
+
+
+def _workflow_run_pages(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, dict):
+        pages = [value]
+    elif isinstance(value, list) and all(isinstance(page, dict) for page in value):
+        pages = value
+    else:
+        raise AttesterError("CI workflow-run response is malformed")
+    runs: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for page in pages:
+        page_runs = page.get("workflow_runs")
+        total = page.get("total_count")
+        if (
+            not isinstance(total, int)
+            or isinstance(total, bool)
+            or total < 0
+            or not isinstance(page_runs, list)
+        ):
+            raise AttesterError("CI workflow-run page is malformed")
+        for run in page_runs:
+            run_id = run.get("id") if isinstance(run, dict) else None
+            if (
+                not isinstance(run, dict)
+                or not isinstance(run_id, int)
+                or isinstance(run_id, bool)
+                or run_id < 1
+                or run_id in seen
+            ):
+                raise AttesterError("CI workflow-run listing has an invalid run")
+            seen.add(run_id)
+            runs.append(run)
+    return runs
+
+
+def _validate_recheck_pull(
+    run: dict[str, Any],
+    *,
+    repository: str,
+    admission: dict[str, Any],
+) -> None:
+    pulls = run.get("pull_requests")
+    if not isinstance(pulls, list) or len(pulls) != 1:
+        raise AttesterError("post-attestation CI run is not bound to one pull request")
+    pull = pulls[0]
+    head = pull.get("head") if isinstance(pull, dict) else None
+    base = pull.get("base") if isinstance(pull, dict) else None
+    head_repo = head.get("repo") if isinstance(head, dict) else None
+    base_repo = base.get("repo") if isinstance(base, dict) else None
+    repository_url = f"https://api.github.com/repos/{repository}"
+    repository_name = repository.split("/", 1)[1]
+    if (
+        not isinstance(pull, dict)
+        or pull.get("number") != admission["pull"]
+        or not isinstance(head, dict)
+        or head.get("ref") != guard.WAVE_BRANCH
+        or head.get("sha") != admission["head"]
+        or not isinstance(head_repo, dict)
+        or head_repo.get("name") != repository_name
+        or head_repo.get("url") != repository_url
+        or not isinstance(base, dict)
+        or base.get("ref") != guard.EXPECTED_BASE
+        or base.get("sha") != admission["base"]
+        or not isinstance(base_repo, dict)
+        or base_repo.get("name") != repository_name
+        or base_repo.get("url") != repository_url
+    ):
+        raise AttesterError(
+            "post-attestation CI run is not bound to the exact admitted pull"
+        )
+
+
+def _validate_recheck_job(
+    value: Any,
+    *,
+    repository: str,
+    run_id: int,
+) -> dict[str, Any]:
+    jobs = value.get("jobs") if isinstance(value, dict) else None
+    total = value.get("total_count") if isinstance(value, dict) else None
+    if (
+        not isinstance(total, int)
+        or isinstance(total, bool)
+        or total < 0
+        or not isinstance(jobs, list)
+        or total != len(jobs)
+    ):
+        raise AttesterError("post-attestation CI job listing is malformed")
+    required = [
+        job
+        for job in jobs
+        if isinstance(job, dict) and job.get("name") == CI_REQUIRED_JOB
+    ]
+    if len(required) != 1:
+        raise AttesterError(
+            "post-attestation CI run does not publish exactly one required fast gate"
+        )
+    job = required[0]
+    job_id = job.get("id")
+    status = job.get("status")
+    if (
+        not isinstance(job_id, int)
+        or isinstance(job_id, bool)
+        or job_id < 1
+        or status not in RECHECK_STATUSES
+        or job.get("run_url")
+        != f"https://api.github.com/repos/{repository}/actions/runs/{run_id}"
+    ):
+        raise AttesterError("post-attestation required fast gate is malformed")
+    if status == "completed" and not isinstance(job.get("conclusion"), str):
+        raise AttesterError("completed post-attestation fast gate has no conclusion")
+    if status != "completed" and job.get("conclusion") is not None:
+        raise AttesterError("pending post-attestation fast gate has a conclusion")
+    return job
+
+
+def _post_attestation_recheck(
+    *,
+    repository: str,
+    admission: dict[str, Any],
+    attestation: dict[str, Any],
+) -> dict[str, Any] | None:
+    response = gh_json(
+        [
+            "api",
+            "--paginate",
+            "--slurp",
+            "--method",
+            "GET",
+            f"repos/{repository}/actions/workflows/ci.yml/runs",
+            "-f",
+            "event=pull_request",
+            "-f",
+            f"head_sha={admission['head']}",
+            "-f",
+            "per_page=100",
+        ]
+    )
+    cutoff = _timestamp(
+        attestation["comment_created_at"],
+        "attestation comment creation",
+    )
+    candidates: list[dict[str, Any]] = []
+    for run in _workflow_run_pages(response):
+        created_at = _timestamp(run.get("created_at"), "CI run creation")
+        if created_at < cutoff:
+            continue
+        repository_doc = run.get("repository")
+        head_repository = run.get("head_repository")
+        run_attempt = run.get("run_attempt")
+        if (
+            run.get("name") != CI_WORKFLOW_NAME
+            or run.get("path") != CI_WORKFLOW_PATH
+            or run.get("event") != "pull_request"
+            or run.get("head_branch") != guard.WAVE_BRANCH
+            or run.get("head_sha") != admission["head"]
+            or not isinstance(repository_doc, dict)
+            or repository_doc.get("full_name") != repository
+            or not isinstance(head_repository, dict)
+            or head_repository.get("full_name") != repository
+            or not isinstance(run_attempt, int)
+            or isinstance(run_attempt, bool)
+            or run_attempt < 1
+        ):
+            raise AttesterError("post-attestation CI run has the wrong authority")
+        _validate_recheck_pull(run, repository=repository, admission=admission)
+        jobs = gh_json(
+            [
+                "api",
+                "--method",
+                "GET",
+                (
+                    f"repos/{repository}/actions/runs/{run['id']}"
+                    f"/attempts/{run_attempt}/jobs"
+                ),
+                "-f",
+                "filter=all",
+                "-f",
+                "per_page=100",
+            ]
+        )
+        job = _validate_recheck_job(
+            jobs,
+            repository=repository,
+            run_id=int(run["id"]),
+        )
+        candidates.append(
+            {
+                "run_id": int(run["id"]),
+                "run_attempt": run_attempt,
+                "job_id": int(job["id"]),
+                "job_status": str(job["status"]),
+                "job_conclusion": job.get("conclusion"),
+                "created_at": run["created_at"],
+            }
+        )
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: int(item["run_id"]))
+
+
+def recheck_status(
+    *,
+    admission_file: Path,
+    workspace: Path,
+    repository: str,
+    wait_seconds: int,
+    require_recheck: bool,
+) -> dict[str, Any]:
+    if not 0 <= wait_seconds <= 120:
+        raise AttesterError("post-attestation CI wait must be between 0 and 120 seconds")
+    admission = _load_changed_admission(
+        admission_file=admission_file,
+        repository=repository,
+    )
+    validate_live_admission(
+        workspace=workspace,
+        repository=repository,
+        admission=admission,
+    )
+    attestation = _existing_attestation(
+        workspace=workspace,
+        repository=repository,
+        admission=admission,
+        verify_server_run=True,
+    )
+    if attestation is None:
+        raise AttesterError("exact admitted head still has no App attestation")
+
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        recheck = _post_attestation_recheck(
+            repository=repository,
+            admission=admission,
+            attestation=attestation,
+        )
+        if recheck is not None:
+            validate_live_admission(
+                workspace=workspace,
+                repository=repository,
+                admission=admission,
+            )
+            return {
+                "needs_retrigger": False,
+                "attestation_comment_id": attestation["comment_id"],
+                **recheck,
+            }
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            if require_recheck:
+                raise AttesterError(
+                    "no exact required CI recheck materialized after the App attestation"
+                )
+            return {
+                "needs_retrigger": True,
+                "attestation_comment_id": attestation["comment_id"],
+            }
+        time.sleep(min(2.0, remaining))
+
+
+def _exact_pull_state(
+    pull: Any,
+    *,
+    repository: str,
+    admission: dict[str, Any],
+    state: str,
+) -> None:
+    head = pull.get("head") if isinstance(pull, dict) else None
+    base = pull.get("base") if isinstance(pull, dict) else None
+    if (
+        not isinstance(pull, dict)
+        or pull.get("number") != admission["pull"]
+        or pull.get("state") != state
+        or pull.get("merged_at") is not None
+        or pull.get("auto_merge") is not None
+        or not isinstance(head, dict)
+        or head.get("sha") != admission["head"]
+        or head.get("ref") != guard.WAVE_BRANCH
+        or not isinstance(head.get("repo"), dict)
+        or head["repo"].get("full_name") != repository
+        or not isinstance(base, dict)
+        or base.get("sha") != admission["base"]
+        or base.get("ref") != guard.EXPECTED_BASE
+    ):
+        raise AttesterError(f"pull {state} response differs from the exact admission")
+
+
+def _reopen_pull(
+    *,
+    repository: str,
+    pull_number: int,
+) -> Any:
+    errors: list[str] = []
+    for _ in range(3):
+        try:
+            response = gh_json(
+                [
+                    "api",
+                    "--method",
+                    "PATCH",
+                    f"repos/{repository}/pulls/{pull_number}",
+                    "-f",
+                    "state=open",
+                ]
+            )
+            if (
+                isinstance(response, dict)
+                and response.get("number") == pull_number
+                and response.get("state") == "open"
+            ):
+                return response
+            errors.append("reopen response did not report the exact pull open")
+        except AttesterError as exc:
+            errors.append(str(exc))
+        try:
+            observed = gh_json(["api", f"repos/{repository}/pulls/{pull_number}"])
+            if (
+                isinstance(observed, dict)
+                and observed.get("number") == pull_number
+                and observed.get("state") == "open"
+            ):
+                return observed
+            errors.append("pull remained closed after a reopen attempt")
+        except AttesterError as exc:
+            errors.append(str(exc))
+    raise AttesterError(
+        "dependency pull could not be reopened after CI retrigger: "
+        + " | ".join(errors)
+    )
+
+
+def retrigger_pull(
+    *,
+    admission_file: Path,
+    workspace: Path,
+    repository: str,
+) -> dict[str, Any]:
+    admission = _load_changed_admission(
+        admission_file=admission_file,
+        repository=repository,
+    )
+    validate_live_admission(
+        workspace=workspace,
+        repository=repository,
+        admission=admission,
+    )
+    if (
+        _existing_attestation(
+            workspace=workspace,
+            repository=repository,
+            admission=admission,
+            verify_server_run=False,
+        )
+        is None
+    ):
+        raise AttesterError("cannot retrigger CI without an exact App attestation")
+
+    pull_number = int(admission["pull"])
+    close_error: AttesterError | None = None
+    try:
+        closed = gh_json(
+            [
+                "api",
+                "--method",
+                "PATCH",
+                f"repos/{repository}/pulls/{pull_number}",
+                "-f",
+                "state=closed",
+            ]
+        )
+        _exact_pull_state(
+            closed,
+            repository=repository,
+            admission=admission,
+            state="closed",
+        )
+    except AttesterError as exc:
+        close_error = exc
+
+    try:
+        reopened = _reopen_pull(
+            repository=repository,
+            pull_number=pull_number,
+        )
+        _exact_pull_state(
+            reopened,
+            repository=repository,
+            admission=admission,
+            state="open",
+        )
+    except AttesterError as exc:
+        raise AttesterError(
+            "dependency pull could not be proven reopened after CI retrigger"
+        ) from exc
+    if close_error is not None:
+        raise AttesterError(
+            f"dependency pull was reopened after an invalid close response: {close_error}"
+        )
+
+    validate_live_admission(
+        workspace=workspace,
+        repository=repository,
+        admission=admission,
+    )
+    if (
+        _existing_attestation(
+            workspace=workspace,
+            repository=repository,
+            admission=admission,
+            verify_server_run=False,
+        )
+        is None
+    ):
+        raise AttesterError("App attestation disappeared across CI retrigger")
+    return {"reopened": True, "pull": pull_number, "head": admission["head"]}
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("--event-file", type=Path, required=True)
+    for name in ("validate", "post", "recheck-status", "retrigger"):
+        command = (
+            validate_parser if name == "validate" else subparsers.add_parser(name)
+        )
+        command.add_argument("--admission-file", type=Path, required=True)
+        command.add_argument("--workspace", type=Path, required=True)
+        command.add_argument("--repository", required=True)
+        if name == "recheck-status":
+            command.add_argument("--wait-seconds", type=int, default=0)
+            command.add_argument("--require-recheck", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        if args.repository != EXPECTED_REPOSITORY:
+            raise AttesterError("attester repository is not firelock-ai/kin")
+        if args.command == "validate":
+            result = validate_for_attestation(
+                event_file=args.event_file,
+                admission_file=args.admission_file,
+                workspace=args.workspace,
+                repository=args.repository,
+            )
+        elif args.command == "post":
+            result = post_attestation(
+                admission_file=args.admission_file,
+                workspace=args.workspace,
+                repository=args.repository,
+            )
+        elif args.command == "recheck-status":
+            result = recheck_status(
+                admission_file=args.admission_file,
+                workspace=args.workspace,
+                repository=args.repository,
+                wait_seconds=args.wait_seconds,
+                require_recheck=args.require_recheck,
+            )
+        else:
+            result = retrigger_pull(
+                admission_file=args.admission_file,
+                workspace=args.workspace,
+                repository=args.repository,
+            )
+    except (AttesterError, OSError, UnicodeDecodeError) as exc:
+        print(
+            f"::error title=Invalid completed Kin registry admission::{exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/attest-kin-registry-wave.py
+++ b/scripts/attest-kin-registry-wave.py
@@ -246,6 +246,8 @@ def _existing_attestation(
         body = comment.get("body")
         if not isinstance(body, str) or not body.startswith(guard.ATTESTATION_MARKER):
             continue
+        if not guard._has_exact_attestation_app_identity(comment):
+            continue
         evidence = guard._parse_comment_body(body)
         if evidence["head"] == head:
             current.append((comment, evidence))
@@ -615,6 +617,37 @@ def _workflow_run_pages(value: Any) -> list[dict[str, Any]]:
     return runs
 
 
+def _is_recheck_run_candidate(
+    run: dict[str, Any],
+    *,
+    repository: str,
+    admission: dict[str, Any],
+) -> bool:
+    if run.get("head_sha") != admission["head"]:
+        return False
+    pulls = run.get("pull_requests")
+    bound_to_admitted_pull = isinstance(pulls, list) and any(
+        isinstance(pull, dict) and pull.get("number") == admission["pull"]
+        for pull in pulls
+    )
+    if bound_to_admitted_pull:
+        return True
+    if isinstance(pulls, list) and pulls and all(
+        isinstance(pull, dict)
+        and isinstance(pull.get("number"), int)
+        and not isinstance(pull.get("number"), bool)
+        for pull in pulls
+    ):
+        return False
+    head_repository = run.get("head_repository")
+    first_party_wave = (
+        run.get("head_branch") == guard.WAVE_BRANCH
+        and isinstance(head_repository, dict)
+        and head_repository.get("full_name") == repository
+    )
+    return first_party_wave
+
+
 def _validate_recheck_pull(
     run: dict[str, Any],
     *,
@@ -715,6 +748,8 @@ def _post_attestation_recheck(
             "-f",
             f"head_sha={admission['head']}",
             "-f",
+            f"branch={guard.WAVE_BRANCH}",
+            "-f",
             "per_page=100",
         ]
     )
@@ -724,6 +759,12 @@ def _post_attestation_recheck(
     )
     candidates: list[dict[str, Any]] = []
     for run in _workflow_run_pages(response):
+        if not _is_recheck_run_candidate(
+            run,
+            repository=repository,
+            admission=admission,
+        ):
+            continue
         created_at = _timestamp(run.get("created_at"), "CI run creation")
         if created_at < cutoff:
             continue

--- a/scripts/ensure-kin-registry-wave-no-automerge.py
+++ b/scripts/ensure-kin-registry-wave-no-automerge.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Clear every server-owned landing arm on Kin's fixed dependency PR."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any, Sequence
+
+
+class LandingStateError(RuntimeError):
+    """The fixed dependency PR is missing, ambiguous, or still landable."""
+
+
+LOWER_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+PULL_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      id
+      number
+      state
+      headRefName
+      headRefOid
+      baseRefName
+      headRepository { nameWithOwner }
+      autoMergeRequest { enabledAt }
+      mergeQueueEntry { id }
+    }
+  }
+}
+""".strip()
+
+DEQUEUE_MUTATION = """
+mutation($id: ID!) {
+  dequeuePullRequest(input: {id: $id}) {
+    mergeQueueEntry { id }
+  }
+}
+""".strip()
+
+
+def run_gh(arguments: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["gh", *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise LandingStateError(f"gh {' '.join(arguments)} failed: {detail}")
+    return result.stdout
+
+
+def _json(arguments: Sequence[str]) -> Any:
+    try:
+        return json.loads(run_gh(arguments))
+    except json.JSONDecodeError as exc:
+        raise LandingStateError("GitHub returned malformed JSON") from exc
+
+
+def _positive_number(value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise LandingStateError(f"pull request number is invalid: {value!r}")
+    return value
+
+
+def _validate_rest_pull(
+    pull: Any,
+    *,
+    repository: str,
+    branch: str,
+    base: str,
+    expected_number: int | None,
+    expected_head: str | None,
+) -> tuple[int, str]:
+    if not isinstance(pull, dict):
+        raise LandingStateError("GitHub pull response is not an object")
+    number = _positive_number(pull.get("number"))
+    head = pull.get("head")
+    base_value = pull.get("base")
+    if not isinstance(head, dict) or not isinstance(base_value, dict):
+        raise LandingStateError("GitHub pull response has no head or base object")
+    head_repo = head.get("repo")
+    if not isinstance(head_repo, dict):
+        raise LandingStateError("GitHub pull response has no head repository")
+    head_sha = head.get("sha")
+    if (
+        pull.get("state") != "open"
+        or head_repo.get("full_name") != repository
+        or head.get("ref") != branch
+        or base_value.get("ref") != base
+    ):
+        raise LandingStateError("pull request is not the exact open first-party wave")
+    if not isinstance(head_sha, str) or LOWER_SHA.fullmatch(head_sha) is None:
+        raise LandingStateError(f"pull request head is invalid: {head_sha!r}")
+    if expected_number is not None and number != expected_number:
+        raise LandingStateError(
+            f"pull request number moved from {expected_number} to {number}"
+        )
+    if expected_head is not None and head_sha != expected_head:
+        raise LandingStateError(
+            f"pull request head moved from {expected_head} to {head_sha}"
+        )
+    return number, head_sha
+
+
+def _graphql_pull(repository: str, number: int) -> Any:
+    owner, name = repository.split("/", 1)
+    response = _json(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={PULL_QUERY}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"number={number}",
+        ]
+    )
+    if not isinstance(response, dict):
+        raise LandingStateError("GitHub GraphQL response is not an object")
+    data = response.get("data")
+    repository_data = data.get("repository") if isinstance(data, dict) else None
+    pull = (
+        repository_data.get("pullRequest")
+        if isinstance(repository_data, dict)
+        else None
+    )
+    if not isinstance(pull, dict):
+        raise LandingStateError("GitHub GraphQL response omitted the exact pull request")
+    return pull
+
+
+def _validate_graphql_pull(
+    pull: Any,
+    *,
+    repository: str,
+    branch: str,
+    base: str,
+    expected_number: int,
+    expected_head: str,
+) -> tuple[str, bool, bool]:
+    if not isinstance(pull, dict):
+        raise LandingStateError("GitHub GraphQL pull is not an object")
+    head_repository = pull.get("headRepository")
+    if (
+        pull.get("number") != expected_number
+        or pull.get("state") != "OPEN"
+        or pull.get("headRefName") != branch
+        or pull.get("headRefOid") != expected_head
+        or pull.get("baseRefName") != base
+        or not isinstance(head_repository, dict)
+        or head_repository.get("nameWithOwner") != repository
+    ):
+        raise LandingStateError("GraphQL pull is not the exact open first-party wave")
+    pull_id = pull.get("id")
+    if not isinstance(pull_id, str) or not pull_id:
+        raise LandingStateError("GraphQL pull omitted its node id")
+    if "autoMergeRequest" not in pull or "mergeQueueEntry" not in pull:
+        raise LandingStateError("GraphQL pull omitted landing-state fields")
+    auto_armed = pull["autoMergeRequest"] is not None
+    queue_armed = pull["mergeQueueEntry"] is not None
+    return pull_id, auto_armed, queue_armed
+
+
+def _read_state(
+    *,
+    repository: str,
+    number: int,
+    branch: str,
+    base: str,
+    head: str,
+) -> tuple[str, bool, bool]:
+    return _validate_graphql_pull(
+        _graphql_pull(repository, number),
+        repository=repository,
+        branch=branch,
+        base=base,
+        expected_number=number,
+        expected_head=head,
+    )
+
+
+def ensure_disabled(
+    *,
+    repository: str,
+    branch: str,
+    base: str,
+    expected_number: int | None = None,
+    expected_head: str | None = None,
+) -> dict[str, object]:
+    if repository.count("/") != 1:
+        raise LandingStateError("repository must be owner/name")
+    owner = repository.split("/", 1)[0]
+    pulls = _json(
+        [
+            "api",
+            "--method",
+            "GET",
+            f"repos/{repository}/pulls",
+            "-f",
+            "state=open",
+            "-f",
+            f"head={owner}:{branch}",
+            "-f",
+            f"base={base}",
+            "-f",
+            "per_page=100",
+        ]
+    )
+    if not isinstance(pulls, list):
+        raise LandingStateError("GitHub pull listing is not an array")
+    if len(pulls) > 1:
+        raise LandingStateError(
+            f"fixed dependency branch has {len(pulls)} open pull requests"
+        )
+    if not pulls:
+        if expected_number is not None or expected_head is not None:
+            raise LandingStateError("expected fixed dependency pull request is missing")
+        return {"found": False, "auto_merge": None, "merge_queue_entry": None}
+
+    number, head_sha = _validate_rest_pull(
+        pulls[0],
+        repository=repository,
+        branch=branch,
+        base=base,
+        expected_number=expected_number,
+        expected_head=expected_head,
+    )
+    pull_id, auto_armed, queue_armed = _read_state(
+        repository=repository,
+        number=number,
+        branch=branch,
+        base=base,
+        head=head_sha,
+    )
+    if auto_armed:
+        run_gh(
+            [
+                "pr",
+                "merge",
+                str(number),
+                "--repo",
+                repository,
+                "--disable-auto",
+                "--match-head-commit",
+                head_sha,
+            ]
+        )
+        pull_id, auto_armed, queue_armed = _read_state(
+            repository=repository,
+            number=number,
+            branch=branch,
+            base=base,
+            head=head_sha,
+        )
+    if queue_armed:
+        _json(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={DEQUEUE_MUTATION}",
+                "-f",
+                f"id={pull_id}",
+            ]
+        )
+        pull_id, auto_armed, queue_armed = _read_state(
+            repository=repository,
+            number=number,
+            branch=branch,
+            base=base,
+            head=head_sha,
+        )
+    if auto_armed or queue_armed:
+        raise LandingStateError(
+            f"pull request {number} still has server-owned landing state armed"
+        )
+    return {
+        "found": True,
+        "number": number,
+        "head": head_sha,
+        "auto_merge": None,
+        "merge_queue_entry": None,
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--expected-number", type=int)
+    parser.add_argument("--expected-head")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        result = ensure_disabled(
+            repository=args.repository,
+            branch=args.branch,
+            base=args.base,
+            expected_number=args.expected_number,
+            expected_head=args.expected_head,
+        )
+    except LandingStateError as exc:
+        print(
+            f"::error title=Unsafe Kin dependency PR landing state::{exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kin-registry-wave-artifact.py
+++ b/scripts/kin-registry-wave-artifact.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Create and verify the data-only handoff for a Kin registry dependency wave."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import re
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Sequence
+
+
+EXPECTED_REPOSITORY = "firelock-ai/kin"
+EXPECTED_WORKFLOW_PATH = ".github/workflows/kin-registry-release.yml"
+ALLOWED_PATHS = ("Cargo.lock", "Cargo.toml")
+LOWER_SHA = re.compile(r"^[0-9a-f]{40}$")
+HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+VERSION_EVIDENCE = re.compile(r"^(?:absent|[0-9A-Za-z.+-]+)$")
+MAX_FILE_BYTES = 32 * 1024 * 1024
+CANDIDATE_KEYS = frozenset(
+    {
+        "schema",
+        "repository",
+        "policy_sha",
+        "base",
+        "tree",
+        "delta_sha256",
+        "package_version",
+        "workspace_version",
+        "paths",
+        "files",
+    }
+)
+ADMISSION_KEYS = CANDIDATE_KEYS | frozenset(
+    {"changed", "pull", "head", "workflow_path", "run_id", "run_attempt"}
+)
+NO_CHANGE_KEYS = frozenset(
+    {
+        "schema",
+        "repository",
+        "changed",
+        "policy_sha",
+        "base",
+        "workflow_path",
+        "run_id",
+        "run_attempt",
+    }
+)
+
+
+class ArtifactError(RuntimeError):
+    """The dependency-wave artifact is malformed or not bound to this run."""
+
+
+def _load_guard() -> ModuleType:
+    path = Path(__file__).resolve().with_name("verify-kin-registry-wave-head.py")
+    spec = importlib.util.spec_from_file_location("kin_registry_wave_runtime_guard", path)
+    if spec is None or spec.loader is None:
+        raise ArtifactError(f"cannot load trusted verifier {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _require_sha(label: str, value: Any) -> str:
+    if not isinstance(value, str) or LOWER_SHA.fullmatch(value) is None:
+        raise ArtifactError(f"{label} must be 40-character lowercase hex")
+    return value
+
+
+def _require_positive(label: str, value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ArtifactError(f"{label} must be a positive integer")
+    return value
+
+
+def _pairs_no_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ArtifactError(f"JSON object repeats key {key!r}")
+        result[key] = value
+    return result
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        raw = _safe_regular(path).decode("utf-8")
+        value = json.loads(raw, object_pairs_hook=_pairs_no_duplicates)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ArtifactError(f"cannot read exact JSON artifact {path.name}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ArtifactError(f"{path.name} is not a JSON object")
+    return value
+
+
+def _safe_regular(path: Path) -> bytes:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise ArtifactError(f"artifact file {path.name} is missing: {exc}") from exc
+    if not stat.S_ISREG(info.st_mode) or path.is_symlink():
+        raise ArtifactError(f"artifact entry {path.name} is not a regular file")
+    if info.st_size > MAX_FILE_BYTES:
+        raise ArtifactError(f"artifact entry {path.name} exceeds the size limit")
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise ArtifactError(f"cannot read artifact entry {path.name}: {exc}") from exc
+
+
+def _exact_entries(directory: Path, expected: frozenset[str]) -> None:
+    if directory.is_symlink() or not directory.is_dir():
+        raise ArtifactError("artifact path is not an exact directory")
+    entries = frozenset(item.name for item in directory.iterdir())
+    if entries != expected:
+        raise ArtifactError(
+            "artifact entries differ from the allowlist: "
+            + ", ".join(sorted(entries ^ expected))
+        )
+
+
+def _validate_candidate(
+    value: dict[str, Any],
+    *,
+    repository: str,
+    policy_sha: str,
+    base: str,
+) -> dict[str, Any]:
+    if frozenset(value) != CANDIDATE_KEYS:
+        raise ArtifactError("candidate manifest keys differ from the exact schema")
+    if value.get("schema") != 1:
+        raise ArtifactError("candidate manifest schema is not 1")
+    if repository != EXPECTED_REPOSITORY or value.get("repository") != repository:
+        raise ArtifactError("candidate repository is not firelock-ai/kin")
+    policy_sha = _require_sha("expected policy sha", policy_sha)
+    base = _require_sha("expected candidate base", base)
+    if policy_sha != base:
+        raise ArtifactError("current protected main differs from the workflow policy sha")
+    if value.get("policy_sha") != policy_sha or value.get("base") != base:
+        raise ArtifactError("candidate policy or base does not match protected main")
+    _require_sha("candidate tree", value.get("tree"))
+    if not isinstance(value.get("delta_sha256"), str) or HEX_64.fullmatch(
+        value["delta_sha256"]
+    ) is None:
+        raise ArtifactError("candidate delta digest is invalid")
+    for field in ("package_version", "workspace_version"):
+        item = value.get(field)
+        if not isinstance(item, str) or VERSION_EVIDENCE.fullmatch(item) is None:
+            raise ArtifactError(f"candidate {field} is invalid")
+    if value.get("paths") != list(ALLOWED_PATHS):
+        raise ArtifactError("candidate paths differ from the exact allowlist")
+    files = value.get("files")
+    if not isinstance(files, dict) or frozenset(files) != frozenset(ALLOWED_PATHS):
+        raise ArtifactError("candidate file digest map differs from the allowlist")
+    for path in ALLOWED_PATHS:
+        digest = files.get(path)
+        if not isinstance(digest, str) or HEX_64.fullmatch(digest) is None:
+            raise ArtifactError(f"candidate digest for {path} is invalid")
+    return value
+
+
+def _git(workspace: Path, *arguments: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(workspace), *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ArtifactError(f"git {' '.join(arguments)} failed: {detail or 'no output'}")
+    return result.stdout
+
+
+def prepare_candidate(
+    *,
+    workspace: Path,
+    output_dir: Path,
+    repository: str,
+    policy_sha: str,
+    base: str,
+    expected_tree: str,
+) -> dict[str, Any]:
+    if policy_sha != base:
+        raise ArtifactError("candidate base must equal the workflow policy sha")
+    guard = _load_guard()
+    try:
+        evidence = guard.validate_index_delta(workspace, base, expected_tree)
+    except guard.AdmissionError as exc:
+        raise ArtifactError(str(exc)) from exc
+    if output_dir.exists():
+        if output_dir.is_symlink() or any(output_dir.iterdir()):
+            raise ArtifactError("candidate output directory must be absent or empty")
+    else:
+        output_dir.mkdir(parents=True)
+
+    files: dict[str, str] = {}
+    for path in ALLOWED_PATHS:
+        content = _git(workspace, "show", f":{path}")
+        (output_dir / path).write_bytes(content)
+        files[path] = _sha256(content)
+    manifest: dict[str, Any] = {
+        "schema": 1,
+        "repository": repository,
+        "policy_sha": policy_sha,
+        "base": base,
+        "tree": evidence.tree,
+        "delta_sha256": evidence.delta_sha256,
+        "package_version": evidence.package_version,
+        "workspace_version": evidence.workspace_version,
+        "paths": list(ALLOWED_PATHS),
+        "files": files,
+    }
+    _validate_candidate(
+        manifest,
+        repository=repository,
+        policy_sha=policy_sha,
+        base=base,
+    )
+    (output_dir / "candidate.json").write_text(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def apply_candidate(
+    *,
+    workspace: Path,
+    artifact_dir: Path,
+    repository: str,
+    policy_sha: str,
+    base: str,
+) -> dict[str, Any]:
+    _exact_entries(
+        artifact_dir,
+        frozenset({"candidate.json", *ALLOWED_PATHS}),
+    )
+    value = _validate_candidate(
+        _read_json(artifact_dir / "candidate.json"),
+        repository=repository,
+        policy_sha=policy_sha,
+        base=base,
+    )
+    if _git(workspace, "rev-parse", "HEAD").decode("ascii").strip() != base:
+        raise ArtifactError("mutation checkout is not the exact protected main")
+    if _git(workspace, "status", "--porcelain", "-z", "--untracked-files=all"):
+        raise ArtifactError("mutation checkout is not clean before artifact admission")
+
+    for path in ALLOWED_PATHS:
+        content = _safe_regular(artifact_dir / path)
+        if _sha256(content) != value["files"][path]:
+            raise ArtifactError(f"artifact bytes for {path} differ from their digest")
+    for path in ALLOWED_PATHS:
+        (workspace / path).write_bytes((artifact_dir / path).read_bytes())
+    _git(workspace, "add", "--", *ALLOWED_PATHS)
+
+    guard = _load_guard()
+    try:
+        evidence = guard.validate_index_delta(workspace, base, str(value["tree"]))
+    except guard.AdmissionError as exc:
+        raise ArtifactError(str(exc)) from exc
+    observed = {
+        "tree": evidence.tree,
+        "delta_sha256": evidence.delta_sha256,
+        "package_version": evidence.package_version,
+        "workspace_version": evidence.workspace_version,
+        "paths": sorted(evidence.paths),
+    }
+    expected = {
+        "tree": value["tree"],
+        "delta_sha256": value["delta_sha256"],
+        "package_version": value["package_version"],
+        "workspace_version": value["workspace_version"],
+        "paths": value["paths"],
+    }
+    if observed != expected:
+        raise ArtifactError("fresh mutation admission differs from prepared evidence")
+    return value
+
+
+def finalize_admission(
+    *,
+    artifact_dir: Path,
+    output_file: Path,
+    repository: str,
+    policy_sha: str,
+    base: str,
+    pull: int,
+    head: str,
+    workflow_path: str,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, Any]:
+    _exact_entries(
+        artifact_dir,
+        frozenset({"candidate.json", *ALLOWED_PATHS}),
+    )
+    candidate = _validate_candidate(
+        _read_json(artifact_dir / "candidate.json"),
+        repository=repository,
+        policy_sha=policy_sha,
+        base=base,
+    )
+    pull = _require_positive("pull request number", pull)
+    head = _require_sha("pull request head", head)
+    run_id = _require_positive("workflow run id", run_id)
+    run_attempt = _require_positive("workflow run attempt", run_attempt)
+    if workflow_path != EXPECTED_WORKFLOW_PATH:
+        raise ArtifactError("receiver workflow path is not the exact admitted path")
+    result = dict(candidate)
+    result.update(
+        {
+            "changed": True,
+            "pull": pull,
+            "head": head,
+            "workflow_path": workflow_path,
+            "run_id": run_id,
+            "run_attempt": run_attempt,
+        }
+    )
+    if frozenset(result) != ADMISSION_KEYS:
+        raise ArtifactError("final admission keys differ from the exact schema")
+    if output_file.exists() and output_file.is_symlink():
+        raise ArtifactError("final admission output is a symlink")
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(
+        json.dumps(result, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def finalize_no_change(
+    *,
+    output_file: Path,
+    repository: str,
+    policy_sha: str,
+    base: str,
+    workflow_path: str,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, Any]:
+    policy_sha = _require_sha("no-change policy sha", policy_sha)
+    base = _require_sha("no-change base", base)
+    if repository != EXPECTED_REPOSITORY:
+        raise ArtifactError("no-change repository is not firelock-ai/kin")
+    if policy_sha != base:
+        raise ArtifactError("no-change base differs from the workflow policy sha")
+    if workflow_path != EXPECTED_WORKFLOW_PATH:
+        raise ArtifactError("no-change workflow path is not the receiver")
+    run_id = _require_positive("workflow run id", run_id)
+    run_attempt = _require_positive("workflow run attempt", run_attempt)
+    result: dict[str, Any] = {
+        "schema": 1,
+        "repository": repository,
+        "changed": False,
+        "policy_sha": policy_sha,
+        "base": base,
+        "workflow_path": workflow_path,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+    }
+    if frozenset(result) != NO_CHANGE_KEYS:
+        raise ArtifactError("no-change result keys differ from the exact schema")
+    if output_file.exists() and output_file.is_symlink():
+        raise ArtifactError("receiver result output is a symlink")
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(
+        json.dumps(result, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def validate_admission(
+    *,
+    admission_file: Path,
+    repository: str,
+    workflow_path: str,
+    policy_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, Any]:
+    value = _read_json(admission_file)
+    if frozenset(value) != ADMISSION_KEYS:
+        raise ArtifactError("final admission keys differ from the exact schema")
+    if value.get("changed") is not True:
+        raise ArtifactError("final admission is not a changed receiver result")
+    _validate_candidate(
+        {key: value[key] for key in CANDIDATE_KEYS},
+        repository=repository,
+        policy_sha=policy_sha,
+        base=policy_sha,
+    )
+    _require_positive("admission pull", value.get("pull"))
+    _require_sha("admission head", value.get("head"))
+    if value.get("workflow_path") != workflow_path or workflow_path != EXPECTED_WORKFLOW_PATH:
+        raise ArtifactError("admission workflow path differs from the completed receiver")
+    if value.get("run_id") != run_id or value.get("run_attempt") != run_attempt:
+        raise ArtifactError("admission run identity differs from the completed receiver")
+    _require_positive("expected workflow run id", run_id)
+    _require_positive("expected workflow run attempt", run_attempt)
+    return value
+
+
+def validate_result(
+    *,
+    result_file: Path,
+    repository: str,
+    workflow_path: str,
+    policy_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, Any]:
+    value = _read_json(result_file)
+    if value.get("changed") is True:
+        return validate_admission(
+            admission_file=result_file,
+            repository=repository,
+            workflow_path=workflow_path,
+            policy_sha=policy_sha,
+            run_id=run_id,
+            run_attempt=run_attempt,
+        )
+    if value.get("changed") is not False or frozenset(value) != NO_CHANGE_KEYS:
+        raise ArtifactError("receiver result is neither exact changed nor no-change schema")
+    if (
+        value.get("schema") != 1
+        or value.get("repository") != repository
+        or repository != EXPECTED_REPOSITORY
+        or value.get("workflow_path") != workflow_path
+        or workflow_path != EXPECTED_WORKFLOW_PATH
+        or value.get("policy_sha") != policy_sha
+        or value.get("base") != policy_sha
+        or value.get("run_id") != run_id
+        or value.get("run_attempt") != run_attempt
+    ):
+        raise ArtifactError("no-change result differs from completed receiver authority")
+    _require_sha("no-change policy sha", policy_sha)
+    _require_positive("expected workflow run id", run_id)
+    _require_positive("expected workflow run attempt", run_attempt)
+    return value
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--workspace", type=Path, required=True)
+    prepare.add_argument("--output-dir", type=Path, required=True)
+    prepare.add_argument("--repository", required=True)
+    prepare.add_argument("--policy-sha", required=True)
+    prepare.add_argument("--base", required=True)
+    prepare.add_argument("--expected-tree", required=True)
+    apply = subparsers.add_parser("apply")
+    apply.add_argument("--workspace", type=Path, required=True)
+    apply.add_argument("--artifact-dir", type=Path, required=True)
+    apply.add_argument("--repository", required=True)
+    apply.add_argument("--policy-sha", required=True)
+    apply.add_argument("--base", required=True)
+    finalize = subparsers.add_parser("finalize")
+    finalize.add_argument("--artifact-dir", type=Path, required=True)
+    finalize.add_argument("--output-file", type=Path, required=True)
+    finalize.add_argument("--repository", required=True)
+    finalize.add_argument("--policy-sha", required=True)
+    finalize.add_argument("--base", required=True)
+    finalize.add_argument("--pull", type=int, required=True)
+    finalize.add_argument("--head", required=True)
+    finalize.add_argument("--workflow-path", required=True)
+    finalize.add_argument("--run-id", type=int, required=True)
+    finalize.add_argument("--run-attempt", type=int, required=True)
+    no_change = subparsers.add_parser("finalize-no-change")
+    no_change.add_argument("--output-file", type=Path, required=True)
+    no_change.add_argument("--repository", required=True)
+    no_change.add_argument("--policy-sha", required=True)
+    no_change.add_argument("--base", required=True)
+    no_change.add_argument("--workflow-path", required=True)
+    no_change.add_argument("--run-id", type=int, required=True)
+    no_change.add_argument("--run-attempt", type=int, required=True)
+    validate = subparsers.add_parser("validate-admission")
+    validate.add_argument("--admission-file", type=Path, required=True)
+    validate.add_argument("--repository", required=True)
+    validate.add_argument("--workflow-path", required=True)
+    validate.add_argument("--policy-sha", required=True)
+    validate.add_argument("--run-id", type=int, required=True)
+    validate.add_argument("--run-attempt", type=int, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        if args.command == "prepare":
+            result = prepare_candidate(
+                workspace=args.workspace,
+                output_dir=args.output_dir,
+                repository=args.repository,
+                policy_sha=args.policy_sha,
+                base=args.base,
+                expected_tree=args.expected_tree,
+            )
+        elif args.command == "apply":
+            result = apply_candidate(
+                workspace=args.workspace,
+                artifact_dir=args.artifact_dir,
+                repository=args.repository,
+                policy_sha=args.policy_sha,
+                base=args.base,
+            )
+        elif args.command == "finalize":
+            result = finalize_admission(
+                artifact_dir=args.artifact_dir,
+                output_file=args.output_file,
+                repository=args.repository,
+                policy_sha=args.policy_sha,
+                base=args.base,
+                pull=args.pull,
+                head=args.head,
+                workflow_path=args.workflow_path,
+                run_id=args.run_id,
+                run_attempt=args.run_attempt,
+            )
+        elif args.command == "finalize-no-change":
+            result = finalize_no_change(
+                output_file=args.output_file,
+                repository=args.repository,
+                policy_sha=args.policy_sha,
+                base=args.base,
+                workflow_path=args.workflow_path,
+                run_id=args.run_id,
+                run_attempt=args.run_attempt,
+            )
+        else:
+            result = validate_admission(
+                admission_file=args.admission_file,
+                repository=args.repository,
+                workflow_path=args.workflow_path,
+                policy_sha=args.policy_sha,
+                run_id=args.run_id,
+                run_attempt=args.run_attempt,
+            )
+    except (ArtifactError, OSError, UnicodeDecodeError) as exc:
+        print(
+            f"::error title=Invalid Kin registry wave artifact::{exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-kin-registry-release-receiver.py
+++ b/scripts/test-kin-registry-release-receiver.py
@@ -3,27 +3,53 @@
 
 from __future__ import annotations
 
+import copy
 import importlib.util
 import json
 import os
+import re
 import subprocess
+import sys
 import tempfile
 import tomllib
 import unittest
 from pathlib import Path
+from typing import Any
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
 VALIDATOR_PATH = ROOT / "scripts" / "validate-kin-registry-release.py"
+AUTO_MERGE_PATH = ROOT / "scripts" / "ensure-kin-registry-wave-no-automerge.py"
+IDENTITY_PATH = ROOT / "scripts" / "verify-kin-release-app-token.py"
+ARTIFACT_PATH = ROOT / "scripts" / "kin-registry-wave-artifact.py"
+ATTESTER_PATH = ROOT / "scripts" / "attest-kin-registry-wave.py"
+HEAD_GUARD_PATH = ROOT / "scripts" / "verify-kin-registry-wave-head.py"
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "kin-registry-release.yml"
+ATTEST_WORKFLOW_PATH = (
+    ROOT / ".github" / "workflows" / "kin-registry-release-attest.yml"
+)
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
 KIN_ACTIONS_SHA = "398595fa14ba1eaebca6eb176facd8a57ce9db05"
 SOURCE_SHA = "f1ac2bd93f0e3b7162f01481822087151e3b3af4"
 
-spec = importlib.util.spec_from_file_location("kin_registry_receiver", VALIDATOR_PATH)
-if spec is None or spec.loader is None:
-    raise RuntimeError("could not load Kin registry receiver validator")
-validator = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(validator)
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = load_module("kin_registry_receiver", VALIDATOR_PATH)
+auto_merge = load_module("kin_registry_auto_merge", AUTO_MERGE_PATH)
+identity = load_module("kin_registry_app_identity", IDENTITY_PATH)
+artifact = load_module("kin_registry_wave_artifact_tests", ARTIFACT_PATH)
+head_guard = load_module("kin_registry_head_guard", HEAD_GUARD_PATH)
+attester = load_module("kin_registry_wave_attester_tests", ATTESTER_PATH)
 
 
 def valid_payload(
@@ -53,22 +79,397 @@ def valid_context(**overrides: str) -> dict[str, str]:
     return context
 
 
+def job_block(workflow: str, job_id: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_id)}:\n.*?(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"workflow job {job_id!r} is missing")
+    return match.group(0)
+
+
+def step_block(workflow: str, step_name: str) -> str:
+    match = re.search(
+        rf"(?ms)^      - name: {re.escape(step_name)}\n.*?"
+        r"(?=^      - (?:name|uses):|^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"workflow step {step_name!r} is missing")
+    return match.group(0)
+
+
+def run_git(repo: Path, *arguments: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *arguments],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+def manifest(
+    dependency: str = "=0.7.67",
+    *,
+    workspace_version: str = "0.6.1",
+    extra: str = "",
+) -> str:
+    return (
+        "[workspace]\n"
+        "members = []\n\n"
+        "[workspace.package]\n"
+        f'version = "{workspace_version}"\n\n'
+        "[workspace.dependencies]\n"
+        f'kin-db = {{ version = "{dependency}", registry = "kin" }}\n'
+        f"{extra}"
+    )
+
+
+def initialize_repo(repo: Path) -> str:
+    run_git(repo, "init", "-q")
+    run_git(repo, "config", "user.name", "Kin Test")
+    run_git(repo, "config", "user.email", "kin-test@example.com")
+    run_git(repo, "config", "commit.gpgsign", "false")
+    run_git(repo, "config", "core.hooksPath", "/dev/null")
+    (repo / "Cargo.toml").write_text(manifest(), encoding="utf-8")
+    (repo / "Cargo.lock").write_text("version = 4\nkin-db 0.7.67\n", encoding="utf-8")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    run_git(repo, "add", "Cargo.toml", "Cargo.lock", "README.md")
+    run_git(repo, "commit", "-q", "-m", "base")
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+def restore_dependency_files(repo: Path, revision: str) -> None:
+    run_git(
+        repo,
+        "restore",
+        "--source",
+        revision,
+        "--staged",
+        "--worktree",
+        "--",
+        "Cargo.lock",
+        "Cargo.toml",
+    )
+
+
+def commit_dependency_head(
+    repo: Path,
+    *,
+    dependency: str = "=0.7.69",
+    workspace_version: str = "0.6.1",
+    extra: str = "",
+    lock_version: str = "0.7.69",
+    marker: bool = True,
+    readme: str | None = None,
+) -> str:
+    (repo / "Cargo.toml").write_text(
+        manifest(dependency, workspace_version=workspace_version, extra=extra),
+        encoding="utf-8",
+    )
+    (repo / "Cargo.lock").write_text(
+        f"version = 4\nkin-db {lock_version}\n", encoding="utf-8"
+    )
+    if readme is not None:
+        (repo / "README.md").write_text(readme, encoding="utf-8")
+    run_git(repo, "add", "-A")
+    message = "dependency wave"
+    if marker:
+        message += f"\n\n{head_guard.COMMIT_MARKER}"
+    run_git(repo, "commit", "-q", "-m", message)
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+def attestation_documents(
+    repo: Path,
+    base: str,
+    head: str,
+    *,
+    pull: int = 77,
+    review_id: int = 41,
+    comment_id: int = 51,
+    run_id: int = 331,
+    run_attempt: int = 2,
+    created_at: str = "2026-08-27T22:00:01Z",
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    evidence = head_guard.validate_delta(repo, base, head, require_marker=True)
+    tree = evidence.tree
+    review_body = head_guard._review_body(
+        head_guard.EXPECTED_REPOSITORY,
+        pull,
+        head,
+        tree,
+        base,
+        evidence.delta_sha256,
+        evidence.package_version,
+        evidence.workspace_version,
+        head_guard.RECEIVER_WORKFLOW_PATH,
+        base,
+        run_id,
+        run_attempt,
+    )
+    review = {
+        "id": review_id,
+        "state": "COMMENTED",
+        "commit_id": head,
+        "body": review_body,
+        "submitted_at": "2026-08-27T22:00:00Z",
+        "user": {
+            "id": head_guard.ATTESTATION_CREATOR_ID,
+            "login": head_guard.ATTESTATION_CREATOR,
+            "type": "Bot",
+        },
+    }
+    comment_body = head_guard._comment_body(
+        head_guard.EXPECTED_REPOSITORY,
+        pull,
+        review_id,
+        head,
+        tree,
+        base,
+        evidence.delta_sha256,
+        evidence.package_version,
+        evidence.workspace_version,
+        head_guard.RECEIVER_WORKFLOW_PATH,
+        base,
+        run_id,
+        run_attempt,
+    )
+    comment = {
+        "id": comment_id,
+        "body": comment_body,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "issue_url": f"https://api.github.com/repos/firelock-ai/kin/issues/{pull}",
+        "html_url": (
+            f"https://github.com/firelock-ai/kin/pull/{pull}"
+            f"#issuecomment-{comment_id}"
+        ),
+        "user": {
+            "id": head_guard.ATTESTATION_CREATOR_ID,
+            "login": head_guard.ATTESTATION_CREATOR,
+            "type": "Bot",
+        },
+        "performed_via_github_app": {
+            "id": head_guard.ATTESTATION_APP_ID,
+            "slug": head_guard.ATTESTATION_APP_SLUG,
+            "owner": {
+                "id": head_guard.ATTESTATION_APP_OWNER_ID,
+                "login": head_guard.ATTESTATION_APP_OWNER,
+            },
+        },
+    }
+    return [review], [comment]
+
+
+def workflow_run_document(
+    policy_sha: str,
+    *,
+    conclusion: str = "success",
+    run_id: int = 331,
+    run_attempt: int = 2,
+) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "run_attempt": run_attempt,
+        "name": head_guard.RECEIVER_WORKFLOW_NAME,
+        "path": head_guard.RECEIVER_WORKFLOW_PATH,
+        "status": "completed",
+        "conclusion": conclusion,
+        "event": "repository_dispatch",
+        "head_branch": head_guard.EXPECTED_BASE,
+        "head_sha": policy_sha,
+        "repository": {"full_name": head_guard.EXPECTED_REPOSITORY},
+        "head_repository": {"full_name": head_guard.EXPECTED_REPOSITORY},
+    }
+
+
+def guard_api_fake(
+    *,
+    pull: dict[str, object],
+    reviews: list[dict[str, object]],
+    comments: list[dict[str, object]],
+    policy_sha: str,
+    open_pulls: list[dict[str, object]] | None = None,
+    associated_pulls: list[dict[str, object]] | None = None,
+):
+    def fake(arguments: list[str]) -> object:
+        endpoint = next(
+            (item for item in arguments if item.startswith("repos/")), ""
+        )
+        if endpoint.endswith("/reviews?per_page=100"):
+            return [reviews]
+        if endpoint.endswith("/comments?per_page=100"):
+            return [comments]
+        if "/actions/runs/331/attempts/2" in endpoint:
+            return workflow_run_document(policy_sha)
+        if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+            return pull
+        if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls":
+            return open_pulls if open_pulls is not None else [{"number": 77}]
+        if endpoint.endswith("/pulls") and "/commits/" in endpoint:
+            return associated_pulls if associated_pulls is not None else [pull]
+        raise AssertionError(f"unexpected mocked GitHub request: {arguments}")
+
+    return fake
+
+
+def pull_document(
+    head: str,
+    base: str,
+    *,
+    auto_merge_value: object = None,
+    state: str = "open",
+    merged_at: str | None = None,
+) -> dict[str, object]:
+    return {
+        "number": 77,
+        "state": state,
+        "merged_at": merged_at,
+        "head": {
+            "sha": head,
+            "ref": head_guard.WAVE_BRANCH,
+            "repo": {"full_name": head_guard.EXPECTED_REPOSITORY},
+        },
+        "base": {"sha": base, "ref": head_guard.EXPECTED_BASE},
+        "auto_merge": auto_merge_value,
+    }
+
+
+def graphql_pull_document(
+    head: str,
+    *,
+    auto_merge: bool = False,
+    queued: bool = False,
+) -> str:
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "id": "PR_node_77",
+                        "number": 77,
+                        "state": "OPEN",
+                        "headRefName": head_guard.WAVE_BRANCH,
+                        "headRefOid": head,
+                        "baseRefName": head_guard.EXPECTED_BASE,
+                        "headRepository": {
+                            "nameWithOwner": head_guard.EXPECTED_REPOSITORY
+                        },
+                        "autoMergeRequest": {"enabledAt": "now"}
+                        if auto_merge
+                        else None,
+                        "mergeQueueEntry": {"id": "MQE_node_77"}
+                        if queued
+                        else None,
+                    }
+                }
+            }
+        }
+    )
+
+
+def graphql_pull_node(head: str) -> dict[str, object]:
+    return json.loads(graphql_pull_document(head))["data"]["repository"][
+        "pullRequest"
+    ]
+
+
+def ci_run_document(
+    head: str,
+    base: str,
+    *,
+    run_id: int = 901,
+    run_attempt: int = 1,
+    created_at: str = "2026-08-27T22:00:02Z",
+) -> dict[str, object]:
+    repository_url = "https://api.github.com/repos/firelock-ai/kin"
+    return {
+        "id": run_id,
+        "run_attempt": run_attempt,
+        "name": attester.CI_WORKFLOW_NAME,
+        "path": attester.CI_WORKFLOW_PATH,
+        "event": "pull_request",
+        "head_branch": head_guard.WAVE_BRANCH,
+        "head_sha": head,
+        "status": "in_progress",
+        "conclusion": None,
+        "created_at": created_at,
+        "repository": {"full_name": head_guard.EXPECTED_REPOSITORY},
+        "head_repository": {"full_name": head_guard.EXPECTED_REPOSITORY},
+        "pull_requests": [
+            {
+                "number": 77,
+                "head": {
+                    "ref": head_guard.WAVE_BRANCH,
+                    "sha": head,
+                    "repo": {"name": "kin", "url": repository_url},
+                },
+                "base": {
+                    "ref": head_guard.EXPECTED_BASE,
+                    "sha": base,
+                    "repo": {"name": "kin", "url": repository_url},
+                },
+            }
+        ],
+    }
+
+
+def ci_jobs_document(
+    *,
+    run_id: int = 901,
+    name: str = "Fast gate lint and policy",
+    status: str = "queued",
+    conclusion: str | None = None,
+) -> dict[str, object]:
+    return {
+        "total_count": 1,
+        "jobs": [
+            {
+                "id": 9901,
+                "name": name,
+                "status": status,
+                "conclusion": conclusion,
+                "run_url": (
+                    "https://api.github.com/repos/firelock-ai/kin/actions/runs/"
+                    f"{run_id}"
+                ),
+            }
+        ],
+    }
+
+
 class ValidatorTests(unittest.TestCase):
     def test_accepts_exact_kindb_release_contract(self) -> None:
-        validator.validate_context(**valid_context())
+        self.assertEqual(
+            validator.validate_context(**valid_context()), validator.DISPATCH_EVENT
+        )
         self.assertEqual(
             validator.validate_payload(valid_payload())["crate_version"], "0.7.69"
         )
 
+    def test_accepts_trusted_eventless_schedule(self) -> None:
+        context = valid_context(
+            event_name="schedule",
+            event_action="",
+            actor="schedule-owner-not-dispatch-allowlisted",
+        )
+        self.assertEqual(validator.validate_context(**context), validator.SCHEDULE_EVENT)
+        result = self.run_cli(
+            None, context=context, event={"schedule": "17 * * * *"}
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("scheduled Kin registry reconciliation", result.stdout)
+
     def test_accepts_every_allowed_root_manifest_source_pair(self) -> None:
         for crate, source in validator.ALLOWED_SOURCES.items():
             with self.subTest(crate=crate):
-                self.assertEqual(
-                    validator.validate_payload(
-                        valid_payload(crate=crate, source=source)
-                    )["source_repo"],
-                    source,
+                payload = validator.validate_payload(
+                    valid_payload(crate=crate, source=source)
                 )
+                self.assertEqual(payload["source_repo"], source)
 
     def test_allowed_crates_are_exactly_the_root_registry_boundary(self) -> None:
         with (ROOT / "Cargo.toml").open("rb") as stream:
@@ -83,6 +484,10 @@ class ValidatorTests(unittest.TestCase):
     def test_rejects_wrong_event_action(self) -> None:
         with self.assertRaisesRegex(validator.ValidationError, "event action"):
             validator.validate_context(**valid_context(event_action="dependency-updated"))
+
+    def test_rejects_untrusted_event_kind(self) -> None:
+        with self.assertRaisesRegex(validator.ValidationError, "event name"):
+            validator.validate_context(**valid_context(event_name="workflow_dispatch"))
 
     def test_rejects_missing_delivery_id(self) -> None:
         payload = valid_payload()
@@ -100,15 +505,13 @@ class ValidatorTests(unittest.TestCase):
         with self.assertRaisesRegex(validator.ValidationError, "stable SemVer"):
             validator.validate_payload(payload)
 
-    def test_rejects_package_outside_boundary(self) -> None:
-        payload = valid_payload(crate="serde", source="serde-rs/serde")
+    def test_rejects_package_and_source_outside_boundary(self) -> None:
         with self.assertRaisesRegex(validator.ValidationError, "outside Kin's"):
-            validator.validate_payload(payload)
-
-    def test_rejects_source_repo_mismatch(self) -> None:
-        payload = valid_payload(source="firelock-ai/kin-model")
+            validator.validate_payload(
+                valid_payload(crate="serde", source="serde-rs/serde")
+            )
         with self.assertRaisesRegex(validator.ValidationError, "must come from"):
-            validator.validate_payload(payload)
+            validator.validate_payload(valid_payload(source="firelock-ai/kin-model"))
 
     def test_rejects_unbound_delivery_id(self) -> None:
         payload = valid_payload()
@@ -123,27 +526,26 @@ class ValidatorTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("::error title=Invalid Kin registry release::", result.stderr)
 
-    def test_cli_accepts_valid_payload(self) -> None:
+    def test_cli_labels_sender_sha_as_metadata_not_provenance(self) -> None:
         result = self.run_cli(valid_payload())
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("validated Kin registry release kin-db@0.7.69", result.stdout)
+        self.assertIn("correlation metadata, not source provenance", result.stdout)
 
-    def run_cli(self, payload: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    def run_cli(
+        self,
+        payload: dict[str, str] | None,
+        *,
+        context: dict[str, str] | None = None,
+        event: dict[str, object] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        chosen_context = context or valid_context()
+        if event is None:
+            event = {"action": "kin-registry-release", "client_payload": payload}
         with tempfile.TemporaryDirectory() as directory:
             event_path = Path(directory) / "event.json"
-            event_path.write_text(
-                json.dumps(
-                    {"action": "kin-registry-release", "client_payload": payload}
-                ),
-                encoding="utf-8",
-            )
-            command = [
-                "python3",
-                str(VALIDATOR_PATH),
-                "--event-file",
-                str(event_path),
-            ]
-            for key, value in valid_context().items():
+            event_path.write_text(json.dumps(event), encoding="utf-8")
+            command = ["python3", str(VALIDATOR_PATH), "--event-file", str(event_path)]
+            for key, value in chosen_context.items():
                 command.extend([f"--{key.replace('_', '-')}", value])
             return subprocess.run(
                 command,
@@ -155,34 +557,1505 @@ class ValidatorTests(unittest.TestCase):
             )
 
 
+class AutoMergeTests(unittest.TestCase):
+    def test_clears_auto_merge_and_queue_then_rereads_both_null(self) -> None:
+        armed = pull_document("b" * 40, "a" * 40, auto_merge_value={"by": "captain"})
+        with mock.patch.object(
+            auto_merge,
+            "run_gh",
+            side_effect=[
+                json.dumps([armed]),
+                graphql_pull_document("b" * 40, auto_merge=True, queued=True),
+                "",
+                graphql_pull_document("b" * 40, queued=True),
+                json.dumps({"data": {"dequeuePullRequest": {"mergeQueueEntry": None}}}),
+                graphql_pull_document("b" * 40),
+            ],
+        ) as runner:
+            result = auto_merge.ensure_disabled(
+                repository="firelock-ai/kin",
+                branch=head_guard.WAVE_BRANCH,
+                base="main",
+            )
+        self.assertIsNone(result["auto_merge"])
+        self.assertIsNone(result["merge_queue_entry"])
+        disable = runner.call_args_list[2].args[0]
+        self.assertIn("--disable-auto", disable)
+        self.assertIn("--match-head-commit", disable)
+        self.assertNotIn("--auto", disable)
+        dequeue = runner.call_args_list[4].args[0]
+        self.assertIn("dequeuePullRequest", " ".join(dequeue))
+        self.assertIn("id=PR_node_77", dequeue)
+
+    def test_fails_if_queue_state_remains_after_dequeue(self) -> None:
+        armed = pull_document("b" * 40, "a" * 40)
+        with mock.patch.object(
+            auto_merge,
+            "run_gh",
+            side_effect=[
+                json.dumps([armed]),
+                graphql_pull_document("b" * 40, queued=True),
+                json.dumps({"data": {"dequeuePullRequest": {"mergeQueueEntry": None}}}),
+                graphql_pull_document("b" * 40, queued=True),
+            ],
+        ):
+            with self.assertRaisesRegex(auto_merge.LandingStateError, "still has"):
+                auto_merge.ensure_disabled(
+                    repository="firelock-ai/kin",
+                    branch=head_guard.WAVE_BRANCH,
+                    base="main",
+                )
+
+    def test_post_write_binding_rejects_a_moved_head(self) -> None:
+        moved = pull_document("c" * 40, "a" * 40)
+        with mock.patch.object(
+            auto_merge, "run_gh", return_value=json.dumps([moved])
+        ):
+            with self.assertRaisesRegex(auto_merge.LandingStateError, "moved"):
+                auto_merge.ensure_disabled(
+                    repository="firelock-ai/kin",
+                    branch=head_guard.WAVE_BRANCH,
+                    base="main",
+                    expected_number=77,
+                    expected_head="b" * 40,
+                )
+
+
+class HeadAdmissionTests(unittest.TestCase):
+    def test_staged_evidence_matches_the_committed_dependency_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            (repo / "Cargo.toml").write_text(manifest("=0.7.69"), encoding="utf-8")
+            (repo / "Cargo.lock").write_text(
+                "version = 4\nkin-db 0.7.69\n", encoding="utf-8"
+            )
+            run_git(repo, "add", "Cargo.toml", "Cargo.lock")
+            tree = run_git(repo, "write-tree")
+            staged = head_guard.validate_index_delta(repo, base, tree)
+            run_git(
+                repo,
+                "commit",
+                "-q",
+                "-m",
+                f"dependency wave\n\n{head_guard.COMMIT_MARKER}",
+            )
+            head = run_git(repo, "rev-parse", "HEAD")
+            committed = head_guard.validate_delta(
+                repo, base, head, require_marker=True
+            )
+            self.assertEqual(staged.tree, committed.tree)
+            self.assertEqual(staged.delta_sha256, committed.delta_sha256)
+            self.assertEqual(staged.package_version, committed.package_version)
+            self.assertEqual(staged.workspace_version, committed.workspace_version)
+
+    def test_exact_release_app_attestation_binds_allowed_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head)
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments,
+                expected_base=base,
+            )
+            self.assertEqual(evidence.paths, head_guard.ALLOWED_PATHS)
+
+    def test_attestation_requires_exact_terminal_receiver_run(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head)
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments,
+                expected_base=base,
+                workflow_run=workflow_run_document(base),
+            )
+            self.assertEqual(evidence.head, head)
+            failed = workflow_run_document(base, conclusion="failure")
+            with self.assertRaisesRegex(head_guard.AdmissionError, "successful"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    reviews,
+                    comments,
+                    workflow_run=failed,
+                )
+            wrong_policy = workflow_run_document("d" * 40)
+            with self.assertRaisesRegex(head_guard.AdmissionError, "successful"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    reviews,
+                    comments,
+                    workflow_run=wrong_policy,
+                )
+
+    def test_rejects_non_admitted_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo, readme="not admitted\n")
+            with self.assertRaisesRegex(head_guard.AdmissionError, "README.md"):
+                head_guard.validate_delta(repo, base, head, require_marker=True)
+
+    def test_rejects_workspace_version_change(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo, workspace_version="0.6.2")
+            with self.assertRaisesRegex(head_guard.AdmissionError, "workspace version"):
+                head_guard.validate_delta(repo, base, head, require_marker=True)
+
+    def test_rejects_body_spoof_without_exact_app_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head)
+            comments[0]["performed_via_github_app"]["id"] = 15368
+            with self.assertRaisesRegex(head_guard.AdmissionError, "exact release App"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    reviews,
+                    comments,
+                )
+            _, same_login_comments = attestation_documents(repo, base, head)
+            same_login_comments[0]["user"]["id"] = 1
+            with self.assertRaisesRegex(head_guard.AdmissionError, "exact release App"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    reviews,
+                    same_login_comments,
+                )
+
+    def test_rejects_edited_comment_deleted_review_and_dismissed_review(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head)
+            edited = copy.deepcopy(comments)
+            edited[0]["updated_at"] = "2026-08-27T22:01:00Z"
+            with self.assertRaisesRegex(head_guard.AdmissionError, "was edited"):
+                head_guard.validate_attestation(
+                    repo, head_guard.EXPECTED_REPOSITORY, 77, head, reviews, edited
+                )
+            with self.assertRaisesRegex(head_guard.AdmissionError, "deleted or missing"):
+                head_guard.validate_attestation(
+                    repo, head_guard.EXPECTED_REPOSITORY, 77, head, [], comments
+                )
+            dismissed = copy.deepcopy(reviews)
+            dismissed[0]["state"] = "DISMISSED"
+            with self.assertRaisesRegex(head_guard.AdmissionError, "dismissed"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    dismissed,
+                    comments,
+                )
+
+    def test_rejects_stale_review_and_post_review_synchronize(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head)
+            stale = copy.deepcopy(reviews)
+            stale[0]["commit_id"] = base
+            with self.assertRaisesRegex(head_guard.AdmissionError, "stale"):
+                head_guard.validate_attestation(
+                    repo, head_guard.EXPECTED_REPOSITORY, 77, head, stale, comments
+                )
+            with self.assertRaises(head_guard.PendingAttestation):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    "c" * 40,
+                    reviews,
+                    comments,
+                )
+
+    def test_rejects_conflicting_current_head_attestations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head)
+            second_reviews, second_comments = attestation_documents(
+                repo,
+                base,
+                head,
+                review_id=42,
+                comment_id=52,
+            )
+            actual_tree = run_git(repo, "rev-parse", f"{head}^{{tree}}")
+            conflicting_tree = "d" * 40
+            second_reviews[0]["body"] = str(second_reviews[0]["body"]).replace(
+                f"tree={actual_tree}", f"tree={conflicting_tree}"
+            )
+            second_comments[0]["body"] = str(second_comments[0]["body"]).replace(
+                f"tree={actual_tree}", f"tree={conflicting_tree}"
+            )
+            with self.assertRaisesRegex(head_guard.AdmissionError, "conflicting"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    reviews + second_reviews,
+                    comments + second_comments,
+                )
+
+    def test_rejects_tampered_delta_and_version_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head)
+            admitted = head_guard.validate_delta(repo, base, head, require_marker=True)
+
+            bad_delta_reviews = copy.deepcopy(reviews)
+            bad_delta_comments = copy.deepcopy(comments)
+            for document in (bad_delta_reviews[0], bad_delta_comments[0]):
+                document["body"] = str(document["body"]).replace(
+                    f"delta_sha256={admitted.delta_sha256}",
+                    f"delta_sha256={'c' * 64}",
+                )
+            with self.assertRaisesRegex(head_guard.AdmissionError, "fingerprint"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    bad_delta_reviews,
+                    bad_delta_comments,
+                )
+
+            bad_version_reviews = copy.deepcopy(reviews)
+            bad_version_comments = copy.deepcopy(comments)
+            for document in (bad_version_reviews[0], bad_version_comments[0]):
+                document["body"] = str(document["body"]).replace(
+                    f"workspace_version={admitted.workspace_version}",
+                    "workspace_version=9.9.9",
+                )
+            with self.assertRaisesRegex(head_guard.AdmissionError, "workspace version"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    bad_version_reviews,
+                    bad_version_comments,
+                )
+
+    def test_rejects_wrong_pull_and_wrong_base_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head, pull=78)
+            with self.assertRaisesRegex(head_guard.AdmissionError, "another pull"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    reviews,
+                    comments,
+                )
+            pull = pull_document(head, base)
+            pull["base"]["ref"] = "not-main"
+            with self.assertRaisesRegex(head_guard.AdmissionError, "first-party"):
+                head_guard.validate_pull(
+                    pull,
+                    repository=head_guard.EXPECTED_REPOSITORY,
+                    expected_head=head,
+                    require_open=True,
+                )
+
+    def test_rejects_attested_base_that_is_not_the_current_pull_base(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head)
+            run_git(repo, "switch", "-q", "-c", "advanced", base)
+            (repo / "README.md").write_text("advanced\n", encoding="utf-8")
+            run_git(repo, "add", "README.md")
+            run_git(repo, "commit", "-q", "-m", "advance main")
+            current_base = run_git(repo, "rev-parse", "HEAD")
+            with self.assertRaisesRegex(head_guard.AdmissionError, "not current"):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    reviews,
+                    comments,
+                    expected_base=current_base,
+                )
+
+    def test_rejects_server_side_auto_merge(self) -> None:
+        pull = pull_document(
+            "b" * 40,
+            "a" * 40,
+            auto_merge_value={"enabled_by": {"login": "captain"}},
+        )
+        with self.assertRaisesRegex(head_guard.AdmissionError, "auto-merge armed"):
+            head_guard.validate_pull(
+                pull,
+                repository=head_guard.EXPECTED_REPOSITORY,
+                expected_head="b" * 40,
+                require_open=True,
+            )
+
+    def test_classic_delivery_compares_intended_patch_not_full_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            run_git(repo, "switch", "-q", "-c", "admitted")
+            admitted_head = commit_dependency_head(repo)
+            admitted = head_guard.validate_delta(
+                repo, base, admitted_head, require_marker=True
+            )
+
+            run_git(repo, "switch", "-q", "-c", "delivery", base)
+            (repo / "README.md").write_text("main advanced\n", encoding="utf-8")
+            run_git(repo, "add", "README.md")
+            run_git(repo, "commit", "-q", "-m", "main advanced")
+            delivery_base = run_git(repo, "rev-parse", "HEAD")
+            delivery_head = commit_dependency_head(repo, marker=False)
+            delivered = head_guard.validate_delta(
+                repo, delivery_base, delivery_head, require_marker=False
+            )
+            self.assertNotEqual(admitted.tree, delivered.tree)
+            head_guard.verify_delivery_tree(repo, admitted, delivered)
+
+    def test_classic_delivery_rejects_a_different_patch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            run_git(repo, "switch", "-q", "-c", "admitted")
+            admitted_head = commit_dependency_head(repo)
+            admitted = head_guard.validate_delta(
+                repo, base, admitted_head, require_marker=True
+            )
+            run_git(repo, "switch", "-q", "-c", "delivery", base)
+            delivered_head = commit_dependency_head(
+                repo,
+                dependency="=0.7.70",
+                lock_version="0.7.70",
+                marker=False,
+            )
+            delivered = head_guard.validate_delta(
+                repo, base, delivered_head, require_marker=False
+            )
+            with self.assertRaisesRegex(head_guard.AdmissionError, "delivery tree"):
+                head_guard.verify_delivery_tree(repo, admitted, delivered)
+
+
+class InstallationIdentityTests(unittest.TestCase):
+    def test_contract_fake_accepts_only_installation_compatible_endpoints(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake(arguments: list[str]) -> str:
+            calls.append(arguments)
+            if arguments == ["api", "users/kin-release-bot[bot]"]:
+                return json.dumps(
+                    {
+                        "id": identity.EXPECTED_BOT_ID,
+                        "login": identity.EXPECTED_BOT_LOGIN,
+                        "type": "Bot",
+                    }
+                )
+            if arguments == ["api", "installation/repositories?per_page=100"]:
+                return json.dumps(
+                    {
+                        "total_count": 1,
+                        "repositories": [{"full_name": identity.EXPECTED_REPOSITORY}],
+                    }
+                )
+            raise AssertionError(f"unsupported token-class endpoint: {arguments}")
+
+        with mock.patch.object(identity, "run_gh", side_effect=fake):
+            result = identity.verify_identity(
+                app_slug=identity.EXPECTED_APP_SLUG,
+                repository=identity.EXPECTED_REPOSITORY,
+            )
+        self.assertEqual(result["bot_id"], identity.EXPECTED_BOT_ID)
+        self.assertEqual(
+            calls,
+            [
+                ["api", "users/kin-release-bot[bot]"],
+                ["api", "installation/repositories?per_page=100"],
+            ],
+        )
+        self.assertNotIn(["api", "user"], calls)
+
+    def test_rejects_wrong_installation_scope(self) -> None:
+        responses = [
+            json.dumps(
+                {
+                    "id": identity.EXPECTED_BOT_ID,
+                    "login": identity.EXPECTED_BOT_LOGIN,
+                    "type": "Bot",
+                }
+            ),
+            json.dumps(
+                {
+                    "total_count": 2,
+                    "repositories": [
+                        {"full_name": identity.EXPECTED_REPOSITORY},
+                        {"full_name": "firelock-ai/kin-db"},
+                    ],
+                }
+            ),
+        ]
+        with mock.patch.object(identity, "run_gh", side_effect=responses):
+            with self.assertRaisesRegex(identity.IdentityError, "scoped"):
+                identity.verify_identity(
+                    app_slug=identity.EXPECTED_APP_SLUG,
+                    repository=identity.EXPECTED_REPOSITORY,
+                )
+
+
+class CandidateArtifactTests(unittest.TestCase):
+    def _prepared(self, directory: str) -> tuple[Path, Path, str, str]:
+        root = Path(directory)
+        repo = root / "repo"
+        repo.mkdir()
+        candidate = root / "candidate"
+        base = initialize_repo(repo)
+        (repo / "Cargo.toml").write_text(manifest("=0.7.69"), encoding="utf-8")
+        (repo / "Cargo.lock").write_text(
+            "version = 4\nkin-db 0.7.69\n", encoding="utf-8"
+        )
+        run_git(repo, "add", "Cargo.toml", "Cargo.lock")
+        tree = run_git(repo, "write-tree")
+        artifact.prepare_candidate(
+            workspace=repo,
+            output_dir=candidate,
+            repository=artifact.EXPECTED_REPOSITORY,
+            policy_sha=base,
+            base=base,
+            expected_tree=tree,
+        )
+        return repo, candidate, base, tree
+
+    def test_hash_bound_candidate_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, candidate, base, tree = self._prepared(directory)
+            restore_dependency_files(repo, base)
+            result = artifact.apply_candidate(
+                workspace=repo,
+                artifact_dir=candidate,
+                repository=artifact.EXPECTED_REPOSITORY,
+                policy_sha=base,
+                base=base,
+            )
+            self.assertEqual(result["tree"], tree)
+            self.assertEqual(
+                run_git(repo, "diff", "--cached", "--name-only").splitlines(),
+                ["Cargo.lock", "Cargo.toml"],
+            )
+
+    def test_rejects_path_and_github_env_poisoning_entries_before_apply(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, candidate, base, _ = self._prepared(directory)
+            restore_dependency_files(repo, base)
+            poison = candidate / "python3"
+            poison.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            poison.chmod(0o755)
+            env_file = Path(directory) / "github-env"
+            with mock.patch.dict(
+                os.environ,
+                {"PATH": str(candidate), "GITHUB_ENV": str(env_file)},
+                clear=False,
+            ):
+                with self.assertRaisesRegex(artifact.ArtifactError, "allowlist"):
+                    artifact.apply_candidate(
+                        workspace=repo,
+                        artifact_dir=candidate,
+                        repository=artifact.EXPECTED_REPOSITORY,
+                        policy_sha=base,
+                        base=base,
+                    )
+            self.assertEqual(run_git(repo, "status", "--porcelain"), "")
+            self.assertFalse(env_file.exists())
+
+    def test_rejects_tampered_candidate_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, candidate, base, _ = self._prepared(directory)
+            restore_dependency_files(repo, base)
+            (candidate / "Cargo.lock").write_text("tampered\n", encoding="utf-8")
+            with self.assertRaisesRegex(artifact.ArtifactError, "digest"):
+                artifact.apply_candidate(
+                    workspace=repo,
+                    artifact_dir=candidate,
+                    repository=artifact.EXPECTED_REPOSITORY,
+                    policy_sha=base,
+                    base=base,
+                )
+
+    def test_no_change_result_is_explicit_and_server_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result_file = Path(directory) / "result.json"
+            policy = "a" * 40
+            result = artifact.finalize_no_change(
+                output_file=result_file,
+                repository=artifact.EXPECTED_REPOSITORY,
+                policy_sha=policy,
+                base=policy,
+                workflow_path=artifact.EXPECTED_WORKFLOW_PATH,
+                run_id=331,
+                run_attempt=2,
+            )
+            self.assertIs(result["changed"], False)
+            validated = artifact.validate_result(
+                result_file=result_file,
+                repository=artifact.EXPECTED_REPOSITORY,
+                workflow_path=artifact.EXPECTED_WORKFLOW_PATH,
+                policy_sha=policy,
+                run_id=331,
+                run_attempt=2,
+            )
+            self.assertEqual(validated, result)
+            with self.assertRaisesRegex(artifact.ArtifactError, "authority"):
+                artifact.validate_result(
+                    result_file=result_file,
+                    repository=artifact.EXPECTED_REPOSITORY,
+                    workflow_path=artifact.EXPECTED_WORKFLOW_PATH,
+                    policy_sha="b" * 40,
+                    run_id=331,
+                    run_attempt=2,
+                )
+
+
+class PostCompletionAttesterTests(unittest.TestCase):
+    def _changed(
+        self,
+        directory: str,
+        *,
+        run_id: int = 331,
+        run_attempt: int = 2,
+    ) -> tuple[Path, Path, Path, str, str]:
+        root = Path(directory)
+        repo = root / "repo"
+        repo.mkdir()
+        candidate = root / "candidate"
+        base = initialize_repo(repo)
+        (repo / "Cargo.toml").write_text(manifest("=0.7.69"), encoding="utf-8")
+        (repo / "Cargo.lock").write_text(
+            "version = 4\nkin-db 0.7.69\n", encoding="utf-8"
+        )
+        run_git(repo, "add", "Cargo.toml", "Cargo.lock")
+        tree = run_git(repo, "write-tree")
+        artifact.prepare_candidate(
+            workspace=repo,
+            output_dir=candidate,
+            repository=artifact.EXPECTED_REPOSITORY,
+            policy_sha=base,
+            base=base,
+            expected_tree=tree,
+        )
+        run_git(
+            repo,
+            "commit",
+            "-q",
+            "-m",
+            f"dependency wave\n\n{head_guard.COMMIT_MARKER}",
+        )
+        head = run_git(repo, "rev-parse", "HEAD")
+        result_file = root / f"result-{run_id}" / "result.json"
+        artifact.finalize_admission(
+            artifact_dir=candidate,
+            output_file=result_file,
+            repository=artifact.EXPECTED_REPOSITORY,
+            policy_sha=base,
+            base=base,
+            pull=77,
+            head=head,
+            workflow_path=artifact.EXPECTED_WORKFLOW_PATH,
+            run_id=run_id,
+            run_attempt=run_attempt,
+        )
+        return repo, candidate, result_file, base, head
+
+    @staticmethod
+    def _live_graphql(head: str):
+        return mock.patch.object(
+            attester.landing,
+            "_graphql_pull",
+            return_value=graphql_pull_node(head),
+        )
+
+    def test_no_change_receiver_completes_without_minting_an_attestation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            result_dir = root / "result"
+            result_file = result_dir / "result.json"
+            policy = "a" * 40
+            artifact.finalize_no_change(
+                output_file=result_file,
+                repository=artifact.EXPECTED_REPOSITORY,
+                policy_sha=policy,
+                base=policy,
+                workflow_path=artifact.EXPECTED_WORKFLOW_PATH,
+                run_id=331,
+                run_attempt=2,
+            )
+            event_file = root / "event.json"
+            event_file.write_text(
+                json.dumps(
+                    {
+                        "action": "completed",
+                        "workflow_run": workflow_run_document(policy),
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(
+                attester,
+                "gh_json",
+                return_value=workflow_run_document(policy),
+            ) as api:
+                result = attester.validate_for_attestation(
+                    event_file=event_file,
+                    admission_file=result_file,
+                    workspace=root,
+                    repository=attester.EXPECTED_REPOSITORY,
+                )
+            self.assertIs(result["changed"], False)
+            self.assertEqual(api.call_count, 1)
+            self.assertIn("/attempts/2", api.call_args.args[0][-1])
+
+    def test_changed_post_is_persisted_and_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _, result_file, base, head = self._changed(directory)
+            pull = pull_document(head, base)
+            reviews, comments = attestation_documents(repo, base, head)
+            posted = False
+            writes: list[str] = []
+
+            def fake(arguments: list[str]) -> object:
+                nonlocal posted
+                endpoint = next(
+                    (item for item in arguments if item.startswith("repos/")), ""
+                )
+                if endpoint.endswith("/git/ref/heads/main"):
+                    return {"object": {"sha": base}}
+                if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+                    return pull
+                if endpoint.endswith("/reviews?per_page=100"):
+                    return [reviews if posted else []]
+                if endpoint.endswith("/comments?per_page=100"):
+                    return [comments if posted else []]
+                if endpoint.endswith("/pulls/77/reviews"):
+                    writes.append("review")
+                    return reviews[0]
+                if endpoint.endswith("/issues/77/comments"):
+                    writes.append("comment")
+                    posted = True
+                    return comments[0]
+                if endpoint.endswith("/pulls/77/reviews/41"):
+                    return reviews[0]
+                if endpoint.endswith("/issues/comments/51"):
+                    return comments[0]
+                raise AssertionError(f"unexpected mocked GitHub request: {arguments}")
+
+            with mock.patch.object(attester, "gh_json", side_effect=fake), self._live_graphql(
+                head
+            ):
+                first = attester.post_attestation(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                )
+                second = attester.post_attestation(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                )
+            self.assertIs(first["created"], True)
+            self.assertIs(second["created"], False)
+            self.assertEqual(first["comment_created_at"], comments[0]["created_at"])
+            self.assertEqual(second["comment_id"], first["comment_id"])
+            self.assertEqual(writes, ["review", "comment"])
+
+    def test_repeated_receiver_reuses_one_attestation_and_guard_stays_green(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, candidate, _, base, head = self._changed(directory)
+            second_result = Path(directory) / "result-332" / "result.json"
+            artifact.finalize_admission(
+                artifact_dir=candidate,
+                output_file=second_result,
+                repository=artifact.EXPECTED_REPOSITORY,
+                policy_sha=base,
+                base=base,
+                pull=77,
+                head=head,
+                workflow_path=artifact.EXPECTED_WORKFLOW_PATH,
+                run_id=332,
+                run_attempt=1,
+            )
+            second_run = workflow_run_document(
+                base,
+                run_id=332,
+                run_attempt=1,
+            )
+            event_file = Path(directory) / "event-332.json"
+            event_file.write_text(
+                json.dumps({"action": "completed", "workflow_run": second_run}),
+                encoding="utf-8",
+            )
+            pull = pull_document(head, base)
+            reviews, comments = attestation_documents(repo, base, head)
+
+            def fake(arguments: list[str]) -> object:
+                endpoint = next(
+                    (item for item in arguments if item.startswith("repos/")), ""
+                )
+                if "/actions/runs/332/attempts/1" in endpoint:
+                    return second_run
+                if endpoint.endswith("/git/ref/heads/main"):
+                    return {"object": {"sha": base}}
+                if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+                    return pull
+                if endpoint.endswith("/reviews?per_page=100"):
+                    return [reviews]
+                if endpoint.endswith("/comments?per_page=100"):
+                    return [comments]
+                raise AssertionError(f"unexpected mocked GitHub request: {arguments}")
+
+            with mock.patch.object(attester, "gh_json", side_effect=fake), mock.patch.object(
+                attester.guard,
+                "gh_json",
+                return_value=workflow_run_document(base),
+            ), self._live_graphql(head):
+                result = attester.validate_for_attestation(
+                    event_file=event_file,
+                    admission_file=second_result,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                )
+            self.assertIs(result["changed"], True)
+            self.assertIs(result["needs_attestation"], False)
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments,
+                expected_base=base,
+                workflow_run=workflow_run_document(base),
+            )
+            self.assertEqual(evidence.head, head)
+
+    def test_late_attestation_retriggers_and_materializes_required_recheck(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _, result_file, base, head = self._changed(directory)
+            pull = pull_document(head, base)
+            reviews, comments = attestation_documents(repo, base, head)
+            empty_runs = [{"total_count": 0, "workflow_runs": []}]
+
+            def read_without_recheck(arguments: list[str]) -> object:
+                endpoint = next(
+                    (item for item in arguments if item.startswith("repos/")), ""
+                )
+                if endpoint.endswith("/git/ref/heads/main"):
+                    return {"object": {"sha": base}}
+                if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+                    return pull
+                if endpoint.endswith("/reviews?per_page=100"):
+                    return [reviews]
+                if endpoint.endswith("/comments?per_page=100"):
+                    return [comments]
+                if endpoint.endswith("/actions/workflows/ci.yml/runs"):
+                    return empty_runs
+                raise AssertionError(f"unexpected mocked GitHub request: {arguments}")
+
+            with mock.patch.object(
+                attester, "gh_json", side_effect=read_without_recheck
+            ), mock.patch.object(
+                attester.guard,
+                "gh_json",
+                return_value=workflow_run_document(base),
+            ), self._live_graphql(head):
+                before = attester.recheck_status(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                    wait_seconds=0,
+                    require_recheck=False,
+                )
+            self.assertIs(before["needs_retrigger"], True)
+
+            states: list[str] = []
+
+            def writer(arguments: list[str]) -> object:
+                endpoint = next(
+                    (item for item in arguments if item.startswith("repos/")), ""
+                )
+                if endpoint.endswith("/git/ref/heads/main"):
+                    return {"object": {"sha": base}}
+                if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+                    requested_state = next(
+                        (
+                            item.split("=", 1)[1]
+                            for item in arguments
+                            if item.startswith("state=")
+                        ),
+                        None,
+                    )
+                    if requested_state is not None:
+                        states.append(requested_state)
+                        return pull_document(head, base, state=requested_state)
+                    return pull
+                if endpoint.endswith("/reviews?per_page=100"):
+                    return [reviews]
+                if endpoint.endswith("/comments?per_page=100"):
+                    return [comments]
+                raise AssertionError(f"unexpected mocked GitHub request: {arguments}")
+
+            with mock.patch.object(attester, "gh_json", side_effect=writer), self._live_graphql(
+                head
+            ):
+                reopened = attester.retrigger_pull(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                )
+            self.assertIs(reopened["reopened"], True)
+            self.assertEqual(states, ["closed", "open"])
+
+            run = ci_run_document(head, base)
+
+            def read_with_recheck(arguments: list[str]) -> object:
+                endpoint = next(
+                    (item for item in arguments if item.startswith("repos/")), ""
+                )
+                if endpoint.endswith("/git/ref/heads/main"):
+                    return {"object": {"sha": base}}
+                if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+                    return pull
+                if endpoint.endswith("/reviews?per_page=100"):
+                    return [reviews]
+                if endpoint.endswith("/comments?per_page=100"):
+                    return [comments]
+                if endpoint.endswith("/actions/workflows/ci.yml/runs"):
+                    return [{"total_count": 1, "workflow_runs": [run]}]
+                if endpoint.endswith("/actions/runs/901/attempts/1/jobs"):
+                    return ci_jobs_document()
+                raise AssertionError(f"unexpected mocked GitHub request: {arguments}")
+
+            with mock.patch.object(
+                attester, "gh_json", side_effect=read_with_recheck
+            ), mock.patch.object(
+                attester.guard,
+                "gh_json",
+                return_value=workflow_run_document(base),
+            ), self._live_graphql(head):
+                after = attester.recheck_status(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                    wait_seconds=0,
+                    require_recheck=True,
+                )
+            self.assertIs(after["needs_retrigger"], False)
+            self.assertEqual(after["job_status"], "queued")
+
+            def missing_gate(arguments: list[str]) -> object:
+                endpoint = next(
+                    (item for item in arguments if item.startswith("repos/")), ""
+                )
+                if endpoint.endswith("/actions/runs/901/attempts/1/jobs"):
+                    return ci_jobs_document(name="not the required context")
+                return read_with_recheck(arguments)
+
+            with mock.patch.object(
+                attester, "gh_json", side_effect=missing_gate
+            ), mock.patch.object(
+                attester.guard,
+                "gh_json",
+                return_value=workflow_run_document(base),
+            ), self._live_graphql(head):
+                with self.assertRaisesRegex(
+                    attester.AttesterError,
+                    "exactly one required fast gate",
+                ):
+                    attester.recheck_status(
+                        admission_file=result_file,
+                        workspace=repo,
+                        repository=attester.EXPECTED_REPOSITORY,
+                        wait_seconds=0,
+                        require_recheck=True,
+                    )
+
+    def test_retrigger_reopens_after_an_uncertain_close_response(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _, result_file, base, head = self._changed(directory)
+            pull = pull_document(head, base)
+            reviews, comments = attestation_documents(repo, base, head)
+            reopened = False
+
+            def writer(arguments: list[str]) -> object:
+                nonlocal reopened
+                endpoint = next(
+                    (item for item in arguments if item.startswith("repos/")), ""
+                )
+                if endpoint.endswith("/git/ref/heads/main"):
+                    return {"object": {"sha": base}}
+                if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+                    requested_state = next(
+                        (
+                            item.split("=", 1)[1]
+                            for item in arguments
+                            if item.startswith("state=")
+                        ),
+                        None,
+                    )
+                    if requested_state == "closed":
+                        raise attester.AttesterError("close response was lost")
+                    if requested_state == "open":
+                        reopened = True
+                        return pull
+                    return pull
+                if endpoint.endswith("/reviews?per_page=100"):
+                    return [reviews]
+                if endpoint.endswith("/comments?per_page=100"):
+                    return [comments]
+                raise AssertionError(f"unexpected mocked GitHub request: {arguments}")
+
+            with mock.patch.object(attester, "gh_json", side_effect=writer), self._live_graphql(
+                head
+            ):
+                with self.assertRaisesRegex(
+                    attester.AttesterError,
+                    "reopened after an invalid close response",
+                ):
+                    attester.retrigger_pull(
+                        admission_file=result_file,
+                        workspace=repo,
+                        repository=attester.EXPECTED_REPOSITORY,
+                    )
+            self.assertIs(reopened, True)
+
+
+class EventHandlerTests(unittest.TestCase):
+    @staticmethod
+    def pull_event(head: str, base: str, *, branch: str | None = None) -> dict[str, Any]:
+        return {
+            "pull_request": {
+                "number": 77,
+                "head": {"sha": head, "ref": branch or head_guard.WAVE_BRANCH},
+                "base": {"sha": base, "ref": head_guard.EXPECTED_BASE},
+            }
+        }
+
+    def test_verify_pull_request_and_current_base_movement(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            pull = pull_document(head, base)
+            reviews, comments = attestation_documents(repo, base, head)
+            fake = guard_api_fake(
+                pull=pull,
+                reviews=reviews,
+                comments=comments,
+                policy_sha=base,
+            )
+            with mock.patch.object(head_guard, "gh_json", side_effect=fake):
+                message = head_guard.verify_pull_request(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    self.pull_event(head, base),
+                    wait_seconds=0,
+                )
+            self.assertIn("verified dependency-wave pull request", message)
+
+            moved = pull_document(head, "c" * 40)
+            with mock.patch.object(head_guard, "_fresh_pull", return_value=moved):
+                with self.assertRaisesRegex(head_guard.AdmissionError, "base moved"):
+                    head_guard.verify_pull_request(
+                        repo,
+                        head_guard.EXPECTED_REPOSITORY,
+                        self.pull_event(head, base),
+                        wait_seconds=0,
+                    )
+
+    def test_non_wave_pull_rejects_reserved_marker_before_early_return(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            with self.assertRaisesRegex(head_guard.AdmissionError, "reserved"):
+                head_guard.verify_pull_request(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    self.pull_event(head, base, branch="feature/not-a-wave"),
+                    wait_seconds=0,
+                )
+
+    def test_pull_handler_fails_loud_for_missing_and_malformed_attestation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            pull = pull_document(head, base)
+            with mock.patch.object(head_guard, "_fresh_pull", return_value=pull), mock.patch.object(
+                head_guard, "_attestation_documents", return_value=([], [])
+            ):
+                with self.assertRaises(head_guard.PendingAttestation):
+                    head_guard.verify_pull_request(
+                        repo,
+                        head_guard.EXPECTED_REPOSITORY,
+                        self.pull_event(head, base),
+                        wait_seconds=0,
+                    )
+            malformed = [{"body": head_guard.ATTESTATION_MARKER + "\nspoof"}]
+            with mock.patch.object(head_guard, "_fresh_pull", return_value=pull), mock.patch.object(
+                head_guard, "_attestation_documents", return_value=([], malformed)
+            ):
+                with self.assertRaisesRegex(head_guard.AdmissionError, "malformed"):
+                    head_guard.verify_pull_request(
+                        repo,
+                        head_guard.EXPECTED_REPOSITORY,
+                        self.pull_event(head, base),
+                        wait_seconds=0,
+                    )
+
+    def test_merge_group_accepts_readme_peer_and_rejects_second_cargo_change(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            admitted_head = commit_dependency_head(repo)
+            (repo / "README.md").write_text("queued docs\n", encoding="utf-8")
+            run_git(repo, "add", "README.md")
+            run_git(repo, "commit", "-q", "-m", "queued docs")
+            docs_group = run_git(repo, "rev-parse", "HEAD")
+            pull = pull_document(admitted_head, base)
+            reviews, comments = attestation_documents(repo, base, admitted_head)
+            fake = guard_api_fake(
+                pull=pull,
+                reviews=reviews,
+                comments=comments,
+                policy_sha=base,
+                open_pulls=[{"number": 77}],
+            )
+            with mock.patch.object(head_guard, "gh_json", side_effect=fake):
+                message = head_guard.verify_merge_group(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    {"merge_group": {"base_sha": base, "head_sha": docs_group}},
+                    wait_seconds=0,
+                )
+            self.assertIn("in merge group", message)
+
+            (repo / "Cargo.toml").write_text(manifest("=0.7.70"), encoding="utf-8")
+            (repo / "Cargo.lock").write_text(
+                "version = 4\nkin-db 0.7.70\n", encoding="utf-8"
+            )
+            run_git(repo, "add", "Cargo.toml", "Cargo.lock")
+            run_git(repo, "commit", "-q", "-m", "queued cargo change")
+            cargo_group = run_git(repo, "rev-parse", "HEAD")
+            fake = guard_api_fake(
+                pull=pull,
+                reviews=reviews,
+                comments=comments,
+                policy_sha=base,
+                open_pulls=[{"number": 77}],
+            )
+            with mock.patch.object(head_guard, "gh_json", side_effect=fake):
+                with self.assertRaisesRegex(head_guard.AdmissionError, "outside the wave"):
+                    head_guard.verify_merge_group(
+                        repo,
+                        head_guard.EXPECTED_REPOSITORY,
+                        {"merge_group": {"base_sha": base, "head_sha": cargo_group}},
+                        wait_seconds=0,
+                    )
+
+    def test_verify_push_accepts_exact_classic_squash_and_rejects_other_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            run_git(repo, "switch", "-q", "-c", "admitted")
+            admitted_head = commit_dependency_head(repo)
+            run_git(repo, "switch", "-q", "-c", "delivery", base)
+            delivery_head = commit_dependency_head(repo, marker=False)
+            pull = pull_document(
+                admitted_head,
+                base,
+                state="closed",
+                merged_at="2026-08-27T23:00:00Z",
+            )
+            reviews, comments = attestation_documents(repo, base, admitted_head)
+            fake = guard_api_fake(
+                pull=pull,
+                reviews=reviews,
+                comments=comments,
+                policy_sha=base,
+                associated_pulls=[pull],
+            )
+            with mock.patch.object(head_guard, "gh_json", side_effect=fake):
+                message = head_guard.verify_push(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    {
+                        "ref": "refs/heads/main",
+                        "before": base,
+                        "after": delivery_head,
+                    },
+                    wait_seconds=0,
+                )
+            self.assertIn("classic-main delivery", message)
+
+            run_git(repo, "switch", "-q", "-c", "wrong-delivery", base)
+            wrong_head = commit_dependency_head(
+                repo,
+                dependency="=0.7.70",
+                lock_version="0.7.70",
+                marker=False,
+            )
+            fake = guard_api_fake(
+                pull=pull,
+                reviews=reviews,
+                comments=comments,
+                policy_sha=base,
+                associated_pulls=[pull],
+            )
+            with mock.patch.object(head_guard, "gh_json", side_effect=fake):
+                with self.assertRaisesRegex(head_guard.AdmissionError, "delivery tree"):
+                    head_guard.verify_push(
+                        repo,
+                        head_guard.EXPECTED_REPOSITORY,
+                        {
+                            "ref": "refs/heads/main",
+                            "before": base,
+                            "after": wrong_head,
+                        },
+                        wait_seconds=0,
+                    )
+
+
 class WorkflowContractTests(unittest.TestCase):
-    def test_receiver_trigger_and_write_boundary_are_pinned(self) -> None:
-        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
-        self.assertIn("types: [kin-registry-release]", workflow)
-        self.assertNotIn("workflow_dispatch:", workflow)
-        self.assertNotIn("schedule:", workflow)
-        self.assertIn("group: kin-registry-release-${{ github.repository }}", workflow)
-        self.assertIn("cancel-in-progress: false", workflow)
-        self.assertIn("needs: validate-dispatch", workflow)
-        self.assertIn("environment: release-tag", workflow)
-        self.assertIn(
-            f"KIN_ACTIONS_SHA: {KIN_ACTIONS_SHA}",
-            workflow,
-        )
-        self.assertIn("repository: firelock-ai/kin-actions", workflow)
-        self.assertIn(
-            "WAVE_BRANCH: automation/kin-registry-dependency-wave",
-            workflow,
-        )
-        self.assertIn("--bump-own-version false", workflow)
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.disarm_job = job_block(cls.workflow, "disarm-wave")
+        cls.prepare_job = job_block(cls.workflow, "prepare-wave")
+        cls.mutation_job = job_block(cls.workflow, "mutate-wave")
+        cls.attest_workflow = ATTEST_WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.ci = CI_PATH.read_text(encoding="utf-8")
+        cls.fast_gate = job_block(cls.ci, "fast-gate-lint")
+
+    def test_default_branch_triggers_and_post_validation_concurrency(self) -> None:
+        trigger = self.workflow.split("jobs:", 1)[0]
+        self.assertIn("types: [kin-registry-release]", trigger)
+        self.assertIn('cron: "17 * * * *"', trigger)
+        self.assertNotIn("workflow_dispatch:", trigger)
+        self.assertNotIn("concurrency:", trigger)
+        for job in (self.disarm_job, self.prepare_job, self.mutation_job):
+            self.assertLess(job.index("needs:"), job.index("concurrency:"))
+            self.assertIn("cancel-in-progress: false", job)
+        self.assertIn("kin-registry-release-disarm-${{ github.repository }}", self.disarm_job)
+        self.assertIn("kin-registry-release-prepare-${{ github.repository }}", self.prepare_job)
+        self.assertIn("kin-registry-release-mutate-${{ github.repository }}", self.mutation_job)
+
+    def test_schedule_refreshes_full_set_without_event_floor(self) -> None:
+        update = step_block(self.workflow, "Update the allowed root-manifest pins")
+        self.assertIn('case "$GITHUB_EVENT_NAME" in', update)
+        self.assertIn("repository_dispatch)", update)
+        self.assertIn("schedule) ;;", update)
         for crate in validator.ALLOWED_SOURCES:
-            self.assertIn(f"--crate {crate}", workflow)
-        self.assertEqual(workflow.count("--crate "), len(validator.ALLOWED_SOURCES) + 1)
-        self.assertIn("Open or update the dependency bump PR", workflow)
-        self.assertIn("base: ${{ github.event.repository.default_branch }}", workflow)
-        self.assertIn("Verify exact first-party generated PR", workflow)
-        self.assertNotIn("gh pr merge", workflow)
-        self.assertNotIn("KIN_DOWNSTREAM_DISPATCH_TOKEN", workflow)
+            self.assertIn(f"--crate {crate}", update)
+        self.assertEqual(update.count("--crate "), len(validator.ALLOWED_SOURCES))
+        self.assertIn('--event-crate "$EVENT_CRATE"', update)
+        self.assertIn('--version "$EVENT_VERSION"', update)
+        self.assertNotIn('--crate "$EVENT_CRATE"', update)
+
+    def test_generated_smoke_and_admission_order_is_exact(self) -> None:
+        snapshot = step_block(
+            self.workflow, "Snapshot the exact generated dependency delta"
+        )
+        smoke = step_block(
+            self.workflow,
+            "Verify the updated Kin consumers on the credential-free runner",
+        )
+        admission = step_block(
+            self.workflow, "Admit the generated dependency delta before compilation"
+        )
+        self.assertIn(
+            "run: cargo check --locked -p kin-core -p kin-cli -p kin-daemon -p kin-mcp",
+            smoke,
+        )
+        for block in (snapshot, admission):
+            self.assertIn("--version-mode manual", block)
+            self.assertIn("--bump-own-version false", block)
+        self.assertIn("expected_tree=", snapshot)
+        self.assertIn('--expected-tree "$EXPECTED_TREE"', admission)
+        prepare_names = [
+            "Snapshot the exact generated dependency delta",
+            "Admit the generated dependency delta before compilation",
+            "Build the hash-bound data-only candidate handoff",
+            "Upload the exact candidate before dependency code executes",
+            "Verify the updated Kin consumers on the credential-free runner",
+        ]
+        prepare_positions = [
+            self.prepare_job.index(f"- name: {name}") for name in prepare_names
+        ]
+        self.assertEqual(prepare_positions, sorted(prepare_positions))
+        self.assertNotIn("- name:", self.prepare_job[prepare_positions[-1] + 1 :])
+
+        mutation_names = [
+            "Clear inherited landing state before candidate handling",
+            "Download the compiled data-only candidate",
+            "Revalidate and apply only the admitted manifest bytes",
+            "Refuse protected-main movement before repository mutation",
+            "Open or update the dependency bump PR",
+            "Clear and verify landing state on the generated PR",
+            "Verify exact first-party generated PR",
+            "Build the post-completion admission record",
+            "Upload exact result for the post-completion attester",
+        ]
+        mutation_positions = [
+            self.mutation_job.index(f"- name: {name}") for name in mutation_names
+        ]
+        self.assertEqual(mutation_positions, sorted(mutation_positions))
+
+    def test_base_branch_and_admitted_paths_bind_the_writer(self) -> None:
+        early_resolve = step_block(
+            self.workflow, "Bind early disarm to the queued workflow policy"
+        )
+        resolve = step_block(self.workflow, "Bind preparation to the queued workflow policy")
+        checkout = step_block(self.workflow, "Checkout exact queued protected main")
+        mutation_fence = step_block(
+            self.workflow, "Refuse protected-main movement immediately before token mint"
+        )
+        admission = step_block(
+            self.workflow, "Revalidate and apply only the admitted manifest bytes"
+        )
+        writer = step_block(self.workflow, "Open or update the dependency bump PR")
+        verifier = step_block(self.workflow, "Verify exact first-party generated PR")
+        self.assertIn("base_sha=", resolve)
+        self.assertIn('!= "$GITHUB_SHA"', early_resolve)
+        self.assertIn('!= "$GITHUB_SHA"', resolve)
+        self.assertIn("ref: ${{ steps.base.outputs.base_sha }}", checkout)
+        self.assertIn('!= "$GITHUB_SHA"', mutation_fence)
+        self.assertIn("kin-registry-wave-artifact.py apply", admission)
+        self.assertIn("branch: ${{ env.WAVE_BRANCH }}", writer)
+        self.assertIn("base: ${{ env.BASE_BRANCH }}", writer)
+        self.assertIn("add-paths: |", writer)
+        self.assertIn("Cargo.lock", writer)
+        self.assertIn("Cargo.toml", writer)
+        self.assertIn("ADMITTED_BASE", verifier)
+        self.assertIn(".base.sha", verifier)
+        self.assertIn(".auto_merge == null", verifier)
+        self.assertIn("api_tree", verifier)
+        self.assertIn('!= "$EXPECTED_TREE"', verifier)
+
+    def test_fixed_pr_landing_state_is_cleared_before_and_after_write(self) -> None:
+        early = step_block(
+            self.workflow, "Clear inherited landing state before dependency preparation"
+        )
+        before = step_block(
+            self.workflow, "Clear inherited landing state before candidate handling"
+        )
+        after = step_block(
+            self.workflow, "Clear and verify landing state on the generated PR"
+        )
+        no_change = step_block(
+            self.workflow, "Verify no-change reconciliation left no landing state"
+        )
+        script = AUTO_MERGE_PATH.read_text(encoding="utf-8")
+        for block in (early, before, after, no_change):
+            self.assertIn("ensure-kin-registry-wave-no-automerge.py", block)
+            self.assertIn('--branch "$WAVE_BRANCH"', block)
+            self.assertIn('--base "$BASE_BRANCH"', block)
+        self.assertNotIn("if:", early)
+        self.assertNotIn("if:", before)
+        self.assertIn("needs: [validate-dispatch, disarm-wave]", self.prepare_job)
+        self.assertIn('--expected-number "$PR"', after)
+        self.assertIn('--expected-head "$ACTION_HEAD"', after)
+        self.assertIn('"--disable-auto"', script)
+        self.assertIn('"--match-head-commit"', script)
+        self.assertIn("mergeQueueEntry", script)
+        self.assertIn("dequeuePullRequest", script)
+        self.assertIn("server-owned landing state", script)
+        self.assertNotIn('"--auto"', script)
+        self.assertLess(
+            self.mutation_job.index("Clear inherited landing state"),
+            self.mutation_job.index("Download the compiled data-only candidate"),
+        )
+
+    def test_write_token_is_isolated_from_candidate_execution(self) -> None:
+        token = step_block(
+            self.workflow, "Mint repository-scoped dependency-wave token"
+        )
+        self.assertIn("permission-contents: write", token)
+        self.assertIn("permission-pull-requests: write", token)
+        self.assertIn("permission-issues: write", token)
+        self.assertNotIn("permission-statuses", token)
+        self.assertNotIn("environment: release-tag", self.prepare_job)
+        self.assertNotIn("create-github-app-token", self.prepare_job)
+        self.assertNotIn("cargo ", self.disarm_job)
+        self.assertNotIn("cargo ", self.mutation_job)
+        upload = step_block(
+            self.workflow, "Upload the exact candidate before dependency code executes"
+        )
+        smoke = step_block(
+            self.workflow,
+            "Verify the updated Kin consumers on the credential-free runner",
+        )
+        self.assertLess(self.prepare_job.index(upload), self.prepare_job.index(smoke))
+        self.assertEqual(
+            self.prepare_job.rfind("- name:"),
+            self.prepare_job.index(
+                "- name: Verify the updated Kin consumers on the credential-free runner"
+            ),
+        )
+        identity_step = step_block(
+            self.workflow, "Verify exact App installation identity and scope"
+        )
+        self.assertIn("verify-kin-release-app-token.py", identity_step)
+        identity_source = IDENTITY_PATH.read_text(encoding="utf-8")
+        self.assertIn('f"users/{EXPECTED_BOT_LOGIN}"', identity_source)
+        self.assertIn("installation/repositories?per_page=100", identity_source)
+        self.assertNotIn('["api", "user"]', identity_source)
+        self.assertNotIn("KIN_DOWNSTREAM_DISPATCH_TOKEN", self.workflow)
+        self.assertNotIn("/statuses/", self.workflow)
+
+    def test_attestation_is_post_completion_and_server_verified(self) -> None:
+        trigger = self.attest_workflow.split("jobs:", 1)[0]
+        self.assertIn("workflow_run:", trigger)
+        self.assertIn("workflows: [Kin Registry Release Receiver]", trigger)
+        self.assertIn("types: [completed]", trigger)
+        self.assertIn("github.event.workflow_run.conclusion == 'success'", self.attest_workflow)
+        validate = step_block(
+            self.attest_workflow,
+            "Validate terminal server authority and live admitted head",
+        )
+        token = step_block(
+            self.attest_workflow, "Mint repository-scoped attestation token"
+        )
+        post = step_block(
+            self.attest_workflow,
+            "Persist exact post-completion admission attestation",
+        )
+        inspect = step_block(
+            self.attest_workflow,
+            "Inspect exact-head CI after the persisted attestation",
+        )
+        retrigger = step_block(
+            self.attest_workflow,
+            "Retrigger exact-head CI when the attestation arrived late",
+        )
+        recheck = step_block(
+            self.attest_workflow,
+            "Verify a required exact-head CI recheck materialized",
+        )
+        self.assertLess(self.attest_workflow.index(validate), self.attest_workflow.index(token))
+        self.assertLess(self.attest_workflow.index(token), self.attest_workflow.index(post))
+        self.assertLess(self.attest_workflow.index(post), self.attest_workflow.index(inspect))
+        self.assertLess(
+            self.attest_workflow.index(inspect),
+            self.attest_workflow.index(retrigger),
+        )
+        self.assertLess(
+            self.attest_workflow.index(retrigger),
+            self.attest_workflow.index(recheck),
+        )
+        self.assertIn("attest-kin-registry-wave.py validate", validate)
+        self.assertIn("attest-kin-registry-wave.py post", post)
+        self.assertIn("if: steps.validate.outputs.changed == 'true'", token)
+        self.assertIn("steps.validate.outputs.needs_attestation == 'true'", post)
+        self.assertIn("attest-kin-registry-wave.py recheck-status", inspect)
+        self.assertIn("steps.recheck.outputs.needs_retrigger == 'true'", retrigger)
+        self.assertIn("attest-kin-registry-wave.py retrigger", retrigger)
+        self.assertIn("--require-recheck", recheck)
+        self.assertIn(
+            "group: kin-registry-admission-${{ github.repository }}",
+            self.attest_workflow,
+        )
+        self.assertNotIn("github.event.workflow_run.id }}-${{", self.attest_workflow)
+        no_change = step_block(
+            self.workflow, "Build the post-completion no-change record"
+        )
+        result_upload = step_block(
+            self.workflow, "Upload exact result for the post-completion attester"
+        )
+        self.assertIn("finalize-no-change", no_change)
+        self.assertNotIn("if:", result_upload)
+        guard_source = HEAD_GUARD_PATH.read_text(encoding="utf-8")
+        for field in (
+            "workflow_path",
+            "policy_sha",
+            "run_id",
+            "run_attempt",
+            'workflow_run.get("status") != "completed"',
+            'workflow_run.get("conclusion") != "success"',
+        ):
+            self.assertIn(field, guard_source)
+        self.assertIn("kin-registry-dependency-admission:v2", guard_source)
+
+    def test_required_fast_gate_revalidates_every_delivery_event(self) -> None:
+        ci_trigger = self.ci.split("permissions:", 1)[0]
+        self.assertIn("types: [opened, synchronize, reopened]", ci_trigger)
+        self.assertIn("permissions:", self.fast_gate)
+        self.assertIn("actions: read", self.fast_gate)
+        self.assertIn("issues: read", self.fast_gate)
+        self.assertIn("pull-requests: read", self.fast_gate)
+        self.assertNotIn("statuses: read", self.fast_gate)
+        self.assertIn("fetch-depth: 0", self.fast_gate)
+        verifier = step_block(self.ci, "Verify registry dependency-wave admission")
+        self.assertIn("verify-kin-registry-wave-head.py", verifier)
+        self.assertIn('--event-name "$GITHUB_EVENT_NAME"', verifier)
+        self.assertIn('--workflow-sha "$GITHUB_SHA"', verifier)
+        self.assertIn("--attestation-wait-seconds 300", verifier)
+        guard_source = HEAD_GUARD_PATH.read_text(encoding="utf-8")
+        for event in ("pull_request", "merge_group", "push"):
+            self.assertIn(f'args.event_name == "{event}"', guard_source)
+        self.assertIn("classic-main delivery tree differs", guard_source)
+        self.assertIn("merge group changes admitted dependency paths", guard_source)
+        self.assertIn("non-wave pull request uses the reserved", guard_source)
+        self.assertIn('"merge-tree"', guard_source)
+        self.assertIn("package or workspace version", guard_source)
+        self.assertIn("ALLOWED_PATHS", guard_source)
+        self.assertIn("performed_via_github_app", guard_source)
+        self.assertIn("review.get(\"commit_id\") != head", guard_source)
+
+    def test_dispatch_metadata_is_not_claimed_as_provenance(self) -> None:
+        self.assertIn(
+            "sender-supplied correlation metadata. They are not treated as source provenance.",
+            self.workflow,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test-kin-registry-release-receiver.py
+++ b/scripts/test-kin-registry-release-receiver.py
@@ -264,6 +264,25 @@ def attestation_documents(
     return [review], [comment]
 
 
+def outsider_attestation_comment(
+    template: dict[str, object],
+    *,
+    comment_id: int = 52,
+    malformed: bool = False,
+) -> dict[str, object]:
+    comment = copy.deepcopy(template)
+    comment["id"] = comment_id
+    comment["html_url"] = (
+        f"https://github.com/{head_guard.EXPECTED_REPOSITORY}/pull/77"
+        f"#issuecomment-{comment_id}"
+    )
+    comment["performed_via_github_app"] = None
+    comment["user"] = {"id": 123, "login": "outsider", "type": "User"}
+    if malformed:
+        comment["body"] = head_guard.ATTESTATION_MARKER + "\nspoof"
+    return comment
+
+
 def workflow_run_document(
     policy_sha: str,
     *,
@@ -683,6 +702,24 @@ class HeadAdmissionTests(unittest.TestCase):
                 workflow_run=workflow_run_document(base),
             )
             self.assertEqual(evidence.head, head)
+            wrong_bot = outsider_attestation_comment(comments[0], comment_id=55)
+            wrong_bot["performed_via_github_app"] = copy.deepcopy(
+                comments[0]["performed_via_github_app"]
+            )
+            wrong_bot["user"] = {
+                "id": 1,
+                "login": head_guard.ATTESTATION_CREATOR,
+                "type": "Bot",
+            }
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments + [wrong_bot],
+            )
+            self.assertEqual(evidence.head, head)
             failed = workflow_run_document(base, conclusion="failure")
             with self.assertRaisesRegex(head_guard.AdmissionError, "successful"):
                 head_guard.validate_attestation(
@@ -722,32 +759,111 @@ class HeadAdmissionTests(unittest.TestCase):
             with self.assertRaisesRegex(head_guard.AdmissionError, "workspace version"):
                 head_guard.validate_delta(repo, base, head, require_marker=True)
 
-    def test_rejects_body_spoof_without_exact_app_identity(self) -> None:
+    def test_ignores_body_spoof_without_exact_app_identity(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repo = Path(directory)
             base = initialize_repo(repo)
             head = commit_dependency_head(repo)
             reviews, comments = attestation_documents(repo, base, head)
-            comments[0]["performed_via_github_app"]["id"] = 15368
-            with self.assertRaisesRegex(head_guard.AdmissionError, "exact release App"):
+            wrong_app = outsider_attestation_comment(comments[0])
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments + [wrong_app],
+            )
+            self.assertEqual(evidence.head, head)
+            with self.assertRaises(head_guard.PendingAttestation):
                 head_guard.validate_attestation(
                     repo,
                     head_guard.EXPECTED_REPOSITORY,
                     77,
                     head,
                     reviews,
-                    comments,
+                    [wrong_app],
                 )
-            _, same_login_comments = attestation_documents(repo, base, head)
-            same_login_comments[0]["user"]["id"] = 1
-            with self.assertRaisesRegex(head_guard.AdmissionError, "exact release App"):
+            same_login = outsider_attestation_comment(comments[0], comment_id=53)
+            same_login["user"] = {
+                "id": 1,
+                "login": head_guard.ATTESTATION_CREATOR,
+                "type": "Bot",
+            }
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments + [same_login],
+            )
+            self.assertEqual(evidence.head, head)
+            different_app = outsider_attestation_comment(
+                comments[0], comment_id=54, malformed=True
+            )
+            different_app["performed_via_github_app"] = copy.deepcopy(
+                comments[0]["performed_via_github_app"]
+            )
+            different_app["performed_via_github_app"]["id"] = 15368
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments + [different_app],
+            )
+            self.assertEqual(evidence.head, head)
+
+    def test_rejects_malformed_exact_app_comment_but_ignores_outsider_marker(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_dependency_head(repo)
+            reviews, comments = attestation_documents(repo, base, head)
+            outsider = outsider_attestation_comment(comments[0], malformed=True)
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments + [outsider],
+            )
+            self.assertEqual(evidence.head, head)
+            exact_app_malformed = copy.deepcopy(comments[0])
+            exact_app_malformed["body"] = head_guard.ATTESTATION_MARKER + "\nspoof"
+            with self.assertRaisesRegex(head_guard.AdmissionError, "malformed"):
                 head_guard.validate_attestation(
                     repo,
                     head_guard.EXPECTED_REPOSITORY,
                     77,
                     head,
                     reviews,
-                    same_login_comments,
+                    [exact_app_malformed],
+                )
+            wrong_exact_app_identity = copy.deepcopy(comments[0])
+            wrong_exact_app_identity["performed_via_github_app"]["slug"] = "wrong"
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments + [wrong_exact_app_identity],
+            )
+            self.assertEqual(evidence.head, head)
+            with self.assertRaises(head_guard.PendingAttestation):
+                head_guard.validate_attestation(
+                    repo,
+                    head_guard.EXPECTED_REPOSITORY,
+                    77,
+                    head,
+                    reviews,
+                    [wrong_exact_app_identity],
                 )
 
     def test_rejects_edited_comment_deleted_review_and_dismissed_review(self) -> None:
@@ -1259,6 +1375,9 @@ class PostCompletionAttesterTests(unittest.TestCase):
             repo, _, result_file, base, head = self._changed(directory)
             pull = pull_document(head, base)
             reviews, comments = attestation_documents(repo, base, head)
+            comments.append(
+                outsider_attestation_comment(comments[0], malformed=True)
+            )
             posted = False
             writes: list[str] = []
 
@@ -1376,6 +1495,138 @@ class PostCompletionAttesterTests(unittest.TestCase):
                 workflow_run=workflow_run_document(base),
             )
             self.assertEqual(evidence.head, head)
+
+    def test_recheck_filters_irrelevant_same_sha_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _, result_file, base, head = self._changed(directory)
+            pull = pull_document(head, base)
+            reviews, comments = attestation_documents(repo, base, head)
+            exact = ci_run_document(head, base, run_id=901)
+            irrelevant = copy.deepcopy(exact)
+            irrelevant["id"] = 900
+            irrelevant["head_repository"] = {"full_name": "outsider/kin"}
+            irrelevant["created_at"] = "not-a-timestamp"
+            irrelevant["pull_requests"][0]["number"] = 123
+            other_pull_same_branch = copy.deepcopy(irrelevant)
+            other_pull_same_branch["id"] = 899
+            other_pull_same_branch["head_repository"] = {
+                "full_name": head_guard.EXPECTED_REPOSITORY
+            }
+
+            def fake_for_runs(runs: list[dict[str, object]]):
+                def fake(arguments: list[str]) -> object:
+                    endpoint = next(
+                        (item for item in arguments if item.startswith("repos/")), ""
+                    )
+                    if endpoint.endswith("/git/ref/heads/main"):
+                        return {"object": {"sha": base}}
+                    if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+                        return pull
+                    if endpoint.endswith("/reviews?per_page=100"):
+                        return [reviews]
+                    if endpoint.endswith("/comments?per_page=100"):
+                        return [comments]
+                    if endpoint.endswith("/actions/workflows/ci.yml/runs"):
+                        return [{"total_count": len(runs), "workflow_runs": runs}]
+                    if endpoint.endswith("/actions/runs/901/attempts/1/jobs"):
+                        return ci_jobs_document(run_id=901)
+                    if endpoint.endswith("/actions/runs/902/attempts/1/jobs"):
+                        return ci_jobs_document(run_id=902)
+                    raise AssertionError(
+                        f"unexpected mocked GitHub request: {arguments}"
+                    )
+
+                return fake
+
+            for runs in (
+                [irrelevant, other_pull_same_branch, exact],
+                [exact, other_pull_same_branch, irrelevant],
+            ):
+                with (
+                    self.subTest(order=[int(run["id"]) for run in runs]),
+                    mock.patch.object(
+                        attester,
+                        "gh_json",
+                        side_effect=fake_for_runs(runs),
+                    ),
+                    mock.patch.object(
+                        attester.guard,
+                        "gh_json",
+                        return_value=workflow_run_document(base),
+                    ),
+                    self._live_graphql(head),
+                ):
+                    recheck = attester.recheck_status(
+                        admission_file=result_file,
+                        workspace=repo,
+                        repository=attester.EXPECTED_REPOSITORY,
+                        wait_seconds=0,
+                        require_recheck=True,
+                    )
+                    self.assertEqual(recheck["run_id"], 901)
+
+            newest = ci_run_document(
+                head,
+                base,
+                run_id=902,
+                created_at="2026-08-27T22:00:03Z",
+            )
+            with mock.patch.object(
+                attester,
+                "gh_json",
+                side_effect=fake_for_runs([newest, exact]),
+            ), mock.patch.object(
+                attester.guard,
+                "gh_json",
+                return_value=workflow_run_document(base),
+            ), self._live_graphql(head):
+                selected = attester.recheck_status(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                    wait_seconds=0,
+                    require_recheck=True,
+                )
+            self.assertEqual(selected["run_id"], 902)
+
+            with mock.patch.object(
+                attester,
+                "gh_json",
+                side_effect=fake_for_runs([irrelevant, other_pull_same_branch]),
+            ), mock.patch.object(
+                attester.guard,
+                "gh_json",
+                return_value=workflow_run_document(base),
+            ), self._live_graphql(head):
+                missing = attester.recheck_status(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                    wait_seconds=0,
+                    require_recheck=False,
+                )
+            self.assertIs(missing["needs_retrigger"], True)
+
+            associated_but_wrong = copy.deepcopy(irrelevant)
+            associated_but_wrong["created_at"] = "2026-08-27T22:00:03Z"
+            associated_but_wrong["pull_requests"][0]["number"] = 77
+            with mock.patch.object(
+                attester,
+                "gh_json",
+                side_effect=fake_for_runs([associated_but_wrong]),
+            ), mock.patch.object(
+                attester.guard,
+                "gh_json",
+                return_value=workflow_run_document(base),
+            ), self._live_graphql(head):
+                with self.assertRaisesRegex(attester.AttesterError, "wrong authority"):
+                    attester.recheck_status(
+                        admission_file=result_file,
+                        workspace=repo,
+                        repository=attester.EXPECTED_REPOSITORY,
+                        wait_seconds=0,
+                        require_recheck=False,
+                    )
 
     def test_late_attestation_retriggers_and_materializes_required_recheck(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -1640,7 +1891,8 @@ class EventHandlerTests(unittest.TestCase):
                         self.pull_event(head, base),
                         wait_seconds=0,
                     )
-            malformed = [{"body": head_guard.ATTESTATION_MARKER + "\nspoof"}]
+            _, malformed = attestation_documents(repo, base, head)
+            malformed[0]["body"] = head_guard.ATTESTATION_MARKER + "\nspoof"
             with mock.patch.object(head_guard, "_fresh_pull", return_value=pull), mock.patch.object(
                 head_guard, "_attestation_documents", return_value=([], malformed)
             ):

--- a/scripts/test-kin-registry-release-receiver.py
+++ b/scripts/test-kin-registry-release-receiver.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Deterministic contract tests for the Kin registry-release receiver."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT / "scripts" / "validate-kin-registry-release.py"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "kin-registry-release.yml"
+KIN_ACTIONS_SHA = "398595fa14ba1eaebca6eb176facd8a57ce9db05"
+SOURCE_SHA = "f1ac2bd93f0e3b7162f01481822087151e3b3af4"
+
+spec = importlib.util.spec_from_file_location("kin_registry_receiver", VALIDATOR_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError("could not load Kin registry receiver validator")
+validator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validator)
+
+
+def valid_payload(
+    *, crate: str = "kin-db", source: str = "firelock-ai/kin-db"
+) -> dict[str, str]:
+    version = "0.7.69"
+    return {
+        "crate_name": crate,
+        "crate_version": version,
+        "delivery_id": f"{source}@{SOURCE_SHA}:{crate}@{version}",
+        "source_repo": source,
+        "source_sha": SOURCE_SHA,
+    }
+
+
+def valid_context(**overrides: str) -> dict[str, str]:
+    context = {
+        "event_name": "repository_dispatch",
+        "event_action": "kin-registry-release",
+        "actor": "troyjr4103",
+        "repository": "firelock-ai/kin",
+        "default_branch": "main",
+        "ref": "refs/heads/main",
+        "workflow_sha": "a" * 40,
+    }
+    context.update(overrides)
+    return context
+
+
+class ValidatorTests(unittest.TestCase):
+    def test_accepts_exact_kindb_release_contract(self) -> None:
+        validator.validate_context(**valid_context())
+        self.assertEqual(
+            validator.validate_payload(valid_payload())["crate_version"], "0.7.69"
+        )
+
+    def test_accepts_every_allowed_root_manifest_source_pair(self) -> None:
+        for crate, source in validator.ALLOWED_SOURCES.items():
+            with self.subTest(crate=crate):
+                self.assertEqual(
+                    validator.validate_payload(
+                        valid_payload(crate=crate, source=source)
+                    )["source_repo"],
+                    source,
+                )
+
+    def test_allowed_crates_are_exactly_the_root_registry_boundary(self) -> None:
+        with (ROOT / "Cargo.toml").open("rb") as stream:
+            dependencies = tomllib.load(stream)["workspace"]["dependencies"]
+        root_registry_dependencies = {
+            name
+            for name, value in dependencies.items()
+            if isinstance(value, dict) and value.get("registry") == "kin"
+        }
+        self.assertEqual(set(validator.ALLOWED_SOURCES), root_registry_dependencies)
+
+    def test_rejects_wrong_event_action(self) -> None:
+        with self.assertRaisesRegex(validator.ValidationError, "event action"):
+            validator.validate_context(**valid_context(event_action="dependency-updated"))
+
+    def test_rejects_missing_delivery_id(self) -> None:
+        payload = valid_payload()
+        del payload["delivery_id"]
+        with self.assertRaisesRegex(validator.ValidationError, "missing=.*delivery_id"):
+            validator.validate_payload(payload)
+
+    def test_rejects_malformed_version(self) -> None:
+        payload = valid_payload()
+        payload["crate_version"] = "0.7"
+        payload["delivery_id"] = (
+            f"{payload['source_repo']}@{payload['source_sha']}:"
+            f"{payload['crate_name']}@{payload['crate_version']}"
+        )
+        with self.assertRaisesRegex(validator.ValidationError, "stable SemVer"):
+            validator.validate_payload(payload)
+
+    def test_rejects_package_outside_boundary(self) -> None:
+        payload = valid_payload(crate="serde", source="serde-rs/serde")
+        with self.assertRaisesRegex(validator.ValidationError, "outside Kin's"):
+            validator.validate_payload(payload)
+
+    def test_rejects_source_repo_mismatch(self) -> None:
+        payload = valid_payload(source="firelock-ai/kin-model")
+        with self.assertRaisesRegex(validator.ValidationError, "must come from"):
+            validator.validate_payload(payload)
+
+    def test_rejects_unbound_delivery_id(self) -> None:
+        payload = valid_payload()
+        payload["delivery_id"] = "not-the-source-tuple"
+        with self.assertRaisesRegex(validator.ValidationError, "does not bind"):
+            validator.validate_payload(payload)
+
+    def test_cli_fails_loud_on_malformed_payload(self) -> None:
+        payload = valid_payload()
+        del payload["source_sha"]
+        result = self.run_cli(payload)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("::error title=Invalid Kin registry release::", result.stderr)
+
+    def test_cli_accepts_valid_payload(self) -> None:
+        result = self.run_cli(valid_payload())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("validated Kin registry release kin-db@0.7.69", result.stdout)
+
+    def run_cli(self, payload: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            event_path.write_text(
+                json.dumps(
+                    {"action": "kin-registry-release", "client_payload": payload}
+                ),
+                encoding="utf-8",
+            )
+            command = [
+                "python3",
+                str(VALIDATOR_PATH),
+                "--event-file",
+                str(event_path),
+            ]
+            for key, value in valid_context().items():
+                command.extend([f"--{key.replace('_', '-')}", value])
+            return subprocess.run(
+                command,
+                cwd=ROOT,
+                env=os.environ.copy(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_receiver_trigger_and_write_boundary_are_pinned(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("types: [kin-registry-release]", workflow)
+        self.assertNotIn("workflow_dispatch:", workflow)
+        self.assertNotIn("schedule:", workflow)
+        self.assertIn("group: kin-registry-release-${{ github.repository }}", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertIn("needs: validate-dispatch", workflow)
+        self.assertIn("environment: release-tag", workflow)
+        self.assertIn(
+            f"KIN_ACTIONS_SHA: {KIN_ACTIONS_SHA}",
+            workflow,
+        )
+        self.assertIn("repository: firelock-ai/kin-actions", workflow)
+        self.assertIn(
+            "WAVE_BRANCH: automation/kin-registry-dependency-wave",
+            workflow,
+        )
+        self.assertIn("--bump-own-version false", workflow)
+        for crate in validator.ALLOWED_SOURCES:
+            self.assertIn(f"--crate {crate}", workflow)
+        self.assertEqual(workflow.count("--crate "), len(validator.ALLOWED_SOURCES) + 1)
+        self.assertIn("Open or update the dependency bump PR", workflow)
+        self.assertIn("base: ${{ github.event.repository.default_branch }}", workflow)
+        self.assertIn("Verify exact first-party generated PR", workflow)
+        self.assertNotIn("gh pr merge", workflow)
+        self.assertNotIn("KIN_DOWNSTREAM_DISPATCH_TOKEN", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-kin-registry-release-receiver.py
+++ b/scripts/test-kin-registry-release-receiver.py
@@ -2119,7 +2119,7 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("base_sha=", resolve)
         self.assertIn('!= "$GITHUB_SHA"', early_resolve)
         self.assertIn('!= "$GITHUB_SHA"', resolve)
-        self.assertIn("ref: ${{ steps.base.outputs.base_sha }}", checkout)
+        self.assertIn("ref: ${{ github.sha }}", checkout)
         self.assertIn('!= "$GITHUB_SHA"', mutation_fence)
         self.assertIn("kin-registry-wave-artifact.py apply", admission)
         self.assertIn("branch: ${{ env.WAVE_BRANCH }}", writer)

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -736,6 +736,13 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/install-proof.yml": {
         "install-proof": "${{ matrix.os }}",
     },
+    # The dispatch-only dependency receiver first validates the exact payload,
+    # then uses protected App credentials and pinned updater bytes to write one
+    # fixed PR branch. It publishes no pull request or merge-group context.
+    ".github/workflows/kin-registry-release.yml": {
+        "validate-dispatch": "Validate Kin registry release",
+        "dependency-wave": "Refresh Kin registry pins",
+    },
     ".github/workflows/link-check.yml": {
         "link-check": "Check public documentation links",
     },

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -333,6 +333,7 @@ DOCS_ONLY_WORKFLOW_HEADER = textwrap.dedent(
         branches: [main]
       pull_request:
         branches: [main]
+        types: [opened, synchronize, reopened]
       merge_group:
       repository_dispatch:
         types: [dependency-updated]
@@ -736,12 +737,21 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/install-proof.yml": {
         "install-proof": "${{ matrix.os }}",
     },
-    # The dispatch-only dependency receiver first validates the exact payload,
-    # then uses protected App credentials and pinned updater bytes to write one
-    # fixed PR branch. It publishes no pull request or merge-group context.
+    # The dependency receiver validates the exact payload, prepares and compiles
+    # candidate registry bytes without a write credential, then admits only the
+    # hash-bound manifest delta on a fresh App-authenticated runner. It publishes
+    # no pull-request or merge-group context.
     ".github/workflows/kin-registry-release.yml": {
         "validate-dispatch": "Validate Kin registry release",
-        "dependency-wave": "Refresh Kin registry pins",
+        "disarm-wave": "Disarm inherited Kin registry landing state",
+        "prepare-wave": "Prepare and compile Kin registry pins",
+        "mutate-wave": "Update the fixed Kin registry PR",
+    },
+    # This workflow_run consumer persists the exact App attestation only after
+    # the receiver attempt is terminal-successful. It produces no required
+    # context; the required CI gate reads and revalidates its server evidence.
+    ".github/workflows/kin-registry-release-attest.yml": {
+        "attest-completed-receiver": "Attest completed Kin registry receiver",
     },
     ".github/workflows/link-check.yml": {
         "link-check": "Check public documentation links",

--- a/scripts/validate-kin-registry-release.py
+++ b/scripts/validate-kin-registry-release.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Validate Kin registry-release dispatches before granting write authority."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_EVENT = "repository_dispatch"
+EXPECTED_ACTION = "kin-registry-release"
+EXPECTED_REPOSITORY = "firelock-ai/kin"
+EXPECTED_DEFAULT_BRANCH = "main"
+ALLOWED_ACTORS = frozenset({"troyjr4103", "kin-release-bot[bot]"})
+ALLOWED_SOURCES = {
+    "kin-blobs": "firelock-ai/kin-blobs",
+    "kin-db": "firelock-ai/kin-db",
+    "kin-lsp": "firelock-ai/kin-lsp",
+    "kin-model": "firelock-ai/kin-model",
+    "kin-vfs-core": "firelock-ai/kin-vfs",
+}
+PAYLOAD_KEYS = frozenset(
+    {"crate_name", "crate_version", "delivery_id", "source_repo", "source_sha"}
+)
+LOWER_SHA = re.compile(r"^[0-9a-f]{40}$")
+STABLE_SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+
+
+class ValidationError(ValueError):
+    """The dispatch does not satisfy Kin's receiver contract."""
+
+
+def _require_exact(label: str, actual: str, expected: str) -> None:
+    if actual != expected:
+        raise ValidationError(f"{label} must be {expected!r}, got {actual!r}")
+
+
+def validate_context(
+    *,
+    event_name: str,
+    event_action: str,
+    actor: str,
+    repository: str,
+    default_branch: str,
+    ref: str,
+    workflow_sha: str,
+) -> None:
+    """Validate GitHub-owned dispatch context before loading write credentials."""
+
+    _require_exact("event name", event_name, EXPECTED_EVENT)
+    _require_exact("event action", event_action, EXPECTED_ACTION)
+    _require_exact("repository", repository, EXPECTED_REPOSITORY)
+    _require_exact("default branch", default_branch, EXPECTED_DEFAULT_BRANCH)
+    _require_exact("workflow ref", ref, f"refs/heads/{EXPECTED_DEFAULT_BRANCH}")
+    if actor not in ALLOWED_ACTORS:
+        raise ValidationError(f"actor {actor!r} is not authorized")
+    if LOWER_SHA.fullmatch(workflow_sha) is None:
+        raise ValidationError(
+            f"workflow sha must be 40-character lowercase hex, got {workflow_sha!r}"
+        )
+
+
+def validate_payload(payload: Any) -> dict[str, str]:
+    """Validate the sender payload and its package-to-source boundary."""
+
+    if not isinstance(payload, dict):
+        raise ValidationError("client_payload must be an object")
+    actual_keys = frozenset(payload)
+    if actual_keys != PAYLOAD_KEYS:
+        missing = sorted(PAYLOAD_KEYS - actual_keys)
+        unexpected = sorted(actual_keys - PAYLOAD_KEYS)
+        raise ValidationError(
+            f"client_payload keys differ from contract; missing={missing}, "
+            f"unexpected={unexpected}"
+        )
+    if any(not isinstance(payload[key], str) for key in PAYLOAD_KEYS):
+        raise ValidationError("every client_payload value must be a string")
+
+    normalized: dict[str, str] = {key: payload[key] for key in PAYLOAD_KEYS}
+    crate_name = normalized["crate_name"]
+    source_repo = normalized["source_repo"]
+    expected_source = ALLOWED_SOURCES.get(crate_name)
+    if expected_source is None:
+        raise ValidationError(
+            f"crate {crate_name!r} is outside Kin's root-manifest dependency boundary"
+        )
+    if source_repo != expected_source:
+        raise ValidationError(
+            f"crate {crate_name!r} must come from {expected_source!r}, "
+            f"got {source_repo!r}"
+        )
+
+    crate_version = normalized["crate_version"]
+    if STABLE_SEMVER.fullmatch(crate_version) is None:
+        raise ValidationError(
+            f"crate version must be stable SemVer X.Y.Z, got {crate_version!r}"
+        )
+    source_sha = normalized["source_sha"]
+    if LOWER_SHA.fullmatch(source_sha) is None:
+        raise ValidationError(
+            f"source sha must be 40-character lowercase hex, got {source_sha!r}"
+        )
+    expected_delivery = (
+        f"{source_repo}@{source_sha}:{crate_name}@{crate_version}"
+    )
+    if normalized["delivery_id"] != expected_delivery:
+        raise ValidationError(
+            "delivery_id does not bind the exact source repo, source sha, crate, "
+            "and version"
+        )
+    return normalized
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event-file", type=Path, required=True)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--event-action", required=True)
+    parser.add_argument("--actor", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--default-branch", required=True)
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        with args.event_file.open(encoding="utf-8") as stream:
+            event = json.load(stream)
+        if not isinstance(event, dict):
+            raise ValidationError("event document must be an object")
+        _require_exact(
+            "event document action", str(event.get("action", "")), args.event_action
+        )
+        validate_context(
+            event_name=args.event_name,
+            event_action=args.event_action,
+            actor=args.actor,
+            repository=args.repository,
+            default_branch=args.default_branch,
+            ref=args.ref,
+            workflow_sha=args.workflow_sha,
+        )
+        payload = validate_payload(event.get("client_payload"))
+    except (OSError, json.JSONDecodeError, ValidationError) as error:
+        print(
+            f"::error title=Invalid Kin registry release::{error}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "validated Kin registry release "
+        f"{payload['crate_name']}@{payload['crate_version']} from "
+        f"{payload['source_repo']}@{payload['source_sha']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/validate-kin-registry-release.py
+++ b/scripts/validate-kin-registry-release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate Kin registry-release dispatches before granting write authority."""
+"""Validate Kin registry-release triggers before granting write authority."""
 
 from __future__ import annotations
 
@@ -11,7 +11,8 @@ from pathlib import Path
 from typing import Any
 
 
-EXPECTED_EVENT = "repository_dispatch"
+DISPATCH_EVENT = "repository_dispatch"
+SCHEDULE_EVENT = "schedule"
 EXPECTED_ACTION = "kin-registry-release"
 EXPECTED_REPOSITORY = "firelock-ai/kin"
 EXPECTED_DEFAULT_BRANCH = "main"
@@ -48,20 +49,28 @@ def validate_context(
     default_branch: str,
     ref: str,
     workflow_sha: str,
-) -> None:
-    """Validate GitHub-owned dispatch context before loading write credentials."""
+) -> str:
+    """Validate GitHub-owned trigger context before loading write credentials."""
 
-    _require_exact("event name", event_name, EXPECTED_EVENT)
-    _require_exact("event action", event_action, EXPECTED_ACTION)
     _require_exact("repository", repository, EXPECTED_REPOSITORY)
     _require_exact("default branch", default_branch, EXPECTED_DEFAULT_BRANCH)
     _require_exact("workflow ref", ref, f"refs/heads/{EXPECTED_DEFAULT_BRANCH}")
-    if actor not in ALLOWED_ACTORS:
-        raise ValidationError(f"actor {actor!r} is not authorized")
     if LOWER_SHA.fullmatch(workflow_sha) is None:
         raise ValidationError(
             f"workflow sha must be 40-character lowercase hex, got {workflow_sha!r}"
         )
+    if event_name == DISPATCH_EVENT:
+        _require_exact("event action", event_action, EXPECTED_ACTION)
+        if actor not in ALLOWED_ACTORS:
+            raise ValidationError(f"actor {actor!r} is not authorized")
+        return DISPATCH_EVENT
+    if event_name == SCHEDULE_EVENT:
+        _require_exact("scheduled event action", event_action, "")
+        return SCHEDULE_EVENT
+    raise ValidationError(
+        f"event name must be {DISPATCH_EVENT!r} or {SCHEDULE_EVENT!r}, "
+        f"got {event_name!r}"
+    )
 
 
 def validate_payload(payload: Any) -> dict[str, str]:
@@ -135,10 +144,7 @@ def main(argv: list[str]) -> int:
             event = json.load(stream)
         if not isinstance(event, dict):
             raise ValidationError("event document must be an object")
-        _require_exact(
-            "event document action", str(event.get("action", "")), args.event_action
-        )
-        validate_context(
+        event_mode = validate_context(
             event_name=args.event_name,
             event_action=args.event_action,
             actor=args.actor,
@@ -147,7 +153,15 @@ def main(argv: list[str]) -> int:
             ref=args.ref,
             workflow_sha=args.workflow_sha,
         )
-        payload = validate_payload(event.get("client_payload"))
+        if event_mode == DISPATCH_EVENT:
+            _require_exact(
+                "event document action",
+                str(event.get("action", "")),
+                args.event_action,
+            )
+            payload = validate_payload(event.get("client_payload"))
+        else:
+            payload = None
     except (OSError, json.JSONDecodeError, ValidationError) as error:
         print(
             f"::error title=Invalid Kin registry release::{error}",
@@ -155,11 +169,18 @@ def main(argv: list[str]) -> int:
         )
         return 1
 
-    print(
-        "validated Kin registry release "
-        f"{payload['crate_name']}@{payload['crate_version']} from "
-        f"{payload['source_repo']}@{payload['source_sha']}"
-    )
+    if payload is None:
+        print(
+            "validated scheduled Kin registry reconciliation from protected main "
+            f"at {args.workflow_sha}"
+        )
+    else:
+        print(
+            "validated Kin registry release "
+            f"{payload['crate_name']}@{payload['crate_version']} from "
+            f"{payload['source_repo']}; source_sha and delivery_id are "
+            "sender-supplied correlation metadata, not source provenance"
+        )
     return 0
 
 

--- a/scripts/verify-kin-registry-wave-head.py
+++ b/scripts/verify-kin-registry-wave-head.py
@@ -567,6 +567,24 @@ def _parse_comment_body(body: Any) -> dict[str, str | int]:
     }
 
 
+def _has_exact_attestation_app_identity(comment: dict[str, Any]) -> bool:
+    app = comment.get("performed_via_github_app")
+    owner = app.get("owner") if isinstance(app, dict) else None
+    user = comment.get("user")
+    return (
+        isinstance(app, dict)
+        and app.get("id") == ATTESTATION_APP_ID
+        and app.get("slug") == ATTESTATION_APP_SLUG
+        and isinstance(owner, dict)
+        and owner.get("id") == ATTESTATION_APP_OWNER_ID
+        and owner.get("login") == ATTESTATION_APP_OWNER
+        and isinstance(user, dict)
+        and user.get("id") == ATTESTATION_CREATOR_ID
+        and user.get("login") == ATTESTATION_CREATOR
+        and user.get("type") == "Bot"
+    )
+
+
 def validate_workflow_run(
     repository: str,
     evidence: dict[str, str | int],
@@ -654,28 +672,15 @@ def validate_attestation(
         body = comment.get("body")
         if not isinstance(body, str) or not body.startswith(ATTESTATION_MARKER):
             continue
+        if not _has_exact_attestation_app_identity(comment):
+            continue
         evidence = _parse_comment_body(body)
-        app = comment.get("performed_via_github_app")
-        owner = app.get("owner") if isinstance(app, dict) else None
-        user = comment.get("user")
         comment_id = comment.get("id")
         if (
             not isinstance(comment_id, int)
             or isinstance(comment_id, bool)
-            or not isinstance(app, dict)
-            or app.get("id") != ATTESTATION_APP_ID
-            or app.get("slug") != ATTESTATION_APP_SLUG
-            or not isinstance(owner, dict)
-            or owner.get("id") != ATTESTATION_APP_OWNER_ID
-            or owner.get("login") != ATTESTATION_APP_OWNER
-            or not isinstance(user, dict)
-            or user.get("id") != ATTESTATION_CREATOR_ID
-            or user.get("login") != ATTESTATION_CREATOR
-            or user.get("type") != "Bot"
         ):
-            raise AdmissionError(
-                "reserved dependency admission comment is not from the exact release App"
-            )
+            raise AdmissionError("exact App admission comment has an invalid id")
         if comment.get("created_at") != comment.get("updated_at"):
             raise AdmissionError("dependency admission comment was edited")
         if comment.get("issue_url") != (

--- a/scripts/verify-kin-registry-wave-head.py
+++ b/scripts/verify-kin-registry-wave-head.py
@@ -1,0 +1,1228 @@
+#!/usr/bin/env python3
+"""Verify every landable Kin registry dependency-wave head and delivery."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+
+EXPECTED_REPOSITORY = "firelock-ai/kin"
+EXPECTED_BASE = "main"
+WAVE_BRANCH = "automation/kin-registry-dependency-wave"
+ATTESTATION_MARKER = "<!-- kin-registry-dependency-admission:v2 -->"
+ATTESTATION_APP_ID = 4370197
+ATTESTATION_APP_SLUG = "kin-release-bot"
+ATTESTATION_APP_OWNER = "firelock-ai"
+ATTESTATION_APP_OWNER_ID = 69090636
+ATTESTATION_CREATOR = "kin-release-bot[bot]"
+ATTESTATION_CREATOR_ID = 308181894
+COMMIT_MARKER = "Kin-Registry-Dependency-Wave: v1"
+RECEIVER_WORKFLOW_NAME = "Kin Registry Release Receiver"
+RECEIVER_WORKFLOW_PATH = ".github/workflows/kin-registry-release.yml"
+ALLOWED_PATHS = frozenset({"Cargo.toml", "Cargo.lock"})
+LOWER_SHA = re.compile(r"^[0-9a-f]{40}$")
+VERSION_EVIDENCE = re.compile(r"^(?:absent|[0-9A-Za-z.+-]+)$")
+
+
+class AdmissionError(RuntimeError):
+    """A dependency-wave head or delivered delta is not admitted."""
+
+
+class PendingAttestation(AdmissionError):
+    """The exact App attestation may still be arriving from the receiver."""
+
+
+@dataclass(frozen=True)
+class DeltaEvidence:
+    base: str
+    head: str
+    tree: str
+    paths: frozenset[str]
+    delta_sha256: str
+    package_version: str
+    workspace_version: str
+
+
+@dataclass(frozen=True)
+class PullEvidence:
+    number: int
+    base: str
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[bytes]:
+    result = subprocess.run(
+        list(command),
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        if not detail:
+            detail = result.stdout.decode("utf-8", errors="replace").strip()
+        raise AdmissionError(
+            f"{' '.join(command)} failed: {detail or 'no error output'}"
+        )
+    return result
+
+
+def git(workspace: Path, *arguments: str, check: bool = True) -> bytes:
+    return _run(
+        ["git", "-C", str(workspace), *arguments],
+        check=check,
+    ).stdout
+
+
+def gh_json(arguments: Sequence[str]) -> Any:
+    output = _run(["gh", *arguments]).stdout
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise AdmissionError("GitHub returned malformed JSON") from exc
+
+
+def require_sha(label: str, value: Any) -> str:
+    if not isinstance(value, str) or LOWER_SHA.fullmatch(value) is None:
+        raise AdmissionError(f"{label} must be 40-character lowercase hex")
+    return value
+
+
+def _paths(output: bytes) -> frozenset[str]:
+    return frozenset(
+        value.decode("utf-8", errors="surrogateescape")
+        for value in output.split(b"\0")
+        if value
+    )
+
+
+def _version_fields(document: dict[str, object]) -> tuple[object, object]:
+    package = document.get("package")
+    package_version: object = None
+    if isinstance(package, dict):
+        package_version = package.get("version")
+    workspace = document.get("workspace")
+    workspace_version: object = None
+    if isinstance(workspace, dict):
+        workspace_package = workspace.get("package")
+        if isinstance(workspace_package, dict):
+            workspace_version = workspace_package.get("version")
+    return package_version, workspace_version
+
+
+def _toml_at(workspace: Path, revision: str, path: str) -> dict[str, object]:
+    raw = git(workspace, "show", f"{revision}:{path}")
+    try:
+        value = tomllib.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        raise AdmissionError(f"cannot parse {path} at {revision}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AdmissionError(f"{path} at {revision} is not a TOML object")
+    return value
+
+
+def exact_patch(workspace: Path, base: str, head: str) -> bytes:
+    return git(
+        workspace,
+        "diff",
+        "--binary",
+        "--full-index",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-renames",
+        base,
+        head,
+        "--",
+        *sorted(ALLOWED_PATHS),
+    )
+
+
+def _version_evidence(value: object) -> str:
+    if value is None:
+        return "absent"
+    if not isinstance(value, str) or VERSION_EVIDENCE.fullmatch(value) is None:
+        raise AdmissionError(f"version field cannot be attested safely: {value!r}")
+    return value
+
+
+def is_ancestor(workspace: Path, base: str, head: str) -> bool:
+    return (
+        _run(
+            ["git", "-C", str(workspace), "merge-base", "--is-ancestor", base, head],
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def ensure_pull_head(workspace: Path, pull_number: int, head: str) -> None:
+    present = _run(
+        ["git", "-C", str(workspace), "cat-file", "-e", f"{head}^{{commit}}"],
+        check=False,
+    ).returncode
+    if present == 0:
+        return
+    _run(
+        [
+            "git",
+            "-C",
+            str(workspace),
+            "fetch",
+            "--no-tags",
+            "origin",
+            f"refs/pull/{pull_number}/head",
+        ]
+    )
+    if (
+        _run(
+            ["git", "-C", str(workspace), "cat-file", "-e", f"{head}^{{commit}}"],
+            check=False,
+        ).returncode
+        != 0
+    ):
+        raise AdmissionError(
+            f"pull request {pull_number} ref did not contain expected head {head}"
+        )
+
+
+def validate_delta(
+    workspace: Path,
+    base: str,
+    head: str,
+    *,
+    require_marker: bool,
+) -> DeltaEvidence:
+    base = require_sha("delta base", base)
+    head = require_sha("delta head", head)
+    for label, revision in (("base", base), ("head", head)):
+        if (
+            _run(
+                ["git", "-C", str(workspace), "cat-file", "-e", f"{revision}^{{commit}}"],
+                check=False,
+            ).returncode
+            != 0
+        ):
+            raise AdmissionError(f"{label} commit {revision} is absent from checkout")
+    if not is_ancestor(workspace, base, head):
+        raise AdmissionError(f"admission base {base} is not an ancestor of {head}")
+
+    paths = _paths(
+        git(
+            workspace,
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            base,
+            head,
+            "--",
+        )
+    )
+    if not paths:
+        raise AdmissionError("dependency-wave delta is empty")
+    unexpected = sorted(paths - ALLOWED_PATHS)
+    if unexpected:
+        raise AdmissionError(
+            "dependency-wave changed non-admitted paths: " + ", ".join(unexpected)
+        )
+    summary = git(
+        workspace,
+        "diff",
+        "--summary",
+        "--no-renames",
+        base,
+        head,
+        "--",
+    ).decode("utf-8", errors="replace").strip()
+    if summary:
+        raise AdmissionError(
+            "dependency-wave changed file identity or mode: " + summary
+        )
+    before_versions = _version_fields(_toml_at(workspace, base, "Cargo.toml"))
+    after_versions = _version_fields(_toml_at(workspace, head, "Cargo.toml"))
+    if before_versions != after_versions:
+        raise AdmissionError("dependency-wave changed package or workspace version")
+    if require_marker:
+        body = git(workspace, "show", "-s", "--format=%B", head).decode(
+            "utf-8", errors="replace"
+        )
+        if body.splitlines().count(COMMIT_MARKER) != 1:
+            raise AdmissionError("dependency-wave head lacks its exact commit marker")
+    tree = require_sha(
+        "dependency-wave tree",
+        git(workspace, "rev-parse", f"{head}^{{tree}}").decode("ascii").strip(),
+    )
+    patch = exact_patch(workspace, base, head)
+    if not patch:
+        raise AdmissionError("dependency-wave patch carries no content change")
+    return DeltaEvidence(
+        base=base,
+        head=head,
+        tree=tree,
+        paths=paths,
+        delta_sha256=hashlib.sha256(patch).hexdigest(),
+        package_version=_version_evidence(after_versions[0]),
+        workspace_version=_version_evidence(after_versions[1]),
+    )
+
+
+def validate_index_delta(
+    workspace: Path,
+    base: str,
+    expected_tree: str,
+) -> DeltaEvidence:
+    """Validate and describe the exact staged tree before the PR writer runs."""
+
+    base = require_sha("staged delta base", base)
+    expected_tree = require_sha("staged dependency-wave tree", expected_tree)
+    if (
+        _run(
+            ["git", "-C", str(workspace), "cat-file", "-e", f"{base}^{{commit}}"],
+            check=False,
+        ).returncode
+        != 0
+    ):
+        raise AdmissionError(f"staged delta base {base} is absent from checkout")
+    checked_out_head = git(workspace, "rev-parse", "HEAD").decode("ascii").strip()
+    if checked_out_head != base:
+        raise AdmissionError(
+            f"staged dependency base {base} is not checked-out HEAD {checked_out_head}"
+        )
+    actual_tree = git(workspace, "write-tree").decode("ascii").strip()
+    if actual_tree != expected_tree:
+        raise AdmissionError(
+            f"staged dependency tree {actual_tree} differs from admitted {expected_tree}"
+        )
+    paths = _paths(
+        git(
+            workspace,
+            "diff",
+            "--cached",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            base,
+            "--",
+        )
+    )
+    if not paths:
+        raise AdmissionError("staged dependency-wave delta is empty")
+    unexpected = sorted(paths - ALLOWED_PATHS)
+    if unexpected:
+        raise AdmissionError(
+            "staged dependency-wave changed non-admitted paths: "
+            + ", ".join(unexpected)
+        )
+    summary = git(
+        workspace,
+        "diff",
+        "--cached",
+        "--summary",
+        "--no-renames",
+        base,
+        "--",
+    ).decode("utf-8", errors="replace").strip()
+    if summary:
+        raise AdmissionError(
+            "staged dependency-wave changed file identity or mode: " + summary
+        )
+    before_versions = _version_fields(_toml_at(workspace, base, "Cargo.toml"))
+    raw_manifest = git(workspace, "show", ":Cargo.toml")
+    try:
+        staged_document = tomllib.loads(raw_manifest.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        raise AdmissionError(f"cannot parse staged Cargo.toml: {exc}") from exc
+    after_versions = _version_fields(staged_document)
+    if before_versions != after_versions:
+        raise AdmissionError("staged dependency-wave changed package or workspace version")
+    patch = git(
+        workspace,
+        "diff",
+        "--cached",
+        "--binary",
+        "--full-index",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-renames",
+        base,
+        "--",
+        *sorted(ALLOWED_PATHS),
+    )
+    if not patch:
+        raise AdmissionError("staged dependency-wave patch carries no content change")
+    return DeltaEvidence(
+        base=base,
+        head="index",
+        tree=expected_tree,
+        paths=paths,
+        delta_sha256=hashlib.sha256(patch).hexdigest(),
+        package_version=_version_evidence(after_versions[0]),
+        workspace_version=_version_evidence(after_versions[1]),
+    )
+
+
+def verify_delivery_tree(
+    workspace: Path,
+    admitted: DeltaEvidence,
+    delivered: DeltaEvidence,
+) -> None:
+    """Apply the admitted patch to the actual delivery base and require its tree."""
+
+    if not is_ancestor(workspace, admitted.base, delivered.base):
+        raise AdmissionError(
+            "classic-main delivery base does not descend from the admitted base"
+        )
+    expected_tree = git(
+        workspace,
+        "merge-tree",
+        "--write-tree",
+        delivered.base,
+        admitted.head,
+    ).decode("ascii").strip()
+    require_sha("reconciled dependency-wave tree", expected_tree)
+    if expected_tree != delivered.tree:
+        raise AdmissionError(
+            "classic-main delivery tree differs from applying the exact admitted delta"
+        )
+
+
+def verify_merge_group_dependency_tree(
+    workspace: Path,
+    base: str,
+    group_head: str,
+    admitted: DeltaEvidence,
+) -> None:
+    """Reject any queued peer that changes the admitted dependency paths."""
+
+    if admitted.base != base:
+        raise AdmissionError(
+            "merge group base differs from the admitted dependency base"
+        )
+    expected_tree = git(
+        workspace,
+        "merge-tree",
+        "--write-tree",
+        base,
+        admitted.head,
+    ).decode("ascii").strip()
+    require_sha("candidate-only merge-group tree", expected_tree)
+    expected_entries = git(
+        workspace,
+        "ls-tree",
+        "-z",
+        expected_tree,
+        "--",
+        *sorted(ALLOWED_PATHS),
+    )
+    delivered_entries = git(
+        workspace,
+        "ls-tree",
+        "-z",
+        group_head,
+        "--",
+        *sorted(ALLOWED_PATHS),
+    )
+    if expected_entries != delivered_entries:
+        raise AdmissionError(
+            "merge group changes admitted dependency paths outside the wave"
+        )
+
+
+def _review_body(
+    repository: str,
+    pull_number: int,
+    head: str,
+    tree: str,
+    base: str,
+    delta_sha256: str,
+    package_version: str,
+    workspace_version: str,
+    workflow_path: str,
+    policy_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> str:
+    return "\n".join(
+        (
+            "Kin registry dependency admission review v2",
+            f"repository={repository}",
+            f"pull={pull_number}",
+            f"head={head}",
+            f"tree={tree}",
+            f"base={base}",
+            f"delta_sha256={delta_sha256}",
+            f"package_version={package_version}",
+            f"workspace_version={workspace_version}",
+            f"workflow_path={workflow_path}",
+            f"policy_sha={policy_sha}",
+            f"run_id={run_id}",
+            f"run_attempt={run_attempt}",
+        )
+    )
+
+
+def _comment_body(
+    repository: str,
+    pull_number: int,
+    review_id: int,
+    head: str,
+    tree: str,
+    base: str,
+    delta_sha256: str,
+    package_version: str,
+    workspace_version: str,
+    workflow_path: str,
+    policy_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> str:
+    return "\n".join(
+        (
+            ATTESTATION_MARKER,
+            f"repository={repository}",
+            f"pull={pull_number}",
+            f"review_id={review_id}",
+            f"head={head}",
+            f"tree={tree}",
+            f"base={base}",
+            f"delta_sha256={delta_sha256}",
+            f"package_version={package_version}",
+            f"workspace_version={workspace_version}",
+            f"workflow_path={workflow_path}",
+            f"policy_sha={policy_sha}",
+            f"run_id={run_id}",
+            f"run_attempt={run_attempt}",
+        )
+    )
+
+
+def _parse_comment_body(body: Any) -> dict[str, str | int]:
+    if not isinstance(body, str):
+        raise AdmissionError("dependency admission comment has no text body")
+    match = re.fullmatch(
+        re.escape(ATTESTATION_MARKER)
+        + r"\nrepository=(firelock-ai/kin)"
+        + r"\npull=([1-9][0-9]*)"
+        + r"\nreview_id=([1-9][0-9]*)"
+        + r"\nhead=([0-9a-f]{40})"
+        + r"\ntree=([0-9a-f]{40})"
+        + r"\nbase=([0-9a-f]{40})"
+        + r"\ndelta_sha256=([0-9a-f]{64})"
+        + r"\npackage_version=(absent|[0-9A-Za-z.+-]+)"
+        + r"\nworkspace_version=(absent|[0-9A-Za-z.+-]+)"
+        + r"\nworkflow_path=(\.github/workflows/kin-registry-release\.yml)"
+        + r"\npolicy_sha=([0-9a-f]{40})"
+        + r"\nrun_id=([1-9][0-9]*)"
+        + r"\nrun_attempt=([1-9][0-9]*)",
+        body.strip(),
+    )
+    if match is None:
+        raise AdmissionError("dependency admission comment has malformed evidence")
+    (
+        repository,
+        pull,
+        review_id,
+        head,
+        tree,
+        base,
+        delta_sha256,
+        package_version,
+        workspace_version,
+        workflow_path,
+        policy_sha,
+        run_id,
+        run_attempt,
+    ) = match.groups()
+    return {
+        "repository": repository,
+        "pull": int(pull),
+        "review_id": int(review_id),
+        "head": head,
+        "tree": tree,
+        "base": base,
+        "delta_sha256": delta_sha256,
+        "package_version": package_version,
+        "workspace_version": workspace_version,
+        "workflow_path": workflow_path,
+        "policy_sha": policy_sha,
+        "run_id": int(run_id),
+        "run_attempt": int(run_attempt),
+    }
+
+
+def validate_workflow_run(
+    repository: str,
+    evidence: dict[str, str | int],
+    workflow_run: Any | None = None,
+) -> None:
+    run_id = evidence.get("run_id")
+    run_attempt = evidence.get("run_attempt")
+    policy_sha = evidence.get("policy_sha")
+    workflow_path = evidence.get("workflow_path")
+    if (
+        not isinstance(run_id, int)
+        or isinstance(run_id, bool)
+        or run_id < 1
+        or not isinstance(run_attempt, int)
+        or isinstance(run_attempt, bool)
+        or run_attempt < 1
+        or workflow_path != RECEIVER_WORKFLOW_PATH
+        or policy_sha != evidence.get("base")
+    ):
+        raise AdmissionError("dependency admission has invalid receiver run authority")
+    if workflow_run is None:
+        workflow_run = gh_json(
+            [
+                "api",
+                f"repos/{repository}/actions/runs/{run_id}/attempts/{run_attempt}",
+            ]
+        )
+    run_repository = (
+        workflow_run.get("repository") if isinstance(workflow_run, dict) else None
+    )
+    head_repository = (
+        workflow_run.get("head_repository")
+        if isinstance(workflow_run, dict)
+        else None
+    )
+    if (
+        not isinstance(workflow_run, dict)
+        or workflow_run.get("id") != run_id
+        or workflow_run.get("run_attempt") != run_attempt
+        or workflow_run.get("name") != RECEIVER_WORKFLOW_NAME
+        or workflow_run.get("path") != RECEIVER_WORKFLOW_PATH
+        or workflow_run.get("status") != "completed"
+        or workflow_run.get("conclusion") != "success"
+        or workflow_run.get("event") not in {"repository_dispatch", "schedule"}
+        or workflow_run.get("head_branch") != EXPECTED_BASE
+        or workflow_run.get("head_sha") != policy_sha
+        or not isinstance(run_repository, dict)
+        or run_repository.get("full_name") != repository
+        or not isinstance(head_repository, dict)
+        or head_repository.get("full_name") != repository
+    ):
+        raise AdmissionError(
+            "dependency admission does not cite the exact successful receiver run"
+        )
+
+
+def validate_attestation(
+    workspace: Path,
+    repository: str,
+    pull_number: int,
+    head: str,
+    reviews: Any,
+    comments: Any,
+    *,
+    expected_base: str | None = None,
+    workflow_run: Any | None = None,
+    verify_server_run: bool = False,
+) -> DeltaEvidence:
+    if not isinstance(reviews, list) or not isinstance(comments, list):
+        raise AdmissionError("dependency admission review or comment listing is malformed")
+    reviews_by_id: dict[int, dict[str, Any]] = {}
+    for review in reviews:
+        if not isinstance(review, dict):
+            raise AdmissionError("dependency admission review listing has a non-object")
+        review_id = review.get("id")
+        if isinstance(review_id, int) and not isinstance(review_id, bool):
+            if review_id in reviews_by_id:
+                raise AdmissionError("dependency admission review id is duplicated")
+            reviews_by_id[review_id] = review
+
+    current: list[tuple[dict[str, Any], dict[str, str | int]]] = []
+    for comment in comments:
+        if not isinstance(comment, dict):
+            raise AdmissionError("dependency admission comment listing has a non-object")
+        body = comment.get("body")
+        if not isinstance(body, str) or not body.startswith(ATTESTATION_MARKER):
+            continue
+        evidence = _parse_comment_body(body)
+        app = comment.get("performed_via_github_app")
+        owner = app.get("owner") if isinstance(app, dict) else None
+        user = comment.get("user")
+        comment_id = comment.get("id")
+        if (
+            not isinstance(comment_id, int)
+            or isinstance(comment_id, bool)
+            or not isinstance(app, dict)
+            or app.get("id") != ATTESTATION_APP_ID
+            or app.get("slug") != ATTESTATION_APP_SLUG
+            or not isinstance(owner, dict)
+            or owner.get("id") != ATTESTATION_APP_OWNER_ID
+            or owner.get("login") != ATTESTATION_APP_OWNER
+            or not isinstance(user, dict)
+            or user.get("id") != ATTESTATION_CREATOR_ID
+            or user.get("login") != ATTESTATION_CREATOR
+            or user.get("type") != "Bot"
+        ):
+            raise AdmissionError(
+                "reserved dependency admission comment is not from the exact release App"
+            )
+        if comment.get("created_at") != comment.get("updated_at"):
+            raise AdmissionError("dependency admission comment was edited")
+        if comment.get("issue_url") != (
+            f"https://api.github.com/repos/{repository}/issues/{pull_number}"
+        ):
+            raise AdmissionError("dependency admission comment belongs to another pull")
+        if comment.get("html_url") != (
+            f"https://github.com/{repository}/pull/{pull_number}"
+            f"#issuecomment-{comment_id}"
+        ):
+            raise AdmissionError("dependency admission comment has an invalid canonical URL")
+        if evidence["head"] == head:
+            current.append((comment, evidence))
+
+    if not current:
+        raise PendingAttestation(
+            "dependency-wave head has no exact release-App admission attestation"
+        )
+    evidence_shapes = {
+        (
+            item["repository"],
+            item["pull"],
+            item["head"],
+            item["tree"],
+            item["base"],
+            item["delta_sha256"],
+            item["package_version"],
+            item["workspace_version"],
+            item["workflow_path"],
+            item["policy_sha"],
+            item["run_id"],
+            item["run_attempt"],
+        )
+        for _, item in current
+    }
+    if len(evidence_shapes) != 1:
+        raise AdmissionError("dependency-wave head has conflicting App attestations")
+
+    for comment, item in current:
+        if item["repository"] != repository or item["pull"] != pull_number:
+            raise AdmissionError("dependency admission payload names another pull")
+        review = reviews_by_id.get(int(item["review_id"]))
+        if review is None:
+            raise AdmissionError("App attestation references a deleted or missing review")
+        review_user = review.get("user")
+        expected_review_body = _review_body(
+            repository,
+            pull_number,
+            head,
+            str(item["tree"]),
+            str(item["base"]),
+            str(item["delta_sha256"]),
+            str(item["package_version"]),
+            str(item["workspace_version"]),
+            str(item["workflow_path"]),
+            str(item["policy_sha"]),
+            int(item["run_id"]),
+            int(item["run_attempt"]),
+        )
+        if (
+            review.get("state") != "COMMENTED"
+            or review.get("commit_id") != head
+            or review.get("body") != expected_review_body
+            or not isinstance(review_user, dict)
+            or review_user.get("id") != ATTESTATION_CREATOR_ID
+            or review_user.get("login") != ATTESTATION_CREATOR
+            or review_user.get("type") != "Bot"
+        ):
+            raise AdmissionError(
+                "cross-linked dependency admission review is stale, edited, or dismissed"
+            )
+        submitted = review.get("submitted_at")
+        created = comment.get("created_at")
+        if not isinstance(submitted, str) or not isinstance(created, str) or submitted > created:
+            raise AdmissionError("dependency admission review/comment ordering is invalid")
+
+    _, latest = max(current, key=lambda item: item[0]["id"])
+    if verify_server_run or workflow_run is not None:
+        validate_workflow_run(repository, latest, workflow_run)
+    expected_tree = str(latest["tree"])
+    base = str(latest["base"])
+    if expected_base is not None and base != expected_base:
+        raise AdmissionError(
+            f"dependency admission base {base} is not current pull base {expected_base}"
+        )
+    evidence = validate_delta(workspace, base, head, require_marker=True)
+    if evidence.tree != expected_tree:
+        raise AdmissionError(
+            f"dependency head tree {evidence.tree} differs from admitted {expected_tree}"
+        )
+    if evidence.delta_sha256 != latest["delta_sha256"]:
+        raise AdmissionError("dependency head delta differs from admitted fingerprint")
+    if evidence.package_version != latest["package_version"]:
+        raise AdmissionError("dependency head package version differs from admission")
+    if evidence.workspace_version != latest["workspace_version"]:
+        raise AdmissionError("dependency head workspace version differs from admission")
+    if evidence.base != latest["policy_sha"]:
+        raise AdmissionError("dependency admission policy differs from its exact base")
+    return evidence
+
+
+def validate_pull(
+    pull: Any,
+    *,
+    repository: str,
+    expected_head: str,
+    require_open: bool,
+) -> PullEvidence:
+    if not isinstance(pull, dict):
+        raise AdmissionError("pull response is not an object")
+    number = pull.get("number")
+    head = pull.get("head")
+    base = pull.get("base")
+    if (
+        not isinstance(number, int)
+        or isinstance(number, bool)
+        or number < 1
+        or not isinstance(head, dict)
+        or not isinstance(base, dict)
+        or not isinstance(head.get("repo"), dict)
+    ):
+        raise AdmissionError("pull response has malformed identity fields")
+    if (
+        head["repo"].get("full_name") != repository
+        or head.get("ref") != WAVE_BRANCH
+        or head.get("sha") != expected_head
+        or base.get("ref") != EXPECTED_BASE
+    ):
+        raise AdmissionError("pull is not the exact first-party dependency wave")
+    base_sha = require_sha("pull request base", base.get("sha"))
+    if "auto_merge" not in pull:
+        raise AdmissionError("pull response omitted server-side auto-merge state")
+    if pull["auto_merge"] is not None:
+        raise AdmissionError("dependency-wave pull request has auto-merge armed")
+    if require_open and pull.get("state") != "open":
+        raise AdmissionError("dependency-wave pull request is not open")
+    if not require_open and not pull.get("merged_at"):
+        raise AdmissionError("dependency-wave delivery is not associated with a merge")
+    return PullEvidence(number=number, base=base_sha)
+
+
+def _fresh_pull(repository: str, number: int) -> Any:
+    return gh_json(["api", f"repos/{repository}/pulls/{number}"])
+
+
+def _paginated_items(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise AdmissionError(f"{label} response is not an array")
+    if value and all(isinstance(page, list) for page in value):
+        return [item for page in value for item in page]
+    return value
+
+
+def _attestation_documents(repository: str, pull_number: int) -> tuple[list[Any], list[Any]]:
+    reviews = _paginated_items(
+        gh_json(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{repository}/pulls/{pull_number}/reviews?per_page=100",
+            ]
+        ),
+        "pull review",
+    )
+    comments = _paginated_items(
+        gh_json(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{repository}/issues/{pull_number}/comments?per_page=100",
+            ]
+        ),
+        "pull comment",
+    )
+    return reviews, comments
+
+
+def verify_attestation(
+    workspace: Path,
+    repository: str,
+    pull_number: int,
+    head: str,
+    *,
+    wait_seconds: int,
+    expected_base: str | None = None,
+) -> DeltaEvidence:
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        reviews, comments = _attestation_documents(repository, pull_number)
+        try:
+            return validate_attestation(
+                workspace,
+                repository,
+                pull_number,
+                head,
+                reviews,
+                comments,
+                expected_base=expected_base,
+                verify_server_run=True,
+            )
+        except PendingAttestation:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            time.sleep(min(5.0, remaining))
+
+
+def _open_wave_pulls(repository: str) -> list[Any]:
+    owner = repository.split("/", 1)[0]
+    value = gh_json(
+        [
+            "api",
+            "--method",
+            "GET",
+            f"repos/{repository}/pulls",
+            "-f",
+            "state=open",
+            "-f",
+            f"head={owner}:{WAVE_BRANCH}",
+            "-f",
+            f"base={EXPECTED_BASE}",
+            "-f",
+            "per_page=100",
+        ]
+    )
+    if not isinstance(value, list):
+        raise AdmissionError("open dependency pull listing is not an array")
+    if len(value) > 1:
+        raise AdmissionError("fixed dependency branch has multiple open pulls")
+    return value
+
+
+def _associated_pulls(repository: str, commit: str) -> list[Any]:
+    value = gh_json(["api", f"repos/{repository}/commits/{commit}/pulls"])
+    if not isinstance(value, list):
+        raise AdmissionError("associated pull listing is not an array")
+    selected = []
+    for pull in value:
+        if not isinstance(pull, dict):
+            continue
+        head = pull.get("head")
+        base = pull.get("base")
+        if (
+            isinstance(head, dict)
+            and isinstance(base, dict)
+            and isinstance(head.get("repo"), dict)
+            and head["repo"].get("full_name") == repository
+            and head.get("ref") == WAVE_BRANCH
+            and base.get("ref") == EXPECTED_BASE
+        ):
+            selected.append(pull)
+    if len(selected) > 1:
+        raise AdmissionError("commit is associated with multiple dependency-wave pulls")
+    return selected
+
+
+def marked_commits(workspace: Path, base: str, head: str) -> list[str]:
+    revisions = git(workspace, "rev-list", f"{base}..{head}").decode().splitlines()
+    return [
+        revision
+        for revision in revisions
+        if git(workspace, "show", "-s", "--format=%B", revision)
+        .decode("utf-8", errors="replace")
+        .splitlines()
+        .count(COMMIT_MARKER)
+        > 0
+    ]
+
+
+def verify_pull_request(
+    workspace: Path,
+    repository: str,
+    event: dict[str, Any],
+    *,
+    wait_seconds: int,
+) -> str:
+    event_pull = event.get("pull_request")
+    if not isinstance(event_pull, dict):
+        raise AdmissionError("pull_request event omitted pull_request")
+    event_head = event_pull.get("head")
+    event_base = event_pull.get("base")
+    if not isinstance(event_head, dict) or not isinstance(event_base, dict):
+        raise AdmissionError("pull_request event omitted head or base")
+    head = require_sha("pull request head", event_head.get("sha"))
+    base = require_sha("pull request base", event_base.get("sha"))
+    number = event_pull.get("number")
+    if not isinstance(number, int) or isinstance(number, bool) or number < 1:
+        raise AdmissionError("pull_request event has no valid number")
+    ensure_pull_head(workspace, number, head)
+    markers = marked_commits(workspace, base, head)
+    if event_head.get("ref") != WAVE_BRANCH:
+        if markers:
+            raise AdmissionError(
+                "non-wave pull request uses the reserved dependency-wave marker"
+            )
+        return "not a registry dependency-wave pull request"
+    pull = _fresh_pull(repository, number)
+    pull_evidence = validate_pull(
+        pull,
+        repository=repository,
+        expected_head=head,
+        require_open=True,
+    )
+    if pull_evidence.base != base:
+        raise AdmissionError(
+            "pull request base moved after the delivered pull_request event"
+        )
+    admitted = verify_attestation(
+        workspace,
+        repository,
+        pull_evidence.number,
+        head,
+        wait_seconds=wait_seconds,
+        expected_base=pull_evidence.base,
+    )
+    if markers != [head] or admitted.head != head:
+        raise AdmissionError("dependency-wave pull marker is missing or ambiguous")
+    return (
+        f"verified dependency-wave pull request {pull_evidence.number} at {head}"
+    )
+
+
+def verify_merge_group(
+    workspace: Path,
+    repository: str,
+    event: dict[str, Any],
+    *,
+    wait_seconds: int,
+) -> str:
+    group = event.get("merge_group")
+    if not isinstance(group, dict):
+        raise AdmissionError("merge_group event omitted merge_group")
+    base = require_sha("merge-group base", group.get("base_sha"))
+    head = require_sha("merge-group head", group.get("head_sha"))
+    markers = marked_commits(workspace, base, head)
+    pulls = _open_wave_pulls(repository)
+    if not pulls:
+        if markers:
+            raise AdmissionError(
+                "merge group contains a dependency-wave marker without its open pull"
+            )
+        return "merge group contains no registry dependency wave"
+    candidate_summary = pulls[0]
+    candidate_number = candidate_summary.get("number")
+    if (
+        not isinstance(candidate_number, int)
+        or isinstance(candidate_number, bool)
+        or candidate_number < 1
+    ):
+        raise AdmissionError("open dependency pull has no valid number")
+    candidate = _fresh_pull(repository, candidate_number)
+    candidate_head = require_sha(
+        "dependency-wave pull head",
+        candidate.get("head", {}).get("sha")
+        if isinstance(candidate.get("head"), dict)
+        else None,
+    )
+    if not is_ancestor(workspace, candidate_head, head):
+        if markers:
+            raise AdmissionError(
+                "merge group contains stale dependency-wave bytes after its pull moved"
+            )
+        return "merge group does not contain the open registry dependency wave"
+    if markers != [candidate_head]:
+        raise AdmissionError("merge group dependency-wave marker is missing or ambiguous")
+    pull_evidence = validate_pull(
+        candidate,
+        repository=repository,
+        expected_head=candidate_head,
+        require_open=True,
+    )
+    if pull_evidence.base != base:
+        raise AdmissionError(
+            "merge group base differs from the current dependency pull base"
+        )
+    admitted = verify_attestation(
+        workspace,
+        repository,
+        pull_evidence.number,
+        candidate_head,
+        wait_seconds=wait_seconds,
+        expected_base=pull_evidence.base,
+    )
+    verify_merge_group_dependency_tree(workspace, base, head, admitted)
+    return (
+        "verified dependency-wave pull request "
+        f"{pull_evidence.number} in merge group"
+    )
+
+
+def verify_push(
+    workspace: Path,
+    repository: str,
+    event: dict[str, Any],
+    *,
+    wait_seconds: int,
+) -> str:
+    if event.get("ref") != f"refs/heads/{EXPECTED_BASE}":
+        return "push is not protected main"
+    before = require_sha("push before", event.get("before"))
+    head = require_sha("push head", event.get("after"))
+    markers = marked_commits(workspace, before, head)
+    pulls = _associated_pulls(repository, head)
+    if not pulls:
+        if markers:
+            raise AdmissionError(
+                "main delivery contains a dependency-wave marker without its pull"
+            )
+        return "main push is not a registry dependency-wave delivery"
+    associated = pulls[0]
+    number = associated.get("number")
+    if not isinstance(number, int) or isinstance(number, bool) or number < 1:
+        raise AdmissionError("associated dependency pull has no valid number")
+    pull = _fresh_pull(repository, number)
+    pull_head = require_sha(
+        "delivered pull head",
+        pull.get("head", {}).get("sha")
+        if isinstance(pull, dict) and isinstance(pull.get("head"), dict)
+        else None,
+    )
+    pull_evidence = validate_pull(
+        pull,
+        repository=repository,
+        expected_head=pull_head,
+        require_open=False,
+    )
+    ensure_pull_head(workspace, pull_evidence.number, pull_head)
+    admitted = verify_attestation(
+        workspace,
+        repository,
+        pull_evidence.number,
+        pull_head,
+        wait_seconds=wait_seconds,
+    )
+    delivered = validate_delta(
+        workspace,
+        before,
+        head,
+        require_marker=False,
+    )
+    verify_delivery_tree(workspace, admitted, delivered)
+    return (
+        "verified classic-main delivery of dependency-wave pull request "
+        f"{pull_evidence.number}"
+    )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event-file", type=Path, required=True)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--attestation-wait-seconds", type=int, default=0)
+    return parser.parse_args(argv)
+
+
+def emit_index_evidence(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--expected-tree", required=True)
+    args = parser.parse_args(argv)
+    try:
+        evidence = validate_index_delta(
+            args.workspace,
+            args.base,
+            args.expected_tree,
+        )
+    except AdmissionError as exc:
+        print(
+            f"::error title=Invalid staged Kin registry dependency delta::{exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        json.dumps(
+            {
+                "base": evidence.base,
+                "tree": evidence.tree,
+                "delta_sha256": evidence.delta_sha256,
+                "package_version": evidence.package_version,
+                "workspace_version": evidence.workspace_version,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = list(argv or sys.argv[1:])
+    if arguments[:1] == ["emit-index-evidence"]:
+        return emit_index_evidence(arguments[1:])
+    args = parse_args(arguments)
+    try:
+        if args.repository != EXPECTED_REPOSITORY:
+            raise AdmissionError(
+                f"repository must be {EXPECTED_REPOSITORY}, got {args.repository}"
+            )
+        if not 0 <= args.attestation_wait_seconds <= 300:
+            raise AdmissionError("attestation wait must be between 0 and 300 seconds")
+        require_sha("workflow sha", args.workflow_sha)
+        with args.event_file.open(encoding="utf-8") as stream:
+            event = json.load(stream)
+        if not isinstance(event, dict):
+            raise AdmissionError("event document is not an object")
+        if args.event_name == "pull_request":
+            message = verify_pull_request(
+                args.workspace,
+                args.repository,
+                event,
+                wait_seconds=args.attestation_wait_seconds,
+            )
+        elif args.event_name == "merge_group":
+            message = verify_merge_group(
+                args.workspace,
+                args.repository,
+                event,
+                wait_seconds=args.attestation_wait_seconds,
+            )
+        elif args.event_name == "push":
+            if args.ref != f"refs/heads/{EXPECTED_BASE}":
+                raise AdmissionError("push workflow ref is not protected main")
+            if event.get("after") != args.workflow_sha:
+                raise AdmissionError("push event after does not match workflow sha")
+            message = verify_push(
+                args.workspace,
+                args.repository,
+                event,
+                wait_seconds=args.attestation_wait_seconds,
+            )
+        else:
+            message = f"event {args.event_name} carries no dependency-wave delivery"
+    except (OSError, json.JSONDecodeError, AdmissionError) as exc:
+        print(
+            f"::error title=Invalid Kin registry dependency head::{exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-kin-release-app-token.py
+++ b/scripts/verify-kin-release-app-token.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Verify a Kin release App installation token without using GET /user."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any, Sequence
+
+
+EXPECTED_APP_SLUG = "kin-release-bot"
+EXPECTED_BOT_LOGIN = "kin-release-bot[bot]"
+EXPECTED_BOT_ID = 308181894
+EXPECTED_REPOSITORY = "firelock-ai/kin"
+
+
+class IdentityError(RuntimeError):
+    """The token is not the exact repository-scoped Kin release installation."""
+
+
+def run_gh(arguments: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["gh", *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise IdentityError(f"gh {' '.join(arguments)} failed: {detail}")
+    return result.stdout
+
+
+def _json(arguments: Sequence[str]) -> Any:
+    try:
+        return json.loads(run_gh(arguments))
+    except json.JSONDecodeError as exc:
+        raise IdentityError("GitHub returned malformed JSON") from exc
+
+
+def verify_identity(*, app_slug: str, repository: str) -> dict[str, object]:
+    if app_slug != EXPECTED_APP_SLUG:
+        raise IdentityError(
+            f"token action resolved App slug {app_slug!r}, expected {EXPECTED_APP_SLUG!r}"
+        )
+    if repository != EXPECTED_REPOSITORY:
+        raise IdentityError(
+            f"token repository is {repository!r}, expected {EXPECTED_REPOSITORY!r}"
+        )
+
+    bot = _json(["api", f"users/{EXPECTED_BOT_LOGIN}"])
+    if (
+        not isinstance(bot, dict)
+        or bot.get("id") != EXPECTED_BOT_ID
+        or bot.get("login") != EXPECTED_BOT_LOGIN
+        or bot.get("type") != "Bot"
+    ):
+        raise IdentityError("GitHub bot lookup did not resolve the exact release bot")
+
+    installation = _json(
+        ["api", "installation/repositories?per_page=100"]
+    )
+    repositories = (
+        installation.get("repositories") if isinstance(installation, dict) else None
+    )
+    if (
+        not isinstance(installation, dict)
+        or installation.get("total_count") != 1
+        or not isinstance(repositories, list)
+        or len(repositories) != 1
+        or not isinstance(repositories[0], dict)
+        or repositories[0].get("full_name") != repository
+    ):
+        raise IdentityError(
+            "installation token is not scoped to exactly firelock-ai/kin"
+        )
+    return {
+        "app_slug": app_slug,
+        "bot_id": EXPECTED_BOT_ID,
+        "bot_login": EXPECTED_BOT_LOGIN,
+        "repository": repository,
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app-slug", required=True)
+    parser.add_argument("--repository", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        result = verify_identity(
+            app_slug=args.app_slug,
+            repository=args.repository,
+        )
+    except IdentityError as exc:
+        print(
+            f"::error title=Invalid Kin release App installation token::{exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Kin's default branch had no receiver for the kin-registry-release repository dispatch event, so a KinDB release like kin-db@0.7.69 could post the event and Kin would accept it and do nothing. No workflow ran and no pin PR ever opened. This restores both default-branch entry points from the original contract, the exact dispatch type and an hourly eventless recovery, and opens a fixed automation pull request that bumps the pinned crate's Cargo.toml and Cargo.lock and nothing else.

The receiver validates the event, actor, default branch, full payload, stable version, source SHA, and the crate-to-source map before it loads any write credential, and it runs through three isolated workflow stages so no later step can consume state an earlier candidate wrote. A separate attestation workflow checks the exact terminal run before the release App writes anything, and the App token can write pull requests and issues but cannot write commit statuses.

An independent exact-commit review of this candidate found two P2 availability blockers and confirmed both are closed in this patch. The receiver now authenticates a marker comment's App and Bot identity before it parses the comment body, so an outsider cannot poison the attestation path with a copied or forged marker. It also selects a recheck candidate run by exact workflow, event, branch, head SHA and pull association before it trusts a timestamp or a job state, so an irrelevant run sharing the dispatch SHA cannot deny or spoof the real one. The review's tally on this exact commit is zero P0, zero P1, and zero P2.

CodeQL's actions/cache-poisoning/poisonable-step query separately flagged five alerts in this workflow, all naming the same shape: disarm-wave, prepare-wave, and mutate-wave checked out steps.base.outputs.base_sha, a value a static checker cannot see is already proven equal to github.sha by the preceding step's own hard assertion. All three checkouts now use github.sha directly, the literal trusted context expression the query recognizes, which checks out the identical commit in every case the job would otherwise have proceeded; the live re-read-and-refuse guards that catch main moving mid-job are unchanged. Four further alerts landed in .github/actions/rust-toolchain/action.yml, a file this PR never touches; two of the four carry an August 19 creation date, nine days before this commit existed, so all four predate this PR and are not part of this diff.

One P3 remains and stays retained rather than fixed here. If the process dies between closing the fixed PR and reopening it, the PR can stay closed until the next hourly reconciliation repairs it. That gap is fail-safe, since a closed PR cannot merge, and closing it for good needs its own durable retrigger record or reviewed rerun authority, which is separate follow-up work.

Fifty-seven receiver tests, the release-workflow-authority suite, actionlint on all three touched workflows, ruff check, and a full AST parse are all green on this exact commit. No registry event was replayed and no dependency, credential, or cloud state changed to produce this patch.

Closes FIR-2626
