### PR TITLE
Measure the working copy before saying the graph is level with it

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -230,6 +230,18 @@ jobs:
       - name: Falsify the trace spine-clipping graders
         run: python3 scripts/acceptance/trace_spine_clipping_repro.py --self-test
 
+      # FIR-2820. The v0.6.1 yardstick run wrote a module, did not commit it, and
+      # got three surfaces agreeing on an absence a one-line grep refutes: the
+      # durability block read "0 uncommitted", kin status read "matching its base
+      # change", and find_references certified the constant authoritatively
+      # absent. One reading is behind all three, and it is a record a commit
+      # writes as empty and nothing ever expires. Each grader is handed the exact
+      # envelope that shipped, and the sharper one beside it: a reading that
+      # withdrew the sentence and left `recorded` and a zero standing in the
+      # fields a caller branches on.
+      - name: Falsify the working-copy freshness graders
+        run: python3 scripts/acceptance/working_copy_freshness_repro.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -735,6 +747,31 @@ jobs:
             echo "::warning title=Verdict-limits acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: Working-copy freshness acceptance suite (verdict comes from the gate step)
+        id: workingcopyfreshness
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/working_copy_freshness_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/working_copy_freshness.json \
+            --verbose >acceptance/working_copy_freshness.log 2>&1 || rc=$?
+          cat acceptance/working_copy_freshness.log
+          {
+            echo "### Working-copy freshness acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/working_copy_freshness.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=Working-copy freshness acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
+          fi
+
       # Always, including on a cancelled or timed-out run: the reports are how a
       # failure is diagnosed without re-running the job.
       - name: Upload the acceptance reports
@@ -778,4 +815,5 @@ jobs:
             --report eject_journal=acceptance/eject_journal.json \
             --report first_query=acceptance/first_query.json \
             --report verdict_limits=acceptance/verdict_limits.json \
+            --report working_copy_freshness=acceptance/working_copy_freshness.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk is truncated on ubuntu-latest, and its clipped_steps metadata confirms dropped callee and cross-file rows. This check therefore cannot distinguish an absent required edge from one the walk dropped. Any FAIL or other UNREADABLE still fails the gate, and the moment this check passes the allowance announces itself stale and can go.'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -769,7 +769,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
           if [ "$rc" -ne 0 ]; then
-            echo "::error title=Working-copy freshness acceptance suite failed::exit $rc (1 FAIL, 2 UNREADABLE, 3 setup); see the CHECK lines above"
+            echo "::warning title=Working-copy freshness acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
       # Always, including on a cancelled or timed-out run: the reports are how a

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -317,6 +317,11 @@ pub const BACKLOG_STALE_SECONDS: u64 = 900;
 /// Counters are cumulative for this daemon process and reset on restart. Ages
 /// are monotonic and therefore unaffected by a wall-clock adjustment; the
 /// paired timestamps are wall clock, for lining an incident up against a log.
+/// A false flag is the ordinary case and stays off the wire.
+fn untracked_observation_applies(not_applicable: &bool) -> bool {
+    !*not_applicable
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReconcileHealth {
     /// Reconcile events dropped after erroring. Each one leaves exactly one
@@ -384,6 +389,18 @@ pub struct ReconcileHealth {
     /// Wall-clock time of the measurement above, RFC 3339.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub untracked_observed_at: Option<String>,
+    /// Whether a walk of the working copy can mean anything for this daemon.
+    ///
+    /// An absent measurement has three producers and only one of them is a
+    /// disclosure: a reading was taken, a reading cannot apply here, and a
+    /// reading should exist and does not. This field separates the second from
+    /// the third, which the clock above cannot do on its own. It is true when
+    /// filesystem-to-graph ingestion is off, so nothing on disk is ever
+    /// admitted and host content is not a gap the graph failed to close;
+    /// counting a projected checkout there would manufacture a disclosure out
+    /// of the projection (FIR-2820).
+    #[serde(default, skip_serializing_if = "untracked_observation_applies")]
+    pub untracked_observation_not_applicable: bool,
     /// Untracked host entries the effective ignore rules excluded from the most
     /// recent walk.
     ///

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -371,6 +371,19 @@ pub struct ReconcileHealth {
     /// reader can act on without a large working copy flooding the surface.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub untracked_paths_sample: Vec<String>,
+    /// Seconds since the count above was measured.
+    ///
+    /// The count cannot be read without it. Zero is written by a pass that
+    /// found nothing untracked and by an explicit seam that admitted
+    /// everything, neither record expires, and a reader given the bare number
+    /// takes it for a statement about now. Absent means no measurement has ever
+    /// been taken, which is the weakest possible basis for a zero and has to be
+    /// reported as such rather than as an all-clear (FIR-2820).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub untracked_observed_age_seconds: Option<u64>,
+    /// Wall-clock time of the measurement above, RFC 3339.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub untracked_observed_at: Option<String>,
     /// Untracked host entries the effective ignore rules excluded from the most
     /// recent walk.
     ///

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1045,6 +1045,15 @@ async fn untracked_host_content_line(layout: &kin_core::KinLayout) -> String {
         return format!("{LEAD} not measured; this repository's daemon did not answer");
     };
     let reconcile = health.reconcile;
+    // Fifth arm, and the one that is not a gap. A daemon that admits nothing
+    // from the filesystem has no host content waiting to be taken, so counting
+    // its projected checkout would report a shortfall the graph is not in.
+    if reconcile.untracked_observation_not_applicable {
+        return format!(
+            "{LEAD} not applicable; filesystem ingestion is off for this repository's daemon, so \
+             nothing on disk is waiting to be admitted"
+        );
+    }
     let Some(age) = reconcile.untracked_observed_age_seconds else {
         return format!(
             "{LEAD} not measured; this repository's daemon reports no measurement of it, so the \

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1003,8 +1003,76 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
         if let Some(line) = daemon_memory_line(layout.root()) {
             println!("{line}");
         }
+        // What the working copy holds that graph truth does not. Appended for
+        // the same reason as the three lines above, and it is the one this
+        // command was missing: every line before it is authority truth, so a
+        // reader was told the tree matched its base change over a repository
+        // holding a module the graph had never met, and `kin refs` then
+        // certified that module's constant authoritatively absent (FIR-2820).
+        //
+        // Never silent. A count of zero and a daemon that measured nothing are
+        // different facts and this line says which it has, because "no
+        // untracked files were named" is exactly the shape a reader takes for
+        // "there are none".
+        println!("{}", untracked_host_content_line(&layout).await);
     }
     Ok(())
+}
+
+/// The `kin status` reading of host content graph truth does not carry.
+///
+/// Asked of the daemon rather than measured here, so one walk answers for every
+/// surface and two readings of one working copy can never disagree. Each arm
+/// names its own basis: a measured count with the age of the measurement, a
+/// measured nothing with the same age, a daemon that has taken no measurement,
+/// and no daemon at all. Only the first two are statements about the working
+/// copy, and the other two say so rather than rendering as a clean tree.
+async fn untracked_host_content_line(layout: &kin_core::KinLayout) -> String {
+    const LEAD: &str = "Untracked host content:";
+    let Some(base_url) = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await
+    else {
+        return format!(
+            "{LEAD} not measured; no daemon is running for this repository, and this \
+                        command reads durable authority, which cannot see a path no admission has \
+                        taken"
+        );
+    };
+    let Ok(client) = crate::daemon_client::DaemonClient::from_base_url_for_layout(base_url, layout)
+    else {
+        return format!("{LEAD} not measured; this repository's daemon could not be addressed");
+    };
+    let Ok(health) = client.health().await else {
+        return format!("{LEAD} not measured; this repository's daemon did not answer");
+    };
+    let reconcile = health.reconcile;
+    let Some(age) = reconcile.untracked_observed_age_seconds else {
+        return format!(
+            "{LEAD} not measured; this repository's daemon reports no measurement of it, so the \
+             count it carries stands for nothing"
+        );
+    };
+    if reconcile.untracked_path_count == 0 {
+        return format!("{LEAD} none, measured {age}s ago");
+    }
+    let named = if reconcile.untracked_paths_sample.is_empty() {
+        String::new()
+    } else {
+        let more = reconcile
+            .untracked_path_count
+            .saturating_sub(reconcile.untracked_paths_sample.len() as u64);
+        let listed = reconcile.untracked_paths_sample.join(", ");
+        if more > 0 {
+            format!(" ({listed}, and {more} more)")
+        } else {
+            format!(" ({listed})")
+        }
+    };
+    format!(
+        "{LEAD} {} host path(s) on disk that graph truth does not carry{named}, measured {age}s \
+         ago; nothing above describes them, `kin admit` takes them now, and a commit takes them \
+         anyway",
+        reconcile.untracked_path_count
+    )
 }
 
 /// The daemon footprint line, when this store carries a published standing.

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -107,6 +107,14 @@ pub struct HealthResponse {
     pub behavior_env: kin_core::behavior_env::BehaviorEnv,
     #[serde(default)]
     pub build: Option<BuildResponse>,
+    /// What the reconciliation loop is managing to admit, and what the working
+    /// copy holds that it has not.
+    ///
+    /// Read by `kin status`, which otherwise reports durable authority truth
+    /// alone and so could describe a repository as matching its base change
+    /// while a module the graph has never met sat beside it (FIR-2820).
+    #[serde(default)]
+    pub reconcile: crate::commands::resources::ReconcileHealth,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -10157,6 +10157,7 @@ mod tests {
             pid: Some(std::process::id()),
             behavior_env: Default::default(),
             build: None,
+            reconcile: Default::default(),
         }
     }
 
@@ -10896,6 +10897,7 @@ mod tests {
             pid: Some(std::process::id()),
             behavior_env: Default::default(),
             build: None,
+            reconcile: Default::default(),
         };
 
         let error = validate_health_repo(&health, dir.path()).unwrap_err();
@@ -10916,6 +10918,7 @@ mod tests {
             pid: Some(std::process::id()),
             behavior_env: Default::default(),
             build: None,
+            reconcile: Default::default(),
         }
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3160,6 +3160,7 @@ async fn health(
     let coordination_event_persist_failures = state
         .coordination_event_persist_failures
         .load(std::sync::atomic::Ordering::Relaxed);
+    measure_untracked_host_content(&state).await;
     let sampled_at = std::time::Instant::now();
     let background_passes = state.background_work.reports(sampled_at);
     let background_pass_stopped = state.background_work.any_stopped();
@@ -4204,7 +4205,7 @@ async fn command_dead_code(
     // daemon holds it (FIR-2524). A clean "No dead code found." off a degraded
     // daemon is the one way that line can lie, and a thinner envelope is exactly
     // what would hide it.
-    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state));
+    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state).await);
     let response = kin_cli::commands::dead_code::build_dead_code_response(
         Some(&repository_authority),
         graph.as_ref(),
@@ -4237,7 +4238,7 @@ async fn command_dead_code_seeded(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state));
+    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state).await);
     let response = kin_cli::commands::dead_code::build_dead_code_seeded_response(
         graph.as_ref(),
         &request,
@@ -4375,7 +4376,7 @@ async fn command_refs(
     // impact route builds one (FIR-2524): only the daemon holds it, and a
     // thinner envelope is the shortcut that makes the CLI MORE confident than
     // MCP on exactly the degraded daemon nobody exercises.
-    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state));
+    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state).await);
     let response = kin_cli::commands::refs::build_refs_response(
         &state.layout,
         graph.as_ref(),
@@ -6690,7 +6691,7 @@ async fn search(
         // Same substrate reading the impact and trace routes supply, from the
         // same helper, so no CLI surface can be more confident than its MCP
         // counterpart about one daemon at one instant (FIR-2524).
-        &kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state)),
+        &kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state).await),
     )
     .map_err(internal_error)?;
     if req.show_body {
@@ -6746,7 +6747,7 @@ async fn trace(
     // Same substrate reading the impact route supplies, from the same helper, so
     // `kin trace` and `get_context_pack` cannot disagree about one daemon at one
     // instant (FIR-2524).
-    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state));
+    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state).await);
     let result = kin_cli::commands::trace::build_trace_response(
         &state.layout,
         &repository_authority,
@@ -6769,7 +6770,44 @@ async fn trace(
 ///
 /// `graph_loaded` is derived from a nonzero entity count exactly as `/health`
 /// derives it, rather than asserted.
-fn daemon_health_snapshot(state: &Arc<DaemonState>) -> serde_json::Value {
+/// Read host content graph truth does not carry, before anything states that it
+/// does.
+///
+/// A recorded zero does not expire, so a reading inherited from whatever pass
+/// ran last states an all-clear measured at the previous commit over a working
+/// copy that has moved since (FIR-2820). The walk rate-limits itself and runs
+/// off the runtime's worker threads. A failure leaves the previous reading
+/// standing with its own age rather than clearing it, which is the honest
+/// fallback because the age is what every surface judges the count by.
+async fn measure_untracked_host_content(state: &Arc<DaemonState>) {
+    let probing = Arc::clone(state);
+    match tokio::task::spawn_blocking(move || {
+        crate::loop_runner::refresh_untracked_reading(&probing)
+    })
+    .await
+    {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => {
+            tracing::debug!(%error, "could not measure untracked host content")
+        }
+        Err(error) => {
+            tracing::debug!(%error, "the untracked host-content measurement did not run")
+        }
+    }
+}
+
+/// The health an answer's own envelope is built from.
+///
+/// Async and measuring, because the alternative is a second authority for one
+/// fact. This snapshot carried `initialized`, `graph_loaded` and two degraded
+/// flags, so every envelope built from it reached the negative gates with no
+/// reconcile reading at all, and `graph_behind_working_tree` could not fire on
+/// any daemon-built answer however far behind the store was: the stdio shim
+/// decorated `_kin.behind` from its own `/health` probe afterwards, while the
+/// `negative` block a caller acts on had already certified the absence from
+/// this thinner body (FIR-2820). The two now read one snapshot.
+async fn daemon_health_snapshot(state: &Arc<DaemonState>) -> serde_json::Value {
+    measure_untracked_host_content(state).await;
     let entity_count = state.graph.entity_count();
     serde_json::json!({
         "initialized": state
@@ -6777,6 +6815,7 @@ fn daemon_health_snapshot(state: &Arc<DaemonState>) -> serde_json::Value {
             .load(std::sync::atomic::Ordering::Relaxed),
         "graph_loaded": entity_count > 0,
         "graph_entity_count": entity_count as u64,
+        "durable_entity_count": state.durable_entity_count(),
         "graph_generation": state
             .snapshot_generation
             .load(std::sync::atomic::Ordering::Relaxed),
@@ -6786,6 +6825,9 @@ fn daemon_health_snapshot(state: &Arc<DaemonState>) -> serde_json::Value {
         "mass_deletion_blocked": state
             .mass_deletion_blocked
             .load(std::sync::atomic::Ordering::Relaxed),
+        "reconcile": state
+            .background_work
+            .reconcile_report(std::time::Instant::now()),
     })
 }
 
@@ -6817,7 +6859,7 @@ async fn impact(
     // degraded signal makes the CLI MORE confident than MCP on exactly the
     // degraded daemon nobody exercises, and every test written against a healthy
     // one would pass.
-    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state));
+    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state).await);
     let result = kin_cli::commands::impact::build_impact_response(
         &state.layout,
         graph.as_ref(),
@@ -9460,7 +9502,8 @@ async fn mcp_tools_call_inner(
         };
         // Same substrate reading the CLI route gets, so this MCP path and
         // `kin dead-code <query>` cannot reach different verdicts on one store.
-        let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state));
+        let envelope =
+            kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state).await);
         let result = match kin_cli::commands::dead_code::build_dead_code_seeded_response(
             graph.as_ref(),
             &req,

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -774,6 +774,25 @@ struct ReconcileProbesInner {
     untracked_path_count: u64,
     /// A bounded sample of those paths.
     untracked_paths_sample: Vec<String>,
+    /// When the reading above was taken.
+    ///
+    /// The count alone cannot be read. Zero is written by a pass that genuinely
+    /// found nothing untracked AND by an explicit seam that admitted everything,
+    /// and neither record expires, so a zero from a commit five minutes ago is
+    /// indistinguishable from one measured this instant while the working copy
+    /// holds a module the graph has never met (FIR-2820). The stamp is what
+    /// separates them, and it is what lets a surface refresh the reading rather
+    /// than restate it.
+    ///
+    /// Carries no message; it is a clock, and `RecordedFault` is reused for the
+    /// pair of instants it already keeps.
+    untracked_observed: Option<RecordedFault>,
+    /// What the last measurement of that reading cost.
+    ///
+    /// The refresh rate is derived from it rather than fixed, so the walk can
+    /// never take more than a bounded share of the daemon's own time on a
+    /// working copy large enough for it to matter.
+    untracked_measurement_cost: Option<Duration>,
     /// What the most recent complete walk deliberately did not observe.
     excluded: ExcludedHostContent,
     /// The publication error that left a commit's deferred tree unpublished.
@@ -810,6 +829,20 @@ pub struct ExcludedHostContent {
     /// the set that used to fail the whole admission instead of being skipped.
     pub policy_excluded: u64,
 }
+
+/// The shortest interval between two measurements of untracked host content.
+///
+/// One second is the window a caller who writes a file and asks about it in the
+/// same breath can still fall inside, and it is disclosed rather than hidden:
+/// every surface carrying the count carries the age of the reading beside it.
+const UNTRACKED_REFRESH_FLOOR: Duration = Duration::from_secs(1);
+
+/// The share of its own time the refresh may spend, as a divisor.
+///
+/// A walk that costs three milliseconds refreshes on the floor above. One that
+/// costs half a second refreshes every five, so the measurement can never take
+/// more than a tenth of the daemon under continuous polling.
+const UNTRACKED_REFRESH_DUTY_DIVISOR: u32 = 10;
 
 /// How many untracked paths a disclosure names outright.
 ///
@@ -921,6 +954,73 @@ impl ReconcileProbes {
         inner.untracked_path_count = count;
         inner.untracked_paths_sample = sample;
         inner.excluded = excluded;
+        inner.untracked_observed = Some(RecordedFault::new(String::new(), Instant::now()));
+    }
+
+    /// How long ago the untracked reading was taken, or `None` if none has been.
+    ///
+    /// The question a surface asks before it repeats the reading as a fact about
+    /// now. `None` is the strongest answer here and not the weakest: a daemon
+    /// that has never measured has no basis at all for the zero its counter
+    /// carries.
+    pub fn untracked_observation_age(&self, now: Instant) -> Option<Duration> {
+        self.lock()
+            .untracked_observed
+            .as_ref()
+            .map(|observed| now.saturating_duration_since(observed.at))
+    }
+
+    /// Whether the untracked reading is old enough to be worth measuring again.
+    ///
+    /// The interval is derived from what the last measurement cost rather than
+    /// fixed, because the two working copies this has to serve are three
+    /// milliseconds apart and a thousand. The floor is what a caller writing a
+    /// file and asking about it immediately can be behind by; the duty rule is
+    /// the ceiling on what the walk may spend, so a large repository refreshes
+    /// less often instead of continuously.
+    ///
+    /// A reading nothing has ever taken is always due. That is the case with no
+    /// measurement behind it at all, and it is the one a fixed interval would
+    /// have treated as freshly measured.
+    pub fn untracked_refresh_due(&self, now: Instant) -> bool {
+        let inner = self.lock();
+        let Some(observed) = inner.untracked_observed.as_ref() else {
+            return true;
+        };
+        let interval = inner
+            .untracked_measurement_cost
+            .map(|cost| cost * UNTRACKED_REFRESH_DUTY_DIVISOR)
+            .unwrap_or(UNTRACKED_REFRESH_FLOOR)
+            .max(UNTRACKED_REFRESH_FLOOR);
+        now.saturating_duration_since(observed.at) >= interval
+    }
+
+    /// Record a measurement of untracked host paths taken outside a reconcile
+    /// pass.
+    ///
+    /// Deliberately narrower than [`Self::record_untracked_observation`]: it
+    /// replaces the untracked reading and its clock and leaves the excluded
+    /// counts exactly as the last complete walk measured them. This pass did not
+    /// measure exclusions, so restating them would be a second authority for a
+    /// fact it never observed.
+    pub fn record_untracked_measurement<T: std::fmt::Display>(
+        &self,
+        paths: impl IntoIterator<Item = T>,
+        cost: Duration,
+    ) {
+        let mut count: u64 = 0;
+        let mut sample = Vec::new();
+        for path in paths {
+            count = count.saturating_add(1);
+            if sample.len() < UNTRACKED_SAMPLE_LIMIT {
+                sample.push(path.to_string());
+            }
+        }
+        let mut inner = self.lock();
+        inner.untracked_path_count = count;
+        inner.untracked_paths_sample = sample;
+        inner.untracked_measurement_cost = Some(cost);
+        inner.untracked_observed = Some(RecordedFault::new(String::new(), Instant::now()));
     }
 
     /// The disclosure surfaces' view of all of it.
@@ -951,6 +1051,11 @@ impl ReconcileProbes {
                 .map(|since| now.saturating_duration_since(since).as_secs()),
             untracked_path_count: inner.untracked_path_count,
             untracked_paths_sample: inner.untracked_paths_sample.clone(),
+            untracked_observed_age_seconds: inner.untracked_observed.as_ref().map(age),
+            untracked_observed_at: inner
+                .untracked_observed
+                .as_ref()
+                .map(|observed| observed.wall_clock.to_rfc3339()),
             ignored_path_count: inner.excluded.ignored,
             unsupported_path_count: inner.excluded.unsupported,
             policy_excluded_path_count: inner.excluded.policy_excluded,
@@ -1600,5 +1705,132 @@ mod tests {
         assert_eq!(report.backlog_age_seconds, None);
         assert!(!report.degraded());
         assert!(report.degraded_reasons().is_empty());
+    }
+
+    /// FIR-2820. A zero nobody measured is not a zero, and it is the reading
+    /// three surfaces repeated as an all-clear.
+    ///
+    /// The counter starts at zero because a `u64` does. Until something walks
+    /// the working copy, that zero stands for nothing at all, so the surfaces
+    /// need a way to tell it from a measured one and the probe needs to know a
+    /// refresh is due. Both hang off the same stamp.
+    #[test]
+    fn an_unmeasured_untracked_reading_carries_no_clock_and_is_always_due() {
+        let probes = ReconcileProbes::default();
+        let now = Instant::now();
+
+        let report = probes.report(now);
+        assert_eq!(
+            report.untracked_path_count, 0,
+            "the counter's initial value, which is the whole problem"
+        );
+        assert_eq!(
+            report.untracked_observed_age_seconds, None,
+            "and nothing measured it, which is what the surfaces have to be told"
+        );
+        assert_eq!(report.untracked_observed_at, None);
+        assert!(
+            probes.untracked_observation_age(now).is_none(),
+            "there is no age because there is no observation"
+        );
+        assert!(
+            probes.untracked_refresh_due(now),
+            "a reading nothing has ever taken is due the first time anyone asks"
+        );
+    }
+
+    /// FIR-2820. A measurement stamps its own clock, and the stamp is what
+    /// stops the next caller re-walking the working copy.
+    #[test]
+    fn a_measurement_stamps_its_clock_and_holds_off_the_next_one() {
+        let probes = ReconcileProbes::default();
+        probes.record_untracked_measurement(
+            ["notekeeper/linkgraph.py", "notekeeper/search.py"],
+            Duration::from_millis(3),
+        );
+        let now = Instant::now();
+
+        let report = probes.report(now);
+        assert_eq!(report.untracked_path_count, 2);
+        assert_eq!(
+            report.untracked_paths_sample,
+            vec![
+                "notekeeper/linkgraph.py".to_string(),
+                "notekeeper/search.py".to_string()
+            ]
+        );
+        assert_eq!(
+            report.untracked_observed_age_seconds,
+            Some(0),
+            "a measurement taken this instant is zero seconds old, which is a reading and not \
+             an absent one"
+        );
+        assert!(report.untracked_observed_at.is_some());
+        assert!(
+            !probes.untracked_refresh_due(now),
+            "a reading taken this instant is not due again"
+        );
+        assert!(
+            probes.untracked_refresh_due(now + UNTRACKED_REFRESH_FLOOR),
+            "and it is due once the floor has passed"
+        );
+    }
+
+    /// FIR-2820. What the walk costs sets how often it may run, so a working
+    /// copy large enough for the measurement to matter cannot be walked
+    /// continuously by a client polling health.
+    #[test]
+    fn an_expensive_measurement_stretches_its_own_interval() {
+        let cheap = ReconcileProbes::default();
+        cheap.record_untracked_measurement(std::iter::empty::<&str>(), Duration::from_millis(3));
+        let costly = ReconcileProbes::default();
+        costly.record_untracked_measurement(std::iter::empty::<&str>(), Duration::from_millis(500));
+        let now = Instant::now();
+
+        let just_past_the_floor = now + UNTRACKED_REFRESH_FLOOR + Duration::from_millis(10);
+        assert!(
+            cheap.untracked_refresh_due(just_past_the_floor),
+            "a three-millisecond walk refreshes on the floor"
+        );
+        assert!(
+            !costly.untracked_refresh_due(just_past_the_floor),
+            "a half-second walk does not, or continuous polling would spend the daemon on it"
+        );
+        assert!(
+            costly.untracked_refresh_due(
+                now + Duration::from_millis(500) * UNTRACKED_REFRESH_DUTY_DIVISOR
+            ),
+            "it comes due at its own duty interval, which is the ceiling and not a refusal"
+        );
+    }
+
+    /// FIR-2820. The measurement pass observed no exclusions, so it restates
+    /// none.
+    ///
+    /// Two authorities for one fact is what this avoids. The excluded counts
+    /// answer "why will nothing ever index my file" and only a complete walk
+    /// measures them; a measurement that zeroed them would turn a real
+    /// `.kinignore` rule into silence every time anyone read health.
+    #[test]
+    fn a_measurement_leaves_the_excluded_counts_to_the_walk_that_measured_them() {
+        let probes = ReconcileProbes::default();
+        probes.record_untracked_observation(
+            ["left/behind.py"],
+            ExcludedHostContent {
+                ignored: 7,
+                unsupported: 2,
+                policy_excluded: 4,
+            },
+        );
+        probes.record_untracked_measurement(["fresh.py", "fresher.py"], Duration::from_millis(1));
+
+        let report = probes.report(Instant::now());
+        assert_eq!(
+            report.untracked_path_count, 2,
+            "the untracked reading moved"
+        );
+        assert_eq!(report.ignored_path_count, 7, "the exclusions did not");
+        assert_eq!(report.unsupported_path_count, 2);
+        assert_eq!(report.policy_excluded_path_count, 4);
     }
 }

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -793,6 +793,16 @@ struct ReconcileProbesInner {
     /// never take more than a bounded share of the daemon's own time on a
     /// working copy large enough for it to matter.
     untracked_measurement_cost: Option<Duration>,
+    /// Whether measuring the working copy can mean anything on this daemon.
+    ///
+    /// Set once, by the refresh itself, on a daemon whose filesystem-to-graph
+    /// ingestion is off. Nothing on disk is ever admitted there, so host
+    /// content is not a gap the graph failed to close and the projected
+    /// checkout is not evidence about one. Without this the stamp above cannot
+    /// tell that case from a walk that should have run and did not, and a
+    /// consumer gating on the stamp alone would turn every graph-authority
+    /// daemon into a permanent disclosure (FIR-2820).
+    untracked_observation_not_applicable: bool,
     /// What the most recent complete walk deliberately did not observe.
     excluded: ExcludedHostContent,
     /// The publication error that left a commit's deferred tree unpublished.
@@ -1023,6 +1033,17 @@ impl ReconcileProbes {
         inner.untracked_observed = Some(RecordedFault::new(String::new(), Instant::now()));
     }
 
+    /// Record that measuring the working copy cannot mean anything here.
+    ///
+    /// The third producer of an absent reading, and the one that is not a
+    /// disclosure. A consumer that gates on the stamp alone reads a daemon with
+    /// ingestion off as one whose walk failed, and refuses to certify any
+    /// absence for the life of the process. Enumerating this producer is what
+    /// keeps the gate honest in both directions.
+    pub fn record_untracked_not_applicable(&self) {
+        self.lock().untracked_observation_not_applicable = true;
+    }
+
     /// The disclosure surfaces' view of all of it.
     pub fn report(&self, now: Instant) -> ReconcileHealth {
         let inner = self.lock();
@@ -1056,6 +1077,7 @@ impl ReconcileProbes {
                 .untracked_observed
                 .as_ref()
                 .map(|observed| observed.wall_clock.to_rfc3339()),
+            untracked_observation_not_applicable: inner.untracked_observation_not_applicable,
             ignored_path_count: inner.excluded.ignored,
             unsupported_path_count: inner.excluded.unsupported,
             policy_excluded_path_count: inner.excluded.policy_excluded,
@@ -1736,6 +1758,36 @@ mod tests {
         assert!(
             probes.untracked_refresh_due(now),
             "a reading nothing has ever taken is due the first time anyone asks"
+        );
+    }
+
+    /// FIR-2820, the review's second finding. The third producer of an absent
+    /// reading, which is the one that is not a disclosure.
+    ///
+    /// A daemon with filesystem ingestion off never walks, so the stamp above
+    /// stays absent forever. Without this record every consumer gating on the
+    /// stamp would read that daemon as one whose walk went missing and refuse to
+    /// certify any absence for the life of the process, which is a disclosure
+    /// manufactured out of a projection.
+    #[test]
+    fn a_daemon_that_admits_nothing_from_disk_says_so_rather_than_going_quiet() {
+        let probes = ReconcileProbes::default();
+        let now = Instant::now();
+        assert!(
+            !probes.report(now).untracked_observation_not_applicable,
+            "the ordinary case is a daemon that does walk"
+        );
+
+        probes.record_untracked_not_applicable();
+        let report = probes.report(now);
+        assert!(report.untracked_observation_not_applicable);
+        assert_eq!(
+            report.untracked_observed_age_seconds, None,
+            "nothing measured, and nothing should have: the flag is what says which"
+        );
+        assert_eq!(
+            report.untracked_path_count, 0,
+            "a projected checkout holds no content anything failed to admit"
         );
     }
 

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -553,10 +553,18 @@ pub(crate) fn refresh_untracked_reading(state: &DaemonState) -> Result<bool> {
     // A graph-authority daemon does not scan a projected checkout in the first
     // place, so host paths there are not content anything failed to admit and
     // counting them would manufacture a disclosure out of the projection.
+    //
+    // Recorded rather than merely returned, because every consumer downstream
+    // gates on whether a reading was taken, and "no reading" here has to be
+    // told apart from "a reading that should exist and does not". Silence on
+    // its own reads as the second, which would leave every daemon with
+    // ingestion off refusing to certify any absence for the life of the
+    // process.
+    let probes = state.background_work.reconcile();
     if state.filesystem_reconcile_disabled() {
+        probes.record_untracked_not_applicable();
         return Ok(false);
     }
-    let probes = state.background_work.reconcile();
     if !probes.untracked_refresh_due(Instant::now()) {
         return Ok(false);
     }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -4170,6 +4170,56 @@ mod tests {
         );
     }
 
+    /// FIR-2820. The wiring itself, which nothing else covers.
+    ///
+    /// `refresh_untracked_reading` has two early returns and the unit tests
+    /// beside the probes cannot see either of them, because they call the probe
+    /// directly. This one drives the function on a daemon whose filesystem
+    /// ingestion is ON, which is every ordinary daemon, and requires it to take
+    /// a reading rather than declare the question inapplicable. Without it a
+    /// flag stuck true would silence every disclosure this fix exists to make
+    /// and no test would notice.
+    #[test]
+    fn an_ingesting_daemon_measures_rather_than_calling_the_question_inapplicable() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        std::fs::write(
+            repo.path().join("unadmitted.rs"),
+            b"pub fn unadmitted() -> u32 { 1 }\n",
+        )
+        .unwrap();
+
+        assert!(
+            !state.filesystem_reconcile_disabled(),
+            "this test is about the ordinary daemon and says so rather than assuming it"
+        );
+        let measured = refresh_untracked_reading(&state).expect("the walk runs");
+        assert!(
+            measured,
+            "a reading nothing has ever taken is due the first time anyone asks"
+        );
+
+        let report = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert!(
+            !report.untracked_observation_not_applicable,
+            "a daemon that admits from disk has a working copy worth measuring: {report:?}"
+        );
+        assert!(
+            report.untracked_observed_age_seconds.is_some(),
+            "the walk ran, so it stamped: {report:?}"
+        );
+        assert!(
+            report
+                .untracked_paths_sample
+                .iter()
+                .any(|path| path == "unadmitted.rs"),
+            "the reading names the file nothing admitted: {report:?}"
+        );
+    }
+
     /// Read the repository-authority generation one admission would advance.
     ///
     /// Every committed repository transaction advances it by exactly one, and

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -530,6 +530,59 @@ pub(crate) fn current_authority_admission(
     Ok((roots, policy))
 }
 
+/// Measure host content graph truth does not carry, right now.
+///
+/// The reconcile loop records this set as a side effect of a pass, and an
+/// explicit seam records it empty because the seam admitted everything. Both
+/// are true when written and neither expires, so between a host write and the
+/// pass that observes it every surface reading the record is told zero over a
+/// working copy holding a module the graph has never met. Three of them then
+/// agree on an absence a one-line grep refutes: the durability block reports
+/// "0 uncommitted", `kin status` reports a tree matching its base, and
+/// `find_references` certifies the name authoritatively absent (FIR-2820).
+///
+/// So the reading is taken when a surface is about to state it, not inherited
+/// from whatever ran last. The walk opens nothing and hashes nothing, which is
+/// what makes that affordable: it is strictly cheaper than the complete content
+/// scan this loop already runs on every batch of watcher events.
+///
+/// Returns whether a measurement was taken. `false` is not a failure; it is the
+/// reading still being current enough, or a daemon whose graph is its own write
+/// authority and whose checkout is therefore not evidence about anything.
+pub(crate) fn refresh_untracked_reading(state: &DaemonState) -> Result<bool> {
+    // A graph-authority daemon does not scan a projected checkout in the first
+    // place, so host paths there are not content anything failed to admit and
+    // counting them would manufacture a disclosure out of the projection.
+    if state.filesystem_reconcile_disabled() {
+        return Ok(false);
+    }
+    let probes = state.background_work.reconcile();
+    if !probes.untracked_refresh_due(Instant::now()) {
+        return Ok(false);
+    }
+    let working_dir = state.layout.working_dir();
+    let (_roots, policy) = current_authority_admission(state)?;
+    let previous = state.graph.resolved_tree();
+    let tracked_paths = previous
+        .artifacts_by_path()
+        .map(|artifact| artifact.path.clone())
+        .collect::<Vec<_>>();
+    let graph_only_paths = crate::graph_only_members::members_of(&previous)?;
+    let ignore =
+        kin_index::RepositoryIgnore::load(working_dir).map_err(kin_index::IndexError::from)?;
+    let started = Instant::now();
+    let untracked = kin_index::scan_repository_untracked_paths(
+        working_dir,
+        &ignore,
+        policy.as_ref(),
+        tracked_paths.iter(),
+        graph_only_paths.iter(),
+    )
+    .map_err(kin_index::IndexError::from)?;
+    probes.record_untracked_measurement(untracked.iter(), started.elapsed());
+    Ok(true)
+}
+
 /// What one complete walk declined to observe, taken from its own diagnostics.
 ///
 /// Read off the scan rather than recomputed, so the counts a surface prints and

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -75,10 +75,11 @@ pub use repository::{
     canonicalize_host_parent_preserving_leaf, host_path_from_repo_path, is_repository_control_path,
     read_verified_scanned_entry, repo_path_from_host_relative, scan_repository,
     scan_repository_modified_since, scan_repository_preserving_graph_only,
-    should_track_host_relative_path, tracked_paths_covered_by_ignore,
-    tracked_paths_retracted_by_ignore, CompleteRepositoryScan, CompleteScanToken,
-    IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore, RepositoryScanDiagnostics,
-    ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES, PYTHON_VIRTUALENV_MARKER,
+    scan_repository_untracked_paths, should_track_host_relative_path,
+    tracked_paths_covered_by_ignore, tracked_paths_retracted_by_ignore, CompleteRepositoryScan,
+    CompleteScanToken, IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore,
+    RepositoryScanDiagnostics, ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES,
+    PYTHON_VIRTUALENV_MARKER,
 };
 pub use resolution::{RelationResolution, RESOLUTION_FIELD, RESOLUTION_TIER_LADDER};
 pub use support::{compute_coverage_report, CoverageReport};

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -1637,7 +1637,7 @@ mod tests {
         std::fs::write(root.join("brand_new/module.py"), "NEW = 3\n").unwrap();
 
         let ignore = RepositoryIgnore::load(root).unwrap();
-        let tracked = vec![path("known/tracked.py")];
+        let tracked = [path("known/tracked.py")];
         let untracked = scan_repository_untracked_paths(
             root,
             &ignore,
@@ -1657,7 +1657,7 @@ mod tests {
         // The control that keeps this from naming everything: a working copy
         // whose every leaf is tracked measures nothing, which is what makes a
         // count of zero worth reporting rather than noise.
-        let all_tracked = vec![
+        let all_tracked = [
             path("brand_new/module.py"),
             path("known/fresh.py"),
             path("known/tracked.py"),

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -955,6 +955,18 @@ enum ScanMode {
     /// [`ScanMode::Content`] by two rules: a tracked path is never kept, and
     /// neither is a leaf inside a directory graph truth has never met.
     ModifiedSince(SystemTime),
+    /// Keep the path of every admissible leaf graph truth does not track, and
+    /// nothing else. Opens nothing, hashes nothing, stats nothing beyond the
+    /// directory entry the walk already read, and produces no completion proof.
+    ///
+    /// This is the measurement [`ScanMode::ModifiedSince`] is deliberately not.
+    /// That mode proposes work to admit with no operator in the loop, so it
+    /// declines a whole directory graph truth has never met, on the grounds
+    /// that modification times cannot tell a clone from authored work. Naming
+    /// content is the opposite obligation: a reader asking whether the graph is
+    /// level with the working copy has to be told about that directory, and its
+    /// own comment says the behind disclosure is what counts and names it.
+    Untracked,
 }
 
 /// Repository paths whose host entry was last modified at or after `since`.
@@ -1003,6 +1015,47 @@ pub fn scan_repository_modified_since<'a>(
     Ok(scanner.modified)
 }
 
+/// Repository paths on the host that graph truth does not carry.
+///
+/// The measurement behind every "is the graph level with the working copy"
+/// claim the product makes. It walks with the content scan's own rules, through
+/// the same [`Scanner`], and keeps a path rather than reading a byte, so it can
+/// answer that question at the moment it is asked instead of from whatever a
+/// previous pass happened to record.
+///
+/// That distinction is the whole reason it exists. The reconcile loop records
+/// this set as a side effect of a pass, and an explicit seam records it empty
+/// because the seam admitted everything. Both records are true when written and
+/// neither expires, so between a host write and the pass that observes it the
+/// recorded answer is zero while the working copy holds a module the graph has
+/// never met. Three surfaces read that zero as a verified all-clear (FIR-2820).
+///
+/// Produces no [`CompleteScanToken`], which is deliberate: this walk observed no
+/// content and must never be mistaken for one that did.
+pub fn scan_repository_untracked_paths<'a>(
+    root: &Path,
+    ignore: &RepositoryIgnore,
+    policy: Option<&ResolvedAdmissionMatcher>,
+    tracked_paths: impl IntoIterator<Item = &'a RepoPath>,
+    graph_only_paths: impl IntoIterator<Item = &'a RepoPath>,
+) -> Result<Vec<RepoPath>, IncompleteRepositoryScan> {
+    let mut scanner = prepare_scanner(
+        root,
+        ignore,
+        policy,
+        tracked_paths,
+        graph_only_paths,
+        ScanMode::Untracked,
+    )?;
+    scanner.walk(root, false, true)?;
+    // Sorted, because the bounded sample a disclosure prints is the head of
+    // this list and directory order is whatever the host hands back. A sample
+    // that reshuffles between two readings of one unchanged working copy reads
+    // as the set having changed.
+    scanner.modified.sort();
+    Ok(scanner.modified)
+}
+
 /// Was this directory entry last modified at or after `since`?
 ///
 /// `None` means the entry is no longer there. An unreadable modification time
@@ -1028,7 +1081,7 @@ struct Scanner<'a> {
     entries: BTreeMap<RepoPath, ScannedRepositoryEntry>,
     diagnostics: RepositoryScanDiagnostics,
     mode: ScanMode,
-    /// Paths [`ScanMode::ModifiedSince`] kept. Empty in every other mode.
+    /// Paths a stat-only mode kept. Empty under [`ScanMode::Content`].
     modified: Vec<RepoPath>,
 }
 
@@ -1197,6 +1250,21 @@ impl Scanner<'_> {
             if !self.tracked_paths.contains(&repo_path)
                 && self.policy_excludes_untracked(&repo_path, false)
             {
+                continue;
+            }
+
+            // A measurement pass stops here, one exclusion earlier than the
+            // proposing one below, because it proposes nothing. Every rule
+            // above has already run, so what it keeps is exactly the set a
+            // content walk would have admitted and graph truth does not carry,
+            // minus every read. Restricted to the two leaf kinds the content
+            // walk admits so this mode invents no membership of its own.
+            if matches!(self.mode, ScanMode::Untracked) {
+                if !self.tracked_paths.contains(&repo_path)
+                    && (file_type.is_file() || file_type.is_symlink())
+                {
+                    self.modified.push(repo_path);
+                }
                 continue;
             }
 
@@ -1545,6 +1613,125 @@ mod tests {
             )],
         )
         .unwrap()
+    }
+
+    /// FIR-2820. The measurement every "is the graph level with the working
+    /// copy" claim rests on, and the two rules that decide what it may name.
+    ///
+    /// A tracked path is not untracked and never appears. A leaf inside a
+    /// directory graph truth has never met DOES appear, which is where this
+    /// parts company with [`scan_repository_modified_since`]: that mode
+    /// proposes work to admit with no operator in the loop and declines a whole
+    /// unmet directory on the grounds that a clone looks like authored work,
+    /// and its own comment says this reading is what counts and names that
+    /// content instead.
+    #[test]
+    fn the_untracked_measurement_names_host_content_graph_truth_does_not_carry() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir_all(root.join("known")).unwrap();
+        std::fs::write(root.join("known/tracked.py"), "TRACKED = 1\n").unwrap();
+        std::fs::write(root.join("known/fresh.py"), "FRESH = 2\n").unwrap();
+        // A directory nothing has ever admitted, arriving whole.
+        std::fs::create_dir_all(root.join("brand_new")).unwrap();
+        std::fs::write(root.join("brand_new/module.py"), "NEW = 3\n").unwrap();
+
+        let ignore = RepositoryIgnore::load(root).unwrap();
+        let tracked = vec![path("known/tracked.py")];
+        let untracked = scan_repository_untracked_paths(
+            root,
+            &ignore,
+            None,
+            tracked.iter(),
+            std::iter::empty::<&RepoPath>(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            untracked,
+            vec![path("brand_new/module.py"), path("known/fresh.py")],
+            "the measurement names every admissible leaf authority does not carry, in a \
+             directory it knows and one it has never met"
+        );
+
+        // The control that keeps this from naming everything: a working copy
+        // whose every leaf is tracked measures nothing, which is what makes a
+        // count of zero worth reporting rather than noise.
+        let all_tracked = vec![
+            path("brand_new/module.py"),
+            path("known/fresh.py"),
+            path("known/tracked.py"),
+        ];
+        assert!(
+            scan_repository_untracked_paths(
+                root,
+                &ignore,
+                None,
+                all_tracked.iter(),
+                std::iter::empty::<&RepoPath>(),
+            )
+            .unwrap()
+            .is_empty(),
+            "a fully admitted working copy has nothing untracked to name"
+        );
+    }
+
+    /// FIR-2820. The measurement shares the content walk's exclusion rules,
+    /// through the same scanner, so the two can never disagree about what the
+    /// repository holds.
+    ///
+    /// This is the failure a second traversal written beside the first would
+    /// have: a path the content walk refuses to admit, reported as content
+    /// nothing has admitted yet, sends a reader to `kin admit` for a file no
+    /// admission will ever take.
+    #[test]
+    fn the_untracked_measurement_excludes_exactly_what_the_content_walk_excludes() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join(".kinignore"), "ignored.py\n").unwrap();
+        std::fs::write(root.join("ignored.py"), "IGNORED = 1\n").unwrap();
+        std::fs::write(root.join("excluded.py"), "EXCLUDED = 2\n").unwrap();
+        std::fs::write(root.join("kept.py"), "KEPT = 3\n").unwrap();
+
+        let ignore = RepositoryIgnore::load(root).unwrap();
+        let policy = graph_owned_policy("excluded.py\n");
+        let untracked = scan_repository_untracked_paths(
+            root,
+            &ignore,
+            Some(&policy),
+            std::iter::empty::<&RepoPath>(),
+            std::iter::empty::<&RepoPath>(),
+        )
+        .unwrap();
+
+        let content = scan_repository_preserving_graph_only(
+            root,
+            &ignore,
+            Some(&policy),
+            std::iter::empty::<&RepoPath>(),
+            std::iter::empty::<&RepoPath>(),
+        )
+        .unwrap();
+        let admitted = content.paths().cloned().collect::<Vec<_>>();
+
+        assert_eq!(
+            untracked, admitted,
+            "with nothing tracked, what the measurement names and what the content walk would \
+             admit are the same set: measured {untracked:?}, admissible {admitted:?}"
+        );
+        assert!(
+            !untracked.contains(&path("ignored.py")),
+            "the ignore rules bind the measurement: {untracked:?}"
+        );
+        assert!(
+            !untracked.contains(&path("excluded.py")),
+            "the graph-owned policy binds it too: {untracked:?}"
+        );
+        assert!(
+            untracked.contains(&path("kept.py")),
+            "and the positive control has to survive both, or this proves only that the walk \
+             refuses everything: {untracked:?}"
+        );
     }
 
     /// The walk skips what the graph-owned policy excludes, and does not read

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -607,9 +607,7 @@ impl GraphBehind {
             .get("untracked_observation_not_applicable")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        if unadmitted_paths == 0
-            && (measured_age_seconds.is_some() || observation_not_applicable)
-        {
+        if unadmitted_paths == 0 && (measured_age_seconds.is_some() || observation_not_applicable) {
             return None;
         }
         let since = reconcile
@@ -3027,7 +3025,9 @@ mod tests {
         );
         assert_eq!(durability.live_only_entities, None);
         assert!(
-            durability.note.contains("nothing has measured this working copy"),
+            durability
+                .note
+                .contains("nothing has measured this working copy"),
             "{}",
             durability.note
         );

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -3135,7 +3135,10 @@ mod tests {
             Some(&serde_json::json!(true)),
             "the control: a walk did produce this count: {wire}"
         );
-        assert_eq!(wire.get("measured_age_seconds"), Some(&serde_json::json!(4)));
+        assert_eq!(
+            wire.get("measured_age_seconds"),
+            Some(&serde_json::json!(4))
+        );
     }
 
     /// The control that keeps the gate above from firing on every daemon whose

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -548,10 +548,13 @@ pub struct Durability {
 /// clock cannot say whether the store fell behind a second ago or a month ago,
 /// and a clock with no count cannot say whether anything is actually missing.
 ///
-/// Present only when the store IS behind. An absent object is not a claim that
-/// it is current: a runtime that reported no reconcile reading has nothing to
-/// say here, and reporting a zero it never verified is the shape of wrong
-/// answer this object exists to stop.
+/// Present when there is something to say, which is two cases and not one:
+/// the store is behind by a measured count, or NOTHING MEASURED the working
+/// copy, so whether it is behind is unknown. An absent object is a measured
+/// all-clear and only that. The second case exists because the first version of
+/// this object gated on the count alone, so a zero nobody had measured read
+/// exactly like a zero somebody had, and reporting a zero it never verified is
+/// the shape of wrong answer this object exists to stop (FIR-2820).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GraphBehind {
     /// Host paths on disk that no admission has taken.
@@ -563,22 +566,50 @@ pub struct GraphBehind {
     /// you just wrote.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sample: Vec<String>,
+    /// Seconds since the walk that produced `unadmitted_paths` ran.
+    ///
+    /// `None` is the whole reason this object can be present with a count of
+    /// zero: it means no walk has stamped a reading, so the count above is a
+    /// default rather than an observation and nothing here is a statement about
+    /// the working copy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub measured_age_seconds: Option<u64>,
     /// One line an agent can act on without reading the counts.
     pub note: String,
 }
 
 impl GraphBehind {
-    /// Read the two halves out of a daemon `/health` body.
+    /// Read the reading, and the basis for it, out of a daemon `/health` body.
     ///
-    /// `None` when the body carries no reconcile reading at all, and `None`
-    /// again when it reports nothing unadmitted. The two are different facts and
-    /// both are correctly silent here: this object speaks only when the store is
-    /// behind, and the gates that consume it treat its silence as no reading
-    /// rather than as an all-clear.
+    /// `None` when the body carries no reconcile block at all, because there is
+    /// then nothing to read rather than something to report.
+    ///
+    /// Otherwise the count alone does not decide this, and that is the fix. A
+    /// zero has three producers and only one of them is an all-clear: a walk
+    /// measured it, this daemon admits nothing from the filesystem so the
+    /// question does not apply, or a walk should have measured it and none has.
+    /// The first two are silence. The third is a disclosure, because a zero
+    /// nobody measured is not a zero, and gating on the count alone published it
+    /// as one on every surface built from this object while `kin status` on the
+    /// same daemon at the same instant correctly answered "not measured"
+    /// (FIR-2820).
     pub fn from_health(health: &Value) -> Option<Self> {
         let reconcile = health.get("reconcile")?;
         let unadmitted_paths = reconcile.get("untracked_path_count")?.as_u64()?;
-        if unadmitted_paths == 0 {
+        let measured_age_seconds = reconcile
+            .get("untracked_observed_age_seconds")
+            .and_then(Value::as_u64);
+        // Named by the daemon, not inferred here. A projected checkout on a
+        // daemon whose graph is its own write authority holds no content
+        // anything failed to admit, so an unstamped zero there is the question
+        // not applying rather than a walk that went missing.
+        let observation_not_applicable = reconcile
+            .get("untracked_observation_not_applicable")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if unadmitted_paths == 0
+            && (measured_age_seconds.is_some() || observation_not_applicable)
+        {
             return None;
         }
         let since = reconcile
@@ -596,26 +627,56 @@ impl GraphBehind {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
-        let note = Self::describe(unadmitted_paths, since.as_deref());
+        let note = Self::describe(unadmitted_paths, since.as_deref(), measured_age_seconds);
         Some(Self {
             unadmitted_paths,
             since,
             sample,
+            measured_age_seconds,
             note,
         })
     }
 
-    fn describe(unadmitted_paths: u64, since: Option<&str>) -> String {
+    /// Whether this object is the no-measurement disclosure rather than a count.
+    ///
+    /// The count is the discriminator, and there is no third shape:
+    /// [`Self::from_health`] emits a zero only when nothing measured the working
+    /// copy, and returns `None` for every zero that something did. A consumer
+    /// asks this before sending a reader to `kin admit`, because there is no
+    /// path to admit.
+    pub fn unmeasured(&self) -> bool {
+        self.unadmitted_paths == 0
+    }
+
+    fn describe(
+        unadmitted_paths: u64,
+        since: Option<&str>,
+        measured_age_seconds: Option<u64>,
+    ) -> String {
         let clock = match since {
             Some(since) => format!("the last complete admission was at {since}"),
             None => {
                 "this daemon has not reported when a complete admission last succeeded".to_string()
             }
         };
+        if unadmitted_paths == 0 {
+            return format!(
+                "nothing has measured this working copy, so whether graph truth is level with it \
+                 is unknown, and {clock}. Answers here cover admitted content only. `kin status` \
+                 reports the same, and a commit takes any unadmitted path anyway."
+            );
+        }
+        // The age rides in the sentence as well as the field, because a count
+        // with no clock cannot say whether the store fell behind a second ago
+        // or a month ago, and a reader of the note gets only the sentence.
+        let measured = match measured_age_seconds {
+            Some(age) => format!(", measured {age}s ago,"),
+            None => String::new(),
+        };
         format!(
-            "{unadmitted_paths} host path(s) are on disk that graph truth does not carry, and \
-             {clock}. Answers here cover admitted content only. `kin admit` takes those paths \
-             now, and a commit takes them anyway."
+            "{unadmitted_paths} host path(s) are on disk that graph truth does not carry\
+             {measured} and {clock}. Answers here cover admitted content only. `kin admit` takes \
+             those paths now, and a commit takes them anyway."
         )
     }
 
@@ -631,6 +692,17 @@ impl GraphBehind {
             Some(since) => format!("the last complete admission was at {since}"),
             None => "no complete admission has been reported".to_string(),
         };
+        // Two readings, two reasons, and the reader is sent to a different
+        // lever by each. One says the graph is behind by a known amount; the
+        // other says nobody knows, which is not the same news and must not
+        // borrow the first one's words.
+        if self.unmeasured() {
+            return format!(
+                "working_copy_unmeasured: nothing has measured this working copy, so whether \
+                 graph truth is level with it is unknown and {clock}; an absence here cannot be \
+                 told apart from content the graph has not taken yet"
+            );
+        }
         format!(
             "graph_behind_working_tree: {} host path(s) on disk have never been admitted and \
              {clock}, so an absence here cannot be told apart from content the graph has not \
@@ -808,18 +880,36 @@ impl Durability {
     /// number goes rather than growing: how many entities an unadmitted file
     /// holds is not knowable from a graph that never parsed it, and inventing a
     /// figure is the one thing this object promises never to do.
+    ///
+    /// So the sentence does not state one either. The first version of this
+    /// composed its lead from `live_only_entities` and then withdrew the field,
+    /// which is the FIR-2499 failure with the halves swapped: a reader grepping
+    /// the payload for "0 uncommitted" over an unadmitted module still found it,
+    /// one clause before the note explained that no such number was derivable.
+    /// The lead now states the live count, which is a fact, and nothing else.
     pub fn qualified_by(mut self, behind: &GraphBehind) -> Self {
-        let counts = match (self.live_entities, self.live_only_entities) {
-            (Some(live), Some(live_only)) => format!("{live} entities, {live_only} uncommitted"),
-            (Some(live), None) => format!("{live} entities"),
-            _ => "this graph".to_string(),
+        let counts = match self.live_entities {
+            Some(live) => format!("{live} entities answered here"),
+            None => "this graph answered".to_string(),
         };
-        self.note = format!(
-            "{counts}, and {} host path(s) on disk that no admission has taken, so how much of \
-             this working copy is recorded is unknown; this reading covers admitted content only. \
-             `kin admit` takes those paths now, and a commit takes them anyway.",
-            behind.unadmitted_paths
-        );
+        // Two readings and two sentences, for the same reason the limiting
+        // factor carries two: a measured count and no measurement at all send a
+        // reader to different levers, and one of them is `kin admit`.
+        self.note = if behind.unmeasured() {
+            format!(
+                "{counts}, and nothing has measured this working copy, so how much of it is \
+                 recorded is unknown; this reading covers admitted content only. `kin status` \
+                 reports the same, and a commit takes any unadmitted path anyway."
+            )
+        } else {
+            format!(
+                "{counts}, and {} host path(s) on disk that no admission has taken, so how much \
+                 of this working copy is recorded is unknown; this reading covers admitted \
+                 content only. `kin admit` takes those paths now, and a commit takes them \
+                 anyway.",
+                behind.unadmitted_paths
+            )
+        };
         self.state = DURABILITY_UNKNOWN.to_string();
         self.live_only_entities = None;
         self
@@ -2882,7 +2972,12 @@ mod tests {
     fn the_working_copy_lift_leaves_a_level_store_alone() {
         let env = Envelope::daemon()
             .with_working_copy_health(&serde_json::json!({
-                "reconcile": { "untracked_path_count": 0 },
+                // Stamped, which is what makes the zero an all-clear rather
+                // than a default nothing measured.
+                "reconcile": {
+                    "untracked_path_count": 0,
+                    "untracked_observed_age_seconds": 0,
+                },
             }))
             .with_selected_graph_observation(6, 6, 0, 6, Some(6));
 
@@ -2890,6 +2985,112 @@ mod tests {
         let durability = env.durability.expect("graph status reports the counts");
         assert_eq!(durability.state, DURABILITY_RECORDED);
         assert_eq!(durability.live_only_entities, Some(0));
+    }
+
+    /// FIR-2820, the review's second finding. A zero nobody measured is not a
+    /// zero, and the first version of this gated on the count alone.
+    ///
+    /// Two routes reach an unstamped zero on a daemon that should have measured:
+    /// a walk that errored, which is logged and swallowed so the previous
+    /// reading stands, and a daemon that has not walked yet. On both,
+    /// `kin status` correctly answered "not measured" while durability, behind
+    /// and negative on the same daemon at the same instant answered
+    /// "0 uncommitted", `recorded` and `authoritative`. That is the ticket's own
+    /// two-readers-disagreeing shape, inverted: the field existed and three of
+    /// its four readers ignored it.
+    #[test]
+    fn an_unmeasured_working_copy_is_a_disclosure_rather_than_a_zero() {
+        let env = Envelope::daemon().with_health(&serde_json::json!({
+            "graph_entity_count": 51,
+            "durable_entity_count": 51,
+            "reconcile": { "untracked_path_count": 0 },
+        }));
+
+        let behind = env
+            .behind
+            .as_ref()
+            .expect("a zero with no measurement behind it is a disclosure");
+        assert!(behind.unmeasured());
+        assert_eq!(behind.measured_age_seconds, None);
+        assert!(
+            behind.limiting_factor().contains("working_copy_unmeasured"),
+            "an unmeasured reading must not borrow the behind-by-a-count words, which send a \
+             reader to `kin admit` for a path that does not exist: {}",
+            behind.limiting_factor()
+        );
+
+        let durability = env.durability.expect("the counts still answer");
+        assert_eq!(
+            durability.state, DURABILITY_UNKNOWN,
+            "a working copy nobody measured cannot report its work recorded: {}",
+            durability.note
+        );
+        assert_eq!(durability.live_only_entities, None);
+        assert!(
+            durability.note.contains("nothing has measured this working copy"),
+            "{}",
+            durability.note
+        );
+    }
+
+    /// The control that keeps the gate above from firing on every daemon whose
+    /// graph is its own write authority.
+    ///
+    /// Filesystem ingestion off means nothing on disk is ever admitted, so host
+    /// content is not a gap the graph failed to close and there is no walk to
+    /// miss. Gating on the stamp alone would turn every such daemon into a
+    /// permanent disclosure, which is why the daemon names this case rather than
+    /// leaving the envelope to infer it.
+    #[test]
+    fn a_daemon_that_admits_nothing_from_the_filesystem_stays_silent() {
+        let env = Envelope::daemon().with_health(&serde_json::json!({
+            "graph_entity_count": 51,
+            "durable_entity_count": 51,
+            "reconcile": {
+                "untracked_path_count": 0,
+                "untracked_observation_not_applicable": true,
+            },
+        }));
+
+        assert!(
+            env.behind.is_none(),
+            "a projected checkout is not evidence about what the graph failed to admit: {:?}",
+            env.behind
+        );
+        let durability = env.durability.expect("the counts still answer");
+        assert_eq!(durability.state, DURABILITY_RECORDED);
+        assert_eq!(durability.live_only_entities, Some(0));
+    }
+
+    /// The note the fields withdrew must not survive in the sentence.
+    ///
+    /// FIR-2499 withdrew the prose and left the fields; the first version of
+    /// this fix withdrew the fields and left the prose, composing its own lead
+    /// out of `live_only_entities` one statement before setting it to `None`. A
+    /// stranger grepping the payload for "0 uncommitted" over an unadmitted
+    /// module still found it.
+    #[test]
+    fn a_qualified_durability_note_states_no_uncommitted_count() {
+        let env = Envelope::daemon().with_health(&serde_json::json!({
+            "graph_entity_count": 6,
+            "durable_entity_count": 6,
+            "reconcile": {
+                "untracked_path_count": 1,
+                "untracked_paths_sample": ["linkgraph/predicates.py"],
+                "untracked_observed_age_seconds": 0,
+            },
+        }));
+        let durability = env.durability.expect("the counts still answer");
+        assert!(
+            !durability.note.contains("uncommitted"),
+            "the field is gone and the sentence has to go with it: {}",
+            durability.note
+        );
+        assert!(
+            durability.note.contains("6 entities answered here"),
+            "the live count is a fact and stays: {}",
+            durability.note
+        );
     }
 
     /// The control for the case above, and the one that keeps this from
@@ -2900,7 +3101,12 @@ mod tests {
         let env = Envelope::daemon().with_health(&serde_json::json!({
             "graph_entity_count": 51,
             "durable_entity_count": 51,
-            "reconcile": { "untracked_path_count": 0 },
+            // Stamped: a measured zero is the all-clear, an unstamped one is the
+            // disclosure the test below this asserts.
+            "reconcile": {
+                "untracked_path_count": 0,
+                "untracked_observed_age_seconds": 3,
+            },
         }));
 
         assert!(env.behind.is_none(), "nothing unadmitted is nothing to say");

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -574,6 +574,16 @@ pub struct GraphBehind {
     /// the working copy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub measured_age_seconds: Option<u64>,
+    /// Whether a walk produced `unadmitted_paths`.
+    ///
+    /// Always on the wire, unlike the age beside it, and that is the point. The
+    /// unmeasured disclosure reaches a machine consumer as
+    /// `unadmitted_paths: 0`, which is the exact number the object exists to say
+    /// means nothing, and the only other tell was the ABSENCE of the age above,
+    /// which is an inference from an absence rather than a reading. That is the
+    /// field-versus-prose split this whole ticket is about, one object over from
+    /// where it was fixed, so the block now states it positively.
+    pub measured: bool,
     /// One line an agent can act on without reading the counts.
     pub note: String,
 }
@@ -631,19 +641,21 @@ impl GraphBehind {
             since,
             sample,
             measured_age_seconds,
+            measured: measured_age_seconds.is_some(),
             note,
         })
     }
 
     /// Whether this object is the no-measurement disclosure rather than a count.
     ///
-    /// The count is the discriminator, and there is no third shape:
-    /// [`Self::from_health`] emits a zero only when nothing measured the working
-    /// copy, and returns `None` for every zero that something did. A consumer
-    /// asks this before sending a reader to `kin admit`, because there is no
-    /// path to admit.
+    /// Both halves, because they are two facts. [`Self::from_health`] emits a
+    /// zero only when nothing measured the working copy and returns `None` for
+    /// every zero that something did, so the pair is exactly the unmeasured
+    /// shape; a count with no stamp is still a count and still sends a reader to
+    /// `kin admit`. A consumer asks this before naming that remedy, because on
+    /// the unmeasured shape there is no path to admit.
     pub fn unmeasured(&self) -> bool {
-        self.unadmitted_paths == 0
+        !self.measured && self.unadmitted_paths == 0
     }
 
     fn describe(
@@ -2813,6 +2825,7 @@ mod tests {
             "reconcile": {
                 "untracked_path_count": 1,
                 "untracked_paths_sample": ["notekeeper/search.py"],
+                "untracked_observed_age_seconds": 0,
                 "last_admission_success_at": "2026-08-20T13:00:00Z",
             },
         }));
@@ -3031,6 +3044,53 @@ mod tests {
             "{}",
             durability.note
         );
+    }
+
+    /// FIR-2820, the delta review's finding 12. The disclosure has to be honest
+    /// on the wire, not only in Rust.
+    ///
+    /// The unmeasured shape reaches a machine consumer as `unadmitted_paths: 0`,
+    /// which is the exact number it exists to say means nothing, and the only
+    /// other tell was the ABSENCE of `measured_age_seconds`, which
+    /// `skip_serializing_if` drops. Inferring from an absence is what this whole
+    /// ticket is about, so the block states it positively and the serialized
+    /// form is what this test reads.
+    #[test]
+    fn the_serialized_behind_block_says_whether_anything_measured_it() {
+        let unmeasured = GraphBehind::from_health(&serde_json::json!({
+            "reconcile": { "untracked_path_count": 0 },
+        }))
+        .expect("an unstamped zero is a disclosure");
+        let wire = serde_json::to_value(&unmeasured).expect("the block serializes");
+        assert_eq!(
+            wire.get("measured"),
+            Some(&serde_json::json!(false)),
+            "a consumer branching on the count alone reads 0 here: {wire}"
+        );
+        assert_eq!(
+            wire.get("unadmitted_paths"),
+            Some(&serde_json::json!(0)),
+            "and that zero is still what it reads, which is why the flag is beside it: {wire}"
+        );
+        assert!(
+            wire.get("measured_age_seconds").is_none(),
+            "the age is absent on this shape, which is the inference the flag replaces: {wire}"
+        );
+
+        let measured = GraphBehind::from_health(&serde_json::json!({
+            "reconcile": {
+                "untracked_path_count": 2,
+                "untracked_observed_age_seconds": 4,
+            },
+        }))
+        .expect("a nonzero count is a disclosure");
+        let wire = serde_json::to_value(&measured).expect("the block serializes");
+        assert_eq!(
+            wire.get("measured"),
+            Some(&serde_json::json!(true)),
+            "the control: a walk did produce this count: {wire}"
+        );
+        assert_eq!(wire.get("measured_age_seconds"), Some(&serde_json::json!(4)));
     }
 
     /// The control that keeps the gate above from firing on every daemon whose

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -3046,6 +3046,51 @@ mod tests {
         );
     }
 
+    /// The predicate reads both halves, and this asserts the predicate rather
+    /// than the producer's invariant.
+    ///
+    /// `from_health` never emits a stamped zero, so within that one producer the
+    /// count would be discriminator enough and the `measured` half of the
+    /// conjunct would be a clause no mutation could kill. The clause is there
+    /// for a caller that builds one of these itself, and a check that cannot
+    /// fail is worth nothing, so the object is built here by hand.
+    #[test]
+    fn a_stamped_zero_is_not_the_unmeasured_shape() {
+        let stamped = GraphBehind {
+            unadmitted_paths: 0,
+            since: None,
+            sample: Vec::new(),
+            measured_age_seconds: Some(9),
+            measured: true,
+            note: String::new(),
+        };
+        assert!(
+            !stamped.unmeasured(),
+            "a walk ran and found nothing, which is an all-clear and not an absence of one"
+        );
+
+        let unstamped = GraphBehind {
+            measured_age_seconds: None,
+            measured: false,
+            ..stamped.clone()
+        };
+        assert!(
+            unstamped.unmeasured(),
+            "the same zero with nothing behind it is the disclosure"
+        );
+
+        let counted = GraphBehind {
+            unadmitted_paths: 3,
+            measured_age_seconds: None,
+            measured: false,
+            ..stamped
+        };
+        assert!(
+            !counted.unmeasured(),
+            "a count with no stamp is still a count, and `kin admit` is still the remedy"
+        );
+    }
+
     /// FIR-2820, the delta review's finding 12. The disclosure has to be honest
     /// on the wire, not only in Rust.
     ///

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -783,6 +783,15 @@ impl Durability {
     /// the graph had never met (FIR-2499). The counts are left exactly as
     /// observed, because they were never the wrong part; what changes is the
     /// claim made from them.
+    ///
+    /// The claim is three things and only the prose was withdrawn. `state` kept
+    /// reading `recorded` and `live_only_entities` kept reading zero beside a
+    /// note explaining that neither could be relied on, so a caller keying on
+    /// the fields, which is what fields are for, was told the all-clear the
+    /// sentence had just taken back (FIR-2820). Both move here. The derived
+    /// number goes rather than growing: how many entities an unadmitted file
+    /// holds is not knowable from a graph that never parsed it, and inventing a
+    /// figure is the one thing this object promises never to do.
     pub fn qualified_by(mut self, behind: &GraphBehind) -> Self {
         let counts = match (self.live_entities, self.live_only_entities) {
             (Some(live), Some(live_only)) => format!("{live} entities, {live_only} uncommitted"),
@@ -790,11 +799,13 @@ impl Durability {
             _ => "this graph".to_string(),
         };
         self.note = format!(
-            "{counts}, and {} host path(s) on disk that no admission has taken; this reading \
-             covers admitted content only. `kin admit` takes those paths now, and a commit takes \
-             them anyway.",
+            "{counts}, and {} host path(s) on disk that no admission has taken, so how much of \
+             this working copy is recorded is unknown; this reading covers admitted content only. \
+             `kin admit` takes those paths now, and a commit takes them anyway.",
             behind.unadmitted_paths
         );
+        self.state = DURABILITY_UNKNOWN.to_string();
+        self.live_only_entities = None;
         self
     }
 
@@ -1853,6 +1864,34 @@ impl Envelope {
         self
     }
 
+    /// Read only what the daemon's health body says about the WORKING COPY,
+    /// leaving every count it carries alone.
+    ///
+    /// For the one answer that may not take the rest. `kin_graph_status` reports
+    /// the exact graph view the daemon selected, so borrowing `/health`'s entity
+    /// count or generation would put two authorities for one number in one
+    /// response, and the stdio path therefore skipped the health lift outright.
+    /// It skipped the reconcile block with it, so a graph-status answer could
+    /// never learn that the host holds content the graph has never met, and it
+    /// published "0 uncommitted" over exactly that working copy (FIR-2820).
+    ///
+    /// There is no second authority for these two. Neither describes the
+    /// selected graph: one counts host paths outside it and the other is a clock
+    /// about admissions. Durability is requalified if it is already set, and
+    /// [`Self::with_selected_graph_observation`] requalifies from `behind` when
+    /// it runs after this, so either order reaches the same reading.
+    pub fn with_working_copy_health(mut self, health: &Value) -> Self {
+        self.behind = GraphBehind::from_health(health);
+        self.freshness = GraphFreshness::from_health(health);
+        if let Some(behind) = self.behind.as_ref() {
+            self.durability = self
+                .durability
+                .take()
+                .map(|durability| durability.qualified_by(behind));
+        }
+        self
+    }
+
     /// Lift `semantic_coverage` and `graph_as_of` out of a tool payload when the
     /// daemon already computed them, so they live in one predictable place on the
     /// envelope. Absent fields stay unknown.
@@ -2562,6 +2601,19 @@ mod tests {
             "the note has to name what it does not cover: {}",
             durability.note
         );
+        // FIR-2820. The half a caller keys on. Withdrawing the sentence and
+        // leaving `recorded` and a zero standing is telling a reader of the
+        // prose one thing and a reader of the fields the opposite, and the
+        // fields are what an agent branches on.
+        assert_eq!(
+            durability.state, DURABILITY_UNKNOWN,
+            "a store the working copy has outrun cannot report its work recorded"
+        );
+        assert_eq!(
+            durability.live_only_entities, None,
+            "how much of an unadmitted file is uncommitted is not derivable from a graph that \
+             never parsed it, so the number goes rather than growing"
+        );
     }
 
     /// FIR-2499. The graph-status path sets durability after `with_health` has
@@ -2601,6 +2653,87 @@ mod tests {
             "the note has to keep naming what it does not cover: {}",
             durability.note
         );
+        // FIR-2820, on the second path for the same reason it is asserted on
+        // the first: this call requalifies rather than assigns, so a state that
+        // moved on one path and not the other is exactly the shape that stays
+        // green while shipping the defect.
+        assert_eq!(durability.state, DURABILITY_UNKNOWN, "{}", durability.note);
+        assert_eq!(durability.live_only_entities, None, "{}", durability.note);
+    }
+
+    /// FIR-2820. The one answer that may not take the counts still has to take
+    /// the working copy.
+    ///
+    /// `kin_graph_status` reports the graph view the daemon selected, so
+    /// borrowing `/health`'s entity count would put two authorities for one
+    /// number in one response, and the stdio path skipped the health lift
+    /// outright rather than pick. It skipped the reconcile block with it, and
+    /// published "0 uncommitted" over a working copy holding a module the graph
+    /// had never met.
+    #[test]
+    fn the_working_copy_lift_takes_the_reconcile_block_and_none_of_the_counts() {
+        let health = serde_json::json!({
+            "graph_entity_count": 900,
+            "durable_entity_count": 900,
+            "graph_generation": 77,
+            "reconcile": {
+                "untracked_path_count": 1,
+                "untracked_paths_sample": ["linkgraph/predicates.py"],
+                "last_admission_success_at": "2026-08-27T09:00:00Z",
+            },
+        });
+        let env = Envelope::daemon()
+            .with_working_copy_health(&health)
+            .with_selected_graph_observation(6, 6, 0, 6, Some(6));
+
+        assert_eq!(
+            env.graph_state.entity_count,
+            Some(6),
+            "the selected graph's own count answers, never the health body's 900"
+        );
+        let behind = env.behind.as_ref().expect("the working copy was read");
+        assert_eq!(behind.unadmitted_paths, 1);
+        let durability = env.durability.expect("graph status reports the counts");
+        assert_eq!(
+            durability.state, DURABILITY_UNKNOWN,
+            "the reading has to move, or this lift changed nothing: {}",
+            durability.note
+        );
+        assert_eq!(durability.live_only_entities, None);
+        assert!(
+            durability
+                .note
+                .contains("host path(s) on disk that no admission has taken"),
+            "{}",
+            durability.note
+        );
+
+        // The order the stdio path does not use, asserted because either order
+        // has to reach the same reading or the fix depends on a call sequence
+        // nobody is holding still.
+        let reversed = Envelope::daemon()
+            .with_selected_graph_observation(6, 6, 0, 6, Some(6))
+            .with_working_copy_health(&health)
+            .durability
+            .expect("graph status reports the counts");
+        assert_eq!(reversed.state, DURABILITY_UNKNOWN);
+        assert_eq!(reversed.live_only_entities, None);
+    }
+
+    /// The control for the lift above: a store with nothing unadmitted keeps the
+    /// clean graph-status reading, so this cannot qualify every answer.
+    #[test]
+    fn the_working_copy_lift_leaves_a_level_store_alone() {
+        let env = Envelope::daemon()
+            .with_working_copy_health(&serde_json::json!({
+                "reconcile": { "untracked_path_count": 0 },
+            }))
+            .with_selected_graph_observation(6, 6, 0, 6, Some(6));
+
+        assert!(env.behind.is_none(), "nothing unadmitted is nothing to say");
+        let durability = env.durability.expect("graph status reports the counts");
+        assert_eq!(durability.state, DURABILITY_RECORDED);
+        assert_eq!(durability.live_only_entities, Some(0));
     }
 
     /// The control for the case above, and the one that keeps this from

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -2690,6 +2690,18 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
         );
     }
 
+    // Host content the graph never met answers every name inside it identically,
+    // for the same reason an empty graph does one gate up. This is the purest
+    // absence claim the product makes, and it was the one that never asked: the
+    // retrieval builder scopes this gap to answers that claim an absence, which
+    // is every answer here, and a focal miss took a different route and skipped
+    // it. So a constant declared and used in an unadmitted module came back
+    // `safe_to_conclude_absent: true`, `structural_authoritative`, beside a
+    // `behind` object in the same envelope naming the file it was in (FIR-2820).
+    if let Some(gap) = unadmitted_host_content_gap(envelope) {
+        push_gap(&mut trustworthy, &mut trust_reason, gap);
+    }
+
     let consequence = if trustworthy {
         "The name is authoritatively absent from this graph: no entity carries it. That is a fact about the name and not about the symbol's usage, because nothing was looked up.".to_string()
     } else {
@@ -6170,6 +6182,71 @@ mod tests {
             assert_eq!(negative["safe_to_conclude_absent"], json!(true));
             assert_eq!(negative["trust"], json!("authoritative"));
         }
+    }
+
+    /// FIR-2820. The purest absence claim the product makes, over a store the
+    /// working copy has outrun.
+    ///
+    /// The v0.6.1 yardstick run asked `find_references` about a constant
+    /// declared and used twice in a module on disk that no admission had taken.
+    /// It came back `safe_to_conclude_absent: true`, `structural_authoritative`,
+    /// beside a `behind` object in the same envelope naming that very file. The
+    /// retrieval builder had this gate and scopes it to answers claiming an
+    /// absence, which is every answer on this path; a focal miss took a
+    /// different route and never asked.
+    #[test]
+    fn resolution_miss_over_unadmitted_host_content_is_inconclusive() {
+        let envelope = Envelope::daemon().with_health(&json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 38,
+            "reconcile": {
+                "untracked_path_count": 1,
+                "untracked_paths_sample": ["notekeeper/linkgraph.py"],
+                "last_admission_success_at": "2026-08-27T03:14:08Z",
+            },
+        }));
+        let negative = resolution_miss_for("find_references", "Entity not found", &envelope)
+            .expect("a miss is still qualified");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "a name may be absent from the graph and present in the repository while a module \
+             the graph never read sits on disk"
+        );
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("graph_behind_working_tree"),
+            "an answer withheld for an unnamed reason sends the reader to the wrong lever: \
+             {reason}"
+        );
+        let advice = negative["advice"].as_str().unwrap();
+        assert!(
+            !advice.contains("authoritatively absent"),
+            "the advice cannot still read as settled: {advice}"
+        );
+    }
+
+    /// The control for the case above, on the same builder. A store with nothing
+    /// unadmitted certifies exactly as it did, because a gate that fires on
+    /// every working copy is one an agent learns to skip.
+    #[test]
+    fn resolution_miss_over_a_level_working_copy_still_certifies() {
+        let envelope = Envelope::daemon().with_health(&json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 38,
+            "reconcile": { "untracked_path_count": 0 },
+        }));
+        let negative = resolution_miss_for("find_references", "Entity not found", &envelope)
+            .expect("a miss is still qualified");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+        assert_eq!(negative["trust"], json!("authoritative"));
+        assert!(!negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("graph_behind_working_tree"));
     }
 
     #[test]

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -3938,6 +3938,7 @@ mod tests {
             "reconcile": {
                 "untracked_path_count": unadmitted_paths,
                 "untracked_paths_sample": ["notekeeper/search.py"],
+                "untracked_observed_age_seconds": 0,
                 "last_admission_success_at": "2026-08-20T13:00:00Z",
             },
         }))
@@ -6335,7 +6336,12 @@ mod tests {
             "initialized": true,
             "graph_loaded": true,
             "graph_entity_count": 38,
-            "reconcile": { "untracked_path_count": 0 },
+            // Stamped. An unstamped zero is a different fact and the two tests
+            // below this one are what separate them.
+            "reconcile": {
+                "untracked_path_count": 0,
+                "untracked_observed_age_seconds": 0,
+            },
         }));
         let negative = resolution_miss_for("find_references", "Entity not found", &envelope)
             .expect("a miss is still qualified");
@@ -6345,6 +6351,60 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("graph_behind_working_tree"));
+    }
+
+    /// FIR-2820, the review's second finding, on the surface a caller acts on.
+    ///
+    /// A walk that errored is logged at debug and swallowed, and a daemon that
+    /// has not walked yet has taken no reading at all. Both leave the count at
+    /// its `u64` default with no stamp, and `kin status` on the same daemon at
+    /// the same instant says "not measured" while this builder certified.
+    #[test]
+    fn resolution_miss_over_an_unmeasured_working_copy_is_inconclusive() {
+        let envelope = Envelope::daemon().with_health(&json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 38,
+            "reconcile": { "untracked_path_count": 0 },
+        }));
+        let negative = resolution_miss_for("find_references", "Entity not found", &envelope)
+            .expect("a miss is still qualified");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "a zero nobody measured is not a zero, and certifying on it is the whole ticket"
+        );
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("working_copy_unmeasured"),
+            "the reason has to name the lever, and it is not `kin admit` here: {reason}"
+        );
+    }
+
+    /// The control for the case above. A daemon that admits nothing from the
+    /// filesystem has no walk to miss, so a gate keyed on the stamp alone would
+    /// refuse every absence it ever answers.
+    #[test]
+    fn resolution_miss_over_a_daemon_that_admits_nothing_from_disk_certifies() {
+        let envelope = Envelope::daemon().with_health(&json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 38,
+            "reconcile": {
+                "untracked_path_count": 0,
+                "untracked_observation_not_applicable": true,
+            },
+        }));
+        let negative = resolution_miss_for("find_references", "Entity not found", &envelope)
+            .expect("a miss is still qualified");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+        assert_eq!(negative["trust"], json!("authoritative"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            !reason.contains("working_copy_unmeasured"),
+            "there is no working copy to measure here: {reason}"
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -1293,18 +1293,31 @@ async fn handle_tools_call_daemon(
     // borrowing its entity count or generation here would mix two authorities
     // in one response. Build the standard `_kin` envelope from the report
     // itself and validate the fully annotated stdio payload instead.
+    // Enrich the envelope with honest degraded/freshness signals from the daemon
+    // `/health` body when the daemon is actually reachable. When it was already
+    // determined unreachable, skip the probe — there is nothing to ask.
+    //
+    // Fetched before the graph-status branch below, not after it. That branch
+    // used to return first and so never reached this probe at all, which took
+    // the working-copy reading away from it along with the counts it is right to
+    // refuse, and left it publishing "0 uncommitted" over a repository holding a
+    // module the graph had never met (FIR-2820).
+    let health = if base_env.degraded.daemon_unreachable == Some(true) {
+        None
+    } else {
+        daemon_delegate::fetch_health_snapshot().await
+    };
+
     if call_params.name == "kin_graph_status" {
+        if let Some(health) = health.as_ref() {
+            base_env = base_env.with_working_copy_health(health);
+        }
         let enveloped = finalize_daemon_graph_status(result, base_env);
         return JsonRpcResponse::success(id, serde_json::to_value(&enveloped).unwrap_or_default());
     }
 
-    // Enrich the envelope with honest degraded/freshness signals from the daemon
-    // `/health` body when the daemon is actually reachable. When it was already
-    // determined unreachable, skip the probe — there is nothing to ask.
-    if base_env.degraded.daemon_unreachable != Some(true) {
-        if let Some(health) = daemon_delegate::fetch_health_snapshot().await {
-            base_env = base_env.with_health(&health);
-        }
+    if let Some(health) = health.as_ref() {
+        base_env = base_env.with_health(health);
     }
 
     let enveloped = envelope::finalize_bounded(result, base_env, &call_params.name, &budget);

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -1117,16 +1117,24 @@ mod tests {
             }))
         }
 
+        // Both carry the untracked measurement stamp, because a zero with no
+        // stamp is now its own disclosure and `behind` is present for it. These
+        // two are about the ADMISSION clock, which is a different reading, so
+        // they say plainly that the working copy was measured and level.
         fn with_clock() -> Envelope {
             envelope_with(json!({
                 "untracked_path_count": 0,
+                "untracked_observed_age_seconds": 0,
                 "last_admission_success_at": "2026-08-26T00:00:00Z",
                 "last_admission_success_age_seconds": 12,
             }))
         }
 
         fn without_clock() -> Envelope {
-            envelope_with(json!({ "untracked_path_count": 0 }))
+            envelope_with(json!({
+                "untracked_path_count": 0,
+                "untracked_observed_age_seconds": 0,
+            }))
         }
 
         /// The disclosure, which is what step 1 actually delivers. Both stores

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -297,6 +297,16 @@ absent. Without it the other three are satisfied by a product that qualifies
 every answer it gives, which is the failure mode that would make this fix
 worthless without ever failing a test.
 
+`--self-test` carries one fixture per assertion, not one per grader, and the
+distinction was bought. The first version's two durability fixtures both read
+`recorded` AND `live_only_entities: 0`, so deleting either field check left the
+other one catching the same input a step later and the self-test stayed green:
+three of four grader mutations survived, and the claim above that this suite
+asserts the fields rather than the note was unfalsifiable for either field
+alone. Every assertion now has an input only it can catch, so deleting a
+defence turns the suite red and nothing else does. Adding inputs is the fix for
+that class; deleting the second assertion never is.
+
 `eject_journal_repro.py` covers the eject archive round trip the rc0552n green
 stranger lost on 0.5.52 (FIR-2664). A finished `kin eject` left its journal in
 the archived `kin/` at the detach phase, `cp -r` of that archive back to `.kin`

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -258,6 +258,45 @@ dies of something that is not the network, the check reports UNREADABLE and says
 which reason it got, because a classifier that was never asked the question has
 not answered it.
 
+`working_copy_freshness_repro.py` covers what the product says about a working
+copy it has not read, which the v0.6.1 yardstick run caught three surfaces
+getting wrong at once (FIR-2820). The stranger wrote a module, did not commit it,
+and asked about a constant inside it: the durability block answered "38 entities,
+0 uncommitted", `kin status` answered "12 artifacts, matching its base change",
+and `find_references` answered `safe_to_conclude_absent: true` with
+`structural_authoritative`, while `grep -n` found the constant on two lines. One
+reading sits behind all three. `untracked_path_count` is a record a complete
+reconcile pass leaves behind, and an explicit seam records it EMPTY because the
+seam admitted everything, so a zero written by the last commit answers for the
+rest of the daemon's life and cannot be told from a zero measured this instant.
+
+The fixture reaches that state through a documented product rule rather than a
+race, which is what lets it run on a loaded runner. The daemon's startup
+catch-up walks with `scan_repository_modified_since`, which declines a leaf
+inside a directory graph truth has never met, on the grounds that a directory
+arriving whole is a clone as often as it is authored work. A file written into a
+NEW directory while the daemon is down is therefore never admitted and never
+observed, for as long as nothing touches it again, and that walk's own comment
+says such content "is exactly what the behind disclosure counts and names".
+
+Check `durability` requires the durability block not to read `recorded` with
+`live_only_entities: 0` over that working copy, and to name how many host paths
+it cannot see. It asserts the fields and not only the note, because the fix
+before it withdrew the prose and left `recorded` and a zero standing in exactly
+the two places a caller branches on. Check `status` requires `kin status` to name
+the file with the age of the measurement, since every other line that command
+prints is authority truth and authority cannot see the file at all. Check
+`absence` requires the focal miss not to certify, and its reason to name
+`graph_behind_working_tree` rather than some other gap, because an answer
+withheld for the wrong reason sends the reader to the wrong lever.
+
+Check `committed` is the control and it carries all three: once the tree is
+committed the clean durability read is back with its zero intact, `kin status`
+reports nothing untracked, and a name nothing declares is still authoritatively
+absent. Without it the other three are satisfied by a product that qualifies
+every answer it gives, which is the failure mode that would make this fix
+worthless without ever failing a test.
+
 `eject_journal_repro.py` covers the eject archive round trip the rc0552n green
 stranger lost on 0.5.52 (FIR-2664). A finished `kin eject` left its journal in
 the archived `kin/` at the detach phase, `cp -r` of that archive back to `.kin`
@@ -354,6 +393,10 @@ python3 scripts/acceptance/eject_journal_repro.py \
 python3 scripts/acceptance/verdict_limits_repro.py \
   --kin target/release/kin --daemon target/release/kin-daemon \
   --json acceptance/verdict_limits.json --verbose
+
+python3 scripts/acceptance/working_copy_freshness_repro.py \
+  --kin target/release/kin --daemon target/release/kin-daemon \
+  --json acceptance/working_copy_freshness.json --verbose
 ```
 
 Release, not debug. Release is what ships, so it is what an acceptance answer

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -107,6 +107,11 @@ EXPECTED_SUITES = (
         "verdict_limits",
         "acceptance/verdict_limits.json",
     ),
+    ExpectedSuite(
+        "scripts/acceptance/working_copy_freshness_repro.py",
+        "working_copy_freshness",
+        "acceptance/working_copy_freshness.json",
+    ),
 )
 
 
@@ -1002,8 +1007,12 @@ def main() -> int:
         print("VIOLATION: %s" % problem)
     if problems:
         return 1
+    # Counted from the reviewed inventory rather than written out. A hardcoded
+    # total drifts the moment a suite is added, and it drifts downward silently:
+    # the guard keeps passing while its own summary understates what it graded.
     print(
-        "workflow authority holds: 13 suite reports reach one always-running verdict in order"
+        "workflow authority holds: %d suite reports reach one always-running verdict in order"
+        % len(EXPECTED_SUITES)
     )
     return 0
 

--- a/scripts/acceptance/working_copy_freshness_repro.py
+++ b/scripts/acceptance/working_copy_freshness_repro.py
@@ -171,6 +171,16 @@ def grade_durability_withholds_the_all_clear(payload):
     note = block.get("note") or ""
     if "host path(s) on disk that no admission has taken" not in note:
         return FAIL, "the note does not name the host paths it cannot see: %r" % (note,)
+    # FIR-2499 withdrew the prose and left the fields. The first cut of the
+    # FIR-2820 fix withdrew the fields and left the prose, composing the note's
+    # own lead out of live_only_entities one statement before setting it to
+    # None, so a reader grepping the payload for "0 uncommitted" over an
+    # unadmitted module still found it. The two halves move together or neither
+    # of them has moved.
+    if "uncommitted" in note:
+        return FAIL, (
+            "the note still states an uncommitted count the field withdrew: %r" % (note,)
+        )
     return PASS, "state %r, live_only_entities %r, note names the host paths" % (
         state, block.get("live_only_entities"),
     )
@@ -487,12 +497,14 @@ CHECKS = [
 ]
 
 
+QUALIFIED_NOTE = (
+    "6 entities answered here, and 1 host path(s) on disk that no admission has taken, so how "
+    "much of this working copy is recorded is unknown; this reading covers admitted content "
+    "only. `kin admit` takes those paths now, and a commit takes them anyway.")
+
 BEHIND = {"_kin": {"durability": {
     "state": "unknown", "live_entities": 6, "durable_entities": 6,
-    "note": "6 entities, 0 uncommitted, and 1 host path(s) on disk that no admission has taken, "
-            "so how much of this working copy is recorded is unknown; this reading covers "
-            "admitted content only. `kin admit` takes those paths now, and a commit takes them "
-            "anyway."}}}
+    "note": QUALIFIED_NOTE}}}
 SHIPPED_0_6_1 = {"_kin": {"durability": {
     "state": "recorded", "live_entities": 38, "durable_entities": 38,
     "live_only_entities": 0,
@@ -506,6 +518,29 @@ PROSE_ONLY = {"_kin": {"durability": {
             "admitted content only. `kin admit` takes those paths now, and a commit takes them "
             "anyway."}}}
 
+# ── one fixture per assertion, because two assertions that can both catch one
+# input hide each other's absence ─────────────────────────────────────────────
+#
+# Every durability fixture above carries `recorded` AND `live_only_entities: 0`,
+# so mutating away either field check left the other one catching the same input
+# one step later and the self-test stayed green. Each dict below is caught by
+# exactly one assertion, so deleting that assertion turns this suite red and
+# nothing else does. Written as inputs, never by deleting a defence.
+STATE_ONLY = {"_kin": {"durability": {
+    "state": "recorded", "live_entities": 6, "durable_entities": 6,
+    "note": QUALIFIED_NOTE}}}
+FIELD_ONLY = {"_kin": {"durability": {
+    "state": "unknown", "live_entities": 6, "durable_entities": 6,
+    "live_only_entities": 0,
+    "note": QUALIFIED_NOTE}}}
+NOTE_STATES_A_COUNT = {"_kin": {"durability": {
+    "state": "unknown", "live_entities": 6, "durable_entities": 6,
+    "note": "6 entities, 0 uncommitted, and 1 host path(s) on disk that no admission has taken, "
+            "so how much of this working copy is recorded is unknown."}}}
+NOTE_NAMES_NOTHING = {"_kin": {"durability": {
+    "state": "unknown", "live_entities": 6, "durable_entities": 6,
+    "note": "This daemon has not levelled its query graph with durable repository authority."}}}
+
 STATUS_HEAD = "Kin repository-v6 status\nTree: abc (3 artifacts, matching its base change)\n"
 STATUS_NAMING = STATUS_HEAD + (
     "Untracked host content: 1 host path(s) on disk that graph truth does not carry "
@@ -515,6 +550,17 @@ STATUS_UNMEASURED = STATUS_HEAD + (
     "of it\n")
 STATUS_SILENT = STATUS_HEAD
 STATUS_CLEAN = STATUS_HEAD + "Untracked host content: none, measured 0s ago\n"
+# Names the file AND says nothing measured it, which is the only input the
+# "not measured" arm can catch on its own: the unmeasured line above is caught
+# one step later for not naming the file.
+STATUS_UNMEASURED_NAMING = STATUS_HEAD + (
+    "Untracked host content: not measured; this repository's daemon reports no measurement of "
+    "1 host path(s) including linkgraph/predicates.py\n")
+# Names the file and never says when, which is the only input the "does not say
+# when it was measured" arm can catch on its own.
+STATUS_NAMING_UNDATED = STATUS_HEAD + (
+    "Untracked host content: 1 host path(s) on disk that graph truth does not carry "
+    "(linkgraph/predicates.py); nothing above describes them\n")
 
 CERTIFIED = {"negative": {
     "safe_to_conclude_absent": True, "trust": "authoritative",
@@ -548,6 +594,15 @@ def self_test():
            grade_durability_withholds_the_all_clear(PROSE_ONLY), FAIL)
     expect("durability cannot read a response with no envelope",
            grade_durability_withholds_the_all_clear({"entity_count": 6}), UNREADABLE)
+    # One arm per assertion in that grader, each caught by exactly one of them.
+    expect("durability fails a recorded state on its own",
+           grade_durability_withholds_the_all_clear(STATE_ONLY), FAIL)
+    expect("durability fails a zero live_only_entities on its own",
+           grade_durability_withholds_the_all_clear(FIELD_ONLY), FAIL)
+    expect("durability fails a note that still states an uncommitted count",
+           grade_durability_withholds_the_all_clear(NOTE_STATES_A_COUNT), FAIL)
+    expect("durability fails a note that names no host paths",
+           grade_durability_withholds_the_all_clear(NOTE_NAMES_NOTHING), FAIL)
 
     expect("durability control passes a committed tree",
            grade_durability_reads_clean_over_a_committed_tree(SHIPPED_0_6_1), PASS)
@@ -567,6 +622,12 @@ def self_test():
            grade_status_names_the_unadmitted_file(STATUS_NAMING, "other/module.py"), FAIL)
     expect("status cannot read something that is not a status",
            grade_status_names_the_unadmitted_file("nope", "linkgraph/predicates.py"), UNREADABLE)
+    expect("status fails an unmeasured line that does name the file",
+           grade_status_names_the_unadmitted_file(STATUS_UNMEASURED_NAMING,
+                                                  "linkgraph/predicates.py"), FAIL)
+    expect("status fails a line that names the file and never says when",
+           grade_status_names_the_unadmitted_file(STATUS_NAMING_UNDATED,
+                                                  "linkgraph/predicates.py"), FAIL)
 
     expect("status control passes a clean measured tree",
            grade_status_reports_nothing_untracked(STATUS_CLEAN), PASS)

--- a/scripts/acceptance/working_copy_freshness_repro.py
+++ b/scripts/acceptance/working_copy_freshness_repro.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove the product never states an all-clear about a working copy it has not read.
+
+FIR-2820. The v0.6.1 candidate's yardstick run wrote a module, did not commit it,
+and asked `find_references` about a constant inside it. Three surfaces answered
+together and all three were wrong the same way:
+
+  _kin.durability   "38 entities, 0 uncommitted", state `recorded`
+  kin status        "12 artifacts, matching its base change"
+  negative          safe_to_conclude_absent true, trust `structural_authoritative`
+
+Fourteen uncommitted entities sat in the file, and `grep -n` found the constant on
+two lines. The stranger's sentence: three surfaces agreeing on an answer a one-line
+grep refutes.
+
+The mechanism is one reading, read by all three. `untracked_path_count` is a record
+a complete reconcile pass leaves behind, and an explicit seam records it EMPTY
+because the seam admitted everything. Both are true when written and neither
+expires, so a zero from the last commit answers for the rest of the daemon's life
+and is indistinguishable from a zero measured this instant. The durability block
+then turns a difference between two ENTITY counts, which cannot see a file the graph
+never parsed, into a claim about the working tree.
+
+The fixture reaches that state through a documented product rule rather than a
+race. The daemon's startup catch-up walks with `scan_repository_modified_since`,
+which declines "a leaf inside a directory graph truth has never met", because a
+directory arriving whole is a clone as often as it is authored work. So a file
+written into a NEW directory while the daemon is down is never admitted, never
+observed, and never counted, for as long as nothing touches it again. Its own
+comment says that content "is exactly what the behind disclosure counts and names",
+which is the claim this suite grades.
+
+Four checks, one seeded repository, run in order because the experiment is
+destructive: the last one commits what the first three are about.
+
+  durability  the durability block does not read `recorded` with zero uncommitted
+              over a working copy holding a module authority does not carry, and
+              names how many host paths it cannot see
+  status      `kin status` names that file, with the age of the measurement, so a
+              reader is never shown authority truth alone and left to infer
+  absence     `find_references` on a constant only that file declares does not
+              certify the absence, and its reason names the working copy
+  committed   the control: once the tree is committed, the clean durability read
+              is back with its zero intact, `kin status` reports nothing
+              untracked, and an absence over a name nothing carries is still
+              authoritative. Without this the other three are satisfied by a
+              product that qualifies every answer it gives.
+
+Exit status is 0 when every check passed, 1 when one failed, 2 when one could not
+be read, and 3 when the run could not be set up. `--self-test` exercises every
+grader against a payload that must pass and one that must fail, and needs no
+binary, so a grader that cannot fail is a failure here rather than a silent pass
+in CI.
+"""
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+TICKET = "FIR-2820"
+
+print = functools.partial(print, flush=True)
+
+# The constant the query is about. Declared once and used once, inside the module
+# the graph is never given, so a grep finds two lines and the graph finds none.
+SYMBOL = "RESOLVE_PREDICATE"
+
+# A name nothing in the fixture declares, used as the control's absence. It has to
+# be absent for a reason that is about the name rather than about the working copy,
+# which is the distinction the whole suite turns on.
+ABSENT_SYMBOL = "NOTHING_IN_THIS_REPOSITORY_CARRIES_THIS_NAME"
+
+PARSING_SRC = '''STEM_SPLIT = "#"
+
+
+def parse_key(raw):
+    return raw.split(STEM_SPLIT)[0]
+'''
+
+STORAGE_SRC = '''from notekeeper.parsing import parse_key
+
+
+def store(rows, raw):
+    rows.append(parse_key(raw))
+    return rows
+'''
+
+# Written into a directory graph truth has never met, while nothing is watching.
+LINKGRAPH_SRC = '''%s = "(notes.key = links.target_key)"
+
+
+def dangling_links(conn):
+    return conn.execute("SELECT 1 FROM notes WHERE " + %s)
+
+
+def resolve_key(conn, key):
+    return conn.execute("SELECT 1 FROM notes WHERE key = ?", (key,))
+''' % (SYMBOL, SYMBOL)
+
+
+def run(cmd, cwd=None, env=None, timeout=600, stdin=None):
+    proc = subprocess.Popen(
+        cmd, cwd=cwd, env=env,
+        stdin=subprocess.PIPE if stdin is not None else None,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    try:
+        out, err = proc.communicate(input=stdin, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        out, err = proc.communicate()
+        return 124, out, err
+    return proc.returncode, out, err
+
+
+# ── graders ────────────────────────────────────────────────────────────────
+#
+# Every grader takes parsed payloads or rendered text and returns (status, detail).
+# Kept apart from the run so `--self-test` can hand each one an input that must
+# pass and one that must fail, with no binary anywhere.
+
+
+def durability_of(payload):
+    """The durability block, or None when the response carries no envelope."""
+    if not isinstance(payload, dict):
+        return None
+    envelope = payload.get("_kin")
+    if not isinstance(envelope, dict):
+        return None
+    block = envelope.get("durability")
+    return block if isinstance(block, dict) else None
+
+
+def grade_durability_withholds_the_all_clear(payload):
+    """The claim the fields make, not the sentence beside them.
+
+    `state` and `live_only_entities` are what a caller branches on, and an
+    earlier fix withdrew only the prose: the note explained that the reading
+    could not be relied on while the two fields went on saying it could.
+    """
+    block = durability_of(payload)
+    if block is None:
+        return UNREADABLE, "the response carries no _kin.durability block"
+    state = block.get("state")
+    if state is None:
+        return UNREADABLE, "the durability block carries no state: %r" % (block,)
+    if state == "recorded":
+        return FAIL, (
+            "state %r over a working copy holding an unadmitted module; note %r"
+            % (state, block.get("note"))
+        )
+    if block.get("live_only_entities") == 0:
+        return FAIL, (
+            "live_only_entities 0 beside state %r, which is the all-clear a caller "
+            "reads off the field: %r" % (state, block)
+        )
+    note = block.get("note") or ""
+    if "host path(s) on disk that no admission has taken" not in note:
+        return FAIL, "the note does not name the host paths it cannot see: %r" % (note,)
+    return PASS, "state %r, live_only_entities %r, note names the host paths" % (
+        state, block.get("live_only_entities"),
+    )
+
+
+def grade_durability_reads_clean_over_a_committed_tree(payload):
+    """The control. A disclosure that always fires is noise nobody reads."""
+    block = durability_of(payload)
+    if block is None:
+        return UNREADABLE, "the response carries no _kin.durability block"
+    if block.get("state") != "recorded":
+        return FAIL, (
+            "a fully committed tree still does not read recorded: %r" % (block,)
+        )
+    if block.get("live_only_entities") != 0:
+        return FAIL, (
+            "a fully committed tree does not report zero uncommitted: %r" % (block,)
+        )
+    return PASS, "recorded, 0 uncommitted, which is what a committed tree is"
+
+
+def grade_status_names_the_unadmitted_file(text, expected_path):
+    """`kin status` reads durable authority, which cannot see this file at all."""
+    if not isinstance(text, str) or "Kin repository-v6 status" not in text:
+        return UNREADABLE, "this is not a kin status rendering"
+    line = None
+    for candidate in text.splitlines():
+        if candidate.startswith("Untracked host content:"):
+            line = candidate
+            break
+    if line is None:
+        return FAIL, "kin status carries no untracked host content line at all"
+    if "not measured" in line:
+        return FAIL, "kin status took no measurement: %r" % (line,)
+    if expected_path not in line:
+        return FAIL, "the line does not name the file: %r" % (line,)
+    if "measured" not in line:
+        return FAIL, "the line does not say when it was measured: %r" % (line,)
+    return PASS, line
+
+
+def grade_status_reports_nothing_untracked(text):
+    """The control for the line above, on the same surface."""
+    if not isinstance(text, str) or "Kin repository-v6 status" not in text:
+        return UNREADABLE, "this is not a kin status rendering"
+    for candidate in text.splitlines():
+        if candidate.startswith("Untracked host content:"):
+            if "none, measured" in candidate:
+                return PASS, candidate
+            return FAIL, "a committed tree still reports untracked content: %r" % (candidate,)
+    return FAIL, "kin status carries no untracked host content line at all"
+
+
+def negative_of(payload):
+    if not isinstance(payload, dict):
+        return None
+    block = payload.get("negative")
+    if isinstance(block, dict):
+        return block
+    data = payload.get("data")
+    if isinstance(data, dict) and isinstance(data.get("negative"), dict):
+        return data["negative"]
+    return None
+
+
+def grade_absence_names_the_working_copy(payload):
+    """An absence over a graph the working copy has outrun is not authoritative.
+
+    The `negative` block was never the wrong part on its own: the name really is
+    not in the graph. What it may not do is present that as settled while a module
+    declaring the name sits on disk unread.
+    """
+    block = negative_of(payload)
+    if block is None:
+        return UNREADABLE, "the response carries no negative block"
+    if "safe_to_conclude_absent" not in block:
+        return UNREADABLE, "the negative block does not answer the absence question"
+    if block.get("safe_to_conclude_absent") is True:
+        return FAIL, (
+            "the absence is certified over a graph that never read the declaring "
+            "module: trust %r, reason %r"
+            % (block.get("trust"), block.get("trust_reason"))
+        )
+    reason = "%s %s" % (block.get("trust_reason") or "", block.get("advice") or "")
+    if "graph_behind_working_tree" not in reason:
+        return FAIL, (
+            "the answer is withheld without naming the working copy as why: %r"
+            % (block.get("trust_reason"),)
+        )
+    return PASS, "not certified, and the reason names graph_behind_working_tree"
+
+
+def grade_absence_stays_authoritative_over_a_committed_tree(payload):
+    """The control. A name nothing carries is still absent, and saying so is the
+    product's job; qualifying it here would make the disclosure worthless."""
+    block = negative_of(payload)
+    if block is None:
+        return UNREADABLE, "the response carries no negative block"
+    if "safe_to_conclude_absent" not in block:
+        return UNREADABLE, "the negative block does not answer the absence question"
+    if block.get("safe_to_conclude_absent") is not True:
+        return FAIL, (
+            "a name nothing declares, over a fully committed tree, is no longer "
+            "authoritatively absent: trust %r, reason %r"
+            % (block.get("trust"), block.get("trust_reason"))
+        )
+    reason = block.get("trust_reason") or ""
+    if "graph_behind_working_tree" in reason:
+        return FAIL, "a committed tree is still being called behind: %r" % (reason,)
+    return PASS, "authoritatively absent, with no working-copy caveat"
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.home = os.path.join(workdir, "home")
+        os.makedirs(self.home)
+        # kin refuses to invent an author, which is correct product behavior and
+        # not an obstacle. The run isolates HOME so it cannot read the machine's
+        # identity, so it brings one of its own.
+        with open(os.path.join(self.home, ".gitconfig"), "w") as handle:
+            handle.write("[user]\n\tname = working-copy-freshness-repro\n"
+                         "\temail = repro@example.invalid\n"
+                         "[commit]\n\tgpgsign = false\n")
+        self.env = dict(os.environ)
+        self.env["HOME"] = self.home
+        self.env["USERPROFILE"] = self.home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(self.home, "registry.toml")
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DAEMON_URL", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repo = None
+        self.unadmitted_path = "linkgraph/predicates.py"
+
+    def git(self, args, repo):
+        base = ["git", "-c", "core.hooksPath=/dev/null",
+                "-c", "user.email=repro@example.invalid",
+                "-c", "user.name=working-copy-freshness-repro",
+                "-c", "commit.gpgsign=false"]
+        return run(base + args, cwd=repo, env=self.env)
+
+    def kin_run(self, args, timeout=600):
+        rc, out, err = run([self.kin] + args, cwd=self.repo(), env=self.env, timeout=timeout)
+        if self.verbose:
+            print("  $ kin %s -> rc=%s" % (" ".join(args), rc))
+        return rc, out, err
+
+    def repo(self):
+        if self._repo:
+            return self._repo
+        path = os.path.realpath(os.path.join(self.workdir, "notekeeper-repo"))
+        os.makedirs(os.path.join(path, "notekeeper"))
+        for rel, body in (
+            ("notekeeper/__init__.py", ""),
+            ("notekeeper/parsing.py", PARSING_SRC),
+            ("notekeeper/storage.py", STORAGE_SRC),
+        ):
+            with open(os.path.join(path, rel), "w") as handle:
+                handle.write(body)
+        self.git(["init", "-q", "."], path)
+        self._repo = path
+        rc, out, err = self.kin_run(["init", "."])
+        if rc != 0:
+            raise RuntimeError("kin init failed: %s" % (err or out)[-400:])
+        rc, out, err = self.kin_run(["commit", "-m", "seed the modules the graph knows"])
+        if rc != 0:
+            raise RuntimeError("kin commit failed: %s" % (err or out)[-400:])
+        self.strand_the_module()
+        return path
+
+    def strand_the_module(self):
+        """Put a module on disk that nothing will ever admit on its own.
+
+        Written while the daemon is down, into a directory graph truth has never
+        met, which is the one population the startup catch-up declines outright
+        (`scan_repository_modified_since`, "a leaf inside a directory graph truth
+        has never met"). Nothing replays an arrival that happened before the watch
+        existed, so this file stays unadmitted until an explicit seam takes it,
+        with no race for a loaded runner to lose.
+        """
+        self.kin_run(["daemon", "stop"], timeout=180)
+        target = os.path.join(self._repo, self.unadmitted_path)
+        os.makedirs(os.path.dirname(target))
+        with open(target, "w") as handle:
+            handle.write(LINKGRAPH_SRC)
+        # Bring the daemon back and let its startup catch-up run, because that
+        # pass declining this directory is the mechanism under test rather than
+        # an accident of timing. A daemon that is merely absent would make every
+        # surface below report "not measured", which is honest and is not what
+        # this suite is grading.
+        rc, out, err = self.kin_run(["graph", "status"], timeout=600)
+        if rc != 0:
+            raise RuntimeError("the daemon did not come back: %s" % (err or out)[-400:])
+
+    def ground_truth(self):
+        """What a one-line grep says, which is the whole point of the finding."""
+        target = os.path.join(self.repo(), self.unadmitted_path)
+        with open(target) as handle:
+            return sum(1 for line in handle if SYMBOL in line)
+
+    def mcp(self, calls):
+        """Drive the real stdio MCP surface and return payloads keyed by id."""
+        frames = [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+             "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                        "clientInfo": {"name": "working-copy-freshness-repro", "version": "0"}}},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        ]
+        for index, (name, arguments) in enumerate(calls):
+            frames.append({"jsonrpc": "2.0", "id": index + 2, "method": "tools/call",
+                           "params": {"name": name, "arguments": arguments}})
+        payload_in = "\n".join(json.dumps(frame) for frame in frames) + "\n"
+        rc, out, err = run([self.kin, "mcp", "start"], cwd=self.repo(), env=self.env,
+                           timeout=600, stdin=payload_in)
+        if self.verbose:
+            print("  $ kin mcp start (%d calls) -> rc=%s" % (len(calls), rc))
+        payloads = {}
+        for line in out.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except ValueError:
+                continue
+            ident = message.get("id")
+            if not isinstance(ident, int) or ident < 2:
+                continue
+            body = message.get("result") or message.get("error") or {}
+            text = None
+            if isinstance(body, dict) and isinstance(body.get("content"), list):
+                try:
+                    text = body["content"][0]["text"]
+                except (KeyError, IndexError, TypeError):
+                    text = None
+            try:
+                payloads[ident] = json.loads(text) if text else body
+            except ValueError:
+                payloads[ident] = body
+        return payloads
+
+    def status_text(self):
+        rc, out, err = self.kin_run(["status"])
+        return out
+
+
+class Result(object):
+    def __init__(self, ident, status, detail):
+        self.ident = ident
+        self.status = status
+        self.detail = detail
+
+
+def check_durability(suite):
+    lines = suite.ground_truth()
+    if lines < 2:
+        return Result("durability", UNREADABLE,
+                      "%s the fixture module does not declare and use the symbol" % TICKET)
+    payloads = suite.mcp([("kin_graph_status", {})])
+    status, detail = grade_durability_withholds_the_all_clear(payloads.get(2))
+    return Result("durability", status,
+                  "%s grep finds %s on %d lines; %s" % (TICKET, SYMBOL, lines, detail))
+
+
+def check_status(suite):
+    text = suite.status_text()
+    status, detail = grade_status_names_the_unadmitted_file(text, suite.unadmitted_path)
+    return Result("status", status, "%s %s" % (TICKET, detail))
+
+
+def check_absence(suite):
+    payloads = suite.mcp([("find_references", {"query": SYMBOL})])
+    status, detail = grade_absence_names_the_working_copy(payloads.get(2))
+    return Result("absence", status, "%s %s" % (TICKET, detail))
+
+
+def check_committed(suite):
+    rc, out, err = suite.kin_run(["commit", "-m", "land the stranded module"])
+    if rc != 0:
+        return Result("committed", UNREADABLE,
+                      "%s the control's commit failed: %s" % (TICKET, (err or out)[-200:]))
+    payloads = suite.mcp([
+        ("kin_graph_status", {}),
+        ("find_references", {"query": ABSENT_SYMBOL}),
+    ])
+    verdicts = [
+        ("durability", grade_durability_reads_clean_over_a_committed_tree(payloads.get(2))),
+        ("status", grade_status_reports_nothing_untracked(suite.status_text())),
+        ("absence", grade_absence_stays_authoritative_over_a_committed_tree(payloads.get(3))),
+    ]
+    # Every arm is reported, never the first bad one, because the control is
+    # three separate claims and knowing which of them broke is the whole value.
+    detail = "; ".join("%s %s %s" % (name, status, note) for name, (status, note) in verdicts)
+    if any(status == FAIL for _, (status, _) in verdicts):
+        return Result("committed", FAIL, "%s %s" % (TICKET, detail))
+    if any(status == UNREADABLE for _, (status, _) in verdicts):
+        return Result("committed", UNREADABLE, "%s %s" % (TICKET, detail))
+    return Result("committed", PASS, "%s %s" % (TICKET, detail))
+
+
+# Ordered, and the order is load bearing: `committed` commits the module the
+# first three checks are about.
+CHECKS = [
+    ("durability", check_durability),
+    ("status", check_status),
+    ("absence", check_absence),
+    ("committed", check_committed),
+]
+
+
+BEHIND = {"_kin": {"durability": {
+    "state": "unknown", "live_entities": 6, "durable_entities": 6,
+    "note": "6 entities, 0 uncommitted, and 1 host path(s) on disk that no admission has taken, "
+            "so how much of this working copy is recorded is unknown; this reading covers "
+            "admitted content only. `kin admit` takes those paths now, and a commit takes them "
+            "anyway."}}}
+SHIPPED_0_6_1 = {"_kin": {"durability": {
+    "state": "recorded", "live_entities": 38, "durable_entities": 38,
+    "live_only_entities": 0,
+    "note": "38 entities, 0 uncommitted; durable repository authority records everything "
+            "answering here."}}}
+PROSE_ONLY = {"_kin": {"durability": {
+    "state": "recorded", "live_entities": 6, "durable_entities": 6,
+    "live_only_entities": 0,
+    "note": "6 entities, 0 uncommitted, and 1 host path(s) on disk that no admission has taken, "
+            "so how much of this working copy is recorded is unknown; this reading covers "
+            "admitted content only. `kin admit` takes those paths now, and a commit takes them "
+            "anyway."}}}
+
+STATUS_HEAD = "Kin repository-v6 status\nTree: abc (3 artifacts, matching its base change)\n"
+STATUS_NAMING = STATUS_HEAD + (
+    "Untracked host content: 1 host path(s) on disk that graph truth does not carry "
+    "(linkgraph/predicates.py), measured 0s ago; nothing above describes them\n")
+STATUS_UNMEASURED = STATUS_HEAD + (
+    "Untracked host content: not measured; this repository's daemon reports no measurement "
+    "of it\n")
+STATUS_SILENT = STATUS_HEAD
+STATUS_CLEAN = STATUS_HEAD + "Untracked host content: none, measured 0s ago\n"
+
+CERTIFIED = {"negative": {
+    "safe_to_conclude_absent": True, "trust": "authoritative",
+    "trust_reason": "structural_authoritative: daemon graph initialized and loaded, with no "
+                    "degraded signals",
+    "advice": "The name is authoritatively absent from this graph: no entity carries it."}}
+WITHHELD = {"negative": {
+    "safe_to_conclude_absent": False, "trust": "inconclusive",
+    "trust_reason": "graph_behind_working_tree: 1 host path(s) on disk have never been admitted",
+    "advice": "graph_behind_working_tree: 1 host path(s) on disk have never been admitted"}}
+WITHHELD_UNEXPLAINED = {"negative": {
+    "safe_to_conclude_absent": False, "trust": "inconclusive",
+    "trust_reason": "some other reason entirely", "advice": "some other reason entirely"}}
+
+
+def self_test():
+    graded = []
+    failures = []
+
+    def expect(label, got, want):
+        graded.append(label)
+        status = got[0]
+        if status != want:
+            failures.append("%s: wanted %s got %s (%s)" % (label, want, status, got[1]))
+
+    expect("durability passes the qualified reading",
+           grade_durability_withholds_the_all_clear(BEHIND), PASS)
+    expect("durability fails the shipped 0.6.1 envelope",
+           grade_durability_withholds_the_all_clear(SHIPPED_0_6_1), FAIL)
+    expect("durability fails a reading that withdrew only the prose",
+           grade_durability_withholds_the_all_clear(PROSE_ONLY), FAIL)
+    expect("durability cannot read a response with no envelope",
+           grade_durability_withholds_the_all_clear({"entity_count": 6}), UNREADABLE)
+
+    expect("durability control passes a committed tree",
+           grade_durability_reads_clean_over_a_committed_tree(SHIPPED_0_6_1), PASS)
+    expect("durability control fails a tree still reporting unknown",
+           grade_durability_reads_clean_over_a_committed_tree(BEHIND), FAIL)
+    expect("durability control cannot read a response with no envelope",
+           grade_durability_reads_clean_over_a_committed_tree({}), UNREADABLE)
+
+    expect("status passes a line naming the file",
+           grade_status_names_the_unadmitted_file(STATUS_NAMING, "linkgraph/predicates.py"), PASS)
+    expect("status fails a status with no such line",
+           grade_status_names_the_unadmitted_file(STATUS_SILENT, "linkgraph/predicates.py"), FAIL)
+    expect("status fails a line that measured nothing",
+           grade_status_names_the_unadmitted_file(STATUS_UNMEASURED, "linkgraph/predicates.py"),
+           FAIL)
+    expect("status fails a line naming a different file",
+           grade_status_names_the_unadmitted_file(STATUS_NAMING, "other/module.py"), FAIL)
+    expect("status cannot read something that is not a status",
+           grade_status_names_the_unadmitted_file("nope", "linkgraph/predicates.py"), UNREADABLE)
+
+    expect("status control passes a clean measured tree",
+           grade_status_reports_nothing_untracked(STATUS_CLEAN), PASS)
+    expect("status control fails a tree still naming a file",
+           grade_status_reports_nothing_untracked(STATUS_NAMING), FAIL)
+    expect("status control fails a status with no such line",
+           grade_status_reports_nothing_untracked(STATUS_SILENT), FAIL)
+    expect("status control cannot read something that is not a status",
+           grade_status_reports_nothing_untracked(""), UNREADABLE)
+
+    expect("absence passes a withheld answer that names the working copy",
+           grade_absence_names_the_working_copy(WITHHELD), PASS)
+    expect("absence fails the shipped certified answer",
+           grade_absence_names_the_working_copy(CERTIFIED), FAIL)
+    expect("absence fails an answer withheld for an unrelated reason",
+           grade_absence_names_the_working_copy(WITHHELD_UNEXPLAINED), FAIL)
+    expect("absence cannot read a response with no negative block",
+           grade_absence_names_the_working_copy({"results": []}), UNREADABLE)
+
+    expect("absence control passes a certified answer",
+           grade_absence_stays_authoritative_over_a_committed_tree(CERTIFIED), PASS)
+    expect("absence control fails an answer withheld over a committed tree",
+           grade_absence_stays_authoritative_over_a_committed_tree(WITHHELD), FAIL)
+    expect("absence control cannot read a response with no negative block",
+           grade_absence_stays_authoritative_over_a_committed_tree({}), UNREADABLE)
+
+    for line in failures:
+        print("SELFTEST FAIL %s" % line)
+    # Counted, never written out. A hardcoded total drifts from the assertions it
+    # claims to describe, and it drifts silently downward.
+    print("self-test: %d grader assertions, %d failed" % (len(graded), len(failures)))
+    if len(graded) != len(set(graded)):
+        print("SELFTEST FAIL duplicate assertion labels, so one shadowed another")
+        return 1
+    if not graded:
+        print("SELFTEST FAIL no grader assertion ran")
+        return 1
+    return 1 if failures else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN") or shutil.which("kin"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path")
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    opts = parser.parse_args(argv)
+
+    if opts.self_test:
+        return self_test()
+
+    if not opts.kin:
+        print("SETUP no kin binary: pass --kin or set KIN_BIN")
+        return 3
+
+    workdir = tempfile.mkdtemp(prefix="working-copy-freshness-")
+    suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
+    try:
+        results = []
+        for ident, check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - a setup failure is not a verdict
+                results.append(Result(ident, UNREADABLE, "%s check raised: %s" % (TICKET, error)))
+        for result in results:
+            print("CHECK %s %s %s %s" % (result.ident, TICKET, result.status, result.detail))
+        asked = [ident for ident, _ in CHECKS]
+        answered = [result.ident for result in results]
+        if answered != asked:
+            print("SETUP asked for %r and %r answered" % (asked, answered))
+            return 3
+        if opts.json_path:
+            directory = os.path.dirname(os.path.abspath(opts.json_path))
+            if directory:
+                try:
+                    os.makedirs(directory)
+                except OSError:
+                    pass
+            with open(opts.json_path, "w") as handle:
+                json.dump({"suite": "working_copy_freshness", "ticket": TICKET,
+                           "checks": [{"id": r.ident, "status": r.status, "detail": r.detail}
+                                      for r in results]}, handle, indent=2)
+        if any(result.status == FAIL for result in results):
+            return 1
+        if any(result.status == UNREADABLE for result in results):
+            return 2
+        return 0
+    finally:
+        try:
+            if suite._repo:
+                run([opts.kin, "daemon", "stop"], cwd=suite._repo, env=suite.env, timeout=180)
+        except Exception:  # noqa: BLE001 - teardown must not change the verdict
+            pass
+        if not opts.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+        else:
+            print("kept fixtures under %s" % workdir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
The v0.6.1 stranger run wrote a module, did not commit it, and asked
`find_references` about a constant declared and used inside it. Three surfaces
answered together and all three were wrong the same way: `_kin.durability` read
38 entities and 0 uncommitted with state `recorded`, `kin status` read 12
artifacts matching its base change, and the `negative` block read
`safe_to_conclude_absent: true` with `structural_authoritative`. A one-line grep
found the constant on two lines of a file sitting on disk. Fourteen of those
entities were uncommitted.

One reading is behind all three. `untracked_path_count` is a record a complete
reconcile pass leaves behind, and an explicit seam records it EMPTY because the
seam admitted everything. Both are true when written and neither expires, so a
zero from the last commit answers for the rest of the daemon's life and cannot
be told from a zero measured this instant. The durability block then turns a
difference between two entity counts, which cannot see a file the graph never
parsed, into a claim about the working tree.

The reading is now taken when a surface is about to state it. A new
measurement-only scan mode walks with the content scan's own rules, through the
same scanner so the two cannot drift, and keeps a path instead of reading a
byte. It rate-limits itself off what the last walk cost, so a large working copy
refreshes less often rather than continuously, and every surface carrying the
count now carries the age of the measurement beside it.

Four more faces went with it, each its own defect. The daemon's envelope
snapshot carried four fields and no reconcile block, so `graph_behind_working_tree`
could not fire on any daemon-built answer however far behind the store was. The
stdio path returned before its health lift for `kin_graph_status`, to avoid
borrowing counts it is right to refuse, and lost the working-copy reading with
them. A focal miss, the purest absence claim the product makes, took a route
that never asked about unadmitted content at all. And the earlier fix for this
family withdrew only the prose: `state` kept reading `recorded` and
`live_only_entities` kept reading zero beside a note explaining that neither
could be relied on.

`kin status` grows a line for what the working copy holds that graph truth does
not, naming its own basis in every arm, because a measured count, a measured
nothing, a daemon that measured nothing and no daemon at all are four different
facts and only the first two are statements about the working copy.

`scripts/acceptance/working_copy_freshness_repro.py` pins the shape and reaches
the unadmitted state through a documented product rule rather than a race: the
daemon's startup catch-up declines a leaf inside a directory graph truth has
never met, so a file written into a new directory while the daemon is down is
never admitted for as long as nothing touches it again. Three checks assert the
disclosure on all three surfaces and the fourth is the control, requiring a
committed tree to keep its clean durability read, report nothing untracked, and
still answer authoritatively about a name nothing declares.

Two commits beyond the fix are the price of the rebase. The step-visibility
guard that landed with #1196 pins the reviewed inventory of report-producing
acceptance suites and refuses a suite step that emits a failure-level
annotation, so the new step now emits the same deferred warning every other
suite emits and joins that inventory. And two gates the fix had never been run
through refused it: clippy rejected two `vec!` literals that are only iterated,
and the workspace test build could not compile kin-cli, because `HealthResponse`
grew a `reconcile` field and three test constructors still named every field but
that one.

An independent review of this branch found the new age field reaching one of its
four readers, so a second commit gates the disclosure on the measurement rather
than the count. An absent measurement has three producers and only one is an
all-clear: a walk took the reading, this daemon admits nothing from the
filesystem so the question does not apply, or a walk should have taken it and
none has. The third is now a disclosure with its own words, since sending a
reader to `kin admit` for a path that does not exist is the wrong lever, and the
second is named by the daemon rather than inferred, because gating on the stamp
alone would turn every graph-authority daemon into a permanent refusal to
certify. `qualified_by` also stops stating an uncommitted count in the sentence
it withdrew from the field, and the acceptance self-test now carries one fixture
per assertion, because both durability fixtures read `recorded` AND
`live_only_entities: 0` and three of four grader mutations survived on that.

Follow-ups, named rather than fixed here. FIR-2840 is the sibling arm of the same
class: a TRACKED file edited while the daemon was down is never re-admitted, the
new walk stats nothing so it cannot see the edit, and the same three surfaces go
quiet over a symbol grep finds. This PR makes `kin status` say "none, measured 0s
ago" over that state, which is literally accurate and reads as a measured
all-clear. Four smaller ones stay open: the refresh duty bound starts its clock
after the tracked-path collect that is the actual cost and nothing serializes
concurrent walks; the two staleness constants are expressed in terms of
themselves so no test can see the window grow; `kin graph status` reads the same
record from a route that never measures; and the walk materializes and sorts the
whole untracked set before the caller keeps a bounded sample.

Closes FIR-2820
