### PR TITLE
Count Python call sites so the parse side reaches a converted store

### DIFF
--- a/crates/kin-cli/tests/caller_arrival_separates_a_measured_shortfall.rs
+++ b/crates/kin-cli/tests/caller_arrival_separates_a_measured_shortfall.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! FIR-2828, the reading half. Does the arrival gate's arithmetic actually run
+//! on a store built by the product's own path?
+//!
+//! `kin_mcp::caller_arrival` decides whether an empty reference list may be read
+//! as the whole truth by subtracting a family file's resolved `Calls` edges from
+//! the call sites the parser read there. Before this fixture existed, that
+//! subtraction had never happened on a real Python store: the extractor withheld
+//! the parse-side count from any file whose call extraction it could not fully
+//! represent, so every family file landed in the gate's absent-count branch and
+//! a file whose every call became an edge was indistinguishable from one holding
+//! calls the graph never saw.
+//!
+//! The fixture is built so the two are distinguishable only if the arithmetic
+//! runs. Both family files reach the focal's file through a direct-name import,
+//! so both hold an `Imports` edge and both land in the family. `clean.py`
+//! resolves every call it writes. `messy.py` writes one more through a subscript
+//! callee the extractor cannot name, so its call sites and its edges differ by
+//! exactly one. A gate reading a count taken off the emitted relations rather
+//! than off the file's call sites certifies `messy.py` too.
+
+use std::collections::HashMap;
+
+use kin_db::InMemoryGraph;
+use kin_index::{link_cross_file, FileParseData, IndexPipeline};
+use kin_mcp::caller_arrival::{observe_caller_arrival, ArrivalState};
+use kin_model::{
+    ArtifactId, Entity, FilePathId, GraphStore, Hash256, LocatedEntry, RelationKind, RepoPath,
+    TransactionDelta, TreeDelta, TreeEntry,
+};
+
+const STORE_PY: &str = r#"def open_db():
+    return {}
+
+
+def note_body(db, note_id):
+    return ""
+"#;
+
+/// Two call sites, and the linker records an edge for both. The receiver call
+/// is what made the extractor withhold this file's count.
+const CLEAN_PY: &str = r#"from notepkg import store
+from notepkg.store import note_body
+
+
+def summarize(note_id):
+    db = store.open_db()
+    return note_body(db, note_id)
+"#;
+
+/// Three call sites, two edges. `handlers["render"](body)` has no name the
+/// extractor can bind, so it produces no relation at all.
+const MESSY_PY: &str = r#"from notepkg import store
+from notepkg.store import note_body
+
+
+def summarize_messy(note_id, handlers):
+    db = store.open_db()
+    body = note_body(db, note_id)
+    return handlers["render"](body)
+"#;
+
+/// The same family shape as `messy.py` with the unnameable call removed, so the
+/// control differs from the subject in exactly one call site.
+const SECOND_CLEAN_PY: &str = r#"from notepkg import store
+from notepkg.store import note_body
+
+
+def summarize_again(note_id):
+    db = store.open_db()
+    return note_body(db, note_id)
+"#;
+
+fn parse(path: &str, source: &str) -> (FileParseData, Vec<Entity>) {
+    let indexed = IndexPipeline::new()
+        .index_file_content_with_tests(
+            &FilePathId::new(path),
+            source.as_bytes(),
+            Hash256::from_bytes([5; 32]),
+        )
+        .unwrap_or_else(|error| panic!("indexing {path} failed: {error}"))
+        .indexed_file;
+    (
+        FileParseData {
+            file_path: path.to_string(),
+            entities: indexed.entities.clone(),
+            relations: indexed.extracted_relations,
+            imports: indexed.imports,
+        },
+        indexed.entities,
+    )
+}
+
+/// Admit one artifact per parsed file, the way a persist gate requires, and
+/// return the identity map the linker takes.
+fn admit_file_artifacts(
+    graph: &InMemoryGraph,
+    files: &[FileParseData],
+) -> HashMap<String, ArtifactId> {
+    let mut artifact_ids = HashMap::new();
+    for file in files {
+        let artifact_id = ArtifactId::new();
+        let mut seed = [0u8; 32];
+        for (slot, byte) in seed.iter_mut().zip(file.file_path.as_bytes()) {
+            *slot = *byte;
+        }
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id,
+                    new: LocatedEntry::new(
+                        RepoPath::from_utf8(&file.file_path).expect("fixture path is utf-8"),
+                        TreeEntry::blob(Hash256::from_bytes(seed), false),
+                    ),
+                }],
+                ..TransactionDelta::default()
+            })
+            .expect("admit fixture artifact");
+        artifact_ids.insert(file.file_path.clone(), artifact_id);
+    }
+    artifact_ids
+}
+
+fn project(sources: &[(&str, &str)]) -> (InMemoryGraph, Vec<Entity>) {
+    let parsed: Vec<(FileParseData, Vec<Entity>)> = sources
+        .iter()
+        .map(|(path, source)| parse(path, source))
+        .collect();
+    let files: Vec<FileParseData> = parsed.iter().map(|(file, _)| file.clone()).collect();
+    let entities: Vec<Entity> = parsed
+        .iter()
+        .flat_map(|(_, entities)| entities.iter().cloned())
+        .collect();
+
+    let graph = InMemoryGraph::new();
+    let artifact_ids = admit_file_artifacts(&graph, &files);
+    let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
+    for entity in &entities {
+        graph.upsert_entity(entity).expect("upsert entity");
+    }
+    for relation in &relations {
+        graph.upsert_relation(relation).expect("upsert relation");
+    }
+    (graph, entities)
+}
+
+fn focal(entities: &[Entity], name: &str, file: &str) -> Entity {
+    entities
+        .iter()
+        .find(|entity| {
+            entity.name == name && entity.file_origin.as_ref().is_some_and(|f| f.0 == file)
+        })
+        .unwrap_or_else(|| panic!("fixture entity `{name}` in {file} not found"))
+        .clone()
+}
+
+/// Resolved `Calls` edges leaving one file, counted the way the gate counts
+/// them, so the fixture cannot drift into proving something else.
+fn resolved_call_edges(graph: &InMemoryGraph, entities: &[Entity], file: &str) -> u64 {
+    let mut total = 0;
+    for entity in entities
+        .iter()
+        .filter(|entity| entity.file_origin.as_ref().is_some_and(|f| f.0 == file))
+    {
+        let relations = graph
+            .get_all_relations_for_entity(&entity.id)
+            .expect("relations read");
+        total += relations
+            .iter()
+            .filter(|relation| {
+                relation.kind == RelationKind::Calls && relation.src.as_entity() == Some(entity.id)
+            })
+            .count() as u64;
+    }
+    total as u64
+}
+
+/// The finding, in one reading. The gate must name the file holding a call the
+/// graph never saw, and must not name the file whose calls all became edges.
+#[test]
+fn the_gate_names_only_the_family_file_holding_an_unresolved_call() {
+    let (graph, entities) = project(&[
+        ("notepkg/__init__.py", ""),
+        ("notepkg/store.py", STORE_PY),
+        ("notepkg/clean.py", CLEAN_PY),
+        ("notepkg/messy.py", MESSY_PY),
+    ]);
+    let note_body = focal(&entities, "note_body", "notepkg/store.py");
+
+    // The fixture's own premises, asserted before the verdict is read. Without
+    // these a family that collapsed to nothing would certify and read as a pass.
+    let arrival = observe_caller_arrival(&graph, &note_body);
+    assert_eq!(
+        arrival.family_files, 2,
+        "both importers must reach the family, or the verdict below is about a different set"
+    );
+    assert_eq!(
+        arrival.family_measured, 2,
+        "and both must carry a parse-side count, which is the whole point of this ticket"
+    );
+    assert_eq!(
+        resolved_call_edges(&graph, &entities, "notepkg/clean.py"),
+        2,
+        "the control file's two calls must both become edges, or it is not a clean control"
+    );
+    assert_eq!(
+        resolved_call_edges(&graph, &entities, "notepkg/messy.py"),
+        2,
+        "and the subject file must resolve the same two, so the only difference between them \
+         is the call site that produced no relation"
+    );
+
+    assert_eq!(
+        arrival.state,
+        ArrivalState::Unaccounted,
+        "a family file holding a call the graph never saw must stop certification"
+    );
+    let named: Vec<&str> = arrival
+        .unaccounted
+        .iter()
+        .map(|file| file.file.as_str())
+        .collect();
+    assert_eq!(
+        named,
+        vec!["notepkg/messy.py"],
+        "and only that file: naming the clean sibling too is the blanket refusal this gate \
+         exists to avoid"
+    );
+    let row = &arrival.unaccounted[0];
+    assert_eq!(
+        (
+            row.parsed_call_sites,
+            row.resolved_call_edges,
+            row.unaccounted_call_sites
+        ),
+        (Some(3), 2, Some(1)),
+        "and the row must carry the arithmetic it rests on, not a bare refusal"
+    );
+}
+
+/// The control that keeps the gate from being a blanket refusal over every
+/// Python family. Replace the one unnameable call with a sibling that resolves
+/// everything, and the same focal certifies.
+#[test]
+fn a_family_whose_every_call_resolved_still_certifies() {
+    let (graph, entities) = project(&[
+        ("notepkg/__init__.py", ""),
+        ("notepkg/store.py", STORE_PY),
+        ("notepkg/clean.py", CLEAN_PY),
+        ("notepkg/second.py", SECOND_CLEAN_PY),
+    ]);
+    let note_body = focal(&entities, "note_body", "notepkg/store.py");
+
+    let arrival = observe_caller_arrival(&graph, &note_body);
+    assert_eq!(
+        arrival.family_files, 2,
+        "the control must have the same family size as the subject"
+    );
+    assert_eq!(arrival.family_measured, 2, "and the same measured coverage");
+    assert_eq!(
+        arrival.state,
+        ArrivalState::Accounted,
+        "a family whose every call site became an edge must certify: {:?}",
+        arrival.unaccounted
+    );
+    assert!(
+        arrival.unaccounted.is_empty(),
+        "and name nothing: {:?}",
+        arrival.unaccounted
+    );
+}

--- a/crates/kin-cli/tests/caller_arrival_separates_a_measured_shortfall.rs
+++ b/crates/kin-cli/tests/caller_arrival_separates_a_measured_shortfall.rs
@@ -27,7 +27,7 @@ use kin_db::InMemoryGraph;
 use kin_index::{link_cross_file, FileParseData, IndexPipeline};
 use kin_mcp::caller_arrival::{observe_caller_arrival, ArrivalState};
 use kin_model::{
-    ArtifactId, Entity, FilePathId, GraphStore, Hash256, LocatedEntry, RelationKind, RepoPath,
+    ArtifactId, Entity, EntityStore, FilePathId, Hash256, LocatedEntry, RelationKind, RepoPath,
     TransactionDelta, TreeDelta, TreeEntry,
 };
 
@@ -78,7 +78,7 @@ fn parse(path: &str, source: &str) -> (FileParseData, Vec<Entity>) {
         .index_file_content_with_tests(
             &FilePathId::new(path),
             source.as_bytes(),
-            Hash256::from_bytes([5; 32]),
+            kin_blobs::Hash256::from_bytes([5; 32]),
         )
         .unwrap_or_else(|error| panic!("indexing {path} failed: {error}"))
         .indexed_file;
@@ -159,7 +159,7 @@ fn focal(entities: &[Entity], name: &str, file: &str) -> Entity {
 /// Resolved `Calls` edges leaving one file, counted the way the gate counts
 /// them, so the fixture cannot drift into proving something else.
 fn resolved_call_edges(graph: &InMemoryGraph, entities: &[Entity], file: &str) -> u64 {
-    let mut total = 0;
+    let mut total: u64 = 0;
     for entity in entities
         .iter()
         .filter(|entity| entity.file_origin.as_ref().is_some_and(|f| f.0 == file))
@@ -174,7 +174,7 @@ fn resolved_call_edges(graph: &InMemoryGraph, entities: &[Entity], file: &str) -
             })
             .count() as u64;
     }
-    total as u64
+    total
 }
 
 /// The finding, in one reading. The gate must name the file holding a call the

--- a/crates/kin-cli/tests/caller_arrival_separates_a_measured_shortfall.rs
+++ b/crates/kin-cli/tests/caller_arrival_separates_a_measured_shortfall.rs
@@ -31,7 +31,11 @@ use kin_model::{
     TransactionDelta, TreeDelta, TreeEntry,
 };
 
-const STORE_PY: &str = r#"def open_db():
+const STORE_PY: &str = r#"def audited(fn):
+    return fn
+
+
+def open_db():
     return {}
 
 
@@ -39,12 +43,19 @@ def note_body(db, note_id):
     return ""
 "#;
 
-/// Two call sites, and the linker records an edge for both. The receiver call
-/// is what made the extractor withhold this file's count.
+/// Three call sites, and the linker records an edge for all three. The receiver
+/// call is what made the extractor withhold this file's count.
+///
+/// The bare decorator is the third site and it is the one that decides this
+/// test. It produces a `Calls` relation and no `call` node, so a census counting
+/// only `call` nodes reports two against three edges here, the gate's shortfall
+/// floors at zero, and this file drops out of `unaccounted` while holding a site
+/// the graph never saw.
 const CLEAN_PY: &str = r#"from notepkg import store
-from notepkg.store import note_body
+from notepkg.store import audited, note_body
 
 
+@audited
 def summarize(note_id):
     db = store.open_db()
     return note_body(db, note_id)
@@ -65,9 +76,10 @@ def summarize_messy(note_id, handlers):
 /// The same family shape as `messy.py` with the unnameable call removed, so the
 /// control differs from the subject in exactly one call site.
 const SECOND_CLEAN_PY: &str = r#"from notepkg import store
-from notepkg.store import note_body
+from notepkg.store import audited, note_body
 
 
+@audited
 def summarize_again(note_id):
     db = store.open_db()
     return note_body(db, note_id)
@@ -156,6 +168,21 @@ fn focal(entities: &[Entity], name: &str, file: &str) -> Entity {
         .clone()
 }
 
+/// The parse-side count stamped on a file's entities, read the way every
+/// consumer reads it.
+fn stamped_call_sites(entities: &[Entity], file: &str) -> Option<u64> {
+    entities
+        .iter()
+        .filter(|entity| entity.file_origin.as_ref().is_some_and(|f| f.0 == file))
+        .find_map(|entity| {
+            entity
+                .metadata
+                .extra
+                .get(kin_parser::FILE_PARSED_CALL_SITES_KEY)
+                .and_then(serde_json::Value::as_u64)
+        })
+}
+
 /// Resolved `Calls` edges leaving one file, counted the way the gate counts
 /// them, so the fixture cannot drift into proving something else.
 fn resolved_call_edges(graph: &InMemoryGraph, entities: &[Entity], file: &str) -> u64 {
@@ -202,14 +229,28 @@ fn the_gate_names_only_the_family_file_holding_an_unresolved_call() {
     );
     assert_eq!(
         resolved_call_edges(&graph, &entities, "notepkg/clean.py"),
-        2,
-        "the control file's two calls must both become edges, or it is not a clean control"
+        3,
+        "the control file's two calls and its decorator must all become edges, or it is not a \
+         clean control"
     );
     assert_eq!(
         resolved_call_edges(&graph, &entities, "notepkg/messy.py"),
         2,
-        "and the subject file must resolve the same two, so the only difference between them \
-         is the call site that produced no relation"
+        "and the subject file must resolve its two, so the only difference between the two \
+         files is the call site that produced no relation"
+    );
+    // The shape the reviewer of this lane found, asserted where it bites, and
+    // deliberately NOT off `arrival.unaccounted`. A file whose parsed count
+    // falls below its resolved count is exactly the file the gate drops from
+    // that list, because `saturating_sub` floors the shortfall at zero, so an
+    // assertion ranging over the list cannot see the defect it is written for.
+    // The store is where it is visible.
+    assert_eq!(
+        stamped_call_sites(&entities, "notepkg/clean.py"),
+        Some(resolved_call_edges(&graph, &entities, "notepkg/clean.py")),
+        "a file whose every call site became an edge must report exactly as many sites as the \
+         graph holds edges for it; fewer means the gate floors the difference at zero and \
+         certifies over a call site the graph never saw"
     );
 
     assert_eq!(

--- a/crates/kin-core/src/reference_coverage.rs
+++ b/crates/kin-core/src/reference_coverage.rs
@@ -994,8 +994,17 @@ fn classify(
         // `[resolved]` under a no-issues banner.
         None | Some(0) => ReferenceResolution::Unmeasured,
         Some(_) if resolved_call_edges == 0 => ReferenceResolution::NoneResolved,
-        Some(parsed) if resolved_call_edges < parsed => ReferenceResolution::PartiallyResolved,
-        Some(_) => ReferenceResolution::FullyResolved,
+        // Fully resolved is the claim that every parsed call site became an
+        // edge, and only an exact match says that. MORE edges than sites is not
+        // a stronger result, it is fan-out: one ambiguous call site binds
+        // several same-named targets under the linker's fanout cap, so the
+        // numerator counts edges the denominator never counted sites for and
+        // the ratio stops being coverage. Reading that as `[resolved]` is the
+        // same wrong word the zero-denominator case above produced, arrived at
+        // from the other side, and it became reachable for Python the moment
+        // the parse side started being measured at all.
+        Some(parsed) if resolved_call_edges == parsed => ReferenceResolution::FullyResolved,
+        Some(_) => ReferenceResolution::PartiallyResolved,
     }
 }
 
@@ -2028,6 +2037,49 @@ mod tests {
             resolution: ReferenceResolution::FullyResolved,
             reference_enrichment: enrichment,
         }
+    }
+
+    /// Fan-out can put more edges on the numerator than the denominator ever
+    /// counted sites for, and the word `resolved` must not follow it there.
+    ///
+    /// One ambiguous call site binds several same-named targets under the
+    /// linker's fanout cap, so `resolved > parsed` is a real state on a real
+    /// repository rather than a hypothetical. It became reachable for Python
+    /// the moment the parse side started being measured at all: before that,
+    /// the zero denominator held every Python row at `Unmeasured`. Reading it
+    /// as `FullyResolved` prints `[resolved]` and `100%` off a ratio that is no
+    /// longer coverage, which is the same wrong word the zero-denominator case
+    /// produced, arrived at from the other side.
+    #[test]
+    fn more_edges_than_sites_is_not_fully_resolved() {
+        assert_eq!(
+            classify(1, Some(4), 4),
+            ReferenceResolution::FullyResolved,
+            "an exact match is the only thing that says every parsed site became an edge"
+        );
+        assert_eq!(
+            classify(1, Some(4), 5),
+            ReferenceResolution::PartiallyResolved,
+            "more edges than sites is fan-out, not a stronger result, so the row must not claim \
+             the call side is fully resolved"
+        );
+        // The controls on either side of the new arm, so a fix that floors
+        // everything to partial is visible here rather than in a later ticket.
+        assert_eq!(
+            classify(1, Some(4), 3),
+            ReferenceResolution::PartiallyResolved,
+            "fewer edges than sites is still partial"
+        );
+        assert_eq!(
+            classify(1, Some(4), 0),
+            ReferenceResolution::NoneResolved,
+            "and no edges at all is still the state an absence cannot be concluded from"
+        );
+        assert_eq!(
+            classify(1, None, 5),
+            ReferenceResolution::Unmeasured,
+            "and an absent parse side is still unmeasured rather than resolved"
+        );
     }
 
     #[test]

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -145,6 +145,7 @@ impl IndexPipeline {
             imports,
             tests,
             parse_state,
+            parsed_call_sites,
         } = output;
 
         let role = classify_file_role(&file_id.0);
@@ -170,7 +171,12 @@ impl IndexPipeline {
             })
             .collect();
         attach_file_context_metadata(&mut entities, file_id, &imports);
-        attach_file_reference_parse_counts(&mut entities, &extracted_relations, &imports);
+        attach_file_reference_parse_counts(
+            &mut entities,
+            &extracted_relations,
+            &imports,
+            parsed_call_sites,
+        );
         attach_equivalence_class(&mut entities, &tree, source, language);
         if language == LanguageId::Go {
             kin_parser::attach_go_command_effect_contract_metadata(&tree, source, &mut entities);
@@ -298,6 +304,7 @@ impl IndexPipeline {
             imports,
             tests,
             parse_state,
+            parsed_call_sites,
         } = output;
 
         // Convert extracted entities to model entities.
@@ -324,7 +331,12 @@ impl IndexPipeline {
             })
             .collect();
         attach_file_context_metadata(&mut entities, file_id, &imports);
-        attach_file_reference_parse_counts(&mut entities, &extracted_relations, &imports);
+        attach_file_reference_parse_counts(
+            &mut entities,
+            &extracted_relations,
+            &imports,
+            parsed_call_sites,
+        );
         attach_equivalence_class(&mut entities, &tree, &source, language);
         if language == LanguageId::Go {
             kin_parser::attach_go_command_effect_contract_metadata(&tree, &source, &mut entities);

--- a/crates/kin-index/tests/certified_answers_account_for_the_file.rs
+++ b/crates/kin-index/tests/certified_answers_account_for_the_file.rs
@@ -176,13 +176,20 @@ fn a_file_with_a_broken_top_level_statement_cannot_certify_its_enumeration() {
 /// Two things are asserted and they are different claims. The first is the
 /// finding itself: the call produces no entity-level `Calls` edge, so
 /// `find_references("note_body")` sees nothing. The second is the one the
-/// certification gate rests on: the parser withholds the file's call-site count
-/// when it could not represent a call, and that withheld count is the signal
-/// `kin_mcp::caller_arrival` reads to decline authority. Without this second
-/// assertion the gate is tested only against a hand-built store and could be
-/// keyed on a signal the real path never emits.
+/// certification gate rests on: the file reports how many call sites it holds,
+/// which is the number `kin_mcp::caller_arrival` subtracts the graph's resolved
+/// edges from. Without this second assertion the gate is tested only against a
+/// hand-built store and could be keyed on a signal the real path never emits.
+///
+/// This arm asserted the opposite until FIR-2828: the extractor used to
+/// withhold the count from any file whose call extraction it could not fully
+/// represent, and the gate keyed on that absence. The absence was the right
+/// refusal for the wrong number, since the count it withheld was taken off the
+/// relations it emitted and understated any file holding a call it could not
+/// name. Counting the call sites instead makes the number safe to report, and a
+/// count that is present is the only one the gate can do arithmetic with.
 #[test]
-fn an_absolute_module_import_attribute_call_leaves_the_files_call_count_withheld() {
+fn an_absolute_module_import_attribute_call_still_counts_the_files_call_sites() {
     let caller = index(
         "tests/test_storage.py",
         "from notekeeper import storage\n\n\ndef test_bodies_round_trip(db, note):\n    assert \"x\" in storage.note_body(db, note.id)\n",
@@ -205,22 +212,26 @@ fn an_absolute_module_import_attribute_call_leaves_the_files_call_count_withheld
         "the call must carry its receiver; the receiver is what the failing tier keys on"
     );
 
-    // The signal the certification gate reads. The extractor removes this key
-    // from every entity of a file whose call extraction it could not represent,
-    // and a reader treats an absent count as unmeasured rather than as zero.
-    // `kin_mcp::caller_arrival` reads exactly this absence.
+    // The number the certification gate subtracts from. It is stamped on every
+    // entity of the file, because a consumer settles the file on whichever one
+    // it reads first, and it counts the call sites the file holds rather than
+    // the relations extraction emitted: this file writes one call, and the
+    // linker records no entity-level edge for it, so the gate must see one
+    // parsed site against zero edges and decline.
     assert!(
         !caller.entities.is_empty(),
         "the fixture must produce entities, or the count would be absent for the wrong reason"
     );
     for entity in &caller.entities {
-        assert!(
-            !entity
+        assert_eq!(
+            entity
                 .metadata
                 .extra
-                .contains_key(kin_parser::FILE_PARSED_CALL_SITES_KEY),
-            "a file whose call extraction was incomplete must withhold its call-site count, \
-             because a zero there reads as a fully accounted file: {} carries {:?}",
+                .get(kin_parser::FILE_PARSED_CALL_SITES_KEY)
+                .and_then(serde_json::Value::as_u64),
+            Some(1),
+            "every entity of the file must carry the file's one call site, or the gate has \
+             nothing to subtract the graph's edges from: {} carries {:?}",
             entity.name,
             entity
                 .metadata

--- a/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
+++ b/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
@@ -270,6 +270,36 @@ fn a_call_outside_every_function_body_is_still_a_call_site() {
     );
 }
 
+/// The call-form decorator must be counted exactly once, not twice.
+///
+/// `@app.route("/")` holds a real `call` node AND yields a decorator name, so
+/// the two producers overlap on it and the emitter pushes exactly one relation.
+/// Counting every decorator site regardless would count this one twice, which
+/// inflates the parsed side and makes the arrival gate refuse a file whose
+/// calls all resolved. That is the opposite error from the one this fix is
+/// about, and it is the reason the census excludes a decorator holding a `call`
+/// node rather than counting decorators outright.
+#[test]
+fn a_decorator_written_as_a_call_is_counted_once() {
+    let indexed = index(
+        "notepkg/routed.py",
+        "@app.route(\"/\")\ndef handler():\n    return \"\"\n",
+    );
+
+    let emitted = emitted_call_relations(&indexed);
+    assert_eq!(
+        emitted, 1,
+        "the emitter pushes one relation for a call-form decorator, or this fixture is not the \
+         overlapping shape"
+    );
+    assert_eq!(
+        stamped_call_sites(&indexed.entities, "notepkg/routed.py"),
+        Some(1),
+        "a decorator written as a call is one call site, counted through its own `call` node; \
+         counting the decorator too would report two and refuse a file whose calls all resolved"
+    );
+}
+
 /// The other stamp site, which nothing else here reaches.
 ///
 /// `IndexPipeline` stamps in two places: the content path every other test in

--- a/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
+++ b/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! FIR-2828. The scripted check for the class where a completeness denominator
+//! never reaches the store it is supposed to qualify.
+//!
+//! `kin_mcp::caller_arrival` decides whether an absence may be certified by
+//! subtracting a file's resolved `Calls` edges from the call sites the parser
+//! read there. The parse side of that subtraction is
+//! [`kin_parser::FILE_PARSED_CALL_SITES_KEY`], and on a converted Python
+//! repository it was absent from every file: the extractor withheld it from any
+//! file whose call extraction it could not fully represent, which on real Python
+//! is nearly all of them. So the gate had no numerator to subtract from, every
+//! file landed in its absent-count branch, and a file whose every call became an
+//! edge was indistinguishable from one holding calls the graph never saw.
+//!
+//! Two claims are asserted here and they are different. The first is that the
+//! count is the file's WHOLE call side rather than the relations extraction
+//! managed to emit, because a short count subtracts to zero and reads as a fully
+//! accounted file. The second is that the count survives the conversion path, so
+//! the gate is not keyed on a signal only a hand-built fixture emits.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use kin_blobs::BlobStore;
+use kin_git::{
+    admit_semantic_git_import, capture_lossless_git_repository, plan_semantic_git_import,
+};
+use kin_index::{derive_historical_semantic_deltas, IndexPipeline};
+use kin_model::{
+    ChangeStore, Entity, EntityDelta, FilePathId, Relation, RelationDelta, RelationKind,
+    RepositoryId, SemanticChange,
+};
+
+/// The focal's file. Nothing here reaches outward, so it never joins its own
+/// family.
+const STORE_PY: &str = r#"def open_db():
+    return {}
+
+
+def note_body(db, note_id):
+    return ""
+"#;
+
+/// A family file with no shortfall: two call sites, and the linker records an
+/// edge for both. The receiver call is what made the extractor withhold this
+/// file's count, and it is also an edge the graph holds.
+const CLEAN_PY: &str = r#"from notepkg import store
+from notepkg.store import note_body
+
+
+def summarize(note_id):
+    db = store.open_db()
+    return note_body(db, note_id)
+"#;
+
+/// A family file with a real shortfall: three call sites, two relations. The
+/// subscript callee has no name the extractor can bind, so it produces no
+/// relation at all and a count taken off the relations cannot see it.
+const MESSY_PY: &str = r#"from notepkg import store
+from notepkg.store import note_body
+
+
+def summarize_messy(note_id, handlers):
+    db = store.open_db()
+    body = note_body(db, note_id)
+    return handlers["render"](body)
+"#;
+
+fn blob_hash() -> kin_blobs::Hash256 {
+    kin_blobs::Hash256::from_bytes([9; 32])
+}
+
+fn index(path: &str, source: &str) -> kin_index::IndexedFile {
+    IndexPipeline::new()
+        .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash())
+        .unwrap_or_else(|error| panic!("indexing {path} failed: {error}"))
+        .indexed_file
+}
+
+/// The one count every entity of a file carries, read the way every consumer
+/// reads it.
+fn stamped_call_sites(entities: &[Entity], path: &str) -> Option<u64> {
+    let of_file: Vec<&Entity> = entities
+        .iter()
+        .filter(|entity| entity.file_origin.as_ref().is_some_and(|f| f.0 == path))
+        .collect();
+    assert!(
+        !of_file.is_empty(),
+        "no entity of {path} reached the store, so its count would be absent for the wrong reason"
+    );
+    let counts: BTreeSet<Option<u64>> = of_file
+        .iter()
+        .map(|entity| {
+            entity
+                .metadata
+                .extra
+                .get(kin_parser::FILE_PARSED_CALL_SITES_KEY)
+                .and_then(serde_json::Value::as_u64)
+        })
+        .collect();
+    assert_eq!(
+        counts.len(),
+        1,
+        "every entity of {path} must carry the same count, since a consumer settles the file on \
+         whichever entity it reads first: {counts:?}"
+    );
+    counts.into_iter().next().expect("one count")
+}
+
+fn emitted_call_relations(indexed: &kin_index::IndexedFile) -> usize {
+    indexed
+        .extracted_relations
+        .iter()
+        .filter(|relation| relation.kind == RelationKind::Calls)
+        .count()
+}
+
+/// The claim the gate's arithmetic rests on: the stamped number is the file's
+/// whole call side, not the relations extraction managed to emit.
+///
+/// `messy.py` writes three calls. Two carry a name the extractor can bind and
+/// become relations; `handlers["render"](body)` does not and becomes nothing.
+/// A count taken off the relations reports two, the graph resolves two, and the
+/// subtraction finds no shortfall on a file holding a call the graph never saw.
+#[test]
+fn a_file_whose_callee_cannot_be_named_still_reports_every_call_site() {
+    let indexed = index("notepkg/messy.py", MESSY_PY);
+
+    assert_eq!(
+        emitted_call_relations(&indexed),
+        2,
+        "the fixture must hold exactly one call the extractor cannot represent, or it is not \
+         testing the gap between the two numbers"
+    );
+    assert_eq!(
+        stamped_call_sites(&indexed.entities, "notepkg/messy.py"),
+        Some(3),
+        "the stamped count must be every call site the file holds, including the one that \
+         produced no relation"
+    );
+}
+
+/// The control, and it is what keeps the change from being a blanket inflation.
+/// A file whose every call site became a relation reports exactly the number it
+/// always reported, so no reading that was already right moves.
+#[test]
+fn a_file_whose_calls_all_became_relations_reports_the_number_it_always_did() {
+    let indexed = index("notepkg/clean.py", CLEAN_PY);
+
+    let emitted = emitted_call_relations(&indexed);
+    assert_eq!(
+        emitted, 2,
+        "the control fixture must emit both of its calls"
+    );
+    assert_eq!(
+        stamped_call_sites(&indexed.entities, "notepkg/clean.py"),
+        Some(emitted as u64),
+        "a file with nothing unrepresentable must report the relation count, or the census and \
+         the relations disagree where they must not"
+    );
+}
+
+/// A call written where no callable entity owns the edge is still a call site
+/// the graph holds no edge for, so it counts. Module scope is the cheapest
+/// instance and the one a converted repository is full of.
+#[test]
+fn a_call_outside_every_function_body_is_still_a_call_site() {
+    let indexed = index(
+        "notepkg/toplevel.py",
+        "from notepkg import store\n\nDB = store.open_db()\n\n\ndef reader(note_id):\n    return DB\n",
+    );
+
+    assert_eq!(
+        emitted_call_relations(&indexed),
+        0,
+        "a module-scope call owns no calling entity, so the extractor emits no relation for it"
+    );
+    assert_eq!(
+        stamped_call_sites(&indexed.entities, "notepkg/toplevel.py"),
+        Some(1),
+        "and it is still a call site, so the file's count is one rather than absent or zero"
+    );
+}
+
+/// The join, over the path a brownfield repository actually takes. Every claim
+/// above is about one parse; this is about what a converted store holds, which
+/// is the surface `kin graph status` and `caller_arrival` read.
+#[test]
+fn every_file_of_a_converted_history_carries_its_call_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = admit_repository(
+        dir.path(),
+        "fir2828-parse-side-counts",
+        &[
+            ("notepkg/__init__.py", ""),
+            ("notepkg/store.py", STORE_PY),
+            ("notepkg/clean.py", CLEAN_PY),
+            ("notepkg/messy.py", MESSY_PY),
+        ],
+    );
+
+    let mut files: BTreeSet<String> = BTreeSet::new();
+    for entity in &repo.entities {
+        // An external reference target stands for a symbol another repository
+        // owns. It has no file, so it has no call side and is not what this is
+        // about.
+        if kin_index::is_external_reference_target(entity) {
+            continue;
+        }
+        if let Some(file) = entity.file_origin.as_ref() {
+            files.insert(file.0.clone());
+        }
+    }
+    assert_eq!(
+        files.iter().cloned().collect::<Vec<_>>(),
+        vec![
+            "notepkg/__init__.py".to_string(),
+            "notepkg/clean.py".to_string(),
+            "notepkg/messy.py".to_string(),
+            "notepkg/store.py".to_string(),
+        ],
+        "the conversion must hold entities for every file, or a missing count below would be \
+         missing for the wrong reason"
+    );
+
+    let mut unmeasured = Vec::new();
+    for file in &files {
+        if stamped_call_sites(&repo.entities, file).is_none() {
+            unmeasured.push(file.clone());
+        }
+    }
+    assert!(
+        unmeasured.is_empty(),
+        "a converted store must carry a parse-side call count for every file whose entities it \
+         holds; these carry none: {unmeasured:?}"
+    );
+
+    assert_eq!(
+        stamped_call_sites(&repo.entities, "notepkg/messy.py"),
+        Some(3),
+        "and the count that survives conversion is the whole call side, not the relations"
+    );
+    assert_eq!(
+        stamped_call_sites(&repo.entities, "notepkg/clean.py"),
+        Some(2),
+        "while the file with nothing unrepresentable is unchanged"
+    );
+}
+
+/// One admitted repository, reduced to the entity and relation state its
+/// first-parent history replays to.
+struct AdmittedRepository {
+    entities: Vec<Entity>,
+    #[allow(dead_code)]
+    relations: Vec<Relation>,
+}
+
+/// Build a Git repository from `files`, admit it exactly as `kin init` does,
+/// and replay its first-parent history into entity and relation state.
+fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> AdmittedRepository {
+    std::fs::create_dir_all(dir).unwrap();
+    git_ok(dir, ["init", "--quiet", "--initial-branch", "main"]);
+    git_ok(dir, ["config", "user.name", "Fixture"]);
+    git_ok(dir, ["config", "user.email", "fixture@example.invalid"]);
+    for (path, body) in files {
+        let file = dir.join(path);
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, body).unwrap();
+    }
+    git_ok(dir, ["add", "--all"]);
+    git_ok(dir, ["commit", "--quiet", "--message", "seed"]);
+
+    let blob_store = BlobStore::new(dir.join(".fixture-cas")).unwrap();
+    let snapshot = capture_lossless_git_repository(
+        dir,
+        RepositoryId::new(repository_id).unwrap(),
+        &blob_store,
+    )
+    .unwrap();
+    let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+    let trees = plan
+        .aliases
+        .iter()
+        .map(|alias| {
+            (
+                alias.change_id,
+                plan.commit_trees
+                    .get(&alias.oid)
+                    .expect("every imported commit has an exact resolved tree")
+                    .clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let bindings = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store)
+        .unwrap()
+        .into_iter()
+        .map(|delta| {
+            kin_git::HistoricalSemanticBinding::owned(
+                delta.change_id,
+                delta.entity_deltas,
+                delta.relation_deltas,
+            )
+        })
+        .collect::<Vec<_>>();
+    let admitted = admit_semantic_git_import(
+        &plan
+            .with_historical_semantics(&blob_store, bindings)
+            .unwrap(),
+        &blob_store,
+    )
+    .unwrap();
+    admitted.validate(&blob_store).unwrap();
+
+    let graph = kin_db::InMemoryGraph::new();
+    for change in &admitted.changes {
+        graph.create_change(change).unwrap();
+    }
+    let head = admitted
+        .changes
+        .iter()
+        .map(|change| change.id)
+        .find(|candidate| {
+            !admitted
+                .changes
+                .iter()
+                .any(|change| change.parents.contains(candidate))
+        })
+        .expect("history must have a head");
+    graph
+        .resolve_graph_at(&head)
+        .expect("admitted history must replay");
+
+    replay_first_parent(&admitted.changes)
+}
+
+/// Apply every change's deltas in parent-first order, the way durable authority
+/// replay derives the state a workspace reports.
+fn replay_first_parent(changes: &[SemanticChange]) -> AdmittedRepository {
+    let known: BTreeSet<_> = changes.iter().map(|change| change.id).collect();
+    let mut applied = BTreeSet::new();
+    let mut ordered = Vec::with_capacity(changes.len());
+    while ordered.len() < changes.len() {
+        let next = changes
+            .iter()
+            .find(|change| {
+                !applied.contains(&change.id)
+                    && change
+                        .parents
+                        .iter()
+                        .all(|parent| !known.contains(parent) || applied.contains(parent))
+            })
+            .expect("the admitted change set must be a DAG rooted in this history");
+        applied.insert(next.id);
+        ordered.push(next);
+    }
+
+    let mut entities = BTreeMap::new();
+    let mut relations = BTreeMap::new();
+    for change in ordered {
+        for delta in &change.entity_deltas {
+            match delta {
+                EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => {
+                    entities.insert(new.id, new.clone());
+                }
+                EntityDelta::Removed { old } => {
+                    entities.remove(&old.id);
+                }
+            }
+        }
+        for delta in &change.relation_deltas {
+            match delta {
+                RelationDelta::Added { new } | RelationDelta::Modified { new, .. } => {
+                    relations.insert(new.id, new.clone());
+                }
+                RelationDelta::Removed { old } => {
+                    relations.remove(&old.id);
+                }
+            }
+        }
+    }
+
+    AdmittedRepository {
+        entities: entities.into_values().collect(),
+        relations: relations.into_values().collect(),
+    }
+}
+
+fn git_ok<I, S>(repo: &Path, args: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = git_output(repo, args);
+    assert!(
+        output.status.success(),
+        "git failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_output<I, S>(repo: &Path, args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("git runs")
+}

--- a/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
+++ b/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
@@ -37,7 +37,11 @@ use kin_model::{
 
 /// The focal's file. Nothing here reaches outward, so it never joins its own
 /// family.
-const STORE_PY: &str = r#"def open_db():
+const STORE_PY: &str = r#"def audited(fn):
+    return fn
+
+
+def open_db():
     return {}
 
 
@@ -45,13 +49,19 @@ def note_body(db, note_id):
     return ""
 "#;
 
-/// A family file with no shortfall: two call sites, and the linker records an
-/// edge for both. The receiver call is what made the extractor withhold this
-/// file's count, and it is also an edge the graph holds.
+/// A family file with no shortfall: three call sites, and the linker records an
+/// edge for all three. The receiver call is what made the extractor withhold
+/// this file's count, and it is also an edge the graph holds.
+///
+/// The bare decorator is the third site and it is the sharp one. It produces a
+/// `Calls` relation and no `call` node, so a census counting only `call` nodes
+/// reports two against three edges, which is the shape that puts the stamped
+/// count BELOW the resolved edge count.
 const CLEAN_PY: &str = r#"from notepkg import store
-from notepkg.store import note_body
+from notepkg.store import audited, note_body
 
 
+@audited
 def summarize(note_id):
     db = store.open_db()
     return note_body(db, note_id)
@@ -68,6 +78,22 @@ def summarize_messy(note_id, handlers):
     db = store.open_db()
     body = note_body(db, note_id)
     return handlers["render"](body)
+"#;
+
+/// A file whose extraction is COMPLETE, so the old code measured it and stamped
+/// the relations it emitted. Every call site here became a relation, the callee
+/// of the one call is a bare imported name, and the decorator is bare, so
+/// nothing is unrepresentable and nothing sits where the walker cannot reach it.
+///
+/// This is the fixture the no-regression invariant needs and `CLEAN_PY` is not:
+/// `store.open_db()` leaves that file incomplete, so its count was withheld and
+/// the number it "always did" report is a number it never had.
+const MEASURED_PY: &str = r#"from notepkg.store import audited, note_body
+
+
+@audited
+def summarize_measured(db, note_id):
+    return note_body(db, note_id)
 "#;
 
 fn blob_hash() -> kin_blobs::Hash256 {
@@ -111,6 +137,15 @@ fn stamped_call_sites(entities: &[Entity], path: &str) -> Option<u64> {
     counts.into_iter().next().expect("one count")
 }
 
+/// Whether the parser recorded that it could not represent every call in the
+/// file, which is the state that made the old code withhold the count.
+fn extraction_was_incomplete(indexed: &kin_index::IndexedFile) -> bool {
+    indexed
+        .extracted_relations
+        .iter()
+        .any(kin_parser::is_call_extraction_incomplete_marker)
+}
+
 fn emitted_call_relations(indexed: &kin_index::IndexedFile) -> usize {
     indexed
         .extracted_relations
@@ -144,23 +179,72 @@ fn a_file_whose_callee_cannot_be_named_still_reports_every_call_site() {
     );
 }
 
-/// The control, and it is what keeps the change from being a blanket inflation.
-/// A file whose every call site became a relation reports exactly the number it
-/// always reported, so no reading that was already right moves.
+/// The two sides must agree about what a Python call site is, and the bare
+/// decorator is where they disagreed.
+///
+/// `@audited` produces a `Calls` relation and no `call` node. A census counting
+/// only `call` nodes reports two here against three emitted relations, so the
+/// stamped count lands BELOW the resolved edge count, the arrival gate floors
+/// that difference at zero, and it certifies an absence over a file holding a
+/// call site the graph never saw. That is a correct refusal turning into a
+/// wrong certification, so the equality below is the assertion rather than the
+/// tally beside it.
+///
+/// This file is NOT a measured-file control despite what its name suggests, and
+/// the parse-state assertion says so out loud: `store.open_db()` leaves
+/// extraction incomplete, so the old code withheld this file's count entirely
+/// and the number it "always did" report is a number it never had. The
+/// invariant about readings that were already right lives on `MEASURED_PY` in
+/// the test below.
 #[test]
 fn a_file_whose_calls_all_became_relations_reports_the_number_it_always_did() {
     let indexed = index("notepkg/clean.py", CLEAN_PY);
 
     let emitted = emitted_call_relations(&indexed);
     assert_eq!(
-        emitted, 2,
-        "the control fixture must emit both of its calls"
+        emitted, 3,
+        "the fixture must emit two calls and one decorator edge, or it is not testing the \
+         direction where the parsed count falls below the resolved one"
+    );
+    assert!(
+        extraction_was_incomplete(&indexed),
+        "this fixture is deliberately an INCOMPLETE file, so nothing reads it as evidence about \
+         the files the old code measured"
     );
     assert_eq!(
         stamped_call_sites(&indexed.entities, "notepkg/clean.py"),
         Some(emitted as u64),
-        "a file with nothing unrepresentable must report the relation count, or the census and \
-         the relations disagree where they must not"
+        "every call site the extractor emitted an edge for must be in the count, or the stamped \
+         number sits below the resolved edge count and the gate certifies over the difference"
+    );
+}
+
+/// The no-regression invariant, on a file that really was measured before.
+///
+/// The change rests on the claim that no reading which was already right moves,
+/// and that claim is only testable on a file whose extraction was COMPLETE,
+/// because those are the only files the old code stamped at all. Every call
+/// site here became a relation and nothing sits where the walker cannot reach
+/// it, so the old code stamped the relation count and the new code must stamp
+/// the same number.
+#[test]
+fn a_file_that_was_already_measured_reports_the_number_it_always_did() {
+    let indexed = index("notepkg/measured.py", MEASURED_PY);
+
+    assert!(
+        !extraction_was_incomplete(&indexed),
+        "the fixture must parse to a COMPLETE extraction, or it is not a file the old code \
+         measured and the invariant has no guard again"
+    );
+    let emitted = emitted_call_relations(&indexed);
+    assert_eq!(
+        emitted, 2,
+        "one call and one decorator edge, so a census missing either one is visible here"
+    );
+    assert_eq!(
+        stamped_call_sites(&indexed.entities, "notepkg/measured.py"),
+        Some(emitted as u64),
+        "a file the old code measured must report the same number it always did"
     );
 }
 
@@ -186,6 +270,35 @@ fn a_call_outside_every_function_body_is_still_a_call_site() {
     );
 }
 
+/// The other stamp site, which nothing else here reaches.
+///
+/// `IndexPipeline` stamps in two places: the content path every other test in
+/// this file drives, and the incremental edit-hint path `kin_reconcile` drives
+/// on every save. The two edits are byte-identical, so the code is right by
+/// inspection, but inspection is not a check: a regression at the hint site
+/// alone would survive this whole suite, and the mutation that removes the
+/// stamp cannot separate them because it edits the one function they share.
+#[test]
+fn the_incremental_edit_hint_path_stamps_the_same_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let file = root.join("notepkg").join("clean.py");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(&file, CLEAN_PY).unwrap();
+    let blob_store = BlobStore::new(root.join(".hint-cas")).unwrap();
+
+    let (indexed, _tree) = IndexPipeline::new()
+        .index_file_relative_with_hint(&file, &blob_store, root, None, None)
+        .expect("the hint path indexes the fixture");
+
+    assert_eq!(
+        stamped_call_sites(&indexed.entities, "notepkg/clean.py"),
+        Some(3),
+        "the incremental path must stamp the same count the content path does, or a file saved \
+         through reconcile carries a different parse side than the same file converted"
+    );
+}
+
 /// The join, over the path a brownfield repository actually takes. Every claim
 /// above is about one parse; this is about what a converted store holds, which
 /// is the surface `kin graph status` and `caller_arrival` read.
@@ -199,6 +312,7 @@ fn every_file_of_a_converted_history_carries_its_call_count() {
             ("notepkg/__init__.py", ""),
             ("notepkg/store.py", STORE_PY),
             ("notepkg/clean.py", CLEAN_PY),
+            ("notepkg/measured.py", MEASURED_PY),
             ("notepkg/messy.py", MESSY_PY),
         ],
     );
@@ -220,6 +334,7 @@ fn every_file_of_a_converted_history_carries_its_call_count() {
         vec![
             "notepkg/__init__.py".to_string(),
             "notepkg/clean.py".to_string(),
+            "notepkg/measured.py".to_string(),
             "notepkg/messy.py".to_string(),
             "notepkg/store.py".to_string(),
         ],
@@ -246,8 +361,14 @@ fn every_file_of_a_converted_history_carries_its_call_count() {
     );
     assert_eq!(
         stamped_call_sites(&repo.entities, "notepkg/clean.py"),
+        Some(3),
+        "and the file whose bare decorator produces an edge counts that site too, so the count \
+         never lands below the edges the graph holds for it"
+    );
+    assert_eq!(
+        stamped_call_sites(&repo.entities, "notepkg/measured.py"),
         Some(2),
-        "while the file with nothing unrepresentable is unchanged"
+        "while a file the old code already measured survives conversion with the same number"
     );
 }
 

--- a/crates/kin-parser/src/extract.rs
+++ b/crates/kin-parser/src/extract.rs
@@ -399,24 +399,39 @@ pub fn attach_file_context_metadata(
 ///
 /// This is the parse side of reference-edge completeness. It is written where
 /// extraction already holds both numbers, so no surface has to re-parse to say
-/// how much of the relation graph resolved. A file whose parser recovery
-/// omitted calls records no call-site count rather than a count it cannot
-/// stand behind, and a reader treats an absent count as unmeasured rather than
-/// as zero.
+/// how much of the relation graph resolved. The call side comes from the
+/// adapter's own census when it took one, which counts every call site the file
+/// holds and not only the ones extraction could represent; where no census was
+/// taken the emitted relations are the count, and a file whose extraction was
+/// incomplete records no count at all, which a reader treats as unmeasured
+/// rather than as zero.
 pub fn attach_file_reference_parse_counts(
     entities: &mut [Entity],
     relations: &[ExtractedRelation],
     imports: &[FileImport],
+    parsed_call_sites: Option<u64>,
 ) {
     if entities.is_empty() {
         return;
     }
 
     let call_extraction_complete = !relations.iter().any(is_call_extraction_incomplete_marker);
-    let call_sites = relations
+    let representable_call_sites = relations
         .iter()
         .filter(|relation| relation.kind == RelationKind::Calls)
-        .count();
+        .count() as u64;
+    // An adapter that censused its call sites reports every one it read, so the
+    // count stands whether or not extraction could represent them all: it is
+    // the file's whole call side, and the sites that reached no relation are
+    // the difference a reader is entitled to see. Without a census the
+    // relations are all there is, and a file whose extraction was incomplete
+    // records no count at all rather than one it cannot stand behind, because a
+    // short count subtracts to zero and reads as a fully accounted file.
+    let call_sites = match parsed_call_sites {
+        Some(census) => Some(census),
+        None if call_extraction_complete => Some(representable_call_sites),
+        None => None,
+    };
     let import_statements = imports.len();
     let external_module_imports = imports
         .iter()
@@ -424,13 +439,16 @@ pub fn attach_file_reference_parse_counts(
         .count();
 
     for entity in entities {
-        if call_extraction_complete {
-            entity.metadata.extra.insert(
-                FILE_PARSED_CALL_SITES_KEY.into(),
-                serde_json::Value::from(call_sites),
-            );
-        } else {
-            entity.metadata.extra.remove(FILE_PARSED_CALL_SITES_KEY);
+        match call_sites {
+            Some(count) => {
+                entity.metadata.extra.insert(
+                    FILE_PARSED_CALL_SITES_KEY.into(),
+                    serde_json::Value::from(count),
+                );
+            }
+            None => {
+                entity.metadata.extra.remove(FILE_PARSED_CALL_SITES_KEY);
+            }
         }
         entity.metadata.extra.insert(
             FILE_PARSED_IMPORT_STATEMENTS_KEY.into(),
@@ -658,6 +676,21 @@ pub struct ParseOutput {
     /// Test functions discovered in this file.
     pub tests: Vec<ExtractedTest>,
     pub parse_state: ParseState,
+    /// Call sites this adapter counted in the file, including every one it
+    /// could not represent as a [`RelationKind::Calls`] relation.
+    ///
+    /// This is the denominator of reference-edge completeness, and it is
+    /// counted rather than derived from the relations because the two differ
+    /// exactly where the answer matters. A subscript or otherwise unnamed
+    /// callee, and a call written where no callable entity owns the edge,
+    /// produce no relation at all, so a denominator taken off the relations
+    /// understates the file and the shortfall it is subtracted from reads as
+    /// zero: a file the graph holds no edge for reports as fully accounted.
+    ///
+    /// `None` from an adapter that does not census its call sites. The
+    /// relations it emitted are the count then, which is the same number
+    /// whenever every call site became one.
+    pub parsed_call_sites: Option<u64>,
 }
 
 #[cfg(test)]
@@ -820,7 +853,7 @@ mod tests {
             import("@scope/thing"),
             import("#internal/shim"),
         ];
-        attach_file_reference_parse_counts(&mut entities, &[], &imports);
+        attach_file_reference_parse_counts(&mut entities, &[], &imports, None);
 
         let extra = &entities[0].metadata.extra;
         assert_eq!(
@@ -847,7 +880,12 @@ mod tests {
         let mut entity = test_entity("app/parsing.py");
         entity.language = LanguageId::Python;
         let mut entities = vec![entity];
-        attach_file_reference_parse_counts(&mut entities, &[], &[import("os"), import("helpers")]);
+        attach_file_reference_parse_counts(
+            &mut entities,
+            &[],
+            &[import("os"), import("helpers")],
+            None,
+        );
 
         let extra = &entities[0].metadata.extra;
         assert_eq!(

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -80,6 +80,7 @@ impl LanguageAdapter for CAdapter {
             imports,
             tests: Vec::new(),
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -98,6 +98,7 @@ impl LanguageAdapter for CppAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/go.rs
+++ b/crates/kin-parser/src/languages/go.rs
@@ -178,6 +178,7 @@ impl LanguageAdapter for GoAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/hcl.rs
+++ b/crates/kin-parser/src/languages/hcl.rs
@@ -77,6 +77,7 @@ impl LanguageAdapter for HclAdapter {
             imports,
             tests: Vec::new(),
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/java.rs
+++ b/crates/kin-parser/src/languages/java.rs
@@ -89,6 +89,7 @@ impl LanguageAdapter for JavaAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -144,6 +144,7 @@ impl LanguageAdapter for JavaScriptAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/kotlin.rs
+++ b/crates/kin-parser/src/languages/kotlin.rs
@@ -91,6 +91,7 @@ impl LanguageAdapter for KotlinAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/php.rs
+++ b/crates/kin-parser/src/languages/php.rs
@@ -93,6 +93,7 @@ impl LanguageAdapter for PhpAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -1457,9 +1457,15 @@ fn contains_call_node(node: &tree_sitter::Node) -> bool {
     if node.kind() == "call" {
         return true;
     }
+    // Bound rather than returned as the tail expression: the iterator borrows
+    // `cursor`, and a temporary at the end of a block outlives the block's own
+    // locals. `has_unobserved_call` carried the same binding for the same
+    // reason before this change replaced it.
     let mut cursor = node.walk();
-    node.children(&mut cursor)
-        .any(|child| contains_call_node(&child))
+    let found = node
+        .children(&mut cursor)
+        .any(|child| contains_call_node(&child));
+    found
 }
 
 struct PythonNamedCallee {

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -282,7 +282,11 @@ impl LanguageAdapter for PythonAdapter {
         // entity owns the edge. Keep syntax state and call-coverage completeness
         // separate: carry one reserved negative record to the linker, which
         // fails closed without rejecting the valid file.
-        if call_audit.incomplete || has_unobserved_call(&root, &call_audit.seen_calls) {
+        // One walk answers both questions. `seen_calls` holds one span per call
+        // node extraction visited, so the census is at least its size and
+        // exceeds it exactly when a call node was never visited at all.
+        let parsed_call_sites = count_python_call_sites(&root);
+        if call_audit.incomplete || parsed_call_sites > call_audit.seen_calls.len() as u64 {
             relations.push(call_extraction_incomplete_marker());
         }
 
@@ -366,7 +370,7 @@ impl LanguageAdapter for PythonAdapter {
             imports,
             tests,
             parse_state,
-            parsed_call_sites: Some(count_python_call_sites(&root)),
+            parsed_call_sites: Some(parsed_call_sites),
         })
     }
 }
@@ -1357,8 +1361,8 @@ struct PythonCallExtractionAudit {
 /// graph's resolved edges from that number finds no shortfall on a file whose
 /// calls the graph never saw.
 ///
-/// The traversal is every child rather than every named child, matching
-/// [`has_unobserved_call`], so the two agree about which nodes are call sites.
+/// The count is also what settles whether extraction was complete: it exceeds
+/// the number of call sites the walker visited exactly when one was missed.
 fn count_python_call_sites(node: &tree_sitter::Node) -> u64 {
     let mut total = u64::from(node.kind() == "call");
     let mut cursor = node.walk();
@@ -1366,20 +1370,6 @@ fn count_python_call_sites(node: &tree_sitter::Node) -> u64 {
         total += count_python_call_sites(&child);
     }
     total
-}
-
-fn has_unobserved_call(
-    node: &tree_sitter::Node,
-    seen_calls: &std::collections::HashSet<(usize, usize)>,
-) -> bool {
-    if node.kind() == "call" && !seen_calls.contains(&(node.start_byte(), node.end_byte())) {
-        return true;
-    }
-    let mut cursor = node.walk();
-    let found = node
-        .children(&mut cursor)
-        .any(|child| has_unobserved_call(&child, seen_calls));
-    found
 }
 
 struct PythonNamedCallee {

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -283,10 +283,14 @@ impl LanguageAdapter for PythonAdapter {
         // separate: carry one reserved negative record to the linker, which
         // fails closed without rejecting the valid file.
         // One walk answers both questions. `seen_calls` holds one span per call
-        // node extraction visited, so the census is at least its size and
-        // exceeds it exactly when a call node was never visited at all.
-        let parsed_call_sites = count_python_call_sites(&root);
-        if call_audit.incomplete || parsed_call_sites > call_audit.seen_calls.len() as u64 {
+        // node extraction visited, so `call_nodes` is at least its size and
+        // exceeds it exactly when a call node was never visited at all. The
+        // decorator half is deliberately not in that comparison: the extractor
+        // emits an edge for each of those without ever visiting a `call` node,
+        // so counting them here would report every decorated file incomplete.
+        let mut census = PythonCallSiteCensus::default();
+        census_python_call_sites(&root, source, &mut census);
+        if call_audit.incomplete || census.call_nodes > call_audit.seen_calls.len() as u64 {
             relations.push(call_extraction_incomplete_marker());
         }
 
@@ -370,7 +374,7 @@ impl LanguageAdapter for PythonAdapter {
             imports,
             tests,
             parse_state,
-            parsed_call_sites: Some(parsed_call_sites),
+            parsed_call_sites: Some(census.total()),
         })
     }
 }
@@ -1349,27 +1353,113 @@ struct PythonCallExtractionAudit {
     incomplete: bool,
 }
 
-/// Every call site this file holds, counted off the tree rather than off the
-/// relations extraction produced.
+/// The call sites a Python file holds, split into the two kinds that reach the
+/// graph by different routes.
 ///
-/// The two numbers are not the same one, and the gap between them is the whole
-/// reason this exists. A call whose callee the adapter cannot name
-/// (`handlers["render"](body)`), and a call written where no callable entity
-/// owns the edge, produce no [`kin_model::RelationKind::Calls`] relation at
-/// all. A denominator taken off the relations therefore reports such a file as
-/// holding fewer call sites than it does, and a consumer subtracting the
-/// graph's resolved edges from that number finds no shortfall on a file whose
-/// calls the graph never saw.
+/// A denominator taken off the emitted relations understates the file, because
+/// a call whose callee the adapter cannot name (`handlers["render"](body)`) and
+/// a call written where no callable entity owns the edge produce no
+/// [`kin_model::RelationKind::Calls`] relation at all. A consumer subtracting
+/// the graph's resolved edges from a short count finds no shortfall on a file
+/// whose calls the graph never saw.
 ///
-/// The count is also what settles whether extraction was complete: it exceeds
-/// the number of call sites the walker visited exactly when one was missed.
-fn count_python_call_sites(node: &tree_sitter::Node) -> u64 {
-    let mut total = u64::from(node.kind() == "call");
+/// It has to be split rather than summed in one field, because the two halves
+/// answer different questions and one of them is asymmetric in the other
+/// direction. See each field.
+#[derive(Default)]
+struct PythonCallSiteCensus {
+    /// Nodes whose kind is `call`.
+    ///
+    /// This is exactly the set extraction walks, so it is the one the
+    /// completeness check compares against: it exceeds the number of call sites
+    /// the walker visited precisely when one was missed.
+    call_nodes: u64,
+    /// Decorators that produce a `Calls` relation and hold no `call` node of
+    /// their own, meaning every form but `@mod.name(args)`.
+    ///
+    /// Counted apart from `call_nodes` in both directions for a reason. Folding
+    /// them in would report a file carrying a bare decorator as extraction-
+    /// incomplete, because the walker never visits a `call` node for one, and
+    /// that would withhold the count from a file that was measured before.
+    /// Leaving them out of the total is worse: the extractor emits an edge for
+    /// each, so the stamped count lands BELOW the resolved edge count, the
+    /// arrival gate floors that difference at zero, and it certifies an absence
+    /// over a file holding a call site the graph never saw.
+    decorator_sites: u64,
+}
+
+impl PythonCallSiteCensus {
+    /// Every call site the file holds, which is the number stamped on its
+    /// entities.
+    fn total(&self) -> u64 {
+        self.call_nodes + self.decorator_sites
+    }
+}
+
+/// Walk `node` once and count both halves of the census.
+fn census_python_call_sites(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    census: &mut PythonCallSiteCensus,
+) {
+    if node.kind() == "call" {
+        census.call_nodes += 1;
+    }
+    if node.kind() == "decorated_definition" {
+        census.decorator_sites += bare_decorator_call_sites(node, source);
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        total += count_python_call_sites(&child);
+        census_python_call_sites(&child, source, census);
     }
-    total
+}
+
+/// Decorators on `definition` that produce a `Calls` relation and carry no
+/// `call` node of their own.
+///
+/// The predicate is the emitter's own, deliberately: the same
+/// [`extract_decorator_payload_name`] and the same [`is_valid_callee_name`]
+/// filter the `decorated_definition` arm applies before it pushes a relation,
+/// and the same requirement that the definition actually decorates a function
+/// or a class. Re-deriving the condition here is what would let the two sides
+/// drift into disagreeing about what a decorator site is, which is the whole
+/// defect this counts.
+///
+/// `@app.route("/")` is excluded because its own `call` node is already counted
+/// and the emitter produces exactly one relation for it, so the two sides
+/// already balance there.
+fn bare_decorator_call_sites(definition: &tree_sitter::Node, source: &[u8]) -> u64 {
+    let mut cursor = definition.walk();
+    let mut decorates_a_definition = false;
+    let mut sites = 0;
+    for child in definition.children(&mut cursor) {
+        match child.kind() {
+            "function_definition" | "class_definition" => decorates_a_definition = true,
+            "decorator" => {
+                let names_a_callee = extract_decorator_payload_name(&child, source)
+                    .is_some_and(|name| is_valid_callee_name(&name));
+                if names_a_callee && !contains_call_node(&child) {
+                    sites += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    if decorates_a_definition {
+        sites
+    } else {
+        0
+    }
+}
+
+/// Whether `node` or anything under it is a `call`.
+fn contains_call_node(node: &tree_sitter::Node) -> bool {
+    if node.kind() == "call" {
+        return true;
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .any(|child| contains_call_node(&child))
 }
 
 struct PythonNamedCallee {

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -366,6 +366,7 @@ impl LanguageAdapter for PythonAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: Some(count_python_call_sites(&root)),
         })
     }
 }
@@ -1342,6 +1343,29 @@ fn extract_module_docstring(root: &tree_sitter::Node, source: &[u8]) -> Option<S
 struct PythonCallExtractionAudit {
     seen_calls: std::collections::HashSet<(usize, usize)>,
     incomplete: bool,
+}
+
+/// Every call site this file holds, counted off the tree rather than off the
+/// relations extraction produced.
+///
+/// The two numbers are not the same one, and the gap between them is the whole
+/// reason this exists. A call whose callee the adapter cannot name
+/// (`handlers["render"](body)`), and a call written where no callable entity
+/// owns the edge, produce no [`kin_model::RelationKind::Calls`] relation at
+/// all. A denominator taken off the relations therefore reports such a file as
+/// holding fewer call sites than it does, and a consumer subtracting the
+/// graph's resolved edges from that number finds no shortfall on a file whose
+/// calls the graph never saw.
+///
+/// The traversal is every child rather than every named child, matching
+/// [`has_unobserved_call`], so the two agree about which nodes are call sites.
+fn count_python_call_sites(node: &tree_sitter::Node) -> u64 {
+    let mut total = u64::from(node.kind() == "call");
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        total += count_python_call_sites(&child);
+    }
+    total
 }
 
 fn has_unobserved_call(

--- a/crates/kin-parser/src/languages/rust_lang.rs
+++ b/crates/kin-parser/src/languages/rust_lang.rs
@@ -119,6 +119,7 @@ impl LanguageAdapter for RustAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/shallow_backed.rs
+++ b/crates/kin-parser/src/languages/shallow_backed.rs
@@ -96,6 +96,7 @@ fn extract_csharp_output(tree: &Tree, source: &[u8], file_id: &FilePathId) -> Pa
         imports,
         tests: Vec::new(),
         parse_state,
+        parsed_call_sites: None,
     }
 }
 
@@ -530,6 +531,7 @@ fn extract_ruby_output(tree: &Tree, source: &[u8], file_id: &FilePathId) -> Pars
         imports,
         tests: Vec::new(),
         parse_state,
+        parsed_call_sites: None,
     }
 }
 

--- a/crates/kin-parser/src/languages/swift.rs
+++ b/crates/kin-parser/src/languages/swift.rs
@@ -104,6 +104,7 @@ impl LanguageAdapter for SwiftAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -150,6 +150,7 @@ impl LanguageAdapter for TypeScriptAdapter {
             imports,
             tests,
             parse_state,
+            parsed_call_sites: None,
         })
     }
 }


### PR DESCRIPTION
The arrival gate decides whether an empty reference list may be read as the
whole truth by subtracting a family file's resolved `Calls` edges from the call
sites the parser read there. On a converted Python repository it had never done
that subtraction, because the parse side reached the store on almost no file.

## The ticket's mechanism is not the mechanism

FIR-2828 reads this as plumbing between the stamp at `pipeline.rs:173` and the
store. It is not. The conversion path carries what it is given; it is given
nothing. `attach_file_reference_parse_counts` removed `file_parsed_call_sites`
from every entity of a file whose call extraction it could not fully represent,
and the Python adapter declares that whenever it saw a call whose target it
could not prove or a `call` node somewhere it never walked. An attribute call
through an imported module, a subscript callee, a call at module scope: ordinary
Python, and each one silences the whole file. The one file `kin graph status`
reported the parse side measured on was the one with no calls at all.

The withholding was a correct refusal of a wrong number rather than a preference
for absence. The number it withheld was the count of `Calls` relations
extraction emitted, which understates any file holding a call it could not name,
and a short count subtracts to zero and reads as a fully accounted file.

## The change

The Python adapter now counts the call sites themselves, off the tree, including
every one that produces no relation, and publishes that census on `ParseOutput`.
A census reporting the file's whole call side is safe to stamp whether or not
extraction was complete. An adapter that takes no census reports `None` and
keeps the old behaviour exactly, so no other language moves. The two numbers
agree on every file that was already measured, because a file whose extraction
was complete is one where every call site became a relation.

A decorator is a call site too, and the two forms behave differently.
`@app.route("/")` holds a real `call` node and the emitter pushes one relation
for it, so the two sides balance. `@register` holds no `call` node and still
produces a relation, so a census counting only `call` nodes would report FEWER
sites than the graph holds edges for the file. That direction is the dangerous
one: the arrival gate floors the shortfall at zero, the file drops out of the
unaccounted list, and it certifies an absence over a call site the graph never
saw. So the census counts a decorator site exactly when the emitter would push a
relation for it and the decorator carries no `call` node, using the emitter's own
name extraction and callee filter rather than re-deriving the condition.

The two halves stay separate counts. Folding decorator sites into the `call`
node count would report every decorated file as extraction-incomplete, because
the walker never visits a `call` node for one, and would withhold the count from
a file that was measured before. One walk answers both, because `seen_calls`
holds one span per call node extraction visited, so the call-node count is at
least its size and exceeds it exactly when a call node was missed.

Beside it, `classify` in `reference_coverage.rs` now requires an exact match for
`FullyResolved`. Fan-out binds one ambiguous call site to several same-named
targets under the linker's cap, so more edges than sites is a real state, and
reading it as fully resolved prints `[resolved]` at 100% off a ratio that is no
longer coverage. That is the same wrong word the zero-denominator case used to
produce, arrived at from the other side, and it became reachable for Python the
moment its parse side started being measured.

`caller_arrival` is not touched. Its arithmetic already did the subtraction; it
only ever lacked an input.

## Before and after, verbatim

`kin graph status` on the notekeeper corpus, base source, binary stamped
`9dd00748493c7bce3d4eecd6ad080d6a98184599-dirty`:

```
python: 14 files, calls 265 resolved, parse side measured on 1 of 14 files (0 sites there),
        imports 13/40 (32%), 27 name a module outside this repository,
        cross-file 323, intra-file 194 [unmeasured]
```

The same corpus, binary stamped `872d00c9333d157559a77a92a70af4f996b2a054`:

```
python: 14 files, calls 265/485 (54%), imports 13/40 (32%),
        27 name a module outside this repository, cross-file 323, intra-file 194 [partial]
```

The resolved count is the same 265 and cross-file is the same 323. The linker
does not move; the denominator comes into existence.

The `caller_arrival` block over a converted four-file fixture, base source:

```json
{ "family_files": 2, "family_measured": 0, "state": "unaccounted",
  "unaccounted_file_count": 2,
  "unaccounted_files": [
    { "file": "notepkg/clean.py", "parsed_call_sites": null,
      "resolved_call_edges": 2, "unaccounted_call_sites": null },
    { "file": "notepkg/messy.py", "parsed_call_sites": null,
      "resolved_call_edges": 2, "unaccounted_call_sites": null } ] }
```

The same store, with the change:

```json
{ "family_files": 2, "family_measured": 2, "state": "unaccounted",
  "unaccounted_file_count": 1,
  "unaccounted_files": [
    { "file": "notepkg/messy.py", "parsed_call_sites": 3,
      "resolved_call_edges": 2, "unaccounted_call_sites": 1 } ] }
```

`clean.py` resolves every call it writes and is no longer named at all.
`messy.py` writes one more through a subscript callee the extractor cannot name,
and carries the arithmetic it rests on instead of a bare refusal.

## Checks

Three scripted checks. One asserts the stamped count is the file's whole call
side rather than the relations emitted, with a control proving an
already-measured file does not move. One drives the real git conversion and
requires a count on every file whose entities the store holds. One reads the
gate over a store built by the product's own path and requires it to name the
file holding an unresolved call and only that file, with a control family that
still certifies. The FIR-2775 arm asserted the old contract and now asserts this
one.

A seventh check pins that a decorator written as a call, `@app.route("/")`, is
counted once through its own `call` node rather than twice, which is the error
in the opposite direction.

Falsified at `c10706d7c0f91cd93e72841bf05ec606f2cb62cc` by six mutations over
four targets, thirteen tests, ninety-one cells with none missing, each mutation
removing a property of the code rather than weakening an assertion:

| arm | what it removes | rows killed |
|---|---|---:|
| M1 | publishes the relation count in place of the census | 4 |
| M2 | the stamp ignores the census | 9 |
| M3 | the census over-counts by one | 10 |
| M4 | drops the decorator half of the census | 5 |
| M5 | `FullyResolved` accepts more edges than sites | 1 |
| M6 | counts every decorator, not only those with no `call` node | 1 |

Every row this change owns goes red under at least one arm. M4, M5 and M6 each
kill exactly the rows written for them and nothing else. The only two rows green
across every arm are pre-existing enumeration checks about a different class.

That claim is only worth the grid it rests on, and the grid's own driver could
not fail on a graded-nothing run: it ended on a print, so an earlier pass whose
every cell was a build failure still exited zero. Its terminal statement now
refuses on a cell that graded nothing, a missing cell, a row count that does not
reconcile against the arms times the tests the targets listed, a baseline that is
not clean, an arm that killed nothing, and a row nothing kills. Each of those
refusals is exercised against a grid built to trip exactly it.

The clean fixture now asserts that its own extraction is incomplete, because the
no-regression invariant used to rest on it and that file was never measured by
the old code, so the claim had no guard. A second fixture whose extraction is
complete carries the invariant now, and it PASSES under M2, the arm that
restores the old withholding, which is the invariant demonstrating itself. The
arrival test reads the store rather than ranging over the gate's unaccounted
list, because a file whose parsed count falls below its resolved count is
exactly the file that list drops.

## What this does not do

On real Python most family files will still read `unaccounted`, because a call
into the standard library or a third-party package is a call site the graph
holds no in-repo edge for. Their outcome is unchanged, since those files already
declined through the absent-count branch. What is new is that a file whose every
call site did become an edge can now certify instead of being lumped in with
them.

The reported Python call ratio will appear to fall on any repository, from a
number that was never a ratio to one that is. The identical 265 above is the
evidence that this is a correction rather than a regression.

One user-visible behaviour changes and it is not cosmetic. `unsupportable_reason`
fires on `NoneResolved`, which was unreachable for Python while its parse side
was unmeasured. A Python repository whose census reads above zero with no `Calls`
edges now flips its `reference_edge_coverage` health row from Healthy to Pending,
and `kin setup` drops "First-run ready" because that row is no longer Healthy.
That reading is honest, since such a repository really does have a broken call
graph and the row exists to say so, so it is disclosed rather than suppressed.

One unrelated red is worth naming so nobody attributes it here. At `8b32d8e2`
`cargo test -p kin-core --all-targets` reported 719 passed, 1 failed, on
`init::tests::a_reclaimed_stage_reaches_the_operator_and_a_clean_parent_stays_silent`,
and the same command at `c10706d7` reported 720 passed, 0 failed, with
`crates/kin-core/src/init.rs` byte-identical between them and identical to
`origin/main` (blob `eccbff39`). Both results are FIR-2857's evidence: that is
main's own defect, where a skipped reclaim reports `(0, 0)` exactly as a clean
parent does, and it is intermittent by that skip route. Nothing in this PR
touches it.

`crates/kin-mcp/src/caller_arrival.rs` is untouched here on purpose. Its module
header and the `UnaccountedFile::parsed_call_sites` doc describe a withholding
that no longer happens for Python, so both become stale once this lands. They
are corrected in a follow-up after FIR-2821 lands, since that lane is editing
the same file.

Closes FIR-2828
