### PR TITLE
Gate the test-only finalize wrapper to unix so Windows lib tests build

### DIFF
--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -5762,7 +5762,10 @@ impl DaemonState {
         Ok(())
     }
 
-    #[cfg(test)]
+    // The only caller is the #[cfg(unix)] test at api.rs, so on Windows this
+    // wrapper has no callers and -D dead-code fails the lib test build. Gate it
+    // to match its caller exactly rather than widening the private method it wraps.
+    #[cfg(all(test, unix))]
     pub(crate) fn finalize_committed_generation_for_test(&self, generation: u64) -> Result<()> {
         self.finalize_committed_generation(generation)
     }


### PR DESCRIPTION
## Outcome

Restores the `Windows authority tests` leg on `main`, which has failed on every
push since 2026-08-27T16:44:21Z. The leg reports `cargo test --no-run built 0
test binaries` and advises narrowing the target selection, which points at the
wrong file. The real cause is ninety seconds earlier in the same log: the lib
test does not compile, so zero binaries is a symptom of that.

```
error: method `finalize_committed_generation_for_test` is never used
  --> crates\kin-daemon\src\state.rs:5766:19
  = note: `-D dead-code` implied by `-D warnings`
error: could not compile `kin-daemon` (lib test) due to 1 previous error
```

## Mechanism

`finalize_committed_generation_for_test` was declared `#[cfg(test)]`, but its
only caller is the test at `crates/kin-daemon/src/api.rs:17121`, inside
`#[cfg(unix)] #[tokio::test] async fn
hosted_authority_materialization_survives_schema_four_receive_and_reopen()` at
`api.rs:16935`. On Windows that caller compiles out, the wrapper is left with no
callers, and `-D dead-code` under `-D warnings` makes it a hard error. Unix
runners stay green because the caller is present, which is why every `Check &
Test` shard passes while only the Windows leg fails. The test module holds 81
`#[cfg(unix)]` attributes and zero `#[cfg(windows)]`.

The symbol occurs exactly twice in the tree, the declaration and that one
caller, so nothing else is stranded by the change.

## Why this shape

`#[cfg(all(test, unix))]` on the wrapper, rather than moving it beside its
caller. The method it wraps, `finalize_committed_generation` at
`state.rs:5752`, is private; the wrapper exists purely to expose it to
`api.rs`'s tests as `pub(crate)`. Moving the wrapper into the caller's module
would mean widening that private method's visibility, which is a larger change
and a weaker boundary. Gating the wrapper makes it mirror its caller exactly,
which is the property that was violated.

## Timeline

| Commit | CI |
| --- | --- |
| `4d63e6987` 2026-08-27T15:31:34Z | success, last green |
| `d6b61e550` 2026-08-27T16:44:21Z | first red, "Materialize hosted repository refs for queries (#1195)" |
| `043fa5063` 2026-08-27T18:00:29Z | red |
| `cacfb340c` 2026-08-27T18:00:41Z | red |
| `170f1fe72` 2026-08-27T18:13:35Z | red |
| `8c957a077` 2026-08-28T06:34:58Z | red |

`git log -S finalize_committed_generation_for_test -- crates/kin-daemon/src/state.rs`
names one commit, `d6b61e550`, which is the first red. Five consecutive main CI
runs have carried this.

`Windows authority tests` is not one of `main`'s six required contexts, so the
red has not gated merges. It has made every main CI run conclude failure.

## Verification

The mechanism is falsified locally on the real target. The crate itself cannot be
built for Windows from macOS, so that half still rests on the post-merge leg.

**Mechanism, red then green on `x86_64-pc-windows-msvc`.** A minimal reproduction
carrying the same shape, a private method, an ungated production caller, a
`#[cfg(test)]` wrapper and a sole `#[cfg(unix)]` test caller, compiled with
`rustc --test --emit=metadata` so no linker or C build script is involved:

| wrapper gate | target | rc | diagnostic |
| --- | --- | ---: | --- |
| `#[cfg(test)]` | aarch64-apple-darwin | 0 | clean |
| `#[cfg(test)]` | x86_64-pc-windows-msvc | 1 | ``method `finalize_committed_generation_for_test` is never used`` |
| `#[cfg(all(test, unix))]` | aarch64-apple-darwin | 0 | clean |
| `#[cfg(all(test, unix))]` | x86_64-pc-windows-msvc | 0 | clean |

The red cell names the same symbol and the same lint as the CI failure, and only
the gate changes between rows.

**The chain that keeps the private method alive on Windows.** Removing the
wrapper on Windows must not simply move the dead-code error down to
`finalize_committed_generation` itself. It does not. That method has two other
callers, `state.rs:5559` in `save_snapshot_impl` and `state.rs:5632` in
`flush_embed_progress`. `flush_embed_progress` is `#[cfg(feature =
"embeddings")]` and so is absent from the leg's `--no-default-features` build,
but `save_snapshot_impl` is ungated, and it is reached from `state.rs:4813` and
`state.rs:4824`, both ungated. So one live caller survives on Windows with no
default features, which is what the fourth row above confirms.

This is worth stating because the first version of that reproduction omitted the
production caller and therefore reported the fix as still red, naming
`finalize_committed_generation` rather than the wrapper. That was an artifact of
the reproduction, not a property of the change, and reading which symbol the
error named is what separated the two.

**What is not covered locally.** Building this crate for Windows from macOS is
not possible here: `cargo check --locked --target x86_64-pc-windows-msvc -p
kin-daemon --no-default-features --tests` fails inside `ring`'s C build script,
where cc cannot find `assert.h` for that target, ending `rc=101` in `cc-rs`
before any Rust in this workspace is compiled. That is an unrelated
cross-compilation limit and says nothing about this change. The
`Windows authority tests` job on the squash commit remains the verification that
the whole crate builds, and it runs post-merge.

**Also run on the host, and passing:**

- `cargo check -p kin-daemon --tests --locked`
- `rustfmt --edition 2021 --check crates/kin-daemon/src/state.rs`, with a
  deliberately misformatted copy as a control that exits nonzero, so the clean
  result is not a check that cannot fail.
