### PR TITLE
Make max_chars a hard ceiling on a final locate page too

### DIFF
--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1020,13 +1020,17 @@ fn run_ladder(
             .get(*key)
             .and_then(Value::as_array)
             .map_or(0, Vec::len);
-        // A final semantic-locate page has no cursor. Removing primary rows from
-        // it would make those answers unrecoverable, so keep them and let the
-        // residual-over-budget disclosure tell the caller to narrow the fresh
-        // request. Secondary rollups can still be trimmed safely.
-        if tool == "semantic_locate" && Some(*key) == primary && locate_cursor.is_none() {
-            continue;
-        }
+        // Every collection is cut, including a final page's primary one.
+        // `max_chars` is the caller's context budget rather than a preference,
+        // so nothing licenses exceeding it, and a page with no cursor is not an
+        // exception: it is the case where the caller cannot page to the rest and
+        // therefore most needs to be told what was withheld and how to reach it.
+        // The floor of one entry per list is what keeps this from producing the
+        // empty array FIR-2600 exists to prevent, and the remediation below says
+        // `max_chars` rather than `next_cursor` when there is no cursor to
+        // follow. Retaining rows here instead shipped a response over the
+        // ceiling and published no elision at all, which is what took
+        // `response_budget:3` to UNREADABLE on main.
         let (withheld, narrowed) = trim_collection(payload, key, target, 1);
         if withheld > 0 {
             accounting.bounded = true;
@@ -1068,6 +1072,15 @@ fn run_ladder(
         if primary_withheld > 0 && cursor_rebased && kept > 0 {
             remediations.push(format!(
                 "re-issue with `page_size: {kept}` and follow `next_cursor`"
+            ));
+        } else if tool == "semantic_locate" && primary_withheld > 0 && locate_cursor.is_none() {
+            // Naming a cursor here would be a recovery the response cannot
+            // provide. The two things that do reach the withheld rows are a
+            // larger ceiling and a narrower question, and the caller owns both.
+            remediations.push(format!(
+                "raise `max_chars`, or narrow the request with `{}`; this page has no \
+                 `next_cursor`, so the withheld entries cannot be reached by paging",
+                shape.narrow_param
             ));
         } else {
             remediations.push(format!("narrow the request with `{}`", shape.narrow_param));
@@ -2139,8 +2152,16 @@ mod tests {
         assert!(!disclosure.contains("primary `entities`"), "{disclosure}");
     }
 
+    /// A final page is still bound by the ceiling, and says what it withheld.
+    ///
+    /// `max_chars` is the caller's context budget, so a page with no cursor does
+    /// not get to exceed it. What a final page owes instead is honesty about the
+    /// cut: at least one entry survives per list, the elision is published, and
+    /// the remedy names the ceiling rather than a `next_cursor` it does not
+    /// have. The earlier contract kept the rows and shipped over budget, which
+    /// took `response_budget:3` to UNREADABLE on main because nothing was cut.
     #[test]
-    fn a_null_cursor_never_claims_recovery_or_loses_final_page_rows() {
+    fn a_final_page_is_cut_to_its_ceiling_and_names_no_cursor_recovery() {
         let mut payload = cosine_locate_payload(20);
         payload["next_cursor"] = Value::Null;
         let before = payload["results"].as_array().unwrap().len();
@@ -2148,20 +2169,52 @@ mod tests {
             max_chars: RESPONSE_MIN_MAX_CHARS,
             ..ResponseBudget::default()
         };
-        enforce(&mut payload, "semantic_locate", &budget).expect("budgeted");
-        assert_eq!(
-            payload["results"].as_array().unwrap().len(),
-            before,
-            "a final page has no recovery cursor, so its primary rows must remain"
+        let accounting = enforce(&mut payload, "semantic_locate", &budget).expect("budgeted");
+        let kept = payload["results"].as_array().unwrap().len();
+        assert!(
+            kept < before,
+            "a final page over its ceiling must still be cut: kept {kept} of {before}"
         );
-        assert!(payload["degradations"]
+        assert!(
+            kept >= 1,
+            "the cut must leave an entry rather than an empty array"
+        );
+        assert!(
+            accounting.chars_after <= budget.max_chars,
+            "a final page must not ship over its ceiling: {} against {}",
+            accounting.chars_after,
+            budget.max_chars
+        );
+        let elisions = payload["elisions"]["results"]
+            .as_object()
+            .expect("the cut list publishes its elision");
+        assert_eq!(elisions["kept"].as_u64().unwrap() as usize, kept);
+        assert_eq!(elisions["elided"].as_u64().unwrap() as usize, before - kept);
+        let remediations = payload["degradations"]
             .as_array()
             .unwrap()
             .iter()
-            .all(|entry| !entry["remediation"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("follow `next_cursor`")));
+            .filter_map(|entry| entry["remediation"].as_str())
+            .collect::<Vec<_>>();
+        assert!(
+            remediations
+                .iter()
+                .all(|remedy| !remedy.contains("follow `next_cursor`")),
+            "a final page cannot offer cursor recovery: {remediations:?}"
+        );
+        // `max_chars` alone is not evidence this branch ran. The residual
+        // disclosure names it too, so a bare substring test is satisfied by a
+        // producer this assertion is not about, and the mutation that deletes
+        // the branch survived exactly that test. Key on the clause only the cut
+        // disclosure writes.
+        assert!(
+            remediations.iter().any(|remedy| {
+                remedy.contains("raise `max_chars`")
+                    && remedy.contains("cannot be reached by paging")
+            }),
+            "the cut disclosure itself must name the ceiling and say why paging cannot reach \
+             the withheld rows: {remediations:?}"
+        );
     }
 
     #[test]

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -1162,6 +1162,110 @@ def check_7(suite):
     return res
 
 
+def grade_final_page(payload, ceiling, lists):
+    """Problems with a final page that went over its ceiling.
+
+    A page with no cursor cannot be continued, so the budget owes it this: the
+    ranked list is cut and says so, the cut leaves an entry, the page either
+    fits under the ceiling or discloses that one entry per list cannot fit, and
+    no remediation names a cursor the page does not have. Returns a list of
+    problems, empty when the page is correct, so the self-test can drive it with
+    no binary and no fixture.
+    """
+    problems = []
+    after = ((payload.get("_kin") or {}).get("response") or {}).get("chars_after_budget")
+    reasons = [entry.get("reason") for entry in (payload.get("degradations") or [])]
+    residual = "response_over_budget" in reasons
+    if not isinstance(after, int):
+        problems.append("the response published no integer chars_after_budget")
+    elif after > ceiling and not residual:
+        problems.append(
+            "the final page shipped %d characters against a %d ceiling and disclosed no "
+            "residual" % (after, ceiling)
+        )
+    elif after <= ceiling and residual:
+        problems.append(
+            "the final page fits at %d under %d yet still claims it could not fit"
+            % (after, ceiling)
+        )
+    elisions = payload.get("elisions") or {}
+    cut_lists = [key for key in lists if key in elisions]
+    if not cut_lists:
+        problems.append(
+            "no ranked list published an elision, so the ceiling was not paid for by a cut"
+        )
+    for key in cut_lists:
+        rows = payload.get(key)
+        if not isinstance(rows, list) or not rows:
+            problems.append("`%s` was cut to %r, so the budget emptied it" % (key, rows))
+    remedies = [
+        entry.get("remediation") or "" for entry in (payload.get("degradations") or [])
+    ]
+    if any("follow `next_cursor`" in remedy for remedy in remedies):
+        problems.append(
+            "a page with no cursor offered cursor recovery: %r" % (remedies,)
+        )
+    if not any("max_chars" in remedy for remedy in remedies):
+        problems.append(
+            "no remediation named max_chars as the way to the withheld rows: %r" % (remedies,)
+        )
+    return problems
+
+
+def check_8(suite):
+    res = Result("8", "FIR-2600", "a final page over the ceiling is cut, fits, and says so")
+    ceiling = 2000
+    lists = ["entities", "files"]
+    try:
+        cut = suite.mcp(
+            "semantic_locate", {"query": "hop", "limit": 60, "max_chars": ceiling}
+        )
+    except McpError as exc:
+        res.unknown("semantic_locate unreadable: %s" % exc)
+        return res
+
+    # This check is about the page that cannot be continued. A followable cursor
+    # means the caller was handed a recovery path and check 3 owns that case, so
+    # say the case was not reached rather than grading the wrong one.
+    cursor = cut.get("next_cursor")
+    if cursor:
+        res.unknown(
+            "the floor call returned a followable cursor (%r), so the final-page "
+            "case was not exercised" % (cursor,)
+        )
+        return res
+    # A page that was never over its ceiling has nothing to pay for, so there is
+    # no cut to grade. Anything else, over the ceiling or already cut, is the
+    # case this check owns.
+    after = ((cut.get("_kin") or {}).get("response") or {}).get("chars_after_budget")
+    if isinstance(after, int) and after <= ceiling and not (cut.get("elisions") or {}):
+        res.unknown(
+            "the floor call fit under its ceiling with nothing cut, so the "
+            "final-page elision rule was not exercised"
+        )
+        return res
+    for problem in grade_final_page(cut, ceiling, lists):
+        res.bad(problem)
+    if not res.failed:
+        after = ((cut.get("_kin") or {}).get("response") or {}).get("chars_after_budget")
+        # Say which of the two legal outcomes held. Calling an over-ceiling page
+        # "under its ceiling" would be the check reporting something false while
+        # passing, which is the shape this suite exists to catch.
+        if isinstance(after, int) and after <= ceiling:
+            where = "and fits at %s characters under its %d ceiling" % (after, ceiling)
+        else:
+            where = (
+                "and, at %s characters against a %d ceiling, discloses that one entry per "
+                "list still does not fit" % (after, ceiling)
+            )
+        res.ok(
+            "the final page was cut, kept an entry in every list it cut, named the ceiling "
+            "rather than a cursor, %s: %s"
+            % (where, json.dumps(cut.get("elisions") or {}, sort_keys=True))
+        )
+    return res
+
+
 CHECKS = [
     ("0", check_0),
     ("1", check_1),
@@ -1171,6 +1275,7 @@ CHECKS = [
     ("5", check_5),
     ("6", check_6),
     ("7", check_7),
+    ("8", check_8),
 ]
 
 
@@ -1181,6 +1286,104 @@ def self_test():
     def expect(label, got, want):
         if got != want:
             problems.append("%s: got %r, wanted %r" % (label, got, want))
+
+    # The final-page grader, against one correct page and one break per rule it
+    # enforces. A grader that cannot fail is what lets a regression ship green.
+    def final_page(**over):
+        page = {
+            "_kin": {"response": {"chars_after_budget": 1900}},
+            "entities": [{"id": "a"}],
+            "elisions": {"entities": {"kept": 1, "elided": 19, "total": 20}},
+            "degradations": [
+                {"remediation": "raise `max_chars`, or narrow the request with `limit`"}
+            ],
+        }
+        page.update(over)
+        return page
+
+    expect("a correct final page passes", grade_final_page(final_page(), 2000, ["entities"]), [])
+    # The second legal outcome. The envelope alone can exceed a 2000-character
+    # ceiling, measured at 19,344 on the real fixture, so a page that cannot fit
+    # even at one entry per list is correct when it says exactly that.
+    expect(
+        "an over-ceiling page that discloses the residual passes",
+        grade_final_page(
+            final_page(
+                _kin={"response": {"chars_after_budget": 2400}},
+                degradations=[
+                    {
+                        "reason": "response_over_budget",
+                        "remediation": "narrow the request, or raise max_chars",
+                    }
+                ],
+            ),
+            2000,
+            ["entities"],
+        ),
+        [],
+    )
+    expect(
+        "a final page over its ceiling with no residual disclosure fails",
+        len(grade_final_page(
+            final_page(_kin={"response": {"chars_after_budget": 2400}}), 2000, ["entities"]
+        )),
+        1,
+    )
+    expect(
+        "a page that fits yet claims it could not fit fails",
+        len(grade_final_page(
+            final_page(
+                degradations=[
+                    {
+                        "reason": "response_over_budget",
+                        "remediation": "narrow the request, or raise max_chars",
+                    }
+                ]
+            ),
+            2000,
+            ["entities"],
+        )),
+        1,
+    )
+    expect(
+        "a final page that cut nothing fails",
+        len(grade_final_page(final_page(elisions={}), 2000, ["entities"])),
+        1,
+    )
+    expect(
+        "a final page with an emptied list fails",
+        len(grade_final_page(final_page(entities=[]), 2000, ["entities"])),
+        1,
+    )
+    expect(
+        "a final page claiming cursor recovery fails",
+        len(grade_final_page(
+            final_page(degradations=[{"remediation": "follow `next_cursor`"}]),
+            2000,
+            ["entities"],
+        )),
+        2,
+    )
+    # This input separates the two remedy rules. The one above breaks both at
+    # once, so either rule going missing showed up as the same 2-to-1 count and
+    # the two hid each other. Here the ceiling IS named, so only the cursor
+    # claim is wrong and only that rule can catch it.
+    expect(
+        "a cursor claim is caught even when the ceiling is named",
+        len(grade_final_page(
+            final_page(degradations=[
+                {"remediation": "follow `next_cursor`, or raise `max_chars`"}
+            ]),
+            2000,
+            ["entities"],
+        )),
+        1,
+    )
+    expect(
+        "a final page with no size fails",
+        len(grade_final_page(final_page(_kin={}), 2000, ["entities"])),
+        1,
+    )
 
     whole = {
         "chain": [{"step": 1}, {"step": 2}],


### PR DESCRIPTION
A locate page with no followable cursor skipped its primary collection in the response budget
entirely, so it never elided and shipped over the caller's ceiling. This makes `max_chars` a
hard ceiling on a final page too, and repairs the main red that #1204 introduced.

Measured on release binaries built from `2f8d17c8` before a line was changed, with the
response-budget acceptance fixture at `max_chars: 2000`, the floor call returned 19,344
characters against that 2,000-character ceiling, kept all 25 entities uncut, and published an
elision for `body` only, with no entry for `entities` at all. The same query at
`max_chars: 60000` measured 25,664 characters and fit. That 9.7x overrun is what took
`response_budget:3` to UNREADABLE on Product Acceptance run 33167923749, because a check that
grades the elision rule has nothing to grade when nothing is cut.

`max_chars` is the caller's context budget rather than a preference, so nothing licenses
exceeding it, and a page with no cursor is not an exception. It is the case where the caller
cannot page to the rest and therefore most needs to be told what was withheld and how to reach
it. The guard is removed, so every collection is cut including a final page's primary one. The
existing floor of one entry per list is what keeps this from producing the empty array FIR-2600
exists to prevent, and the remediation now names `max_chars` and says the withheld entries
cannot be reached by paging, rather than offering a `next_cursor` the page does not have.

After the change the same floor call cuts `entities` from 25 to 1, publishes that elision, and
ships 8,621 characters. It is still over 2,000 because the envelope alone exceeds that ceiling,
which is the narrower job the residual disclosure keeps: a page that cannot fit even at one
entry per list is correct only when it says exactly that. Both graders accept fits-or-discloses
and reject each without the other, so a response can neither claim it could not fit while
fitting, nor exceed the ceiling in silence. `disclose_residual` itself is unchanged.

Verification on `0f56479b2`, all through the fleet's heavy slot against release binaries built
from this branch:

- `scripts/acceptance/response_budget_elisions.py` exits 0. `CHECK 3` is PASS again, reading
  the same way it read on `8c957a077` before #1204, and the new `CHECK 8` is PASS.
- `cargo test -p kin-mcp --lib`: 737 passed, 0 failed.
- `bin/kin-precheck kin`: 16 gates ran, 16 passed, 0 failed.

Falsification found one assertion that could not fail, and it is fixed here rather than left
standing. Six mutations of the Python grader each turn `--self-test` red on their own arm,
after a seventh self-test input was added because the cursor-recovery rule and the max_chars
rule were both caught by one fixture at a 2-to-1 count and were hiding each other. On the Rust
side, restoring the skip turns the product test red at "a final page over its ceiling must
still be cut: kept 20 of 20", but deleting the new remediation branch first SURVIVED: the
generic remedy already contains the bare substring `max_chars` ("or raise max_chars, up to the
60000 this server will build"), so the assertion was satisfied by a producer it was not about.
It now keys on the clause only the cut disclosure writes, and that mutation is red at "the cut
disclosure itself must name the ceiling and say why paging cannot reach the withheld rows".

One process finding worth carrying: `bin/kin-parity` runs three acceptance suites and hosted
`Product Acceptance` runs fourteen, `response_budget` among them, and `Product Acceptance` was
SKIPPED on #1204. No amount of care with the local parity gate could have caught this class
before landing. Running `response_budget_elisions.py` directly against release binaries belongs
in the inner loop for any change to `budget.rs`, and it is cheap once the binaries exist.
