### PR TITLE
State the shipped final-page budget rule in semantic_locate's description

### DIFF
--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1079,7 +1079,7 @@ fn run_ladder(
             // larger ceiling and a narrower question, and the caller owns both.
             remediations.push(format!(
                 "raise `max_chars`, or narrow the request with `{}`; this page has no \
-                 `next_cursor`, so the withheld entries are unrecoverable by further requests",
+                 `next_cursor`, so the withheld entries cannot be reached by paging",
                 shape.narrow_param
             ));
         } else {

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1079,7 +1079,7 @@ fn run_ladder(
             // larger ceiling and a narrower question, and the caller owns both.
             remediations.push(format!(
                 "raise `max_chars`, or narrow the request with `{}`; this page has no \
-                 `next_cursor`, so the withheld entries cannot be reached by paging",
+                 `next_cursor`, so the withheld entries are unrecoverable by further requests",
                 shape.narrow_param
             ));
         } else {

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -231,8 +231,8 @@ in `degradations` and in `_kin.response`, which carries the budget applied and w
 measured before it. When primary rows are withheld and `next_cursor` can be rebased, every row \
 stays reachable and the remedy says so. A cursorless final page is cut to its ceiling too, keeping \
 at least one entry, and the cut is published in `elisions` and `degradations`; its remedy names \
-`max_chars` and a narrower request, because with no `next_cursor` the withheld entries cannot be \
-reached by paging. Only when one surviving entry per list still exceeds the ceiling does the \
+`max_chars` and a narrower request, because with no `next_cursor` the withheld entries stay \
+withheld. Only when one surviving entry per list still exceeds the ceiling does the \
 response ship over budget, and it discloses that as `response_over_budget`.";
 
 /// Offline/generic dispatch arm for `semantic_locate`.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -231,7 +231,7 @@ in `degradations` and in `_kin.response`, which carries the budget applied and w
 measured before it. When primary rows are withheld and `next_cursor` can be rebased, every row \
 stays reachable and the remedy says so. A cursorless final page is cut to its ceiling too, keeping \
 at least one entry, and the cut is published in `elisions` and `degradations`; its remedy names \
-a narrower request, because with no `next_cursor` the withheld entries cannot be \
+`max_chars` and a narrower request, because with no `next_cursor` the withheld entries cannot be \
 reached by paging. Only when one surviving entry per list still exceeds the ceiling does the \
 response ship over budget, and it discloses that as `response_over_budget`.";
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -228,10 +228,12 @@ sheds its secondary per-file symbol roll-up. File granularity preserves those sy
 are primary answer detail. It then sheds inline snippets, and only then withholds hits from the end \
 of the page. Any cut is reported \
 in `degradations` and in `_kin.response`, which carries the budget applied and what the response \
-measured before it. Primary rows are withheld only when `next_cursor` can be rebased so every row \
-stays reachable. A cursorless final page keeps its primary rows instead; if those rows alone exceed \
-the ceiling, the response ships over budget with `response_over_budget` disclosure rather than \
-silently losing unrecoverable answers, and a size-limited client may still refuse it.";
+measured before it. When primary rows are withheld and `next_cursor` can be rebased, every row \
+stays reachable and the remedy says so. A cursorless final page is cut to its ceiling too, keeping \
+at least one entry, and the cut is published in `elisions` and `degradations`; its remedy names \
+a narrower request, because with no `next_cursor` the withheld entries cannot be \
+reached by paging. Only when one surviving entry per list still exceeds the ceiling does the \
+response ship over budget, and it discloses that as `response_over_budget`.";
 
 /// Offline/generic dispatch arm for `semantic_locate`.
 ///

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -231,8 +231,8 @@ in `degradations` and in `_kin.response`, which carries the budget applied and w
 measured before it. When primary rows are withheld and `next_cursor` can be rebased, every row \
 stays reachable and the remedy says so. A cursorless final page is cut to its ceiling too, keeping \
 at least one entry, and the cut is published in `elisions` and `degradations`; its remedy names \
-`max_chars` and a narrower request, because with no `next_cursor` the withheld entries stay \
-withheld. Only when one surviving entry per list still exceeds the ceiling does the \
+`max_chars` and a narrower request, because with no `next_cursor` the withheld entries cannot be \
+reached by paging. Only when one surviving entry per list still exceeds the ceiling does the \
 response ship over budget, and it discloses that as `response_over_budget`.";
 
 /// Offline/generic dispatch arm for `semantic_locate`.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -228,10 +228,12 @@ sheds its secondary per-file symbol roll-up. File granularity preserves those sy
 are primary answer detail. It then sheds inline snippets, and only then withholds hits from the end \
 of the page. Any cut is reported \
 in `degradations` and in `_kin.response`, which carries the budget applied and what the response \
-measured before it. Primary rows are withheld only when `next_cursor` can be rebased so every row \
-stays reachable. A cursorless final page keeps its primary rows instead; if those rows alone exceed \
-the ceiling, the response ships over budget with `response_over_budget` disclosure rather than \
-silently losing unrecoverable answers, and a size-limited client may still refuse it.";
+measured before it. When primary rows are withheld and `next_cursor` can be rebased, every row \
+stays reachable and the remedy says so. A cursorless final page is cut to its ceiling too, keeping \
+at least one entry, and the cut is published in `elisions` and `degradations`; its remedy names \
+`max_chars` and a narrower request, because with no `next_cursor` the withheld entries cannot be \
+reached by paging. Only when one surviving entry per list still exceeds the ceiling does the \
+response ship over budget, and it discloses that as `response_over_budget`.";
 
 /// Offline/generic dispatch arm for `semantic_locate`.
 ///
@@ -5430,6 +5432,90 @@ mod tests {
         GraphNodeId, Relation, RelationEvidence, RelationKind, RelationOrigin,
     };
     use kin_spine::SpineBackend as _;
+
+    /// The `semantic_locate` description and the budget it describes must not
+    /// drift apart again.
+    ///
+    /// kin #1208 reversed the final-page rule and the description kept the old
+    /// one (FIR-2860). Agents read the description to decide how to page, so
+    /// main told them to expect rows this server cuts.
+    ///
+    /// Asserting `SEMANTIC_LOCATE_DESC.contains("max_chars")` would be a check
+    /// that cannot fail. The description already names `max_chars` where it
+    /// introduces the budget, so that assertion passes with the final-page
+    /// sentence deleted outright. `budget.rs` met the same trap from the other
+    /// side: a bare `max_chars` substring was satisfied by the residual
+    /// disclosure, and the mutation that deleted the branch survived it. So the
+    /// budget half binds to the producer, by running the real budget over a
+    /// cursorless over-budget page and requiring the description to carry the
+    /// clause the remedy actually emitted, and the `max_chars` half is scoped to
+    /// the final-page sentence rather than to the whole string.
+    #[test]
+    fn the_locate_description_states_the_final_page_rule_the_budget_enforces() {
+        // The old claim in the words it shipped in. This is the assertion that
+        // goes red if the pre-#1208 sentence is restored.
+        assert!(
+            !SEMANTIC_LOCATE_DESC.contains("keeps its primary rows"),
+            "the description still promises a cursorless final page keeps its primary rows, \
+             which is the rule kin #1208 reversed"
+        );
+
+        // A cursorless page whose primary list alone exceeds the floor budget,
+        // which is the branch the description is about.
+        let hits = 20;
+        let mut payload = serde_json::json!({
+            "query": "where redirects are resolved",
+            "routing": "cosine-v0",
+            "results": (0..hits).map(|index| serde_json::json!({
+                "entity_id": format!("00000000-0000-0000-0000-{index:012}"),
+                "name": format!("handler_{index}_{}", "x".repeat(500)),
+                "kind": "function",
+                "score": 0.5,
+            })).collect::<Vec<_>>(),
+            "next_cursor": serde_json::Value::Null,
+        });
+        let budget = crate::budget::ResponseBudget {
+            max_chars: crate::budget::RESPONSE_MIN_MAX_CHARS,
+            ..crate::budget::ResponseBudget::default()
+        };
+        crate::budget::enforce(&mut payload, "semantic_locate", &budget).expect("budgeted");
+
+        // Read what the producer wrote rather than a second copy of it. If the
+        // budget's no-cursor wording moves, this fails here and names the
+        // description as the thing to rewrite, which is the drift both halves
+        // exist to catch.
+        let no_cursor_clause = "cannot be reached by paging";
+        let remedy = payload["degradations"]
+            .as_array()
+            .expect("a cut publishes a degradation")
+            .iter()
+            .filter_map(|entry| entry["remediation"].as_str())
+            .find(|remedy| remedy.contains(no_cursor_clause))
+            .unwrap_or_else(|| {
+                panic!(
+                    "the budget no longer emits a no-cursor remedy saying {no_cursor_clause:?}; \
+                     the rule moved and SEMANTIC_LOCATE_DESC is what needs rewriting"
+                )
+            });
+        assert!(
+            SEMANTIC_LOCATE_DESC.contains(no_cursor_clause),
+            "the budget's no-cursor remedy says {no_cursor_clause:?} and the description does \
+             not, so an agent reading it cannot tell that paging will not recover the withheld \
+             rows. Remedy emitted: {remedy:?}"
+        );
+
+        // Scoped, so the `max_chars` the description already names when it
+        // introduces the budget cannot satisfy this on its own.
+        let final_page = SEMANTIC_LOCATE_DESC
+            .split_once("A cursorless final page")
+            .expect("the description must describe the cursorless final page")
+            .1;
+        assert!(
+            final_page.contains("max_chars"),
+            "the final-page sentence must name `max_chars` as the remedy, because no cursor \
+             reaches the withheld rows: {final_page:?}"
+        );
+    }
 
     /// A row as the wire carries it, so the field cannot be added to the struct
     /// and dropped by the serializer.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -228,12 +228,10 @@ sheds its secondary per-file symbol roll-up. File granularity preserves those sy
 are primary answer detail. It then sheds inline snippets, and only then withholds hits from the end \
 of the page. Any cut is reported \
 in `degradations` and in `_kin.response`, which carries the budget applied and what the response \
-measured before it. When primary rows are withheld and `next_cursor` can be rebased, every row \
-stays reachable and the remedy says so. A cursorless final page is cut to its ceiling too, keeping \
-at least one entry, and the cut is published in `elisions` and `degradations`; its remedy names \
-`max_chars` and a narrower request, because with no `next_cursor` the withheld entries cannot be \
-reached by paging. Only when one surviving entry per list still exceeds the ceiling does the \
-response ship over budget, and it discloses that as `response_over_budget`.";
+measured before it. Primary rows are withheld only when `next_cursor` can be rebased so every row \
+stays reachable. A cursorless final page keeps its primary rows instead; if those rows alone exceed \
+the ceiling, the response ships over budget with `response_over_budget` disclosure rather than \
+silently losing unrecoverable answers, and a size-limited client may still refuse it.";
 
 /// Offline/generic dispatch arm for `semantic_locate`.
 ///


### PR DESCRIPTION
kin #1208 reversed the cursorless final-page budget rule and `semantic_locate`'s tool description kept the old one. Agents read that description to decide how to page, so main has been telling them to expect rows this server cuts.

The description said a cursorless final page keeps its primary rows and ships over budget with `response_over_budget` disclosure. The server does the opposite: every collection is cut to `max_chars` including a final page's primary one, a floor of one entry per list holds, the cut is published in `elisions` and `degradations`, and the remedy names `max_chars` and a narrower request because no cursor reaches the withheld rows. `crates/kin-mcp/src/budget.rs` asserts the shipped rule in `a_final_page_is_cut_to_its_ceiling_and_names_no_cursor_recovery`.

The rewrite keeps the one true part of the old sentence where it still applies. `response_over_budget` is now the residual case, reached only when one surviving entry per list still exceeds the ceiling, and it is still emitted at `budget.rs:1139`.

## The test binds the description to the producer, not to a copy of itself

Asserting `SEMANTIC_LOCATE_DESC.contains("max_chars")` would be a check that cannot fail. The description already names `max_chars` where it introduces the budget, so that assertion passes today and would still pass with the final-page sentence deleted outright. `budget.rs` met the same trap from the other side and its own comment records it: a bare `max_chars` substring was satisfied by the residual disclosure, and the mutation that deleted the branch survived exactly that test.

So the test runs the real budget over a cursorless over-budget page, reads the remedy the producer actually emitted, and requires the description to carry that clause. The `max_chars` half is scoped to the final-page sentence rather than to the whole string.

## Falsification, on hosted CI, with the assertion named for each arm

No build slot on this lane, so each mutation is a real commit pushed to this branch and reverted by a real commit rather than a force-push, leaving the evidence reachable in the history. Each mutation was shown to remove its target property, and only its target, before being pushed.

| Arm | Commit | Mutation | Run | Job | Assertion that fired |
|---|---|---|---|---|---|
| 1 | `574359436` | restore the pre-#1208 sentence | 33188221870 | 98906797258 | `entities.rs:5455` "the description still promises a cursorless final page keeps its primary rows" |
| 2 | `430f93220` | drop `max_chars` from the final-page clause only | 33189096945 | 98909716624 | `entities.rs:5513` "the final-page sentence must name `max_chars` as the remedy" |
| 3 | `dd349a430` | change the producer's clause in `budget.rs` | 33190153084 | 98913335144 | `entities.rs:5495` "the budget no longer emits a no-cursor remedy" |
| 4 | `a0802e1aa` | strip the clause from the description, producer untouched | 33191193987 | 98916906342 | `entities.rs:5500` "the budget's no-cursor remedy says ... and the description does not" |

Four assertion sites, four arms, each firing its own site with every other assertion message reading zero in its log.

Arm 2 is the one that matters most for the design: written as a bare `contains("max_chars")`, that exact mutation passes green. Arms 3 and 4 are the pair proving this test is not a duplicate of `budget.rs`'s own: arm 3 mutates the producer and fires both tests in two different shards, arm 4 mutates only the description and fires only this one. Arm 4's failure message quotes the remedy the producer emitted at run time, which is the join working rather than a literal comparing itself to a literal.

Each arm was confirmed to have actually run rather than being filtered out: the test name appears in the shard log and the summary counts it among the tests run, against a fabricated name returning zero. That matters because the fast gate scopes to changed crates and shards by nextest partition, so a test can land in no shard at all.

## Restore

Final head `1d04d001f`. All four mutations reverted by real commits. `f49918451^{tree}` and the final `HEAD^{tree}` both read `b0463c794f7322753951ff8fbe6b996d2b8c5aa5`, byte-identical, with zero mutation markers left in the tree.

One run in this branch's history is neither green nor red and is not cited as evidence: 33190948150 concluded `cancelled` with 0 failed jobs, superseded when arm 4 was pushed, since `ci.yml:28-30` sets `cancel-in-progress` for non-main refs.

## Sweep

The three other phrases from the old sentence return zero files across the tree. The only remaining occurrences of "keeps its primary rows" are inside the new test, which names the old claim in order to reject it. `docs/` carries no final-page or budget claim, and that zero is trustworthy: a control shows the search reaches `docs/`, which holds 24 tracked files, four of which discuss `semantic_locate`, and none of which mentions `max_chars`.

## Gates

`cargo fmt --all -- --check` passes at rc 0. This lane holds no build slot, so nothing was compiled locally and hosted CI is the gate.

Closes FIR-2860
