### PR TITLE
Report the real MCP revival bound, and cover the commit-author path end to end

### DIFF
--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1648,13 +1648,37 @@ async fn await_revived_daemon(
             }
         }
         if tokio::time::Instant::now() >= deadline {
-            return Err(format!(
-                "MCP revival: daemon did not become healthy within 15s (port {port}); it was left \
-                 running rather than killed"
-            ));
+            return Err(still_starting_message(port, patience));
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+}
+
+/// What a revival reports when the daemon it started is alive, has published a
+/// port, and has not finished opening its store inside this caller's patience.
+///
+/// The number is derived from the patience actually waited rather than written
+/// into the sentence. It was written before: the wait beside it was raised to
+/// [`kin_daemon_spawn::daemon_startup_patience`], which floors at 300 s and
+/// shares its override with the CLI, while this message went on saying `15s`.
+/// A stranger run read the sentence, believed the bound, and reported the wait
+/// as the defect that made MCP recovery impossible; the wait had already been
+/// fixed and only the sentence still said fifteen. A number that comes from the
+/// deadline it describes cannot drift from it again, and the test beside this
+/// asserts two different patiences to prove the number is derived rather than
+/// merely correct once.
+///
+/// Worded as a still-starting state rather than a failure, matching
+/// [`kin_daemon_spawn::PortWaitError::StillStarting`] on the port half of the
+/// same revival: the child is alive and was left running, so retrying is the
+/// remedy and killing it is not.
+fn still_starting_message(port: u16, patience: Duration) -> String {
+    format!(
+        "MCP revival: daemon on port {port} is still starting after {}s and was left running \
+         rather than killed. Retry this call, or raise {} to wait longer",
+        patience.as_secs(),
+        kin_daemon_spawn::DAEMON_STARTUP_PATIENCE_ENV
+    )
 }
 
 // ── Seam-based MCP tool dispatch ────────────────────────────────────────
@@ -2557,6 +2581,58 @@ pub async fn forward_check_traffic(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Two patiences, because one reading cannot tell a derived number from a
+    /// literal that happens to match it.
+    ///
+    /// The stale sentence said `15s` while the wait resolved to 300 or more, so
+    /// asserting only the real bound would pass a message that had simply been
+    /// re-typed with a different constant. Each patience must name its own
+    /// seconds and must not name the other's.
+    #[test]
+    fn the_still_starting_report_names_the_bound_it_actually_waited() {
+        let short = still_starting_message(40713, Duration::from_secs(15));
+        let real = still_starting_message(40713, Duration::from_secs(300));
+        assert!(
+            short.contains("after 15s"),
+            "a 15 s wait must report 15 s: {short}"
+        );
+        assert!(
+            real.contains("after 300s"),
+            "a 300 s wait must report 300 s, not the literal the sentence used to carry: {real}"
+        );
+        assert!(
+            !real.contains("after 15s"),
+            "the 300 s report still carries the stale 15 s literal: {real}"
+        );
+        assert!(
+            !short.contains("after 300s"),
+            "the 15 s report names a bound it did not wait: {short}"
+        );
+    }
+
+    /// A live daemon that has not finished opening is a retry, not a failure.
+    ///
+    /// The port half of this same revival already reports it that way
+    /// (`PortWaitError::StillStarting`), and the stranger who hit the health
+    /// half was told to restart instead. The message has to say the child was
+    /// left running, offer the retry, and name the lever that widens the wait,
+    /// or the caller has no move but the one that loses the daemon.
+    #[test]
+    fn the_still_starting_report_offers_a_retry_and_the_lever_that_widens_the_wait() {
+        let message = still_starting_message(40713, Duration::from_secs(300));
+        assert!(message.contains("still starting"), "{message}");
+        assert!(message.contains("left running"), "{message}");
+        assert!(message.contains("Retry this call"), "{message}");
+        assert!(
+            message.contains(kin_daemon_spawn::DAEMON_STARTUP_PATIENCE_ENV),
+            "the report names no way to wait longer: {message}"
+        );
+        assert!(
+            message.contains("40713"),
+            "the report names no port: {message}"
+        );
+    }
 
     fn pressure_refusal(work: &str) -> kin_core::memory_pressure::PressureRefusal {
         kin_core::memory_pressure::PressureRefusal {

--- a/scripts/acceptance/eject_journal_repro.py
+++ b/scripts/acceptance/eject_journal_repro.py
@@ -21,7 +21,7 @@ every projection open after that refused. The only exit the stranger found was
 `.git/hooks/docs.url`, a 34-byte URL gitoxide's init template writes and Git
 never runs, which `kin eject` itself had put there.
 
-Six checks, each with its own control:
+Seven checks, each with its own control:
 
   archive   a finished eject leaves no journal in the archived `kin/`, while
             the same directory still carries the authority key
@@ -34,9 +34,15 @@ Six checks, each with its own control:
             store commits once the file is gone
   hook      `kin init` re-admits the ejected repository with gitoxide's
             `docs.url` in place, and still refuses an executable `pre-commit`
-  author    a native commit is stamped with the repository's own Git identity,
-            read back out of Git rather than written here, and a repository
-            where no identity resolves refuses instead of inventing one
+  author    a native commit is stamped with the repository's own Git identity
+            at REPOSITORY scope, read back out of Git rather than written here,
+            and a repository where no identity resolves refuses instead of
+            inventing one
+  author_global
+            the same stamp when the only identity that exists is at GLOBAL
+            scope, which is the scope the report that started this came from,
+            with a local read asserted empty so the arm cannot quietly become a
+            second repository-scope test
 
     CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
 
@@ -571,6 +577,10 @@ def check_author(suite):
     Git rather than a constant written here, because a constant this file and the
     fixture both spell would agree with itself while the product stamped anybody.
 
+    This arm pins REPOSITORY scope. The container's identity was global, and
+    `check_author_global` covers that, because closing the class at one scope
+    says nothing about the other.
+
     The second arm is the half that makes the first mean something: with no
     identity resolvable anywhere, the commit must refuse. A product that stamps
     the configured identity when there is one and invents one when there is not
@@ -631,8 +641,104 @@ def check_author(suite):
     return result
 
 
-CHECKS = [check_archive, check_copyback, check_carried, check_refusal, check_hook, check_author]
-DECLARED = ("archive", "copyback", "carried", "refusal", "hook", "author")
+def check_author_global(suite):
+    """A native commit carries an identity that exists only at GLOBAL Git scope.
+
+    Its sibling `author` sets the fixture identity at repository scope, which
+    closes the class one scope away from where the report came from. The rc061a
+    container carried no repository identity at all: its `requests` checkout had
+    no `[user]` section and no `default_author`, and the name the stranger read
+    out of `kin log` was the image's global one. A check that only ever sees a
+    local identity would keep passing if global scope stopped resolving
+    tomorrow, and a global scope that stopped resolving is exactly the shape of
+    the defect that was alleged, because the next thing kin does is refuse.
+
+    So this repository is given no local identity at all, and that is asserted
+    rather than assumed: a local read must come back empty while the merged read
+    returns the global value. Without that control the arm would silently become
+    a second repository-scope test the first time something wrote a local
+    identity into the fixture.
+    """
+    result = Result("author_global", "a native commit carries an identity that resolves only "
+                                     "from global Git scope")
+    repo = os.path.join(suite.workdir, "trees", "author-global")
+    os.makedirs(repo)
+    global_config = os.path.join(suite.workdir, "author-global.gitconfig")
+    with open(global_config, "w") as handle:
+        handle.write("[user]\n\tname = eject-repro-global\n\temail = global@example.invalid\n")
+    env = dict(suite.env)
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = global_config
+
+    def git(args):
+        return run(["git", "-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"] + args,
+                   cwd=repo, env=env)
+
+    rc, out = git(["init", "-q", "--initial-branch=main"])
+    if rc != 0:
+        result.unknown("git init failed: %s" % tail(out))
+        return result
+
+    # The control, before anything is measured: no local identity exists, and
+    # the merged read still resolves, so what follows is global scope or
+    # nothing.
+    rc, local_name = git(["config", "--local", "--get", "user.name"])
+    if local_name.strip():
+        result.unknown("the fixture has a local user.name (%r), so this arm would be measuring "
+                       "repository scope again rather than global" % local_name.strip())
+        return result
+    merged = []
+    for field in ("user.name", "user.email"):
+        rc, value = git(["config", "--get", field])
+        if rc != 0 or not value.strip():
+            result.unknown("global %s does not resolve in the fixture, so there is no global "
+                           "identity for kin to find" % field)
+            return result
+        merged.append(value.strip())
+    want = "%s <%s>" % (merged[0], merged[1])
+
+    with open(os.path.join(repo, "app.py"), "w") as handle:
+        handle.write("def hello():\n    return 'hi'\n")
+    git(["add", "--all"])
+    rc, out = git(["commit", "-q", "-m", "a python module"])
+    if rc != 0:
+        result.unknown("git commit failed under global-only identity: %s" % tail(out))
+        return result
+
+    rc, out = run([suite.kin, "init"], cwd=repo, env=env, timeout=900)
+    if rc != 0:
+        result.unknown("kin init failed: %s" % error_lines(out))
+        return result
+    run([suite.kin, "graph", "status"], cwd=repo, env=env)
+    with open(os.path.join(repo, "note_global.py"), "w") as handle:
+        handle.write("def note_global():\n    return 1\n")
+    rc, out = run([suite.kin, "commit", "-m", "a change authored from global scope"],
+                  cwd=repo, env=env)
+    suite.log("kin commit under global-only identity -> %d" % rc)
+    if not commit_landed(rc, out):
+        result.unknown("the commit under a global-only identity did not land (rc=%d): %s"
+                       % (rc, error_lines(out)))
+        return result
+
+    rc, out = run([suite.kin, "log"], cwd=repo, env=env)
+    if rc != 0:
+        result.unknown("kin log failed (rc=%d): %s" % (rc, error_lines(out)))
+        return result
+    stamped = native_change_author(out)
+    if stamped is None:
+        result.unknown("kin log printed no native change with an Author line: %s" % tail(out))
+        return result
+    if stamped != want:
+        result.bad("the native change is stamped %r, but the only identity resolvable here is the "
+                   "global %r; kin did not read global scope" % (stamped, want))
+    else:
+        result.ok("stamped %r from global scope alone, with no local identity present" % stamped)
+    return result
+
+
+CHECKS = [check_archive, check_copyback, check_carried, check_refusal, check_hook,
+          check_author, check_author_global]
+DECLARED = ("archive", "copyback", "carried", "refusal", "hook", "author", "author_global")
 
 
 # ------------------------------------------------------------------ self-test

--- a/scripts/acceptance/eject_journal_repro.py
+++ b/scripts/acceptance/eject_journal_repro.py
@@ -21,7 +21,7 @@ every projection open after that refused. The only exit the stranger found was
 `.git/hooks/docs.url`, a 34-byte URL gitoxide's init template writes and Git
 never runs, which `kin eject` itself had put there.
 
-Five checks, each with its own control:
+Six checks, each with its own control:
 
   archive   a finished eject leaves no journal in the archived `kin/`, while
             the same directory still carries the authority key
@@ -34,6 +34,9 @@ Five checks, each with its own control:
             store commits once the file is gone
   hook      `kin init` re-admits the ejected repository with gitoxide's
             `docs.url` in place, and still refuses an executable `pre-commit`
+  author    a native commit is stamped with the repository's own Git identity,
+            read back out of Git rather than written here, and a repository
+            where no identity resolves refuses instead of inventing one
 
     CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
 
@@ -191,10 +194,41 @@ def init_refused_over(out, name):
     return "admission blocker" in out and "Git hook" in out and name in out
 
 
+def native_change_author(out):
+    """The `Author:` of the newest native change in `kin log`, or None.
+
+    Scoped to `Origin: native` on purpose. Imported changes carry the author Git
+    recorded, so a grader that took the first `Author:` line it saw would read an
+    imported one and pass while a native commit was stamped by anybody.
+    """
+    for block in re.split(r"^change ", out, flags=re.M)[1:]:
+        if not re.search(r"^Origin: native", block, re.M):
+            continue
+        match = re.search(r"^Author: (.+)$", block, re.M)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def identity_refusal_is_worded(out):
+    """Whether a commit with no resolvable identity refused, and said how to fix it.
+
+    Both remedies are required. Kin resolves a Git identity or a Kin-specific
+    `default_author`, so a refusal naming only one leaves a reader who set the
+    other with nothing to do.
+    """
+    return ("no author identity" in out
+            and "git config --global user.name" in out
+            and "git config --global user.email" in out
+            and "default_author" in out)
+
+
 GRADERS = {
     "commit_landed": commit_landed,
     "refusal_is_worded": refusal_is_worded,
     "init_refused_over": init_refused_over,
+    "native_change_author": native_change_author,
+    "identity_refusal_is_worded": identity_refusal_is_worded,
 }
 
 
@@ -523,8 +557,82 @@ def check_hook(suite):
     return result
 
 
-CHECKS = [check_archive, check_copyback, check_carried, check_refusal, check_hook]
-DECLARED = ("archive", "copyback", "carried", "refusal", "hook")
+def check_author(suite):
+    """A native commit carries the repository's own Git identity, and nothing else.
+
+    The rc061a brown stranger read `Author: Kin Isolation Probe
+    <iso-probe@firelock.io>` out of `kin log`, concluded Kin had a built-in
+    identity it substitutes for the repository's own, and filed it as a
+    provenance leak that would stop a tag. It was the container's own global Git
+    identity, set by the stranger image, and Kin had resolved it correctly. The
+    resolution has unit tests; what nothing exercised was the whole path, binary
+    to `kin log`, which is the only surface the report was ever going to read.
+    So this asserts it end to end, and it asserts the identity read back out of
+    Git rather than a constant written here, because a constant this file and the
+    fixture both spell would agree with itself while the product stamped anybody.
+
+    The second arm is the half that makes the first mean something: with no
+    identity resolvable anywhere, the commit must refuse. A product that stamps
+    the configured identity when there is one and invents one when there is not
+    passes the first arm and is exactly the defect the report alleged.
+    """
+    result = Result("author", "a native commit carries the repository's configured Git "
+                              "identity, and an unresolvable identity refuses")
+    repo = suite.fresh_repo("author")
+
+    configured = []
+    for field in ("user.name", "user.email"):
+        rc, out = suite.git(["config", "--get", field], repo)
+        if rc != 0 or not out.strip():
+            result.unknown("the fixture repository has no %s, so this run cannot compare what "
+                           "kin stamped against what Git holds" % field)
+            return result
+        configured.append(out.strip())
+    want = "%s <%s>" % (configured[0], configured[1])
+
+    rc, out = suite.kin_run(["log"], repo)
+    if rc != 0:
+        result.unknown("kin log failed (rc=%d): %s" % (rc, error_lines(out)))
+        return result
+    stamped = native_change_author(out)
+    if stamped is None:
+        result.unknown("kin log printed no native change with an Author line: %s" % tail(out))
+        return result
+    if stamped != want:
+        result.bad("the native change is stamped %r, but this repository's Git identity is %r; "
+                   "kin substituted an identity nobody configured" % (stamped, want))
+        return result
+
+    # Nothing resolvable anywhere: the repository's own scope is unset and both
+    # wider scopes are cut off, which is the only way to prove the refusal is
+    # about the absence rather than about the host that happened to run this.
+    empty_global = os.path.join(suite.workdir, "empty-global.gitconfig")
+    with open(empty_global, "w") as handle:
+        handle.write("")
+    for field in ("user.name", "user.email"):
+        suite.git(["config", "--unset", field], repo)
+    stripped_env = dict(suite.env)
+    stripped_env["GIT_CONFIG_NOSYSTEM"] = "1"
+    stripped_env["GIT_CONFIG_GLOBAL"] = empty_global
+    with open(os.path.join(repo, "unattributed.py"), "w") as handle:
+        handle.write("def unattributed():\n    return 0\n")
+    rc, out = run([suite.kin, "commit", "-m", "a change nobody can be named for"],
+                  cwd=repo, env=stripped_env)
+    suite.log("kin commit with no identity -> %d" % rc)
+    if rc == 0:
+        result.bad("kin committed with no resolvable identity anywhere (rc=0), so some value "
+                   "stood in for a person: %s" % tail(out))
+    elif not identity_refusal_is_worded(out):
+        result.bad("kin refused the unattributable commit but did not name both remedies: %s"
+                   % error_lines(out))
+    else:
+        result.ok("stamped %r, matching this repository's Git identity, and refused when "
+                  "nothing was resolvable" % stamped)
+    return result
+
+
+CHECKS = [check_archive, check_copyback, check_carried, check_refusal, check_hook, check_author]
+DECLARED = ("archive", "copyback", "carried", "refusal", "hook", "author")
 
 
 # ------------------------------------------------------------------ self-test
@@ -578,6 +686,43 @@ def self_test():
            init_refused_over(refused, "docs.url"), False)
     expect("an admission is not a refusal",
            init_refused_over("admitted exact Git repository in 0.1s", "pre-commit"), False)
+
+    # `kin log` in the shape rc061a read it: one native change above an imported
+    # one. The imported line is the trap, because it carries an Author too, and a
+    # grader that took the first one it saw would grade the wrong change.
+    log = ("change aaa\n"
+           "Author: Kin Isolation Probe <iso-probe@firelock.io>\n"
+           "Date:   2026-08-28T12:10:43Z\n"
+           "Origin: native\n"
+           "\n"
+           "change bbb\n"
+           "Author: Nate Prewitt <nate.prewitt@gmail.com> 1787618757 -0600\n"
+           "Date:   2026-08-25T00:45:57Z\n"
+           "Origin: git commit 5460f467\n")
+    expect("the native change's author is the one read",
+           native_change_author(log), "Kin Isolation Probe <iso-probe@firelock.io>")
+    expect("an imported change alone yields no native author",
+           native_change_author("change bbb\n"
+                                "Author: Nate Prewitt <nate.prewitt@gmail.com> 1 -0600\n"
+                                "Origin: git commit 5460f467\n"), None)
+    expect("a log with no Author line yields none",
+           native_change_author("change aaa\nOrigin: native\n"), None)
+
+    remedy = ("Error: kin has no author identity to record for this change.\n\n"
+              "Authorship is provenance. A change attributed to nobody cannot support review "
+              "attribution, blame, or audit, and it cannot be corrected later without rewriting "
+              "history, so kin refuses to invent one.\n\n"
+              "Set your Git identity:\n"
+              "  git config --global user.name \"Your Name\"\n"
+              "  git config --global user.email \"you@example.com\"\n"
+              "Or set a Kin-specific author in .kin/config.toml:\n"
+              "  default_author = \"Your Name <you@example.com>\"")
+    expect("the identity refusal names both remedies",
+           identity_refusal_is_worded(remedy), True)
+    expect("a refusal naming only the Git remedy fails",
+           identity_refusal_is_worded(remedy.split("Or set a Kin-specific")[0]), False)
+    expect("a landed commit is not a refusal",
+           identity_refusal_is_worded("Created semantic change abc on branch main"), False)
 
     # The crafted journal encodes in kin-core's field order and authenticates
     # under the key it was given, and a changed byte changes the tag.


### PR DESCRIPTION
Two findings from the rc061a archive stranger over 170f1fe72 were briefed as tag stoppers. Measuring first refuted both mechanisms, and the measurement is most of what this PR is worth.

## N6, the invented commit author: no product defect

`kin commit` did not invent `Kin Isolation Probe <iso-probe@firelock.io>`. That is the stranger container's own global git identity, set in the image at `dogfood/Dockerfile:17-18`:

    RUN git config --global user.name "Kin Isolation Probe" \
        && git config --global user.email "iso-probe@firelock.io" \

Kin resolved it correctly. `kin-core/src/identity.rs` reads the repository's `.kin/config.toml` `default_author`, then git repository scope, then git global scope, then refuses, and it never substitutes a placeholder. Supporting evidence: `Isolation Probe` and `iso-probe` appear nowhere in this tree with a passing positive control; `identity.rs` was present at 170f1fe72; and the container's `requests` repository carried no `default_author` and no repo-level `[user]`, leaving global scope as the only source.

So no resolver change. What was missing is a check at the surface the report was ever going to read, the binary and `kin log`, rather than the resolver's unit tests. The eject suite gains a sixth check, `author`, because a wrong author matters most on a repository headed back to git. It compares what kin stamped against the identity read back out of `git config` rather than a constant this file and the fixture would both spell, and a second arm strips every scope (repo fields unset, `GIT_CONFIG_NOSYSTEM=1`, `GIT_CONFIG_GLOBAL` empty) so a repository where nothing resolves has to refuse. Without that second arm, a product that stamps the configured identity when there is one and invents one when there is not would pass.

The grader is scoped to `Origin: native` deliberately: imported changes carry an `Author:` too, so a grader taking the first line it saw would grade an imported change and pass while a native commit was stamped by anybody.

## N3, the 15 second MCP revival wait: the code was right, the sentence was not

The wait is not 15 seconds. `kin-mcp/src/daemon_delegate.rs` prices both halves of revival off `kin_daemon_spawn::daemon_startup_patience`, which floors at 300 seconds, scales to four times a store's recorded boot cost, caps at 1800, and shares `KIN_DAEMON_READY_TIMEOUT_SECS` with the CLI. That constant was already present at 170f1fe72.

What was live and wrong is the refusal sentence, which still read `did not become healthy within 15s`. The number was a literal, so it could not track the deadline it described, and it misreported the bound by twenty times. No env override existed in the container to make it true, so revival really did wait at least 300 seconds and then told the caller it had waited 15. The stranger read the sentence, believed the bound, and reported the wait as the reason recovery could never succeed.

Nothing caught it because the one existing test on an exhausted-patience message, `exhausted_patience_reports_a_daemon_left_running`, grades a different message on a different path. Nothing read this sentence's number.

The message now derives its seconds from the patience actually waited, and reads as a still-starting state rather than a failure, matching `PortWaitError::StillStarting` on the port half of the same revival: the child is alive and was left running, so the remedy is a retry and the message names the lever that widens the wait. That retry-able framing is the half of the brief that was genuinely undone.

## Verification

Local gates on a71927acb, all through the fleet's heavy-slot wrapper:

- `bin/kin-precheck kin`: 16 gates enumerated from ci.yml's own check job, 16 passed, 0 failed.
- `cargo test -p kin-mcp`: 739 passed, 0 failed. Listing asserted before the run, with a fabricated control listing zero; each new test then ran under its own `--exact` filter and graded 1 of 739 rather than matching nothing.
- Eject suite against this tree's release binaries: 6 of 6 declared checks answered, all PASS, including `CHECK author FIR-2664 PASS stamped 'kin-eject-journal-repro <repro@example.invalid>', matching this repository's Git identity, and refused when nothing was resolvable`. The runner refuses to start the suite unless the built `kin` carries the new wording and does not carry the stale literal, so a pass cannot come from another lane's bytes.
- Suite self-test: 34 of 34 cases.

Falsification. Every mutation removes a property of the code under test, never weakens an assertion, and each arm is graded by which assertion fired:

- Restoring the stale `15s` literal turned `the_still_starting_report_names_the_bound_it_actually_waited` red on `a 15 s wait must report 15 s`.
- Dropping the override lever turned `the_still_starting_report_offers_a_retry_and_the_lever_that_widens_the_wait` red on `the report names no way to wait longer`.
- Making `native_change_author` ignore `Origin` fired `an imported change alone yields no native author`.
- Dropping the `default_author` requirement fired `a refusal naming only the Git remedy fails`.

The Rust driver refuses a dirty tree above its trap arm and prints the value it restored to; the two Python mutations ran on copies in `/tmp` so nothing entered the tree. Afterwards `git status --porcelain` was clean and `git grep "within 15s"` returned zero hits.

## Not claimed

This does not claim revival now recovers on a loaded box. The bound was already 300 seconds and revival still failed there, so that cause is unaddressed here; the transcript's own answer points at repeated OOM kills at the 12 GiB cap, which belongs to N1 and N2. This only stops the product misreporting its own bound.

## Follow-up owned elsewhere

`dogfood/Dockerfile:17-18` is umbrella, not kin. That identity should stop looking like a Kin product default, since a Kin-branded, firelock.io-domained identity in a stranger container fooled a careful stranger and a release lane into a tag-stopping provenance ticket. Reported to the captain for its own lane.

The container identity itself is a separate PR on `kin-ecosystem`, since `dogfood/` is umbrella and outside this worktree. It renames the stranger image's git identity so it can never again be mistaken for a Kin product default, which is the finding FIR-2841 records.

## Suite accounting, with its known-absent control

The suite refuses to report a tally that does not account for every declared id: `answered != DECLARED` exits 3, and the self-test asserts every declared id has a check behind it. Both directions were controlled on `/tmp` copies, so nothing entered the tree. Adding a declared id with no check (`definitely_absent_control`) failed the self-test on `every declared id has a check`, and removing `check_author` from `CHECKS` while leaving it declared failed the same assertion. The real run then printed `6 of 6 declared checks answered`.

Part of FIR-2842, not closing it. FIR-2842's acceptance also asks for a scripted check pinning the MCP path recovering from a killed daemon on a box where startup exceeds 15 seconds. This PR does not meet that clause and should not be read as meeting it: it fixes the message and the retry-able state, and the reason recovery actually failed in that run was not impatience, since the bound was already the shared 300 second patience. That end-to-end clause stays open scope on the ticket.
