### PR TITLE
Repair the Kin registry pin wave: re-lock the fuzz workspace and name the refusal check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -1130,7 +1130,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1239,7 +1239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3286,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.67"
+version = "0.7.71"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "1b11a925682d8fe6114ae50bb96a1b55eb19babe7520f2efb77402f39cc344ca"
+checksum = "3cb869cfc5468f0ab34170b85fafae12aa61f08ec2d145fc09ac85ad21de2a38"
 dependencies = [
  "bincode",
  "bstr",
@@ -3429,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.7.0"
+version = "0.7.12"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "de8108477768a3f1470f7719c0e6cd572efbe71a750edb2f086045e71a9fae60"
+checksum = "9d9e9acdb3dea7a4d1da9110fbfe5b365ffe322395780368727f4b16257fc873"
 dependencies = [
  "kin-model",
  "serde",
@@ -3504,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.20"
+version = "0.7.22"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "34bd9edbec6bd133ba71d96721deac5bde53c58dd3f1ddf8a2cfd01994f0659a"
+checksum = "3550abd2115b4885d7594e8d1cfe045f68ff1b62c374217bbf0e7f24c81a7a86"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -3780,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.4.14"
+version = "0.4.21"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "49e9e18523938c55a6bce736ba82079bc06693ff318db7b7965a6fab2fba2a3f"
+checksum = "f2503190c57364c3573735fc6f9f2a7b932ce2659cac6e4901c27e031b6094d0"
 dependencies = [
  "lru",
  "parking_lot",
@@ -4146,7 +4146,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5068,7 +5068,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5137,7 +5137,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5581,7 +5581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5725,7 +5725,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6658,7 +6658,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.20", registry = "kin" }
+kin-model = { version = "=0.7.22", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -149,14 +149,14 @@ kin-daemon-spawn = { path = "crates/kin-daemon-spawn" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "=0.7.0", registry = "kin" }
+kin-lsp = { version = "=0.7.12", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.67", registry = "kin", default-features = false }
-kin-vfs-core = { version = "=0.4.14", registry = "kin" }
+kin-db = { version = "=0.7.71", registry = "kin", default-features = false }
+kin-vfs-core = { version = "=0.4.21", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2337,11 +2337,29 @@ impl DaemonState {
                 };
             }
             Ok(_) if !had_persisted_index => return VectorSidecarOpen::default(),
-            Ok(_) => format!(
-                "the persisted vector index at {} no longer matches this repository's graph or \
-                 embedding model, so it was not loaded",
-                vector_path.display()
-            ),
+            // kin-db carries WHY it refused, and collapsing every non-attach
+            // into one sentence about the graph and the embedding model
+            // misdiagnoses the ones that are about neither. A metadata version
+            // this build cannot read is not a stamp that drifted, and telling
+            // an operator to expect a rebuild for a mismatch they do not have
+            // sends them looking in the wrong place.
+            Ok(outcome) => match &outcome.disposition {
+                kin_db::VectorSidecarDisposition::RefusedSidecar { check } => format!(
+                    "the persisted vector index at {} was refused by the {check} check, so it \
+                     was not loaded",
+                    vector_path.display()
+                ),
+                kin_db::VectorSidecarDisposition::ArchivedIncompatibleIndex { reason } => format!(
+                    "the persisted vector index at {} contradicted the metadata beside it \
+                     ({reason}), so it was archived aside and not loaded",
+                    vector_path.display()
+                ),
+                _ => format!(
+                    "the persisted vector index at {} no longer matches this repository's graph \
+                     or embedding model, so it was not loaded",
+                    vector_path.display()
+                ),
+            },
             Err(error) => format!(
                 "the persisted vector index at {} could not be read ({error}), so it was not loaded",
                 vector_path.display()
@@ -11323,8 +11341,13 @@ mod tests {
             .discarded
             .expect("a refused sidecar must be announced, not dropped silently");
         assert!(
-            reason.contains("graph.kvec") && reason.contains("could not be read"),
-            "the announcement must name what was discarded and why: {reason}"
+            reason.contains("graph.kvec"),
+            "the announcement must name what was discarded: {reason}"
+        );
+        assert!(
+            reason.contains("metadata_version_future"),
+            "and WHY, by the check kin-db refused on, not by a generic sentence about a graph \
+             or model mismatch this sidecar does not have: {reason}"
         );
         assert_eq!(
             graph.embedding_status().indexed,

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.20"
+version = "0.7.22"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "34bd9edbec6bd133ba71d96721deac5bde53c58dd3f1ddf8a2cfd01994f0659a"
+checksum = "3550abd2115b4885d7594e8d1cfe045f68ff1b62c374217bbf0e7f24c81a7a86"
 dependencies = [
  "chrono",
  "gix-hash",


### PR DESCRIPTION
Supersedes #1209.

The automation dependency wave moved the four Kin registry pins correctly and then went red on two
things it could not have known about. This carries the same pin move, byte-identical, plus the two
repairs.

## The four pins

Each version is the one the registry now publishes, and each lock entry keeps its
`sparse+https://kinlab.ai/registry/cargo/` source and gains the checksum the index carries.

| Crate | From | To | Checksum |
|---|---|---|---|
| `kin-model` | =0.7.20 | =0.7.22 | `3550abd2115b4885d7594e8d1cfe045f68ff1b62c374217bbf0e7f24c81a7a86` |
| `kin-lsp` | =0.7.0 | =0.7.12 | `9d9e9acdb3dea7a4d1da9110fbfe5b365ffe322395780368727f4b16257fc873` |
| `kin-db` | =0.7.67 | =0.7.71 | `3cb869cfc5468f0ab34170b85fafae12aa61f08ec2d145fc09ac85ad21de2a38` |
| `kin-vfs-core` | =0.4.14 | =0.4.21 | `f2503190c57364c3573735fc6f9f2a7b932ce2659cac6e4901c27e031b6094d0` |

`Cargo.toml` and `Cargo.lock` are byte-identical to `automation/kin-registry-dependency-wave` at
`ede222d2589bfe17d84dcfb14dc3948a64d93a37`, reproduced rather than cherry-picked so the authorship
is a person's. The kin-db checksum agrees with three independent reads: the wave's own lock, the
sparse index row, and `shasum -a 256` of the downloaded `.crate`.

## Repair one: the second tracked lock

Both cargo-fuzz jobs failed at "Verify committed fuzz lock resolves the manifest" with
`cannot update the lock file fuzz/Cargo.lock because --locked was passed`. This workspace carries
two tracked locks and a root re-lock does not reach the second one.

The fuzz lock diff is one version and one checksum, nothing else:

```
 name = "kin-model"
-version = "0.7.20"
+version = "0.7.22"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "34bd9edbec6bd133ba71d96721deac5bde53c58dd3f1ddf8a2cfd01994f0659a"
+checksum = "3550abd2115b4885d7594e8d1cfe045f68ff1b62c374217bbf0e7f24c81a7a86"
```

Nothing else in that graph moves: kin-model 0.7.22 requires kin-blobs 0.1.5 and kin-vector 0.1.12,
both already pinned at exactly those versions in the fuzz lock, and its dependency name list is
unchanged. Sweeping every `git ls-files '*Cargo.lock'` for the four OLD versions returns zero hits,
with the four NEW versions as the positive control that the sweep can see anything at all. Every
`kin-*` entry across both locks still carries a `sparse+` source and a checksum.

## Repair two: the refusal that lost its diagnosis

Fast gate test shard 3 failed `state::tests::a_sidecar_in_an_unknown_format_is_refused_and_announced`.
The cause is not the text the assertion pinned; it is that kin-db 0.7.71 turned a metadata version
this build cannot read into a structured `RefusedSidecar { check }` rather than an `Err`. That is
strictly better, and it moved the daemon off the branch that says "could not be read" onto the
generic one, which tells an operator their graph or embedding model no longer matched. For a future
metadata version that is a mismatch they do not have, and it sends them to run an embed pass for the
wrong reason.

kin-db already carries which comparison failed. The daemon now renders it, so the announcement names
`metadata_version_future`, and the archived-index case names the reason the index itself reported.
Everything that genuinely is a graph or model mismatch still says so.

The test now asserts the stable parts: that the sidecar is refused and announced, that the
announcement names the file, and that it names the check kin-db refused on. Falsified by reverting
the assertion to the old `could not be read` string, which goes red against 0.7.71 exactly as it does
on `automation/kin-registry-dependency-wave` today.

## What this does not carry

No consumer code. The strict hosted-producer allowlist and the query producer evidence the kin-db
vector review asked for are a separate PR that bases on this one, so the pin move and the consumer
change are reviewable apart.

No `Closes` line: neither the wave PR nor the reports behind these four pins name a Linear ticket,
and inventing one would be worse than leaving it out. Tell me the ids and I will add them.
