### PR TITLE
Discriminate, retry and count the reclaim scan's owner lock

### DIFF
--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -2326,19 +2326,106 @@ fn filesystem_entry_exists(path: &Path) -> Result<bool> {
     }
 }
 
-/// Reap only stages whose exact owner record is private, destination-bound,
-/// inode-bound, and no longer locked by a live initializer.
+/// How many times the recovery scan attempts one candidate's owner lock before
+/// it gives up on that candidate.
 ///
-/// Invalid, ambiguous, replaced, or active candidates are retained. Automatic
-/// orphan recovery is disabled when the platform cannot expose a stable file
-/// identity and current-user ownership.
+/// Deliberately far shorter than `OWN_STAGE_OWNER_LOCK_ATTEMPTS`. There the
+/// contention is transient by construction: the file is one nobody else can
+/// name, and the only thing that can be holding it is a scan reading a single
+/// record. Here the holder is a live initializer that may keep its own stage
+/// for the length of an init, so no budget worth paying would outlast a real
+/// one, and waiting longer would only make every init that meets a live sibling
+/// slower before it gave the same answer. This retry exists to cross the far
+/// side of that same create-then-lock window, which is microseconds.
+#[cfg(unix)]
+const RECOVERY_SCAN_LOCK_ATTEMPTS: u32 = 3;
+#[cfg(unix)]
+const RECOVERY_SCAN_LOCK_RETRY: std::time::Duration = std::time::Duration::from_millis(5);
+
+/// What one attempt on a recovery candidate's owner lock established.
+#[cfg(unix)]
+enum RecoveryLock {
+    /// The lock is held, so this pass may read the record and decide.
+    Taken,
+    /// Someone else holds it, and still held it at the end of the retry budget.
+    /// A live initializer looks exactly like this.
+    Contended,
+    /// The lock could not be attempted at all, for a reason that is not
+    /// contention.
+    Refused(std::io::Error),
+}
+
+// Gated on unix as well as test because the recovery scan is unix-only, so the
+// tests that drive this injection are too. Leaving it on every test build would
+// make it dead code on Windows, which CI rejects under `-D warnings`.
+#[cfg(all(unix, test))]
+std::thread_local! {
+    /// Fails the next recovery-scan lock attempt with this raw errno.
+    static RECOVERY_LOCK_FAULT: std::cell::Cell<Option<i32>> = const { std::cell::Cell::new(None) };
+}
+
+/// Fail the next recovery-scan lock attempt with `errno`, so a test can drive an
+/// arm no filesystem produces on demand rather than assume it.
+///
+/// One-shot, and taken rather than read, so the attempt after it meets the real
+/// lock; that is what lets one test assert the retry crosses a contention which
+/// has already cleared. Thread-local because `cargo test` runs a binary's tests
+/// as threads in one process, where a process-global fault would reach every
+/// pass running beside this one.
+#[cfg(all(unix, test))]
+fn fail_next_recovery_lock(errno: i32) {
+    RECOVERY_LOCK_FAULT.set(Some(errno));
+}
+
+#[cfg(all(unix, test))]
+fn try_lock_recovery_candidate(owner_file: &File) -> std::io::Result<()> {
+    match RECOVERY_LOCK_FAULT.take() {
+        Some(errno) => Err(std::io::Error::from_raw_os_error(errno)),
+        None => owner_file.try_lock_exclusive(),
+    }
+}
+
+#[cfg(all(unix, not(test)))]
+fn try_lock_recovery_candidate(owner_file: &File) -> std::io::Result<()> {
+    owner_file.try_lock_exclusive()
+}
+
+/// Take a recovery candidate's owner lock, retrying contention on a bounded
+/// budget and keeping a failure that is not contention apart from it.
+///
+/// The two are separated because they mean opposite things. A contended lock is
+/// the healthy case: a live init owns that stage and this pass must leave it
+/// alone. A refusal is a fault on this machine, and the pass has learned nothing
+/// at all about the stage behind it. Collapsing them is what let `EINTR`,
+/// `ENOLCK` and a real `EWOULDBLOCK` leave through one `continue` that counted
+/// nothing, so a pass which walked past its only candidate returned the
+/// `ReclaimedStages` a clean parent returns. FIR-2857.
+#[cfg(unix)]
+fn lock_recovery_candidate(owner_file: &File) -> RecoveryLock {
+    let mut attempts_left = RECOVERY_SCAN_LOCK_ATTEMPTS;
+    loop {
+        match try_lock_recovery_candidate(owner_file) {
+            Ok(()) => return RecoveryLock::Taken,
+            Err(error) if !is_lock_contention(&error) => return RecoveryLock::Refused(error),
+            Err(_) => {
+                if attempts_left <= 1 {
+                    return RecoveryLock::Contended;
+                }
+                attempts_left -= 1;
+                std::thread::sleep(RECOVERY_SCAN_LOCK_RETRY);
+            }
+        }
+    }
+}
+
 /// What one reclaim pass over abandoned repository stages did.
 ///
-/// Two numbers rather than one, because an operator's question after a killed
+/// More than one number, because an operator's question after a killed
 /// conversion is not only what came back but what is still sitting on their
-/// disk. Both tallies existed already and neither left this function: the
-/// return value was dropped at both call sites and the retained count reached
-/// an `info!` and nothing a person running `kin init` would ever see. FIR-2792.
+/// disk. Both original tallies existed already and neither left this function:
+/// the return value was dropped at both call sites and the retained count
+/// reached an `info!` and nothing a person running `kin init` would ever see.
+/// FIR-2792.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct ReclaimedStages {
     /// Stages whose owner was proven gone, whose disk this pass took back.
@@ -2346,8 +2433,33 @@ pub(crate) struct ReclaimedStages {
     /// Stages this pass declined to touch, because it could not prove them
     /// unused.
     pub retained: usize,
+    /// Candidate owner records this pass walked past without reaching any
+    /// verdict on the stage behind them.
+    ///
+    /// Distinct from `retained`, which is a stage this pass examined and
+    /// declined. A skip is one it never examined: a live initializer holds the
+    /// owner lock, or the record does not describe a stage this destination
+    /// could reclaim. It exists because every skip route used to leave through a
+    /// bare `continue`, so a pass that walked past the only stranded stage on
+    /// the disk returned exactly what a pass over an empty directory returns,
+    /// and neither a caller nor a test could tell the two apart. With all three
+    /// counted, an all-zero return means a clean parent and nothing else.
+    /// FIR-2857.
+    ///
+    /// Deliberately absent from the operator's printed report. A contended owner
+    /// lock is the healthy concurrent case and has nothing to tell a person
+    /// running `kin init`, while a lock that fails for any other reason is
+    /// counted into `retained` instead, where the existing sentence already says
+    /// a directory was kept.
+    pub skipped: usize,
 }
 
+/// Reap only stages whose exact owner record is private, destination-bound,
+/// inode-bound, and no longer locked by a live initializer.
+///
+/// Invalid, ambiguous, replaced, or active candidates are retained. Automatic
+/// orphan recovery is disabled when the platform cannot expose a stable file
+/// identity and current-user ownership.
 pub(crate) fn recover_orphaned_repository_stages(
     staging_parent: &Path,
     final_kin_dir: &Path,
@@ -2368,6 +2480,7 @@ pub(crate) fn recover_orphaned_repository_stages(
         entries.sort_by_key(std::fs::DirEntry::file_name);
         let mut recovered = 0;
         let mut retained = 0;
+        let mut skipped = 0;
         for entry in entries {
             let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
                 continue;
@@ -2388,8 +2501,25 @@ pub(crate) fn recover_orphaned_repository_stages(
                     continue;
                 }
             };
-            if owner_file.try_lock_exclusive().is_err() {
-                continue;
+            match lock_recovery_candidate(&owner_file) {
+                RecoveryLock::Taken => {}
+                RecoveryLock::Contended => {
+                    debug!(
+                        path = %owner_path.display(),
+                        "skipping repository stage whose owner a live initializer holds"
+                    );
+                    skipped += 1;
+                    continue;
+                }
+                RecoveryLock::Refused(error) => {
+                    tracing::warn!(
+                        path = %owner_path.display(),
+                        %error,
+                        "retaining repository stage whose owner lock could not be attempted"
+                    );
+                    retained += 1;
+                    continue;
+                }
             }
             let record = match read_stage_owner_record(&owner_file, &owner_path) {
                 Ok(record) => record,
@@ -2408,6 +2538,11 @@ pub(crate) fn recover_orphaned_repository_stages(
                 || record.stage_path != exact_path_identity(&stage_root)?
                 || record.destination_path != expected_destination
             {
+                debug!(
+                    path = %owner_path.display(),
+                    "skipping owner record that names a different stage or destination"
+                );
+                skipped += 1;
                 continue;
             }
             let repository_uuid = uuid::Uuid::parse_str(&record.repository_id).ok();
@@ -2430,6 +2565,11 @@ pub(crate) fn recover_orphaned_repository_stages(
                 })
                 || repository_uuid == workspace_uuid
             {
+                debug!(
+                    path = %owner_path.display(),
+                    "skipping owner record carrying identities this build does not write"
+                );
+                skipped += 1;
                 continue;
             }
             let reap_root = staging_parent.join(format!(".kin.reap-{stage_id}"));
@@ -2549,9 +2689,17 @@ pub(crate) fn recover_orphaned_repository_stages(
                 staging_parent.display()
             );
         }
+        if skipped > 0 {
+            debug!(
+                count = skipped,
+                parent = %staging_parent.display(),
+                "kin init walked past repository stage owners it reached no verdict on"
+            );
+        }
         Ok(ReclaimedStages {
             recovered,
             retained,
+            skipped,
         })
     }
 }
@@ -2729,6 +2877,30 @@ mod tests {
         assert!(is_lock_contention(
             &lock_own_stage_owner(&owner_file).unwrap_err()
         ));
+    }
+
+    /// The discriminator's other half, which nothing asserted.
+    ///
+    /// Both tests above prove a real holder reads as contention. Neither can
+    /// fail if the answer were simply always yes, and always yes is what the
+    /// recovery scan used to assume: it would then retry a fault it can never
+    /// clear and count the result as a live owner. These are the errnos a lock
+    /// call returns when the machine, rather than another process, is the
+    /// reason.
+    #[cfg(unix)]
+    #[test]
+    fn a_lock_failure_that_is_not_contention_does_not_read_as_contention() {
+        for errno in [libc::ENOLCK, libc::EINTR, libc::EBADF] {
+            let error = std::io::Error::from_raw_os_error(errno);
+            assert!(
+                !is_lock_contention(&error),
+                "errno {errno} is a fault on this machine, not a live owner: {error}"
+            );
+        }
+        assert!(
+            is_lock_contention(&fs2::lock_contended_error()),
+            "and the lock crate's own contention error still reads as contention"
+        );
     }
 
     fn prepare_unborn(
@@ -3447,7 +3619,17 @@ mod tests {
         drop(prepared);
         assert!(stage_root.is_dir(), "the stage must exist to be reclaimed");
 
-        let reclaimed = recover_orphaned_repository_stages(&parent, &final_kin).unwrap();
+        let reclaimed = reclaim_until_no_skip(&parent, &final_kin);
+        // Asserted before `recovered`, because a pass that walked past this
+        // stage and a pass that found nothing to walk past both return zero
+        // recovered. Only this number separates them, so the assertion below
+        // used to be able to fail without naming which of the two happened.
+        // FIR-2857.
+        assert_eq!(
+            reclaimed.skipped, 0,
+            "the pass reached a verdict on the one candidate rather than walking past it: \
+             {reclaimed:?}"
+        );
         assert!(
             reclaimed.recovered > 0,
             "the pass took a stage back: {reclaimed:?}"
@@ -3464,6 +3646,199 @@ mod tests {
             lines[0].contains(&format!("reclaimed {}", reclaimed.recovered)),
             "the sentence carries the count the pass actually returned, not a literal: {lines:?}"
         );
+    }
+
+    /// One stranded stage of the exact shape this pass reclaims, plus the path
+    /// of its owner record. Built the way `orphan_recovery_is_bound_to_the_exact_destination`
+    /// builds the stage it proves recoverable, so a test using this and getting
+    /// zero back has learned something about the pass rather than about its own
+    /// fixture.
+    #[cfg(unix)]
+    fn strand_one_reclaimable_stage(parent: &Path, final_kin: &Path) -> (PathBuf, PathBuf) {
+        let staging_root = parent.join(format!(".kin.init-{}", uuid::Uuid::new_v4()));
+        let mut prepared = prepare_repository_layout_at(
+            &staging_root,
+            final_kin,
+            KinConfig::default(),
+            KinManifest::new(),
+        )
+        .unwrap();
+        let owner_path = prepared.stage_lease.as_ref().unwrap().owner_path.clone();
+        prepared.cleanup_armed = false;
+        drop(prepared);
+        assert!(
+            staging_root.is_dir(),
+            "the stage must exist to be reclaimed"
+        );
+        assert!(owner_path.is_file(), "and its owner record with it");
+        (staging_root, owner_path)
+    }
+
+    /// Run the reclaim pass until it reaches a verdict on every candidate.
+    ///
+    /// A sibling test's descendant can still hold an inherited descriptor on an
+    /// owner file for a window after this process dropped its own, which is
+    /// real flock contention on a path nobody can name. That is a skip rather
+    /// than a verdict, so a test asserting on the first pass is asserting
+    /// against a premise it has not established. Measured on this host, the
+    /// kin-core lib suite went red 2 runs in 10 that way, and 3 in 13 before
+    /// this change, when the same skip was invisible.
+    ///
+    /// The wait is bounded, so a skip that is real still fails the caller's own
+    /// assertion, carrying the count. And it is only possible because the pass
+    /// reports skips now: before FIR-2857 it returned the same value for
+    /// "nothing here" and "walked past it", so there was nothing to wait on.
+    #[cfg(unix)]
+    fn reclaim_until_no_skip(parent: &Path, final_kin: &Path) -> ReclaimedStages {
+        let mut reclaimed = recover_orphaned_repository_stages(parent, final_kin).unwrap();
+        for _ in 0..40 {
+            if reclaimed.skipped == 0 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            reclaimed = recover_orphaned_repository_stages(parent, final_kin).unwrap();
+        }
+        reclaimed
+    }
+
+    /// A live initializer's lock is counted, not walked past in silence.
+    ///
+    /// The owner lock is the one route through this pass that can fail
+    /// intermittently, and until FIR-2857 it left through a bare `continue`. So
+    /// a pass that walked past the only stranded stage on the disk returned
+    /// `recovered: 0, retained: 0`, which is exactly what a pass over a clean
+    /// parent returns: the pass condition of one arm of
+    /// `a_reclaimed_stage_reaches_the_operator_and_a_clean_parent_stays_silent`
+    /// and the fail condition of the other.
+    ///
+    /// The holder is released and the same parent scanned again, so the skip is
+    /// a fact about the lock rather than about anything else on this disk.
+    #[cfg(unix)]
+    #[test]
+    fn a_locked_owner_is_counted_as_a_skip_rather_than_left_as_silence() {
+        let directory = tempfile::tempdir().unwrap();
+        let parent = directory.path().canonicalize().unwrap();
+        let final_kin = parent.join(".kin");
+        let (staging_root, owner_path) = strand_one_reclaimable_stage(&parent, &final_kin);
+
+        // A live initializer, standing in as the only thing that holds this.
+        // Taking the lock is itself subject to the contention this test is
+        // about, so it goes through the repository's own bounded retry rather
+        // than a bare `unwrap`, which failed here 2 runs in 10.
+        let holder = open_stage_owner_for_recovery(&owner_path).unwrap();
+        lock_own_stage_owner(&holder).expect("this test has to be the one holding the lock");
+
+        let contended = recover_orphaned_repository_stages(&parent, &final_kin).unwrap();
+        assert_eq!(
+            contended.skipped, 1,
+            "the held lock is counted where a caller can see it: {contended:?}"
+        );
+        assert_ne!(
+            contended,
+            ReclaimedStages::default(),
+            "and a skipped pass no longer returns what a clean parent returns"
+        );
+        assert_eq!(contended.recovered, 0, "nothing was taken: {contended:?}");
+        assert!(staging_root.is_dir(), "and the live stage is untouched");
+
+        // The control. With the holder gone the same parent reclaims, so the
+        // skip above measured the lock and not this stage.
+        fs2::FileExt::unlock(&holder).unwrap();
+        drop(holder);
+        let reclaimed = reclaim_until_no_skip(&parent, &final_kin);
+        assert_eq!(
+            (reclaimed.recovered, reclaimed.skipped, reclaimed.retained),
+            (1, 0, 0),
+            "the same stage comes back once nobody holds it: {reclaimed:?}"
+        );
+        assert!(!staging_root.exists());
+    }
+
+    /// Contention that has already cleared is crossed rather than counted.
+    ///
+    /// The init side of this same lock retries for the reason `lock_own_stage_owner`
+    /// gives: a recovery scan can hold a sibling owner for as long as it takes
+    /// to read one record. This is the far side of that window. The injected
+    /// error is one-shot, so the attempt after it meets the real lock, which
+    /// nobody holds; with no retry the pass gives up on the first refusal and
+    /// this stage's disk is never taken back.
+    #[cfg(unix)]
+    #[test]
+    fn a_contention_that_has_cleared_is_retried_rather_than_counted_as_a_skip() {
+        let directory = tempfile::tempdir().unwrap();
+        let parent = directory.path().canonicalize().unwrap();
+        let final_kin = parent.join(".kin");
+        let (staging_root, owner_path) = strand_one_reclaimable_stage(&parent, &final_kin);
+
+        // Establish that nobody else holds this owner lock before injecting
+        // one, so what the retry crosses is the injected contention and not a
+        // descendant's inherited descriptor. Deliberately NOT
+        // `reclaim_until_no_skip` below: the injected error is one-shot, so a
+        // second pass would meet a free lock and reclaim whether or not the
+        // retry works, and the mutation that deletes the retry would survive.
+        {
+            let probe = open_stage_owner_for_recovery(&owner_path).unwrap();
+            lock_own_stage_owner(&probe)
+                .expect("the owner lock has to be free before this measures a retry");
+            fs2::FileExt::unlock(&probe).unwrap();
+        }
+        fail_next_recovery_lock(
+            fs2::lock_contended_error()
+                .raw_os_error()
+                .expect("the lock crate's contention error carries an errno"),
+        );
+        let reclaimed = recover_orphaned_repository_stages(&parent, &final_kin).unwrap();
+        assert_eq!(
+            (reclaimed.recovered, reclaimed.skipped, reclaimed.retained),
+            (1, 0, 0),
+            "the retry crossed a contention that had already cleared: {reclaimed:?}"
+        );
+        assert!(!staging_root.exists());
+    }
+
+    /// A lock failure that is not contention is retained and said out loud,
+    /// rather than counted as a live owner or dropped on the floor.
+    ///
+    /// `ENOLCK` is the shape of the fault this pass used to swallow, and no
+    /// filesystem produces it on demand, so it is injected. It must not reach
+    /// `skipped`, because that is where a live owner goes and a fault is not a
+    /// live owner. It lands in `retained`, whose operator sentence already says
+    /// a directory was kept, beside a `warn!` carrying the errno.
+    ///
+    /// The pass must also not fail outright: one unreadable owner file wedging
+    /// every later init in that directory would be worse than the silence this
+    /// replaces.
+    #[cfg(unix)]
+    #[test]
+    fn a_lock_error_that_is_not_contention_is_retained_rather_than_swallowed() {
+        let directory = tempfile::tempdir().unwrap();
+        let parent = directory.path().canonicalize().unwrap();
+        let final_kin = parent.join(".kin");
+        let (staging_root, _owner_path) = strand_one_reclaimable_stage(&parent, &final_kin);
+
+        fail_next_recovery_lock(libc::ENOLCK);
+        let faulted = recover_orphaned_repository_stages(&parent, &final_kin).unwrap();
+        assert_eq!(
+            (faulted.retained, faulted.skipped, faulted.recovered),
+            (1, 0, 0),
+            "a fault on this machine is counted apart from a live owner: {faulted:?}"
+        );
+        assert!(staging_root.is_dir(), "and it left the stage alone");
+        assert!(
+            !crate::init_attempt::reclaimed_stage_lines(faulted.recovered, faulted.retained)
+                .is_empty(),
+            "a retained stage reaches the sentence an operator reads: {faulted:?}"
+        );
+
+        // The control. The fault is one-shot, so nothing about this stage was
+        // wrong but the injected errno, and the next pass proves it.
+        let reclaimed = reclaim_until_no_skip(&parent, &final_kin);
+        assert_eq!(
+            (reclaimed.recovered, reclaimed.retained, reclaimed.skipped),
+            (1, 0, 0),
+            "the same stage comes back on the next pass: {reclaimed:?}"
+        );
+        assert!(!staging_root.exists());
     }
 
     #[test]
@@ -3567,19 +3942,14 @@ mod tests {
         prepared.cleanup_armed = false;
         drop(prepared);
 
-        assert_eq!(
-            recover_orphaned_repository_stages(&parent, &other_final_kin)
-                .unwrap()
-                .recovered,
-            0
-        );
+        let elsewhere = recover_orphaned_repository_stages(&parent, &other_final_kin).unwrap();
+        assert_eq!(elsewhere.recovered, 0);
+        // A stage bound to another destination is walked past, and the count now
+        // says so, so this pass is not a silence that happens to look right.
+        // FIR-2857.
+        assert_eq!(elsewhere.skipped, 1, "{elsewhere:?}");
         assert!(staging_root.is_dir());
-        assert_eq!(
-            recover_orphaned_repository_stages(&parent, &final_kin)
-                .unwrap()
-                .recovered,
-            1
-        );
+        assert_eq!(reclaim_until_no_skip(&parent, &final_kin).recovered, 1);
         assert!(!staging_root.exists());
     }
 


### PR DESCRIPTION
## What this fixes

The reclaim scan took each candidate's owner lock with
`try_lock_exclusive().is_err()` and treated any error as "someone holds it": no retry, no
counter, no discrimination. `EINTR`, `ENOLCK` and a real `EWOULDBLOCK` all left through one
silent `continue`, so a pass that walked past the only stranded stage on the disk returned
`ReclaimedStages { recovered: 0, retained: 0 }`, byte-identical to what a pass over an empty
directory returns.

That value is the pass condition of one arm of
`init::tests::a_reclaimed_stage_reaches_the_operator_and_a_clean_parent_stays_silent`
(`init.rs:3429`) and the fail condition of the other (`init.rs:3451`), so the pass could fail
without saying which of the two had happened. The init side of the same lock already had all
three pieces, 1452 lines earlier in the same file: `is_lock_contention`, a bounded retry in
`lock_own_stage_owner`, and a doc comment explaining why testing the error kind alone
recognizes contention on Unix and nothing on Windows. Far enough away to be easy to miss, which
is the kindest available reading of how this path came to reimplement none of it.

## Measurement, before any code changed

The brief said measure first, so the reproduction ran on pristine `origin/main`
(`6ce07ed8a08262801bc3497b2ad8797734cb1e4b`, `init.rs` blob `eccbff39`, `git status
--porcelain` empty) before the patch was applied. Plain `cargo test -p kin-core --lib`, which is
the authority here: hosted CI runs nextest, and `crates/kin-core/src/test_env.rs:11` says in the
repo's own words that giving each test its own process makes this class structurally invisible.

**3 red in 13 runs**, every one with the same signature at the same line.

| block | runs | red | signature |
|---|---|---|---|
| baseline, 3 runs | `run1.log` to `run3.log` | 1 | `ReclaimedStages { recovered: 0, retained: 0 }` at `init.rs:3451` |
| pristine repeat, 10 runs | `rep-pre-1.log` to `rep-pre-10.log` | 2 | same, on runs 2 and 6 |

Suite size is taken from `cargo test -p kin-core --lib -- --list` (719 tests, the target test
named once, a fabricated name listing zero), never from a summary line, because concurrent test
output interleaves with it. Every verdict is the process exit code plus a zero count of
` FAILED$`, neither of which interleaving can corrupt.

This settles what the ticket was carrying as claims. It is main's defect and not FIR-2828's,
because this tree holds none of that lane's diff and the failure arrived anyway. It is
intermittent rather than deterministic. And it satisfies `.config/nextest.toml:37`'s bar for the
word flake in one hold: failing run 1, same-code re-runs 2 and 3 green, same sha and same blob.
Meeting that bar is not a reason to write "flake" here. It establishes intermittency, which is
the premise of the route elimination.

### The route, by elimination

For the pass to return `(0,0)` with one candidate present, that candidate must leave through a
`continue` touching neither counter. There are five, and only three can apply to a candidate
past the name filter:

| line | route | can it vary between runs? |
|---|---|---|
| `:2373` | entry name is not UTF-8 | no, the name is a uuid string |
| `:2376` | not an owner name | no, that is the staging directory |
| `:2392` | **the owner lock failed** | **yes, the only one** |
| `:2411` | record names a different stage or destination | no, both sides written by the same fixture |
| `:2433` | identities are not ones this build writes | no, `KinManifest::new()` mints v4 uuids |

Arm M5 below is the mechanical half: it restores the original line and the new contention test
observes exactly `recovered: 0, retained: 0, skipped: 0` on a disk holding one reclaimable stage.

## The change

`lock_recovery_candidate` classifies the outcome as `Taken`, `Contended` or `Refused`, using the
existing `is_lock_contention` rather than `is_err()`.

Contention is retried three times at 5 ms, deliberately far shorter than the init side's 100
attempts. The constant's doc says why: there the holder is a scan reading one record and
contention is transient by construction, while here it may be a live initializer holding its
stage for the length of an init, so no budget worth paying would outlast a real one. The retry
crosses the far side of the same create-then-lock window `lock_own_stage_owner` describes.

A failure that is not contention goes to `retained`, not `skipped`, beside a `warn!` carrying
the errno. That is the treatment the sibling IO error four lines above already gets, and
`retained`'s existing operator sentence is true for it: `reclaimed_stage_lines(0, 1)` prints
"1 more repository staging directory is still on disk and this run left it alone, because it
could not prove it unused". Sending it to a different field from contention is also what makes
the two dispositions falsifiable apart, which arm M7 exists to check. The pass does not fail on
such an error: one unreadable owner file wedging every later init in that directory would be
worse than the silence it replaces.

`ReclaimedStages` gains `skipped` for candidates the pass walked past without reaching a verdict.
All three uncounted `continue`s now increment it, so an all-zero return means a clean parent and
nothing else. It is deliberately absent from the operator's printed report: a contended owner
lock is the healthy concurrent case and has nothing to tell a person running `kin init`.

`fail_next_recovery_lock` is a one-shot thread-local fault under `cfg(all(unix, test))`,
following the pattern in `git_init.rs:52` and `tree.rs:3620`. Thread-local because `cargo test`
runs a binary's tests as threads in one process and a process-global fault would reach every
pass beside it; taken rather than read so the attempt after it meets the real lock, which is
what lets one test assert the retry crosses a contention that has already cleared.

One doc comment moved. `recover_orphaned_repository_stages`'s own doc sat directly above the
`ReclaimedStages` doc with no blank line between them, so rustdoc had attached it to the struct.

## Tests

Four new tests, one seam, three existing tests strengthened, and one new test helper.

`a_locked_owner_is_counted_as_a_skip_rather_than_left_as_silence` holds a second file description
on the owner record, which is genuine flock contention in one process and the mechanism
`a_concurrent_scan_holding_the_new_owner_file_does_not_fail_the_lease` already relies on. It
asserts `skipped == 1`, asserts the return is not `ReclaimedStages::default()`, then releases the
holder and asserts the same parent reclaims, so the skip is a fact about the lock and not about
anything else on that disk.

`a_contention_that_has_cleared_is_retried_rather_than_counted_as_a_skip` injects one contention
errno and requires the stage still to come back, which is the only assertion that can see the
retry at all.

`a_lock_error_that_is_not_contention_is_retained_rather_than_swallowed` injects `ENOLCK` and
requires `(retained, skipped, recovered) == (1, 0, 0)`, the stage untouched, and the count to
reach `reclaimed_stage_lines`, which is the sentence an operator reads. Its control is the next
pass, which reclaims.

`a_lock_failure_that_is_not_contention_does_not_read_as_contention` is the discriminator's
negative half, which nothing asserted before. Both existing lock tests prove a real holder reads
as contention, and neither can fail if the answer were always yes, which is exactly what the
recovery scan assumed.

`a_reclaimed_stage_reaches_the_operator_and_a_clean_parent_stays_silent` now asserts
`skipped == 0` before `recovered > 0`, so the next occurrence names the route.
`orphan_recovery_is_bound_to_the_exact_destination` now asserts the skip it always produced.

`cargo test -p kin-core --lib` reads `724 passed; 0 failed`. The total reconciles rather than
being trusted: 719 at `6ce07ed8` from `-- --list`, plus 1 that kin#1206 added to kin-core, plus
the 4 here. Each new test is confirmed by name in the run, with a fabricated name that must
appear zero times, because a filter that matches nothing prints the same `ok` a real pass prints.

### One thing the measurement caught that I would otherwise have shipped

The 10 repeats on the fixed tree still read 2 red of 10, and the two reds were different things.
One was the pre-existing test failing with `skipped: 1`, which is this change working: the pass
named the route instead of printing two zeros. The other was my own new test failing on a bare
`try_lock_exclusive().unwrap()` in its SETUP, with `EWOULDBLOCK`.

That second one is a defect I introduced, and it is also the sharpest evidence here.
`EWOULDBLOCK` immediately after `drop(prepared)` proves a second open description still holds
that lock. On a uuid-named file in a fresh `tempfile::tempdir()` the only candidates are this
process's own `File`, just dropped, and a descendant that inherited the descriptor across `fork`
before `exec` closed it. The first is eliminated by construction. That is the hypothesis the
FIR-2828 reviewer flagged and could not test from a read-only position. Stated exactly: this
eliminates the only other candidate rather than sighting the child.

Both reds were premises asserted rather than established. `reclaim_until_no_skip` retries while
`skipped` is nonzero, bounded at 40 attempts of 25 ms; the caller's assertions are unchanged, so
a skip that is real still fails carrying the count. The holder setup goes through
`lock_own_stage_owner`, the repository's own bounded retry. This is only possible because of this
change: before it the pass returned the same value for "nothing here" and "walked past it", so a
test had nothing to wait on. `a_contention_that_has_cleared...` deliberately does not use the
helper, because a second pass would reclaim whether or not the retry works and arm M3 would
survive; it probes for a free lock before injecting instead.

I did not lengthen the production retry to chase this. Its stated reason is to cross a
create-then-lock window, not to outlast an owner, and tuning a product constant until a test
stops failing is fixing the symptom. Eliminating the inherited-descriptor contention is a
separate concern and wants its own ticket if the fleet wants it gone; this change makes it report
itself, which it could not do before.

### The rate, end to end

| tree | runs of `cargo test -p kin-core --lib` | red |
|---|---|---|
| pristine `origin/main` | 13 | 3, all `ReclaimedStages { recovered: 0, retained: 0 }` |
| the pass fixed, test premises assumed | 10 | 2, one naming `skipped: 1`, one a setup `unwrap` |
| the pass fixed, premises established | 20 | **0** |

The last row is counted twice: the driver's own tally and an independent recount off the twenty
run logs, 20 of 20 present, 0 matching ` FAILED$`, 20 of 20 carrying `test result: ok`. The same
grep over the ten pristine logs returns 2, which is the control proving it can see a red at all.

## Falsification

Nine arms, one mutation of PRODUCTION source each, one test per process so every verdict names
its own assertion. The first eight ran twice, at `db848511` and again at the pushed head
`8cb5088b` after the test-premise follow-up, and the two are identical arm for arm, checked by
diffing the `ARM Mn observed red:` lines rather than by eye. The ninth ran at `8cb5088b` with its
own control.

The listing control ran first: all eight test paths listed exactly once out of 724, and a
fabricated name listed zero.

| arm | what it removes | tests red | assertion that fired |
|---|---|---|---|
| M0 | nothing (control) | **none** | (control, all green) |
| M1 | `is_lock_contention` always answers yes | `a_lock_error_that_is_not_contention_is_retained_rather_than_swallowed`<br>`a_lock_failure_that_is_not_contention_does_not_read_as_contention` | a fault on this machine is counted apart from a live owner: ReclaimedStages { recovered: 1, retained: 0, skipp |
| M2 | `is_lock_contention` always answers no | `a_locked_owner_is_counted_as_a_skip_rather_than_left_as_silence`<br>`a_contention_that_has_cleared_is_retried_rather_than_counted_as_a_skip`<br>`a_lock_failure_that_is_not_contention_does_not_read_as_contention`<br>`a_concurrent_scan_holding_the_new_owner_file_does_not_fail_the_lease`<br>`an_unyielding_holder_still_fails_the_lease_closed` | the held lock is counted where a caller can see it: ReclaimedStages { recovered: 0, retained: 1, skipped: 0 }<br>the retry crossed a contention that had already cleared: ReclaimedStages { recovered: 0, retained: 1, skipped:<br>is_lock_contention(&lock_own_stage_owner(&owner_file).unwrap_err()) |
| M3 | the retry (`RECOVERY_SCAN_LOCK_ATTEMPTS` 3 to 1) | `a_contention_that_has_cleared_is_retried_rather_than_counted_as_a_skip` | the retry crossed a contention that had already cleared: ReclaimedStages { recovered: 0, retained: 0, skipped: |
| M4 | the `skipped` counter on the contention arm | `a_locked_owner_is_counted_as_a_skip_rather_than_left_as_silence` | the held lock is counted where a caller can see it: ReclaimedStages { recovered: 0, retained: 0, skipped: 0 } |
| M5 | the whole match, restoring `try_lock_exclusive().is_err()` | `a_locked_owner_is_counted_as_a_skip_rather_than_left_as_silence`<br>`a_lock_error_that_is_not_contention_is_retained_rather_than_swallowed` | the held lock is counted where a caller can see it: ReclaimedStages { recovered: 0, retained: 0, skipped: 0 }<br>a fault on this machine is counted apart from a live owner: ReclaimedStages { recovered: 1, retained: 0, skipp |
| M6 | the `skipped` counter on the destination-mismatch route | `orphan_recovery_is_bound_to_the_exact_destination` | ReclaimedStages { recovered: 0, retained: 0, skipped: 0 } |
| M7 | the split, sending a refusal to `skipped` instead of `retained` | `a_lock_error_that_is_not_contention_is_retained_rather_than_swallowed` | a fault on this machine is counted apart from a live owner: ReclaimedStages { recovered: 0, retained: 0, skipp |
| M8 | the `Taken` arm's pass-through, counting every taken lock as a skip | `a_reclaimed_stage_reaches_the_operator_and_a_clean_parent_stays_silent`<br>`a_locked_owner_...`<br>`a_contention_that_has_cleared_...`<br>`a_lock_error_that_is_not_contention_...`<br>`orphan_recovery_is_bound_to_the_exact_destination` | the pass reached a verdict on the one candidate rather than walking past it: ReclaimedStages { recovered: 0, retained: 0, skipped: 1 }, left 1 right 0 |

Every arm caught something and no row is green all the way across, each naming a different
assertion or a different observed value, with no NOT-RUN and no BUILD-FAILED cell.

Three matter most. **M4** proves the counter is load-bearing rather than decorative. **M7** is
the mutation this design exists to survive: it redirects a non-contention refusal into `skipped`
instead of `retained`, which is the catalogued case a field-level assertion cannot see when two
branches report the same field. It goes red naming `retained`, which is what proves the two
dispositions really are separated, and **M2** is its mirror.

**M8 exists because the review found a hole in the other eight.** The `skipped == 0` assertion
added to the strengthened test is green under every one of M1 to M7, so nothing showed it was
load-bearing rather than decorative. M8 makes `RecoveryLock::Taken` count a skip and continue,
and that assertion fires at `init.rs:3632` reading `left: 1, right: 0` with
`ReclaimedStages { recovered: 0, retained: 0, skipped: 1 }` in the message. Its control arm is
all-green across the same eight tests, and the two lease tests plus the discriminator test stay
green under M8, which is right: it touches neither the discriminator nor the init side of the
lock.

**One prediction was wrong and the grid caught it.** I predicted M5, which restores the original
line, would redden three tests. It reddened two: M5 replaces the whole match, so
`try_lock_recovery_candidate` is never called, the injected fault is never consumed, and the real
lock succeeds. The restored defect is still falsified, by two other tests.

After the grid: `dirty_lines=0`, `markers=0`, `TREE CLEAN vs HEAD`, and the restore line prints
the blob it restored to rather than the word restored.

## Gates

`bin/kin-precheck kin` at the pushed head, run through the lane wrapper from the lane worktree:

```
kin-precheck: repo=kin tree=.../worktrees/reclaim2857-kin sha=8cb5088b1... branch=chore/lane-reclaim2857-kin
kin-precheck: 16 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 16 gates ran, 16 passed, 0 failed, on kin 8cb5088b102a84fe66962d143973f63ac46763f9
```

No NOT RUN, so the tally means what it says. Beside it at the same tree:
`cargo test -p kin-core --lib` 724 passed 0 failed; `--all-targets` 724 plus seven integration
binaries, 0 failed; `cargo nextest run -p kin-core` 733 run 733 passed; `--doc` rc 0;
`cargo fmt --all -- --check` rc 0; clippy rc 0 with ci.yml's own 45-lint debt list and zero errors
in `init.rs`.

An earlier gate of mine ran clippy hand-rolled as `-D warnings` and went red on
`clippy::needless_return` and `clippy::too_many_arguments` in `kin-daemon-spawn` and `kin-parser`,
neither of them files this PR touches and both on `.github/clippy-allowed-lints.txt`. That was my
invocation, not a defect, and the reruns use ci.yml's.

**Base.** Gated at `8cb5088b`, one commit on `fcd21a98`. `origin/main` has since moved to
`9e7092e9` with kin#1205, which `git show --name-only` confirms touches none of the files this PR
touches, and main's `crates/kin-core/src/init.rs` is still blob `eccbff39`, byte-identical to this
branch's base.

## Claims not being made

- It does not claim to have eliminated the contention. Nothing here removes it. The pass reports
  it now, and the tests establish their premise instead of assuming it.
- It does not identify what holds the inherited descriptor. The `EWOULDBLOCK` probe eliminates
  the only other candidate; it does not sight the child.
- The 0 in 20 is one host under one load profile, measured in the same slot hold as the 2 in 10
  it is compared against. It is not a claim about hosted CI, which runs nextest and gives each
  test its own process; `crates/kin-core/src/test_env.rs:11` records in the repo's own words that
  this makes the class structurally invisible there.
- The `:2433` identity-gate route gains its counter without a dedicated test. Reaching it needs
  an owner record whose identities are not ones this build writes, and
  `prepare_repository_layout_at` rejects such a manifest before writing, so it would take a
  hand-written owner record. The two reachable routes, `:2392` and `:2411`, are both tested.
- Nextest reported `the_admission_ladder_accounts_for_the_whole_of_init` FLAKY on one run. It is
  not this change: it lives in `crates/kin-core/tests/init_phase_ladder_contiguous.rs`, appears
  zero times in this diff, and is the single quarantine row in `.config/nextest.toml` under
  FIR-2809.

Closes FIR-2857
