### PR TITLE
Bound the TODO import scan root, and triage all 70 CodeQL alerts on main

### DIFF
--- a/crates/kin-cli/src/commands/work.rs
+++ b/crates/kin-cli/src/commands/work.rs
@@ -884,9 +884,27 @@ pub fn execute_work_request(
             out
         }
         WorkRequest::TodoImport { path } => {
-            let scan_root = path
-                .map(std::path::PathBuf::from)
-                .unwrap_or_else(|| _layout.working_dir().to_path_buf());
+            // `path` is caller supplied: this arm serves the daemon's POST
+            // /work and POST /note routes and the `kin_todo_import` MCP tool,
+            // so the value arrives in a request body rather than from an
+            // operator's shell. Resolve it against the repository working
+            // directory and refuse anything that lands outside. Joining an
+            // absolute path discards the base, so containment is the test that
+            // rejects it, and `is_within` canonicalizes both sides, which also
+            // resolves `..` before the comparison.
+            let working_dir = _layout.working_dir();
+            let scan_root = match path {
+                Some(requested) => {
+                    let candidate = working_dir.join(requested);
+                    if !crate::commands::managed_config_scope::is_within(working_dir, &candidate) {
+                        anyhow::bail!(
+                            "todo import scan root must stay inside the repository working directory"
+                        );
+                    }
+                    candidate
+                }
+                None => working_dir.to_path_buf(),
+            };
             let todos = kin_parser::extract_todos(&scan_root)?;
             let existing = graph.list_work_items(&WorkFilter::default())?;
             let mut existing_keys: HashSet<(WorkKind, String, String)> = existing
@@ -1462,5 +1480,90 @@ mod tests {
         assert!(report.missing_scope_proof.is_empty());
         assert_eq!(report.direct_work_runs.len(), 1);
         assert_eq!(report.direct_work_runs[0].run_id, run.run_id);
+    }
+
+    // The two tests below drive `execute_work_request` rather than
+    // `todo_import_in_layout_direct`, which is a second copy of this arm's
+    // body and cannot observe a change to the product path.
+
+    #[tokio::test]
+    async fn todo_import_refuses_a_scan_root_outside_the_repository() {
+        let repo = tempfile::tempdir().unwrap();
+        kin_core::init(repo.path()).unwrap();
+        std::fs::write(repo.path().join("inside.rs"), "// TODO: inside the repo\n").unwrap();
+        let layout = kin_core::KinLayout::discover(repo.path()).unwrap();
+
+        // A tree this request has no business reading. The marker text is what
+        // says whether the walk actually reached it.
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(
+            outside.path().join("secret.rs"),
+            "// TODO: outside the repo\n",
+        )
+        .unwrap();
+
+        let snap = crate::backend::open_kindb_snapshot(&layout).unwrap();
+        let graph = snap.graph();
+        let refused = execute_work_request(
+            &layout,
+            graph.as_ref(),
+            WorkRequest::TodoImport {
+                path: Some(outside.path().to_string_lossy().into_owned()),
+            },
+        );
+        assert!(
+            refused.is_err(),
+            "a scan root outside the repository must be refused"
+        );
+
+        let titles: Vec<String> = graph
+            .list_work_items(&WorkFilter::default())
+            .unwrap()
+            .into_iter()
+            .map(|item| item.title)
+            .collect();
+        assert!(
+            !titles
+                .iter()
+                .any(|title| title.contains("outside the repo")),
+            "nothing outside the repository may be imported: {titles:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn todo_import_accepts_a_scan_root_inside_the_repository() {
+        let repo = tempfile::tempdir().unwrap();
+        kin_core::init(repo.path()).unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(
+            repo.path().join("src").join("lib.rs"),
+            "// TODO: inside a subdirectory\n",
+        )
+        .unwrap();
+        let layout = kin_core::KinLayout::discover(repo.path()).unwrap();
+
+        let snap = crate::backend::open_kindb_snapshot(&layout).unwrap();
+        let graph = snap.graph();
+        execute_work_request(
+            &layout,
+            graph.as_ref(),
+            WorkRequest::TodoImport {
+                path: Some("src".to_string()),
+            },
+        )
+        .expect("a subdirectory of the repository is a legitimate scan root");
+
+        let titles: Vec<String> = graph
+            .list_work_items(&WorkFilter::default())
+            .unwrap()
+            .into_iter()
+            .map(|item| item.title)
+            .collect();
+        assert!(
+            titles
+                .iter()
+                .any(|title| title.contains("inside a subdirectory")),
+            "a legitimate subdirectory scan must still import: {titles:?}"
+        );
     }
 }

--- a/crates/kin-cli/src/commands/work.rs
+++ b/crates/kin-cli/src/commands/work.rs
@@ -885,26 +885,13 @@ pub fn execute_work_request(
         }
         WorkRequest::TodoImport { path } => {
             // `path` is caller supplied: this arm serves the daemon's POST
-            // /work and POST /note routes and the `kin_todo_import` MCP tool,
-            // so the value arrives in a request body rather than from an
-            // operator's shell. Resolve it against the repository working
-            // directory and refuse anything that lands outside. Joining an
-            // absolute path discards the base, so containment is the test that
-            // rejects it, and `is_within` canonicalizes both sides, which also
-            // resolves `..` before the comparison.
-            let working_dir = _layout.working_dir();
-            let scan_root = match path {
-                Some(requested) => {
-                    let candidate = working_dir.join(requested);
-                    if !crate::commands::managed_config_scope::is_within(working_dir, &candidate) {
-                        anyhow::bail!(
-                            "todo import scan root must stay inside the repository working directory"
-                        );
-                    }
-                    candidate
-                }
-                None => working_dir.to_path_buf(),
-            };
+            // /work and POST /note routes, so the value arrives in a request
+            // body rather than from an operator's shell. The `kin_todo_import`
+            // MCP tool does NOT reach this arm; it has its own handler, which
+            // calls the same resolver. Containment lives in kin-parser beside
+            // the walk so both callers share one implementation.
+            let scan_root = kin_parser::resolve_scan_root(_layout.working_dir(), path.as_deref())
+                .context("resolve todo import scan root")?;
             let todos = kin_parser::extract_todos(&scan_root)?;
             let existing = graph.list_work_items(&WorkFilter::default())?;
             let mut existing_keys: HashSet<(WorkKind, String, String)> = existing
@@ -1159,76 +1146,6 @@ mod tests {
         Ok(vec![])
     }
 
-    async fn todo_import_in_layout_direct(
-        layout: &kin_core::KinLayout,
-        path: Option<String>,
-    ) -> Result<(usize, usize)> {
-        let snap = crate::backend::open_kindb_snapshot(layout)?;
-        let graph = snap.graph();
-        let scan_root = path
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| layout.working_dir().to_path_buf());
-        let todos = kin_parser::extract_todos(&scan_root)?;
-        let existing = graph.list_work_items(&WorkFilter::default())?;
-        let mut existing_keys: HashSet<(WorkKind, String, String)> = existing
-            .into_iter()
-            .flat_map(|item| {
-                item.scopes
-                    .into_iter()
-                    .filter_map(move |scope| match scope {
-                        WorkScope::Artifact(file_id) => {
-                            Some((item.kind, item.title.clone(), file_id.0))
-                        }
-                        _ => None,
-                    })
-            })
-            .collect();
-        let mut imported = 0usize;
-        let mut skipped = 0usize;
-        for todo in &todos {
-            let work_kind = match todo.kind.as_str() {
-                "FIXME" => WorkKind::Issue,
-                "HACK" => WorkKind::Debt,
-                _ => WorkKind::Todo,
-            };
-            let key = (work_kind, todo.body.clone(), todo.file_path.clone());
-            if existing_keys.contains(&key) {
-                skipped += 1;
-                continue;
-            }
-            let scope = WorkScope::Artifact(FilePathId::new(&todo.file_path));
-            let item = WorkItem {
-                work_id: WorkId::new(),
-                kind: work_kind,
-                title: todo.body.clone(),
-                description: format!(
-                    "Imported from {} (line {})",
-                    todo.file_path, todo.line_number
-                ),
-                status: WorkStatus::Proposed,
-                priority: if todo.kind == "FIXME" {
-                    Priority::High
-                } else {
-                    Priority::Medium
-                },
-                scopes: vec![scope.clone()],
-                acceptance_criteria: vec![],
-                external_refs: vec![],
-                created_by: IdentityRef::human("kin-todo-import"),
-                created_at: Timestamp::now(),
-            };
-            graph.create_work_item(&item)?;
-            graph.create_work_link(&WorkLink::Affects {
-                work_id: item.work_id,
-                scope,
-            })?;
-            existing_keys.insert(key);
-            imported += 1;
-        }
-        snap.save()?;
-        Ok((imported, skipped))
-    }
-
     #[tokio::test]
     async fn create_and_link_work_persist_to_snapshot() {
         let dir = tempfile::tempdir().unwrap();
@@ -1385,13 +1302,30 @@ mod tests {
         .unwrap();
         let layout = kin_core::KinLayout::discover(dir.path()).unwrap();
 
-        let first = todo_import_in_layout_direct(&layout, None).await.unwrap();
-        let second = todo_import_in_layout_direct(&layout, None).await.unwrap();
-        assert_eq!(first, (2, 0));
-        assert_eq!(second, (0, 2));
-
         let snap = crate::backend::open_kindb_snapshot(&layout).unwrap();
         let graph = snap.graph();
+        let import = || {
+            execute_work_request(
+                &layout,
+                graph.as_ref(),
+                WorkRequest::TodoImport { path: None },
+            )
+            .unwrap()
+            .response
+            .text
+        };
+
+        let first = import();
+        let second = import();
+        assert!(
+            first.contains("Imported 2 TODO(s)") && !first.contains("Skipped"),
+            "the first import takes both markers: {first:?}"
+        );
+        assert!(
+            second.contains("Imported 0 TODO(s)") && second.contains("Skipped 2 TODO(s)"),
+            "the second import skips both as duplicates: {second:?}"
+        );
+
         let items = graph.list_work_items(&WorkFilter::default()).unwrap();
         assert_eq!(items.len(), 2);
     }
@@ -1482,9 +1416,11 @@ mod tests {
         assert_eq!(report.direct_work_runs[0].run_id, run.run_id);
     }
 
-    // The two tests below drive `execute_work_request` rather than
-    // `todo_import_in_layout_direct`, which is a second copy of this arm's
-    // body and cannot observe a change to the product path.
+    // Every test here drives `execute_work_request`. A `todo_import_in_layout_direct`
+    // helper used to stand in for it, reproducing this arm's body verbatim, so no
+    // test could observe a change to the product path and the arm shipped
+    // unguarded. It is gone rather than fixed: a second copy of the code under
+    // test only ever fails in the shape of a passing run.
 
     #[tokio::test]
     async fn todo_import_refuses_a_scan_root_outside_the_repository() {

--- a/crates/kin-mcp/src/handlers/work.rs
+++ b/crates/kin-mcp/src/handlers/work.rs
@@ -544,11 +544,28 @@ pub fn handle_todo_import<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
-    let path = args
-        .get("path")
-        .and_then(|v| v.as_str())
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    // `path` arrives in a tool call, and the schema advertises it to every
+    // connected agent, so it is untrusted input. This handler holds only a
+    // GraphStore, which carries no filesystem root, so the scan boundary is
+    // discovered the way the rest of kin-mcp resolves one: `KinLayout::discover`
+    // from the process working directory, as in daemon_delegate.rs and
+    // repository_authority.rs. That is the same directory this handler already
+    // used as its default scan root, so a well-formed call is unchanged; what
+    // changes is that a caller-supplied path is now bounded by it. Fail closed
+    // when no repository is found rather than walking the working directory.
+    let start = std::env::current_dir()
+        .map_err(|e| McpError::Other(format!("cannot read the working directory: {e}")))?;
+    let layout = kin_core::KinLayout::discover(&start).ok_or_else(|| {
+        McpError::Other(format!(
+            "kin_todo_import needs a Kin repository; none found from {}",
+            start.display()
+        ))
+    })?;
+    let path = kin_parser::resolve_scan_root(
+        layout.working_dir(),
+        args.get("path").and_then(|v| v.as_str()),
+    )
+    .map_err(|e| McpError::Other(format!("todo import scan root refused: {e}")))?;
 
     let todos = kin_parser::extract_todos(&path)
         .map_err(|e| McpError::Other(format!("todo extraction failed: {}", e)))?;
@@ -596,4 +613,101 @@ pub fn handle_todo_import<G: GraphStore>(
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    // `handle_todo_import` discovers its scan boundary from the process working
+    // directory, which is global to the test binary, so the tests that move it
+    // share one lock and restore it on drop.
+    static CWD_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct CurrentDirGuard(PathBuf);
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
+    fn path_args(path: &str) -> HashMap<String, serde_json::Value> {
+        let mut args = HashMap::new();
+        args.insert(
+            "path".to_string(),
+            serde_json::Value::String(path.to_string()),
+        );
+        args
+    }
+
+    fn result_text(result: &ToolCallResult) -> String {
+        result
+            .content
+            .iter()
+            .map(|block| match block {
+                crate::types::ContentBlock::Text { text } => text.clone(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn mcp_todo_import_refuses_a_scan_root_outside_the_repository() {
+        let _lock = CWD_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _cwd = CurrentDirGuard(std::env::current_dir().unwrap());
+
+        let repo = tempfile::tempdir().unwrap();
+        kin_core::init(repo.path()).unwrap();
+
+        // A tree this tool has no business reading. The marker text is what says
+        // whether the walk reached it.
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(
+            outside.path().join("secret.rs"),
+            "// TODO: outside the repo\n",
+        )
+        .unwrap();
+
+        std::env::set_current_dir(repo.path()).unwrap();
+        let store = kin_db::InMemoryGraph::new();
+        let refused = handle_todo_import(&path_args(&outside.path().to_string_lossy()), &store);
+        assert!(
+            refused.is_err(),
+            "the MCP route must refuse a scan root outside the repository, got {:?}",
+            refused.map(|ok| result_text(&ok))
+        );
+    }
+
+    #[test]
+    fn mcp_todo_import_accepts_a_scan_root_inside_the_repository() {
+        let _lock = CWD_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _cwd = CurrentDirGuard(std::env::current_dir().unwrap());
+
+        let repo = tempfile::tempdir().unwrap();
+        kin_core::init(repo.path()).unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(
+            repo.path().join("src").join("lib.rs"),
+            "// TODO: inside a subdirectory\n",
+        )
+        .unwrap();
+
+        std::env::set_current_dir(repo.path()).unwrap();
+        let store = kin_db::InMemoryGraph::new();
+        let text = result_text(
+            &handle_todo_import(&path_args("src"), &store)
+                .expect("a subdirectory of the repository is a legitimate scan root"),
+        );
+        assert!(
+            text.contains("\"work_items_created\": 1"),
+            "a legitimate subdirectory scan must still import: {text}"
+        );
+    }
 }

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -67,4 +67,4 @@ pub use shallow::{
     extract_shallow, get_shallow_grammar, parse_shallow_file, ShallowDecl, ShallowDeclKind,
     ShallowFile, ShallowFingerprint, ShallowImport,
 };
-pub use todos::{extract_todos, ExtractedTodo};
+pub use todos::{extract_todos, resolve_scan_root, ExtractedTodo};

--- a/crates/kin-parser/src/todos.rs
+++ b/crates/kin-parser/src/todos.rs
@@ -37,6 +37,46 @@ const TODO_MARKERS: &[&str] = &["TODO", "FIXME", "HACK", "NOTE"];
 /// ends the walk instead. No real source tree approaches this depth.
 const MAX_SCAN_DEPTH: usize = 64;
 
+/// Resolve a caller-supplied scan root against `boundary`, refusing anything
+/// outside it.
+///
+/// Containment lives here rather than at each call site because every caller of
+/// `extract_todos` takes its root from a request: the daemon's POST /work and
+/// POST /note routes, and the `kin_todo_import` MCP tool. Guarding them one at a
+/// time is what left the MCP handler reading any directory the process could
+/// reach while the daemon routes were already bounded, so the check belongs next
+/// to the walk it protects and a fourth caller inherits it.
+///
+/// Fails closed in both directions. The boundary and the resolved candidate must
+/// each canonicalize, so a path that cannot be resolved is refused rather than
+/// compared unresolved, and a scan root that does not exist is an error rather
+/// than a silently empty import. Joining an absolute path discards the base, so
+/// the containment test is the single check that rejects an absolute path and a
+/// `..` traversal alike.
+pub fn resolve_scan_root(boundary: &Path, requested: Option<&str>) -> Result<PathBuf> {
+    let base = boundary.canonicalize().map_err(|e| {
+        crate::error::ParseError::Extraction(format!(
+            "scan boundary {} cannot be resolved: {e}",
+            boundary.display()
+        ))
+    })?;
+    let Some(requested) = requested else {
+        return Ok(base);
+    };
+    let candidate = base.join(requested).canonicalize().map_err(|e| {
+        crate::error::ParseError::Extraction(format!(
+            "scan root {requested:?} cannot be resolved: {e}"
+        ))
+    })?;
+    if !candidate.starts_with(&base) {
+        return Err(crate::error::ParseError::Extraction(format!(
+            "scan root {requested:?} resolves outside {}",
+            base.display()
+        )));
+    }
+    Ok(candidate)
+}
+
 /// Scan a directory tree for inline TODO/FIXME/HACK/NOTE markers.
 pub fn extract_todos(root: &Path) -> Result<Vec<ExtractedTodo>> {
     let mut todos = Vec::new();
@@ -234,6 +274,46 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let todos = extract_todos(dir.path()).unwrap();
         assert!(todos.is_empty());
+    }
+
+    #[test]
+    fn resolve_scan_root_accepts_a_subdirectory_and_defaults_to_the_boundary() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let base = dir.path().canonicalize().unwrap();
+
+        assert_eq!(resolve_scan_root(dir.path(), None).unwrap(), base);
+        assert_eq!(
+            resolve_scan_root(dir.path(), Some("src")).unwrap(),
+            base.join("src")
+        );
+    }
+
+    #[test]
+    fn resolve_scan_root_refuses_a_path_outside_the_boundary() {
+        let dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+
+        let refused = resolve_scan_root(dir.path(), Some(&outside.path().to_string_lossy()));
+        assert!(
+            refused.is_err(),
+            "an absolute path outside the boundary must be refused, got {refused:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_scan_root_refuses_a_traversal_that_cannot_be_resolved() {
+        // The one that fails open if canonicalization is treated as optional.
+        // `<base>/../escape` starts with `<base>` as plain text, so a resolver
+        // that falls back to the unresolved join admits it while the directory
+        // it names sits outside. Refusing an unresolvable path is what closes
+        // that, so this asserts the refusal rather than the comparison.
+        let dir = TempDir::new().unwrap();
+        let refused = resolve_scan_root(dir.path(), Some("../escape-does-not-exist"));
+        assert!(
+            refused.is_err(),
+            "an unresolvable traversal must be refused, got {refused:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-parser/src/todos.rs
+++ b/crates/kin-parser/src/todos.rs
@@ -29,14 +29,25 @@ const TODO_EXTENSIONS: &[&str] = &["rs", "ts", "js", "tsx", "jsx", "py", "go", "
 /// Regex-like markers we scan for (case-insensitive match on the tag).
 const TODO_MARKERS: &[&str] = &["TODO", "FIXME", "HACK", "NOTE"];
 
+/// Directory depth this walk descends before it stops.
+///
+/// `path.is_dir()` follows symlinks, so a link pointing at any ancestor makes
+/// the recursion below unbounded and overflows the stack. The caller is a
+/// daemon route, so that crash is reachable from a request; a depth ceiling
+/// ends the walk instead. No real source tree approaches this depth.
+const MAX_SCAN_DEPTH: usize = 64;
+
 /// Scan a directory tree for inline TODO/FIXME/HACK/NOTE markers.
 pub fn extract_todos(root: &Path) -> Result<Vec<ExtractedTodo>> {
     let mut todos = Vec::new();
-    scan_dir(root, root, &mut todos)?;
+    scan_dir(root, root, 0, &mut todos)?;
     Ok(todos)
 }
 
-fn scan_dir(base: &Path, dir: &Path, out: &mut Vec<ExtractedTodo>) -> Result<()> {
+fn scan_dir(base: &Path, dir: &Path, depth: usize, out: &mut Vec<ExtractedTodo>) -> Result<()> {
+    if depth >= MAX_SCAN_DEPTH {
+        return Ok(());
+    }
     let read_dir = match std::fs::read_dir(dir) {
         Ok(rd) => rd,
         Err(_) => return Ok(()),
@@ -54,7 +65,7 @@ fn scan_dir(base: &Path, dir: &Path, out: &mut Vec<ExtractedTodo>) -> Result<()>
         }
 
         if path.is_dir() {
-            scan_dir(base, &path, out)?;
+            scan_dir(base, &path, depth + 1, out)?;
         } else if path.is_file() {
             let has_ext = path
                 .extension()
@@ -223,5 +234,38 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let todos = extract_todos(dir.path()).unwrap();
         assert!(todos.is_empty());
+    }
+
+    #[test]
+    fn the_walk_stops_at_the_depth_ceiling() {
+        let dir = TempDir::new().unwrap();
+        write_file(dir.path(), "shallow.rs", "// TODO: inside the ceiling\n");
+
+        // A chain two levels past the ceiling. Asserting both halves is what
+        // makes this fail for the right reason: a bound set to zero would also
+        // hide the deep marker, and the shallow assertion catches that.
+        let mut chain = PathBuf::new();
+        for _ in 0..MAX_SCAN_DEPTH + 2 {
+            chain.push("d");
+        }
+        let deep = chain.join("deep.rs");
+        write_file(
+            dir.path(),
+            deep.to_str().unwrap(),
+            "// TODO: past the ceiling\n",
+        );
+
+        let todos = extract_todos(dir.path()).unwrap();
+        let bodies: Vec<&str> = todos.iter().map(|todo| todo.body.as_str()).collect();
+        assert!(
+            bodies
+                .iter()
+                .any(|body| body.contains("inside the ceiling")),
+            "a marker above the ceiling must still be found: {bodies:?}"
+        );
+        assert!(
+            !bodies.iter().any(|body| body.contains("past the ceiling")),
+            "the walk must stop at the depth ceiling: {bodies:?}"
+        );
     }
 }

--- a/scripts/publish-boundary-contracts.mjs
+++ b/scripts/publish-boundary-contracts.mjs
@@ -111,7 +111,12 @@ function normalizeRegistryUrl(value) {
 }
 
 function encodePackageForMetadataPath(name) {
-  return name.replace("/", "%2F");
+  // replaceAll, not replace: a string pattern replaces the first match only,
+  // so any name carrying a second slash would reach the registry path
+  // half-encoded. The one call site passes a name already proven equal to
+  // @kin/boundary-contracts above, so this is correctness rather than a fix
+  // for a reachable input.
+  return name.replaceAll("/", "%2F");
 }
 
 function registryAuthLine(registryUrl) {


### PR DESCRIPTION
Triage of all 70 open CodeQL alerts on kin main, plus the two real defects it found. Two are fixed here; a third is recorded because nothing available before merge can compile it.

Worktree created from `origin/main` at `fcd21a98d51c34013bd05f12af75957db2017ad3`. Full report with every command and control: `.kin-coord/reports/codeql-triage-20260828.md`.

## Inventory

```
gh api 'repos/firelock-ai/kin/code-scanning/alerts?state=open&ref=refs/heads/main&per_page=100' \
  --paginate --jq '.[]' > alerts-open-main.ndjson
```

70 alerts. Reconciled three ways: distinct alert numbers = 70, `per_page=1` Link header `rel="last"` = page 70, same query at `per_page=30` = 70. Negative control, `state=closed` = 2, so the filter is live. It also reconciles against the analysis: the `/language:rust` analysis at `fcd21a98` reports `results_count: 71`, and 69 open rust alerts plus 2 dismissed rust alerts is 71. The 70th open alert is the lone JavaScript one.

| rule | n | severity | verdict |
|---|---|---|---|
| `rust/path-injection` | 38 | high / error | 1 REAL, 37 FALSE-POSITIVE |
| `rust/cleartext-logging` | 18 | high / warning | 18 FALSE-POSITIVE |
| `rust/cleartext-transmission` | 7 | high / warning | 7 FALSE-POSITIVE |
| `rust/access-invalid-pointer` | 3 | high / error | 1 REAL, 2 FALSE-POSITIVE |
| `rust/uncontrolled-allocation-size` | 2 | high / warning | 2 FALSE-POSITIVE |
| `rust/non-https-url` | 1 | high / warning | 1 FALSE-POSITIVE |
| `js/incomplete-sanitization` | 1 | high / warning | 1 FALSE-POSITIVE, fixed anyway |

Top files: `kin-daemon/src/state.rs` 12, `kin-core/src/last_admission.rs` 6, `kin-daemon/src/loop_runner.rs` 5, `kin-daemon-spawn/src/lib.rs` 5, `kin-cli/src/daemon_client.rs` 4, then 19 files with 3 or fewer.

## Why there is no `codeql-config.yml` in this PR

The brief asked for one config exclusion per false-positive group. That remedy does not exist on this repository, and shipping it anyway would be a change that cannot fail and cannot work.

CodeQL here is default setup only. There is no advanced setup:

```
$ git grep -c 'github/codeql-action' -- .github/                # 0
$ git grep -c 'uses: actions/checkout' -- .github/workflows/    # 63   (control)
```

`sast.yml` exists but runs `cargo-deny` and nothing else. Default setup reads a config file only when the repo property `github-codeql-config-file` names it, and neither the value nor the schema exists:

```
$ gh api repos/firelock-ai/kin/properties/values          # HTTP/2.0 200, []
$ gh api orgs/firelock-ai/properties/schema               # HTTP/2.0 200, []
$ gh api orgs/firelock-ai/properties/schema/nonexistent   # HTTP 404   (control)
```

Both answer 200 with an empty array and the control returns a real 404, so the absence is genuine rather than a permissions blind spot. The org defines no properties at all, so the property cannot be set until one is created. A config file committed today would be read by nothing while every alert kept firing.

The levers that work are fixing the code, dismissing through the API with a reason, or moving to advanced setup. This PR takes the first for two alerts and recommends the second for 67; the third is a decision above this lane, since it replaces default setup for all ten languages.

## FIR-2837's mechanism is wrong, and the real one is measured

FIR-2837 says the repo runs default setup "alongside the advanced sast.yml workflow" and calls that a double configuration. Every analysis on main carries `analysis_key: dynamic/github-code-scanning/codeql:analyze`, the default-setup key, one per language. There is no second configuration to remove, so acceptance criterion 1 cannot be the fix.

The real behaviour, measured after three wrong models of my own were refuted:

**The PR-time Rust analysis is narrower than main's, and CodeQL fails exactly when it is non-empty.** `results_count` for `/language:rust` by ref:

| ref | Rust lines | `results_count` | CodeQL |
|---|---|---|---|
| `refs/heads/main` | n/a | **71** | n/a |
| #1216 (this PR) | 451 | **0** | success |
| #1217 | 3759 | **12** | failure |
| #1204 | 9111 | **42** | failure |
| #1212 | 18349 | **42** | failure |

Tested across 19 PRs: 15 with `results_count` 0 all pass, 3 non-zero all fail, 1 with no Rust analysis is neutral. Eighteen for eighteen where an analysis exists. There is no baseline subtraction anywhere; passing PRs pass on an empty result set and every result that exists is reported as new. The relation is monotonic in Rust diff size and saturates at 42, the complete two-rule population plus 2 already-dismissed alerts.

The cheap discriminator, worth running before anyone opens an annotation:

```
gh api 'repos/firelock-ai/kin/code-scanning/analyses?ref=refs/pull/<n>/head&per_page=100' --paginate \
  --jq '[.[] | select(.category=="/language:rust")] | max_by(.created_at).results_count'
```

What stays unsettled is what defines the analysis scope. Sections 11 through 15 of the report record five hypotheses and five refutations, mine and a reviewer's, each killed by a row already in the data.

## The real defect this PR fixes

`WorkRequest::TodoImport` carried a caller-supplied path into `std::fs::read_dir` with no validation:

```rust
// before
let scan_root = path
    .map(std::path::PathBuf::from)
    .unwrap_or_else(|| _layout.working_dir().to_path_buf());
let todos = kin_parser::extract_todos(&scan_root)?;
```

`WorkRequest` is `#[serde(tag = "op", rename_all = "snake_case")]`, so one request body does it.

**Correction after review NO-GO on d6b32006e.** The first version of this PR said three routes reach that arm and counted the MCP tool among them. Two do: `POST /work` (`api.rs:7171`) and `POST /note` (`note.rs:260-264`). `kin_todo_import` dispatches at `handlers/mod.rs:136` to a **separate** `handle_todo_import` at `kin-mcp/src/handlers/work.rs:543`, which carried its own copy of the same pattern, taking `path` from the tool arguments and defaulting to `std::env::current_dir()`. `git grep execute_work_request -- crates/kin-mcp/` returns nothing, which is the one command that would have caught it; I read the dispatch line and assumed where it went. So the first fix left unguarded exactly the surface this PR calls the one that matters. `api.rs:7659` names the tool but is a classification predicate, and `todo_import` appears nowhere in `daemon_delegate.rs`.

The MCP schema advertises the parameter to every connected agent (`tools.rs:1156`), and that surface is the one that matters: an agent prompt-injected by repo content can aim the walk anywhere the daemon user can read.

Stated at its real strength: a filesystem existence oracle, the text of TODO/FIXME/HACK/NOTE lines in eight extensions, an uncapped walk as denial of service, and attacker-chosen strings written into the work graph. Not arbitrary file read. The daemon binds loopback by default (`api.rs:14046-14051`), though `api.rs:1906` records that the cloud daemon binds `0.0.0.0` behind a token.

The fix puts containment in kin-parser as `resolve_scan_root`, beside the walk it protects, and calls it from **both** routes. Guarding one call site is the shape of mistake that produced this defect, so a fourth caller now inherits the check rather than having to remember it. Joining an absolute path discards the base, so one containment test rejects both the absolute and the traversal shape.

It fails closed: the boundary and the resolved candidate must each canonicalize. The tolerant fallback the first version inherited was itself exploitable, since for a non-existent `../escape` an unresolved join yields `<base>/../escape`, which passes a textual `starts_with(<base>)` while naming a directory outside it. Mutation M5 shows the test on that input go red when the resolver falls open.

The MCP boundary is a design call and is stated in the code: `handle_todo_import` holds only a `GraphStore` with no filesystem root, so it discovers the boundary with `KinLayout::discover` from the process working directory, the resolution kin-mcp already uses in `daemon_delegate.rs:268` and `repository_authority.rs:62`. That is the directory the handler already defaulted to, so a well-formed call is unchanged; it fails closed when no repository is found.

A second defect in the same path is fixed alongside: `path.is_dir()` follows symlinks, so a link to any ancestor recursed until the stack overflowed, reachable from the same request even once the root is contained. CodeQL did not flag it. `todos.rs` gains a depth ceiling.

`todo_import_in_layout_direct` is deleted rather than fixed. It reproduced the arm's body verbatim, so no test could observe a change to the product path, and after the first fix its copy still carried the vulnerable pattern. Its test now drives `execute_work_request` like the rest. A second copy of the code under test only ever fails in the shape of a passing run.

## The real defect this PR does not fix

`update_windows.rs:883` forms a `&ACCESS_ALLOWED_ACE` before checking the ACE type on line 889, and its SAFETY comment claims the reverse order. It also lacks the `ace.is_null()` check its sibling at line 953 has. Severity is low, but it sits in a security gate.

Nothing before merge can grade it. All four Windows jobs carry `if: ${{ github.event_name != 'pull_request' }}` (`ci.yml` lines 194, 423, 496, 595), and the local cross-check fails on the host rather than the code: `cargo check --locked --target x86_64-pc-windows-msvc -p kin-cli --no-default-features --lib` exits 101 in `ring v0.17.14`'s build script with `VCINSTALLDIR = None`, before any kin code is type-checked. An unfalsifiable edit to unsafe FFI in a security gate is the change most likely to land looking green and be wrong, so it is recorded as FIR-2867 with the fix shape written out.

## Classification evidence, in brief

**37 path-injection false positives, one mechanism.** CodeQL's axum model treats the `State<Arc<DaemonState>>` extractor as remote input. Alert 50 proves it: its only source is the `health` handler, whose one request argument `Query(repo_query)` is consumed by a branch returning 400, so `state` is the only value reaching the sink. All 37 are `layout.root()` or `layout.working_dir()` joined with a compile-time constant, and `KinLayout` is built only by `discover()` walking the local filesystem.

**25 cleartext false positives, three facts.** No credential is printed: `credential.token` occurs three times in `auth.rs`, at line 435 (returned) and lines 590 and 612 (`.bearer_auth`), and no print or tracing macro touches it; the flagged lines 574 and 575 print `user_email` and `expires_at`, and 642 is an `assert!` inside `#[cfg(test)]`. A session id is not a credential, per the daemon's own comment at `api.rs:1977-1982` ("the session record carries no owner token to check against"), with the real gate a bearer token at `api.rs:1305`. No sink is a log file: all 18 sites are `println!`, `eprintln!`, `assert!` or `panic!`, subscribers write to stderr, and `tracing_appender` is not a dependency. `account_archive_entry` is a zip-bomb guard, "account" as a verb.

**2 allocation-size false positives, bounded on the line.** `refs.rs:612` is preceded nine lines earlier by `if request.entity_ids.len() > MAX_BULK_ENTITIES { bail }` with the constant at 200. `log.rs:101` is `Vec::with_capacity(count.min(snapshot.changes.len()))`, capped by the data that exists.

**1 non-https false positive.** `firestore.rs:360` is the GCE metadata server, which is link-local and does not serve HTTPS, with the required `Metadata-Flavor: Google` header on the next line.

**1 JS false positive, fixed anyway.** `name.replace("/", "%2F")` replaces the first match only, but the sole call site passes a name line 24 already proved equal to a one-slash literal. One word to correct, and with the config route closed a correction beats a suppression.

## Gates

`bin/kin-precheck kin` through the fleet heavy slot, against the tree it printed
(`sha=c23adca8c47ff6e49c08a8c54a68c9467ade3583 branch=chore/lane-codeql-triage-kin`):

```
kin-precheck: 16 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 16 gates ran, 16 passed, 0 failed, on kin c23adca8c47ff6e49c08a8c54a68c9467ade3583
```

fmt, clippy with the repo's 45-entry allow list, and all fourteen guard scripts.

Base is 4 commits behind origin/main. This PR touches neither `AGENTS.md` nor `docs/traps.md`, so
it carries no whole-tree claim a moved main would invalidate.

### Falsification, round 2

Round 1 is superseded and that is the lesson: every arm in it passed while the MCP route sat
unguarded. A grid can only falsify the route its tests exercise, so a green grid says nothing about
a sibling nobody wrote a test for.

Driver at `.kin-coord/reports/codeql-triage-logs/falsify2.sh`, graded at `c23adca8c` which the
artifact records with the branch and UTC date. It refuses a dirty tree above the restore trap,
restores on EXIT/INT/TERM, compile-checks all three crates first, asserts all ten listings (one a
fabricated name that must list zero) before running anything, one filter per invocation, and prints
the fired assertion in full rather than truncating at 140 characters.

| arm | mutation | expect | got | assertion that fired |
|---|---|---|---|---|
| M0 x9 | none | green | green | every test passes, both routes and the resolver |
| M1 cli-refuse | delete the containment refusal | red | red | `a scan root outside the repository must be refused` |
| M1 mcp-refuse | same mutation | red | red | `the MCP route must refuse a scan root outside the repository` |
| M2 depth | delete the depth ceiling | red | red | `the walk must stop at the depth ceiling` |
| M3 parser-accept | containment refuses everything | red | red | the subdirectory case |
| M3 cli-accept | same mutation | red | red | `a legitimate subdirectory scan must still import` |
| M3 mcp-accept | same mutation | red | red | the MCP subdirectory case |
| M4 mcp-refuse | revert the MCP handler to its unguarded form | red | red | `the MCP route must refuse a scan root outside the repository` |
| M4 cli-refuse | **control**, same mutation | green | green | stays green, so the arm is specific to the MCP route |
| M5 unres | fall open on canonicalize | red | red | see below |

Twenty arms, twenty matching expectation.

Three earn their place. **M1 kills both refusal tests from one mutation**, which is what proves the
routes share a guard rather than each carrying a copy. **M4 is the P0 arm**: revert only the MCP
handler, the MCP test goes red, the cli test stays green, so the arm is specific and the MCP route
is independently covered. That control is the one round 1 could not have had. **M5 prints the
fall-open bug** instead of arguing it:

```
an unresolvable traversal must be refused, got
Ok("/private/var/folders/.../T/.tmpimkDSr/../escape-does-not-exist")
```

That path contains `/../`, textually starts with the base, and names a directory outside it.

M5 aborted on its first run, and the cause is the same class as the P0, so it is recorded rather
than quietly re-run. The driver asserted the mutation removed `cannot be resolved: {e}`, expecting
zero, but that needle has **two** producers in the file, the boundary error and the candidate
error, so the count went 2 to 1 and never 0. The mutation had applied correctly; the check could
not tell the two apart. Re-run with a needle naming the candidate branch alone
(`falsify2-m5.sh`), with its own green baseline. A marker needle needs the same single-producer
discipline as any other signal.

Also run: `cargo fmt --all -- --check` clean, and `cargo check --locked -p kin-cli -p kin-parser
-p kin-mcp --all-targets` clean at 0 errors before the first arm.

### This PR's own CodeQL check, which is a third shape

It first read `neutral`, titled `1 configuration not found`, warning that `Default setup
/language:rust` present on main was not found on the PR. That is the exact warning FIR-2837 quotes
from #1198 and calls the double-configuration symptom. The rust analysis for this head then uploaded
at 17:30:27Z and the same check, still the only CodeQL check run on the commit, read `success`,
`No new alerts in code changed by this pull request`. Rust does run on PRs here: #1213, #1212,
#1211, #1207 and #1205 all carry it. So that warning is a race against the slowest analysis, not a
second configuration.

## Not dismissing anything here

FIR-2837 records the position that the main alerts "are real debt that should stay visible; dismissing them to clear PRs would hide it". With 68 now classified false-positive on the evidence above, dismissal is the right disposition for most, but it changes the security surface and is awkward to reverse, so the report recommends it per group rather than doing it. The count is **67** (37 path-injection, 18 cleartext-logging, 7 cleartext-transmission, 2 access-invalid-pointer, 2 allocation-size, 1 non-https-url), which reconciles as 67 dismissal candidates + 1 kept open under FIR-2867 + 2 that this PR fixes = 70 (main at 70 open alerts, read 2026-08-28T18:57Z). An earlier draft said 66, summed by hand and wrong by one.

Closes FIR-2868
Part of FIR-2837
