### PR TITLE
Name the collection a locate page answers with

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9403,6 +9403,19 @@ fn fused_semantic_locate_payload(
     // restart from an absent field. The cosine arm always states its page; now both
     // arms answer the question the same way.
     payload.insert("page".to_string(), json!(result.page));
+    // State the primary collection and its total explicitly, for the reason the
+    // line above states the page: `LocateResult` skips `entities` when it is
+    // empty and `total_ranked` when it is zero, so the one page that most needs
+    // to read as empty shipped neither key beside a `files` roll-up that
+    // serializes whatever it holds. A reader taking the first present array read
+    // that as a file answer. At file granularity `files` is the primary and is
+    // already serialized unconditionally, so only the entity arm needs this.
+    if !file_granularity {
+        payload
+            .entry("entities".to_string())
+            .or_insert_with(|| json!([]));
+    }
+    payload.insert("total_ranked".to_string(), json!(result.total_ranked));
     // The one list the per-hit variant attribution indexes. Written explicitly
     // rather than left to the `LocateResult` serialization, because a cursor page
     // restores it from the cached ranking and the two paths must publish the same
@@ -16026,10 +16039,12 @@ mod tests {
             kin_cli::commands::locate::LocateResult::default(),
             "where does the daemon start",
         );
-        assert!(
-            body.get("entities").is_none(),
-            "an empty fused page omits `entities` entirely: {body}"
+        assert_eq!(
+            body["entities"],
+            json!([]),
+            "an empty fused page states its primary rather than omitting it: {body}"
         );
+        assert_eq!(body["total_ranked"], json!(0));
         assert_eq!(body["files"], json!([]));
         let negative = kin_mcp::negative::negative_for(
             "semantic_locate",

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -223,6 +223,30 @@ pub struct BudgetAccounting {
     pub bounded: bool,
     /// True when explanation and per-signal breakdowns were shed.
     pub compact: bool,
+    /// The literal key of the collection this response answers with: the one a
+    /// `next_cursor` advances and the one a reader counts. `entities` on a
+    /// fused locate page, `results` on a cosine one, `files` at file
+    /// granularity, and the tool's own ranked list everywhere else.
+    ///
+    /// Published because presence cannot identify it. `LocateResult` skips its
+    /// `entities` array when empty while the secondary `files` roll-up
+    /// serializes whatever it holds, so on the one page that most needs
+    /// qualifying the first present array is the wrong one. A reader that has
+    /// to re-derive this from `granularity` and `routing` is a second copy of
+    /// the rule, and two copies is how the block beside this one came to count
+    /// a different collection from the one the ladder cut.
+    ///
+    /// Absent only on a response whose shape declares no primary and carries
+    /// none, because naming a collection that is not there would be worse than
+    /// saying nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_collection: Option<String>,
+    /// Rows the response ships in [`Self::primary_collection`].
+    ///
+    /// Zero is an answer here, not a missing field: it says the primary is
+    /// empty, which no secondary collection beside it can soften.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_rows: Option<usize>,
 }
 
 impl BudgetAccounting {
@@ -787,21 +811,88 @@ fn shape_for(tool: &str) -> Option<ResponseShape> {
 /// granularity. Prefer the response's declared arm and granularity; retain the
 /// presence fallback for older/test payloads that predate those fields.
 fn primary_collection(payload: &Value, tool: &str, shape: &ResponseShape) -> Option<&'static str> {
-    if tool == "semantic_locate" {
-        if payload.get("granularity").and_then(Value::as_str) == Some("file") {
-            return Some("files");
-        }
-        match payload.get("routing").and_then(Value::as_str) {
-            Some("cosine-v0") => return Some("results"),
-            Some("fused-v1") => return Some("entities"),
-            _ => {}
+    declared_primary_collection(payload, tool).or_else(|| {
+        shape
+            .collections
+            .iter()
+            .copied()
+            .find(|key| payload.get(*key).is_some_and(Value::is_array))
+    })
+}
+
+/// The primary a response DECLARES, from the fields it publishes about itself,
+/// with no appeal to which arrays happen to be present.
+///
+/// Split out from the presence fallback because the two answer different
+/// questions. This one asks what the response said it is; the fallback guesses
+/// from what it carries, and a guess is exactly what relabels an empty entity
+/// page as a file one.
+///
+/// The last arm is the one worth reading twice. A response that echoed a
+/// granularity other than `file` has already ruled the secondary roll-up out,
+/// whether or not it named an arm: an entity answer's primary is `results` when
+/// it carries that array and `entities` otherwise, and a page carrying neither
+/// is an empty entity page rather than a file one. Only a payload that named no
+/// granularity at all is left to the fallback.
+fn declared_primary_collection(payload: &Value, tool: &str) -> Option<&'static str> {
+    if tool != "semantic_locate" {
+        return None;
+    }
+    let granularity = payload.get("granularity").and_then(Value::as_str);
+    if granularity == Some("file") {
+        return Some("files");
+    }
+    match payload.get("routing").and_then(Value::as_str) {
+        Some("cosine-v0") => Some("results"),
+        Some("fused-v1") => Some("entities"),
+        _ => granularity.map(|_| {
+            if payload.get("results").is_some_and(Value::is_array) {
+                "results"
+            } else {
+                "entities"
+            }
+        }),
+    }
+}
+
+/// The collection one budgeted response answers with, for a caller outside this
+/// module.
+///
+/// Public because it is the ONE rule. [`crate::negative`] counts a locate page's
+/// rows through this function rather than through a copy of it: two derivations
+/// of "which array is the answer" is how one response came to carry a ladder
+/// that cut `entities` beside a negative block that had counted `files`.
+pub fn primary_collection_for(payload: &Value, tool: &str) -> Option<&'static str> {
+    let shape = shape_for(tool)?;
+    primary_collection(payload, tool, &shape)
+}
+
+/// Name this response's primary collection, and make the response carry it.
+///
+/// A declared primary the producer omitted is materialized as an empty array.
+/// That is the whole of the disguise this fixes: `LocateResult` skips an empty
+/// `entities` while the secondary `files` roll-up serializes whatever it holds,
+/// so a fused entity page that ranked nothing shipped no primary key at all
+/// beside a populated roll-up, and a reader taking the first present array read
+/// an empty answer as a file answer.
+///
+/// Materialized only for a primary the response DECLARED. Inventing a key from
+/// the presence fallback would fabricate a collection rather than disclose an
+/// empty one, and a key that was never absent needs nothing done to it.
+fn declare_primary_collection(
+    payload: &mut Value,
+    tool: &str,
+    shape: &ResponseShape,
+) -> Option<&'static str> {
+    let Some(declared) = declared_primary_collection(payload, tool) else {
+        return primary_collection(payload, tool, shape);
+    };
+    if payload.get(declared).is_none() {
+        if let Some(map) = payload.as_object_mut() {
+            map.insert(declared.to_string(), Value::Array(Vec::new()));
         }
     }
-    shape
-        .collections
-        .iter()
-        .copied()
-        .find(|key| payload.get(*key).is_some_and(Value::is_array))
+    Some(declared)
 }
 
 /// Whether this tool's response is governed by the budget.
@@ -832,6 +923,10 @@ pub fn enforce(
     budget: &ResponseBudget,
 ) -> Option<BudgetAccounting> {
     let shape = shape_for(tool)?;
+    // Named and materialized BEFORE anything is measured. Adding an omitted
+    // empty primary changes the size the accounting reports, and the accounting
+    // has to describe the response that ships.
+    let primary = declare_primary_collection(payload, tool, &shape);
     let chars_before = measure(payload);
 
     // Two arms bound one response. The daemon's `/mcp/tools/call` route cuts
@@ -853,8 +948,11 @@ pub fn enforce(
         chars_after: chars_before,
         bounded: prior.is_some(),
         compact: budget.compact,
+        primary_collection: primary.map(str::to_string),
+        // Solved after the ladder, which is the only thing that can change it.
+        primary_rows: None,
     };
-    run_ladder(payload, tool, &shape, budget, &mut accounting);
+    run_ladder(payload, tool, &shape, budget, primary, &mut accounting);
     accounting.chars_after = measure(payload);
 
     // A response the ladder could not bring under its ceiling is the case
@@ -864,7 +962,17 @@ pub fn enforce(
     // but the caller has to be told which of the two it is holding.
     reconcile_residual(payload, budget);
     accounting.chars_after = measure(payload);
+    accounting.primary_rows = primary.map(|key| collection_rows(payload, key));
     Some(accounting)
+}
+
+/// Rows one collection carries in a payload. A key that is absent or is not an
+/// array carries none, which is the same reading a caller gets from the JSON.
+fn collection_rows(payload: &Value, key: &str) -> usize {
+    payload
+        .get(key)
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len)
 }
 
 /// Run the ladder over one payload, recording what it cost in `accounting`.
@@ -877,17 +985,15 @@ fn run_ladder(
     tool: &str,
     shape: &ResponseShape,
     budget: &ResponseBudget,
+    // Resolved once by [`enforce`] and passed in rather than derived again
+    // here. The ladder and the accounting must name the same collection, and a
+    // second derivation is what would let them drift apart.
+    primary: Option<&'static str>,
     accounting: &mut BudgetAccounting,
 ) {
     let started_at = measure(payload);
     let mut cuts: Vec<String> = Vec::new();
     let mut remediations: Vec<String> = Vec::new();
-    // `semantic_locate` declares its primary through routing and granularity:
-    // `entities` for fused entity pages, `results` for cosine entity pages, and
-    // `files` for either file arm. Other tools retain the first-present rule.
-    // Presence alone is not authoritative here because an empty fused entity
-    // array is omitted while its secondary file roll-up remains serialized.
-    let primary = primary_collection(payload, tool, shape);
 
     // Compact by default, whether or not the payload is over budget: the
     // breakdowns are diagnostics a caller did not ask for, and shipping them
@@ -3129,5 +3235,148 @@ mod tests {
             !accounting.bounded,
             "nothing was carried, so nothing was cut: {payload}"
         );
+    }
+
+    /// One fused entity page in the shape the daemon's serializer produces:
+    /// `entities` omitted when the ranking held none, `files` present whatever
+    /// it holds. That asymmetry is where the relabelling lives, so the fixture
+    /// reproduces it rather than writing both keys out.
+    fn fused_entity_page(entities: usize, files: usize) -> Value {
+        let mut payload = json!({
+            "query": "where redirects are resolved",
+            "granularity": "entity",
+            "routing": "fused-v1",
+            "page": 0,
+            "files": (0..files)
+                .map(|index| json!({ "path": format!("src/f{index}.rs"), "score": 0.5 }))
+                .collect::<Vec<_>>(),
+        });
+        if entities > 0 {
+            payload["entities"] = json!((0..entities)
+                .map(|index| json!({
+                    "entity_id": format!("00000000-0000-0000-0000-{index:012}"),
+                    "name": format!("handler_{index}"),
+                    "kind": "function",
+                    "score": 0.5,
+                }))
+                .collect::<Vec<_>>());
+        }
+        payload
+    }
+
+    #[test]
+    fn entity_and_file_granularity_each_name_their_literal_primary() {
+        let budget = ResponseBudget::default();
+
+        let mut entity = fused_entity_page(3, 2);
+        let fused = enforce(&mut entity, "semantic_locate", &budget).expect("budgeted");
+        assert_eq!(fused.primary_collection.as_deref(), Some("entities"));
+        assert_eq!(fused.primary_rows, Some(3));
+
+        let mut cosine_payload = cosine_locate_payload(4);
+        let cosine = enforce(&mut cosine_payload, "semantic_locate", &budget).expect("budgeted");
+        assert_eq!(cosine.primary_collection.as_deref(), Some("results"));
+        assert_eq!(cosine.primary_rows, Some(4));
+
+        let mut file_payload = file_locate_payload(5, 2);
+        let files = enforce(&mut file_payload, "semantic_locate", &budget).expect("budgeted");
+        assert_eq!(files.primary_collection.as_deref(), Some("files"));
+        assert_eq!(files.primary_rows, Some(5));
+
+        // The three together, because a rule answering `files` to everything
+        // satisfies the file case on its own and one answering `entities` to
+        // everything satisfies the entity case on its own.
+        assert_ne!(fused.primary_collection, files.primary_collection);
+        assert_ne!(fused.primary_collection, cosine.primary_collection);
+    }
+
+    #[test]
+    fn an_empty_entity_page_ships_its_primary_rather_than_a_file_roll_up() {
+        let mut payload = fused_entity_page(0, 3);
+        assert!(
+            payload.get("entities").is_none(),
+            "the fixture must reproduce the omission this fixes: {payload}"
+        );
+
+        let accounting =
+            enforce(&mut payload, "semantic_locate", &ResponseBudget::default()).expect("budgeted");
+
+        assert_eq!(accounting.primary_collection.as_deref(), Some("entities"));
+        assert_eq!(accounting.primary_rows, Some(0));
+        assert_eq!(
+            payload.get("entities"),
+            Some(&json!([])),
+            "an empty primary is disclosed as empty, never omitted: {payload}"
+        );
+        assert_eq!(
+            payload["files"].as_array().map(Vec::len),
+            Some(3),
+            "the secondary roll-up is untouched; it is only no longer the answer: {payload}"
+        );
+    }
+
+    #[test]
+    fn an_entity_page_that_named_no_arm_never_names_the_file_roll_up() {
+        // Older and hand-built payloads carry a granularity and no routing. The
+        // presence fallback would pick `files` here, which is the exact
+        // relabelling the declared rule exists to refuse.
+        let mut payload = json!({
+            "query": "where redirects are resolved",
+            "granularity": "entity",
+            "files": [{ "path": "src/secondary.rs", "score": 0.4 }],
+        });
+        let accounting =
+            enforce(&mut payload, "semantic_locate", &ResponseBudget::default()).expect("budgeted");
+        assert_eq!(accounting.primary_collection.as_deref(), Some("entities"));
+        assert_eq!(accounting.primary_rows, Some(0));
+        assert_eq!(payload.get("entities"), Some(&json!([])));
+        assert_eq!(payload["files"].as_array().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn a_response_that_declares_no_primary_has_none_invented_for_it() {
+        // The known-absent control. `semantic_search` declares nothing about its
+        // collection, so a response carrying none must be reported as naming
+        // none rather than having `results` fabricated for it.
+        let mut absent = json!({ "query": "where redirects are resolved" });
+        let accounting =
+            enforce(&mut absent, "semantic_search", &ResponseBudget::default()).expect("budgeted");
+        assert_eq!(accounting.primary_collection, None);
+        assert_eq!(accounting.primary_rows, None);
+        assert_eq!(
+            absent.get("results"),
+            None,
+            "no collection was invented: {absent}"
+        );
+
+        // The positive control beside it, so the assertion above cannot pass by
+        // the accounting never naming anything at all.
+        let mut present = json!({ "query": "q", "results": [{ "name": "a" }] });
+        let accounting =
+            enforce(&mut present, "semantic_search", &ResponseBudget::default()).expect("budgeted");
+        assert_eq!(accounting.primary_collection.as_deref(), Some("results"));
+        assert_eq!(accounting.primary_rows, Some(1));
+    }
+
+    #[test]
+    fn the_primary_row_count_is_what_the_response_ships_after_a_cut() {
+        // `primary_rows` describes the response, not the ranking behind it. A
+        // count taken before the ladder would tell a caller it holds rows the
+        // budget had already withheld, which is the reading `total_ranked` is
+        // for.
+        let mut payload = locate_payload(60, 2_000);
+        let budget = ResponseBudget {
+            max_chars: RESPONSE_MIN_MAX_CHARS,
+            ..ResponseBudget::default()
+        };
+        let accounting = enforce(&mut payload, "semantic_locate", &budget).expect("budgeted");
+        assert!(accounting.bounded, "the fixture must be cut: {payload}");
+        let shipped = payload["entities"].as_array().expect("entities").len();
+        assert!(
+            shipped < 60,
+            "the fixture must lose rows: shipped {shipped}"
+        );
+        assert_eq!(accounting.primary_rows, Some(shipped));
+        assert_eq!(payload["total_ranked"], json!(60));
     }
 }

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1062,7 +1062,10 @@ pub fn enforce(
 
 /// Rows one collection carries in a payload. A key that is absent or is not an
 /// array carries none, which is the same reading a caller gets from the JSON.
-fn collection_rows(payload: &Value, key: &str) -> usize {
+///
+/// Public to the crate so the envelope's placeholder accounting counts rows
+/// through this function rather than through a third inline copy of it.
+pub(crate) fn collection_rows(payload: &Value, key: &str) -> usize {
     payload
         .get(key)
         .and_then(Value::as_array)

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -2536,6 +2536,17 @@ fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &Respon
         chars_after: chars_before,
         bounded: false,
         compact: budget.compact,
+        // Seeded with the real values for the same reason the size placeholder
+        // is: the stanza written first has to be the width of the stanza that
+        // ships, or the ladder charges the budget for the wrong bytes.
+        primary_collection: crate::budget::primary_collection_for(annotated, tool_name)
+            .map(str::to_string),
+        primary_rows: crate::budget::primary_collection_for(annotated, tool_name).map(|key| {
+            annotated
+                .get(key)
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len)
+        }),
     };
     write_response_accounting(annotated, &accounting);
     let mut bounded = false;

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -2527,6 +2527,10 @@ fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &Respon
         return;
     }
     let chars_before = crate::budget::measure(annotated);
+    // Resolved once. Two calls in adjacent expressions cannot disagree today,
+    // but a change whose whole argument is that one rule lives in one place
+    // should not keep a second reader of it here.
+    let primary = crate::budget::primary_collection_for(annotated, tool_name);
     let mut accounting = crate::budget::BudgetAccounting {
         max_chars: budget.max_chars,
         chars_before,
@@ -2539,14 +2543,8 @@ fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &Respon
         // Seeded with the real values for the same reason the size placeholder
         // is: the stanza written first has to be the width of the stanza that
         // ships, or the ladder charges the budget for the wrong bytes.
-        primary_collection: crate::budget::primary_collection_for(annotated, tool_name)
-            .map(str::to_string),
-        primary_rows: crate::budget::primary_collection_for(annotated, tool_name).map(|key| {
-            annotated
-                .get(key)
-                .and_then(Value::as_array)
-                .map_or(0, Vec::len)
-        }),
+        primary_collection: primary.map(str::to_string),
+        primary_rows: primary.map(|key| crate::budget::collection_rows(annotated, key)),
     };
     write_response_accounting(annotated, &accounting);
     let mut bounded = false;

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1208,20 +1208,21 @@ fn locate_result_count(payload: &Value) -> Option<usize> {
 /// Rows in the response's declared primary locate collection, before applying
 /// cross-field consistency checks.
 fn locate_primary_count(payload: &Value) -> Option<usize> {
-    let count = if payload.get("granularity").and_then(Value::as_str) == Some("file") {
-        collection_len(payload, "files")?
-    } else if payload.get("routing").and_then(Value::as_str) == Some("fused-v1") {
-        // `files` is serialized unconditionally by LocateResult and proves the
-        // fused shape even when its primary entity array is omitted as empty.
-        payload.get("files").and_then(Value::as_array)?;
-        payload
-            .get("entities")
-            .and_then(Value::as_array)
-            .map_or(0, Vec::len)
-    } else {
-        collection_len(payload, "results")?
-    };
-    Some(count)
+    // Which collection is the answer is decided in one place, by the budget's
+    // own rule, and read here. This block and the response budget's ladder used
+    // to derive it separately, from slightly different rules, so a payload
+    // existed for which the ladder cut one collection while this counted
+    // another.
+    let primary = crate::budget::primary_collection_for(payload, "semantic_locate")?;
+    match collection_len(payload, primary) {
+        Some(count) => Some(count),
+        // A producer that omitted its empty primary still proves the locate
+        // shape through `files`, which `LocateResult` serializes whatever it
+        // holds. An absent primary there is zero rows. A payload carrying
+        // neither is not a locate response, and its count stays unknown rather
+        // than being guessed at zero.
+        None => collection_len(payload, "files").map(|_| 0),
+    }
 }
 
 fn locate_empty_window_over_nonempty_ranking(payload: &Value) -> bool {
@@ -6882,6 +6883,83 @@ mod tests {
             &semantic_authoritative_envelope(),
         )
         .is_none());
+    }
+
+    /// The join, not the two endpoints.
+    ///
+    /// This block's row count and the response budget's ladder have to name one
+    /// collection on every locate shape the daemon produces. Two tests each
+    /// hardcoding the same key string would both stay green while the two sides
+    /// drifted apart, because neither can see the agreement. So this reads what
+    /// the budget chose and requires this block to have counted THAT array,
+    /// which no renaming on either side can satisfy by accident.
+    #[test]
+    fn the_negative_count_and_the_budget_primary_name_one_collection() {
+        let shapes = [
+            (
+                "fused entity page",
+                json!({
+                    "query": "q", "granularity": "entity", "routing": "fused-v1",
+                    "page": 0, "total_ranked": 2, "files": [],
+                    "entities": [{ "name": "a" }, { "name": "b" }],
+                }),
+            ),
+            (
+                "fused entity page that ranked nothing",
+                json!({
+                    "query": "q", "granularity": "entity", "routing": "fused-v1",
+                    "page": 0, "total_ranked": 0,
+                    "files": [{ "path": "src/secondary.rs", "score": 0.4 }],
+                }),
+            ),
+            (
+                "fused entity page that ships its empty primary",
+                json!({
+                    "query": "q", "granularity": "entity", "routing": "fused-v1",
+                    "page": 0, "total_ranked": 0, "entities": [],
+                    "files": [{ "path": "src/secondary.rs", "score": 0.4 }],
+                }),
+            ),
+            (
+                "cosine entity page",
+                json!({
+                    "query": "q", "granularity": "entity", "routing": "cosine-v0",
+                    "page": 0, "total_ranked": 1, "files": [],
+                    "results": [{ "name": "a" }],
+                }),
+            ),
+            (
+                "cosine file page",
+                json!({
+                    "query": "q", "granularity": "file", "routing": "cosine-v0",
+                    "page": 0, "total_ranked": 2,
+                    "files": [{ "path": "a.rs" }, { "path": "b.rs" }],
+                }),
+            ),
+            (
+                "fused file page",
+                json!({
+                    "query": "q", "granularity": "file", "routing": "fused-v1",
+                    "page": 0, "total_ranked": 1, "entities": [],
+                    "files": [{ "path": "a.rs" }],
+                }),
+            ),
+        ];
+        for (label, payload) in shapes {
+            let primary = crate::budget::primary_collection_for(&payload, "semantic_locate")
+                .unwrap_or_else(|| panic!("{label}: the budget named no primary collection"));
+            let counted = locate_primary_count(&payload)
+                .unwrap_or_else(|| panic!("{label}: the negative block counted nothing"));
+            let rows = payload
+                .get(primary)
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len);
+            assert_eq!(
+                counted, rows,
+                "{label}: the negative counted {counted} rows while the budget's primary \
+                 `{primary}` carries {rows}"
+            );
+        }
     }
 
     #[test]

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -119,7 +119,27 @@ which is the shape of a `compact` call and of source the graph never had, so it
 now keeps a null `body` beside a marker naming what went. Check 7 drives
 `kin context`, whose rendered lines are the whole of what a reader of that
 surface sees, and asserts the lines and `--json` report the same cut and name the
-lever that recovers it.
+lever that recovers it. Check 8 covers the page a cursor cannot rescue: a final
+page has no continuation, so the rows it withheld are reachable only by raising
+`max_chars` or narrowing the question, and it has to name those rather than a
+cursor it does not have.
+
+Checks 9 to 11 are FIR-2814, and they are the same reading defect one field over.
+A `LocateResult` skips its `entities` array when empty while the secondary
+`files` roll-up serializes whatever it holds, so a fused entity page that ranked
+nothing shipped no primary key at all beside a populated roll-up, and a reader
+taking the first present array read an empty answer as a file answer. Every
+reader had to re-derive which array was the answer from `granularity` and
+`routing`, and two of them did, in two places, under rules that were not the
+same. Check 9 asks each granularity to name the literal collection it answers
+with and to publish a row count that matches the array it ships, and it grades
+both granularities in one check because a server answering `files` to everything
+would satisfy the file half on its own. Check 10 asks a file page to be a window
+over the file ranking rather than the whole roll-up re-emitted under an advancing
+cursor, which reads as paging and is not. Check 11 asks an entity page that
+ranked nothing to still ship its primary as an empty array and count it zero,
+with a populated page as the control, since a server reporting every page empty
+would satisfy the empty arm on every call.
 
 `memory_pressure_refusal.py` covers the back-off Kin owes a machine it is
 running on, and the disclosure it owes the person running it. A daemon that

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -2319,6 +2319,25 @@ def self_test():
     return 1 if problems else 0
 
 
+def tree_sha():
+    """The sha of the tree this suite was read from, measured rather than typed.
+
+    A `--label` is a string the caller writes; this is a value the run reads. When
+    the two disagree the report shows it, which is the whole defect a hand-typed
+    sha has: the numbers are right and nothing downstream reads as broken.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", os.path.dirname(os.path.abspath(__file__)), "rev-parse", "HEAD"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return proc.stdout.decode("utf-8", "replace").strip() if proc.returncode == 0 else None
+
+
 def main(argv):
     parser = argparse.ArgumentParser(
         add_help=True,
@@ -2382,7 +2401,11 @@ def main(argv):
             os.makedirs(directory)
         with open(opts.json, "w") as handle:
             json.dump(
-                {"label": opts.label, "results": [r.row() for r in results]},
+                {
+                    "label": opts.label,
+                    "tree_sha": tree_sha(),
+                    "results": [r.row() for r in results],
+                },
                 handle,
                 indent=2,
                 sort_keys=True,

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -1486,10 +1486,14 @@ def check_10(suite):
     # reaches two files is a property of the fixture rather than of the rule
     # under test. So the query is chosen by measuring, and the sizes each one
     # reached are reported when none of them does.
+    # `return` is measured rather than guessed: on this fixture it is the one
+    # token both source modules carry, so it ranks two files where every other
+    # candidate ranks one. The others stay as fallbacks in case the fixture
+    # grows.
     seen = []
     first = None
     query = None
-    for candidate in ("hop", "value", "def"):
+    for candidate in ("return", "hop", "value"):
         try:
             probe = suite.mcp(
                 "semantic_locate",
@@ -1546,16 +1550,30 @@ def check_11(suite):
     res = Result(
         "11", "FIR-2814", "an entity page that ranked nothing ships its empty primary"
     )
+    # Which query empties the ranking is a property of the fixture, not of the
+    # rule under test, so it is measured rather than guessed. A multi-token
+    # absent symbol does NOT empty it: fused retrieval returns its best
+    # candidates and flags `all_fallback`, which is the documented behaviour
+    # rather than a defect. A single unmatched token does.
+    seen = []
+    empty = None
     try:
-        empty = suite.mcp(
-            "semantic_locate",
-            {
-                "query": "zzqqxx_nonexistent_symbol_9f3a",
-                "granularity": "entity",
-                "limit": 5,
-                "include_snippet": False,
-            },
-        )
+        for candidate in ("zzz", "quaternion sedimentation", "a0"):
+            probe = suite.mcp(
+                "semantic_locate",
+                {
+                    "query": candidate,
+                    "granularity": "entity",
+                    "limit": 5,
+                    "include_snippet": False,
+                },
+            )
+            named = declared_primary(probe)
+            rows = probe.get(named) if isinstance(named, str) else None
+            seen.append((candidate, named, len(rows) if isinstance(rows, list) else rows))
+            if isinstance(rows, list) and not rows:
+                empty = probe
+                break
         populated = suite.mcp(
             "semantic_locate",
             {"query": "hop", "granularity": "entity", "limit": 5, "include_snippet": False},
@@ -1563,12 +1581,10 @@ def check_11(suite):
     except McpError as exc:
         res.unknown("semantic_locate unreadable: %s" % exc)
         return res
-    named = declared_primary(empty)
-    rows = empty.get(named) if isinstance(named, str) else None
-    if isinstance(rows, list) and rows:
+    if empty is None:
         res.unknown(
-            "the absent-symbol query ranked %d row(s) in `%s`, so the empty-primary case "
-            "was not reached" % (len(rows), named)
+            "no fixture query emptied the primary collection, so the empty-primary case "
+            "was not reached: %r" % (seen,)
         )
         return res
     for problem in grade_empty_primary(empty):

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -25,6 +25,12 @@ can be satisfied by a broken tool:
      budget's name, and leaves no group empty
   6  a row whose inline source the budget took says so on the row
   7  `kin context` names the same cut in its lines and in its `--json`
+  9  each granularity names the literal collection it answers with, and the
+     count it publishes for it matches the array it ships
+ 10  a file page is a window over the file ranking rather than the whole
+     roll-up re-emitted under an advancing cursor
+ 11  an entity page that ranked nothing still ships its primary as an empty
+     array and counts it zero, with a populated page as the control
 
 FIR-2482 is checks 5 to 7, and it is the same rule reached through the OTHER
 budget. A context pack is cut twice: its own token budget refuses candidates
@@ -35,6 +41,13 @@ six dependencies serializes, and `kin context` printed "Dependencies: 6 entries"
 for both. The body case is the same defect one field down: a row that lost its
 source to the budget lost the key outright, which is the shape of a `compact`
 call and of source the graph never had.
+
+FIR-2814 is checks 9 to 11, and it is the same reading defect one field over. A
+`LocateResult` skips its `entities` array when empty while the secondary `files`
+roll-up serializes whatever it holds, so the one page that most needs to read as
+empty shipped no primary key at all beside a populated roll-up, and every reader
+had to re-derive which array was the answer from `granularity` and `routing`.
+Two of them did, in two places, with two slightly different rules.
 
 FIR-2602 is check 4. `impact_analysis` reported `{"bounded": false,
 "chars_before_budget": 50354, "max_chars": 2000}` and shipped all 50,354
@@ -1266,6 +1279,317 @@ def check_8(suite):
     return res
 
 
+# The keys a `semantic_locate` response may name as its primary collection:
+# `entities` on the fused arm, `results` on the cosine arm, `files` at file
+# granularity. Named here so a check grading a key outside this set is grading
+# something that is not a locate primary.
+LOCATE_PRIMARIES = ("entities", "results", "files")
+ENTITY_PRIMARIES = ("entities", "results")
+
+
+def declared_primary(payload):
+    """The collection this response names as its answer, or None."""
+    return ((payload.get("_kin") or {}).get("response") or {}).get("primary_collection")
+
+
+def declared_rows(payload):
+    """The row count this response publishes for its named primary, or None."""
+    return ((payload.get("_kin") or {}).get("response") or {}).get("primary_rows")
+
+
+def grade_primary_declaration(payload, allowed):
+    """Problems with how one locate page identifies its primary collection.
+
+    A reader must not have to infer which array is the answer, because presence
+    cannot tell it. `LocateResult` skips its `entities` field when empty while
+    the secondary `files` roll-up serializes whatever it holds, so on the one
+    page that most needs qualifying the first present array is the wrong one.
+    Returns a list of problems, empty on pass, so the self-test can drive it
+    with no binary.
+    """
+    problems = []
+    named = declared_primary(payload)
+    if not isinstance(named, str) or not named:
+        problems.append(
+            "the response named no primary collection in _kin.response, so a reader has to "
+            "guess which of %s is the answer" % (LOCATE_PRIMARIES,)
+        )
+        return problems
+    if named not in allowed:
+        problems.append(
+            "granularity %r named %r as its primary, which is not one of %s"
+            % (payload.get("granularity"), named, allowed)
+        )
+    rows = payload.get(named)
+    if not isinstance(rows, list):
+        problems.append(
+            "the response named %r as its primary and does not carry it as an array (got "
+            "%r), so an empty primary reads as a shape that has none"
+            % (named, type(rows).__name__)
+        )
+        return problems
+    count = declared_rows(payload)
+    if not isinstance(count, int):
+        problems.append(
+            "the response published no integer primary_rows beside `%s`" % named
+        )
+    elif count != len(rows):
+        problems.append(
+            "_kin.response.primary_rows says %d and `%s` carries %d rows"
+            % (count, named, len(rows))
+        )
+    return problems
+
+
+def grade_file_window(page1, page2, page_size):
+    """Problems with a file-granularity page that has to be a window.
+
+    A continuation that re-emits the whole roll-up hands back the same answer
+    while advancing a cursor, which reads as paging and is not. Pass `page2` as
+    None when the first page minted no cursor.
+    """
+    problems = []
+    rows = page1.get("files")
+    if not isinstance(rows, list):
+        problems.append("the first file page carries no `files` array")
+        return problems
+    if len(rows) > page_size:
+        problems.append(
+            "a page_size of %d returned %d file rows, so the page is not a window"
+            % (page_size, len(rows))
+        )
+    pages = [("page 1", page1)] + ([("page 2", page2)] if page2 is not None else [])
+    for label, page in pages:
+        for key in ENTITY_PRIMARIES:
+            carried = page.get(key)
+            if isinstance(carried, list) and carried:
+                problems.append(
+                    "%s of a file answer carries %d `%s` rows, so the entity ranking rides "
+                    "along with the file one" % (label, len(carried), key)
+                )
+    if page2 is None:
+        return problems
+    second = page2.get("files")
+    if not isinstance(second, list):
+        problems.append("the continuation carries no `files` array")
+        return problems
+    first_paths = [row.get("path") for row in rows]
+    second_paths = [row.get("path") for row in second]
+    if first_paths and first_paths == second_paths:
+        problems.append(
+            "the continuation repeated the first page verbatim: %r" % (first_paths,)
+        )
+    overlap = sorted(set(first_paths) & set(second_paths))
+    if overlap:
+        problems.append(
+            "the continuation repeated %d path(s) the first page already carried: %r"
+            % (len(overlap), overlap)
+        )
+    return problems
+
+
+def grade_empty_primary(payload):
+    """Problems with a page whose primary collection holds nothing.
+
+    Zero rows is an answer and has to read as one. The defect this grades is the
+    page that omits its empty primary outright and ships a secondary roll-up
+    beside it, which a reader takes for the answer. Fails when handed a
+    populated page, so the populated control cannot satisfy it by accident.
+    """
+    problems = grade_primary_declaration(payload, LOCATE_PRIMARIES)
+    named = declared_primary(payload)
+    if not isinstance(named, str) or not isinstance(payload.get(named), list):
+        return problems
+    rows = payload[named]
+    if rows:
+        problems.append(
+            "this grader was handed a populated primary: %d rows in `%s`"
+            % (len(rows), named)
+        )
+        return problems
+    if declared_rows(payload) != 0:
+        problems.append(
+            "`%s` is empty and _kin.response.primary_rows says %r"
+            % (named, declared_rows(payload))
+        )
+    return problems
+
+
+def grade_populated_primary(payload):
+    """Problems with a page that ranked something. The control direction.
+
+    A server that reported every page empty would satisfy `grade_empty_primary`
+    on every call, so the populated arm is graded by its own rule.
+    """
+    problems = grade_primary_declaration(payload, LOCATE_PRIMARIES)
+    named = declared_primary(payload)
+    if not isinstance(named, str) or not isinstance(payload.get(named), list):
+        return problems
+    if not payload[named]:
+        problems.append(
+            "this grader was handed an empty primary `%s`, so the populated control did "
+            "not rank anything" % named
+        )
+    return problems
+
+
+def secondary_rows(payload):
+    """Rows the page carries in collections that are NOT its declared primary."""
+    named = declared_primary(payload)
+    return {
+        key: len(payload[key])
+        for key in LOCATE_PRIMARIES
+        if key != named and isinstance(payload.get(key), list) and payload[key]
+    }
+
+
+def check_9(suite):
+    res = Result(
+        "9", "FIR-2814", "each granularity names the literal collection it answers with"
+    )
+    try:
+        entity = suite.mcp(
+            "semantic_locate",
+            {"query": "hop", "granularity": "entity", "limit": 5, "include_snippet": False},
+        )
+        files = suite.mcp(
+            "semantic_locate", {"query": "hop", "granularity": "file", "limit": 5}
+        )
+    except McpError as exc:
+        res.unknown("semantic_locate unreadable: %s" % exc)
+        return res
+    for problem in grade_primary_declaration(entity, ENTITY_PRIMARIES):
+        res.bad("entity granularity: %s" % problem)
+    for problem in grade_primary_declaration(files, ("files",)):
+        res.bad("file granularity: %s" % problem)
+    # Both halves together, because a server answering `files` to everything
+    # satisfies the file half alone and a server answering `entities` to
+    # everything satisfies the entity half alone.
+    if not res.failed:
+        res.ok(
+            "entity granularity named `%s` with %s rows and file granularity named `%s` "
+            "with %s rows"
+            % (
+                declared_primary(entity),
+                declared_rows(entity),
+                declared_primary(files),
+                declared_rows(files),
+            )
+        )
+    return res
+
+
+def check_10(suite):
+    res = Result("10", "FIR-2814", "a file page is a window, not the whole roll-up")
+    page_size = 1
+    # The continuation case needs a ranking wider than one page, and which query
+    # reaches two files is a property of the fixture rather than of the rule
+    # under test. So the query is chosen by measuring, and the sizes each one
+    # reached are reported when none of them does.
+    seen = []
+    first = None
+    query = None
+    for candidate in ("hop", "value", "def"):
+        try:
+            probe = suite.mcp(
+                "semantic_locate",
+                {
+                    "query": candidate,
+                    "granularity": "file",
+                    "page_size": page_size,
+                    "limit": 20,
+                },
+            )
+        except McpError as exc:
+            res.unknown("semantic_locate unreadable: %s" % exc)
+            return res
+        seen.append((candidate, probe.get("total_ranked")))
+        if isinstance(probe.get("total_ranked"), int) and probe["total_ranked"] > page_size:
+            first, query = probe, candidate
+            break
+    if first is None:
+        res.unknown(
+            "no fixture query ranked more than %d file(s), so the continuation case was "
+            "not reached: %r" % (page_size, seen)
+        )
+        return res
+    total = first["total_ranked"]
+    cursor = first.get("next_cursor")
+    if not cursor:
+        res.bad(
+            "a %d-row file ranking returned %d row(s) and no cursor, so the rest is "
+            "unreachable" % (total, len(first.get("files") or []))
+        )
+        return res
+    try:
+        second = suite.mcp(
+            "semantic_locate", {"query": query, "granularity": "file", "cursor": cursor}
+        )
+    except McpError as exc:
+        res.unknown("the file continuation was unreadable: %s" % exc)
+        return res
+    for problem in grade_file_window(first, second, page_size):
+        res.bad(problem)
+    if not res.failed:
+        res.ok(
+            "page 1 carried %r and page 2 carried %r out of %d ranked files"
+            % (
+                [row.get("path") for row in first["files"]],
+                [row.get("path") for row in second["files"]],
+                total,
+            )
+        )
+    return res
+
+
+def check_11(suite):
+    res = Result(
+        "11", "FIR-2814", "an entity page that ranked nothing ships its empty primary"
+    )
+    try:
+        empty = suite.mcp(
+            "semantic_locate",
+            {
+                "query": "zzqqxx_nonexistent_symbol_9f3a",
+                "granularity": "entity",
+                "limit": 5,
+                "include_snippet": False,
+            },
+        )
+        populated = suite.mcp(
+            "semantic_locate",
+            {"query": "hop", "granularity": "entity", "limit": 5, "include_snippet": False},
+        )
+    except McpError as exc:
+        res.unknown("semantic_locate unreadable: %s" % exc)
+        return res
+    named = declared_primary(empty)
+    rows = empty.get(named) if isinstance(named, str) else None
+    if isinstance(rows, list) and rows:
+        res.unknown(
+            "the absent-symbol query ranked %d row(s) in `%s`, so the empty-primary case "
+            "was not reached" % (len(rows), named)
+        )
+        return res
+    for problem in grade_empty_primary(empty):
+        res.bad("empty page: %s" % problem)
+    for problem in grade_populated_primary(populated):
+        res.bad("populated control: %s" % problem)
+    if not res.failed:
+        beside = secondary_rows(empty)
+        res.ok(
+            "the empty page carries `%s: []` with primary_rows 0 beside %s, and the "
+            "populated control carries %s rows in `%s`"
+            % (
+                declared_primary(empty),
+                beside or "no secondary rows",
+                declared_rows(populated),
+                declared_primary(populated),
+            )
+        )
+    return res
+
+
 CHECKS = [
     ("0", check_0),
     ("1", check_1),
@@ -1276,6 +1600,9 @@ CHECKS = [
     ("6", check_6),
     ("7", check_7),
     ("8", check_8),
+    ("9", check_9),
+    ("10", check_10),
+    ("11", check_11),
 ]
 
 
@@ -1827,6 +2154,144 @@ def self_test():
         "a whole pack grades nothing here",
         grade_cli_context(cli_whole, cli_doc(50), "  Dependencies: 50 entries")[1],
         0,
+    )
+
+    # The granularity graders, each against one correct page and one break per
+    # rule. FIR-2814.
+    def locate_page(primary="entities", rows=2, granularity="entity", **over):
+        page = {
+            "query": "hop",
+            "granularity": granularity,
+            "routing": "fused-v1",
+            primary: [{"path": "src/f%d.py" % i, "name": "hop_%d" % i} for i in range(rows)],
+            "_kin": {"response": {"primary_collection": primary, "primary_rows": rows}},
+        }
+        page.update(over)
+        return page
+
+    expect(
+        "a page that names its primary and counts it grades clean",
+        grade_primary_declaration(locate_page(), ENTITY_PRIMARIES),
+        [],
+    )
+    expect(
+        "a page that names no primary is caught",
+        len(grade_primary_declaration(locate_page(_kin={"response": {}}), ENTITY_PRIMARIES))
+        >= 1,
+        True,
+    )
+    expect(
+        "an entity page naming the file roll-up as its primary is caught",
+        len(
+            grade_primary_declaration(
+                locate_page(primary="files"), ENTITY_PRIMARIES
+            )
+        )
+        >= 1,
+        True,
+    )
+    absent = locate_page()
+    del absent["entities"]
+    expect(
+        "a named primary the page does not carry is caught",
+        len(grade_primary_declaration(absent, ENTITY_PRIMARIES)) >= 1,
+        True,
+    )
+    miscounted = locate_page()
+    miscounted["_kin"]["response"]["primary_rows"] = 7
+    expect(
+        "a primary_rows that disagrees with the array is caught",
+        len(grade_primary_declaration(miscounted, ENTITY_PRIMARIES)) >= 1,
+        True,
+    )
+    uncounted = locate_page()
+    del uncounted["_kin"]["response"]["primary_rows"]
+    expect(
+        "a named primary with no row count is caught",
+        len(grade_primary_declaration(uncounted, ENTITY_PRIMARIES)) >= 1,
+        True,
+    )
+
+    def file_page(paths, **over):
+        page = {
+            "query": "hop",
+            "granularity": "file",
+            "routing": "fused-v1",
+            "files": [{"path": path} for path in paths],
+            "_kin": {"response": {"primary_collection": "files", "primary_rows": len(paths)}},
+        }
+        page.update(over)
+        return page
+
+    expect(
+        "two disjoint single-row file pages grade clean",
+        grade_file_window(file_page(["a.py"]), file_page(["b.py"]), 1),
+        [],
+    )
+    expect(
+        "a continuation that repeats the first page is caught",
+        len(grade_file_window(file_page(["a.py"]), file_page(["a.py"]), 1)) >= 1,
+        True,
+    )
+    expect(
+        "a continuation that overlaps the first page is caught",
+        len(grade_file_window(file_page(["a.py"]), file_page(["a.py", "b.py"]), 2)) >= 1,
+        True,
+    )
+    expect(
+        "a page wider than the page size is caught",
+        len(grade_file_window(file_page(["a.py", "b.py"]), file_page(["c.py"]), 1)) >= 1,
+        True,
+    )
+    expect(
+        "a file page carrying entity rows is caught",
+        len(
+            grade_file_window(
+                file_page(["a.py"], entities=[{"name": "hop_0"}]), file_page(["b.py"]), 1
+            )
+        )
+        >= 1,
+        True,
+    )
+    expect(
+        "a first file page with no cursor still grades what it can",
+        grade_file_window(file_page(["a.py"]), None, 1),
+        [],
+    )
+
+    empty_page = locate_page(rows=0)
+    expect(
+        "an empty primary present and counted zero grades clean",
+        grade_empty_primary(empty_page),
+        [],
+    )
+    disguised = locate_page(rows=0)
+    del disguised["entities"]
+    disguised["files"] = [{"path": "src/secondary.py"}]
+    expect(
+        "an omitted empty primary beside a populated roll-up is caught",
+        len(grade_empty_primary(disguised)) >= 1,
+        True,
+    )
+    expect(
+        "the empty grader refuses a populated page",
+        len(grade_empty_primary(locate_page(rows=2))) >= 1,
+        True,
+    )
+    expect(
+        "the populated grader accepts a populated page",
+        grade_populated_primary(locate_page(rows=2)),
+        [],
+    )
+    expect(
+        "the populated grader refuses an empty page",
+        len(grade_populated_primary(empty_page)) >= 1,
+        True,
+    )
+    expect(
+        "secondary rows are reported beside an empty primary",
+        secondary_rows(disguised),
+        {"files": 1},
     )
 
     for line in problems:


### PR DESCRIPTION
## Measurement, before a line of product code changed

A release build of unmodified `main` at `fcd21a98`, graded by checks 9 to 11 of
`scripts/acceptance/response_budget_elisions.py`, which were committed before the run so
the numbers reproduce against a ref:

```
CHECK 9  FIR-2814 FAIL  entity granularity: the response named no primary collection in
                        _kin.response, so a reader has to guess which of ('entities',
                        'results', 'files') is the answer; file granularity: the same
CHECK 10 FIR-2814 UNREADABLE no fixture query ranked more than 1 file(s), so the
                        continuation case was not reached: [('hop', 1), ('value', 1),
                        ('def', 1)]
CHECK 11 FIR-2814 FAIL  empty page: the response named no primary collection ...;
                        populated control: the same
response budget elisions: 9 PASS, 2 FAIL, 1 UNREADABLE
```

Raw payloads off the same binary, `_kin.response` carrying exactly the same five keys on
every one of them and none of them naming a collection:

| query | granularity | collection keys present | lengths | `total_ranked` |
|---|---|---|---|---|
| one that ranks | entity | `entities`, `files` | 3, 3 | 3 |
| the same one | file | `files` | 3 | 3 |
| one matching nothing | entity | `files` | 0 | ABSENT |

Three answers against the exit criterion.

**Which collection is primary.** Neither granularity says. On the first row a reader is
handed three entities and three files and nothing states which is the answer or which a
cursor would advance. The rule existed in the code twice, at `budget.rs:790` and
`negative.rs:1210`, derived from `granularity` and `routing` under rules that were not the
same, and neither published its result, so an external consumer had no third option but a
third copy.

**Whether a file page repeats a full roll-up.** It does not, and this half already held:
`apply_file_page_at_offset` clears `entities` and windows `files` on both the first page
and the cursor path, and the cosine arm windows through `cosine_file_surface(&window)`.
What the run could not confirm was the continuation, because the acceptance fixture holds
three files and every candidate query ranked exactly one, which is why check 10 read
UNREADABLE rather than PASS. Measured against the fixture, the one token both source
modules carry is `return`, which ranks two.

**Whether an empty entity page can be disguised.** Yes, through a serializer asymmetry.
`LocateResult.entities` carries `skip_serializing_if = "Vec::is_empty"` and
`LocateResult.files` carries no skip attribute at all, so the third row ships no
`entities` key, no `total_ranked` (skipped at zero) and no `all_fallback`: nine top-level
keys where the populated answer had eleven, and the two that went missing are the two that
would have said the answer was empty. A reader taking the first present array is left with
`files`.

One honest limit. On both fixtures the empty page also had an empty `files`, so the
populated-secondary form of the disguise was not reached empirically. What was reached is
the structural half, which is the load-bearing one: the primary key is omitted and nothing
names it, so `files` becomes the first present array the moment it holds anything. The
populated form is covered by unit tests, including the one main already carried for exactly
that payload.

## The change

One rule, published once, in one place.

`budget.rs` splits `declared_primary_collection` out from the presence fallback, because
the two answer different questions: what the response said it is, versus a guess from what
it carries. Its granularity-only arm is the one worth reading twice. A response that echoed
a granularity other than `file` has already ruled the secondary roll-up out whether or not
it named an arm, so it resolves to `results` when that array is present and `entities`
otherwise; without that arm the fallback picks `files` for a routing-less entity page,
which is the exact relabelling this fixes. `primary_collection_for` exposes the one rule.
`declare_primary_collection` materializes a DECLARED primary the producer omitted, as `[]`,
and only a declared one, since inventing a key from a presence guess would fabricate a
collection rather than disclose an empty one. `BudgetAccounting` gains `primary_collection`
and `primary_rows`, so `_kin.response` names the collection and the rows the response ships
in it. `run_ladder` receives the primary instead of deriving it again, so the ladder and the
accounting cannot name different collections.

`negative.rs` reads `budget::primary_collection_for` instead of its own copy, keeping the
`files`-presence shape guard: an absent primary on a proven locate payload is zero rows, and
a payload carrying neither key stays unknown rather than being guessed at zero.

`envelope.rs` seeds the placeholder accounting with the real primary, for the reason the
size placeholder already is: the stanza written first has to be the width of the stanza that
ships.

`api.rs` has `fused_semantic_locate_payload` state `entities` and `total_ranked` explicitly,
for the reason it already states `page` explicitly. Only the entity arm needs it, because
`files` is serialized unconditionally.

Nothing in `SEMANTIC_LOCATE_DESC` was touched, so #1210 is unaffected. `POST /locate` shares
the same `LocateResult` skip behaviour and is deliberately left alone: its schema is shared
with `kin locate --json`, and it refuses a file-granularity cursor outright, so granularity
is a `semantic_locate` concept rather than a `/locate` one.

## After

The same suite against the fixed binary, on the same fixture:

```
CHECK 9  FIR-2814 PASS entity granularity named `entities` with 5 rows and file
                       granularity named `files` with 1 rows
CHECK 10 FIR-2814 PASS page 1 carried ['src/chain.py'] and page 2 carried ['src/wide.py']
                       out of 2 ranked files
CHECK 11 FIR-2814 PASS the empty page carries `entities: []` with primary_rows 0 beside no
                       secondary rows, and the populated control carries 5 rows in
                       `entities`
response budget elisions: 12 PASS, 0 FAIL, 0 UNREADABLE
```

The probe's own file continuation, which the acceptance fixture is too small to reach,
pages a wider fixture: `total_ranked` 11, page 1 `['src/mod_09.py']`, page 2
`['src/mod_04.py']`, zero overlap. And an entity page over a query matching nothing now
carries `entities: []` with `total_ranked: 0` and names `entities` as its primary, where the
same call on main carried neither key.

## Falsification

Ten arms and one baseline. Every arm removes a property of the code under test; none
weakens an assertion, because an arm that weakens an assertion always passes and grades
the test rather than the code. The driver refuses a dirty tree BEFORE arming its restore,
compile-checks `--workspace --all-targets` first so a tree that will not build cannot print
red cells that graded nothing, resolves every test's full module path from `-- --list` with
a fabricated name that must list zero, scores a red that fired no assertion as NOT RUN, and
prints the full grid rather than a tally.

| Arm | What it removes | Verdict | Tests red | The assertion that fired |
|---|---|---|---|---|
| M0 baseline | nothing | GREEN | 0 of 8 | 8 of 8 green |
| M1 no-materialize | `declare_primary_collection` stops materializing an omitted declared primary | RED | 2 of 7 | "an empty primary is disclosed as empty, never omitted", left `Null` right `Array []` |
| M2 never-name-primary | `_kin.response.primary_collection` is always `None` | RED | 4 of 7 | the four naming assertions |
| M3 count-the-ranking | `primary_rows` reads `total_ranked` instead of the shipped array | RED | 5 of 7 | `the_primary_row_count_is_what_the_response_ships_after_a_cut` among them |
| M4 drop-granularity-only-arm | the declared rule's granularity-only arm returns `None` | RED | 1 of 7 | `an_entity_page_that_named_no_arm_never_names_the_file_roll_up`, alone |
| M5 negative-counts-the-rollup | `negative` counts `files` rather than the declared primary | RED | 2 of 7 | the join test: "the negative counted 0 rows while the budget's primary carries ..." |
| M6 payload-omits-entity-primary | `fused_semantic_locate_payload` stops stating `entities` | RED | 1 of 1 | "an empty fused page states its primary rather than omitting it", left `Null` right `Array []` |
| M7 payload-omits-total-ranked | it stops stating `total_ranked` | RED | 1 of 1 | left `Null` right `Number(0)` |
| M8 grader-primary-blind | `grade_primary_declaration` returns no problems | RED | self-test | 6 assertions fired |
| M9 grader-window-blind | `grade_file_window` returns no problems | RED | self-test | 4 assertions fired |
| M10 grader-empty-blind | `grade_empty_primary` returns no problems | RED | self-test | 2 assertions fired |

Ten red, one green baseline, zero NOT RUN, and no row green all the way across.

**M4 is the arm worth naming.** It turns exactly one test red, which is what proves the
granularity-only branch is load-bearing rather than defensive: without it the presence
fallback labels a routing-less entity page `files`, and nothing else in the suite sees it.

**M6 and M7 fire DIFFERENT assertions on the same test.** Two statements about one payload
would otherwise be jointly covered and separately invisible, which is the class where a
mutation that merely redirects between branches survives.

**One prediction was wrong and the grid found it.** I expected M2 to turn the row-count test
red as well. It stayed green, because `primary_rows` is computed from the local primary
rather than from the published name, so nulling the name leaves the count correct. The code
is right and the prediction was too broad; M3 owns the count. The expectation is corrected
in the driver with that reason beside it.

`the_negative_count_and_the_budget_primary_name_one_collection` is the test that matters
most, and it asserts the JOIN rather than the endpoints: two tests each hardcoding the same
key string would both stay green while the two sides drifted, because neither can see the
agreement. It reads what the budget chose over six real locate shapes and requires the
negative block to have counted THAT array.

## Gates

Everything ran through the fleet's heavy-slot wrapper from the lane worktree, and each
tool's own printed sha line is quoted rather than remembered.

* `bin/kin-precheck kin`, on the tree it printed as
  `sha=257946e373... branch=chore/lane-granularity2814-kin`: 16 gates enumerated from
  ci.yml's own check job, **16 ran, 16 passed, 0 failed**.
* `bin/kin-parity`, same head, `dirty False`, binary reporting that head:
  **FINAL PASS-WITH-ALLOWANCES in 1136.9s** over magic, brownfield and firstrun, with three
  pre-existing allowances and none of them this change's (firstrun/9 FIR-2580, firstrun/3
  FIR-2501, brownfield/4 FIR-2464).
* `cargo test -p kin-mcp --lib`: 743 passed, 0 failed. `cargo test -p kin-daemon --lib`
  under `--exact`: 1 passed, 1111 filtered out, so the filter graded something.

Precheck reported the branch four commits behind, and three of those landings touched files
this change also touches. A green against a four-commit-stale base is a claim about a tree
nothing will land, so the branch was rebased onto a freshly fetched `origin/main`, proved
textually clean with `git merge-tree` first, and re-graded on `17dc46c84`:

* `bin/kin-parity`: **FINAL PASS-WITH-ALLOWANCES in 1570.1s**, same three pre-existing
  allowances, no new ones.
* The acceptance suite against the rebased binary: **12 PASS, 0 FAIL, 0 UNREADABLE**.
* `bin/kin-precheck kin`: 16 gates ran, **15 passed, 1 failed**, and that one failure is
  inherited from main rather than caused by this change. `guard:check-kin-vfs-compat.mjs`
  reports "Kin resolves kin-vfs-core 0.4.21, but the pinned kin-vfs checkout builds 0.4.14".
  This branch changes none of that guard's inputs, which is checkable in one command:
  `git diff origin/main HEAD --name-only -- Cargo.lock Cargo.toml
  .github/workflows/release.yml scripts/check-kin-vfs-compat.mjs` returns nothing. And main
  itself is red on the same step, at `d69de0830` and at `bd24bb872` before it, in the job
  `Check & Test ubuntu shard (1)`. The pin was last moved in #1034 and no open PR touches
  it. Advancing a release pin is captain work, so this lane reports it rather than fixing
  it inside a locate change.

Worth knowing when reading the green above: `Check & Test ubuntu shard`, the job carrying
that guard, is one of the sixteen skipping on the pull-request path, so hosted CI reads
clean on a tree the local gate correctly refuses.

One thing not to misread: `Product Acceptance` reports `skipping` here, and that is by
design rather than a gap. The job went off the pull-request path under FIR-2815 and reports
`skipped` to satisfy its required context, running for real on every commit that reaches
main. Checks 9 to 11 are graded by hand above, twelve of twelve against the built binary,
and will be graded by CI on the first push to main after this lands.

## Re-gated on the merged head

The gates above ran at `17dc46c84`. `origin/main` then moved six commits, one of which edits the
same `run_ladder` this change threads a primary through, so nothing had graded the two together.
The branch merged main in at `111792a9c` with zero conflicts, and every gate was re-run on that
tree rather than inherited from the one above.

* `bin/kin-precheck kin`, on the tree the tool printed as
  `111792a9c78bd5730731b43fc54900bd9e581fca`: 16 gates ran, **16 passed, 0 failed**. The single
  failure above was `guard:check-kin-vfs-compat.mjs`, inherited from main rather than caused here,
  and #1223 fixed that pin on main. Merging main in is what collected the fix.
* The acceptance suite against a release build of that head: **12 PASS, 0 FAIL, 0 UNREADABLE**,
  checks 9, 10 and 11 all green. The report's label is derived from `git rev-parse HEAD` rather than
  typed, and its `tree_sha` field reads that same head, so the artifact names the tree it graded
  instead of the tree its caller believed it graded.
* `cargo test -p kin-mcp -p kin-core -p kin-daemon`: rc=0, with zero `FAILED` lines, zero
  `test result: FAILED` and zero panics across 17 `test result: ok` blocks.

`bin/kin-parity` did not run on the merged head. Its last green is the `17dc46c84` run quoted
above, and that is the one limit on this section.

Closes FIR-2814
