### PR TITLE
Let the exact-head recheck wait for a young run's job listing

### DIFF
--- a/scripts/attest-kin-registry-wave.py
+++ b/scripts/attest-kin-registry-wave.py
@@ -690,7 +690,15 @@ def _validate_recheck_job(
     *,
     repository: str,
     run_id: int,
-) -> dict[str, Any]:
+    run_status: str,
+) -> dict[str, Any] | None:
+    """Return the run's required fast gate, or None while it is still arriving.
+
+    A run's job listing is empty for the first seconds of its life, so an absent
+    required job on a run that has not completed is news about the clock and not
+    about the run's authority. Returning None keeps that case inside the caller's
+    wait loop; raising would end the step before the wait it was given.
+    """
     jobs = value.get("jobs") if isinstance(value, dict) else None
     total = value.get("total_count") if isinstance(value, dict) else None
     if (
@@ -706,9 +714,17 @@ def _validate_recheck_job(
         for job in jobs
         if isinstance(job, dict) and job.get("name") == CI_REQUIRED_JOB
     ]
-    if len(required) != 1:
+    if len(required) > 1:
         raise AttesterError(
-            "post-attestation CI run does not publish exactly one required fast gate"
+            f"post-attestation CI run {run_id} publishes {len(required)} jobs named "
+            f"{CI_REQUIRED_JOB!r}; the recheck requires exactly one"
+        )
+    if not required:
+        if run_status != "completed":
+            return None
+        raise AttesterError(
+            f"completed post-attestation CI run {run_id} publishes no job named "
+            f"{CI_REQUIRED_JOB!r} among its {len(jobs)} jobs"
         )
     job = required[0]
     job_id = job.get("id")
@@ -734,7 +750,14 @@ def _post_attestation_recheck(
     repository: str,
     admission: dict[str, Any],
     attestation: dict[str, Any],
-) -> dict[str, Any] | None:
+) -> dict[str, Any]:
+    """Report the newest validated recheck, plus the runs still arriving.
+
+    The two are separate answers. A validated recheck ends the wait. A run whose
+    required fast gate has not been listed yet is the reason to keep waiting, and
+    is also the reason not to retrigger, since reopening the pull would cancel
+    the run already in flight.
+    """
     response = gh_json(
         [
             "api",
@@ -758,6 +781,7 @@ def _post_attestation_recheck(
         "attestation comment creation",
     )
     candidates: list[dict[str, Any]] = []
+    arriving: list[dict[str, Any]] = []
     for run in _workflow_run_pages(response):
         if not _is_recheck_run_candidate(
             run,
@@ -771,12 +795,14 @@ def _post_attestation_recheck(
         repository_doc = run.get("repository")
         head_repository = run.get("head_repository")
         run_attempt = run.get("run_attempt")
+        run_status = run.get("status")
         if (
             run.get("name") != CI_WORKFLOW_NAME
             or run.get("path") != CI_WORKFLOW_PATH
             or run.get("event") != "pull_request"
             or run.get("head_branch") != guard.WAVE_BRANCH
             or run.get("head_sha") != admission["head"]
+            or run_status not in RECHECK_STATUSES
             or not isinstance(repository_doc, dict)
             or repository_doc.get("full_name") != repository
             or not isinstance(head_repository, dict)
@@ -787,7 +813,7 @@ def _post_attestation_recheck(
         ):
             raise AttesterError("post-attestation CI run has the wrong authority")
         _validate_recheck_pull(run, repository=repository, admission=admission)
-        jobs = gh_json(
+        job_listing = gh_json(
             [
                 "api",
                 "--method",
@@ -803,10 +829,20 @@ def _post_attestation_recheck(
             ]
         )
         job = _validate_recheck_job(
-            jobs,
+            job_listing,
             repository=repository,
             run_id=int(run["id"]),
+            run_status=str(run_status),
         )
+        if job is None:
+            arriving.append(
+                {
+                    "run_id": int(run["id"]),
+                    "run_status": str(run_status),
+                    "job_count": len(job_listing["jobs"]),
+                }
+            )
+            continue
         candidates.append(
             {
                 "run_id": int(run["id"]),
@@ -817,9 +853,44 @@ def _post_attestation_recheck(
                 "created_at": run["created_at"],
             }
         )
-    if not candidates:
-        return None
-    return max(candidates, key=lambda item: int(item["run_id"]))
+    return {
+        "recheck": (
+            max(candidates, key=lambda item: int(item["run_id"]))
+            if candidates
+            else None
+        ),
+        "arriving": sorted(arriving, key=lambda item: int(item["run_id"])),
+    }
+
+
+def _missing_recheck_message(
+    *,
+    head: str,
+    arriving: list[dict[str, Any]],
+    wait_seconds: int,
+) -> str:
+    """Say what the recheck looked for, where it looked, and what it found.
+
+    The old message named none of the three, so the same sentence covered a run
+    whose jobs had not been listed yet and a run that genuinely never published
+    the gate.
+    """
+    where = f"{CI_WORKFLOW_PATH} runs on {guard.WAVE_BRANCH} at head {head}"
+    if not arriving:
+        return (
+            f"no exact required CI recheck materialized after the App attestation: "
+            f"looked for a job named {CI_REQUIRED_JOB!r} on {where} created after the "
+            f"attestation comment, and found no such run within {wait_seconds}s"
+        )
+    described = ", ".join(
+        f"run {item['run_id']} ({item['run_status']}, {item['job_count']} jobs listed)"
+        for item in arriving
+    )
+    return (
+        f"no exact required CI recheck materialized after the App attestation: "
+        f"looked for a job named {CI_REQUIRED_JOB!r} on {where} created after the "
+        f"attestation comment, and within {wait_seconds}s found only {described}"
+    )
 
 
 def recheck_status(
@@ -852,11 +923,13 @@ def recheck_status(
 
     deadline = time.monotonic() + wait_seconds
     while True:
-        recheck = _post_attestation_recheck(
+        observed = _post_attestation_recheck(
             repository=repository,
             admission=admission,
             attestation=attestation,
         )
+        recheck = observed["recheck"]
+        arriving = observed["arriving"]
         if recheck is not None:
             validate_live_admission(
                 workspace=workspace,
@@ -872,10 +945,14 @@ def recheck_status(
         if remaining <= 0:
             if require_recheck:
                 raise AttesterError(
-                    "no exact required CI recheck materialized after the App attestation"
+                    _missing_recheck_message(
+                        head=str(admission["head"]),
+                        arriving=arriving,
+                        wait_seconds=wait_seconds,
+                    )
                 )
             return {
-                "needs_retrigger": True,
+                "needs_retrigger": not arriving,
                 "attestation_comment_id": attestation["comment_id"],
             }
         time.sleep(min(2.0, remaining))

--- a/scripts/test-kin-registry-release-receiver.py
+++ b/scripts/test-kin-registry-release-receiver.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import importlib.util
 import json
@@ -436,6 +437,34 @@ def ci_run_document(
     }
 
 
+def ci_job_document(
+    *,
+    run_id: int = 901,
+    job_id: int = 9901,
+    name: str = "Fast gate lint and policy",
+    status: str = "queued",
+    conclusion: str | None = None,
+) -> dict[str, object]:
+    return {
+        "id": job_id,
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "run_url": (
+            f"https://api.github.com/repos/firelock-ai/kin/actions/runs/{run_id}"
+        ),
+    }
+
+
+def ci_jobs_listing(jobs: list[dict[str, object]]) -> dict[str, object]:
+    """Wrap an explicit job list the way the jobs endpoint reports it.
+
+    A run that is seconds old reports an empty list here, which is the shape
+    FIR-2865 turned into a hard failure, so tests need to build it directly.
+    """
+    return {"total_count": len(jobs), "jobs": jobs}
+
+
 def ci_jobs_document(
     *,
     run_id: int = 901,
@@ -443,21 +472,16 @@ def ci_jobs_document(
     status: str = "queued",
     conclusion: str | None = None,
 ) -> dict[str, object]:
-    return {
-        "total_count": 1,
-        "jobs": [
-            {
-                "id": 9901,
-                "name": name,
-                "status": status,
-                "conclusion": conclusion,
-                "run_url": (
-                    "https://api.github.com/repos/firelock-ai/kin/actions/runs/"
-                    f"{run_id}"
-                ),
-            }
-        ],
-    }
+    return ci_jobs_listing(
+        [
+            ci_job_document(
+                run_id=run_id,
+                name=name,
+                status=status,
+                conclusion=conclusion,
+            )
+        ]
+    )
 
 
 class ValidatorTests(unittest.TestCase):
@@ -1759,7 +1783,8 @@ class PostCompletionAttesterTests(unittest.TestCase):
             ), self._live_graphql(head):
                 with self.assertRaisesRegex(
                     attester.AttesterError,
-                    "exactly one required fast gate",
+                    r"looked for a job named 'Fast gate lint and policy'.*"
+                    r"found only run 901 \(in_progress, 1 jobs listed\)",
                 ):
                     attester.recheck_status(
                         admission_file=result_file,
@@ -1768,6 +1793,181 @@ class PostCompletionAttesterTests(unittest.TestCase):
                         wait_seconds=0,
                         require_recheck=True,
                     )
+
+    def test_recheck_waits_for_a_young_runs_jobs_to_be_listed(self) -> None:
+        """FIR-2865: the recheck read a three-second-old run and found no jobs.
+
+        Run 33185320130 was created at 15:28:38Z, the attester read it at
+        15:28:41Z, and its one 'Fast gate lint and policy' job started at
+        15:28:57Z. The old code raised on that empty listing, so the raise
+        escaped the wait loop and the step died 3.3 seconds into a 120 second
+        budget. Each arm below pins one producer of an absent required fast gate
+        apart from the others, because one message used to cover them all.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _, result_file, base, head = self._changed(directory)
+            pull = pull_document(head, base)
+            reviews, comments = attestation_documents(repo, base, head)
+            empty = ci_jobs_listing([])
+            with_gate = ci_jobs_document()
+            live = ci_run_document(head, base)
+            finished = copy.deepcopy(live)
+            finished["status"] = "completed"
+            finished["conclusion"] = "failure"
+
+            def reader(
+                runs: list[dict[str, object]],
+                listings: list[dict[str, object]],
+            ) -> tuple[object, dict[str, int]]:
+                """Serve the jobs endpoint one listing per call, then repeat the last."""
+                calls = {"jobs": 0, "runs": 0}
+
+                def fake(arguments: list[str]) -> object:
+                    endpoint = next(
+                        (item for item in arguments if item.startswith("repos/")), ""
+                    )
+                    if endpoint.endswith("/git/ref/heads/main"):
+                        return {"object": {"sha": base}}
+                    if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+                        return pull
+                    if endpoint.endswith("/reviews?per_page=100"):
+                        return [reviews]
+                    if endpoint.endswith("/comments?per_page=100"):
+                        return [comments]
+                    if endpoint.endswith("/actions/workflows/ci.yml/runs"):
+                        calls["runs"] += 1
+                        return [{"total_count": len(runs), "workflow_runs": runs}]
+                    if endpoint.endswith("/actions/runs/901/attempts/1/jobs"):
+                        index = min(calls["jobs"], len(listings) - 1)
+                        calls["jobs"] += 1
+                        return listings[index]
+                    raise AssertionError(
+                        f"unexpected mocked GitHub request: {arguments}"
+                    )
+
+                return fake, calls
+
+            @contextlib.contextmanager
+            def observing(
+                runs: list[dict[str, object]],
+                listings: list[dict[str, object]],
+            ):
+                fake, calls = reader(runs, listings)
+                slept: list[float] = []
+                with mock.patch.object(
+                    attester, "gh_json", side_effect=fake
+                ), mock.patch.object(
+                    attester.guard,
+                    "gh_json",
+                    return_value=workflow_run_document(base),
+                ), mock.patch.object(
+                    attester.time, "sleep", side_effect=slept.append
+                ), self._live_graphql(head):
+                    yield calls, slept
+
+            # Arm one, the production shape. The gate appears on the third poll
+            # and the wait has to survive the two empty ones.
+            with observing([live], [empty, empty, with_gate]) as (calls, slept):
+                arrived = attester.recheck_status(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                    wait_seconds=5,
+                    require_recheck=True,
+                )
+            self.assertIs(arrived["needs_retrigger"], False)
+            self.assertEqual(arrived["run_id"], 901)
+            self.assertEqual(arrived["job_id"], 9901)
+            self.assertEqual(arrived["job_status"], "queued")
+            self.assertEqual(calls["jobs"], 3)
+            self.assertEqual(len(slept), 2)
+
+            # Arm two. A run already in flight is the reason NOT to retrigger,
+            # because reopening the pull would cancel it.
+            with observing([live], [empty]) as (calls, _):
+                in_flight = attester.recheck_status(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                    wait_seconds=0,
+                    require_recheck=False,
+                )
+            self.assertIs(in_flight["needs_retrigger"], False)
+            self.assertEqual(calls["jobs"], 1)
+
+            # Arm three. Under --require-recheck the deadline is still a
+            # refusal, and the message names the job, the branch, the head and
+            # the run it did find.
+            with observing([live], [empty]) as (_, _slept):
+                with self.assertRaisesRegex(
+                    attester.AttesterError,
+                    r"looked for a job named 'Fast gate lint and policy' on "
+                    r"\.github/workflows/ci\.yml runs on "
+                    r"automation/kin-registry-dependency-wave at head "
+                    rf"{head}.*found only run 901 \(in_progress, 0 jobs listed\)",
+                ):
+                    attester.recheck_status(
+                        admission_file=result_file,
+                        workspace=repo,
+                        repository=attester.EXPECTED_REPOSITORY,
+                        wait_seconds=0,
+                        require_recheck=True,
+                    )
+
+            # Arm four. A COMPLETED run that never published the gate is a real
+            # authority failure, and no wait may soften it. One jobs call proves
+            # it refused rather than waited.
+            with observing(
+                [finished], [ci_jobs_document(name="not the required context")]
+            ) as (calls, slept):
+                with self.assertRaisesRegex(
+                    attester.AttesterError,
+                    r"completed post-attestation CI run 901 publishes no job named "
+                    r"'Fast gate lint and policy' among its 1 jobs",
+                ):
+                    attester.recheck_status(
+                        admission_file=result_file,
+                        workspace=repo,
+                        repository=attester.EXPECTED_REPOSITORY,
+                        wait_seconds=5,
+                        require_recheck=True,
+                    )
+            self.assertEqual(calls["jobs"], 1)
+            self.assertEqual(slept, [])
+
+            # Arm five. Two gates never resolve by waiting, so a live run with
+            # duplicates refuses on the first poll too.
+            duplicated = ci_jobs_listing(
+                [ci_job_document(job_id=9901), ci_job_document(job_id=9902)]
+            )
+            with observing([live], [duplicated]) as (calls, slept):
+                with self.assertRaisesRegex(
+                    attester.AttesterError,
+                    r"post-attestation CI run 901 publishes 2 jobs named "
+                    r"'Fast gate lint and policy'; the recheck requires exactly one",
+                ):
+                    attester.recheck_status(
+                        admission_file=result_file,
+                        workspace=repo,
+                        repository=attester.EXPECTED_REPOSITORY,
+                        wait_seconds=5,
+                        require_recheck=True,
+                    )
+            self.assertEqual(calls["jobs"], 1)
+            self.assertEqual(slept, [])
+
+            # Arm six. No candidate run at all is the one case that still asks
+            # for a retrigger, which is what separates it from arm two.
+            with observing([], [empty]) as (calls, _):
+                absent = attester.recheck_status(
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                    wait_seconds=0,
+                    require_recheck=False,
+                )
+            self.assertIs(absent["needs_retrigger"], True)
+            self.assertEqual(calls["jobs"], 0)
 
     def test_retrigger_reopens_after_an_uncertain_close_response(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Measurement first

The Kin Registry Release Admission Attester has run exactly once, and that once failed.

`gh api repos/firelock-ai/kin/actions/workflows/kin-registry-release-attest.yml/runs?per_page=1 --jq .total_count`
prints `1`. The same call against `kin-registry-release.yml` prints `1`. So a3e843cb (#1207),
fcd21a98 (#1206) and 9e7092e9 (#1205) produced no attester run at all: the workflow fires on the
receiver completing, not on a push to main. This is neither one-off nor intermittent nor
every-push. It is one of one.

Run 33185274454 concluded failure at the step `Verify a required exact-head CI recheck
materialized`. The step name says nothing materialized. `gh run view 33185274454 --log` line 514
says something else:

```
##[error]post-attestation CI run does not publish exactly one required fast gate
```

The step started at `15:28:38.6302225Z` and errored at `15:28:41.9394117Z`. That is 3.3 seconds
into the 120 second budget the step itself passes as `--wait-seconds 120`.

Step 9, the retrigger, succeeded and printed `{"head": "ede222d2589bfe17d84dcfb14dc3948a64d93a37",
"pull": 1209, "reopened": true}`. So the recheck was dispatched, and on the exact admitted head.

```
gh api --method GET repos/firelock-ai/kin/actions/workflows/ci.yml/runs \
  -f event=pull_request -f head_sha=ede222d2589bfe17d84dcfb14dc3948a64d93a37 \
  -f branch=automation/kin-registry-dependency-wave -f per_page=100
```

prints `total=2`. Run 33185320130 has `created_at` and `run_started_at` both
`2026-08-28T15:28:38Z`, the same second the failing step started. Its job listing
(`.../runs/33185320130/attempts/1/jobs`) now prints `total_count=27` with exactly one job named
`Fast gate lint and policy`, `started_at` `2026-08-28T15:28:57Z`. The earliest `started_at` of any
of the 27 is `15:28:55Z`.

So the run was three seconds old and its job listing was still empty when the attester read it.

Calling `_validate_recheck_job` directly on three inputs:

| input | result |
|---|---|
| `{"total_count": 0, "jobs": []}`, a run seconds old | `AttesterError: post-attestation CI run does not publish exactly one required fast gate` |
| one job named `Fast gate lint and policy` | `OK` |
| one job named `Some other job`, a run that genuinely lacks the gate | `AttesterError: post-attestation CI run does not publish exactly one required fast gate` |

The first and third are indistinguishable from the message, and both were fatal.

## Which producer failed

None of the three the ticket proposed. The recheck was dispatched, it was dispatched on the exact
head, and it did not materialize after the wait because the wait never ran. The producer that
failed is the job listing.

`_post_attestation_recheck` accepts a run as a candidate the instant it appears, then treats a
listing without the required job as a permanent authority error. The raise escapes the `while`
loop in `recheck_status`, and that loop is the only place the wait could happen: it gets a second
iteration only when `_post_attestation_recheck` returns, and a raise is not a return.

## Fix

An absent required job on a run that has not completed is now news about the clock, so the
detector reports it as arriving and the caller keeps waiting. Three cases stay refusals: a
completed run that published no such job, a run publishing more than one, and the deadline
expiring. Because a run already in flight is the reason not to reopen the pull and cancel it,
`needs_retrigger` is now false while one is arriving and true only when no candidate run exists at
all. The run's `status` joins the authority check, since the arriving branch reads it.

The refusal message now names the job it looked for, the workflow, the branch, the head and the
runs it did find, instead of one sentence covering every case.

No workflow change is needed. `--wait-seconds 120` was always the right budget; it was simply
unreachable.

## Falsification

Seven mutations against the committed tree, each removing a property of the code and none of a
test. Driver and logs under `.kin-coord/reports/attester-logs/`. Baseline green, all seven red,
zero not-run, and every arm ran all 58 tests.

| arm | mutation | verdict | assertion that fired |
|---|---|---|---|
| M0 | none, baseline | green | rc=0, 58 tests OK |
| M1 | empty listing raises again, the production bug | red | `recheck_status` raised out of arm one, line 1871, plus line 1784 |
| M2 | completed run no longer fatal | red | line 1923, completed-run message not raised |
| M3 | duplicate gates accepted | red | line 1944, `AttesterError not raised` |
| M4 | always retrigger | red | line 1895, `True is not False` |
| M5 | message drops what it looked for | red | line 1902, regex mismatch |
| M6 | never retrigger | red | line 1969, `False is not True`, plus lines 1632 and 1692 |
| M7 | the wait stops sleeping | red | line 1883, `0 != 2` |

M7 exists because `assertEqual(len(slept), 2)` had no killer of its own in the first grid: M1
kills arm one before that line is reached. `assertEqual(calls["jobs"], 3)` in arm one is
corroborating rather than independently guarded, and I am not claiming otherwise.

The driver refuses a dirty tree above its own trap, asserts each mutation's marker is in the tree
before building, restores with `git checkout HEAD -- <paths>`, and ends with `git status
--porcelain` empty and zero `FALSIFY-M` markers left.

## Gates run

`python3 scripts/test-kin-registry-release-receiver.py` prints `Ran 58 tests ... OK`, up from 57.
`python3 scripts/test-release-workflow-authority.py` exits 0.
`bin/kin-precheck kin` through the fleet heavy slot prints `16 gates ran, 16 passed, 0 failed, on kin af23ec5c644b3857d149be2e0992d5ea0b9dce18`, with no NOT RUN, against `tree=.kin-coord/worktrees/attester-kin sha=af23ec5c644b3857d149be2e0992d5ea0b9dce18 branch=chore/lane-attester-kin`. That gate list is the check job's, which does not carry `test-kin-registry-release-receiver.py`; that suite lives in the release-ordering job and is the first line above.

The diff is two python scripts, no Rust and no workflow yaml.

Closes FIR-2865
