### PR TITLE
Verify each cursor identity dimension by the refusal it owns

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -15309,6 +15309,257 @@ mod tests {
         }
     }
 
+    /// The exact refusal each cursor-identity dimension owns.
+    ///
+    /// Asserting the MESSAGE rather than `is_err()` is the whole point of these
+    /// tests. `cursor_projection_inherits_omissions_and_rejects_conflicts` and
+    /// `fused_cursor_explanation_can_contract_but_cannot_expand` already prove
+    /// that a conflict fails, but a validator that answered every conflict with
+    /// one dimension's message would satisfy both of them: a mutation that
+    /// merely redirects a refusal from one branch into another survives an
+    /// `is_err()` assertion, because both branches still error. Naming the
+    /// message per dimension is what makes the dimensions independently
+    /// verifiable, which is what C4 asks for and what an `is_err()` cannot give.
+    const CURSOR_REFUSAL_QUERY: &str =
+        "semantic_locate cursor belongs to a different query; re-run the requested query";
+    const CURSOR_REFUSAL_GRANULARITY: &str =
+        "semantic_locate cursor preserves its original granularity; re-run the original query to change it";
+    const CURSOR_REFUSAL_SNIPPET: &str =
+        "semantic_locate cursor preserves its original snippet projection; re-run the original query to change it";
+    const CURSOR_REFUSAL_ALIAS: &str =
+        "semantic_locate cursor preserves its original snippet alias setting; re-run the original query to change it";
+    const CURSOR_REFUSAL_VARIANTS: &str =
+        "semantic_locate cursor preserves its original query variants; re-run the original query to change them";
+    const CURSOR_REFUSAL_TEST_SCOPE: &str =
+        "semantic_locate cursor preserves its original test-role scope; re-run the original query to change it";
+    const CURSOR_REFUSAL_EXPLAIN: &str =
+        "semantic_locate cursor cannot expand a ranking whose explanation was not built; re-run the original query with explain: true";
+
+    /// Every refusal message a cursor validator can produce, so a test can
+    /// require that the message it expected is the one that answered AND that no
+    /// other dimension's message did. Without the second half, a redirected
+    /// refusal reads exactly like the right one.
+    fn assert_only_this_refusal(error: &str, expected: &str, dimension: &str) {
+        assert_eq!(
+            error, expected,
+            "{dimension} must be refused by its own message"
+        );
+        for other in [
+            CURSOR_REFUSAL_QUERY,
+            CURSOR_REFUSAL_GRANULARITY,
+            CURSOR_REFUSAL_SNIPPET,
+            CURSOR_REFUSAL_ALIAS,
+            CURSOR_REFUSAL_VARIANTS,
+            CURSOR_REFUSAL_TEST_SCOPE,
+            CURSOR_REFUSAL_EXPLAIN,
+        ] {
+            if other != expected {
+                assert_ne!(
+                    error, other,
+                    "{dimension} must not be refused by another dimension's message"
+                );
+            }
+        }
+    }
+
+    /// Query variants are their own cursor-identity dimension.
+    ///
+    /// No unit test reached this branch before: every existing call to
+    /// `validate_fused_cursor_shape` passes an empty held variant list and sets
+    /// no `queries` argument, so only the explanation branch was exercised.
+    #[test]
+    fn cursor_identity_binds_query_variants_independently() {
+        let held = vec!["parse config".to_string(), "config loader".to_string()];
+
+        // Control: an unchanged dimension reuses the held entry. Omitting the
+        // field inherits, and repeating it exactly is not a conflict.
+        assert!(
+            validate_fused_cursor_shape(&HashMap::new(), &held, false, false).is_ok(),
+            "an omitted variant list must inherit the held ranking"
+        );
+        let repeated = HashMap::from([(
+            "queries".to_string(),
+            json!(["parse config", "config loader"]),
+        )]);
+        assert!(
+            validate_fused_cursor_shape(&repeated, &held, false, false).is_ok(),
+            "repeating the held variant list exactly must reuse the held ranking"
+        );
+
+        // Only this dimension changes in each arm below.
+        for (label, arguments) in [
+            (
+                "a reordered list",
+                HashMap::from([(
+                    "queries".to_string(),
+                    json!(["config loader", "parse config"]),
+                )]),
+            ),
+            (
+                "a dropped variant",
+                HashMap::from([("queries".to_string(), json!(["parse config"]))]),
+            ),
+            (
+                "an added variant",
+                HashMap::from([(
+                    "queries".to_string(),
+                    json!(["parse config", "config loader", "settings"]),
+                )]),
+            ),
+            (
+                "an explicitly emptied list",
+                HashMap::from([("queries".to_string(), json!([]))]),
+            ),
+        ] {
+            let error = validate_fused_cursor_shape(&arguments, &held, false, false)
+                .expect_err(label)
+                .to_string();
+            assert_only_this_refusal(&error, CURSOR_REFUSAL_VARIANTS, label);
+        }
+    }
+
+    /// Test-role scope is its own cursor-identity dimension. Also previously
+    /// unreached at the unit level: no existing call sets `include_tests`.
+    #[test]
+    fn cursor_identity_binds_test_scope_independently() {
+        // Control, in both directions, so the assertion cannot be satisfied by a
+        // validator that simply refuses every explicit value.
+        for held in [true, false] {
+            assert!(
+                validate_fused_cursor_shape(&HashMap::new(), &[], held, true).is_ok(),
+                "an omitted test scope must inherit the held ranking"
+            );
+            let repeated = HashMap::from([("include_tests".to_string(), json!(held))]);
+            assert!(
+                validate_fused_cursor_shape(&repeated, &[], held, true).is_ok(),
+                "repeating the held test scope must reuse the held ranking"
+            );
+
+            let flipped = HashMap::from([("include_tests".to_string(), json!(!held))]);
+            let error = validate_fused_cursor_shape(&flipped, &[], held, true)
+                .expect_err("a flipped test scope must be refused")
+                .to_string();
+            assert_only_this_refusal(&error, CURSOR_REFUSAL_TEST_SCOPE, "test scope");
+        }
+    }
+
+    /// Explanation is one-directional identity: a page may shed held explanation
+    /// but cannot expand a ranking that never built one. The existing test proves
+    /// the direction; this one proves the refusal carries its own message and is
+    /// not another dimension's refusal wearing the right shape.
+    #[test]
+    fn cursor_identity_binds_explanation_independently() {
+        let expanding = HashMap::from([("explain".to_string(), json!(true))]);
+        let error = validate_fused_cursor_shape(&expanding, &[], false, false)
+            .expect_err("explain:true over a ranking with no explanation must be refused")
+            .to_string();
+        assert_only_this_refusal(&error, CURSOR_REFUSAL_EXPLAIN, "explanation");
+
+        // Control: the same argument over a ranking that DID build explanation is
+        // not a conflict, so the refusal above is about the held ranking rather
+        // than about the argument being present.
+        assert!(
+            validate_fused_cursor_shape(&expanding, &[], false, true).is_ok(),
+            "a held explanation must still serve an explaining continuation"
+        );
+
+        // `compact` reaches identity only through this branch: it decides whether
+        // the page requests explanation, and owns no refusal of its own. A
+        // continuation may flip it freely over a ranking that built explanation.
+        let compact_off = HashMap::from([("compact".to_string(), json!(false))]);
+        assert!(
+            fused_explanation_requested(&compact_off),
+            "compact:false is an effective request for explanation"
+        );
+        let error = validate_fused_cursor_shape(&compact_off, &[], false, false)
+            .expect_err("compact:false cannot expand a ranking with no explanation")
+            .to_string();
+        assert_only_this_refusal(&error, CURSOR_REFUSAL_EXPLAIN, "compact as explanation");
+        for compact in [true, false] {
+            assert!(
+                validate_fused_cursor_shape(
+                    &HashMap::from([("compact".to_string(), json!(compact))]),
+                    &[],
+                    false,
+                    true,
+                )
+                .is_ok(),
+                "compact is per-page presentation over a ranking that built explanation"
+            );
+        }
+    }
+
+    /// Each projection dimension owns its own refusal.
+    ///
+    /// The existing projection test perturbs the same four dimensions but asserts
+    /// only `is_err()`, so a validator that answered all four with one message
+    /// would pass it. These arms name the message per dimension, and each control
+    /// proves the matching value is accepted rather than refused for some other
+    /// reason.
+    #[test]
+    fn cursor_identity_binds_each_projection_dimension_independently() {
+        let held_query = "find parser";
+        let held_mode = kin_cli::commands::locate::projection_mode(true, true);
+
+        // Control: every dimension repeated at its held value reuses the entry.
+        let matching = HashMap::from([
+            ("query".to_string(), json!(held_query)),
+            ("granularity".to_string(), json!("entity")),
+            ("include_snippet".to_string(), json!(true)),
+            ("snippet_alias".to_string(), json!(false)),
+        ]);
+        assert!(
+            validate_cursor_projection(&matching, held_query, false, held_mode, Some(false))
+                .is_ok(),
+            "every dimension at its held value must reuse the held ranking"
+        );
+
+        for (dimension, expected, arguments) in [
+            (
+                "query",
+                CURSOR_REFUSAL_QUERY,
+                HashMap::from([("query".to_string(), json!("some other query"))]),
+            ),
+            (
+                "granularity",
+                CURSOR_REFUSAL_GRANULARITY,
+                HashMap::from([("granularity".to_string(), json!("file"))]),
+            ),
+            (
+                "snippet projection",
+                CURSOR_REFUSAL_SNIPPET,
+                HashMap::from([("include_snippet".to_string(), json!(false))]),
+            ),
+            (
+                "snippet alias",
+                CURSOR_REFUSAL_ALIAS,
+                HashMap::from([("snippet_alias".to_string(), json!(true))]),
+            ),
+        ] {
+            let error =
+                validate_cursor_projection(&arguments, held_query, false, held_mode, Some(false))
+                    .expect_err(dimension)
+                    .to_string();
+            assert_only_this_refusal(&error, expected, dimension);
+        }
+
+        // An invalid granularity is a different refusal from a conflicting one,
+        // and folding the two together would let a typo read as a cursor
+        // conflict and send a caller to re-run a query that was never the problem.
+        let invalid = HashMap::from([("granularity".to_string(), json!("entities"))]);
+        let error = validate_cursor_projection(&invalid, held_query, false, held_mode, Some(false))
+            .expect_err("an unknown granularity must be refused")
+            .to_string();
+        assert!(
+            error.contains("invalid granularity 'entities'"),
+            "an unknown granularity must name itself, not the cursor: {error}"
+        );
+        assert_ne!(
+            error, CURSOR_REFUSAL_GRANULARITY,
+            "a malformed value and a conflicting value are different news"
+        );
+    }
+
     /// One cosine-arm ranked row, in the shape the serving loop builds.
     fn cosine_row(
         name: &str,


### PR DESCRIPTION
## The measurement that decided this PR's shape

Checklist item C4 asks that cursor cache identity bind repository, ranking shape, query variants,
test scope, projection, explain, compact and pipeline. kin #1204 landed the identity. The item
stayed open because the dimensions were never independently verified, and measuring the existing
tests says exactly why.

`cursor_projection_inherits_omissions_and_rejects_conflicts` and
`fused_cursor_explanation_can_contract_but_cannot_expand` assert `is_ok()` and `is_err()` only. A
validator that answered every conflict with one dimension's message satisfies both of them, so a
mutation that redirects a refusal from one branch into another survives.

Two branches had no unit coverage at all. All ten unit-test calls to `validate_fused_cursor_shape`
pass `&[]` as the held variant list and `false` as the held test scope, and the test range sets
neither `queries` nor `include_tests` as an argument. Measured with a control: those two keys
appear 0 times in that range, `explain` appears 5. Only the explanation branch was reached.

## What this adds

Four tests that each change one dimension, assert the exact message that dimension owns, and assert
that no other dimension's message answered. Each has a control proving the held value is accepted
rather than refused for some other reason, and test scope gets its control in both directions so
the assertion cannot be satisfied by a validator that refuses every explicit value. Malformed and
conflicting granularity are separated too, since folding them together sends a caller with a typo
off to re-run a query that was never the problem.

## Falsification

Every arm turns one production check into `if false && <the same condition>`, removing the property
while keeping every binding used. All four tests run on every arm, so cross-dimension leakage is
visible rather than assumed.

| Arm | Check removed | Tests that went red |
|---|---|---|
| N0 | none, baseline | none |
| N1 | held variant list comparison | query variants |
| N2 | test scope comparison, shared validator | test scope |
| N3 | explanation expansion guard | explanation |
| N4 | held query comparison | projection |
| N5 | granularity comparison | projection |
| N6 | snippet projection comparison | projection |
| N7 | snippet alias comparison | projection |
| N8 | granularity's refusal redirected to the snippet message | projection |
| N9 | test scope comparison, cosine arm's hand-copied check | none, predicted |

**N8 is the arm that justifies the approach.** Nothing stops erroring under it: the granularity
conflict still fails, just with the wrong message. Every `is_err()` assertion in the repository
stays green. Only a message-level assertion sees it.

**N9 is a finding, not a pass.** The cosine arm does not call `validate_fused_cursor_shape`; it
hand-copies the test-scope check inline at `api.rs:8898` with the same message and logic as
`api.rs:8313`. The two can drift, and these tests cover only the shared copy. It surfaced
mechanically: the first N2 needle matched twice, the driver refused with
`MUTATION-FAILED: needle appears 2 times`, and the grid came back one arm short of nine. Not fixed
here, because de-duplicating a production check on the cosine continuation path wants its own
measured slice rather than riding along with a test PR.

## Three of the item's eight words, checked against the code

**compact owns no refusal, and should not.** It reaches identity only through
`fused_explanation_requested`. Compaction is per-page presentation, so a continuation may flip it
freely over a ranking that built explanation. The tests assert that rather than a binding that does
not exist.

**repository is bound by construction, not by a check.** One `DaemonState` holds one store and both
caches are its fields, so no cross-repository path exists inside one daemon to test. FIR-2863
covers the hosted case, where it is a real runtime dimension.

**ranking shape is bound only where it can be set.** `max_files` is checked at `api.rs:6281` on
`POST /locate` and is absent from the `semantic_locate` schema, so the MCP arms cannot receive it.
Reporting an unbound retrieval breadth there would have been a clean, quotable finding about an
argument no caller can send.

Pipeline is bound properly and by name, derived from which cache holds the key and refused at
`api.rs:10373`, and is covered end-to-end by an existing test rather than by these four, because
the routing decision is inline in the handler and not a pure function.

## One red gate here is main's, not this PR's

`bin/kin-precheck kin` returns 15 of 16 on the rebased head. The failure is
`guard:check-kin-vfs-compat.mjs`:

```
Kin resolves kin-vfs-core 0.4.21, but the pinned kin-vfs checkout builds 0.4.14; advance the
immutable kin-vfs pin in .github/workflows/release.yml, or hold this lock change until kin-vfs
ships a matching commit.
```

It was green before the rebase and red after, and the code stays fixed either way. The guard reads
`Cargo.lock` and the kin-vfs pin in `.github/workflows/release.yml`. This PR's entire diff against
`origin/main` is 251 added lines in `crates/kin-daemon/src/api.rs`, and the diff over those two
files is empty, so the guard reads byte-identical inputs on main and here.

GitHub says the same independently: on main's head `d69de0830`, `Check & Test ubuntu shard (1)` and
`Check & Test (ubuntu-latest)` concluded `failure`, and the failing step is `Verify Kin/kin-vfs
compatibility at the pinned release input`. Main needs the pin advanced or the lock change held.
That is a captain's call, not a fix for a test-only PR to smuggle in.

## Gates run

`bin/kin-precheck kin` on the lane tree, and the four tests run one filter per invocation against a
listing control: each real name matched exactly 1 row, a fabricated name matched 0, out of 1122
listed.

No GPU, daemon or quiet lock was taken. No Kin MCP tool was called.

Closes FIR-2874
