### PR TITLE
Let the freshness suite find its binary and write a report the gate reads

### DIFF
--- a/scripts/acceptance/working_copy_freshness_repro.py
+++ b/scripts/acceptance/working_copy_freshness_repro.py
@@ -576,6 +576,36 @@ WITHHELD_UNEXPLAINED = {"negative": {
     "trust_reason": "some other reason entirely", "advice": "some other reason entirely"}}
 
 
+def report_payload(results):
+    """The report shape `scripts/acceptance/gate.py` reads.
+
+    The key is `results` and not `checks`. That is not a style choice: the gate
+    calls `payload.get("results")` at `gate.py:98` and refuses anything else
+    with "carries no results list". This suite shipped keyed `checks`, so the
+    post-merge run on kin#1205's squash printed four CHECK lines, wrote a report
+    carrying all four rows, and the verdict step still could not read one of
+    them. That is the second time this key has broken this gate; the first is
+    recorded in `same_owner_call_repro.py`. Written once here and read back
+    through the gate's own loader by the self-test, so it cannot drift again.
+    """
+    return {"suite": "working_copy_freshness", "ticket": TICKET,
+            "results": [{"id": r.ident, "ticket": TICKET, "status": r.status,
+                         "detail": r.detail} for r in results]}
+
+
+def absolute_binary(path):
+    """A binary path the fixtures can still find after they change directory.
+
+    Every check runs the binary with `cwd=` a `tempfile.mkdtemp` workspace, so a
+    relative `--kin target/release/kin` resolves against that temp directory
+    rather than the caller's, and raises `[Errno 2] No such file or directory`.
+    That is what happened to all four checks on kin#1205's squash, with the
+    workflow passing exactly the path every sibling step passes. The siblings
+    absolutize at parse time (`eject_journal_repro.py:918`); this does the same.
+    """
+    return path and os.path.abspath(os.path.expanduser(path))
+
+
 def self_test():
     graded = []
     failures = []
@@ -654,6 +684,99 @@ def self_test():
     expect("absence control cannot read a response with no negative block",
            grade_absence_stays_authoritative_over_a_committed_tree({}), UNREADABLE)
 
+    # The report shape, driven through the gate's own reader rather than through
+    # a copy of its rules. This suite printed four CHECK lines on kin#1205's
+    # squash and the verdict step still could not read one of them; a self-test
+    # that only grades graders cannot see that, and this one could not.
+    import importlib.util
+
+    gate_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gate.py")
+    if not os.path.exists(gate_path):
+        failures.append("gate.py is not beside this file, so the report shape went unchecked")
+    else:
+        spec = importlib.util.spec_from_file_location("acceptance_gate", gate_path)
+        gate = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(gate)
+        scratch = tempfile.mkdtemp(prefix="working-copy-freshness-selftest-")
+        try:
+            rows = [Result(ident, UNREADABLE, "%s check raised: fabricated" % TICKET)
+                    for ident, _ in CHECKS]
+            good = os.path.join(scratch, "good.json")
+            with open(good, "w") as handle:
+                json.dump(report_payload(rows), handle)
+            try:
+                loaded = gate.load_report(good)
+                expect("the gate reads every row this suite writes",
+                       (sorted(loaded), "loaded"), sorted(ident for ident, _ in CHECKS))
+                expect("the gate reads a status off each row",
+                       (loaded[CHECKS[0][0]].get("status"), "row status"), UNREADABLE)
+            except Exception as exc:  # noqa: BLE001 - a refusal is the finding
+                failures.append("the gate refused this suite's own report: %s" % exc)
+
+            # CONTROL: the shape that shipped must still be refused, or the two
+            # assertions above would pass over any payload at all.
+            bad = os.path.join(scratch, "bad.json")
+            with open(bad, "w") as handle:
+                json.dump({"suite": "working_copy_freshness", "ticket": TICKET,
+                           "checks": [{"id": ident, "status": UNREADABLE}
+                                      for ident, _ in CHECKS]}, handle)
+            try:
+                gate.load_report(bad)
+                refused = False
+            except Exception:  # noqa: BLE001 - the refusal is what is wanted
+                refused = True
+            expect("CONTROL the gate still refuses the `checks`-keyed shape that broke CI",
+                   (refused, "refused"), True)
+        finally:
+            shutil.rmtree(scratch, ignore_errors=True)
+
+    # The path the fixtures need, driven through this file's own resolver. An
+    # assertion on `os.path.abspath` would say the standard library works, not
+    # that this suite calls it, and this suite's defect was that it did not.
+    expect("a relative kin path is absolutized by this suite",
+           (os.path.isabs(absolute_binary("target/release/kin")), "isabs"), True)
+    expect("and an absent binary stays absent rather than becoming the cwd",
+           (absolute_binary(None), "absent"), None)
+
+    # And that main() actually calls it, which the two assertions above cannot
+    # see: deleting the call leaves every one of them green, measured. So this
+    # drives this file as a subprocess from another directory with a relative
+    # --kin, which is the shape the workflow passes, against a stub that exists
+    # only from that directory. A stub rather than a real binary because the
+    # question is whether the fixtures can FIND it, and that needs no build.
+    stub_root = tempfile.mkdtemp(prefix="working-copy-freshness-stub-")
+    try:
+        os.makedirs(os.path.join(stub_root, "bin"))
+        stub = os.path.join(stub_root, "bin", "kin")
+        with open(stub, "w") as handle:
+            handle.write("#!/bin/sh\nexit 42\n")
+        os.chmod(stub, 0o755)
+
+        def relative_run(binary):
+            """This file, run from `stub_root`, told to use `binary` relatively."""
+            proc = subprocess.Popen(
+                [sys.executable, os.path.abspath(__file__), "--kin", binary,
+                 "--json", os.path.join(stub_root, binary.replace("/", "-") + ".json")],
+                cwd=stub_root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            try:
+                return proc.communicate(timeout=180)[0].decode("utf-8", "replace")
+            except Exception:  # noqa: BLE001 - a hang is a failure, not a verdict
+                proc.kill()
+                proc.communicate()
+                return "SELFTEST the relative run did not finish inside 180s"
+
+        found = relative_run("bin/kin")
+        expect("main absolutizes, so the fixtures find a relative --kin from elsewhere",
+               ("No such file or directory: 'bin/kin'" in found, "relative run"), False)
+        # CONTROL: a binary that is absent from every directory must still be
+        # reported absent, or the assertion above would pass over a suite that
+        # never tried to run anything at all.
+        absent = relative_run("bin/not-kin")
+        expect("CONTROL a binary absent everywhere is still reported absent",
+               ("No such file or directory" in absent, "absent run"), True)
+    finally:
+        shutil.rmtree(stub_root, ignore_errors=True)
+
     for line in failures:
         print("SELFTEST FAIL %s" % line)
     # Counted, never written out. A hardcoded total drifts from the assertions it
@@ -684,6 +807,8 @@ def main(argv):
     if not opts.kin:
         print("SETUP no kin binary: pass --kin or set KIN_BIN")
         return 3
+    opts.kin = absolute_binary(opts.kin)
+    opts.daemon = absolute_binary(opts.daemon)
 
     workdir = tempfile.mkdtemp(prefix="working-copy-freshness-")
     suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
@@ -698,9 +823,10 @@ def main(argv):
             print("CHECK %s %s %s %s" % (result.ident, TICKET, result.status, result.detail))
         asked = [ident for ident, _ in CHECKS]
         answered = [result.ident for result in results]
-        if answered != asked:
-            print("SETUP asked for %r and %r answered" % (asked, answered))
-            return 3
+        # Written before the asked/answered guard below, not after it. Four
+        # UNREADABLE rows are a verdict the gate can name; a missing report is
+        # one it can only refuse, and the refusal names the file rather than
+        # the check that broke.
         if opts.json_path:
             directory = os.path.dirname(os.path.abspath(opts.json_path))
             if directory:
@@ -709,9 +835,10 @@ def main(argv):
                 except OSError:
                     pass
             with open(opts.json_path, "w") as handle:
-                json.dump({"suite": "working_copy_freshness", "ticket": TICKET,
-                           "checks": [{"id": r.ident, "status": r.status, "detail": r.detail}
-                                      for r in results]}, handle, indent=2)
+                json.dump(report_payload(results), handle, indent=2)
+        if answered != asked:
+            print("SETUP asked for %r and %r answered" % (asked, answered))
+            return 3
         if any(result.status == FAIL for result in results):
             return 1
         if any(result.status == UNREADABLE for result in results):


### PR DESCRIPTION
## What this fixes

The post-merge Product Acceptance run on kin#1205's squash
([run 33192820414](https://github.com/firelock-ai/kin/actions/runs/33192820414), head
`9e7092e9`) failed with

```
##[error]working_copy_freshness: report acceptance/working_copy_freshness.json carries no results list
```

after all four checks reported

```
CHECK durability FIR-2820 UNREADABLE FIR-2820 check raised: [Errno 2] No such file or directory: 'target/release/kin'
```

Two defects, both in the suite script, and both of them defects a sibling script already hit,
fixed, and left a comment about. Neither is in the workflow.

## The workflow is already correct, so this changes no workflow file

The brief this lane started from said the new step passes no binary argument while its six
siblings pass `--kin target/release/kin`. It does pass it, and it did at the failing sha.
`git show 9e7092e9c:.github/workflows/acceptance.yml`, lines 757 to 761:

```
          python3 scripts/acceptance/working_copy_freshness_repro.py \
            --kin target/release/kin \
            --daemon target/release/kin-daemon \
            --json acceptance/working_copy_freshness.json \
            --verbose >acceptance/working_copy_freshness.log 2>&1 || rc=$?
```

Byte-identical at current main. The step order is also fine: the step is workflow line 750 and
the build is line 278. And the build succeeded, which the log settles rather than assumes: the
entire job log carries exactly two `##[error]` lines and both come from the verdict step, so
every other suite ran and was graded.

The script also already honoured `--kin` and `KIN_BIN` (line 673) and already refused when
neither was given (line 684).

## Defect one: the path was never made absolute

Every check runs the binary with `cwd=` a `tempfile.mkdtemp` workspace (`:332`, `:329`, `:402`,
`:723`). A relative `target/release/kin` therefore resolves against that temp directory rather
than the caller's, which is the Errno 2. The house idiom is `eject_journal_repro.py:918`,
`os.path.abspath(os.path.expanduser(args.kin))`. Sweeping every acceptance script that takes
`--kin`, all of them carry two or more resolution sites except this one and
`trace_spine_clipping_repro.py`.

## Defect two: the report key, which is a documented repeat

`gate.py:98` reads `results = payload.get("results")` and `:100` raises `"report %s carries no
results list"`. This suite wrote `checks` (`:713`). The report existed and carried all four rows;
the gate could not see one of them.

`same_owner_call_repro.py:125` already documents this in the repo's own voice: "The key is
`results` and not `checks`. That is not a style choice: the gate calls `payload.get("results")`
and refuses anything else with 'carries no results list', which is what it did to the first
version of this file." So this is the second occurrence. That sibling also carries the fix that
keeps it honest, driving the gate's own reader from the self-test, and this suite now does the
same.

## What changed

One file, `scripts/acceptance/working_copy_freshness_repro.py`.

`absolute_binary()` resolves `--kin` and `--daemon` at parse time. `report_payload()` writes the
shape `gate.py` reads, in one place whose docstring records why the key matters. The self-test
loads `gate.py` by path and drives its own `load_report` over that payload, with the shipped
`checks` shape as the control that must still be refused. And it runs this file as a subprocess
from another directory with a relative `--kin` against a stub binary, requiring the fixtures to
find it, with a binary absent everywhere as the control that must still be reported absent.

The report is also written before the asked-versus-answered guard rather than after it, so a
suite that falls over leaves rows the verdict can name. That part is defensive: no current input
reaches that guard, so it carries no falsification arm, and this says so rather than implying
coverage it does not have.

## Evidence

**The suite passes, with the relative path shape that broke.** Run against a local release build
passed as `../../cargo-target/freshstep-kin/release/kin`, a genuinely relative path:

```
SUITE rc=0
CHECK durability FIR-2820 PASS ...
CHECK status FIR-2820 PASS ...
CHECK absence FIR-2820 PASS ...
CHECK committed FIR-2820 PASS ...
  Errno-2-on-the-binary hits=0
```

**The gate reads it**, which is the step that failed on main:

```
GATE rc=0
working_copy_freshness: 4 PASS
acceptance gate passed
  report keys: ['results', 'suite', 'ticket']   rows: 4
```

**And on the failing input**, with a fabricated binary so it needs no build, the same four
UNREADABLE rows now produce four named findings where they produced one refusal:

| | gate output |
|---|---|
| before, keyed `checks` | `::error::working_copy_freshness: report ... carries no results list` / `FAILED on 1 finding(s)` |
| after, keyed `results` | `working_copy_freshness: 4 UNREADABLE` / four `::error::` lines naming each check / `FAILED on 4 finding(s)` |

The "before" line is byte-identical to what CI printed.

## Falsification

Three mutations of this file, each restored on an EXIT, INT and TERM trap, the driver refusing a
dirty tree above the trap.

| arm | what it removes | self-test | assertion that fired |
|---|---|---|---|
| N0 | nothing (control) | rc=0, 36 assertions, 0 failed | none |
| N1 | the `results` key, back to `checks` | rc=1 | `the gate refused this suite's own report: ... carries no results list` |
| N2 | main's call to the resolver | rc=1 | `main absolutizes, so the fixtures find a relative --kin from elsewhere: wanted False got True` |
| N3 | the resolver's body | rc=1, 2 failed | `a relative kin path is absolutized by this suite`, and N2's |

**The first run of this grid found a gap, and closing it is why the last guard exists.** Before
it, N2 came back green on all 36 assertions: the self-test proved `absolute_binary` works and
never that `main` calls it. Only an end-to-end run caught it. That run now lives in the
self-test, so CI carries the guard. The whole self-test still runs in 0.34 seconds.

N1 reports 34 assertions rather than 36 because the gate's refusal skips the two `expect` calls
inside its `try`. That is real, not a miscount.

## Gates, including one failure that is not this change

`bin/kin-precheck kin` at `11e51590b`: **16 gates ran, 15 passed, 1 failed.** The failure is
`guard:check-kin-vfs-compat.mjs`:

```
::error::Kin resolves kin-vfs-core 0.4.21, but the pinned kin-vfs checkout builds 0.4.14
```

That is not this change, and there is a control for saying so. This commit touches one Python
file and no lock, manifest or workflow. The same guard passes on a lane worktree at
`fcd21a98`, printing `Verified Kin/kin-vfs compatibility at kin-vfs-core 0.4.14`, rc 0.

**Main is already red on it.** The CI runs at `bd24bb872` (kin#1213) and `d69de0830` (kin#1211)
both fail the job step "Verify Kin/kin-vfs compatibility at the pinned release input", while
`7e2065512` before them succeeded. kin#1213 is "Repair the Kin registry pin wave: re-lock the
fuzz workspace", touching `Cargo.lock`, `Cargo.toml` and `fuzz/Cargo.lock`, which is what moved
the resolved version away from the pin. The guard's own message names the fix: advance the
immutable kin-vfs pin in `release.yml`, or hold the lock change.

So landing this alone will not turn main green. It fixes the acceptance suite; the check job
stays red on the kin-vfs pin until that is resolved separately.

## Claims not being made

- No claim that this makes the whole acceptance run green, only that the suite that failed now
  passes and its report is readable. The post-merge run is what says the rest.
- `trace_spine_clipping_repro.py` has the identical path defect (`:290`, `:328`, no absolutize)
  and is untouched here. It gates nothing today: it appears in `acceptance.yml` exactly once, at
  line 231, as `--self-test` only, so its real leg never runs. Control: `eject_journal_repro.py`
  appears twice. It wants its own ticket rather than an unfalsified change.
- The stub binary in the self-test proves the fixtures can find the path. It proves nothing about
  what the four checks assert, which is what the release-build run above measures.

Part of FIR-2820
