### PR TITLE
Advance the pinned kin-vfs release input to the commit that builds kin-vfs-core 0.4.21

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -191,7 +191,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
+          ref: d6c72979a3837c484ce7a604377df1837f9de8bd
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -665,7 +665,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
+          EXPECTED_VFS_COMMIT: d6c72979a3837c484ce7a604377df1837f9de8bd
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,7 +528,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
+          ref: d6c72979a3837c484ce7a604377df1837f9de8bd
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -1154,7 +1154,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
+          EXPECTED_VFS_COMMIT: d6c72979a3837c484ce7a604377df1837f9de8bd
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1442,7 +1442,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
+          ref: d6c72979a3837c484ce7a604377df1837f9de8bd
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1510,7 +1510,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
+          EXPECTED_VFS_COMMIT: d6c72979a3837c484ce7a604377df1837f9de8bd
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1872,7 +1872,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
+      expected_vfs_commit: d6c72979a3837c484ce7a604377df1837f9de8bd
     permissions:
       contents: read
       attestations: read

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -15356,7 +15356,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: b1355e67df7dc020002c3a73fb99692c2f3fa7b4",
+        "expected_vfs_commit: d6c72979a3837c484ce7a604377df1837f9de8bd",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
Closes FIR-2881

main's own `bin/kin-precheck kin` has read 15 of 16 since #1213 landed, failing
`guard:check-kin-vfs-compat.mjs`. This advances the pinned kin-vfs release input so it reads 16 of 16.

## Measured before anything was changed

The guard reproduces on an unchanged lane tree cut from `origin/main d69de0830`:

```
node scripts/check-kin-vfs-compat.mjs
::error::Kin resolves kin-vfs-core 0.4.21, but the pinned kin-vfs checkout builds 0.4.14 ...
rc=1
```

That guard exists because the comparison runs nowhere else. A pull request that moves Kin's
kin-vfs-core requirement satisfies every required context and fails only after the tag exists, where
the tag's own workflows are already resolved and no fix lands without cutting another tag.

## No kin-vfs commit is needed first

The ticket allowed that kin-vfs might have to ship a matching commit before this could land. It does
not. kin-vfs `d6c72979a3837c484ce7a604377df1837f9de8bd`, merged as kin-vfs #136 on 2026-08-27, is
kin-vfs main's tip and already builds `kin-vfs-core 0.4.21`, read from that commit's own `Cargo.lock`
where the entry carries no `source` line because it is a workspace member. It is also the commit that
introduced 0.4.21, found with `git log -S`. So this is one PR in kin, not two.

For what it is worth beside the guard's own question, that kin-vfs commit resolves `kin-model 0.7.22`,
the same version #1213 pinned here.

## The pin has eight homes, and the guard reads five

The guard reads release.yml only. Sweeping the whole tree found three more:

| File | Sites | Read by the guard |
|---|---|---|
| `.github/workflows/release.yml` | 2 checkout refs, 3 expected-commit values | yes |
| `.github/workflows/rc-build.yml` | 1 checkout ref, 1 `EXPECTED_VFS_COMMIT` | no |
| `scripts/test-release-workflow-authority.py` | 1 asserted `expected_vfs_commit` line | no |

All eight move together. `rc-build.yml` matters because it builds the candidate archive the release
proof loop grades before the cut, so leaving it behind would prove one kin-vfs and ship another.
`test-release-workflow-authority.py` asserts the exact `expected_vfs_commit:` line, so it is a second
reader that enforces agreement, and it passes here.

Sweep after the move: the old sha `b1355e67df7dc020002c3a73fb99692c2f3fa7b4` returns **zero** hits
across the tree, with the new sha found **eight** times as the positive control that the sweep can
see anything at all.

## Gate

`bin/kin-precheck kin`, on the sha the tool printed for itself:

```
kin-precheck: repo=kin tree=.../vectorconsumer-vfspin-kin sha=116b417a6377fead206fdb1822c5090c4c819424
guard:check-kin-vfs-compat.mjs           PASS
guard:test-release-workflow-authority.py PASS
kin-precheck: 16 gates ran, 16 passed, 0 failed, on kin 116b417a6377fead206fdb1822c5090c4c819424
```

The tally is the tool's own verdict line rather than a hand sum of the rows; the row count reads 16
independently.

## Falsification

Two arms, and they fire different assertions, which is why both are here rather than one.

Pointing only release.yml's two checkout refs back, a half-updated pin:

```
::error::release.yml records disagreeing firelock-ai/kin-vfs pins: b1355e67... (checkout ref) and
d6c72979... (expected_vfs_commit); the release would build one commit and prove another
rc=1
```

Pointing all five release.yml sites back, the original red:

```
::error::Kin resolves kin-vfs-core 0.4.21, but the pinned kin-vfs checkout builds 0.4.14 ...
rc=1
```

Restored from HEAD afterwards and verified: eight occurrences of the new sha, `git diff HEAD` clean.
