### PR TITLE
FALSIFICATION ONLY: prove the widened kin-vfs guard is red on a pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -930,6 +930,21 @@ jobs:
       - name: Check the flake quarantine
         run: python3 scripts/check-quarantine.py
 
+      # ADDED here rather than moved out of `check`, deliberately, for two
+      # reasons. `check` carries `github.event_name != 'pull_request'`, so the
+      # thinned six-context pull-request gate never runs it and main failed its
+      # own kin-vfs compatibility guard with no pull-request check ever showing
+      # it (FIR-2887); this job runs on a pull request, so the answer now
+      # arrives while a commit can still change it. And `bin/kin-precheck`
+      # enumerates the gate list out of `check` by name and refuses with no
+      # tally when a script it expects is missing there, so moving the step
+      # would have dropped it from every lane's local gate at the same time. The
+      # cost of running it in both places is one API read on a push.
+      - name: Verify Kin/kin-vfs compatibility at the pinned release input
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/check-kin-vfs-compat.mjs
+
       # Byte-identical to the `check` job's clippy step, deliberately. The two
       # run on different events now and there is no event on which neither runs,
       # so the workspace is linted exactly once per event rather than twice.

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -665,7 +665,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: d6c72979a3837c484ce7a604377df1837f9de8bd
+          EXPECTED_VFS_COMMIT: b1355e67df7dc020002c3a73fb99692c2f3fa7b4
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/scripts/check-kin-vfs-compat.mjs
+++ b/scripts/check-kin-vfs-compat.mjs
@@ -12,10 +12,20 @@
 // existed, where the tag's own workflows are already resolved and no fix lands
 // without cutting another tag.
 //
-// The pinned commit is read out of release.yml rather than recorded again here.
-// The pin already has five homes in that file; a sixth living in the gate that
-// predicts the release would be the one most likely to drift, and a gate
-// checking a different commit than the release uses is worse than no gate.
+// The pinned commit is read out of the workflows rather than recorded again
+// here. A copy living in the gate that predicts the release would be the one
+// most likely to drift, and a gate checking a different commit than the release
+// uses is worse than no gate.
+//
+// The homes are DISCOVERED rather than listed, because listing them is what went
+// wrong. This gate used to read release.yml alone and its comment said the pin
+// had five homes; a sweep during FIR-2881 found eight. The three it never read
+// were rc-build.yml's own checkout ref and EXPECTED_VFS_COMMIT, which build the
+// candidate archive the release proof loop grades before the cut, and the exact
+// expected_vfs_commit line scripts/test-release-workflow-authority.py asserts.
+// A pin move that skipped rc-build.yml would grade one kin-vfs and ship another.
+// Discovery means a ninth home is read the day it appears rather than the day it
+// breaks a tag.
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -32,42 +42,73 @@ const COMMIT_SHA = /^[0-9a-f]{40}$/;
 // install proof assert against. Requiring them to agree is stronger than
 // reading any one of them, because a half-updated pin (checkout moved, proof
 // left behind) is exactly the shape that reaches a tag before anyone notices.
-export function readPinnedVfsCommit(releaseYaml) {
-  const sites = new Map();
-  const record = (sha, site) => {
-    if (!COMMIT_SHA.test(sha)) {
-      throw new Error(
-        `${site} records "${sha}", which is not a 40-character commit sha; ` +
-        'release inputs must be immutable',
-      );
-    }
-    sites.set(sha, [...(sites.get(sha) ?? []), site]);
-  };
+// Files that may record the pin. Every workflow, plus the release-authority
+// script whose assertion carries the expected commit as a literal. The gate's
+// own source and test are excluded on purpose: a guard that scans the file it
+// lives in matches its own patterns and passes on a tree where nothing else
+// does.
+export const PIN_SOURCE_DIRECTORIES = ['.github/workflows', 'scripts'];
+export const PIN_SOURCE_EXCLUSIONS = new Set([
+  'scripts/check-kin-vfs-compat.mjs',
+  'scripts/check-kin-vfs-compat.test.mjs',
+]);
 
-  for (const step of releaseYaml.split(/^\s*-\s+name:/m).slice(1)) {
+// A bare 40-hex value. `expected_vfs_commit` legitimately appears with no value
+// at all (an input declaration), as an empty string (a caller opting out), as a
+// shell variable, as `process.env` plumbing and inside a regex literal, all of
+// which were read out of the tree before this rule was written. Only a literal
+// sha is a pin site; the rest are not sites and are not errors. A checkout ref
+// is held to a stricter rule below, because a kin-vfs checkout that floats is
+// the failure this gate exists for.
+export function collectVfsPinSites(text, file) {
+  const found = [];
+
+  for (const step of text.split(/^\s*-\s+name:/m).slice(1)) {
     if (!step.includes(`repository: ${VFS_REPOSITORY}`)) {
       continue;
     }
     const ref = step.match(/^\s*ref:\s*(\S+)/m);
     if (!ref) {
       throw new Error(
-        `a ${VFS_REPOSITORY} checkout in release.yml records no ref, so the ` +
+        `a ${VFS_REPOSITORY} checkout in ${file} records no ref, so the ` +
         'release input floats with that repository default branch',
       );
     }
-    record(ref[1], `${VFS_REPOSITORY} checkout ref`);
+    if (!COMMIT_SHA.test(ref[1])) {
+      throw new Error(
+        `${file} records a ${VFS_REPOSITORY} checkout ref "${ref[1]}", which is ` +
+        'not a 40-character commit sha; release inputs must be immutable',
+      );
+    }
+    found.push({ sha: ref[1], site: `${file} ${VFS_REPOSITORY} checkout ref` });
   }
 
-  for (const match of releaseYaml.matchAll(
-    /^\s*(?:EXPECTED_VFS_COMMIT|expected_vfs_commit):\s*(\S+)/gm,
+  for (const match of text.matchAll(
+    /(?:EXPECTED_VFS_COMMIT|expected_vfs_commit):\s*"?([0-9a-f]{40})"?/g,
   )) {
-    record(match[1], 'expected_vfs_commit');
+    found.push({ sha: match[1], site: `${file} expected_vfs_commit` });
+  }
+
+  return found;
+}
+
+// Every site that records the pin, across every file that records one, required
+// to agree. A half-updated pin (release.yml moved, the candidate archive left
+// behind) is exactly the shape that reaches a tag before anyone notices, and it
+// is the shape this returns an error for rather than a commit.
+export function readPinnedVfsCommit(sources) {
+  const sites = new Map();
+  for (const { path: file, text } of sources) {
+    for (const { sha, site } of collectVfsPinSites(text, file)) {
+      sites.set(sha, [...(sites.get(sha) ?? []), site]);
+    }
   }
 
   if (sites.size === 0) {
     throw new Error(
-      `release.yml records no ${VFS_REPOSITORY} pin, so this gate has nothing ` +
-      'to compare against and cannot be trusted to have checked anything',
+      `no ${VFS_REPOSITORY} pin was found in any of ${sources.length} scanned ` +
+      'file(s), so this gate has nothing to compare against and cannot be ' +
+      'trusted to have checked anything',
     );
   }
   if (sites.size > 1) {
@@ -76,11 +117,48 @@ export function readPinnedVfsCommit(releaseYaml) {
       .sort()
       .join(' and ');
     throw new Error(
-      `release.yml records disagreeing ${VFS_REPOSITORY} pins: ${detail}; ` +
-      'the release would build one commit and prove another',
+      `disagreeing ${VFS_REPOSITORY} pins: ${detail}; the release would build ` +
+      'one commit and prove another',
     );
   }
   return [...sites.keys()][0];
+}
+
+// Read every candidate file off disk. Missing directories are not an error, so
+// the gate still runs in a checkout that carries one and not the other, but a
+// scan that found no file at all is, because zero files scanned and zero
+// disagreements look identical from the outside.
+export async function readPinSources(root, { fsImpl = fs } = {}) {
+  const sources = [];
+  for (const dir of PIN_SOURCE_DIRECTORIES) {
+    let entries;
+    try {
+      entries = await fsImpl.readdir(path.join(root, dir));
+    } catch {
+      continue;
+    }
+    for (const entry of entries.sort()) {
+      const rel = `${dir}/${entry}`;
+      if (PIN_SOURCE_EXCLUSIONS.has(rel)) {
+        continue;
+      }
+      if (!/\.(ya?ml|py)$/.test(entry)) {
+        continue;
+      }
+      const text = await fsImpl.readFile(path.join(root, dir, entry), 'utf8');
+      if (!text.includes(VFS_REPOSITORY) && !/expected_vfs_commit/i.test(text)) {
+        continue;
+      }
+      sources.push({ path: rel, text });
+    }
+  }
+  if (sources.length === 0) {
+    throw new Error(
+      'no file mentioning the kin-vfs pin was found; refusing to read an empty ' +
+      'scan as agreement',
+    );
+  }
+  return sources;
 }
 
 // Mirrors release.yml's own lock reader. Kept deliberately identical so the two
@@ -167,18 +245,26 @@ export async function main({
   fetchImpl = fetch,
   log = console.log,
 } = {}) {
-  const releaseYaml = await fs.readFile(
-    path.join(root, '.github', 'workflows', 'release.yml'),
-    'utf8',
-  );
-  const commit = readPinnedVfsCommit(releaseYaml);
+  const sources = await readPinSources(root);
+  const commit = readPinnedVfsCommit(sources);
   const kinLock = await fs.readFile(path.join(root, 'Cargo.lock'), 'utf8');
   const pinnedLock = await fetchPinnedLock(commit, {
     token: env.GH_TOKEN || env.GITHUB_TOKEN,
     fetchImpl,
   });
   const version = compareVfsCore(kinLock, pinnedLock);
-  log(`Verified Kin/kin-vfs compatibility at ${VFS_CORE} ${version} (pinned kin-vfs ${commit})`);
+  // Name how many homes agreed and which files hold them, so a scan that
+  // silently narrowed reads differently from one that checked them all. The
+  // count is of SITES that recorded a sha, not of files opened: several files
+  // mention the pin without recording one, and counting those would report
+  // coverage this gate does not have.
+  const sites = sources.flatMap(({ path: file, text }) => collectVfsPinSites(text, file));
+  const files = [...new Set(sites.map(({ site }) => site.split(' ')[0]))].sort();
+  log(
+    `Verified Kin/kin-vfs compatibility at ${VFS_CORE} ${version} ` +
+    `(pinned kin-vfs ${commit}, agreed across ${sites.length} site(s) in ` +
+    `${files.length} file(s): ${files.join(', ')})`,
+  );
   return version;
 }
 

--- a/scripts/check-kin-vfs-compat.test.mjs
+++ b/scripts/check-kin-vfs-compat.test.mjs
@@ -12,7 +12,9 @@ import {
   VFS_REPOSITORY,
   compareVfsCore,
   fetchPinnedLock,
+  collectVfsPinSites,
   lockPackages,
+  readPinSources,
   readPinnedVfsCommit,
 } from './check-kin-vfs-compat.mjs';
 
@@ -50,21 +52,36 @@ const lockWith = (entries) =>
 
 const REGISTRY = 'sparse+https://kinlab.ai/registry/cargo/';
 
+const RELEASE = '.github/workflows/release.yml';
+const RC_BUILD = '.github/workflows/rc-build.yml';
+const AUTHORITY = 'scripts/test-release-workflow-authority.py';
+const asSources = (text, file = RELEASE) => [{ path: file, text }];
+
+// The authority script records the pin as a quoted literal inside a Python
+// tuple, which is why the reader accepts an optional quote around the value.
+const authorityPyWith = (commit) => `
+    for policy in (
+        "uses: ./.github/workflows/install-proof.yml",
+        "expected_vfs_commit: ${commit}",
+    ):
+        require(install_proof_job, policy, "mandatory public install proof")
+`;
+
 test('reads a single agreeing pin from every site that records one', () => {
-  assert.equal(readPinnedVfsCommit(releaseYamlWith(PIN_A, PIN_A)), PIN_A);
+  assert.equal(readPinnedVfsCommit(asSources(releaseYamlWith(PIN_A, PIN_A))), PIN_A);
 });
 
 test('refuses a half-updated pin where the checkout moved and the proof did not', () => {
   assert.throws(
-    () => readPinnedVfsCommit(releaseYamlWith(PIN_B, PIN_A)),
+    () => readPinnedVfsCommit(asSources(releaseYamlWith(PIN_B, PIN_A))),
     /disagreeing .* pins/,
   );
 });
 
 test('refuses a release workflow that records no pin at all', () => {
   assert.throws(
-    () => readPinnedVfsCommit('jobs:\n  build:\n    steps: []\n'),
-    /records no .* pin/,
+    () => readPinnedVfsCommit(asSources('jobs:\n  build:\n    steps: []\n')),
+    /no .* pin was found/,
   );
 });
 
@@ -78,11 +95,11 @@ jobs:
           repository: ${VFS_REPOSITORY}
           path: kin-vfs
 `;
-  assert.throws(() => readPinnedVfsCommit(floating), /records no ref/);
+  assert.throws(() => readPinnedVfsCommit(asSources(floating)), /records no ref/);
 });
 
 test('refuses a pin that is not a full commit sha', () => {
-  assert.throws(() => readPinnedVfsCommit(releaseYamlWith('main', 'main')), /not a 40-character/);
+  assert.throws(() => readPinnedVfsCommit(asSources(releaseYamlWith('main', 'main'))), /not a 40-character/);
 });
 
 test('reads the real release workflow and finds one pin', () => {
@@ -90,8 +107,91 @@ test('reads the real release workflow and finds one pin', () => {
     path.join(ROOT, '.github', 'workflows', 'release.yml'),
     'utf8',
   );
-  const commit = readPinnedVfsCommit(releaseYaml);
+  const commit = readPinnedVfsCommit(asSources(releaseYaml));
   assert.match(commit, /^[0-9a-f]{40}$/);
+});
+
+test('reads the pin out of rc-build.yml, which the old gate never opened', () => {
+  const sites = collectVfsPinSites(releaseYamlWith(PIN_A, PIN_A), RC_BUILD);
+  assert.equal(sites.length, 2, 'a checkout ref and an expected commit');
+  assert.ok(
+    sites.every(({ site }) => site.startsWith(RC_BUILD)),
+    `every site must name its file: ${JSON.stringify(sites)}`,
+  );
+});
+
+test('reads the pin out of the authority script quoted literal', () => {
+  const sites = collectVfsPinSites(authorityPyWith(PIN_A), AUTHORITY);
+  assert.deepEqual(sites, [{ sha: PIN_A, site: `${AUTHORITY} expected_vfs_commit` }]);
+});
+
+test('refuses a pin that release.yml moved and rc-build.yml did not', () => {
+  assert.throws(
+    () => readPinnedVfsCommit([
+      { path: RELEASE, text: releaseYamlWith(PIN_A, PIN_A) },
+      { path: RC_BUILD, text: releaseYamlWith(PIN_B, PIN_B) },
+    ]),
+    (error) => {
+      assert.match(error.message, /disagreeing/);
+      assert.match(error.message, new RegExp(RC_BUILD.replace(/[./]/g, '\\$&')));
+      return true;
+    },
+    'the failure must name rc-build.yml, or an operator cannot tell which home lagged',
+  );
+});
+
+test('refuses a pin the authority script alone did not follow', () => {
+  assert.throws(
+    () => readPinnedVfsCommit([
+      { path: RELEASE, text: releaseYamlWith(PIN_A, PIN_A) },
+      { path: AUTHORITY, text: authorityPyWith(PIN_B) },
+    ]),
+    new RegExp(AUTHORITY.replace(/[./]/g, '\\$&')),
+  );
+});
+
+test('accepts every home agreeing across all three files', () => {
+  assert.equal(
+    readPinnedVfsCommit([
+      { path: RELEASE, text: releaseYamlWith(PIN_A, PIN_A) },
+      { path: RC_BUILD, text: releaseYamlWith(PIN_A, PIN_A) },
+      { path: AUTHORITY, text: authorityPyWith(PIN_A) },
+    ]),
+    PIN_A,
+    'the agreeing case must still pass, or the arms above only prove it refuses',
+  );
+});
+
+// The values that are NOT pin sites. Every one of these was read out of the
+// real tree: an input declaration, a caller opting out, shell plumbing and a
+// regex literal all spell the key the same way and carry no sha.
+test('ignores expected_vfs_commit spellings that record no sha', () => {
+  for (const text of [
+    '      expected_vfs_commit: ""\n',
+    '      expected_vfs_commit:\n',
+    "          REVIEWED_VFS_COMMIT: ${{ inputs.expected_vfs_commit || '' }}\n",
+    '          expected_vfs_commit="$REVIEWED_VFS_COMMIT"\n',
+    '    re.findall(r"expected_vfs_commit:\\s*([0-9a-f]{40})", release)\n',
+  ]) {
+    assert.deepEqual(
+      collectVfsPinSites(text, '.github/workflows/ci.yml'),
+      [],
+      `must not be read as a pin site: ${text.trim()}`,
+    );
+  }
+});
+
+test('the real tree records one pin across every file that holds one', async () => {
+  const sources = await readPinSources(ROOT);
+  const sites = sources.flatMap(({ path: file, text }) => collectVfsPinSites(text, file));
+  const files = [...new Set(sites.map(({ site }) => site.split(' ')[0]))].sort();
+  assert.ok(sites.length >= 8, `expected at least the eight known homes, found ${sites.length}`);
+  assert.deepEqual(files, [RC_BUILD, RELEASE, AUTHORITY].sort());
+  assert.equal(new Set(sites.map(({ sha }) => sha)).size, 1, 'every home agrees');
+  assert.ok(
+    !sources.some(({ path: file }) => file.includes('check-kin-vfs-compat')),
+    'the gate must not scan its own source, which carries its own patterns',
+  );
 });
 
 test('parses lock entries the way the release workflow does', () => {


### PR DESCRIPTION
Temporary. Proves FIR-2887's third falsification arm: a deliberate kin-vfs pin disagreement planted in rc-build.yml must turn the fast gate lint and policy check red ON A PULL REQUEST, not only on a push to main. Closed as soon as the check reports. Do not land.