### PR TITLE
Run the kin-vfs compat guard on a pull request, and read every home of the pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -930,6 +930,21 @@ jobs:
       - name: Check the flake quarantine
         run: python3 scripts/check-quarantine.py
 
+      # ADDED here rather than moved out of `check`, deliberately, for two
+      # reasons. `check` carries `github.event_name != 'pull_request'`, so the
+      # thinned six-context pull-request gate never runs it and main failed its
+      # own kin-vfs compatibility guard with no pull-request check ever showing
+      # it (FIR-2887); this job runs on a pull request, so the answer now
+      # arrives while a commit can still change it. And `bin/kin-precheck`
+      # enumerates the gate list out of `check` by name and refuses with no
+      # tally when a script it expects is missing there, so moving the step
+      # would have dropped it from every lane's local gate at the same time. The
+      # cost of running it in both places is one API read on a push.
+      - name: Verify Kin/kin-vfs compatibility at the pinned release input
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/check-kin-vfs-compat.mjs
+
       # Byte-identical to the `check` job's clippy step, deliberately. The two
       # run on different events now and there is no event on which neither runs,
       # so the workspace is linted exactly once per event rather than twice.

--- a/scripts/check-kin-vfs-compat.mjs
+++ b/scripts/check-kin-vfs-compat.mjs
@@ -12,10 +12,20 @@
 // existed, where the tag's own workflows are already resolved and no fix lands
 // without cutting another tag.
 //
-// The pinned commit is read out of release.yml rather than recorded again here.
-// The pin already has five homes in that file; a sixth living in the gate that
-// predicts the release would be the one most likely to drift, and a gate
-// checking a different commit than the release uses is worse than no gate.
+// The pinned commit is read out of the workflows rather than recorded again
+// here. A copy living in the gate that predicts the release would be the one
+// most likely to drift, and a gate checking a different commit than the release
+// uses is worse than no gate.
+//
+// The homes are DISCOVERED rather than listed, because listing them is what went
+// wrong. This gate used to read release.yml alone and its comment said the pin
+// had five homes; a sweep during FIR-2881 found eight. The three it never read
+// were rc-build.yml's own checkout ref and EXPECTED_VFS_COMMIT, which build the
+// candidate archive the release proof loop grades before the cut, and the exact
+// expected_vfs_commit line scripts/test-release-workflow-authority.py asserts.
+// A pin move that skipped rc-build.yml would grade one kin-vfs and ship another.
+// Discovery means a ninth home is read the day it appears rather than the day it
+// breaks a tag.
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -32,42 +42,73 @@ const COMMIT_SHA = /^[0-9a-f]{40}$/;
 // install proof assert against. Requiring them to agree is stronger than
 // reading any one of them, because a half-updated pin (checkout moved, proof
 // left behind) is exactly the shape that reaches a tag before anyone notices.
-export function readPinnedVfsCommit(releaseYaml) {
-  const sites = new Map();
-  const record = (sha, site) => {
-    if (!COMMIT_SHA.test(sha)) {
-      throw new Error(
-        `${site} records "${sha}", which is not a 40-character commit sha; ` +
-        'release inputs must be immutable',
-      );
-    }
-    sites.set(sha, [...(sites.get(sha) ?? []), site]);
-  };
+// Files that may record the pin. Every workflow, plus the release-authority
+// script whose assertion carries the expected commit as a literal. The gate's
+// own source and test are excluded on purpose: a guard that scans the file it
+// lives in matches its own patterns and passes on a tree where nothing else
+// does.
+export const PIN_SOURCE_DIRECTORIES = ['.github/workflows', 'scripts'];
+export const PIN_SOURCE_EXCLUSIONS = new Set([
+  'scripts/check-kin-vfs-compat.mjs',
+  'scripts/check-kin-vfs-compat.test.mjs',
+]);
 
-  for (const step of releaseYaml.split(/^\s*-\s+name:/m).slice(1)) {
+// A bare 40-hex value. `expected_vfs_commit` legitimately appears with no value
+// at all (an input declaration), as an empty string (a caller opting out), as a
+// shell variable, as `process.env` plumbing and inside a regex literal, all of
+// which were read out of the tree before this rule was written. Only a literal
+// sha is a pin site; the rest are not sites and are not errors. A checkout ref
+// is held to a stricter rule below, because a kin-vfs checkout that floats is
+// the failure this gate exists for.
+export function collectVfsPinSites(text, file) {
+  const found = [];
+
+  for (const step of text.split(/^\s*-\s+name:/m).slice(1)) {
     if (!step.includes(`repository: ${VFS_REPOSITORY}`)) {
       continue;
     }
     const ref = step.match(/^\s*ref:\s*(\S+)/m);
     if (!ref) {
       throw new Error(
-        `a ${VFS_REPOSITORY} checkout in release.yml records no ref, so the ` +
+        `a ${VFS_REPOSITORY} checkout in ${file} records no ref, so the ` +
         'release input floats with that repository default branch',
       );
     }
-    record(ref[1], `${VFS_REPOSITORY} checkout ref`);
+    if (!COMMIT_SHA.test(ref[1])) {
+      throw new Error(
+        `${file} records a ${VFS_REPOSITORY} checkout ref "${ref[1]}", which is ` +
+        'not a 40-character commit sha; release inputs must be immutable',
+      );
+    }
+    found.push({ sha: ref[1], site: `${file} ${VFS_REPOSITORY} checkout ref` });
   }
 
-  for (const match of releaseYaml.matchAll(
-    /^\s*(?:EXPECTED_VFS_COMMIT|expected_vfs_commit):\s*(\S+)/gm,
+  for (const match of text.matchAll(
+    /(?:EXPECTED_VFS_COMMIT|expected_vfs_commit):\s*"?([0-9a-f]{40})"?/g,
   )) {
-    record(match[1], 'expected_vfs_commit');
+    found.push({ sha: match[1], site: `${file} expected_vfs_commit` });
+  }
+
+  return found;
+}
+
+// Every site that records the pin, across every file that records one, required
+// to agree. A half-updated pin (release.yml moved, the candidate archive left
+// behind) is exactly the shape that reaches a tag before anyone notices, and it
+// is the shape this returns an error for rather than a commit.
+export function readPinnedVfsCommit(sources) {
+  const sites = new Map();
+  for (const { path: file, text } of sources) {
+    for (const { sha, site } of collectVfsPinSites(text, file)) {
+      sites.set(sha, [...(sites.get(sha) ?? []), site]);
+    }
   }
 
   if (sites.size === 0) {
     throw new Error(
-      `release.yml records no ${VFS_REPOSITORY} pin, so this gate has nothing ` +
-      'to compare against and cannot be trusted to have checked anything',
+      `no ${VFS_REPOSITORY} pin was found in any of ${sources.length} scanned ` +
+      'file(s), so this gate has nothing to compare against and cannot be ' +
+      'trusted to have checked anything',
     );
   }
   if (sites.size > 1) {
@@ -76,11 +117,48 @@ export function readPinnedVfsCommit(releaseYaml) {
       .sort()
       .join(' and ');
     throw new Error(
-      `release.yml records disagreeing ${VFS_REPOSITORY} pins: ${detail}; ` +
-      'the release would build one commit and prove another',
+      `disagreeing ${VFS_REPOSITORY} pins: ${detail}; the release would build ` +
+      'one commit and prove another',
     );
   }
   return [...sites.keys()][0];
+}
+
+// Read every candidate file off disk. Missing directories are not an error, so
+// the gate still runs in a checkout that carries one and not the other, but a
+// scan that found no file at all is, because zero files scanned and zero
+// disagreements look identical from the outside.
+export async function readPinSources(root, { fsImpl = fs } = {}) {
+  const sources = [];
+  for (const dir of PIN_SOURCE_DIRECTORIES) {
+    let entries;
+    try {
+      entries = await fsImpl.readdir(path.join(root, dir));
+    } catch {
+      continue;
+    }
+    for (const entry of entries.sort()) {
+      const rel = `${dir}/${entry}`;
+      if (PIN_SOURCE_EXCLUSIONS.has(rel)) {
+        continue;
+      }
+      if (!/\.(ya?ml|py)$/.test(entry)) {
+        continue;
+      }
+      const text = await fsImpl.readFile(path.join(root, dir, entry), 'utf8');
+      if (!text.includes(VFS_REPOSITORY) && !/expected_vfs_commit/i.test(text)) {
+        continue;
+      }
+      sources.push({ path: rel, text });
+    }
+  }
+  if (sources.length === 0) {
+    throw new Error(
+      'no file mentioning the kin-vfs pin was found; refusing to read an empty ' +
+      'scan as agreement',
+    );
+  }
+  return sources;
 }
 
 // Mirrors release.yml's own lock reader. Kept deliberately identical so the two
@@ -167,18 +245,26 @@ export async function main({
   fetchImpl = fetch,
   log = console.log,
 } = {}) {
-  const releaseYaml = await fs.readFile(
-    path.join(root, '.github', 'workflows', 'release.yml'),
-    'utf8',
-  );
-  const commit = readPinnedVfsCommit(releaseYaml);
+  const sources = await readPinSources(root);
+  const commit = readPinnedVfsCommit(sources);
   const kinLock = await fs.readFile(path.join(root, 'Cargo.lock'), 'utf8');
   const pinnedLock = await fetchPinnedLock(commit, {
     token: env.GH_TOKEN || env.GITHUB_TOKEN,
     fetchImpl,
   });
   const version = compareVfsCore(kinLock, pinnedLock);
-  log(`Verified Kin/kin-vfs compatibility at ${VFS_CORE} ${version} (pinned kin-vfs ${commit})`);
+  // Name how many homes agreed and which files hold them, so a scan that
+  // silently narrowed reads differently from one that checked them all. The
+  // count is of SITES that recorded a sha, not of files opened: several files
+  // mention the pin without recording one, and counting those would report
+  // coverage this gate does not have.
+  const sites = sources.flatMap(({ path: file, text }) => collectVfsPinSites(text, file));
+  const files = [...new Set(sites.map(({ site }) => site.split(' ')[0]))].sort();
+  log(
+    `Verified Kin/kin-vfs compatibility at ${VFS_CORE} ${version} ` +
+    `(pinned kin-vfs ${commit}, agreed across ${sites.length} site(s) in ` +
+    `${files.length} file(s): ${files.join(', ')})`,
+  );
   return version;
 }
 

--- a/scripts/check-kin-vfs-compat.test.mjs
+++ b/scripts/check-kin-vfs-compat.test.mjs
@@ -12,7 +12,9 @@ import {
   VFS_REPOSITORY,
   compareVfsCore,
   fetchPinnedLock,
+  collectVfsPinSites,
   lockPackages,
+  readPinSources,
   readPinnedVfsCommit,
 } from './check-kin-vfs-compat.mjs';
 
@@ -50,21 +52,36 @@ const lockWith = (entries) =>
 
 const REGISTRY = 'sparse+https://kinlab.ai/registry/cargo/';
 
+const RELEASE = '.github/workflows/release.yml';
+const RC_BUILD = '.github/workflows/rc-build.yml';
+const AUTHORITY = 'scripts/test-release-workflow-authority.py';
+const asSources = (text, file = RELEASE) => [{ path: file, text }];
+
+// The authority script records the pin as a quoted literal inside a Python
+// tuple, which is why the reader accepts an optional quote around the value.
+const authorityPyWith = (commit) => `
+    for policy in (
+        "uses: ./.github/workflows/install-proof.yml",
+        "expected_vfs_commit: ${commit}",
+    ):
+        require(install_proof_job, policy, "mandatory public install proof")
+`;
+
 test('reads a single agreeing pin from every site that records one', () => {
-  assert.equal(readPinnedVfsCommit(releaseYamlWith(PIN_A, PIN_A)), PIN_A);
+  assert.equal(readPinnedVfsCommit(asSources(releaseYamlWith(PIN_A, PIN_A))), PIN_A);
 });
 
 test('refuses a half-updated pin where the checkout moved and the proof did not', () => {
   assert.throws(
-    () => readPinnedVfsCommit(releaseYamlWith(PIN_B, PIN_A)),
+    () => readPinnedVfsCommit(asSources(releaseYamlWith(PIN_B, PIN_A))),
     /disagreeing .* pins/,
   );
 });
 
 test('refuses a release workflow that records no pin at all', () => {
   assert.throws(
-    () => readPinnedVfsCommit('jobs:\n  build:\n    steps: []\n'),
-    /records no .* pin/,
+    () => readPinnedVfsCommit(asSources('jobs:\n  build:\n    steps: []\n')),
+    /no .* pin was found/,
   );
 });
 
@@ -78,11 +95,11 @@ jobs:
           repository: ${VFS_REPOSITORY}
           path: kin-vfs
 `;
-  assert.throws(() => readPinnedVfsCommit(floating), /records no ref/);
+  assert.throws(() => readPinnedVfsCommit(asSources(floating)), /records no ref/);
 });
 
 test('refuses a pin that is not a full commit sha', () => {
-  assert.throws(() => readPinnedVfsCommit(releaseYamlWith('main', 'main')), /not a 40-character/);
+  assert.throws(() => readPinnedVfsCommit(asSources(releaseYamlWith('main', 'main'))), /not a 40-character/);
 });
 
 test('reads the real release workflow and finds one pin', () => {
@@ -90,8 +107,91 @@ test('reads the real release workflow and finds one pin', () => {
     path.join(ROOT, '.github', 'workflows', 'release.yml'),
     'utf8',
   );
-  const commit = readPinnedVfsCommit(releaseYaml);
+  const commit = readPinnedVfsCommit(asSources(releaseYaml));
   assert.match(commit, /^[0-9a-f]{40}$/);
+});
+
+test('reads the pin out of rc-build.yml, which the old gate never opened', () => {
+  const sites = collectVfsPinSites(releaseYamlWith(PIN_A, PIN_A), RC_BUILD);
+  assert.equal(sites.length, 2, 'a checkout ref and an expected commit');
+  assert.ok(
+    sites.every(({ site }) => site.startsWith(RC_BUILD)),
+    `every site must name its file: ${JSON.stringify(sites)}`,
+  );
+});
+
+test('reads the pin out of the authority script quoted literal', () => {
+  const sites = collectVfsPinSites(authorityPyWith(PIN_A), AUTHORITY);
+  assert.deepEqual(sites, [{ sha: PIN_A, site: `${AUTHORITY} expected_vfs_commit` }]);
+});
+
+test('refuses a pin that release.yml moved and rc-build.yml did not', () => {
+  assert.throws(
+    () => readPinnedVfsCommit([
+      { path: RELEASE, text: releaseYamlWith(PIN_A, PIN_A) },
+      { path: RC_BUILD, text: releaseYamlWith(PIN_B, PIN_B) },
+    ]),
+    (error) => {
+      assert.match(error.message, /disagreeing/);
+      assert.match(error.message, new RegExp(RC_BUILD.replace(/[./]/g, '\\$&')));
+      return true;
+    },
+    'the failure must name rc-build.yml, or an operator cannot tell which home lagged',
+  );
+});
+
+test('refuses a pin the authority script alone did not follow', () => {
+  assert.throws(
+    () => readPinnedVfsCommit([
+      { path: RELEASE, text: releaseYamlWith(PIN_A, PIN_A) },
+      { path: AUTHORITY, text: authorityPyWith(PIN_B) },
+    ]),
+    new RegExp(AUTHORITY.replace(/[./]/g, '\\$&')),
+  );
+});
+
+test('accepts every home agreeing across all three files', () => {
+  assert.equal(
+    readPinnedVfsCommit([
+      { path: RELEASE, text: releaseYamlWith(PIN_A, PIN_A) },
+      { path: RC_BUILD, text: releaseYamlWith(PIN_A, PIN_A) },
+      { path: AUTHORITY, text: authorityPyWith(PIN_A) },
+    ]),
+    PIN_A,
+    'the agreeing case must still pass, or the arms above only prove it refuses',
+  );
+});
+
+// The values that are NOT pin sites. Every one of these was read out of the
+// real tree: an input declaration, a caller opting out, shell plumbing and a
+// regex literal all spell the key the same way and carry no sha.
+test('ignores expected_vfs_commit spellings that record no sha', () => {
+  for (const text of [
+    '      expected_vfs_commit: ""\n',
+    '      expected_vfs_commit:\n',
+    "          REVIEWED_VFS_COMMIT: ${{ inputs.expected_vfs_commit || '' }}\n",
+    '          expected_vfs_commit="$REVIEWED_VFS_COMMIT"\n',
+    '    re.findall(r"expected_vfs_commit:\\s*([0-9a-f]{40})", release)\n',
+  ]) {
+    assert.deepEqual(
+      collectVfsPinSites(text, '.github/workflows/ci.yml'),
+      [],
+      `must not be read as a pin site: ${text.trim()}`,
+    );
+  }
+});
+
+test('the real tree records one pin across every file that holds one', async () => {
+  const sources = await readPinSources(ROOT);
+  const sites = sources.flatMap(({ path: file, text }) => collectVfsPinSites(text, file));
+  const files = [...new Set(sites.map(({ site }) => site.split(' ')[0]))].sort();
+  assert.ok(sites.length >= 8, `expected at least the eight known homes, found ${sites.length}`);
+  assert.deepEqual(files, [RC_BUILD, RELEASE, AUTHORITY].sort());
+  assert.equal(new Set(sites.map(({ sha }) => sha)).size, 1, 'every home agrees');
+  assert.ok(
+    !sources.some(({ path: file }) => file.includes('check-kin-vfs-compat')),
+    'the gate must not scan its own source, which carries its own patterns',
+  );
 });
 
 test('parses lock entries the way the release workflow does', () => {

--- a/scripts/check-kin-vfs-compat.test.mjs
+++ b/scripts/check-kin-vfs-compat.test.mjs
@@ -22,6 +22,12 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PIN_A = 'a'.repeat(40);
 const PIN_B = 'b'.repeat(40);
 
+// Escapes every RegExp metacharacter, backslash included. A class of only `.`
+// and `/` leaves a backslash in the input free to open an escape sequence in
+// the compiled pattern, so the match quietly stops meaning what the literal
+// says instead of failing.
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const releaseYamlWith = (checkoutRef, expectedCommit) => `
 jobs:
   build:
@@ -133,7 +139,7 @@ test('refuses a pin that release.yml moved and rc-build.yml did not', () => {
     ]),
     (error) => {
       assert.match(error.message, /disagreeing/);
-      assert.match(error.message, new RegExp(RC_BUILD.replace(/[./]/g, '\\$&')));
+      assert.match(error.message, new RegExp(escapeRegExp(RC_BUILD)));
       return true;
     },
     'the failure must name rc-build.yml, or an operator cannot tell which home lagged',
@@ -146,7 +152,7 @@ test('refuses a pin the authority script alone did not follow', () => {
       { path: RELEASE, text: releaseYamlWith(PIN_A, PIN_A) },
       { path: AUTHORITY, text: authorityPyWith(PIN_B) },
     ]),
-    new RegExp(AUTHORITY.replace(/[./]/g, '\\$&')),
+    new RegExp(escapeRegExp(AUTHORITY)),
   );
 });
 


### PR DESCRIPTION
Closes FIR-2887

Two faults, one guard. It read five of the pin's eight homes, and it ran only in a job pull requests
skip.

## Where it ran

`check-kin-vfs-compat.mjs` runs in the `check` job, which carries
`github.event_name != 'pull_request'`. The thinned six-context fast gate skips that job, so main
failed its own kin-vfs compatibility guard with no pull-request check ever showing it, which is
exactly how FIR-2881 reached main.

The step is **added** to the fast gate's lint and policy job rather than moved out of `check`, for a
reason worth stating: `bin/kin-precheck` enumerates its gate list out of `check` by name and refuses
with no tally when a script it expects is missing there. Moving the step would have fixed the
pull-request gap and silently dropped the guard from every lane's local precheck at the same time.
Verified: `bin/kin-precheck kin` still reads **16 gates ran, 16 passed, 0 failed** on
`43604e54c3e2d9f6ad9422aee948411e2900eb28`, with `guard:check-kin-vfs-compat.mjs` PASS. The cost of
running it in both places is one API read on a push.

## What it read, and a correction to my own framing

The guard read release.yml and its comment said the pin had five homes. The FIR-2881 sweep found
eight, in rc-build.yml and `scripts/test-release-workflow-authority.py` as well.

**An earlier version of this body said those three homes were unprotected. That was wrong, and the
review of #1223 caught the same overstatement there.** Every one of the eight is already guarded on a
pull request today, which I established by mutating each and watching what caught it:

| Mutation | Caught by | How it reads |
|---|---|---|
| rc-build.yml checkout `ref` | `check-rc-build-drift.mjs` | `rc-build.yml no longer mirrors release.yml's build steps; first difference in step "Checkout kin-vfs"` |
| rc-build.yml `EXPECTED_VFS_COMMIT` | `check-rc-build-drift.mjs` | same, naming step `"Generate artifact provenance manifest"` |
| the authority script's own literal | `test-release-workflow-authority.py` | `mandatory public install proof is missing required policy: expected_vfs_commit: ...` |
| release.yml's expected values | `test-release-workflow-authority.py` | `release workflow must use one immutable kin-vfs commit for build and provenance verification` |

Both of those guards run in the fast gate's lint and policy job, so they are PR-visible. The drift
guard works by byte-equality against release.yml's step block, which is why it covers a pin edit it
was never written for.

So this PR does **not** close an agreement-coverage hole. What it actually buys, stated at the size
of the evidence:

1. **The live version comparison now runs on a pull request.** This is the real fix and the
   unduplicated one. Nothing above compares Kin's resolved `kin-vfs-core` against the pinned
   checkout's; that is this guard's job alone, and it ran only in `check`, which pull requests skip.
   It is how FIR-2881 reached main. Arm three below proves it now fails on a PR.
2. **Discovery instead of a list**, so a ninth home in a file no existing guard mirrors is read the
   day it appears. Future value, and speculative by nature; today it finds exactly the known eight.
3. **A direct diagnosis.** A pin disagreement now reads as a pin disagreement naming the lagging
   file, rather than as a byte-diff against a mirrored step block or a missing policy string.

The count line reports what agreed:

```
Verified Kin/kin-vfs compatibility at kin-vfs-core 0.4.21 (pinned kin-vfs d6c72979...,
agreed across 8 site(s) in 3 file(s): rc-build.yml, release.yml, test-release-workflow-authority.py)
```

It counts SITES that recorded a sha, not files opened. Six files mention the pin and three record
one; an earlier version of that line said "6 file(s)", which would have reported coverage the gate
does not have.

Only a bare forty-hex value is a pin site. The same key appears in the tree with no value, as `""`,
as shell plumbing, as `process.env` passthrough and inside a regex literal; each has a test arm
asserting it is not read as a pin. A kin-vfs checkout `ref` stays stricter and still refuses anything
that is not an immutable sha, because a floating checkout is the original hazard. The gate excludes
its own source and test, because a guard that scans the file it lives in matches its own patterns and
passes on a tree where nothing else does.

## Falsification, three arms

**One rc-build.yml home moved back.** Must fail naming rc-build.yml.

```
::error::disagreeing firelock-ai/kin-vfs pins: b1355e67... (.github/workflows/rc-build.yml
expected_vfs_commit) and d6c72979... (rc-build.yml checkout ref, release.yml expected_vfs_commit,
release.yml checkout ref, test-release-workflow-authority.py expected_vfs_commit); the release
would build one commit and prove another
rc=1
```

**The authority script's line moved back.** Fails, naming
`scripts/test-release-workflow-authority.py` as the lagging home, rc=1.

**A pull-request-shaped run with a deliberate disagreement.** Proven on a throwaway PR, #1225, now
closed unmerged with its branch deleted. `Fast gate lint and policy` concluded FAILURE on that pull
request, and reading the job's steps, the only failing step was
`Verify Kin/kin-vfs compatibility at the pinned release input`. Before this change that job did not
run the guard at all.

Control on the unmutated tree: passes, rc=0, the line above. Restored from HEAD on a trap after each
arm with `git diff HEAD` clean.

## Tests

`scripts/check-kin-vfs-compat.test.mjs` goes from 13 to 20, and it already runs in the fast gate's
lint and policy job. New arms cover reading rc-build.yml, reading the authority script's quoted
literal, refusing a release-moved-rc-build-did-not pin naming the file, refusing an
authority-script-alone lag, accepting all three files agreeing, ignoring the five non-sha spellings,
and a real-tree arm asserting eight sites across exactly those three files with one agreeing sha and
the gate not scanning its own source.

The existing tests move to the reader's new sources shape. One asserted the old wording of the
no-pin-found error and was updated to the message that now covers several files; it caught the
change, which is what it is for.
