### PR TITLE
Install a language server without the toolchain the recipe names

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -134,6 +134,16 @@ jobs:
       - name: Falsify the same-owner call graders
         run: python3 scripts/acceptance/same_owner_call_repro.py --self-test
 
+      # The 2026-08-28 cold walk. A stranger followed the documented install,
+      # initialized a Rust repository, got imports 0/1085, ran the repair the
+      # product named, and was told to install rustup. The grader is handed that
+      # exact refusal and has to fail on it. Its two failing branches carry
+      # different sentences and each gets an input only it can catch, because
+      # the text that shipped trips both and two branches that overlap hide each
+      # other's absence.
+      - name: Falsify the toolchain-free repair grader
+        run: python3 scripts/acceptance/first_contact_honesty.py --self-test
+
       - name: Falsify the acceptance gate
         run: python3 scripts/acceptance/gate.py --self-test
 

--- a/crates/kin-cli/src/commands/language_server_release.rs
+++ b/crates/kin-cli/src/commands/language_server_release.rs
@@ -826,7 +826,7 @@ mod tests {
         // over the PATH `kin_core::tool_prefix` composes.
         let path = kin_core::tool_prefix::path_with_managed_tools(
             Some(&std::ffi::OsString::from("/nonexistent-for-this-test")),
-            &[bin_dir.clone()],
+            std::slice::from_ref(&bin_dir),
         )
         .expect("the tool dir must be added to a PATH that lacks it");
         let found = which::which_in("rust-analyzer", Some(&path), home.path())

--- a/crates/kin-cli/src/commands/language_server_release.rs
+++ b/crates/kin-cli/src/commands/language_server_release.rs
@@ -1,0 +1,989 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Installing a language server from its project's own release binaries, for a
+//! host that carries none of the toolchains the package route needs.
+//!
+//! The gap this closes is the one a cold walkthrough measured on 2026-08-28. A
+//! stranger followed the documented install, initialized a Rust repository, and
+//! got `rust: imports 0/1085 (0%)` with "no language server found". The product
+//! named its own repair, `kin doctor --fix --install-language-servers`, and the
+//! repair exited 1 with "'rustup' is not installed on this host; install
+//! 'rustup', then run 'rustup component add rust-analyzer'". Every step of that
+//! is honest and the outcome is still that a developer who is not a Rust
+//! developer cannot get reference edges for a Rust repository by following the
+//! product's own instructions. Kin asked them to install a toolchain to read
+//! somebody else's code.
+//!
+//! So Kin fetches the binary itself when the toolchain is absent. Three
+//! properties make that safe enough to do on a user's machine without asking
+//! them to trust a URL:
+//!
+//! * The release is PINNED. One tag, named here, for every host. An install
+//!   that resolved "latest" would put a different binary on two machines
+//!   initialized a week apart and give their graphs different edges with
+//!   nothing recording why.
+//! * Every asset carries its own sha256, recorded in this source file and
+//!   verified against the bytes before anything is written to a durable path. A
+//!   digest that does not match refuses loudly and installs nothing;
+//!   [`InstallFailure::ChecksumMismatch`] is a separate outcome from a network
+//!   error for that reason, because the two need different words and only one
+//!   of them means the bytes were wrong.
+//! * The rustup route stays PREFERRED. A host that has rustup gets the
+//!   component that tracks its own toolchain, and Kin's pinned copy is a
+//!   fallback for a host that has neither. The tool directory is appended to
+//!   `PATH` rather than prepended for the same reason
+//!   (`kin_core::tool_prefix`).
+//!
+//! ## Re-measuring the pins
+//!
+//! The digests below were measured by downloading each asset and hashing it.
+//! To move the pin, change [`RUST_ANALYZER_RELEASE`]'s tag and re-run:
+//!
+//! ```text
+//! tag=<new tag>
+//! for a in rust-analyzer-x86_64-unknown-linux-gnu.gz \
+//!          rust-analyzer-aarch64-unknown-linux-gnu.gz \
+//!          rust-analyzer-aarch64-apple-darwin.gz \
+//!          rust-analyzer-x86_64-apple-darwin.gz; do
+//!   curl -fsSL -o "$a" \
+//!     "https://github.com/rust-lang/rust-analyzer/releases/download/$tag/$a"
+//! done
+//! shasum -a 256 *.gz
+//! ```
+//!
+//! The recorded `size` is the second reading: it is the release API's own
+//! `assets[].size` for the same file, so a download truncated by a proxy is
+//! named as a truncation rather than as a digest that happens not to match.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+/// One release asset, for one host, with the digest Kin verifies it against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReleaseAsset {
+    /// The Rust target triple this asset serves, as `cfg!` reports the host.
+    pub(crate) target: &'static str,
+    /// The file name inside the release.
+    pub(crate) name: &'static str,
+    /// The sha256 of the asset as published, lowercase hex.
+    pub(crate) sha256: &'static str,
+    /// The published size in bytes, from the release API.
+    pub(crate) size: u64,
+}
+
+/// How an asset is packed, and therefore how it is unpacked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AssetFormat {
+    /// A single gzip-compressed executable.
+    Gzip,
+}
+
+/// A project's pinned release, and the assets Kin will install from it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PinnedRelease {
+    /// The binary that lands on disk, which is also the name discovery matches.
+    pub(crate) binary: &'static str,
+    /// The upstream project, for the disclosure line.
+    pub(crate) project: &'static str,
+    /// The release tag every asset here comes from.
+    pub(crate) tag: &'static str,
+    /// Where the release lives, without the tag or the file name.
+    pub(crate) base_url: &'static str,
+    pub(crate) format: AssetFormat,
+    pub(crate) assets: &'static [ReleaseAsset],
+}
+
+impl PinnedRelease {
+    /// The asset for a host target, or `None` when this release does not build
+    /// one.
+    pub(crate) fn asset_for(&self, target: &str) -> Option<&'static ReleaseAsset> {
+        self.assets.iter().find(|asset| asset.target == target)
+    }
+
+    /// The full URL an asset is fetched from, honouring the test base override.
+    pub(crate) fn asset_url(&self, asset: &ReleaseAsset, base: &str) -> String {
+        format!("{}/{}/{}", base.trim_end_matches('/'), self.tag, asset.name)
+    }
+}
+
+/// rust-analyzer's own release binaries.
+///
+/// Four hosts: the two Linux and the two macOS targets Kin ships for. Windows
+/// carries `.zip` assets in the same release and is deliberately not pinned
+/// here, because Kin has never exercised that unpack path and an unproven
+/// install route is worse than a refusal that names the rustup command.
+///
+/// The Linux assets are the `-gnu` builds. A musl host is not covered and does
+/// not need a special case here: the readiness probe already reports a server
+/// that installed and would not start, which is the honest answer for a binary
+/// this host's loader refuses.
+pub(crate) const RUST_ANALYZER_RELEASE: PinnedRelease = PinnedRelease {
+    binary: "rust-analyzer",
+    project: "rust-lang/rust-analyzer",
+    tag: "2026-08-24",
+    base_url: "https://github.com/rust-lang/rust-analyzer/releases/download",
+    format: AssetFormat::Gzip,
+    assets: &[
+        ReleaseAsset {
+            target: "x86_64-unknown-linux-gnu",
+            name: "rust-analyzer-x86_64-unknown-linux-gnu.gz",
+            sha256: "c4d409690b98d84ce98174829362a59214825d72304fe2504f4b906a116b51fe",
+            size: 14_865_773,
+        },
+        ReleaseAsset {
+            target: "aarch64-unknown-linux-gnu",
+            name: "rust-analyzer-aarch64-unknown-linux-gnu.gz",
+            sha256: "3463f9115c725fc5dfb002431833ec83d1f1f9c4c35b76ad5f47b92c58a521f1",
+            size: 14_317_193,
+        },
+        ReleaseAsset {
+            target: "aarch64-apple-darwin",
+            name: "rust-analyzer-aarch64-apple-darwin.gz",
+            sha256: "5f4557c2ea4d62f80f1ffeea2646d0d56fab7172a0db11f3065c4d246b763989",
+            size: 13_875_126,
+        },
+        ReleaseAsset {
+            target: "x86_64-apple-darwin",
+            name: "rust-analyzer-x86_64-apple-darwin.gz",
+            sha256: "822cc4369562fc2ed26d1cf3953ef93927d8fdda4302d82e2eec407e2734eefd",
+            size: 14_591_602,
+        },
+    ],
+};
+
+/// The target triple for the host this build runs on, as the pin table spells
+/// it.
+///
+/// A runtime match over `cfg!` rather than a `#[cfg]` block, so every arm is
+/// compiled and type-checked on every host including the one this fleet builds
+/// on.
+pub(crate) fn host_target() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => Some("x86_64-unknown-linux-gnu"),
+        ("linux", "aarch64") => Some("aarch64-unknown-linux-gnu"),
+        ("macos", "aarch64") => Some("aarch64-apple-darwin"),
+        ("macos", "x86_64") => Some("x86_64-apple-darwin"),
+        _ => None,
+    }
+}
+
+/// Where release assets are fetched from.
+///
+/// The override exists so an acceptance check can drive the whole route,
+/// download included, against bytes it controls rather than against the
+/// internet. It is honoured on its own; the DIGEST override beside it is not,
+/// and that asymmetry is deliberate: pointing the fetch somewhere else is a
+/// test setup step, while relaxing the digest is the guard itself and must be
+/// impossible to do by accident against the real release.
+pub(crate) const ASSET_BASE_ENV: &str = "KIN_LANGUAGE_SERVER_ASSET_BASE";
+
+/// The digest an overridden base URL is verified against.
+///
+/// Ignored unless [`ASSET_BASE_ENV`] is also set, so this can never weaken the
+/// check against the pinned release. A fixture has different bytes and
+/// therefore a different digest, and stating it here is what keeps the
+/// acceptance check exercising a real verification rather than a disabled one.
+pub(crate) const ASSET_SHA256_ENV: &str = "KIN_LANGUAGE_SERVER_ASSET_SHA256";
+
+/// Where this run fetches from, and what digest it demands, read from the
+/// process environment.
+///
+/// The one place these two variables are read. Everything below takes the
+/// answer as an argument, so a test states the whole environment it asserts
+/// against rather than mutating a table every other test shares.
+pub(crate) fn resolve_source_from_env(
+    release: &PinnedRelease,
+    asset: &ReleaseAsset,
+) -> (String, String) {
+    resolve_source(release, asset, |key| std::env::var(key).ok())
+}
+
+/// Where this run fetches from, and what digest it demands, resolved from an
+/// arbitrary lookup.
+///
+/// Pure in the lookup, so the precedence rule is testable without touching the
+/// process environment.
+pub(crate) fn resolve_source<F>(
+    release: &PinnedRelease,
+    asset: &ReleaseAsset,
+    lookup: F,
+) -> (String, String)
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let base = lookup(ASSET_BASE_ENV).filter(|value| !value.trim().is_empty());
+    match base {
+        None => (release.base_url.to_string(), asset.sha256.to_string()),
+        Some(base) => {
+            let digest = lookup(ASSET_SHA256_ENV)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| asset.sha256.to_string());
+            (base, digest)
+        }
+    }
+}
+
+/// Why a release install could not happen, in the operator's terms.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum InstallFailure {
+    /// No asset is pinned for this host.
+    UnsupportedHost { target: String },
+    /// The bytes never arrived.
+    Download { url: String, reason: String },
+    /// The bytes arrived and are not the pinned ones.
+    ChecksumMismatch {
+        url: String,
+        expected: String,
+        actual: String,
+        bytes: u64,
+    },
+    /// The bytes arrived, verified, and could not be unpacked or written.
+    Install {
+        destination: PathBuf,
+        reason: String,
+    },
+}
+
+impl InstallFailure {
+    /// One line naming what happened, for a report row.
+    pub(crate) fn reason(&self) -> String {
+        match self {
+            Self::UnsupportedHost { target } => format!(
+                "Kin pins no {} release binary for this host ({target})",
+                RUST_ANALYZER_RELEASE.binary
+            ),
+            Self::Download { url, reason } => {
+                format!("could not download {url}: {reason}")
+            }
+            Self::ChecksumMismatch {
+                url,
+                expected,
+                actual,
+                bytes,
+            } => format!(
+                "the {bytes} bytes served by {url} hash to sha256 {actual}, and Kin pins \
+                 {expected}. Nothing was installed."
+            ),
+            Self::Install {
+                destination,
+                reason,
+            } => format!("could not install into {}: {reason}", destination.display()),
+        }
+    }
+}
+
+/// What one release install did, in enough detail for the operator to check it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReleaseInstall {
+    pub(crate) binary: &'static str,
+    pub(crate) project: &'static str,
+    pub(crate) tag: &'static str,
+    pub(crate) url: String,
+    pub(crate) sha256: String,
+    pub(crate) destination: PathBuf,
+}
+
+impl ReleaseInstall {
+    /// The disclosure a run prints: what landed, from where, and the digest
+    /// that was verified before it landed.
+    pub(crate) fn evidence_lines(&self) -> Vec<String> {
+        vec![
+            format!(
+                "{} {} from the {} release {}",
+                self.binary, self.tag, self.project, self.tag
+            ),
+            format!("source:   {}", self.url),
+            format!("sha256:   {} (verified before install)", self.sha256),
+            format!("installed to: {}", self.destination.display()),
+        ]
+    }
+}
+
+/// How many bytes a release asset may be before Kin stops reading.
+///
+/// A ceiling rather than a trust: an overridden base URL is a test fixture and
+/// a real one is a fifteen-megabyte binary, so a body that keeps arriving is a
+/// misrouted download rather than a language server.
+const MAX_ASSET_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Fetch, verify and install the pinned server for this host.
+///
+/// The order is the guarantee. Bytes are hashed as they arrive into a temporary
+/// file, the digest is compared before anything is unpacked, and only a
+/// verified archive is expanded and renamed into place. A mismatch removes the
+/// temporary file and returns [`InstallFailure::ChecksumMismatch`]; nothing
+/// reaches [`kin_core::tool_prefix::managed_tool_bin_dir`] on that path.
+pub(crate) fn install_pinned_release(
+    release: &PinnedRelease,
+    target: Option<&'static str>,
+    bin_dir: &Path,
+    base: &str,
+    expected: &str,
+) -> Result<ReleaseInstall, InstallFailure> {
+    let target = target.ok_or_else(|| InstallFailure::UnsupportedHost {
+        target: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+    })?;
+    let asset = release
+        .asset_for(target)
+        .ok_or_else(|| InstallFailure::UnsupportedHost {
+            target: target.to_string(),
+        })?;
+    let url = release.asset_url(asset, base);
+
+    std::fs::create_dir_all(bin_dir).map_err(|error| InstallFailure::Install {
+        destination: bin_dir.to_path_buf(),
+        reason: error.to_string(),
+    })?;
+
+    let (archive, digest, bytes) = download_to_temp(&url, bin_dir)?;
+    if digest != expected.to_lowercase() {
+        let _ = std::fs::remove_file(&archive);
+        return Err(InstallFailure::ChecksumMismatch {
+            url,
+            expected: expected.to_lowercase(),
+            actual: digest,
+            bytes,
+        });
+    }
+
+    let destination = bin_dir.join(release.binary);
+    expand_into_place(release.format, &archive, &destination).map_err(|reason| {
+        InstallFailure::Install {
+            destination: destination.clone(),
+            reason,
+        }
+    })?;
+    let _ = std::fs::remove_file(&archive);
+
+    Ok(ReleaseInstall {
+        binary: release.binary,
+        project: release.project,
+        tag: release.tag,
+        url,
+        sha256: digest,
+        destination,
+    })
+}
+
+/// Stream `url` into a temporary file beside the destination, hashing as it
+/// goes.
+///
+/// Written beside the destination rather than into the system temp directory so
+/// the rename that follows is on one filesystem, which is what makes it atomic:
+/// a crash mid-write leaves a partial temporary file and never a partial
+/// `rust-analyzer` that discovery would find and start.
+fn download_to_temp(url: &str, bin_dir: &Path) -> Result<(PathBuf, String, u64), InstallFailure> {
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(concat!("kin/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|error| InstallFailure::Download {
+            url: url.to_string(),
+            reason: error.to_string(),
+        })?;
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|error| InstallFailure::Download {
+            url: url.to_string(),
+            reason: error.to_string(),
+        })?;
+    if !response.status().is_success() {
+        return Err(InstallFailure::Download {
+            url: url.to_string(),
+            reason: format!("the server answered {}", response.status()),
+        });
+    }
+
+    let temp = bin_dir.join(format!(".kin-download-{}", std::process::id()));
+    let mut file = std::fs::File::create(&temp).map_err(|error| InstallFailure::Download {
+        url: url.to_string(),
+        reason: format!("could not open {}: {error}", temp.display()),
+    })?;
+    let mut hasher = Sha256::new();
+    let mut total: u64 = 0;
+    let mut reader = response;
+    let mut buffer = vec![0u8; 64 * 1024];
+    loop {
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(error) => {
+                let _ = std::fs::remove_file(&temp);
+                return Err(InstallFailure::Download {
+                    url: url.to_string(),
+                    reason: error.to_string(),
+                });
+            }
+        };
+        total += read as u64;
+        if total > MAX_ASSET_BYTES {
+            let _ = std::fs::remove_file(&temp);
+            return Err(InstallFailure::Download {
+                url: url.to_string(),
+                reason: format!("the response passed {MAX_ASSET_BYTES} bytes and was abandoned"),
+            });
+        }
+        hasher.update(&buffer[..read]);
+        if let Err(error) = file.write_all(&buffer[..read]) {
+            let _ = std::fs::remove_file(&temp);
+            return Err(InstallFailure::Download {
+                url: url.to_string(),
+                reason: error.to_string(),
+            });
+        }
+    }
+    if let Err(error) = file.flush() {
+        let _ = std::fs::remove_file(&temp);
+        return Err(InstallFailure::Download {
+            url: url.to_string(),
+            reason: error.to_string(),
+        });
+    }
+    drop(file);
+
+    Ok((temp, hex::encode(hasher.finalize()), total))
+}
+
+/// Unpack a verified archive and put the binary in place, executable.
+fn expand_into_place(
+    format: AssetFormat,
+    archive: &Path,
+    destination: &Path,
+) -> Result<(), String> {
+    let staged = destination.with_extension("kin-staged");
+    {
+        let source = std::fs::File::open(archive).map_err(|error| error.to_string())?;
+        let mut out = std::fs::File::create(&staged).map_err(|error| error.to_string())?;
+        match format {
+            AssetFormat::Gzip => {
+                let mut decoder = flate2::read::GzDecoder::new(source);
+                std::io::copy(&mut decoder, &mut out).map_err(|error| error.to_string())?;
+            }
+        }
+        out.flush().map_err(|error| error.to_string())?;
+    }
+    set_executable(&staged)?;
+    std::fs::rename(&staged, destination).map_err(|error| {
+        let _ = std::fs::remove_file(&staged);
+        error.to_string()
+    })
+}
+
+/// Make a staged file executable, before it takes the name discovery matches.
+///
+/// Done on the staged path rather than after the rename so the binary is never
+/// visible under its real name without the bit: `which` accepts a file only
+/// when it is executable, and a window where it is not is a window where
+/// discovery walks past a server that is there.
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = std::fs::metadata(path)
+        .map_err(|error| error.to_string())?
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).map_err(|error| error.to_string())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every pinned asset states a full sha256 and a real size.
+    ///
+    /// The failing case is a pin moved by hand where one digest was pasted
+    /// short or one size left at zero. Both read as ordinary table rows and
+    /// only fail at install time, on the one host that asset serves, which is
+    /// the host nobody is on when the pin moves.
+    #[test]
+    fn every_pinned_asset_carries_a_full_digest_and_a_size() {
+        assert!(
+            !RUST_ANALYZER_RELEASE.assets.is_empty(),
+            "a release with no assets can install nothing"
+        );
+        for asset in RUST_ANALYZER_RELEASE.assets {
+            assert_eq!(
+                asset.sha256.len(),
+                64,
+                "{}: sha256 must be 64 hex characters, got {:?}",
+                asset.name,
+                asset.sha256
+            );
+            assert!(
+                asset
+                    .sha256
+                    .chars()
+                    .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+                "{}: sha256 must be lowercase hex, got {:?}",
+                asset.name,
+                asset.sha256
+            );
+            assert!(
+                asset.size > 1_000_000,
+                "{}: a language server smaller than a megabyte is not the published asset",
+                asset.name
+            );
+            assert!(
+                asset.name.contains(asset.target),
+                "{}: the asset name must carry the target it serves, {}",
+                asset.name,
+                asset.target
+            );
+        }
+    }
+
+    /// Two hosts must never share one digest.
+    ///
+    /// A copy-paste while moving the pin puts one host's binary on another's,
+    /// and the install succeeds: the digest matches the bytes that were served,
+    /// because they are the bytes that were asked for. Only the loader
+    /// disagrees, later, on somebody else's machine.
+    #[test]
+    fn no_two_hosts_share_a_digest_or_a_name() {
+        for (index, asset) in RUST_ANALYZER_RELEASE.assets.iter().enumerate() {
+            for other in &RUST_ANALYZER_RELEASE.assets[index + 1..] {
+                assert_ne!(
+                    asset.sha256, other.sha256,
+                    "{} and {} carry the same digest",
+                    asset.name, other.name
+                );
+                assert_ne!(
+                    asset.target, other.target,
+                    "two assets both claim to serve {}",
+                    asset.target
+                );
+            }
+        }
+    }
+
+    /// The four hosts Kin ships binaries for are the four hosts pinned.
+    #[test]
+    fn the_pinned_hosts_are_the_hosts_kin_ships_for() {
+        let mut targets: Vec<&str> = RUST_ANALYZER_RELEASE
+            .assets
+            .iter()
+            .map(|asset| asset.target)
+            .collect();
+        targets.sort_unstable();
+        assert_eq!(
+            targets,
+            vec![
+                "aarch64-apple-darwin",
+                "aarch64-unknown-linux-gnu",
+                "x86_64-apple-darwin",
+                "x86_64-unknown-linux-gnu",
+            ]
+        );
+    }
+
+    /// The host this test runs on resolves to a pinned asset.
+    ///
+    /// Not a tautology over the table: it asserts the OS and ARCH strings this
+    /// build reports are the ones [`host_target`] matches on, which is the join
+    /// a hand-written match arm gets wrong.
+    #[test]
+    fn this_host_resolves_to_an_asset() {
+        let target = host_target().expect("this fleet builds on a pinned host");
+        assert!(
+            RUST_ANALYZER_RELEASE.asset_for(target).is_some(),
+            "{target} resolves to no pinned asset"
+        );
+    }
+
+    /// A digest override is ignored unless the base URL is overridden too.
+    ///
+    /// This is the whole safety of the test lever. Without the pairing rule,
+    /// one environment variable would relax verification against the real
+    /// release, which is the guard removing itself.
+    #[test]
+    fn a_digest_override_alone_cannot_relax_the_pin() {
+        let asset = RUST_ANALYZER_RELEASE.assets[0];
+        let (base, digest) = resolve_source(&RUST_ANALYZER_RELEASE, &asset, |key| {
+            if key == ASSET_SHA256_ENV {
+                Some("0".repeat(64))
+            } else {
+                None
+            }
+        });
+        assert_eq!(base, RUST_ANALYZER_RELEASE.base_url);
+        assert_eq!(
+            digest, asset.sha256,
+            "a digest override with no base override must leave the pin standing"
+        );
+    }
+
+    /// With both set, the fixture's own base and digest are used.
+    #[test]
+    fn an_overridden_base_takes_its_own_digest() {
+        let asset = RUST_ANALYZER_RELEASE.assets[0];
+        let fixture_digest = "a".repeat(64);
+        let (base, digest) = resolve_source(&RUST_ANALYZER_RELEASE, &asset, |key| match key {
+            ASSET_BASE_ENV => Some("http://127.0.0.1:9/x".to_string()),
+            ASSET_SHA256_ENV => Some(fixture_digest.clone()),
+            _ => None,
+        });
+        assert_eq!(base, "http://127.0.0.1:9/x");
+        assert_eq!(digest, fixture_digest);
+    }
+
+    /// An overridden base with no digest still demands the pinned one.
+    #[test]
+    fn an_overridden_base_without_a_digest_keeps_the_pin() {
+        let asset = RUST_ANALYZER_RELEASE.assets[0];
+        let (_, digest) = resolve_source(&RUST_ANALYZER_RELEASE, &asset, |key| {
+            (key == ASSET_BASE_ENV).then(|| "http://127.0.0.1:9/x".to_string())
+        });
+        assert_eq!(digest, asset.sha256);
+    }
+
+    /// The URL is the base, the tag and the asset name, in that order.
+    #[test]
+    fn the_asset_url_names_the_tag_and_the_file() {
+        let asset = RUST_ANALYZER_RELEASE.assets[0];
+        assert_eq!(
+            RUST_ANALYZER_RELEASE.asset_url(&asset, "https://example.invalid/releases/download/"),
+            format!(
+                "https://example.invalid/releases/download/{}/{}",
+                RUST_ANALYZER_RELEASE.tag, asset.name
+            ),
+            "a trailing slash on the base must not double in the URL"
+        );
+    }
+
+    /// A mismatch reason names both digests and the bytes it read.
+    ///
+    /// A refusal that says only "checksum mismatch" sends an operator to a
+    /// search engine. Naming what was served, what was demanded, and how many
+    /// bytes arrived separates a corrupted download from a proxy that served an
+    /// HTML error page under a 200.
+    #[test]
+    fn a_mismatch_names_both_digests_and_refuses_out_loud() {
+        let failure = InstallFailure::ChecksumMismatch {
+            url: "https://example.invalid/a.gz".to_string(),
+            expected: "b".repeat(64),
+            actual: "c".repeat(64),
+            bytes: 1234,
+        };
+        let reason = failure.reason();
+        assert!(reason.contains(&"b".repeat(64)), "{reason}");
+        assert!(reason.contains(&"c".repeat(64)), "{reason}");
+        assert!(reason.contains("1234"), "{reason}");
+        assert!(
+            reason.contains("Nothing was installed"),
+            "a mismatch must say what it did NOT do: {reason}"
+        );
+    }
+
+    // ---- the standalone route, end to end --------------------------------
+    //
+    // A local HTTP server, a gzip of a fixture "binary", and the real
+    // download-verify-unpack-install path. What is NOT exercised here is which
+    // URL production reads, and that is deliberate: `resolve_source` is tested
+    // above for the precedence rule, and the acceptance check drives the shipped
+    // binary against a fixture server through the environment. Everything
+    // between the response body and the executable on disk is the same code on
+    // both paths.
+
+    /// A one-request HTTP server that serves `body` and then stops.
+    ///
+    /// Returns the base URL. Hand-rolled rather than pulled in as a dependency
+    /// because the whole protocol surface used here is a status line, a length
+    /// and a body.
+    fn serve_once(body: Vec<u8>) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::BufRead;
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind a loopback port");
+        let port = listener.local_addr().expect("read the bound port").port();
+        let handle = std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            // Drain the request head so the client is not writing into a socket
+            // nobody reads, which on some platforms surfaces as a broken pipe
+            // rather than as the response.
+            {
+                let mut reader =
+                    std::io::BufReader::new(stream.try_clone().expect("clone the accepted stream"));
+                let mut line = String::new();
+                while reader.read_line(&mut line).unwrap_or(0) > 0 {
+                    if line == "\r\n" || line == "\n" {
+                        break;
+                    }
+                    line.clear();
+                }
+            }
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(head.as_bytes());
+            let _ = stream.write_all(&body);
+            let _ = stream.flush();
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    /// A gzip of `payload`, as the release serves its binaries.
+    fn gzipped(payload: &[u8]) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(payload).expect("gzip the fixture");
+        encoder.finish().expect("finish the gzip stream")
+    }
+
+    fn sha256_of(bytes: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        hex::encode(hasher.finalize())
+    }
+
+    /// A release whose one asset serves whatever host the test runs on.
+    fn fixture_release(target: &'static str) -> PinnedRelease {
+        // Leaked so the asset can carry the `'static` lifetime the real table
+        // has. One small allocation per test run, in a test binary.
+        let assets: &'static [ReleaseAsset] = Box::leak(Box::new([ReleaseAsset {
+            target,
+            name: "rust-analyzer-fixture.gz",
+            // Never consulted: every call below passes the expected digest in.
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+            size: 1,
+        }]));
+        PinnedRelease {
+            binary: "rust-analyzer",
+            project: "rust-lang/rust-analyzer",
+            tag: "fixture-tag",
+            base_url: "http://127.0.0.1:1/never-used",
+            format: AssetFormat::Gzip,
+            assets,
+        }
+    }
+
+    /// The whole standalone route: fetch, verify, unpack, install, and be found
+    /// by the same `which` lookup enrichment discovery performs.
+    ///
+    /// The discovery half is the one that would otherwise be assumed. A binary
+    /// on disk with the right name is not a discovered server: `which` accepts
+    /// a file only when it is executable and only when its directory is on the
+    /// path being searched, and both of those are decisions this code makes.
+    ///
+    /// Falsified by removing the `set_executable` call in `expand_into_place`:
+    /// the install still reports success and `which_in` returns nothing, so the
+    /// discovery assertion is the one that fires.
+    #[test]
+    fn the_standalone_route_installs_a_binary_discovery_can_find() {
+        let target = host_target().expect("this fleet builds on a pinned host");
+        let release = fixture_release(target);
+        let payload = b"#!/bin/sh\necho rust-analyzer 1.2.3\n";
+        let archive = gzipped(payload);
+        let digest = sha256_of(&archive);
+        let (base, server) = serve_once(archive.clone());
+
+        let home = tempfile::tempdir().expect("a scratch tool root");
+        let bin_dir = home.path().join("tools").join("bin");
+
+        let install = install_pinned_release(&release, Some(target), &bin_dir, &base, &digest)
+            .expect("a served archive whose digest matches must install");
+        server.join().expect("the fixture server thread must end");
+
+        assert_eq!(install.destination, bin_dir.join("rust-analyzer"));
+        assert_eq!(install.sha256, digest);
+        assert!(
+            install.url.starts_with(&base) && install.url.ends_with("rust-analyzer-fixture.gz"),
+            "the evidence must name the URL the bytes came from: {}",
+            install.url
+        );
+
+        // Unpacked, not merely copied.
+        let written = std::fs::read(&install.destination).expect("read the installed binary");
+        assert_eq!(
+            written, payload,
+            "the installed file must be the decompressed payload, not the archive"
+        );
+
+        // The archive is not left behind under a name a later run would trip on.
+        let leftovers: Vec<String> = std::fs::read_dir(&bin_dir)
+            .expect("list the tool bin dir")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .filter(|name| name != "rust-analyzer")
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "the download and staging files must be cleaned up, found {leftovers:?}"
+        );
+
+        // Registered where discovery looks: the same crate, the same lookup,
+        // over the PATH `kin_core::tool_prefix` composes.
+        let path = kin_core::tool_prefix::path_with_managed_tools(
+            Some(&std::ffi::OsString::from("/nonexistent-for-this-test")),
+            &[bin_dir.clone()],
+        )
+        .expect("the tool dir must be added to a PATH that lacks it");
+        let found = which::which_in("rust-analyzer", Some(&path), home.path())
+            .expect("discovery must find the installed server on that PATH");
+        assert_eq!(
+            found.canonicalize().expect("canonicalize what which found"),
+            install
+                .destination
+                .canonicalize()
+                .expect("canonicalize the install destination"),
+            "discovery must resolve to the binary this install wrote"
+        );
+    }
+
+    /// Bytes that are not the pinned ones are refused, and nothing is written.
+    ///
+    /// The arm that proves verification runs at all. The happy-path test above
+    /// passes with verification deleted, because there the digest matches by
+    /// construction; only this one goes red.
+    ///
+    /// Falsified by deleting the `if digest != expected` block in
+    /// `install_pinned_release`: this test then reports `Ok`, and the
+    /// assertion that fires is the `expected a checksum refusal` panic on the
+    /// `match`, followed on a repeat run by the destination-does-not-exist
+    /// assertion.
+    #[test]
+    fn bytes_that_do_not_match_the_pin_are_refused_and_nothing_is_installed() {
+        let target = host_target().expect("this fleet builds on a pinned host");
+        let release = fixture_release(target);
+        let archive = gzipped(b"a language server nobody pinned");
+        let served_digest = sha256_of(&archive);
+        // Stated independently of the bytes, which is the whole point: a digest
+        // computed from what was served could never disagree with it.
+        let pinned_digest = "f".repeat(64);
+        assert_ne!(served_digest, pinned_digest);
+        let (base, server) = serve_once(archive.clone());
+
+        let home = tempfile::tempdir().expect("a scratch tool root");
+        let bin_dir = home.path().join("tools").join("bin");
+
+        let failure =
+            install_pinned_release(&release, Some(target), &bin_dir, &base, &pinned_digest)
+                .expect_err("bytes that do not match the pin must not install");
+        server.join().expect("the fixture server thread must end");
+
+        match &failure {
+            InstallFailure::ChecksumMismatch {
+                expected,
+                actual,
+                bytes,
+                ..
+            } => {
+                assert_eq!(expected, &pinned_digest);
+                assert_eq!(actual, &served_digest);
+                assert_eq!(*bytes, archive.len() as u64);
+            }
+            other => panic!("expected a checksum refusal, got {other:?}"),
+        }
+
+        assert!(
+            !bin_dir.join("rust-analyzer").exists(),
+            "a refused download must leave no binary behind"
+        );
+        let leftovers: Vec<String> = std::fs::read_dir(&bin_dir)
+            .expect("list the tool bin dir")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "a refused download must leave no temporary file either, found {leftovers:?}"
+        );
+    }
+
+    /// A server that answers with an error status is a download failure, not a
+    /// digest failure.
+    ///
+    /// The control for the arm above. A classifier that reported every unhappy
+    /// path as a checksum mismatch would pass that test while telling every
+    /// operator behind a proxy that their bytes were tampered with.
+    #[test]
+    fn a_refused_request_is_a_download_failure_rather_than_a_mismatch() {
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind a loopback port");
+        let port = listener.local_addr().expect("read the bound port").port();
+        let server = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let _ = stream.write_all(
+                    b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                );
+            }
+        });
+
+        let target = host_target().expect("this fleet builds on a pinned host");
+        let release = fixture_release(target);
+        let home = tempfile::tempdir().expect("a scratch tool root");
+        let bin_dir = home.path().join("tools").join("bin");
+        let failure = install_pinned_release(
+            &release,
+            Some(target),
+            &bin_dir,
+            &format!("http://127.0.0.1:{port}"),
+            &"e".repeat(64),
+        )
+        .expect_err("a 404 must not install");
+        server.join().expect("the fixture server thread must end");
+
+        match &failure {
+            InstallFailure::Download { reason, .. } => {
+                assert!(reason.contains("404"), "{reason}");
+            }
+            other => panic!("a 404 must read as a download failure, got {other:?}"),
+        }
+    }
+
+    /// A host with no pinned asset is refused before any request is made.
+    #[test]
+    fn a_host_with_no_pinned_asset_is_refused_by_name() {
+        let release = fixture_release("x86_64-unknown-linux-gnu");
+        let home = tempfile::tempdir().expect("a scratch tool root");
+        let failure = install_pinned_release(
+            &release,
+            Some("powerpc64-unknown-linux-gnu"),
+            &home.path().join("bin"),
+            "http://127.0.0.1:1/never-used",
+            &"e".repeat(64),
+        )
+        .expect_err("an unpinned host must be refused");
+        match &failure {
+            InstallFailure::UnsupportedHost { target } => {
+                assert_eq!(target, "powerpc64-unknown-linux-gnu");
+            }
+            other => panic!("expected an unsupported-host refusal, got {other:?}"),
+        }
+    }
+
+    /// The evidence lines carry the source and the digest, not just a tick.
+    #[test]
+    fn the_evidence_names_the_source_and_the_digest() {
+        let install = ReleaseInstall {
+            binary: "rust-analyzer",
+            project: "rust-lang/rust-analyzer",
+            tag: "2026-08-24",
+            url: "https://example.invalid/rust-analyzer.gz".to_string(),
+            sha256: "d".repeat(64),
+            destination: PathBuf::from("/home/u/.kin/tools/bin/rust-analyzer"),
+        };
+        let lines = install.evidence_lines().join("\n");
+        assert!(
+            lines.contains("https://example.invalid/rust-analyzer.gz"),
+            "{lines}"
+        );
+        assert!(lines.contains(&"d".repeat(64)), "{lines}");
+        assert!(
+            lines.contains("/home/u/.kin/tools/bin/rust-analyzer"),
+            "{lines}"
+        );
+        assert!(lines.contains("2026-08-24"), "{lines}");
+    }
+}

--- a/crates/kin-cli/src/commands/language_servers.rs
+++ b/crates/kin-cli/src/commands/language_servers.rs
@@ -29,6 +29,89 @@ use std::process::{Command, Stdio};
 
 use kin_model::LanguageId;
 
+use super::language_server_release::{self, PinnedRelease, RUST_ANALYZER_RELEASE};
+
+/// What Kin can do for a language whose named installer this host does not
+/// have, or cannot use.
+///
+/// The recipes name a package manager or a toolchain: `rustup` for Rust, `npm`
+/// for the rest. Both assumptions break on an ordinary machine, and they break
+/// differently. A developer who is not a Rust developer has no rustup at all,
+/// so the Rust row's only advice was to install a toolchain in order to read
+/// somebody else's code. A user running as themselves in a Node base image has
+/// npm, and its global prefix is owned by root, so the install cannot write
+/// where it would put the binary.
+///
+/// Neither of those is a reason to leave a repository with no reference edges,
+/// so each recipe carries the route Kin takes instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Fallback {
+    /// Kin fetches the project's own release binary, pinned to one tag and
+    /// verified against a digest recorded in Kin's source.
+    PinnedRelease(&'static PinnedRelease),
+    /// Kin re-runs the same installer against a prefix Kin owns, under
+    /// `KIN_HOME`, which needs no privilege and no shared directory.
+    ManagedPrefix,
+}
+
+/// Which of a recipe's routes one run takes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstallRoute {
+    /// The recipe's own installer, against its own default target. Preferred
+    /// wherever it works: a rustup component tracks the toolchain that compiles
+    /// the repository, and Kin's pinned copy does not.
+    Installer,
+    /// The pinned release binary Kin downloads and verifies itself.
+    PinnedRelease,
+    /// The recipe's installer, redirected at a prefix Kin owns.
+    ManagedPrefix,
+}
+
+/// What this host can offer one recipe, measured before a route is chosen.
+///
+/// Taken as data rather than probed inside [`choose_route`] so the rule is
+/// decidable with no host, no network and no subprocess. Every field is a fact
+/// somebody measured; none of them is a preference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HostRoutes {
+    /// The recipe's named program is on `PATH`.
+    pub(crate) installer_on_path: bool,
+    /// The installer's default target refuses this user, so running it would
+    /// spend the download and end in the installer's own permission trace.
+    pub(crate) default_target_blocked: bool,
+    /// Kin pins a release binary for this host's os and architecture.
+    pub(crate) pinned_release_for_this_host: bool,
+}
+
+/// Which route this host leaves open for a recipe, or `None` when it leaves
+/// none.
+///
+/// Ordered by what serves the operator best, not by what is easiest. The
+/// installer wins whenever it can actually run, because a server the operator's
+/// own toolchain manages is the one their toolchain expects. Kin's own routes
+/// are what a host without that toolchain gets instead of a refusal.
+pub(crate) fn choose_route(
+    recipe: &LanguageServerRecipe,
+    host: HostRoutes,
+) -> Option<InstallRoute> {
+    if host.installer_on_path && !host.default_target_blocked {
+        return Some(InstallRoute::Installer);
+    }
+    match recipe.fallback {
+        // A pinned release needs nothing from this host but a network, so it
+        // serves both the no-installer case and the blocked-target one.
+        Fallback::PinnedRelease(_) if host.pinned_release_for_this_host => {
+            Some(InstallRoute::PinnedRelease)
+        }
+        // A managed prefix is the same installer pointed somewhere else, so it
+        // answers a blocked target and cannot answer a missing installer. npm
+        // absent means Node absent, and Kin does not install a language
+        // runtime behind a user's back.
+        Fallback::ManagedPrefix if host.installer_on_path => Some(InstallRoute::ManagedPrefix),
+        _ => None,
+    }
+}
+
 /// How to install the language server for one language.
 ///
 /// `binaries` mirrors `kin_lsp::discovery::KNOWN_SERVERS` for the same
@@ -41,6 +124,8 @@ pub(crate) struct LanguageServerRecipe {
     pub(crate) binaries: &'static [&'static str],
     pub(crate) program: &'static str,
     pub(crate) args: &'static [&'static str],
+    /// What Kin does when [`Self::program`] cannot serve this host.
+    pub(crate) fallback: Fallback,
     /// What the operator is spending by saying yes. Named per recipe rather
     /// than as one sentence, because "this downloads a package" is exactly the
     /// disclosure that reads as boilerplate and gets clicked through.
@@ -72,6 +157,76 @@ impl LanguageServerRecipe {
     pub(crate) fn installer_available(&self) -> bool {
         which::which(self.program).is_ok()
     }
+
+    /// The arguments for the same installer pointed at a prefix Kin owns.
+    ///
+    /// `-g` is dropped and `--prefix` inserted, which turns a global install
+    /// into a local one rooted where Kin can always write. The package
+    /// arguments are untouched, pin included, because the whole hazard the
+    /// TypeScript pin exists for is a copy that quietly drops it.
+    pub(crate) fn managed_prefix_args(&self, prefix: &Path) -> Vec<String> {
+        let mut args: Vec<String> = vec!["install".to_string()];
+        args.push("--prefix".to_string());
+        args.push(prefix.display().to_string());
+        for arg in self.args {
+            if matches!(*arg, "install" | "-g" | "--global") {
+                continue;
+            }
+            args.push((*arg).to_string());
+        }
+        args
+    }
+
+    /// What one route does, as a line an operator reads back.
+    ///
+    /// This is the string every report row quotes, and the key `provision`
+    /// deduplicates on, so two languages served by one route still ask once and
+    /// run once.
+    pub(crate) fn route_command_line(&self, route: InstallRoute) -> String {
+        match route {
+            InstallRoute::Installer => self.command_line(),
+            InstallRoute::ManagedPrefix => format!(
+                "{} {}",
+                self.program,
+                self.managed_prefix_args(&kin_core::tool_prefix::managed_node_prefix())
+                    .join(" ")
+            ),
+            InstallRoute::PinnedRelease => match self.fallback {
+                Fallback::PinnedRelease(release) => format!(
+                    "download {} {} from the {} release binaries",
+                    release.binary, release.tag, release.project
+                ),
+                // Unreachable through `choose_route`, which only returns this
+                // route for a recipe whose fallback is a pinned release. Stated
+                // rather than panicked, because a report row is not worth an
+                // abort.
+                Fallback::ManagedPrefix => self.command_line(),
+            },
+        }
+    }
+}
+
+/// What this host leaves open for a recipe, measured against the live machine.
+///
+/// The probe half of [`choose_route`], kept apart from the rule so the rule
+/// stays decidable without a host. `default_target_blocked` costs an `npm
+/// config get prefix` subprocess for the npm recipes and nothing for the rest.
+pub(crate) fn resolve_host_routes(recipe: &LanguageServerRecipe) -> HostRoutes {
+    let installer_on_path = recipe.installer_available();
+    HostRoutes {
+        installer_on_path,
+        default_target_blocked: installer_on_path && install_blocker(recipe).is_some(),
+        pinned_release_for_this_host: match recipe.fallback {
+            Fallback::PinnedRelease(release) => language_server_release::host_target()
+                .is_some_and(|target| release.asset_for(target).is_some()),
+            Fallback::ManagedPrefix => false,
+        },
+    }
+}
+
+/// The route this host leaves open for a recipe, probing the machine.
+pub(crate) fn resolve_route(recipe: &LanguageServerRecipe) -> Option<InstallRoute> {
+    choose_route(recipe, resolve_host_routes(recipe))
 }
 
 /// The typescript package `typescript-language-server` is installed beside.
@@ -101,6 +256,7 @@ pub(crate) const LANGUAGE_SERVERS: &[LanguageServerRecipe] = &[
         binaries: &["rust-analyzer"],
         program: "rustup",
         args: &["component", "add", "rust-analyzer"],
+        fallback: Fallback::PinnedRelease(&RUST_ANALYZER_RELEASE),
         disclosure: "adds a rustup component to the active toolchain",
     },
     LanguageServerRecipe {
@@ -108,6 +264,7 @@ pub(crate) const LANGUAGE_SERVERS: &[LanguageServerRecipe] = &[
         binaries: &["pyright-langserver", "pylsp"],
         program: "npm",
         args: &["install", "-g", "pyright"],
+        fallback: Fallback::ManagedPrefix,
         disclosure: "downloads the pyright npm package into your global npm prefix",
     },
     LanguageServerRecipe {
@@ -120,6 +277,7 @@ pub(crate) const LANGUAGE_SERVERS: &[LanguageServerRecipe] = &[
             "typescript-language-server",
             TYPESCRIPT_PACKAGE,
         ],
+        fallback: Fallback::ManagedPrefix,
         disclosure: "downloads the typescript-language-server and typescript npm packages into \
                      your global npm prefix",
     },
@@ -133,6 +291,7 @@ pub(crate) const LANGUAGE_SERVERS: &[LanguageServerRecipe] = &[
             "typescript-language-server",
             TYPESCRIPT_PACKAGE,
         ],
+        fallback: Fallback::ManagedPrefix,
         disclosure: "downloads the typescript-language-server and typescript npm packages into \
                      your global npm prefix",
     },
@@ -229,6 +388,35 @@ pub(crate) fn install_commands_for_names(names: &[&str]) -> Vec<String> {
     seen
 }
 
+/// What Kin would actually do for each missing language on THIS host,
+/// deduplicated.
+///
+/// The sibling of [`install_commands_for`], and the one to print at a person.
+/// That function answers "what does this recipe say", which is the right answer
+/// for a doc and the wrong one at a terminal: on a host with no rustup it prints
+/// `rustup component add rust-analyzer`, an instruction to install a toolchain
+/// in order to read somebody else's code. This one probes the host and prints
+/// the route Kin has, which on that host is a pinned download.
+pub(crate) fn route_commands_for(missing: &[LanguageId]) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for language in missing {
+        let Some(recipe) = recipe_for(*language) else {
+            continue;
+        };
+        let command = match resolve_route(recipe) {
+            Some(route) => recipe.route_command_line(route),
+            // No route at all. The recipe's own command is still the honest
+            // thing to print, because installing what it names is exactly what
+            // would open one.
+            None => recipe.command_line(),
+        };
+        if !seen.contains(&command) {
+            seen.push(command);
+        }
+    }
+    seen
+}
+
 /// The fix line for a set of languages whose servers are missing.
 ///
 /// Names the command rather than describing it. A row that says "install a
@@ -251,6 +439,38 @@ pub(crate) fn install_fix_line(missing_names: &[&str]) -> String {
             .collect::<Vec<_>>()
             .join(" and "),
     )
+}
+
+/// What the operator is spending by saying yes to one ROUTE.
+///
+/// The recipe's own `disclosure` describes its installer, and it is the wrong
+/// sentence for two of the three routes. "Adds a rustup component to the active
+/// toolchain" is not what a pinned download does, and a person consenting to a
+/// network fetch of a binary from a project's releases is owed the tag, the
+/// digest and the directory rather than a sentence about a toolchain they do
+/// not have.
+pub(crate) fn route_disclosure(recipe: &LanguageServerRecipe, route: InstallRoute) -> String {
+    match route {
+        InstallRoute::Installer => recipe.disclosure.to_string(),
+        InstallRoute::ManagedPrefix => format!(
+            "runs the same install against {}, a prefix Kin owns under KIN_HOME, because this \
+             host's global npm prefix refuses this user",
+            kin_core::tool_prefix::managed_node_prefix().display()
+        ),
+        InstallRoute::PinnedRelease => match recipe.fallback {
+            Fallback::PinnedRelease(release) => format!(
+                "downloads {} {} from the {} release binaries, checks it against a sha256 \
+                 recorded in Kin's own source, and installs it into {}. Your toolchain is not \
+                 touched, and this route is taken because `{}` is not on this host.",
+                release.binary,
+                release.tag,
+                release.project,
+                kin_core::tool_prefix::managed_tool_bin_dir().display(),
+                recipe.program,
+            ),
+            Fallback::ManagedPrefix => recipe.disclosure.to_string(),
+        },
+    }
 }
 
 /// Whether Kin may install a language server, and on whose say-so.
@@ -281,13 +501,35 @@ impl InstallConsent {
     }
 }
 
+/// Why one install could not be completed, separated by what a reader has to
+/// do about it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum InstallProblem {
+    /// The installer ran, or the download was attempted, and it did not work.
+    Failed { reason: String },
+    /// Bytes arrived and are not the bytes Kin pins. Its own variant because it
+    /// is the one failure that is never worth retrying and never the network's
+    /// fault, and because a reader must not read it as a flaky download.
+    ChecksumMismatch { reason: String },
+}
+
 /// What happened to one language's server.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum InstallOutcome {
     /// A binary for this language was already on `PATH`.
     AlreadyPresent,
     /// The install command ran and the binary is now on `PATH`.
-    Installed { command: String },
+    ///
+    /// `evidence` is what the run can show for it: for a download Kin performed
+    /// itself, the URL the bytes came from and the digest verified before they
+    /// were written. Empty for a route where the disclosure belongs to the
+    /// installer, which printed its own output live.
+    Installed {
+        command: String,
+        evidence: Vec<String>,
+    },
+    /// Bytes were served and refused. Nothing was installed.
+    ChecksumRefused { command: String, reason: String },
     /// The install command ran and the binary is still not on `PATH`. Reported
     /// rather than assumed installed: a zero exit from a package manager that
     /// wrote to a prefix outside `PATH` is the failure that reads as success.
@@ -316,28 +558,33 @@ pub(crate) struct InstallReport {
 /// which is a green test that has stopped checking its own subject. As written,
 /// a test states the whole environment it is asserting against.
 ///
+/// `route` reports which of a recipe's routes this host leaves open, and `None`
+/// is the state that used to be the only answer for a host with no installer.
+/// `ask` and `run` both take the route, because the disclosure and the work
+/// differ by it: consenting to a rustup component and consenting to a download
+/// from a release Kin pins are not the same consent.
+///
 /// `ask` is called at most once per distinct command, so consenting to
 /// TypeScript does not produce a second prompt for JavaScript.
 pub(crate) fn provision(
     missing: &[LanguageId],
     consent: InstallConsent,
     mut installed: impl FnMut(&LanguageServerRecipe) -> bool,
-    mut installer_available: impl FnMut(&LanguageServerRecipe) -> bool,
-    mut ask: impl FnMut(&LanguageServerRecipe) -> bool,
-    mut run: impl FnMut(&LanguageServerRecipe) -> Result<(), String>,
+    mut route: impl FnMut(&LanguageServerRecipe) -> Option<InstallRoute>,
+    mut ask: impl FnMut(&LanguageServerRecipe, InstallRoute) -> bool,
+    mut run: impl FnMut(&LanguageServerRecipe, InstallRoute) -> Result<Vec<String>, InstallProblem>,
 ) -> Vec<InstallReport> {
     let mut reports = Vec::new();
     // Keyed on the command rather than the language: one npm install serves
     // both JavaScript and TypeScript, and running it twice would download the
     // same package again and ask twice for one decision.
     let mut decided: Vec<(String, bool)> = Vec::new();
-    let mut ran: Vec<(String, Result<(), String>)> = Vec::new();
+    let mut ran: Vec<(String, Result<Vec<String>, InstallProblem>)> = Vec::new();
 
     for language in missing {
         let Some(recipe) = recipe_for(*language) else {
             continue;
         };
-        let command = recipe.command_line();
 
         if installed(recipe) {
             reports.push(InstallReport {
@@ -347,16 +594,17 @@ pub(crate) fn provision(
             continue;
         }
 
-        if !installer_available(recipe) {
+        let Some(chosen) = route(recipe) else {
             reports.push(InstallReport {
                 language: *language,
                 outcome: InstallOutcome::NoInstaller {
                     program: recipe.program.to_string(),
-                    command,
+                    command: recipe.command_line(),
                 },
             });
             continue;
-        }
+        };
+        let command = recipe.route_command_line(chosen);
 
         let approved = match consent {
             InstallConsent::Granted => true,
@@ -364,7 +612,7 @@ pub(crate) fn provision(
             InstallConsent::Ask => match decided.iter().find(|(cmd, _)| cmd == &command) {
                 Some((_, answer)) => *answer,
                 None => {
-                    let answer = ask(recipe);
+                    let answer = ask(recipe, chosen);
                     decided.push((command.clone(), answer));
                     answer
                 }
@@ -382,20 +630,23 @@ pub(crate) fn provision(
         let result = match ran.iter().find(|(cmd, _)| cmd == &command) {
             Some((_, result)) => result.clone(),
             None => {
-                let result = run(recipe);
+                let result = run(recipe, chosen);
                 ran.push((command.clone(), result.clone()));
                 result
             }
         };
 
         let outcome = match result {
-            Err(reason) => InstallOutcome::Failed { command, reason },
+            Err(InstallProblem::ChecksumMismatch { reason }) => {
+                InstallOutcome::ChecksumRefused { command, reason }
+            }
+            Err(InstallProblem::Failed { reason }) => InstallOutcome::Failed { command, reason },
             // Re-probe `PATH` rather than trusting the exit code. A global npm
             // prefix outside `PATH` installs successfully and leaves the binary
             // unreachable, which is the shape of success that would let doctor
             // report a closed gap that is still open.
-            Ok(()) if installed(recipe) => InstallOutcome::Installed { command },
-            Ok(()) => InstallOutcome::RanButStillMissing { command },
+            Ok(evidence) if installed(recipe) => InstallOutcome::Installed { command, evidence },
+            Ok(_) => InstallOutcome::RanButStillMissing { command },
         };
         reports.push(InstallReport {
             language: *language,
@@ -787,25 +1038,112 @@ pub(crate) fn unreachable_after_install_remediation(recipe: &LanguageServerRecip
     )]
 }
 
-/// Run a recipe's install command, streaming the installer's own output.
+/// Perform one recipe's install along the route this host left open.
 ///
-/// Two things happen here that a bare `status()` cannot do. The prefix is
-/// checked before the command runs, because `npm install -g` against a prefix
-/// this user cannot write ends in an EACCES trace that is npm's diagnostic
-/// rather than Kin's, and Kin can know the answer without spending the attempt.
-/// And stderr is teed rather than inherited, so the operator still reads the
-/// installer live while a failure keeps the installer's own words for the
-/// report at the end: a reason that says only "exited with 243" sends someone
-/// back to scroll a terminal for the cause (FIR-2547).
-pub(crate) fn run_install(recipe: &LanguageServerRecipe) -> Result<(), String> {
-    if let Some(blocker) = install_blocker(recipe) {
-        return Err(blocker);
+/// Three routes, one contract: the returned lines are what the run can SHOW for
+/// what it did, and an error is either an ordinary failure or a digest that did
+/// not match. Nothing here reports success it did not verify; `provision`
+/// re-probes `PATH` afterwards either way, because a package manager that
+/// wrote to a prefix nothing reads exits zero.
+pub(crate) fn run_install(
+    recipe: &LanguageServerRecipe,
+    route: InstallRoute,
+) -> Result<Vec<String>, InstallProblem> {
+    match route {
+        InstallRoute::Installer => {
+            if let Some(blocker) = install_blocker(recipe) {
+                return Err(InstallProblem::Failed { reason: blocker });
+            }
+            run_program(
+                recipe,
+                recipe.program,
+                &recipe
+                    .args
+                    .iter()
+                    .map(|a| (*a).to_string())
+                    .collect::<Vec<_>>(),
+                &recipe.command_line(),
+            )
+            .map(|()| Vec::new())
+        }
+        InstallRoute::ManagedPrefix => {
+            let prefix = kin_core::tool_prefix::managed_node_prefix();
+            std::fs::create_dir_all(&prefix).map_err(|error| InstallProblem::Failed {
+                reason: format!("could not create {}: {error}", prefix.display()),
+            })?;
+            let args = recipe.managed_prefix_args(&prefix);
+            let command = recipe.route_command_line(route);
+            run_program(recipe, recipe.program, &args, &command).map(|()| {
+                vec![
+                    format!("source:   {}, integrity checked by npm", recipe.program),
+                    format!(
+                        "installed to: {}",
+                        kin_core::tool_prefix::managed_node_bin_dir().display()
+                    ),
+                ]
+            })
+        }
+        InstallRoute::PinnedRelease => {
+            let Fallback::PinnedRelease(release) = recipe.fallback else {
+                return Err(InstallProblem::Failed {
+                    reason: format!(
+                        "{}: no pinned release binary is recorded for this language",
+                        recipe.language
+                    ),
+                });
+            };
+            let bin_dir = kin_core::tool_prefix::managed_tool_bin_dir();
+            let target = language_server_release::host_target();
+            let Some(asset) = target.and_then(|target| release.asset_for(target)) else {
+                return Err(InstallProblem::Failed {
+                    reason: language_server_release::InstallFailure::UnsupportedHost {
+                        target: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+                    }
+                    .reason(),
+                });
+            };
+            let (base, expected) = language_server_release::resolve_source_from_env(release, asset);
+            match language_server_release::install_pinned_release(
+                release, target, &bin_dir, &base, &expected,
+            ) {
+                Ok(install) => Ok(install.evidence_lines()),
+                Err(failure @ language_server_release::InstallFailure::ChecksumMismatch { .. }) => {
+                    Err(InstallProblem::ChecksumMismatch {
+                        reason: failure.reason(),
+                    })
+                }
+                Err(failure) => Err(InstallProblem::Failed {
+                    reason: failure.reason(),
+                }),
+            }
+        }
     }
-    let mut child = Command::new(recipe.program)
-        .args(recipe.args)
+}
+
+/// Run one installer, streaming its own output and keeping its words on a
+/// failure.
+///
+/// Two things happen here that a bare `status()` cannot do. Stderr is teed
+/// rather than inherited, so the operator still reads the installer live while
+/// a failure keeps the installer's own words for the report at the end: a
+/// reason that says only "exited with 243" sends someone back to scroll a
+/// terminal for the cause (FIR-2547). And the command as an operator would type
+/// it is passed in rather than recomposed, so a redirected install reports the
+/// command that actually ran.
+fn run_program(
+    recipe: &LanguageServerRecipe,
+    program: &str,
+    args: &[String],
+    command_line: &str,
+) -> Result<(), InstallProblem> {
+    let _ = recipe;
+    let mut child = Command::new(program)
+        .args(args)
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|error| format!("could not run `{}`: {error}", recipe.command_line()))?;
+        .map_err(|error| InstallProblem::Failed {
+            reason: format!("could not run `{command_line}`: {error}"),
+        })?;
     let mut stderr_lines: Vec<String> = Vec::new();
     if let Some(stderr) = child.stderr.take() {
         for line in BufReader::new(stderr).lines().map_while(Result::ok) {
@@ -822,17 +1160,15 @@ pub(crate) fn run_install(recipe: &LanguageServerRecipe) -> Result<(), String> {
             }
         }
     }
-    let status = child
-        .wait()
-        .map_err(|error| format!("could not wait for `{}`: {error}", recipe.command_line()))?;
+    let status = child.wait().map_err(|error| InstallProblem::Failed {
+        reason: format!("could not wait for `{command_line}`: {error}"),
+    })?;
     if status.success() {
         Ok(())
     } else {
-        Err(installer_failure_reason(
-            &recipe.command_line(),
-            status.code(),
-            &stderr_lines,
-        ))
+        Err(InstallProblem::Failed {
+            reason: installer_failure_reason(command_line, status.code(), &stderr_lines),
+        })
     }
 }
 
@@ -1292,8 +1628,11 @@ mod tests {
     fn nothing_installed(_: &LanguageServerRecipe) -> bool {
         false
     }
-    fn installer_present(_: &LanguageServerRecipe) -> bool {
-        true
+    fn installer_present(_: &LanguageServerRecipe) -> Option<InstallRoute> {
+        Some(InstallRoute::Installer)
+    }
+    fn no_route(_: &LanguageServerRecipe) -> Option<InstallRoute> {
+        None
     }
 
     /// The whole point of the consent model: nothing runs unless someone said so.
@@ -1305,10 +1644,10 @@ mod tests {
             InstallConsent::Withheld,
             nothing_installed,
             installer_present,
-            |_| panic!("must not prompt when consent is withheld"),
-            |_| {
+            |_, _| panic!("must not prompt when consent is withheld"),
+            |_, _| {
                 runs += 1;
-                Ok(())
+                Ok(Vec::new())
             },
         );
         assert_eq!(runs, 0, "an install ran without consent");
@@ -1328,10 +1667,10 @@ mod tests {
             InstallConsent::Ask,
             nothing_installed,
             installer_present,
-            |_| false,
-            |_| {
+            |_, _| false,
+            |_, _| {
                 runs += 1;
-                Ok(())
+                Ok(Vec::new())
             },
         );
         assert_eq!(runs, 0);
@@ -1353,13 +1692,13 @@ mod tests {
             InstallConsent::Ask,
             nothing_installed,
             installer_present,
-            |_| {
+            |_, _| {
                 prompts += 1;
                 true
             },
-            |_| {
+            |_, _| {
                 runs += 1;
-                Ok(())
+                Ok(Vec::new())
             },
         );
         assert_eq!(prompts, 1, "one install command must ask exactly once");
@@ -1383,10 +1722,10 @@ mod tests {
             InstallConsent::Granted,
             |_| ran.get(),
             installer_present,
-            |_| panic!("granted consent must not prompt"),
-            |_| {
+            |_, _| panic!("granted consent must not prompt"),
+            |_, _| {
                 ran.set(true);
-                Ok(())
+                Ok(Vec::new())
             },
         );
         assert!(ran.get(), "the install command never ran");
@@ -1416,8 +1755,8 @@ mod tests {
             InstallConsent::Granted,
             nothing_installed,
             installer_present,
-            |_| true,
-            |_| Ok(()),
+            |_, _| true,
+            |_, _| Ok(Vec::new()),
         );
         assert!(
             matches!(
@@ -1435,8 +1774,12 @@ mod tests {
             InstallConsent::Granted,
             nothing_installed,
             installer_present,
-            |_| true,
-            |_| Err("network unreachable".to_string()),
+            |_, _| true,
+            |_, _| {
+                Err(InstallProblem::Failed {
+                    reason: "network unreachable".to_string(),
+                })
+            },
         );
         match reports.first().map(|r| &r.outcome) {
             Some(InstallOutcome::Failed { reason, command }) => {
@@ -1456,11 +1799,11 @@ mod tests {
             &[LanguageId::Python],
             InstallConsent::Granted,
             nothing_installed,
-            |_| false,
-            |_| panic!("must not prompt when the installer is absent"),
-            |_| {
+            no_route,
+            |_, _| panic!("must not prompt when no route is open"),
+            |_, _| {
                 runs += 1;
-                Ok(())
+                Ok(Vec::new())
             },
         );
         assert_eq!(runs, 0);
@@ -1483,10 +1826,10 @@ mod tests {
             InstallConsent::Granted,
             |_| true,
             installer_present,
-            |_| panic!("must not prompt for something already installed"),
-            |_| {
+            |_, _| panic!("must not prompt for something already installed"),
+            |_, _| {
                 runs += 1;
-                Ok(())
+                Ok(Vec::new())
             },
         );
         assert_eq!(runs, 0);
@@ -1495,6 +1838,275 @@ mod tests {
                 .iter()
                 .all(|r| r.outcome == InstallOutcome::AlreadyPresent),
             "{reports:?}"
+        );
+    }
+
+    // ---- route selection --------------------------------------------------
+
+    fn host(installer: bool, blocked: bool, pinned: bool) -> HostRoutes {
+        HostRoutes {
+            installer_on_path: installer,
+            default_target_blocked: blocked,
+            pinned_release_for_this_host: pinned,
+        }
+    }
+
+    /// The host the cold walkthrough measured: node and npm present, no rustup.
+    ///
+    /// This is the finding, stated as a test. On 2026-08-28 a stranger followed
+    /// the documented install on exactly this host and `kin doctor --fix
+    /// --install-language-servers` exited 1 with "'rustup' is not installed on
+    /// this host", leaving a Rust repository at `imports 0/1085 (0%)`. Rust must
+    /// now route to the pinned release, and the npm-served languages must keep
+    /// the installer they already had, because changing those would be a
+    /// regression dressed as a fix.
+    #[test]
+    fn a_host_with_npm_and_no_rustup_gets_every_language_a_route() {
+        let rust = recipe_for(LanguageId::Rust).expect("rust must have a recipe");
+        assert_eq!(
+            choose_route(rust, host(false, false, true)),
+            Some(InstallRoute::PinnedRelease),
+            "a host with no rustup must still get a Rust language server"
+        );
+        for language in [
+            LanguageId::Python,
+            LanguageId::TypeScript,
+            LanguageId::JavaScript,
+        ] {
+            let recipe = recipe_for(language).expect("recipe must exist");
+            assert_eq!(
+                choose_route(recipe, host(true, false, false)),
+                Some(InstallRoute::Installer),
+                "{language}: a working npm must keep its own route"
+            );
+        }
+    }
+
+    /// rustup wins wherever it exists.
+    ///
+    /// The direction matters as much as the fallback. A rustup component tracks
+    /// the toolchain that compiles the repository and Kin's pinned copy does
+    /// not, so a host that has rustup must never be quietly moved onto Kin's
+    /// download.
+    #[test]
+    fn the_recipes_own_installer_outranks_kins_fallback() {
+        let rust = recipe_for(LanguageId::Rust).expect("rust must have a recipe");
+        assert_eq!(
+            choose_route(rust, host(true, false, true)),
+            Some(InstallRoute::Installer),
+            "a host with rustup must get the rustup component"
+        );
+    }
+
+    /// An npm whose global prefix refuses this user is redirected, not refused.
+    ///
+    /// The container case: a Node base image sets the global prefix to
+    /// `/usr/local`, whose `lib/node_modules` is owned by root. Before this
+    /// route the install was correctly refused before it spent the download,
+    /// and correctly refused is still no language server.
+    #[test]
+    fn a_blocked_npm_prefix_routes_to_a_prefix_kin_owns() {
+        for language in [
+            LanguageId::Python,
+            LanguageId::TypeScript,
+            LanguageId::JavaScript,
+        ] {
+            let recipe = recipe_for(language).expect("recipe must exist");
+            assert_eq!(
+                choose_route(recipe, host(true, true, false)),
+                Some(InstallRoute::ManagedPrefix),
+                "{language}: a prefix this user cannot write must not end the attempt"
+            );
+        }
+    }
+
+    /// A blocked rustup falls to the pinned release rather than to nothing.
+    #[test]
+    fn a_blocked_rust_installer_still_reaches_the_pinned_release() {
+        let rust = recipe_for(LanguageId::Rust).expect("rust must have a recipe");
+        assert_eq!(
+            choose_route(rust, host(true, true, true)),
+            Some(InstallRoute::PinnedRelease)
+        );
+    }
+
+    /// The cases that genuinely leave no route, so the refusal is still real.
+    ///
+    /// A rule that always answers `Some` is a rule that has stopped deciding.
+    /// Two hosts must still come back with nothing: a Rust host Kin pins no
+    /// binary for, and a machine with no Node at all, where the only honest
+    /// move is to say so rather than install a language runtime unasked.
+    #[test]
+    fn a_host_that_leaves_no_route_open_is_still_refused() {
+        let rust = recipe_for(LanguageId::Rust).expect("rust must have a recipe");
+        assert_eq!(
+            choose_route(rust, host(false, false, false)),
+            None,
+            "no rustup and no pinned binary for this host is a real refusal"
+        );
+        let python = recipe_for(LanguageId::Python).expect("python must have a recipe");
+        assert_eq!(
+            choose_route(python, host(false, false, false)),
+            None,
+            "no npm means no Node, and Kin does not install a runtime unasked"
+        );
+        assert_eq!(
+            choose_route(python, host(false, false, true)),
+            None,
+            "a pinned-release flag must not rescue a recipe with no pinned release"
+        );
+    }
+
+    /// The managed-prefix command is the same install, redirected, pin intact.
+    ///
+    /// The TypeScript 5.x pin is the reason this is asserted rather than
+    /// assumed. Every copy of the install command that drops it walks the
+    /// operator into a TypeScript 7 that ships no `lib/tsserver.js`, and this
+    /// route rewrites the argument list, which is exactly where a pin gets
+    /// lost.
+    #[test]
+    fn the_managed_prefix_command_keeps_the_packages_and_their_pin() {
+        let recipe = recipe_for(LanguageId::TypeScript).expect("typescript must have a recipe");
+        let args = recipe.managed_prefix_args(Path::new("/home/u/.kin/tools/node"));
+        assert_eq!(
+            args,
+            vec![
+                "install".to_string(),
+                "--prefix".to_string(),
+                "/home/u/.kin/tools/node".to_string(),
+                "typescript-language-server".to_string(),
+                "typescript@^5".to_string(),
+            ],
+            "the global flag is dropped, the prefix inserted, and the packages untouched"
+        );
+        assert!(
+            !args.contains(&"-g".to_string()),
+            "a redirected install must not also be global"
+        );
+    }
+
+    /// Two languages behind one redirected install still ask and run once.
+    ///
+    /// The deduplication key moved from the recipe's command to the route's
+    /// command, and a key that no longer collides would download the same npm
+    /// package twice and prompt twice for one decision.
+    #[test]
+    fn one_redirected_install_serves_both_javascript_and_typescript() {
+        let mut prompts = 0;
+        let mut runs = 0;
+        let reports = provision(
+            &[LanguageId::TypeScript, LanguageId::JavaScript],
+            InstallConsent::Ask,
+            nothing_installed,
+            |_| Some(InstallRoute::ManagedPrefix),
+            |_, route| {
+                assert_eq!(route, InstallRoute::ManagedPrefix);
+                prompts += 1;
+                true
+            },
+            |_, _| {
+                runs += 1;
+                Ok(Vec::new())
+            },
+        );
+        assert_eq!(prompts, 1, "one route command must ask exactly once");
+        assert_eq!(runs, 1, "one route command must run exactly once");
+        assert_eq!(reports.len(), 2);
+    }
+
+    /// A digest that did not match is its own outcome, never a plain failure.
+    ///
+    /// The two need different words and different advice, and a reader must not
+    /// take "the bytes were wrong" for "the network was flaky" and retry into
+    /// the same wall.
+    #[test]
+    fn a_checksum_mismatch_reports_its_own_outcome() {
+        let ran = std::cell::Cell::new(false);
+        let reports = provision(
+            &[LanguageId::Rust],
+            InstallConsent::Granted,
+            |_| ran.get(),
+            |_| Some(InstallRoute::PinnedRelease),
+            |_, _| panic!("granted consent must not prompt"),
+            |_, _| {
+                ran.set(true);
+                Err(InstallProblem::ChecksumMismatch {
+                    reason: "served bytes hash to abc, Kin pins def".to_string(),
+                })
+            },
+        );
+        match reports.first().map(|r| &r.outcome) {
+            Some(InstallOutcome::ChecksumRefused { reason, command }) => {
+                assert!(reason.contains("Kin pins def"), "{reason}");
+                assert!(
+                    command.contains("download rust-analyzer"),
+                    "the row must name the route that was refused: {command}"
+                );
+            }
+            other => panic!("a mismatch must not read as an ordinary failure: {other:?}"),
+        }
+    }
+
+    /// A successful pinned install carries its evidence into the report.
+    ///
+    /// A tick beside "installed" is not a disclosure. The URL and the digest
+    /// have to reach the row an operator reads, or the verification happened
+    /// somewhere nobody can check it.
+    #[test]
+    fn a_pinned_install_carries_its_source_and_digest_into_the_report() {
+        let ran = std::cell::Cell::new(false);
+        let reports = provision(
+            &[LanguageId::Rust],
+            InstallConsent::Granted,
+            |_| ran.get(),
+            |_| Some(InstallRoute::PinnedRelease),
+            |_, _| panic!("granted consent must not prompt"),
+            |_, _| {
+                ran.set(true);
+                Ok(vec![
+                    "source:   https://example.invalid/rust-analyzer.gz".to_string(),
+                    "sha256:   abc (verified before install)".to_string(),
+                ])
+            },
+        );
+        match reports.first().map(|r| &r.outcome) {
+            Some(InstallOutcome::Installed { evidence, .. }) => {
+                let joined = evidence.join("\n");
+                assert!(joined.contains("https://example.invalid"), "{joined}");
+                assert!(joined.contains("sha256"), "{joined}");
+            }
+            other => panic!("unexpected outcome {other:?}"),
+        }
+    }
+
+    /// The pinned-download disclosure describes the download, not rustup.
+    ///
+    /// A person consenting to a network fetch of somebody's release binary is
+    /// owed the tag, the digest promise and the directory. "Adds a rustup
+    /// component to the active toolchain" is a true sentence about a route this
+    /// host is not taking, and it is the sentence the recipe carries.
+    #[test]
+    fn the_download_disclosure_describes_the_download() {
+        let rust = recipe_for(LanguageId::Rust).expect("rust must have a recipe");
+        let disclosure = route_disclosure(rust, InstallRoute::PinnedRelease);
+        assert!(
+            disclosure.contains(RUST_ANALYZER_RELEASE.tag),
+            "{disclosure}"
+        );
+        assert!(disclosure.contains("sha256"), "{disclosure}");
+        assert!(
+            disclosure.contains("rust-lang/rust-analyzer"),
+            "the project the bytes come from must be named: {disclosure}"
+        );
+        assert!(
+            !disclosure.contains("rustup component"),
+            "the download must not be described as a toolchain change: {disclosure}"
+        );
+
+        // Control: the installer route keeps the recipe's own sentence.
+        assert_eq!(
+            route_disclosure(rust, InstallRoute::Installer),
+            rust.disclosure
         );
     }
 

--- a/crates/kin-cli/src/commands/language_servers.rs
+++ b/crates/kin-cli/src/commands/language_servers.rs
@@ -1172,6 +1172,54 @@ fn run_program(
     }
 }
 
+/// A dependency the installed server itself needs, which Kin did not install.
+///
+/// Installing the server is not the same as the server being able to answer,
+/// and for Rust the difference is total. rust-analyzer loads a workspace by
+/// running `cargo metadata`; with no `cargo` on PATH it starts, completes a
+/// handshake, reports itself available, and loads no project at all, so every
+/// reference query comes back empty from a server that is running. Its own
+/// words on such a host are "Failed to load the project at Cargo.toml", caused
+/// by `cargo locate-project` failing.
+///
+/// Measured on 2026-08-28 in a Debian 12 container on `tokio-rs/axum` at
+/// `8f6bb9ce`, twice from a fresh store with only this variable changed. With
+/// cargo: `calls 3498/11883 (29%)`, `cross-file 5345`, and `find_references`
+/// on `Router` answers. Without it: `calls 2191/11883 (18%)`, `cross-file
+/// 1557`, and the same query answers zero.
+///
+/// Kin does not install a language toolchain on a user's machine, so the only
+/// honest move is to name the gap beside the install that did not close it.
+/// `present` is taken as an argument so a test states the host it asserts
+/// against rather than inheriting whichever machine ran it.
+pub(crate) fn unmet_runtime_dependency(
+    recipe: &LanguageServerRecipe,
+    present: impl Fn(&str) -> bool,
+) -> Option<String> {
+    if recipe.language != LanguageId::Rust || present("cargo") {
+        return None;
+    }
+    Some(
+        "the rust language server is installed and cannot resolve this project yet: \
+         rust-analyzer loads a Rust workspace by running `cargo metadata`, and no `cargo` is \
+         on PATH. Cross-file Rust reference edges stay parse-derived until a Rust toolchain is \
+         installed, so `find_references` on a Rust symbol will keep answering empty and Kin \
+         will keep reporting that answer as inconclusive rather than as an absence."
+            .to_string(),
+    )
+}
+
+/// The remedy for the gap [`unmet_runtime_dependency`] names.
+pub(crate) fn runtime_dependency_remedy() -> Vec<String> {
+    vec![
+        "install a Rust toolchain, which is what rust-analyzer reads the project through:"
+            .to_string(),
+        "    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh".to_string(),
+        format!("then {RESTART_AFTER_INSTALL}"),
+        WORKS_WITHOUT_LANGUAGE_SERVERS.to_string(),
+    ]
+}
+
 /// Whether a newly installed server reaches a daemon that is already running.
 ///
 /// It does not, when the daemon started on a host with no server at all.
@@ -1839,6 +1887,62 @@ mod tests {
                 .all(|r| r.outcome == InstallOutcome::AlreadyPresent),
             "{reports:?}"
         );
+    }
+
+    // ---- the dependency the installed server itself needs ------------------
+
+    /// Rust with no cargo is named; Rust with cargo is silent.
+    ///
+    /// The container proof is what this encodes. Installing rust-analyzer on a
+    /// host with no toolchain leaves a server that starts and loads nothing, and
+    /// a run that reported only "installed" would be telling a reader their
+    /// reference edges are coming.
+    #[test]
+    fn rust_without_cargo_is_named_and_rust_with_cargo_is_not() {
+        let rust = recipe_for(LanguageId::Rust).expect("rust must have a recipe");
+        let gap = unmet_runtime_dependency(rust, |_| false)
+            .expect("a host with no cargo must be told what the server still cannot do");
+        assert!(gap.contains("cargo metadata"), "{gap}");
+        assert!(
+            gap.contains("parse-derived"),
+            "the reader must be told what they still have: {gap}"
+        );
+        assert_eq!(
+            unmet_runtime_dependency(rust, |program| program == "cargo"),
+            None,
+            "a host with cargo has no gap to name"
+        );
+    }
+
+    /// No other language claims a toolchain dependency it does not have.
+    ///
+    /// The control. A check that named a gap for every language would fire on
+    /// every host and be wallpaper, and the npm-served servers genuinely need
+    /// nothing beyond Node, which installing them already proved present.
+    #[test]
+    fn the_npm_served_languages_name_no_toolchain_gap() {
+        for language in [
+            LanguageId::Python,
+            LanguageId::TypeScript,
+            LanguageId::JavaScript,
+        ] {
+            let recipe = recipe_for(language).expect("recipe must exist");
+            assert_eq!(
+                unmet_runtime_dependency(recipe, |_| false),
+                None,
+                "{language}: no toolchain gap exists for an npm-served server"
+            );
+        }
+    }
+
+    /// The remedy names the toolchain installer and the restart, and says what
+    /// still works.
+    #[test]
+    fn the_toolchain_remedy_names_the_installer_and_the_restart() {
+        let lines = runtime_dependency_remedy().join("\n");
+        assert!(lines.contains("sh.rustup.rs"), "{lines}");
+        assert!(lines.contains("kin daemon stop"), "{lines}");
+        assert!(lines.contains("Kin runs without this server"), "{lines}");
     }
 
     // ---- route selection --------------------------------------------------

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -42,6 +42,7 @@ pub mod history;
 pub mod impact;
 pub mod init;
 pub mod intent;
+pub mod language_server_release;
 pub mod language_servers;
 pub mod languages;
 pub mod locate;

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13306,6 +13306,34 @@ async fn apply_language_server_provisioning(
                 for line in evidence {
                     applied.push(format!("    {line}"));
                 }
+                // Installed is not the same as able to answer. On a host with
+                // no Rust toolchain the server Kin just installed starts,
+                // reports itself available, and loads no project, so a run that
+                // stopped at the tick would be telling a reader their reference
+                // edges are coming when they are not.
+                if let Some(recipe) = recipe {
+                    if let Some(gap) =
+                        language_servers::unmet_runtime_dependency(recipe, |program| {
+                            which::which(program).is_ok()
+                        })
+                    {
+                        println!("  {} {gap}", style("!").yellow());
+                        unfinished.push(UnfinishedRepair {
+                            what: format!(
+                                "produce cross-file reference edges for {}",
+                                report.language
+                            ),
+                            reason: gap,
+                            remediation: language_servers::runtime_dependency_remedy(),
+                            // The repair that was asked for did happen: the
+                            // server is installed. This is the separate gap it
+                            // left standing, so it is reported loudly and does
+                            // not flip the exit code of a request that
+                            // completed.
+                            requested: false,
+                        });
+                    }
+                }
             }
             // Its own arm, above `Failed`, because the two need different
             // words. A network error is worth retrying and a digest that did

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -12903,6 +12903,23 @@ fn print_next_steps(
     println!("  kin setup doctor     -- run health checks (use --fix to repair)");
     println!("  kin setup ledger     -- show what setup wrote + verify it on disk");
     println!("  kin setup uninstall  -- remove exactly what setup wrote (ledger-verified)");
+    // Named here because this is the list a first run reads to the end. Cross-file
+    // reference edges are the answer Kin is sold on and they need a server per
+    // language, so a host missing one is owed the command rather than the
+    // discovery that `find_references` returns nothing.
+    let missing_servers = language_servers::missing_enrichable_languages();
+    if !missing_servers.is_empty() {
+        println!(
+            "  kin doctor --fix --install-language-servers  -- install the {} language \
+             server{} this host is missing, which is what cross-file reference edges need",
+            missing_servers
+                .iter()
+                .map(|language| language.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            if missing_servers.len() == 1 { "" } else { "s" }
+        );
+    }
 
     let configured_any = configured_assistants.iter().any(|(_, p)| p.is_some());
     if matches!(intent, SetupIntent::AgentOnly | SetupIntent::Advanced) && configured_any {
@@ -13230,11 +13247,18 @@ async fn apply_language_server_provisioning(
                 .join(", "),
             if missing.len() == 1 { "it" } else { "them" }
         );
-        for command in language_servers::install_commands_for(missing) {
+        // The ROUTE's command, not the recipe's. On a host with no rustup the
+        // recipe's line is `rustup component add rust-analyzer`, which is the
+        // exact sentence that ended a cold walkthrough on 2026-08-28: a reader
+        // who is not a Rust developer sees an instruction to install a
+        // toolchain and stops. What Kin would actually do here is fetch a
+        // pinned, checksummed release binary, and that is what has to be on the
+        // line.
+        for command in language_servers::route_commands_for(missing) {
             println!("      {command}");
         }
         println!(
-            "      or re-run with --install-language-servers to have Kin run {}",
+            "      or re-run with --install-language-servers to have Kin do {}",
             if missing.len() == 1 { "it" } else { "them" }
         );
         return ProvisioningOutcome::default();
@@ -13244,16 +13268,19 @@ async fn apply_language_server_provisioning(
         missing,
         consent,
         |recipe| recipe.installed(),
-        |recipe| recipe.installer_available(),
-        |recipe| {
+        language_servers::resolve_route,
+        |recipe, route| {
             println!();
             println!(
                 "  Kin can enrich {} with cross-file reference edges, but its language server is \
                  not installed.",
                 recipe.language
             );
-            println!("    Command:    {}", recipe.command_line());
-            println!("    This will:  {}", recipe.disclosure);
+            println!("    Command:    {}", recipe.route_command_line(route));
+            println!(
+                "    This will:  {}",
+                language_servers::route_disclosure(recipe, route)
+            );
             prompt_yn("  Install it now?", false, true)
         },
         language_servers::run_install,
@@ -13266,12 +13293,50 @@ async fn apply_language_server_provisioning(
         let recipe = language_servers::recipe_for(report.language);
         match report.outcome {
             InstallOutcome::AlreadyPresent => {}
-            InstallOutcome::Installed { command } => {
+            InstallOutcome::Installed { command, evidence } => {
                 installed_any = true;
                 applied.push(format!(
                     "installed the {} language server (`{command}`)",
                     report.language
                 ));
+                // What a run downloaded itself is shown, not summarised. A tick
+                // beside "installed" says nothing a reader can check; the URL,
+                // the digest Kin verified before writing anything, and the
+                // directory it landed in are all checkable in one command each.
+                for line in evidence {
+                    applied.push(format!("    {line}"));
+                }
+            }
+            // Its own arm, above `Failed`, because the two need different
+            // words. A network error is worth retrying and a digest that did
+            // not match never is: something served bytes that are not the ones
+            // Kin pins, and the only safe reading is that the install must not
+            // happen on this path today.
+            InstallOutcome::ChecksumRefused { command, reason } => {
+                println!(
+                    "  {} refused to install the {} language server: {reason}",
+                    style("✗").red(),
+                    report.language
+                );
+                unfinished.push(UnfinishedRepair {
+                    what: format!("install the {} language server", report.language),
+                    reason,
+                    remediation: vec![
+                        "Kin installed nothing. The bytes served are not the ones this build \
+                         pins, so either the download was corrupted in transit or something \
+                         between this host and the release is rewriting it."
+                            .to_string(),
+                        format!(
+                            "retry once; if it repeats, install the server yourself with `{}` \
+                             and run `kin daemon stop`",
+                            recipe
+                                .map(|recipe| recipe.command_line())
+                                .unwrap_or_else(|| command.clone())
+                        ),
+                        language_servers::WORKS_WITHOUT_LANGUAGE_SERVERS.to_string(),
+                    ],
+                    requested: true,
+                });
             }
             // A zero exit that left the binary unreachable is reported as the
             // gap it still is. Counting it as applied is how a closed-looking
@@ -13319,17 +13384,31 @@ async fn apply_language_server_provisioning(
                 style("-").dim(),
                 report.language
             ),
+            // Reached only when this host leaves NO route open: the recipe's
+            // installer is absent AND Kin's own fallback cannot serve it. For
+            // the npm recipes that means no Node at all, and Kin does not
+            // install a language runtime behind a user's back. For Rust it
+            // means a host Kin pins no release binary for.
             InstallOutcome::NoInstaller { program, command } => {
                 println!(
-                    "  {} `{program}` is not installed, so Kin cannot run `{command}` to \
-                     provision the {} language server",
+                    "  {} `{program}` is not installed and Kin has no other route to the {} \
+                     language server on this host, so it cannot run `{command}`",
                     style("✗").red(),
                     report.language
                 );
                 unfinished.push(UnfinishedRepair {
                     what: format!("install the {} language server", report.language),
-                    reason: format!("`{program}` is not installed on this host"),
-                    remediation: vec![format!("install `{program}`, then run `{command}`")],
+                    reason: format!(
+                        "`{program}` is not installed on this host, and Kin pins no {} release \
+                         binary for {}-{}",
+                        report.language,
+                        std::env::consts::OS,
+                        std::env::consts::ARCH
+                    ),
+                    remediation: vec![
+                        format!("install `{program}`, then run `{command}`"),
+                        language_servers::WORKS_WITHOUT_LANGUAGE_SERVERS.to_string(),
+                    ],
                     // Consent was never asked for here, so only the flag makes
                     // this a repair the operator requested.
                     requested: consent == InstallConsent::Granted,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2570,6 +2570,12 @@ fn main() -> Result<()> {
     if let Ok(cwd) = std::env::current_dir() {
         kin_cli::resource_profile::apply_repository_profile_at(&cwd);
     }
+    // Put Kin's own tool directories on PATH while this process is still
+    // single-threaded, so a language server Kin provisioned is reachable by the
+    // `which` lookup enrichment discovery performs, and by the daemon this
+    // command may spawn, which inherits this environment. Appended rather than
+    // prepended: an operator's own toolchain outranks Kin's fallback copy.
+    kin_core::tool_prefix::augment_path_with_managed_tools();
     if kin_migrate::run_migration_process_host_if_requested()? {
         return Ok(());
     }

--- a/crates/kin-core/env_mutation_allowlist.txt
+++ b/crates/kin-core/env_mutation_allowlist.txt
@@ -24,3 +24,17 @@ crates/kin-cli/src/commands/mcp.rs
 # caches its answer, and the precedence rule itself is a pure function
 # (`product_default_for`) that tests exercise without touching the environment.
 crates/kin-cli/src/resource_profile.rs
+
+# `kin` and `kin-daemon` put Kin's own tool directories on `PATH` in the same
+# single-threaded prologue, immediately after the `resource_profile` calls
+# above. Language-server discovery is `which` over `PATH` and nothing else, so a
+# server Kin downloaded and verified into its managed tool directory is
+# reachable only if that directory is on the `PATH` of the process that starts
+# enrichment, and the repo daemon inherits that environment from whichever `kin`
+# command spawned it. `PATH` is the interface every `which` and every spawned
+# tool already reads, so writing it IS how a binary publishes the tools it
+# provisioned; there is no argument to pass it by across a process boundary. The
+# managed directories are appended rather than prepended, so an operator's own
+# toolchain still wins, and a second call is a no-op so a re-exec cannot grow
+# `PATH` without end.
+crates/kin-core/src/tool_prefix.rs

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -152,6 +152,8 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_MANAGED_BIN", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "explicit native Kin binary used by the @kinlab/kin launcher instead of provisioning" },
     EnvVarSpec { name: "KIN_NO_PROVISION", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "forbid network provisioning by the @kinlab/kin launcher" },
     EnvVarSpec { name: "KIN_LAUNCHER_ADOPT", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "force the @kinlab/kin launcher to provision its pinned release, including an intentional downgrade" },
+    EnvVarSpec { name: "KIN_LANGUAGE_SERVER_ASSET_BASE", kind: Kind::Url, default: "GitHub Releases", sensitivity: Sensitivity::Operational, summary: "base URL the language-server release binaries are fetched from; set by acceptance checks to drive the standalone install against a fixture" },
+    EnvVarSpec { name: "KIN_LANGUAGE_SERVER_ASSET_SHA256", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "sha256 an overridden language-server asset is verified against; IGNORED unless KIN_LANGUAGE_SERVER_ASSET_BASE is also set, so it can never relax the pinned release check" },
     // ---- correctness / retrieval-affecting ------------------------------------
     EnvVarSpec { name: "KIN_SEMLOC_RERANK", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "enable semantic-locate reranking of daemon locate results" },
     EnvVarSpec { name: "KIN_SEARCH_MODE", kind: Kind::OneOf(&["precise"]), default: "", sensitivity: Sensitivity::Correctness, summary: "search strictness; 'precise' rejects broad show-body searches" },

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod sync_state;
 /// `test-support` feature from a dev-dependency, so no product build carries it.
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_env;
+pub mod tool_prefix;
 pub mod tree;
 pub mod vector_producer_policy;
 pub mod workspace_carry;

--- a/crates/kin-core/src/tool_prefix.rs
+++ b/crates/kin-core/src/tool_prefix.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Where Kin installs the tools it provisions for itself, and how the processes
+//! that look for them find them.
+//!
+//! Language-server discovery is `which` over `PATH` and nothing else
+//! (`kin_lsp::discovery::discover_servers`), so a server Kin installs is
+//! reachable only if the directory it landed in is on the `PATH` of the process
+//! that starts the enrichment. That process is the repo daemon, which inherits
+//! the environment of whichever `kin` command spawned it. Both binaries
+//! therefore call [`augment_path_with_managed_tools`] at process start, while
+//! they are still single-threaded, exactly as they both call
+//! `resource_profile::apply_product_default`.
+//!
+//! Two directories, because two installers write in different shapes. A binary
+//! Kin downloads and verifies itself lands in [`managed_tool_bin_dir`]. A
+//! package installed with `npm install --prefix` lands under
+//! [`managed_node_prefix`], whose executables npm links into
+//! [`managed_node_bin_dir`]; that is the same prefix shape
+//! `scripts/ci-install-language-servers.sh` already uses on hosted runners, and
+//! it is what lets a provisioning run succeed on a host whose global npm prefix
+//! is owned by root.
+//!
+//! These directories go on the END of `PATH`, never the front. A server the
+//! operator installed themselves is the one their toolchain expects, and a
+//! rustup `rust-analyzer` tracks the toolchain that compiled the code while
+//! Kin's pinned copy does not. Kin's copy is a fallback for a host that has
+//! none, so it must never shadow one that is already there.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// The root Kin installs provisioned tools under.
+pub fn managed_tool_root() -> PathBuf {
+    crate::registry::managed_kin_home().join("tools")
+}
+
+/// Where a binary Kin downloaded and verified itself is installed.
+pub fn managed_tool_bin_dir() -> PathBuf {
+    managed_tool_root().join("bin")
+}
+
+/// The npm prefix Kin owns, for packages a shared global prefix refuses.
+pub fn managed_node_prefix() -> PathBuf {
+    managed_tool_root().join("node")
+}
+
+/// Where npm links the executables of packages installed into
+/// [`managed_node_prefix`].
+///
+/// `npm install --prefix <dir> <pkg>` is a LOCAL install rooted at `<dir>`, so
+/// its binaries land in `<dir>/node_modules/.bin` rather than in `<dir>/bin`.
+/// Naming the wrong one of those two is a provisioning run that reports success
+/// over a binary nothing can reach, which is the shape `kin doctor` already
+/// re-probes `PATH` to catch.
+pub fn managed_node_bin_dir() -> PathBuf {
+    managed_node_prefix().join("node_modules").join(".bin")
+}
+
+/// Every directory Kin's own provisioning writes executables into.
+pub fn managed_tool_dirs() -> Vec<PathBuf> {
+    vec![managed_tool_bin_dir(), managed_node_bin_dir()]
+}
+
+/// `PATH` with Kin's tool directories appended, or `None` when it already
+/// carries all of them.
+///
+/// Pure over its inputs so the composition is testable without touching the
+/// process environment, and returning `None` for a no-op is what keeps a
+/// repeated call from growing `PATH` once per invocation in a shell that
+/// re-execs `kin`.
+pub fn path_with_managed_tools(current: Option<&OsString>, dirs: &[PathBuf]) -> Option<OsString> {
+    let existing: Vec<PathBuf> = current
+        .map(|value| std::env::split_paths(value).collect())
+        .unwrap_or_default();
+    let missing: Vec<&PathBuf> = dirs.iter().filter(|dir| !existing.contains(dir)).collect();
+    if missing.is_empty() {
+        return None;
+    }
+    let mut joined: Vec<PathBuf> = existing;
+    joined.extend(missing.into_iter().cloned());
+    std::env::join_paths(joined).ok()
+}
+
+/// Put Kin's tool directories on this process's `PATH`.
+///
+/// Call while the process is still single-threaded. Mutating the environment
+/// after threads exist is unsound, and both binaries already have a
+/// single-threaded prologue for exactly this class of change.
+///
+/// Returns whether `PATH` was changed, so a caller can say so rather than
+/// assert it.
+pub fn augment_path_with_managed_tools() -> bool {
+    let dirs = managed_tool_dirs();
+    let current = std::env::var_os("PATH");
+    match path_with_managed_tools(current.as_ref(), &dirs) {
+        Some(updated) => {
+            std::env::set_var("PATH", updated);
+            true
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os(value: &str) -> OsString {
+        OsString::from(value)
+    }
+
+    fn parts(value: &OsString) -> Vec<PathBuf> {
+        std::env::split_paths(value).collect()
+    }
+
+    /// The tool directories land at the END, behind whatever the operator has.
+    ///
+    /// The direction is the whole point. Kin's pinned `rust-analyzer` does not
+    /// track the toolchain that compiled the repository and a rustup component
+    /// does, so a host that has one must keep using it. A composition that put
+    /// Kin's copy first would silently replace a working server with a
+    /// different one and nothing downstream would report the swap.
+    #[test]
+    fn managed_directories_are_appended_rather_than_prepended() {
+        let current = os("/usr/local/bin:/usr/bin");
+        let dirs = vec![PathBuf::from("/home/u/.kin/tools/bin")];
+        let updated = path_with_managed_tools(Some(&current), &dirs)
+            .expect("a PATH without the tool dir must be rewritten");
+        assert_eq!(
+            parts(&updated),
+            vec![
+                PathBuf::from("/usr/local/bin"),
+                PathBuf::from("/usr/bin"),
+                PathBuf::from("/home/u/.kin/tools/bin"),
+            ],
+            "Kin's own tool directory must not shadow an operator's toolchain"
+        );
+    }
+
+    /// A second call adds nothing, so a re-exec cannot grow `PATH` without end.
+    #[test]
+    fn a_path_that_already_carries_the_directories_is_left_alone() {
+        let dirs = vec![
+            PathBuf::from("/home/u/.kin/tools/bin"),
+            PathBuf::from("/home/u/.kin/tools/node/node_modules/.bin"),
+        ];
+        let current =
+            os("/usr/bin:/home/u/.kin/tools/bin:/home/u/.kin/tools/node/node_modules/.bin");
+        assert_eq!(
+            path_with_managed_tools(Some(&current), &dirs),
+            None,
+            "every directory was already present, so there is nothing to add"
+        );
+    }
+
+    /// A partly-present `PATH` gains only what it is missing.
+    #[test]
+    fn only_the_missing_directories_are_added() {
+        let dirs = vec![
+            PathBuf::from("/home/u/.kin/tools/bin"),
+            PathBuf::from("/home/u/.kin/tools/node/node_modules/.bin"),
+        ];
+        let current = os("/home/u/.kin/tools/bin:/usr/bin");
+        let updated = path_with_managed_tools(Some(&current), &dirs)
+            .expect("one directory is missing, so PATH must be rewritten");
+        assert_eq!(
+            parts(&updated),
+            vec![
+                PathBuf::from("/home/u/.kin/tools/bin"),
+                PathBuf::from("/usr/bin"),
+                PathBuf::from("/home/u/.kin/tools/node/node_modules/.bin"),
+            ]
+        );
+    }
+
+    /// An unset `PATH` still yields the tool directories rather than nothing.
+    #[test]
+    fn an_absent_path_becomes_the_tool_directories() {
+        let dirs = vec![PathBuf::from("/home/u/.kin/tools/bin")];
+        let updated =
+            path_with_managed_tools(None, &dirs).expect("an unset PATH must still be composed");
+        assert_eq!(
+            parts(&updated),
+            vec![PathBuf::from("/home/u/.kin/tools/bin")]
+        );
+    }
+
+    /// The npm prefix and the directory npm links binaries into are different
+    /// paths, and provisioning has to name the second one.
+    #[test]
+    fn the_node_bin_directory_is_the_local_install_link_directory() {
+        let prefix = managed_node_prefix();
+        let bin = managed_node_bin_dir();
+        assert_eq!(
+            bin,
+            prefix.join("node_modules").join(".bin"),
+            "`npm install --prefix` links binaries into node_modules/.bin, not into bin"
+        );
+        assert!(
+            managed_tool_dirs().contains(&bin),
+            "a directory provisioning writes into must be one PATH carries"
+        );
+    }
+
+    /// The process mutation and the composition agree, asserted against the
+    /// live environment rather than inferred from the pure half.
+    ///
+    /// Kept separate and behind the workspace's one sanctioned environment
+    /// guard, because this is the only assertion here whose subject IS the
+    /// environment read.
+    #[test]
+    fn the_process_path_gains_the_tool_directories() {
+        let _guard = crate::test_env::EnvVarGuard::set("PATH", "/usr/bin");
+        assert!(
+            augment_path_with_managed_tools(),
+            "a PATH of /usr/bin alone carries none of Kin's tool directories"
+        );
+        let after = std::env::var_os("PATH").expect("PATH must still be set");
+        let entries = parts(&after);
+        for dir in managed_tool_dirs() {
+            assert!(
+                entries.contains(&dir),
+                "PATH must carry {} after augmentation, got {after:?}",
+                dir.display()
+            );
+        }
+        assert!(
+            !augment_path_with_managed_tools(),
+            "a second call must be a no-op rather than a second append"
+        );
+    }
+}

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -398,6 +398,13 @@ fn main() {
     // still single-threaded and still ahead of every reader (FIR-2504). An
     // operator's own KIN_RESOURCE_PROFILE outranks the file and is untouched.
     apply_repository_resource_profile();
+    // Put Kin's own tool directories on PATH, still single-threaded and ahead
+    // of the startup discovery sweep that decides whether this daemon opens an
+    // enrichment channel at all. A daemon started directly, rather than by a
+    // `kin` command that already did this, would otherwise never see a server
+    // Kin provisioned for the user, and a daemon that finds none never opens
+    // that channel for the life of the process.
+    kin_core::tool_prefix::augment_path_with_managed_tools();
     // Build the async runtime explicitly (rather than via `#[tokio::main]`) so
     // we own its teardown. The embedding worker dispatches batches onto the
     // blocking pool doing synchronous GPU compute that cannot observe the

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (501 total, 339 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (503 total, 339 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -58,6 +58,8 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_BUILD_GRAPH_TIMEOUT_SECS` | seconds>=0 | 60 | operational | timeout for building a historical ref-view graph |
 | `KIN_BYPASS_EMBEDDING_COVERAGE_CHECK` | bool | false | correctness | bypass the embedding-coverage correctness gate |
 | `KIN_DISABLE_SPINE` | bool | false | correctness | disable the spine federation layer, narrowing retrieval scope |
+| `KIN_LANGUAGE_SERVER_ASSET_BASE` | url | GitHub Releases | operational | base URL the language-server release binaries are fetched from; set by acceptance checks to drive the standalone install against a fixture |
+| `KIN_LANGUAGE_SERVER_ASSET_SHA256` | string | *(unset)* | operational | sha256 an overridden language-server asset is verified against; IGNORED unless KIN_LANGUAGE_SERVER_ASSET_BASE is also set, so it can never relax the pinned release check |
 | `KIN_MEMORY_PRESSURE` | enum | *(unset)* | operational | force the memory-pressure level heavy work is judged against, in place of measuring the machine: 'critical' refuses the enrichment sweep, the embedding batch and ambient admission with a named reason, 'elevated' shrinks the embedding batch, 'unknown' proceeds exactly as an unreadable host does, and unset measures the cgroup or the host. Read by the daemon at process start, so it takes effect on the command that starts one |
 | `KIN_MEMORY_PRESSURE_CRITICAL_FRACTION` | float>=0 | 0.90 | operational | fraction of the memory ceiling at or above which heavy work refuses to start; must be within 0..=1, anything else keeps 0.90, and a value below the elevated fraction is raised to it |
 | `KIN_MEMORY_PRESSURE_ELEVATED_FRACTION` | float>=0 | 0.75 | operational | fraction of the memory ceiling at or above which heavy work shrinks; must be within 0..=1, and anything else keeps 0.75 |

--- a/scripts/acceptance/first_contact_honesty.py
+++ b/scripts/acceptance/first_contact_honesty.py
@@ -42,6 +42,10 @@ on a setup error, 0 only when every selected check passes.
 """
 
 import argparse
+import gzip
+import hashlib
+import io
+import threading
 import json
 import os
 import re
@@ -49,6 +53,7 @@ import shutil
 import stat
 import subprocess
 import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
 import tempfile
 
 PASS = "PASS"
@@ -568,6 +573,68 @@ def doctor_rows(suite, extra_env=None):
     return {row.get("id"): row for row in report.get("checks", [])}, ""
 
 
+# --------------------------------------------------------- toolchain-free repair
+#
+# The 2026-08-28 walkthrough's finding 2. A stranger followed the documented
+# install, initialized a Rust repository, and got imports 0/1085 with "no
+# language server found". The product named its own repair and the repair
+# refused because `rustup` was absent. Nothing in that chain lied; the outcome
+# was that a developer who is not a Rust developer could not get reference edges
+# for a Rust repository by following the product's own instructions.
+#
+# What this grades is one question: did the repair need a toolchain this host
+# does not have. It does NOT grade whether the installed server works, because
+# the fixture served here is a stub and a stub cannot complete an LSP handshake.
+# A run that gets as far as "installed and did not start" has answered this
+# check's question and is a PASS, which is why the two are told apart below
+# rather than collapsed into "did the row go green".
+#
+# The two failing branches carry DIFFERENT sentences on purpose, and the
+# self-test asserts which one answered. They overlap on the text 0.6.0 actually
+# shipped, which carried both the refusal and the remedy, and two branches that
+# can each catch one input hide each other's absence: a mutation that merely
+# redirects between them leaves the verdict unchanged and reads as a surviving
+# check. Each branch therefore also gets an input only it can catch.
+
+TOOLCHAIN_REFUSAL = "is not installed on this host"
+TOOLCHAIN_REMEDY = "install 'rustup'"
+PRESCRIBES_TOOLCHAIN = "prescribes a toolchain install"
+ENDED_ON_ABSENCE = "ended on rustup being absent"
+DOWNLOAD_EVIDENCE = "sha256:"
+
+
+def grade_toolchain_free_repair(output):
+    """(ok, detail) for a language-server repair run on a host with no rustup."""
+    flat = flatten(output)
+    if not flat:
+        return None, "the run produced no output, so nothing could be graded"
+    if "rust" not in flat.lower():
+        return None, (
+            "the run never mentioned the rust language server, so it did not "
+            "reach the question this check is about"
+        )
+    if TOOLCHAIN_REMEDY in flat:
+        return False, (
+            "the repair %s, telling a reader to install a toolchain in order to "
+            "read somebody else's code: %s"
+            % (PRESCRIBES_TOOLCHAIN, flat[flat.find(TOOLCHAIN_REMEDY):][:180])
+        )
+    if "rustup" in flat and TOOLCHAIN_REFUSAL in flat:
+        return False, (
+            "the repair %s, so a host without the toolchain still gets no route "
+            "to a server" % ENDED_ON_ABSENCE
+        )
+    if DOWNLOAD_EVIDENCE not in flat:
+        return None, (
+            "no route was taken and no toolchain refusal was reported either, "
+            "so this run establishes nothing either way: %s" % flat[:220]
+        )
+    return True, (
+        "the repair took a route that needs no toolchain and disclosed the "
+        "digest it verified"
+    )
+
+
 def check_3(suite):
     """FIR-2787: the memory this box affords is on the page before `kin init` runs.
 
@@ -672,7 +739,119 @@ def check_3(suite):
     return res
 
 
-CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3)]
+def check_4(suite):
+    """The language-server repair works on a host with no rustup.
+
+    Driven against a fixture the suite serves itself, so the check needs no
+    network and cannot fail on a bad morning at a release host. What the fixture
+    replaces is the URL and the digest, both taken as arguments by the install;
+    the download, the verification, the unpack, the executable bit and the
+    registration are the shipped code on both paths.
+
+    `rustup` is scrubbed from PATH rather than assumed absent, because the
+    runner that builds this suite installs a Rust toolchain and a check that
+    merely hoped for its absence would silently grade the rustup route instead.
+    The scrub is asserted before the repair runs.
+    """
+    res = Result("4", "cold-walk-2026-08-28",
+                 "kin doctor --fix --install-language-servers needs no toolchain the host lacks")
+
+    stub = b"#!/bin/sh\necho 'rust-analyzer 0.0.0-fixture'\n"
+    archive = io.BytesIO()
+    with gzip.GzipFile(fileobj=archive, mode="wb", mtime=0) as raw:
+        raw.write(stub)
+    body = archive.getvalue()
+    digest = hashlib.sha256(body).hexdigest()
+
+    served = _serve_asset(body)
+    if served is None:
+        res.unknown("could not bind a loopback port for the fixture asset")
+        return res
+    base, httpd, thread = served
+    try:
+        home = suite.scratch("toolchain-free-home")
+        env = suite.base_env()
+        env["HOME"] = home
+        env["KIN_HOME"] = os.path.join(home, ".kin")
+        env["KIN_LANGUAGE_SERVER_ASSET_BASE"] = base
+        env["KIN_LANGUAGE_SERVER_ASSET_SHA256"] = digest
+        # Every PATH entry carrying rustup is dropped, then the drop is checked.
+        # A scrub that missed one would grade the route this check exists to
+        # avoid, and would do it silently.
+        kept = [entry for entry in env.get("PATH", "").split(os.pathsep)
+                if entry and not os.path.exists(os.path.join(entry, "rustup"))]
+        env["PATH"] = os.pathsep.join(kept)
+        still_there = [entry for entry in kept
+                       if os.path.exists(os.path.join(entry, "rustup"))]
+        if still_there:
+            res.unknown("the PATH scrub left rustup reachable at %s" % still_there[0])
+            return res
+
+        work = suite.scratch("toolchain-free-repo")
+        rc, out, err = run([suite.kin, "init", "."], cwd=work, env=env, timeout=900)
+        if rc != 0:
+            res.unknown("kin init exited %d in the fixture repository: %s"
+                        % (rc, flatten(err)[:220]))
+            return res
+        rc, out, err = run(
+            [suite.kin, "doctor", "--fix", "--install-language-servers"],
+            cwd=work, env=env, timeout=900)
+        combined = (out or "") + "\n" + (err or "")
+
+        ok, detail = grade_toolchain_free_repair(combined)
+        if ok is None:
+            res.unknown(detail)
+            return res
+        if not ok:
+            res.bad(detail)
+            return res
+
+        installed = os.path.join(env["KIN_HOME"], "tools", "bin", "rust-analyzer")
+        if not os.path.exists(installed):
+            res.bad("the run disclosed a digest and wrote no binary to %s" % installed)
+            return res
+        if not os.access(installed, os.X_OK):
+            res.bad("the binary at %s is not executable, so `which` walks past it"
+                    % installed)
+            return res
+        on_disk = hashlib.sha256(open(installed, "rb").read()).hexdigest()
+        if on_disk != hashlib.sha256(stub).hexdigest():
+            res.bad("the installed bytes are not the unpacked asset")
+            return res
+        res.ok("%s, and the unpacked binary is executable at %s" % (detail, installed))
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=5)
+    return res
+
+
+def _serve_asset(body):
+    """A loopback HTTP server answering any path with `body`.
+
+    Returns (base_url, httpd, thread), or None when no port could be bound.
+    """
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            return
+
+    try:
+        httpd = HTTPServer(("127.0.0.1", 0), Handler)
+    except OSError:
+        return None
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return "http://127.0.0.1:%d" % httpd.server_address[1], httpd, thread
+
+
+CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3),
+          ("4", check_4)]
 
 
 # ----------------------------------------------------------------------- suite
@@ -840,6 +1019,52 @@ def self_test():
            ["npx -y @kinlab/kin --version",
             "export PATH=\"$HOME/.kin/bin:$PATH\"",
             "kin --version"])
+
+
+    # The 0.6.0 refusal, verbatim from the walkthrough, and its inverse. The
+    # shipped text trips BOTH failing branches, so it cannot tell them apart on
+    # its own; the two inputs after it can, and the detail is asserted rather
+    # than only the verdict.
+    shipped_refusal = (
+        "  x install the rust language server: 'rustup' is not installed on this host\n"
+        "      install 'rustup', then run 'rustup component add rust-analyzer'\n"
+    )
+    only_remedy = (
+        "  x install the rust language server: run `rustup component add rust-analyzer`\n"
+        "      install 'rustup', then run 'rustup component add rust-analyzer'\n"
+    )
+    only_absence = (
+        "  x install the rust language server: rustup is not installed on this host\n"
+    )
+    routed = (
+        "  v installed the rust language server (`download rust-analyzer 2026-08-24 from the "
+        "rust-lang/rust-analyzer release binaries`)\n"
+        "      source:   http://127.0.0.1:9/2026-08-24/rust-analyzer-fixture.gz\n"
+        "      sha256:   " + ("a" * 64) + " (verified before install)\n"
+        "      installed to: /root/.kin/tools/bin/rust-analyzer\n"
+    )
+    expect("the shipped 0.6.0 refusal must FAIL",
+           grade_toolchain_free_repair(shipped_refusal)[0], False)
+    expect("a routed install must PASS", grade_toolchain_free_repair(routed)[0], True)
+    expect("no output is UNREADABLE", grade_toolchain_free_repair("")[0], None)
+    expect("a run that never mentioned rust is UNREADABLE",
+           grade_toolchain_free_repair("Summary: 9 passed")[0], None)
+    expect("a silent no-op is UNREADABLE",
+           grade_toolchain_free_repair("  - skipped the rust language server\n")[0], None)
+    expect("installed-but-unusable still PASSes",
+           grade_toolchain_free_repair(
+               routed + "  x the rust language server installed but did not start\n")[0], True)
+    # Only the remedy branch can catch this one: it prescribes rustup without
+    # ever saying rustup is absent.
+    expect("a prescription with no refusal must FAIL",
+           grade_toolchain_free_repair(only_remedy)[0], False)
+    expect("and it must be the prescription branch that answered",
+           PRESCRIBES_TOOLCHAIN in grade_toolchain_free_repair(only_remedy)[1], True)
+    # Only the absence branch can catch this one: it reports rustup absent with
+    # no remedy sentence at all.
+    expect("a bare absence must FAIL", grade_toolchain_free_repair(only_absence)[0], False)
+    expect("and it must be the absence branch that answered",
+           ENDED_ON_ABSENCE in grade_toolchain_free_repair(only_absence)[1], True)
 
     for line in failures:
         print("SELF-TEST FAIL %s" % line)


### PR DESCRIPTION
## The finding

A cold walkthrough on 2026-08-28 (`.kin-coord/reports/coldwalk-20260828.md`, finding 2) followed the documented install at kinlab.ai/install, cloned `tokio-rs/axum` at `8f6bb9ce`, and ran `kin init`. The graph came back with `rust: calls 4052/11883 (34%), imports 0/1085 (0%)` and "cross-file reference and override edges unavailable for javascript, rust: no language server found". MCP `find_references{query:"Router"}` returned `references count: 0`, correctly refused as inconclusive rather than presented as an absence.

The product named its own repair. The repair exited 1:

```
✗ install the rust language server: 'rustup' is not installed on this host
  install 'rustup', then run 'rustup component add rust-analyzer'
```

Every step of that is honest, and the outcome is still that a developer who is not a Rust developer cannot get reference edges for a Rust repository by following Kin's own instructions. Kin asked them to install a toolchain in order to read somebody else's code.

## The fix

Each recipe now carries the route Kin takes when the installer it names cannot serve the host, and `choose_route` is a pure rule over three measured facts about the machine.

- **Rust falls back to rust-analyzer's own release binaries.** Pinned to tag `2026-08-24`, one asset per host, each with a sha256 recorded in `language_server_release.rs`. Bytes are hashed as they stream into a temporary file beside the destination, the digest is compared before anything is unpacked, and only a verified archive is expanded and renamed into place. A mismatch removes the temporary file, installs nothing, and reports as `ChecksumRefused`, its own outcome beside `Failed`, because a digest that did not match is never worth retrying and a reader must not take it for a flaky download.
- **The npm-served languages fall back to a prefix Kin owns** under `KIN_HOME`, which is the same `npm install --prefix` shape `scripts/ci-install-language-servers.sh` already uses. That is the container case: the Node base images set the global prefix to `/usr/local`, whose `lib/node_modules` is owned by root, and Kin already detected that and refused before spending the download. Correctly refused is still no language server.
- **The recipe's own installer stays preferred wherever it works.** A rustup component tracks the toolchain that compiles the repository and a pinned copy does not.
- **Discovery is `which` over `PATH`,** so `kin` and `kin-daemon` both append Kin's tool directories to `PATH` in their single-threaded prologue, beside the `resource_profile` calls that are there for the same reason. Appended, never prepended, so a server the operator installed is not shadowed. The daemon does it too, because a daemon that finds no server at startup never opens its enrichment channel for the life of the process.
- **The doctor prints what it installed, from where, and the digest it verified,** and the withheld-consent line now prints the route this host can actually take rather than the recipe's command. On a host with no rustup that line used to read `rustup component add rust-analyzer`, which is the exact sentence that ended the walkthrough.
- `kin setup`'s next steps name the language-server command when this host is missing one.

Two new environment variables are registered in `env_registry.rs` and `docs/env-vars.md`. `KIN_LANGUAGE_SERVER_ASSET_BASE` points the fetch at a fixture. `KIN_LANGUAGE_SERVER_ASSET_SHA256` is ignored unless the base is also overridden, so it can never relax the check against the real release, and a test asserts that pairing.

## Digests, and how they were measured

Downloaded and hashed on 2026-08-28T21:25:07Z with `curl -fsSL` then `shasum -a 256`. The recorded `size` is a second, independent reading: it is the release API's own `assets[].size` for the same file, and all four matched the bytes on disk exactly.

| asset | sha256 | size |
|---|---|---|
| `rust-analyzer-x86_64-unknown-linux-gnu.gz` | `c4d409690b98d84ce98174829362a59214825d72304fe2504f4b906a116b51fe` | 14865773 |
| `rust-analyzer-aarch64-unknown-linux-gnu.gz` | `3463f9115c725fc5dfb002431833ec83d1f1f9c4c35b76ad5f47b92c58a521f1` | 14317193 |
| `rust-analyzer-aarch64-apple-darwin.gz` | `5f4557c2ea4d62f80f1ffeea2646d0d56fab7172a0db11f3065c4d246b763989` | 13875126 |
| `rust-analyzer-x86_64-apple-darwin.gz` | `822cc4369562fc2ed26d1cf3953ef93927d8fdda4302d82e2eec407e2734eefd` | 14591602 |

Windows carries `.zip` assets in the same release and is deliberately not pinned: Kin has never exercised that unpack path, and an unproven install route is worse than a refusal that names the rustup command.

## The scripted checks

Two of them are the ones the brief asks for, both hermetic, both in `language_server_release.rs`. A local HTTP server serves a gzipped fixture and the real download, verify, unpack, install and discover path runs against it end to end. The discovery half resolves through `which::which_in` over the `PATH` `kin_core::tool_prefix` composes, which is the same crate and the same lookup `kin_lsp::discovery` performs. The second serves bytes whose digest is stated independently of them and asserts the refusal, that no binary is left behind, and that no temporary file is either. Two controls sit beside them so the classifier cannot collapse: a 404 must read as a download failure rather than a mismatch, and an unpinned host must be refused by name before any request is made.

## Falsification

Twelve arms, each removing a property of the CODE rather than weakening an assertion, each asserting its marker reached the tree before the build. Driver at `.kin-coord/bin/lspinstall-falsify.sh`, which refuses a dirty tree above its restore trap and ends by asserting the tree is clean. All twelve went red on a named assertion.

| mutation | test that fired | assertion |
|---|---|---|
| digest comparison replaced with `if false` | `bytes_that_do_not_match_the_pin_are_refused_and_nothing_is_installed` | expected a checksum refusal |
| `set_executable` removed | `the_standalone_route_installs_a_binary_discovery_can_find` | discovery must find the installed server on that PATH |
| `choose_route` returns `None` before the fallback | `a_host_with_npm_and_no_rustup_gets_every_language_a_route` | a host with no rustup must still get a Rust language server |
| installer preference removed | `the_recipes_own_installer_outranks_kins_fallback` | a host with rustup must get the rustup component |
| TypeScript pin dropped from the redirected args | `the_managed_prefix_command_keeps_the_packages_and_their_pin` | the global flag is dropped, the prefix inserted, the packages untouched |
| mismatch mapped to `Failed` | `a_checksum_mismatch_reports_its_own_outcome` | a mismatch must not read as an ordinary failure |
| evidence dropped on the way to the report | `a_pinned_install_carries_its_source_and_digest_into_the_report` | the URL and digest must reach the row |
| download described with the recipe's sentence | `the_download_disclosure_describes_the_download` | the tag must be named |
| tool dirs prepended instead of appended | `managed_directories_are_appended_rather_than_prepended` | Kin's own tool directory must not shadow an operator's toolchain |
| `set_var` removed | `the_process_path_gains_the_tool_directories` | PATH must carry the tool dir after augmentation |
| npm bin dir named `bin` | `the_node_bin_directory_is_the_local_install_link_directory` | npm links binaries into node_modules/.bin |
| digest override honoured unpaired | `a_digest_override_alone_cannot_relax_the_pin` | an override with no base override must leave the pin standing |

A thirteenth attempt failed to compile, which is its own grade and not a red. It was repaired and re-run, and its arm is the disclosure row above.

## Container proof, and the second gap it found

This host cannot cross-build a Linux archive, so the binaries came from `rc-build.yml` run
**33220958585**, whose provenance file names commit `e06c754b1ea36b062accce00dd16858fd058211a`
and archive sha256 `d080d1d60d0b35e486301b2ac168c0cb0d543b213b8b1c396998ceea80754f06`, matching
the sidecar. Driver at `.kin-coord/bin/lspinstall-container-proof.sh`, artifacts in
`/tmp/lspinstall-proof-out/`. The container is kept alive rather than run with `--rm`.

Host: `node:22-bookworm`, Debian GNU/Linux 12, node v22.23.2, npm 10.9.8, aarch64, `--cpus 4
--memory 8g`, no published port. Controls read before anything else: rustup NO, cargo NO,
rust-analyzer NO, node YES. Subject `tokio-rs/axum` at `8f6bb9cead28a3880fe2e448a41ffbfe2c7fe7d9`,
503 tracked files, the walkthrough's own subject and count. Binary self-reports
`kin 0.6.1 (e06c754b1... chore/lane-lspinstall-kin)`.

**The install gap is closed.** `kin doctor --fix --install-language-servers` installed
`rust-analyzer 0.3.3025-standalone` into `/root/.kin/tools/bin/rust-analyzer`, 40713728 bytes,
sha256 `a2c4598036bc160cb3e0d93de4b1329509cf9056bb7f7af81d55a94e07b89c3e` on disk after unpack.
The "no language server found" line disappeared from `kin graph status`, and the daemon then
reported `"enrichment_available":true` and ran a sweep to `sweep complete (303/303 files)`. That
is the install being discovered and used through the real daemon, end to end, on a host with no
rustup. Before this change the same command on the same host exited 1 with "'rustup' is not
installed on this host".

**The reference edges did not follow, and that is a second gap.** On that host
`find_references{query:"Router"}` still answers 0 and `kin refs` still reports no cross-file
Rust reference edges. rust-analyzer's own diagnostic says why: `Error: Failed to load the
project at /root/axum/./Cargo.toml`, caused by `cargo locate-project` failing, because there is
no cargo. It starts, completes a handshake, reports itself available, and loads no project.

**Confirmed with a one-variable control, twice, from a fresh store each time.** A first control
was inconclusive and is recorded as such: the sweep is resumable, so a second sweep over
unchanged files completed in 34 s and moved nothing, which cannot separate "still zero" from
"never re-enriched". The deciding pair deleted the store and re-ran `kin init` in each arm.

| fresh-store arm | cargo | rust calls | cross-file | intra-file | `find_references` Router |
|---|---|---|---|---|---|
| cargo present | yes | 3498/11883 (29%) | 5345 | 2605 | 63 rows, `kin refs` names 305 referencing entities |
| cargo absent | no | 2191/11883 (18%) | 1557 | 558 | 0 |

Same binary, same installed rust-analyzer, one variable. So the download is necessary and not
sufficient for Rust: rust-analyzer reads a Rust project through cargo, and Kin does not install
a language toolchain on a user's machine.

**What that changed in this lane.** `unmet_runtime_dependency` now names the gap beside the
install that did not close it, with the command that closes it and a line saying what still
works, reported as an unrequested repair so it is loud without flipping the exit code of a
request that did complete. The kinlab copy says the same thing in one sentence on the page and
one in the agent prompt.

**`imports 0/1085 (0%)` is a correct zero, not a defect.** The graph's own line says why: "1085
name a module outside this repository". Every import site in axum targets an external crate.
The brief's "rust imports above zero" is not reachable on this subject and never was; the
walkthrough read a correct zero there. The number that moves is calls and cross-file edges,
above.

**One instrument caveat, recorded.** The proof driver's step 09 asked for `kin daemon lsp-sweep`,
which does not exist, and the step reported `rc=0` because the command was piped into `tail`.
The real subcommand is `kin daemon sweep`, and every reading after that point was re-taken
without a pipe. This is the coldwalk's own trap 1 repeated, in my driver.

Measured delta between the built sha `e06c754b1` and the reviewed head: the container proved
`e06c754b1`. The commits after it are the clippy fix (one line inside `mod tests`, which begins
at line 496 under `#[cfg(test)]`, so not in the shipped binary), the acceptance grader and its
workflow step, and the toolchain-gap disclosure the proof itself asked for. The last of those
changes doctor output and is covered by unit tests rather than by a second container run.

## Falsification of the toolchain-gap disclosure

| mutation | test that fired | assertion |
|---|---|---|
| gap never named (`if true` short-circuit) | `rust_without_cargo_is_named_and_rust_with_cargo_is_not` | a host with no cargo must be told what the server still cannot do |
| gap named for every language | `the_npm_served_languages_name_no_toolchain_gap` | python: no toolchain gap exists for an npm-served server |

The first arm's filter matched nothing on its first attempt and the driver reported NOT RUN
rather than a pass. It was re-run against a name asserted by `-- --list` first.

## The allowlist entry the PATH write needs

`kin-core`'s environment-mutation guard scans every source in the workspace and exempts only what `crates/kin-core/env_mutation_allowlist.txt` names, so the `set_var("PATH", ...)` above turned `Fast gate build and tests` red on the first head. `crates/kin-core/src/tool_prefix.rs` now sits on that list beside `resource_profile.rs`, which is there for the same reason: the write is product behaviour rather than test setup, and `PATH` is the interface every `which` and every spawned tool already reads, so there is nothing to pass it by argument to across a process boundary.

Two mutations grade the entry rather than the green. Deleting the line reproduces CI's failure exactly, naming `crates/kin-core/src/tool_prefix.rs:99`. Adding a new unlisted `env::set_var` in a file nothing exempts still turns the guard red, so the entry exempts one file rather than disabling the check. Both arms went red on the named test, both baselines went green, the listing gate proved the filter matched one test while a fabricated name matched zero, and the driver restored the tree to zero dirty paths.

## Gates

Measured on the landing head `18e7efef621e0d158bb4e64c93784c3aa24b5955`, which is this branch rebased onto `5088b0e4c`. The rebase resolved one conflict, in the generated `docs/env-vars.md` header, where main added one environment variable and this branch adds two: the merged file carries 503 rows and the header now says 503.

- `bin/kin-precheck kin`: **16 gates ran, 16 passed, 0 failed**, printed against `.kin-coord/worktrees/lspinstall-kin` at that sha.
- `cargo test -p kin-core --lib`: **775 passed, 0 failed, 0 filtered out**.
- All six required contexts green by name, `Fast gate build and tests` among them.

The pre-rebase head `d4c483332` measured 16 of 16 the same way, plus `cargo test -p kin-cli --lib commands::language_server` at 52 passed and `cargo test -p kin-core --lib tool_prefix` at 6 passed. Those two filtered runs were not repeated on the landing head; the fast gate's own shards cover them there.

## Not claiming

- **This does not deliver Rust reference edges on a machine with no Rust toolchain.** It delivers the installed server, the discovery, the sweep, and an honest statement of what is still missing. The measurement is in the container section above.
- Windows and musl hosts are not covered by the pinned table. A musl host gets the gnu binary and the readiness probe reports a server that installed and would not start, which is the honest answer rather than a special case.
- The unit tests drive the install with the base URL and digest passed as arguments. Which URL production reads is covered separately by the precedence tests on `resolve_source`; everything between the response body and the executable on disk is the same code on both paths.

