### PR TITLE
Serve initialize outside a repository, and name what a sweep skipped

### DIFF
--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -954,14 +954,20 @@ async fn wait_for_sweep(
                     .get("files_blocked")
                     .and_then(|v| v.as_u64())
                     .unwrap_or(0);
-                if done == 0 && total > 0 {
-                    println!(
-                        "sweep finished without enriching any of the {total} files it walked \
-                         ({blocked} blocked); see .kin/daemon.log for what stopped it"
-                    );
-                } else {
-                    println!("sweep complete ({done}/{total} files)");
-                }
+                // The same claim `kin init` prints, from the same function, off
+                // the same status object. This command held the whole payload
+                // and read only two of its numbers, so it printed
+                // "sweep complete (3/6 files)" while `languages_skipped` in its
+                // own hand named rust, three files and the reason the daemon
+                // observed. It is also the command the pending line from
+                // `kin init` tells a reader to run next, so the two surfaces
+                // disagreeing is the defect arriving at its own remedy.
+                let skipped = super::init::skipped_languages_from_status(&status);
+                let (line, _) =
+                    super::init::cross_file_enrichment_outcome(done, total, blocked, &skipped);
+                // The leading indent belongs to the note block `kin init` prints
+                // this under. Continuation lines keep their own.
+                println!("{}", line.trim_start());
             }
             return Ok(());
         }

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -435,7 +435,7 @@ pub(crate) struct SkippedLanguage {
 /// keys its whole verdict on whether this comes back empty. A daemon too old to
 /// send the field reads as nothing skipped, which is the same conservative
 /// reading an unpublished readiness map already gets.
-fn skipped_languages_from_status(status: &serde_json::Value) -> Vec<SkippedLanguage> {
+pub(crate) fn skipped_languages_from_status(status: &serde_json::Value) -> Vec<SkippedLanguage> {
     let Some(rows) = status.get("languages_skipped").and_then(|v| v.as_array()) else {
         return Vec::new();
     };
@@ -464,12 +464,57 @@ fn plural_count(n: u64, one: &str, many: &str) -> String {
     }
 }
 
+/// The detail lines under a sweep outcome: one per language, plus the remainder.
+///
+/// `blocked` is the daemon's own total and the rows are the part of it the
+/// daemon could attribute to a language. They are not the same number. A file is
+/// also blocked when its extension maps to no language server this build wires,
+/// or when its source could not be read from graph authority, and neither of
+/// those paths records a row. Measured on a three-rust, three-typescript,
+/// two-ruby repository: `files_blocked` 5, rows accounting for 3, and a reader
+/// who added the sentence's own figures got six of eight with nowhere to go for
+/// the other two. So the remainder is stated rather than dropped, because a
+/// sentence whose whole purpose is to name what was lost cannot leave part of it
+/// out and stay honest.
+fn skipped_detail_lines(blocked: u64, skipped: &[SkippedLanguage]) -> Vec<String> {
+    let mut lines: Vec<String> = skipped
+        .iter()
+        .map(|entry| {
+            format!(
+                "    {}: {} not enriched, because {}",
+                entry.language,
+                plural_count(entry.files, "file", "files"),
+                entry.reason
+            )
+        })
+        .collect();
+    let named: u64 = skipped.iter().map(|entry| entry.files).sum();
+    let unattributed = blocked.saturating_sub(named);
+    if unattributed > 0 {
+        // `further` only when there are rows above for it to be further than.
+        let count = if skipped.is_empty() {
+            plural_count(unattributed, "file", "files")
+        } else {
+            plural_count(unattributed, "further file", "further files")
+        };
+        lines.push(format!(
+            "    {count} blocked for a reason this sweep did not attribute to a language: an \
+             extension no language server here serves, or source it could not read from graph \
+             authority; `.kin/daemon.log` records each one"
+        ));
+    }
+    lines
+}
+
 /// What a FINISHED sweep amounts to: the line to print and the verdict to carry.
 ///
 /// One function rather than a wording helper beside a branch, because the two
 /// are the same claim and a test that reaches only one of them proves nothing
 /// about the other: a renderer test stays green when the branch that calls it is
-/// deleted.
+/// deleted. `kin daemon sweep` calls it too, for the same reason: it is the
+/// command the pending line below tells a reader to run next, and it printed
+/// `sweep complete (3/6 files)` off the same status object that named a language
+/// it could not serve.
 ///
 /// The middle arm is coldwalk finding 6. A macOS pass on `tokio-rs/axum`, on a
 /// host that DID carry rustup and rust-analyzer, printed
@@ -480,30 +525,57 @@ fn plural_count(n: u64, one: &str, many: &str) -> String {
 /// were JavaScript. One store cannot say both things. The zero-file guard could
 /// not catch it, because `done` was five rather than zero, and the count alone
 /// never could: `files_blocked` counts files and cannot name a language.
-fn cross_file_enrichment_outcome(
+///
+/// Only one arm here is entitled to the word `complete`, and it is the one where
+/// nothing at all was blocked. `complete (6/8 files)` was measured live on a
+/// ruby fixture: its own two numbers disagree, and the two files between them
+/// were named by nothing.
+pub(crate) fn cross_file_enrichment_outcome(
     done: u64,
     total: u64,
     blocked: u64,
     skipped: &[SkippedLanguage],
 ) -> (String, CrossFileEnrichment) {
+    let languages: Vec<&str> = skipped
+        .iter()
+        .map(|entry| entry.language.as_str())
+        .collect();
+
     // A sweep that enriched nothing reported the same sentence as one that had
     // nothing left to do, and on a JavaScript repository with 66 admitted files
     // that sentence was "complete (0/66 files)".
     if done == 0 && total > 0 {
-        return (
+        let mut lines = vec![format!(
+            "note: cross-file enrichment finished without enriching any of the {total} files \
+             it walked ({blocked} blocked); reference and import edges will be missing until \
+             it can run, and `.kin/daemon.log` records what stopped it"
+        )];
+        // The arm that loses the most used to name the least: it returned before
+        // it looked at the rows, so the coldwalk's own container leg, where the
+        // sweep walked 66 files and enriched none, handed a reader a count and a
+        // blocked number and never said which language they had lost or why.
+        // With no rows the headline already accounts for every blocked file, so
+        // nothing is appended and the sentence stays the one that shipped.
+        if !skipped.is_empty() {
+            lines.extend(skipped_detail_lines(blocked, skipped));
+        }
+        let pending = if languages.is_empty() {
             format!(
-                "note: cross-file enrichment finished without enriching any of the {total} files \
-                 it walked ({blocked} blocked); reference and import edges will be missing until \
-                 it can run"
-            ),
-            CrossFileEnrichment::Withheld {
-                pending: format!(
-                    "the sweep walked {total} files and enriched none of them, so cross-file \
-                     reference and override edges are not in this graph; `kin daemon sweep` \
-                     retries it"
-                ),
-            },
-        );
+                "the sweep walked {total} files and enriched none of them, so cross-file \
+                 reference and override edges are not in this graph; `kin daemon sweep` \
+                 retries it"
+            )
+        } else {
+            format!(
+                "the sweep walked {total} files and enriched none of them, so cross-file \
+                 reference and override edges are not in this graph, and it could not serve \
+                 {} at all: {}; the note above names what each one needs, and `kin daemon \
+                 sweep` retries once that is repaired",
+                plural_count(languages.len() as u64, "language", "languages"),
+                languages.join(", ")
+            )
+        };
+        return (lines.join("\n"), CrossFileEnrichment::Withheld { pending });
     }
     if !skipped.is_empty() {
         let mut lines = vec![format!(
@@ -511,18 +583,7 @@ fn cross_file_enrichment_outcome(
              unserved:",
             plural_count(skipped.len() as u64, "language", "languages")
         )];
-        for entry in skipped {
-            lines.push(format!(
-                "    {}: {} not enriched, because {}",
-                entry.language,
-                plural_count(entry.files, "file", "files"),
-                entry.reason
-            ));
-        }
-        let languages: Vec<&str> = skipped
-            .iter()
-            .map(|entry| entry.language.as_str())
-            .collect();
+        lines.extend(skipped_detail_lines(blocked, skipped));
         return (
             lines.join("\n"),
             CrossFileEnrichment::Withheld {
@@ -536,6 +597,19 @@ fn cross_file_enrichment_outcome(
                 ),
             },
         );
+    }
+    if blocked > 0 {
+        // Blocked files the daemon could not attribute to a language. The
+        // verdict deliberately stays `Produced`: every language this build
+        // serves WAS served, and telling a reader that `kin daemon sweep` would
+        // repair a file whose extension no server here handles is the same
+        // fabricated-cause defect in the other direction. What changes is the
+        // sentence, which no longer calls a pass with blocked files complete.
+        let mut lines = vec![format!(
+            "  cross-file enrichment covered {done} of {total} files:"
+        )];
+        lines.extend(skipped_detail_lines(blocked, skipped));
+        return (lines.join("\n"), CrossFileEnrichment::Produced);
     }
     (
         format!("  cross-file enrichment complete ({done}/{total} files)"),
@@ -1654,6 +1728,124 @@ mod tests {
             );
             assert!(!line.contains("complete"), "{line}");
             assert!(matches!(outcome, CrossFileEnrichment::Withheld { .. }));
+        }
+
+        /// The sentence accounts for every file the daemon says was blocked.
+        ///
+        /// Measured, at the sha this test lands on, on three rust, three
+        /// typescript and two ruby files with both language servers reachable:
+        /// `files_total` 8, `files_done` 3, `files_blocked` 5, and one skip row
+        /// naming rust with three files. The sentence's own figures added to six
+        /// of eight and the two ruby files were named by nothing, which is the
+        /// overclaim this whole function exists to close, surviving on an input
+        /// the row list cannot describe.
+        #[test]
+        fn every_blocked_file_is_accounted_for_even_when_no_row_names_it() {
+            let skipped = vec![SkippedLanguage {
+                language: "rust".to_string(),
+                files: 3,
+                reason: "the `rust-analyzer` language server did not start".to_string(),
+            }];
+            let (line, _) = cross_file_enrichment_outcome(3, 8, 5, &skipped);
+
+            assert!(
+                line.contains("rust: 3 files not enriched"),
+                "the row still names what it can: {line}"
+            );
+            assert!(
+                line.contains("2 further files"),
+                "the five blocked files minus the three the row names leaves two the \
+                 sentence must still account for: {line}"
+            );
+            assert!(
+                line.contains("did not attribute to a language"),
+                "the remainder says what it is rather than appearing as a gap in the \
+                 arithmetic: {line}"
+            );
+        }
+
+        /// One blocked file reads `1 further file`, never `1 further files`.
+        #[test]
+        fn the_remainder_counts_one_file_in_the_singular() {
+            let skipped = vec![SkippedLanguage {
+                language: "rust".to_string(),
+                files: 3,
+                reason: "the `rust-analyzer` language server did not start".to_string(),
+            }];
+            let (line, _) = cross_file_enrichment_outcome(4, 8, 4, &skipped);
+            assert!(line.contains("1 further file "), "{line}");
+            assert!(!line.contains("1 further files"), "{line}");
+        }
+
+        /// A pass with blocked files and no row to name them is not complete.
+        ///
+        /// `cross_file_enrichment_outcome(6, 8, 2, &[])` is the ruby fixture
+        /// above with both servers reachable, and it printed
+        /// `cross-file enrichment complete (6/8 files)` on a real `kin init` at
+        /// the parent commit. The function took `blocked` and used it only in
+        /// the zero-file arm, so the argument that catches this was already in
+        /// the signature.
+        ///
+        /// The verdict stays `Produced` on purpose: every language this build
+        /// serves was served, and promising that `kin daemon sweep` would repair
+        /// a file whose extension no server here handles is the fabricated-cause
+        /// defect pointing the other way. What is fixed is the sentence.
+        #[test]
+        fn blocked_files_with_no_row_still_end_the_word_complete() {
+            let (line, outcome) = cross_file_enrichment_outcome(6, 8, 2, &[]);
+            assert!(
+                !line.contains("complete"),
+                "a pass that blocked two of eight files did not complete: {line}"
+            );
+            assert!(
+                line.contains("covered 6 of 8 files"),
+                "the line still says what it did cover: {line}"
+            );
+            assert!(
+                line.contains("2 files blocked"),
+                "and it accounts for the rest: {line}"
+            );
+            assert!(
+                !line.contains("further"),
+                "there is no row above for these to be further than: {line}"
+            );
+            assert_eq!(outcome, CrossFileEnrichment::Produced);
+        }
+
+        /// With nothing enriched, the language the daemon named is still named.
+        ///
+        /// This is the coldwalk's own container leg: no language server existed,
+        /// `kin init` walked 66 files and enriched none. The arm that loses the
+        /// most used to name the least, because it returned before it looked at
+        /// the rows, so a user was told a count and a blocked number and never
+        /// which language they had lost.
+        #[test]
+        fn the_zero_file_case_names_the_language_when_the_daemon_named_one() {
+            let skipped = vec![SkippedLanguage {
+                language: "rust".to_string(),
+                files: 60,
+                reason: "the `rust-analyzer` language server did not start".to_string(),
+            }];
+            let (line, outcome) = cross_file_enrichment_outcome(0, 66, 66, &skipped);
+
+            assert!(!line.contains("complete"), "{line}");
+            assert!(
+                line.contains("rust: 60 files not enriched"),
+                "the language, its file count and its reason: {line}"
+            );
+            assert!(
+                line.contains("6 further files"),
+                "and the blocked files no row names: {line}"
+            );
+            match outcome {
+                CrossFileEnrichment::Withheld { pending } => assert!(
+                    pending.contains("rust"),
+                    "the withheld reason must name the language still owed: {pending}"
+                ),
+                CrossFileEnrichment::Produced => {
+                    panic!("a sweep that enriched nothing did not produce cross-file edges")
+                }
+            }
         }
     }
 

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -419,6 +419,130 @@ impl CrossFileEnrichment {
     }
 }
 
+/// One language a cold sweep could not serve, as `/lsp/sweep/status` reports it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SkippedLanguage {
+    language: String,
+    files: u64,
+    reason: String,
+}
+
+/// The languages `/lsp/sweep/status` says this sweep could not serve.
+///
+/// A row missing either half is dropped rather than defaulted. A language with
+/// no reason would print a skip nothing explains, and a reason with no language
+/// names nothing; both are worse than a shorter list, because the caller below
+/// keys its whole verdict on whether this comes back empty. A daemon too old to
+/// send the field reads as nothing skipped, which is the same conservative
+/// reading an unpublished readiness map already gets.
+fn skipped_languages_from_status(status: &serde_json::Value) -> Vec<SkippedLanguage> {
+    let Some(rows) = status.get("languages_skipped").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    rows.iter()
+        .filter_map(|row| {
+            let language = row.get("language")?.as_str()?.to_string();
+            let reason = row.get("reason")?.as_str()?.to_string();
+            if language.is_empty() || reason.is_empty() {
+                return None;
+            }
+            Some(SkippedLanguage {
+                language,
+                files: row.get("files").and_then(|v| v.as_u64()).unwrap_or(0),
+                reason,
+            })
+        })
+        .collect()
+}
+
+/// `1 file` and `2 files`, so a count never reads `1 files`.
+fn plural_count(n: u64, one: &str, many: &str) -> String {
+    if n == 1 {
+        format!("{n} {one}")
+    } else {
+        format!("{n} {many}")
+    }
+}
+
+/// What a FINISHED sweep amounts to: the line to print and the verdict to carry.
+///
+/// One function rather than a wording helper beside a branch, because the two
+/// are the same claim and a test that reaches only one of them proves nothing
+/// about the other: a renderer test stays green when the branch that calls it is
+/// deleted.
+///
+/// The middle arm is coldwalk finding 6. A macOS pass on `tokio-rs/axum`, on a
+/// host that DID carry rustup and rust-analyzer, printed
+/// `cross-file enrichment complete (5/303 files)`, and the same store's next
+/// `kin graph status` read `imports 0/1085 (0%)` and `cross-file reference and
+/// override edges unavailable for rust: no language server found`, numbers
+/// byte-identical to a container with no language server at all. The five files
+/// were JavaScript. One store cannot say both things. The zero-file guard could
+/// not catch it, because `done` was five rather than zero, and the count alone
+/// never could: `files_blocked` counts files and cannot name a language.
+fn cross_file_enrichment_outcome(
+    done: u64,
+    total: u64,
+    blocked: u64,
+    skipped: &[SkippedLanguage],
+) -> (String, CrossFileEnrichment) {
+    // A sweep that enriched nothing reported the same sentence as one that had
+    // nothing left to do, and on a JavaScript repository with 66 admitted files
+    // that sentence was "complete (0/66 files)".
+    if done == 0 && total > 0 {
+        return (
+            format!(
+                "note: cross-file enrichment finished without enriching any of the {total} files \
+                 it walked ({blocked} blocked); reference and import edges will be missing until \
+                 it can run"
+            ),
+            CrossFileEnrichment::Withheld {
+                pending: format!(
+                    "the sweep walked {total} files and enriched none of them, so cross-file \
+                     reference and override edges are not in this graph; `kin daemon sweep` \
+                     retries it"
+                ),
+            },
+        );
+    }
+    if !skipped.is_empty() {
+        let mut lines = vec![format!(
+            "  cross-file enrichment ended having enriched {done} of {total} files, leaving {} \
+             unserved:",
+            plural_count(skipped.len() as u64, "language", "languages")
+        )];
+        for entry in skipped {
+            lines.push(format!(
+                "    {}: {} not enriched, because {}",
+                entry.language,
+                plural_count(entry.files, "file", "files"),
+                entry.reason
+            ));
+        }
+        let languages: Vec<&str> = skipped
+            .iter()
+            .map(|entry| entry.language.as_str())
+            .collect();
+        return (
+            lines.join("\n"),
+            CrossFileEnrichment::Withheld {
+                pending: format!(
+                    "the sweep enriched {done} of {total} files and could not serve {}, so \
+                     cross-file reference and override edges for {} are not in this graph; the \
+                     note above names what each one needs, and `kin daemon sweep` retries once \
+                     that is repaired",
+                    plural_count(skipped.len() as u64, "language", "languages"),
+                    languages.join(", ")
+                ),
+            },
+        );
+    }
+    (
+        format!("  cross-file enrichment complete ({done}/{total} files)"),
+        CrossFileEnrichment::Produced,
+    )
+}
+
 /// Run the conversion phase and ALWAYS clean up after it.
 ///
 /// The cleanup used to sit after the happy-path wait, so every early return
@@ -631,26 +755,10 @@ async fn enrich_phase(kin_root: &Path, layout: &kin_core::KinLayout) -> CrossFil
                 .get("files_blocked")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0);
-            // A sweep that enriched nothing reported the same sentence as one
-            // that had nothing left to do, and on a JavaScript repository with
-            // 66 admitted files that sentence was "complete (0/66 files)". The
-            // conversion had not failed and nothing said the enrichment had.
-            if done == 0 && total > 0 {
-                note!(
-                    "note: cross-file enrichment finished without enriching any of the {total} \
-                     files it walked ({blocked} blocked); reference and import edges will be \
-                     missing until it can run"
-                );
-                return CrossFileEnrichment::Withheld {
-                    pending: format!(
-                        "the sweep walked {total} files and enriched none of them, so cross-file \
-                         reference and override edges are not in this graph; `kin daemon sweep` \
-                         retries it"
-                    ),
-                };
-            }
-            note!("  cross-file enrichment complete ({done}/{total} files)");
-            return CrossFileEnrichment::Produced;
+            let skipped = skipped_languages_from_status(&status);
+            let (line, outcome) = cross_file_enrichment_outcome(done, total, blocked, &skipped);
+            note!("{}", line);
+            return outcome;
         }
         if std::time::Instant::now() >= deadline {
             note!(
@@ -1405,6 +1513,150 @@ mod tests {
     /// other half, the sentence a user reads, because the defect this replaced
     /// lived in the sentence: the daemon computed the truth, logged the truth
     /// to itself, and handed the reader a fabrication.
+    /// Coldwalk finding 6, as its own module.
+    ///
+    /// Every fixture below is that walk's measurement rather than a shape
+    /// invented here: `tokio-rs/axum` on a macOS host carrying rustup and
+    /// rust-analyzer, `enriched 5/303 files`, the five JavaScript, and the same
+    /// store's next `kin graph status` reading `cross-file reference and
+    /// override edges unavailable for rust: no language server found`.
+    mod a_sweep_that_skipped_a_language {
+        use super::super::{
+            cross_file_enrichment_outcome, skipped_languages_from_status, CrossFileEnrichment,
+            SkippedLanguage,
+        };
+
+        const RUST_REASON: &str = "the `rust-analyzer` language server did not start (No such \
+                                   file or directory (os error 2)), so nothing in this language \
+                                   was enriched";
+
+        fn coldwalk_status() -> serde_json::Value {
+            serde_json::json!({
+                "running": false,
+                "files_done": 5,
+                "files_total": 303,
+                "files_blocked": 298,
+                "sweeps_completed": 1,
+                "enrichment_available": true,
+                "languages_skipped": [
+                    { "language": "rust", "files": 298, "reason": RUST_REASON }
+                ]
+            })
+        }
+
+        /// The sentence the walk caught, on the input that produced it.
+        ///
+        /// The ban on "complete" is the assertion rather than a style note. This
+        /// is the one place in that whole walkthrough where the product stated a
+        /// completion that did not happen, and it happened because `done` was 5
+        /// rather than 0, so the only guard on this branch could not fire.
+        #[test]
+        fn the_word_complete_is_not_used_and_the_gap_is_named() {
+            let skipped = skipped_languages_from_status(&coldwalk_status());
+            assert_eq!(skipped.len(), 1, "the fixture carries one skipped language");
+            let (line, outcome) = cross_file_enrichment_outcome(5, 303, 298, &skipped);
+
+            assert!(
+                !line.contains("complete"),
+                "a pass that could not serve a language must not report a completion: {line}"
+            );
+            assert!(
+                line.contains("enriched 5 of 303 files"),
+                "the line must say what WAS enriched: {line}"
+            );
+            assert!(
+                line.contains("rust"),
+                "the line must name the language that was skipped: {line}"
+            );
+            assert!(
+                line.contains("298 files"),
+                "the line must say how much was skipped: {line}"
+            );
+            assert!(
+                line.contains("rust-analyzer"),
+                "the line must say WHY, from what the daemon observed: {line}"
+            );
+            match outcome {
+                CrossFileEnrichment::Withheld { pending } => assert!(
+                    pending.contains("rust"),
+                    "the withheld reason must name the language still owed: {pending}"
+                ),
+                CrossFileEnrichment::Produced => {
+                    panic!("a sweep that skipped a whole language did not produce that language")
+                }
+            }
+        }
+
+        /// The control, and it is half of the test above.
+        ///
+        /// A ban on one word is satisfied by never saying anything, so the same
+        /// function on a sweep that skipped nothing must still reach the
+        /// completion line and `Produced`. Without this, deleting the word
+        /// everywhere would pass.
+        #[test]
+        fn a_sweep_that_skipped_nothing_still_reports_a_completion() {
+            let status = serde_json::json!({
+                "files_done": 303,
+                "files_total": 303,
+                "files_blocked": 0,
+                "languages_skipped": []
+            });
+            let skipped = skipped_languages_from_status(&status);
+            assert!(skipped.is_empty(), "no rows means nothing was skipped");
+
+            let (line, outcome) = cross_file_enrichment_outcome(303, 303, 0, &skipped);
+            assert!(
+                line.contains("cross-file enrichment complete (303/303 files)"),
+                "a sweep that served every language it met still completes: {line}"
+            );
+            assert_eq!(outcome, CrossFileEnrichment::Produced);
+        }
+
+        /// A daemon too old to send the field reads as nothing skipped, never as
+        /// an empty list dressed up as knowledge.
+        #[test]
+        fn a_status_without_the_field_reports_no_skipped_language() {
+            let status = serde_json::json!({ "files_done": 5, "files_total": 303 });
+            assert!(skipped_languages_from_status(&status).is_empty());
+        }
+
+        /// A row missing its reason is dropped rather than defaulted, because a
+        /// skip nothing explains sends its reader hunting a cause the daemon
+        /// never observed.
+        #[test]
+        fn a_row_missing_a_half_is_dropped_rather_than_defaulted() {
+            let status = serde_json::json!({
+                "languages_skipped": [
+                    { "language": "rust", "files": 298 },
+                    { "files": 12, "reason": "no language was named" },
+                    { "language": "python", "files": 12, "reason": "pyright did not start" }
+                ]
+            });
+            assert_eq!(
+                skipped_languages_from_status(&status),
+                vec![SkippedLanguage {
+                    language: "python".to_string(),
+                    files: 12,
+                    reason: "pyright did not start".to_string(),
+                }]
+            );
+        }
+
+        /// The zero-file case keeps its own sentence, which predates this and is
+        /// a different claim: nothing at all moved, rather than one language
+        /// moving while another could not.
+        #[test]
+        fn the_zero_file_case_keeps_its_own_sentence() {
+            let (line, outcome) = cross_file_enrichment_outcome(0, 66, 66, &[]);
+            assert!(
+                line.contains("without enriching any of the 66 files"),
+                "{line}"
+            );
+            assert!(!line.contains("complete"), "{line}");
+            assert!(matches!(outcome, CrossFileEnrichment::Withheld { .. }));
+        }
+    }
+
     mod enrichment_unavailable_notes {
         use super::super::enrichment_unavailable_note;
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -15257,6 +15257,15 @@ async fn lsp_sweep_status(State(state): State<Arc<DaemonState>>) -> impl IntoRes
         // without it `kin init` printed "complete (0/66 files)" over a sweep
         // whose language server never started.
         "files_blocked": state.lsp_sweep_files_blocked.load(Ordering::SeqCst),
+        // Which languages the sweep could not serve, and what it saw. The count
+        // above cannot name a language, so a pass that enriched one language and
+        // skipped another reported a nonzero `files_done` and nothing else, and
+        // `kin init` called that complete. This is the half that names it.
+        "languages_skipped": state
+            .lsp_sweep_languages_skipped
+            .lock()
+            .map(|skipped| serde_json::to_value(&*skipped).unwrap_or(json!([])))
+            .unwrap_or_else(|_| json!([])),
         "sweeps_completed": state.lsp_sweeps_completed.load(Ordering::SeqCst),
         // Reported rather than left for the caller to infer from a zero total:
         // a daemon with no language server never sweeps, and a caller waiting

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -5131,6 +5131,20 @@ pub async fn run_with_authority_on(
                         let mut server_start_failed: std::collections::HashSet<
                             kin_model::LanguageId,
                         > = std::collections::HashSet::new();
+                        // What this process OBSERVED when it tried to serve each
+                        // language it could not, and how many files that cost.
+                        // `files_blocked` counts files and cannot name a
+                        // language, which is why a completion line could read
+                        // "complete (5/303 files)" over a pass whose Rust server
+                        // never started. Kept beside the set rather than
+                        // replacing it so the retry short-circuit above stays a
+                        // set membership test.
+                        let mut skip_reason: std::collections::HashMap<
+                            kin_model::LanguageId,
+                            String,
+                        > = std::collections::HashMap::new();
+                        let mut skip_files: std::collections::HashMap<kin_model::LanguageId, u64> =
+                            std::collections::HashMap::new();
 
                         // Build entity index for the whole graph (used for target matching).
                         let entity_refs: Vec<kin_lsp::EntityRef> = entities
@@ -5225,6 +5239,7 @@ pub async fn run_with_authority_on(
                             // not retried for every remaining file.
                             if server_start_failed.contains(&lang) {
                                 tally.server_unavailable += 1;
+                                *skip_files.entry(lang).or_insert(0) += 1;
                                 continue;
                             }
 
@@ -5263,7 +5278,15 @@ pub async fn run_with_authority_on(
                                                  files in this language are left unenriched"
                                             );
                                             server_start_failed.insert(lang);
+                                            skip_reason.entry(lang).or_insert_with(|| {
+                                                format!(
+                                                    "the `{cmd}` language server did not start \
+                                                     ({e}), so nothing in this language was \
+                                                     enriched"
+                                                )
+                                            });
                                             tally.server_unavailable += 1;
+                                            *skip_files.entry(lang).or_insert(0) += 1;
                                             continue;
                                         }
                                     }
@@ -5276,7 +5299,13 @@ pub async fn run_with_authority_on(
                                 // uncounted file is how `files=0 total_files=66`
                                 // came to read as a completed sweep.
                                 server_start_failed.insert(lang);
+                                skip_reason.entry(lang).or_insert_with(|| {
+                                    "this build wires no language server for this language, so \
+                                     none was started"
+                                        .to_string()
+                                });
                                 tally.server_unavailable += 1;
+                                *skip_files.entry(lang).or_insert(0) += 1;
                                 continue;
                             };
 
@@ -5576,6 +5605,35 @@ pub async fn run_with_authority_on(
                         lsp_state
                             .lsp_sweep_files_blocked
                             .store(tally.blocked() as u64, std::sync::atomic::Ordering::SeqCst);
+                        // Published with the counts, so a caller reading a
+                        // nonzero blocked count can also say which language it
+                        // lost and what this process saw. Replaces the previous
+                        // sweep's record wholesale: a fresh answer supersedes an
+                        // old one, and a merged one would keep naming a language
+                        // whose server now starts.
+                        {
+                            let mut skipped: Vec<crate::state::SweepLanguageSkip> = skip_files
+                                .iter()
+                                .map(|(language, files)| crate::state::SweepLanguageSkip {
+                                    language: language.to_string(),
+                                    files: *files,
+                                    reason: skip_reason.get(language).cloned().unwrap_or_else(
+                                        || {
+                                            "this sweep could not serve the language and did not \
+                                             record why"
+                                                .to_string()
+                                        },
+                                    ),
+                                })
+                                .collect();
+                            // A HashMap iterates in an arbitrary order, so two
+                            // broken servers would otherwise hand the same host
+                            // a different sentence each run.
+                            skipped.sort_by(|a, b| a.language.cmp(&b.language));
+                            if let Ok(mut slot) = lsp_state.lsp_sweep_languages_skipped.lock() {
+                                *slot = skipped;
+                            }
+                        }
                         let unaccounted = tally.unaccounted(total_files);
                         let not_visited = tally.not_visited(total_files);
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2068,6 +2068,22 @@ fn salvage_from_sidecar_outcome(
     })
 }
 
+/// One language a cold sweep could not enrich, and the observation behind it.
+///
+/// The reason is what this process OBSERVED when it tried, never a cause
+/// derived from a count, which is the same discipline `enrichment_unavailable`
+/// already follows: a note that asserts a cause it did not measure tells a user
+/// with a working server that they have none.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct SweepLanguageSkip {
+    /// The language, as `LanguageId` renders it.
+    pub language: String,
+    /// Files in that language the sweep walked past.
+    pub files: u64,
+    /// What this process saw when it tried to serve the language.
+    pub reason: String,
+}
+
 pub struct DaemonState {
     pub layout: KinLayout,
     pub graph: Arc<kin_db::InMemoryGraph>,
@@ -2438,6 +2454,22 @@ pub struct DaemonState {
     /// running/idle flag cannot: a waiter that polls before the worker picks the
     /// message up reads idle and concludes it is done.
     pub lsp_sweeps_completed: AtomicU64,
+    /// Which languages the last cold sweep could not enrich, and why.
+    ///
+    /// `files_blocked` counts the files and cannot name a language, so a caller
+    /// holding a nonzero blocked count still cannot say what a user lost. That
+    /// gap is what let `kin init` print "cross-file enrichment complete
+    /// (5/303 files)" over a pass whose Rust server never started: five
+    /// JavaScript files moved, `files_done` was above zero, and the completion
+    /// branch had nothing to consult about the other language.
+    ///
+    /// The sweep already computes this to avoid retrying a failed server once
+    /// per file. Recording it here is what makes it readable off
+    /// `/lsp/sweep/status` instead of only in a log line.
+    ///
+    /// Written once at the end of a sweep, replacing whatever the previous
+    /// sweep left, because a fresh answer supersedes an old one wholesale.
+    pub lsp_sweep_languages_skipped: std::sync::Mutex<Vec<SweepLanguageSkip>>,
     /// Set while a sweep is in flight.
     pub lsp_sweep_running: AtomicBool,
     /// Files a sweep has finished enriching, so a later pass can skip them.
@@ -4460,6 +4492,7 @@ impl DaemonState {
             lsp_sweep_files_done: AtomicU64::new(0),
             lsp_sweep_files_total: AtomicU64::new(0),
             lsp_sweep_files_blocked: AtomicU64::new(0),
+            lsp_sweep_languages_skipped: std::sync::Mutex::new(Vec::new()),
             lsp_sweeps_completed: AtomicU64::new(0),
             lsp_sweep_running: AtomicBool::new(false),
             lsp_enriched_files: std::sync::Mutex::new(std::collections::HashSet::new()),
@@ -4739,6 +4772,7 @@ impl DaemonState {
             lsp_sweep_files_done: AtomicU64::new(0),
             lsp_sweep_files_total: AtomicU64::new(0),
             lsp_sweep_files_blocked: AtomicU64::new(0),
+            lsp_sweep_languages_skipped: std::sync::Mutex::new(Vec::new()),
             lsp_sweeps_completed: AtomicU64::new(0),
             lsp_sweep_running: AtomicBool::new(false),
             lsp_enriched_files: std::sync::Mutex::new(std::collections::HashSet::new()),
@@ -10062,6 +10096,45 @@ mod tests {
             .ingest_cas_dir()
             .join(&encoded[..2])
             .join(&encoded[2..])
+    }
+
+    /// The wire shape `/lsp/sweep/status` serves for a skipped language.
+    ///
+    /// `kin init` reads `language`, `files` and `reason` off each row to decide
+    /// whether a finished sweep may call itself complete, and it lives in
+    /// another crate that shares no type with this one. So a rename here is a
+    /// silent break there: the CLI's parser drops a row it cannot read, comes
+    /// back empty, and prints the completion sentence this whole record exists
+    /// to stop. Asserting the exact key set is what turns that into a red.
+    ///
+    /// What this does NOT close: that the handler still serves these rows under
+    /// `languages_skipped`, and that a real daemon reaches this branch at all.
+    /// Both need one language served while another is not, and the adapters'
+    /// server commands are constants in kin-lsp with no override, so no
+    /// hermetic fixture on an arbitrary host can arrange it yet.
+    #[test]
+    fn a_skipped_language_serializes_the_three_keys_kin_init_reads() {
+        let row = SweepLanguageSkip {
+            language: "rust".to_string(),
+            files: 298,
+            reason: "the `rust-analyzer` language server did not start".to_string(),
+        };
+        let value = serde_json::to_value(&row).expect("a skip row must serialize");
+        let object = value.as_object().expect("a skip row is a JSON object");
+        let mut keys: Vec<&str> = object.keys().map(|k| k.as_str()).collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["files", "language", "reason"],
+            "kin init reads exactly these three; adding or renaming one breaks a crate this \
+             one shares no type with"
+        );
+        assert_eq!(object["language"], serde_json::json!("rust"));
+        assert_eq!(object["files"], serde_json::json!(298));
+        assert!(object["reason"]
+            .as_str()
+            .expect("reason is a string")
+            .contains("rust-analyzer"));
     }
 
     fn test_state(layout: KinLayout, working_dir: &std::path::Path) -> DaemonState {

--- a/packages/kin-mcp/src/index.js
+++ b/packages/kin-mcp/src/index.js
@@ -196,25 +196,31 @@ export async function runKinMcp(argv = [], options = {}) {
   const cwd = options.cwd || process.cwd();
   if (!await kinRepoExists(cwd)) {
     if (!isTruthyEnv(env.KIN_MCP_AUTO_INIT)) {
-      stderr.write(
-        'No .kin/ found. Run `kin init .` first, or set KIN_MCP_AUTO_INIT=1 to allow this wrapper to initialize the repo.\n'
+      // Start anyway. This wrapper used to exit 2 here, and the configuration
+      // every client is handed points at this wrapper, so the advertised
+      // agent-setup path produced a server that died on `initialize` before a
+      // first-time user had any repository to bind. `kin mcp start` already
+      // treats an unbound launch directory as the ordinary case: it serves
+      // `initialize` and `tools/list`, re-resolves its repository on every
+      // later tool call, and answers each tool with the instruction to run
+      // `kin init`. Refusing here is the only thing that ever made this fatal.
+      stderr.write(noRepositoryNotice(cwd));
+    } else {
+      stderr.write('No .kin/ found; KIN_MCP_AUTO_INIT=1, running kin init...\n');
+      const initCode = await spawnKin(
+        binaryPath,
+        ['init', '.'],
+        {
+          ...spawnOptions,
+          cwd,
+          stdio: ['ignore', 'pipe', 'pipe']
+        },
+        { forwardOutputTo: stderr }
       );
-      return 2;
-    }
-    stderr.write('No .kin/ found; KIN_MCP_AUTO_INIT=1, running kin init...\n');
-    const initCode = await spawnKin(
-      binaryPath,
-      ['init', '.'],
-      {
-        ...spawnOptions,
-        cwd,
-        stdio: ['ignore', 'pipe', 'pipe']
-      },
-      { forwardOutputTo: stderr }
-    );
-    if (initCode !== 0) {
-      stderr.write('kin init failed. Cannot start MCP server.\n');
-      return initCode;
+      if (initCode !== 0) {
+        stderr.write('kin init failed. Cannot start MCP server.\n');
+        return initCode;
+      }
     }
   }
 
@@ -514,6 +520,26 @@ function parseChecksum(text) {
 
 function sha256(bytes) {
   return crypto.createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * What a launch directory that is no Kin repository is told, on stderr.
+ *
+ * Exported so the wording is assertable without spawning a server, and stderr
+ * rather than stdout because stdout is the protocol channel and a byte of prose
+ * on it corrupts the first frame.
+ */
+export function noRepositoryNotice(cwd) {
+  return [
+    `kin-mcp: no .kin/ found in ${cwd}, so no repository is bound yet.`,
+    'Starting anyway. The MCP transport comes up, `initialize` and `tools/list` are served,',
+    'and a graph tool called before a repository exists answers by naming the gap and telling',
+    'the caller to run `kin init .` rather than failing silently.',
+    'Run `kin init .` in the repository you want served, or point this client\'s workspace',
+    'roots at one. This server re-resolves its repository on later tool calls, so nothing here',
+    'needs a restart. Set KIN_MCP_AUTO_INIT=1 to let this wrapper run `kin init .` for you.',
+    ''
+  ].join('\n');
 }
 
 async function kinRepoExists(cwd) {

--- a/packages/kin-mcp/test/index.test.js
+++ b/packages/kin-mcp/test/index.test.js
@@ -86,6 +86,18 @@ const fakeKinPreload = [
   "      fs.mkdirSync(path.join(process.env.KIN_MCP_FAKE_REPO, '.kin'), { recursive: true });",
   "    }",
   "  }",
+  "  if (command === 'mcp' && process.env.KIN_MCP_FAKE_ECHO_INITIALIZE) {",
+  "    let request = '';",
+  "    try { request = fs.readFileSync(0, 'utf8'); } catch (error) { request = ''; }",
+  "    const method = /\"method\"\\s*:\\s*\"([^\"]+)\"/.exec(request);",
+  "    const payload = JSON.stringify({",
+  "      jsonrpc: '2.0',",
+  "      id: 1,",
+  "      result: { served: method ? method[1] : 'nothing-arrived', cwd: process.cwd() }",
+  "    });",
+  "    process.stdout.write(`Content-Length: ${Buffer.byteLength(payload)}\\r\\n\\r\\n${payload}`);",
+  "    process.exit(0);",
+  "  }",
   "  if (command === 'mcp') {",
   "    if (process.env.KIN_MCP_FAKE_PROFILE) {",
   "      fs.writeFileSync(process.env.KIN_MCP_FAKE_PROFILE, process.env.KIN_MCP_TOOL_PROFILE || '');",
@@ -569,20 +581,96 @@ test('runKinMcp invokes kin mcp start', async () => {
   }
 });
 
-test('runKinMcp refuses implicit init when .kin/ is missing', async () => {
+// Coldwalk finding 5. The install page hands every client
+// `{"command":"npx","args":["-y","@kinlab/kin-mcp"]}`, and this wrapper used to
+// exit 2 before `kin mcp start` ever ran when the launch directory held no
+// `.kin/`. Measured on 2026-08-28: EOF on `initialize`, process gone in 862 ms,
+// against `kin mcp start` in the same directory serving `initialize` in 6 ms
+// with 20 tools listed. So the advertised agent-setup path died on first
+// contact for exactly the user it exists for, the one who has not run
+// `kin init` yet.
+test('runKinMcp starts the server when the launch directory is no Kin repository', async () => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-no-autoinit-'));
+  const argsPath = path.join(tmpDir, 'args.txt');
+  const env = await fakeKinEnvironment(tmpDir, { KIN_MCP_FAKE_LOG: argsPath });
+  delete env.KIN_MCP_AUTO_INIT;
+  // fakeKinEnvironment points the fake `kin init` at tmpDir, and this test is
+  // about the path where init must not run at all.
+  delete env.KIN_MCP_FAKE_REPO;
 
   try {
     let stderr = '';
     const exitCode = await runKinMcp([], {
-      env: { ...process.env, KIN_MCP_KIN_BINARY: process.execPath },
+      env,
       cwd: tmpDir,
       stderr: { write(chunk) { stderr += chunk; } },
       stdio: 'ignore'
     });
 
-    assert.equal(exitCode, 2);
-    assert.match(stderr, /Run `kin init \.` first/);
+    assert.equal(exitCode, 0, 'a directory with no .kin/ must not be fatal');
+    assert.equal(
+      await fs.readFile(argsPath, 'utf8'),
+      'mcp\nstart\n',
+      'the wrapper must reach `kin mcp start`, and must not run `kin init` unasked'
+    );
+    assert.match(stderr, /Run `kin init \.`/);
+    assert.match(stderr, /Starting anyway/);
+    assert.equal(
+      await exists(path.join(tmpDir, '.kin')),
+      false,
+      'starting unbound must not initialize a repository behind the user'
+    );
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// The end-to-end half of finding 5: a real `initialize` request written to the
+// wrapper's stdin in an empty directory must reach the server and be answered.
+// The fixture reports the method it actually received, so a server that started
+// but was handed nothing answers `nothing-arrived` rather than passing.
+test('initialize is served through the wrapper in an empty directory', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-initialize-'));
+  const env = await fakeKinEnvironment(tmpDir, {
+    KIN_MCP_FAKE_ECHO_INITIALIZE: '1'
+  });
+  delete env.KIN_MCP_AUTO_INIT;
+  delete env.KIN_MCP_FAKE_REPO;
+
+  const request = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {} }
+  });
+
+  try {
+    const result = cp.spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL('../bin/kin-mcp.js', import.meta.url))],
+      {
+        cwd: tmpDir,
+        encoding: 'utf8',
+        env,
+        input: `Content-Length: ${Buffer.byteLength(request)}\r\n\r\n${request}`
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const framed = /Content-Length: \d+\r\n\r\n(\{.*\})$/.exec(result.stdout);
+    assert.ok(framed, `expected one framed response, got: ${JSON.stringify(result.stdout)}`);
+    const response = JSON.parse(framed[1]);
+    assert.equal(
+      response.result.served,
+      'initialize',
+      'the initialize request must reach the server, not die with the wrapper'
+    );
+    assert.doesNotMatch(
+      result.stdout,
+      /no \.kin\/ found/i,
+      'the notice belongs on stderr; a byte of prose on stdout corrupts the first frame'
+    );
+    assert.match(result.stderr, /Run `kin init \.`/);
     assert.equal(await exists(path.join(tmpDir, '.kin')), false);
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });

--- a/scripts/acceptance/first_contact_honesty.py
+++ b/scripts/acceptance/first_contact_honesty.py
@@ -4,10 +4,11 @@
 
 """First-contact honesty: what a stranger meets before the graph answers anything.
 
-Four defects strangers hit on shipped builds, each on a surface that runs before
+Seven defects strangers hit on shipped builds, each on a surface that runs before
 any semantic question is asked, and none of them visible to the suites that grade
 answers. Checks 0 to 2 come from the npm0549 green stranger on 0.5.49; check 3
-comes from the rc060n brown stranger on 0.6.0:
+comes from the rc060n brown stranger on 0.6.0; checks 4 to 6 come from the
+2026-08-28 cold walkthrough:
 
   CHECK 0 (FIR-2627)  `kin commit --help` never said a Kin commit is not a git
                       commit, so the write-through assumption formed at help and
@@ -30,12 +31,25 @@ comes from the rc060n brown stranger on 0.6.0:
                       conversion had already spent itself. Graded outside a
                       repository, which is the only place the question is asked
                       in time.
+  CHECK 4 (coldwalk)  `kin doctor --fix --install-language-servers` refused on a
+                      host with no `rustup`, so following the product's own
+                      repair left a Rust repository with no reference edges.
+  CHECK 5 (coldwalk)  the MCP entry the install page hands every client exited 2
+                      on `initialize` when the launch directory held no `.kin/`,
+                      which the page's own ordering guarantees for a first-time
+                      user.
+  CHECK 6 (coldwalk)  `kin init` printed `cross-file enrichment complete
+                      (5/303 files)` over a sweep whose Rust server never
+                      started, and the same store's `kin graph status` said the
+                      Rust edges were missing. One store cannot say both things.
 
-A new suite rather than three rows bolted onto the graph suites, for one reason:
-none of these needs a store, a daemon or a corpus, and all three are minutes
-faster without one. The CHECK line format, the exit codes and the JSON shape are
-the same as every other suite here, because scripts/acceptance/gate.py reads all
-of them through one contract.
+A new suite rather than rows bolted onto the graph suites, for one reason: these
+are graded on the surfaces a stranger meets first, and most of them need no
+store, no daemon and no corpus at all. Checks 4 and 6 do build one, because the
+defects they cover live in `kin init` and in a sweep; each builds its own from a
+handful of files and none of them touches a corpus. The CHECK line format, the
+exit codes and the JSON shape are the same as every other suite here, because
+scripts/acceptance/gate.py reads all of them through one contract.
 
 Exit status: 1 when any check fails, 2 when none fail but some are unreadable, 3
 on a setup error, 0 only when every selected check passes.
@@ -825,6 +839,556 @@ def check_4(suite):
     return res
 
 
+# --------------------------------------------------- an unbound MCP server
+#
+# The 2026-08-28 walkthrough's finding 5. The install page hands every client
+# the same MCP entry, `{"command":"npx","args":["-y","@kinlab/kin-mcp"]}`, and
+# the wrapper behind it refused before `kin mcp start` ever ran when the launch
+# directory held no `.kin/`. The page's own ordering guarantees the failure: it
+# says to point a client at the server and then run `kin init`, so a first-time
+# user restarts their client before any repository exists. Measured on 0.6.0:
+# EOF on `initialize` with the process gone in 862 ms.
+#
+# What this grades is the handshake, on the wrapper the install page names,
+# in a directory with no `.kin/`. The binary is supplied explicitly, because the
+# wrapper's own provisioning path downloads a release asset and a check that
+# needed the network would fail on a bad morning rather than on a defect.
+
+MCP_SERVED = "SERVED"
+MCP_EOF = "EOF_NO_RESPONSE"
+MCP_TIMEOUT = "TIMEOUT_NO_RESPONSE"
+MCP_PROBE_ID = 4242
+
+# Two sentences the notice owes a reader who is about to be served nothing.
+UNBOUND_NOTICE = "no repository is bound yet"
+UNBOUND_REPAIR = "kin init ."
+
+
+def mcp_initialize(command, cwd, env, timeout=180):
+    """Hand one `initialize` frame to a stdio MCP server and read the answer.
+
+    (verdict, stdout_lines, stderr_text, alive_after_answer). The verdict is
+    matched on this request's own JSON-RPC id rather than on something coming
+    back, because a server that writes a banner and dies would otherwise read as
+    one that answered. `alive` is read at the moment the answer arrives: the
+    defect is a wrapper that exits, and a served response from a process that
+    then died is not a server a client can use.
+    """
+    request = json.dumps({
+        "jsonrpc": "2.0",
+        "id": MCP_PROBE_ID,
+        "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                   "clientInfo": {"name": "first-contact-honesty", "version": "1"}},
+    })
+    try:
+        proc = subprocess.Popen(
+            command, cwd=cwd, env=env,
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True, bufsize=1)
+    except OSError as exc:
+        return "SPAWN_FAILED", [], "could not execute %s: %s" % (command[0], exc), False
+
+    lines = []
+    errors = []
+    answered = []
+
+    def drain_stderr():
+        for chunk in proc.stderr:
+            errors.append(chunk)
+
+    def read_stdout():
+        for line in proc.stdout:
+            lines.append(line)
+            try:
+                message = json.loads(line.strip())
+            except ValueError:
+                continue
+            if message.get("id") == MCP_PROBE_ID:
+                answered.append(message)
+                return
+
+    err_thread = threading.Thread(target=drain_stderr)
+    err_thread.daemon = True
+    err_thread.start()
+    out_thread = threading.Thread(target=read_stdout)
+    out_thread.daemon = True
+    out_thread.start()
+
+    try:
+        proc.stdin.write(request + "\n")
+        proc.stdin.flush()
+    except (IOError, OSError, ValueError):
+        # A process that has already gone takes the write with it. That is a
+        # reading, not an error: the verdict below reports EOF.
+        pass
+
+    out_thread.join(timeout)
+    alive = proc.poll() is None
+    if answered:
+        verdict = MCP_SERVED
+    elif out_thread.is_alive():
+        verdict = MCP_TIMEOUT
+    else:
+        verdict = MCP_EOF
+
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=10)
+    except Exception:  # noqa: BLE001 - a stuck child must not fail the suite
+        pass
+    err_thread.join(timeout=5)
+    return verdict, lines, "".join(errors), alive
+
+
+def grade_unbound_start(verdict, alive, stderr_text, stdout_lines, kin_created):
+    """(ok, detail) for a wrapper started where no repository exists."""
+    if verdict == MCP_TIMEOUT:
+        return None, ("the server neither answered `initialize` nor exited inside the "
+                      "budget, so this run says nothing about either behaviour")
+    if verdict.startswith("SPAWN_FAILED"):
+        return None, "the wrapper could not be started at all: %s" % flatten(stderr_text)[:200]
+    if verdict == MCP_EOF:
+        return False, (
+            "`initialize` got EOF with no response in a directory holding no `.kin/`, which "
+            "is the advertised MCP entry dying before a first-time user has a repository: %s"
+            % flatten(stderr_text)[:220])
+    if not alive:
+        return False, ("`initialize` was answered and the process was gone immediately after, "
+                       "so a client gets one frame and a dead server")
+    if kin_created:
+        return False, ("starting unbound initialized a repository behind the user; "
+                       "KIN_MCP_AUTO_INIT is what asks for that")
+    body = [line for line in stdout_lines if line.strip()]
+    if not body:
+        return None, "the server answered but wrote nothing this probe could read back"
+    try:
+        json.loads(body[0].strip())
+    except ValueError:
+        return False, ("the first thing on stdout is not a JSON-RPC frame, so prose is being "
+                       "written to the protocol channel: %r" % body[0][:120])
+    flat = flatten(stderr_text)
+    if UNBOUND_NOTICE not in flat:
+        return False, ("the server started and never said that no repository is bound, so the "
+                       "user is served an empty graph with no explanation: %s" % flat[:220])
+    if UNBOUND_REPAIR not in flat:
+        return False, ("the notice states the gap and not the repair, so a reader is told "
+                       "something is wrong and not what to run: %s" % flat[:220])
+    return True, ("`initialize` was served, the process stayed up, no repository was created "
+                  "behind the user, and the notice named the gap and the repair on stderr")
+
+
+def check_5(suite):
+    """The advertised MCP entry serves `initialize` outside a repository.
+
+    Probed through `packages/kin-mcp/bin/kin-mcp.js`, which is what
+    `npx -y @kinlab/kin-mcp` runs, rather than through `kin mcp start`: the
+    finding is about the wrapper, and the binary underneath it already served
+    this case. A probe pointed at the convenient surface would have reported the
+    product healthy.
+
+    The prober is proven able to say both words before either reading is
+    believed. A node process that exits without answering must read EOF, and a
+    four-line stub that answers any frame must read SERVED; without that pair, a
+    prober stuck on one verdict grades every wrapper as whatever it is stuck on.
+    """
+    res = Result("5", "cold-walk-2026-08-28",
+                 "the npx MCP wrapper serves initialize in a directory with no .kin/")
+
+    node = shutil.which("node")
+    if node is None:
+        res.unknown("no node on PATH, so the npm wrapper cannot be started here")
+        return res
+    wrapper = os.path.join(suite.repo_root, "packages", "kin-mcp", "bin", "kin-mcp.js")
+    if not os.path.exists(wrapper):
+        res.unknown("no wrapper at %s" % wrapper)
+        return res
+
+    work = suite.scratch("unbound-mcp")
+    home = suite.scratch("unbound-mcp-home")
+    env = suite.base_env()
+    env["HOME"] = home
+    env["KIN_HOME"] = os.path.join(home, ".kin")
+    # The wrapper's own provisioning downloads a release asset for its package
+    # version. Held fixed rather than measured, because this check is about the
+    # refusal in front of the server and not about how the binary arrives.
+    env["KIN_MCP_KIN_BINARY"] = suite.kin
+    env.pop("KIN_MCP_AUTO_INIT", None)
+
+    verdict, _, _, _ = mcp_initialize([node, "-e", "process.exit(2)"], work, env, timeout=60)
+    if verdict != MCP_EOF:
+        res.unknown("the negative control (a node process that answers nothing) read %s, so "
+                    "this prober cannot report a server that never answered" % verdict)
+        return res
+    answering_stub = (
+        'let buf="";process.stdin.on("data",d=>{buf+=d;const parts=buf.split("\\n");'
+        'buf=parts.pop();for(const line of parts){if(!line.trim())continue;'
+        'const m=JSON.parse(line);'
+        'process.stdout.write(JSON.stringify({jsonrpc:"2.0",id:m.id,result:{}})+"\\n");}});'
+        'setTimeout(()=>{},60000);'
+    )
+    verdict, _, _, alive = mcp_initialize([node, "-e", answering_stub], work, env, timeout=60)
+    if verdict != MCP_SERVED or not alive:
+        res.unknown("the positive control (a stub that answers every frame) read %s alive=%s, "
+                    "so this prober cannot report a server that did answer" % (verdict, alive))
+        return res
+    res.ok("the prober tells a served handshake from a process that exits, proven both ways "
+           "before the product was read")
+
+    verdict, out_lines, err, alive = mcp_initialize([node, wrapper], work, env, timeout=300)
+    kin_created = os.path.exists(os.path.join(work, ".kin"))
+    ok, detail = grade_unbound_start(verdict, alive, err, out_lines, kin_created)
+    if ok is None:
+        res.unknown(detail)
+        return res
+    if not ok:
+        res.bad(detail)
+        return res
+    res.ok(detail)
+    return res
+
+
+# ------------------------------------------- a sweep that skipped a language
+#
+# The 2026-08-28 walkthrough's finding 6. `kin init` on `tokio-rs/axum`, on a
+# macOS host that DID carry rustup and rust-analyzer, printed `cross-file
+# enrichment complete (5/303 files)`, and the same store's next `kin graph
+# status` read `imports 0/1085 (0%)` and `cross-file reference and override
+# edges unavailable for rust: no language server found`. The five files were
+# JavaScript. One store cannot say both things.
+#
+# Arranging it needs one language served while another is not, and the adapters'
+# server commands are constants in kin-lsp. PATH is the lever anyway:
+# `kin_lsp::lifecycle::LspServer::start` spawns them with `Command::new(command)`
+# on the bare name. So this scrubs `rust-analyzer` off PATH the way check 4
+# scrubs `rustup`, and puts a stub server on it under the TypeScript adapter's
+# name. The stub is what makes the check hermetic: no host is asked to have a
+# real language server, and the served language is served by bytes this file
+# writes.
+#
+# The control is the same fixture with the same stub reachable under BOTH names.
+# One PATH entry apart, one sweep must refuse the word `complete` and one must
+# use it. Without that pair a check that always reports a skipped language would
+# pass on a product that always reported one.
+
+# Rust files in the fixture below, which is the count the skipped-language row
+# has to report back. Named once so the fixture and the assertion cannot drift.
+RUST_FIXTURE_FILES = 3
+
+STUB_LSP_SERVER = r'''#!/usr/bin/env python3
+"""A stdio LSP server that completes the handshake and answers nothing else.
+
+Enough of the protocol for a sweep to count a file as visited. It declares the
+capabilities the daemon's readiness probe keys on and answers `workspace/symbol`
+at once, so readiness returns on the first poll instead of sleeping out its
+budget, and it answers every other request with a null result, so no query waits
+for a timeout. It resolves no reference and produces no edge: what it stands in
+for is a server that STARTS, which is the whole difference this check measures.
+"""
+import json
+import sys
+
+
+def read_message(stream):
+    length = None
+    while True:
+        line = stream.readline()
+        if not line:
+            return None
+        line = line.strip()
+        if not line:
+            break
+        if line.lower().startswith(b"content-length:"):
+            length = int(line.split(b":", 1)[1].strip())
+    if length is None:
+        return None
+    return json.loads(stream.read(length).decode("utf-8"))
+
+
+def write_message(stream, payload):
+    body = json.dumps(payload).encode("utf-8")
+    stream.write(b"Content-Length: %d\r\n\r\n" % len(body))
+    stream.write(body)
+    stream.flush()
+
+
+def main():
+    if "--version" in sys.argv[1:]:
+        sys.stdout.write("kin-acceptance-stub 0.0.0\n")
+        return 0
+    while True:
+        message = read_message(sys.stdin.buffer)
+        if message is None:
+            return 0
+        if "id" not in message:
+            if message.get("method") == "exit":
+                return 0
+            continue
+        if message.get("method") == "initialize":
+            result = {"capabilities": {
+                "referencesProvider": True,
+                "definitionProvider": True,
+                "typeDefinitionProvider": True,
+                "workspaceSymbolProvider": True,
+                "callHierarchyProvider": True,
+                "typeHierarchyProvider": True,
+            }}
+        else:
+            result = None
+        write_message(sys.stdout.buffer,
+                      {"jsonrpc": "2.0", "id": message["id"], "result": result})
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+# Both surfaces this check grades, in both their wordings. `kin init` and
+# `kin daemon sweep` share one function now, but they did not: the sweep printed
+# `sweep complete (3/6 files)` and nothing else. Keying the precondition on the
+# post-fix phrasing alone would grade the pre-fix sweep as a run that never
+# reached the phase, which reports UNREADABLE over a live completion claim.
+OUTCOME_MARKERS = ("cross-file enrichment", "sweep complete", "sweep finished")
+COMPLETION_CLAIMS = ("cross-file enrichment complete", "sweep complete")
+SKIP_ROW = re.compile(r"rust: (\d+) files? not enriched, because")
+
+
+def _outcome_reported(flat):
+    """The offset of the sweep's own outcome line, or None if it never printed one."""
+    found = [flat.find(marker) for marker in OUTCOME_MARKERS if marker in flat]
+    return min(found) if found else None
+
+
+def grade_skipped_language_outcome(output, expected_files=None):
+    """(ok, detail) for a sweep that served one language and not the other.
+
+    `expected_files` is the fixture's own count of files in the skipped
+    language. The daemon tallies one per blocked file, and a tally that stopped
+    after the first would report `1 file` for a language that lost hundreds:
+    that number reaches a user in a sentence, and nothing else in this suite or
+    in the unit tests reads it off a real sweep.
+    """
+    flat = flatten(output)
+    if not flat:
+        return None, "the run produced no output, so nothing could be graded"
+    at = _outcome_reported(flat)
+    if at is None:
+        return None, ("the run never reported a sweep outcome at all, so its silence about a "
+                      "skipped language is not evidence: %s" % flat[-220:])
+    claimed = [claim for claim in COMPLETION_CLAIMS if claim in flat]
+    if claimed:
+        return False, ("the pass reported a completion while a language went unserved, which "
+                       "is the sentence the walkthrough caught: %s"
+                       % flat[flat.find(claimed[0]):][:200])
+    row = SKIP_ROW.search(flat)
+    if row is None:
+        return False, ("the outcome never names the language it could not serve and how many "
+                       "files that cost, so a reader is told a count and nothing else: %s"
+                       % flat[at:][:260])
+    if "rust-analyzer" not in flat:
+        return False, ("the outcome names the language but not what the daemon observed when "
+                       "it tried, so the reason is left to be guessed: %s" % flat[at:][:260])
+    if expected_files is not None and int(row.group(1)) != expected_files:
+        return False, ("the outcome's count for the language is %s where this fixture holds %d "
+                       "files, so the count a user reads is not the count that was blocked: %s"
+                       % (row.group(1), expected_files, flat[at:][:260]))
+    return True, ("the pass refused the word complete and named the language, its %s files and "
+                  "the reason the daemon observed" % row.group(1))
+
+
+def grade_served_sweep_outcome(output):
+    """(ok, detail) for the control: every language met was served."""
+    flat = flatten(output)
+    if not flat:
+        return None, "the control run produced no output"
+    at = _outcome_reported(flat)
+    if at is None:
+        return None, ("the control never reported a sweep outcome at all, so it constrains "
+                      "nothing: %s" % flat[-220:])
+    if SKIP_ROW.search(flat):
+        return False, ("the control names a skipped language on a run where every server "
+                       "started, so the outcome reports a skip whatever happened: %s"
+                       % flat[at:][:260])
+    if not any(claim in flat for claim in COMPLETION_CLAIMS):
+        return False, ("a sweep that served every language it met still did not report a "
+                       "completion, so the ban on the word is satisfied by never saying "
+                       "anything: %s" % flat[at:][:260])
+    return True, "with both servers reachable the same fixture reports a completion"
+
+
+def _fixture_repository(suite, name):
+    """A git repository of three Rust and three TypeScript files, or None.
+
+    Both languages produce entities, so both reach the sweep's per-file loop.
+    Nothing else is added: a file whose extension no server here serves is
+    blocked for a different reason, and this check is about the language that
+    had one and could not use it.
+    """
+    git = shutil.which("git")
+    if git is None:
+        return None, "no git on PATH, so no repository can be admitted"
+    work = suite.scratch(name)
+    hooks = suite.scratch(name + "-nohooks")
+    os.makedirs(os.path.join(work, "src"))
+    os.makedirs(os.path.join(work, "web"))
+    for letter in ("a", "b", "c"):
+        with open(os.path.join(work, "src", "%s.rs" % letter), "w") as handle:
+            handle.write("pub fn %s_one() -> u32 { 1 }\n"
+                         "pub fn %s_two() -> u32 { %s_one() + 1 }\n"
+                         % (letter, letter, letter))
+    for letter in ("x", "y", "z"):
+        with open(os.path.join(work, "web", "%s.ts" % letter), "w") as handle:
+            handle.write("export function %sOne(): number { return 1; }\n"
+                         "export function %sTwo(): number { return %sOne() + 1; }\n"
+                         % (letter, letter, letter))
+    # The operator's own hooks are pointed away from, so a fixture commit cannot
+    # be refused by a policy that has nothing to do with this check.
+    common = [git, "-c", "core.hooksPath=%s" % hooks,
+              "-c", "user.email=acceptance@kin.invalid", "-c", "user.name=kin acceptance",
+              "-c", "commit.gpgsign=false"]
+    for args in (["init", "-q", "."], ["add", "-A"], ["commit", "-q", "-m", "fixture"]):
+        rc, _, err = run(common + args, cwd=work, timeout=300)
+        if rc != 0:
+            return None, "could not build the fixture repository (%s): %s" % (args[0],
+                                                                             flatten(err)[:200])
+    return work, "three Rust and three TypeScript files under one commit"
+
+
+def _stub_server_path(suite, name, names):
+    """A bin directory carrying the stub LSP server under each of `names`."""
+    binpath = suite.scratch(name)
+    source = os.path.join(binpath, "stub-language-server.py")
+    with open(source, "w") as handle:
+        handle.write(STUB_LSP_SERVER)
+    os.chmod(source, os.stat(source).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    for served in names:
+        os.symlink(source, os.path.join(binpath, served))
+    return binpath
+
+
+def _path_without_rust_analyzer(env):
+    """(PATH, complaint). Every entry that could resolve rust-analyzer is dropped.
+
+    `rustup` is dropped with it, because a rustup shim resolves `rust-analyzer`
+    through a proxy this scrub would otherwise walk straight past. The drop is
+    asserted rather than hoped for: the runner that builds this suite installs a
+    Rust toolchain, and a check that merely hoped for its absence would grade a
+    run where the real server started.
+    """
+    kept = [entry for entry in env.get("PATH", "").split(os.pathsep)
+            if entry
+            and not os.path.exists(os.path.join(entry, "rust-analyzer"))
+            and not os.path.exists(os.path.join(entry, "rustup"))]
+    path = os.pathsep.join(kept)
+    if shutil.which("rust-analyzer", path=path) is not None:
+        return None, ("the scrub left rust-analyzer reachable at %s"
+                      % shutil.which("rust-analyzer", path=path))
+    return path, ""
+
+
+def check_6(suite):
+    """A sweep that could not serve a language never calls the pass complete.
+
+    Two `kin init` runs on the same fixture, one PATH entry apart. In the first,
+    a stub language server is reachable under the TypeScript adapter's name and
+    `rust-analyzer` is not reachable at all, so three files are enriched and
+    three are not: the walkthrough's exact shape. In the second the same stub is
+    reachable under both names, so nothing is skipped and the completion line is
+    required. A ban on one word is satisfied by saying nothing, which is what the
+    second run is for.
+
+    `kin daemon sweep` is graded on the same store afterwards, because it is the
+    command the pending line tells a reader to run next and it printed
+    `sweep complete (3/6 files)` off the same status object that named rust.
+    """
+    res = Result("6", "cold-walk-2026-08-28",
+                 "a sweep that could not serve a language names it instead of reporting complete")
+
+    if shutil.which("python3") is None:
+        res.unknown("no python3 on PATH to run the stub language server")
+        return res
+
+    env = suite.base_env()
+    path, complaint = _path_without_rust_analyzer(env)
+    if path is None:
+        res.unknown(complaint)
+        return res
+    res.ok("rust-analyzer is unreachable on the scrubbed PATH, asserted rather than assumed")
+
+    work, detail = _fixture_repository(suite, "skipped-language-repo")
+    if work is None:
+        res.unknown(detail)
+        return res
+
+    home = suite.scratch("skipped-language-home")
+    served_only = _stub_server_path(suite, "skipped-language-bin",
+                                    ["typescript-language-server"])
+    skipped_env = dict(env)
+    skipped_env["HOME"] = home
+    skipped_env["KIN_HOME"] = os.path.join(home, ".kin")
+    skipped_env["PATH"] = os.pathsep.join([served_only, path])
+
+    rc, out, err = run([suite.kin, "init", "."], cwd=work, env=skipped_env, timeout=1800)
+    combined = (out or "") + "\n" + (err or "")
+    if rc != 0:
+        res.unknown("kin init exited %d on the fixture: %s" % (rc, flatten(err)[-260:]))
+        return res
+    ok, detail = grade_skipped_language_outcome(combined, RUST_FIXTURE_FILES)
+    if ok is None:
+        res.unknown(detail)
+        return res
+    if not ok:
+        res.bad("`kin init`: %s" % detail)
+        return res
+    res.ok("`kin init`: %s" % detail)
+
+    # The sibling command, on the store that run just built. It holds the whole
+    # status object and used to read two numbers out of it.
+    rc, out, err = run([suite.kin, "daemon", "sweep"], cwd=work, env=skipped_env, timeout=1800)
+    sweep_output = (out or "") + "\n" + (err or "")
+    if rc != 0:
+        res.unknown("kin daemon sweep exited %d: %s" % (rc, flatten(err)[-260:]))
+        return res
+    ok, detail = grade_skipped_language_outcome(sweep_output, RUST_FIXTURE_FILES)
+    if ok is None:
+        res.unknown("`kin daemon sweep`: %s" % detail)
+        return res
+    if not ok:
+        res.bad("`kin daemon sweep`: %s" % detail)
+        return res
+    res.ok("`kin daemon sweep`: %s" % detail)
+
+    control, detail = _fixture_repository(suite, "served-language-repo")
+    if control is None:
+        res.unknown("the control fixture could not be built: %s" % detail)
+        return res
+    control_home = suite.scratch("served-language-home")
+    both = _stub_server_path(suite, "served-language-bin",
+                             ["typescript-language-server", "rust-analyzer"])
+    control_env = dict(env)
+    control_env["HOME"] = control_home
+    control_env["KIN_HOME"] = os.path.join(control_home, ".kin")
+    control_env["PATH"] = os.pathsep.join([both, path])
+
+    rc, out, err = run([suite.kin, "init", "."], cwd=control, env=control_env, timeout=1800)
+    control_output = (out or "") + "\n" + (err or "")
+    if rc != 0:
+        res.unknown("the control kin init exited %d: %s" % (rc, flatten(err)[-260:]))
+        return res
+    ok, detail = grade_served_sweep_outcome(control_output)
+    if ok is None:
+        res.unknown(detail)
+        return res
+    if not ok:
+        res.bad(detail)
+        return res
+    res.ok(detail)
+    return res
+
+
 def _serve_asset(body):
     """A loopback HTTP server answering any path with `body`.
 
@@ -851,7 +1415,7 @@ def _serve_asset(body):
 
 
 CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3),
-          ("4", check_4)]
+          ("4", check_4), ("5", check_5), ("6", check_6)]
 
 
 # ----------------------------------------------------------------------- suite
@@ -1065,6 +1629,114 @@ def self_test():
     expect("a bare absence must FAIL", grade_toolchain_free_repair(only_absence)[0], False)
     expect("and it must be the absence branch that answered",
            ENDED_ON_ABSENCE in grade_toolchain_free_repair(only_absence)[1], True)
+
+
+    # The wrapper's notice, verbatim from `noRepositoryNotice` in
+    # packages/kin-mcp/src/index.js, and the 0.6.0 refusal it replaced. Held as
+    # literals the product emits rather than rebuilt from parts, because a
+    # grader fed a fixture this file invented cannot tell you what the wrapper
+    # says.
+    shipped_refusal_stderr = (
+        "No .kin/ found. Run `kin init .` first, or set KIN_MCP_AUTO_INIT=1 to allow "
+        "this wrapper to initialize the repo.\n"
+    )
+    fixed_notice_stderr = (
+        "kin-mcp: no .kin/ found in /tmp/empty, so no repository is bound yet.\n"
+        "Starting anyway. The MCP transport comes up, `initialize` and `tools/list` are served,\n"
+        "and a graph tool called before a repository exists answers by naming the gap and telling\n"
+        "the caller to run `kin init .` rather than failing silently.\n"
+        "Run `kin init .` in the repository you want served, or point this client's workspace\n"
+        "roots at one. This server re-resolves its repository on later tool calls, so nothing here\n"
+        "needs a restart. Set KIN_MCP_AUTO_INIT=1 to let this wrapper run `kin init .` for you.\n"
+    )
+    served_frame = ['{"jsonrpc":"2.0","id":4242,"result":{"protocolVersion":"2024-11-05"}}\n']
+    expect("the 0.6.0 wrapper dying on initialize must FAIL",
+           grade_unbound_start(MCP_EOF, False, shipped_refusal_stderr, [], False)[0], False)
+    expect("the fixed wrapper must PASS",
+           grade_unbound_start(MCP_SERVED, True, fixed_notice_stderr, served_frame, False)[0],
+           True)
+    expect("a server that neither answered nor exited is UNREADABLE",
+           grade_unbound_start(MCP_TIMEOUT, True, "", [], False)[0], None)
+    expect("an answer from a process that is already gone must FAIL",
+           grade_unbound_start(MCP_SERVED, False, fixed_notice_stderr, served_frame, False)[0],
+           False)
+    expect("starting unbound and initializing the repository anyway must FAIL",
+           grade_unbound_start(MCP_SERVED, True, fixed_notice_stderr, served_frame, True)[0],
+           False)
+    expect("the notice on the protocol channel must FAIL",
+           grade_unbound_start(MCP_SERVED, True, "",
+                               [fixed_notice_stderr] + served_frame, False)[0], False)
+    expect("a silent start with no notice at all must FAIL",
+           grade_unbound_start(MCP_SERVED, True, "", served_frame, False)[0], False)
+    expect("a notice naming the gap and not the repair must FAIL",
+           grade_unbound_start(MCP_SERVED, True,
+                               "kin-mcp: no .kin/ found in /tmp/empty, so no repository is "
+                               "bound yet.\n", served_frame, False)[0], False)
+
+    # The walkthrough's own sentence, and the one this suite requires instead.
+    # Both are what the product printed: the first on 0.6.0 against axum, the
+    # second on a three-Rust three-TypeScript fixture with rust-analyzer off
+    # PATH.
+    walkthrough_completion = (
+        "Enriching cross-file references (language server)...\n"
+        "  enriched 5/303 files\n"
+        "  cross-file enrichment complete (5/303 files)\n"
+    )
+    named_skip = (
+        "Enriching cross-file references (language server)...\n"
+        "  enriched 3/6 files\n"
+        "  cross-file enrichment ended having enriched 3 of 6 files, leaving 1 language "
+        "unserved:\n"
+        "    rust: 3 files not enriched, because the `rust-analyzer` language server did not "
+        "start (server failed to start: rust-analyzer: No such file or directory (os error 2)), "
+        "so nothing in this language was enriched\n"
+    )
+    expect("the walkthrough's completion sentence must FAIL",
+           grade_skipped_language_outcome(walkthrough_completion)[0], False)
+    expect("the named skip must PASS", grade_skipped_language_outcome(named_skip)[0], True)
+    expect("the named skip with the fixture's own count must PASS",
+           grade_skipped_language_outcome(named_skip, 3)[0], True)
+    # The tally that stopped counting after the first blocked file. The sentence
+    # is otherwise perfect, which is why only the number can catch it.
+    expect("a row reporting one file for a language that lost three must FAIL",
+           grade_skipped_language_outcome(
+               named_skip.replace("rust: 3 files", "rust: 1 file"), 3)[0], False)
+    expect("no output is UNREADABLE", grade_skipped_language_outcome("")[0], None)
+    expect("a run that never enriched anything is UNREADABLE",
+           grade_skipped_language_outcome("Initialized Kin repository authority at /tmp/x\n")[0],
+           None)
+    expect("an outcome that names no language must FAIL",
+           grade_skipped_language_outcome(
+               "Enriching cross-file references (language server)...\n"
+               "  cross-file enrichment ended having enriched 3 of 6 files\n")[0], False)
+    expect("an outcome that names the language and not the reason must FAIL",
+           grade_skipped_language_outcome(
+               "  cross-file enrichment ended having enriched 3 of 6 files, leaving 1 language "
+               "unserved:\n"
+               "    rust: 3 files not enriched, because the server was unavailable\n")[0], False)
+    # The pre-fix `kin daemon sweep`, which shares no wording with `kin init`.
+    # Its completion claim must be caught as a completion, never reported as a
+    # run that produced no outcome.
+    expect("the pre-fix sweep's own sentence must FAIL",
+           grade_skipped_language_outcome("  enriched 3/6 files\nsweep complete (3/6 files)\n")[0],
+           False)
+    # The control's own grader, which is what stops "never say complete" from
+    # passing a product that never says anything.
+    expect("the control must PASS on a sweep that served every language",
+           grade_served_sweep_outcome(
+               "Enriching cross-file references (language server)...\n"
+               "  cross-file enrichment complete (6/6 files)\n")[0], True)
+    expect("the control must FAIL when a skip is reported on a clean run",
+           grade_served_sweep_outcome(named_skip)[0], False)
+    expect("the control must FAIL when the outcome claims neither",
+           grade_served_sweep_outcome(
+               "  cross-file enrichment covered 6 of 8 files:\n"
+               "    2 files blocked for a reason this sweep did not attribute to a language\n"
+           )[0], False)
+    expect("the control on progress lines alone is UNREADABLE",
+           grade_served_sweep_outcome("  enriched 6/6 files\n")[0], None)
+    expect("the control on no output is UNREADABLE",
+           grade_served_sweep_outcome("")[0], None)
 
     for line in failures:
         print("SELF-TEST FAIL %s" % line)


### PR DESCRIPTION
## The findings

Two open items from the 2026-08-28 cold walkthrough, neither of which kin #1230 closed. The reviewer of that PR confirmed both were untouched by it and asked that they not be read as retired.

**Finding 5.** The install page hands every client the same MCP entry, `{"command":"npx","args":["-y","@kinlab/kin-mcp"]}`, and both one-click deeplinks carry that exact object. The wrapper behind it refused before `kin mcp start` ever ran when the launch directory held no `.kin/`. Measured in `/tmp` on macOS: `npx -y @kinlab/kin-mcp` gave EOF on `initialize` with the process gone in 862 ms, while `kin mcp start` in the same directory served `initialize` in 6 ms, listed 20 tools, and stayed alive. The page's own ordering guarantees the failure, since it says to point a client at the server and then run `kin init`, so a first-time user restarts their client before any repository exists.

**Finding 6.** `kin init` on `tokio-rs/axum`, on a macOS host that did carry rustup and rust-analyzer, printed `cross-file enrichment complete (5/303 files)`. The same store's next `kin graph status` read `rust: calls 4052/11883 (34%), imports 0/1085 (0%)` and `cross-file reference and override edges unavailable for rust: no language server found`, numbers byte-identical to a container that had no language server at all. The five files were JavaScript. One store cannot say both things, and this is the only place in that whole walkthrough where the product stated a completion that did not happen.

## Finding 5: start, and say what is missing

The refusal was the only thing that made this fatal. `kin mcp start` already treats an unbound launch directory as the ordinary case: `crates/kin-cli/src/commands/mcp.rs:183` prints its own guidance and continues, and a graph tool called before a repository exists gets `DelegateGap::NoRepository`, whose message already says "Run `kin init .` in the repository you want served". So the wrapper prints that guidance on stderr and starts the server.

`KIN_MCP_AUTO_INIT` is unchanged. Starting unbound still never initializes a repository behind the user, which is its own assertion below. The notice is exported so its wording is assertable without spawning, and it goes to stderr because stdout is the protocol channel.

## Finding 6: name what was skipped, and stop saying complete

The zero-file guard could not catch this. It fires on `done == 0` and `done` was five. `files_blocked` was the only other signal on that branch, and a file count cannot name a language.

The sweep already computed the missing half and threw it away: it keeps a per-language set of servers that failed to start, so it does not retry one once per file. Beside that set it now records what this process observed when it tried, and how many files that cost. The daemon serves those rows on `/lsp/sweep/status` as `languages_skipped`, and `kin init` reads them.

The decision and its wording are one function, `cross_file_enrichment_outcome`, because they are the same claim. A renderer tested on its own stays green when the branch that calls it is deleted. Its middle arm never uses the word complete, names what was enriched, names each skipped language with its file count and the reason the daemon observed, and returns `Withheld` so the pending line downstream names the language still owed.

## Both classes now carry a scripted acceptance check

The Lane Contract asks that every stranger finding class get one before its fix PR merges, and `scripts/acceptance/first_contact_honesty.py` is where the sibling coldwalk fix landed its own, one commit earlier. Check 5 and check 6 go beside it, on the same `PATH`-scrub technique check 4 already uses.

Check 5 hands the wrapper the install page names one `initialize` frame in a directory holding no `.kin/`, and requires a served response matched on its own JSON-RPC id, a process still alive at that moment, no repository created behind the user, the first thing on stdout parsing as a frame, and the notice naming both the gap and the repair on stderr. The prober is proven able to report both outcomes before either reading is believed: a node process that answers nothing must read EOF, and a stub that answers any frame must read SERVED. Without that pair a prober stuck on one verdict grades every wrapper as whatever it is stuck on.

Check 6 arranges one language served while another is not. The claim that no hermetic fixture could do that was wrong: `kin_lsp::lifecycle::LspServer::start` spawns a server with `Command::new(command)` on the adapter's bare name, so `PATH` is the lever. `rust-analyzer` and `rustup` are dropped from every entry that could resolve them, the drop is asserted rather than hoped for, and a stub LSP server the suite writes itself goes on `PATH` under the TypeScript adapter's name. Three files enrich and three do not, which is the walkthrough's exact shape on a host that needs no real language server, and the outcome must name the language, the reason the daemon observed, and a file count equal to the fixture's own three. That count is asserted rather than merely printed because the daemon tallies one per blocked file, and a tally that stopped after the first would report one file for a language that lost hundreds, in a sentence a user reads. `kin daemon sweep` is then graded on the same store, because it is the command the pending line tells a reader to run next. The control is the same fixture with the same stub reachable under both names, one `PATH` entry apart, where the completion line is required: a ban on one word is satisfied by never saying anything.

## Three sentences that were still overclaiming

**`kin daemon sweep` called a skipped-language sweep complete.** It printed `sweep complete (3/6 files)` while `languages_skipped`, in the status object it already held, named rust, three files and the reason the daemon observed. Measured live at the parent commit. It now calls the same function `kin init` does, so the two surfaces cannot drift.

**With nothing enriched, the skipped language was never named.** The zero-file arm returned before it looked at the rows, so the walkthrough's own container leg, where the sweep walked 66 files and enriched none, handed a reader a count and a blocked number and never said which language they had lost or why, even though the daemon now knows and is sending it. The arm that loses the most named the least.

**The rows and `files_blocked` are not the same number, and nothing said so.** Only the three `server_unavailable` paths record a row; `unsupported_language` and `source_unreadable` are blocked too. Measured end to end on three rust, three typescript and two ruby files with both language servers reachable: `files_total` 8, `files_done` 3, `files_blocked` 5, one row accounting for 3, and a reader who added the sentence's own figures got six of eight with nowhere to go for the other two. The same shape reached the completion arm: the same fixture with both servers reachable printed `cross-file enrichment complete (6/8 files)`, whose own two numbers disagree. Every blocked file is now accounted for, and only a pass that blocked nothing reports a completion.

The verdict deliberately stays `Produced` when no row names a language. Every language this build serves was served, and promising that `kin daemon sweep` repairs a file whose extension no server here handles is the fabricated-cause defect pointing the other way. What changed is the sentence. Separating `unsupported_language` from `source_unreadable` at the daemon, so each such file can be named rather than counted, is a follow-up rather than this PR.

## Falsification

Two grids, run after committing, both refusing a wrong sha and a dirty tree ABOVE the restore handler with their own exit codes, both restoring on EXIT, INT and TERM from an explicit `HEAD` source with every signal path ending in an exit, both asserting each mutation's marker is in the tree before its arm runs, both printing the restored VALUE rather than the word restored, and both counting distinct verdict markers against the arm list.

The first grid is the one the previous head carried, unchanged and still green. The second is this round's:

```
listing gate: new tests listed = 4 (expect 4), fabricated = 0 (expect 0)
VERDICT A0-init-baseline                       green  (rc=0, failures=0)
VERDICT A1-reconciliation-deleted              red    (rc=101, failed 4 test(s), first fired init.rs:1837 assert!()
VERDICT A2-blocked-arm-deleted                 red    (rc=101, failed 1 test(s), first fired init.rs:1797 assert!()
VERDICT A3-zero-arm-rows-deleted               red    (rc=101, failed 1 test(s), first fired init.rs:1833 assert!()
VERDICT A4-zero-arm-pending-unnamed            red    (rc=101, failed 1 test(s), first fired init.rs:1842 CrossFileEnrichment::Withheld { pending } => assert!()
VERDICT B0-acceptance-baseline                 green  (rc=0 check5=PASS check6=PASS)
VERDICT B1-mcp-refusal-restored                red    (check5=FAIL)
VERDICT B2-parser-reports-nothing              red    (check6=FAIL)
VERDICT B3-sweep-reuse-reverted                red    (check6=FAIL)
VERDICT B4-file-tally-stops-after-the-first    red    (check6=FAIL)
  distinct arms 10 (expect 10), baselines green 2 of 2, mutations red 8 of 8, survived 0, NOT-RUN 0
restored: did=2 (expect 2) cross-file=1 (expect 1) lines.extend(skipp=3 (expect 3) super::init::cross=1 (expect 1) noRepositoryNotice=2 (expect 2) *skip_files.entry(=3 (expect 3) markers=0 (expect 0) dirty=0 (expect 0)
```

Each mutation removes a property of the code rather than weakening an assertion. A1 stops stating the remainder, A2 lets a blocked pass fall through to the completion arm, A3 stops appending the rows in the zero-file arm, A4 stops naming the language in that arm's pending line, B1 restores the `return 2` the wrapper deletes, B2 makes the status parser report nothing skipped, B3 restores the sweep's own `sweep complete` line, and B4 stops the daemon counting a blocked file after the first so the row reports one where three were lost. A3 and A4 both turn one test red on DIFFERENT assertions inside it, which is why the fired line is read rather than the colour.

B2 is deliberately not "delete the skipped-language branch". With the reconciliation arm in place that mutation leaves the language named by a second producer, so it would have survived while looking like a caught mutant: adding a fallback arm silently weakened a mutation that used to be decisive.

## Gates

```
kin-precheck: repo=kin tree=lspinstall2-kin sha=000c07ffcef6fc1df5f391a0803dfa5081ac5767 branch=chore/lane-lspinstall2-kin
kin-precheck: 16 gates ran, 16 passed, 0 failed, on kin 000c07ffcef6fc1df5f391a0803dfa5081ac5767
16 per-check lines, 16 PASS, 0 FAIL, 0 NOT RUN
```

- `cargo test -p kin-cli --lib commands::init`: `running 41 tests`, 41 passed, 0 failed, 1864 filtered out. The falsification grid's listing gate asserted the four new tests are listed and that a fabricated filter lists zero, so the count is a count and not an empty filter.
- `node --test packages/kin-mcp/test/index.test.js`: 22 tests, 22 pass, 0 fail. No JavaScript changed this round.
- `python3 scripts/acceptance/first_contact_honesty.py --self-test`: 0 grader cases failed, over 22 new cases. It caught two real defects in the new graders before any product run.
- `python3 scripts/acceptance/first_contact_honesty.py --only 5,6` against binaries built from this tree: both PASS. That is the B0 baseline above.

`acceptance.yml` runs this suite in one job on `ubuntu-latest` with no `--only`, so checks 5 and 6 run there as soon as they land. That job is `if: github.event_name != 'pull_request'`, so their first run is on main after the merge rather than on this PR.

## Not claiming

- **The acceptance suite's own runs here are local.** `Product Acceptance` is `if: github.event_name != 'pull_request'`, so these two checks first speak on main after the merge rather than on this PR. Both were run against binaries built from this tree.
- Check 6's served language is served by a stub that completes the handshake and resolves nothing. What it stands in for is a server that STARTS, which is the whole difference the check measures; it produces no edge and no timing from it means anything.
- The finding 5 unit tests drive the wrapper against the suite's existing fake kin, not against a real `kin mcp start`. Check 5 drives the real binary.
- P2-3's `unsupported_language` half was arranged and measured on a ruby fixture. Its `source_unreadable` half was not: no run was arranged in which graph authority failed to hand the sweep a file's source, so that producer is asserted from the code and not from a run.
- This changes no behaviour on a launch directory that already holds a `.kin/`, none for `KIN_MCP_AUTO_INIT=1`, and none for a sweep that blocked nothing.
