### PR TITLE
Gate #1217's feature-only items, and stop grading an unclassifiable pid as a killed daemon

### DIFF
--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -1127,10 +1127,33 @@ pub fn read_serving_daemon(kin_root: &Path) -> Option<ServingDaemon> {
 /// attributes nothing either.
 ///
 /// A daemon whose pid is still alive is not settled: it is serving, and its
-/// record is doing its job.
+/// record is doing its job. Neither is one whose pid this host cannot
+/// classify, which is a third answer and not the second: see
+/// [`settle_unwatched_daemon_death_with`].
 pub fn settle_unwatched_daemon_death(kin_root: &Path) -> Option<DaemonKillRecord> {
+    settle_unwatched_daemon_death_with(kin_root, process_liveness)
+}
+
+/// [`settle_unwatched_daemon_death`] against a named liveness probe.
+///
+/// The probe is a parameter so a test can produce the answer a real host will
+/// not produce on demand, which is the `Unknown` this grading turns on.
+///
+/// A death is graded on `Dead` and on nothing else. `!process_is_alive(pid)`
+/// looks like the same test and is not: it folds `Unknown` in with `Dead`, so
+/// a host whose probe cannot classify a pid reports every serving record as a
+/// killed daemon. [`process_liveness`] is implemented for `unix` only and
+/// answers `Unknown` everywhere else, so on Windows that negation graded a
+/// kill for every store that had ever started a daemon, and `kin init` began
+/// exiting non-zero for it once FIR-2639 wired the record to the exit status.
+/// `unix` reaches it too, through the `EPERM` a reused pid owned by another
+/// user returns.
+fn settle_unwatched_daemon_death_with(
+    kin_root: &Path,
+    liveness: impl Fn(u32) -> Liveness,
+) -> Option<DaemonKillRecord> {
     let serving = read_serving_daemon(kin_root)?;
-    if process_is_alive(serving.pid) {
+    if liveness(serving.pid) != Liveness::Dead {
         return None;
     }
     retire_serving_daemon(kin_root);
@@ -1167,8 +1190,18 @@ pub fn settle_unwatched_daemon_death(kin_root: &Path) -> Option<DaemonKillRecord
 /// what the store WOULD record, not what the store has recorded, and a caller
 /// wanting the tally reads [`read_daemon_kill_record`] instead.
 pub fn peek_unwatched_daemon_death(kin_root: &Path) -> Option<DaemonKillRecord> {
+    peek_unwatched_daemon_death_with(kin_root, process_liveness)
+}
+
+/// [`peek_unwatched_daemon_death`] against a named liveness probe. Grades a
+/// death on `Dead` alone, for the reason
+/// [`settle_unwatched_daemon_death_with`] states.
+fn peek_unwatched_daemon_death_with(
+    kin_root: &Path,
+    liveness: impl Fn(u32) -> Liveness,
+) -> Option<DaemonKillRecord> {
     let serving = read_serving_daemon(kin_root)?;
-    if process_is_alive(serving.pid) {
+    if liveness(serving.pid) != Liveness::Dead {
         return None;
     }
     if read_daemon_death_note(kin_root).is_some_and(|note| note.pid == serving.pid) {
@@ -8682,6 +8715,62 @@ Shared_Dirty:          0 kB\n";
         let dir = tempfile::tempdir().unwrap();
         assert!(settle_unwatched_daemon_death(dir.path()).is_none());
         assert!(read_daemon_kill_record(dir.path()).is_none());
+    }
+
+    /// A pid this host cannot classify is not a death, and the same store with
+    /// the same record IS one when the probe can say so.
+    ///
+    /// Both halves in one test on purpose: the refusal alone would pass on a
+    /// grader that never reports anything, so the `Dead` arm is what proves the
+    /// `Unknown` arm refused something real.
+    ///
+    /// The arm that matters is `Unknown`, which is every non-`unix` answer
+    /// [`process_liveness`] has. Grading it as a death is what made every
+    /// Windows `kin init` report a killed daemon, and, once FIR-2639 wired that
+    /// record to the exit status, exit non-zero after publishing complete
+    /// authority.
+    #[test]
+    fn a_pid_this_host_cannot_classify_is_not_a_death() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid = u32::MAX;
+        fs::write(
+            serving_path(dir.path()),
+            serde_json::to_vec(&ServingDaemon {
+                pid,
+                oom_kills_at_start: Some(0),
+                at_unix: 1_000,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert!(
+            peek_unwatched_daemon_death_with(dir.path(), |_| Liveness::Unknown).is_none(),
+            "a probe that cannot classify a pid says nothing about whether it died"
+        );
+        assert!(
+            settle_unwatched_daemon_death_with(dir.path(), |_| Liveness::Unknown).is_none(),
+            "an unclassifiable pid must not be settled as a death"
+        );
+        assert!(
+            read_daemon_kill_record(dir.path()).is_none(),
+            "nothing may be written about a death nothing established"
+        );
+        assert!(
+            read_serving_daemon(dir.path()).is_some(),
+            "the record must survive, because retiring it claims the daemon ended"
+        );
+
+        assert!(
+            peek_unwatched_daemon_death_with(dir.path(), |_| Liveness::Alive).is_none(),
+            "a living daemon is serving, not dead"
+        );
+
+        let settled = settle_unwatched_daemon_death_with(dir.path(), |_| Liveness::Dead)
+            .expect("a probe that proves the pid is gone must grade the death");
+        assert_eq!(settled.kills, 1);
+        assert_eq!(settled.last_pid, Some(pid));
+        assert!(read_serving_daemon(dir.path()).is_none());
     }
 
     /// The peek reads what settling would take, and leaves it there.

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -306,12 +306,18 @@ struct DurableVectorTestState {
     artifacts: HashMap<(String, u64, u32, [u8; 32]), kin_db::PersistedVectorArtifact>,
     corrupt_loads: HashSet<String>,
     next_cursor: u64,
+    // Save counters and fault injection. Every reader is an `embeddings` test
+    // below, so a featureless build neither writes nor reads these three.
+    #[cfg(feature = "embeddings")]
     saves: u64,
+    #[cfg(feature = "embeddings")]
     last_expected_cursor: Option<kin_db::VectorArtifactCursor>,
+    #[cfg(feature = "embeddings")]
     next_save_fault: Option<DurableVectorSaveFault>,
 }
 
-#[cfg(test)]
+/// Every variant is constructed by an `embeddings` test and by nothing else.
+#[cfg(all(test, feature = "embeddings"))]
 #[derive(Debug, Clone, Copy)]
 enum DurableVectorSaveFault {
     ConflictInstallWinner,
@@ -347,6 +353,7 @@ impl DurableVectorTestBackend {
             .expect("test graph snapshot must publish")
     }
 
+    #[cfg(feature = "embeddings")]
     pub(crate) fn corrupt_vector_loads(&self, repo_id: &str) {
         self.vectors
             .lock()
@@ -384,6 +391,7 @@ impl DurableVectorTestBackend {
         state.corrupt_loads.insert(repo_id.to_string());
     }
 
+    #[cfg(feature = "embeddings")]
     pub(crate) fn vector_save_count(&self) -> u64 {
         self.vectors
             .lock()
@@ -391,6 +399,7 @@ impl DurableVectorTestBackend {
             .saves
     }
 
+    #[cfg(feature = "embeddings")]
     pub(crate) fn last_expected_vector_cursor(&self) -> Option<kin_db::VectorArtifactCursor> {
         self.vectors
             .lock()
@@ -398,6 +407,7 @@ impl DurableVectorTestBackend {
             .last_expected_cursor
     }
 
+    #[cfg(feature = "embeddings")]
     fn inject_next_save_fault(&self, fault: DurableVectorSaveFault) {
         self.vectors
             .lock()
@@ -405,6 +415,7 @@ impl DurableVectorTestBackend {
             .next_save_fault = Some(fault);
     }
 
+    #[cfg(feature = "embeddings")]
     fn current_vector_artifact(&self, repo_id: &str) -> Option<kin_db::PersistedVectorArtifact> {
         let binding = self.current_binding(repo_id).ok()?;
         self.vectors
@@ -415,6 +426,7 @@ impl DurableVectorTestBackend {
             .cloned()
     }
 
+    #[cfg(feature = "embeddings")]
     fn corrupt_current_vector_indexed_count(&self, repo_id: &str) {
         let binding = self
             .current_binding(repo_id)
@@ -550,7 +562,10 @@ impl StorageBackend for DurableVectorTestBackend {
             .vectors
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        state.last_expected_cursor = Some(expected);
+        #[cfg(feature = "embeddings")]
+        {
+            state.last_expected_cursor = Some(expected);
+        }
         let key = Self::artifact_key(repo_id, artifact.binding);
         let installed = state.artifacts.get(&key).map(|stored| stored.cursor);
         if installed.unwrap_or(kin_db::VectorArtifactCursor::INITIAL) != expected {
@@ -561,29 +576,36 @@ impl StorageBackend for DurableVectorTestBackend {
                 observed_cursor: installed,
             };
         }
+        #[cfg(feature = "embeddings")]
         let fault = state.next_save_fault.take();
-        if matches!(fault, Some(DurableVectorSaveFault::ConflictWithoutCursor)) {
-            return kin_db::VectorArtifactSaveOutcome::NotCommitted {
-                error: kin_db::KinDbError::StorageError(format!(
-                    "repo {repo_id}: injected vector conflict without cursor evidence"
-                )),
-                observed_cursor: None,
-            };
-        }
-        if matches!(
-            fault,
-            Some(DurableVectorSaveFault::IndeterminateNotInstalled)
-        ) {
-            return kin_db::VectorArtifactSaveOutcome::Indeterminate {
-                error: kin_db::KinDbError::StorageError(format!(
-                    "repo {repo_id}: injected ambiguous pre-install vector failure"
-                )),
-                observed_cursor: installed,
-            };
+        #[cfg(feature = "embeddings")]
+        {
+            if matches!(fault, Some(DurableVectorSaveFault::ConflictWithoutCursor)) {
+                return kin_db::VectorArtifactSaveOutcome::NotCommitted {
+                    error: kin_db::KinDbError::StorageError(format!(
+                        "repo {repo_id}: injected vector conflict without cursor evidence"
+                    )),
+                    observed_cursor: None,
+                };
+            }
+            if matches!(
+                fault,
+                Some(DurableVectorSaveFault::IndeterminateNotInstalled)
+            ) {
+                return kin_db::VectorArtifactSaveOutcome::Indeterminate {
+                    error: kin_db::KinDbError::StorageError(format!(
+                        "repo {repo_id}: injected ambiguous pre-install vector failure"
+                    )),
+                    observed_cursor: installed,
+                };
+            }
         }
         let cursor = kin_db::VectorArtifactCursor::from_backend_generation(state.next_cursor);
         state.next_cursor += 1;
-        state.saves += 1;
+        #[cfg(feature = "embeddings")]
+        {
+            state.saves += 1;
+        }
         state.corrupt_loads.remove(repo_id);
         state.artifacts.insert(
             key,
@@ -593,22 +615,26 @@ impl StorageBackend for DurableVectorTestBackend {
                 artifact_sha256,
             },
         );
-        if matches!(fault, Some(DurableVectorSaveFault::ConflictInstallWinner)) {
-            return kin_db::VectorArtifactSaveOutcome::NotCommitted {
-                error: kin_db::KinDbError::StorageError(format!(
-                    "repo {repo_id}: injected concurrent vector winner"
-                )),
-                observed_cursor: Some(cursor),
-            };
+        #[cfg(feature = "embeddings")]
+        {
+            if matches!(fault, Some(DurableVectorSaveFault::ConflictInstallWinner)) {
+                return kin_db::VectorArtifactSaveOutcome::NotCommitted {
+                    error: kin_db::KinDbError::StorageError(format!(
+                        "repo {repo_id}: injected concurrent vector winner"
+                    )),
+                    observed_cursor: Some(cursor),
+                };
+            }
+            if matches!(fault, Some(DurableVectorSaveFault::IndeterminateInstalled)) {
+                return kin_db::VectorArtifactSaveOutcome::Indeterminate {
+                    error: kin_db::KinDbError::StorageError(format!(
+                        "repo {repo_id}: injected lost vector acknowledgement"
+                    )),
+                    observed_cursor: Some(cursor),
+                };
+            }
         }
-        if matches!(fault, Some(DurableVectorSaveFault::IndeterminateInstalled)) {
-            return kin_db::VectorArtifactSaveOutcome::Indeterminate {
-                error: kin_db::KinDbError::StorageError(format!(
-                    "repo {repo_id}: injected lost vector acknowledgement"
-                )),
-                observed_cursor: Some(cursor),
-            };
-        }
+        #[cfg(feature = "embeddings")]
         let acknowledged_sha256 =
             if matches!(fault, Some(DurableVectorSaveFault::CommittedWrongDigest)) {
                 let mut wrong = artifact_sha256;
@@ -617,6 +643,8 @@ impl StorageBackend for DurableVectorTestBackend {
             } else {
                 artifact_sha256
             };
+        #[cfg(not(feature = "embeddings"))]
+        let acknowledged_sha256 = artifact_sha256;
         kin_db::VectorArtifactSaveOutcome::Committed {
             cursor,
             artifact_sha256: acknowledged_sha256,
@@ -1882,6 +1910,12 @@ struct HostedVectorProducerPolicy {
     allowed: kin_db::EmbeddingProducerSet,
 }
 
+/// The profile half of the policy on its own.
+///
+/// Gated on the two features that build its call sites: the sidecar refresh in
+/// `flush_embed_progress` (`embeddings`) and the sidecar write in
+/// `persist_vector_sidecar` (`vector`). A featureless build constructs neither.
+#[cfg(any(feature = "embeddings", feature = "vector"))]
 fn hosted_vector_producer_profile() -> std::result::Result<String, String> {
     hosted_vector_producer_policy().map(|policy| policy.profile)
 }
@@ -1985,6 +2019,9 @@ enum HostedVectorPersistenceState {
         authority: HostedVectorArtifactAuthority,
         detail: String,
     },
+    /// Constructed only by `persist_hosted_vector_artifact` and the reload it
+    /// runs after a conflict, both of which the `vector` feature builds.
+    #[cfg(feature = "vector")]
     ConflictReloading {
         binding: kin_db::VectorArtifactBinding,
         observed_cursor: Option<kin_db::VectorArtifactCursor>,
@@ -2003,10 +2040,9 @@ impl HostedVectorPersistenceState {
             Self::Empty { authority }
             | Self::Ready { authority, .. }
             | Self::RepairableCorrupt { authority, .. } => Some(*authority),
-            Self::NotHosted
-            | Self::Unsupported { .. }
-            | Self::ConflictReloading { .. }
-            | Self::Indeterminate { .. } => None,
+            Self::NotHosted | Self::Unsupported { .. } | Self::Indeterminate { .. } => None,
+            #[cfg(feature = "vector")]
+            Self::ConflictReloading { .. } => None,
         }
     }
 }
@@ -6334,6 +6370,7 @@ impl DaemonState {
                     ..HostedVectorPersistenceHealth::default()
                 }
             }
+            #[cfg(feature = "vector")]
             HostedVectorPersistenceState::ConflictReloading {
                 binding,
                 observed_cursor,


### PR DESCRIPTION
kin `main` has been red since #1217 landed, and a second failure joined it with
#1232. Every push to `main` since has produced a red run, and each one reads like
new news. This fixes both.

Neither leg runs on a pull request, so this PR's own green does not prove either
fix. That is the same push-only-guard shape as FIR-2892, and it is why the
evidence below is local runs of the exact CI commands rather than a check name.

## The boundary, read from the runs

`gh run list --repo firelock-ai/kin --branch main --workflow ci.yml`, sorted by
`createdAt` explicitly, with each run's failing jobs read from its own `jobs`
array rather than from the rollup:

| created (UTC) | run | head | failing jobs |
|---|---|---|---|
| 2026-08-28T21:37:07Z | 33213340084 | `7fc7801d7` | none |
| 2026-08-28T21:43:06Z | 33213757329 | `0b2d92815` (#1217) | Windows authority tests, Windows authority runtime tests, Feature permutation tests (ubuntu-latest) |
| 2026-08-28T23:47:06Z | 33221540930 | `e7122ccb9` (#1229) | the same three |
| 2026-08-29T01:54:36Z | 33227618508 | `5088b0e4c` (#1232) | those three plus Windows installer + vector release build |
| 2026-08-29T04:42:43Z | 33234472343 | `a943eb20a` (#1230) | the same four |

`git log --oneline 7fc7801d7..0b2d92815` and
`git log --oneline e7122ccb9..5088b0e4c` are each exactly one commit, so both
attributions are single-commit ranges rather than a guess over a span.

## 1. Dead-code lints, from #1217 `0b2d92815`

`RUSTFLAGS: -D warnings` is workflow-level (`ci.yml:40`), so `dead_code` is
denied. Three jobs build `kin-daemon` with the feature set that makes #1217's new
items unreachable, and all three fail during the build:

```
error: function `hosted_vector_producer_profile` is never used
error: variant `ConflictReloading` is never constructed
error: could not compile `kin-daemon` (lib) due to 2 previous errors
error: variants `ConflictInstallWinner`, `ConflictWithoutCursor`, `IndeterminateInstalled`, `IndeterminateNotInstalled`, and `CommittedWrongDigest` are never constructed
error: methods `corrupt_vector_loads`, `vector_save_count`, `last_expected_vector_cursor`, `inject_next_save_fault`, `current_vector_artifact`, and `corrupt_current_vector_indexed_count` are never used
error: could not compile `kin-daemon` (lib test) due to 4 previous errors
```

Nothing here is Windows-specific. `cargo check -p kin-daemon
--no-default-features --lib --tests --locked` under `RUSTFLAGS="-D warnings"`
reproduces all six lines on macOS, exit 101.

Each item is gated on the feature that builds its producers, found with
`git grep` over every call site rather than by guessing:

| item | producers | gate |
|---|---|---|
| `hosted_vector_producer_profile` | `flush_embed_progress` (`embeddings`), `persist_vector_sidecar` (`vector`) | `cfg(any(feature = "embeddings", feature = "vector"))` |
| `HostedVectorPersistenceState::ConflictReloading` | `reload_hosted_vector_persistence_after_conflict`, `persist_hosted_vector_artifact`, both `cfg(feature = "vector")` | `cfg(feature = "vector")` on the variant and on its two reader arms |
| `DurableVectorSaveFault` | five `#[cfg(feature = "embeddings")] #[test]` fns | `cfg(all(test, feature = "embeddings"))` |
| the six harness methods | every call site is an `embeddings` test | `cfg(feature = "embeddings")` |

No `allow(dead_code)`, blanket or `cfg_attr`, was added.

Two items are in this change that the compiler had not reported yet. Gating
`vector_save_count` and `last_expected_vector_cursor` leaves the `saves` and
`last_expected_cursor` fields written but never read, which is the same lint one
step later, so those fields and their write sites inside `save_vector_artifact`
are gated with them. That is why `save_vector_artifact` grew five `#[cfg]`
attributes rather than one.

`DurableVectorTestBackend` itself stays ungated on purpose. Four tests drive it
with no feature gate at all, two in `state.rs` and two in `api.rs`, so gating the
whole struct would have been fourteen attributes cheaper and would have deleted
four featureless tests.

## 2. The Windows admission contract, from #1232 `5088b0e4c`

The failing step is `Assert the Windows admission contract` (`ci.yml:749`), and
its errors are:

```
##[error]Windows exact-Git admission failed
##[error]Windows native-unborn bootstrap failed
##[error]Windows admission violated its shipped contract (2 check(s) failed)
```

Both are `require_admitted` in `scripts/assert-windows-init-contract.sh`, which
fails when `kin init` exits non-zero. `.kin` was published in both cases, and the
captured output carries `a daemon serving this store was killed`.

(The `::error::Windows registry authority --fix must fail as unsupported` line
visible in that job's log at 02:17:41Z is the step's own echoed source, not an
emitted error. It carries the command-echo escape, it lives at `ci.yml:698` in
`Verify Windows build provenance and feature set`, and that step passed.)

#1232 changed `kin init` from returning `Ok(())` unconditionally to exiting
`EXIT_ENRICHMENT_UNATTESTED = 7` when the store can prove a daemon serving it was
killed. That decision is right and is unchanged here. What is wrong is what "can
prove" reads on a host whose liveness probe cannot answer:

1. `init.rs:265` calls `daemon_death::recorded_for_store`.
2. `daemon_death.rs:50` calls `kin_daemon_spawn::peek_unwatched_daemon_death`.
3. That opened with `if process_is_alive(serving.pid) { return None; }` and
   graded everything else as a death.
4. `process_is_alive` is `matches!(process_liveness(pid), Liveness::Alive)`.
5. `process_liveness` is `#[cfg(unix)]` only. Its `#[cfg(not(unix))]` arm returns
   `Liveness::Unknown` unconditionally.

So on Windows `process_is_alive` answers `false` for every pid including a
running one, and step 3's negation graded a kill for every store carrying a
serving record. `kin init` publishes a store and starts a daemon for the
enrichment sweep, so that is every `kin init` on Windows. Before #1232 the same
false reading only printed a warning; #1232 wired it to the exit status.

`process_is_alive`'s own doc comment already forbids this use: "`true` is
positive proof of life, and every other outcome is the absence of proof rather
than proof of death." Two call sites read it as the negation.

Both graders now delegate to `*_with(kin_root, process_liveness)` seams that
grade a death on `liveness(pid) == Liveness::Dead` and nothing else. The probe is
a parameter so a test can produce the `Unknown` no host here produces on demand.
This reaches `unix` too, where `EPERM` on a pid recycled under another user maps
to `Unknown` and was being graded as a killed daemon.

**What this does not restore.** Windows still has no daemon-kill detection, and
had none before: `DaemonWatch::record_exit` has a `#[cfg(not(unix))]` arm
returning `None`, and `cgroup_memory` reads Linux files. This removes a false
positive; it does not remove a working detector. Said plainly, because "Windows
exits 0 again" is only good news if nothing true went with the false part.

**Evidence caveat.** I cannot run Windows here, so the Windows half rests on
source reading plus the run-level differential above, not on execution. One
control I ran and am not citing: the passing installer job at `e7122ccb9` has
zero occurrences of "a daemon serving this store was killed", but the script only
`cat`s the captured `kin init` output when a check FAILS, so a passing run cannot
contain that line whatever the binary did. That absence measures the script's
logging, not the behaviour.

## Where the new test runs

`a_pid_this_host_cannot_classify_is_not_a_death` runs wherever
`cargo test -p kin-daemon-spawn --lib` runs, so on both Check & Test legs. It does
NOT run on Windows: `ci.yml:404` and `ci.yml:413` are the only two
kin-daemon-spawn legs on that target and they are filtered to
`managed_spawn_fence` and
`tests::a_detached_spawn_does_not_hold_the_callers_stdout_open`. The test proves
the logic on a host where `Unknown` is injected; the source proves Windows is the
platform that answers `Unknown` for every pid.

No Windows leg asserts the old behaviour either. `kin-cli`'s `daemon_death::tests`
build serving records at `pid: u32::MAX` and would go red on Windows under this
change, but `Windows authority CLI tests` runs only the filters at
`ci.yml:462-491`, none of which selects them.

## Verification

Every command below ran in the lane worktree through `bin/kin-lane run`, which
prints the path, sha and branch it resolved.

Compile, `RUSTFLAGS="-D warnings"`, the five flag sets CI builds:

```
WINFIX SUMMARY featureless=0 default=0 gcs=0 cli=0 spawn=0
```

Tests, the CI steps verbatim:

```
WINFIX2 ARM spawn-lib-tests rc=0              cargo test -p kin-daemon-spawn --lib
WINFIX2 ARM featureless-kin-daemon-tests rc=0 cargo test -p kin-daemon --no-default-features --lib --tests --locked
WINFIX2 ARM featureless-kin-cli-tests rc=0    cargo test -p kin-cli --no-default-features --lib --tests --locked
WINFIX2 ARM gcs-nextest rc=0                  cargo nextest run -p kin-daemon --features gcs --locked
WINFIX2 SUMMARY spawn=0 daemon=0 cli=0 gcs=0
```

Zero `test result: FAILED` and zero `FAIL [` lines across all four. The gcs arm's
own verdict block reads `1217 tests run: 1217 passed (3 slow, 2 leaky), 3 skipped`.
The new test executed rather than being filtered out:
`test tests::a_pid_this_host_cannot_classify_is_not_a_death ... ok`.

Falsification, run on the clean pushed tree with the unmutated baseline graded
first. Each arm removes a property of the product, never weakens an assertion,
and a lint arm is graded only when the LINT fired, since an arm that fails to
compile is its own grade and not a red:

```
CONTROL listing real=1 fake=0 (expect 1 and 0)
ARM M0 baseline featureless=0 livetest=0
M1 cfg-still-on-target=0 (expect 0)
M2 cfg-still-on-target=0 (expect 0)
M3 cfg-still-on-a-ConflictReloading-site=0 (expect 0)
M4 mutation sites applied=2 (expect 2)
VERDICT M0-baseline GREEN
VERDICT M1-corrupt_vector_loads RED-ON-TARGET rc=101 lint=corrupt_vector_loads
VERDICT M2-hosted_vector_producer_profile RED-ON-TARGET rc=101 lint=hosted_vector_producer_profile
VERDICT M3-ConflictReloading RED-ON-TARGET rc=101 lint=ConflictReloading
VERDICT M4-unknown-is-not-a-death RED-ON-TARGET rc=101
WINFIX-FALSIFY distinct-arms=5 (expect 5) fails=0
RESTORED to c737ef6fa; dirty=[]
```

M1 ungates one harness method whose body still compiles featurelessly, M2 the
producer-profile helper, M3 the `ConflictReloading` variant AND both of its
reader arms, which is the pre-fix tree for that item (ungating the variant alone
leaves the match non-exhaustive, a compile error rather than this lint). M4
removes the property the daemon-death fix adds, restoring
`liveness(pid) == Liveness::Alive`, and the test went red on its `Unknown`
assertion by name rather than on a later one.

`bin/kin-precheck kin`:

```
kin-precheck: 16 gates ran, 16 passed, 0 failed, on kin c737ef6faa920e259f0788425fa000b462be00a9
```

Refs FIR-2892
