### PR TITLE
Make overall health the join over the component states

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -665,8 +665,27 @@ jobs:
             throw new Error(`Windows registry authority must report exactly one unsupported capability check: ${JSON.stringify(authority.checks ?? null)}`);
           }
 
-          const nonHealthyChecks = (report) => (report.checks ?? [])
-            .filter((check) => check.status !== "healthy")
+          // --- BEGIN HEALTH JOIN ---
+          // A check is out of scope only when the platform or the context puts it out of
+          // scope, which is exactly `unsupported`. Every other status is a component that
+          // is not answering at full strength, so a report claiming readiness over one
+          // claims more than its components support (FIR-2919).
+          const healthNeedsAttention = (check) =>
+            check.status !== "healthy" && check.status !== "unsupported";
+          // Something wrong with the INSTALL, as against work in flight or ground the
+          // host never had. A different question from the one above, and conflating the
+          // two is what fenced v0.6.1.
+          const healthBlocksReadiness = (check) =>
+            check.status === "missing" ||
+            check.status === "misconfigured" ||
+            (check.id === "semantic_query_readiness" && check.status === "stale");
+          const healthJoin = (checks) => {
+            if (checks.some(healthBlocksReadiness)) return "failing";
+            return checks.some(healthNeedsAttention) ? "needs_attention" : "ready";
+          };
+          // --- END HEALTH JOIN ---
+          const attentionRows = (report) => (report.checks ?? [])
+            .filter(healthNeedsAttention)
             .map((check) => `${check.id}=${check.status}`)
             .join(", ") || "none";
           const validateHealthReport = (report, reportPath) => {
@@ -677,15 +696,22 @@ jobs:
             if (checks.size !== report.checks.length) {
               throw new Error(`${reportPath}: duplicate health-check ids are not authoritative`);
             }
-            const expectedHealthy = !report.checks.some(
-              (check) =>
-                check.status === "missing" ||
-                check.status === "misconfigured" ||
-                (check.id === "semantic_query_readiness" && check.status === "stale")
-            );
-            if (report.healthy !== expectedHealthy) {
+            // Required, not optional. A report with no `verdict` came from a build that
+            // predates FIR-2919, whose aggregate gated on missing and misconfigured alone
+            // and read `true` over a pending or degraded row. Grading it against either
+            // rule would be a claim about bytes that cannot carry it.
+            if (report.verdict === undefined) {
               throw new Error(
-                `${reportPath}: aggregate healthy=${report.healthy} disagrees with checks; expected ${expectedHealthy}`
+                `${reportPath}: the report carries no verdict field, so these bytes predate FIR-2919 and their aggregate cannot be graded against the health join`
+              );
+            }
+            const verdict = healthJoin(report.checks);
+            if (report.verdict !== verdict) {
+              throw new Error(`${reportPath}: verdict=${report.verdict} disagrees with checks; expected ${verdict}`);
+            }
+            if (report.healthy !== (verdict === "ready")) {
+              throw new Error(
+                `${reportPath}: aggregate healthy=${report.healthy} disagrees with checks; expected ${verdict === "ready"}`
               );
             }
             return checks;
@@ -727,30 +753,40 @@ jobs:
           for (const reportPath of ["kin-windows-health.json", "kin-windows-doctor.json"]) {
             const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
             const checks = validateHealthReport(report, reportPath);
-            // Missing `repo_init` is the one degradation this repo-free posture
-            // expects, and it flips the aggregate report.healthy to false on its
-            // own. Accept that single named reason and keep every other
-            // degradation fatal, so a real regression in any other check still
-            // fails this leg.
-            // Work a correct install has not done yet, named as one check and
-            // one status. A public runner has never fetched the embedding
-            // model, so `embedding_model` reads `pending`, which is why the
-            // product's own readiness aggregate does not block on it either:
-            // it names expected first-run work rather than ground a working
-            // install lost. Tolerating it by name is the difference between a
+            // Everything a correct fresh repo-free Windows install reports
+            // beyond healthy and not-applicable, each named with the statuses it
+            // is allowed to hold. Tolerating by name is the difference between a
             // sweep that still fails when a second check goes pending and one
             // that waves through every status it has never seen.
-            const firstRunPending = new Map([["embedding_model", "pending"]]);
-            const tolerated = report.checks.every(
+            //
+            // `embedding_model` is pending because a public runner has never
+            // fetched the model. `memory_floor` is degraded because the runner
+            // has 4 GiB and Kin has no host-memory probe for target_os windows,
+            // so the row is scored against a stand-in rather than a measurement.
+            // Both are facts about the runner and not about the install, which is
+            // why the product's verdict for this report is `needs_attention` and
+            // not `failing`.
+            //
+            // `memory_floor` is here because it was NOT here. This sweep took
+            // `report.healthy` as its subject, the product answered `true` over
+            // both rows, and the contradiction reached the release instead of
+            // this step (FIR-2919). `repo_init` needed an exemption while it read
+            // `missing`; the required map below pins it `unsupported` and it no
+            // longer needs one.
+            const firstRunAttention = new Map([
+              ["embedding_model", ["pending"]],
+              ["memory_floor", ["degraded"]],
+            ]);
+            const untolerated = report.checks.filter(
               (check) =>
-                check.id === "repo_init" ||
-                check.status === "healthy" ||
-                check.status === "unsupported" ||
-                firstRunPending.get(check.id) === check.status
+                healthNeedsAttention(check) &&
+                !(firstRunAttention.get(check.id) ?? []).includes(check.status)
             );
-            if (!tolerated) {
+            if (untolerated.length > 0) {
               throw new Error(
-                `${reportPath}: overall healthy=${report.healthy}; non-healthy checks: ${nonHealthyChecks(report)}`
+                `${reportPath}: rows needing attention that a fresh repo-free install does not expect: ` +
+                `${untolerated.map((check) => `${check.id}=${check.status}`).join(", ")}; ` +
+                `verdict=${report.verdict}; every row needing attention: ${attentionRows(report)}`
               );
             }
             for (const [id, expected] of required) {
@@ -1754,8 +1790,27 @@ jobs:
             path,
             JSON.parse(fs.readFileSync(path, "utf8")),
           ]);
-          const nonHealthyChecks = (report) => (report.checks ?? [])
-            .filter((check) => check.status !== "healthy")
+          // --- BEGIN HEALTH JOIN ---
+          // A check is out of scope only when the platform or the context puts it out of
+          // scope, which is exactly `unsupported`. Every other status is a component that
+          // is not answering at full strength, so a report claiming readiness over one
+          // claims more than its components support (FIR-2919).
+          const healthNeedsAttention = (check) =>
+            check.status !== "healthy" && check.status !== "unsupported";
+          // Something wrong with the INSTALL, as against work in flight or ground the
+          // host never had. A different question from the one above, and conflating the
+          // two is what fenced v0.6.1.
+          const healthBlocksReadiness = (check) =>
+            check.status === "missing" ||
+            check.status === "misconfigured" ||
+            (check.id === "semantic_query_readiness" && check.status === "stale");
+          const healthJoin = (checks) => {
+            if (checks.some(healthBlocksReadiness)) return "failing";
+            return checks.some(healthNeedsAttention) ? "needs_attention" : "ready";
+          };
+          // --- END HEALTH JOIN ---
+          const attentionRows = (report) => (report.checks ?? [])
+            .filter(healthNeedsAttention)
             .map((check) => `${check.id}=${check.status}`)
             .join(", ") || "none";
           const validateHealthReport = (report, reportPath) => {
@@ -1766,15 +1821,22 @@ jobs:
             if (checks.size !== report.checks.length) {
               throw new Error(`${reportPath}: duplicate health-check ids are not authoritative`);
             }
-            const expectedHealthy = !report.checks.some(
-              (check) =>
-                check.status === "missing" ||
-                check.status === "misconfigured" ||
-                (check.id === "semantic_query_readiness" && check.status === "stale")
-            );
-            if (report.healthy !== expectedHealthy) {
+            // Required, not optional. A report with no `verdict` came from a build that
+            // predates FIR-2919, whose aggregate gated on missing and misconfigured alone
+            // and read `true` over a pending or degraded row. Grading it against either
+            // rule would be a claim about bytes that cannot carry it.
+            if (report.verdict === undefined) {
               throw new Error(
-                `${reportPath}: aggregate healthy=${report.healthy} disagrees with checks; expected ${expectedHealthy}`
+                `${reportPath}: the report carries no verdict field, so these bytes predate FIR-2919 and their aggregate cannot be graded against the health join`
+              );
+            }
+            const verdict = healthJoin(report.checks);
+            if (report.verdict !== verdict) {
+              throw new Error(`${reportPath}: verdict=${report.verdict} disagrees with checks; expected ${verdict}`);
+            }
+            if (report.healthy !== (verdict === "ready")) {
+              throw new Error(
+                `${reportPath}: aggregate healthy=${report.healthy} disagrees with checks; expected ${verdict === "ready"}`
               );
             }
             return checks;
@@ -1820,28 +1882,45 @@ jobs:
 
           for (const [path, report] of reports) {
             const checks = validateHealthReport(report, path);
-            // This capability capture runs before `kin embed`, so the daemon
-            // graph still has embeddings pending. A first fill reports
-            // semantic_query_readiness=pending and leaves report.healthy true,
-            // so this tolerance is not what carries the ordinary run. It
-            // remains for the one case that still blocks with work in flight:
-            // a store that had completed a fill and lost it, which reports
-            // stale. The post-embed embedded-health capture below still
-            // requires healthy=true with readiness=healthy, and every other
-            // unhealthy reason stays fatal here: any missing/misconfigured
-            // check, or any other check that is neither healthy nor
-            // unsupported, still fails.
-            const onlyPendingEmbeddingsBlocks =
-              checks.get("semantic_query_readiness")?.status === "stale" &&
-              report.checks.every(
-                (check) =>
-                  check.id === "semantic_query_readiness" ||
-                  check.status === "healthy" ||
-                  check.status === "unsupported"
-              );
-            if (report.healthy !== true && !onlyPendingEmbeddingsBlocks) {
+            // Every row a correct fresh Unix install reports beyond healthy and
+            // not-applicable, named with the statuses it may hold. This capture
+            // runs before `kin embed`, so the daemon graph still has embeddings
+            // pending and the model has never been fetched.
+            //
+            // This used to read `report.healthy !== true` with one tolerance for
+            // a stale readiness. On the v0.6.1 release run's own
+            // `install-proof-ubuntu-latest-33235776577` artifact,
+            // `kin-health.json` carried FIVE rows needing attention under
+            // `healthy: true`, so that assertion passed while naming none of
+            // them. Listing them is what makes a sixth fail (FIR-2919).
+            //
+            //   projection_mode          stale, the shim is installed and not
+            //                            engaged in this shell
+            //   semantic_query_readiness pending while the first pass fills,
+            //                            stale for a store that finished a fill
+            //                            and lost ground
+            //   reference_edge_coverage  pending, no language server on the
+            //                            runner
+            //   embedding_model          pending, the runner has never fetched
+            //                            the model
+            //   memory_floor             degraded, the runner is a small host
+            const firstRunAttention = new Map([
+              ["projection_mode", ["stale"]],
+              ["semantic_query_readiness", ["pending", "stale"]],
+              ["reference_edge_coverage", ["pending"]],
+              ["embedding_model", ["pending"]],
+              ["memory_floor", ["degraded"]],
+            ]);
+            const untolerated = report.checks.filter(
+              (check) =>
+                healthNeedsAttention(check) &&
+                !(firstRunAttention.get(check.id) ?? []).includes(check.status)
+            );
+            if (untolerated.length > 0) {
               throw new Error(
-                `${path}: overall healthy=${report.healthy}; non-healthy checks: ${nonHealthyChecks(report)}`
+                `${path}: rows needing attention that a fresh install does not expect: ` +
+                `${untolerated.map((check) => `${check.id}=${check.status}`).join(", ")}; ` +
+                `verdict=${report.verdict}; every row needing attention: ${attentionRows(report)}`
               );
             }
             for (const [id, expected] of required) {
@@ -1956,11 +2035,37 @@ jobs:
               const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
               const checks = validateHealthReport(report, reportPath);
               const readiness = checks.get("semantic_query_readiness")?.status;
-              if (report.healthy !== true || readiness !== "healthy") {
+              if (readiness !== "healthy") {
                 throw new Error(
-                  `${reportPath}: overall healthy=${report.healthy}; ` +
-                  `semantic_query_readiness=${readiness ?? "missing"}; ` +
-                  `non-healthy checks: ${nonHealthyChecks(report)}`
+                  `${reportPath}: semantic_query_readiness=${readiness ?? "missing"} after a ` +
+                  `completed embed; verdict=${report.verdict}; every row needing attention: ` +
+                  `${attentionRows(report)}`
+                );
+              }
+              // What a completed embed leaves behind on this runner, named. The
+              // model is cached and the fill is done, so `embedding_model` and
+              // `semantic_query_readiness` are gone from the list the pre-embed
+              // capture carries; the three below are the runner, not the embed.
+              // This used to read `report.healthy !== true`, which passed on the
+              // v0.6.1 run's own `kin-embedded-health.json` while those three
+              // rows sat inside it unnamed (FIR-2919). Naming them is what makes
+              // a fourth fail.
+              const postEmbedAttention = new Map([
+                ["projection_mode", ["stale"]],
+                ["reference_edge_coverage", ["pending"]],
+                ["memory_floor", ["degraded"]],
+              ]);
+              const stillWaiting = report.checks.filter(
+                (check) =>
+                  healthNeedsAttention(check) &&
+                  !(postEmbedAttention.get(check.id) ?? []).includes(check.status)
+              );
+              if (stillWaiting.length > 0) {
+                throw new Error(
+                  `${reportPath}: rows needing attention after a completed embed that this ` +
+                  `runner does not expect: ` +
+                  `${stillWaiting.map((check) => `${check.id}=${check.status}`).join(", ")}; ` +
+                  `verdict=${report.verdict}`
                 );
               }
             }

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -1159,6 +1159,26 @@ jobs:
             "vfs_projection",
             "projection_mode",
           ];
+          // --- BEGIN HEALTH JOIN ---
+          // A check is out of scope only when the platform or the context puts it out of
+          // scope, which is exactly `unsupported`. Every other status is a component that
+          // is not answering at full strength, so a report claiming readiness over one
+          // claims more than its components support (FIR-2919).
+          const healthNeedsAttention = (check) =>
+            check.status !== "healthy" && check.status !== "unsupported";
+          // Something wrong with the INSTALL, as against work in flight or ground the
+          // host never had. A different question from the one above, and conflating the
+          // two is what fenced v0.6.1.
+          const healthBlocksReadiness = (check) =>
+            check.status === "missing" ||
+            check.status === "misconfigured" ||
+            (check.id === "semantic_query_readiness" && check.status === "stale");
+          const healthJoin = (checks) => {
+            if (checks.some(healthBlocksReadiness)) return "failing";
+            return checks.some(healthNeedsAttention) ? "needs_attention" : "ready";
+          };
+          // --- END HEALTH JOIN ---
+
           const summary = [];
           const problems = [];
           for (const name of ["kin-health.json", "kin-doctor.json"]) {
@@ -1174,17 +1194,26 @@ jobs:
             // The rollup has to agree with the checks it summarizes. A release
             // has already been abandoned over an aggregate that disagreed with
             // its own list, and that defect is invisible to any check that only
-            // reads `healthy`.
-            const expectedHealthy = !report.checks.some(
-              (check) =>
-                check.status === "missing" ||
-                check.status === "misconfigured" ||
-                (check.id === "semantic_query_readiness" && check.status === "stale")
-            );
-            if (report.healthy !== expectedHealthy) {
+            // reads `healthy`. The rule is pasted above rather than restated
+            // here: this copy and the two in install-proof.yml said one thing
+            // while the product said another, which is how v0.6.1 was fenced
+            // (FIR-2919).
+            if (report.verdict === undefined) {
               problems.push(
-                `${name}: aggregate healthy=${report.healthy} disagrees with its checks; expected ${expectedHealthy}`
+                `${name}: the report carries no verdict field, so these bytes predate FIR-2919 and their aggregate cannot be graded against the health join`
               );
+            } else {
+              const verdict = healthJoin(report.checks);
+              if (report.verdict !== verdict) {
+                problems.push(
+                  `${name}: verdict=${report.verdict} disagrees with its checks; expected ${verdict}`
+                );
+              }
+              if (report.healthy !== (verdict === "ready")) {
+                problems.push(
+                  `${name}: aggregate healthy=${report.healthy} disagrees with its checks; expected ${verdict === "ready"}`
+                );
+              }
             }
             for (const id of asserted) {
               const status = byId.get(id)?.status;
@@ -1202,7 +1231,8 @@ jobs:
               .join("\n");
             summary.push(
               `### ${process.env.PROBE_OS}: ${name}\n\n` +
-                `Candidate archive \`${process.env.ARTIFACT}\`, aggregate healthy=${report.healthy}.\n\n` +
+                `Candidate archive \`${process.env.ARTIFACT}\`, aggregate healthy=${report.healthy}, ` +
+                `verdict=${report.verdict ?? "absent"}.\n\n` +
                 `| check | status | this job |\n| --- | --- | --- |\n${rows}\n`
             );
           }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -30,16 +30,18 @@ pub enum HealthStatus {
     Missing,
     Stale,
     Misconfigured,
-    /// Expected first-run work a correct install is still doing. It counts as
-    /// needing attention, because the surface is not answering at full strength
-    /// yet, but it never blocks readiness: nothing is wrong and nothing is lost.
+    /// Expected first-run work a correct install is still doing. Nothing is
+    /// wrong and nothing is lost, so it never makes the verdict
+    /// [`HealthVerdict::Failing`]. It does keep the report out of
+    /// [`HealthVerdict::Ready`], because the surface is not answering at full
+    /// strength yet and a roll-up that said otherwise would claim more than
+    /// this row supports.
     Pending,
     /// A real shortfall in the machine or container Kin was asked to run on,
-    /// rather than in the install. It reads red because ignoring it costs the
-    /// reader work, and it never blocks readiness because nothing about the
-    /// install is wrong: a host below a measured cost is a fact about the host,
-    /// and a gate that failed on one would fail every correct install on a
-    /// small machine.
+    /// rather than in the install. Nothing about the install is wrong, so it
+    /// never makes the verdict [`HealthVerdict::Failing`]: a host below a
+    /// measured cost is a fact about the host. It does keep the report out of
+    /// [`HealthVerdict::Ready`], for the same reason `Pending` does.
     Degraded,
     Unsupported,
 }
@@ -56,12 +58,40 @@ pub struct HealthCheck {
     pub manual_fix: Option<String>,
 }
 
+/// The overall verdict a [`HealthReport`] carries, as one word.
+///
+/// The boolean beside it answers "is everything answering at full strength",
+/// which is the only question a boolean can carry honestly. This says which of
+/// the two ways a report can fall short of that it is in, so a reader can tell
+/// an install that is still warming up on a small host from one that is broken
+/// without re-deriving it from the rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthVerdict {
+    /// Every check in scope is [`HealthStatus::Healthy`].
+    Ready,
+    /// Nothing about the install is wrong, and something is not answering at
+    /// full strength yet: work still in flight, or ground the host never had.
+    NeedsAttention,
+    /// Something about the install itself is wrong, or the semantic authority
+    /// cannot be read. See [`blocks_readiness`].
+    Failing,
+}
+
 /// Aggregated report across every health check.
+///
+/// `healthy` and `verdict` are derived from `checks` by [`join_over_checks`]
+/// and are private for that reason: the aggregate is not an independent
+/// opinion, and every place that could write one by hand is a place the
+/// roll-up can start claiming more than its components support. Build one with
+/// [`HealthReport::from_checks`], read the aggregate with [`HealthReport::healthy`]
+/// and [`HealthReport::verdict`].
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct HealthReport {
     pub platform: String,
     pub checks: Vec<HealthCheck>,
-    pub healthy: bool,
+    healthy: bool,
+    verdict: HealthVerdict,
 }
 
 impl HealthCheck {
@@ -97,14 +127,14 @@ fn is_failing(status: &HealthStatus) -> bool {
     matches!(status, HealthStatus::Missing | HealthStatus::Misconfigured)
 }
 
-/// Whether a check prevents the aggregate report from claiming readiness.
+/// Whether a check names something wrong with the INSTALL.
 ///
 /// Most `Stale` checks describe recoverable local drift and remain advisory,
 /// but semantic readiness is an authority gate: if daemon graph coverage is
 /// stale or cannot be read, the report cannot honestly claim the semantic
 /// query surface is ready.
 ///
-/// `Pending` sits deliberately outside that gate. It names work a correct
+/// `Pending` sits deliberately outside this predicate. It names work a correct
 /// install is expected to be doing on its way to ready, not ground a ready
 /// install lost, and a gate that cannot tell those apart fails every fresh
 /// install for succeeding.
@@ -112,18 +142,57 @@ fn is_failing(status: &HealthStatus) -> bool {
 /// `Degraded` sits outside it too, for the opposite reason. It names ground the
 /// host never had rather than ground a correct install lost, and a gate that
 /// failed on one would fail every correct install on a small machine.
+///
+/// This is not the same question as whether the report may claim readiness.
+/// That is [`needs_attention`], and conflating the two is what FIR-2919
+/// records.
 fn blocks_readiness(check: &HealthCheck) -> bool {
     is_failing(&check.status)
         || (check.id == "semantic_query_readiness" && matches!(check.status, HealthStatus::Stale))
 }
 
-fn assemble_health_report(platform: String, checks: Vec<HealthCheck>) -> HealthReport {
-    let healthy = !checks.iter().any(blocks_readiness);
-    HealthReport {
-        platform,
-        checks,
-        healthy,
+/// Whether a check keeps the report out of [`HealthVerdict::Ready`].
+///
+/// The one rule the whole roll-up is built from, and the reason it is one line:
+/// a check is out of scope only when the platform or the context puts it out of
+/// scope, which is exactly `Unsupported`. Every other status is a component
+/// that is not answering at full strength, so a report claiming readiness over
+/// one claims more than its components support.
+///
+/// FIR-2919 is what that costs when it is spelt twice. The roll-up gated on
+/// `blocks_readiness` while the printed readiness line gated on this, so a
+/// fresh Windows install emitted 19 `unsupported` rows, `embedding_model`
+/// `pending` and `memory_floor` `degraded` under `"healthy": true` while its
+/// own last printed line read "2 checks need attention". The release's install
+/// proof threw on the contradiction and fenced v0.6.1.
+///
+/// `pub(crate)` so the printed readiness line in `setup.rs` can call it. It
+/// held a verbatim copy of this predicate to derive its own count, which is the
+/// same shape as the defect one layer up: two surfaces of one report, each
+/// correct on its own, deriving the same rule twice.
+pub(crate) fn needs_attention(check: &HealthCheck) -> bool {
+    !matches!(
+        check.status,
+        HealthStatus::Healthy | HealthStatus::Unsupported
+    )
+}
+
+/// The whole roll-up, as one function of the checks.
+///
+/// Nothing else in Kin may compute an overall health verdict. Callers that
+/// need one build a [`HealthReport`] and read it back.
+fn join_over_checks(checks: &[HealthCheck]) -> HealthVerdict {
+    if checks.iter().any(blocks_readiness) {
+        HealthVerdict::Failing
+    } else if checks.iter().any(needs_attention) {
+        HealthVerdict::NeedsAttention
+    } else {
+        HealthVerdict::Ready
     }
+}
+
+fn assemble_health_report(platform: String, checks: Vec<HealthCheck>) -> HealthReport {
+    HealthReport::from_checks(platform, checks)
 }
 
 /// A pass/attention/skip tally over a set of checks, used for the one-line
@@ -132,14 +201,52 @@ fn assemble_health_report(platform: String, checks: Vec<HealthCheck>) -> HealthR
 pub struct HealthSummary {
     /// Checks that are Healthy.
     pub passed: usize,
-    /// Checks that need attention (Missing, Misconfigured, or Stale).
+    /// Checks that need attention, which is every check [`needs_attention`]
+    /// answers true for: Missing, Misconfigured, Stale, Pending or Degraded.
+    /// The list was already this long when the doc said three; the tally and
+    /// the roll-up read one predicate now, so they cannot drift again.
     pub attention: usize,
     /// Checks that do not apply on this platform / context (Unsupported).
     pub skipped: usize,
 }
 
 impl HealthReport {
+    /// Build a report and derive its aggregate from the checks it carries.
+    ///
+    /// The only way to make one. `healthy` and `verdict` are computed here by
+    /// [`join_over_checks`] and are private, so no caller and no test can hand
+    /// the report an aggregate its own rows do not support.
+    pub fn from_checks(platform: String, checks: Vec<HealthCheck>) -> Self {
+        let verdict = join_over_checks(&checks);
+        Self {
+            platform,
+            checks,
+            healthy: verdict == HealthVerdict::Ready,
+            verdict,
+        }
+    }
+
+    /// Whether every check in scope is answering at full strength.
+    ///
+    /// True exactly when [`HealthReport::verdict`] is [`HealthVerdict::Ready`].
+    /// A reader that needs to tell a warming install from a broken one reads
+    /// the verdict; this boolean cannot carry that difference and must not be
+    /// asked to.
+    pub fn healthy(&self) -> bool {
+        self.healthy
+    }
+
+    /// The overall verdict, derived from the checks by [`join_over_checks`].
+    pub fn verdict(&self) -> HealthVerdict {
+        self.verdict
+    }
+
     /// Tally checks into pass / needs-attention / not-applicable buckets.
+    ///
+    /// The attention bucket is [`needs_attention`] rather than its own list of
+    /// statuses, so the tally and the roll-up cannot disagree about what needs
+    /// attention. They did: the printed tally counted `pending` and `degraded`
+    /// while the aggregate did not (FIR-2919).
     pub fn summary(&self) -> HealthSummary {
         let mut summary = HealthSummary {
             passed: 0,
@@ -147,14 +254,12 @@ impl HealthReport {
             skipped: 0,
         };
         for check in &self.checks {
-            match check.status {
-                HealthStatus::Healthy => summary.passed += 1,
-                HealthStatus::Unsupported => summary.skipped += 1,
-                HealthStatus::Missing
-                | HealthStatus::Misconfigured
-                | HealthStatus::Stale
-                | HealthStatus::Pending
-                | HealthStatus::Degraded => summary.attention += 1,
+            if needs_attention(check) {
+                summary.attention += 1;
+            } else if matches!(check.status, HealthStatus::Unsupported) {
+                summary.skipped += 1;
+            } else {
+                summary.passed += 1;
             }
         }
         summary
@@ -5714,15 +5819,21 @@ mod tests {
         );
     }
 
-    /// Neither warning band may fail an install.
+    /// Neither warning band may report the install as broken.
     ///
-    /// The install proof computes its own aggregate from the check statuses and
-    /// fails a fresh install whose report disagrees with it, so a headroom band
-    /// that blocked readiness would fence a release at tag time, where no fix on
-    /// `main` can reach it. Both bands are asserted here rather than trusted to
-    /// the enum, because `blocks_readiness` is where that would go wrong.
+    /// A headroom band names ground the host never had. It keeps the report out
+    /// of `Ready`, because the row is real and the reader is entitled to see it
+    /// in the roll-up, and it must never reach `Failing`, which is the verdict
+    /// that says something about the install itself is wrong. Both bands are
+    /// asserted here rather than trusted to the enum, because `blocks_readiness`
+    /// is where that would go wrong.
+    ///
+    /// This used to assert `report.healthy` was true over a `Degraded` row,
+    /// which is the overclaim FIR-2919 records: the aggregate said ready while
+    /// the row said the machine had no measured room. The property the test was
+    /// written for survives as the `Failing` assertion; the overclaim does not.
     #[test]
-    fn no_commit_headroom_band_blocks_aggregate_readiness() {
+    fn no_commit_headroom_band_reports_the_install_as_broken() {
         for limit in [
             MEASURED_COMMIT_PEAKS[1].peak_bytes,
             12288 * MIB,
@@ -5740,11 +5851,28 @@ mod tests {
                 check.status
             );
             let report = assemble_health_report("test".to_string(), vec![check]);
+            assert_eq!(
+                report.verdict(),
+                HealthVerdict::NeedsAttention,
+                "a small machine needs attention and is not a broken install: {:?}",
+                check_status_of(&report, "commit_memory_headroom")
+            );
             assert!(
-                report.healthy,
-                "commit headroom must never flip the aggregate the install proof reads"
+                !report.healthy(),
+                "the roll-up may not claim readiness over a row that says the host has no \
+                 measured room"
             );
         }
+    }
+
+    /// The status a report carries for one id, for an assertion message.
+    fn check_status_of(report: &HealthReport, id: &str) -> String {
+        report
+            .checks
+            .iter()
+            .find(|check| check.id == id)
+            .map(|check| format!("{:?}", check.status))
+            .unwrap_or_else(|| format!("{id} absent"))
     }
 
     /// A machine with the headroom is told so, quoting the same measurement.
@@ -6170,9 +6298,9 @@ mod tests {
         );
     }
 
-    /// A `Stale` row needs attention without failing readiness. A missing
-    /// language server degrades a working install; calling it a failure would
-    /// turn `kin doctor` red on every host that never installed one.
+    /// A `Stale` row needs attention without reporting a broken install. A
+    /// missing language server degrades a working install; calling it a failure
+    /// would turn `kin doctor` red on every host that never installed one.
     #[test]
     fn a_missing_language_server_needs_attention_without_blocking_readiness() {
         let missing = missing_language_servers(
@@ -6186,8 +6314,17 @@ mod tests {
         );
         assert!(!blocks_readiness(&check));
         let report = assemble_health_report("test".to_string(), vec![check]);
-        assert!(report.healthy);
+        assert_eq!(
+            report.verdict(),
+            HealthVerdict::NeedsAttention,
+            "a host with no language server is not a broken install: {:?}",
+            report.checks[0].status
+        );
         assert_eq!(report.summary().attention, 1);
+        assert!(
+            !report.healthy(),
+            "the tally says one row needs attention, so the aggregate may not say ready"
+        );
     }
 
     /// A healthy response for the fetch tests to hand back.
@@ -8423,7 +8560,7 @@ mod tests {
         assert_eq!(summary.passed, 2);
         assert_eq!(summary.skipped, 1);
         assert!(
-            report.healthy,
+            report.healthy(),
             "the footer must close green on an install whose only unconfigured surface is one setup was told not to touch"
         );
 
@@ -8438,7 +8575,7 @@ mod tests {
             ],
         );
         assert_eq!(regressed.summary().attention, 1);
-        assert!(!regressed.healthy);
+        assert!(!regressed.healthy());
     }
 
     #[cfg(feature = "vector")]
@@ -8567,7 +8704,7 @@ mod tests {
         let summary = report.summary();
 
         assert!(
-            report.healthy,
+            report.healthy(),
             "a correct fresh install must not report as broken: {:?}",
             report
                 .checks
@@ -8962,40 +9099,248 @@ mod tests {
         ));
     }
 
+    // ------------------------------------------------------------------ join
+    //
+    // FIR-2919. The roll-up is one function of the rows, and these pin it. Each
+    // case is built through `HealthReport::from_checks`, which is the only
+    // constructor, so no fixture can describe an aggregate the product cannot
+    // produce.
+
+    fn joined(statuses: &[(&str, HealthStatus)]) -> HealthReport {
+        HealthReport::from_checks(
+            "test".to_string(),
+            statuses
+                .iter()
+                .map(|(id, status)| HealthCheck::new(id, id, status.clone(), "fixture"))
+                .collect(),
+        )
+    }
+
+    /// Every check healthy is the only shape that may claim readiness.
+    #[test]
+    fn the_join_reports_ready_over_all_healthy_checks() {
+        let report = joined(&[
+            ("kin_binary", HealthStatus::Healthy),
+            ("shell_path", HealthStatus::Healthy),
+        ]);
+        assert_eq!(report.verdict(), HealthVerdict::Ready);
+        assert!(report.healthy());
+        assert_eq!(report.summary().attention, 0);
+    }
+
+    /// `Unsupported` is out of scope, not a shortfall, so it does not
+    /// disqualify a ready verdict. This is the half of the rule that must NOT
+    /// change: 19 of the 33 rows a fresh Windows install emits are unsupported,
+    /// and a join that counted them would report every correct Windows install
+    /// as needing attention.
+    #[test]
+    fn the_join_reports_ready_over_healthy_plus_unsupported_checks() {
+        let report = joined(&[
+            ("kin_binary", HealthStatus::Healthy),
+            ("vfs_projection", HealthStatus::Unsupported),
+            ("registry_authority", HealthStatus::Unsupported),
+        ]);
+        assert_eq!(report.verdict(), HealthVerdict::Ready);
+        assert!(report.healthy());
+        assert_eq!(report.summary().skipped, 2);
+    }
+
+    /// One `Pending` row is enough. The install is not broken, so the verdict
+    /// is `NeedsAttention` and not `Failing`, and it is not ready either.
+    #[test]
+    fn the_join_refuses_ready_over_any_pending_check() {
+        let report = joined(&[
+            ("kin_binary", HealthStatus::Healthy),
+            ("vfs_projection", HealthStatus::Unsupported),
+            ("embedding_model", HealthStatus::Pending),
+        ]);
+        assert!(
+            !report.healthy(),
+            "a pending row is a component not answering at full strength"
+        );
+        assert_eq!(report.verdict(), HealthVerdict::NeedsAttention);
+        assert_eq!(serde_json::to_value(&report).unwrap()["healthy"], false);
+    }
+
+    /// One `Degraded` row is enough, for the same reason and not the same
+    /// cause: pending is work in flight, degraded is ground the host never had.
+    /// Both keep the report out of ready; neither makes it failing.
+    #[test]
+    fn the_join_refuses_ready_over_any_degraded_check() {
+        let report = joined(&[
+            ("kin_binary", HealthStatus::Healthy),
+            ("vfs_projection", HealthStatus::Unsupported),
+            ("memory_floor", HealthStatus::Degraded),
+        ]);
+        assert!(!report.healthy());
+        assert_eq!(report.verdict(), HealthVerdict::NeedsAttention);
+        assert_eq!(serde_json::to_value(&report).unwrap()["healthy"], false);
+    }
+
+    /// A broken install is a third answer, not the same one louder. Without
+    /// this, `healthy: false` would mean two different things and no consumer
+    /// could tell a warming install from one that cannot work.
+    #[test]
+    fn the_join_reports_failing_over_a_missing_check() {
+        let report = joined(&[
+            ("kin_binary", HealthStatus::Healthy),
+            ("embedding_model", HealthStatus::Pending),
+            ("shell_path", HealthStatus::Missing),
+        ]);
+        assert!(!report.healthy());
+        assert_eq!(
+            report.verdict(),
+            HealthVerdict::Failing,
+            "a missing component outranks work in flight"
+        );
+        assert_eq!(serde_json::to_value(&report).unwrap()["verdict"], "failing");
+    }
+
+    /// `Stale` on the semantic authority is the one stale that fails, and it
+    /// must still fail now that stale rows elsewhere merely need attention.
+    #[test]
+    fn the_join_separates_authority_stale_from_ordinary_stale() {
+        let authority = joined(&[
+            ("kin_binary", HealthStatus::Healthy),
+            ("semantic_query_readiness", HealthStatus::Stale),
+        ]);
+        assert_eq!(authority.verdict(), HealthVerdict::Failing);
+
+        let ordinary = joined(&[
+            ("kin_binary", HealthStatus::Healthy),
+            ("projection_mode", HealthStatus::Stale),
+        ]);
+        assert_eq!(
+            ordinary.verdict(),
+            HealthVerdict::NeedsAttention,
+            "an ordinary stale row is drift, not a broken install"
+        );
+        assert!(!ordinary.healthy());
+    }
+
+    /// The exact row set a fresh Windows install emitted on the v0.6.1 release
+    /// run, lifted from the `install-proof-windows-latest-33235776577`
+    /// artifact's `kin-windows-health.json` rather than composed here.
+    ///
+    /// This host cannot run Windows. What is portable is the rule, and the rule
+    /// is what the fixture exercises: 12 healthy rows, 19 unsupported, one
+    /// pending and one degraded, under `"healthy": true` on the shipped bytes.
+    /// That contradiction is what the release's install proof threw on, and it
+    /// is what this asserts is gone.
+    const WINDOWS_V061_ROWS: &[(&str, HealthStatus)] = &[
+        ("kin_binary", HealthStatus::Healthy),
+        ("kin_daemon_binary", HealthStatus::Healthy),
+        ("supervisor_startup_protocol", HealthStatus::Healthy),
+        ("daemon_running", HealthStatus::Unsupported),
+        ("daemon_idle_window", HealthStatus::Unsupported),
+        ("vfs_projection", HealthStatus::Unsupported),
+        ("projection_mode", HealthStatus::Unsupported),
+        ("repo_init", HealthStatus::Unsupported),
+        ("session_runtime", HealthStatus::Unsupported),
+        ("shell_path", HealthStatus::Healthy),
+        ("registry_authority", HealthStatus::Unsupported),
+        ("mcp_client_claude", HealthStatus::Healthy),
+        ("mcp_client_cursor", HealthStatus::Healthy),
+        ("mcp_client_gemini", HealthStatus::Healthy),
+        ("mcp_client_windsurf", HealthStatus::Healthy),
+        ("setup_ledger", HealthStatus::Healthy),
+        ("editor", HealthStatus::Unsupported),
+        ("kinlab_connect", HealthStatus::Unsupported),
+        ("semantic_query_readiness", HealthStatus::Unsupported),
+        ("reference_edge_coverage", HealthStatus::Unsupported),
+        ("relation_census", HealthStatus::Unsupported),
+        ("parse_coverage", HealthStatus::Unsupported),
+        ("background_work", HealthStatus::Unsupported),
+        ("embedding_model", HealthStatus::Pending),
+        ("memory_floor", HealthStatus::Degraded),
+        ("commit_memory_headroom", HealthStatus::Unsupported),
+        ("daemon_kill_record", HealthStatus::Unsupported),
+        ("interrupted_init", HealthStatus::Healthy),
+        ("suspended_sweep", HealthStatus::Unsupported),
+        ("host_memory_pressure", HealthStatus::Unsupported),
+        ("retrieval_profile", HealthStatus::Healthy),
+        ("update_policy", HealthStatus::Healthy),
+        ("binary_assessment_load", HealthStatus::Unsupported),
+    ];
+
+    #[test]
+    fn the_windows_first_install_row_set_no_longer_claims_ready() {
+        let report = joined(WINDOWS_V061_ROWS);
+        assert_eq!(report.checks.len(), 33, "the shipped row set is 33 rows");
+        let summary = report.summary();
+        assert_eq!(summary.passed, 12);
+        assert_eq!(summary.skipped, 19);
+        assert_eq!(
+            summary.attention, 2,
+            "embedding_model pending and memory_floor degraded"
+        );
+        assert!(
+            !report.healthy(),
+            "the shipped report emitted healthy=true over these exact rows"
+        );
+        assert_eq!(
+            report.verdict(),
+            HealthVerdict::NeedsAttention,
+            "nothing about that install was broken; it had not fetched the model \
+             and the host was small"
+        );
+
+        // The control that makes the assertion above mean something. Drop the
+        // two rows that need attention and the same 31 rows must read ready, or
+        // this is a fixture that fails for having any rows at all.
+        let in_scope_only: Vec<(&str, HealthStatus)> = WINDOWS_V061_ROWS
+            .iter()
+            .filter(|(id, _)| *id != "embedding_model" && *id != "memory_floor")
+            .map(|(id, status)| (*id, status.clone()))
+            .collect();
+        let control = joined(&in_scope_only);
+        assert_eq!(control.checks.len(), 31);
+        assert_eq!(
+            control.verdict(),
+            HealthVerdict::Ready,
+            "19 unsupported rows must not be what refuses readiness"
+        );
+        assert!(control.healthy());
+    }
+
     #[test]
     fn summary_tallies_pass_attention_skip_buckets() {
-        let report = HealthReport {
-            platform: "test".to_string(),
-            checks: vec![
+        // Every status the enum carries, so the tally is graded over the whole
+        // vocabulary rather than the four an author happens to think of.
+        let report = HealthReport::from_checks(
+            "test".to_string(),
+            vec![
                 check_with("a", HealthStatus::Healthy),
                 check_with("b", HealthStatus::Healthy),
                 check_with("c", HealthStatus::Missing),
                 check_with("d", HealthStatus::Misconfigured),
                 check_with("e", HealthStatus::Stale),
                 check_with("f", HealthStatus::Unsupported),
+                check_with("g", HealthStatus::Pending),
+                check_with("h", HealthStatus::Degraded),
             ],
-            healthy: false,
-        };
+        );
         let summary = report.summary();
         assert_eq!(summary.passed, 2, "two Healthy checks pass");
         assert_eq!(
-            summary.attention, 3,
-            "Missing + Misconfigured + Stale need attention"
+            summary.attention, 5,
+            "Missing + Misconfigured + Stale + Pending + Degraded need attention"
         );
         assert_eq!(summary.skipped, 1, "Unsupported is not applicable");
     }
 
     #[test]
     fn summary_buckets_sum_to_total_checks() {
-        let report = HealthReport {
-            platform: "test".to_string(),
-            checks: vec![
+        let report = HealthReport::from_checks(
+            "test".to_string(),
+            vec![
                 check_with("a", HealthStatus::Healthy),
                 check_with("b", HealthStatus::Stale),
                 check_with("c", HealthStatus::Unsupported),
+                check_with("d", HealthStatus::Pending),
+                check_with("e", HealthStatus::Degraded),
             ],
-            healthy: false,
-        };
+        );
         let summary = report.summary();
         assert_eq!(
             summary.passed + summary.attention + summary.skipped,
@@ -9064,7 +9409,7 @@ mod tests {
         );
 
         assert!(
-            !report.healthy,
+            !report.healthy(),
             "unknown graph authority must fail aggregate semantic readiness"
         );
         let value = serde_json::to_value(&report).unwrap();
@@ -9196,7 +9541,7 @@ mod tests {
         );
         assert!(stale.manual_fix.is_some());
         assert!(
-            !assemble_health_report("test".to_string(), vec![stale]).healthy,
+            !assemble_health_report("test".to_string(), vec![stale]).healthy(),
             "a retired coverage has to fail the aggregate, as a discard does"
         );
     }
@@ -9244,7 +9589,7 @@ mod tests {
         assert!(matches!(stale.status, HealthStatus::Stale));
         assert!(stale.manual_fix.is_some());
         assert!(
-            !assemble_health_report("test".to_string(), vec![stale]).healthy,
+            !assemble_health_report("test".to_string(), vec![stale]).healthy(),
             "a discarded index still has to fail the aggregate"
         );
 
@@ -9288,7 +9633,7 @@ mod tests {
 
         let report = assemble_health_report("test".to_string(), vec![semantic]);
         assert!(
-            report.healthy,
+            report.healthy(),
             "a corpus that grew after its fill completed must not report the install unhealthy"
         );
 
@@ -9337,7 +9682,7 @@ mod tests {
         // Unsupported is a statement about the host, not a way to stay quiet:
         // it must not block the aggregate, and the same store must report
         // pending again the moment local persistence is available.
-        assert!(assemble_health_report("test".to_string(), vec![semantic]).healthy);
+        assert!(assemble_health_report("test".to_string(), vec![semantic]).healthy());
         let local = crate::commands::resources::EmbedRuntimeState {
             embed_persistence_unavailable: false,
             ..no_local_sidecar
@@ -9441,17 +9786,25 @@ mod tests {
         assert!(semantic.manual_fix.is_some());
 
         let report = assemble_health_report("test".to_string(), vec![semantic]);
-        assert!(
-            report.healthy,
-            "a fresh install mid-first-fill must not report the whole install unhealthy"
+        assert_eq!(
+            report.verdict(),
+            HealthVerdict::NeedsAttention,
+            "a fresh install mid-first-fill is warming up, not broken: {:?}",
+            report.checks[0].status
         );
         assert_eq!(
             report.summary().attention,
             1,
             "the fill is still work in progress, so it is attention rather than not-applicable"
         );
+        // The emitted pair, read off the serialized report rather than the
+        // struct, because the JSON is what the install proof and every other
+        // consumer actually reads. `healthy` false with `verdict`
+        // `needs_attention` is the whole difference FIR-2919 bought: the old
+        // shape emitted `true` here, over this exact row.
         let json = serde_json::to_value(&report).unwrap();
-        assert_eq!(json["healthy"], true);
+        assert_eq!(json["healthy"], false);
+        assert_eq!(json["verdict"], "needs_attention");
         assert_eq!(json["checks"][0]["status"], "pending");
 
         // Falsification: same call, same fixture, discard reason set. If this
@@ -9469,7 +9822,7 @@ mod tests {
             after_discard.status
         );
         assert!(
-            !assemble_health_report("test".to_string(), vec![after_discard]).healthy,
+            !assemble_health_report("test".to_string(), vec![after_discard]).healthy(),
             "a rebuild after a discard must still block readiness"
         );
 
@@ -9491,7 +9844,7 @@ mod tests {
             "a backlog on a store whose fill completed is not lost ground: {:?}",
             after_top_up.status
         );
-        assert!(assemble_health_report("test".to_string(), vec![after_top_up]).healthy);
+        assert!(assemble_health_report("test".to_string(), vec![after_top_up]).healthy());
 
         // A wedged worker fails outright whether or not the fill ever finished.
         let wedged = crate::commands::resources::EmbedRuntimeState {
@@ -9504,7 +9857,7 @@ mod tests {
             "a failed embedding worker is a failure at any point in a store's life: {:?}",
             after_wedge.status
         );
-        assert!(!assemble_health_report("test".to_string(), vec![after_wedge]).healthy);
+        assert!(!assemble_health_report("test".to_string(), vec![after_wedge]).healthy());
     }
 
     #[test]
@@ -10454,7 +10807,7 @@ mod tests {
         );
 
         let report = assemble_health_report("test".to_string(), vec![check]);
-        assert!(report.healthy);
+        assert!(report.healthy());
         let summary = report.summary();
         assert_eq!(
             (summary.attention, summary.skipped),

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13028,46 +13028,51 @@ struct ReadinessLine {
 
 /// Compose the closing line from the rows the table just printed.
 ///
-/// It used to be read off `report.healthy` alone, which asks a narrower
-/// question than the table answers: `healthy` gates on Missing and
+/// It used to be read off `report.healthy` alone, which asked a narrower
+/// question than the table answers: `healthy` gated on Missing and
 /// Misconfigured, so a container run whose `Reference edge coverage` row read
 /// PENDING for want of a language server closed with "First-run ready" one line
 /// under its own "4 need attention" tally, and the repair that would have
 /// closed that row had failed in the same output (FIR-2547). The row knew; the
-/// summary did not read it. A reader who trusts the last line is entitled to
-/// have it agree with the rows above it, so claiming readiness now requires
-/// that nothing at all needs attention, and the line names what does.
+/// summary did not read it. That was repaired HERE, by deriving the honest join
+/// a second time in this function, which left the two surfaces of one report
+/// disagreeing in the other direction: this line read "5 checks need attention"
+/// while the JSON beside it read `"healthy": true` (FIR-2919).
+///
+/// So both halves of this line come from `health.rs` and neither is derived
+/// here. `report.healthy()` decides whether readiness may be claimed, and
+/// `health::needs_attention` decides which rows are counted and named. A
+/// verbatim copy of that predicate stood in this function through the first
+/// round of this fix, which is the same defect wearing a smaller costume: one
+/// surface counting by its own rule while the aggregate uses another is exactly
+/// what FIR-2919 is.
 fn readiness_line(report: &crate::commands::health::HealthReport) -> ReadinessLine {
-    use crate::commands::health::HealthStatus;
+    use crate::commands::health::{HealthStatus, HealthVerdict};
 
     /// How many rows the line names before it counts the rest.
     const NAMED: usize = 4;
 
-    let summary = report.summary();
     let waiting: Vec<&crate::commands::health::HealthCheck> = report
         .checks
         .iter()
-        .filter(|check| {
-            !matches!(
-                check.status,
-                HealthStatus::Healthy | HealthStatus::Unsupported
-            )
-        })
+        .filter(|check| crate::commands::health::needs_attention(check))
         .collect();
-    if report.healthy && summary.attention == 0 && waiting.is_empty() {
+    if report.healthy() {
         return ReadinessLine {
             ready: true,
             severe: false,
-            sentence: "First-run ready — no component is missing or misconfigured.".to_string(),
+            sentence: "First-run ready. Every check that applies here is healthy.".to_string(),
         };
     }
-    let severe = !report.healthy
-        || waiting.iter().any(|check| {
-            matches!(
-                check.status,
-                HealthStatus::Missing | HealthStatus::Misconfigured | HealthStatus::Degraded
-            )
-        });
+    // Red is for a broken install, and for a host that is short of ground, which
+    // is what the row marks above already say. Work still in flight stays
+    // yellow. Reading `!report.healthy()` here would turn every warming
+    // install's closing mark red, because that boolean now answers the wider
+    // question.
+    let severe = report.verdict() == HealthVerdict::Failing
+        || waiting
+            .iter()
+            .any(|check| matches!(check.status, HealthStatus::Degraded));
     let mut labels: Vec<String> = waiting
         .iter()
         .take(NAMED)
@@ -15490,7 +15495,7 @@ pub async fn uninstall(all: bool, dry_run: bool, force: bool, json: bool) -> Res
 mod tests {
     use super::projection_mode_to_record;
     use super::{fix_verdict, readiness_line, UnfinishedRepair};
-    use crate::commands::health::{HealthCheck, HealthReport, HealthStatus};
+    use crate::commands::health::{HealthCheck, HealthReport, HealthStatus, HealthVerdict};
     use kin_model::LanguageId;
 
     fn check(id: &str, label: &str, status: HealthStatus) -> HealthCheck {
@@ -15505,16 +15510,21 @@ mod tests {
         }
     }
 
-    /// The state the container run was actually in: `healthy` true, because
-    /// nothing was Missing or Misconfigured, while the coverage row read
+    /// The state the container run was actually in: the coverage row read
     /// PENDING because no language server was found and the repair meant to
     /// install one had just failed. The closing line said "First-run ready"
     /// under its own "4 need attention" tally (FIR-2547).
+    ///
+    /// Built through `from_checks` rather than as a literal. The literal this
+    /// used to carry set `healthy: true` beside a PENDING row, which was the
+    /// product's real answer then and is a state it can no longer produce
+    /// (FIR-2919); a fixture that keeps describing it would be grading a report
+    /// nothing emits.
     #[test]
     fn a_pending_row_keeps_the_summary_from_claiming_first_run_ready() {
-        let report = HealthReport {
-            platform: "linux".to_string(),
-            checks: vec![
+        let report = HealthReport::from_checks(
+            "linux".to_string(),
+            vec![
                 check("kin_binary", "Kin binary", HealthStatus::Healthy),
                 check(
                     "reference_edge_coverage",
@@ -15522,8 +15532,11 @@ mod tests {
                     HealthStatus::Pending,
                 ),
             ],
-            healthy: true,
-        };
+        );
+        assert!(
+            !report.healthy(),
+            "the join has to see the pending row, or this fixture proves nothing about the line"
+        );
         let line = readiness_line(&report);
         assert!(
             !line.ready,
@@ -15552,9 +15565,9 @@ mod tests {
     /// ready, or the line would refuse every correct install.
     #[test]
     fn a_report_with_nothing_waiting_still_reads_first_run_ready() {
-        let report = HealthReport {
-            platform: "linux".to_string(),
-            checks: vec![
+        let report = HealthReport::from_checks(
+            "linux".to_string(),
+            vec![
                 check("kin_binary", "Kin binary", HealthStatus::Healthy),
                 check(
                     "vfs_projection",
@@ -15562,8 +15575,11 @@ mod tests {
                     HealthStatus::Unsupported,
                 ),
             ],
-            healthy: true,
-        };
+        );
+        assert!(
+            report.healthy(),
+            "an unsupported row is out of scope, not attention: the join must still say ready"
+        );
         let line = readiness_line(&report);
         assert!(line.ready, "{}", line.sentence);
         assert!(
@@ -15573,19 +15589,206 @@ mod tests {
         );
     }
 
+    /// FIR-2919, as a reader meets it: the last printed line and the JSON
+    /// boolean are two renderings of one report, and they must not disagree.
+    ///
+    /// Graded over the row set a fresh Windows install actually emitted on the
+    /// v0.6.1 release run, taken from that run's own
+    /// `install-proof-windows-latest` artifact. This host cannot run Windows,
+    /// and it does not need to: the join is platform-independent and the rows
+    /// are the platform's contribution, so replaying the rows replays the case.
+    /// On the shipped bytes this line read "2 checks need attention" while the
+    /// JSON beside it read `"healthy": true`.
+    #[test]
+    fn the_printed_line_and_the_emitted_boolean_agree_on_the_windows_row_set() {
+        let rows: &[(&str, HealthStatus)] = &[
+            ("kin_binary", HealthStatus::Healthy),
+            ("kin_daemon_binary", HealthStatus::Healthy),
+            ("supervisor_startup_protocol", HealthStatus::Healthy),
+            ("daemon_running", HealthStatus::Unsupported),
+            ("daemon_idle_window", HealthStatus::Unsupported),
+            ("vfs_projection", HealthStatus::Unsupported),
+            ("projection_mode", HealthStatus::Unsupported),
+            ("repo_init", HealthStatus::Unsupported),
+            ("session_runtime", HealthStatus::Unsupported),
+            ("shell_path", HealthStatus::Healthy),
+            ("registry_authority", HealthStatus::Unsupported),
+            ("mcp_client_claude", HealthStatus::Healthy),
+            ("mcp_client_cursor", HealthStatus::Healthy),
+            ("mcp_client_gemini", HealthStatus::Healthy),
+            ("mcp_client_windsurf", HealthStatus::Healthy),
+            ("setup_ledger", HealthStatus::Healthy),
+            ("editor", HealthStatus::Unsupported),
+            ("kinlab_connect", HealthStatus::Unsupported),
+            ("semantic_query_readiness", HealthStatus::Unsupported),
+            ("reference_edge_coverage", HealthStatus::Unsupported),
+            ("relation_census", HealthStatus::Unsupported),
+            ("parse_coverage", HealthStatus::Unsupported),
+            ("background_work", HealthStatus::Unsupported),
+            ("embedding_model", HealthStatus::Pending),
+            ("memory_floor", HealthStatus::Degraded),
+            ("commit_memory_headroom", HealthStatus::Unsupported),
+            ("daemon_kill_record", HealthStatus::Unsupported),
+            ("interrupted_init", HealthStatus::Healthy),
+            ("suspended_sweep", HealthStatus::Unsupported),
+            ("host_memory_pressure", HealthStatus::Unsupported),
+            ("retrieval_profile", HealthStatus::Healthy),
+            ("update_policy", HealthStatus::Healthy),
+            ("binary_assessment_load", HealthStatus::Unsupported),
+        ];
+        let report = HealthReport::from_checks(
+            "windows".to_string(),
+            rows.iter()
+                .map(|(id, status)| check(id, id, status.clone()))
+                .collect(),
+        );
+        let line = readiness_line(&report);
+        assert_eq!(
+            line.ready,
+            report.healthy(),
+            "the printed line and the emitted boolean are the same claim: line ready={}, \
+             healthy={}, sentence={}",
+            line.ready,
+            report.healthy(),
+            line.sentence
+        );
+        assert!(!line.ready, "{}", line.sentence);
+        assert!(
+            line.sentence.contains("2 checks need attention"),
+            "the line has to name the count the rows support: {}",
+            line.sentence
+        );
+        // The mark and the verdict answer different questions, and this pins the
+        // difference. `memory_floor` reads DEGRADED, which is red on this
+        // surface and was red before this change too: the v0.6.1 Unix leg
+        // printed "✗ 5 checks need attention" over its own degraded row. What
+        // must NOT happen is the report calling itself a broken install, and
+        // that is the verdict, not the mark.
+        assert!(
+            line.severe,
+            "a degraded row is red on the printed page, as it was before: {}",
+            line.sentence
+        );
+        assert_eq!(
+            report.verdict(),
+            HealthVerdict::NeedsAttention,
+            "a red mark over a degraded row is not a broken install"
+        );
+
+        // The control. The same 33 rows with the two attention rows made
+        // healthy must agree the other way, or the assertion above passes for
+        // any report at all.
+        let ready_rows: Vec<(&str, HealthStatus)> = rows
+            .iter()
+            .map(|(id, status)| {
+                if *id == "embedding_model" || *id == "memory_floor" {
+                    (*id, HealthStatus::Healthy)
+                } else {
+                    (*id, status.clone())
+                }
+            })
+            .collect();
+        let ready = HealthReport::from_checks(
+            "windows".to_string(),
+            ready_rows
+                .iter()
+                .map(|(id, status)| check(id, id, status.clone()))
+                .collect(),
+        );
+        let ready_line = readiness_line(&ready);
+        assert_eq!(ready_line.ready, ready.healthy());
+        assert!(ready_line.ready, "{}", ready_line.sentence);
+        assert!(
+            ready_line.sentence.contains("First-run ready"),
+            "{}",
+            ready_line.sentence
+        );
+    }
+
+    /// The printed count and the emitted tally are one number, because both
+    /// come from `health::needs_attention` and neither is derived here.
+    ///
+    /// This is the assertion that would have caught the copy this function
+    /// carried through the first round of FIR-2919. A verbatim copy passes any
+    /// test that only reads the printed sentence, and it passes this one too
+    /// while it agrees; what it cannot survive is the copy being edited away
+    /// from the original, which is the way every duplicated rule eventually
+    /// fails. Graded over a row set holding one of every status the join treats
+    /// differently, so no single status carries the equality on its own.
+    #[test]
+    fn the_printed_count_is_the_tally_and_both_come_from_one_predicate() {
+        let report = HealthReport::from_checks(
+            "linux".to_string(),
+            vec![
+                check("kin_binary", "Kin binary", HealthStatus::Healthy),
+                check(
+                    "vfs_projection",
+                    "VFS projection",
+                    HealthStatus::Unsupported,
+                ),
+                check("embedding_model", "Embedding model", HealthStatus::Pending),
+                check("memory_floor", "Memory floor", HealthStatus::Degraded),
+                check(
+                    "projection_mode",
+                    "Projection in force",
+                    HealthStatus::Stale,
+                ),
+            ],
+        );
+        let attention = report.summary().attention;
+        assert_eq!(
+            attention, 3,
+            "the fixture must hold three rows needing attention, or the equality below is \
+             trivially true"
+        );
+        let line = readiness_line(&report);
+        assert!(
+            line.sentence
+                .starts_with(&format!("{attention} checks need attention")),
+            "the printed count must be the tally: tally={attention}, line={}",
+            line.sentence
+        );
+        // The control that keeps the assertion above from passing for any
+        // report at all: turn the three rows healthy and the line has to stop
+        // counting entirely.
+        let ready = HealthReport::from_checks(
+            "linux".to_string(),
+            vec![
+                check("kin_binary", "Kin binary", HealthStatus::Healthy),
+                check(
+                    "vfs_projection",
+                    "VFS projection",
+                    HealthStatus::Unsupported,
+                ),
+                check("embedding_model", "Embedding model", HealthStatus::Healthy),
+                check("memory_floor", "Memory floor", HealthStatus::Healthy),
+                check(
+                    "projection_mode",
+                    "Projection in force",
+                    HealthStatus::Healthy,
+                ),
+            ],
+        );
+        assert_eq!(ready.summary().attention, 0);
+        assert!(
+            readiness_line(&ready).ready,
+            "{}",
+            readiness_line(&ready).sentence
+        );
+    }
+
     /// A real failure keeps the red mark and the repair route.
     #[test]
     fn a_missing_row_reads_as_severe_and_names_the_repair() {
         let mut missing = check("shell_path", "Shell PATH", HealthStatus::Missing);
         missing.fixable = true;
-        let report = HealthReport {
-            platform: "linux".to_string(),
-            checks: vec![
+        let report = HealthReport::from_checks(
+            "linux".to_string(),
+            vec![
                 check("kin_binary", "Kin binary", HealthStatus::Healthy),
                 missing,
             ],
-            healthy: false,
-        };
+        );
         let line = readiness_line(&report);
         assert!(!line.ready, "{}", line.sentence);
         assert!(line.severe, "{}", line.sentence);

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -480,10 +480,32 @@ kin setup status --json   # machine-readable report
 Each line shows a status mark:
 
 - `✓` **ok** means healthy.
-- `✗` **MISSING** / **MISCONFIGURED** means failing, and these are the only states that
-  make the overall report unhealthy.
-- `!` **STALE** means present but not fully ready (e.g. embeddings pending).
-- `→` **n/a** means unsupported / not applicable on this platform or context.
+- `✗` **MISSING** / **MISCONFIGURED** means the install itself is wrong.
+- `✗` **DEGRADED** means the machine is short of ground Kin measured it needs. Nothing
+  about the install is wrong and the row still costs you work, so it reads red.
+- `!` **STALE** means present but drifted, such as a shim that is installed and not
+  injected into this shell.
+- `…` **PENDING** means expected first-run work still in flight, such as the first
+  embedding pass or the model download.
+- `→` **n/a** means unsupported, so the check does not apply on this platform or in this
+  context.
+
+The report closes with one verdict over all of them, emitted in `--json` as `verdict`
+beside the `healthy` boolean:
+
+- `ready`, and `healthy: true`. Every check in scope is ok. `n/a` rows do not count
+  against it, which is why a correct Windows install can still read ready.
+- `needs_attention`, and `healthy: false`. Something is not answering at full strength:
+  a PENDING or DEGRADED or STALE row. Kin works; the row tells you what you are not
+  getting yet.
+- `failing`, and `healthy: false`. A MISSING or MISCONFIGURED check, or a semantic
+  readiness Kin cannot read.
+
+`healthy` is true only for `ready`. It used to be true whenever nothing was MISSING or
+MISCONFIGURED, which meant a fresh install printing "2 checks need attention" on its last
+line also reported `"healthy": true` to every machine reader (FIR-2919). Read `verdict`
+when you need to tell a warming install from a broken one; the boolean cannot carry that
+difference.
 
 The checks (IDs as emitted in `--json`):
 

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -319,9 +319,9 @@ the daemons it shares the box with. Every probe leaves `KIN_REGISTRY_PATH` unset
 on purpose, since an explicit pin wins on both sides of that fix and a probe that
 kept one could not fail.
 
-`first_contact_honesty.py` covers the three surfaces a stranger meets before the
-graph answers anything, all found by the npm0549 green stranger on shipped
-0.5.49. Check 0 asserts `kin commit --help` carries the same sentence a commit
+`first_contact_honesty.py` covers the surfaces a stranger meets before the
+graph answers anything. Checks 0 to 2 were found by the npm0549 green stranger on
+shipped 0.5.49. Check 0 asserts `kin commit --help` carries the same sentence a commit
 prints, that a Kin commit lands in Kin's own authority and `git status` stays
 dirty until `kin eject` or a push, and asserts the CLI reference quotes it too
 (FIR-2627). Check 1 packs `packages/kin`, makes a global npm prefix unwritable,
@@ -331,7 +331,17 @@ reach a working `kin --version` (FIR-2628). Check 2 points a real npm at a port
 nothing listens on and requires the language-server install failure to name the
 environment as the suspected cause, print the proxy variables that would route
 it, name the offline route to a working server, and state that Kin runs
-without the servers (FIR-2629).
+without the servers (FIR-2629). Check 3 requires `kin doctor` to state this
+machine's memory floor before any repository exists (FIR-2787). Checks 4 to 6
+come from the 2026-08-28 cold walkthrough: the language-server repair must work
+on a host with no rustup, the MCP entry the install page hands every client must
+serve `initialize` from a directory holding no `.kin/`, and `kin init` must not
+report a cross-file sweep complete over a language server that never started.
+Check 7 requires `kin doctor`'s roll-up to agree with the rows it summarizes, in
+both directions, and requires the printed page and the JSON to make the same
+claim; its graders are handed the exact 33-row report a fresh Windows install
+emitted on the v0.6.1 release run, which carried `"healthy": true` over a pending
+and a degraded row and fenced that release (FIR-2919).
 
 Two limits it states rather than hides. Check 1 stubs the archive download with
 `KIN_NO_PROVISION` and a seeded managed binary, so what it proves is that the

--- a/scripts/acceptance/first_contact_honesty.py
+++ b/scripts/acceptance/first_contact_honesty.py
@@ -4,11 +4,11 @@
 
 """First-contact honesty: what a stranger meets before the graph answers anything.
 
-Seven defects strangers hit on shipped builds, each on a surface that runs before
+Eight defects strangers hit on shipped builds, each on a surface that runs before
 any semantic question is asked, and none of them visible to the suites that grade
 answers. Checks 0 to 2 come from the npm0549 green stranger on 0.5.49; check 3
 comes from the rc060n brown stranger on 0.6.0; checks 4 to 6 come from the
-2026-08-28 cold walkthrough:
+2026-08-28 cold walkthrough; check 7 comes from the v0.6.1 release run:
 
   CHECK 0 (FIR-2627)  `kin commit --help` never said a Kin commit is not a git
                       commit, so the write-through assumption formed at help and
@@ -42,6 +42,12 @@ comes from the rc060n brown stranger on 0.6.0; checks 4 to 6 come from the
                       (5/303 files)` over a sweep whose Rust server never
                       started, and the same store's `kin graph status` said the
                       Rust edges were missing. One store cannot say both things.
+  CHECK 7 (FIR-2919)  `kin doctor --json` reported `"healthy": true` on a fresh
+                      Windows install whose own rows read `embedding_model`
+                      pending and `memory_floor` degraded, while the same run's
+                      printed page closed on "2 checks need attention". The
+                      release install proof threw on the contradiction and
+                      fenced v0.6.1.
 
 A new suite rather than rows bolted onto the graph suites, for one reason: these
 are graded on the surfaces a stranger meets first, and most of them need no
@@ -562,13 +568,15 @@ def check_2(suite):
     return res
 
 
-def doctor_rows(suite, extra_env=None):
-    """(rows_by_id, detail) from one `kin doctor --json` run outside a repository.
+def doctor_report(suite, extra_env=None):
+    """(report, detail) from one `kin doctor --json` run outside a repository.
 
-    Outside, deliberately. The row this check grades is the one FIR-2787 says
-    has to answer before `kin init` runs, and every other memory row on that
-    page reads n/a there, so a run inside a repository would grade a different
-    question entirely.
+    Outside, deliberately. The row FIR-2787 grades is the one that has to answer
+    before `kin init` runs, and every other memory row on that page reads n/a
+    there, so a run inside a repository would grade a different question
+    entirely. FIR-2919 grades the same page's roll-up, and outside a repository
+    is where that page carries the most `unsupported` rows, which is exactly the
+    shape its join has to get right.
     """
     env = suite.base_env()
     if extra_env:
@@ -581,10 +589,143 @@ def doctor_rows(suite, extra_env=None):
         return None, "`kin doctor --json` exited %d and printed nothing: %s" % (
             rc, flatten(err)[:200])
     try:
-        report = json.loads(strip_ansi(out))
+        return json.loads(strip_ansi(out)), ""
     except ValueError as exc:
         return None, "`kin doctor --json` did not print JSON: %s" % exc
+
+
+def doctor_rows(suite, extra_env=None):
+    """(rows_by_id, detail) from one `kin doctor --json` run outside a repository."""
+    report, detail = doctor_report(suite, extra_env)
+    if report is None:
+        return None, detail
     return {row.get("id"): row for row in report.get("checks", [])}, ""
+
+
+
+# ---------------------------------------------------------------- the roll-up
+#
+# FIR-2919. `kin doctor --json` emitted per-check rows that were honest and a
+# top-level `"healthy": true` that was not. On a fresh Windows install the page
+# carried 19 `unsupported` rows, `embedding_model` `pending` and `memory_floor`
+# `degraded`, printed "2 checks need attention" as its own last line, and told a
+# machine reader the install was ready. The release's install proof threw on the
+# contradiction and fenced v0.6.1.
+#
+# The rule, in one place here as it is in one place in the product: a check is
+# out of scope only when the platform or the context puts it out of scope, which
+# is exactly `unsupported`. Every other status is a component not answering at
+# full strength. `ready` requires that none of them exists; `failing` is
+# reserved for a broken install so that `healthy: false` cannot mean two things.
+
+HEALTH_VERDICTS = ("ready", "needs_attention", "failing")
+HEALTH_STATUSES = ("healthy", "missing", "stale", "misconfigured", "pending",
+                   "degraded", "unsupported")
+READINESS_ID = "semantic_query_readiness"
+
+
+def health_needs_attention(row):
+    return row.get("status") not in ("healthy", "unsupported")
+
+
+def health_blocks_readiness(row):
+    return (row.get("status") in ("missing", "misconfigured")
+            or (row.get("id") == READINESS_ID and row.get("status") == "stale"))
+
+
+def health_join(rows):
+    """The verdict a report's own rows support."""
+    if any(health_blocks_readiness(row) for row in rows):
+        return "failing"
+    return "needs_attention" if any(health_needs_attention(row) for row in rows) else "ready"
+
+
+def grade_health_rollup(report):
+    """(ok, detail) for whether a health report's roll-up matches its own rows.
+
+    Reads the report the product emitted rather than composing an expected one,
+    so the grader cannot pass by agreeing with itself. Returns None where the
+    payload cannot answer the question at all, which includes a report carrying
+    no `verdict`: that is what pre-FIR-2919 bytes emit, and grading their
+    aggregate against either rule would be a claim those bytes cannot carry.
+    """
+    if not isinstance(report, dict):
+        return None, "the doctor payload is not an object"
+    rows = report.get("checks")
+    if not isinstance(rows, list) or not rows:
+        return None, "the doctor payload carries no checks array"
+    unknown = sorted({row.get("status") for row in rows} - set(HEALTH_STATUSES))
+    if unknown:
+        return None, ("the report carries statuses this grader does not know (%s), so the "
+                      "join it computes would be a guess" % ", ".join(map(str, unknown)))
+    if "healthy" not in report:
+        return None, "the report carries no top-level `healthy` field"
+    if report.get("verdict") not in HEALTH_VERDICTS:
+        return None, ("the report carries no readable `verdict` (%r), so these bytes predate "
+                      "FIR-2919 and their roll-up cannot be graded"
+                      % report.get("verdict"))
+
+    waiting = [row for row in rows if health_needs_attention(row)]
+    named = ", ".join("%s=%s" % (row.get("id"), row.get("status")) for row in waiting) or "none"
+    expected = health_join(rows)
+    if report["verdict"] != expected:
+        return False, ("the page reports verdict %s while its own rows support %s; rows "
+                       "needing attention: %s"
+                       % (report["verdict"], expected, named))
+    if report["healthy"] is not (expected == "ready"):
+        return False, ("the page reports healthy=%s while its own rows support %s; rows "
+                       "needing attention: %s"
+                       % (report["healthy"], expected, named))
+    return True, ("the roll-up is %s over %d rows, %d of which need attention: %s"
+                  % (expected, len(rows), len(waiting), named))
+
+
+
+# The row set a fresh Windows install emitted on the v0.6.1 release run, lifted
+# from that run's own `install-proof-windows-latest-33235776577` artifact
+# (`kin-windows-health.json`) rather than composed here. 33 rows: 12 healthy, 19
+# unsupported, `embedding_model` pending and `memory_floor` degraded. The
+# shipped payload carried `"healthy": true` beside them and no `verdict` field
+# at all.
+#
+# No host that runs this suite can produce that row set, and it does not need
+# to: the rule is platform-independent and the rows are the platform's whole
+# contribution, so replaying the rows replays the case.
+WINDOWS_V061_ROWS = [
+    {"id": "kin_binary", "status": "healthy"},
+    {"id": "kin_daemon_binary", "status": "healthy"},
+    {"id": "supervisor_startup_protocol", "status": "healthy"},
+    {"id": "daemon_running", "status": "unsupported"},
+    {"id": "daemon_idle_window", "status": "unsupported"},
+    {"id": "vfs_projection", "status": "unsupported"},
+    {"id": "projection_mode", "status": "unsupported"},
+    {"id": "repo_init", "status": "unsupported"},
+    {"id": "session_runtime", "status": "unsupported"},
+    {"id": "shell_path", "status": "healthy"},
+    {"id": "registry_authority", "status": "unsupported"},
+    {"id": "mcp_client_claude", "status": "healthy"},
+    {"id": "mcp_client_cursor", "status": "healthy"},
+    {"id": "mcp_client_gemini", "status": "healthy"},
+    {"id": "mcp_client_windsurf", "status": "healthy"},
+    {"id": "setup_ledger", "status": "healthy"},
+    {"id": "editor", "status": "unsupported"},
+    {"id": "kinlab_connect", "status": "unsupported"},
+    {"id": "semantic_query_readiness", "status": "unsupported"},
+    {"id": "reference_edge_coverage", "status": "unsupported"},
+    {"id": "relation_census", "status": "unsupported"},
+    {"id": "parse_coverage", "status": "unsupported"},
+    {"id": "background_work", "status": "unsupported"},
+    {"id": "embedding_model", "status": "pending"},
+    {"id": "memory_floor", "status": "degraded"},
+    {"id": "commit_memory_headroom", "status": "unsupported"},
+    {"id": "daemon_kill_record", "status": "unsupported"},
+    {"id": "interrupted_init", "status": "healthy"},
+    {"id": "suspended_sweep", "status": "unsupported"},
+    {"id": "host_memory_pressure", "status": "unsupported"},
+    {"id": "retrieval_profile", "status": "healthy"},
+    {"id": "update_policy", "status": "healthy"},
+    {"id": "binary_assessment_load", "status": "unsupported"},
+]
 
 
 # --------------------------------------------------------- toolchain-free repair
@@ -1414,8 +1555,64 @@ def _serve_asset(body):
     return "http://127.0.0.1:%d" % httpd.server_address[1], httpd, thread
 
 
+def check_7(suite):
+    """`kin doctor --json` does not claim more than its own rows support.
+
+    Graded outside a repository, where the page carries the most `unsupported`
+    rows and where the join therefore has the most chances to get it wrong in
+    both directions: counting an out-of-scope row as a shortfall would refuse
+    every correct install, and not counting a `pending` or `degraded` row is the
+    overclaim that fenced v0.6.1.
+
+    Whatever this host's own rows happen to be is not the subject. The subject
+    is agreement, between the roll-up and the rows and between the machine
+    report and the human page, so the check answers the same way on a warming
+    laptop and on a settled one. The `--self-test` arms carry the shipped
+    Windows row set, which no host here can reproduce.
+    """
+    res = Result("7", "FIR-2919",
+                 "kin doctor's roll-up agrees with the rows it summarizes")
+
+    report, detail = doctor_report(suite)
+    if report is None:
+        res.unknown(detail)
+        return res
+
+    ok, detail = grade_health_rollup(report)
+    if ok is None:
+        res.unknown(detail)
+        return res
+    if not ok:
+        res.bad(detail)
+        return res
+    res.ok(detail)
+
+    # The same run's human page. The two renderings are one report, and the
+    # defect was that they disagreed: the printed line counted the pending and
+    # degraded rows while the JSON beside it did not. Graded on the closing
+    # line, which is the sentence a reader trusts.
+    env = suite.base_env()
+    work = os.path.join(suite.workdir, "no-repository")
+    if not os.path.isdir(work):
+        os.makedirs(work)
+    rc, out, err = run([suite.kin, "doctor"], cwd=work, env=env, timeout=600)
+    page = flatten(strip_ansi(out or ""))
+    if not page:
+        res.unknown("`kin doctor` exited %d and printed no page: %s" % (rc, flatten(err)[:200]))
+        return res
+    claims_ready = "First-run ready" in page
+    if claims_ready != bool(report.get("healthy")):
+        res.bad("the printed page and the JSON disagree: the page %s claim first-run ready "
+                "while `healthy` is %s. Page tail: %s"
+                % ("does" if claims_ready else "does not", report.get("healthy"), page[-300:]))
+        return res
+    res.ok("the printed page and the JSON agree: first-run ready %s, healthy=%s"
+           % ("claimed" if claims_ready else "withheld", report.get("healthy")))
+    return res
+
+
 CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3),
-          ("4", check_4), ("5", check_5), ("6", check_6)]
+          ("4", check_4), ("5", check_5), ("6", check_6), ("7", check_7)]
 
 
 # ----------------------------------------------------------------------- suite
@@ -1556,6 +1753,64 @@ def self_test():
                "  x could not install the python language server: `npm install -g "
                "pyright` exited with 1: npm error minTimeout is greater than maxTimeout\n"
            )[0], None)
+
+    # FIR-2919, both directions, on the row set that fenced v0.6.1.
+    #
+    # The overclaim must fail, the honest emission of the SAME rows must pass,
+    # and the shipped payload, which carried no verdict at all, must read
+    # unreadable rather than either. Without the third arm the grader would
+    # report a clean product on the exact bytes the defect shipped in.
+    honest = {
+        "platform": "windows",
+        "checks": WINDOWS_V061_ROWS,
+        "healthy": False,
+        "verdict": "needs_attention",
+    }
+    overclaim = dict(honest, healthy=True, verdict="ready")
+    shipped = {"platform": "windows", "checks": WINDOWS_V061_ROWS, "healthy": True}
+    expect("the honest degraded roll-up must PASS",
+           grade_health_rollup(honest)[0], True)
+    expect("the v0.6.1 roll-up violation must FAIL",
+           grade_health_rollup(overclaim)[0], False)
+    expect("the shipped payload carries no verdict and is UNREADABLE",
+           grade_health_rollup(shipped)[0], None)
+    # The failure has to name the rows, or a reader gets a verdict mismatch with
+    # nothing to act on. 19 unsupported rows are not among them.
+    overclaim_detail = grade_health_rollup(overclaim)[1]
+    for wanted in ("embedding_model=pending", "memory_floor=degraded"):
+        if wanted not in overclaim_detail:
+            failures.append("the roll-up failure must name %s: %s" % (wanted, overclaim_detail))
+    for unwanted in ("daemon_running", "binary_assessment_load"):
+        if unwanted in overclaim_detail:
+            failures.append("the roll-up failure must not list out-of-scope rows (%s): %s"
+                            % (unwanted, overclaim_detail))
+
+    # The other three ways the roll-up can lie, each with the honest twin beside
+    # it so a rule that refused everything could not pass this block.
+    only_unsupported = {
+        "checks": [{"id": "kin_binary", "status": "healthy"},
+                   {"id": "vfs_projection", "status": "unsupported"}],
+        "healthy": True, "verdict": "ready",
+    }
+    expect("unsupported rows must not disqualify a ready roll-up",
+           grade_health_rollup(only_unsupported)[0], True)
+    expect("a ready roll-up over an unsupported row must not be refused",
+           grade_health_rollup(dict(only_unsupported, healthy=False,
+                                    verdict="needs_attention"))[0], False)
+    broken = {
+        "checks": [{"id": "kin_binary", "status": "healthy"},
+                   {"id": "shell_path", "status": "missing"}],
+        "healthy": False, "verdict": "failing",
+    }
+    expect("a broken install reports failing, not needs_attention",
+           grade_health_rollup(broken)[0], True)
+    expect("calling a broken install merely warming must FAIL",
+           grade_health_rollup(dict(broken, verdict="needs_attention"))[0], False)
+    expect("a payload with no checks is UNREADABLE",
+           grade_health_rollup({"healthy": True, "verdict": "ready", "checks": []})[0], None)
+    expect("a status this grader does not know is UNREADABLE",
+           grade_health_rollup({"healthy": True, "verdict": "ready",
+                                "checks": [{"id": "x", "status": "warming"}]})[0], None)
 
     expect("npx keeps its flags and gains an explicit bin name",
            localize("npx -y @kinlab/kin --version", "/tmp/p.tgz"),

--- a/scripts/acceptance/memory_pressure_refusal.py
+++ b/scripts/acceptance/memory_pressure_refusal.py
@@ -430,10 +430,17 @@ def row_reports_a_refusal(row):
     return row.get("status") == "degraded" and "memory pressure" in detail
 
 
-# The two statuses `kin doctor` treats as blocking. Mirrored from
-# `blocks_readiness` in crates/kin-cli/src/commands/health.rs, whose third case
-# is `stale` on the one id `semantic_query_readiness` and cannot apply to this
-# row. A row of any other status is advisory and changes no verdict.
+# The two statuses that make `kin doctor` report a BROKEN INSTALL. Mirrored
+# from `blocks_readiness` in crates/kin-cli/src/commands/health.rs, whose third
+# case is `stale` on the one id `semantic_query_readiness` and cannot apply to
+# this row.
+#
+# A row of any other status does not report a broken install. It is no longer
+# true that it "changes no verdict": since FIR-2919 a `degraded` row keeps the
+# report out of `ready` and moves the verdict to `needs_attention`, which is
+# what an honest roll-up owes a reader whose machine is short of memory. What
+# this row must never do is move the verdict to `failing`, and that is the
+# claim `grade_pressure_verdict_shift` grades.
 BLOCKING_STATUSES = ("missing", "misconfigured")
 
 
@@ -452,6 +459,45 @@ def row_blocks_readiness(row):
     not change the verdict at all.
     """
     return bool(row) and row.get("status") in BLOCKING_STATUSES
+
+
+
+# The verdict a report may carry, in the vocabulary `HealthVerdict` serializes.
+HEALTH_VERDICTS = ("ready", "needs_attention", "failing")
+
+
+def grade_pressure_verdict_shift(pressured, healed):
+    """(ok, detail) for what forcing memory pressure did to the page's verdict.
+
+    Before FIR-2919 this compared the `healthy` boolean on both arms and
+    required it identical. That was the right claim about the shape that
+    shipped then, where a `degraded` row could not move the boolean at all, and
+    it is the wrong claim now: a degraded row is supposed to move the report out
+    of `ready`, and requiring it not to would be asking the roll-up to go back
+    to claiming more than its rows support.
+
+    What must not move is the FAILING verdict, which is the one that says the
+    install itself is broken. Pressure is a fact about the machine.
+
+    Returns `None` for ok when either arm carries no `verdict`, because a build
+    that predates FIR-2919 cannot answer this question and reading its silence
+    as agreement is how a check stops being able to fail.
+    """
+    under = (pressured or {}).get("verdict")
+    after = (healed or {}).get("verdict")
+    if under not in HEALTH_VERDICTS or after not in HEALTH_VERDICTS:
+        return None, (
+            "one of the two doctor reports carries no readable `verdict` "
+            "(pressured=%s, healed=%s), so this build cannot answer whether "
+            "pressure moves the page's verdict" % (under, after)
+        )
+    if under == "failing" and after != "failing":
+        return False, (
+            "forcing pressure moved the page's verdict from %s to failing, so this row "
+            "reports a broken install over a busy machine" % after
+        )
+    return True, "the verdict is %s under pressure and %s after the work ran" % (
+        under, after)
 
 
 def reason_names_the_budget(reason):
@@ -680,6 +726,7 @@ GRADERS = {
     "names_memory_with_a_figure": names_memory_with_a_figure,
     "row_reports_a_refusal": row_reports_a_refusal,
     "row_blocks_readiness": row_blocks_readiness,
+    "grade_pressure_verdict_shift": grade_pressure_verdict_shift,
     "status_discloses_the_refusal": status_discloses_the_refusal,
     "reason_names_the_budget": reason_names_the_budget,
     "status_publishes_the_standing": status_publishes_the_standing,
@@ -1276,16 +1323,17 @@ def check_1(suite):
         result.ok("the row heals to %s once the work runs" % healed.get("status"))
 
     if row_blocks_readiness(under) or row_blocks_readiness(healed):
-        result.bad("the row's own status withholds the page's all-clear, so it would fail "
+        result.bad("the row's own status reports a broken install, so it would fail "
                    "the install proof over a busy machine: %s" % json.dumps(under))
-    elif reports["pressured"].get("healthy") != reports["healed"].get("healthy"):
-        result.bad(
-            "forcing pressure moved the page's verdict from %s to %s, so this row decides a "
-            "gate it must not touch"
-            % (reports["healed"].get("healthy"), reports["pressured"].get("healthy"))
-        )
     else:
-        result.ok("the verdict is %s either way" % reports["healed"].get("healthy"))
+        ok, detail = grade_pressure_verdict_shift(
+            reports["pressured"], reports["healed"])
+        if ok is None:
+            result.unknown(detail)
+        elif not ok:
+            result.bad(detail)
+        else:
+            result.ok(detail)
     return result
 
 
@@ -2551,6 +2599,32 @@ def self_test():
         if got != want:
             failures.append("row_blocks_readiness(%s) = %s, wanted %s"
                             % (json.dumps(row), got, want))
+
+    # FIR-2919. What pressure may and may not do to the page's verdict, with
+    # both directions of the claim and the unreadable case beside them. A build
+    # with no `verdict` must answer None rather than True, or a suite run
+    # against pre-FIR-2919 bytes would report a property nothing checked.
+    verdict_cases = [
+        (True, {"verdict": "needs_attention"}, {"verdict": "ready"}),
+        (True, {"verdict": "needs_attention"}, {"verdict": "needs_attention"}),
+        (True, {"verdict": "ready"}, {"verdict": "ready"}),
+        # A machine already broken for its own reasons stays broken. Pressure
+        # did not move it, so this is not the defect.
+        (True, {"verdict": "failing"}, {"verdict": "failing"}),
+        # The defect: pressure alone turned the page into a broken install.
+        (False, {"verdict": "failing"}, {"verdict": "needs_attention"}),
+        (False, {"verdict": "failing"}, {"verdict": "ready"}),
+        (None, {"healthy": True}, {"verdict": "ready"}),
+        (None, {"verdict": "ready"}, {"healthy": True}),
+        (None, {"verdict": "nonsense"}, {"verdict": "ready"}),
+        (None, None, None),
+    ]
+    for want, pressured, healed in verdict_cases:
+        got, _detail = grade_pressure_verdict_shift(pressured, healed)
+        if got != want:
+            failures.append(
+                "grade_pressure_verdict_shift(%s, %s) = %s, wanted %s"
+                % (json.dumps(pressured), json.dumps(healed), got, want))
 
     status_cases = [
         (True, "Entities: 12  |  Files: 3\n\n⚠ host memory pressure is critical, so the "

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import copy
+import difflib
 import hashlib
 import json
 import os
@@ -1486,11 +1487,58 @@ def validator_unix_mcp_home_fixture() -> dict[str, object]:
     }
 
 
+HEALTH_JOIN_BEGIN = "// --- BEGIN HEALTH JOIN ---"
+HEALTH_JOIN_END = "// --- END HEALTH JOIN ---"
+# Every file carrying a copy of the health join. install-proof.yml and
+# rc-build.yml run with no checkout and cannot import the module, so they paste
+# it; `assert_health_join_copies_agree` requires the copies equal.
+HEALTH_JOIN_HOMES = (
+    "scripts/verify-capability-proof.mjs",
+    ".github/workflows/install-proof.yml",
+    ".github/workflows/rc-build.yml",
+)
+
+
+def health_join_verdict(statuses: dict[str, str]) -> str:
+    """The product's roll-up rule, in Python, for building honest fixtures.
+
+    A fourth copy, and deliberately so: a fixture generator that took the
+    aggregate as an argument is what let this harness carry `healthy=True`
+    beside `embedding_model: pending` and pass while the real Windows leg threw
+    on that exact pair (FIR-2919). `assert_health_join_copies_agree` pins the
+    three JavaScript copies to each other; this one is pinned by the fixtures it
+    builds having to survive the extracted validators.
+    """
+
+    if any(
+        status in {"missing", "misconfigured"}
+        or (check_id == "semantic_query_readiness" and status == "stale")
+        for check_id, status in statuses.items()
+    ):
+        return "failing"
+    if any(
+        status not in {"healthy", "unsupported"} for status in statuses.values()
+    ):
+        return "needs_attention"
+    return "ready"
+
+
 def validator_health_report(
-    statuses: dict[str, str], *, healthy: bool
+    statuses: dict[str, str],
+    *,
+    healthy: bool | None = None,
+    verdict: str | None = None,
 ) -> dict[str, object]:
+    """A health report whose aggregate is derived from its own checks.
+
+    `healthy` and `verdict` stay overridable because several probes below have
+    to build a report that disagrees with itself. Nothing else may pass them.
+    """
+
+    joined = health_join_verdict(statuses)
     return {
-        "healthy": healthy,
+        "healthy": joined == "ready" if healthy is None else healthy,
+        "verdict": joined if verdict is None else verdict,
         "checks": [
             {"id": check_id, "status": status}
             for check_id, status in statuses.items()
@@ -1527,13 +1575,20 @@ WINDOWS_REQUIRED_VALIDATOR_CHECKS = {
 WINDOWS_VALIDATOR_CHECKS = {
     **WINDOWS_REQUIRED_VALIDATOR_CHECKS,
     "retrieval_profile": "unsupported",
-    # The one first-run status the leg tolerates beyond healthy and
+    # The two first-run statuses the leg tolerates beyond healthy and
     # not-applicable. A public runner has never fetched the embedding model, so
-    # a correct install reports `pending` here, and the step names this check
-    # and this status rather than accepting `pending` generally. Carried in the
-    # fixture for the reason `retrieval_profile` is: a fixture that omits a
-    # check the real report carries cannot fail the way the real leg does.
+    # a correct install reports `pending` there; the runner has 4 GiB and Kin
+    # has no host-memory probe for target_os windows, so `memory_floor` reports
+    # `degraded`. The step names each check with the status it may hold rather
+    # than accepting those statuses generally. Carried in the fixture for the
+    # reason `retrieval_profile` is: a fixture that omits a check the real
+    # report carries cannot fail the way the real leg does.
+    #
+    # `memory_floor` is the proof of that sentence. It was absent here, the real
+    # v0.6.1 Windows report carried it as `degraded`, and this harness passed
+    # while that leg threw (FIR-2919).
     "embedding_model": "pending",
+    "memory_floor": "degraded",
 }
 
 
@@ -1542,7 +1597,7 @@ def windows_node_validator_fixture() -> tuple[
 ]:
     """Build a complete valid repository-free Windows proof fixture."""
 
-    report = validator_health_report(WINDOWS_VALIDATOR_CHECKS, healthy=True)
+    report = validator_health_report(WINDOWS_VALIDATOR_CHECKS)
     return (
         {
             "expected-commit.txt": VALIDATOR_FIXTURE_COMMIT,
@@ -1606,17 +1661,19 @@ def unix_node_validator_fixture() -> tuple[
 ]:
     """Build a complete valid Unix release-byte proof fixture."""
 
-    pre_embed_report = validator_health_report(UNIX_VALIDATOR_CHECKS, healthy=False)
-    # The post-embed capture reads the aggregate rather than every check, and
-    # `unsupported` must not move it. Carrying the check here is what makes that
-    # a tested claim instead of an assumed one.
+    pre_embed_report = validator_health_report(UNIX_VALIDATOR_CHECKS)
+    # The post-embed capture names the rows a completed embed leaves behind on
+    # this runner, so the fixture carries them: `unsupported` must not move the
+    # aggregate, and `memory_floor` degraded must not fail the leg. Carrying
+    # both here is what makes those tested claims instead of assumed ones.
     embedded_report = validator_health_report(
-        {"semantic_query_readiness": "healthy", "retrieval_profile": "unsupported"},
-        healthy=True,
+        {
+            "semantic_query_readiness": "healthy",
+            "retrieval_profile": "unsupported",
+            "memory_floor": "degraded",
+        }
     )
-    fallback_report = validator_health_report(
-        {"mcp_client_claude": "healthy"}, healthy=True
-    )
+    fallback_report = validator_health_report({"mcp_client_claude": "healthy"})
     executable = f"{VALIDATOR_HOME}/.kin/bin/kin"
     ordinary_config = validator_mcp_config(validator_mcp_entry(executable))
     repository_config = validator_mcp_config(
@@ -1714,6 +1771,30 @@ def fixture_with_json_value(
     for key in keys[:-1]:
         cursor = cursor[key]  # type: ignore[index]
     cursor[keys[-1]] = value  # type: ignore[index]
+    return mutated
+
+
+
+def fixture_with_derived_aggregate(
+    fixture: dict[str, object], path: str
+) -> dict[str, object]:
+    """Re-derive one report's aggregate from the checks it now carries.
+
+    Every arm that mutates a check and still expects the fixture accepted has to
+    call this. Setting `healthy` by hand beside a mutated check is how a probe
+    builds a report the product could not emit, and a validator that rejects it
+    is right for the wrong reason (FIR-2919).
+    """
+
+    mutated = copy.deepcopy(fixture)
+    report = mutated[path]
+    statuses = {
+        check["id"]: check["status"]  # type: ignore[index]
+        for check in report["checks"]  # type: ignore[index]
+    }
+    verdict = health_join_verdict(statuses)
+    report["healthy"] = verdict == "ready"  # type: ignore[index]
+    report["verdict"] = verdict  # type: ignore[index]
     return mutated
 
 
@@ -1943,9 +2024,25 @@ def assert_windows_node_validator_behavior(step: str) -> None:
                 proof, report_path, "kin_binary", "unsupported"
             ),
         )
+        # The overclaim itself, in the shape it shipped. A fresh repo-free
+        # install carries a pending row and a degraded row, so its honest
+        # aggregate is `healthy: false` with `verdict: needs_attention`. The
+        # v0.6.1 Windows binary emitted `true` over exactly those rows; the
+        # first arm is that report and it must be refused. The second is the
+        # aggregate agreeing while the verdict does not, which no build should
+        # be able to emit and which the validator must catch on its own rather
+        # than by inference from the boolean.
         reject(
             f"{report_path} inconsistent healthy aggregate",
-            fixture_with_json_value(proof, report_path, ("healthy",), False),
+            fixture_with_json_value(proof, report_path, ("healthy",), True),
+        )
+        reject(
+            f"{report_path} inconsistent verdict",
+            fixture_with_json_value(proof, report_path, ("verdict",), "ready"),
+        )
+        reject(
+            f"{report_path} verdict absent, as pre-FIR-2919 bytes emit",
+            fixture_without_json_key(proof, report_path, ("verdict",)),
         )
         reject(
             f"{report_path} unexpected hard failure",
@@ -2360,11 +2457,32 @@ def assert_unix_node_validator_behavior(step: str) -> None:
             fixture_with_json_value(proof, report_path, ("healthy",), True),
         )
 
-        healthy_readiness = fixture_with_check_status(
-            proof, report_path, "semantic_query_readiness", "healthy"
+        reject(
+            f"{report_path} inconsistent verdict",
+            fixture_with_json_value(proof, report_path, ("verdict",), "ready"),
         )
-        healthy_readiness = fixture_with_json_value(
-            healthy_readiness, report_path, ("healthy",), True
+        reject(
+            f"{report_path} verdict absent, as pre-FIR-2919 bytes emit",
+            fixture_without_json_key(proof, report_path, ("verdict",)),
+        )
+        # A row that needs attention and is not one this posture named. The
+        # aggregate is re-derived, so the fixture is a report the product could
+        # actually emit and only the tolerance sweep can refuse it.
+        reject(
+            f"{report_path} an unnamed row needs attention",
+            fixture_with_derived_aggregate(
+                fixture_with_extra_check(
+                    proof, report_path, "kinlab_connect", "degraded"
+                ),
+                report_path,
+            ),
+        )
+
+        healthy_readiness = fixture_with_derived_aggregate(
+            fixture_with_check_status(
+                proof, report_path, "semantic_query_readiness", "healthy"
+            ),
+            report_path,
         )
         assert_node_validator_accepts_fixture(
             step,
@@ -2374,11 +2492,11 @@ def assert_unix_node_validator_behavior(step: str) -> None:
             environment,
         )
 
-        unsupported_readiness = fixture_with_check_status(
-            proof, report_path, "semantic_query_readiness", "unsupported"
-        )
-        unsupported_readiness = fixture_with_json_value(
-            unsupported_readiness, report_path, ("healthy",), True
+        unsupported_readiness = fixture_with_derived_aggregate(
+            fixture_with_check_status(
+                proof, report_path, "semantic_query_readiness", "unsupported"
+            ),
+            report_path,
         )
         reject(
             f"{report_path} semantic readiness unsupported",
@@ -2386,9 +2504,24 @@ def assert_unix_node_validator_behavior(step: str) -> None:
         )
 
     for report_path in ("kin-embedded-health.json", "kin-embedded-doctor.json"):
+        # The post-embed capture carries `memory_floor: degraded`, so its honest
+        # aggregate is already false. The overclaim is the true one.
         reject(
             f"{report_path} inconsistent healthy aggregate",
-            fixture_with_json_value(proof, report_path, ("healthy",), False),
+            fixture_with_json_value(proof, report_path, ("healthy",), True),
+        )
+        reject(
+            f"{report_path} verdict absent, as pre-FIR-2919 bytes emit",
+            fixture_without_json_key(proof, report_path, ("verdict",)),
+        )
+        reject(
+            f"{report_path} an unnamed row needs attention after the embed",
+            fixture_with_derived_aggregate(
+                fixture_with_extra_check(
+                    proof, report_path, "kinlab_connect", "pending"
+                ),
+                report_path,
+            ),
         )
         reject(
             f"{report_path} contradictory duplicate check",
@@ -8630,6 +8763,101 @@ def assert_release_hold_marker_contract(
         )
 
 
+
+def health_join_copies() -> list[tuple[str, str]]:
+    """Every pasted copy of the health join, as (home, dedented text).
+
+    Extracted from the start of the BEGIN line so the first line carries the
+    same indentation as the rest, which is what makes `textwrap.dedent` able to
+    remove it. Slicing from the marker itself leaves line one at column zero,
+    dedent finds a common prefix of "" and every copy compares unequal for a
+    reason that has nothing to do with the rule.
+    """
+
+    found: list[tuple[str, str]] = []
+    for home in HEALTH_JOIN_HOMES:
+        text = (ROOT / home).read_text(encoding="utf-8")
+        cursor = 0
+        while True:
+            begin = text.find(HEALTH_JOIN_BEGIN, cursor)
+            if begin < 0:
+                break
+            line_start = text.rfind("\n", 0, begin) + 1
+            end = text.index(HEALTH_JOIN_END, begin)
+            end = text.index("\n", end) + 1
+            found.append((home, textwrap.dedent(text[line_start:end])))
+            cursor = end
+    return found
+
+
+def assert_health_join_copies_agree() -> None:
+    """One roll-up rule, however many files have to carry the letters.
+
+    FIR-2919. install-proof.yml and rc-build.yml run with no checkout by design,
+    so they cannot import `scripts/verify-capability-proof.mjs` and each pastes
+    the rule instead. Four copies of a rule drift, and this set drifts in the
+    worst direction: every copy kept agreeing with every other while all four
+    disagreed with the product, so a fresh Windows install emitted
+    `"healthy": true` over a pending and a degraded row and the release's own
+    proof threw at tag time, where no fix on main can reach the tag.
+    """
+
+    copies = health_join_copies()
+    expected = 4
+    if len(copies) != expected:
+        raise AssertionError(
+            f"the health join must appear exactly {expected} times across "
+            f"{', '.join(HEALTH_JOIN_HOMES)}; found {len(copies)}: "
+            f"{[home for home, _ in copies]}"
+        )
+    # The module's copy is the reference. It is the one with a test suite.
+    reference_home, reference = copies[0]
+    if reference_home != HEALTH_JOIN_HOMES[0]:
+        raise AssertionError(
+            f"the first copy must come from {HEALTH_JOIN_HOMES[0]}, which is the "
+            f"one with unit tests; found {reference_home}"
+        )
+    for home, block in copies[1:]:
+        if block != reference:
+            diff = "\n".join(
+                difflib.unified_diff(
+                    reference.splitlines(),
+                    block.splitlines(),
+                    fromfile=reference_home,
+                    tofile=home,
+                    lineterm="",
+                )
+            )
+            raise AssertionError(
+                f"{home} carries a health join that differs from "
+                f"{reference_home}; one rule, one text:\n{diff}"
+            )
+    # The extractor itself must be able to come up empty, or "every copy agrees"
+    # is a sentence about a list nothing ever put anything into.
+    if HEALTH_JOIN_BEGIN.replace("HEALTH JOIN", "HEALTH JOIN THAT IS NOT THERE") in reference:
+        raise AssertionError("the control marker must not appear in the real block")
+    for home in HEALTH_JOIN_HOMES:
+        text = (ROOT / home).read_text(encoding="utf-8")
+        if "// --- BEGIN HEALTH JOIN THAT IS NOT THERE ---" in text:
+            raise AssertionError(
+                f"{home} carries the fabricated control marker, so the extractor "
+                "cannot be trusted to have found the real ones"
+            )
+    # Every copy must carry both halves of the rule. A block that lost
+    # `healthNeedsAttention` would still be identical in four places.
+    for clause in (
+        'check.status !== "healthy" && check.status !== "unsupported"',
+        'check.status === "missing"',
+        'check.id === "semantic_query_readiness" && check.status === "stale"',
+        'return checks.some(healthNeedsAttention) ? "needs_attention" : "ready";',
+    ):
+        if clause not in reference:
+            raise AssertionError(
+                f"the health join must carry the clause {clause!r}; four identical "
+                "copies of the wrong rule is the failure this pin exists to catch"
+            )
+
+
 def assert_capability_canary_contract(
     install_proof: str,
     canary: str,
@@ -8680,13 +8908,13 @@ def assert_capability_canary_contract(
             f"required by the canary but not the proof: {extra or 'none'}"
         )
 
-    # The rule the proof applies to every health report it reads. A canary that
-    # judges the aggregate differently would pass a report the proof rejects.
-    if 'check.id === READINESS_ID && check.status === "stale"' not in capability_script:
-        raise AssertionError(
-            "the canary must apply the proof's own aggregate-health rule, in "
-            "which a stale readiness makes the report unhealthy"
-        )
+    # The rule the proof applies to every health report it reads lives in one
+    # delimited block, pasted into the workflows that cannot import it, and
+    # `assert_health_join_copies_agree` requires every copy identical. A text
+    # probe for one clause was what stood here, and a clause probe cannot see the
+    # half of the rule that was wrong: the copies all agreed on `stale` while
+    # none of them counted `pending` or `degraded`, which is what fenced v0.6.1.
+    assert_health_join_copies_agree()
 
     # Everything below is judged on active lines only, in both directions.
     #
@@ -11492,9 +11720,16 @@ def main() -> None:
         "export SHELL=/bin/zsh",
     ):
         require(embedding, policy, "embedded-health shell reset")
+    # A health failure has to name the rows it failed on. It used to name every
+    # row that was not `healthy`, which on a fresh Windows install is 21 rows of
+    # which 19 are `unsupported` and irrelevant, so the message buried its own
+    # cause. These needles are the replacement: the rows that were NOT tolerated
+    # first, then the verdict, then the full attention list (FIR-2919).
     for policy in (
-        "overall healthy=${report.healthy}",
-        "non-healthy checks: ${nonHealthyChecks(report)}",
+        "rows needing attention that a fresh repo-free install does not expect:",
+        "rows needing attention that a fresh install does not expect:",
+        "verdict=${report.verdict}",
+        "every row needing attention: ${attentionRows(report)}",
     ):
         require(install_proof, policy, "actionable install-proof health failure")
     require(

--- a/scripts/verify-capability-proof.mjs
+++ b/scripts/verify-capability-proof.mjs
@@ -57,10 +57,42 @@ function fail(message) {
   throw new CapabilityProofError(message);
 }
 
-// Byte-for-byte the rule the install proof applies to every health report it
-// reads. The aggregate is not an independent opinion: it is a function of the
-// checks, and a report whose summary disagrees with its own contents is the
-// failure mode that hides every other one.
+// The one rule, mirrored verbatim into the workflows that cannot import it.
+//
+// install-proof.yml and rc-build.yml run with no checkout by design, so they
+// cannot `import` this module and each carries a copy of the block below
+// instead. scripts/test-release-workflow-authority.py extracts the three copies
+// between these markers, strips leading indentation, and requires them equal, so
+// a change here that is not made there fails on `main` rather than at tag time.
+//
+// Keep the block free of anything a workflow cannot paste: no `export`, no
+// import, no reference to a name defined outside it.
+//
+// --- BEGIN HEALTH JOIN ---
+// A check is out of scope only when the platform or the context puts it out of
+// scope, which is exactly `unsupported`. Every other status is a component that
+// is not answering at full strength, so a report claiming readiness over one
+// claims more than its components support (FIR-2919).
+const healthNeedsAttention = (check) =>
+  check.status !== "healthy" && check.status !== "unsupported";
+// Something wrong with the INSTALL, as against work in flight or ground the
+// host never had. A different question from the one above, and conflating the
+// two is what fenced v0.6.1.
+const healthBlocksReadiness = (check) =>
+  check.status === "missing" ||
+  check.status === "misconfigured" ||
+  (check.id === "semantic_query_readiness" && check.status === "stale");
+const healthJoin = (checks) => {
+  if (checks.some(healthBlocksReadiness)) return "failing";
+  return checks.some(healthNeedsAttention) ? "needs_attention" : "ready";
+};
+// --- END HEALTH JOIN ---
+
+export { healthNeedsAttention, healthBlocksReadiness, healthJoin };
+
+// The aggregate a health report carries is not an independent opinion: it is a
+// function of the checks, and a report whose summary disagrees with its own
+// contents is the failure mode that hides every other one.
 export function validateHealthReport(report, reportPath) {
   if (!report || typeof report !== "object" || !Array.isArray(report.checks)) {
     fail(`${reportPath}: checks is missing or malformed`);
@@ -69,19 +101,41 @@ export function validateHealthReport(report, reportPath) {
   if (checks.size !== report.checks.length) {
     fail(`${reportPath}: duplicate health-check ids are not authoritative`);
   }
-  const expectedHealthy = !report.checks.some(
-    (check) =>
-      check.status === "missing" ||
-      check.status === "misconfigured" ||
-      (check.id === READINESS_ID && check.status === "stale"),
-  );
-  if (report.healthy !== expectedHealthy) {
+  // Required, not optional. A report with no `verdict` was produced by a build
+  // that predates FIR-2919, where the aggregate gated on missing and
+  // misconfigured alone and read `true` over a pending or degraded row. Grading
+  // such a report against either rule would be a claim about bytes that cannot
+  // carry it, so the proof says which bytes it met instead.
+  if (report.verdict === undefined) {
+    fail(
+      `${reportPath}: the report carries no \`verdict\` field, so these bytes predate ` +
+        "FIR-2919 and their aggregate cannot be graded against the health join",
+    );
+  }
+  const verdict = healthJoin(report.checks);
+  if (report.verdict !== verdict) {
+    fail(
+      `${reportPath}: verdict=${report.verdict} disagrees with checks; ` +
+        `expected ${verdict}`,
+    );
+  }
+  if (report.healthy !== (verdict === "ready")) {
     fail(
       `${reportPath}: aggregate healthy=${report.healthy} disagrees with checks; ` +
-        `expected ${expectedHealthy}`,
+        `expected ${verdict === "ready"}`,
     );
   }
   return checks;
+}
+
+// The rows that keep a report out of `ready`, as `id=status`, for a message.
+export function attentionRows(report) {
+  return (
+    (report.checks ?? [])
+      .filter(healthNeedsAttention)
+      .map((check) => `${check.id}=${check.status}`)
+      .join(", ") || "none"
+  );
 }
 
 export function assertRequiredChecksPresent(checks, reportPath) {

--- a/scripts/verify-capability-proof.test.mjs
+++ b/scripts/verify-capability-proof.test.mjs
@@ -13,14 +13,21 @@ import {
   CapabilityProofError,
   REQUIRED_CHECK_IDS,
   assertReadinessCoherent,
+  attentionRows,
   coverageRegime,
+  healthJoin,
   validateHealthReport,
   verifyReport,
 } from './verify-capability-proof.mjs';
 
 const SCRIPT = fileURLToPath(new URL('./verify-capability-proof.mjs', import.meta.url));
 
-function report({ readiness = 'healthy', overrides = {}, healthy = null } = {}) {
+// The aggregate is derived by the module's own join rather than a second copy
+// here, so a fixture cannot describe a report the product could not produce and
+// a change to the rule cannot leave this file quietly agreeing with the old one.
+// `healthy` and `verdict` stay overridable, because a report that disagrees with
+// its own checks is exactly what several tests below have to build.
+function report({ readiness = 'healthy', overrides = {}, healthy = null, verdict = null } = {}) {
   const checks = REQUIRED_CHECK_IDS.map((id) => ({
     id,
     label: id,
@@ -28,13 +35,12 @@ function report({ readiness = 'healthy', overrides = {}, healthy = null } = {}) 
     detail: '',
     ...(overrides[id] ?? {}),
   }));
-  const blocking = checks.some(
-    (check) =>
-      check.status === 'missing' ||
-      check.status === 'misconfigured' ||
-      (check.id === 'semantic_query_readiness' && check.status === 'stale'),
-  );
-  return { healthy: healthy === null ? !blocking : healthy, checks };
+  const joined = healthJoin(checks);
+  return {
+    healthy: healthy === null ? joined === 'ready' : healthy,
+    verdict: verdict === null ? joined : verdict,
+    checks,
+  };
 }
 
 const settled = { state: 'observed', source: 'live_query_graph', indexed: 18, pending: 0, total: 18 };
@@ -100,9 +106,99 @@ test('an aggregate that disagrees with its own checks fails', () => {
 test('a stale readiness must drag the aggregate unhealthy, exactly as the proof requires', () => {
   const honest = report({ readiness: 'stale' });
   assert.equal(honest.healthy, false);
+  assert.equal(honest.verdict, 'failing');
   expectFailure(
     () => verifyReport(report({ readiness: 'stale', healthy: true }), settled, 'p'),
     /disagrees with checks/,
+  );
+});
+
+// ---------------------------------------------------------------- FIR-2919
+//
+// The join, in the four cases the fix contract names, plus the two the shipped
+// Windows report actually carried. Each negative has a positive beside it: a
+// rule that refused everything would satisfy every "must fail" assertion here
+// on its own.
+
+test('unsupported rows do not disqualify a ready verdict', () => {
+  const rows = [
+    { id: 'kin_binary', status: 'healthy' },
+    { id: 'vfs_projection', status: 'unsupported' },
+    { id: 'registry_authority', status: 'unsupported' },
+  ];
+  assert.equal(healthJoin(rows), 'ready');
+  assert.equal(attentionRows({ checks: rows }), 'none');
+});
+
+test('a pending row keeps the report out of ready without calling it failing', () => {
+  const rows = [
+    { id: 'kin_binary', status: 'healthy' },
+    { id: 'embedding_model', status: 'pending' },
+  ];
+  assert.equal(healthJoin(rows), 'needs_attention');
+  assert.equal(attentionRows({ checks: rows }), 'embedding_model=pending');
+});
+
+test('a degraded row keeps the report out of ready without calling it failing', () => {
+  const rows = [
+    { id: 'kin_binary', status: 'healthy' },
+    { id: 'memory_floor', status: 'degraded' },
+  ];
+  assert.equal(healthJoin(rows), 'needs_attention');
+});
+
+test('a missing row is failing, which is a different answer from needs_attention', () => {
+  const rows = [
+    { id: 'kin_binary', status: 'healthy' },
+    { id: 'embedding_model', status: 'pending' },
+    { id: 'shell_path', status: 'missing' },
+  ];
+  assert.equal(healthJoin(rows), 'failing');
+});
+
+// The exact shape v0.6.1 shipped: 19 unsupported rows, one pending, one
+// degraded, under healthy=true. It is the report that fenced the release.
+test('the v0.6.1 Windows aggregate is rejected against its own rows', () => {
+  const rows = [
+    { id: 'kin_binary', status: 'healthy' },
+    ...Array.from({ length: 19 }, (_, index) => ({ id: `unsupported_${index}`, status: 'unsupported' })),
+    { id: 'embedding_model', status: 'pending' },
+    { id: 'memory_floor', status: 'degraded' },
+  ];
+  assert.equal(healthJoin(rows), 'needs_attention');
+  expectFailure(
+    () => validateHealthReport({ healthy: true, verdict: 'ready', checks: rows }, 'kin-windows-health.json'),
+    /verdict=ready disagrees with checks; expected needs_attention/,
+  );
+  // The honest emission of the same rows is accepted, or the assertion above
+  // would pass for a rule that rejected every Windows report.
+  assert.doesNotThrow(() =>
+    validateHealthReport(
+      { healthy: false, verdict: 'needs_attention', checks: rows },
+      'kin-windows-health.json',
+    ),
+  );
+});
+
+test('a report with no verdict field is refused as pre-FIR-2919 bytes', () => {
+  const rows = [{ id: 'kin_binary', status: 'healthy' }];
+  expectFailure(
+    () => validateHealthReport({ healthy: true, checks: rows }, 'kin-health.json'),
+    /predate FIR-2919/,
+  );
+  assert.doesNotThrow(() =>
+    validateHealthReport({ healthy: true, verdict: 'ready', checks: rows }, 'kin-health.json'),
+  );
+});
+
+test('a verdict that agrees with the rows but not with the boolean is refused', () => {
+  const rows = [
+    { id: 'kin_binary', status: 'healthy' },
+    { id: 'memory_floor', status: 'degraded' },
+  ];
+  expectFailure(
+    () => validateHealthReport({ healthy: true, verdict: 'needs_attention', checks: rows }, 'p'),
+    /aggregate healthy=true disagrees with checks; expected false/,
   );
 });
 


### PR DESCRIPTION
`kin doctor --json` reported `"healthy": true` on a fresh Windows install whose own rows read `embedding_model=pending` and `memory_floor=degraded`, under 19 platform `unsupported` rows. The same run printed "2 checks need attention" as its last human line. The release install proof threw on the contradiction and fenced v0.6.1 (run 33235776577, job 99059508607).

## The rule, once

The roll-up was spelt in five places and they did not agree. `summary()` and the printed readiness line counted `pending` and `degraded`; `blocks_readiness`, which decided the boolean, did not, and neither did the two inline validators in `install-proof.yml` or the one in `rc-build.yml`. That disagreement is the defect: one report printed "2 checks need attention" and told a machine reader `"healthy": true` in the same run.

There is one rule now, `needs_attention` in `health.rs`: a check is out of scope only when the platform or the context puts it out of scope, which is exactly `unsupported`, and every other status keeps the report out of ready. It is `pub(crate)`, and `summary()` and `readiness_line` call it. Neither derives it a second time. `readiness_line` held a verbatim copy of the predicate through the first round of this fix, which is the same defect wearing a smaller costume, and a test now pins its printed count to `summary().attention` so the two cannot drift apart again.

The report gains `verdict`, one of `ready`, `needs_attention` or `failing`, and `healthy` is true exactly for `ready`. Without the third value `healthy: false` would mean two different things and no consumer could tell a warming install from a broken one. `healthy` and `verdict` are private and derived by `HealthReport::from_checks`, so no caller and no fixture can hand a report an aggregate its own rows do not support.

## The proof asserts the same join over the real emitted set

The rule lives between BEGIN/END markers in `scripts/verify-capability-proof.mjs` and is pasted into the two workflows that run with no checkout. `assert_health_join_copies_agree` extracts all four copies, dedents them, requires them identical, and requires each to carry both halves of the rule; a fabricated marker is the control that must extract nothing.

The environment's own expectations move off the aggregate boolean and onto the rows. Measured on that release run's own artifacts, `report.healthy !== true` passed over six reports carrying rows it never named:

| report | rows needing attention |
| --- | --- |
| `kin-windows-health.json`, `kin-windows-doctor.json` | 2: `embedding_model=pending`, `memory_floor=degraded` |
| `kin-health.json`, `kin-doctor.json` (Unix, pre-embed) | 5: `projection_mode=stale`, `semantic_query_readiness=pending`, `reference_edge_coverage=pending`, `embedding_model=pending`, `memory_floor=degraded` |
| `kin-embedded-health.json`, `kin-embedded-doctor.json` (Unix, post-embed) | 3: `projection_mode=stale`, `reference_edge_coverage=pending`, `memory_floor=degraded` |

Each leg now names its rows with the statuses they may hold, so a row that goes non-healthy outside that list fails. Those row sets were read off all four Unix legs of that run, not one: `install-proof-macos-latest`, `install-proof-macos-15-intel` and `install-proof-ubuntu-24.04-arm` emit the identical set. A report carrying no `verdict` is refused as pre-fix bytes rather than graded against either rule.

## The scripted check for the class

`scripts/acceptance/first_contact_honesty.py` gains check 7: the roll-up must agree with its rows, and the printed page must make the same claim as the JSON. Its graders are handed the 33-row report that fenced v0.6.1, lifted verbatim from the `install-proof-windows-latest-33235776577` artifact. The overclaim must fail, the honest emission of the same rows must pass, and the shipped payload, which carries no `verdict`, must read unreadable rather than either.

## Rebased onto #1233

#1233 landed while this was building and added checks 5 and 6 to `first_contact_honesty.py`. Mine was also numbered 5, and Python does not complain about two `def check_5` in one file: the later one silently wins, so a textually clean merge would have dropped one of the two checks with both PRs reading green. This branch was rebuilt on `origin/main` rather than replayed: every other file is byte-identical to the pre-rebase tree, verified per file, and the acceptance suite was re-applied onto main's version with the check renumbered 7. The suite now carries eight checks and its self-test is green.

## Accepted risks

Check 7 and the edited install proof execute on the push to main, not on this PR: `ci.yml:2327` and `acceptance.yml:93` both carry `github.event_name != 'pull_request'`, so `Install Proof (PR)` and `Product Acceptance` are skipped here.

The weekly install proof, cron `0 12 * * 1`, will red against v0.6.0 until v0.6.2 promotes, because those bytes carry no `verdict` and this change makes the proof refuse such a report by name rather than grade it against a rule it cannot carry. Next firing is Monday 12:00Z.

PR-time coverage of the changed rule is three things: the release authority suite, `scripts/test-release-workflow-authority.py`, which extracts both inline node validators from the workflow text and drives them against fixtures; the canary, `Capability Contract Canary`, which builds kin from this branch and holds a real `kin doctor --json` to the rule; and the copies-agree gate, which runs inside `Fast gate lint and policy`, a required context. All three are green on this PR.

## Consumers swept

Every reader of the emitted `healthy` field was swept. No exit code anywhere in kin depends on it: `kin doctor` returns `Ok(())` on the report path and its only nonzero verdict is `fix_verdict` over requested repairs. Two consumers outside this repo do change behavior and are named in the lane report as follow-ups, because they already mishandle `pending` and `degraded` today and this change makes that visible: `kin-editor/src/setup-health.ts` coerces any status outside its five-variant union to `missing`, and `kinlab/apps/web/lib/setup-health.ts` throws on a report containing either status. Their "you are ready" banners key on `healthy` and will withhold on a warming install.

## Falsification

The join was mutated four ways and every arm went red on the assertion written for it; the grid, with the fired test names per arm, is in the lane report. The acceptance grader was mutated three ways with the same result. `--list` was asserted before every run with a fabricated name that must match zero, so no arm graded nothing.

## Bounded

This host cannot run Windows. The rule is platform-independent and is proven on the host's own shape. The Windows case is proven by replaying that release run's own row set verbatim, in a Rust unit test and in the acceptance self-test. Nothing here claims a Windows execution.

Closes FIR-2919
