### PR TITLE
Tolerate the first relation census still filling in the Unix install-proof legs

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -1910,6 +1910,14 @@ jobs:
               ["reference_edge_coverage", ["pending"]],
               ["embedding_model", ["pending"]],
               ["memory_floor", ["degraded"]],
+              // The first relation census is its own background pass, so a
+              // capture that beats it reads `pending`, the same first-run
+              // class as reference_edge_coverage above. The v0.6.2 preflight
+              // measured exactly that on a native-arch containerized fresh
+              // install (both health captures pending) while this workflow's
+              // own v0.6.1 arm leg happened to win the race and read healthy,
+              // so whether the row appears is host timing, not install state.
+              ["relation_census", ["pending"]],
             ]);
             const untolerated = report.checks.filter(
               (check) =>
@@ -2054,6 +2062,10 @@ jobs:
                 ["projection_mode", ["stale"]],
                 ["reference_edge_coverage", ["pending"]],
                 ["memory_floor", ["degraded"]],
+                // The census pass is not tied to `kin embed`, so a capture can
+                // still beat it after a completed embed; same measurement as
+                // the pre-embed entry.
+                ["relation_census", ["pending"]],
               ]);
               const stillWaiting = report.checks.filter(
                 (check) =>


### PR DESCRIPTION
The v0.6.2 preflight failed its native-arch containerized Linux leg on relation_census=pending, a row FIR-2919's Unix tolerance maps do not name, in both the pre-embed and post-embed captures, with the product's own verdict honestly reading needs_attention. Measured rather than argued before widening anything: the census is its own background pass, so a capture that beats it reads pending, the same first-run class as reference_edge_coverage; this workflow's own v0.6.1 ubuntu-24.04-arm artifact read the row healthy in both captures because that runner won the race, so whether the row appears is host timing, not install state, and a runner that loses the race would fence the tag exactly the way FIR-2919 was opened over. This adds relation_census with pending as its one allowed status to both Unix maps, pre-embed and post-embed, with the measurement in the comments; the Windows repo-free map is untouched because the row cannot appear there. The untolerated-row sweep these maps feed was falsified in #1236's review, so a census status other than pending still fails by name.

Refs FIR-2919
