### PR TITLE
Complete the rollout acquisition before the gcs fence admission probe

### DIFF
--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -6136,6 +6136,11 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(stale, object_store::Error::Precondition { .. }));
+        // Complete the acquisition first. An uncompleted lease is refused for
+        // its incomplete fence, which is a different refusal from the schema
+        // incompatibility this test is about, and taking the first one would
+        // pass the assertion below while proving nothing about compatibility.
+        let rollout = checkpoint_rollout_for_test(&control, &rollout);
         assert!(matches!(
             control.admit_reader(AdmitReaderRequest {
                 lease: proof(&rollout),


### PR DESCRIPTION
kin `main` has been red on every push since a27c99bb9 (#1227). One test fails,
`publication_lease::tests::object_generation_fence_rereads_winner_and_rejects_paused_writer`,
under `cargo nextest run -p kin-daemon --features gcs --locked`.

The test was wrong, not the fence. The fence refused the reader, and refused
correctly. It refused for a different reason than the test asserted.

## Cause, measured rather than inferred

`assert!` prints the failing expression and never the values, so the panic says
nothing about which side is wrong. I printed the value the probe actually returns:

    FIR2940-PROBE first admit_reader = Err(Fenced("rollout lease fence 1 has not fenced graph generations"))

`acquire_rollout` returns through `require_gcs_fencing_ready`, which hands back a
lease at the point where GCS resource fencing has finished and the Firestore spine
fence has not, leaving `authority_fenced_at` unset. Only `complete_rollout_acquisition`,
after `checkpoint_spine_rollout_fence`, sets it. So `require_complete_authority_fence`
answers `Fenced`, while the test asserts `Admission`. They are separate variants,
so the assertion fails on a refusal that is entirely correct.

The test probed admission on a lease it had never finished acquiring.

## Why the test is the side that was wrong

The in-memory twin of this test, `a_writer_winning_before_fence_is_reread_into_compatibility_evidence`,
performs the identical probe and already completes the acquisition first, carrying
a comment saying exactly why: an incomplete fence is a different refusal from the
schema incompatibility the test is about, and taking the first one would pass the
assertion while proving nothing. The gcs twin was left without that step. This
adds it, with the same comment.

Three further facts settle it against changing the fence:

- `publication_lease.rs` is entirely new in #1227, absent at its parent, so the
  fence and its test arrived together. No contract drifted from a test.
- Making `require_complete_authority_fence` answer `Admission` would turn the
  assertion green for the wrong reason and the next `.unwrap()` two lines below
  would then panic. That branch is visibly wrong at the second assertion.
- `checkpoint_rollout_for_test` is already green over `ObjectStorePublicationControlStore`.
  Two gcs tests reach it through the `release()` helper and both pass in the same
  CI job that reports this failure.

## Verification

Both permutation legs that compile this test, run locally through the fleet heavy
slot on this branch's own tree:

- `cargo nextest run -p kin-daemon --features gcs --locked`: `1313 tests run: 1313 passed (2 slow), 3 skipped`
- `cargo nextest run -p kin-daemon --features gcs,firestore --locked`: `1313 tests run: 1313 passed (2 slow), 3 skipped`

Falsification. Deleting the refusal block inside `validate_reader_against_authority_fence`
so it can only return `Ok(())` turns the target test red on exactly the assertion
that must refuse `READER_B`. The mutation is 14 lines shorter than the code it
replaces, so I proved the line identity rather than assuming it: the reported
`publication_lease.rs:6130:9` is the `assert!(matches!(` opening the `admit_reader`
probe, and it is the only such assertion in this test. The arm compiled and graded
(`Starting 1 test`, `1 test run`, no `error[E`), and the tree restored byte-identical
with zero mutant markers left.

## One thing worth knowing about this repo's gate

The two `Feature permutation tests` contexts on this pull request will be green,
and that green is not evidence. `ci.yml:2060` defines `feature-tests-pr-fast-path`,
which runs on `pull_request` and only echoes three lines; the real `feature-tests`
job carries `github.event_name != 'pull_request'`. The file says so at ci.yml:2046.

Measured, not just read: #1227's own head 226c94c86 carried
`Feature permutation tests (ubuntu-latest)` and `(macos-latest)` both green, and
its push to `main` as a27c99bb9 (run 33250307731) failed with exactly one job,
`Feature permutation tests (macos-latest)`. Same job name, green before the merge
and red after it, because the pre-merge one runs nothing. That is why the
verification above is local.

That CI job also dies at its first step, so six later steps have not executed on
any push since #1227 landed: hosted gcs spine cursor hold, kin-spine durable
publication paths, hosted production features, hosted production durable spine
selection, featureless kin-cli, featureless kin-daemon. This change unblocks them.
The two that compile the affected test are green above; the rest run for the first
time on the push after this lands.

Closes FIR-2940
