### PR TITLE
Write the hosted repository transfer seam down once, and run the contract suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,6 +985,34 @@ jobs:
       # one. The wrapper routes its own failures by event: hard for anything
       # reaching release machinery, for the release pull request, for a push and
       # for a diff it cannot read, and a warning annotation otherwise.
+      - name: Boundary contract tests
+        # packages/boundary-contracts holds the wire contracts both sides of a
+        # boundary read, and until now no workflow ran its suite: the tests
+        # existed and no required context could report them, which is a guard
+        # that cannot fail. The hosted transfer seam is asserted there against
+        # the Rust authority and the TypeScript declarations at once, so the
+        # suite has to run where a pull request can go red.
+        #
+        # The exit code is the verdict. The pass count is only a floor, so a
+        # suite that silently graded nothing cannot report the same green a
+        # clean run reports; it moves only when tests are REMOVED.
+        working-directory: packages/boundary-contracts
+        run: |
+          node --check src/index.js
+          node --check test/contracts.test.js
+          if out=$(node --test 2>&1); then status=0; else status=$?; fi
+          printf '%s\n' "$out"
+          if [ "$status" -ne 0 ]; then
+            echo "boundary-contracts suite failed with status $status" >&2
+            exit 1
+          fi
+          passed=$(printf '%s\n' "$out" | sed -n 's/^# pass \([0-9][0-9]*\)$/\1/p')
+          if [ -z "$passed" ] || [ "$passed" -lt 7 ]; then
+            echo "boundary-contracts reported '$passed' passing tests, below the 7 it carries" >&2
+            exit 1
+          fi
+          echo "boundary-contracts: $passed tests passed"
+
       - name: Validate automatic release policy
         env:
           GH_TOKEN: ${{ github.token }}

--- a/packages/boundary-contracts/schemas/hosted-repository-transfer.schema.json
+++ b/packages/boundary-contracts/schemas/hosted-repository-transfer.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kin://contracts/hosted-repository-transfer",
+  "description": "The one place the hosted repository-v6 transfer seam is written down. A Kin client addresses this route to push and pull against a hosted KinLab organization, and the control plane serves it. Both sides read this document rather than spelling the route, the envelope keys or the refusal codes twice.",
+  "definitions": {
+    "seam": {
+      "description": "Route, leaves and envelope keys. Held as a const so a reader gets the literal rather than a shape that would admit a renamed field.",
+      "const": {
+        "protocol": "kin-repository-v6-fast-forward",
+        "schemaVersion": 4,
+        "routeTemplate": "/api/v1/orgs/{orgId}/repos/{repoId}/transfer/{leaf}",
+        "authorizationScheme": "Bearer",
+        "orgScoped": true,
+        "leaves": [
+          {
+            "leaf": "advertise",
+            "method": "GET",
+            "requestKeys": [],
+            "responseKeys": [
+              "schema_version",
+              "protocol",
+              "repository_id",
+              "refs",
+              "default_ref",
+              "roots",
+              "supported_features",
+              "limits"
+            ]
+          },
+          {
+            "leaf": "status",
+            "method": "POST",
+            "requestKeys": ["destination_ref"],
+            "responseKeys": [
+              "schema_version",
+              "protocol",
+              "repository_id",
+              "destination_ref",
+              "destination_target",
+              "destination_head",
+              "destination_tree_hash",
+              "roots",
+              "default_ref",
+              "git_authority_hash",
+              "supported_features",
+              "limits",
+              "push_apply_ready",
+              "bounded_envelope_export_ready",
+              "pull_apply_ready"
+            ]
+          },
+          {
+            "leaf": "export",
+            "method": "POST",
+            "requestKeys": ["source_ref", "expectation"],
+            "responseKeys": [
+              "schema_version",
+              "protocol",
+              "transfer_id",
+              "operation_id",
+              "repository_id",
+              "source_ref",
+              "destination_ref",
+              "source_head",
+              "transfer_target_head",
+              "source_tree_hash",
+              "expected_destination_target",
+              "expected_destination_head",
+              "expected_destination_roots",
+              "expected_destination_default_ref",
+              "source_git_authority_hash",
+              "expected_destination_git_authority_hash",
+              "git_authority_bootstrap",
+              "required_features",
+              "changes",
+              "trees",
+              "external_objects",
+              "aliases",
+              "bodies"
+            ]
+          },
+          {
+            "leaf": "receive",
+            "method": "POST",
+            "requestKeys": ["destination_ref", "pack"],
+            "responseKeys": [
+              "schema_version",
+              "protocol",
+              "transfer_id",
+              "repository_id",
+              "destination_ref",
+              "destination_head",
+              "outcome",
+              "authority_receipt"
+            ]
+          }
+        ],
+        "expectationKeys": [
+          "repository_id",
+          "destination_ref",
+          "destination_target",
+          "destination_head",
+          "roots",
+          "default_ref",
+          "git_authority_hash",
+          "supported_features",
+          "limits"
+        ],
+        "limitsKeys": [
+          "max_changes",
+          "max_trees",
+          "max_bodies",
+          "max_external_objects",
+          "max_aliases",
+          "max_decoded_body_bytes",
+          "max_single_body_bytes"
+        ],
+        "refusals": [
+          {
+            "status": 401,
+            "reason": "no session, or a session this seam does not accept"
+          },
+          {
+            "status": 403,
+            "reason": "the session is not a member of the organization, the repository is not readable by it, or a write the branch protection refuses"
+          },
+          {
+            "status": 404,
+            "reason": "the organization or the repository is not served here"
+          },
+          {
+            "status": 409,
+            "reason": "a repository-v6 lease or fast-forward conflict"
+          },
+          {
+            "status": 413,
+            "reason": "the envelope is larger than the declared transfer body limit"
+          },
+          {
+            "status": 422,
+            "reason": "the envelope is not a valid repository-v6 payload"
+          },
+          {
+            "status": 424,
+            "reason": "the seam is intact and the repository authority behind it failed"
+          }
+        ]
+      }
+    },
+    "refusal": {
+      "description": "Every refusal body on this seam. The client renders `error` verbatim, so this string is the sentence a user reads.",
+      "type": "object",
+      "required": ["error"],
+      "properties": {
+        "error": {
+          "type": "string",
+          "minLength": 1
+        },
+        "apiVersion": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/packages/boundary-contracts/schemas/hosted-repository-transfer.schema.json
+++ b/packages/boundary-contracts/schemas/hosted-repository-transfer.schema.json
@@ -11,6 +11,7 @@
         "routeTemplate": "/api/v1/orgs/{orgId}/repos/{repoId}/transfer/{leaf}",
         "authorizationScheme": "Bearer",
         "orgScoped": true,
+        "remoteName": "origin",
         "leaves": [
           {
             "leaf": "advertise",

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -632,6 +632,33 @@ export interface RepositoryTransferStatus {
   pull_apply_ready: boolean;
 }
 
+/** One advertised ref and the change it resolves to. */
+export interface RepositoryRefAdvertisementEntry {
+  name: RepositoryTransferRefName;
+  target: RepositoryTransferRefTarget;
+  head: string;
+}
+
+/**
+ * What a repository publishes before any history moves.
+ *
+ * A clone starts here: it has no ref of its own to ask about yet, so it cannot
+ * use the per-ref transfer status, and it needs the default ref before it can
+ * initialize a replica that adopts the remote layout. An unborn repository
+ * publishes a `default_ref` that is absent from `refs`, which a clone must
+ * reproduce rather than treat as an error.
+ */
+export interface RepositoryRefAdvertisement {
+  schema_version: 4;
+  protocol: "kin-repository-v6-fast-forward";
+  repository_id: string;
+  refs: RepositoryRefAdvertisementEntry[];
+  default_ref: RepositoryTransferRefName | null;
+  roots: RepositoryTransferRootBundle;
+  supported_features: string[];
+  limits: RepositoryTransferLimits;
+}
+
 export interface RepositoryTransferBody {
   hash: string;
   byte_len: number;

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -695,6 +695,50 @@ export interface RepositoryTransferReceipt {
   };
 }
 
+/**
+ * One leaf of the hosted repository-v6 transfer seam, as the contract declares
+ * it. `requestKeys` is the exact top-level key set of the request body, and
+ * `responseKeys` the exact top-level key set the client deserializes.
+ */
+export interface HostedRepositoryTransferLeaf {
+  leaf: "advertise" | "status" | "export" | "receive";
+  method: "GET" | "POST";
+  requestKeys: string[];
+  responseKeys: string[];
+}
+
+export interface HostedRepositoryTransferRefusal {
+  status: number;
+  reason: string;
+}
+
+/**
+ * The hosted transfer seam a `kin push` and a `kin pull` address, and the one
+ * KinLab serves. Read it rather than spelling the route or the envelope keys
+ * again.
+ */
+export interface HostedRepositoryTransferSeam {
+  protocol: "kin-repository-v6-fast-forward";
+  schemaVersion: 4;
+  routeTemplate: string;
+  authorizationScheme: "Bearer";
+  orgScoped: true;
+  leaves: HostedRepositoryTransferLeaf[];
+  expectationKeys: string[];
+  limitsKeys: string[];
+  refusals: HostedRepositoryTransferRefusal[];
+}
+
+export declare function hostedRepositoryTransferSeam(): Promise<HostedRepositoryTransferSeam>;
+export declare function hostedRepositoryTransferLeaf(
+  leaf: string
+): Promise<HostedRepositoryTransferLeaf>;
+export declare function hostedRepositoryTransferPath(
+  orgId: string,
+  repoId: string,
+  leaf: string
+): Promise<string>;
+
 export interface RepositoryTransferPublishRequest {
   pack: RepositoryTransferPack;
   publishReviewState: boolean;

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -659,6 +659,25 @@ export interface RepositoryRefAdvertisement {
   limits: RepositoryTransferLimits;
 }
 
+/**
+ * What a sender must satisfy for the receiver to admit its pack.
+ *
+ * Derived from a transfer status by bounding the peer's declared limits with
+ * the local ones, so neither side can be made to build an envelope the other
+ * would refuse. It travels as the `expectation` member of an export request.
+ */
+export interface RepositoryTransferExpectation {
+  repository_id: string;
+  destination_ref: RepositoryTransferRefName;
+  destination_target: RepositoryTransferRefTarget | null;
+  destination_head: string | null;
+  roots: RepositoryTransferRootBundle;
+  default_ref: RepositoryTransferRefName | null;
+  git_authority_hash: string | null;
+  supported_features: string[];
+  limits: RepositoryTransferLimits;
+}
+
 export interface RepositoryTransferBody {
   hash: string;
   byte_len: number;

--- a/packages/boundary-contracts/src/index.js
+++ b/packages/boundary-contracts/src/index.js
@@ -27,7 +27,8 @@ const schemaFiles = {
   repoScopedSemanticToolCall: 'repo-scoped-semantic-tool-call.schema.json',
   repoScopedSemanticToolResponse: 'repo-scoped-semantic-tool-response.schema.json',
   repoScopedSemanticToolError: 'repo-scoped-semantic-tool-error.schema.json',
-  shadowGateReport: 'shadow-gate-report.schema.json'
+  shadowGateReport: 'shadow-gate-report.schema.json',
+  hostedRepositoryTransfer: 'hosted-repository-transfer.schema.json'
 };
 
 const schemaIdMap = {
@@ -66,6 +67,65 @@ export async function validateContract(name, payload) {
     ok: errors.length === 0,
     errors
   };
+}
+
+/**
+ * The hosted repository-v6 transfer seam, as one literal.
+ *
+ * A caller that needs the route, the four leaves or the envelope keys reads
+ * them from here rather than spelling them again. Both replicas of this seam,
+ * the Kin client and the KinLab control plane, resolve it through this one
+ * function, so a rename in the contract moves both and a rename in either
+ * implementation fails its own test rather than a stranger's push.
+ */
+export async function hostedRepositoryTransferSeam() {
+  const schema = await loadSchema('hostedRepositoryTransfer');
+  const seam = schema?.definitions?.seam?.const;
+  if (!seam) {
+    throw new Error(
+      'hosted-repository-transfer.schema.json carries no definitions.seam.const'
+    );
+  }
+  return seam;
+}
+
+/**
+ * One leaf of that seam by name, refusing rather than returning undefined.
+ *
+ * A missing leaf is a contract that moved under a caller, which is exactly the
+ * case a silent `undefined` would carry into a request URL.
+ */
+export async function hostedRepositoryTransferLeaf(leaf) {
+  const seam = await hostedRepositoryTransferSeam();
+  const found = seam.leaves.find(candidate => candidate.leaf === leaf);
+  if (!found) {
+    throw new Error(
+      `hosted repository transfer seam serves no leaf ${leaf}; it serves ` +
+        seam.leaves.map(candidate => candidate.leaf).join(', ')
+    );
+  }
+  return found;
+}
+
+/**
+ * The org-scoped path for one leaf, with the template's own placeholders
+ * substituted and each segment encoded.
+ *
+ * Encoding is not cosmetic here: a repository id admits a slash, and an
+ * unencoded one would silently address a different route.
+ */
+export async function hostedRepositoryTransferPath(orgId, repoId, leaf) {
+  const seam = await hostedRepositoryTransferSeam();
+  await hostedRepositoryTransferLeaf(leaf);
+  for (const [name, value] of [['orgId', orgId], ['repoId', repoId]]) {
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error(`hosted repository transfer path needs a non-empty ${name}`);
+    }
+  }
+  return seam.routeTemplate
+    .replace('{orgId}', encodeURIComponent(orgId))
+    .replace('{repoId}', encodeURIComponent(repoId))
+    .replace('{leaf}', leaf);
 }
 
 export async function assertContract(name, payload) {

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -632,6 +632,11 @@ test('the hosted transfer seam is one contract three implementations read', asyn
   // The two request members that carry a shape of their own.
   const expectation = rustStructFields(transferSource, 'RepositoryTransferExpectation');
   assert.deepEqual(expectation.fields, seam.expectationKeys);
+  assert.deepEqual(
+    declaredInterfaceFields(declarations, 'RepositoryTransferExpectation'),
+    seam.expectationKeys,
+    'the expectation an export request carries must be declared with the contract keys'
+  );
   const limits = rustStructFields(transferSource, 'RepositoryTransferLimits');
   assert.deepEqual(limits.fields, seam.limitsKeys);
   const entry = rustStructFields(transferSource, 'RepositoryRefAdvertisementEntry');
@@ -662,6 +667,10 @@ test('the hosted transfer route is built from the contract, and refuses what it 
   const seam = await hostedRepositoryTransferSeam();
   assert.equal(seam.orgScoped, true);
   assert.equal(seam.authorizationScheme, 'Bearer');
+  // The peer protocol carries no remote name, so the server records one. The
+  // founder's decision of 2026-08-29 is that a push naming no remote lands on
+  // origin, and this is the one place that name is written.
+  assert.equal(seam.remoteName, 'origin');
   assert.equal(
     seam.routeTemplate,
     '/api/v1/orgs/{orgId}/repos/{repoId}/transfer/{leaf}',

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -584,11 +584,20 @@ test('the hosted transfer seam is one contract three implementations read', asyn
     export: 'RepositoryTransferPack',
     receive: 'RepositoryTransferReceipt'
   };
+  // Every response type carries a declaration, so no leaf's envelope is
+  // described in Rust alone. The advertise leaf was the one that was: a pull
+  // starts there, and nothing on the TypeScript side named its shape.
   const declaredHere = new Set([
+    'RepositoryRefAdvertisement',
     'RepositoryTransferStatus',
     'RepositoryTransferPack',
     'RepositoryTransferReceipt'
   ]);
+  assert.deepEqual(
+    [...declaredHere].sort(),
+    Object.values(responseTypes).sort(),
+    'every response type must be declared, or the join covers only some leaves'
+  );
 
   assert.deepEqual(
     seam.leaves.map(leaf => leaf.leaf).sort(),
@@ -625,6 +634,12 @@ test('the hosted transfer seam is one contract three implementations read', asyn
   assert.deepEqual(expectation.fields, seam.expectationKeys);
   const limits = rustStructFields(transferSource, 'RepositoryTransferLimits');
   assert.deepEqual(limits.fields, seam.limitsKeys);
+  const entry = rustStructFields(transferSource, 'RepositoryRefAdvertisementEntry');
+  assert.deepEqual(
+    declaredInterfaceFields(declarations, 'RepositoryRefAdvertisementEntry'),
+    entry.fields,
+    'an advertised ref entry must be declared with the keys the Rust struct sends'
+  );
   assert.deepEqual(
     declaredInterfaceFields(declarations, 'RepositoryTransferLimits'),
     seam.limitsKeys

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -7,7 +7,15 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { assertContract, loadAllSchemas, validateContract } from '../src/index.js';
+import {
+  assertContract,
+  hostedRepositoryTransferLeaf,
+  hostedRepositoryTransferPath,
+  hostedRepositoryTransferSeam,
+  loadAllSchemas,
+  loadSchema,
+  validateContract
+} from '../src/index.js';
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repositoryRoot = path.resolve(packageRoot, '../..');
@@ -496,4 +504,206 @@ test('shadow gate report contract accepts the kin review shadow payload shape', 
   const malformedHash = structuredClone(report);
   malformedHash.changed_artifacts[0].new.entry.hash.pop();
   assert.equal((await validateContract('shadowGateReport', malformedHash)).ok, false);
+});
+
+/**
+ * Read the top-level field names of one `pub struct` out of the Rust source.
+ *
+ * The names are the wire names only while nothing renames them, so the caller
+ * checks that separately; this returns the declaration as written.
+ */
+function rustStructFields(source, name) {
+  const opening = `pub struct ${name} {`;
+  const start = source.indexOf(opening);
+  if (start < 0) {
+    return null;
+  }
+  const end = source.indexOf('\n}', start);
+  if (end < 0) {
+    return null;
+  }
+  const body = source.slice(start + opening.length, end);
+  return {
+    body,
+    fields: [...body.matchAll(/^ {4}pub ([a-z0-9_]+):/gm)].map(match => match[1])
+  };
+}
+
+/** The same for one `export interface` in the TypeScript declarations. */
+function declaredInterfaceFields(declarations, name) {
+  const opening = `export interface ${name} {`;
+  const start = declarations.indexOf(opening);
+  if (start < 0) {
+    return null;
+  }
+  const end = declarations.indexOf('\n}', start);
+  if (end < 0) {
+    return null;
+  }
+  const body = declarations.slice(start + opening.length, end);
+  return [...body.matchAll(/^ {2}([a-z0-9_]+)\??:/gm)].map(match => match[1]);
+}
+
+test('the hosted transfer seam is one contract three implementations read', async () => {
+  const seam = await hostedRepositoryTransferSeam();
+  const [declarations, transferSource] = await Promise.all([
+    fs.readFile(path.join(packageRoot, 'src/index.d.ts'), 'utf8'),
+    fs.readFile(
+      path.join(repositoryRoot, 'crates/kin-remote/src/repository_transfer.rs'),
+      'utf8'
+    )
+  ]);
+
+  // The extractors must be shown to work before an empty result is read as
+  // agreement. A struct that does not exist returns null rather than [], and a
+  // struct that does returns a field this test names.
+  assert.equal(
+    rustStructFields(transferSource, 'RepositoryTransferNotAStruct'),
+    null,
+    'the Rust extractor must miss a struct that does not exist'
+  );
+  assert.ok(
+    rustStructFields(transferSource, 'RepositoryTransferStatus').fields.includes(
+      'push_apply_ready'
+    ),
+    'the Rust extractor must find a field the struct is known to declare'
+  );
+  assert.equal(
+    declaredInterfaceFields(declarations, 'RepositoryTransferNotAnInterface'),
+    null,
+    'the TypeScript extractor must miss an interface that does not exist'
+  );
+
+  // Each leaf's response envelope, against the Rust struct that produces it and
+  // the TypeScript interface that describes it. The three key sets are compared
+  // to the contract rather than to each other, so no two of them can agree on a
+  // name the contract never had.
+  const responseTypes = {
+    advertise: 'RepositoryRefAdvertisement',
+    status: 'RepositoryTransferStatus',
+    export: 'RepositoryTransferPack',
+    receive: 'RepositoryTransferReceipt'
+  };
+  const declaredHere = new Set([
+    'RepositoryTransferStatus',
+    'RepositoryTransferPack',
+    'RepositoryTransferReceipt'
+  ]);
+
+  assert.deepEqual(
+    seam.leaves.map(leaf => leaf.leaf).sort(),
+    Object.keys(responseTypes).sort(),
+    'every contract leaf needs a response type, and every response type a leaf'
+  );
+
+  for (const leaf of seam.leaves) {
+    const typeName = responseTypes[leaf.leaf];
+    const rust = rustStructFields(transferSource, typeName);
+    assert.ok(rust, `${typeName} must remain readable in the Rust authority`);
+    assert.equal(
+      rust.body.includes('rename'),
+      false,
+      `${typeName} renames a field, so its declared names are no longer its wire names`
+    );
+    assert.deepEqual(
+      rust.fields,
+      leaf.responseKeys,
+      `${typeName} and the ${leaf.leaf} response envelope must carry the same keys in the same order`
+    );
+
+    if (declaredHere.has(typeName)) {
+      assert.deepEqual(
+        declaredInterfaceFields(declarations, typeName),
+        leaf.responseKeys,
+        `the ${typeName} declaration and the ${leaf.leaf} response envelope must carry the same keys`
+      );
+    }
+  }
+
+  // The two request members that carry a shape of their own.
+  const expectation = rustStructFields(transferSource, 'RepositoryTransferExpectation');
+  assert.deepEqual(expectation.fields, seam.expectationKeys);
+  const limits = rustStructFields(transferSource, 'RepositoryTransferLimits');
+  assert.deepEqual(limits.fields, seam.limitsKeys);
+  assert.deepEqual(
+    declaredInterfaceFields(declarations, 'RepositoryTransferLimits'),
+    seam.limitsKeys
+  );
+
+  // The constants both sides stamp on every envelope.
+  const protocol = transferSource.match(
+    /pub const REPOSITORY_TRANSFER_PROTOCOL: &str = "([^"]+)";/
+  );
+  assert.ok(protocol, 'the Rust protocol constant must remain readable');
+  assert.equal(protocol[1], seam.protocol);
+  const version = transferSource.match(
+    /pub const REPOSITORY_TRANSFER_SCHEMA_VERSION: u32 = (\d+);/
+  );
+  assert.ok(version, 'the Rust schema version constant must remain readable');
+  assert.equal(Number(version[1]), seam.schemaVersion);
+});
+
+test('the hosted transfer route is built from the contract, and refuses what it cannot address', async () => {
+  const seam = await hostedRepositoryTransferSeam();
+  assert.equal(seam.orgScoped, true);
+  assert.equal(seam.authorizationScheme, 'Bearer');
+  assert.equal(
+    seam.routeTemplate,
+    '/api/v1/orgs/{orgId}/repos/{repoId}/transfer/{leaf}',
+    'the org-scoped route is the seam; a bare repository id names no organization'
+  );
+
+  assert.equal(
+    await hostedRepositoryTransferPath('kin-open-core', 'kin', 'receive'),
+    '/api/v1/orgs/kin-open-core/repos/kin/transfer/receive'
+  );
+  // A repository id admits a slash. An unencoded one would address a route the
+  // caller never asked for, which is a silent cross-repository write.
+  assert.equal(
+    await hostedRepositoryTransferPath('acme', 'group/repo name', 'status'),
+    '/api/v1/orgs/acme/repos/group%2Frepo%20name/transfer/status'
+  );
+
+  await assert.rejects(
+    () => hostedRepositoryTransferPath('acme', 'kin', 'zzznotaleaf'),
+    /serves no leaf zzznotaleaf/,
+    'a leaf the contract does not declare must refuse rather than build a URL'
+  );
+  await assert.rejects(
+    () => hostedRepositoryTransferPath('', 'kin', 'status'),
+    /non-empty orgId/,
+    'an empty organization must refuse rather than address /orgs//repos/'
+  );
+  await assert.rejects(
+    () => hostedRepositoryTransferLeaf('advertize'),
+    /serves no leaf advertize/
+  );
+
+  // Every method and request envelope the seam declares, so a leaf cannot
+  // quietly change verb or lose a body key.
+  assert.deepEqual(
+    seam.leaves.map(leaf => [leaf.leaf, leaf.method, leaf.requestKeys.join(',')]),
+    [
+      ['advertise', 'GET', ''],
+      ['status', 'POST', 'destination_ref'],
+      ['export', 'POST', 'source_ref,expectation'],
+      ['receive', 'POST', 'destination_ref,pack']
+    ]
+  );
+
+  // The refusal statuses the seam promises, each with a sentence. The client
+  // renders `error` verbatim, so a refusal with no body is a refusal a user
+  // cannot act on.
+  assert.deepEqual(
+    seam.refusals.map(refusal => refusal.status),
+    [401, 403, 404, 409, 413, 422, 424]
+  );
+  for (const refusal of seam.refusals) {
+    assert.ok(refusal.reason.length > 0, `refusal ${refusal.status} needs a reason`);
+  }
+  // The refusal body itself. The client prints `error` verbatim, so a schema
+  // that stopped requiring it would let a server refuse with no sentence.
+  const schema = await loadSchema('hostedRepositoryTransfer');
+  assert.deepEqual(schema.definitions.refusal.required, ['error']);
+  assert.equal(schema.definitions.refusal.properties.error.minLength, 1);
 });


### PR DESCRIPTION
First of three landings for FIR-2945, the local-to-cloud byte path. This one adds no
behaviour. It writes the seam down once so the two implementations that must agree can be
made to fail when they stop agreeing.

## What was spelled twice

A `kin push` and a hosted KinLab both speak the repository-v6 transfer protocol, and every
part of it lived in two places at once. The route in one implementation and the other. The
envelope keys in the Rust structs in `crates/kin-remote/src/repository_transfer.rs` and
again as TypeScript interfaces in `packages/boundary-contracts/src/index.d.ts`. The
protocol string and the schema version in three. Two spellings of one contract agree right
up until one of them is renamed, and then they disagree in the one place nobody looks,
which is a stranger's push.

The existing drift alarm shows the shape of the gap. It asserted that each of three
interfaces declares `schema_version: 4`, and nothing else. Rename a field on either side
and it stayed green.

## What the contract holds

`schemas/hosted-repository-transfer.schema.json` carries the org-scoped route template,
the four leaves with their methods, the exact top-level request and response key set for
each one, the expectation and limits key sets, and the seven refusal statuses with the
sentence each carries. It is a `const` rather than a shape, because a shape would admit a
renamed field and refusing one is the entire point.

The route is `/api/v1/orgs/{orgId}/repos/{repoId}/transfer/{leaf}`. That spelling is the
founder's decision of 2026-08-29: a hosted remote names its organization, and the server
never infers one from a bare repository id, so nothing crosses an org boundary by
accident.

## How the join is asserted

Over the real set, not at the endpoints. The suite extracts the field names out of the
Rust structs and out of the TypeScript interfaces, and compares each of them to the
contract. Neither is compared to the other, so no two of the three can agree on a name the
contract never had.

Both extractors are proven before an empty result is read as agreement. A struct that does
not exist returns null rather than an empty list, and a struct that does returns a field
the test names by hand. The Rust arm also refuses a struct carrying `#[serde(rename)]`,
because a renamed field's declared name is no longer its wire name and the extraction
would be reading the wrong thing.

The path builder lives beside the contract so a caller never spells the route again, and
it encodes each segment. A repository id admits a slash, and an unencoded one addresses a
route the caller never asked for.

## The suite ran nowhere

`packages/boundary-contracts/test/contracts.test.js` was run by no workflow in this
repository. Zero matches for the package under `.github/workflows/`, with 82 matches for
`cargo` in `ci.yml` as the control that the search works. The tests existed and no required
context could report them, so the guard could not fail.

It now runs as a step in `Fast gate lint and policy`, which `main` requires by name, in a
job carrying no `if` that a pull request skips. The step keys its verdict on the exit code
and treats the pass count only as a floor, so a suite that graded nothing cannot report the
green a clean run reports.

## Falsification

Eleven mutations plus a baseline, each removing a property of the code or the contract and
never weakening an assertion. The driver refuses a dirty tree above its own restore trap,
restores with `git checkout HEAD --` and prints the sha it restored to, aborts an arm whose
anchor is not present exactly once rather than running it on an unmutated tree, asserts the
marker is in the tree before grading, and computes its exit from the grid.

```
M0-baseline                             GREEN, 7 tests
M1-rust-field-renamed                   caught on the extractor control
M1b-rust-field-renamed-off-control      caught on the Rust-to-contract key join
M2-contract-key-dropped                 caught on the Rust-to-contract key join
M3-declaration-renamed                  caught on the declaration-to-contract join
M4-route-template-changed               caught on the route template assertion
M5-receive-leaf-dropped                 caught on the leaf table, in both tests
M6-serde-rename-added                   caught on the serde-rename guard
M7-refusal-body-optional                caught on the refusal required-key assertion
M8-protocol-constant-moved              caught on the protocol constant assertion
M9-seam-const-deleted                   caught, the seam loader threw
M10-path-segments-unencoded             caught on the slash-encoding assertion
M11-advertisement-declaration-renamed   caught on the declaration-to-contract join
M12-advertisement-entry-renamed         caught on the advertised-entry join
caught=13 bad=0
```

One arm did not apply on its first spelling, and the driver reported it NOT-RUN rather
than counting it. That is the whole reason the anchor is required to match exactly once.

M1b is in the grid because of what M1 alone would have hidden. M1 renames
`push_apply_ready`, which is the very field the extractor control names, so the arm goes
red on the control and the join behind it is never reached. Read as a whole-arm verdict,
that reads exactly like the join working. M1b renames a field no control mentions, and it
fires at 608, the Rust-to-contract key comparison. The two assertions are separated only
because the driver reports which line answered rather than that the suite went red.

## Gates

`node --test` in `packages/boundary-contracts`, 7 passing. `node --check` on both files.
`actionlint .github/workflows/ci.yml` clean. The inserted step was confirmed to sit inside
`fast-gate-lint`, which spans lines 875 to 1056, by reading the job boundaries rather than
by trusting the anchor.

No Rust source changes, so no cargo gate applies to this branch.

## Claims not being made

Not claiming `kin push` works. It does not, and this changes nothing a user can run.

The advertise leaf gained its declaration in the second commit, so all four response
envelopes are now described on both sides and the suite asserts the set of declared types
equals the set of leaves rather than trusting a hand-kept list.

Not claiming the contract is complete. It binds the top-level envelope, the route and the
refusal codes. It deliberately does not describe the interior of a pack, which the hosted
server proxies rather than interprets.

Not claiming the refusal statuses are all handled today. The client maps 409, 422, 424,
404 and 413; 401 and 403 fall into its `other` arm and surface as storage failures. The
contract declares them because the seam produces them, and the client PR is where they get
their arms.

Refs FIR-2945.
