### PR TITLE
Name the read view's authority accessor so the file-search guard can see it

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13422,7 +13422,16 @@ enum RepositoryReadView {
 }
 
 impl RepositoryReadView {
-    fn metadata(&self) -> Result<&kin_db::PersistedRepositoryAuthority, (StatusCode, String)> {
+    /// This generation's authority envelope.
+    ///
+    /// Named `authority` and not `metadata` on purpose.
+    /// `scripts/verify-zero-file-search.py` reads `.metadata()` as a filesystem
+    /// metadata probe, which is exactly the call the zero-file-search rule
+    /// exists to keep out of an answer path. A repository-authority accessor
+    /// wearing that name spends the guard's allowlist on a call that touches no
+    /// filesystem, and the guard runs only in the `check` job, which pull
+    /// requests skip, so the cost lands on main rather than on the PR.
+    fn authority(&self) -> Result<&kin_db::PersistedRepositoryAuthority, (StatusCode, String)> {
         match self {
             Self::Hosted { metadata, .. } => Ok(metadata.as_ref()),
             Self::Local { snapshot } => repository_metadata(snapshot),
@@ -13434,7 +13443,7 @@ impl RepositoryReadView {
         &self,
         target: &kin_model::RefTarget,
     ) -> Result<kin_model::SemanticChangeId, (StatusCode, String)> {
-        crate::state::resolve_repository_target(self.metadata()?, target)
+        crate::state::resolve_repository_target(self.authority()?, target)
             .map_err(repository_authority_error)
     }
 
@@ -14431,7 +14440,7 @@ async fn repo_files(
     State(state): State<Arc<DaemonState>>,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, String)> {
     let view = repository_read_view(&state, &repo_id).await?;
-    let selected = default_repository_ref(view.metadata()?)?.cloned();
+    let selected = default_repository_ref(view.authority()?)?.cloned();
     let files = if let Some(repository_ref) = selected {
         let change_id = view.resolve_target(&repository_ref.target)?;
         view.resolve_tree_at(&state, &change_id)?
@@ -14519,7 +14528,7 @@ async fn repo_history(
     State(state): State<Arc<DaemonState>>,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, String)> {
     let view = repository_read_view(&state, &repo_id).await?;
-    let metadata = view.metadata()?;
+    let metadata = view.authority()?;
     let Some(repository_ref) = default_repository_ref(metadata)? else {
         return Ok(Json(RepoHistoryResponse {
             repo_id,


### PR DESCRIPTION
`scripts/verify-zero-file-search.py` reads `.metadata()` as a filesystem
metadata probe, which is exactly the call the zero-file-search rule exists to
keep out of an answer path. `RepositoryReadView::metadata()`, added in #1242,
returns the repository authority envelope and touches no filesystem, but it
wears the name the guard matches, so it spent that file's allowlist entry:

```
[VIOLATION] crates/kin-daemon/src/api.rs contains forbidden filesystem access:
  Line 13437: crate::state::resolve_repository_target(self.metadata()?, target)
  Line 14434: let selected = default_repository_ref(view.metadata()?)?.cloned();
  Line 14522: let metadata = view.metadata()?;
Verification FAILED: Found 4 zero-file-search violations.
Allowlist validation FAILED:
  entry crates/kin-daemon/src/api.rs allow_match '.metadata()' occurs 4 times in scanned code (want 1)
```

Renaming the accessor to `authority()` is the fix rather than widening the
allowlist. Raising that count to four would weaken the guard for every future
`.metadata()` in this file, and `authority` is the more accurate name for what
the accessor returns. Verified by running the guard itself on this tree:
`Verification PASSED: Zero File-Search Invariant holds`, against the four
violations above on the tree without it.

## Why #1242 was green and main was not

The guard has exactly one invocation, `ci.yml:1488`, inside the `check` job at
`ci.yml:1217`. A pull request takes `check-pr-fast-path` instead
(`ci.yml:1179`, `if: github.event_name == 'pull_request'`), so no PR check runs
it and the cost lands on main. This is the catalogued class: a guard that runs
only in a job the pull-request gate skips fails on main forever with no PR check
reporting it.

`bin/kin-precheck kin` does run it, and did report it: fifteen of sixteen gates
passed at c9559ad2f, the one failure being this guard. I read that output after
#1242 had already landed, which is the sequencing mistake here, not the tool's.

Refs FIR-2924
