### PR TITLE
Point the agent-install docs at the MCP entry Kin's own health check calls canonical

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,29 @@ can open later.
 
 ## Shortest graph-backed path
 
+Five commands, and the last one is the answer:
+
+```sh
+curl -fsSL https://get.kinlab.dev/install | sh
+exec "$SHELL" -l
+cd /path/to/your/repository
+kin init .
+kin locate "where are webhook retries handled"
+```
+
+`kin init` is the slow step and the one that earns the rest. It admits your Git
+history into the graph, and every answer after it comes from that graph rather
+than from re-reading the tree. Measured on a fresh Debian 12 container with 4
+CPUs and 8 GiB against the release npm serves today, the installer took 4
+seconds, `kin init` took 139 seconds on a 503-file repository with 1,983
+commits, and the first `kin locate` answered in 6.7 seconds while the daemon
+cold-started, then in 71 milliseconds warm. Those are separately measured legs
+of one sitting, not one timed run, and a repository with deeper history takes
+longer.
+
+Wire your agent after `kin init`, not before. The rest of this section is the
+same path with the detail behind each step.
+
 ### 1. Install and configure Kin
 
 On macOS or Linux:
@@ -328,6 +351,12 @@ stays first class. `kin setup --intent agent` configures every client it detects
 in one pass. These are the per-client one-liners when you would rather install Kin
 directly.
 
+Run `kin init .` in the repository before you wire a client, not after. These
+tools answer from the graph, so a client pointed at a directory with no graph
+gets a tool surface with nothing behind it. `kin setup` says so itself: its
+round-trip check reports "no initialized Kin repository at or above" the
+directory it ran in, and tells you to run `kin init` there and re-run setup.
+
 Claude Code, from inside a session:
 
 ```
@@ -352,11 +381,11 @@ Cursor takes a one-click install link. Paste this into Cursor or into your
 browser's address bar:
 
 ```
-cursor://anysphere.cursor-deeplink/mcp/install?name=kin&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBraW5sYWIva2luLW1jcCJdfQ==
+cursor://anysphere.cursor-deeplink/mcp/install?name=kin&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBraW5sYWIva2luIiwibWNwIiwic3RhcnQiXX0=
 ```
 
 Kiro takes the same thing as a web link:
-[Add Kin to Kiro](https://kiro.dev/launch/mcp/add?name=kin&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40kinlab%2Fkin-mcp%22%5D%7D).
+[Add Kin to Kiro](https://kiro.dev/launch/mcp/add?name=kin&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40kinlab%2Fkin%22%2C%22mcp%22%2C%22start%22%5D%7D).
 
 Cline takes the standard entry below rather than a one-liner. Its CLI reads
 `~/.cline/mcp.json`. In the VS Code extension, open the MCP Servers panel, then
@@ -367,10 +396,17 @@ Every other client that reads a standard MCP config takes this entry:
 ```json
 {
   "mcpServers": {
-    "kin": { "command": "npx", "args": ["-y", "@kinlab/kin-mcp"] }
+    "kin": { "command": "npx", "args": ["-y", "@kinlab/kin", "mcp", "start"] }
   }
 }
 ```
+
+`kin setup status` and `kin doctor` recognize this exact shape, alongside the
+absolute-path form `kin setup` writes, and grade anything else MISCONFIGURED. Do
+not shorten `command` to a bare `kin`, because agent clients do not reliably
+inherit your shell `PATH`. `@kinlab/kin-mcp` is the older launcher and keeps
+working for configurations that already name it; new ones should point at
+`@kinlab/kin`, which ships the same MCP server as one mode of the full CLI.
 
 The wrapper needs Node 20 or newer, and on its first run it downloads the
 matching Kin release, verifies its published SHA-256, and caches the binaries per

--- a/llms-install.md
+++ b/llms-install.md
@@ -189,7 +189,7 @@ SHA-256, and caches the binaries per user:
   "mcpServers": {
     "kin": {
       "command": "npx",
-      "args": ["-y", "@kinlab/kin-mcp"]
+      "args": ["-y", "@kinlab/kin", "mcp", "start"]
     }
   }
 }
@@ -200,13 +200,16 @@ Codex CLI uses TOML rather than JSON:
 ```toml
 [mcp_servers.kin]
 command = "npx"
-args = ["-y", "@kinlab/kin-mcp"]
+args = ["-y", "@kinlab/kin", "mcp", "start"]
 ```
 
-The wrapper refuses to start against a directory with no `.kin/`. If you want it to admit a
-repository on its own instead of running step 2 first, add
-`"env": { "KIN_MCP_AUTO_INIT": "1" }` to the entry. Say so out loud before enabling it,
-because it means an agent session can admit a repository without being asked.
+`kin setup status` and `kin doctor` recognize this exact shape and the absolute-path form
+above, and grade any other argument vector MISCONFIGURED. The older `@kinlab/kin-mcp`
+package keeps working for configurations that already name it. Run step 2 before you wire
+a client either way, because a client pointed at a directory with no graph gets a tool
+surface with nothing behind it. If you want the older wrapper to admit a repository on its
+own instead, add `"env": { "KIN_MCP_AUTO_INIT": "1" }` to the entry. Say so out loud before
+enabling it, because it means an agent session can admit a repository without being asked.
 
 ## Step 5: verify
 


### PR DESCRIPTION
## What this changes

The standard MCP entry in `README.md` and `llms-install.md`, and both one-click deeplinks,
handed every client `npx -y @kinlab/kin-mcp`. Kin's own health check grades that entry
MISCONFIGURED. This points all of them at the entry it calls canonical, adds the
five-command path to the top of the README's shortest-path section, and says in both files
to run `kin init` before wiring a client rather than after.

## Verified, and how

Everything below was measured in a fresh Debian 12 container (`--cpus 4 --memory 8g`, node
22.23.1) against **the 0.6.0 release npm serves today** (`npm view @kinlab/kin version` ->
`0.6.0`; installed binary self-reports `kin 0.6.0 (37b6e37b8... 2026-08-26T21:15:48Z)`).
No local build was used. Nothing here was run against a primary checkout.

**Which MCP entry the product accepts.** Three arms, each written into `~/.claude.json`
and graded with `kin setup status`:

| Entry | Verdict |
| --- | --- |
| `npx -y @kinlab/kin mcp start` (this PR) | `ok  mcpServers.kin present, no KIN_MCP_TOOL_PROFILE set; the server defaults to the agent-default profile` |
| `npx -y @kinlab/kin-mcp` (what these files said) | `MISCONFIGURED  mcpServers.kin does not use the exact supported MCP argument vector for claude` |
| `command: "kin"` (negative control) | `MISCONFIGURED  command is kin (expected the exact Kin launcher for this installation ... or the canonical` + "`npx -y @kinlab/kin ...` wrapper)" |

The third arm is the control that proves the check discriminates rather than failing
everything that is not byte-identical to what `kin setup` writes: it fails for a different,
named reason, and its remedy text names the shape this PR adopts.

**That the entry starts a usable server.** A JSON-RPC probe that matches responses by id,
run in a directory with no `.kin/` anywhere above it (`/tmp/nowhere`):

| Command | `initialize` | `tools/list` | process |
| --- | --- | --- | --- |
| `npx -y @kinlab/kin mcp start` | OK in 792 ms | 20 tools | alive |
| `kin mcp start` | OK in 44 ms | 20 tools | alive |
| `npx -y @kinlab/kin-mcp` | exits code 2 in 767 ms, "No .kin/ found." | not reached | dead |
| `npx -y @kinlab/kin-not-a-real-package-9182` (control) | fails, npm E404 | not reached | dead |

The last row is the control proving the probe can report a failure. The third row is the
2026-08-28 walkthrough's finding 5 reproducing on Linux; it is already repaired on main by
#1233 and will stop reproducing on the next release, which is why this PR's copy does not
describe that failure and just names the entry that works on both.

**That the tool profile needs no `env` block.** Bare `kin mcp start` reports on stderr:
"serving the default 'agent-default' tool profile (20 tools)". So the entry here is
complete without one, which matters because the same object is rendered as TOML and as an
Amp command elsewhere and those forms carry no `env`.

**That the deeplinks carry what the block says.** Both payloads are regenerated from the
new entry and decoded back out of the committed file: the Cursor base64 and the Kiro
percent-encoding each round-trip to
`{"command":"npx","args":["-y","@kinlab/kin","mcp","start"]}`.

**The timings in the new README block**, all from that container, in one sitting:

| Leg | Value |
| --- | --- |
| `curl -fsSL https://get.kinlab.dev/install \| sh` | 4 s, rc=0 |
| `git clone` + pin of `tokio-rs/axum` (503 files, 1,983 commits) | 2 s |
| `kin init .` | 139 s, rc=0 (read without a pipe) |
| first `kin locate`, cold daemon | 6,733 ms |
| second `kin locate`, warm | 71 ms |

They are separately measured legs, not one timed run, and the README says so.

**That `kin init` before the client is the product's own advice.** `kin setup --intent
agent --no-interactive` in a directory with no repository reports: "Claude Code: not
exercised -- no initialized Kin repository at or above /home/dev, so there is nothing for a
tool call to answer about; run `kin init` there and re-run `kin setup`".

## What I did not verify

The Claude Code, Codex and Gemini plugin one-liners in the same README section were not
exercised; this PR does not touch them. The plugin manifests under `plugins/` still name
`@kinlab/kin-mcp`, which is correct behaviour once #1233 ships and is left alone
deliberately rather than churned before a tag.

## Gates

Docs only. No Rust changed, and this lane runs no local build by contract; hosted CI is the
gate of record. I checked that no guard reads the text I edited: the README language-count
guard in `ci.yml` grades a number this PR does not touch, and the acceptance suite's
finding-5 check probes `packages/kin-mcp/bin/kin-mcp.js` directly rather than the README's
prose.
