### PR TITLE
Address a hosted transfer at the organization's route, so a push reaches Kin

### DIFF
--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -252,6 +252,22 @@ pub(crate) fn resolve_native_remote_target(
     })
 }
 
+/// The organization a native-Kin remote URL names, when it names one.
+///
+/// Only a locator carries an organization: `kinlab://<org>/<repo>`,
+/// `https://<default-host>/<org>/<repo>`, or any base ending
+/// `/api/orgs/<org>/repos/<repo>`. A bare base URL such as
+/// `https://kinlab.ai` or `http://127.0.0.1:4010` names none, and answering
+/// `None` there is the point: the caller decides whether a missing organization
+/// is a peer daemon, which has no organizations at all, or a hosted remote that
+/// cannot be addressed without one.
+pub(crate) fn native_remote_organization_id(url: &str) -> Option<String> {
+    parse_native_remote_locator(url)
+        .map(|target| target.organization_id)
+        .map(|organization_id| organization_id.trim().to_string())
+        .filter(|organization_id| !organization_id.is_empty())
+}
+
 pub(crate) fn default_cli_actor_id(base_url: &str) -> String {
     auth::default_cli_actor_id(base_url)
 }

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -252,7 +252,7 @@ pub(crate) fn resolve_native_remote_target(
     })
 }
 
-/// The organization a native-Kin remote URL names, when it names one.
+/// The hosted target a native-Kin remote URL names, when it names one.
 ///
 /// Only a locator carries an organization: `kinlab://<org>/<repo>`,
 /// `https://<default-host>/<org>/<repo>`, or any base ending
@@ -261,11 +261,19 @@ pub(crate) fn resolve_native_remote_target(
 /// `None` there is the point: the caller decides whether a missing organization
 /// is a peer daemon, which has no organizations at all, or a hosted remote that
 /// cannot be addressed without one.
-pub(crate) fn native_remote_organization_id(url: &str) -> Option<String> {
-    parse_native_remote_locator(url)
-        .map(|target| target.organization_id)
-        .map(|organization_id| organization_id.trim().to_string())
-        .filter(|organization_id| !organization_id.is_empty())
+///
+/// The whole target is returned rather than the organization alone, because the
+/// two have to be taken together. A locator's base URL is the part BEFORE
+/// `/api/orgs/...`, so a caller that kept the locator as its base and took only
+/// the organization from here would address
+/// `<base>/api/orgs/<org>/repos/<repo>/api/v1/orgs/<org>/repos/<repo>/transfer/...`,
+/// which is nobody's route.
+pub(crate) fn native_remote_locator(url: &str) -> Option<NativeRemoteTarget> {
+    let target = parse_native_remote_locator(url)?;
+    if target.organization_id.trim().is_empty() || target.base_url.trim().is_empty() {
+        return None;
+    }
+    Some(target)
 }
 
 pub(crate) fn default_cli_actor_id(base_url: &str) -> String {

--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -14,7 +14,7 @@
 //! replica holds.
 
 use anyhow::{bail, Context, Result};
-use kin_core::{KinConfig, KinLayout, RemoteTransportKind};
+use kin_core::{KinConfig, KinLayout, RemoteHostKind, RemoteTransportKind};
 use kin_model::RefName;
 use kin_remote::repository_transfer_negotiation::{
     RepositoryPushPlan, RepositoryTransferDirection, RepositoryTransferOutcome,
@@ -29,6 +29,14 @@ pub struct CommandTransferRequest {
     pub remote_base_url: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_token: Option<String>,
+    /// The hosted organization whose repository this transfer addresses.
+    ///
+    /// Absent means a peer daemon, which serves the seam at its own root. A
+    /// daemon that predates this field defaults it to absent and so keeps
+    /// addressing peers exactly as it did, which is why the absent case has to
+    /// stay the daemon route rather than becoming an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_organization_id: Option<String>,
     /// Defaults to the repository this daemon serves.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository_id: Option<String>,
@@ -140,6 +148,13 @@ pub struct CommandTransferPlanResponse {
 pub(crate) struct TransferPeer {
     pub(crate) base_url: String,
     pub(crate) token: Option<String>,
+    /// The hosted organization whose repository this transfer addresses.
+    ///
+    /// `None` is a peer daemon, which serves the seam at its own root and has
+    /// no organizations. A hosted remote always resolves to `Some`, because
+    /// `resolve_peer` refuses one it cannot name an organization for rather
+    /// than addressing it as though it were a daemon.
+    pub(crate) organization_id: Option<String>,
 }
 
 /// Resolve the peer from an explicit URL or a configured native-Kin remote.
@@ -153,7 +168,12 @@ pub(crate) fn resolve_peer(
     explicit_url: Option<&str>,
 ) -> Result<TransferPeer> {
     if let Some(url) = explicit_url.map(str::trim).filter(|url| !url.is_empty()) {
+        // An explicit `--url` is taken literally. A locator naming an
+        // organization addresses that hosted repository; anything else is a
+        // peer daemon, which is what `--url http://127.0.0.1:<port>` has always
+        // meant and must keep meaning.
         return Ok(TransferPeer {
+            organization_id: crate::commands::remote::native_remote_organization_id(url),
             base_url: url.trim_end_matches('/').to_string(),
             token: crate::commands::remote::native_remote_bearer_token(url),
         });
@@ -204,9 +224,42 @@ pub(crate) fn resolve_peer(
             )
         })?;
     let base_url = base_url.trim_end_matches('/').to_string();
+
+    // A KinLab remote is hosted, and a hosted seam is org scoped. The
+    // organization comes from the remote's own locator, or from KIN_ORG_ID, and
+    // nowhere else: the server never infers one from a bare repository id, so
+    // nothing crosses an organization boundary because a default was convenient
+    // (founder decision, 2026-08-29).
+    //
+    // Refusing beats falling back to the daemon route. That route on a hosted
+    // host is outside `/api/`, where kinlab.ai's edge serves the static bucket,
+    // and the push dies in Google Cloud Storage XML that names neither Kin nor
+    // the organization the user forgot to set (FIR-2945).
+    let organization_id = match selected.host {
+        RemoteHostKind::KinLab => Some(
+            crate::commands::remote::native_remote_organization_id(&base_url)
+                .or_else(|| {
+                    std::env::var("KIN_ORG_ID")
+                        .ok()
+                        .map(|value| value.trim().to_string())
+                        .filter(|value| !value.is_empty())
+                })
+                .with_context(|| {
+                    format!(
+                        "native-kin remote {} is hosted on KinLab, whose transfer seam is scoped \
+                         to an organization, and {base_url} names none. Re-add it with a full \
+                         locator like `--url kinlab://<org>/<repo>`, or set KIN_ORG_ID.",
+                        selected.name
+                    )
+                })?,
+        ),
+        _ => None,
+    };
+
     Ok(TransferPeer {
         token: crate::commands::remote::native_remote_bearer_token(&base_url),
         base_url,
+        organization_id,
     })
 }
 
@@ -254,6 +307,7 @@ fn build_request(
     Ok(CommandTransferRequest {
         remote_base_url: peer.base_url,
         remote_token: peer.token,
+        remote_organization_id: peer.organization_id,
         repository_id: None,
         source_ref,
         destination_ref,
@@ -468,6 +522,7 @@ mod tests {
         let peer = TransferPeer {
             base_url: "http://127.0.0.1:4010".to_string(),
             token: None,
+            organization_id: None,
         };
         let request = build_request(peer, Some("main"), None).unwrap();
         assert_eq!(request.source_ref, request.destination_ref);

--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -157,6 +157,25 @@ pub(crate) struct TransferPeer {
     pub(crate) organization_id: Option<String>,
 }
 
+/// Split a peer URL into the base the seam is served from and the organization
+/// it names, if any.
+///
+/// A locator carries both, and they must be taken together: its base URL is the
+/// part before `/api/orgs/...`, so keeping the whole locator as the base and
+/// lifting only the organization out of it addresses
+/// `<base>/api/orgs/<org>/repos/<repo>/api/v1/orgs/<org>/...`, which is nobody's
+/// route. Anything that is not a locator is a peer daemon base with no
+/// organization.
+pub(crate) fn peer_base_and_organization(url: &str) -> (String, Option<String>) {
+    match crate::commands::remote::native_remote_locator(url) {
+        Some(target) => (
+            target.base_url.trim_end_matches('/').to_string(),
+            Some(target.organization_id),
+        ),
+        None => (url.trim().trim_end_matches('/').to_string(), None),
+    }
+}
+
 /// Resolve the peer from an explicit URL or a configured native-Kin remote.
 ///
 /// This fails closed rather than guessing a host. A transfer publishes exact
@@ -172,10 +191,11 @@ pub(crate) fn resolve_peer(
         // organization addresses that hosted repository; anything else is a
         // peer daemon, which is what `--url http://127.0.0.1:<port>` has always
         // meant and must keep meaning.
+        let (base_url, organization_id) = peer_base_and_organization(url);
         return Ok(TransferPeer {
-            organization_id: crate::commands::remote::native_remote_organization_id(url),
-            base_url: url.trim_end_matches('/').to_string(),
-            token: crate::commands::remote::native_remote_bearer_token(url),
+            token: crate::commands::remote::native_remote_bearer_token(&base_url),
+            base_url,
+            organization_id,
         });
     }
 
@@ -223,7 +243,9 @@ pub(crate) fn resolve_peer(
                 selected.name
             )
         })?;
-    let base_url = base_url.trim_end_matches('/').to_string();
+    // A locator names both the base and the organization, so split it here
+    // rather than treating the whole locator as a base URL.
+    let (base_url, located_organization) = peer_base_and_organization(base_url);
 
     // A KinLab remote is hosted, and a hosted seam is org scoped. The
     // organization comes from the remote's own locator, or from KIN_ORG_ID, and
@@ -237,7 +259,7 @@ pub(crate) fn resolve_peer(
     // the organization the user forgot to set (FIR-2945).
     let organization_id = match selected.host {
         RemoteHostKind::KinLab => Some(
-            crate::commands::remote::native_remote_organization_id(&base_url)
+            located_organization
                 .or_else(|| {
                     std::env::var("KIN_ORG_ID")
                         .ok()
@@ -508,6 +530,41 @@ mod tests {
         assert_eq!(
             parse_ref(Some("refs/tags/v1")).unwrap(),
             Some(RefName::from_bytes(b"refs/tags/v1".to_vec()).unwrap())
+        );
+    }
+
+    #[test]
+    fn a_locator_gives_up_its_base_and_its_organization_together() {
+        // The bug this pins: taking the organization from a locator while
+        // keeping the whole locator as the base URL builds
+        // `<base>/api/orgs/o/repos/r/api/v1/orgs/o/repos/r/transfer/...`.
+        let (base, org) =
+            peer_base_and_organization("http://127.0.0.1:8080/api/orgs/acme/repos/kin");
+        assert_eq!(base, "http://127.0.0.1:8080");
+        assert_eq!(org.as_deref(), Some("acme"));
+        // Said as the property rather than as two literals: the base must not
+        // still contain the organization path the locator carried.
+        assert!(
+            !base.contains("/api/orgs/"),
+            "the base still carries the locator's own org path: {base}"
+        );
+    }
+
+    #[test]
+    fn a_bare_peer_base_names_no_organization() {
+        let (base, org) = peer_base_and_organization("http://127.0.0.1:4010/");
+        assert_eq!(base, "http://127.0.0.1:4010");
+        assert_eq!(org, None);
+    }
+
+    #[test]
+    fn a_kinlab_scheme_locator_names_an_organization_and_the_default_host() {
+        let (base, org) = peer_base_and_organization("kinlab://acme/kin");
+        assert_eq!(org.as_deref(), Some("acme"));
+        assert!(!base.is_empty(), "a locator must still resolve a base URL");
+        assert!(
+            !base.contains("/api/orgs/"),
+            "base carries an org path: {base}"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13980,6 +13980,17 @@ fn transfer_command_context(
     {
         endpoint = endpoint.with_auth(token);
     }
+    // A request naming an organization is addressing a hosted KinLab peer,
+    // whose seam is org scoped. One naming none is a peer daemon, which serves
+    // the seam at its own root, so the endpoint keeps the route it already had.
+    if let Some(organization_id) = request
+        .remote_organization_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|organization_id| !organization_id.is_empty())
+    {
+        endpoint = endpoint.with_organization(organization_id);
+    }
 
     Ok(TransferCommandContext {
         repository_id,
@@ -23574,6 +23585,9 @@ mod tests {
 
         let destination_url = serve_replica(Arc::clone(&destination_state)).await;
         let request = kin_cli::commands::transfer::CommandTransferRequest {
+            // A peer daemon serves the seam at its own root and has no
+            // organizations; only a hosted KinLab peer is org scoped.
+            remote_organization_id: None,
             remote_base_url: destination_url.clone(),
             remote_token: None,
             repository_id: Some(repo_id.clone()),
@@ -23754,6 +23768,9 @@ mod tests {
         let source_state = Arc::new(DaemonState::open_with_repo_id(init.layout, None).unwrap());
 
         let request = kin_cli::commands::transfer::CommandTransferRequest {
+            // A peer daemon serves the seam at its own root and has no
+            // organizations; only a hosted KinLab peer is org scoped.
+            remote_organization_id: None,
             remote_base_url: hosted_url,
             remote_token: None,
             repository_id: Some(hosted_id.clone()),
@@ -23831,6 +23848,9 @@ mod tests {
         let source_state = Arc::new(DaemonState::open_with_repo_id(init.layout, None).unwrap());
 
         let request = kin_cli::commands::transfer::CommandTransferRequest {
+            // A peer daemon serves the seam at its own root and has no
+            // organizations; only a hosted KinLab peer is org scoped.
+            remote_organization_id: None,
             remote_base_url: hosted_url,
             remote_token: None,
             // Left unset on purpose, so the push sends what the store actually
@@ -23903,6 +23923,9 @@ mod tests {
         let source_state = Arc::new(DaemonState::open_with_repo_id(init.layout, None).unwrap());
 
         let request = kin_cli::commands::transfer::CommandTransferRequest {
+            // A peer daemon serves the seam at its own root and has no
+            // organizations; only a hosted KinLab peer is org scoped.
+            remote_organization_id: None,
             remote_base_url: hosted_url,
             remote_token: None,
             repository_id: Some(hosted_id.clone()),
@@ -24709,6 +24732,9 @@ mod tests {
             );
 
             let request = kin_cli::commands::transfer::CommandTransferRequest {
+                // A peer daemon serves the seam at its own root and has no
+                // organizations; only a hosted KinLab peer is org scoped.
+                remote_organization_id: None,
                 remote_base_url: hosted_url,
                 remote_token: None,
                 repository_id: Some(hosted_id.clone()),
@@ -24856,6 +24882,9 @@ mod tests {
         let source_state =
             Arc::new(DaemonState::open_with_repo_id(fixture.layout.clone(), None).unwrap());
         let request = kin_cli::commands::transfer::CommandTransferRequest {
+            // A peer daemon serves the seam at its own root and has no
+            // organizations; only a hosted KinLab peer is org scoped.
+            remote_organization_id: None,
             remote_base_url: hosted_url,
             remote_token: None,
             // Left unset so the push sends what the store actually holds.
@@ -26036,6 +26065,9 @@ mod tests {
         repo_id: &str,
     ) -> kin_cli::commands::transfer::CommandTransferRequest {
         kin_cli::commands::transfer::CommandTransferRequest {
+            // A peer daemon serves the seam at its own root and has no
+            // organizations; only a hosted KinLab peer is org scoped.
+            remote_organization_id: None,
             remote_base_url: url.to_string(),
             remote_token: None,
             repository_id: Some(repo_id.to_string()),
@@ -26634,6 +26666,9 @@ mod tests {
             .store(u64::MAX, std::sync::atomic::Ordering::SeqCst);
 
         let request = kin_cli::commands::transfer::CommandTransferRequest {
+            // A peer daemon serves the seam at its own root and has no
+            // organizations; only a hosted KinLab peer is org scoped.
+            remote_organization_id: None,
             remote_base_url: source_url,
             remote_token: None,
             repository_id: Some(repo_id.clone()),
@@ -26739,6 +26774,9 @@ mod tests {
 
         let destination_url = serve_replica(Arc::clone(&destination_state)).await;
         let request = kin_cli::commands::transfer::CommandTransferRequest {
+            // A peer daemon serves the seam at its own root and has no
+            // organizations; only a hosted KinLab peer is org scoped.
+            remote_organization_id: None,
             remote_base_url: destination_url,
             remote_token: None,
             repository_id: Some(repo_id.clone()),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13933,6 +13933,44 @@ impl TransferCommandContext {
     }
 }
 
+/// Where this transfer's peer is, and how to address it.
+///
+/// The authentication and the organization scope are applied here rather than
+/// inline at the one call site, so neither can be dropped on its own: an
+/// endpoint is not optional, and this is the only place that builds one. A
+/// separate `if let` beside the constructor was deletable without breaking any
+/// build, and a falsification arm that deleted it passed every test.
+///
+/// A request naming an organization addresses a hosted KinLab peer, whose seam
+/// is org scoped. One naming none is a peer daemon, which serves the seam at
+/// its own root, so the endpoint keeps the route it already had. A daemon that
+/// predates the field sends none and so keeps addressing peers exactly as it
+/// did.
+fn transfer_endpoint(
+    base_url: &str,
+    request: &kin_cli::commands::transfer::CommandTransferRequest,
+) -> kin_remote::repository_transfer_http::RepositoryTransferEndpoint {
+    let mut endpoint =
+        kin_remote::repository_transfer_http::RepositoryTransferEndpoint::new(base_url);
+    if let Some(token) = request
+        .remote_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+    {
+        endpoint = endpoint.with_auth(token);
+    }
+    if let Some(organization_id) = request
+        .remote_organization_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|organization_id| !organization_id.is_empty())
+    {
+        endpoint = endpoint.with_organization(organization_id);
+    }
+    endpoint
+}
+
 /// Resolve the repository, refs, and peer for one transfer command.
 ///
 /// An absent source ref means the repository's own default ref, which is the
@@ -13970,27 +14008,7 @@ fn transfer_command_context(
         .clone()
         .or_else(|| source_ref.clone());
 
-    let mut endpoint =
-        kin_remote::repository_transfer_http::RepositoryTransferEndpoint::new(base_url);
-    if let Some(token) = request
-        .remote_token
-        .as_deref()
-        .map(str::trim)
-        .filter(|token| !token.is_empty())
-    {
-        endpoint = endpoint.with_auth(token);
-    }
-    // A request naming an organization is addressing a hosted KinLab peer,
-    // whose seam is org scoped. One naming none is a peer daemon, which serves
-    // the seam at its own root, so the endpoint keeps the route it already had.
-    if let Some(organization_id) = request
-        .remote_organization_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|organization_id| !organization_id.is_empty())
-    {
-        endpoint = endpoint.with_organization(organization_id);
-    }
+    let endpoint = transfer_endpoint(base_url, request);
 
     Ok(TransferCommandContext {
         repository_id,
@@ -17223,6 +17241,44 @@ mod tests {
     /// embedding worker has failed while `impact_analysis` refuses on the same
     /// instant. Human surface more confident than agent surface is the exact
     /// divergence this ticket closes.
+    /// One transfer request, carrying only what these tests vary.
+    fn transfer_request_for(
+        organization_id: Option<&str>,
+    ) -> kin_cli::commands::transfer::CommandTransferRequest {
+        kin_cli::commands::transfer::CommandTransferRequest {
+            remote_base_url: "https://kinlab.ai".to_string(),
+            remote_token: None,
+            remote_organization_id: organization_id.map(str::to_string),
+            repository_id: None,
+            source_ref: None,
+            destination_ref: None,
+        }
+    }
+
+    #[test]
+    fn a_request_naming_an_organization_scopes_the_endpoint_to_it() {
+        // The daemon is where a transfer runs, so the organization the CLI
+        // resolved has to survive the trip into the endpoint. A daemon that
+        // dropped it would address a hosted peer on the daemon route, which on
+        // kinlab.ai is outside /api/ and answers from the static bucket.
+        let endpoint = transfer_endpoint("https://kinlab.ai", &transfer_request_for(Some("acme")));
+        assert_eq!(endpoint.organization_id.as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn a_request_naming_no_organization_stays_on_the_peer_daemon_route() {
+        let endpoint = transfer_endpoint("http://127.0.0.1:4010", &transfer_request_for(None));
+        assert_eq!(endpoint.organization_id, None);
+    }
+
+    #[test]
+    fn a_blank_organization_on_the_wire_is_not_an_organization() {
+        // A caller that sends an empty string is not naming an organization,
+        // and taking it would build `/orgs//repos/...`.
+        let endpoint = transfer_endpoint("https://kinlab.ai", &transfer_request_for(Some("   ")));
+        assert_eq!(endpoint.organization_id, None);
+    }
+
     #[test]
     fn the_impact_envelope_carries_the_daemons_degraded_signals() {
         let health = serde_json::json!({

--- a/crates/kin-daemon/src/replica_adoption.rs
+++ b/crates/kin-daemon/src/replica_adoption.rs
@@ -196,6 +196,9 @@ pub async fn clone_native_replica(
 
     let adopted = identity.repository_id.clone();
     let request = kin_cli::commands::transfer::CommandTransferRequest {
+        // A peer daemon serves the seam at its own root and has no
+        // organizations; only a hosted KinLab peer is org scoped.
+        remote_organization_id: None,
         remote_base_url: endpoint.base_url.clone(),
         remote_token: endpoint.auth_token.clone(),
         repository_id: Some(adopted.to_string()),

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -78,6 +78,13 @@ pub struct RepositoryTransferEndpoint {
     pub base_url: String,
     pub auth_token: Option<String>,
     pub timeout_secs: u64,
+    /// The hosted organization this peer's repository belongs to.
+    ///
+    /// `None` is another Kin daemon, which serves the seam at its own root and
+    /// has no organizations. `Some` is a hosted KinLab peer, whose seam is org
+    /// scoped, and the two are different route spaces rather than one route
+    /// with an optional segment.
+    pub organization_id: Option<String>,
 }
 
 /// Written by hand so a bearer token cannot reach a log through any derived
@@ -103,11 +110,24 @@ impl RepositoryTransferEndpoint {
             base_url: base_url.into().trim_end_matches('/').to_string(),
             auth_token: None,
             timeout_secs,
+            organization_id: None,
         }
     }
 
     pub fn with_auth(mut self, token: impl Into<String>) -> Self {
         self.auth_token = Some(token.into());
+        self
+    }
+
+    /// Address this peer as a hosted organization's repository.
+    ///
+    /// An empty or whitespace organization is not an organization, and taking
+    /// it would build `/orgs//repos/...`, which a host answers as some other
+    /// route or as a 404 that reads like a missing repository. Refusing it here
+    /// keeps the endpoint on the daemon peer route it already had.
+    pub fn with_organization(mut self, organization_id: impl Into<String>) -> Self {
+        let organization_id = organization_id.into().trim().to_string();
+        self.organization_id = (!organization_id.is_empty()).then_some(organization_id);
         self
     }
 
@@ -151,12 +171,37 @@ impl HttpRepositoryTransferTransport {
         &self.endpoint.base_url
     }
 
+    /// Where one leaf of the seam lives on this peer.
+    ///
+    /// Two route spaces, chosen by whether the peer is a hosted organization.
+    ///
+    /// A daemon serves the seam at its own root, so a daemon peer keeps
+    /// `/repos/{id}/transfer/{leaf}`. A hosted peer serves it under the
+    /// versioned, org-scoped template the shared contract declares, and
+    /// addressing a hosted peer the daemon way is not a 404: on kinlab.ai every
+    /// path outside `/api/` falls through the edge to the static bucket, which
+    /// answers a POST with Google Cloud Storage XML. A user pushing then reads
+    /// `InvalidArgument ... POST object expects Content-Type multipart/form-data`
+    /// and has no way to tell that nothing of Kin's ever saw the request
+    /// (FIR-2945).
+    ///
+    /// The template is `/api/v1/orgs/{orgId}/repos/{repoId}/transfer/{leaf}`,
+    /// pinned in `packages/boundary-contracts` and asserted against it by the
+    /// contract suite, so this spelling and the server's are one document.
     fn url(&self, repository_id: &RepositoryId, leaf: &str) -> String {
-        format!(
-            "{}/repos/{}/transfer/{leaf}",
-            self.endpoint.base_url,
-            urlencoded(repository_id.as_str())
-        )
+        match self.endpoint.organization_id.as_deref() {
+            Some(organization_id) => format!(
+                "{}/api/v1/orgs/{}/repos/{}/transfer/{leaf}",
+                self.endpoint.base_url,
+                urlencoded(organization_id),
+                urlencoded(repository_id.as_str())
+            ),
+            None => format!(
+                "{}/repos/{}/transfer/{leaf}",
+                self.endpoint.base_url,
+                urlencoded(repository_id.as_str())
+            ),
+        }
     }
 
     fn get_json<R: serde::de::DeserializeOwned>(
@@ -413,6 +458,121 @@ mod tests {
         assert_eq!(
             transport.url(&repository_id, "receive"),
             "http://127.0.0.1:4010/repos/org%2Frepo%20name/transfer/receive"
+        );
+    }
+
+    /// The seam contract itself, so the route is not spelled twice.
+    ///
+    /// `packages/boundary-contracts` is the one document both halves of this
+    /// seam read. Hardcoding the hosted template here as well would leave the
+    /// Rust client and the control plane free to drift apart while both suites
+    /// stayed green, which is the failure this file is fixing.
+    const SEAM_CONTRACT: &str = include_str!(
+        "../../../packages/boundary-contracts/schemas/hosted-repository-transfer.schema.json"
+    );
+
+    fn contract_route_template() -> String {
+        let contract: serde_json::Value =
+            serde_json::from_str(SEAM_CONTRACT).expect("the seam contract is valid JSON");
+        contract["definitions"]["seam"]["const"]["routeTemplate"]
+            .as_str()
+            .expect("the seam contract declares a routeTemplate")
+            .to_string()
+    }
+
+    /// Render the contract's own template, so the expected URL is derived from
+    /// the contract rather than typed beside it.
+    fn expected_hosted_url(base_url: &str, organization_id: &str, repo_id: &str, leaf: &str) -> String {
+        let rendered = contract_route_template()
+            .replace("{orgId}", organization_id)
+            .replace("{repoId}", repo_id)
+            .replace("{leaf}", leaf);
+        format!("{base_url}{rendered}")
+    }
+
+    #[test]
+    fn a_hosted_peer_is_addressed_at_the_contract_route() {
+        // The defect this pins: without the organization scope the client built
+        // `{base}/repos/{id}/transfer/{leaf}`, which on kinlab.ai is outside
+        // `/api/` and falls through the edge to the static bucket, so a push
+        // came back as Google Cloud Storage XML (FIR-2945).
+        let transport = HttpRepositoryTransferTransport::new(
+            RepositoryTransferEndpoint::new("https://kinlab.ai").with_organization("acme"),
+        );
+        let repository_id = RepositoryId::new("kin").unwrap();
+        assert_eq!(
+            transport.url(&repository_id, "receive"),
+            expected_hosted_url("https://kinlab.ai", "acme", "kin", "receive"),
+        );
+        // The literal, so a contract template that changed shape without anyone
+        // noticing cannot be satisfied by a renderer that changed with it.
+        assert_eq!(
+            transport.url(&repository_id, "receive"),
+            "https://kinlab.ai/api/v1/orgs/acme/repos/kin/transfer/receive",
+        );
+    }
+
+    #[test]
+    fn every_contract_leaf_is_addressed_under_api_v1() {
+        // The join over the real set rather than one sampled leaf: a leaf added
+        // to the contract that this client cannot address is the drift the
+        // shared document exists to prevent.
+        let contract: serde_json::Value =
+            serde_json::from_str(SEAM_CONTRACT).expect("the seam contract is valid JSON");
+        let leaves = contract["definitions"]["seam"]["const"]["leaves"]
+            .as_array()
+            .expect("the seam contract declares its leaves");
+        assert_eq!(leaves.len(), 4, "the seam has four leaves");
+        let transport = HttpRepositoryTransferTransport::new(
+            RepositoryTransferEndpoint::new("https://kinlab.ai").with_organization("acme"),
+        );
+        let repository_id = RepositoryId::new("kin").unwrap();
+        for leaf in leaves {
+            let leaf = leaf["leaf"].as_str().expect("every leaf is named");
+            let url = transport.url(&repository_id, leaf);
+            assert_eq!(url, expected_hosted_url("https://kinlab.ai", "acme", "kin", leaf));
+            assert!(
+                url.starts_with("https://kinlab.ai/api/"),
+                "leaf {leaf} is addressed outside /api/, where the edge serves the bucket: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_peer_daemon_keeps_the_unscoped_route() {
+        // A daemon has no organizations and serves the seam at its own root.
+        // This is the case an org-scoped rewrite would have broken silently.
+        let transport = transport("http://127.0.0.1:4010");
+        let repository_id = RepositoryId::new("kin").unwrap();
+        assert_eq!(
+            transport.url(&repository_id, "advertise"),
+            "http://127.0.0.1:4010/repos/kin/transfer/advertise"
+        );
+    }
+
+    #[test]
+    fn a_blank_organization_is_not_an_organization() {
+        // `/orgs//repos/...` is a different route, and a host answers it as
+        // something else or as a 404 that reads like a missing repository.
+        let transport = HttpRepositoryTransferTransport::new(
+            RepositoryTransferEndpoint::new("https://kinlab.ai").with_organization("   "),
+        );
+        let repository_id = RepositoryId::new("kin").unwrap();
+        assert_eq!(
+            transport.url(&repository_id, "status"),
+            "https://kinlab.ai/repos/kin/transfer/status"
+        );
+    }
+
+    #[test]
+    fn a_hosted_organization_is_percent_encoded() {
+        let transport = HttpRepositoryTransferTransport::new(
+            RepositoryTransferEndpoint::new("https://kinlab.ai").with_organization("a c/me"),
+        );
+        let repository_id = RepositoryId::new("kin").unwrap();
+        assert_eq!(
+            transport.url(&repository_id, "export"),
+            "https://kinlab.ai/api/v1/orgs/a%20c%2Fme/repos/kin/transfer/export"
         );
     }
 

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -482,7 +482,12 @@ mod tests {
 
     /// Render the contract's own template, so the expected URL is derived from
     /// the contract rather than typed beside it.
-    fn expected_hosted_url(base_url: &str, organization_id: &str, repo_id: &str, leaf: &str) -> String {
+    fn expected_hosted_url(
+        base_url: &str,
+        organization_id: &str,
+        repo_id: &str,
+        leaf: &str,
+    ) -> String {
         let rendered = contract_route_template()
             .replace("{orgId}", organization_id)
             .replace("{repoId}", repo_id)
@@ -530,7 +535,10 @@ mod tests {
         for leaf in leaves {
             let leaf = leaf["leaf"].as_str().expect("every leaf is named");
             let url = transport.url(&repository_id, leaf);
-            assert_eq!(url, expected_hosted_url("https://kinlab.ai", "acme", "kin", leaf));
+            assert_eq!(
+                url,
+                expected_hosted_url("https://kinlab.ai", "acme", "kin", leaf)
+            );
             assert!(
                 url.starts_with("https://kinlab.ai/api/"),
                 "leaf {leaf} is addressed outside /api/, where the edge serves the bucket: {url}"


### PR DESCRIPTION
`kin push` and `kin pull` now address a hosted KinLab peer at the route the shared contract declares, so a hosted transfer reaches Kin instead of dying in a storage vendor's error.

The transport built `{base}/repos/{id}/transfer/{leaf}` for every peer. Against a hosted host that path is outside `/api/`, where kinlab.ai's edge serves the static bucket, so a push came back as `InvalidArgument ... POST object expects Content-Type multipart/form-data` and nothing of Kin's ever saw the request. A hosted peer is now addressed at `/api/v1/orgs/{orgId}/repos/{repoId}/transfer/{leaf}`, pinned in `packages/boundary-contracts` by #1244.

The tests render their expected URL from that contract rather than spelling it a second time, so the client and the control plane cannot drift while both suites stay green. Two falsification arms mutate the contract and leave the Rust alone, and both go red, which is what proves the route is not written down twice.

A peer daemon has no organizations and keeps the unscoped route it already had. That is the case an unconditional rewrite would have broken silently, so it has its own test, as does a blank organization, which would otherwise build `/orgs//repos/...` and read back as a missing repository.

The organization comes from the remote's own locator or from `KIN_ORG_ID`, never inferred, so nothing crosses an organization boundary because a default was convenient. A KinLab remote that can name neither is refused with a sentence naming both fixes, since falling back to the daemon route on a hosted host is what produced the bucket XML.

Two things falsification and an end-to-end run found, both fixed here:

Deleting the daemon's `with_organization` call left every test green, because the organization was applied by a standalone `if let` beside the endpoint constructor. Authentication and organization scope now happen inside `transfer_endpoint`, the one function that builds an endpoint, so the wiring cannot be deleted on its own, and three tests grade that function directly.

Lifting the organization out of a locator while keeping the whole locator as the base URL built `<base>/api/orgs/o/repos/r/api/v1/orgs/o/repos/r/transfer/...`, which is nobody's route. Every route test still passed, because they grade `url()` from an endpoint built in the test rather than one resolved from a configured remote. `peer_base_and_organization` now does the split in one place and three tests grade it.

Falsification grid, `.kin-coord/reports/bridgebytes-falsify-bytes-20260829T213031Z.txt`: caught=8 survived=0 bad=0, both baselines green, every arm naming the assertion that answered.

Proved end to end against a real kinlab control plane in cloud mode over a real kin daemon, with a real API token and two client machines. A push now carries a 19.6 KB pack through the hosted route to hosted repository authority, and `status` and `advertise` return real repository-v6 envelopes. It is refused there by a repository-v6 rule that refuses any native change introducing artifacts, and a control arm pushing the same commit straight to the peer route is refused identically, same change id, same message, so that refusal is not this route. It is filed as FIR-2959.

Closes FIR-2945
