### PR TITLE
Forecast the daemon's share, not just the conversion's

### DIFF
--- a/crates/kin-core/src/init_budget.rs
+++ b/crates/kin-core/src/init_budget.rs
@@ -171,6 +171,43 @@ pub enum BudgetVerdict {
         forecast_bytes: u64,
         ceiling_bytes: u64,
     },
+    /// The forecast fits the ceiling, but not the daemon's share of it.
+    ///
+    /// `kin init` does not end when the conversion ends. It starts a repository
+    /// daemon on the store it just wrote, and that daemon is allowed half this
+    /// same ceiling by [`memory_pressure::FootprintBudget`]. A forecast under
+    /// [`TIGHT_FRACTION`] of the ceiling but over that half is the band where
+    /// the conversion succeeds and the daemon it starts arrives already past
+    /// what it is allowed to hold.
+    ///
+    /// Measured on psf/requests at 6493 commits inside a 12 GiB container: the
+    /// forecast was 0.61 of the ceiling, so this module said nothing, all
+    /// seventeen phases completed, and the daemon was then killed four times
+    /// across `kin init` and three `kin graph status` attempts. The same corpus
+    /// in a 9 GiB container held 8.351 GiB of resident set in the daemon
+    /// against 5.518 GiB in the conversion, so the daemon is the larger of the
+    /// two and it is the one nothing was forecasting.
+    ///
+    /// No new coefficient pays for this. Both numbers already exist: the
+    /// conversion forecast and the allowance. What makes the first a usable
+    /// floor for the second is measured rather than assumed. The daemon's cost
+    /// to load that store was read at three different ceilings and came back
+    /// 8.351 GiB by resident set at 9 GiB, 8.0 GiB by the daemon's own footprint
+    /// accounting at 12 GiB, and 7.9 GiB by the same accounting at 16 GiB, the
+    /// last of those being the only one taken with room to spare. The forecast
+    /// for the same repository is 7.26 GiB, so it sits just under the load,
+    /// understating it by about eight percent, which is the direction a floor
+    /// should err in.
+    ///
+    /// A per-commit rate is deliberately NOT quoted here. The obvious one is
+    /// wrong: the two largest runs both peaked at exactly their cap, so a rate
+    /// derived from them measures the caps rather than the daemon.
+    DaemonAllowance {
+        survey: HistorySurvey,
+        forecast_bytes: u64,
+        ceiling_bytes: u64,
+        allowance_bytes: u64,
+    },
     /// The forecast is over the ceiling. The conversion refuses here.
     Exceeds {
         survey: HistorySurvey,
@@ -193,6 +230,20 @@ impl BudgetVerdict {
     /// `None` for every other verdict, including the refusal, whose prose is
     /// several lines and lives in [`Self::refusal_lines`].
     pub fn advisory_line(&self) -> Option<String> {
+        if let Self::DaemonAllowance {
+            survey,
+            forecast_bytes,
+            ceiling_bytes,
+            allowance_bytes,
+        } = self
+        {
+            return Some(Self::daemon_allowance_line(
+                survey,
+                *forecast_bytes,
+                *ceiling_bytes,
+                *allowance_bytes,
+            ));
+        }
         let Self::Tight {
             survey,
             forecast_bytes,
@@ -221,6 +272,66 @@ impl BudgetVerdict {
             survey.tracked_artifacts,
             human_bytes(*forecast_bytes),
         ))
+    }
+
+    /// The line for a conversion that fits the machine but not the daemon's
+    /// share of it.
+    ///
+    /// Its own wording rather than the [`Self::Tight`] sentence, because the
+    /// two say different things. Tight says the conversion might not finish.
+    /// This says the conversion will finish and the thing that serves it
+    /// afterward may not start, which is a worse outcome to be surprised by: it
+    /// leaves a store on disk that reports success and answers nothing.
+    ///
+    /// The sentence states the allowance as a number and does not say where the
+    /// number came from. It is half the ceiling when Kin derived it and it is
+    /// whatever an operator typed when they set
+    /// `KIN_DAEMON_MEMORY_BUDGET_BYTES`, so a sentence that named one of those
+    /// provenances would be false in the other case.
+    ///
+    /// The remedy is stated as a number the reader can act on rather than as a
+    /// direction. Below the derived budget's own ceiling the allowance is half
+    /// the machine, so twice the forecast is the size that leaves the daemon
+    /// room. Above it the allowance is capped whatever the machine has, so more
+    /// memory is not a remedy and the line says so instead of sending a reader
+    /// to buy some. Nothing here offers `KIN_DAEMON_MEMORY_BUDGET_BYTES`:
+    /// raising a self-imposed allowance does not create memory, and advice that
+    /// cannot work is the defect this product already has one ticket for.
+    fn daemon_allowance_line(
+        survey: &HistorySurvey,
+        forecast_bytes: u64,
+        ceiling_bytes: u64,
+        allowance_bytes: u64,
+    ) -> String {
+        let remedy = if forecast_bytes <= memory_pressure::DERIVED_BUDGET_CEILING_BYTES {
+            format!(
+                "give this {} more than {}",
+                ceiling_noun(),
+                human_bytes(forecast_bytes.saturating_mul(2))
+            )
+        } else {
+            format!(
+                "no machine size fixes this, because one repository daemon is never allowed more                  than {}, so this store needs less history",
+                human_bytes(memory_pressure::DERIVED_BUDGET_CEILING_BYTES)
+            )
+        };
+        format!(
+            "  this conversion is expected to hold about {}, which fits the {} this {} allows. \
+             The daemon `kin init` starts on the finished store is a different matter: one \
+             repository daemon here is allowed {}, and {} commits over {} tracked files is \
+             forecast above that. So the conversion will probably finish and \
+             the daemon that serves it afterward starts already past its allowance, which stops \
+             its background work and can end with the kernel stopping the daemon, leaving a \
+             store that reports success and answers nothing. To leave it room, {}, or convert a \
+             repository with less history",
+            human_bytes(forecast_bytes),
+            human_bytes(ceiling_bytes),
+            ceiling_noun(),
+            human_bytes(allowance_bytes),
+            survey.commits,
+            survey.tracked_artifacts,
+            remedy,
+        )
     }
 
     /// The refusal, as the lines an operator reads.
@@ -400,7 +511,15 @@ pub fn assess(source: &Path) -> BudgetVerdict {
         Ok(survey) => survey,
         Err(reason) => return BudgetVerdict::Unmeasured { reason },
     };
-    verdict_for(survey, ceiling_bytes)
+    // The allowance the daemon will actually run under, not merely the one
+    // this ceiling would derive. An operator who set
+    // `KIN_DAEMON_MEMORY_BUDGET_BYTES` has named the daemon's share outright,
+    // and forecasting against a number the daemon will not use would be a
+    // check measuring a machine nobody is running on.
+    let allowance_bytes = memory_pressure::FootprintBudget::resolve(Some(ceiling_bytes))
+        .map(|budget| budget.bytes)
+        .unwrap_or_else(|| memory_pressure::FootprintBudget::derived_from(ceiling_bytes));
+    verdict_for_with_allowance(survey, ceiling_bytes, allowance_bytes)
 }
 
 /// The decision itself, over numbers rather than over a repository.
@@ -408,6 +527,24 @@ pub fn assess(source: &Path) -> BudgetVerdict {
 /// Separated so the thresholds are testable without a Git repository and
 /// without a machine of any particular size.
 pub fn verdict_for(survey: HistorySurvey, ceiling_bytes: u64) -> BudgetVerdict {
+    verdict_for_with_allowance(
+        survey,
+        ceiling_bytes,
+        memory_pressure::FootprintBudget::derived_from(ceiling_bytes),
+    )
+}
+
+/// The same decision, with the daemon's allowance named rather than derived.
+///
+/// Separate from [`verdict_for`] so that function stays a pure function of two
+/// numbers and its tests keep needing no environment. Only [`assess`] passes an
+/// allowance it read from the environment, because only [`assess`] is running on
+/// the machine the daemon will start on.
+pub fn verdict_for_with_allowance(
+    survey: HistorySurvey,
+    ceiling_bytes: u64,
+    allowance_bytes: u64,
+) -> BudgetVerdict {
     let forecast_bytes = survey.forecast_peak_bytes();
     if forecast_bytes as f64 > ceiling_bytes as f64 * REFUSE_MULTIPLE {
         return BudgetVerdict::Exceeds {
@@ -421,6 +558,28 @@ pub fn verdict_for(survey: HistorySurvey, ceiling_bytes: u64) -> BudgetVerdict {
             survey,
             forecast_bytes,
             ceiling_bytes,
+        };
+    }
+    // The conversion is not the whole command. Below TIGHT_FRACTION the
+    // conversion has room, and the question that remains is whether the daemon
+    // this command starts on the finished store has any. A forecast over the
+    // allowance describes a store that daemon cannot hold within its own share
+    // of this machine. The share is half the ceiling when Kin derived it and
+    // whatever an operator named when they set the budget outright, which is
+    // why it arrives as an argument rather than being computed here.
+    //
+    // Checked against every case this module has measured. requests at 6493
+    // commits moves from silent to spoken at a 12 GiB ceiling, which is the one
+    // band where the conversion succeeded and the daemon died. axum at 46
+    // percent of an 8 GiB ceiling stays silent, because 46 percent is under the
+    // half. flask and prometheus are unaffected, being already Tight and
+    // already Exceeds.
+    if forecast_bytes > allowance_bytes {
+        return BudgetVerdict::DaemonAllowance {
+            survey,
+            forecast_bytes,
+            ceiling_bytes,
+            allowance_bytes,
         };
     }
     BudgetVerdict::Fits {
@@ -676,6 +835,156 @@ mod tests {
                 "{name}'s advisory does not state what it expects to hold"
             );
         }
+    }
+
+    /// The band the measurement opened: the conversion fits and the daemon
+    /// does not.
+    ///
+    /// psf/requests at 6493 commits over 130 tracked files inside a 12 GiB
+    /// container is the exact case that was silent and should not have been.
+    /// The conversion completed all seventeen phases there and the repository
+    /// daemon was then killed, four times across `kin init` and three
+    /// `kin graph status` attempts, on the v0.6.2 candidate bytes.
+    #[test]
+    fn a_conversion_that_fits_the_machine_but_not_the_daemon_says_so() {
+        const CEILING: u64 = 12 * 1024 * 1024 * 1024;
+        let survey = survey(6_493, 130);
+        let verdict = verdict_for(survey, CEILING);
+        assert!(
+            matches!(verdict, BudgetVerdict::DaemonAllowance { .. }),
+            "requests at a 12 GiB ceiling should speak about the daemon, got {verdict:?}"
+        );
+        assert!(!verdict.refuses(), "this band warns, it does not refuse");
+
+        // The two figures that make the case are both in the sentence, because
+        // a reader who is told only one of them cannot see why it applies.
+        let line = verdict
+            .advisory_line()
+            .expect("this band prints its one line");
+        for phrase in ["repository daemon", "is allowed", "6493 commits"] {
+            assert!(line.contains(phrase), "line was: {line}");
+        }
+        // And it does not reuse the Tight sentence, whose claim is about the
+        // conversion rather than about what runs after it.
+        assert!(
+            !line.contains("It will probably finish. If the kernel stops it"),
+            "the daemon band borrowed the Tight wording: {line}"
+        );
+    }
+
+    /// The lower edge of the new band is the allowance, to the byte.
+    ///
+    /// Written as a pair rather than as one assertion, because a band whose
+    /// floor is never crossed in either direction is a rule nothing exercises.
+    #[test]
+    fn the_daemon_band_starts_exactly_at_the_allowance() {
+        let survey = survey(6_493, 130);
+        let forecast = survey.forecast_peak_bytes();
+        // A ceiling whose half is exactly the forecast leaves the daemon room,
+        // because the comparison is strictly greater.
+        let roomy = forecast * 2;
+        assert_eq!(
+            memory_pressure::FootprintBudget::derived_from(roomy),
+            forecast,
+            "this test's arithmetic assumes the allowance is half the ceiling here"
+        );
+        assert!(
+            matches!(verdict_for(survey, roomy), BudgetVerdict::Fits { .. }),
+            "a ceiling of exactly twice the forecast should be silent"
+        );
+        // One byte of ceiling less puts the forecast over the allowance.
+        assert!(
+            matches!(
+                verdict_for(survey, roomy - 2),
+                BudgetVerdict::DaemonAllowance { .. }
+            ),
+            "two bytes below twice the forecast should speak"
+        );
+    }
+
+    /// A forecast no machine size can give the daemon room for is told that,
+    /// rather than told to find a bigger machine.
+    ///
+    /// The derived allowance is capped at [`memory_pressure::DERIVED_BUDGET_CEILING_BYTES`]
+    /// regardless of the host, so above that cap "give it more memory" is
+    /// advice that cannot work, which is the failure mode this product already
+    /// carries a ticket for on its OOM recovery text.
+    #[test]
+    fn a_forecast_past_the_allowance_cap_does_not_send_a_reader_to_buy_memory() {
+        // Large enough that twice the forecast is still short of what the
+        // allowance would need, and the ceiling is large enough that the
+        // conversion itself has room.
+        let survey = survey(20_000, 100);
+        let forecast = survey.forecast_peak_bytes();
+        assert!(
+            forecast > memory_pressure::DERIVED_BUDGET_CEILING_BYTES,
+            "this test needs a forecast past the allowance cap"
+        );
+        let ceiling = forecast * 4;
+        let verdict = verdict_for(survey, ceiling);
+        let line = verdict
+            .advisory_line()
+            .expect("this band prints its one line");
+        assert!(
+            line.contains("no machine size fixes this"),
+            "line was: {line}"
+        );
+        assert!(
+            !line.contains("give this"),
+            "a capped allowance was still told to find more memory: {line}"
+        );
+    }
+
+    /// The new band does not swallow the silence the old one guaranteed.
+    ///
+    /// axum sits at 46.4 percent of an 8 GiB ceiling, which is under the half
+    /// by about seven percent. That margin is small, so it is pinned here as
+    /// well as in the band test above: a change that widened the daemon rule
+    /// would make an ordinary conversion narrate itself, which is the noise
+    /// TIGHT_FRACTION's own comment exists to prevent.
+    #[test]
+    fn the_daemon_band_leaves_an_ordinary_conversion_silent() {
+        const CEILING: u64 = 8 * 1024 * 1024 * 1024;
+        let survey = survey(1_983, 503);
+        let allowance = memory_pressure::FootprintBudget::derived_from(CEILING);
+        assert!(
+            survey.forecast_peak_bytes() < allowance,
+            "axum's forecast must sit under the allowance for this to be silence rather than luck"
+        );
+        let verdict = verdict_for(survey, CEILING);
+        assert!(
+            matches!(verdict, BudgetVerdict::Fits { .. }),
+            "axum should stay silent, got {verdict:?}"
+        );
+        assert_eq!(verdict.advisory_line(), None);
+    }
+
+    /// A named allowance decides the band, so an operator who gave the daemon
+    /// a different share is judged against the share the daemon will have.
+    ///
+    /// The pair matters more than either half. The same survey and the same
+    /// ceiling land in two different verdicts depending only on the allowance,
+    /// which is what makes this a real input rather than a value the function
+    /// could have derived and ignored.
+    #[test]
+    fn the_named_allowance_and_not_the_ceiling_decides_the_daemon_band() {
+        const CEILING: u64 = 8 * 1024 * 1024 * 1024;
+        let survey = survey(1_983, 503);
+        let forecast = survey.forecast_peak_bytes();
+        assert!(
+            matches!(
+                verdict_for_with_allowance(survey, CEILING, forecast + 1),
+                BudgetVerdict::Fits { .. }
+            ),
+            "an allowance above the forecast leaves the daemon room"
+        );
+        assert!(
+            matches!(
+                verdict_for_with_allowance(survey, CEILING, forecast - 1),
+                BudgetVerdict::DaemonAllowance { .. }
+            ),
+            "an allowance below the forecast does not"
+        );
     }
 
     /// An operator ceiling Kin cannot read refuses rather than falling back.

--- a/scripts/acceptance/init_budget_refusal.py
+++ b/scripts/acceptance/init_budget_refusal.py
@@ -426,6 +426,20 @@ class Suite(object):
         self.repos[name] = repo
         return repo
 
+    def commit_count(self, repo):
+        """Commits reachable from HEAD, or None when git will not say.
+
+        None rather than 0, because a failed count and an empty repository are
+        different facts and only one of them is a measurement.
+        """
+        rc, out = self.git(["rev-list", "--count", "HEAD"], repo)
+        if rc != 0:
+            return None
+        try:
+            return int(out.strip().splitlines()[-1])
+        except (ValueError, IndexError):
+            return None
+
     def store_exists(self, repo):
         return os.path.isdir(os.path.join(repo, ".kin"))
 
@@ -761,11 +775,42 @@ def check_5(suite):
     else:
         result.ok("a store was written")
 
+    # A "no band at all" outcome is graded FAIL here, deliberately, and an
+    # earlier draft of this check got that wrong in a way worth recording.
+    #
+    # That draft treated silence as UNREADABLE on the theory that a pin which
+    # failed to apply would produce it. It does. So does the defect: an
+    # unpatched binary has no band to print. The two are indistinguishable from
+    # the output, so the guard excused the exact behaviour this check exists to
+    # catch, and against the shipped v0.6.2 candidate it reported UNREADABLE
+    # where it had previously reported FAIL. A guard that cannot separate its
+    # two causes is worse than no guard, because it renames a defect as an
+    # environment problem.
+    #
+    # What actually rules the runner out is source, not output. `ceiling()`
+    # returns the pinned value before consulting the host at all, and
+    # `FootprintBudget::resolve` returns an operator value unclamped and
+    # unconditionally. Neither reads this machine when the variable is set. And
+    # checks 0 and 2 already prove the ceiling pin applies wherever this suite
+    # runs: one refuses under a tiny ceiling and one is silent under a roomy
+    # one, on every host that has ever run them.
     missing = [p for p in REQUIRED_DAEMON_BAND_PHRASES if p not in out]
     if missing:
         result.bad("the line does not say %s: %s" % (", ".join(missing), tail(out, 900)))
     else:
         result.ok("the line names the daemon, its allowance and what a reader can do")
+
+    # And prove the line is about THIS fixture rather than some other forecast,
+    # by requiring the survey it was computed from. Only this repository's
+    # commit count produces this number.
+    commits = suite.commit_count(repo)
+    if commits is None:
+        result.unknown("could not count the fixture's commits, so the line's survey is unchecked")
+    elif ("%d commits" % commits) not in out:
+        result.bad("the line does not name this fixture's %d commits, so it is reporting a "
+                   "forecast for something else: %s" % (commits, tail(out, 700)))
+    else:
+        result.ok("the line names this fixture's own %d commits" % commits)
 
     # The Tight sentence claims the CONVERSION might not finish. Borrowing it
     # here would send a reader to watch the wrong half of the command.

--- a/scripts/acceptance/init_budget_refusal.py
+++ b/scripts/acceptance/init_budget_refusal.py
@@ -46,8 +46,21 @@ serving it, which is what a host with no language server does, it writes the sam
 record naming a pid confirmed not to be running. Either route exercises the
 product's own grading path; neither fabricates a verdict.
 
+Check 5 grades the band the release measurement opened. `kin init` does not end
+when the conversion ends: it starts a repository daemon on the store it just
+wrote, and that daemon has its own share of the same machine. A forecast that
+fits the ceiling but exceeds that share is the band where the conversion
+succeeds and the daemon it starts cannot, which on psf/requests inside a 12 GiB
+container meant seventeen completed phases, a 1.2 GB store, and four OOM kills,
+with nothing said before the run. It pins the daemon's share with
+`KIN_DAEMON_MEMORY_BUDGET_BYTES` for the same reason checks 0 to 3 pin the
+ceiling, and it carries a silent arm, because a band that fired on everything
+would satisfy every assertion in its loud arm.
+
 It does NOT measure how much memory a conversion really needs, and nothing here
-should be read as calibrating the forecast. The forecast's coefficient was fitted
+should be read as calibrating the forecast. Check 5 in particular grades the
+decision and its wording, never a resident set: what a daemon holds is
+FIR-2955's structural half and no check in this workspace gates it. The forecast's coefficient was fitted
 to sampled cgroup readings from full conversions of real repositories and that
 measurement lives in the lane report, not here. What this asserts is that the
 decision is made, disclosed and acted on.
@@ -92,6 +105,7 @@ UNREADABLE = "UNREADABLE"
 TICKET_SILENCE = "FIR-2639"
 TICKET_EXIT = "FIR-2650"
 TICKET_REPORT = "FIR-2929"
+TICKET_DAEMON = "FIR-2955"
 
 # What a seeded row says before its check answers. Named once, because the
 # self-test reads it back to prove `main` replaced the row rather than shipping
@@ -100,6 +114,11 @@ TICKET_REPORT = "FIR-2929"
 PENDING_MARKER = "did not answer"
 
 CEILING_ENV = "KIN_INIT_MEMORY_CEILING_BYTES"
+# The daemon's own share, which `kin init` forecasts against because the daemon
+# it starts at the end runs under it. Pinned rather than produced, for the same
+# reason every other limit here is: a test that fills a machine to prove Kin
+# noticed takes the runner down beside every other job.
+DAEMON_BUDGET_ENV = "KIN_DAEMON_MEMORY_BUDGET_BYTES"
 
 # A ceiling no conversion of anything can fit under, so the refusal is decided by
 # the comparison rather than by the fixture's size. One byte rather than zero,
@@ -109,6 +128,25 @@ TINY_CEILING = "1"
 # Room for any fixture this suite builds, so check 2's silence is the product
 # choosing to say nothing rather than the check failing to look.
 ROOMY_CEILING = str(512 * 1024 * 1024 * 1024)
+# A daemon share smaller than any fixture this suite builds will produce, so
+# check 5's band is entered by the comparison rather than by the fixture's size.
+# The four-commit fixture forecasts 4,800,000 bytes, one BYTES_PER_COMMIT term
+# per commit, so anything well under that works and this is two orders below.
+TIGHT_DAEMON_BUDGET = str(64 * 1024)
+# And a share no fixture can exceed, for the silent control.
+ROOMY_DAEMON_BUDGET = str(512 * 1024 * 1024 * 1024)
+
+# What the daemon-allowance band owes a reader. It is a different sentence from
+# the Tight one on purpose: Tight says the conversion might not finish, and this
+# says the conversion will finish and the thing that serves it afterward may not
+# start. A reader told the first when the second is true goes looking in the
+# wrong place.
+REQUIRED_DAEMON_BAND_PHRASES = [
+    "repository daemon",
+    "is allowed",
+    "answers nothing",
+    "convert a repository with less history",
+]
 
 # Every phrase the refusal owes an operator. A refusal that fires and does not
 # say what to do next leaves the reader exactly where the silence did.
@@ -332,6 +370,9 @@ class Suite(object):
         self.env["HOME"] = self.home
         self.env["GIT_CONFIG_NOSYSTEM"] = "1"
         self.env.pop(CEILING_ENV, None)
+        # Same reason as the line above. A machine that already exports a daemon
+        # share would decide check 5's control arm instead of the check doing it.
+        self.env.pop(DAEMON_BUDGET_ENV, None)
         self.repos = {}
 
     def git(self, args, cwd):
@@ -646,7 +687,98 @@ def check_4(suite):
     return result
 
 
-CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3), ("4", check_4)]
+def check_5(suite):
+    """A conversion that fits the machine but not the daemon's share says so.
+
+    The stranger finding this exists for, measured on the v0.6.2 candidate on
+    2026-08-29. psf/requests at 6493 commits inside a 12 GiB container: the
+    forecast was 7.3 GB, which is 0.61 of the ceiling and under TIGHT_FRACTION,
+    so `kin init` printed nothing about memory at all. All seventeen phases then
+    completed, a 1.2 GB store was written, and the repository daemon the same
+    command starts was OOM-killed. Four kills across that init and three
+    `kin graph status` attempts. The user is left with a store that reports
+    success and answers nothing.
+
+    Per-process sampling separated the two: the conversion peaked at 5.518 GiB
+    and the daemon at 8.351 GiB, sequentially, so the daemon is the larger of
+    the two and it was the one nothing forecast. The forecast is a conversion
+    forecast by its own constants and had no daemon term.
+
+    WHAT THIS GRADES, and what it does not. It grades the DECISION and its
+    wording, not the memory. Nothing here measures what a daemon holds, and a
+    green run says only that a conversion whose store exceeds the daemon's
+    share is told so before it starts. The resident-set cost itself is
+    FIR-2955's structural half and no check in this workspace gates it.
+
+    Both levers are pinned, which is this suite's standing pattern: the ceiling
+    so the conversion has room, the daemon share so the band is entered by the
+    comparison rather than by the fixture's size. The silent arm is the half
+    that can fail quietly, because a band wired to fire on everything would
+    satisfy every assertion above it and make an ordinary conversion narrate
+    itself.
+    """
+    result = Result("5", TICKET_DAEMON,
+                    "a conversion that fits the machine but not the daemon's share says so")
+
+    # The silent control first, so a band that fires on everything is caught
+    # before its own arm can pass.
+    quiet_repo = suite.fixture("daemonroom")
+    try:
+        rc, out = suite.kin_run(["init", "."], quiet_repo, ceiling=ROOMY_CEILING,
+                                extra_env={DAEMON_BUDGET_ENV: ROOMY_DAEMON_BUDGET})
+    except subprocess.TimeoutExpired:
+        result.unknown("the silent control's `kin init` did not finish inside the timeout")
+        return result
+    if rc != 0:
+        result.bad("the silent control exited %d: %s" % (rc, tail(out, 900)))
+        return result
+    chatter = memory_chatter(out)
+    if chatter:
+        result.bad("a conversion with room in both budgets narrated its memory: %s"
+                   % ", ".join(chatter))
+    else:
+        result.ok("a conversion with room in both budgets said nothing")
+
+    # And the band itself.
+    repo = suite.fixture("daemontight")
+    try:
+        rc, out = suite.kin_run(["init", "."], repo, ceiling=ROOMY_CEILING,
+                                extra_env={DAEMON_BUDGET_ENV: TIGHT_DAEMON_BUDGET})
+    except subprocess.TimeoutExpired:
+        result.unknown("`kin init` did not finish inside the timeout")
+        return result
+
+    # This band warns. A refusal here would cost a user a conversion that does
+    # complete, which is the opposite error and a worse one.
+    if rc != 0:
+        result.bad("a conversion that fits the machine was stopped, exit %d: %s"
+                   % (rc, tail(out, 900)))
+    else:
+        result.ok("`kin init` exited 0, so the band warns rather than refusing")
+
+    if not suite.store_exists(repo):
+        result.bad("the conversion was allowed to proceed and wrote no store")
+    else:
+        result.ok("a store was written")
+
+    missing = [p for p in REQUIRED_DAEMON_BAND_PHRASES if p not in out]
+    if missing:
+        result.bad("the line does not say %s: %s" % (", ".join(missing), tail(out, 900)))
+    else:
+        result.ok("the line names the daemon, its allowance and what a reader can do")
+
+    # The Tight sentence claims the CONVERSION might not finish. Borrowing it
+    # here would send a reader to watch the wrong half of the command.
+    if "It will probably finish. If the kernel stops it" in out:
+        result.bad("the daemon band printed the Tight sentence, whose claim is about the "
+                   "conversion rather than about what runs after it: %s" % tail(out, 700))
+    else:
+        result.ok("the daemon band does not borrow the Tight wording")
+    return result
+
+
+CHECKS = [("0", check_0), ("1", check_1), ("2", check_2), ("3", check_3), ("4", check_4),
+          ("5", check_5)]
 
 
 # ------------------------------------------------------------------ self test

--- a/scripts/acceptance/init_budget_refusal.py
+++ b/scripts/acceptance/init_budget_refusal.py
@@ -142,11 +142,23 @@ ROOMY_DAEMON_BUDGET = str(512 * 1024 * 1024 * 1024)
 # start. A reader told the first when the second is true goes looking in the
 # wrong place.
 REQUIRED_DAEMON_BAND_PHRASES = [
+    # Unique to this band's sentence. Checked by grepping the tree: it occurs
+    # exactly once across kin-core and kin-daemon, in the sentence this check
+    # exists to grade.
+    "is a different matter",
     "repository daemon",
-    "is allowed",
     "answers nothing",
     "convert a repository with less history",
 ]
+# `is allowed` was in this list and has been removed, because it is not this
+# band's phrase. `memory_pressure.rs` uses "it is allowed" four times in the
+# daemon's own footprint warning, which a run under a tight pinned budget prints
+# anyway, so the assertion was satisfied by a DIFFERENT message than the one it
+# named. It was caught on a Linux run whose FAIL detail listed three missing
+# phrases and not four: the daemon's own warning had supplied the fourth. The
+# check still went red, because the other three are genuinely this band's, and
+# an assertion that passes on someone else's output is a passing assertion for
+# the wrong reason whether or not its neighbours cover for it.
 
 # Every phrase the refusal owes an operator. A refusal that fires and does not
 # say what to do next leaves the reader exactly where the silence did.


### PR DESCRIPTION
`kin init` does not end when the conversion ends. It starts a repository daemon on the store it just wrote, and that daemon has its own share of the same machine. The budget ladder only ever forecast the conversion, so a repository whose store the daemon cannot hold got no warning at all.

## The measurement this comes from

psf/requests at 6493 commits inside a 12 GiB container forecasts 7.3 GB, which is 0.61 of the ceiling and under `TIGHT_FRACTION`, so the run said nothing. All seventeen phases then completed, a 1.2 GB store was written, and the repository daemon was OOM-killed four times across that init and three `kin graph status` attempts. The user is left with a store that reports success and answers nothing.

Three arms, one clean copy of the repository, the only variable `KIN_INIT_MEMORY_CEILING_BYTES`, each arm reset to the same clean state and repeated in the order 12, 9, 12:

| pinned ceiling | what step 1 printed |
|---|---|
| 12.0 GiB | nothing at all |
| 9.0 GiB | "expected to hold about 7.3 GB, against the 9.0 GB this container allows" |
| 4.0 GiB | "needs more memory than this container has: at least 7.3 GB" |

Both 12 GiB arms silent, the 9 GiB arm loud, so the silence is a decision and the two loud arms are the controls proving the line can print.

Per-process sampling at 2 Hz separates the two peaks. The conversion held 5.518 GiB at t=800.7 s and the daemon held 8.351 GiB at t=915.6 s, by which time the conversion held 0.16 GiB. They are sequential, so they do not add, and **the daemon is the larger of the two and it was the one nothing forecast.**

## What this changes

A `DaemonAllowance` band: a forecast that fits the ceiling and exceeds the daemon's allowance at that same ceiling is no longer silent.

**No new coefficient pays for it.** Both numbers already exist. What makes the conversion forecast a usable floor for the daemon's startup cost is measured at three different ceilings, which is the pattern a ceiling artifact does not produce: 8.351 GiB by resident set at 9 GiB, 8.0 GiB by the daemon's own footprint accounting at 12 GiB, and 7.9 GiB by the same accounting at 16 GiB, the last being the only one taken with room to spare. The forecast for the same repository is 7.26 GiB, so it sits just under, understating by about eight percent.

No per-commit rate is quoted, deliberately. The obvious one is wrong: the two largest runs both peaked at exactly their cap, so a rate derived from them measures the caps rather than the daemon.

Checked against every measured case before a line was written. The daemon column is a lower bound wherever the run was ceiling-bound, which does not weaken the check, since the band fires when the forecast exceeds the allowance and a larger true demand only makes that more correct:

| case | forecast | allowance | daemon | today | after | correct |
|---|---|---|---|---|---|---|
| 249 commits at 4 GiB | 0.28 GiB | 2.00 GiB | 0.20 GiB | silent | silent | yes |
| 806 commits at 4 GiB | 0.90 GiB | 2.00 GiB | 0.38 GiB | silent | silent | yes |
| 2991 commits at 4 GiB | 3.34 GiB | 2.00 GiB | >3.93 GiB | Tight | Tight | yes |
| 6493 commits at 9 GiB | 7.26 GiB | 4.50 GiB | >8.35 GiB | Tight | Tight | yes |
| **6493 commits at 12 GiB** | **7.26 GiB** | **6.00 GiB** | **>8.00 GiB** | **silent** | **DaemonAllowance** | **yes** |

It changes exactly one case, the one that fails. axum stays silent at 46.4 percent of an 8 GiB ceiling, which is under the half by about seven percent; that margin is small enough that it now has its own pinned test rather than being left to the band test.

`assess` resolves the allowance the daemon will actually run under, so an operator who set `KIN_DAEMON_MEMORY_BUDGET_BYTES` is judged against their own number. `verdict_for` keeps its signature and stays a pure function of two numbers; the work moves to `verdict_for_with_allowance`, so the unit tests still need no environment.

## What it does not change

It is not the memory fix. The daemon needs two transients a normal machine does not have: 8 to 9.6 GiB to start on a converted store, which then releases back to about 5.4 GiB, and about 16 GiB to answer one `kin graph status`. Both are structural and both are FIR-2955. No machine size is currently known to work for psf/requests: 9, 12 and 16 GiB all ended in an OOM kill.

The new sentence states the allowance without claiming where it came from, because "half the ceiling" is false the moment an operator names it. It does not offer `KIN_DAEMON_MEMORY_BUDGET_BYTES` as a remedy either: raising a self-imposed allowance does not create memory. Above the derived budget's own 8 GiB cap it says no machine size fixes it rather than sending a reader to buy memory.

## The scripted check

Check 5 in `scripts/acceptance/init_budget_refusal.py`, the suite that already owns this ladder and is already wired into `acceptance.yml`, so no new CI wiring. Both levers pinned, which is this suite's standing pattern.

The silent arm runs first, because a band wired to fire on everything would satisfy every assertion in the loud arm. The loud arm asserts the band fires, that it warns rather than refusing, that a store is still written, that the line names the daemon and its allowance and what a reader can do, and that it does not borrow the `Tight` sentence, whose claim is about the conversion rather than about what runs after it.

Its docstring says plainly that it grades the decision and its wording and never a resident set, so it cannot later be read as a memory gate.

Refs FIR-2955, FIR-2956, FIR-2639.

This closes nothing. FIR-2955 owns the memory itself and is structural; this is the warning
in front of it. FIR-2639 is named only because the checks this one sits beside carry its id,
and its own subject, the post-mortem and the orphaned staging, is untouched here.
