### PR TITLE
Stop kin doctor promising a model fetch kin init may not do

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -4006,8 +4006,9 @@ fn embedding_model_check_from(
         (None, false, _) => (
             HealthStatus::Pending,
             format!(
-                "{model} is not in the cache{location}; `kin init` starts the first embed pass, \
-                 which fetches {download} from {host} before it records anything"
+                "{model} is not in the cache{location}; `kin init` starts the first embed \
+                 pass, which fetches {download} from {host}, and it reports whether that \
+                 pass ran or left the fetch for `kin embed`"
             ),
         ),
     };
@@ -10943,6 +10944,15 @@ mod tests {
             "the detail names what starts the fetch: {}",
             check.detail
         );
+        // FIR-2957: naming `kin init` is right and promising the fetch lands
+        // inside it is not. `kin init` records first and may leave the fetch
+        // for `kin embed`, and its own notice says which happened, so this row
+        // may not tell the reader to expect the download before init returns.
+        assert!(
+            !check.detail.contains("before it records anything"),
+            "the row must not promise the fetch completes inside init: {}",
+            check.detail
+        );
         assert!(
             !check.detail.contains("a later embed pass fetches"),
             "the check must be able to fail: {}",
@@ -10957,6 +10967,58 @@ mod tests {
             check.manual_fix
         );
         assert!(!blocks_readiness(&check));
+    }
+
+    /// The two commands that describe one fetch must not describe it
+    /// differently.
+    ///
+    /// This is a join, not two endpoint checks. `kin doctor` and `kin init`
+    /// each own a sentence about the same embedding-model state, they were
+    /// written at different times, and on the v0.6.2 candidate they disagreed:
+    /// init had been corrected to say it records without fetching, and
+    /// doctor still told the reader the fetch happens before init records
+    /// anything. Two tests asserting two hardcoded strings could not have seen
+    /// that, because each was right about its own half. So this one reads what
+    /// init actually produces for a state and requires doctor's row for the
+    /// same state to be consistent with it, and the one literal both sides are
+    /// checked against is written here once.
+    #[test]
+    #[serial]
+    fn doctor_and_init_agree_about_the_model_fetch() {
+        let _endpoint = EnvVarGuard::unset("HF_ENDPOINT");
+        let absent = absent_model();
+
+        // The state under test: absent when the command opened and absent when
+        // it closed, which is what a cold container with no egress budget gets.
+        let init_line = crate::commands::init::embedding_model_notice(&absent, false, None);
+        let doctor = embedding_model_check_from(&absent, Some(true));
+
+        assert!(
+            init_line.contains("did not fetch it"),
+            "the fixture must be the state where init records without fetching, \
+             or this test is grading the wrong pair: {init_line}"
+        );
+
+        // Read the fallback out of init's own sentence rather than trusting a
+        // second copy of it, then require doctor to name the same one.
+        const FALLBACK: &str = "`kin embed`";
+        assert!(
+            init_line.contains(FALLBACK),
+            "init names the command that does the fetch: {init_line}"
+        );
+        assert!(
+            doctor.detail.contains(FALLBACK),
+            "doctor names the same fallback init does, so a reader who follows \
+             either command lands in the same place: {}",
+            doctor.detail
+        );
+
+        // And doctor may not contradict init about when the download happens.
+        assert!(
+            !doctor.detail.contains("before it records anything"),
+            "doctor promises a fetch init's own line says may not have happened: {}",
+            doctor.detail
+        );
     }
 
     /// A machine without the weights that cannot reach the host fails loud and

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1347,7 +1347,10 @@ fn embed_refusal_for(root: &std::path::Path) -> Option<kin_core::memory_pressure
     )
 }
 
-fn embedding_model_notice(
+/// Visible to the crate so `health.rs` can grade its own row against what
+/// this function actually says, rather than against a second copy of the
+/// sentence. See `doctor_and_init_agree_about_the_model_fetch`.
+pub(crate) fn embedding_model_notice(
     fetch: &crate::embed_model::EmbedModelFetch,
     present_before: bool,
     refusal: Option<&kin_core::memory_pressure::PressureRefusal>,


### PR DESCRIPTION
`kin doctor` and `kin init` describe one fetch and disagree about it. Doctor's row says `kin init` "starts the first embed pass, which fetches about 523 MB from huggingface.co **before it records anything**". On this build `kin init` answers "this command did not fetch it ... run `kin embed` to start it now". A reader budgets for a download during init that never arrives.

Found by the isolated stranger run `rc062a` on the v0.6.2 candidate archive, green arm, `SETUP-REPORT.md:363`, headed "Friction #5 (a real contradiction between two commands)". The stranger's own call: "The init behavior is the better one, and it is what actually happened: no download, 0.692s. But doctor's description of init is wrong, and it is wrong in the direction that makes a user budget for a half-gigabyte download and a long wait that never comes. I would fix the doctor string, not the behavior."

## It is new in this candidate, and that is why it matters now

Proven by running both binaries side by side, each named by the sha it was built from:

```
v0.6.1     kin 0.6.1 (3b1d3eeeb75ac6adc4b8c94c408f5bea16adc0d9)
candidate  kin 0.6.1 (56ff0980c0c7ade17dfa9528971ed092c685b8ea)
```

`kin doctor` is word for word identical on both. `kin init` is not:

```
v0.6.1  ... `kin init` starts the first embed pass, which fetches about 523 MB from
        huggingface.co into <path> and needs egress. On a repository with parseable
        content that download happens during this command, before any vector exists

RC      ... is not on this machine and this command did not fetch it. The first embed
        pass fetches about 523 MB from huggingface.co into <path> and needs egress;
        run `kin embed` to start it now
```

On v0.6.1 the two commands agreed. Commit `21226253c` (#1231) edited `health.rs` and `init.rs` together, corrected init's half, and left doctor's.

## What changed, and what deliberately did not

The init half was right to change. Init records first and may leave the fetch for the background pass or for `kin embed`, and `embedding_model_notice` reports which of its three outcomes the run actually had.

FIR-2555 put `kin init` into doctor's sentence on purpose, because the row must name the command the reader runs next rather than a later one they have no reason to run. That stays. Only the false clause goes:

```
-  `kin init` starts the first embed pass, which fetches {download} from {host}
-  before it records anything
+  `kin init` starts the first embed pass, which fetches {download} from {host},
+  and it reports whether that pass ran or left the fetch for `kin embed`
```

The row still names `kin init`, and now names the same fallback init itself names. The size stays interpolated from `expected_download()` rather than written down, so no number in this diff can go stale.

I swept for other homes of the sentence. `health.rs:4001` (unreachable host) and `embed_model.rs:180` (`kin resources inspect`) carry the FIR-2555 wording without the false clause and are consistent with init, so they are untouched. `before it records anything` now returns zero hits in the production function, with the FIR-2555 phrase returning two on the same range as the control.

## The guard is a join, not two endpoint assertions

Two tests each asserting their own hardcoded sentence could not have caught this, because each was right about its own half. `doctor_and_init_agree_about_the_model_fetch` builds one fetch state, reads what `embedding_model_notice` actually produces for it, and requires `embedding_model_check_from`'s row for the same state to name the same fallback and to drop the contradicted clause. The one literal both sides are checked against is written once. `embedding_model_notice` becomes `pub(crate)` so the join reads the real producer rather than a copy.

## What I ran, and what I did not

Ran: `cargo fmt --check` on both touched files, clean. A sweep proving the false clause is gone from the production function with a positive control on the same range. A falsification of the join's logic against the two format strings as the compiler will unfold them, which passes with the fix and fails on two of its four assertions with the old string restored.

Did not run: any Rust build or test binary. The fleet was at its builder cap when this was written and the captain's instruction was that hosted CI is the gate of record for a one-string doc change. So the join test is falsified at the logic level and unverified as compiled code, and hosted CI is what grades it. That is the one claim in this PR I cannot make myself.

Closes FIR-2957
