### PR TITLE
Answer a prose query from the lexical index as the query finds it, not as a background timer leaves it

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -287,6 +287,18 @@ jobs:
       - name: Falsify the bridge reach graders
         run: python3 scripts/acceptance/bridge_reach_repro.py --self-test
 
+      # FIR-2918. `kin locate` has no daemonless arm, so a prose-only query that
+      # retrieves nothing through one daemon and its file through another is one
+      # code path answering differently depending on which process is up. The
+      # graders here decide two things that look alike from outside: whether two
+      # daemon states named the same files, and whether an answer that could not
+      # read the lexical index said so. Each is handed the input it must refuse,
+      # including the mutation that matters, a gap reader that accepts any
+      # degradation at all and would therefore pass on every query in a suite
+      # that runs with no vector index.
+      - name: Falsify the prose-query parity graders
+        run: python3 scripts/acceptance/prose_query_parity_repro.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -946,6 +958,41 @@ jobs:
             echo "::warning title=Bridge reach acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      # FIR-2918. A stranger installs Kin, commits some code and asks an English
+      # question, and the daemon that answers is the long-lived one that was up
+      # while the code was ingested. This asks one docstring-only term through
+      # that daemon and through a daemon started after `kin daemon stop`, and
+      # requires the same files back. Its own controls decide whether it graded
+      # anything: a symbol the fixture defines must retrieve in both states, and
+      # a fabricated term in neither.
+      - name: Prose-query parity suite (verdict comes from the gate step)
+        id: proseparity
+        if: always()
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/prose_query_parity_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/prose_parity.json \
+            --label "$KIN_ACCEPTANCE_LABEL" \
+            --verbose >acceptance/prose_parity.log 2>&1 || rc=$?
+          cat acceptance/prose_parity.log
+          {
+            echo "### Prose-query parity suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/prose_parity.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Prose-query parity suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
       # Always, including on a cancelled or timed-out run: the reports are how a
       # failure is diagnosed without re-running the job.
       - name: Upload the acceptance reports
@@ -995,4 +1042,5 @@ jobs:
             --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \
             --report init_budget=acceptance/init_budget.json \
             --report bridge_reach=acceptance/bridge_reach.json \
+            --report prose_parity=acceptance/prose_parity.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk is truncated on ubuntu-latest, and its clipped_steps metadata confirms dropped callee and cross-file rows. This check therefore cannot distinguish an absent required edge from one the walk dropped. Any FAIL or other UNREADABLE still fails the gate, and the moment this check passes the allowance announces itself stale and can go.'

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1939,6 +1939,82 @@ pub fn record_degradation(sink: &mut Vec<RetrievalDegradation>, event: Retrieval
     sink.push(event);
 }
 
+/// Make the derived text index answer from graph truth before this query reads
+/// it, and say so when it cannot.
+///
+/// Every write that puts a document into the lexical index STAGES it.
+/// `refresh_text_index_for_entities` and the three artifact upserts all go
+/// through `TextIndex::upsert`, whose contract in kin-db is "Stages the change
+/// — call `commit()` to make it visible to searches", and
+/// `InMemoryGraph::flush_text_index` is that commit. Until it runs, `text_search`
+/// answers every term with zero hits, which is why this module's own fixtures
+/// call it by hand before they assert on ranking.
+///
+/// Nothing on the query path used to call it. In a live daemon the only caller
+/// is the background persistence loop, which flushes two seconds after the last
+/// mutation or every thirty seconds, so whether an English question could be
+/// answered depended on whether that timer had fired in the process serving the
+/// query. Measured on this fixture at the default cadence: zero of seventeen
+/// entities indexed at the moment a first question arrives, seventeen of
+/// seventeen sixty seconds later, on one unchanged daemon process, and the
+/// answer in between is "No relevant files found." over a graph that holds the
+/// word (FIR-2918). A daemon opened afterwards always answers, because
+/// `from_snapshot_inner` rebuilds the index from graph truth at open and that
+/// rebuild commits.
+///
+/// Deliberately at query entry rather than at every mutation. The mutation
+/// surface is commit, checkout, rename, stash, merge, rollback, tag, the MCP
+/// writes and the language-server sweep; the read surface is this function's two
+/// callers. Two call sites cover every mutation, a clean index costs one atomic
+/// load, and a dirty one pays exactly the commit the daemon would have paid
+/// moments later.
+///
+/// The second half is the graph-gap report. A graph whose lexical index holds
+/// nothing cannot answer a lexical question from graph truth, and the rule here
+/// is to fail loud or report the gap rather than answer thin, so it goes in the
+/// degradation ledger the daemon logs at WARN and the human surface renders as a
+/// coverage note. Before this, an answer built with no lexical evidence at all
+/// carried three degradations and not one of them mentioned the index.
+pub(crate) fn ensure_lexical_index_queryable(
+    graph: &kin_db::InMemoryGraph,
+    sink: &mut Vec<RetrievalDegradation>,
+) {
+    if let Err(error) = graph.flush_text_index() {
+        record_degradation(
+            sink,
+            RetrievalDegradation {
+                component: "text_index".to_string(),
+                reason: "flush_failed".to_string(),
+                detail: format!(
+                    "the derived text index could not be brought up to date with graph truth, \
+                     so lexical evidence for this query is whatever was last committed: {error}"
+                ),
+                remediation: "restart the repository daemon, which rebuilds the text index from \
+                              the graph when it opens the store"
+                    .to_string(),
+            },
+        );
+        return;
+    }
+    let entities = graph.entity_count();
+    if entities > 0 && graph.text_document_count() == 0 {
+        record_degradation(
+            sink,
+            RetrievalDegradation {
+                component: "text_index".to_string(),
+                reason: "empty".to_string(),
+                detail: format!(
+                    "the derived text index holds no documents for a graph of {entities} \
+                     entities, so no lexical evidence ranked this query"
+                ),
+                remediation: "restart the repository daemon, which rebuilds the text index from \
+                              the graph when it opens the store"
+                    .to_string(),
+            },
+        );
+    }
+}
+
 /// The producer lineage of the vector index this graph currently serves.
 ///
 /// `None` in a build without the vector feature, where no index exists to have
@@ -2848,15 +2924,18 @@ fn run_with_graph_capture_budgeted(
     let cleaned_text = clean_issue_text(text);
     let semantic_text = strip_pr_template_boilerplate(&cleaned_text);
     let text = semantic_text.as_str();
-    let (semantic_coverage, vector_index_attached) =
-        evaluate_embedding_coverage(graph, vector_source)?;
-
     // Quality profile: supplies the DEFAULT for each retrieval lever below;
     // explicit env vars always win. Resolved once per query so one run cannot
     // mix profiles.
     let quality = crate::retrieval_profile::RetrievalProfile::from_env();
     // No-silent-degradation ledger for this query (attached to the result).
     let mut degradations: Vec<RetrievalDegradation> = Vec::new();
+    // FIR-2918, and it runs before anything below reads the lexical index.
+    // Hoisted above `evaluate_embedding_coverage` only so the ledger exists to
+    // receive its report; nothing between the two reads text.
+    ensure_lexical_index_queryable(graph, &mut degradations);
+    let (semantic_coverage, vector_index_attached) =
+        evaluate_embedding_coverage(graph, vector_source)?;
     record_vector_index_degradation(&semantic_coverage, vector_index_attached, &mut degradations);
     // Per-stage prune attribution, recorded only under --explain.
     let mut prune_ledger: Vec<PruneEvent> = Vec::new();
@@ -18930,6 +19009,113 @@ mod tests {
             .degradations
             .iter()
             .find(|event| event.component == "artifact_candidates" && event.reason == reason)
+    }
+
+    fn text_index_degradation<'a>(result: &'a LocateResult) -> Option<&'a RetrievalDegradation> {
+        result
+            .degradations
+            .iter()
+            .find(|event| event.component == "text_index")
+    }
+
+    /// The state a live daemon sits in between its own persistence flushes:
+    /// documents staged into the lexical index and not committed.
+    ///
+    /// Deliberately NO `graph.flush_text_index()` here, and that absence is the
+    /// whole fixture. Every other graph builder in this module makes that call
+    /// by hand, with a comment saying that without it `text_search` answers
+    /// every term with zero hits. A caller does not get to make it, which is why
+    /// the pipeline has to.
+    fn unflushed_prose_graph() -> kin_db::InMemoryGraph {
+        let graph = kin_db::InMemoryGraph::new();
+        let mut overview = test_entity("describe_layers", "pkg/overview.py", 1, 3);
+        overview.doc_summary = Some(
+            "Nothing here opens a socket or speaks to a server over the network.".to_string(),
+        );
+        graph.upsert_entity(&overview).unwrap();
+        let parsing = test_entity("normalize_title", "pkg/parsing.py", 1, 3);
+        graph.upsert_entity(&parsing).unwrap();
+        graph
+    }
+
+    /// FIR-2918. A prose term the graph holds has to be answerable from the
+    /// index as the query finds it, not as a background timer will leave it.
+    ///
+    /// Measured on the product before this: a four-module store reported zero of
+    /// seventeen entities text indexed at the moment a first English question
+    /// arrived, seventeen of seventeen sixty seconds later, on one unchanged
+    /// daemon process, and answered "No relevant files found." in between.
+    #[test]
+    #[serial_test::serial]
+    fn a_docstring_term_answers_on_a_graph_whose_text_index_was_never_flushed() {
+        let graph = unflushed_prose_graph();
+        assert_eq!(
+            graph.text_document_count(),
+            0,
+            "the fixture must start with nothing committed, or this test grades a flushed index"
+        );
+
+        let result = agent_locate(&graph, "socket");
+
+        assert!(
+            graph.text_document_count() > 0,
+            "the query path left the lexical index empty, so no lexical evidence could have \
+             ranked this answer"
+        );
+        assert!(
+            result.files.iter().any(|file| file.path == "pkg/overview.py"),
+            "a term only this file's docstring carries did not retrieve it; got {:?}",
+            result
+                .files
+                .iter()
+                .map(|file| file.path.as_str())
+                .collect::<Vec<_>>()
+        );
+        // The control that keeps the report from becoming noise: an index that
+        // answered must not also be reported as a gap.
+        assert!(
+            text_index_degradation(&result).is_none(),
+            "an index that answered was reported as a gap: {:?}",
+            text_index_degradation(&result)
+        );
+    }
+
+    /// The other half, and it has to be a separate test or the two hide each
+    /// other. A graph with entities and no lexical index at all cannot answer a
+    /// lexical question from graph truth, and the rule here is to report that
+    /// rather than answer thin from somewhere else.
+    #[test]
+    #[serial_test::serial]
+    fn a_graph_with_no_lexical_index_reports_the_gap_rather_than_answering_thin() {
+        let source = unflushed_prose_graph();
+        let snapshot = source.to_snapshot();
+        let graph = kin_db::InMemoryGraph::from_snapshot_without_text_index(snapshot).unwrap();
+        assert!(
+            graph.entity_count() > 0,
+            "the fixture must carry entities, or the gap report is about an empty graph"
+        );
+
+        let result = agent_locate(&graph, "socket");
+
+        let reported = text_index_degradation(&result).unwrap_or_else(|| {
+            panic!(
+                "a graph with no lexical index answered without reporting the gap; ledger: {:?}",
+                result
+                    .degradations
+                    .iter()
+                    .map(|event| (event.component.as_str(), event.reason.as_str()))
+                    .collect::<Vec<_>>()
+            )
+        });
+        assert_eq!(reported.reason, "empty", "gap report: {reported:?}");
+        assert!(
+            reported.detail.contains("no documents"),
+            "the report must say what is missing: {reported:?}"
+        );
+        assert!(
+            !reported.remediation.is_empty(),
+            "a gap report with no remediation tells a caller nothing to do: {reported:?}"
+        );
     }
 
     /// A store whose answer lives in an artifact must be able to say so on the

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -19021,7 +19021,7 @@ mod tests {
             .find(|event| event.component == "artifact_candidates" && event.reason == reason)
     }
 
-    fn text_index_degradation<'a>(result: &'a LocateResult) -> Option<&'a RetrievalDegradation> {
+    fn text_index_degradation(result: &LocateResult) -> Option<&RetrievalDegradation> {
         result
             .degradations
             .iter()
@@ -19039,9 +19039,8 @@ mod tests {
     fn unflushed_prose_graph() -> kin_db::InMemoryGraph {
         let graph = kin_db::InMemoryGraph::new();
         let mut overview = test_entity("describe_layers", "pkg/overview.py", 1, 3);
-        overview.doc_summary = Some(
-            "Nothing here opens a socket or speaks to a server over the network.".to_string(),
-        );
+        overview.doc_summary =
+            Some("Nothing here opens a socket or speaks to a server over the network.".to_string());
         graph.upsert_entity(&overview).unwrap();
         let parsing = test_entity("normalize_title", "pkg/parsing.py", 1, 3);
         graph.upsert_entity(&parsing).unwrap();
@@ -19073,7 +19072,10 @@ mod tests {
              ranked this answer"
         );
         assert!(
-            result.files.iter().any(|file| file.path == "pkg/overview.py"),
+            result
+                .files
+                .iter()
+                .any(|file| file.path == "pkg/overview.py"),
             "a term only this file's docstring carries did not retrieve it; got {:?}",
             result
                 .files

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1965,16 +1965,26 @@ pub fn record_degradation(sink: &mut Vec<RetrievalDegradation>, event: Retrieval
 /// Deliberately at query entry rather than at every mutation. The mutation
 /// surface is commit, checkout, rename, stash, merge, rollback, tag, the MCP
 /// writes and the language-server sweep; the read surface is this function's two
-/// callers. Two call sites cover every mutation, a clean index costs one atomic
-/// load, and a dirty one pays exactly the commit the daemon would have paid
+/// callers. Two call sites cover every mutation, a clean index returns on two
+/// atomics, and a dirty one pays exactly the commit the daemon would have paid
 /// moments later.
+///
+/// One state costs more than a commit, and it is taken deliberately. A batch
+/// relation write sets `text_full_rebuild_required`, and `flush_text_index`
+/// does that whole rebuild here rather than deferring it. The alternative is
+/// worse than the cost: while that flag is set `text_search` refuses outright,
+/// and this pipeline swallows the refusal with a bare `continue` at four of its
+/// stages while propagating it with `?` at others, so one store answers thin or
+/// errors depending only on which stage reached the index first.
 ///
 /// The second half is the graph-gap report. A graph whose lexical index holds
 /// nothing cannot answer a lexical question from graph truth, and the rule here
 /// is to fail loud or report the gap rather than answer thin, so it goes in the
-/// degradation ledger the daemon logs at WARN and the human surface renders as a
-/// coverage note. Before this, an answer built with no lexical evidence at all
-/// carried three degradations and not one of them mentioned the index.
+/// degradation ledger. `coverage_notes` renders that ledger as one
+/// component-prefixed note per entry, collapsed to a line and printed whole
+/// under `--explain`, and the daemon carries it into the answer's own
+/// `degradations[]`. Before this, an answer built with no lexical evidence at
+/// all carried three degradations and not one of them mentioned the index.
 pub(crate) fn ensure_lexical_index_queryable(
     graph: &kin_db::InMemoryGraph,
     sink: &mut Vec<RetrievalDegradation>,

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -552,8 +552,15 @@ pub fn collect_daemon_search_response(
     request: &DaemonSearchRequest,
     envelope: &kin_mcp::Envelope,
 ) -> Result<DaemonSearchResponse> {
+    // FIR-2918. `kin search` reads the same staged-on-write lexical index
+    // `kin locate` does, so it needs the same guarantee: the index answers from
+    // graph truth before this query reads it, and a graph gap is reported rather
+    // than answered thin.
+    let mut lexical: Vec<crate::commands::locate::RetrievalDegradation> = Vec::new();
+    crate::commands::locate::ensure_lexical_index_queryable(graph, &mut lexical);
     if request.semantic {
         let mut response = collect_daemon_semantic_search_response(graph, request, envelope)?;
+        response.degradations.extend(lexical.iter().cloned());
         if response.records.is_empty() {
             let reported = response.degradations.clone();
             response.absence_qualifier = search_absence_qualifier(graph, envelope, &reported);
@@ -579,7 +586,7 @@ pub fn collect_daemon_search_response(
         .map(|matched| record_to_daemon_record(&matched.record, matched.match_kind, matched.score))
         .collect::<Vec<_>>();
     let absence_qualifier = if records.is_empty() {
-        search_absence_qualifier(graph, envelope, &[])
+        search_absence_qualifier(graph, envelope, &lexical)
     } else {
         Vec::new()
     };
@@ -591,7 +598,7 @@ pub fn collect_daemon_search_response(
         records,
         semantic_coverage: None,
         absence_qualifier,
-        degradations: Vec::new(),
+        degradations: lexical,
     })
 }
 

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -585,7 +585,24 @@ pub fn collect_daemon_search_response(
         .iter()
         .map(|matched| record_to_daemon_record(&matched.record, matched.match_kind, matched.score))
         .collect::<Vec<_>>();
-    let absence_qualifier = if records.is_empty() {
+    // An all-fallback answer is an absence, and it has to qualify like one.
+    //
+    // The rows below the name matches are the index's NEAREST documents, not
+    // matches: `collect_search_results` says so in its own comment, and BM25 is
+    // disjunctive, so a query token that occurs nowhere can still retrieve a
+    // document through a substring of itself. Measured on this fixture:
+    // `definitelyNoSuchSymbol` retrieves `present` at 0.45 because `def` occurs
+    // in `def present()` and is a substring of `definitely`, over a corpus where
+    // no token of the query occurs at all.
+    //
+    // Qualifying only on `records.is_empty()` therefore silenced the disclosure
+    // exactly when the fallback produced a row, which is the common case once
+    // the index is populated: a stranger on a degraded daemon got a nearest
+    // document and no word about the degradation. `text_fallback` is already the
+    // product's own name for "nothing matched by name", so the absence gate
+    // reads it too, and a single name match still carries no qualifier, which
+    // the sibling control asserts.
+    let absence_qualifier = if records.is_empty() || text_fallback {
         search_absence_qualifier(graph, envelope, &lexical)
     } else {
         Vec::new()

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -1822,6 +1822,61 @@ mod tests {
         assert_eq!(json["match_kind"].as_str(), Some("semantic"));
     }
 
+    /// FIR-2918, on the second surface that reads the same lexical index.
+    ///
+    /// `kin search` and `kin locate` both read an index that is STAGED on write
+    /// and committed by `flush_text_index`, which in a live daemon only the
+    /// background persistence loop calls. This fixture stages a document and
+    /// never flushes it, which is what a daemon holds between those flushes, and
+    /// the prose term has to come back anyway.
+    ///
+    /// The sibling test below flushes by hand and says so. That call is exactly
+    /// what a caller does not get to make, and its absence here is the fixture.
+    #[test]
+    fn a_docstring_term_answers_search_on_a_graph_whose_text_index_was_never_flushed() {
+        use super::{collect_daemon_search_response, DaemonSearchRequest};
+        use kin_model::EntityStore;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let graph = kin_db::InMemoryGraph::with_text_index(dir.path().join("text-index"));
+        let mut overview = dedupe_test_entity("describe_layers", "pkg/overview.py");
+        overview.doc_summary = Some(
+            "Nothing here opens a socket or speaks to a server over the network.".to_string(),
+        );
+        graph.upsert_entity(&overview).expect("upsert");
+        assert_eq!(
+            graph.text_document_count(),
+            0,
+            "the fixture must start with nothing committed, or this test grades a flushed index"
+        );
+
+        let response = collect_daemon_search_response(
+            &graph,
+            &DaemonSearchRequest {
+                query: "socket".to_string(),
+                kind: None,
+                language: None,
+                limit: None,
+                semantic: false,
+                show_body: false,
+                body_limit: None,
+            },
+            &healthy_search_envelope(),
+        )
+        .expect("search answers");
+
+        assert!(
+            graph.text_document_count() > 0,
+            "the search path left the lexical index empty, so no lexical evidence could have \
+             answered"
+        );
+        assert!(
+            response.total_matches > 0,
+            "a term only this entity's docstring carries returned nothing: {:?}",
+            response.records
+        );
+    }
+
     /// The collector must label a guess as a guess against a real graph.
     ///
     /// This runs the mechanism rather than the serializer: a live text index, a

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -1840,9 +1840,8 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let graph = kin_db::InMemoryGraph::with_text_index(dir.path().join("text-index"));
         let mut overview = dedupe_test_entity("describe_layers", "pkg/overview.py");
-        overview.doc_summary = Some(
-            "Nothing here opens a socket or speaks to a server over the network.".to_string(),
-        );
+        overview.doc_summary =
+            Some("Nothing here opens a socket or speaks to a server over the network.".to_string());
         graph.upsert_entity(&overview).expect("upsert");
         assert_eq!(
             graph.text_document_count(),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -38185,7 +38185,26 @@ mod tests {
         let result: kin_cli::commands::search::DaemonSearchResponse =
             serde_json::from_slice(&body).unwrap();
 
-        assert!(result.records.is_empty(), "the query must match nothing");
+        // FIR-2918. This assertion used to read `records.is_empty()`, and it
+        // held for the wrong reason: the fixture's lexical index was never
+        // committed, so every query returned nothing. Now that the query path
+        // brings the index current, the disjunctive fallback answers with the
+        // index's NEAREST document rather than a match, measured here as
+        // `definitelyNoSuchSymbol` retrieving `present` at 0.45 because `def`
+        // occurs in `def present()` and is a substring of `definitely`, over a
+        // corpus holding no token of the query.
+        //
+        // So the property this test is about is unchanged and is now stated
+        // directly: nothing matched BY NAME. `text_fallback` is the product's
+        // own name for that, and it is true only when the answer is non-empty
+        // and every row is a fallback row. The qualifier assertions below are
+        // untouched, and they are what this test exists for; making them survive
+        // a labelled-fallback answer is the fix this change carries.
+        assert!(
+            result.text_fallback,
+            "nothing may match this query by name; an answer with a name match would make the \
+             qualifier assertions below vacuous: {result:?}"
+        );
         let qualifier = result.absence_qualifier.join(" ");
         assert!(
             qualifier.contains("Kin cannot rule out"),

--- a/scripts/acceptance/prose_query_parity_repro.py
+++ b/scripts/acceptance/prose_query_parity_repro.py
@@ -1,0 +1,805 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""One English question, two daemon states, one answer required.
+
+FIR-2918. `kin locate` has no daemonless arm: `capture` refuses
+`KIN_LOCATE_FORCE_LOCAL` outright and every query goes to `POST /locate` on a
+daemon, auto-starting one when none is up. So the two readings this ticket was
+filed on are not two code paths. They are one path against two daemon states,
+and the discriminator is which daemon process answers: the one `kin init` left
+running, or the one the next command starts after `kin daemon stop`.
+
+That distinction is the whole finding. A stranger installs Kin, runs `kin init`,
+commits some code and asks an English question, and the daemon answering is the
+one `kin init` left behind. If a prose-only term retrieves nothing there and
+retrieves its file after a restart, the product told that stranger their code
+does not mention something it does mention, and said nothing about why.
+
+Two checks, and the second is underneath the first.
+
+  `prose_parity` asks the behaviour question. One term that lives only in a
+  docstring, asked through both daemon states, has to come back with the same
+  files. Two controls decide whether the arm graded anything at all: a symbol
+  the fixture defines must retrieve in both states, or the fixture was never
+  ingested and an agreement at zero is agreement about nothing; and a fabricated
+  term must retrieve in neither, or the row counter is counting something other
+  than rows.
+
+  `lexical_index_parity` asks the mechanism question the behaviour rests on.
+  `kin support --json` is served by the daemon out of its own live graph, so
+  `text_indexed_entity_count` is what the process answering the query can
+  actually see. Both daemon states must report the derived text index carrying
+  documents, and the check reports both numbers whatever it decides, because a
+  number in a detail line is evidence and a verdict alone is not.
+
+Output shape matches the siblings:
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+Exit codes match too: 0 when every check graded, 3 when the suite could not
+start. The verdict belongs to `scripts/acceptance/gate.py`, which reads the
+`--json` report rather than the exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+TICKET = "FIR-2918"
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+ANSI = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+# The three queries, and only the first is the subject.
+#
+# `socket` appears in this fixture exactly once, in `pkg/overview.py`'s module
+# docstring, and no module here defines a symbol by that name. So it can only be
+# answered from the derived text index over graph-owned prose, which is the
+# surface this ticket is about.
+PROSE_QUERY = "socket"
+# The positive control. `describe_layers` is defined in the same file the prose
+# query should retrieve, and entity resolution answers it without the text index
+# at all. A run where this returns nothing has not ingested the fixture, so the
+# prose arm's zero would measure the fixture rather than the product.
+SYMBOL_QUERY = "describe_layers"
+# The negative control. Nothing in this fixture carries these letters. It must
+# retrieve nothing in both daemon states, or `locate_paths` is reading something
+# that is not a result row.
+ABSENT_QUERY = "zzqxnotawordanywhere"
+
+# How long to wait for the daemon `kin init` left to be answering before the
+# first arm reads it. The daemon's own background persistence flushes on an
+# idle interval (KIN_DAEMON_IDLE_FLUSH_SECS, default 2s) and a periodic one
+# (KIN_DAEMON_PERIODIC_FLUSH_SECS, default 30s), so a wait comfortably past both
+# means arm A is not measuring a race the product would win on its own a moment
+# later. If the divergence survives this wait it is a state the product stays
+# in, not a window it passes through.
+SETTLE_SECONDS = int(os.environ.get("KIN_PROSE_PARITY_SETTLE_SECS", "40"))
+
+
+print_ = print
+
+
+def strip_ansi(text):
+    return ANSI.sub("", text or "")
+
+
+def tail(text, limit=400):
+    text = strip_ansi(text or "").strip()
+    return text if len(text) <= limit else "..." + text[-limit:]
+
+
+# ------------------------------------------------------------------- fixture
+#
+# The `_build_answersurface` shape from scripts/acceptance/magic_repro.py, in its
+# own copy so a change to check 24's fixture cannot silently move this suite's
+# subject. `OVERVIEW_PY` is byte-identical to that file's, because the prose
+# query is chosen against its exact words.
+
+PARSING_PY = '''import re
+
+LINK = re.compile(r"\\[\\[([^\\]]+)\\]\\]")
+
+
+def normalize_title(raw):
+    return raw.strip().lower().replace(" ", "-")
+
+
+def parse_note(text):
+    return {"links": [normalize_title(m) for m in LINK.findall(text)]}
+'''
+
+STORAGE_PY = '''from .parsing import parse_note
+
+
+class Database:
+    def __init__(self, path):
+        self.path = path
+        self.notes = {}
+
+    def ingest_dir(self, files):
+        for path, text in files.items():
+            self.notes[path] = parse_note(text)
+
+    def all_notes(self):
+        return [dict(note, path=path) for path, note in self.notes.items()]
+'''
+
+LINKGRAPH_PY = '''from .parsing import normalize_title
+
+
+class LinkGraph:
+    def __init__(self, edges):
+        self.edges = edges
+
+    @classmethod
+    def from_db(cls, db):
+        edges = {}
+        for note in db.all_notes():
+            edges[normalize_title(note["path"])] = [normalize_title(link)
+                                                    for link in note["links"]]
+        return cls(edges)
+
+    def backlinks(self, title):
+        return [src for src, dsts in self.edges.items() if title in dsts]
+'''
+
+# `socket`, `server`, `network` and `deployment` appear here and nowhere else in
+# this fixture, and this module defines no symbol by any of those names.
+OVERVIEW_PY = '''"""How this package fits together, for a reader arriving cold.
+
+The reading layer turns raw text into records, the holding layer keeps those
+records in memory, and the traversal layer walks between them.
+
+Nothing here opens a socket or speaks to a server over the network, so there is
+no deployment step and nothing to keep running between calls.
+"""
+
+
+def describe_layers():
+    return "reading, holding, traversal"
+'''
+
+# The file the prose query must retrieve, named once so a fixture rename cannot
+# leave the assertion pointing at nothing.
+PROSE_FILE = "pkg/overview.py"
+
+
+# ------------------------------------------------------------------- graders
+#
+# Pure, so `--self-test` can falsify each one with no daemon, no repository and
+# no binary. Every grader below is called from `self_test` with an input that
+# must pass and an input that must fail.
+
+
+def locate_paths(payload):
+    """The file paths a `kin locate --json` payload ranked, or None.
+
+    None means the payload could not be read, which is UNREADABLE and never
+    zero. An absent `files` key and an empty one are different facts: the first
+    says the response was not a locate result, the second says locate ranked
+    nothing.
+    """
+    if not isinstance(payload, dict):
+        return None
+    files = payload.get("files")
+    if not isinstance(files, list):
+        return None
+    paths = []
+    for row in files:
+        if not isinstance(row, dict):
+            return None
+        path = row.get("path")
+        if not isinstance(path, str) or not path:
+            return None
+        paths.append(path)
+    return paths
+
+
+def text_index_gap_reported(payload):
+    """Does this answer name a derived-text-index gap, in the ledger locate owns?
+
+    `RetrievalDegradation` is the no-silent-degradation channel: the daemon logs
+    every entry at WARN and the human surface renders it as a coverage note. An
+    answer that could not read the lexical index has to appear here, because the
+    alternative is `No relevant files found.` with nothing said.
+    """
+    if not isinstance(payload, dict):
+        return False
+    degradations = payload.get("degradations")
+    if not isinstance(degradations, list):
+        return False
+    for entry in degradations:
+        if isinstance(entry, dict) and entry.get("component") == "text_index":
+            return True
+    return False
+
+
+def support_text_indexed(payload):
+    """`text_indexed_entity_count` from a `kin support --json` payload, or None.
+
+    None for a payload that does not carry the field or carries a non-count, so
+    an unreadable support response is UNREADABLE rather than a zero that reads
+    like a real measurement of an empty index. A bool is not a count: Python
+    would otherwise accept True as 1.
+    """
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("text_indexed_entity_count")
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def support_total_entities(payload):
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("total_entities")
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def paths_agree(left, right):
+    """Do two arms name the same files, order aside?
+
+    Order is a ranking decision and can legitimately differ under different
+    daemon warmth. Membership cannot: a file one daemon state can retrieve and
+    the other cannot is the defect.
+    """
+    if left is None or right is None:
+        return False
+    return sorted(set(left)) == sorted(set(right))
+
+
+# ---------------------------------------------------------------- result type
+
+
+class Result(object):
+    def __init__(self, check_id, title):
+        self.id = check_id
+        self.title = title
+        self.asserts = []
+
+    def ok(self, detail):
+        self.asserts.append({"status": PASS, "detail": detail})
+
+    def bad(self, detail):
+        self.asserts.append({"status": FAIL, "detail": detail})
+
+    def unknown(self, detail):
+        self.asserts.append({"status": UNREADABLE, "detail": detail})
+
+    @property
+    def status(self):
+        graded = [a for a in self.asserts if a["status"] in (PASS, FAIL, UNREADABLE)]
+        if any(a["status"] == FAIL for a in graded):
+            return FAIL
+        if any(a["status"] == UNREADABLE for a in graded):
+            return UNREADABLE
+        if not graded:
+            return UNREADABLE
+        return PASS
+
+    @property
+    def detail(self):
+        for wanted in (FAIL, UNREADABLE):
+            for a in self.asserts:
+                if a["status"] == wanted:
+                    return a["detail"]
+        graded = [a["detail"] for a in self.asserts if a["status"] == PASS]
+        return "; ".join(graded) if graded else "no assertion was reached"
+
+
+class ProbeError(RuntimeError):
+    """The probe could not produce a reading. UNREADABLE, never FAIL."""
+
+
+# ------------------------------------------------------------------- the suite
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.daemon = daemon
+        self.verbose = verbose
+        self.repo = os.path.join(workdir, "repo")
+        self.env = dict(os.environ)
+        # Scratch HOME and KIN_HOME, so this suite can never touch a developer's
+        # real store and two concurrent runs cannot share one.
+        self.env["HOME"] = os.path.join(workdir, "home")
+        self.env["KIN_HOME"] = os.path.join(workdir, "kin-home")
+        # No vector index, like every sibling here. That is deliberate: with no
+        # embeddings, retrieval for a prose term is lexical and graph only, so
+        # the arm cannot be answered by a semantic signal standing in for the
+        # text index this check is about.
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        # A CLI-autostarted daemon idles out after 60s by default. Without this,
+        # the settle below would let the daemon `kin init` left exit and the
+        # first arm would silently read a REPLACEMENT daemon, which is the one
+        # state where this whole suite passes for the wrong reason. Held open
+        # well past the settle, and the pid is asserted either way.
+        self.env["KIN_DAEMON_IDLE_TIMEOUT_SECS"] = "900"
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DAEMON_URL", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        for path in (self.env["HOME"], self.env["KIN_HOME"], self.repo):
+            os.makedirs(path, exist_ok=True)
+        self._arms = None
+        self._setup_error = None
+
+    # ------------------------------------------------------------- plumbing
+
+    def run(self, args, timeout=900):
+        proc = subprocess.run(
+            [self.kin] + args,
+            cwd=self.repo,
+            env=self.env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            text=True,
+        )
+        out = strip_ansi(proc.stdout)
+        err = strip_ansi(proc.stderr)
+        if self.verbose:
+            sys.stderr.write("$ kin %s\n%s\n%s\n" % (" ".join(args), tail(out, 1200), tail(err, 800)))
+        return proc.returncode, out, err
+
+    def git(self, args):
+        base = ["git", "-c", "core.hooksPath=/dev/null",
+                "-c", "user.email=prose-parity@example.invalid",
+                "-c", "user.name=kin-prose-parity-repro",
+                "-c", "commit.gpgsign=false",
+                "-c", "core.fsmonitor=false"]
+        proc = subprocess.run(base + args, cwd=self.repo, env=self.env,
+                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                              timeout=300, text=True)
+        return proc.returncode, strip_ansi(proc.stdout)
+
+    def write(self, rel, text):
+        full = os.path.join(self.repo, rel)
+        parent = os.path.dirname(full)
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent)
+        with open(full, "w") as handle:
+            handle.write(text)
+
+    # -------------------------------------------------------------- fixture
+
+    def build(self):
+        rc, out = self.git(["init", "-q", "."])
+        if rc != 0:
+            raise ProbeError("git init failed: %s" % tail(out))
+        self.write(".gitignore", "*.db\n__pycache__/\n")
+        self.write("pyproject.toml",
+                   '[project]\nname = "nk"\nversion = "0.1.0"\n\n'
+                   '[project.scripts]\nnk = "pkg.cli:main"\n')
+        self.write("pkg/__init__.py", "")
+        self.write("pkg/parsing.py", PARSING_PY)
+        rc, out, err = self.run(["init", "."])
+        if rc != 0:
+            raise ProbeError("kin init exited %d: %s" % (rc, tail(err or out)))
+        for rel, body, message in (
+                (None, None, "Add parsing module"),
+                ("pkg/storage.py", STORAGE_PY, "Add storage module"),
+                ("pkg/linkgraph.py", LINKGRAPH_PY, "Add link graph module"),
+                (PROSE_FILE, OVERVIEW_PY, "Add the package overview")):
+            if rel:
+                self.write(rel, body)
+            rc, out, err = self.run(["commit", "-m", message])
+            if rc != 0:
+                raise ProbeError("kin commit %r exited %d: %s"
+                                 % (message, rc, tail(err or out)))
+
+    # --------------------------------------------------------------- probes
+
+    def locate_json(self, query):
+        rc, out, err = self.run(["locate", "--json", query])
+        if rc != 0:
+            raise ProbeError("kin locate --json %r exited %d: %s"
+                             % (query, rc, tail(err or out)))
+        try:
+            return json.loads(out)
+        except ValueError:
+            raise ProbeError("kin locate --json %r did not emit JSON: %s"
+                             % (query, tail(out, 200)))
+
+    def support_json(self):
+        rc, out, err = self.run(["support", "--json"])
+        if rc != 0:
+            raise ProbeError("kin support --json exited %d: %s" % (rc, tail(err or out)))
+        try:
+            return json.loads(out)
+        except ValueError:
+            raise ProbeError("kin support --json did not emit JSON: %s" % tail(out, 200))
+
+    def daemon_pid(self):
+        """The pid of the daemon serving this repository, or None.
+
+        Read from `kin daemon status --json`'s `current_repo.pid` rather than
+        parsed out of prose, and used to prove WHICH process answered an arm.
+        The whole finding is about a difference between two daemon processes, so
+        an arm that cannot name its own daemon has not measured one.
+        """
+        rc, out, err = self.run(["daemon", "status", "--json"], timeout=300)
+        if rc != 0:
+            raise ProbeError("kin daemon status --json exited %d: %s" % (rc, tail(err or out)))
+        try:
+            payload = json.loads(out)
+        except ValueError:
+            raise ProbeError("kin daemon status --json did not emit JSON: %s" % tail(out, 200))
+        current = payload.get("current_repo")
+        if not isinstance(current, dict):
+            return None
+        pid = current.get("pid")
+        return pid if isinstance(pid, int) else None
+
+    def read_arm(self, label):
+        arm = {"label": label, "pid": self.daemon_pid(),
+               "support": self.support_json(), "answers": {}}
+        for query in (PROSE_QUERY, SYMBOL_QUERY, ABSENT_QUERY):
+            arm["answers"][query] = self.locate_json(query)
+        return arm
+
+    def arms(self):
+        """Both daemon states, read once and shared by every check.
+
+        Built lazily and cached: rebuilding the fixture per check would give each
+        one a different daemon and make a disagreement between checks impossible
+        to attribute.
+        """
+        if self._setup_error:
+            raise ProbeError(self._setup_error)
+        if self._arms is not None:
+            return self._arms
+        try:
+            self.build()
+            born = self.daemon_pid()
+            # Past both flush intervals, so a divergence here is a state and not
+            # a race the daemon closes on its own a second later.
+            time.sleep(SETTLE_SECONDS)
+            warm = self.read_arm("the daemon kin init left running")
+            if born is None or warm["pid"] is None or born != warm["pid"]:
+                raise ProbeError(
+                    "the daemon serving this repository changed from pid %r to pid %r across "
+                    "the %ds settle, so the first arm is a replacement daemon and this run "
+                    "cannot grade the state the ticket is about"
+                    % (born, warm["pid"], SETTLE_SECONDS))
+            rc, out, err = self.run(["daemon", "stop"])
+            if rc != 0:
+                raise ProbeError("kin daemon stop exited %d: %s" % (rc, tail(err or out)))
+            cold = self.read_arm("a daemon started after kin daemon stop")
+            if cold["pid"] is None or cold["pid"] == warm["pid"]:
+                raise ProbeError(
+                    "the second arm is served by pid %r, the same process as the first, so "
+                    "`kin daemon stop` did not replace the daemon and the two arms are one "
+                    "reading" % (cold["pid"],))
+        except ProbeError as error:
+            self._setup_error = str(error)
+            raise
+        self._arms = (warm, cold)
+        return self._arms
+
+    def stop_daemon(self):
+        try:
+            self.run(["daemon", "stop"], timeout=120)
+        except Exception:  # noqa: BLE001 - teardown must never mask a verdict
+            pass
+
+
+# -------------------------------------------------------------------- checks
+
+
+def check_prose_parity(suite):
+    """One docstring-only term, asked through both daemon states.
+
+    The rule is agreement or a named gap. Two daemon states that retrieve
+    different files for one query mean the product's answer depends on which
+    process happens to be up, and a caller has no way to know which reading it
+    got. If an arm genuinely cannot read the lexical index, that is allowed, but
+    it has to say so through the degradation ledger rather than answer thin.
+    """
+    res = Result("1", "a prose-only query answers the same through both daemon states")
+    warm, cold = suite.arms()
+    res.ok("two daemon processes answered: pid %s is %s, pid %s is %s"
+           % (warm["pid"], warm["label"], cold["pid"], cold["label"]))
+
+    warm_symbol = locate_paths(warm["answers"][SYMBOL_QUERY])
+    cold_symbol = locate_paths(cold["answers"][SYMBOL_QUERY])
+    if warm_symbol is None or cold_symbol is None:
+        res.unknown("the symbol control produced an unreadable locate payload, so nothing "
+                    "below can be attributed to the product")
+        return res
+    if not warm_symbol or not cold_symbol:
+        res.unknown("the symbol control %r retrieved nothing (warm %d rows, cold %d rows), so "
+                    "the fixture was not ingested and an agreement at zero would be agreement "
+                    "about nothing" % (SYMBOL_QUERY, len(warm_symbol), len(cold_symbol)))
+        return res
+
+    warm_absent = locate_paths(warm["answers"][ABSENT_QUERY])
+    cold_absent = locate_paths(cold["answers"][ABSENT_QUERY])
+    if warm_absent is None or cold_absent is None:
+        res.unknown("the absent control produced an unreadable locate payload")
+        return res
+    if warm_absent or cold_absent:
+        res.unknown("the fabricated term %r retrieved %d and %d rows, so the row reader is "
+                    "counting something other than results and no verdict below is safe"
+                    % (ABSENT_QUERY, len(warm_absent), len(cold_absent)))
+        return res
+    res.ok("controls held: %r retrieved %d and %d rows, %r retrieved none in either state"
+           % (SYMBOL_QUERY, len(warm_symbol), len(cold_symbol), ABSENT_QUERY))
+
+    warm_prose = locate_paths(warm["answers"][PROSE_QUERY])
+    cold_prose = locate_paths(cold["answers"][PROSE_QUERY])
+    if warm_prose is None or cold_prose is None:
+        res.unknown("the prose query produced an unreadable locate payload")
+        return res
+
+    if paths_agree(warm_prose, cold_prose):
+        res.ok("%r retrieved the same %d file(s) through both daemon states: %s"
+               % (PROSE_QUERY, len(warm_prose), ", ".join(sorted(set(warm_prose))) or "none"))
+    else:
+        thin = warm if not warm_prose else cold
+        named = text_index_gap_reported(thin["answers"][PROSE_QUERY])
+        res.bad("%r retrieved %r through %s and %r through %s; the thin answer %s the "
+                "text-index gap"
+                % (PROSE_QUERY, sorted(set(warm_prose)), warm["label"],
+                   sorted(set(cold_prose)), cold["label"],
+                   "named" if named else "said nothing about"))
+
+    # The prose file has to be reachable at all, or "they agree" is two identical
+    # empty answers and this check has graded a product that answers nothing.
+    reachable = [arm["label"] for arm, paths in ((warm, warm_prose), (cold, cold_prose))
+                 if PROSE_FILE in paths]
+    if not reachable:
+        res.bad("%r carries the only occurrence of %r in this fixture and neither daemon "
+                "state retrieved it, so the agreement above is two identical silences"
+                % (PROSE_FILE, PROSE_QUERY))
+    else:
+        res.ok("%s retrieved %s for the prose query" % (" and ".join(reachable), PROSE_FILE))
+    return res
+
+
+def check_lexical_index_parity(suite):
+    """The mechanism under the behaviour: does the answering daemon hold the index?
+
+    `kin support --json` is answered by the daemon out of its own live graph, so
+    `text_indexed_entity_count` counts the documents the process serving queries
+    can actually see. A daemon holding a graph full of entities and a text index
+    holding none of them is the state a prose query cannot be answered from, and
+    it is invisible from the answer alone.
+    """
+    res = Result("2", "both daemon states hold a populated derived text index")
+    warm, cold = suite.arms()
+
+    warm_total = support_total_entities(warm["support"])
+    cold_total = support_total_entities(cold["support"])
+    if not warm_total or not cold_total:
+        res.unknown("kin support reported %r and %r entities, so there is no graph to have "
+                    "indexed and this check graded nothing" % (warm_total, cold_total))
+        return res
+
+    warm_indexed = support_text_indexed(warm["support"])
+    cold_indexed = support_text_indexed(cold["support"])
+    if warm_indexed is None or cold_indexed is None:
+        res.unknown("kin support did not carry a readable text_indexed_entity_count "
+                    "(warm %r, cold %r)" % (warm_indexed, cold_indexed))
+        return res
+
+    reading = ("warm %d of %d entities indexed, cold %d of %d"
+               % (warm_indexed, warm_total, cold_indexed, cold_total))
+    if warm_indexed == 0 or cold_indexed == 0:
+        res.bad("a daemon serving %d entities has %d of them in its derived text index, so a "
+                "lexical question cannot be answered from graph truth there: %s"
+                % (warm_total if warm_indexed == 0 else cold_total,
+                   min(warm_indexed, cold_indexed), reading))
+    elif warm_indexed != cold_indexed:
+        res.bad("the two daemon states disagree about how much of the graph is text indexed, "
+                "which is the same divergence one layer down: %s" % reading)
+    else:
+        res.ok(reading)
+    return res
+
+
+CHECKS = [check_prose_parity, check_lexical_index_parity]
+
+
+# ----------------------------------------------------------------- self-test
+
+
+def self_test():
+    """Hand every grader the input it must refuse, beside the one it must accept."""
+    failures = []
+
+    def want(label, condition):
+        if not condition:
+            failures.append(label)
+
+    good = {"files": [{"path": "pkg/overview.py", "score": 1.0}]}
+    want("a locate payload's paths are read",
+         locate_paths(good) == ["pkg/overview.py"])
+    want("an empty ranking reads as zero rows, not as unreadable",
+         locate_paths({"files": []}) == [])
+    want("a payload with no files key is unreadable, never zero",
+         locate_paths({}) is None)
+    want("a non-object payload is unreadable", locate_paths("files") is None)
+    want("a files list of non-objects is unreadable",
+         locate_paths({"files": ["pkg/overview.py"]}) is None)
+    want("a row with no path is unreadable",
+         locate_paths({"files": [{"score": 1.0}]}) is None)
+    want("a row with an empty path is unreadable",
+         locate_paths({"files": [{"path": ""}]}) is None)
+
+    want("a text_index degradation is recognised",
+         text_index_gap_reported(
+             {"degradations": [{"component": "text_index", "reason": "empty"}]}))
+    # The mutation that matters: a degradation ledger carrying some OTHER
+    # component is not a report about the lexical index, and a grader that
+    # accepted any degradation at all would pass on every query that ran with no
+    # vector index, which is every query this suite makes.
+    want("a vector_index degradation is not a text-index report",
+         not text_index_gap_reported(
+             {"degradations": [{"component": "vector_index", "reason": "absent"}]}))
+    want("an answer with no degradations reports no gap",
+         not text_index_gap_reported({"degradations": []}))
+    want("a payload with no ledger reports no gap", not text_index_gap_reported({}))
+
+    want("a support count is read", support_text_indexed({"text_indexed_entity_count": 7}) == 7)
+    want("zero is a real count, not an unreadable one",
+         support_text_indexed({"text_indexed_entity_count": 0}) == 0)
+    want("a missing count is unreadable, never zero",
+         support_text_indexed({}) is None)
+    want("a boolean is not a count",
+         support_text_indexed({"text_indexed_entity_count": True}) is None)
+    want("a string is not a count",
+         support_text_indexed({"text_indexed_entity_count": "7"}) is None)
+    want("a negative count is unreadable",
+         support_text_indexed({"text_indexed_entity_count": -1}) is None)
+    want("total_entities is read the same way",
+         support_total_entities({"total_entities": 12}) == 12)
+    want("a boolean total is not a count",
+         support_total_entities({"total_entities": True}) is None)
+
+    want("two arms naming the same file agree",
+         paths_agree(["a.py"], ["a.py"]))
+    want("order is not disagreement",
+         paths_agree(["a.py", "b.py"], ["b.py", "a.py"]))
+    want("a file one arm cannot retrieve is a disagreement",
+         not paths_agree(["a.py"], []))
+    want("an extra file on one side is a disagreement",
+         not paths_agree(["a.py"], ["a.py", "b.py"]))
+    want("an unreadable arm never agrees with anything",
+         not paths_agree(None, []))
+    want("two empty arms agree, which is why check 1 also asserts reachability",
+         paths_agree([], []))
+
+    empty = Result("x", "x")
+    want("a check that graded nothing is UNREADABLE", empty.status == UNREADABLE)
+    mixed = Result("x", "x")
+    mixed.ok("fine")
+    mixed.bad("not fine")
+    want("one FAIL outranks a pass", mixed.status == FAIL)
+    unreadable = Result("x", "x")
+    unreadable.ok("fine")
+    unreadable.unknown("could not read")
+    want("UNREADABLE outranks a pass", unreadable.status == UNREADABLE)
+
+    if failures:
+        print_("kin-prose-query-parity-repro: SELF-TEST FAILED")
+        for label in failures:
+            print_("  - %s" % label)
+        return 1
+    print_("kin-prose-query-parity-repro: self-test passed, "
+           "every grader refused the input it must refuse")
+    return 0
+
+
+# ---------------------------------------------------------------------- main
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"),
+                        help="the kin binary under test")
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"),
+                        help="the kin-daemon beside it")
+    parser.add_argument("--json", dest="json_path", default=None,
+                        help="write the machine-readable report here, for scripts/acceptance/gate.py")
+    parser.add_argument("--label", default=os.environ.get("KIN_ACCEPTANCE_LABEL"),
+                        help="an opaque run label recorded in the report")
+    parser.add_argument("--keep", action="store_true", help="keep the fixture")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true",
+                        help="falsify this suite's graders and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if not args.kin:
+        print_("kin-prose-query-parity-repro: no kin binary. Pass --kin or set KIN_BIN.")
+        return 3
+    # Absolute, because every command below runs with cwd inside a fixture in a
+    # temp directory, and a relative --daemon would resolve against that fixture.
+    kin = os.path.abspath(os.path.expanduser(args.kin))
+    if not os.path.isfile(kin) or not os.access(kin, os.X_OK):
+        print_("kin-prose-query-parity-repro: %s is not an executable file" % kin)
+        return 3
+    daemon = args.daemon and os.path.abspath(os.path.expanduser(args.daemon))
+    if not daemon:
+        beside = os.path.join(os.path.dirname(kin), "kin-daemon")
+        daemon = beside if os.path.isfile(beside) else None
+
+    workdir = tempfile.mkdtemp(prefix="kin-prose-query-parity-repro-")
+    suite = Suite(kin, workdir, daemon=daemon, verbose=args.verbose)
+    try:
+        results = []
+        for check in CHECKS:
+            try:
+                results.append(check(suite))
+            except ProbeError as error:
+                result = Result(getattr(check, "__name__", "check"), "probe could not read")
+                result.unknown(str(error))
+                results.append(result)
+            except Exception as error:  # noqa: BLE001 - a crashed probe is UNREADABLE
+                result = Result(getattr(check, "__name__", "check"), "probe crashed")
+                result.unknown("%s: %s" % (type(error).__name__, error))
+                results.append(result)
+        for result in results:
+            print_("CHECK %s %s %s %s" % (result.id, TICKET, result.status, result.detail))
+        failed = [r for r in results if r.status == FAIL]
+        unreadable = [r for r in results if r.status == UNREADABLE]
+        print_("kin-prose-query-parity-repro: %d checks, %d pass, %d FAIL, %d UNREADABLE"
+               % (len(results), len(results) - len(failed) - len(unreadable),
+                  len(failed), len(unreadable)))
+        if args.json_path:
+            payload = {
+                "suite": "prose_query_parity_repro",
+                "ticket": TICKET,
+                "label": args.label,
+                "kin": kin,
+                "results": [
+                    {"id": r.id, "ticket": TICKET, "title": r.title,
+                     "status": r.status, "detail": r.detail, "asserts": r.asserts}
+                    for r in results
+                ],
+            }
+            directory = os.path.dirname(os.path.abspath(args.json_path))
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            with open(args.json_path, "w") as handle:
+                json.dump(payload, handle, indent=2)
+                handle.write("\n")
+        return 0
+    finally:
+        suite.stop_daemon()
+        if args.keep:
+            print_("kin-prose-query-parity-repro: fixture kept at %s" % workdir)
+        else:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/acceptance/prose_query_parity_repro.py
+++ b/scripts/acceptance/prose_query_parity_repro.py
@@ -35,9 +35,11 @@ Two checks, and the second is underneath the first.
   `lexical_index_parity` asks the mechanism question the behaviour rests on.
   `kin support --json` is served by the daemon out of its own live graph, so
   `text_indexed_entity_count` is what the process answering the query can
-  actually see. Both daemon states must report the derived text index carrying
-  documents, and the check reports both numbers whatever it decides, because a
-  number in a detail line is evidence and a verdict alone is not.
+  actually see. It is read after that daemon has answered, because the question
+  is what the process serving queries holds, not what it held before anything
+  asked it anything. Both daemon states must report the derived text index
+  carrying documents, and the check reports both numbers whatever it decides,
+  because a number in a detail line is evidence and a verdict alone is not.
 
 Output shape matches the siblings:
 
@@ -460,10 +462,17 @@ class Suite(object):
         return pid if isinstance(pid, int) else None
 
     def read_arm(self, label):
-        arm = {"label": label, "pid": self.daemon_pid(),
-               "support": self.support_json(), "answers": {}}
+        """One daemon state: which process, what it answered, what it then held.
+
+        The support read comes AFTER the queries on purpose. The question check 2
+        asks is whether the daemon that just answered holds a populated lexical
+        index, not what it held before anything asked it anything, and reading it
+        first would grade a moment no caller ever observes.
+        """
+        arm = {"label": label, "pid": self.daemon_pid(), "answers": {}}
         for query in (PROSE_QUERY, SYMBOL_QUERY, ABSENT_QUERY):
             arm["answers"][query] = self.locate_json(query)
+        arm["support"] = self.support_json()
         return arm
 
     def arms(self):
@@ -594,7 +603,7 @@ def check_lexical_index_parity(suite):
     holding none of them is the state a prose query cannot be answered from, and
     it is invisible from the answer alone.
     """
-    res = Result("2", "both daemon states hold a populated derived text index")
+    res = Result("2", "a daemon that just answered holds a populated derived text index")
     warm, cold = suite.arms()
 
     warm_total = support_total_entities(warm["support"])

--- a/scripts/acceptance/prose_query_parity_repro.py
+++ b/scripts/acceptance/prose_query_parity_repro.py
@@ -327,11 +327,24 @@ class Suite(object):
         self.daemon = daemon
         self.verbose = verbose
         self.repo = os.path.join(workdir, "repo")
+        home = os.path.join(workdir, "home")
+        os.makedirs(home, exist_ok=True)
+        # kin refuses to invent an author, which is correct product behaviour and
+        # not an obstacle. This suite isolates HOME so it cannot read the
+        # machine's identity, so it brings one of its own; measured without it,
+        # the first `kin commit` exits 1 on "kin has no author identity to record
+        # for this change" and the whole suite grades nothing.
+        with open(os.path.join(home, ".gitconfig"), "w") as handle:
+            handle.write("[user]\n\tname = kin-prose-parity-repro\n"
+                         "\temail = prose-parity@example.invalid\n"
+                         "[commit]\n\tgpgsign = false\n")
         self.env = dict(os.environ)
-        # Scratch HOME and KIN_HOME, so this suite can never touch a developer's
-        # real store and two concurrent runs cannot share one.
-        self.env["HOME"] = os.path.join(workdir, "home")
+        # Scratch HOME, KIN_HOME and registry, so this suite can never touch a
+        # developer's real store and two concurrent runs cannot share one.
+        self.env["HOME"] = home
+        self.env["USERPROFILE"] = home
         self.env["KIN_HOME"] = os.path.join(workdir, "kin-home")
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(home, "registry.toml")
         # No vector index, like every sibling here. That is deliberate: with no
         # embeddings, retrieval for a prose term is lexical and graph only, so
         # the arm cannot be answered by a semantic signal standing in for the
@@ -349,7 +362,7 @@ class Suite(object):
         self.env.pop("KIN_DAEMON_URL", None)
         if daemon:
             self.env["KIN_DAEMON_BIN"] = daemon
-        for path in (self.env["HOME"], self.env["KIN_HOME"], self.repo):
+        for path in (self.env["KIN_HOME"], self.repo):
             os.makedirs(path, exist_ok=True)
         self._arms = None
         self._setup_error = None

--- a/scripts/acceptance/prose_query_parity_repro.py
+++ b/scripts/acceptance/prose_query_parity_repro.py
@@ -340,10 +340,10 @@ class Suite(object):
         self.env["KIN_EMBED_BACKEND"] = "cpu"
         self.env["KIN_VFS_DISABLE"] = "1"
         # A CLI-autostarted daemon idles out after 60s by default. Without this,
-        # the settle below would let the daemon `kin init` left exit and the
-        # first arm would silently read a REPLACEMENT daemon, which is the one
-        # state where this whole suite passes for the wrong reason. Held open
-        # well past the settle, and the pid is asserted either way.
+        # the settle below would let the long-lived daemon exit and the first arm
+        # would silently read a REPLACEMENT daemon, which is the one state where
+        # this whole suite passes for the wrong reason. Held open well past the
+        # settle, and the pid is asserted either way.
         self.env["KIN_DAEMON_IDLE_TIMEOUT_SECS"] = "900"
         self.env.pop("KIN_MCP_REPO", None)
         self.env.pop("KIN_DAEMON_URL", None)

--- a/scripts/acceptance/prose_query_parity_repro.py
+++ b/scripts/acceptance/prose_query_parity_repro.py
@@ -27,10 +27,12 @@ Two checks, and the second is underneath the first.
   `prose_parity` asks the behaviour question. One term that lives only in a
   docstring, asked through both daemon states, has to come back with the same
   files. Two controls decide whether the arm graded anything at all: a symbol
-  the fixture defines must retrieve in both states, or the fixture was never
-  ingested and an agreement at zero is agreement about nothing; and a fabricated
-  term must retrieve in neither, or the row counter is counting something other
-  than rows.
+  the fixture defines must come back as a NAMED match in both states, or the
+  fixture was never ingested and an agreement at zero is agreement about
+  nothing; and a fabricated term must name nothing in either, which is the shape
+  the product actually has. It is not that a fabricated term retrieves nothing:
+  measured here, it retrieves one row against a populated index, so a control
+  written the obvious way could never have fired.
 
   `lexical_index_parity` asks the mechanism question the behaviour rests on.
   `kin support --json` is served by the daemon out of its own live graph, so
@@ -60,7 +62,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import time
 
 TICKET = "FIR-2918"
 PASS = "PASS"
@@ -86,14 +87,9 @@ SYMBOL_QUERY = "describe_layers"
 # that is not a result row.
 ABSENT_QUERY = "zzqxnotawordanywhere"
 
-# How long to wait for the daemon `kin init` left to be answering before the
-# first arm reads it. The daemon's own background persistence flushes on an
-# idle interval (KIN_DAEMON_IDLE_FLUSH_SECS, default 2s) and a periodic one
-# (KIN_DAEMON_PERIODIC_FLUSH_SECS, default 30s), so a wait comfortably past both
-# means arm A is not measuring a race the product would win on its own a moment
-# later. If the divergence survives this wait it is a state the product stays
-# in, not a window it passes through.
-SETTLE_SECONDS = int(os.environ.get("KIN_PROSE_PARITY_SETTLE_SECS", "40"))
+# The file the prose query must retrieve, named once so a fixture rename cannot
+# leave the assertion pointing at nothing.
+PROSE_FILE = "pkg/overview.py"
 
 
 print_ = print
@@ -179,11 +175,6 @@ def describe_layers():
     return "reading, holding, traversal"
 '''
 
-# The file the prose query must retrieve, named once so a fixture rename cannot
-# leave the assertion pointing at nothing.
-PROSE_FILE = "pkg/overview.py"
-
-
 # ------------------------------------------------------------------- graders
 #
 # Pure, so `--self-test` can falsify each one with no daemon, no repository and
@@ -213,6 +204,27 @@ def locate_paths(payload):
             return None
         paths.append(path)
     return paths
+
+
+def locate_all_fallback(payload):
+    """Did the whole ranking come back without one entity the query named?
+
+    `LocateResult::all_fallback` is the one field that separates "this query
+    found something" from "retrieval returned its best guesses". It is what makes
+    the fabricated control able to fail: measured on this fixture, a term that
+    appears nowhere still retrieves one row once the index is populated, so
+    "a fabricated term retrieves nothing" is false about this product and a
+    control resting on it could never fire.
+
+    None for a payload that is not a locate result, so an unreadable answer is
+    UNREADABLE rather than a confident false.
+    """
+    if not isinstance(payload, dict):
+        return None
+    if "files" not in payload:
+        return None
+    value = payload.get("all_fallback", False)
+    return value if isinstance(value, bool) else None
 
 
 def text_index_gap_reported(payload):
@@ -358,6 +370,22 @@ class Suite(object):
         # this whole suite passes for the wrong reason. Held open well past the
         # settle, and the pid is asserted either way.
         self.env["KIN_DAEMON_IDLE_TIMEOUT_SECS"] = "900"
+        # Hold the daemon's background index flush off, and this is the line that
+        # decides whether this suite can fail at all.
+        #
+        # The lexical index is staged on write and committed by
+        # `InMemoryGraph::flush_text_index`, which in a live daemon only the
+        # background persistence loop calls, 2s after the last mutation or every
+        # 30s (crates/kin-daemon/src/daemon.rs). Measured on
+        # kin 0.6.1 (ff18884e3) with the default cadence: 0 of 17 entities
+        # indexed at the moment the first query arrives, 17 of 17 sixty seconds
+        # later, on one unchanged daemon process. So the divergence is a race the
+        # daemon usually wins, and a suite that waits for it grades nothing.
+        # With both intervals held past this run, the same measurement reads 0 of
+        # 17 in both readings of that daemon, and a build whose query path makes
+        # the index current answers anyway. Both directions become deterministic.
+        self.env["KIN_DAEMON_IDLE_FLUSH_SECS"] = "86400"
+        self.env["KIN_DAEMON_PERIODIC_FLUSH_SECS"] = "86400"
         self.env.pop("KIN_MCP_REPO", None)
         self.env.pop("KIN_DAEMON_URL", None)
         if daemon:
@@ -507,19 +535,17 @@ class Suite(object):
             return self._arms
         try:
             self.build()
-            # The daemon the fixture was ingested through, named before the
-            # settle so the arm below can prove it is the same process.
+            # The daemon the fixture was ingested through, named before the arm
+            # so it can be shown to be the same process that answers it. No wait
+            # here on purpose: a stranger asks their first question seconds after
+            # committing, and that is the moment this suite is about.
             born = self.daemon_pid()
-            # Past both flush intervals, so a divergence here is a state and not
-            # a race the daemon closes on its own a second later.
-            time.sleep(SETTLE_SECONDS)
             warm = self.read_arm("the daemon that was live while the fixture was ingested")
             if born is None or warm["pid"] is None or born != warm["pid"]:
                 raise ProbeError(
-                    "the daemon serving this repository changed from pid %r to pid %r across "
-                    "the %ds settle, so the first arm is a replacement daemon and this run "
-                    "cannot grade the state the ticket is about"
-                    % (born, warm["pid"], SETTLE_SECONDS))
+                    "the daemon serving this repository changed from pid %r to pid %r while the "
+                    "first arm was being read, so that arm is a replacement daemon and this run "
+                    "cannot grade the state the ticket is about" % (born, warm["pid"]))
             rc, out, err = self.run(["daemon", "stop"])
             if rc != 0:
                 raise ProbeError("kin daemon stop exited %d: %s" % (rc, tail(err or out)))
@@ -561,7 +587,10 @@ def check_prose_parity(suite):
 
     warm_symbol = locate_paths(warm["answers"][SYMBOL_QUERY])
     cold_symbol = locate_paths(cold["answers"][SYMBOL_QUERY])
-    if warm_symbol is None or cold_symbol is None:
+    warm_symbol_named = locate_all_fallback(warm["answers"][SYMBOL_QUERY])
+    cold_symbol_named = locate_all_fallback(cold["answers"][SYMBOL_QUERY])
+    if warm_symbol is None or cold_symbol is None or warm_symbol_named is None \
+            or cold_symbol_named is None:
         res.unknown("the symbol control produced an unreadable locate payload, so nothing "
                     "below can be attributed to the product")
         return res
@@ -570,19 +599,33 @@ def check_prose_parity(suite):
                     "the fixture was not ingested and an agreement at zero would be agreement "
                     "about nothing" % (SYMBOL_QUERY, len(warm_symbol), len(cold_symbol)))
         return res
+    if warm_symbol_named or cold_symbol_named:
+        res.unknown("the symbol control %r came back all-fallback (warm %r, cold %r), so this "
+                    "build does not name a symbol it defines and the fabricated control below "
+                    "cannot mean anything" % (SYMBOL_QUERY, warm_symbol_named, cold_symbol_named))
+        return res
 
+    # The fabricated control, and the shape of it is a measurement rather than an
+    # assumption. On this fixture a term that appears nowhere still retrieves one
+    # row once the index is populated, so what it must never do is NAME
+    # something: `all_fallback` has to be true wherever it retrieves at all.
     warm_absent = locate_paths(warm["answers"][ABSENT_QUERY])
     cold_absent = locate_paths(cold["answers"][ABSENT_QUERY])
-    if warm_absent is None or cold_absent is None:
-        res.unknown("the absent control produced an unreadable locate payload")
+    warm_absent_named = locate_all_fallback(warm["answers"][ABSENT_QUERY])
+    cold_absent_named = locate_all_fallback(cold["answers"][ABSENT_QUERY])
+    if warm_absent is None or cold_absent is None or warm_absent_named is None \
+            or cold_absent_named is None:
+        res.unknown("the fabricated control produced an unreadable locate payload")
         return res
-    if warm_absent or cold_absent:
-        res.unknown("the fabricated term %r retrieved %d and %d rows, so the row reader is "
-                    "counting something other than results and no verdict below is safe"
-                    % (ABSENT_QUERY, len(warm_absent), len(cold_absent)))
-        return res
-    res.ok("controls held: %r retrieved %d and %d rows, %r retrieved none in either state"
-           % (SYMBOL_QUERY, len(warm_symbol), len(cold_symbol), ABSENT_QUERY))
+    for label, paths, fallback in (("warm", warm_absent, warm_absent_named),
+                                   ("cold", cold_absent, cold_absent_named)):
+        if paths and not fallback:
+            res.unknown("the fabricated term %r produced a NAMED match on the %s arm (%r), so "
+                        "the fallback reader is not separating a match from a guess and no "
+                        "verdict below is safe" % (ABSENT_QUERY, label, paths))
+            return res
+    res.ok("controls held: %r named a match in both states, %r named one in neither"
+           % (SYMBOL_QUERY, ABSENT_QUERY))
 
     warm_prose = locate_paths(warm["answers"][PROSE_QUERY])
     cold_prose = locate_paths(cold["answers"][PROSE_QUERY])
@@ -684,6 +727,17 @@ def self_test():
          locate_paths({"files": [{"score": 1.0}]}) is None)
     want("a row with an empty path is unreadable",
          locate_paths({"files": [{"path": ""}]}) is None)
+
+    want("a fallback ranking is read as fallback",
+         locate_all_fallback({"files": [], "all_fallback": True}) is True)
+    want("a named match is read as not fallback",
+         locate_all_fallback({"files": [], "all_fallback": False}) is False)
+    want("an omitted all_fallback means a named match, which is how it serializes",
+         locate_all_fallback({"files": []}) is False)
+    want("a payload that is not a locate result is unreadable, not a named match",
+         locate_all_fallback({"all_fallback": True}) is None)
+    want("a non-boolean all_fallback is unreadable",
+         locate_all_fallback({"files": [], "all_fallback": "yes"}) is None)
 
     want("a text_index degradation is recognised",
          text_index_gap_reported(

--- a/scripts/acceptance/prose_query_parity_repro.py
+++ b/scripts/acceptance/prose_query_parity_repro.py
@@ -8,14 +8,19 @@ FIR-2918. `kin locate` has no daemonless arm: `capture` refuses
 `KIN_LOCATE_FORCE_LOCAL` outright and every query goes to `POST /locate` on a
 daemon, auto-starting one when none is up. So the two readings this ticket was
 filed on are not two code paths. They are one path against two daemon states,
-and the discriminator is which daemon process answers: the one `kin init` left
-running, or the one the next command starts after `kin daemon stop`.
+and the discriminator is which daemon process answers.
 
-That distinction is the whole finding. A stranger installs Kin, runs `kin init`,
-commits some code and asks an English question, and the daemon answering is the
-one `kin init` left behind. If a prose-only term retrieves nothing there and
-retrieves its file after a restart, the product told that stranger their code
-does not mention something it does mention, and said nothing about why.
+`kin init` stops the daemon its conversion phase started unless it borrowed a
+live one (`stop_conversion_daemon` in crates/kin-cli/src/commands/init.rs), so
+the long-lived process here is the one the first `kin commit` auto-starts, and it
+stays up through every later commit. That is the daemon a stranger's first
+English question reaches. The other state is a daemon opened after the content
+already exists, which is what `kin daemon stop` plus one more command produces.
+
+That distinction is the whole finding. If a prose-only term retrieves nothing
+through the daemon that was live while the code was ingested, and retrieves its
+file through one opened afterwards, the product told a stranger their code does
+not mention something it does mention, and said nothing about why.
 
 Two checks, and the second is underneath the first.
 
@@ -478,7 +483,7 @@ class Suite(object):
             # Past both flush intervals, so a divergence here is a state and not
             # a race the daemon closes on its own a second later.
             time.sleep(SETTLE_SECONDS)
-            warm = self.read_arm("the daemon kin init left running")
+            warm = self.read_arm("the daemon that was live while the fixture was ingested")
             if born is None or warm["pid"] is None or born != warm["pid"]:
                 raise ProbeError(
                     "the daemon serving this repository changed from pid %r to pid %r across "
@@ -488,7 +493,7 @@ class Suite(object):
             rc, out, err = self.run(["daemon", "stop"])
             if rc != 0:
                 raise ProbeError("kin daemon stop exited %d: %s" % (rc, tail(err or out)))
-            cold = self.read_arm("a daemon started after kin daemon stop")
+            cold = self.read_arm("a daemon opened after the fixture already existed")
             if cold["pid"] is None or cold["pid"] == warm["pid"]:
                 raise ProbeError(
                     "the second arm is served by pid %r, the same process as the first, so "

--- a/scripts/acceptance/prose_query_parity_repro.py
+++ b/scripts/acceptance/prose_query_parity_repro.py
@@ -469,9 +469,15 @@ class Suite(object):
         index, not what it held before anything asked it anything, and reading it
         first would grade a moment no caller ever observes.
         """
-        arm = {"label": label, "pid": self.daemon_pid(), "answers": {}}
+        arm = {"label": label, "answers": {}}
         for query in (PROSE_QUERY, SYMBOL_QUERY, ABSENT_QUERY):
             arm["answers"][query] = self.locate_json(query)
+        # After the queries, for two reasons. `kin daemon status` reads recorded
+        # endpoints and starts nothing, so on the arm that follows
+        # `kin daemon stop` there is no daemon to name until a query has started
+        # one; and reading it here reports the process that actually answered
+        # rather than one that could have been replaced since.
+        arm["pid"] = self.daemon_pid()
         arm["support"] = self.support_json()
         return arm
 
@@ -488,6 +494,8 @@ class Suite(object):
             return self._arms
         try:
             self.build()
+            # The daemon the fixture was ingested through, named before the
+            # settle so the arm below can prove it is the same process.
             born = self.daemon_pid()
             # Past both flush intervals, so a divergence here is a state and not
             # a race the daemon closes on its own a second later.

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -137,6 +137,11 @@ EXPECTED_SUITES = (
         "bridge_reach",
         "acceptance/bridge_reach.json",
     ),
+    ExpectedSuite(
+        "scripts/acceptance/prose_query_parity_repro.py",
+        "prose_parity",
+        "acceptance/prose_parity.json",
+    ),
 )
 
 


### PR DESCRIPTION
A stranger who installs Kin, commits some code and asks an English question gets "No relevant files found." over a graph that holds the word, and a minute later the same daemon answers correctly with nothing done to it. Measured before anything was written, because the ticket's framing decides the fix and it was wrong on the code: `kin locate` has no daemonless path at all, so both readings in the ticket take one code path and what differs is which daemon process answers. The mechanism is that the lexical index is STAGED on write and `flush_text_index` is the commit, and in a live daemon the only caller is the background persistence loop, two seconds after the last mutation or every thirty. On a four-module fixture at the default cadence: 0 of 17 entities text indexed at the moment the first question arrives, 17 of 17 sixty seconds later, on one unchanged daemon pid, with the on-disk index going from 1 file and 133 bytes to 18 files and 44680 bytes across that wait. A second run holding the flush off with the daemon's own two levers never closes the window, which is what proves the flush is the only thing that closes it. So it is a window rather than a state, which is worse than the ticket read it, because it is not reproducible on demand.

The fix is one helper and two call sites. `ensure_lexical_index_queryable` makes the derived index current from graph truth before a query reads it, and `run_with_graph_capture_budgeted` and `collect_daemon_search_response` call it. Query entry rather than every mutation, deliberately: the mutation surface is commit, checkout, rename, stash, merge, rollback, tag, the MCP writes and the language-server sweep, and the read surface is those two. A clean index returns on two atomics and a dirty one pays exactly the commit the daemon would have paid moments later. One state costs more and is taken deliberately: a batch relation write sets `text_full_rebuild_required` and the flush does that whole rebuild inline, which beats the alternative, since while that flag is set `text_search` refuses outright and this pipeline swallows the refusal with a bare `continue` at four of its stages while propagating it with `?` at others. The second half is the silence: an answer built with no lexical evidence at all carried three degradations and not one of them mentioned the index, so a graph whose lexical index holds nothing now reports a `text_index` gap through the degradation ledger, which the human surface renders as a component-prefixed coverage note and the daemon carries into the answer's own `degradations[]`, rather than answering thin.

`scripts/acceptance/prose_query_parity_repro.py` asks one docstring-only term through both daemon states and requires the same files, with its controls gating the verdict: the symbol query must name a match in both states or the run is UNREADABLE rather than a pass, the fabricated term must name one in neither, and two different daemon pids must have answered. A second check reads `kin support --json` from each daemon and fails when either serves a non-empty graph with an empty text index. Two findings came out of building it. The negative control as first written could never fail, because on this fixture a fabricated term still retrieves one row once the index is populated, so it now grades `all_fallback` instead. And a settle before the first arm would have destroyed the check outright, since the daemon wins that race inside sixty seconds, so the suite holds the background flush off with the product's own levers and the pre-fix failure is deterministic.


Falsified as a grid rather than as a pass. Five arms, each removing a property of the CODE and never of a test, graded on WHICH assertion answered rather than on the arm going red, with the listing asserted before every run against the exact filter string the run uses and a fabricated full path that must be absent. Removing the locate call turns the retrieval test red on "the query path left the lexical index empty" and the gap test red on a ledger holding `vector_index` and `graph_source_bodies` and nothing about the text index, which is the pre-fix silence itself; that arm leaves `kin search` green, and only the arm that removes the search call turns it red. Two findings came out of the falsification rather than the fix. The previous driver graded nothing at all, because libtest under `--exact` matches the full test path and it was handed a bare leaf name, so every cell printed the same `test result: ok` a clean pass prints and only an assertion on `running 1 test` separated them. Its listing control could not catch that, and this is the part worth keeping: a leaf name is always a substring of its own full path, so a substring listing control returns PRESENT for exactly the name the run will then fail to match. The control now asserts the exact string the run will use.

Proven end to end with both arms on ONE tree and ONE instrument, because the lane's first before-and-after compared a pre-fix binary at one sha against a fixed binary six upstream commits later, which varies the code and the base at once. The before arm is `origin/main`'s copies of the two product files dropped into HEAD, so the only thing that differs is the fix. Before, on binary `09ddf7c98b097252`: both checks FAIL, with the suite reporting "a daemon serving 17 entities has 0 of them in its derived text index... warm 0 of 17 entities indexed, cold 17 of 17". After, on binary `d426a3d47635a7fb`: both PASS, "'socket' retrieved the same 1 file(s) through both daemon states: pkg/overview.py", two different daemon pids named, both controls holding, warm 17 of 17 and cold 17 of 17. The driver refuses to grade if the two arms share a binary sha256, since a build that did not happen leaves the previous arm's bytes in place and reads exactly like a result, and every verdict comes out of the suite's JSON report rather than its exit code, because the suite returns 0 on every outcome by design and leaves the verdict to the acceptance gate.

Gates run locally: `bin/kin-precheck kin` graded this tree 14 of 16 and named both failures, `cargo fmt -- --check` on three hunks in the new tests and clippy's `needless_lifetimes` on a test helper, which exit 101 turned into a build failure for the whole lib test target. Both are fixed in their own commit; every changed line there is inside `mod tests` and the product region carrying the helper and its two call sites hashes identically before and after, so the grid and the A/B still describe the code being shipped. `cargo fmt --all -- --check` is clean on the rebased tree, the workflow visibility guard passes at 19 suites, and the suite's own `--self-test` passes its 33 grader assertions. The full workspace suite and the clippy leg are left to hosted CI, which is the gate of record.

One thing a reader should know rather than discover: the `Product Acceptance` job carries `if: github.event_name != 'pull_request'`, so this new suite, like all eighteen of its siblings, does not run on the pull request and first grades on main after the merge. That is the existing shape rather than anything this change introduces, and it is the catalogued case of a guard that runs only where the pull-request gate skips.


## The one CI failure this change caused, and where its real defect went

The first push went red on exactly one test, `kin-daemon api::tests::a_degraded_daemon_reaches_the_search_cli_through_the_route`, and the jobs were read rather than the rollup: `Fast gate test shard (1)` failed on a named runner while shards 2 and 3 passed, so this was a genuine red and not the zero-failed-jobs infrastructure shape.

The fixture decides which side the fix belongs on. The corpus is one entity, name `present`, signature `def present()`, file `src/a.py`, no doc summary, and the query is `definitelyNoSuchSymbol`, no token of which occurs in that corpus whether taken whole or camel-split. Reading `kin_search::fuzzy_search` predicted that nothing would score, twice, and both times the story was coherent and wrong. Probing printed the row: one record, `present`, `match_kind: TextFallback`, `score: 0.45207196`, `text_fallback: true`. The mechanism is `def`, which the signature puts in the vocabulary and which is a substring of the query token `definitely`, so the substring branch matched a query token against a vocabulary term contained inside it. That is a wrong answer reported as a right one, and bringing the index current makes it reachable from the first minute rather than the second.

That defect is not fixed here, and deliberately so. Requiring a query term to actually occur in a returned document needs the index's own tokenizer and field builder, and kin-db declares `mod text;` privately inside `search` while re-exporting only `resolve_roles`, `ScoredHit` and `TextIndex`, so a check written in kin-cli would be a second independent reading of what a document contains, hardcoding the metadata keys the producer also hardcodes, and the two would drift with nothing to notice. It is filed as FIR-2968 at High with the printed row and the reproduction.

What is fixed here is the disclosure. The rows already say what they are, per row as `match_kind: TextFallback` and per response as `text_fallback`, whose own comment exists so a reader who never looks at a single row still learns that nothing matched by name. The absence qualifier was gated on `records.is_empty()` alone, so it fell silent the moment the fallback produced a row, which is the normal case once the index is populated: a stranger on a degraded daemon got a nearest document and no word about the degradation. The gate now reads `records.is_empty() || text_fallback`.

The test is not weakened. All three of its qualifier assertions are untouched and they are what it exists for; only its precondition moved, from `records.is_empty()` to `result.text_fallback`, which states the property it always meant, that nothing matched by name, and no longer holds for the wrong reason. Its sibling by-name control is untouched and still requires a populated answer to carry no qualifier.

Falsified with a fabricated test name grading NOT-RUN before any cell counted, which it did at `running 0 tests`. M0, with the gate reading `text_fallback`: the degraded route test, the by-name control and the FIR-2918 search test all PASS, the degraded cell showing `running 1 test ... ok`. M1, with `|| text_fallback` removed, is required to go red on the QUALIFIER assertion specifically rather than merely to go red, because that test also carries a precondition that would fail for a different reason and would look identical from the exit code.

Closes FIR-2918
Refs FIR-2968
