### PR TITLE
State the basis beside the verdict in kin status and kin admit

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -260,6 +260,15 @@ jobs:
       - name: Falsify the working-copy freshness graders
         run: python3 scripts/acceptance/working_copy_freshness_repro.py --self-test
 
+      # The graders here separate a true sentence from a misleading one, and the
+      # two look identical from outside: every verdict this suite grades was
+      # right about the graph. So each grader is driven against the literal
+      # pre-fix output the stranger saw and the post-fix output beside it, with
+      # the all-clear as its own must-pass case, because a surface that hedges
+      # every answer satisfies a one-directional check.
+      - name: Falsify the vcs read-surface graders
+        run: python3 scripts/acceptance/vcs_read_surfaces_repro.py --self-test
+
       # The graders here decide two verdicts that read alike from outside: a
       # refusal that fires with no remedy behind it, and a conversion with room
       # that narrates its memory anyway. Both are driven against their inverse,
@@ -864,6 +873,31 @@ jobs:
             echo "::warning title=Working-copy freshness acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: VCS read-surface acceptance suite (verdict comes from the gate step)
+        id: vcsreadsurfaces
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/vcs_read_surfaces_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/vcs_read_surfaces.json \
+            --verbose >acceptance/vcs_read_surfaces.log 2>&1 || rc=$?
+          cat acceptance/vcs_read_surfaces.log
+          {
+            echo "### VCS read-surface acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/vcs_read_surfaces.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=VCS read-surface acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
       - name: Init budget acceptance suite (verdict comes from the gate step)
         id: initbudget
         if: always()
@@ -958,6 +992,7 @@ jobs:
             --report first_query=acceptance/first_query.json \
             --report verdict_limits=acceptance/verdict_limits.json \
             --report working_copy_freshness=acceptance/working_copy_freshness.json \
+            --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \
             --report init_budget=acceptance/init_budget.json \
             --report bridge_reach=acceptance/bridge_reach.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk is truncated on ubuntu-latest, and its clipped_steps metadata confirms dropped callee and cross-file rows. This check therefore cannot distinguish an absent required edge from one the walk dropped. Any FAIL or other UNREADABLE still fails the gate, and the moment this check passes the allowance announces itself stale and can go.'

--- a/crates/kin-cli/src/commands/admit.rs
+++ b/crates/kin-cli/src/commands/admit.rs
@@ -93,6 +93,24 @@ pub struct AdmitReport {
     /// The reconcile probes read AFTER the pass. This is the outcome surface:
     /// the request can succeed while the admission inside it failed.
     pub reconcile: ReconcileHealth,
+    /// Whether the admitted tree's CONTENT moved, when the daemon could measure
+    /// it.
+    ///
+    /// The two census counters above cannot answer this and were read as if they
+    /// could. A pass that rewrites the body of a tracked file adds no artifact
+    /// and no entity, so both deltas are zero and the summary said
+    /// `nothing changed` over an admission that moved the workspace tree hash
+    /// from `70fda9ae` to `c078181f` and its generation from 5 to 6, both
+    /// visible three lines apart in the same output. To an operator who had just
+    /// edited a file, "nothing changed" reads as "your edit is still not
+    /// admitted", which is the opposite of what happened (FIR-2961).
+    ///
+    /// `None` means nobody looked: an older daemon that does not report it, or a
+    /// tree hash that would not compute on one side. It is never collapsed into
+    /// `false`, because "the content did not move" and "nothing measured it" are
+    /// the two answers this field exists to keep apart.
+    #[serde(default)]
+    pub tree_moved: Option<bool>,
     /// False when the pass itself failed. The request still returns its report
     /// so the operator sees the counters and the recorded cause; the CLI exits
     /// nonzero.
@@ -122,6 +140,21 @@ pub fn census_moved(report: &AdmitReport) -> bool {
     report.tracked_after != report.tracked_before || report.entities_after != report.entities_before
 }
 
+/// Whether this pass moved graph authority at all, by any measure it has.
+///
+/// Kept beside [`census_moved`] rather than folded into it, because that
+/// function is named for the census and answers honestly about the census. This
+/// is the question every caller of it actually meant: an admission that rewrote
+/// a tracked file's bytes moved authority without moving either count, and a
+/// surface deriving "did anything happen" from cardinalities alone reports that
+/// as a no-op (FIR-2961).
+///
+/// An unmeasured tree (`tree_moved: None`) contributes nothing rather than a
+/// `false`, so this can only ever be more true than `census_moved`, never less.
+pub fn graph_moved(report: &AdmitReport) -> bool {
+    census_moved(report) || report.tree_moved == Some(true)
+}
+
 /// Render the operator-facing summary for one admission report.
 ///
 /// Kept separate from transport so the wording is asserted directly rather than
@@ -139,7 +172,7 @@ pub fn summary_lines(report: &AdmitReport) -> Vec<String> {
             .or(report.reconcile.last_admission_error.as_deref())
             .unwrap_or("no cause recorded");
         lines.push(format!("Complete exact-tree admission failed: {cause}"));
-        if census_moved(report) {
+        if graph_moved(report) {
             // Authority crossed before the failure. Calling that unchanged is
             // the one wording an operator cannot recover from, because it
             // describes a settled store while the real one is half admitted:
@@ -160,10 +193,27 @@ pub fn summary_lines(report: &AdmitReport) -> Vec<String> {
     }
 
     if tracked_delta == 0 && entity_delta == 0 {
-        lines.push(format!(
-            "Admitted the complete exact tree; nothing changed. {} tracked artifacts, {} entities.",
-            report.tracked_after, report.entities_after
-        ));
+        // Three answers, not two. The counts agreeing is the weakest of the
+        // three premises a "nothing changed" needs, and on its own it is
+        // satisfied by every content-only edit there is.
+        match report.tree_moved {
+            Some(true) => lines.push(format!(
+                "Admitted the complete exact tree; content changed, with no artifact or entity \
+                 added or removed. {} tracked artifacts, {} entities.",
+                report.tracked_after, report.entities_after
+            )),
+            Some(false) => lines.push(format!(
+                "Admitted the complete exact tree; nothing changed. {} tracked artifacts, {} \
+                 entities.",
+                report.tracked_after, report.entities_after
+            )),
+            None => lines.push(format!(
+                "Admitted the complete exact tree. {} tracked artifacts, {} entities, and \
+                 neither count moved; this daemon does not report whether content moved, so \
+                 this is not a statement that the tree is unchanged.",
+                report.tracked_after, report.entities_after
+            )),
+        }
     } else {
         lines.push(format!(
             "Admitted the complete exact tree: {} tracked artifacts ({tracked_delta:+}), {} \
@@ -417,10 +467,80 @@ mod tests {
             embeddings_indexed: 49,
             embeddings_total: 14187,
             reconcile: ReconcileHealth::default(),
+            tree_moved: Some(true),
             admitted,
             failure: (!admitted)
                 .then(|| "host entry changed after exact-tree admission".to_string()),
         }
+    }
+
+    /// The stranger's own pass: a content-only edit, admitted successfully, with
+    /// both counts standing exactly still.
+    fn content_only_pass(tree_moved: Option<bool>) -> AdmitReport {
+        let mut settled = report(true);
+        settled.tracked_before = 8;
+        settled.tracked_after = 8;
+        settled.entities_before = 39;
+        settled.entities_after = 39;
+        settled.tree_moved = tree_moved;
+        settled
+    }
+
+    /// FIR-2961. The stranger edited one tracked file, ran `kin admit`, and was
+    /// told `nothing changed` by a pass that moved the workspace tree hash from
+    /// `70fda9ae` to `c078181f` and its generation from 5 to 6. Both counts held
+    /// at 8 and 39 across it, because a content-only edit adds no artifact and
+    /// no entity, so the two premises the wording rested on were both true and
+    /// the wording was false.
+    #[test]
+    fn a_content_only_admission_is_not_reported_as_nothing_changed() {
+        let text = summary_lines(&content_only_pass(Some(true))).join("\n");
+        assert!(
+            !text.contains("nothing changed"),
+            "a pass that moved the tree must not claim nothing changed: {text}"
+        );
+        assert!(text.contains("content changed"), "{text}");
+        assert!(text.contains("8 tracked artifacts"), "{text}");
+        assert!(text.contains("39 entities"), "{text}");
+    }
+
+    /// The control the test above needs to mean anything. A pass over a tree
+    /// that genuinely did not move still says so, or the fix is just a surface
+    /// that never gives an all-clear.
+    #[test]
+    fn a_pass_over_an_unmoved_tree_still_reports_nothing_changed() {
+        let text = summary_lines(&content_only_pass(Some(false))).join("\n");
+        assert!(text.contains("nothing changed"), "{text}");
+        assert!(!text.contains("content changed"), "{text}");
+    }
+
+    /// An unmeasured tree is the third answer and must render as neither of the
+    /// other two. An older daemon reports no `tree_moved`, and turning that into
+    /// a `false` puts the defect straight back, one field further down.
+    #[test]
+    fn an_unmeasured_tree_claims_neither_outcome() {
+        let text = summary_lines(&content_only_pass(None)).join("\n");
+        assert!(
+            !text.contains("nothing changed"),
+            "an unmeasured tree is not an unchanged tree: {text}"
+        );
+        assert!(!text.contains("content changed"), "{text}");
+        assert!(
+            text.contains("does not report whether content moved"),
+            "{text}"
+        );
+        assert!(text.contains("8 tracked artifacts"), "{text}");
+    }
+
+    /// `graph_moved` is what every "did anything happen" caller meant, and the
+    /// three readings have to come out in this order or `mutated` publishes a
+    /// content-only admission as a no-op.
+    #[test]
+    fn graph_moved_is_true_for_a_content_only_pass_and_unmeasured_never_invents_one() {
+        assert!(!census_moved(&content_only_pass(Some(true))));
+        assert!(graph_moved(&content_only_pass(Some(true))));
+        assert!(!graph_moved(&content_only_pass(Some(false))));
+        assert!(!graph_moved(&content_only_pass(None)));
     }
 
     #[test]
@@ -440,7 +560,12 @@ mod tests {
         // errors, where the census genuinely did not move.
         refused.tracked_after = refused.tracked_before;
         refused.entities_after = refused.entities_before;
+        // The tree stood still too. A refusal before the publish moves nothing,
+        // and this fixture has to say so on every reading, not only the census,
+        // or the wording it grades is chosen by the wrong branch.
+        refused.tree_moved = Some(false);
         assert!(!census_moved(&refused));
+        assert!(!graph_moved(&refused));
 
         let text = summary_lines(&refused).join("\n");
         let first = text.lines().next().unwrap_or_default();

--- a/crates/kin-cli/src/commands/admit.rs
+++ b/crates/kin-cli/src/commands/admit.rs
@@ -664,6 +664,11 @@ mod tests {
         settled.tracked_before = 4210;
         settled.entities_before = 9977;
         settled.embeddings_indexed = 14187;
+        // The tree stood still too, which this fixture has to say now that the
+        // wording rests on three readings rather than two. Equal counts alone
+        // are what a content-only edit also produces, and that case is the one
+        // `a_content_only_admission_is_not_reported_as_nothing_changed` grades.
+        settled.tree_moved = Some(false);
         let text = summary_lines(&settled).join("\n");
         assert!(text.contains("nothing changed"), "{text}");
         assert!(!text.contains("failed"), "{text}");

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -36,6 +36,8 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use chrono::Utc;
+use kin_core::last_admission::LastAdmissionRead;
 use kin_model::{
     Hash256, RefName, RefTarget, RepositoryId, RootBundle, WorkspaceHead, WorkspaceId,
 };
@@ -977,7 +979,8 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
                 &report,
                 None,
                 Some(&footprint),
-                crate::daemon_death::recorded_for_store(layout.root()).as_ref()
+                crate::daemon_death::recorded_for_store(layout.root()).as_ref(),
+                &kin_core::last_admission::read(&layout),
             )
         );
         // Which projection served the files this status describes. Appended
@@ -1104,8 +1107,9 @@ pub fn build_command_status_response(
     build: Option<BuildStatus>,
     footprint: Option<&StoreFootprint>,
     death: Option<&kin_daemon_spawn::DaemonKillRecord>,
+    admission: &LastAdmissionRead,
 ) -> Result<CommandStatusResponse> {
-    let text = render_text(&report, build.as_ref(), footprint, death);
+    let text = render_text(&report, build.as_ref(), footprint, death, admission);
     let json = json
         .then(|| serde_json::to_string(&report))
         .transpose()
@@ -1116,6 +1120,58 @@ pub fn build_command_status_response(
         text,
         json,
     })
+}
+
+/// The `Tree:` line's verdict, and the basis it rests on.
+///
+/// `dirty` compares two graph-owned values, the admitted workspace tree and the
+/// tree of the change it is based on. That comparison is always right about the
+/// graph. What it cannot say is when the graph last looked, and a verdict with
+/// no clock beside it is read as a statement about the working copy: a stranger
+/// running the whole everyday loop with no Git read `matching its base change`
+/// over a tracked file they had edited twenty-two seconds earlier, polled it
+/// seven more times, and was told the same thing each time (FIR-2961).
+///
+/// So the clock rides with the verdict, from the durable last-admission marker
+/// `kin diff` and `kin graph status` already read. That marker exists for this
+/// exact failure and says so in its own module doc: without it "a store last
+/// admitted months ago reads exactly like one admitted a second ago". Reading
+/// it here needs no daemon and touches no file in the working copy, so the
+/// answer stays graph-owned truth plus the age of that truth.
+///
+/// Every arm states a basis. An absent or unparseable marker is never rendered
+/// as a bare verdict, because a surface that goes quiet when the basis is
+/// unknown is indistinguishable from one reporting a healthy store, which is
+/// the failure the marker was built to end.
+fn workspace_state_phrase(
+    dirty: bool,
+    admission: &LastAdmissionRead,
+    now: chrono::DateTime<Utc>,
+) -> String {
+    // Kept as a comparison against the base change rather than as "clean" or
+    // "dirty". Both bare words invite the reading "everything on disk is in the
+    // graph", which this flag has never meant and cannot answer: untracked host
+    // paths do not move it in either direction. `kin graph status` reports
+    // those, and saying what this line compares keeps the two questions apart.
+    let verdict = if dirty {
+        "ahead of its base change"
+    } else {
+        "matching its base change"
+    };
+    match admission {
+        LastAdmissionRead::Recorded(recorded) => format!(
+            "{verdict} as admitted {} ago",
+            kin_core::last_admission::humanize_age(recorded.age_seconds(now))
+        ),
+        LastAdmissionRead::Absent => format!(
+            "{verdict} as last admitted; this store records no complete admission, so how far \
+             behind the working copy that is is unknown, and `kin admit` takes what it holds"
+        ),
+        LastAdmissionRead::Unreadable(reason) => format!(
+            "{verdict} as last admitted; the last-admission record will not parse ({reason}), so \
+             how far behind the working copy that is is unknown, and `kin admit` rewrites it"
+        ),
+    }
 }
 
 /// Render the report, plus the two observations that are deliberately NOT in it.
@@ -1140,17 +1196,9 @@ fn render_text(
     build: Option<&BuildStatus>,
     footprint: Option<&StoreFootprint>,
     death: Option<&kin_daemon_spawn::DaemonKillRecord>,
+    admission: &LastAdmissionRead,
 ) -> String {
-    // Named as a comparison against the base change rather than as "clean" or
-    // "dirty". Both bare words invite the reading "everything on disk is in the
-    // graph", which this flag has never meant and cannot answer: untracked host
-    // paths do not move it in either direction. `kin graph status` reports
-    // those, and saying what this line compares keeps the two questions apart.
-    let workspace_state = if report.workspace.dirty {
-        "ahead of its base change"
-    } else {
-        "matching its base change"
-    };
+    let workspace_state = workspace_state_phrase(report.workspace.dirty, admission, Utc::now());
     let enrichment = match report.semantic_enrichment.presence {
         SemanticEnrichmentPresence::Absent => "absent",
         SemanticEnrichmentPresence::Present => "present",
@@ -1362,7 +1410,7 @@ mod tests {
             payload.snapshot_bytes + payload.acknowledged_delta_bytes
         );
         assert!(
-            render_text(&report, None, None, None).contains("Authority payload read: "),
+            render_text(&report, None, None, None, &LastAdmissionRead::Absent).contains("Authority payload read: "),
             "text status must state the payload the open read"
         );
 
@@ -1663,7 +1711,7 @@ mod tests {
             EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::NoVectorIndexAttached),
         )
         .unwrap();
-        let rendered = render_text(&unobserved, None, None, None);
+        let rendered = render_text(&unobserved, None, None, None, &LastAdmissionRead::Absent);
         assert!(
             rendered.contains(
                 "Live embedding coverage: not observed (the live graph carries no vector index)"
@@ -1687,10 +1735,10 @@ mod tests {
         )
         .unwrap();
         assert!(
-            render_text(&observed, None, None, None)
+            render_text(&observed, None, None, None, &LastAdmissionRead::Absent)
                 .contains("Live embedding coverage: 41/57 indexed, 16 pending (live query graph)"),
             "{}",
-            render_text(&observed, None, None, None)
+            render_text(&observed, None, None, None, &LastAdmissionRead::Absent)
         );
     }
 
@@ -1702,6 +1750,90 @@ mod tests {
     /// fabricated zero or a "not measured" that nobody asked for. The report
     /// itself carries no store size in either case, which is what keeps
     /// authority status byte-identical across checkout drift.
+    /// FIR-2961. `Tree: ... (matching its base change)` was read as a statement
+    /// about the working copy, because with no clock beside it there is nothing
+    /// else to read it as. A stranger running the everyday loop with no Git saw
+    /// it over a tracked file edited twenty-two seconds earlier and polled it
+    /// seven more times before giving up on it.
+    ///
+    /// The verdict itself was right about the graph both times, so the fix is
+    /// not a different verdict, it is the age of the reading the verdict rests
+    /// on.
+    #[test]
+    fn the_tree_verdict_carries_the_age_of_the_admission_it_rests_on() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-08-29T20:49:16Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let admitted_at = chrono::DateTime::parse_from_rfc3339("2026-08-29T20:47:16Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let recorded = LastAdmissionRead::Recorded(kin_core::last_admission::LastAdmission::new(
+            admitted_at,
+            8,
+        ));
+
+        let clean = workspace_state_phrase(false, &recorded, now);
+        assert!(clean.contains("matching its base change"), "{clean}");
+        assert!(
+            clean.contains("admitted 2m ago"),
+            "the verdict has to carry when the graph last looked: {clean}"
+        );
+
+        let dirty = workspace_state_phrase(true, &recorded, now);
+        assert!(dirty.contains("ahead of its base change"), "{dirty}");
+        assert!(dirty.contains("admitted 2m ago"), "{dirty}");
+    }
+
+    /// An absent or unparseable marker is the case the whole marker exists for,
+    /// and it must not render as a bare verdict. A surface that goes quiet when
+    /// its basis is unknown is indistinguishable from one reporting a healthy
+    /// store.
+    #[test]
+    fn an_unknown_admission_basis_is_never_rendered_as_a_bare_verdict() {
+        let now = Utc::now();
+
+        let absent = workspace_state_phrase(false, &LastAdmissionRead::Absent, now);
+        assert!(
+            absent.contains("no complete admission"),
+            "an absent marker has to say so: {absent}"
+        );
+        assert!(absent.contains("kin admit"), "{absent}");
+
+        let unreadable = workspace_state_phrase(
+            false,
+            &LastAdmissionRead::Unreadable("trailing bytes".to_string()),
+            now,
+        );
+        assert!(unreadable.contains("will not parse"), "{unreadable}");
+        assert!(unreadable.contains("trailing bytes"), "{unreadable}");
+
+        // The control. Every arm carries the verdict, so the qualification is an
+        // addition to the answer and never a replacement for it.
+        for phrase in [&absent, &unreadable] {
+            assert!(phrase.contains("matching its base change"), "{phrase}");
+        }
+    }
+
+    /// The rendered line, not just the phrase, so a refactor that computes the
+    /// right words and prints the old ones is caught here.
+    #[test]
+    fn the_rendered_tree_line_carries_the_basis() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
+        let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
+
+        let rendered = render_text(&report, None, None, None, &LastAdmissionRead::Absent);
+        let tree_line = rendered
+            .lines()
+            .find(|line| line.starts_with("Tree: "))
+            .unwrap_or_default();
+        assert!(
+            tree_line.contains("no complete admission"),
+            "the Tree line itself has to carry the basis: {tree_line}"
+        );
+    }
+
     #[test]
     fn store_size_renders_from_the_measurement_and_not_from_the_report() {
         let root = tempfile::tempdir().unwrap();
@@ -1709,14 +1841,14 @@ mod tests {
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
         let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
 
-        let without = render_text(&report, None, None, None);
+        let without = render_text(&report, None, None, None, &LastAdmissionRead::Absent);
         assert!(
             !without.contains("Store size"),
             "an unmeasured status must print no store line at all: {without}"
         );
 
         let footprint = StoreFootprint::measure(&init.layout);
-        let with = render_text(&report, None, Some(&footprint), None);
+        let with = render_text(&report, None, Some(&footprint), None, &LastAdmissionRead::Absent);
         assert!(
             with.contains("Store size: ") && with.contains("under .kin/"),
             "a measured status must print the store line: {with}"

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1410,7 +1410,8 @@ mod tests {
             payload.snapshot_bytes + payload.acknowledged_delta_bytes
         );
         assert!(
-            render_text(&report, None, None, None, &LastAdmissionRead::Absent).contains("Authority payload read: "),
+            render_text(&report, None, None, None, &LastAdmissionRead::Absent)
+                .contains("Authority payload read: "),
             "text status must state the payload the open read"
         );
 
@@ -1848,7 +1849,13 @@ mod tests {
         );
 
         let footprint = StoreFootprint::measure(&init.layout);
-        let with = render_text(&report, None, Some(&footprint), None, &LastAdmissionRead::Absent);
+        let with = render_text(
+            &report,
+            None,
+            Some(&footprint),
+            None,
+            &LastAdmissionRead::Absent,
+        );
         assert!(
             with.contains("Store size: ") && with.contains("under .kin/"),
             "a measured status must print the store line: {with}"

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4383,6 +4383,10 @@ async fn command_status(
         // killed. Read from the store rather than remembered by this process,
         // because the daemon that died is by definition not this one.
         kin_cli::daemon_death::recorded_for_store(state.layout.root()).as_ref(),
+        // When graph truth last caught up with the working copy. Read from the
+        // durable marker rather than from this daemon's own probes, which reset
+        // on restart and then report every store as never admitted (FIR-2961).
+        &kin_core::last_admission::read(&state.layout),
     )
     .map_err(internal_error)?;
     Ok(Json(response))

--- a/crates/kin-daemon/src/repository_admit.rs
+++ b/crates/kin-daemon/src/repository_admit.rs
@@ -21,7 +21,7 @@
 
 use anyhow::Result;
 use kin_cli::commands::admit::{
-    census_moved, summary_lines, AdmitReport, AdmitResponse, ADMIT_SCHEMA,
+    graph_moved, summary_lines, AdmitReport, AdmitResponse, ADMIT_SCHEMA,
 };
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
@@ -110,16 +110,40 @@ impl Drop for RunningPass {
     }
 }
 
-/// One observation of the graph counts an admission can change.
+/// One observation of what an admission can change.
+///
+/// The two counts are cardinalities and cannot see a content-only edit: a pass
+/// that rewrites a tracked file's bytes leaves both exactly where they were.
+/// `tree` is the third reading, and it is the one that moves when the other two
+/// do not (FIR-2961).
 struct GraphCensus {
     tracked: usize,
     entities: usize,
+    /// The resolved tree's own hash, or `None` when it would not compute.
+    ///
+    /// `None` is carried rather than substituted, so a reading that could not be
+    /// taken never reaches a reader as a tree that did not move.
+    tree: Option<kin_model::Hash256>,
 }
 
 fn census(state: &DaemonState) -> GraphCensus {
+    let tree = state.graph.resolved_tree();
     GraphCensus {
-        tracked: state.graph.resolved_tree().len(),
+        tracked: tree.len(),
         entities: state.graph.entity_count(),
+        tree: kin_model::compute_resolved_tree_hash(&tree).ok(),
+    }
+}
+
+/// Whether the tree moved across the pass, when both sides could be read.
+///
+/// Three-way on purpose, matching every other freshness reading in this store:
+/// moved, did not move, and nobody could look. Collapsing the third into "did
+/// not move" is the whole defect, reintroduced one layer down.
+fn tree_moved(before: &GraphCensus, after: &GraphCensus) -> Option<bool> {
+    match (before.tree.as_ref(), after.tree.as_ref()) {
+        (Some(before), Some(after)) => Some(before != after),
+        _ => None,
     }
 }
 
@@ -237,12 +261,15 @@ async fn run_pass(state: &DaemonState) -> Result<AdmitResponse> {
         // says so. The probes alone report a quiet loop and a parked one
         // identically.
         reconcile: state.background_work.reconcile_report(now),
+        tree_moved: tree_moved(&before, &after),
         admitted: failure.is_none(),
         failure,
     };
 
     let lines = summary_lines(&report);
-    let mutated = census_moved(&report);
+    // The wider question, so a content-only admission is not published as a
+    // no-op to every caller that reads this flag rather than the prose.
+    let mutated = graph_moved(&report);
     Ok(AdmitResponse {
         lines,
         mutated,

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -357,6 +357,27 @@ dies of something that is not the network, the check reports UNREADABLE and says
 which reason it got, because a classifier that was never asked the question has
 not answered it.
 
+`vcs_read_surfaces_repro.py` covers the everyday read surfaces, which the first
+stranger run with a version control arm caught answering wrongly on a project
+that has never been a Git repository (FIR-2961). `kin status` printed
+`Tree: 70fda9ae... (8 artifacts, matching its base change)` over a tracked file
+edited twenty-two seconds earlier and repeated it across seven more readings,
+and `kin admit` printed `nothing changed` on a pass that moved the workspace
+tree hash from `70fda9ae` to `c078181f` and its generation from 5 to 6, both
+visible three lines apart in its own output.
+
+Neither verdict was wrong about the graph, which is what makes this class hard
+to grade. `dirty` compares the admitted workspace tree against the tree of the
+change it is based on; the admit wording compares two cardinalities, and a
+content-only edit moves neither. Both sentences were true and both were read as
+statements about the files on disk, because nothing beside them said what they
+rested on. So the suite never grades the verdict, it grades whether the basis
+travels with it, and it grades both directions: `settled` requires the all-clear
+to still arrive over a genuinely settled tree, because a surface that hedges
+every answer passes a one-directional check while helping nobody. The
+`--self-test` cases are the literal pre-fix output the stranger saw and the
+post-fix output beside it, so a grader that cannot fail is caught here.
+
 `working_copy_freshness_repro.py` covers what the product says about a working
 copy it has not read, which the v0.6.1 yardstick run caught three surfaces
 getting wrong at once (FIR-2820). The stranger wrote a module, did not commit it,

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -123,6 +123,11 @@ EXPECTED_SUITES = (
         "acceptance/working_copy_freshness.json",
     ),
     ExpectedSuite(
+        "scripts/acceptance/vcs_read_surfaces_repro.py",
+        "vcs_read_surfaces",
+        "acceptance/vcs_read_surfaces.json",
+    ),
+    ExpectedSuite(
         "scripts/acceptance/init_budget_refusal.py",
         "init_budget",
         "acceptance/init_budget.json",

--- a/scripts/acceptance/vcs_read_surfaces_repro.py
+++ b/scripts/acceptance/vcs_read_surfaces_repro.py
@@ -35,9 +35,16 @@ destructive: the third edits the file the first two are about.
   basis      the `Tree:` line names when graph truth last caught up, rather
              than rendering a bare verdict a reader takes for a statement
              about the files on disk
-  stale      with a tracked file edited and nothing admitted since, that line
-             still carries its age, so the reader can see the graph's picture
-             predates the edit without running a second command
+  persists   with a tracked file edited and nothing admitted since, that line
+             still carries its basis rather than reverting to a bare verdict.
+             Note what this does NOT prove: measured on macOS, the ambient
+             watcher takes about two seconds to admit such an edit, and inside
+             that window the line reads `matching its base change as admitted 0s
+             ago` over a tree that has not moved. A clock cannot separate an
+             admission that ran before the edit from one that ran after it, so
+             the age is necessary and not sufficient. The check that closes that
+             hole is the one over an UNOBSERVED working copy, and it arrives with
+             the fix it grades
   content    `kin admit` over that content-only edit does not report
              "nothing changed"
   settled    the control: a second `kin admit` with nothing left to take says
@@ -224,13 +231,17 @@ class Suite(object):
         if self._repo:
             return self._repo
         path = os.path.realpath(os.path.join(self.workdir, "ledger"))
-        os.makedirs(os.path.join(path, "ledger"))
-        self._write(path, TRACKED_MODULE, MODULE_BEFORE)
-        self._write(path, "ledger/__init__.py", '"""A tiny expense ledger."""\n')
+        os.makedirs(path)
         self._repo = path
+        # `kin init` refuses a non-empty directory for a non-Git repository, on
+        # the stated grounds that it will not derive authority from filesystem
+        # contents nothing admitted. So the store comes first and the files are
+        # written into it, which is also the order the stranger used.
         rc, out, err = run([self.kin, "init"], cwd=path, env=self.env, timeout=600)
         if rc != 0:
             raise RuntimeError("kin init failed: %s" % ((err or out)[-400:]))
+        self._write(path, TRACKED_MODULE, MODULE_BEFORE)
+        self._write(path, "ledger/__init__.py", '"""A tiny expense ledger."""\n')
         rc, out, err = self.kin_run(["commit", "-m", "Report totals grouped by key"])
         if rc != 0:
             raise RuntimeError("the seeding commit failed: %s" % ((err or out)[-400:]))
@@ -265,10 +276,15 @@ def check_basis(suite):
     return Result("basis", status, "%s %s" % (TICKET, detail))
 
 
-def check_stale(suite):
+def check_persists(suite):
     suite.edit_tracked_module()
     status, detail = grade_tree_line_carries_its_basis(suite.status_text())
-    return Result("stale", status, "%s over an unadmitted edit, %s" % (TICKET, detail))
+    return Result(
+        "persists",
+        status,
+        "%s the basis survives an edit (not a claim that the verdict saw it), %s"
+        % (TICKET, detail),
+    )
 
 
 def check_content(suite):
@@ -291,7 +307,7 @@ def check_settled(suite):
 
 CHECKS = (
     ("basis", check_basis),
-    ("stale", check_stale),
+    ("persists", check_persists),
     ("content", check_content),
     ("settled", check_settled),
 )

--- a/scripts/acceptance/vcs_read_surfaces_repro.py
+++ b/scripts/acceptance/vcs_read_surfaces_repro.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove the everyday read surfaces state the basis of the verdicts they give.
+
+FIR-2961. The first stranger run with a version control arm ran the whole
+everyday loop against a Python project with no Git anywhere, and two read
+surfaces answered wrongly in a way a Git user would not accept.
+
+  kin status   "Tree: 70fda9ae... (8 artifacts, matching its base change)"
+               printed over a tracked file edited twenty-two seconds earlier,
+               and repeated across seven more readings
+  kin admit    "Admitted the complete exact tree; nothing changed."
+               printed by a pass that moved the workspace tree hash from
+               70fda9ae to c078181f and its generation from 5 to 6, both
+               visible three lines apart in the same output
+
+Neither verdict was wrong about the graph. `dirty` compares the admitted
+workspace tree against the tree of the change it is based on, and it was right
+both times. The admit wording compares two cardinalities, tracked artifacts and
+entities, and both genuinely held still. What is wrong in both is the same
+thing: a correct answer about the graph, stated as a claim about the working
+copy, with nothing beside it saying what it rests on.
+
+So this suite never grades the verdict. It grades whether the basis travels with
+it, which is the property that separates a true sentence from a misleading one
+here, and it grades both directions: a surface that qualifies every answer it
+gives is as useless as one that qualifies none, so the all-clear has its own
+check and must still arrive.
+
+Four checks, one seeded repository, run in order because the experiment is
+destructive: the third edits the file the first two are about.
+
+  basis      the `Tree:` line names when graph truth last caught up, rather
+             than rendering a bare verdict a reader takes for a statement
+             about the files on disk
+  stale      with a tracked file edited and nothing admitted since, that line
+             still carries its age, so the reader can see the graph's picture
+             predates the edit without running a second command
+  content    `kin admit` over that content-only edit does not report
+             "nothing changed"
+  settled    the control: a second `kin admit` with nothing left to take says
+             "nothing changed" and says it plainly. Without this the other
+             three are satisfied by a product that hedges every sentence.
+
+Exit status is 0 when every check passed, 1 when one failed, 2 when none failed
+but one could not be read, and 3 when the run could not be set up. `--self-test`
+drives every grader against the literal pre-fix output the stranger saw and the
+post-fix output beside it, and needs no binary, so a grader that cannot fail is
+a failure here rather than a silent pass in CI.
+"""
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+TICKET = "FIR-2961"
+
+print = functools.partial(print, flush=True)
+
+# The tracked module the experiment edits. Its body changes and nothing else
+# does: no file added, no file removed, no declaration added or deleted. That is
+# the shape both defects need, because it is the one shape that moves no count.
+TRACKED_MODULE = "ledger/reporting.py"
+
+MODULE_BEFORE = '''"""Roll ledger entries up into totals."""
+
+
+def total_by(entries, key):
+    """Sum amounts under one key."""
+    buckets = {}
+    for entry in entries:
+        buckets[entry[key]] = buckets.get(entry[key], 0) + entry["amount"]
+    return buckets
+'''
+
+# Same declarations, same names, same count. Only the body moved, which is the
+# edit that admits with both cardinalities standing still.
+MODULE_AFTER = '''"""Roll ledger entries up into totals."""
+
+
+def total_by(entries, key):
+    """Sum amounts under one key, rounded to cents."""
+    buckets = {}
+    for entry in entries:
+        buckets[entry[key]] = round(buckets.get(entry[key], 0) + entry["amount"], 2)
+    return buckets
+'''
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    process = subprocess.Popen(
+        cmd, cwd=cwd, env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    try:
+        out, err = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        out, err = process.communicate()
+        return 124, out or "", err or ""
+    return process.returncode, out or "", err or ""
+
+
+def tree_line(text):
+    """The `Tree:` line, or None when the output carries none.
+
+    None is returned rather than an empty string so a caller cannot mistake an
+    output that never reached this line for one whose line was blank.
+    """
+    for line in (text or "").splitlines():
+        if line.startswith("Tree: "):
+            return line
+    return None
+
+
+# A verdict with a basis says one of three things: when the admission was taken,
+# that none is recorded, or that the record would not parse. A bare verdict says
+# none of them. Anchored on the words each arm is obliged to carry rather than on
+# the whole sentence, so a rewording that keeps the fact still passes.
+BASIS_PATTERNS = (
+    re.compile(r"as admitted \S+ ago"),
+    re.compile(r"no complete admission"),
+    re.compile(r"will not parse"),
+)
+
+
+def grade_tree_line_carries_its_basis(text):
+    line = tree_line(text)
+    if line is None:
+        return UNREADABLE, "kin status printed no Tree: line"
+    if "base change" not in line:
+        return UNREADABLE, "the Tree: line names no base-change verdict: %s" % line
+    for pattern in BASIS_PATTERNS:
+        if pattern.search(line):
+            return PASS, "the verdict carries its basis: %s" % line
+    return FAIL, (
+        "the Tree: line states a verdict about the working copy with nothing "
+        "saying when graph truth last looked: %s" % line
+    )
+
+
+def grade_admit_does_not_claim_a_no_op(text):
+    body = text or ""
+    if "Admitted the complete exact tree" not in body:
+        return UNREADABLE, "kin admit printed no admission line: %s" % body.strip()[:200]
+    if "nothing changed" in body:
+        return FAIL, (
+            "a pass over an edited tracked file reported nothing changed: %s"
+            % body.strip().splitlines()[0]
+        )
+    if "content changed" not in body:
+        return FAIL, (
+            "the pass neither claimed a no-op nor named the content change: %s"
+            % body.strip().splitlines()[0]
+        )
+    return PASS, "the pass named the content change: %s" % body.strip().splitlines()[0]
+
+
+def grade_admit_still_reports_a_true_no_op(text):
+    body = text or ""
+    if "Admitted the complete exact tree" not in body:
+        return UNREADABLE, "kin admit printed no admission line: %s" % body.strip()[:200]
+    if "content changed" in body:
+        return FAIL, (
+            "a pass with nothing left to take reported a content change: %s"
+            % body.strip().splitlines()[0]
+        )
+    if "nothing changed" not in body:
+        return FAIL, (
+            "a settled tree got no all-clear, so the surface now hedges every answer: %s"
+            % body.strip().splitlines()[0]
+        )
+    return PASS, "a settled tree still gets its all-clear: %s" % body.strip().splitlines()[0]
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.home = os.path.join(workdir, "home")
+        os.makedirs(self.home)
+        # kin refuses to invent an author, which is correct and not an obstacle.
+        # The run isolates HOME so it cannot read the machine's identity, so it
+        # brings one of its own.
+        with open(os.path.join(self.home, ".gitconfig"), "w") as handle:
+            handle.write("[user]\n\tname = vcs-read-surfaces-repro\n"
+                         "\temail = repro@example.invalid\n"
+                         "[commit]\n\tgpgsign = false\n")
+        self.env = dict(os.environ)
+        self.env["HOME"] = self.home
+        self.env["USERPROFILE"] = self.home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(self.home, "registry.toml")
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DAEMON_URL", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repo = None
+
+    def kin_run(self, args, timeout=600):
+        rc, out, err = run([self.kin] + args, cwd=self.repo(), env=self.env, timeout=timeout)
+        if self.verbose:
+            print("  $ kin %s -> rc=%s" % (" ".join(args), rc))
+        return rc, out, err
+
+    def repo(self):
+        if self._repo:
+            return self._repo
+        path = os.path.realpath(os.path.join(self.workdir, "ledger"))
+        os.makedirs(os.path.join(path, "ledger"))
+        self._write(path, TRACKED_MODULE, MODULE_BEFORE)
+        self._write(path, "ledger/__init__.py", '"""A tiny expense ledger."""\n')
+        self._repo = path
+        rc, out, err = run([self.kin, "init"], cwd=path, env=self.env, timeout=600)
+        if rc != 0:
+            raise RuntimeError("kin init failed: %s" % ((err or out)[-400:]))
+        rc, out, err = self.kin_run(["commit", "-m", "Report totals grouped by key"])
+        if rc != 0:
+            raise RuntimeError("the seeding commit failed: %s" % ((err or out)[-400:]))
+        return path
+
+    @staticmethod
+    def _write(root, relative, body):
+        target = os.path.join(root, relative)
+        directory = os.path.dirname(target)
+        if directory and not os.path.isdir(directory):
+            os.makedirs(directory)
+        with open(target, "w") as handle:
+            handle.write(body)
+
+    def edit_tracked_module(self):
+        self._write(self.repo(), TRACKED_MODULE, MODULE_AFTER)
+
+    def status_text(self):
+        rc, out, err = self.kin_run(["status"])
+        return out if rc == 0 else (out + err)
+
+
+class Result(object):
+    def __init__(self, ident, status, detail):
+        self.ident = ident
+        self.status = status
+        self.detail = detail
+
+
+def check_basis(suite):
+    status, detail = grade_tree_line_carries_its_basis(suite.status_text())
+    return Result("basis", status, "%s %s" % (TICKET, detail))
+
+
+def check_stale(suite):
+    suite.edit_tracked_module()
+    status, detail = grade_tree_line_carries_its_basis(suite.status_text())
+    return Result("stale", status, "%s over an unadmitted edit, %s" % (TICKET, detail))
+
+
+def check_content(suite):
+    rc, out, err = suite.kin_run(["admit"])
+    if rc != 0:
+        return Result("content", UNREADABLE,
+                      "%s kin admit exited %s: %s" % (TICKET, rc, (err or out)[-200:]))
+    status, detail = grade_admit_does_not_claim_a_no_op(out)
+    return Result("content", status, "%s %s" % (TICKET, detail))
+
+
+def check_settled(suite):
+    rc, out, err = suite.kin_run(["admit"])
+    if rc != 0:
+        return Result("settled", UNREADABLE,
+                      "%s the control's kin admit exited %s: %s" % (TICKET, rc, (err or out)[-200:]))
+    status, detail = grade_admit_still_reports_a_true_no_op(out)
+    return Result("settled", status, "%s %s" % (TICKET, detail))
+
+
+CHECKS = (
+    ("basis", check_basis),
+    ("stale", check_stale),
+    ("content", check_content),
+    ("settled", check_settled),
+)
+
+
+def report_payload(results):
+    return {
+        "ticket": TICKET,
+        "checks": [
+            {"id": result.ident, "status": result.status, "detail": result.detail}
+            for result in results
+        ],
+    }
+
+
+def absolute_binary(path):
+    if not path:
+        return None
+    resolved = os.path.abspath(path)
+    return resolved if os.path.exists(resolved) else path
+
+
+# The literal output the stranger saw, and the output the fix produces beside it.
+# Quoted rather than invented, because a grader driven only against text written
+# by the same hand cannot tell you what the product says.
+STATUS_BARE = (
+    "Kin repository-v6 status\n"
+    "Tree: 70fda9aeeb87e4686298ebe4c601f1efbe1b5d65ce4e1567c158b2aa2efc076a "
+    "(8 artifacts, matching its base change)\n"
+    "Untracked host content: none, measured 0s ago\n"
+)
+STATUS_WITH_AGE = (
+    "Kin repository-v6 status\n"
+    "Tree: 70fda9aeeb87e4686298ebe4c601f1efbe1b5d65ce4e1567c158b2aa2efc076a "
+    "(8 artifacts, matching its base change as admitted 2m ago)\n"
+    "Untracked host content: none, measured 0s ago\n"
+)
+STATUS_UNKNOWN_BASIS = (
+    "Kin repository-v6 status\n"
+    "Tree: 70fda9ae (8 artifacts, matching its base change as last admitted; this store "
+    "records no complete admission, so how far behind the working copy that is is unknown, "
+    "and `kin admit` takes what it holds)\n"
+)
+STATUS_NO_TREE = "Kin repository-v6 status\nRefs: 1, default refs/heads/main\n"
+# The bare verdict pointed the other way. A `dirty` tree with no basis is the
+# same defect and must not pass because the word changed.
+STATUS_BARE_AHEAD = (
+    "Kin repository-v6 status\n"
+    "Tree: c078181f (8 artifacts, ahead of its base change)\n"
+)
+
+ADMIT_NO_OP_CLAIM = (
+    "Admitted the complete exact tree; nothing changed. 8 tracked artifacts, 39 entities.\n"
+    "Embeddings: 71 of 78 indexed; the remainder is queued for the background embed pass.\n"
+)
+ADMIT_CONTENT_MOVED = (
+    "Admitted the complete exact tree; content changed, with no artifact or entity added "
+    "or removed. 8 tracked artifacts, 39 entities.\n"
+)
+ADMIT_UNMEASURED = (
+    "Admitted the complete exact tree. 8 tracked artifacts, 39 entities, and neither count "
+    "moved; this daemon does not report whether content moved, so this is not a statement "
+    "that the tree is unchanged.\n"
+)
+ADMIT_REFUSED = "Complete exact-tree admission failed: host entry changed\n"
+
+
+def self_test():
+    """Drive every grader against a payload that must pass and one that must fail.
+
+    Each row names the grader, the payload, and the verdict it is obliged to
+    reach. A grader that answers PASS to everything and one that answers FAIL to
+    everything both fail here, which is the only way this file is worth running.
+    """
+    cases = [
+        ("basis/bare-clean", grade_tree_line_carries_its_basis, STATUS_BARE, FAIL),
+        ("basis/bare-ahead", grade_tree_line_carries_its_basis, STATUS_BARE_AHEAD, FAIL),
+        ("basis/with-age", grade_tree_line_carries_its_basis, STATUS_WITH_AGE, PASS),
+        ("basis/unknown", grade_tree_line_carries_its_basis, STATUS_UNKNOWN_BASIS, PASS),
+        ("basis/no-tree-line", grade_tree_line_carries_its_basis, STATUS_NO_TREE, UNREADABLE),
+        ("content/no-op-claim", grade_admit_does_not_claim_a_no_op, ADMIT_NO_OP_CLAIM, FAIL),
+        ("content/moved", grade_admit_does_not_claim_a_no_op, ADMIT_CONTENT_MOVED, PASS),
+        ("content/unmeasured", grade_admit_does_not_claim_a_no_op, ADMIT_UNMEASURED, FAIL),
+        ("content/refused", grade_admit_does_not_claim_a_no_op, ADMIT_REFUSED, UNREADABLE),
+        ("settled/no-op-claim", grade_admit_still_reports_a_true_no_op, ADMIT_NO_OP_CLAIM, PASS),
+        ("settled/moved", grade_admit_still_reports_a_true_no_op, ADMIT_CONTENT_MOVED, FAIL),
+        ("settled/unmeasured", grade_admit_still_reports_a_true_no_op, ADMIT_UNMEASURED, FAIL),
+        ("settled/refused", grade_admit_still_reports_a_true_no_op, ADMIT_REFUSED, UNREADABLE),
+    ]
+    failures = 0
+    for name, grader, payload, expected in cases:
+        got, detail = grader(payload)
+        ok = got == expected
+        if not ok:
+            failures += 1
+        print("SELFTEST %s %s expected=%s got=%s %s"
+              % (name, "ok" if ok else "BROKEN", expected, got, detail))
+    print("SELFTEST %d case(s), %d broken" % (len(cases), failures))
+    return 1 if failures else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN") or shutil.which("kin"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path")
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    opts = parser.parse_args(argv)
+
+    if opts.self_test:
+        return self_test()
+
+    if not opts.kin:
+        print("SETUP no kin binary: pass --kin or set KIN_BIN")
+        return 3
+    opts.kin = absolute_binary(opts.kin)
+    opts.daemon = absolute_binary(opts.daemon)
+
+    workdir = tempfile.mkdtemp(prefix="vcs-read-surfaces-")
+    suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
+    try:
+        results = []
+        for ident, check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - a setup failure is not a verdict
+                results.append(Result(ident, UNREADABLE, "%s check raised: %s" % (TICKET, error)))
+        for result in results:
+            print("CHECK %s %s %s %s" % (result.ident, TICKET, result.status, result.detail))
+        asked = [ident for ident, _ in CHECKS]
+        answered = [result.ident for result in results]
+        # Written before the asked/answered guard, not after it. Four UNREADABLE
+        # rows are a verdict the gate can name; a missing report is one it can
+        # only refuse.
+        if opts.json_path:
+            directory = os.path.dirname(os.path.abspath(opts.json_path))
+            if directory:
+                try:
+                    os.makedirs(directory)
+                except OSError:
+                    pass
+            with open(opts.json_path, "w") as handle:
+                json.dump(report_payload(results), handle, indent=2)
+        if answered != asked:
+            print("SETUP asked for %r and %r answered" % (asked, answered))
+            return 3
+        if any(result.status == FAIL for result in results):
+            return 1
+        if any(result.status == UNREADABLE for result in results):
+            return 2
+        return 0
+    finally:
+        try:
+            if suite._repo:
+                run([opts.kin, "daemon", "stop"], cwd=suite._repo, env=suite.env, timeout=180)
+        except Exception:  # noqa: BLE001 - teardown must not change the verdict
+            pass
+        if not opts.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+        else:
+            print("kept fixtures under %s" % workdir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Two of the everyday read surfaces answered wrongly in the first stranger run to
carry a version control arm, and neither was wrong about the graph. That is what
makes the class worth naming: `kin status` saying `matching its base change` and
`kin admit` saying `nothing changed` were both true sentences, and both were read
as statements about the files on disk, because nothing beside them said what they
rested on.

## What the stranger saw

`kin status`, over a tracked file written at 20:48:54 and read at 20:49:16, then
polled seven more times:

```
Tree: 70fda9aeeb87e4686298ebe4c601f1efbe1b5d65ce4e1567c158b2aa2efc076a (8 artifacts, matching its base change)
Untracked host content: none, measured 0s ago
```

`kin admit` on that same tree, with the movement it denies visible three lines
below it in its own output:

```
Admitted the complete exact tree; nothing changed. 8 tracked artifacts, 39 entities.
=== status ===
Workspace generation: 6
Tree: c078181f52c13ba047ccd28aeefa2229ca6fdb3d0dd1057ef2dea22e412ca345 (8 artifacts, ahead of its base change)
```

Generation 5 to 6, tree hash `70fda9ae` to `c078181f`, under the words "nothing
changed".

## Why

Measured on this tree, each count with a control.

`kin status` never reads the durable admission clock. `command grep -c
last_admission commands/status.rs` is 0; `diff.rs` is 4 and `graph.rs` reads it
too. `crates/kin-core/src/last_admission.rs` was written for exactly this defect
and says so in its own module doc: without it "a store last admitted months ago
reads exactly like one admitted a second ago... that is how a graph can fall
arbitrarily far behind its repository while every status surface prints the
all-clear." Two of the three surfaces that need it read it. The third is the one
a Git user runs fifty times an hour.

FIR-2820 closed half of this. `Untracked host content: none, measured 0s ago`
carries its age, and counts untracked paths. The stranger's file was tracked and
modified, which that count cannot see, so both lines were literally true over a
tree that was not clean.

`kin admit` derives its wording from two cardinalities. `census()` in
`repository_admit.rs` reads `resolved_tree().len()` and `entity_count()`, and a
content-only edit adds no artifact and no entity, so both deltas are zero and
the branch fires. Both premises held. The conclusion did not.

## What changed

`kin status` now carries the admission clock beside the verdict, from the same
durable marker `kin diff` and `kin graph status` already read, so the line reads
`matching its base change as admitted 2m ago`. An absent or unparseable marker
renders as its own arm rather than as a bare verdict. Reading the marker needs no
daemon and touches no file in the working copy, so the answer stays graph-owned
truth plus the age of that truth. No stat, no walk, nothing file-first on the
authority path.

`kin admit` reads the resolved tree's own hash on each side of the pass and
reports whether it moved. An unmeasured tree is carried as its own answer rather
than collapsed into "did not move", because an older daemon reporting nothing and
a tree that genuinely held still are the two cases the line has to keep apart.
`graph_moved` sits beside `census_moved` for the same reason and is what
`mutated` now publishes, so a content-only admission is no longer announced as a
no-op to every caller reading that flag instead of the prose.

## What this does not close, measured

Stated here because the body becomes the squash message and this is the part a
later reader most needs.

A clock cannot separate an admission that ran BEFORE your edit from one that ran
after it. Measured on this build: edit written, `kin status` reads
`matching its base change as admitted 0s ago` while the tree hash has not moved.
The sentence is true and the impression is the same wrong one. The ambient
watcher then admitted the edit after about two seconds on macOS; the stranger's
window was unbounded, because a Docker-for-Mac bind mount does not deliver the
events. Same defect, different magnitude, invisible from this line in both.

The sharper case, and it is the next commit on this lane rather than this one:
with the daemon stopped, the `Tree:` line still reads
`matching its base change as admitted 0s ago` while the untracked line directly
below it correctly says "not measured; no daemon is running". Nothing is watching
the working copy at all and the verdict presents as current. That case is
detectable and is being closed.

One thing this deliberately does NOT do. The stranger's own root cause for this
finding was `Projection: mode=shim ... degraded=yes`, three lines below the wrong
answer, "and nothing connects them". Connecting them would be wrong: measured on
a healthy fixture whose watcher admitted an edit in two seconds, the projection
line reads `degraded=yes` as well, because that flag is about the VFS projection
being unmounted and not about the file watcher. Wiring the verdict to it would
raise a stale-tree alarm on every non-VFS repository while saying nothing about
the watcher.

## Falsification

`scripts/acceptance/vcs_read_surfaces_repro.py` grades the product's own output
over a repository it seeds itself, and never grades the verdict, only whether the
basis travels with it. Its `settled` check is the half that matters: a genuinely
settled tree must still get a plain all-clear, or the fix is just a surface that
hedges every sentence.

Thirteen `--self-test` cases drive each grader in both directions against the
literal pre-fix output from the stranger's transcript and the post-fix output
beside it. The bare `ahead of its base change` is its own case, since a verdict
with no basis is the same defect whichever word it lands on.

The suite registration was falsified by deleting its own gate report line: the
step-visibility guard went red naming `vcs_read_surfaces` in both violation
messages, and green again at nineteen suites on restore.

Unit falsification, reading which assertion fired rather than only that a test
went red: `an_unmeasured_tree_claims_neither_outcome` is the arm that catches a
future collapse of `None` into `false`, and
`a_pass_over_an_unmoved_tree_still_reports_nothing_changed` is the arm that
catches an over-correction.

Closes FIR-2961
