### PR TITLE
Bound Git history at the derivation, and the kin-db contract that refuses the result

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -309,6 +309,7 @@ pub async fn run_health_checks() -> HealthReport {
     checks.push(check_background_work().await);
     checks.push(check_embedding_model().await);
     checks.push(check_memory_floor());
+    checks.push(check_unconverted_history_budget());
     checks.push(check_commit_memory_headroom());
     checks.push(check_daemon_kill_record());
     checks.push(check_interrupted_init());
@@ -4192,6 +4193,148 @@ fn check_memory_floor() -> HealthCheck {
         &crate::capability::memory_evidence(),
         &crate::capability::CapabilityDetection::detect(),
     )
+}
+
+/// Whether the Git repository in this directory can be converted whole here.
+///
+/// The row a stranger most needs and the only one that runs BEFORE a store
+/// exists in a repository that has one waiting. `kin init` forecasts the same
+/// number and prints it at step 1, which is eleven minutes too late to be a
+/// decision: by then the operator has already committed to the run. Reading it
+/// from `kin doctor` is what makes it a choice.
+///
+/// Unsupported rather than healthy when there is nothing to judge, because a
+/// green row over a directory with no Git repository is a claim about a
+/// conversion that cannot happen.
+fn check_unconverted_history_budget() -> HealthCheck {
+    const ID: &str = "unconverted_history_budget";
+    const LABEL: &str = "Whole-history conversion";
+    let Ok(cwd) = std::env::current_dir() else {
+        return HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Unsupported,
+            "this directory could not be resolved, so no conversion was forecast",
+        );
+    };
+    if !cwd.join(".git").exists() {
+        return HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Unsupported,
+            "there is no Git repository here to convert, so nothing is forecast",
+        );
+    }
+    if cwd.join(".kin").exists() {
+        return HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Unsupported,
+            "this repository is already converted, so its conversion is not forecast;              `Commit memory headroom` is the row about what writing to it costs",
+        );
+    }
+    let evidence = crate::capability::memory_evidence();
+    match kin_core::init_budget::survey_history(&cwd) {
+        Err(reason) => HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Unsupported,
+            format!("this repository could not be surveyed, so nothing is forecast: {reason}"),
+        ),
+        Ok(survey) => unconverted_history_budget_check_for(survey, evidence.limit_bytes),
+    }
+}
+
+/// Core of [`check_unconverted_history_budget`] over numbers rather than over a
+/// repository, so every branch is testable without a machine of any size.
+///
+/// The verdict is the conversion's own, taken from `init_budget` rather than
+/// recomputed here, so this row and the line `kin init` prints cannot disagree
+/// about the same repository on the same machine.
+fn unconverted_history_budget_check_for(
+    survey: kin_core::init_budget::HistorySurvey,
+    ceiling_bytes: u64,
+) -> HealthCheck {
+    use kin_core::init_budget::BudgetVerdict;
+    const ID: &str = "unconverted_history_budget";
+    const LABEL: &str = "Whole-history conversion";
+
+    let verdict = kin_core::init_budget::verdict_for(survey, ceiling_bytes);
+    let forecast = format_health_bytes(survey.forecast_peak_bytes());
+    let available = format_health_bytes(ceiling_bytes);
+    let scale = format!(
+        "{} commits over {} tracked files",
+        survey.commits, survey.tracked_artifacts
+    );
+
+    let (status, verdict_clause) = match verdict {
+        BudgetVerdict::Fits { .. } => {
+            return HealthCheck::new(
+                ID,
+                LABEL,
+                HealthStatus::Healthy,
+                format!(
+                    "converting all of this repository is expected to hold about {forecast},                      against the {available} here, so {scale} converts whole. That figure is a                      floor taken from the least any measured conversion needed at a smaller                      size, so read it as an order of magnitude rather than as a target"
+                ),
+            );
+        }
+        BudgetVerdict::Tight { .. } => (
+            HealthStatus::Stale,
+            format!(
+                "converting all of this repository is expected to hold about {forecast}, close                  enough to the {available} here that it may not finish"
+            ),
+        ),
+        BudgetVerdict::Exceeds { .. } => (
+            HealthStatus::Degraded,
+            format!(
+                "converting all of this repository is expected to hold about {forecast}, more                  than the {available} here"
+            ),
+        ),
+        // Neither of these is about this repository: one means no ceiling could
+        // be read and the other means an operator set one Kin cannot parse.
+        // `kin init` refuses the second on its own, and repeating its refusal
+        // here as a conversion forecast would name the wrong subject.
+        BudgetVerdict::Unmeasured { reason } => {
+            return HealthCheck::new(
+                ID,
+                LABEL,
+                HealthStatus::Unsupported,
+                format!("no conversion was forecast: {reason}"),
+            );
+        }
+        BudgetVerdict::InvalidCeilingOverride { raw } => {
+            return HealthCheck::new(
+                ID,
+                LABEL,
+                HealthStatus::Unsupported,
+                format!(
+                    "{} is set to {raw:?}, which is not a positive whole number of bytes, so no                      conversion was forecast",
+                    kin_core::init_budget::INIT_MEMORY_CEILING_ENV
+                ),
+            );
+        }
+    };
+
+    let fitting = survey.commits_that_convert_quietly(ceiling_bytes);
+    let remedy = if fitting == 0 || fitting >= survey.commits {
+        "Convert on a machine with more memory. `--history-limit` will not help here: this          repository's tree is wide enough that even one commit exceeds what this machine can          hold."
+            .to_string()
+    } else {
+        format!(
+            "Convert on a machine with more memory, or run `kin init --history-limit {fitting}`,              which takes in the newest {fitting} commits of this repository's first-parent              history and leaves the other {} out of the graph. It keeps every Git object and              every ref, so nothing is thrown away; what it bounds is the semantic history, and              `kin log` reports where the admitted history starts.",
+            survey.commits.saturating_sub(fitting),
+        )
+    };
+
+    HealthCheck::new(
+        ID,
+        LABEL,
+        status,
+        format!(
+            "{verdict_clause}, because {scale} is a large history: a conversion materializes one              resolved tree per commit and holds every one of them. That figure is a floor taken              from the least any measured conversion needed at a smaller size, so this row              forecasts an order of magnitude rather than a total. {remedy}"
+        ),
+    )
+    .with_manual_fix(remedy)
 }
 
 /// Core of [`check_memory_floor`] with both readings as inputs, so every branch

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -163,6 +163,7 @@ pub async fn run(
     json: bool,
     no_enrich: bool,
     adopt_repository_id: Option<String>,
+    history_limit: Option<usize>,
 ) -> Result<i32> {
     let _span = tracing::info_span!("kin.init").entered();
     // Read before any work, so the closing summary can say what this run did
@@ -176,6 +177,7 @@ pub async fn run(
         .unwrap_or_else(|| std::env::current_dir().expect("cannot determine current directory"));
 
     let adopted = parse_adopted_repository_id(adopt_repository_id.as_deref())?;
+    let admission = parse_history_limit(history_limit)?;
 
     ensure_directory(&dir)?;
     reject_existing_repository(&dir)?;
@@ -191,13 +193,29 @@ pub async fn run(
     // was silently ignored on the other would produce a store that looks
     // adopted and pushes nowhere, which is the failure this whole path exists
     // to remove.
+    // A native-unborn repository has no Git history to bound, so asking to
+    // bound one is refused rather than accepted and ignored. A flag that is
+    // silently dropped on one of two boundaries produces a store that looks
+    // bounded and is not, which is the same class of defect as a default that
+    // silently bounds.
+    if !admission.history_limit.is_whole() && boundary == InitBoundary::NativeUnborn {
+        anyhow::bail!(
+            "--history-limit bounds the Git history a conversion takes in, and {} has no Git              repository to take history from",
+            dir.display()
+        );
+    }
+
     let result = match (boundary, &adopted) {
-        (InitBoundary::ExactGit, None) => kin_core::init_from_git(&dir)
-            .context("admit exact reachable Git repository authority")?,
-        (InitBoundary::ExactGit, Some(adopted)) => kin_core::init_from_git_adopting(&dir, adopted)
-            .with_context(|| {
-                format!("admit exact reachable Git repository authority adopting {adopted}")
-            })?,
+        (InitBoundary::ExactGit, adopted) => {
+            kin_core::init_from_git_with_options(&dir, adopted.as_ref(), admission).with_context(
+                || match adopted {
+                    Some(adopted) => format!(
+                        "admit exact reachable Git repository authority adopting {adopted}"
+                    ),
+                    None => "admit exact reachable Git repository authority".to_string(),
+                },
+            )?
+        }
         (InitBoundary::NativeUnborn, None) => {
             kin_core::init(&dir).context("initialize unborn Kin-native repository authority")?
         }
@@ -325,6 +343,27 @@ fn parse_adopted_repository_id(value: Option<&str>) -> Result<Option<kin_model::
     kin_model::RepositoryId::new(trimmed.to_string())
         .map(Some)
         .map_err(|error| anyhow::anyhow!("invalid --adopt-repository-id {trimmed:?}: {error}"))
+}
+
+/// Turn `--history-limit N` into the admission options a conversion runs under.
+///
+/// Zero is refused rather than silently read as whole history, because an
+/// operator who typed `--history-limit 0` asked for something, and the two
+/// things they could have meant are "all of it" and "none of it". Guessing
+/// either one produces a store that is not what they asked for, and the store
+/// is the expensive thing to be wrong about.
+fn parse_history_limit(value: Option<usize>) -> Result<kin_core::GitAdmissionOptions> {
+    let Some(value) = value else {
+        return Ok(kin_core::GitAdmissionOptions::default());
+    };
+    if value == 0 {
+        bail!(
+            "--history-limit needs the number of commits to take in, and it was given 0; omit the              flag to take in every commit"
+        );
+    }
+    Ok(kin_core::GitAdmissionOptions {
+        history_limit: kin_core::HistoryLimit::from_count(value),
+    })
 }
 
 /// How long the conversion phase will wait for the sweep before handing the
@@ -2942,7 +2981,7 @@ mod tests {
         // Enrichment off: this case is about the conversion transaction, and
         // starting a daemon to query a language server would make it depend on
         // what the host has installed.
-        run(Some(repo.to_str().unwrap().to_string()), false, true, None)
+        run(Some(repo.to_str().unwrap().to_string()), false, true, None, None)
             .await
             .expect("kin init must succeed under a scratch registry");
 

--- a/crates/kin-cli/src/commands/log.rs
+++ b/crates/kin-cli/src/commands/log.rs
@@ -66,11 +66,22 @@ pub struct LogReport {
     pub requested_count: usize,
     pub truncated: bool,
     pub entries: Vec<LogEntry>,
+    /// Where admitted Git history ends, when `kin init --history-limit` bounded
+    /// it. Absent on a whole-history repository.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_boundary: Option<kin_core::ManifestHistoryBoundary>,
 }
 
+/// Read one repository's change log.
+///
+/// `history_boundary` is supplied rather than discovered, because this reads an
+/// authority binding and the boundary lives in the manifest beside it. Every
+/// caller has a layout; passing the answer in is what stops one of them from
+/// rendering "no boundary" when it simply could not look.
 pub fn inspect(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     count: usize,
+    history_boundary: Option<kin_core::ManifestHistoryBoundary>,
 ) -> Result<LogReport> {
     let authority = ActiveRepositoryAuthority::open(binding)?;
     let lease = authority.manager().read_authority();
@@ -164,13 +175,14 @@ pub fn inspect(
         requested_count: count,
         truncated: !pending.is_empty(),
         entries,
+        history_boundary,
     })
 }
 
 pub fn run(count: usize, json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
-    let report = inspect(&binding, count)?;
+    let report = inspect(&binding, count, kin_core::history_boundary_for(&layout))?;
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
@@ -185,8 +197,9 @@ pub fn build_log_response(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     _graph: &kin_db::InMemoryGraph,
     request: &LogRequest,
+    history_boundary: Option<kin_core::ManifestHistoryBoundary>,
 ) -> Result<LogResponse> {
-    let report = inspect(binding, request.count)?;
+    let report = inspect(binding, request.count, history_boundary)?;
     Ok(LogResponse {
         lines: render_lines(&report),
         report: Some(report),
@@ -225,6 +238,15 @@ fn render_lines(report: &LogReport) -> Vec<String> {
             entry.admission_policy_changed
         ));
         lines.push(format!("    {}", entry.message.replace('\n', "\n    ")));
+    }
+    // Only once the walk has reached the bottom, because that is the moment a
+    // reader would otherwise conclude the repository began at the last entry.
+    // A truncated page has more to show and needs no such correction.
+    if !report.truncated {
+        if let Some(boundary) = &report.history_boundary {
+            lines.push(String::new());
+            lines.push(boundary.summary());
+        }
     }
     lines
 }

--- a/crates/kin-cli/src/commands/rollback.rs
+++ b/crates/kin-cli/src/commands/rollback.rs
@@ -301,7 +301,11 @@ async fn resolve_feature_target(work_id: &str) -> Result<String> {
     let recorded = resolve_work_item_changes(work_id).await?;
     let layout = crate::commands::require_repository_layout()?;
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
-    let report = crate::commands::log::inspect(&binding, WORK_ITEM_HISTORY_WINDOW)?;
+    let report = crate::commands::log::inspect(
+        &binding,
+        WORK_ITEM_HISTORY_WINDOW,
+        kin_core::history_boundary_for(&layout),
+    )?;
     let line = first_parent_line(&report);
     match plan_work_item_rollback(&line, report.truncated, &recorded) {
         Ok(plan) => {

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -129,6 +129,29 @@ enum Command {
         /// identity, which is right for a repository nothing else holds.
         #[arg(long = "adopt-repository-id", value_name = "ID")]
         adopt_repository_id: Option<String>,
+        /// Take in only the last N commits of HEAD's first-parent history
+        ///
+        /// Off by default: a conversion that says nothing takes in every
+        /// commit, and that is the right answer for almost every repository.
+        ///
+        /// Use it when whole history does not fit the machine. A conversion
+        /// holds one resolved tree per commit and the daemon that serves the
+        /// store afterwards is sized by the same history, so on a large
+        /// repository a small machine can convert successfully and then be
+        /// unable to answer a question. `kin doctor` says when this repository
+        /// is in that band and names the N that would fit here.
+        ///
+        /// What it does not do is throw your history away. The Git capture is
+        /// unchanged, so the store still holds every Git object and every ref,
+        /// byte for byte. What is bounded is the semantic graph: it starts at
+        /// the oldest admitted commit rather than at the repository's first,
+        /// and `kin log` reports where that edge is rather than pretending the
+        /// repository began there.
+        ///
+        /// First-parent because it is the only window whose size you can
+        /// predict. Asking for 800 admits 800.
+        #[arg(long = "history-limit", value_name = "N")]
+        history_limit: Option<usize>,
     },
     /// Show coherent repository-v6 workspace status
     Status {
@@ -2653,9 +2676,16 @@ fn main() -> Result<()> {
                     json,
                     no_enrich,
                     adopt_repository_id,
+                    history_limit,
                 } => {
-                    let code =
-                        commands::init::run(path, json, no_enrich, adopt_repository_id).await?;
+                    let code = commands::init::run(
+                        path,
+                        json,
+                        no_enrich,
+                        adopt_repository_id,
+                        history_limit,
+                    )
+                    .await?;
                     // A conversion whose store exists but whose enrichment a
                     // killed daemon left unattested reports that through the
                     // exit code, so a scripted or agent-driven setup can branch

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -16,10 +16,10 @@ use kin_blobs::BlobStore;
 use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
 use kin_git::{
     admit_semantic_git_import, build_git_external_authority, capture_lossless_git_repository,
-    check_git_admission_blockers, plan_semantic_git_import, preflight_git_migration,
+    check_git_admission_blockers, plan_bounded_semantic_git_import, preflight_git_migration,
     reprove_git_migration, reprove_git_migration_after_publication,
     seal_all_content_observation_observed, AdmittedContentClosure, GitLocalIgnoreSourceKind,
-    GitMigrationPreflightProof, LosslessGitRepository, ProvedImportClosure,
+    GitMigrationPreflightProof, HistoryLimit, LosslessGitRepository, ProvedImportClosure,
     SealedContentObservation, SealedContentSource,
 };
 use kin_model::{
@@ -177,7 +177,31 @@ impl AdmittedContentClosure for DivergedClosure {
 /// [`KinError::RepositoryPublishedButUncertain`] with the published repository
 /// left in place for recovery.
 pub fn init_from_git(working_dir: &Path) -> Result<InitResult> {
-    init_from_git_with_hook(working_dir, None, || {})
+    init_from_git_with_hook(working_dir, None, GitAdmissionOptions::default(), || {})
+}
+
+/// How one Git admission differs from the default, if it does.
+///
+/// A struct rather than more positional arguments, so the whole-history default
+/// is what a caller gets by saying nothing. Every existing caller of
+/// [`init_from_git`] and [`init_from_git_adopting`] keeps whole history by
+/// construction rather than by remembering to pass a zero.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GitAdmissionOptions {
+    /// How much Git history to take into the semantic graph.
+    ///
+    /// The Git capture is unaffected: a bounded repository still holds every
+    /// Git object and every ref its source had.
+    pub history_limit: HistoryLimit,
+}
+
+/// [`init_from_git`], with the admission options a command line supplied.
+pub fn init_from_git_with_options(
+    working_dir: &Path,
+    adopted: Option<&RepositoryId>,
+    options: GitAdmissionOptions,
+) -> Result<InitResult> {
+    init_from_git_with_hook(working_dir, adopted.cloned(), options, || {})
 }
 
 /// Admit one clean materialized Git worktree as a replica of a repository that
@@ -201,20 +225,33 @@ pub fn init_from_git_adopting(
     working_dir: &Path,
     repository_id: &RepositoryId,
 ) -> Result<InitResult> {
-    init_from_git_with_hook(working_dir, Some(repository_id.clone()), || {})
+    init_from_git_with_hook(
+        working_dir,
+        Some(repository_id.clone()),
+        GitAdmissionOptions::default(),
+        || {},
+    )
 }
 
 fn init_from_git_with_hook(
     working_dir: &Path,
     adopted: Option<RepositoryId>,
+    options: GitAdmissionOptions,
     before_final_source_proof: impl FnOnce(),
 ) -> Result<InitResult> {
-    init_from_git_with_hooks(working_dir, adopted, before_final_source_proof, || {})
+    init_from_git_with_hooks(
+        working_dir,
+        adopted,
+        options,
+        before_final_source_proof,
+        || {},
+    )
 }
 
 fn init_from_git_with_hooks(
     working_dir: &Path,
     adopted: Option<RepositoryId>,
+    options: GitAdmissionOptions,
     before_final_source_proof: impl FnOnce(),
     after_repository_publication: impl FnOnce(),
 ) -> Result<InitResult> {
@@ -248,7 +285,7 @@ fn init_from_git_with_hooks(
             .map_err(|error| git_boundary_error("admit this Git repository", error))?;
     }
 
-    let (manifest, identity_origin) = match &adopted {
+    let (mut manifest, identity_origin) = match &adopted {
         Some(adopted) => (
             KinManifest::adopting(adopted.as_str()),
             RepositoryIdentityOrigin::Adopted,
@@ -339,8 +376,9 @@ fn init_from_git_with_hooks(
     progress.begin("plan semantic import");
     let semantic_plan = {
         let _span = info_span!("kin.init.plan_semantic_import").entered();
-        let plan = plan_semantic_git_import(&snapshot, &capture_store)
-            .map_err(|error| git_boundary_error("derive exact semantic Git history", error))?;
+        let plan =
+            plan_bounded_semantic_git_import(&snapshot, &capture_store, options.history_limit)
+                .map_err(|error| git_boundary_error("derive exact semantic Git history", error))?;
         verify_material_workspace_seed(&plan.workspace_seed, &git_authority.material_head)?;
         plan
     };
@@ -354,6 +392,25 @@ fn init_from_git_with_hooks(
         .entered();
         bind_historical_semantics(semantic_plan, &capture_store)?
     };
+
+    // Stamped between the derivation that produced it and the layout staging
+    // that writes it, so a bounded store carries its own edge from the moment
+    // it exists. `kin log` and its siblings read this rather than inferring a
+    // boundary from a change that happens to have no parent, because every
+    // repository's oldest change has no parent and only this record separates
+    // "the history starts here" from "admission started here".
+    manifest.history_boundary = semantic_plan.admitted_boundary.as_ref().map(|boundary| {
+        crate::manifest::ManifestHistoryBoundary {
+            requested_limit: boundary.requested_limit,
+            admitted_commits: boundary.admitted_commits,
+            oldest_admitted_commit: boundary.oldest_admitted_commit.to_string(),
+            unadmitted_parents: boundary
+                .unadmitted_parents
+                .iter()
+                .map(|oid| oid.to_string())
+                .collect(),
+        }
+    });
 
     progress.begin("apply admission policy");
     // Both this phase and the proof after it re-derive the whole history from
@@ -1962,7 +2019,7 @@ mod tests {
         );
 
         let source_for_hook = source.clone();
-        let error = init_from_git_with_hook(&source, None, move || {
+        let error = init_from_git_with_hook(&source, None, GitAdmissionOptions::default(), move || {
             git(
                 &source_for_hook,
                 [
@@ -2013,7 +2070,7 @@ mod tests {
         std::fs::write(&global_config, "").unwrap();
 
         let mut ambient = None;
-        let result = init_from_git_with_hook(&source, None, || {
+        let result = init_from_git_with_hook(&source, None, GitAdmissionOptions::default(), || {
             ambient = Some(
                 crate::test_env::EnvVarGuard::new()
                     .with("GIT_CONFIG_NOSYSTEM", "1")
@@ -2049,6 +2106,7 @@ mod tests {
         let error = init_from_git_with_hooks(
             &source,
             None,
+            GitAdmissionOptions::default(),
             || {},
             move || {
                 std::fs::write(source_for_hook.join("README.md"), b"raced source\n").unwrap();
@@ -2285,7 +2343,7 @@ mod tests {
         git(&source, ["commit", "-m", "private history"]);
 
         let staging_parent = root.path().to_path_buf();
-        let result = init_from_git_with_hook(&source, None, move || {
+        let result = init_from_git_with_hook(&source, None, GitAdmissionOptions::default(), move || {
             let staging = std::fs::read_dir(&staging_parent)
                 .unwrap()
                 .map(|entry| entry.unwrap().path())
@@ -2624,6 +2682,7 @@ mod tests {
         let error = init_from_git_with_hooks(
             &source,
             None,
+            GitAdmissionOptions::default(),
             || {},
             move || remove_published_body(&published_kin_dir, opaque),
         )

--- a/crates/kin-core/src/init_budget.rs
+++ b/crates/kin-core/src/init_budget.rs
@@ -133,11 +133,35 @@ impl HistorySurvey {
     /// whatever this returns, every conversion measured at that scale needed at
     /// least that much.
     pub fn forecast_peak_bytes(&self) -> u64 {
-        let by_commit = self.commits.saturating_mul(BYTES_PER_COMMIT);
-        let by_tree = self
-            .tree_entries()
-            .saturating_mul(BYTES_PER_COMMIT_ARTIFACT);
-        by_commit.max(by_tree)
+        self.commits.saturating_mul(self.bytes_per_commit())
+    }
+
+    /// Bytes the forecast attributes to each commit in this repository.
+    ///
+    /// Factoring this out of [`Self::forecast_peak_bytes`] is what makes the
+    /// forecast invertible, and the reason it inverts exactly is that both of
+    /// its terms are linear in the commit count: the tree term is commits times
+    /// tracked artifacts, so the width divides out and what is left is a
+    /// per-commit cost that does not depend on how many commits there are.
+    fn bytes_per_commit(&self) -> u64 {
+        BYTES_PER_COMMIT.max(
+            self.tracked_artifacts
+                .saturating_mul(BYTES_PER_COMMIT_ARTIFACT),
+        )
+    }
+
+    /// Commits whose forecast fits inside `budget_bytes`.
+    ///
+    /// The number `--history-limit` is offered with, so it is deliberately the
+    /// count that lands under the silent band rather than the count that lands
+    /// exactly on the ceiling. Advising a number that converts and then warns
+    /// would be advice that half works.
+    ///
+    /// Zero means no bound helps: one commit of this repository already exceeds
+    /// the budget, which happens on a very wide tree rather than a long
+    /// history. A caller must not print a zero as a recommendation.
+    pub fn commits_within(&self, budget_bytes: u64) -> u64 {
+        budget_bytes / self.bytes_per_commit().max(1)
     }
 }
 
@@ -208,12 +232,25 @@ impl BudgetVerdict {
         // the second. So it states both figures and lets the reader compare
         // them, and it carries the remedy, because being warned and given
         // nothing to do is most of the way back to being told nothing.
+        // The remedy names the flag when a bound would help and stays silent
+        // about it when one would not, rather than always naming it. A line
+        // that offers a lever which cannot move this repository is worse than
+        // one that offers nothing, because the reader spends a conversion
+        // finding out.
+        let bounded = history_limit_remedy(survey, *ceiling_bytes).map_or_else(
+            || " or convert a repository with less history".to_string(),
+            |_| {
+                format!(
+                    " or take in less history with `kin init --history-limit {}`",
+                    survey.commits_within((*ceiling_bytes as f64 * TIGHT_FRACTION) as u64)
+                )
+            },
+        );
         Some(format!(
             "  this conversion is expected to hold about {}, against the {} this {} allows, \
              because {} commits over {} tracked files is a large history. It will probably \
              finish. If the kernel stops it you will get no message from this run, and the next \
-             one will say what happened; to be sure instead, give it more than {} or convert a \
-             repository with less history",
+             one will say what happened; to be sure instead, give it more than {}{bounded}",
             human_bytes(*forecast_bytes),
             human_bytes(*ceiling_bytes),
             ceiling_noun(),
@@ -276,9 +313,15 @@ impl BudgetVerdict {
                 human_bytes(*forecast_bytes),
                 ceiling_noun(),
             ),
-            "  or convert a repository with less history. Note that a shallow clone is not that \
-             repository: `git clone --depth` leaves a boundary Kin refuses, because a history \
-             whose oldest commits have absent parents cannot be captured losslessly"
+            history_limit_remedy(survey, *ceiling_bytes).unwrap_or_else(|| {
+                "  or convert a repository with less history. `--history-limit` will not help \
+                 here: this repository's tree is wide enough that even one commit exceeds what \
+                 this machine can hold"
+                    .to_string()
+            }),
+            "  a shallow clone is not either of those: `git clone --depth` leaves a boundary Kin \
+             refuses, because a history whose oldest commits have absent parents cannot be \
+             captured losslessly"
                 .to_string(),
             format!(
                 "  if this {} really has more memory than Kin could read, set {} to the true \
@@ -291,6 +334,36 @@ impl BudgetVerdict {
                 .to_string(),
         ]
     }
+}
+
+/// The `--history-limit` sentence, or `None` when no bound would help.
+///
+/// One builder for both the refusal and the advisory, so the two can never
+/// offer different numbers for the same repository on the same machine. The
+/// count is the one that lands in the silent band rather than on the ceiling,
+/// because advice that converts and then warns is advice that half works.
+///
+/// `None` when the recommendation would be zero, or when it would not actually
+/// be a bound because the repository already has that little history. Offering
+/// a limit larger than the history it would bound is a sentence that reads like
+/// a remedy and changes nothing.
+fn history_limit_remedy(survey: &HistorySurvey, ceiling_bytes: u64) -> Option<String> {
+    let budget = (ceiling_bytes as f64 * TIGHT_FRACTION) as u64;
+    let commits = survey.commits_within(budget);
+    if commits == 0 || commits >= survey.commits {
+        return None;
+    }
+    Some(format!(
+        "  or take in less history: `kin init --history-limit {commits}` admits the newest          {commits} commits of this repository's first-parent history, which is about {}, and          leaves the other {} out of the graph. It keeps every Git object and every ref this          repository has, so nothing is thrown away; what it bounds is the semantic history, and          `kin log` reports where the admitted history starts",
+        human_bytes(
+            HistorySurvey {
+                commits,
+                tracked_artifacts: survey.tracked_artifacts,
+            }
+            .forecast_peak_bytes()
+        ),
+        survey.commits.saturating_sub(commits),
+    ))
 }
 
 /// Whether the ceiling this process reads belongs to a container or a machine.

--- a/crates/kin-core/src/init_budget.rs
+++ b/crates/kin-core/src/init_budget.rs
@@ -163,6 +163,18 @@ impl HistorySurvey {
     pub fn commits_within(&self, budget_bytes: u64) -> u64 {
         budget_bytes / self.bytes_per_commit().max(1)
     }
+
+    /// Commits that convert under `ceiling_bytes` without the conversion having
+    /// anything to say about memory.
+    ///
+    /// The number `--history-limit` is offered with, everywhere it is offered,
+    /// so the refusal, the advisory and `kin doctor` cannot name three
+    /// different figures for one repository on one machine. Deliberately the
+    /// count that lands in the silent band rather than on the ceiling: advice
+    /// that converts and then warns is advice that half works.
+    pub fn commits_that_convert_quietly(&self, ceiling_bytes: u64) -> u64 {
+        self.commits_within((ceiling_bytes as f64 * TIGHT_FRACTION) as u64)
+    }
 }
 
 /// What the ladder decided about this conversion's memory before running it.
@@ -242,7 +254,7 @@ impl BudgetVerdict {
             |_| {
                 format!(
                     " or take in less history with `kin init --history-limit {}`",
-                    survey.commits_within((*ceiling_bytes as f64 * TIGHT_FRACTION) as u64)
+                    survey.commits_that_convert_quietly(*ceiling_bytes)
                 )
             },
         );
@@ -348,8 +360,7 @@ impl BudgetVerdict {
 /// a limit larger than the history it would bound is a sentence that reads like
 /// a remedy and changes nothing.
 fn history_limit_remedy(survey: &HistorySurvey, ceiling_bytes: u64) -> Option<String> {
-    let budget = (ceiling_bytes as f64 * TIGHT_FRACTION) as u64;
-    let commits = survey.commits_within(budget);
+    let commits = survey.commits_that_convert_quietly(ceiling_bytes);
     if commits == 0 || commits >= survey.commits {
         return None;
     }
@@ -601,13 +612,101 @@ mod tests {
         assert!(text.contains("1676 tracked files"), "text was:\n{text}");
         assert!(text.contains("8.0 GB"), "text was:\n{text}");
         assert!(text.contains("give it more than"), "text was:\n{text}");
+        // The less-history remedy is now a command with a number in it rather
+        // than an instruction to have a different repository. FIR-2041: this
+        // sentence used to end in a dead end, telling a reader to convert less
+        // history and then ruling out the only way they could reach that.
         assert!(
-            text.contains("convert a repository with less history"),
+            text.contains("`kin init --history-limit 896`"),
             "text was:\n{text}"
         );
+        assert!(text.contains("take in less history"), "text was:\n{text}");
         assert!(text.contains("git clone --depth"), "text was:\n{text}");
         assert!(text.contains(INIT_MEMORY_CEILING_ENV), "text was:\n{text}");
         assert!(text.contains("no staging to reclaim"), "text was:\n{text}");
+    }
+
+    /// The recommended limit is one that actually converts quietly.
+    ///
+    /// Asserted by feeding the recommendation back through the verdict rather
+    /// than by recomputing the arithmetic, because a test that recomputes the
+    /// formula passes whenever the formula is self-consistent, including when
+    /// it is self-consistently wrong.
+    #[test]
+    fn the_recommended_limit_converts_without_the_conversion_saying_anything() {
+        let ceiling = 8 * 1024 * 1024 * 1024;
+        let full = survey(18_514, 1_676);
+        let recommended = full.commits_that_convert_quietly(ceiling);
+        assert!(
+            recommended > 0 && recommended < full.commits,
+            "the recommendation must bound something: {recommended} of {}",
+            full.commits
+        );
+        let bounded = survey(recommended, full.tracked_artifacts);
+        assert!(
+            matches!(verdict_for(bounded, ceiling), BudgetVerdict::Fits { .. }),
+            "a conversion at the recommended limit still spoke: {:?}",
+            verdict_for(bounded, ceiling)
+        );
+        // One more commit than recommended must NOT be silent, or the
+        // recommendation is merely small rather than the largest that fits and
+        // the reader is being told to drop history they could have kept.
+        let one_more = survey(recommended + 1, full.tracked_artifacts);
+        assert!(
+            !matches!(verdict_for(one_more, ceiling), BudgetVerdict::Fits { .. }),
+            "the recommendation is not the largest quiet limit; {} also fits",
+            recommended + 1
+        );
+    }
+
+    /// A tree wide enough that no bound helps is told so rather than offered a
+    /// limit of zero.
+    #[test]
+    fn a_repository_no_bound_can_fit_is_not_offered_a_limit() {
+        // One commit of this tree forecasts far past the ceiling, so no window
+        // of whole commits fits and the remedy has to say that.
+        let ceiling = 1024 * 1024;
+        let wide = survey(4_000, 1_000_000);
+        assert_eq!(wide.commits_that_convert_quietly(ceiling), 0);
+        let text = verdict_for(wide, ceiling).refusal_lines().join("\n");
+        assert!(
+            text.contains("`--history-limit` will not help here"),
+            "text was:\n{text}"
+        );
+        assert!(
+            !text.contains("--history-limit 0"),
+            "a limit of zero was offered as a remedy; text was:\n{text}"
+        );
+    }
+
+    /// The refactor that made the forecast invertible did not change it.
+    ///
+    /// The old form took the larger of two whole-history products; the new one
+    /// factors the commit count out first so the forecast can be inverted. They
+    /// are the same value for every input, and this pins that rather than
+    /// trusting the algebra, because a silent change to the forecast would move
+    /// every band in this module at once.
+    #[test]
+    fn factoring_the_forecast_did_not_change_what_it_forecasts() {
+        for (commits, artifacts) in [
+            (1_u64, 1_u64),
+            (200, 40),
+            (4_000, 1_000),
+            (18_514, 1_676),
+            (6_493, 2_000),
+            (1, 10_000_000),
+        ] {
+            let subject = survey(commits, artifacts);
+            let by_commit = commits.saturating_mul(BYTES_PER_COMMIT);
+            let by_tree = subject
+                .tree_entries()
+                .saturating_mul(BYTES_PER_COMMIT_ARTIFACT);
+            assert_eq!(
+                subject.forecast_peak_bytes(),
+                by_commit.max(by_tree),
+                "the forecast changed for {commits} commits over {artifacts} artifacts"
+            );
+        }
     }
 
     /// A repository large enough to overflow the product saturates high rather

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -78,7 +78,10 @@ pub use exact_tree::{
     exact_tree_correction, plan_artifact_copy, plan_artifact_move, plan_artifact_operations,
     plan_observed_tree_deltas, ArtifactTreeOperation,
 };
-pub use git_init::{init_from_git, init_from_git_adopting};
+pub use git_init::{
+    init_from_git, init_from_git_adopting, init_from_git_with_options, GitAdmissionOptions,
+};
+pub use kin_git::{AdmittedHistoryBoundary, HistoryLimit};
 pub use hooks::{
     generate_claude_hooks, render_hooks_instructions, render_hooks_json, HookTemplate,
 };
@@ -89,7 +92,7 @@ pub use init::{
     RepositoryBootstrap, RepositoryIdentityOrigin, RepositoryPublication,
 };
 pub use layout::KinLayout;
-pub use manifest::KinManifest;
+pub use manifest::{history_boundary_for, KinManifest, ManifestHistoryBoundary};
 pub use paging::LocateCursor;
 pub use resolver::{ImportResolver, PythonResolver, SymbolTable, TypeScriptResolver};
 pub use sync_state::SyncStateStore;

--- a/crates/kin-core/src/manifest.rs
+++ b/crates/kin-core/src/manifest.rs
@@ -55,6 +55,66 @@ pub struct KinManifest {
 
     /// Timestamp of repository creation.
     pub created_at: String,
+
+    /// Where admitted Git history ends, when `kin init --history-limit` bounded
+    /// it.
+    ///
+    /// Absent on every repository admitted with whole history, which is the
+    /// default and every repository written before this field existed, so its
+    /// absence means "nothing was cut" and never "nobody recorded it". A reader
+    /// that finds it present must not describe the oldest change as the point
+    /// where the repository began, because it is the point where admission
+    /// began and the Git commits before it are in this store as Git objects.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_boundary: Option<ManifestHistoryBoundary>,
+}
+
+/// The durable form of a bounded admission's edge.
+///
+/// Kept in the manifest rather than derived on demand, because the only way to
+/// derive it is to notice that the oldest change's Git commit has parents the
+/// graph does not hold, and a reader that has to infer a boundary is a reader
+/// that will sometimes infer it wrongly. Object ids are hex strings so this
+/// record stays readable by anything that can read JSON.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestHistoryBoundary {
+    /// The `--history-limit N` the operator asked for.
+    pub requested_limit: usize,
+    /// Commits actually admitted into the semantic graph.
+    pub admitted_commits: usize,
+    /// Oldest admitted Git commit. Admitted history starts here.
+    pub oldest_admitted_commit: String,
+    /// Git commits that are parents of an admitted commit and were not
+    /// admitted: the first entry of the mainline edge, plus every side branch
+    /// a merge in the window reached for.
+    pub unadmitted_parents: Vec<String>,
+}
+
+/// The admitted-history boundary this repository recorded, if any.
+///
+/// Returns `None` both for a whole-history repository and for a manifest this
+/// build cannot read, and the two are the same answer on purpose: every command
+/// that calls this is about to describe history, and the honest description of
+/// an unreadable manifest is the one that claims no boundary rather than one it
+/// invented. A store whose manifest cannot be read has larger problems, and the
+/// commands that open the authority report them.
+pub fn history_boundary_for(layout: &KinLayout) -> Option<ManifestHistoryBoundary> {
+    KinManifest::load(&layout.manifest_path())
+        .ok()
+        .and_then(|manifest| manifest.history_boundary)
+}
+
+impl ManifestHistoryBoundary {
+    /// One sentence a command prints about where admitted history ends.
+    pub fn summary(&self) -> String {
+        format!(
+            "admitted history starts at Git commit {}, the oldest of {} commit(s) admitted under              `--history-limit {}`; {} older or side-branch Git commit(s) are in this store as Git              objects and are not in the semantic graph",
+            self.oldest_admitted_commit,
+            self.admitted_commits,
+            self.requested_limit,
+            self.unadmitted_parents.len(),
+        )
+    }
 }
 
 impl Default for KinManifest {
@@ -143,6 +203,7 @@ impl KinManifest {
             repo_id: uuid::Uuid::new_v4().to_string(),
             workspace_id: uuid::Uuid::new_v4().to_string(),
             created_at: chrono::Utc::now().to_rfc3339(),
+            history_boundary: None,
         }
     }
 

--- a/crates/kin-core/tests/init_history_limit.rs
+++ b/crates/kin-core/tests/init_history_limit.rs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin init --history-limit N` takes in part of a Git history, and says so.
+//!
+//! The tests here are paired on purpose. Every assertion about a bounded
+//! conversion has a whole-history twin over the same fixture, because the
+//! defect that would matter most is not a bound that fails to cut, it is a
+//! default that silently cuts. A store missing history nobody asked to drop
+//! looks exactly like a store that has it, and nothing downstream would
+//! notice: the counts are self-consistent, every proof passes, and the only
+//! evidence is history that is not there.
+//!
+//! The fixture carries a merge on purpose. A first-parent window is a chain, so
+//! a side branch merged into it is reachable Git history the window does not
+//! admit, and it has to be recorded as an unadmitted parent rather than
+//! silently dropped.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Commits on the fixture's mainline before the side branch is merged.
+const TRUNK_COMMITS: usize = 8;
+
+/// Commits admitted by the bounded arm.
+///
+/// Small enough to leave real history outside the window and large enough to
+/// contain the merge, so the bounded arm exercises both edges: the mainline
+/// cut at the oldest admitted commit, and a merge parent outside the window.
+const LIMIT: usize = 4;
+
+fn git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "Kin Fixture")
+        .env("GIT_AUTHOR_EMAIL", "fixture@firelock.ai")
+        .env("GIT_COMMITTER_NAME", "Kin Fixture")
+        .env("GIT_COMMITTER_EMAIL", "fixture@firelock.ai")
+        .output()
+        .unwrap_or_else(|error| panic!("git {args:?} failed to start: {error}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit(repo: &Path, name: &str, body: &str) {
+    std::fs::write(repo.join(format!("src/{name}.rs")), body.as_bytes()).unwrap();
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-m", &format!("add {name}")]);
+}
+
+/// A history with a mainline, a side branch, and a merge back into it.
+///
+/// Returns the total number of commits, counted from Git rather than from the
+/// arithmetic above, so a fixture that does not build what this file claims
+/// fails here rather than inside an assertion about Kin.
+fn build_history(repo: &Path) -> usize {
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    git(repo, &["init", "--initial-branch=main"]);
+    git(repo, &["config", "user.name", "Kin Fixture"]);
+    git(repo, &["config", "user.email", "fixture@firelock.ai"]);
+
+    for index in 0..TRUNK_COMMITS {
+        commit(
+            repo,
+            &format!("trunk_{index}"),
+            &format!("pub struct Trunk{index} {{ pub field: u32 }}\n"),
+        );
+    }
+
+    git(repo, &["checkout", "-b", "side"]);
+    commit(repo, "side_one", "pub struct SideOne { pub field: u32 }\n");
+    commit(repo, "side_two", "pub struct SideTwo { pub field: u32 }\n");
+    git(repo, &["checkout", "main"]);
+    git(repo, &["merge", "--no-ff", "-m", "merge side", "side"]);
+    commit(repo, "after_merge", "pub struct After { pub field: u32 }\n");
+
+    let listed = Command::new("git")
+        .current_dir(repo)
+        .args(["rev-list", "--all", "--count"])
+        .output()
+        .expect("count fixture commits");
+    String::from_utf8_lossy(&listed.stdout)
+        .trim()
+        .parse()
+        .expect("git prints a commit count")
+}
+
+fn source(workspace: &Path) -> std::path::PathBuf {
+    let repo = workspace.join("source");
+    std::fs::create_dir(&repo).unwrap();
+    repo
+}
+
+/// Whole history is what a conversion that says nothing takes in.
+///
+/// The control for every bounded assertion below, and the one that would catch
+/// a default that started bounding.
+#[test]
+fn the_default_conversion_admits_every_commit_and_records_no_boundary() {
+    let workspace = tempfile::tempdir().unwrap();
+    let repo = source(workspace.path());
+    let total = build_history(&repo);
+    let repo = repo.canonicalize().unwrap();
+
+    let result = kin_core::init_from_git(&repo).expect("admit the fixture repository");
+
+    assert_eq!(
+        result.authority.semantic_enrichment.semantic_change_count, total,
+        "the default takes in every one of the fixture's {total} commits"
+    );
+    assert_eq!(
+        result.manifest.history_boundary, None,
+        "a whole-history conversion records no boundary, so a reader is never told its history \
+         is incomplete when it is not"
+    );
+    assert_eq!(
+        kin_core::history_boundary_for(&result.layout),
+        None,
+        "and the durable manifest agrees with the value the conversion returned"
+    );
+}
+
+/// The same fixture through the options-taking entry point, with no bound.
+///
+/// Separate from the test above because they can fail apart: the default could
+/// be right while the path a bounded conversion takes is wrong even when it is
+/// handed no bound, which is the shape where `--history-limit` with no value
+/// would quietly cut.
+#[test]
+fn the_options_entry_point_with_no_limit_is_the_default() {
+    let workspace = tempfile::tempdir().unwrap();
+    let repo = source(workspace.path());
+    let total = build_history(&repo);
+    let repo = repo.canonicalize().unwrap();
+
+    let result = kin_core::init_from_git_with_options(
+        &repo,
+        None,
+        kin_core::GitAdmissionOptions::default(),
+    )
+    .expect("admit the fixture repository");
+
+    assert_eq!(
+        result.authority.semantic_enrichment.semantic_change_count, total,
+        "the default options take in every commit"
+    );
+    assert_eq!(result.manifest.history_boundary, None);
+}
+
+/// A bound admits exactly what it asked for, and records where it stopped.
+#[test]
+fn a_bounded_conversion_admits_the_window_and_records_its_edge() {
+    let workspace = tempfile::tempdir().unwrap();
+    let repo = source(workspace.path());
+    let total = build_history(&repo);
+    let repo = repo.canonicalize().unwrap();
+    assert!(
+        total > LIMIT,
+        "the fixture must have more history than the bound, or this test proves nothing"
+    );
+
+    let result = kin_core::init_from_git_with_options(
+        &repo,
+        None,
+        kin_core::GitAdmissionOptions {
+            history_limit: kin_core::HistoryLimit::from_count(LIMIT),
+        },
+    )
+    .expect("admit the fixture repository under a history limit");
+
+    assert_eq!(
+        result.authority.semantic_enrichment.semantic_change_count, LIMIT,
+        "a first-parent window of {LIMIT} admits exactly {LIMIT} commits, which is the whole \
+         reason the window is first-parent"
+    );
+
+    let boundary = result
+        .manifest
+        .history_boundary
+        .as_ref()
+        .expect("a conversion that cut history records where it cut");
+    assert_eq!(boundary.requested_limit, LIMIT);
+    assert_eq!(boundary.admitted_commits, LIMIT);
+    assert!(
+        !boundary.oldest_admitted_commit.is_empty(),
+        "the boundary names the commit admitted history starts at"
+    );
+    assert!(
+        !boundary.unadmitted_parents.is_empty(),
+        "cutting {LIMIT} commits out of {total} leaves at least the mainline parent unadmitted"
+    );
+
+    // The durable record, read back off disk rather than from the value the
+    // call returned, because the manifest is what every later command reads.
+    let durable = kin_core::history_boundary_for(&result.layout)
+        .expect("the boundary is durable, not just returned");
+    assert_eq!(&durable, boundary);
+    assert!(
+        durable.summary().contains("are not in the semantic graph"),
+        "the durable summary says what was left out rather than implying nothing was: {}",
+        durable.summary()
+    );
+}
+
+/// The merge in the fixture puts a side-branch commit outside a small window,
+/// and it is recorded rather than dropped.
+#[test]
+fn a_side_branch_outside_the_window_is_recorded_as_unadmitted() {
+    let workspace = tempfile::tempdir().unwrap();
+    let repo = source(workspace.path());
+    build_history(&repo);
+    let repo = repo.canonicalize().unwrap();
+
+    // Two commits back from HEAD is the merge itself, whose second parent is
+    // the side branch and is therefore outside any first-parent window.
+    let result = kin_core::init_from_git_with_options(
+        &repo,
+        None,
+        kin_core::GitAdmissionOptions {
+            history_limit: kin_core::HistoryLimit::from_count(2),
+        },
+    )
+    .expect("admit the fixture repository under a history limit");
+
+    let boundary = result
+        .manifest
+        .history_boundary
+        .expect("a conversion that cut history records where it cut");
+    assert_eq!(boundary.admitted_commits, 2);
+    assert!(
+        boundary.unadmitted_parents.len() >= 2,
+        "a window ending on a merge leaves both the mainline parent and the side branch \
+         unadmitted, and both are recorded: {:?}",
+        boundary.unadmitted_parents
+    );
+}
+
+/// Asking for more history than a repository has is not a boundary.
+#[test]
+fn a_limit_larger_than_the_history_admits_all_of_it_and_records_nothing() {
+    let workspace = tempfile::tempdir().unwrap();
+    let repo = source(workspace.path());
+    let total = build_history(&repo);
+    let repo = repo.canonicalize().unwrap();
+
+    let result = kin_core::init_from_git_with_options(
+        &repo,
+        None,
+        kin_core::GitAdmissionOptions {
+            history_limit: kin_core::HistoryLimit::from_count(total * 10),
+        },
+    )
+    .expect("admit the fixture repository");
+
+    assert_eq!(
+        result.authority.semantic_enrichment.semantic_change_count, total,
+        "a limit nothing binds admits every commit"
+    );
+    assert_eq!(
+        result.manifest.history_boundary, None,
+        "reporting a boundary here would tell an operator their history is incomplete at the \
+         exact moment all of it was admitted"
+    );
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4967,8 +4967,13 @@ async fn command_log(
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
     let response =
-        kin_cli::commands::log::build_log_response(&repository_authority, graph.as_ref(), &request)
-            .map_err(internal_error)?;
+        kin_cli::commands::log::build_log_response(
+            &repository_authority,
+            graph.as_ref(),
+            &request,
+            kin_core::history_boundary_for(&state.layout),
+        )
+        .map_err(internal_error)?;
     Ok(Json(response))
 }
 

--- a/crates/kin-git/src/admission_history.rs
+++ b/crates/kin-git/src/admission_history.rs
@@ -22,6 +22,7 @@ use kin_model::{
 };
 
 use crate::error::{GitError, Result};
+use crate::history_bound::{AdmittedHistoryBoundary, HistoryLimit};
 use crate::lossless::{GitObjectFormat, LosslessGitRepository};
 use crate::semantic_import::{
     derive_enriched_semantic_git_history, GitWorkspaceSeed, SemanticGitImportPlan,
@@ -56,6 +57,11 @@ pub struct AdmittedSemanticGitImportPlan {
     pub workspace_base_change_id: Option<SemanticChangeId>,
     pub ref_mutations: Vec<RefMutation>,
     pub default_ref_mutation: Option<DefaultRefMutation>,
+    /// How much of the snapshot's history this admission took in, carried from
+    /// the plan it admitted so a re-derivation rebuilds the same window.
+    pub history_limit: HistoryLimit,
+    /// Where the admitted history stops, absent when nothing was cut.
+    pub admitted_boundary: Option<AdmittedHistoryBoundary>,
 }
 
 /// Refusal when an admitted plan does not match what its own raw objects,
@@ -137,6 +143,7 @@ impl AdmittedSemanticGitImportPlan {
         let derived = derive_enriched_semantic_git_history(
             &snapshot,
             blob_store,
+            self.history_limit,
             &held_semantics,
             &mut |oid, parent_oids, enriched, _enriched_alias, tree| {
                 let (admitted, alias) =
@@ -166,7 +173,8 @@ impl AdmittedSemanticGitImportPlan {
         // against is the walk's own: how many commits this repository's raw
         // objects actually reach, rather than how many the visitor happened to
         // be handed.
-        if checked != derived.commits
+        if derived.admitted_boundary != self.admitted_boundary
+            || checked != derived.commits
             || admitted.commits != derived.commits
             || self.changes.len() != derived.commits
             || self.aliases.len() != derived.commits
@@ -449,6 +457,8 @@ fn build_admitted_semantic_git_import_plan(
         workspace_base_change_id: derived.workspace_base_change_id,
         ref_mutations: plan.ref_mutations.clone(),
         default_ref_mutation: plan.default_ref_mutation.clone(),
+        history_limit: plan.history_limit,
+        admitted_boundary: plan.admitted_boundary.clone(),
     })
 }
 

--- a/crates/kin-git/src/history_bound.rs
+++ b/crates/kin-git/src/history_bound.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! How much Git history one admission takes in, and where it stopped.
+//!
+//! Git is an ingestion input at this boundary, so a bounded import is a smaller
+//! input rather than a different kind of truth: the graph's own history starts
+//! at admission either way. What changes under a bound is where "admission"
+//! begins, and that edge is recorded here rather than left for a reader to
+//! infer from a change that happens to have no parent.
+//!
+//! Nothing in this module bounds the lossless Git capture. A bounded
+//! repository still holds every Git object and every ref the source had, and
+//! every exactness proof over that capture is unchanged. Only the derived
+//! semantic history is bounded.
+
+use std::num::NonZeroUsize;
+
+use kin_model::GitObjectId;
+
+/// How much Git history one semantic import derives.
+///
+/// [`Self::Whole`] is the default in the type system as well as in the product,
+/// so a caller that says nothing gets every commit. That is deliberate: a
+/// default that silently bounded history would be a worse defect than the
+/// memory ceiling the bound exists to work around, because a store missing
+/// history nobody asked to drop looks exactly like a store that has it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HistoryLimit {
+    /// Every commit the snapshot holds, which is every commit reachable from
+    /// every ref.
+    #[default]
+    Whole,
+    /// The newest `commits` commits of HEAD's first-parent chain.
+    ///
+    /// First-parent because it is the only window whose size a caller can
+    /// predict: `git log --first-parent` is a chain, so asking for N admits N,
+    /// while any reachability-closed window admits however much a merge dragged
+    /// in. A side branch merged into that chain is therefore an unadmitted
+    /// parent, recorded as one.
+    FirstParent { commits: NonZeroUsize },
+}
+
+impl HistoryLimit {
+    /// The bound as a commit count, or `None` for whole history.
+    pub fn commits(&self) -> Option<NonZeroUsize> {
+        match self {
+            Self::Whole => None,
+            Self::FirstParent { commits } => Some(*commits),
+        }
+    }
+
+    /// Whether this admission takes in every commit it can reach.
+    pub fn is_whole(&self) -> bool {
+        matches!(self, Self::Whole)
+    }
+
+    /// Build a limit from a raw count, treating zero as whole history.
+    ///
+    /// Zero means "no bound" rather than "admit nothing", because the only way
+    /// a zero reaches here is a caller threading an unset option through an
+    /// integer, and admitting nothing is never what that caller meant.
+    pub fn from_count(commits: usize) -> Self {
+        match NonZeroUsize::new(commits) {
+            Some(commits) => Self::FirstParent { commits },
+            None => Self::Whole,
+        }
+    }
+}
+
+/// Where a bounded admission stopped taking history in.
+///
+/// Present only when a bound actually cut something. A `--history-limit` larger
+/// than the repository's own history admits all of it and records no boundary,
+/// because there is no edge to report and claiming one would tell a reader
+/// their history is incomplete when it is not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdmittedHistoryBoundary {
+    /// The count the operator asked for.
+    pub requested_limit: usize,
+    /// Commits actually admitted, which is the length of the first-parent chain
+    /// this walk took. Never more than `requested_limit`.
+    pub admitted_commits: usize,
+    /// The oldest commit this admission took in. Its parents are the edge.
+    pub oldest_admitted_commit: GitObjectId,
+    /// Commits that are parents of an admitted commit and were not admitted.
+    ///
+    /// Both kinds live here and a reader can tell them apart by looking: the
+    /// first parent of `oldest_admitted_commit` is where the mainline stops,
+    /// and every other entry is a merge's side branch this window did not
+    /// reach. Sorted, so two runs of the same admission record the same bytes.
+    pub unadmitted_parents: Vec<GitObjectId>,
+}
+
+impl AdmittedHistoryBoundary {
+    /// One sentence a command can print about where admitted history ends.
+    ///
+    /// Says what was admitted and what was not, and never says the repository
+    /// began here, which is the specific untruth this record exists to prevent.
+    pub fn summary(&self) -> String {
+        format!(
+            "admitted history starts at Git commit {}, which is the oldest of the {} commits \
+             `--history-limit {}` took in; {} older or side-branch Git commit(s) are in this \
+             store as Git objects and are not in the semantic graph",
+            self.oldest_admitted_commit,
+            self.admitted_commits,
+            self.requested_limit,
+            self.unadmitted_parents.len(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_default_limit_is_whole_history() {
+        assert_eq!(HistoryLimit::default(), HistoryLimit::Whole);
+        assert!(HistoryLimit::default().is_whole());
+        assert_eq!(HistoryLimit::default().commits(), None);
+    }
+
+    #[test]
+    fn a_zero_count_is_whole_history_rather_than_nothing() {
+        assert_eq!(HistoryLimit::from_count(0), HistoryLimit::Whole);
+    }
+
+    #[test]
+    fn a_positive_count_bounds_the_first_parent_chain() {
+        let limit = HistoryLimit::from_count(800);
+        assert_eq!(limit.commits().map(NonZeroUsize::get), Some(800));
+        assert!(!limit.is_whole());
+    }
+
+    #[test]
+    fn the_summary_never_claims_the_repository_began_at_the_boundary() {
+        let boundary = AdmittedHistoryBoundary {
+            requested_limit: 800,
+            admitted_commits: 800,
+            oldest_admitted_commit: GitObjectId::Sha1([7; 20]),
+            unadmitted_parents: vec![GitObjectId::Sha1([9; 20])],
+        };
+        let summary = boundary.summary();
+        assert!(
+            summary.contains("admitted history starts at"),
+            "the summary names where admission starts: {summary}"
+        );
+        assert!(
+            summary.contains("are not in the semantic graph"),
+            "the summary says what was left out rather than implying nothing was: {summary}"
+        );
+    }
+}

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -26,6 +26,7 @@ pub mod admission_history;
 pub mod authority;
 pub mod error;
 pub mod global_config;
+pub mod history_bound;
 pub mod lossless;
 pub mod preflight;
 pub mod repository_export;
@@ -47,6 +48,7 @@ pub use error::{
     Result, UnsealedContentGap, UntolerableGitWorktree,
 };
 pub use global_config::empty_global_git_config;
+pub use history_bound::{AdmittedHistoryBoundary, HistoryLimit};
 pub use lossless::{
     capture_lossless_git_repository, closure_reconstruction_count,
     rehydrate_lossless_git_repository, sync_git_repository_for_authority_handoff, GitObjectFormat,
@@ -71,6 +73,6 @@ pub use sealed_observation::{
     SealedContentObservation, SealedContentSource,
 };
 pub use semantic_import::{
-    plan_semantic_git_import, GitWorkspaceSeed, HistoricalSemanticBinding, ProvedImportClosure,
-    ProvedPlanFacts, SemanticGitImportPlan,
+    plan_bounded_semantic_git_import, plan_semantic_git_import, GitWorkspaceSeed,
+    HistoricalSemanticBinding, ProvedImportClosure, ProvedPlanFacts, SemanticGitImportPlan,
 };

--- a/crates/kin-git/src/repository_export.rs
+++ b/crates/kin-git/src/repository_export.rs
@@ -28,7 +28,8 @@ use crate::lossless::{
     reject_existing_destination, require_anchored_publication_platform,
     GitObjectFormat as LosslessObjectFormat, LosslessGitRepository,
 };
-use crate::semantic_import::{plan_semantic_git_import, HistoricalSemanticBinding};
+use crate::history_bound::HistoryLimit;
+use crate::semantic_import::{plan_bounded_semantic_git_import, HistoricalSemanticBinding};
 
 /// Complete graph-owned input needed to project one Kin repository to Git.
 #[derive(Debug, Clone)]
@@ -594,7 +595,6 @@ where
     }
 
     let snapshot = lossless_snapshot_from_authority(authority)?;
-    let rebuilt = plan_semantic_git_import(&snapshot, &proof_store)?;
     let mut supplied_by_oid = BTreeMap::new();
     for change in plan
         .changes
@@ -610,6 +610,34 @@ where
             )));
         }
     }
+    // A repository admitted under `kin init --history-limit` holds every Git
+    // object and only part of the semantic history, so rebuilding the whole
+    // history here would compare 800 supplied changes against 6493 derived ones
+    // and refuse a correct store. The rebuild takes the same window instead.
+    //
+    // The supplied count is a HINT and never the proof. Every identity below is
+    // recomputed from raw objects, and the oldest admitted commit is derived as
+    // a root, which changes its tree deltas and therefore its change id and
+    // every descendant's. So a window that is not the one this store was built
+    // from produces different ids and fails the set comparison at the end,
+    // which is the assertion that actually decides this proof.
+    //
+    // Equality with the snapshot's own commit count means whole history, and it
+    // must be read that way rather than as a limit: HEAD's first-parent chain is
+    // shorter than the reachable set on any repository with a merged side
+    // branch, so treating a whole-history count as a limit would manufacture a
+    // boundary on exactly those repositories.
+    let snapshot_commits = snapshot
+        .objects
+        .iter()
+        .filter(|record| record.object.kind == ExternalObjectKind::Commit)
+        .count();
+    let limit = if supplied_by_oid.len() == snapshot_commits {
+        HistoryLimit::Whole
+    } else {
+        HistoryLimit::from_count(supplied_by_oid.len())
+    };
+    let rebuilt = plan_bounded_semantic_git_import(&snapshot, &proof_store, limit)?;
     let historical_deltas = rebuilt
         .changes
         .iter()

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -26,6 +26,7 @@ use kin_model::{
 use uuid::Uuid;
 
 use crate::error::{GitError, Result};
+use crate::history_bound::{AdmittedHistoryBoundary, HistoryLimit};
 use crate::lossless::{validate_snapshot, GitObjectFormat, LosslessGitRepository};
 
 const GIT_ARTIFACT_NAMESPACE: Uuid = Uuid::from_bytes([
@@ -126,6 +127,20 @@ pub struct SemanticGitImportPlan {
     pub workspace_seed: GitWorkspaceSeed,
     pub ref_mutations: Vec<RefMutation>,
     pub default_ref_mutation: Option<DefaultRefMutation>,
+    /// How much of this snapshot's history the plan took in.
+    ///
+    /// Carried on the plan rather than passed to each re-derivation, because
+    /// every proof over this plan rebuilds it from `external_objects`, which is
+    /// the WHOLE object set whatever the bound was. A re-derivation handed a
+    /// different bound than the one that built the plan would refuse a correct
+    /// plan, so the bound has to travel with the thing it shaped.
+    pub history_limit: HistoryLimit,
+    /// Where a bounded admission stopped, absent when nothing was cut.
+    ///
+    /// Derived, never supplied: [`Self::validate`] recomputes it from the raw
+    /// objects and the limit above and refuses a plan that claims a different
+    /// edge, so this field cannot assert a boundary the objects do not produce.
+    pub admitted_boundary: Option<AdmittedHistoryBoundary>,
 }
 
 /// The plan fields every Git source proof reads.
@@ -308,9 +323,17 @@ impl SemanticGitImportPlan {
         let derived = derive_semantic_git_history(
             &snapshot,
             blob_store,
+            self.history_limit,
             TreeRetention::Frontier,
             &mut |oid, change, alias, tree| comparison.check_commit(oid, change, alias, tree),
         )?;
+        if derived.admitted_boundary != self.admitted_boundary {
+            return Err(GitError::InvalidSnapshot(format!(
+                "{DETERMINISTIC_DERIVATION}: this plan records a different admitted-history \
+                 boundary than its own raw objects derive under {:?}",
+                self.history_limit
+            )));
+        }
         comparison.finish(&derived)
     }
 
@@ -332,6 +355,7 @@ impl SemanticGitImportPlan {
         let derived = derive_semantic_git_history(
             &snapshot,
             blob_store,
+            self.history_limit,
             TreeRetention::Frontier,
             &mut |oid, change, alias, tree| comparison.check_commit(oid, change, alias, tree),
         )?;
@@ -345,7 +369,21 @@ pub fn plan_semantic_git_import(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
 ) -> Result<SemanticGitImportPlan> {
-    build_semantic_git_import_plan(snapshot, blob_store)
+    build_semantic_git_import_plan(snapshot, blob_store, HistoryLimit::Whole)
+}
+
+/// [`plan_semantic_git_import`], taking in only part of the snapshot's history.
+///
+/// The snapshot is unchanged and stays the whole exact Git repository. What is
+/// bounded is the semantic history derived from it, so a bounded repository
+/// still holds every Git object and every ref, and the graph simply starts
+/// later. [`HistoryLimit::Whole`] here is byte-for-byte the call above.
+pub fn plan_bounded_semantic_git_import(
+    snapshot: &LosslessGitRepository,
+    blob_store: &BlobStore,
+    limit: HistoryLimit,
+) -> Result<SemanticGitImportPlan> {
+    build_semantic_git_import_plan(snapshot, blob_store, limit)
 }
 
 /// What an enriched re-derivation still holds once every commit has been
@@ -360,6 +398,8 @@ pub(crate) struct DerivedEnrichedHistory {
     pub(crate) default_ref_mutation: Option<DefaultRefMutation>,
     /// Commits derived, which a caller compares against what it holds.
     pub(crate) commits: usize,
+    /// Where this walk stopped taking history in, absent when nothing was cut.
+    pub(crate) admitted_boundary: Option<AdmittedHistoryBoundary>,
 }
 
 /// Re-derive exact semantic history from a lossless snapshot and re-apply the
@@ -378,6 +418,7 @@ pub(crate) struct DerivedEnrichedHistory {
 pub(crate) fn derive_enriched_semantic_git_history<'held>(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
+    limit: HistoryLimit,
     held_semantics: &dyn Fn(GitObjectId) -> Option<(&'held [EntityDelta], &'held [RelationDelta])>,
     visit: &mut dyn FnMut(
         GitObjectId,
@@ -396,6 +437,7 @@ pub(crate) fn derive_enriched_semantic_git_history<'held>(
     let derived = derive_semantic_git_history(
         snapshot,
         blob_store,
+        limit,
         TreeRetention::Frontier,
         &mut |oid, mut change, _unenriched_alias, tree| {
             let unenriched_id = change.id;
@@ -436,6 +478,7 @@ pub(crate) fn derive_enriched_semantic_git_history<'held>(
         ref_mutations: derived.ref_mutations,
         default_ref_mutation: derived.default_ref_mutation,
         commits: derived.commits,
+        admitted_boundary: derived.admitted_boundary,
     })
 }
 
@@ -717,7 +760,116 @@ struct DerivedGitHistory {
     ref_mutations: Vec<RefMutation>,
     default_ref_mutation: Option<DefaultRefMutation>,
     /// Commits derived, which a caller compares against what it accumulated.
+    ///
+    /// Under a bound this is the ADMITTED count rather than the snapshot's, so
+    /// every `!= derived.commits` check in this crate keeps meaning "the plan
+    /// holds exactly what the walk produced" without one of them being edited.
     commits: usize,
+    /// Where this walk stopped taking history in, absent when nothing was cut.
+    admitted_boundary: Option<AdmittedHistoryBoundary>,
+}
+
+/// The commits one admission takes in, with the edge it stopped at.
+struct AdmittedWindow {
+    /// Admitted commits. A parent outside the window has been removed from its
+    /// child's parent list, which is what makes that child a root.
+    commits: BTreeMap<GitObjectId, ParsedCommit>,
+    boundary: Option<AdmittedHistoryBoundary>,
+}
+
+/// Choose the commits a bounded admission takes in.
+///
+/// Walks HEAD's first-parent chain back at most `limit` commits, then strips
+/// every parent edge leaving that set. Stripping rather than skipping is the
+/// whole mechanism: the derivation already treats a commit with no parents as a
+/// root diffed against the empty tree, so the oldest admitted commit becomes a
+/// root by the same rule genesis uses, and no downstream check has to learn a
+/// new case. Leaving a dangling parent instead would fail four different ways,
+/// starting at `topological_commit_order`.
+///
+/// Whole history returns the input untouched and records no boundary, so the
+/// default path is not merely equivalent to today's but is the same values.
+fn admitted_window(
+    all: BTreeMap<GitObjectId, ParsedCommit>,
+    head_commit: Option<GitObjectId>,
+    limit: HistoryLimit,
+) -> Result<AdmittedWindow> {
+    let Some(want) = limit.commits() else {
+        return Ok(AdmittedWindow {
+            commits: all,
+            boundary: None,
+        });
+    };
+    let Some(head_commit) = head_commit else {
+        return Err(GitError::InvalidSnapshot(
+            "a bounded history import counts back from HEAD, and this repository's HEAD reaches \
+             no commit; convert it with whole history instead"
+                .to_string(),
+        ));
+    };
+
+    let mut chain = Vec::new();
+    let mut walked = BTreeSet::new();
+    let mut cursor = Some(head_commit);
+    while let Some(oid) = cursor {
+        if chain.len() == want.get() {
+            break;
+        }
+        if !walked.insert(oid) {
+            return Err(GitError::InvalidSnapshot(format!(
+                "first-parent history from HEAD revisits commit {oid}"
+            )));
+        }
+        let parsed = all.get(&oid).ok_or_else(|| GitError::MissingObject {
+            oid: oid.to_string(),
+            context: "first-parent history from HEAD".to_string(),
+        })?;
+        cursor = parsed.parents.first().copied();
+        chain.push(oid);
+    }
+
+    // Asking for more history than a repository has is not an error and is not
+    // a boundary. Reporting one would tell an operator their history is
+    // incomplete at the exact moment all of it was admitted.
+    if chain.len() == all.len() {
+        return Ok(AdmittedWindow {
+            commits: all,
+            boundary: None,
+        });
+    }
+
+    let admitted = chain.iter().copied().collect::<BTreeSet<_>>();
+    let oldest_admitted_commit = *chain
+        .last()
+        .expect("a non-empty limit over a repository with a HEAD commit admits at least one");
+
+    let mut unadmitted_parents = BTreeSet::new();
+    let mut commits = BTreeMap::new();
+    for (oid, mut parsed) in all {
+        if !admitted.contains(&oid) {
+            continue;
+        }
+        let mut kept = Vec::with_capacity(parsed.parents.len());
+        for parent in parsed.parents {
+            if admitted.contains(&parent) {
+                kept.push(parent);
+            } else {
+                unadmitted_parents.insert(parent);
+            }
+        }
+        parsed.parents = kept;
+        commits.insert(oid, parsed);
+    }
+
+    Ok(AdmittedWindow {
+        boundary: Some(AdmittedHistoryBoundary {
+            requested_limit: want.get(),
+            admitted_commits: commits.len(),
+            oldest_admitted_commit,
+            unadmitted_parents: unadmitted_parents.into_iter().collect(),
+        }),
+        commits,
+    })
 }
 
 /// Derive exact semantic history from a lossless snapshot and its CAS, handing
@@ -730,6 +882,7 @@ struct DerivedGitHistory {
 fn derive_semantic_git_history(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
+    limit: HistoryLimit,
     retention: TreeRetention,
     visit: &mut dyn FnMut(
         GitObjectId,
@@ -745,7 +898,19 @@ fn derive_semantic_git_history(
         .map(|record| (record.object, record))
         .collect::<BTreeMap<_, _>>();
     let hash_kind = gix_hash_kind(snapshot.object_format);
-    let commits = parse_commits(snapshot, &bodies, hash_kind)?;
+    // Resolved before the window rather than beside the reader-count block
+    // below, because the window counts back from this commit. It is ref
+    // arithmetic plus a tag peel, so hoisting it costs nothing.
+    let seed_commit = resolve_workspace_seed_commit(snapshot, &bodies, hash_kind)?;
+    let window = admitted_window(
+        parse_commits(snapshot, &bodies, hash_kind)?,
+        seed_commit,
+        limit,
+    )?;
+    let AdmittedWindow {
+        commits,
+        boundary: admitted_boundary,
+    } = window;
     let order = topological_commit_order(&commits)?;
 
     let mut tree_decoder = TreeDecoder::new(hash_kind, &bodies, &records);
@@ -767,7 +932,6 @@ fn derive_semantic_git_history(
             *remaining_readers.entry(*parent).or_default() += 1;
         }
     }
-    let seed_commit = resolve_workspace_seed_commit(snapshot, &bodies, hash_kind)?;
     if let Some(seed) = seed_commit {
         *remaining_readers.entry(seed).or_default() += 1;
     }
@@ -893,7 +1057,7 @@ fn derive_semantic_git_history(
 
     if derived != commits.len() {
         return Err(GitError::InvalidSnapshot(
-            "not every reachable Git commit was derived exactly once".to_string(),
+            "not every admitted Git commit was derived exactly once".to_string(),
         ));
     }
 
@@ -937,18 +1101,21 @@ fn derive_semantic_git_history(
         ref_mutations,
         default_ref_mutation,
         commits: commits.len(),
+        admitted_boundary,
     })
 }
 
 fn build_semantic_git_import_plan(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
+    limit: HistoryLimit,
 ) -> Result<SemanticGitImportPlan> {
     let mut changes = Vec::new();
     let mut aliases = Vec::new();
     let derived = derive_semantic_git_history(
         snapshot,
         blob_store,
+        limit,
         TreeRetention::Whole,
         &mut |_oid, change, alias, _tree| {
             changes.push(change);
@@ -962,7 +1129,7 @@ fn build_semantic_git_import_plan(
         || aliases.len() != derived.commits
     {
         return Err(GitError::InvalidSnapshot(
-            "not every reachable Git commit produced one tree, change, and alias".to_string(),
+            "not every admitted Git commit produced one tree, change, and alias".to_string(),
         ));
     }
 
@@ -978,6 +1145,8 @@ fn build_semantic_git_import_plan(
         workspace_seed: derived.workspace_seed,
         ref_mutations: derived.ref_mutations,
         default_ref_mutation: derived.default_ref_mutation,
+        history_limit: limit,
+        admitted_boundary: derived.admitted_boundary,
     })
 }
 

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -811,8 +811,13 @@ fn admitted_window(
     let mut chain = Vec::new();
     let mut walked = BTreeSet::new();
     let mut cursor = Some(head_commit);
+    // Which of the two reasons the walk stopped, because they mean opposite
+    // things. Running out of chain means the limit bound nothing; reaching the
+    // limit means it did.
+    let mut reached_the_limit = false;
     while let Some(oid) = cursor {
         if chain.len() == want.get() {
+            reached_the_limit = true;
             break;
         }
         if !walked.insert(oid) {
@@ -831,7 +836,13 @@ fn admitted_window(
     // Asking for more history than a repository has is not an error and is not
     // a boundary. Reporting one would tell an operator their history is
     // incomplete at the exact moment all of it was admitted.
-    if chain.len() == all.len() {
+    //
+    // Keyed on WHY the walk stopped, not on comparing the chain's length to the
+    // repository's commit count. Those differ on any repository with a merged
+    // side branch, because a first-parent chain is shorter than the reachable
+    // set, so a length comparison manufactures a boundary on exactly those
+    // repositories no matter how large the limit was.
+    if !reached_the_limit {
         return Ok(AdmittedWindow {
             commits: all,
             boundary: None,

--- a/scripts/acceptance/history_limit_boundary.py
+++ b/scripts/acceptance/history_limit_boundary.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""NON-CITABLE acceptance suite for bounded Git history admission (FIR-2041).
+
+`kin init --history-limit N` takes in the newest N commits of HEAD's
+first-parent history instead of all of it, so a repository whose whole history
+does not fit a machine can still be converted. This suite proves the flag cuts
+what it says it cuts, records where it stopped, and says so on the surface a
+reader would otherwise misread.
+
+The default arm is the load-bearing one and it runs FIRST. A bound that fails to
+cut is a visible defect: the conversion is as expensive as it always was and the
+operator finds out immediately. A default that silently cuts is not visible at
+all. The store is internally consistent, every proof passes, the counts agree
+with each other, and the only evidence is history that is not there. So check 0
+converts the same fixture with no flag and requires every commit, and check 1's
+pass means nothing without it.
+
+Check 2 grades the boundary as a JOIN rather than against a fixed expectation.
+It takes the commit ids the product published as unadmitted and requires the
+SOURCE repository to hold every one of them, and requires the oldest admitted
+commit to be a commit the source holds too. An expectation that the list is
+merely non-empty passes on a list of fabricated ids, and a boundary naming
+commits that do not exist is exactly what an off-by-one in the window selection
+would produce.
+
+Check 3 is the false-boundary control. A limit larger than the repository's own
+history admits all of it and must record NO boundary, because reporting one
+would tell an operator their history is incomplete at the moment all of it was
+admitted. Without this arm, a boundary written unconditionally satisfies every
+assertion in check 1.
+
+What this suite does NOT grade, said here so nobody later reads it as more: it
+grades the admitted window, the durable record and the reported sentence. It
+grades no resident set and no conversion peak. Whether a bounded conversion
+actually fits a smaller machine is a measurement, not a check, and FIR-2955 owns
+the memory it is a workaround for.
+
+Each check prints:
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+Exit status is 1 when any check fails, 2 when none fail but some are unreadable,
+3 on setup failure, and 0 only when every check passes. ``--self-test`` drives
+every grader against its inverse without building a repository.
+"""
+
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+TICKET = "FIR-2041"
+
+# Commits on the fixture's mainline before the side branch merges in.
+TRUNK_COMMITS = 8
+
+# The bound the bounded arm asks for. Small enough that real history falls
+# outside the window on a fixture this size, and large enough that the window
+# still contains more than one commit.
+LIMIT = 3
+
+# Fragments of the sentence a bounded repository prints at the end of its log.
+# Graded as a set of required fragments rather than by equality, because the
+# sentence carries a commit id and two counts that vary with the fixture; the
+# fragments are the CLAIMS, which do not.
+BOUNDARY_CLAIMS = (
+    "admitted history starts at",
+    "are not in the semantic graph",
+)
+
+# The claim the sentence must never make. `kin log` reaching the oldest admitted
+# change is the exact moment a reader concludes the repository began there, and
+# the whole point of the record is that it did not.
+FORBIDDEN_CLAIM = "repository began"
+
+
+def tail(text, limit=600):
+    text = (text or "").strip()
+    return text if len(text) <= limit else "..." + text[-limit:]
+
+
+def run(cmd, cwd=None, env=None, timeout=900):
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        timeout=timeout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return proc.returncode, proc.stdout
+
+
+class Result(object):
+    def __init__(self, check_id, title):
+        self.id = check_id
+        self.title = title
+        self.asserts = []
+
+    def ok(self, detail):
+        self.asserts.append({"status": PASS, "detail": detail})
+
+    def bad(self, detail):
+        self.asserts.append({"status": FAIL, "detail": detail})
+
+    def unknown(self, detail):
+        self.asserts.append({"status": UNREADABLE, "detail": detail})
+
+    @property
+    def status(self):
+        if any(row["status"] == FAIL for row in self.asserts):
+            return FAIL
+        if any(row["status"] == UNREADABLE for row in self.asserts):
+            return UNREADABLE
+        return PASS if self.asserts else UNREADABLE
+
+    @property
+    def detail(self):
+        for wanted in (FAIL, UNREADABLE):
+            for row in self.asserts:
+                if row["status"] == wanted:
+                    return row["detail"]
+        passed = [row["detail"] for row in self.asserts if row["status"] == PASS]
+        return "; ".join(passed) if passed else "no assertion was reached"
+
+
+def boundary_problems(manifest, expect_bounded, requested=None, admitted=None):
+    """Problems in one manifest's recorded boundary.
+
+    One grader for both directions, so the bounded and unbounded arms cannot
+    drift into disagreeing about what the record means.
+    """
+    if not isinstance(manifest, dict):
+        return None
+    recorded = manifest.get("history_boundary")
+    if not expect_bounded:
+        if recorded is None:
+            return []
+        return ["a conversion that cut nothing recorded a boundary: %r" % (recorded,)]
+    if recorded is None:
+        return ["a conversion that cut history recorded no boundary"]
+    problems = []
+    if requested is not None and recorded.get("requested_limit") != requested:
+        problems.append(
+            "recorded requested_limit %r, asked for %r"
+            % (recorded.get("requested_limit"), requested)
+        )
+    if admitted is not None and recorded.get("admitted_commits") != admitted:
+        problems.append(
+            "recorded admitted_commits %r, admitted %r"
+            % (recorded.get("admitted_commits"), admitted)
+        )
+    if not recorded.get("oldest_admitted_commit"):
+        problems.append("the boundary names no oldest admitted commit")
+    if not recorded.get("unadmitted_parents"):
+        problems.append("the boundary names no unadmitted parent")
+    return problems
+
+
+def log_problems(text, expect_bounded):
+    """Problems in one ``kin log`` rendering's boundary sentence."""
+    body = text or ""
+    hits = [line for line in body.splitlines() if BOUNDARY_CLAIMS[0] in line]
+    if not expect_bounded:
+        return [] if not hits else ["a whole-history repository printed %r" % hits]
+    if len(hits) != 1:
+        return ["expected one boundary sentence, got %d" % len(hits)]
+    line = hits[0]
+    problems = []
+    for claim in BOUNDARY_CLAIMS:
+        if claim not in line:
+            problems.append("the sentence omits %r" % claim)
+    if FORBIDDEN_CLAIM in line:
+        problems.append("the sentence claims the %r there" % FORBIDDEN_CLAIM)
+    return problems
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.daemon = daemon
+        self.workdir = workdir
+        self.verbose = verbose
+        self.env = dict(os.environ)
+        self.env["KIN_HOME"] = os.path.join(workdir, "kin-home")
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DIR", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        os.makedirs(self.env["KIN_HOME"], exist_ok=True)
+        self.total_commits = None
+
+    def log(self, line):
+        if self.verbose:
+            print("  " + line, flush=True)
+
+    def git(self, repo, args, check=True):
+        base = ["git", "-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
+        rc, out = run(base + args, cwd=repo, env=self.env)
+        if check and rc != 0:
+            raise RuntimeError("git %s failed: %s" % (" ".join(args), tail(out)))
+        return rc, out
+
+    def kin_run(self, repo, args, timeout=900):
+        rc, out = run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+        self.log("kin %s -> %d" % (" ".join(args), rc))
+        return rc, out
+
+    def build_fixture(self, name):
+        """A fresh copy of the same history, one per arm.
+
+        Copied rather than shared, because `kin init` writes into the
+        repository it converts and two arms sharing one directory would make the
+        second arm's result depend on the first.
+        """
+        repo = os.path.join(self.workdir, name)
+        os.makedirs(os.path.join(repo, "src"))
+        self.git(repo, ["init", "--initial-branch=main"])
+        self.git(repo, ["config", "user.name", "Kin Acceptance"])
+        self.git(repo, ["config", "user.email", "acceptance@firelock.ai"])
+
+        def commit(label, body):
+            with open(os.path.join(repo, "src", "%s.py" % label), "w") as handle:
+                handle.write(body)
+            self.git(repo, ["add", "-A"])
+            self.git(repo, ["commit", "-m", "add %s" % label])
+
+        for index in range(TRUNK_COMMITS):
+            commit("trunk_%d" % index, "def trunk_%d():\n    return %d\n" % (index, index))
+        self.git(repo, ["checkout", "-b", "side"])
+        commit("side_one", "def side_one():\n    return 1\n")
+        self.git(repo, ["checkout", "main"])
+        self.git(repo, ["merge", "--no-ff", "-m", "merge side", "side"])
+        commit("after_merge", "def after_merge():\n    return 0\n")
+
+        _, out = self.git(repo, ["rev-list", "--all", "--count"])
+        total = int(out.strip())
+        if self.total_commits is None:
+            self.total_commits = total
+        elif self.total_commits != total:
+            raise RuntimeError("fixture builds are not identical across arms")
+        return repo
+
+    def manifest(self, repo):
+        path = os.path.join(repo, ".kin", "manifest.json")
+        if not os.path.isfile(path):
+            return None
+        with open(path) as handle:
+            return json.load(handle)
+
+    def change_count(self, repo):
+        """Git-origin changes in the store, read from `kin log --json`.
+
+        A window wider than the fixture is requested so the walk reaches the
+        bottom; the count is what the report actually returned rather than what
+        was asked for.
+        """
+        rc, out = self.kin_run(repo, ["log", "-n", "10000", "--json"])
+        if rc != 0:
+            return None, out
+        try:
+            start = out.find("{")
+            end = out.rfind("}")
+            report = json.loads(out[start : end + 1])
+        except (ValueError, IndexError):
+            return None, out
+        return len(report.get("entries", [])), out
+
+    def convert(self, repo, limit=None):
+        args = ["init", "--no-enrich"]
+        if limit is not None:
+            args += ["--history-limit", str(limit)]
+        return self.kin_run(repo, args)
+
+
+def check_default_is_whole(suite):
+    """CHECK 0: a conversion that says nothing takes in every commit."""
+    result = Result(0, "the default admits whole history")
+    repo = suite.build_fixture("default-arm")
+    rc, out = suite.convert(repo)
+    if rc != 0:
+        result.unknown("`kin init` with no flag exited %d: %s" % (rc, tail(out)))
+        return result, None
+    count, log_out = suite.change_count(repo)
+    if count is None:
+        result.unknown("`kin log --json` was not readable: %s" % tail(log_out))
+        return result, None
+    if count != suite.total_commits:
+        result.bad(
+            "the default admitted %d of the fixture's %d commits, so it bounded history "
+            "nobody asked to bound" % (count, suite.total_commits)
+        )
+        return result, repo
+    result.ok("the default admitted all %d commits" % count)
+
+    problems = boundary_problems(suite.manifest(repo), expect_bounded=False)
+    if problems is None:
+        result.unknown("the manifest was not readable")
+        return result, repo
+    if problems:
+        result.bad("; ".join(problems))
+        return result, repo
+    result.ok("and recorded no boundary")
+
+    problems = log_problems(log_out, expect_bounded=False)
+    if problems:
+        result.bad("; ".join(problems))
+        return result, repo
+    result.ok("and `kin log` said nothing about an admitted-history edge")
+    return result, repo
+
+
+def check_bound_cuts_and_records(suite):
+    """CHECK 1: a bound admits its window and records where it stopped."""
+    result = Result(1, "a bound admits its window")
+    repo = suite.build_fixture("bounded-arm")
+    rc, out = suite.convert(repo, limit=LIMIT)
+    if rc != 0:
+        result.unknown("`kin init --history-limit %d` exited %d: %s" % (LIMIT, rc, tail(out)))
+        return result, None
+    count, log_out = suite.change_count(repo)
+    if count is None:
+        result.unknown("`kin log --json` was not readable: %s" % tail(log_out))
+        return result, None
+    if count != LIMIT:
+        result.bad(
+            "`--history-limit %d` admitted %d changes; a first-parent window of N admits "
+            "exactly N" % (LIMIT, count)
+        )
+        return result, repo
+    result.ok("`--history-limit %d` admitted exactly %d changes" % (LIMIT, LIMIT))
+
+    problems = boundary_problems(
+        suite.manifest(repo), expect_bounded=True, requested=LIMIT, admitted=LIMIT
+    )
+    if problems is None:
+        result.unknown("the manifest was not readable")
+        return result, repo
+    if problems:
+        result.bad("; ".join(problems))
+        return result, repo
+    result.ok("the manifest records the requested limit, the admitted count and the edge")
+
+    problems = log_problems(log_out, expect_bounded=True)
+    if problems:
+        result.bad("; ".join(problems))
+        return result, repo
+    result.ok("and `kin log` reports where admitted history starts")
+    return result, repo
+
+
+def check_boundary_names_real_commits(suite, repo):
+    """CHECK 2: every commit the boundary names is one the source repository holds."""
+    result = Result(2, "the boundary names real Git commits")
+    if repo is None:
+        result.unknown("the bounded arm produced no repository to read")
+        return result
+    manifest = suite.manifest(repo)
+    recorded = (manifest or {}).get("history_boundary")
+    if not recorded:
+        result.unknown("the bounded arm recorded no boundary to grade")
+        return result
+
+    named = list(recorded.get("unadmitted_parents") or [])
+    oldest = recorded.get("oldest_admitted_commit")
+    if oldest:
+        named.append(oldest)
+    if not named:
+        result.unknown("the boundary named no commits at all")
+        return result
+
+    missing = []
+    for oid in named:
+        rc, _ = suite.git(repo, ["cat-file", "-e", "%s^{commit}" % oid], check=False)
+        if rc != 0:
+            missing.append(oid)
+    if missing:
+        result.bad(
+            "the boundary names %d commit(s) this repository does not hold: %s"
+            % (len(missing), ", ".join(missing[:4]))
+        )
+        return result
+    result.ok("all %d commit(s) the boundary names exist in the repository" % len(named))
+
+    # The must-miss control. Without it, a `cat-file -e` that answered 0 for
+    # everything would pass the arm above on any list at all.
+    fabricated = "0" * 40
+    rc, _ = suite.git(repo, ["cat-file", "-e", "%s^{commit}" % fabricated], check=False)
+    if rc == 0:
+        result.unknown("the existence probe accepts a fabricated commit id, so it proves nothing")
+        return result
+    result.ok("and a fabricated id is rejected by the same probe")
+    return result
+
+
+def check_a_limit_that_binds_nothing_records_nothing(suite):
+    """CHECK 3: asking for more history than there is records no boundary."""
+    result = Result(3, "a limit nothing binds records nothing")
+    repo = suite.build_fixture("roomy-arm")
+    limit = (suite.total_commits or TRUNK_COMMITS) * 10
+    rc, out = suite.convert(repo, limit=limit)
+    if rc != 0:
+        result.unknown("`kin init --history-limit %d` exited %d: %s" % (limit, rc, tail(out)))
+        return result
+    count, log_out = suite.change_count(repo)
+    if count is None:
+        result.unknown("`kin log --json` was not readable: %s" % tail(log_out))
+        return result
+    if count != suite.total_commits:
+        result.bad(
+            "a limit of %d over %d commits admitted only %d"
+            % (limit, suite.total_commits, count)
+        )
+        return result
+    result.ok("a limit of %d admitted all %d commits" % (limit, count))
+
+    problems = boundary_problems(suite.manifest(repo), expect_bounded=False)
+    if problems is None:
+        result.unknown("the manifest was not readable")
+        return result
+    if problems:
+        result.bad("; ".join(problems))
+        return result
+    result.ok("and recorded no boundary, so no reader is told history is incomplete")
+
+    problems = log_problems(log_out, expect_bounded=False)
+    if problems:
+        result.bad("; ".join(problems))
+        return result
+    result.ok("and `kin log` stayed silent")
+    return result
+
+
+def self_test():
+    """Drive every grader against its inverse, with no repository."""
+    checks = 0
+    asserts = 0
+
+    def expect(condition, label):
+        nonlocal asserts
+        asserts += 1
+        if not condition:
+            print("SELFTEST FAIL %s" % label)
+            sys.exit(1)
+
+    checks += 1
+    expect(boundary_problems({"history_boundary": None}, False) == [], "unbounded accepts absent")
+    expect(
+        boundary_problems({"history_boundary": {"requested_limit": 3}}, False) != [],
+        "unbounded rejects a recorded boundary",
+    )
+    expect(
+        boundary_problems({"history_boundary": None}, True) != [],
+        "bounded rejects an absent boundary",
+    )
+
+    checks += 1
+    good = {
+        "history_boundary": {
+            "requested_limit": 3,
+            "admitted_commits": 3,
+            "oldest_admitted_commit": "a" * 40,
+            "unadmitted_parents": ["b" * 40],
+        }
+    }
+    expect(boundary_problems(good, True, 3, 3) == [], "bounded accepts a complete record")
+    expect(
+        boundary_problems(good, True, 4, 3) != [],
+        "bounded rejects a record whose requested limit is not the one asked for",
+    )
+    expect(
+        boundary_problems(good, True, 3, 4) != [],
+        "bounded rejects a record whose admitted count is not the one admitted",
+    )
+    for field in ("oldest_admitted_commit", "unadmitted_parents"):
+        broken = {"history_boundary": dict(good["history_boundary"])}
+        broken["history_boundary"][field] = "" if field.endswith("commit") else []
+        expect(
+            boundary_problems(broken, True, 3, 3) != [],
+            "bounded rejects a record missing %s" % field,
+        )
+    expect(boundary_problems("not a manifest", True) is None, "an unreadable manifest is unknown")
+
+    checks += 1
+    sentence = (
+        "admitted history starts at Git commit abc, the oldest of 3 commit(s) admitted under "
+        "`--history-limit 3`; 2 older or side-branch Git commit(s) are in this store as Git "
+        "objects and are not in the semantic graph"
+    )
+    expect(log_problems("change x\n\n" + sentence, True) == [], "a full sentence passes")
+    expect(log_problems("change x", True) != [], "a missing sentence fails the bounded arm")
+    expect(log_problems("change x", False) == [], "silence passes the unbounded arm")
+    expect(
+        log_problems("change x\n\n" + sentence, False) != [],
+        "a sentence on a whole-history repository fails",
+    )
+    expect(
+        log_problems("change x\n\nadmitted history starts at commit abc", True) != [],
+        "a sentence that omits what was left out fails",
+    )
+    expect(
+        log_problems(
+            "change x\n\n" + sentence + " and the repository began here", True
+        )
+        != [],
+        "a sentence claiming the repository began at the edge fails",
+    )
+    expect(
+        log_problems("change x\n\n" + sentence + "\n" + sentence, True) != [],
+        "two sentences fail rather than passing on the first",
+    )
+
+    print("SELFTEST PASS %d assertions over %d graders" % (asserts, checks))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path", default=None)
+    parser.add_argument("--label", default=os.environ.get("KIN_ACCEPTANCE_LABEL"))
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not args.kin:
+        print("setup error: --kin or KIN_BIN must name the binary under test", file=sys.stderr)
+        return 3
+    if not os.path.isfile(args.kin) or not os.access(args.kin, os.X_OK):
+        print("setup error: %s is not an executable file" % args.kin, file=sys.stderr)
+        return 3
+
+    workdir = tempfile.mkdtemp(prefix="kin-history-limit-")
+    results = []
+    try:
+        suite = Suite(args.kin, workdir, daemon=args.daemon, verbose=args.verbose)
+        # The unbounded control runs first on purpose: check 1 proves nothing
+        # about a product whose default already bounds.
+        default_result, _ = check_default_is_whole(suite)
+        results.append(default_result)
+        bounded_result, bounded_repo = check_bound_cuts_and_records(suite)
+        results.append(bounded_result)
+        results.append(check_boundary_names_real_commits(suite, bounded_repo))
+        results.append(check_a_limit_that_binds_nothing_records_nothing(suite))
+    except Exception as error:  # noqa: BLE001 - a setup failure is its own exit code
+        print("setup error: %s" % error, file=sys.stderr)
+        return 3
+    finally:
+        if not args.keep:
+            import shutil
+
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    for result in results:
+        print("CHECK %d %s %s %s" % (result.id, TICKET, result.status, result.detail), flush=True)
+
+    if args.json_path:
+        with open(args.json_path, "w") as handle:
+            json.dump(
+                {
+                    "label": args.label,
+                    "ticket": TICKET,
+                    "checks": [
+                        {
+                            "id": result.id,
+                            "title": result.title,
+                            "status": result.status,
+                            "detail": result.detail,
+                            "asserts": result.asserts,
+                        }
+                        for result in results
+                    ],
+                },
+                handle,
+                indent=2,
+            )
+
+    if any(result.status == FAIL for result in results):
+        return 1
+    if any(result.status == UNREADABLE for result in results):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**This does not work end to end and must not land as a feature.** The derivation bounds correctly and the store cannot be written, because kin-db and kin-model require a repository's admitted change set to be ancestry-closed to the Git roots. That is a contract in two other repos, not a defect in this branch, and the finding is the deliverable here.

## The wall, measured in two directions and read in the third

**With the Git authority installed as it is today,** every Git commit projection must have a semantic alias. `kin-db-0.7.71/src/storage/repository.rs:3234`. Running `cargo test -p kin-core --test init_history_limit`:

```
Graph("invalid operation: Git commit projection 37c90ee2... has no
repository-scoped semantic alias")
```

Projections are built from every commit record in the object set, inside kin-model's `GitExternalAuthority::from_raw_parts` (`git_authority.rs:651`), so a whole capture makes one per Git commit while aliases exist only for admitted ones.

**Omitting the authority for a bounded admission** is the obvious workaround, and the field allows it: `git_external_authority` is `Option<GitExternalAuthority>` and kin-db skips the block when it is absent. Tested, and it refuses from the other side:

```
Graph("invalid operation: transaction alias fb3b0b5c... has no commit
projection in the resulting Git external authority")
```

So the alias set and the projection set must be equal. That cost one build and it was worth it: nothing in the first error predicts the second.

**Making them equal by bounding the capture instead** fails too, read rather than run because the reading is unambiguous. A commit's decoded dependencies are `[tree, ...parents]`, and `kin-model-0.7.22/src/git_authority.rs:1059` requires every dependency whose `requires_closure_object()` is true to be present, which is every kind except `Gitlink` (`:129`). The boundary commit's parents are absent by construction, so a bounded capture refuses with `MissingDependency`; kin-db checks the projected parents at `repository.rs:3271` as well.

Together: every admitted commit's parents must be admitted, so any set holding a non-root commit pulls its parents transitively to a root, and an ancestry-closed set is whole history. No window satisfies the contract, so nothing inside this repo closes it.

## What is on the branch and does work

The derivation bounds. `derive_semantic_git_history` is the single rule shared by plan construction and by every re-derivation that proves a plan, so a bound there cannot drift between them. The window walks HEAD's first-parent chain and strips parent edges leaving the admitted set, which makes the oldest admitted commit a root by the rule genesis already uses. `HistoryLimit::Whole` is the type's `Default` and `init_from_git` keeps its signature, so every existing caller is unbounded by construction; two integration tests cover the default separately and both pass. The flag, the manifest record, the `kin log` sentence, the budget recommendation and a four-check acceptance suite are all written.

## What it would take to finish

A cross-repo change, kin-model then kin-db then kin. kin-model must let a commit's parent dependency be absent when the authority declares that commit an admission boundary, which needs a new field and therefore a `GIT_EXTERNAL_AUTHORITY_SCHEMA_VERSION` bump; tolerating an absent parent unconditionally would accept a corrupt capture everywhere. kin-db must make the alias and projection sets a bijection over the admitted set. That size is not measured here and no estimate is offered.

## What is not claimed

No memory measurement was taken, because no bounded store could be written to measure. Whether a bounded conversion fits a smaller machine is unknown. FIR-2955 owns the daemon memory this was meant to work around and is untouched.

Refs FIR-2041
Refs FIR-2955

Filed as FIR-2967, which carries all three code sites, both measured errors and the change shape.
