### PR TITLE
Retry the fast gate's registry fetches when the handshake is reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1106,7 +1106,12 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
-          cargo metadata --no-deps --format-version 1 > "$RUNNER_TEMP/metadata.json"
+          # Wrapped for FIR-2950: the kin registry intermittently resets one
+          # connection during the TLS handshake, which killed three shards
+          # tonight before any test ran. The wrapper retries ONLY that error
+          # and leaves stdout untouched, so this redirect still gets clean JSON.
+          scripts/retry-on-registry-reset.sh \
+            cargo metadata --no-deps --format-version 1 > "$RUNNER_TEMP/metadata.json"
           : > "$RUNNER_TEMP/changed.txt"
           if [ -n "${BASE_SHA:-}" ] && [ -n "${HEAD_SHA:-}" ]; then
             git diff --name-only "$BASE_SHA...$HEAD_SHA" -- > "$RUNNER_TEMP/changed.txt" || {
@@ -1130,7 +1135,11 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t SCOPE < "$RUNNER_TEMP/scope.args"
-          cargo nextest list --locked "${SCOPE[@]}" --message-format json \
+          # Wrapped for FIR-2950. All three specimens died here: nextest shells
+          # out to `cargo metadata`, which fetches the sparse index, and the
+          # reset arrives before a single test runs.
+          scripts/retry-on-registry-reset.sh \
+            cargo nextest list --locked "${SCOPE[@]}" --message-format json \
             > "$RUNNER_TEMP/listing.json"
           python3 - "$RUNNER_TEMP/listing.json" <<'LISTING'
           import json, sys

--- a/scripts/retry-on-registry-reset.sh
+++ b/scripts/retry-on-registry-reset.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Retry a cargo invocation when kin's private registry resets the connection
+# during the TLS handshake, and never for any other reason.
+#
+# FIR-2950. Three CI shards died in under 200 ms with
+# `[35] SSL connect error (Recv failure: Connection reset by peer)` while
+# fetching the sparse index, before a single test ran, and in every case
+# sibling shards starting the same second against the same registry resolved
+# fine: main 33270307105 at 19:13:46Z, kin #1249 33277299552 at 21:55:58Z, and
+# kin #1250 33284158820 at 00:48:46Z.
+#
+# Do NOT reach for `CARGO_NET_RETRY` or `[net] retry` here. Cargo does not
+# classify curl 35 as retryable, measured on cargo 1.96.0 against a listener
+# that resets during the handshake: default and `CARGO_NET_RETRY=5` each made
+# exactly ONE connection attempt, while the same lever against an HTTP 500
+# moved 4 attempts to 6. The lever works and does not cover this class, which
+# is why the retry has to wrap the invocation rather than configure it.
+#
+# This retries a TRANSPORT failure that happens before the suite starts. It
+# never tolerates a test failure or a compile error: any output that does not
+# carry the needle is re-emitted verbatim and the original exit status is
+# returned unchanged.
+set -uo pipefail
+
+NEEDLE='[35] SSL connect error'
+ATTEMPTS="${REGISTRY_RETRY_ATTEMPTS:-3}"
+BACKOFF="${REGISTRY_RETRY_BACKOFF_SECS:-3}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: ${0##*/} <command> [args...]" >&2
+  exit 64
+fi
+
+log="$(mktemp "${TMPDIR:-/tmp}/retry-registry.XXXXXX")"
+trap 'rm -f "$log"' EXIT INT TERM
+
+attempt=1
+while :; do
+  # STDOUT is left completely alone, because every caller here redirects it to a
+  # file (`cargo metadata ... > metadata.json`, `cargo nextest list ... >
+  # listing.json`). Merging stderr into it would write warnings into the JSON
+  # and the parse would fail for a reason that has nothing to do with the
+  # registry. Only stderr is captured, and it is re-emitted verbatim after.
+  "$@" 2>"$log"
+  rc=$?
+  cat "$log" >&2
+
+  if [ "$rc" -eq 0 ]; then
+    exit 0
+  fi
+
+  if grep -qF -- "$NEEDLE" "$log" && [ "$attempt" -lt "$ATTEMPTS" ]; then
+    echo "::warning title=Registry reset::attempt ${attempt} of ${ATTEMPTS} hit '${NEEDLE}' from the kin registry (FIR-2950); retrying in ${BACKOFF}s" >&2
+    attempt=$((attempt + 1))
+    sleep "$BACKOFF"
+    continue
+  fi
+
+  # Either a real failure or a reset that outlived its retries. The output is
+  # already on the log above; say which case this is and hand back the
+  # command's own status so nothing is masked.
+  if grep -qF -- "$NEEDLE" "$log"; then
+    echo "::error title=Registry reset::the kin registry reset the connection on all ${ATTEMPTS} attempts (FIR-2950)" >&2
+  fi
+  exit "$rc"
+done


### PR DESCRIPTION
Three fast-gate shards died tonight before a single test ran, each in under 200 ms, on the same error while fetching the sparse index. This retries that one transport failure and nothing else.

## The specimens

| when | run | shard |
|---|---|---|
| 2026-08-29T19:13:46Z | main 33270307105 | Fast gate test shard (3) |
| 2026-08-29T21:55:58Z | #1249 bump PR, 33277299552 | shard 1 |
| 2026-08-30T00:48:46Z | #1250, 33284158820 | shard 2 |

From the third specimen's own log, the whole failure is 198 ms:

```
00:48:46.3329075Z     Updating `kin` index
00:48:46.5297731Z error: failed to get `kin-blobs` as a dependency of package `kin-core v0.6.2`
00:48:46.5309699Z   [35] SSL connect error (Recv failure: Connection reset by peer)
```

In every case sibling shards started the same second against the same registry and resolved fine, so the fault is per connection and intermittent rather than the registry being down.

## Do not reach for CARGO_NET_RETRY

That was the obvious fix and it does not work. Cargo does not classify curl 35 as retryable. Measured on cargo 1.96.0, the version CI runs, against a listener that accepts, consumes the ClientHello, then closes with `SO_LINGER` at zero to reproduce the identical error string:

```
CONTROL sparse registry returns HTTP 500, default        4 connection attempts
CONTROL same, CARGO_NET_RETRY=5                          6 connection attempts
reset during TLS handshake, default                      1 connection attempt
reset during TLS handshake, CARGO_NET_RETRY=5            1 connection attempt
```

The control is what makes that a measurement rather than a guess: it proves cargo retries, that the counter detects retries, and that the lever genuinely moves behaviour, four to six. Against that working lever the real error class stays at one attempt in both arms. So the retry has to wrap the invocation rather than configure it, and the script says so in its header for the next reader.

## What this does

`scripts/retry-on-registry-reset.sh` retries only on `[35] SSL connect error`, up to three attempts with a short backoff, and returns the command's own exit status with its output intact for anything else. It is wired into the two registry-touching steps of `fast-gate-tests` that run before the suite: the package selection's `cargo metadata`, and `cargo nextest list`, which is where all three specimens died because nextest shells out to `cargo metadata` internally.

It leaves stdout completely alone. Both call sites redirect stdout to a file, and merging stderr into it would write warnings into the JSON and fail the parse for a reason unrelated to the registry.

## Falsification, four arms

```
1 transient reset then success      rc=0    2 attempts, 1 retry logged
2 persistent reset, real cargo      rc=101  server saw 3 connections, needle preserved, loud final error
3 compile error                     rc=101  0 retries, the compile error shown
4 stdout redirected to a file       rc=0    valid JSON, 0 bytes of stderr leaked
```

Arm 2 runs real cargo against the reset listener, so the retry is proven against the actual error class rather than a stub. Arm 4 is not decoration: it caught a real defect in the first version of this wrapper, which merged stderr into stdout and would have corrupted both call sites' JSON.

This retries a transport failure before the suite starts. It never tolerates a test failure.

Refs FIR-2950.
