### PR TITLE
Admit the working copy before kin status and kin diff answer about it

### DIFF
--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -623,8 +623,24 @@ fn summarize(
     summary
 }
 
-pub fn run(base: Option<String>, head: Option<String>, json: bool) -> Result<()> {
+pub async fn run(base: Option<String>, head: Option<String>, json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
+    // Admit, THEN diff, for the same reason `kin status` does and by the same
+    // founder-owned decision relayed 2026-08-30. A diff whose WORKSPACE endpoint
+    // is the graph as it was before your edit reports `+0 ~0 -0` over a file you
+    // just wrote, which is the answer that sent a stranger looking for a lost
+    // module (FIR-2499) and told another that a rewritten function body had not
+    // changed (FIR-2961). Reading the working copy to ADMIT it is ingestion at
+    // an explicit input boundary, not answering from files.
+    //
+    // Only when a workspace endpoint is actually involved. A diff between two
+    // changes is history, and walking the tree to answer it would be a cost with
+    // nothing behind it.
+    let pass = if endpoint_is_workspace(base.as_deref()) || endpoint_is_workspace(head.as_deref()) {
+        Some(crate::commands::status::admit_before_reading(&layout).await)
+    } else {
+        None
+    };
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
     let report = inspect(&binding, base.as_deref(), head.as_deref())?;
     if json {
@@ -633,9 +649,66 @@ pub fn run(base: Option<String>, head: Option<String>, json: bool) -> Result<()>
         for line in render_lines(&report) {
             println!("{line}");
         }
+        if let Some(line) = semantic_scope_line(&report) {
+            println!("{line}");
+        }
+        if let Some(crate::commands::status::StatusAdmission::Skipped(why)) = pass.as_ref() {
+            println!("Admission scope: this diff was not measured against the working copy: {why}");
+        }
         println!("{}", admitted_scope_line(&layout));
     }
     Ok(())
+}
+
+/// Whether a requested endpoint spelling names the workspace.
+///
+/// `None` is the workspace on the head side and HEAD on the base side, and the
+/// defaults are applied inside `inspect`, so this asks about the SPELLING a
+/// caller used and errs toward admitting: a bare `kin diff` is the everyday
+/// call and its head endpoint is the workspace.
+fn endpoint_is_workspace(requested: Option<&str>) -> bool {
+    matches!(requested, None | Some("WORKSPACE") | Some("workspace"))
+}
+
+/// What the entity and relation counts above cannot show on a workspace endpoint.
+///
+/// A workspace endpoint's semantic side is its base change's entities and
+/// relations plus the workspace semantic overlay, and no writer in the daemon
+/// ever puts an entity delta into that overlay. The admission seam publishes
+/// with `semantic_delta: WorkspaceSemanticDelta::default()`, unconditionally,
+/// and the one other overlay writer computes its delta with the authority
+/// entities as BOTH the base and the desired side, so it cannot emit an entity
+/// delta either. `Entities: +0 ~0 -0` on a HEAD-to-WORKSPACE diff is therefore
+/// structural rather than an answer about the edit.
+///
+/// A stranger read the pair as an answer, checked it against a fully settled
+/// graph (`kin graph status`: 78 of 78 embeddings indexed, 8 of 8 files at 100%
+/// coverage), and concluded the semantic layer had silently skipped a rewrite of
+/// a function body (FIR-2961). Naming the scope beside the counts is what tells a
+/// real zero apart from one nothing could have moved.
+///
+/// Silent on a diff between two changes, where the entity delta is computed and
+/// means what it says.
+fn semantic_scope_line(report: &DiffReport) -> Option<String> {
+    let base_is_workspace = matches!(report.base.source, DiffEndpointSource::Workspace);
+    let head_is_workspace = matches!(report.head.source, DiffEndpointSource::Workspace);
+    if !base_is_workspace && !head_is_workspace {
+        return None;
+    }
+    let side = if base_is_workspace && head_is_workspace {
+        "Both endpoints are"
+    } else if head_is_workspace {
+        "The head endpoint is"
+    } else {
+        "The base endpoint is"
+    };
+    Some(format!(
+        "Semantic scope: {side} the workspace, whose entities and relations are its base \
+         change's plus a workspace semantic overlay that no admission writes entity or relation \
+         deltas into. So semantic movement made in the working copy since its base change \
+         appears in neither count above, whatever the artifact rows show; commit it and diff \
+         change to change to see it."
+    ))
 }
 
 /// What this diff does not cover, and when the graph last caught up.

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1197,7 +1197,7 @@ pub async fn admit_before_reading(layout: &kin_core::KinLayout) -> StatusAdmissi
             Err(error) => {
                 return StatusAdmission::Skipped(format!(
                     "this store cannot name an author for an admission ({}), so nothing admitted                      the working copy",
-                    crate::error::cause_first(&error)
+                    crate::core::error::cause_first(&error)
                 ))
             }
         },
@@ -1218,11 +1218,11 @@ pub async fn admit_before_reading(layout: &kin_core::KinLayout) -> StatusAdmissi
         },
         crate::daemon_client::AdmitDispatch::Refused(error) => StatusAdmission::Skipped(format!(
             "this repository's daemon refused to admit the working copy ({})",
-            crate::error::cause_first(&error)
+            crate::core::error::cause_first(&error)
         )),
         crate::daemon_client::AdmitDispatch::Unanswered(error) => StatusAdmission::Skipped(format!(
             "the admission of the working copy did not answer ({}), so whether it ran is unknown",
-            crate::error::cause_first(&error)
+            crate::core::error::cause_first(&error)
         )),
     }
 }

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -2066,21 +2066,35 @@ mod tests {
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
         let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
 
-        let rendered = render_text(
-            &report,
-            None,
-            None,
-            None,
-            &LastAdmissionRead::Absent,
-            &skipped_pass(),
-        );
-        let tree_line = rendered
-            .lines()
-            .find(|line| line.starts_with("Tree: "))
-            .unwrap_or_default();
+        let tree_line_of = |pass: &StatusAdmission| {
+            render_text(&report, None, None, None, &LastAdmissionRead::Absent, pass)
+                .lines()
+                .find(|line| line.starts_with("Tree: "))
+                .unwrap_or_default()
+                .to_string()
+        };
+
+        // Read-after-admit outranks the marker, so with no pass behind it the
+        // line names itself unmeasured and never reaches the marker's own arm.
+        // Both are a basis; this asserts WHICH one, because a test that accepted
+        // either could not tell the two apart.
+        let skipped = tree_line_of(&skipped_pass());
         assert!(
-            tree_line.contains("no complete admission"),
-            "the Tree line itself has to carry the basis: {tree_line}"
+            skipped.contains("not measured against the working copy"),
+            "an unmeasured verdict has to say so on the Tree line itself: {skipped}"
+        );
+
+        // With a pass behind it the marker's arm is reachable again, and an
+        // absent marker still has to name itself rather than render as a bare
+        // verdict. This is the arm kin#1254 added and it is still load-bearing.
+        let took = tree_line_of(&took_pass());
+        assert!(
+            took.contains("no complete admission"),
+            "an absent marker behind a real pass still has to name itself: {took}"
+        );
+        assert!(
+            !took.contains("not measured against the working copy"),
+            "a pass that ran must not report itself unmeasured: {took}"
         );
     }
 

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -2111,6 +2111,7 @@ mod tests {
             Some(&footprint),
             None,
             &LastAdmissionRead::Absent,
+            &skipped_pass(),
         );
         assert!(
             with.contains("Store size: ") && with.contains("under .kin/"),

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -968,6 +968,10 @@ where
 
 pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
+    // Admit, THEN read. The order is the whole point: a report read before the
+    // admission describes the graph as it was, which is exactly the answer
+    // FIR-2961 is about.
+    let pass = admit_before_reading(&layout).await;
     let report = settle_embedding_coverage(wait_quiesce, || read_status_once(&layout)).await?;
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -981,6 +985,7 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
                 Some(&footprint),
                 crate::daemon_death::recorded_for_store(layout.root()).as_ref(),
                 &kin_core::last_admission::read(&layout),
+                &pass,
             )
         );
         // Which projection served the files this status describes. Appended
@@ -1017,7 +1022,7 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
         // different facts and this line says which it has, because "no
         // untracked files were named" is exactly the shape a reader takes for
         // "there are none".
-        println!("{}", untracked_host_content_line(&layout).await);
+        println!("{}", untracked_host_content_line(&pass));
     }
     Ok(())
 }
@@ -1030,24 +1035,18 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
 /// measured nothing with the same age, a daemon that has taken no measurement,
 /// and no daemon at all. Only the first two are statements about the working
 /// copy, and the other two say so rather than rendering as a clean tree.
-async fn untracked_host_content_line(layout: &kin_core::KinLayout) -> String {
+fn untracked_host_content_line(pass: &StatusAdmission) -> String {
     const LEAD: &str = "Untracked host content:";
-    let Some(base_url) = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await
-    else {
-        return format!(
-            "{LEAD} not measured; no daemon is running for this repository, and this \
-                        command reads durable authority, which cannot see a path no admission has \
-                        taken"
-        );
+    // Read off the admission this status already took, rather than asked again.
+    // Two independent readings of one working copy is how two lines about it
+    // come to disagree, and the probes ride on the admission response for
+    // exactly this reason.
+    let Some(reconcile) = pass.reconcile().cloned() else {
+        let StatusAdmission::Skipped(why) = pass else {
+            unreachable!("an admission that took a pass carries its probes")
+        };
+        return format!("{LEAD} not measured; {why}");
     };
-    let Ok(client) = crate::daemon_client::DaemonClient::from_base_url_for_layout(base_url, layout)
-    else {
-        return format!("{LEAD} not measured; this repository's daemon could not be addressed");
-    };
-    let Ok(health) = client.health().await else {
-        return format!("{LEAD} not measured; this repository's daemon did not answer");
-    };
-    let reconcile = health.reconcile;
     // Fifth arm, and the one that is not a gap. A daemon that admits nothing
     // from the filesystem has no host content waiting to be taken, so counting
     // its projected checkout would report a shortfall the graph is not in.
@@ -1108,8 +1107,9 @@ pub fn build_command_status_response(
     footprint: Option<&StoreFootprint>,
     death: Option<&kin_daemon_spawn::DaemonKillRecord>,
     admission: &LastAdmissionRead,
+    pass: &StatusAdmission,
 ) -> Result<CommandStatusResponse> {
-    let text = render_text(&report, build.as_ref(), footprint, death, admission);
+    let text = render_text(&report, build.as_ref(), footprint, death, admission, pass);
     let json = json
         .then(|| serde_json::to_string(&report))
         .transpose()
@@ -1120,6 +1120,111 @@ pub fn build_command_status_response(
         text,
         json,
     })
+}
+
+/// Graph truth caught up with the working copy, or the reason it could not be.
+///
+/// `kin status` used to answer from the graph alone. That answer is right about
+/// the graph and is read as a statement about the files on disk, and the two
+/// come apart the moment an edit lands after the last admission: a stranger
+/// running the whole everyday loop with no Git was told `matching its base
+/// change` over a tracked file edited twenty-two seconds earlier, seven readings
+/// running (FIR-2961). Putting the admission's age beside the verdict, which
+/// landed in kin#1254, makes the sentence honest and does not make it right,
+/// because measured on macOS the clock reads `0s ago` inside the roughly
+/// two-second window before the ambient watcher catches up, and on a bind mount
+/// that window has no end.
+///
+/// So status admits first and then answers, which is what `kin commit` has
+/// always done and the reason no commit ever missed an edit. Founder-owned
+/// thesis decision relayed 2026-08-30: the Zero File-Search Authority Rule
+/// permits exactly this, because reading the working copy to ADMIT it is
+/// ingestion at an explicit input boundary, not answering from files. The cost
+/// is a tree walk, which is what makes the answer true, and `git status` pays
+/// the same walk for the same reason.
+///
+/// The report rides along because the admission response already carries the
+/// reconcile probes. One round trip answers the verdict and the untracked line
+/// both, so the two surfaces cannot disagree about one working copy, which is
+/// the principle this file already holds for its enrichment counters.
+pub enum StatusAdmission {
+    /// The pass ran and the status below was read after it.
+    Took(Box<crate::commands::admit::AdmitReport>),
+    /// No pass ran, carrying the clause that says why. The verdict must not
+    /// present as a statement about the working copy in this arm.
+    Skipped(String),
+}
+
+impl StatusAdmission {
+    /// The reconcile probes the pass reported, when one ran.
+    pub fn reconcile(&self) -> Option<&crate::commands::resources::ReconcileHealth> {
+        match self {
+            Self::Took(report) => Some(&report.reconcile),
+            Self::Skipped(_) => None,
+        }
+    }
+}
+
+/// Admit the complete exact tree, then let the caller read.
+///
+/// Best effort by construction and never fatal: a status that refuses to print
+/// because an admission failed is worse than one that prints and says the
+/// admission failed. Every arm names its own basis, and none of them is silence.
+///
+/// No session lease is taken. `kin admit` holds one to keep the daemon awake
+/// across a pass an operator asked for; a status read is not that, and a leaked
+/// lease keeps a daemon alive indefinitely, which is the defect this would be
+/// trading for.
+pub async fn admit_before_reading(layout: &kin_core::KinLayout) -> StatusAdmission {
+    let Some(base_url) = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await
+    else {
+        return StatusAdmission::Skipped(
+            "no daemon is running for this repository, so nothing admitted the working copy and              this reports durable authority alone; `kin admit` takes what the working copy holds"
+                .to_string(),
+        );
+    };
+    let Ok(client) = crate::daemon_client::DaemonClient::from_base_url_for_layout(base_url, layout)
+    else {
+        return StatusAdmission::Skipped(
+            "this repository's daemon could not be addressed, so nothing admitted the working copy"
+                .to_string(),
+        );
+    };
+    let request = crate::commands::admit::AdmitRequest {
+        operation_id: kin_model::OperationId::new(),
+        actor: match crate::commands::require_commit_author() {
+            Ok(actor) => actor,
+            Err(error) => {
+                return StatusAdmission::Skipped(format!(
+                    "this store cannot name an author for an admission ({}), so nothing admitted                      the working copy",
+                    crate::error::cause_first(&error)
+                ))
+            }
+        },
+    };
+    match client.admit(&request).await {
+        crate::daemon_client::AdmitDispatch::Answered(response) => match response.report {
+            // A refused pass is an answer and it is not an admission. Reporting
+            // it as one would put the whole defect back, one layer down.
+            Some(report) if report.admitted => StatusAdmission::Took(Box::new(report)),
+            Some(report) => StatusAdmission::Skipped(format!(
+                "the admission of the working copy failed ({}), so what follows describes graph                  truth from before it",
+                report.failure.as_deref().unwrap_or("no cause recorded")
+            )),
+            None => StatusAdmission::Skipped(
+                "this repository's daemon answered the admission with no report, so whether the                  working copy was admitted is unknown"
+                    .to_string(),
+            ),
+        },
+        crate::daemon_client::AdmitDispatch::Refused(error) => StatusAdmission::Skipped(format!(
+            "this repository's daemon refused to admit the working copy ({})",
+            crate::error::cause_first(&error)
+        )),
+        crate::daemon_client::AdmitDispatch::Unanswered(error) => StatusAdmission::Skipped(format!(
+            "the admission of the working copy did not answer ({}), so whether it ran is unknown",
+            crate::error::cause_first(&error)
+        )),
+    }
 }
 
 /// The `Tree:` line's verdict, and the basis it rests on.
@@ -1146,6 +1251,7 @@ pub fn build_command_status_response(
 fn workspace_state_phrase(
     dirty: bool,
     admission: &LastAdmissionRead,
+    pass: &StatusAdmission,
     now: chrono::DateTime<Utc>,
 ) -> String {
     // Kept as a comparison against the base change rather than as "clean" or
@@ -1158,6 +1264,15 @@ fn workspace_state_phrase(
     } else {
         "matching its base change"
     };
+    // Ahead of the clock, because it outranks it. An age says how old a reading
+    // is; this says whether one was taken at all, and a verdict with nothing
+    // behind it is not a verdict about the working copy. Measured with the
+    // daemon stopped, the untracked line read "no daemon is running" while this
+    // line directly above it read "matching its base change as admitted 0s ago"
+    // (FIR-2961).
+    if let StatusAdmission::Skipped(why) = pass {
+        return format!("{verdict} as last admitted, not measured against the working copy: {why}");
+    }
     match admission {
         LastAdmissionRead::Recorded(recorded) => format!(
             "{verdict} as admitted {} ago",
@@ -1197,8 +1312,10 @@ fn render_text(
     footprint: Option<&StoreFootprint>,
     death: Option<&kin_daemon_spawn::DaemonKillRecord>,
     admission: &LastAdmissionRead,
+    pass: &StatusAdmission,
 ) -> String {
-    let workspace_state = workspace_state_phrase(report.workspace.dirty, admission, Utc::now());
+    let workspace_state =
+        workspace_state_phrase(report.workspace.dirty, admission, pass, Utc::now());
     let enrichment = match report.semantic_enrichment.presence {
         SemanticEnrichmentPresence::Absent => "absent",
         SemanticEnrichmentPresence::Present => "present",
@@ -1410,8 +1527,15 @@ mod tests {
             payload.snapshot_bytes + payload.acknowledged_delta_bytes
         );
         assert!(
-            render_text(&report, None, None, None, &LastAdmissionRead::Absent)
-                .contains("Authority payload read: "),
+            render_text(
+                &report,
+                None,
+                None,
+                None,
+                &LastAdmissionRead::Absent,
+                &skipped_pass()
+            )
+            .contains("Authority payload read: "),
             "text status must state the payload the open read"
         );
 
@@ -1712,7 +1836,14 @@ mod tests {
             EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::NoVectorIndexAttached),
         )
         .unwrap();
-        let rendered = render_text(&unobserved, None, None, None, &LastAdmissionRead::Absent);
+        let rendered = render_text(
+            &unobserved,
+            None,
+            None,
+            None,
+            &LastAdmissionRead::Absent,
+            &skipped_pass(),
+        );
         assert!(
             rendered.contains(
                 "Live embedding coverage: not observed (the live graph carries no vector index)"
@@ -1736,10 +1867,24 @@ mod tests {
         )
         .unwrap();
         assert!(
-            render_text(&observed, None, None, None, &LastAdmissionRead::Absent)
-                .contains("Live embedding coverage: 41/57 indexed, 16 pending (live query graph)"),
+            render_text(
+                &observed,
+                None,
+                None,
+                None,
+                &LastAdmissionRead::Absent,
+                &skipped_pass()
+            )
+            .contains("Live embedding coverage: 41/57 indexed, 16 pending (live query graph)"),
             "{}",
-            render_text(&observed, None, None, None, &LastAdmissionRead::Absent)
+            render_text(
+                &observed,
+                None,
+                None,
+                None,
+                &LastAdmissionRead::Absent,
+                &skipped_pass()
+            )
         );
     }
 
@@ -1751,6 +1896,97 @@ mod tests {
     /// fabricated zero or a "not measured" that nobody asked for. The report
     /// itself carries no store size in either case, which is what keeps
     /// authority status byte-identical across checkout drift.
+    /// The admission arm every existing render test wants: none was taken,
+    /// because these tests drive the formatter and not a daemon.
+    /// A pass that ran, so the arms that grade the admission's AGE are reachable.
+    /// Built through the admit fixture rather than by hand, so a field added
+    /// there has to be considered here too.
+    fn took_pass() -> StatusAdmission {
+        StatusAdmission::Took(Box::new(crate::commands::admit::AdmitReport {
+            schema: crate::commands::admit::ADMIT_SCHEMA.to_string(),
+            repository_id: RepositoryId::new("status-admission").unwrap(),
+            tracked_before: 2,
+            tracked_after: 2,
+            entities_before: 3,
+            entities_after: 3,
+            embeddings_indexed: 6,
+            embeddings_total: 6,
+            reconcile: crate::commands::resources::ReconcileHealth::default(),
+            tree_moved: Some(false),
+            admitted: true,
+            failure: None,
+        }))
+    }
+
+    fn skipped_pass() -> StatusAdmission {
+        StatusAdmission::Skipped("no daemon is running for this repository".to_string())
+    }
+
+    /// The arm this PR exists for. A verdict with no admission behind it is not
+    /// a verdict about the working copy, and the age of an older admission does
+    /// not make it one: measured with the daemon stopped, this line read
+    /// `matching its base change as admitted 0s ago` while the untracked line
+    /// directly below it correctly said nothing had measured anything.
+    #[test]
+    fn a_verdict_with_no_admission_behind_it_says_it_was_not_measured() {
+        let now = Utc::now();
+        let recorded =
+            LastAdmissionRead::Recorded(kin_core::last_admission::LastAdmission::new(now, 8));
+        // The marker is as fresh as it gets, which is the trap: a zero age is
+        // what a skipped pass is most likely to be sitting next to.
+        let phrase = workspace_state_phrase(false, &recorded, &skipped_pass(), now);
+        assert!(
+            phrase.contains("not measured against the working copy"),
+            "{phrase}"
+        );
+        assert!(phrase.contains("no daemon is running"), "{phrase}");
+        assert!(
+            !phrase.contains("as admitted 0s ago"),
+            "a skipped pass must not borrow the clock of an older admission: {phrase}"
+        );
+        // The control, over the same marker: a pass that DID run reaches the age.
+        let took = workspace_state_phrase(false, &recorded, &took_pass(), now);
+        assert!(took.contains("as admitted 0s ago"), "{took}");
+    }
+
+    /// The untracked line reads the pass this status already took. Two readings
+    /// of one working copy is how two lines about it come to disagree.
+    #[test]
+    fn the_untracked_line_reads_the_admission_this_status_took() {
+        let took = untracked_host_content_line(&took_pass());
+        assert!(took.starts_with("Untracked host content:"), "{took}");
+        // A default ReconcileHealth carries no observation age, which is the
+        // "measured nothing" arm rather than an all-clear.
+        assert!(took.contains("not measured"), "{took}");
+
+        let skipped = untracked_host_content_line(&skipped_pass());
+        assert!(skipped.contains("no daemon is running"), "{skipped}");
+    }
+
+    /// A refused admission is an answer and it is not an admission. Reporting it
+    /// as one puts the whole defect back one layer down.
+    #[test]
+    fn a_failed_admission_is_not_treated_as_a_pass() {
+        let now = Utc::now();
+        let recorded =
+            LastAdmissionRead::Recorded(kin_core::last_admission::LastAdmission::new(now, 8));
+        let refused = StatusAdmission::Skipped(
+            "the admission of the working copy failed (host entry changed), so what follows \
+             describes graph truth from before it"
+                .to_string(),
+        );
+        let phrase = workspace_state_phrase(false, &recorded, &refused, now);
+        assert!(
+            phrase.contains("not measured against the working copy"),
+            "{phrase}"
+        );
+        assert!(phrase.contains("host entry changed"), "{phrase}");
+        assert!(
+            refused.reconcile().is_none(),
+            "a skipped pass carries no probes"
+        );
+    }
+
     /// FIR-2961. `Tree: ... (matching its base change)` was read as a statement
     /// about the working copy, because with no clock beside it there is nothing
     /// else to read it as. A stranger running the everyday loop with no Git saw
@@ -1773,14 +2009,14 @@ mod tests {
             8,
         ));
 
-        let clean = workspace_state_phrase(false, &recorded, now);
+        let clean = workspace_state_phrase(false, &recorded, &took_pass(), now);
         assert!(clean.contains("matching its base change"), "{clean}");
         assert!(
             clean.contains("admitted 2m ago"),
             "the verdict has to carry when the graph last looked: {clean}"
         );
 
-        let dirty = workspace_state_phrase(true, &recorded, now);
+        let dirty = workspace_state_phrase(true, &recorded, &took_pass(), now);
         assert!(dirty.contains("ahead of its base change"), "{dirty}");
         assert!(dirty.contains("admitted 2m ago"), "{dirty}");
     }
@@ -1793,7 +2029,7 @@ mod tests {
     fn an_unknown_admission_basis_is_never_rendered_as_a_bare_verdict() {
         let now = Utc::now();
 
-        let absent = workspace_state_phrase(false, &LastAdmissionRead::Absent, now);
+        let absent = workspace_state_phrase(false, &LastAdmissionRead::Absent, &took_pass(), now);
         assert!(
             absent.contains("no complete admission"),
             "an absent marker has to say so: {absent}"
@@ -1803,6 +2039,7 @@ mod tests {
         let unreadable = workspace_state_phrase(
             false,
             &LastAdmissionRead::Unreadable("trailing bytes".to_string()),
+            &took_pass(),
             now,
         );
         assert!(unreadable.contains("will not parse"), "{unreadable}");
@@ -1824,7 +2061,14 @@ mod tests {
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
         let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
 
-        let rendered = render_text(&report, None, None, None, &LastAdmissionRead::Absent);
+        let rendered = render_text(
+            &report,
+            None,
+            None,
+            None,
+            &LastAdmissionRead::Absent,
+            &skipped_pass(),
+        );
         let tree_line = rendered
             .lines()
             .find(|line| line.starts_with("Tree: "))
@@ -1842,7 +2086,14 @@ mod tests {
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
         let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
 
-        let without = render_text(&report, None, None, None, &LastAdmissionRead::Absent);
+        let without = render_text(
+            &report,
+            None,
+            None,
+            None,
+            &LastAdmissionRead::Absent,
+            &skipped_pass(),
+        );
         assert!(
             !without.contains("Store size"),
             "an unmeasured status must print no store line at all: {without}"

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1179,7 +1179,9 @@ pub async fn admit_before_reading(layout: &kin_core::KinLayout) -> StatusAdmissi
     let Some(base_url) = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await
     else {
         return StatusAdmission::Skipped(
-            "no daemon is running for this repository, so nothing admitted the working copy and              this reports durable authority alone; `kin admit` takes what the working copy holds"
+            "no daemon is running for this repository, so nothing admitted the working copy \
+             and this reports durable authority alone; `kin admit` takes what the working \
+             copy holds"
                 .to_string(),
         );
     };
@@ -1196,8 +1198,8 @@ pub async fn admit_before_reading(layout: &kin_core::KinLayout) -> StatusAdmissi
             Ok(actor) => actor,
             Err(error) => {
                 return StatusAdmission::Skipped(format!(
-                    "this store cannot name an author for an admission ({}), so nothing admitted                      the working copy",
-                    crate::core::error::cause_first(&error)
+                    "this store cannot name an author for an admission ({error}), so nothing \
+                     admitted the working copy"
                 ))
             }
         },
@@ -1208,22 +1210,25 @@ pub async fn admit_before_reading(layout: &kin_core::KinLayout) -> StatusAdmissi
             // it as one would put the whole defect back, one layer down.
             Some(report) if report.admitted => StatusAdmission::Took(Box::new(report)),
             Some(report) => StatusAdmission::Skipped(format!(
-                "the admission of the working copy failed ({}), so what follows describes graph                  truth from before it",
+                "the admission of the working copy failed ({}), so what follows describes graph \
+                 truth from before it",
                 report.failure.as_deref().unwrap_or("no cause recorded")
             )),
             None => StatusAdmission::Skipped(
-                "this repository's daemon answered the admission with no report, so whether the                  working copy was admitted is unknown"
+                "this repository's daemon answered the admission with no report, so whether the \
+                 working copy was admitted is unknown"
                     .to_string(),
             ),
         },
         crate::daemon_client::AdmitDispatch::Refused(error) => StatusAdmission::Skipped(format!(
-            "this repository's daemon refused to admit the working copy ({})",
-            crate::core::error::cause_first(&error)
+            "this repository's daemon refused to admit the working copy ({error})"
         )),
-        crate::daemon_client::AdmitDispatch::Unanswered(error) => StatusAdmission::Skipped(format!(
-            "the admission of the working copy did not answer ({}), so whether it ran is unknown",
-            crate::core::error::cause_first(&error)
-        )),
+        crate::daemon_client::AdmitDispatch::Unanswered(error) => {
+            StatusAdmission::Skipped(format!(
+                "the admission of the working copy did not answer ({error}), so whether it ran is \
+             unknown"
+            ))
+        }
     }
 }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2708,7 +2708,7 @@ fn main() -> Result<()> {
                         .await
                     }
                 },
-                Command::Diff { base, head, json } => commands::diff::run(base, head, json),
+                Command::Diff { base, head, json } => commands::diff::run(base, head, json).await,
                 Command::Eject { yes } => commands::eject::run(yes).await,
                 Command::Impact {
                     entity,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4387,6 +4387,16 @@ async fn command_status(
         // durable marker rather than from this daemon's own probes, which reset
         // on restart and then report every store as never admitted (FIR-2961).
         &kin_core::last_admission::read(&state.layout),
+        // This endpoint stays a pure read. The CLI admits before it reads, which
+        // is where the founder's 2026-08-30 decision applies, and a caller of
+        // this route drives its own admission through `/commands/admit`. Saying
+        // so here rather than leaving the verdict unqualified is the point: a
+        // report that did not admit must not present as one that did.
+        &kin_cli::commands::status::StatusAdmission::Skipped(
+            "this report came from the daemon's status route, which does not admit; drive \
+             `/commands/admit` first for an answer measured against the working copy"
+                .to_string(),
+        ),
     )
     .map_err(internal_error)?;
     Ok(Json(response))

--- a/scripts/acceptance/vcs_read_surfaces_repro.py
+++ b/scripts/acceptance/vcs_read_surfaces_repro.py
@@ -29,27 +29,29 @@ here, and it grades both directions: a surface that qualifies every answer it
 gives is as useless as one that qualifies none, so the all-clear has its own
 check and must still arrive.
 
-Four checks, one seeded repository, run in order because the experiment is
-destructive: the third edits the file the first two are about.
+Six checks, one seeded repository, run in order because the experiment is
+destructive: each one sets up the next, and the last stops the daemon.
 
-  basis      the `Tree:` line names when graph truth last caught up, rather
-             than rendering a bare verdict a reader takes for a statement
-             about the files on disk
-  persists   with a tracked file edited and nothing admitted since, that line
-             still carries its basis rather than reverting to a bare verdict.
-             Note what this does NOT prove: measured on macOS, the ambient
-             watcher takes about two seconds to admit such an edit, and inside
-             that window the line reads `matching its base change as admitted 0s
-             ago` over a tree that has not moved. A clock cannot separate an
-             admission that ran before the edit from one that ran after it, so
-             the age is necessary and not sufficient. The check that closes that
-             hole is the one over an UNOBSERVED working copy, and it arrives with
-             the fix it grades
-  content    `kin admit` over that content-only edit does not report
-             "nothing changed"
-  settled    the control: a second `kin admit` with nothing left to take says
-             "nothing changed" and says it plainly. Without this the other
-             three are satisfied by a product that hedges every sentence.
+  basis        the `Tree:` line names when graph truth last caught up, rather
+               than rendering a bare verdict a reader takes for a statement
+               about the files on disk
+  saw_the_edit the check an age could never make. A tracked file's body changes
+               and the tree hash on the `Tree:` line must move, read as two
+               hashes rather than as prose, because no wording can fake a hash
+               moving. This is what read-after-admit buys and it is the only
+               thing that settles the question
+  content      `kin admit` over that content-only edit does not report
+               "nothing changed"
+  settled      the control: a second `kin admit` with nothing left to take says
+               "nothing changed" and says it plainly. Without this the others
+               are satisfied by a product that hedges every sentence
+  diff_scope   a workspace diff names what its entity and relation counts cannot
+               show, rather than printing three zeroes that cannot move
+  unadmitted   with the daemon stopped, the verdict names itself unmeasured
+               instead of borrowing the clock of an older admission. A fresh
+               marker beside no admission at all is the most convincing form of
+               the defect, and its self-test row is the literal line the earlier
+               fix would have printed
 
 Exit status is 0 when every check passed, 1 when one failed, 2 when none failed
 but one could not be read, and 3 when the run could not be set up. `--self-test`
@@ -158,6 +160,83 @@ def grade_tree_line_carries_its_basis(text):
         "the Tree: line states a verdict about the working copy with nothing "
         "saying when graph truth last looked: %s" % line
     )
+
+
+def tree_hash(text):
+    """The tree hash off the `Tree:` line, or None when there is no such line."""
+    line = tree_line(text)
+    if line is None:
+        return None
+    parts = line.split()
+    return parts[1] if len(parts) > 1 else None
+
+
+def grade_status_saw_the_edit(before_text, after_text):
+    """The check the age could never make.
+
+    kin#1254 put the admission's age beside the verdict, which made the sentence
+    honest without making it true: measured on macOS the clock reads `0s ago`
+    inside the roughly two-second window before the ambient watcher catches up,
+    and on a bind mount that window never closes. So this grades the only thing
+    that settles it, which is whether the tree the verdict describes is the tree
+    on disk. Read as two hashes rather than as prose, because no wording can fake
+    a hash moving.
+    """
+    before = tree_hash(before_text)
+    after = tree_hash(after_text)
+    if before is None or after is None:
+        return UNREADABLE, "kin status printed no Tree: line on one of the two reads"
+    if before == after:
+        return FAIL, (
+            "kin status reports the same tree %s after a tracked file changed, so it "
+            "answered from a graph that has not seen the edit" % before[:16]
+        )
+    return PASS, "the tree moved %s -> %s, so the answer was measured against the working copy" % (
+        before[:16], after[:16])
+
+
+def grade_verdict_without_an_admission_says_so(text):
+    """With nothing watching, a verdict is not a verdict.
+
+    The case this catches is the one an age cannot: with the daemon stopped, the
+    old line read `matching its base change as admitted 0s ago` while the
+    untracked line directly below it correctly said nothing had measured
+    anything. A fresh marker beside no admission is the most convincing possible
+    form of the defect.
+    """
+    line = tree_line(text)
+    if line is None:
+        return UNREADABLE, "kin status printed no Tree: line"
+    if "not measured against the working copy" in line:
+        return PASS, "the verdict names itself unmeasured: %s" % line
+    for pattern in BASIS_PATTERNS:
+        if pattern.search(line):
+            return FAIL, (
+                "with nothing admitting the working copy, the verdict still presents a "
+                "basis as though one had: %s" % line
+            )
+    return FAIL, "the verdict states no basis at all: %s" % line
+
+
+def grade_diff_discloses_its_semantic_scope(text):
+    """`Entities: +0 ~0 -0` on a workspace diff cannot move, so it must say so.
+
+    No writer in the daemon puts an entity delta into the workspace semantic
+    overlay: the admission seam publishes `WorkspaceSemanticDelta::default()`
+    unconditionally, and the one other writer passes the authority entities as
+    both the base and the desired side. A stranger checked that zero against a
+    fully settled graph and concluded the semantic layer had skipped a rewritten
+    function body.
+    """
+    body = text or ""
+    if "Entities:" not in body:
+        return UNREADABLE, "kin diff printed no Entities line"
+    if "Semantic scope:" not in body:
+        return FAIL, (
+            "a workspace diff printed its entity and relation counts with nothing saying "
+            "they cannot move"
+        )
+    return PASS, "the workspace diff names what its semantic counts cannot show"
 
 
 def grade_admit_does_not_claim_a_no_op(text):
@@ -276,15 +355,29 @@ def check_basis(suite):
     return Result("basis", status, "%s %s" % (TICKET, detail))
 
 
-def check_persists(suite):
+def check_saw_the_edit(suite):
+    before = suite.status_text()
     suite.edit_tracked_module()
-    status, detail = grade_tree_line_carries_its_basis(suite.status_text())
-    return Result(
-        "persists",
-        status,
-        "%s the basis survives an edit (not a claim that the verdict saw it), %s"
-        % (TICKET, detail),
-    )
+    status, detail = grade_status_saw_the_edit(before, suite.status_text())
+    return Result("saw_the_edit", status, "%s %s" % (TICKET, detail))
+
+
+def check_unadmitted(suite):
+    rc, out, err = suite.kin_run(["daemon", "stop"])
+    if rc != 0:
+        return Result("unadmitted", UNREADABLE,
+                      "%s the daemon would not stop: %s" % (TICKET, (err or out)[-200:]))
+    status, detail = grade_verdict_without_an_admission_says_so(suite.status_text())
+    return Result("unadmitted", status, "%s %s" % (TICKET, detail))
+
+
+def check_diff_scope(suite):
+    rc, out, err = suite.kin_run(["diff", "HEAD", "WORKSPACE"])
+    if rc != 0:
+        return Result("diff_scope", UNREADABLE,
+                      "%s kin diff exited %s: %s" % (TICKET, rc, (err or out)[-200:]))
+    status, detail = grade_diff_discloses_its_semantic_scope(out)
+    return Result("diff_scope", status, "%s %s" % (TICKET, detail))
 
 
 def check_content(suite):
@@ -305,11 +398,17 @@ def check_settled(suite):
     return Result("settled", status, "%s %s" % (TICKET, detail))
 
 
+# Order is load-bearing and the experiment is destructive. `saw_the_edit` makes
+# the edit the next two are about, `content` admits it, `settled` re-admits a
+# settled tree, `diff_scope` reads a workspace diff over it, and `unadmitted`
+# stops the daemon, which nothing after it could survive.
 CHECKS = (
     ("basis", check_basis),
-    ("persists", check_persists),
+    ("saw_the_edit", check_saw_the_edit),
     ("content", check_content),
     ("settled", check_settled),
+    ("diff_scope", check_diff_scope),
+    ("unadmitted", check_unadmitted),
 )
 
 
@@ -359,6 +458,35 @@ STATUS_BARE_AHEAD = (
     "Tree: c078181f (8 artifacts, ahead of its base change)\n"
 )
 
+# The verdict shapes read-after-admit produces, and the one it replaces.
+STATUS_UNMEASURED_VERDICT = (
+    "Kin repository-v6 status\n"
+    "Tree: 70fda9ae (8 artifacts, matching its base change as last admitted, not measured "
+    "against the working copy: no daemon is running for this repository, so nothing admitted "
+    "the working copy)\n"
+)
+# The trap this arm exists for: a marker as fresh as it gets, beside no
+# admission at all. The old line looked exactly like this.
+STATUS_FRESH_CLOCK_NO_PASS = (
+    "Kin repository-v6 status\n"
+    "Tree: 70fda9ae (8 artifacts, matching its base change as admitted 0s ago)\n"
+    "Untracked host content: not measured; no daemon is running for this repository\n"
+)
+
+DIFF_WITHOUT_SCOPE = (
+    "Kin repository-v6 diff\n"
+    "Artifacts: +0 ~1 -0\n"
+    "Entities: +0 ~0 -0\n"
+    "Relations: +0 ~0 -0\n"
+    "M  ledger/reporting.py -> ledger/reporting.py [ce183603] blob f53cc41c -> blob d712bc3d\n"
+)
+DIFF_WITH_SCOPE = DIFF_WITHOUT_SCOPE + (
+    "Semantic scope: The head endpoint is the workspace, whose entities and relations are its "
+    "base change's plus a workspace semantic overlay that no admission writes entity or "
+    "relation deltas into.\n"
+)
+DIFF_NO_ENTITIES_LINE = "Kin repository-v6 diff\nArtifacts: +0 ~1 -0\n"
+
 ADMIT_NO_OP_CLAIM = (
     "Admitted the complete exact tree; nothing changed. 8 tracked artifacts, 39 entities.\n"
     "Embeddings: 71 of 78 indexed; the remainder is queued for the background embed pass.\n"
@@ -388,6 +516,20 @@ def self_test():
         ("basis/with-age", grade_tree_line_carries_its_basis, STATUS_WITH_AGE, PASS),
         ("basis/unknown", grade_tree_line_carries_its_basis, STATUS_UNKNOWN_BASIS, PASS),
         ("basis/no-tree-line", grade_tree_line_carries_its_basis, STATUS_NO_TREE, UNREADABLE),
+        # The arm the age could never reach. A fresh clock beside no admission is
+        # the most convincing form of the defect, so it must FAIL here.
+        ("unadmitted/fresh-clock-no-pass", grade_verdict_without_an_admission_says_so,
+         STATUS_FRESH_CLOCK_NO_PASS, FAIL),
+        ("unadmitted/named", grade_verdict_without_an_admission_says_so,
+         STATUS_UNMEASURED_VERDICT, PASS),
+        ("unadmitted/bare", grade_verdict_without_an_admission_says_so, STATUS_BARE, FAIL),
+        ("unadmitted/no-tree-line", grade_verdict_without_an_admission_says_so,
+         STATUS_NO_TREE, UNREADABLE),
+        ("diffscope/absent", grade_diff_discloses_its_semantic_scope,
+         DIFF_WITHOUT_SCOPE, FAIL),
+        ("diffscope/present", grade_diff_discloses_its_semantic_scope, DIFF_WITH_SCOPE, PASS),
+        ("diffscope/no-entities", grade_diff_discloses_its_semantic_scope,
+         DIFF_NO_ENTITIES_LINE, UNREADABLE),
         ("content/no-op-claim", grade_admit_does_not_claim_a_no_op, ADMIT_NO_OP_CLAIM, FAIL),
         ("content/moved", grade_admit_does_not_claim_a_no_op, ADMIT_CONTENT_MOVED, PASS),
         ("content/unmeasured", grade_admit_does_not_claim_a_no_op, ADMIT_UNMEASURED, FAIL),
@@ -397,9 +539,18 @@ def self_test():
         ("settled/unmeasured", grade_admit_still_reports_a_true_no_op, ADMIT_UNMEASURED, FAIL),
         ("settled/refused", grade_admit_still_reports_a_true_no_op, ADMIT_REFUSED, UNREADABLE),
     ]
+    # The two-hash grader takes a pair, so its rows carry a tuple and are unpacked
+    # here. A grader that ignored one side would pass its own table, which is why
+    # the moved and unmoved rows are both required.
+    cases.extend([
+        ("sawedit/moved", grade_status_saw_the_edit, (STATUS_BARE, STATUS_BARE_AHEAD), PASS),
+        ("sawedit/unmoved", grade_status_saw_the_edit, (STATUS_BARE, STATUS_BARE), FAIL),
+        ("sawedit/no-tree-line", grade_status_saw_the_edit,
+         (STATUS_BARE, STATUS_NO_TREE), UNREADABLE),
+    ])
     failures = 0
     for name, grader, payload, expected in cases:
-        got, detail = grader(payload)
+        got, detail = grader(*payload) if isinstance(payload, tuple) else grader(payload)
         ok = got == expected
         if not ok:
             failures += 1


### PR DESCRIPTION
`kin status` and `kin diff HEAD WORKSPACE` take the admission pass the way
`kin commit` already does. Both are read-after-admit now. Founder-owned thesis
decision, relayed 2026-08-30.

## Why the previous fix was not enough

kin#1254 put the admission's age beside the verdict. That made the sentence
honest and did not make it right, and the measurement is the reason.

Measured on macOS with a working watcher: edit a tracked file, then read.

```
--- 1. kin status over a CLEAN tree ---
Tree: 5ee786a4... (2 artifacts, matching its base change as admitted 0s ago)
--- edit written at 2026-08-30T01:32:28Z ---
--- 2. kin status with the tracked file EDITED and nothing admitted ---
Tree: 5ee786a4... (2 artifacts, matching its base change as admitted 0s ago)
```

Same hash, same sentence, clock reads 0s. A clock cannot separate an admission
that ran BEFORE your edit from one that ran after it. A separate probe polling the
tree hash says the ambient watcher closes that window in about two seconds here;
on the Docker-for-Mac bind mount the stranger was on, it never closes at all.
Same defect, two magnitudes, invisible from this line in both.

## The rule this is allowed under, stated because it looks like the opposite

The Zero File-Search Authority Rule permits this and always has. Reading the
working copy in order to ADMIT it is ingestion at an explicit input boundary. The
graph then answers. What the rule forbids is answering FROM files, and nothing
here does: the report is still read from graph truth, and the only change is that
graph truth has seen the working copy first.

The cost is a tree walk. That walk is what makes the answer true, and `git status`
pays the same one for the same reason.

## Three things that follow from doing it this way

**A verdict with no admission behind it is no longer a verdict.** Every reason a
pass could not run gets its own clause, and the line says so rather than borrowing
the clock of an older admission. That is the case the daemon-stopped reading
exposed: the untracked line correctly said nothing had measured anything, while
the verdict directly above it read `as admitted 0s ago`. A refused pass is an
answer and it is not an admission, so it lands in the same arm.

**The untracked line reads the probes off the admission this status already
took**, rather than asking the daemon a second time. The admit response carries
`ReconcileHealth`, so one round trip answers both lines and two readings of one
working copy can no longer disagree about it. That is the principle this file
already holds for its two enrichment counters.

**`kin diff` admits only when an endpoint names the workspace.** A diff between
two changes is history, and walking the tree to answer it would be a cost with
nothing behind it.

No session lease is taken. `kin admit` holds one to keep the daemon awake across
a pass an operator asked for; a status read is not that, and a leaked lease keeps
a daemon alive indefinitely, which is the defect this would be trading for.

## Finding 5, disclosed rather than printed as zeroes

Beside that, the structural gap in the semantic half of a workspace diff.

`Entities: +0 ~0 -0` on a HEAD-to-WORKSPACE diff cannot move, and the reason is
structural. A workspace endpoint's entities are its base change's plus the
workspace semantic overlay, and no writer in the daemon ever puts an entity delta
into that overlay: the admission seam publishes
`semantic_delta: WorkspaceSemanticDelta::default()` unconditionally, and the one
other overlay writer computes its delta with the authority entities as BOTH the
base and the desired side, so `diff_workspace_semantics` cannot emit one either.

The stranger read the pair as an answer, checked it against a fully settled graph
(`kin graph status`: 78 of 78 embeddings indexed, 8 of 8 files at 100% coverage),
and concluded the semantic layer had silently skipped a rewrite of a function
body. It had not. Nothing could have moved that number. The diff now names the
scope beside the counts, which is what tells a real zero apart from one nothing
could have moved.

Reproduced on both arms of the before/after build, as expected since this PR does
not change the overlay:

```
--- 6. kin diff HEAD WORKSPACE after admit ---
Artifacts: +0 ~1 -0
Entities: +0 ~0 -0
```

## The daemon's status route stays a pure read

And now says so in its own verdict, because a report that did not admit must not
present as one that did. A caller of that route drives its own admission through
`/commands/admit`.

Closes FIR-2961
