### PR TITLE
Give the recovery ladder a bottom rung that works

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -7479,7 +7479,37 @@ async fn resolve_daemon_url_inner(
         Err(
             err @ (AutoStartError::IncompatibleStore(_) | AutoStartError::BehaviorEnvIgnored(_)),
         ) => Err(anyhow::Error::new(err)),
-        Err(err) => Err(anyhow::Error::new(err).context("kin daemon is required")),
+        // The bottom rung of the recovery ladder, and it used to have no remedy
+        // on it at all.
+        //
+        // Walked end to end on 2026-08-30 against the v0.6.2 candidate: rung one
+        // is a good message naming the cap, the kill count and a recovery. Doing
+        // what it says brought the reader here, to a cause and a log tail and
+        // nothing to try next. A ladder whose bottom rung is silent is a ladder
+        // a user cannot get off, and each attempt costs another OOM kill.
+        //
+        // The enrichment state is read from the error's own text rather than
+        // from this process's environment alone, because the environment cannot
+        // tell you that the host has no language server. The daemon says that in
+        // one sentence, and `ENRICHMENT_UNAVAILABLE_MARKER` is that sentence,
+        // named once so neither side can reword it and disarm this.
+        Err(err) => {
+            let detail = err.to_string();
+            let state = if detail.contains(kin_daemon_spawn::ENRICHMENT_UNAVAILABLE_MARKER) {
+                kin_daemon_spawn::EnrichmentState::Unavailable
+            } else if kin_daemon_spawn::enrichment_disabled() {
+                kin_daemon_spawn::EnrichmentState::AlreadyDisabled
+            } else {
+                kin_daemon_spawn::EnrichmentState::Available
+            };
+            let headline = match kin_daemon_spawn::peek_unwatched_daemon_death(layout.root()) {
+                Some(record) => {
+                    format!("kin daemon is required. {}", record.summary_in(state))
+                }
+                None => "kin daemon is required".to_string(),
+            };
+            Err(anyhow::Error::new(err).context(headline))
+        }
     }
 }
 

--- a/crates/kin-cli/tests/daemon_start_failure_remedy.rs
+++ b/crates/kin-cli/tests/daemon_start_failure_remedy.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The recovery ladder's bottom rung carries a remedy.
+//!
+//! Walked end to end on 2026-08-30 against the v0.6.2 candidate, on a host with
+//! five language servers checked by name and none installed. Rung one named the
+//! cap, the kill count and a recovery. Doing what it said landed on rung two: a
+//! cause, a log tail, and nothing to try next. Rung three did what rung two
+//! said and failed identically. Four OOM kills for a lever already at the end
+//! it was being moved to.
+//!
+//! A ladder whose bottom rung is silent is a ladder a user cannot get off, and
+//! on this failure each attempt costs another kill.
+//!
+//! ## Which failure this drives, and which it deliberately cannot
+//!
+//! `resolve_daemon_url_inner` attaches the new context to every `AutoStartError`
+//! except `IncompatibleStore` and `BehaviorEnvIgnored`, which keep their own
+//! headline because for them the daemon is a consequence rather than the story.
+//! So **`incompatible_store_wall.rs` cannot be extended to cover this**: its
+//! pre-v2 store takes one of the two excluded arms and never reaches the code
+//! under test here. The next person to look for a cheap fixture will find that
+//! one first, which is why it is named.
+//!
+//! What this drives instead is `SpawnFailed`, forced with a `KIN_DAEMON_BIN`
+//! that does not exist. It is one env var, it is deterministic, and it reaches
+//! the same arm.
+//!
+//! ## What is NOT measured here
+//!
+//! That the remedy is right on a REAL out-of-memory kill. Forcing one needs a
+//! converted store of real size inside a memory cgroup, which is a container
+//! and a Linux archive rather than a cargo test. The three rungs were walked by
+//! hand on the v0.6.2 candidate and recorded in
+//! `.kin-coord/reports/initmem-20260829.md`; the confirmation on patched bytes
+//! comes from the next Linux archive. This test grades the wiring: that a
+//! daemon which cannot start says what to do about it.
+
+use serial_test::serial;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+fn git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A pid this test has watched exit, so "not running" is observed rather than
+/// assumed. Picking a high number and hoping is how a flake gets written.
+fn a_pid_that_is_certainly_gone() -> u32 {
+    let mut child = std::process::Command::new("true")
+        .spawn()
+        .expect("spawn a process that exits immediately");
+    let pid = child.id();
+    child.wait().expect("reap it");
+    pid
+}
+
+#[test]
+#[serial]
+fn a_daemon_that_cannot_start_still_names_a_remedy() {
+    let repo = tempdir().expect("temp repo");
+    let runtime = common::IsolatedDaemonRuntime::new(repo.path());
+    fs::create_dir_all(repo.path().join("src")).expect("create src dir");
+    fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub fn lexer() -> &'static str { \"lexer\" }\n",
+    )
+    .expect("write source");
+    git(repo.path(), &["init", "-q"]);
+    git(repo.path(), &["add", "-A"]);
+    git(
+        repo.path(),
+        &[
+            "-c",
+            "user.email=kin@example.invalid",
+            "-c",
+            "user.name=Kin",
+            "commit",
+            "-q",
+            "-m",
+            "first",
+        ],
+    );
+
+    let init = runtime
+        .kin_command()
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_READY_TIMEOUT_SECS", "120")
+        .arg("init")
+        .arg(repo.path())
+        .output()
+        .expect("run kin init");
+    assert!(
+        init.status.success(),
+        "the fixture needs a real store: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let kin_root = repo.path().join(".kin");
+
+    // Stop whatever init started, so the next command pays for a start rather
+    // than attaching to a live daemon and never reaching the code under test.
+    runtime
+        .kin_command()
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .args(["daemon", "stop"])
+        .current_dir(repo.path())
+        .output()
+        .expect("stop the daemon init started");
+
+    // A serving record naming a dead pid is what `peek_unwatched_daemon_death`
+    // grades, and it is the same shape the init-budget acceptance suite seeds
+    // for the same reason: an unwatched death leaves no other trace.
+    let gone = a_pid_that_is_certainly_gone();
+    fs::write(
+        kin_daemon_spawn::serving_path(&kin_root),
+        format!(r#"{{"pid":{gone},"oom_kills_at_start":null,"at_unix":4320}}"#),
+    )
+    .expect("seed a serving record for a dead daemon");
+
+    let output = runtime
+        .kin_command()
+        .env("KIN_DAEMON_BIN", repo.path().join("no-such-kin-daemon"))
+        .args(["locate", "lexer"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run a daemon-backed command with no daemon binary");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a command that cannot start a daemon must refuse: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        stderr.contains("kin daemon is required"),
+        "the headline still names what is missing: {stderr}"
+    );
+
+    // The whole point. Before this fix the message ended at the cause.
+    assert!(
+        stderr.contains("To recover:"),
+        "the bottom rung of the ladder carries no remedy, which is the defect: {stderr}"
+    );
+    assert!(
+        stderr.contains("kin doctor"),
+        "and it names where to read this store's headroom: {stderr}"
+    );
+}

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -792,17 +792,58 @@ impl DaemonKillRecord {
     /// of them: the process that would have to be restarted is the one serving
     /// the session asking, and nobody inside that session owns it.
     fn remediation_for(&self, enrichment_disabled: bool) -> String {
-        let more_memory = match self.limit_bytes {
-            Some(limit) => format!(
+        self.remediation_in(if enrichment_disabled {
+            EnrichmentState::AlreadyDisabled
+        } else {
+            EnrichmentState::Available
+        })
+    }
+
+    /// The remedy, for a known enrichment state.
+    ///
+    /// Two things changed here after the ladder was walked end to end on a host
+    /// with no language server.
+    ///
+    /// The memory remedy now names a number the reader can act on. It used to
+    /// say "more than the {limit} it has now", which is true and unhelpful: a
+    /// reader on a 9 GiB box learns only that 9 is not enough. Where the record
+    /// carries what the daemon actually held, that figure is a measurement of
+    /// THIS store rather than a forecast, and it is the floor a bigger machine
+    /// has to clear.
+    ///
+    /// And the enrichment clause is now optional rather than always present.
+    /// See [`EnrichmentState::Unavailable`].
+    ///
+    /// The options are assembled as a list rather than joined into a sentence
+    /// by hand, so a third remedy is one push and not a rewrite. The one this
+    /// is waiting for is bounded history: when a flag exists to convert less of
+    /// it, it belongs here, and until then offering it would be advice nobody
+    /// can take, which is the defect this whole function exists to stop
+    /// repeating.
+    pub fn remediation_in(&self, state: EnrichmentState) -> String {
+        let more_memory = match (self.limit_bytes, self.last_rss_bytes) {
+            (Some(limit), Some(rss)) if rss >= limit => format!(
+                "give this container or machine more than the {} this daemon was holding when \
+                 the kernel stopped it, which is already at the {} it has now",
+                human_bytes(rss),
+                human_bytes(limit)
+            ),
+            (Some(limit), _) => format!(
                 "give this container or machine more than the {} it has now",
                 human_bytes(limit)
             ),
-            None => "run this repository on a machine with more memory".to_string(),
+            (None, Some(rss)) => format!(
+                "run this repository on a machine with more than the {} this daemon was holding",
+                human_bytes(rss)
+            ),
+            (None, None) => "run this repository on a machine with more memory".to_string(),
         };
+        let mut options = vec![more_memory];
+        options.extend(enrichment_remedy_clause_in(state));
         format!(
-            "To recover: {more_memory}, or {}. `kin doctor` reports this store's memory \
-             headroom, and `kin daemon status` reports what is running now.",
-            enrichment_remedy_clause_for(enrichment_disabled)
+            "To recover: {}. `kin doctor` reports this store's memory headroom, and \
+             `kin daemon status` reports what is running now.",
+            join_with_or(&options)
         )
     }
 
@@ -813,11 +854,25 @@ impl DaemonKillRecord {
     /// The cause and the remediation as one sentence-complete line, for a
     /// message that ends with it.
     pub fn summary(&self) -> String {
+        self.summary_in(if enrichment_disabled() {
+            EnrichmentState::AlreadyDisabled
+        } else {
+            EnrichmentState::Available
+        })
+    }
+
+    /// [`Self::summary`] for a caller that knows more about enrichment than
+    /// this process's environment does.
+    ///
+    /// The environment can say the switch is set. It cannot say the host has no
+    /// language server to switch off, which is the case where the switch is not
+    /// a remedy at all.
+    pub fn summary_in(&self, state: EnrichmentState) -> String {
         let mut cause = self.cause_sentence();
         if let Some(first) = cause.get(..1) {
             cause.replace_range(..1, &first.to_uppercase());
         }
-        format!("{cause}. {}", self.remediation())
+        format!("{cause}. {}", self.remediation_in(state))
     }
 }
 
@@ -826,6 +881,38 @@ impl DaemonKillRecord {
 /// Named here rather than spelled into each message so the remediation cannot
 /// drift from the switch `kin-daemon` actually reads.
 pub const DISABLE_ENRICHMENT_ENV: &str = "KIN_DAEMON_DISABLE_LSP";
+
+/// What the daemon says when it finds no language server to enrich with.
+///
+/// Named here for the same reason as the switch above, and read for a sharper
+/// one: a remedy that offers to turn enrichment off is useless when enrichment
+/// was never on, and the only durable record that it was never on is this
+/// sentence in the daemon's own log. Spelling it in two places would let the
+/// daemon reword its line and silently disarm the remedy that keys on it.
+///
+/// Measured on 2026-08-30 against the v0.6.2 candidate: a container with no
+/// language server installed, five checked by name, ran the whole ladder. Rung
+/// one offered `KIN_DAEMON_DISABLE_LSP=1`; rung two said to stop the daemon
+/// first so the next one picks the flag up; rung three did that and failed the
+/// same way. Four OOM kills for a lever that was already at the end it was
+/// being moved to.
+pub const ENRICHMENT_UNAVAILABLE_MARKER: &str = "no LSP servers found";
+
+/// Whether enrichment can be turned off usefully, and if not, why not.
+///
+/// Three states rather than the bool this replaced, because the bool could not
+/// tell "the sweep is running and you may turn it off" from "there is no sweep
+/// and never was". Both of those printed a lever, and only one of them had a
+/// lever to print.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnrichmentState {
+    /// A sweep can run here and is not switched off.
+    Available,
+    /// This process already carries the switch, so a fresh daemon is what is missing.
+    AlreadyDisabled,
+    /// No language server exists on this host, so the switch changes nothing.
+    Unavailable,
+}
 
 /// Whether a value read from [`DISABLE_ENRICHMENT_ENV`] turns enrichment off.
 ///
@@ -868,6 +955,37 @@ pub fn enrichment_remedy_clause_for(disabled: bool) -> String {
              (`{DISABLE_ENRICHMENT_ENV}=1 kin graph status` in this repository) and retry this \
              call"
         )
+    }
+}
+
+/// The clause for a known enrichment state.
+///
+/// `Unavailable` returns `None` rather than a sentence, because the honest
+/// answer there is that this remedy does not exist, and a caller that received
+/// a string would print it beside the memory remedy as though the reader had
+/// two options.
+///
+/// Delegates to [`enrichment_remedy_clause_for`] for the two states that have a
+/// lever, rather than the other way round, so that function keeps returning a
+/// `String` for the callers it already has and nothing here needs an unwrap.
+pub fn enrichment_remedy_clause_in(state: EnrichmentState) -> Option<String> {
+    match state {
+        EnrichmentState::Unavailable => None,
+        EnrichmentState::AlreadyDisabled => Some(enrichment_remedy_clause_for(true)),
+        EnrichmentState::Available => Some(enrichment_remedy_clause_for(false)),
+    }
+}
+
+/// Join remedies so the sentence reads the same with one of them as with three.
+///
+/// Its own function because the alternative is a `format!` that assumes two,
+/// which is exactly what made the enrichment clause impossible to drop: the
+/// sentence had a hole shaped like it.
+fn join_with_or(options: &[String]) -> String {
+    match options {
+        [] => "there is nothing this run can suggest".to_string(),
+        [one] => one.clone(),
+        [head @ .., last] => format!("{}, or {last}", head.join(", ")),
     }
 }
 
@@ -9069,6 +9187,109 @@ Shared_Dirty:          0 kB\n";
             "why the signal is missing is the whole of what is known: {sentence}"
         );
         assert!(sentence.contains("no memory accounting"), "{sentence}");
+    }
+
+    fn killed_holding(limit: Option<u64>, rss: Option<u64>) -> DaemonKillRecord {
+        DaemonKillRecord {
+            kills: 1,
+            memory_kills: 1,
+            first_unix: 4_320,
+            last_unix: 4_320,
+            last_pid: Some(41),
+            last_cause: DaemonKillCause::MemoryLimit {
+                kernel_oom_kills: 1,
+            },
+            limit_bytes: limit,
+            last_rss_bytes: rss,
+        }
+    }
+
+    /// A host with no language server is offered no language-server lever.
+    ///
+    /// The defect this replaces, walked end to end on 2026-08-30 against the
+    /// v0.6.2 candidate in a container with five language servers checked by
+    /// name and none installed: rung one offered the switch, rung two said to
+    /// stop the daemon so the next one picks it up, rung three did that and
+    /// failed identically. Four OOM kills for a lever already at the end it was
+    /// being moved to.
+    #[test]
+    fn an_unavailable_sweep_is_not_offered_as_a_remedy() {
+        let record = killed_holding(Some(9 * 1024 * 1024 * 1024), None);
+        let remedy = record.remediation_in(EnrichmentState::Unavailable);
+        assert!(
+            !remedy.contains(DISABLE_ENRICHMENT_ENV),
+            "a host with no language server was told to turn one off: {remedy}"
+        );
+        assert!(
+            !remedy.contains("kin daemon stop"),
+            "and it must not be told to restart into that switch either: {remedy}"
+        );
+        // It still has to say something actionable, or it is the silence this
+        // whole function exists to end.
+        assert!(remedy.contains("To recover:"), "{remedy}");
+        assert!(remedy.contains("9.0 GiB"), "{remedy}");
+    }
+
+    /// And the two states that DO have a lever still print one, so the change
+    /// above is a third case rather than a deletion.
+    #[test]
+    fn the_two_states_with_a_lever_still_print_it() {
+        let record = killed_holding(Some(9 * 1024 * 1024 * 1024), None);
+        for state in [EnrichmentState::Available, EnrichmentState::AlreadyDisabled] {
+            let remedy = record.remediation_in(state);
+            assert!(
+                remedy.contains(DISABLE_ENRICHMENT_ENV),
+                "{state:?} lost its lever: {remedy}"
+            );
+        }
+        assert_ne!(
+            record.remediation_in(EnrichmentState::Available),
+            record.remediation_in(EnrichmentState::AlreadyDisabled),
+            "the two lever states say different things and must not collapse"
+        );
+    }
+
+    /// The memory remedy names a number the reader can act on.
+    ///
+    /// It used to say only "more than the {limit} it has now", which tells a
+    /// reader on a 9 GiB box that 9 is not enough and nothing else. Where the
+    /// record carries what the daemon was actually holding, that is a
+    /// measurement of THIS store and it is the floor a bigger machine clears.
+    #[test]
+    fn the_memory_remedy_names_what_the_daemon_was_holding() {
+        let limit = 9 * 1024 * 1024 * 1024;
+        let record = killed_holding(Some(limit), Some(limit));
+        let remedy = record.remediation_in(EnrichmentState::Unavailable);
+        assert!(
+            remedy.contains("was holding when the kernel stopped it"),
+            "{remedy}"
+        );
+        // And with no resident figure it falls back rather than inventing one.
+        let unknown = killed_holding(Some(limit), None);
+        let fallback = unknown.remediation_in(EnrichmentState::Unavailable);
+        assert!(
+            fallback.contains("more than the 9.0 GiB it has now"),
+            "{fallback}"
+        );
+        assert!(
+            !fallback.contains("was holding"),
+            "a record with no resident figure must not claim one: {fallback}"
+        );
+    }
+
+    /// The sentence reads correctly with one remedy and with two, which is what
+    /// makes the enrichment clause droppable at all.
+    #[test]
+    fn the_remedy_list_reads_as_a_sentence_at_either_length() {
+        assert_eq!(join_with_or(&["one".to_string()]), "one");
+        assert_eq!(
+            join_with_or(&["one".to_string(), "two".to_string()]),
+            "one, or two"
+        );
+        assert_eq!(
+            join_with_or(&["one".to_string(), "two".to_string(), "three".to_string()]),
+            "one, two, or three"
+        );
     }
 
     /// Every action in the remediation is one the caller can perform, and the

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -3629,9 +3629,15 @@ pub async fn run_with_authority_on(
             state.lsp_enrichment_tx = Some(tx);
             Some(rx)
         } else {
+            // Built from the shared marker rather than spelled here, because a
+            // remedy in kin-daemon-spawn keys on this sentence to know that
+            // offering KIN_DAEMON_DISABLE_LSP would be advice nobody can take.
+            // Two copies of the words would let this one drift and disarm that
+            // remedy silently.
             info!(
-                "no LSP servers found, so enrichment is disabled for the life of this daemon; \
-                 install one and restart to enable it"
+                "{}, so enrichment is disabled for the life of this daemon; install one and \
+                 restart to enable it",
+                kin_daemon_spawn::ENRICHMENT_UNAVAILABLE_MARKER
             );
             None
         }


### PR DESCRIPTION
A user whose repository daemon is OOM-killed gets a good message, follows it, and lands on one with nothing to try next.

## The ladder, walked end to end

2026-08-30, v0.6.2 candidate, a container with five language servers checked by name and none installed. `memory.events` read from inside after each rung.

| rung | command | exit | oom_kill after | what the user is told |
|---|---|---|---|---|
| 1 | `kin graph status` | 1 | 1 to 2 | the cap, the kill count, and a recovery |
| 2 | `KIN_DAEMON_DISABLE_LSP=1 kin graph status` | 1 | 2 to 3 | the cap, the kill count, a log tail, **and no recovery** |
| 3 | `kin daemon stop`, then rung 2 again | 1 | 3 to 4 | the same |

`kin daemon stop` answers `No worker daemon running for repo 'requests' (nothing to stop).` Four OOM kills for a lever already at the end it was being moved to, because the daemon's own log says `no LSP servers found, so enrichment is disabled for the life of this daemon`.

## The bool in the middle is why neither half worked

`enrichment_remedy_clause_for(disabled: bool)` had two branches and **both** offered `KIN_DAEMON_DISABLE_LSP`. A bool cannot separate "the sweep is running and you may turn it off" from "there is no sweep and never was", and only one of those has a lever.

It becomes `EnrichmentState::{Available, AlreadyDisabled, Unavailable}`. `Unavailable` yields `None` rather than a sentence, so a caller cannot print it beside the memory remedy as though the reader had two options.

## Three smaller things that follow from it

**The memory remedy names a figure.** It said "more than the {limit} it has now", which tells a reader on a 9 GiB box that 9 is not enough and nothing else. The record already carries `last_rss_bytes`, so where it exists the remedy names what the daemon was holding when the kernel stopped it, which is a measurement of this store rather than a forecast.

**`kin-core` is deliberately NOT pulled into `kin-daemon-spawn`** to reach `init_budget`'s forecast. That crate is a leaf with no `kin-*` dependencies, and inverting that for a nicer figure is a boundary change the number does not justify. `last_rss_bytes` is the better figure anyway, being measured.

**The remedies are a list joined by `join_with_or`**, so a third is a push rather than a rewrite. The one it waits on is bounded history, and it stays out until a flag exists, because offering a remedy nobody can take is the defect being fixed.

**The marker is named once.** `kin-daemon` builds its "no LSP servers found" line from `ENRICHMENT_UNAVAILABLE_MARKER`, which sits beside `DISABLE_ENRICHMENT_ENV` and carries the same reason: two copies of the words would let one drift and disarm the remedy that keys on it. The rendered sentence is byte-identical.

## Falsification

Four unit tests over every branch, and a grid:

| arm | mutation | verdict | assertion that fired |
|---|---|---|---|
| M0 | none | GREEN | baseline, 124 tests |
| L1 | `Unavailable` offers the lever anyway | **RED** | `an_unavailable_sweep_is_not_offered_as_a_remedy` |
| L2 | the resident-set branch deleted | **RED** | `the_memory_remedy_names_what_the_daemon_was_holding` |
| L3 | `join_with_or`'s single-option arm broken | **RED** | `the_remedy_list_reads_as_a_sentence_at_either_length` |

Each mutation fired exactly one assertion and it was the one written for it. No arm went red on a neighbour's test, and no row is green all the way across.

Plus `daemon_start_failure_remedy.rs`, which grades the wiring the unit tests cannot reach: a daemon that cannot start must still say what to do. It drives `SpawnFailed` with a missing `KIN_DAEMON_BIN`, seeds a serving record naming a pid it watched exit, and stops the daemon `kin init` started so the command pays for a start.

`IncompatibleStore` and `BehaviorEnvIgnored` are the two variants this fix excludes, so `incompatible_store_wall.rs` cannot be extended to cover it. That is in the new test's doc comment for the next person.

## What is NOT measured

**That the remedy is right on a real out-of-memory kill.** Forcing one needs a converted store of real size inside a memory cgroup, which is a container and a Linux archive rather than a cargo test. The three rungs above were walked by hand on the v0.6.2 candidate and are recorded in `.kin-coord/reports/initmem-20260829.md`. The confirmation on patched bytes comes from the next Linux archive, which v0.6.3's own rc-build produces without a dispatch of its own.

Closes FIR-2956.
Refs FIR-2955.
