### PR TITLE
Admit a transferred change as a transfer, so a push that adds a file lands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.71"
+version = "0.7.72"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "3cb869cfc5468f0ab34170b85fafae12aa61f08ec2d145fc09ac85ad21de2a38"
+checksum = "6f676aafeab4224d0ac15d25ea388e754f963abd46e365d0e0c7f80f02a978f5"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.72"
+version = "0.7.74"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "6f676aafeab4224d0ac15d25ea388e754f963abd46e365d0e0c7f80f02a978f5"
+checksum = "0fa49e0651295a820c6ef4b5ac8d7a569049b8feb875a837ccab45fded75fa33"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.71", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.72", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.21", registry = "kin" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.72", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.74", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.21", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -1349,8 +1349,19 @@ where
     // is never left describing history it now holds by a record that predates
     // it.
     before_authority_commit().map_err(storage)?;
+    // Admitted as a transfer, not as a local publish. A receiver performed no
+    // publication, so it is not asked to name a workspace it never had; it is
+    // held instead to the shared admission policy it resolves from the
+    // transferred history, with the full sensitive-content check run on every
+    // introduced artifact because nothing here was already tracked.
+    //
+    // `None` is the publisher's admission case not travelling yet. kin-db
+    // accepts that only where it cannot decide anything, which is a shared
+    // policy with no rule sources, and refuses by name otherwise rather than
+    // choosing matching semantics on the publisher's behalf. Carrying the case
+    // in the pack is the follow-on that lifts that limit.
     let receipt = authority
-        .commit_repository_transaction(transaction)
+        .commit_transferred_repository_transaction(transaction, None)
         .map_err(repository_commit)?;
     let outcome = match receipt.outcome {
         RepositoryCommitOutcome::Committed => RepositoryTransferApplyOutcome::Committed,
@@ -2347,10 +2358,11 @@ mod tests {
     /// Commit one artifact-free native root change, so a publisher exists that
     /// has history and no imported-Git authority at all.
     ///
-    /// Artifact-free on purpose: a Native change that introduces an artifact
-    /// needs a bound workspace admission context and a transfer's receive
-    /// transaction carries none, which is a different bound entirely and not
-    /// what this control is about.
+    /// Artifact-free on purpose. This helper publishes through the LOCAL path,
+    /// where a Native change introducing an artifact still needs a bound
+    /// workspace admission context, and this control is not about that bound.
+    /// A transfer's receive no longer needs one: it is admitted as a transfer
+    /// and held to the shared policy instead (FIR-2959).
     fn seed_native_line(manager: &TestManager, main: &RefName) {
         let change = native_change(Vec::new(), "native root", Vec::new());
         let lease = manager.read_authority();

--- a/scripts/acceptance/hydration_semantics_repro.py
+++ b/scripts/acceptance/hydration_semantics_repro.py
@@ -1244,14 +1244,15 @@ def check_native_transfer(suite):
       replicas, or a destination that has admitted nothing; Git-authority
       divergence is not adapted". An adopting receiver on a bare directory holds
       no Git authority at all.
-    - A native source holding real content: refused at pack validation, "native
-      change ... introduces artifacts without a bound workspace admission
-      context". crates/kin-remote/src/repository_transfer.rs states the rule
-      outright at its seed_native_line helper: a native change that introduces
-      an artifact needs a bound workspace admission context and a transfer's
-      receive transaction carries none. Every kin commit of a real file
-      introduces artifacts, and the CLI exposes no way to author an
-      artifact-free change.
+    - A native source holding real content: admitted since FIR-2959. A transfer
+      is now admitted as a transfer rather than as a local publish, so the
+      receiver is held to the shared admission policy it resolves from the
+      transferred history instead of to a workspace it never had. This fixture
+      stays artifact-free because what it grades is the hydration creation
+      record, not what a transfer may carry, and an artifact-free change keeps
+      that one variable isolated. The one remaining limit: a repository whose
+      shared admission policy carries rule sources refuses by name until the
+      publisher's admission case travels in the pack.
     - A native clone: kin clone is Git transport only, and reject_native_remote
       in crates/kin-cli/src/commands/clone.rs fail-closes on a native remote.
 


### PR DESCRIPTION
`kin push` of a commit that adds a file now lands on the receiver. It did not, on any transport, on every shipped version: the Native admission check requires a bound workspace admission context and a transfer's receive transaction carries none, so any change introducing artifacts failed closed on arrival.

The receive path commits through kin-db 0.7.72's `commit_transferred_repository_transaction`. A receiver performed no publication, so it is not asked to name a workspace it never had. It is held instead to the shared admission policy it resolves from the transferred history, with the full sensitive-content check run on every introduced artifact, because nothing on a receiver was already tracked and so nothing is skipped.

## Why `None` for the case, and what still refuses

`None` is the publisher's `AdmissionCase` not travelling yet. kin-db accepts it only where it cannot decide anything, which is a shared policy carrying no rule sources, and refuses by name otherwise.

The reasoning is exact rather than cautious. `resolve_admission_matcher` compiles the case together with `rule_sets`, and on the transfer path `rule_sets` comes from the shared policy's sources alone. A policy with no sources compiles a matcher over an empty rule set, which matches nothing and decides identically under either case.

**So a repository whose shared admission policy carries rules still refuses a transfer**, with a message saying the publisher's admission case did not travel and that the replica will not choose one on their behalf. That is not the bridge being broken. Carrying the case in the pack is the follow-on that lifts it, and it is the pack field plus the contract key plus the kinlab validator, done calmly.

## Two comments that were about to start lying

`seed_native_line`'s doc said a transfer's receive carries no workspace admission context, as though that were permanent. It stays true of the LOCAL path that helper publishes through, and now says so.

`scripts/acceptance/hydration_semantics_repro.py`'s docstring stated that a native source holding real content is "refused at pack validation". That is now false. It says instead why the fixture stays artifact-free, which is to keep the hydration variable isolated rather than because content cannot travel, and it names the one remaining limit. That one mattered more than the code comment: it is prose in an acceptance script, which the next person reads as authority. Its executable body grades whether the receiver's hydration creation record is withdrawn, not whether content is refused, so the check itself is unaffected; I read the body rather than trusting the docstring.

## The pin

Exact, `=0.7.74`. The registry was confirmed to serve it by reading the sparse index directly (`https://kinlab.ai/registry/cargo/ki/n-/kin-db`) rather than by trusting the publish workflow's conclusion.

The pin moved from `0.7.72` to `0.7.74` in a second commit on this branch, because `0.7.72` shipped `commit_transferred_repository_transaction` inside `impl RepositoryAuthorityManager<LocalFileBackend>` rather than the generic impl beside `commit_repository_transaction`, so the method was unreachable through the generic bound this crate calls it through. kin-db #256 moved it and added a compile-time guard that calls it through a generic bound, so the same mistake cannot pass a kin-db gate again. Worth saying plainly: the branch head CI first graded pinned `0.7.72` and was not the tree the proof below ran on. It is now.

The lock diff is two lines, the version and the checksum, with the `sparse+` source preserved:

```
-version = "0.7.72"
+version = "0.7.74"
-checksum = "6f676aafeab4224d0ac15d25ea388e754f963abd46e365d0e0c7f80f02a978f5"
+checksum = "0fa49e0651295a820c6ef4b5ac8d7a569049b8feb875a837ccab45fded75fa33"
```

`cargo update -p kin-db --precise` churned a dozen `windows-sys` entries on both moves, which only affect a platform this host cannot build and would have shipped unnoticed inside a two-line pin. The lock was restored from HEAD and the kin-db entry re-applied on its own, twice. `fuzz/Cargo.lock` is the repo's other tracked lock and carries no kin-db at all, so it is untouched. Both tracked locks were swept for the superseded versions and neither carries one, with a fabricated `0.7.99` returning nothing as the control that the sweep can answer negatively.

## What is gated where

This was first pushed without a local compile, on the captain's instruction to push early rather than hold a `rust-heavy` slot for a typecheck while a local-model stranger run held the box.

**The end-to-end proof has run twice, and the two runs say different things.** Both are two replicas seeded from one `kin init`, a real kin daemon behind a real KinLab control plane in cloud mode, over the org-scoped transfer route. The pin compiled `--locked` against the published registry kin-db 0.7.74 before either ran, so this is the published crate and not a path patch.

**First run: the bytes moved and the client was told the push failed.**

```
machine A: 105 bytes  sha256 b0ad3b119e8cd676e1052b65dd3a2c688326186de4eeed47c303cc408139efd7
machine B: 105 bytes  sha256 b0ad3b119e8cd676e1052b65dd3a2c688326186de4eeed47c303cc408139efd7
negative control absent, as required
```

The pull reports workspace `advanced`, "Followed refs/heads/main at change c1646a11... (1 projected entries, authority generation 3)", so hosted repository authority had committed the transfer. The push exited rc=1:

```
kin push refused (HTTP 424): repository transfer storage failed:
remote transfer receive failed with HTTP 502:
{"error":"Daemon returned a receipt that does not bind the submitted exact transfer."}
```

**The write lands and the client is told it failed.** That is worse than a refusal, because a user retries. The cause is not in this change: KinLab's gateway treats the receipt's 32-byte digests as strings, and `!==` on two Arrays compares by reference, so the receipt-binding check can never pass for a real pack. Filed as FIR-2978.

**Second run, against a gateway with that fixed, in this lane's harness:**

```
push rc=0
machine A: 105 bytes  sha256 efdeed0b06b2d81874aa117cb8be6b4339753dd8b30307aa2223c41f2123fdc3
machine B: 105 bytes  sha256 efdeed0b06b2d81874aa117cb8be6b4339753dd8b30307aa2223c41f2123fdc3
negative control absent, as required
receive response: outcome "committed", schema_version 4, authority generation 2
```

The receive leaf's own response was captured through a proxy and pinned to the run that produced it, so the receipt above is the seam's bytes rather than a reading of them.

**Production still reports the false failure until the KinLab fix deploys.** kinlab#379 carries it and is in the KinLab queue. So this change makes the transfer admissible; it does not by itself make a user's push report the truth.

### The exact scope of what this unblocks, measured

The guard this change installs lives inside `verify_native_change_admission`, which `continue`s for any change introducing no artifacts, so an edit never reaches it. Four rows, each measured end to end:

| repository | change | result |
|---|---|---|
| bare `kin init`, no rules | adds a file | admitted, bytes byte-identical on the second machine |
| converted git repo, one `.gitignore` rule | adds a file | **refused**, naming 1 rule source |
| converted git repo, one rule | edits an existing artifact | admitted, bytes byte-identical |
| converted git repo | adds a file the rule matches | never becomes a change at all |

So this change makes greenfield push work and leaves a converted repository unable to push a NEW file, because a `.gitignore` gives the shared policy a rule source and the publisher's admission case does not travel. The refusal is this change's own sentence, delivered verbatim through the hosted route as an HTTP 422, which also demonstrates the route's refusal passthrough working as designed.

That remaining half is filed as **FIR-2982**, Urgent, and it is not the calm follow-on the section above calls it: it is what stands between a converted repository and its first push of a new file.

The brownfield case was measured on the same build. An edit to a file git tracked only because it was force-added past its own `*.log` rule commits, crosses the wire, and lands byte-identical on the far machine. A NEW file matching that rule never enters the graph at all: `kin commit` reports `nothing to commit: this tree is already committed`, the same change id as before, because the tree hash never moved. The rule is enforced at admission, before a change exists.

Closes FIR-2959



