### PR TITLE
Make an entity settlement beat the bulk artifact settle that silently erased it

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -306,6 +306,16 @@ jobs:
       # coherence on every clean fixture. The diverged arm returns UNREADABLE
       # rather than PASS when the divergence did not take, since that state and
       # the defect are not separable from outside.
+      # FIR-2958. Two settlements over one file are the case, and the two that
+      # decide it read alike from outside: a projection that took the side
+      # carrying the entity decision, and a bulk settle that overrode it. The
+      # graders are driven against the exact `tree=0` signature the rc062a
+      # stranger recorded, and against a one-parent change whose deltas say
+      # nothing about a merge at all, so a log that could not be read is never
+      # graded as a merge that moved bytes.
+      - name: Falsify the merge precedence graders
+        run: python3 scripts/acceptance/merge_precedence_repro.py --self-test
+
       - name: Falsify the coverage read graders
         run: python3 scripts/acceptance/coverage_read_open.py --self-test
 
@@ -1028,6 +1038,31 @@ jobs:
             echo "::warning title=Prose-query parity suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: Merge precedence acceptance suite (verdict comes from the gate step)
+        id: mergeprecedence
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/merge_precedence_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/merge_precedence.json \
+            --verbose >acceptance/merge_precedence.log 2>&1 || rc=$?
+          cat acceptance/merge_precedence.log
+          {
+            echo "### Merge precedence acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/merge_precedence.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Merge precedence acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
       # Always, including on a cancelled or timed-out run: the reports are how a
       # failure is diagnosed without re-running the job.
       - name: Upload the acceptance reports
@@ -1076,7 +1111,8 @@ jobs:
             --report working_copy_freshness=acceptance/working_copy_freshness.json \
             --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \
             --report init_budget=acceptance/init_budget.json \
+            --report coverage_read=acceptance/coverage_read.json \
             --report bridge_reach=acceptance/bridge_reach.json \
             --report prose_parity=acceptance/prose_parity.json \
-            --report coverage_read=acceptance/coverage_read.json \
+            --report merge_precedence=acceptance/merge_precedence.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk is truncated on ubuntu-latest, and its clipped_steps metadata confirms dropped callee and cross-file rows. This check therefore cannot distinguish an absent required edge from one the walk dropped. Any FAIL or other UNREADABLE still fails the gate, and the moment this check passes the allowance announces itself stale and can go.'

--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -776,22 +776,31 @@ fn shifting_span_repository(root: &Path) -> std::path::PathBuf {
     run_git(&repo, &["config", "user.name", "Kin"]);
     fs::write(repo.join("shared.txt"), b"shared bytes\n").expect("write shared file");
     fs::create_dir_all(repo.join("src")).expect("create source directory");
-    fs::write(repo.join("src/lib.rs"), b"pub fn base() {}\npub fn mate() {}\n")
-        .expect("write base source");
+    fs::write(
+        repo.join("src/lib.rs"),
+        b"pub fn base() {}\npub fn mate() {}\n",
+    )
+    .expect("write base source");
     run_git(&repo, &["add", "--all"]);
     run_git(&repo, &["commit", "-m", "base"]);
 
     run_git(&repo, &["switch", "-c", "feature"]);
     fs::write(repo.join("shared.txt"), b"feature shared\n").expect("edit shared on feature");
-    fs::write(repo.join("src/lib.rs"), b"pub fn base(v: i32) {}\npub fn mate() {}\n")
-        .expect("edit source on feature");
+    fs::write(
+        repo.join("src/lib.rs"),
+        b"pub fn base(v: i32) {}\npub fn mate() {}\n",
+    )
+    .expect("edit source on feature");
     run_git(&repo, &["add", "--all"]);
     run_git(&repo, &["commit", "-m", "feature work"]);
 
     run_git(&repo, &["switch", "main"]);
     fs::write(repo.join("shared.txt"), b"main shared\n").expect("edit shared on main");
-    fs::write(repo.join("src/lib.rs"), b"pub fn base(count: u64) {}\npub fn mate() {}\n")
-        .expect("edit source on main");
+    fs::write(
+        repo.join("src/lib.rs"),
+        b"pub fn base(count: u64) {}\npub fn mate() {}\n",
+    )
+    .expect("edit source on main");
     run_git(&repo, &["add", "--all"]);
     run_git(&repo, &["commit", "-m", "main work"]);
     repo
@@ -807,8 +816,11 @@ fn opposed_entities_repository(root: &Path) -> std::path::PathBuf {
     run_git(&repo, &["config", "user.email", "kin@example.invalid"]);
     run_git(&repo, &["config", "user.name", "Kin"]);
     fs::create_dir_all(repo.join("src")).expect("create source directory");
-    fs::write(repo.join("src/lib.rs"), b"pub fn alpha() {}\npub fn beta() {}\n")
-        .expect("write base source");
+    fs::write(
+        repo.join("src/lib.rs"),
+        b"pub fn alpha() {}\npub fn beta() {}\n",
+    )
+    .expect("write base source");
     run_git(&repo, &["add", "--all"]);
     run_git(&repo, &["commit", "-m", "base"]);
 

--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -760,3 +760,282 @@ fn a_contested_path_listing_names_its_claimants() {
         "the listing carries identities in the form the resolver accepts: {listing}"
     );
 }
+
+/// One file whose two entities both conflict, because editing the first to a
+/// different length on each branch moves the second's span on each branch too.
+///
+/// That shape is the whole difficulty. `mate` is semantically identical on both
+/// sides and still conflicts, so a bulk settle records a decision about it that
+/// only its byte offsets distinguish. The two bodies must stay different
+/// lengths or `mate` never conflicts and the fixture stops being the case.
+fn shifting_span_repository(root: &Path) -> std::path::PathBuf {
+    let repo = root.join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    run_git(&repo, &["init", "--initial-branch=main"]);
+    run_git(&repo, &["config", "user.email", "kin@example.invalid"]);
+    run_git(&repo, &["config", "user.name", "Kin"]);
+    fs::write(repo.join("shared.txt"), b"shared bytes\n").expect("write shared file");
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    fs::write(repo.join("src/lib.rs"), b"pub fn base() {}\npub fn mate() {}\n")
+        .expect("write base source");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "base"]);
+
+    run_git(&repo, &["switch", "-c", "feature"]);
+    fs::write(repo.join("shared.txt"), b"feature shared\n").expect("edit shared on feature");
+    fs::write(repo.join("src/lib.rs"), b"pub fn base(v: i32) {}\npub fn mate() {}\n")
+        .expect("edit source on feature");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "feature work"]);
+
+    run_git(&repo, &["switch", "main"]);
+    fs::write(repo.join("shared.txt"), b"main shared\n").expect("edit shared on main");
+    fs::write(repo.join("src/lib.rs"), b"pub fn base(count: u64) {}\npub fn mate() {}\n")
+        .expect("edit source on main");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "main work"]);
+    repo
+}
+
+/// One file whose two entities BOTH change semantically on both branches, so
+/// settling them to opposite sides leaves no side carrying both decisions and
+/// no committed body to publish.
+fn opposed_entities_repository(root: &Path) -> std::path::PathBuf {
+    let repo = root.join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    run_git(&repo, &["init", "--initial-branch=main"]);
+    run_git(&repo, &["config", "user.email", "kin@example.invalid"]);
+    run_git(&repo, &["config", "user.name", "Kin"]);
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    fs::write(repo.join("src/lib.rs"), b"pub fn alpha() {}\npub fn beta() {}\n")
+        .expect("write base source");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "base"]);
+
+    run_git(&repo, &["switch", "-c", "feature"]);
+    fs::write(
+        repo.join("src/lib.rs"),
+        b"pub fn alpha(v: i32) {}\npub fn beta(v: i32) {}\n",
+    )
+    .expect("edit source on feature");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "feature work"]);
+
+    run_git(&repo, &["switch", "main"]);
+    fs::write(
+        repo.join("src/lib.rs"),
+        b"pub fn alpha(count: u64) {}\npub fn beta(count: u64) {}\n",
+    )
+    .expect("edit source on main");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "main work"]);
+    repo
+}
+
+/// The identity of the one parked entity conflict named `name`, in the form
+/// `kin resolve` accepts back. Asserting there is exactly one keeps a fixture
+/// that grew a second entity of that name from settling the wrong conflict.
+fn entity_conflict(report: &Value, name: &str) -> String {
+    let prefix = format!("{name} in ");
+    let mut found: Vec<String> = report["record"]["entries"]
+        .as_array()
+        .expect("a parked merge lists its entries")
+        .iter()
+        .filter(|entry| entry["subject"]["subject"] == "entity")
+        .filter(|entry| {
+            entry["label"]
+                .as_str()
+                .is_some_and(|label| label.starts_with(&prefix))
+        })
+        .map(|entry| {
+            entry["subject"]["entity"]
+                .as_str()
+                .expect("an entity conflict names its identity")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        found.len(),
+        1,
+        "exactly one parked conflict names entity {name}: {report}"
+    );
+    found.pop().expect("checked immediately above")
+}
+
+/// The graph a published change resolves to, read from authority on disk.
+fn graph_at(
+    layout: &kin_core::KinLayout,
+    change: &SemanticChangeId,
+) -> kin_model::graph::ResolvedGraphState {
+    let manager = open_authority(layout);
+    let lease = manager.read_authority();
+    let mut snapshot = lease.snapshot().clone();
+    snapshot.repository_authority = None;
+    drop(lease);
+    let graph =
+        kin_db::InMemoryGraph::from_snapshot(snapshot).expect("prepare graph-owned history");
+    kin_db::ChangeStore::resolve_graph_at(&graph, change)
+        .expect("resolve the exact graph a change publishes")
+}
+
+/// The one span graph truth records for the entity named `name`, as the byte
+/// range it claims inside its file.
+fn entity_span(state: &kin_model::graph::ResolvedGraphState, name: &str) -> (String, usize, usize) {
+    let mut found: Vec<(String, usize, usize)> = state
+        .entities
+        .values()
+        .filter(|entity| entity.name == name)
+        .filter_map(|entity| {
+            entity
+                .span
+                .as_ref()
+                .map(|span| (span.file.to_string(), span.start_byte, span.end_byte))
+        })
+        .collect();
+    assert_eq!(
+        found.len(),
+        1,
+        "exactly one entity named {name} carries a span in the merged graph"
+    );
+    found.pop().expect("checked immediately above")
+}
+
+/// FIR-2958. A bulk artifact settle must not override the entity decision
+/// already recorded inside that artifact.
+///
+/// Before the precedence rule, `--theirs` on one entity followed by `--all-ours`
+/// reported both settled and every conflict resolved, published the `ours`
+/// bytes, and recorded a merge whose tree delta against the first parent was
+/// empty. The source branch contributed nothing while every conflict read as
+/// settled, and nothing warned.
+#[test]
+fn a_bulk_artifact_settle_does_not_override_a_named_entity_settle() {
+    let root = tempdir().expect("temp root");
+    let repo = shifting_span_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+
+    ok(
+        &run_kin(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+
+    // The specific decision: this one entity takes the source branch's value.
+    let parked = conflicts_report(&runtime, &repo);
+    let base = entity_conflict(&parked, "base");
+    ok(
+        &run_kin(&runtime, &repo, &["resolve", "--theirs", &base]),
+        "settle the entity to the source branch",
+    );
+    // The bulk decision, which covers the artifact holding that entity and the
+    // sibling entity whose span the first edit moved.
+    ok(
+        &run_kin(&runtime, &repo, &["resolve", "--all-ours"]),
+        "settle the rest to the active branch",
+    );
+    let stdout = ok(
+        &run_kin(&runtime, &repo, &["resolve", "--continue", "--json"]),
+        "kin resolve --continue",
+    );
+    let report: Value = serde_json::from_str(&stdout).expect("resolve report is JSON");
+    let merge_change: SemanticChangeId =
+        serde_json::from_value(report["merge_change"].clone()).expect("a published merge change");
+
+    // The entity decision reached the file: specific beats bulk.
+    let published = fs::read(repo.join("src/lib.rs")).expect("the merged source is on disk");
+    assert_eq!(
+        published, b"pub fn base(v: i32) {}\npub fn mate() {}\n",
+        "the entity settled --theirs decides the bytes of the artifact holding it"
+    );
+    // The bulk decision still owns every artifact no entity decision covers.
+    assert_eq!(
+        fs::read(repo.join("shared.txt")).unwrap(),
+        b"main shared\n",
+        "--all-ours still settles the artifacts no entity decision contradicts"
+    );
+
+    let state = graph_at(&layout, &merge_change);
+    // Graph truth and the published bytes describe the same file. `mate` was
+    // settled --ours and its span on that side points four bytes past where it
+    // sits in the bytes this merge published, so a projection that moved the
+    // artifact and left the entity spans behind fails right here.
+    let (file, start, end) = entity_span(&state, "mate");
+    assert!(
+        file.ends_with("lib.rs"),
+        "the merged `mate` still names its own file: {file}"
+    );
+    assert_eq!(
+        published.get(start..end).map(String::from_utf8_lossy),
+        Some(std::borrow::Cow::Borrowed("pub fn mate() {}")),
+        "the span graph truth records for `mate`, {start}..{end}, must select `mate` inside the \
+         {} bytes kin published",
+        published.len()
+    );
+}
+
+/// Two entities in one file whose values both moved on both branches, settled
+/// to opposite sides, have no publishable projection: neither branch's
+/// committed bytes carry both decisions, and kin has no textual line merge to
+/// build a third body from. The merge refuses and names both decisions rather
+/// than honouring one of them in silence.
+#[test]
+fn contradictory_settlements_inside_one_artifact_refuse_and_name_both() {
+    let root = tempdir().expect("temp root");
+    let repo = opposed_entities_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+
+    let main_before = branch_change(&layout, "main");
+    ok(
+        &run_kin(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+
+    let parked = conflicts_report(&runtime, &repo);
+    let alpha = entity_conflict(&parked, "alpha");
+    let beta = entity_conflict(&parked, "beta");
+    ok(
+        &run_kin(&runtime, &repo, &["resolve", "--theirs", &alpha]),
+        "settle alpha to the source branch",
+    );
+    ok(
+        &run_kin(&runtime, &repo, &["resolve", "--ours", &beta]),
+        "settle beta to the active branch",
+    );
+    ok(
+        &run_kin(&runtime, &repo, &["resolve", "--all-ours"]),
+        "settle the artifact in bulk",
+    );
+
+    let refused = run_kin(&runtime, &repo, &["resolve", "--continue"]);
+    assert!(
+        !refused.status.success(),
+        "an unprojectable mix does not publish: stdout={}",
+        String::from_utf8_lossy(&refused.stdout)
+    );
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&refused.stderr),
+        String::from_utf8_lossy(&refused.stdout)
+    );
+    // Both decisions, by name, and the file they disagree about.
+    assert!(
+        said.contains("src/lib.rs"),
+        "the refusal names the file: {said}"
+    );
+    assert!(
+        said.contains("alpha") && said.contains("beta"),
+        "the refusal names both entity decisions: {said}"
+    );
+    assert!(
+        said.contains("--theirs") && said.contains("--ours"),
+        "the refusal names the side each decision took: {said}"
+    );
+
+    // Nothing published, and the resolutions are still there to re-settle.
+    assert_eq!(branch_change(&layout, "main"), main_before);
+    assert!(persisted_record(&layout)
+        .expect("the merge is still parked")
+        .state
+        .is_in_progress());
+}

--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -51,6 +51,38 @@ fn run_kin(
         .expect("run kin")
 }
 
+/// `kin`, with the LSP enrichment sweep off for the daemon this call spawns.
+///
+/// The Python fixture's `kin init` fails on a loaded host, and the product's own
+/// record names both the cause and the remedy: "The daemon for this store was
+/// killed ... start a daemon yourself with the enrichment sweep off
+/// (`KIN_DAEMON_DISABLE_LSP=1 kin graph status`)". `kin init` then exits
+/// `EXIT_ENRICHMENT_UNATTESTED`, which is 7, so every assertion after it reads
+/// as a merge failure. Measured on this suite: six of six runs of the Python
+/// fixture hit it while the Rust fixtures hit it zero times, because Rust has no
+/// language server installed here to sweep with.
+///
+/// Turning the sweep off is not papering over that. This test asserts entity
+/// values, artifact bytes and tree deltas, and enrichment contributes none of
+/// them: it adds cross-file reference and import EDGES, which nothing here
+/// reads. A daemon captures the lever at process start from the command that
+/// spawns it, so it goes on the call that starts the daemon.
+fn run_kin_without_enrichment(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> std::process::Output {
+    runtime
+        .kin_command()
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .current_dir(repo)
+        .output()
+        .expect("run kin")
+}
+
 fn ok(output: &std::process::Output, what: &str) -> String {
     assert!(
         output.status.success(),
@@ -141,6 +173,24 @@ fn change_parents(
         .expect("read the change store")
         .expect("the published merge change exists in history");
     found.parents
+}
+
+/// How many tree deltas a published change carries against its first parent.
+///
+/// Zero is the exact signature the rc062a stranger recorded: `tree=0` means the
+/// merged tree is byte-identical to the target branch, so the source branch
+/// contributed nothing while every conflict read as settled.
+fn change_tree_delta_count(layout: &kin_core::KinLayout, change: &SemanticChangeId) -> usize {
+    let manager = open_authority(layout);
+    let lease = manager.read_authority();
+    let graph = kin_db::InMemoryGraph::from_snapshot(lease.snapshot().clone())
+        .expect("prepare graph-owned history");
+    drop(lease);
+    kin_db::ChangeStore::get_change(&graph, change)
+        .expect("read the change store")
+        .expect("the published merge change exists in history")
+        .tree_deltas
+        .len()
 }
 
 fn conflicts_report(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> Value {
@@ -982,6 +1032,116 @@ fn a_bulk_artifact_settle_does_not_override_a_named_entity_settle() {
         "the span graph truth records for `mate`, {start}..{end}, must select `mate` inside the \
          {} bytes kin published",
         published.len()
+    );
+}
+
+/// A Python module, so the file's own module entity is in the conflict set.
+///
+/// This is the shape the rc062a stranger actually hit and the one a Rust fixture
+/// does NOT produce. A `.py` file yields a Module entity spanning the whole
+/// file, whose behaviour hash is the whole file's text, so a bulk settle records
+/// a decision about the WHOLE FILE beside the decision about one function inside
+/// it. `alpha` is edited to a different length on each branch so `beta`'s span
+/// moves on each branch too, and the module entity conflicts on all three sides.
+fn container_settle_repository(root: &Path) -> std::path::PathBuf {
+    let repo = root.join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    run_git(&repo, &["init", "--initial-branch=main"]);
+    run_git(&repo, &["config", "user.email", "kin@example.invalid"]);
+    run_git(&repo, &["config", "user.name", "Kin"]);
+    fs::create_dir_all(repo.join("ledger")).expect("create package directory");
+    fs::write(
+        repo.join("ledger/report.py"),
+        b"ENTRIES = [1, 2]\n\n\ndef alpha(rows):\n    return len(rows)\n\n\ndef beta(x):\n    return x + 1\n",
+    )
+    .expect("write base source");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "base"]);
+
+    run_git(&repo, &["switch", "-c", "feature"]);
+    fs::write(
+        repo.join("ledger/report.py"),
+        b"ENTRIES = [1, 2]\n\n\ndef alpha(rows):\n    return len(rows) - 7\n\n\ndef beta(x):\n    return x + 1\n",
+    )
+    .expect("edit source on feature");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "feature work"]);
+
+    run_git(&repo, &["switch", "main"]);
+    fs::write(
+        repo.join("ledger/report.py"),
+        b"ENTRIES = [1, 2]\n\n\ndef alpha(rows):\n    return len(rows) + 1000000\n\n\ndef beta(x):\n    return x + 1\n",
+    )
+    .expect("edit source on main");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "main work"]);
+    repo
+}
+
+/// A settlement naming a CONTAINER must not override one naming something
+/// inside it, which is the same precedence rule one level down from the artifact.
+///
+/// The file's module entity spans the whole file, so `--all-ours` records a
+/// decision about the whole file beside the `--theirs` on one function inside
+/// it. Judged as a peer of that function, no side carries both and the merge
+/// refuses, which is the wrong answer: this is exactly the case the founder's
+/// ruling says must project. The first version of the rule refused it, and its
+/// own refusal named the module entity as the reason.
+///
+/// A Rust fixture cannot see this. `src/lib.rs` produces no conflicting module
+/// entity, so the container half of the rule survived every mutation of it until
+/// this test existed. That is what the falsification grid found: M5, which
+/// disables the container split, was green all the way across.
+#[test]
+fn a_container_settle_does_not_override_a_settle_inside_it() {
+    let root = tempdir().expect("temp root");
+    let repo = container_settle_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    // This one call starts the daemon, so it is where the lever belongs.
+    let init = run_kin_without_enrichment(&runtime, &repo, &["init", ".", "--json"]);
+    ok(&init, "kin init");
+    let layout = kin_core::KinLayout::discover(&repo).expect("discover exact layout");
+
+    ok(
+        &run_kin(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+    let parked = conflicts_report(&runtime, &repo);
+    let alpha = entity_conflict(&parked, "alpha");
+    ok(
+        &run_kin(&runtime, &repo, &["resolve", "--theirs", &alpha]),
+        "settle the function to the source branch",
+    );
+    // Settles beta, ENTRIES, the module entity for the whole file, and the
+    // artifact, all to the active branch.
+    ok(
+        &run_kin(&runtime, &repo, &["resolve", "--all-ours"]),
+        "settle the rest to the active branch, including the module entity",
+    );
+    // The refusal this test exists for happens here: a build that treats the
+    // module entity as a peer of the function inside it cannot publish at all.
+    let published = ok(
+        &run_kin(&runtime, &repo, &["resolve", "--continue"]),
+        "kin resolve --continue",
+    );
+
+    assert_eq!(
+        fs::read(repo.join("ledger/report.py")).expect("the merged source is on disk"),
+        b"ENTRIES = [1, 2]\n\n\ndef alpha(rows):\n    return len(rows) - 7\n\n\ndef beta(x):\n    return x + 1\n",
+        "the function settled --theirs decides the bytes, and the module settled --ours follows it"
+    );
+    // And the merge says so, which is the half that makes it not silent. A build
+    // that projected correctly and said nothing would pass the assertion above.
+    assert!(
+        published.contains("Projected") && published.contains("container"),
+        "the merge names the projection and why the bulk settlement followed it: {published}"
+    );
+    // The source branch contributed bytes, which an empty tree delta would deny.
+    let merge_change = branch_change(&layout, "main");
+    assert_ne!(
+        change_tree_delta_count(&layout, &merge_change),
+        0,
+        "the published merge carries the bytes the entity decision chose"
     );
 }
 

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -894,6 +894,20 @@ pub(crate) fn publish_resolved_merge(
         )?;
     }
 
+    // Two settlements can cover one file, and only one of them becomes bytes.
+    // This is the rule that decides which, and refuses when neither composes.
+    let projections = project_artifacts_from_settled_entities(
+        &record,
+        &base_state,
+        &ours_state,
+        &theirs_state,
+        &base_artifacts,
+        &ours_artifacts,
+        &theirs_artifacts,
+        &mut merged_entities,
+        &mut merged_artifacts,
+    )?;
+
     // The resolutions are the caller's, so a composition they leave broken is
     // named rather than parked again: the record already holds one settlement
     // per conflict, and re-opening would discard it.
@@ -1115,16 +1129,20 @@ pub(crate) fn publish_resolved_merge(
     Ok(MergeExecution {
         response: MergeResponse::default(),
         resolve_response: Some(kin_cli::commands::resolve::ResolveResponse {
-            lines: vec![format!(
-                "Merged {} into {} as change {} after settling {} conflict(s) ({} projected \
-                 entries, authority generation {})",
-                record.binding.source_ref,
-                record.binding.target_ref,
-                change.id,
-                resolved_count,
-                materialized,
-                receipt.generation
-            )],
+            lines: {
+                let mut lines = vec![format!(
+                    "Merged {} into {} as change {} after settling {} conflict(s) ({} projected \
+                     entries, authority generation {})",
+                    record.binding.source_ref,
+                    record.binding.target_ref,
+                    change.id,
+                    resolved_count,
+                    materialized,
+                    receipt.generation
+                )];
+                lines.extend(projections);
+                lines
+            },
             mutated: matches!(receipt.outcome, RepositoryCommitOutcome::Committed),
             report: Some(report),
             operation_id: Some(receipt.operation_id),
@@ -1210,11 +1228,8 @@ fn apply_resolution(
             };
         }
         (MergeConflictSubject::Artifact { artifact }, MergeEntryResolution::Side { side, .. }) => {
-            let side_artifacts = match side {
-                MergeSide::Base => base_artifacts,
-                MergeSide::Ours => ours_artifacts,
-                MergeSide::Theirs => theirs_artifacts,
-            };
+            let side_artifacts =
+                artifact_side(*side, base_artifacts, ours_artifacts, theirs_artifacts);
             let value = side_artifacts.get(artifact);
             require_recorded_side(entry, side, MergeSideValue::artifact(value)?)?;
             match value {
@@ -1310,6 +1325,309 @@ fn require_recorded_side(
         )));
     }
     Ok(())
+}
+
+/// An entity settlement, paired with the file paths that entity occupies on the
+/// sides this merge composed. The path is what joins an entity decision to the
+/// artifact decision that would otherwise overwrite it.
+struct SettledEntity<'a> {
+    entry: &'a MergeConflictEntry,
+    entity: kin_model::EntityId,
+    side: MergeSide,
+    paths: BTreeSet<String>,
+}
+
+/// The one precedence rule for two settlements that cover one file:
+/// **entity beats artifact, specific beats bulk.**
+///
+/// A file's bytes are a projection of graph truth, so settling one entity is a
+/// decision about that entity, and settling the artifact holding it is a
+/// decision about the whole file. Those land in two independent maps, and only
+/// the artifact map becomes file bytes. Before this rule both were honoured
+/// separately: a named `--theirs` on an entity followed by a bulk `--all-ours`
+/// reported every conflict settled, published the `ours` bytes, and recorded a
+/// merge whose tree delta against the first parent was empty. The source branch
+/// contributed nothing, and nothing said so.
+///
+/// The rule takes the file, and the entities settled inside it, from whichever
+/// side carries every one of those entity decisions. Nothing is synthesized:
+/// the candidates are the sides this merge already bound, so what publishes is
+/// a side's own committed blob, held to history by the same
+/// `require_recorded_side` check the settled side got. That matters because a
+/// kin merge composes at the granularity of a whole entity or artifact and
+/// never the line, so a choice among recorded sides is one kin can make
+/// honestly and a spliced third body is not.
+///
+/// Where no single side carries every decision, the settlements do not compose
+/// into any publishable file and the merge REFUSES, naming both decisions.
+/// Refusing is the fallback. Publishing one of two contradictory decisions in
+/// silence is the defect this rule exists to remove.
+///
+/// Founder ruling, 2026-08-30: entity beats artifact, a bulk artifact settle
+/// never overrides a recorded entity decision inside it, unprojectable mixes
+/// refuse naming both decisions, never silent.
+fn project_artifacts_from_settled_entities(
+    record: &MergeTransactionRecord,
+    base_state: &kin_model::graph::ResolvedGraphState,
+    ours_state: &kin_model::graph::ResolvedGraphState,
+    theirs_state: &kin_model::graph::ResolvedGraphState,
+    base_artifacts: &std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+    ours_artifacts: &std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+    theirs_artifacts: &std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+    merged_entities: &mut std::collections::HashMap<kin_model::EntityId, kin_model::Entity>,
+    merged_artifacts: &mut std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+) -> Result<Vec<String>> {
+    let settled_entities = settled_entities_by_path(record, base_state, ours_state, theirs_state);
+    if settled_entities.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut projections = Vec::new();
+    for entry in &record.entries {
+        let (MergeConflictSubject::Artifact { artifact }, MergeEntryResolution::Side { side, .. }) =
+            (&entry.subject, &entry.resolution)
+        else {
+            continue;
+        };
+        let Some(path) = artifact_path(artifact, base_artifacts, ours_artifacts, theirs_artifacts)
+        else {
+            continue;
+        };
+        let inside: Vec<&SettledEntity<'_>> = settled_entities
+            .iter()
+            .filter(|settled| settled.paths.contains(&path))
+            .collect();
+        if inside.is_empty() {
+            continue;
+        }
+        if decisions_a_side_drops(*side, &inside, base_state, ours_state, theirs_state).is_empty() {
+            continue;
+        }
+
+        let mut carried: Vec<(MergeSide, Option<&ResolvedArtifact>)> = Vec::new();
+        for candidate in [MergeSide::Ours, MergeSide::Theirs, MergeSide::Base] {
+            if !decisions_a_side_drops(candidate, &inside, base_state, ours_state, theirs_state)
+                .is_empty()
+            {
+                continue;
+            }
+            let value = artifact_side(candidate, base_artifacts, ours_artifacts, theirs_artifacts)
+                .get(artifact);
+            // Sides holding byte-identical artifacts are one choice, not
+            // several, so a base that never moved cannot make a projection
+            // ambiguous merely by existing.
+            let mut seen = false;
+            for (_, kept) in &carried {
+                if MergeSideValue::artifact(*kept)? == MergeSideValue::artifact(value)? {
+                    seen = true;
+                    break;
+                }
+            }
+            if !seen {
+                carried.push((candidate, value));
+            }
+        }
+
+        if carried.len() != 1 {
+            let decisions = name_decisions(&inside);
+            let why = if carried.is_empty() {
+                format!(
+                    "no side of {path} carries every one of those entity decisions, and a kin \
+                     merge composes at the granularity of a whole entity or artifact and never \
+                     the line, so there is no third body to publish"
+                )
+            } else {
+                format!(
+                    "{} sides of {path} carry every one of those entity decisions and their \
+                     bytes differ, so which body to publish is not determined by what was \
+                     settled",
+                    carried.len()
+                )
+            };
+            return Err(merge_conflict(format!(
+                "the recorded resolutions disagree about {path}: {} was settled `{}`, while \
+                 inside it {decisions}. {why}. Settle {path} to the side that carries those \
+                 entity decisions, or re-settle the entities, then continue.",
+                render_subject(entry),
+                side_flag(*side),
+            )));
+        }
+
+        let (projected, value) = carried[0];
+        // The projected side is held to history exactly as the settled one was:
+        // the value that side carries now must be the value the record bound.
+        require_recorded_side(entry, &projected, MergeSideValue::artifact(value)?)?;
+        match value {
+            Some(value) => merged_artifacts.insert(*artifact, value.clone()),
+            None => merged_artifacts.remove(artifact),
+        };
+        // The file and the entities settled inside it come from one side, so
+        // the spans graph truth records are the spans the published bytes have.
+        // Every one of these entities agrees semantically with its settlement
+        // on this side, which is what made the side a candidate at all, so no
+        // decision is lost by taking that side's copy of it.
+        for settled in &inside {
+            let taken = graph_side(&projected, base_state, ours_state, theirs_state)
+                .entities
+                .get(&settled.entity);
+            match taken {
+                Some(taken) => merged_entities.insert(settled.entity, taken.clone()),
+                None => merged_entities.remove(&settled.entity),
+            };
+        }
+        projections.push(format!(
+            "Projected {} from the `{}` side rather than the `{}` it was settled to, because {}; \
+             a file's bytes follow the entities settled inside it.",
+            render_subject(entry),
+            side_flag(projected),
+            side_flag(*side),
+            name_decisions(&inside),
+        ));
+    }
+    Ok(projections)
+}
+
+/// Every entity this merge settled by taking a side, with the file paths that
+/// entity occupies on the sides that were composed.
+fn settled_entities_by_path<'a>(
+    record: &'a MergeTransactionRecord,
+    base_state: &kin_model::graph::ResolvedGraphState,
+    ours_state: &kin_model::graph::ResolvedGraphState,
+    theirs_state: &kin_model::graph::ResolvedGraphState,
+) -> Vec<SettledEntity<'a>> {
+    let mut settled = Vec::new();
+    for entry in &record.entries {
+        let (MergeConflictSubject::Entity { entity }, MergeEntryResolution::Side { side, .. }) =
+            (&entry.subject, &entry.resolution)
+        else {
+            continue;
+        };
+        // An entity names its file in its span, which is the field the conflict
+        // listing labels it by. Reading every side covers an entity that moved:
+        // the decision binds wherever the identity is claimed.
+        let mut paths = BTreeSet::new();
+        for state in [base_state, ours_state, theirs_state] {
+            if let Some(found) = state.entities.get(entity) {
+                if let Some(span) = found.span.as_ref() {
+                    paths.insert(span.file.to_string());
+                }
+            }
+        }
+        if paths.is_empty() {
+            continue;
+        }
+        settled.push(SettledEntity {
+            entry,
+            entity: *entity,
+            side: *side,
+            paths,
+        });
+    }
+    settled
+}
+
+/// Which of these entity decisions one side's published state does not carry.
+fn decisions_a_side_drops<'a>(
+    side: MergeSide,
+    settled: &[&'a SettledEntity<'a>],
+    base_state: &kin_model::graph::ResolvedGraphState,
+    ours_state: &kin_model::graph::ResolvedGraphState,
+    theirs_state: &kin_model::graph::ResolvedGraphState,
+) -> Vec<&'a SettledEntity<'a>> {
+    settled
+        .iter()
+        .filter(|entity| {
+            let decided = graph_side(&entity.side, base_state, ours_state, theirs_state)
+                .entities
+                .get(&entity.entity);
+            let carried = graph_side(&side, base_state, ours_state, theirs_state)
+                .entities
+                .get(&entity.entity);
+            !entities_agree(decided, carried)
+        })
+        .copied()
+        .collect()
+}
+
+/// Whether two sides hold the same SEMANTIC value for one entity.
+///
+/// Byte offsets and the change a revision was recorded in are projection facts,
+/// not semantic ones. Editing one function moves the span of every entity below
+/// it, so a whole-value comparison would report every entity in that file as
+/// disagreeing when only one of them moved. That is the same fan-out the
+/// conflict listing already shows, twenty-two entity conflicts for one edited
+/// function, and judging agreement on it would refuse every mixed settle kin
+/// can honestly project. Agreement is judged on what the graph calls content:
+/// the fingerprint over normalized structure, signature, exact source text and
+/// behaviour class, beside the declaration facts around it.
+fn entities_agree(left: Option<&kin_model::Entity>, right: Option<&kin_model::Entity>) -> bool {
+    match (left, right) {
+        (None, None) => true,
+        (Some(left), Some(right)) => {
+            left.kind == right.kind
+                && left.name == right.name
+                && left.language == right.language
+                && left.fingerprint == right.fingerprint
+                && left.signature == right.signature
+                && left.visibility == right.visibility
+                && left.role == right.role
+        }
+        _ => false,
+    }
+}
+
+/// Name entity decisions the way the caller made them, so a refusal quotes the
+/// identity the listing showed and the flag that settled it.
+fn name_decisions(settled: &[&SettledEntity<'_>]) -> String {
+    settled
+        .iter()
+        .map(|entity| {
+            format!(
+                "{} was settled `{}`",
+                render_subject(entity.entry),
+                side_flag(entity.side)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The path an artifact identity occupies, preferring the branch being merged
+/// into, then the branch being merged in, then the base.
+fn artifact_path(
+    artifact: &kin_model::ArtifactId,
+    base_artifacts: &std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+    ours_artifacts: &std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+    theirs_artifacts: &std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+) -> Option<String> {
+    ours_artifacts
+        .get(artifact)
+        .or_else(|| theirs_artifacts.get(artifact))
+        .or_else(|| base_artifacts.get(artifact))
+        .map(|resolved| resolved.path.to_string())
+}
+
+fn artifact_side<'a>(
+    side: MergeSide,
+    base: &'a std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+    ours: &'a std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+    theirs: &'a std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact>,
+) -> &'a std::collections::HashMap<kin_model::ArtifactId, ResolvedArtifact> {
+    match side {
+        MergeSide::Base => base,
+        MergeSide::Ours => ours,
+        MergeSide::Theirs => theirs,
+    }
+}
+
+/// The spelling of a side a caller actually types, so a refusal names the
+/// decision in the form that produced it rather than in a Rust variant name.
+fn side_flag(side: MergeSide) -> &'static str {
+    match side {
+        MergeSide::Base => "--base",
+        MergeSide::Ours => "--ours",
+        MergeSide::Theirs => "--theirs",
+    }
 }
 
 /// Compose one identity-keyed dimension of the three-way merge.

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -1400,12 +1400,12 @@ fn project_artifacts_from_settled_entities(
         if inside.is_empty() {
             continue;
         }
-        let (specific, bulk) = split_specific_from_bulk(&inside, base_state, ours_state, theirs_state);
+        let (specific, bulk) =
+            split_specific_from_bulk(&inside, base_state, ours_state, theirs_state);
         if specific.is_empty() {
             continue;
         }
-        if decisions_a_side_drops(*side, &specific, base_state, ours_state, theirs_state)
-            .is_empty()
+        if decisions_a_side_drops(*side, &specific, base_state, ours_state, theirs_state).is_empty()
         {
             continue;
         }

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -1400,13 +1400,19 @@ fn project_artifacts_from_settled_entities(
         if inside.is_empty() {
             continue;
         }
-        if decisions_a_side_drops(*side, &inside, base_state, ours_state, theirs_state).is_empty() {
+        let (specific, bulk) = split_specific_from_bulk(&inside, base_state, ours_state, theirs_state);
+        if specific.is_empty() {
+            continue;
+        }
+        if decisions_a_side_drops(*side, &specific, base_state, ours_state, theirs_state)
+            .is_empty()
+        {
             continue;
         }
 
         let mut carried: Vec<(MergeSide, Option<&ResolvedArtifact>)> = Vec::new();
         for candidate in [MergeSide::Ours, MergeSide::Theirs, MergeSide::Base] {
-            if !decisions_a_side_drops(candidate, &inside, base_state, ours_state, theirs_state)
+            if !decisions_a_side_drops(candidate, &specific, base_state, ours_state, theirs_state)
                 .is_empty()
             {
                 continue;
@@ -1429,7 +1435,7 @@ fn project_artifacts_from_settled_entities(
         }
 
         if carried.len() != 1 {
-            let decisions = name_decisions(&inside);
+            let decisions = name_decisions(&specific);
             let why = if carried.is_empty() {
                 format!(
                     "no side of {path} carries every one of those entity decisions, and a kin \
@@ -1475,13 +1481,22 @@ fn project_artifacts_from_settled_entities(
                 None => merged_entities.remove(&settled.entity),
             };
         }
+        let subsumed = if bulk.is_empty() {
+            String::new()
+        } else {
+            format!(
+                ", and the {} settlement(s) covering the whole of {path} follow it, because a \
+                 settlement naming a container never overrides one naming something inside it",
+                bulk.len()
+            )
+        };
         projections.push(format!(
-            "Projected {} from the `{}` side rather than the `{}` it was settled to, because {}; \
-             a file's bytes follow the entities settled inside it.",
+            "Projected {} from the `{}` side rather than the `{}` it was settled to, because {}\
+             {subsumed}; a file's bytes follow the entities settled inside it.",
             render_subject(entry),
             side_flag(projected),
             side_flag(*side),
-            name_decisions(&inside),
+            name_decisions(&specific),
         ));
     }
     Ok(projections)
@@ -1574,6 +1589,67 @@ fn entities_agree(left: Option<&kin_model::Entity>, right: Option<&kin_model::En
         }
         _ => false,
     }
+}
+
+/// Split settlements at one path into the SPECIFIC ones, which constrain what
+/// the file's bytes may be, and the BULK ones, which do not.
+///
+/// A settlement naming a container is bulk relative to a settlement naming
+/// something inside it. That is the founder's rule one level down from the
+/// artifact: an artifact conflict exists beside the entities inside it only
+/// while the file is still a unit of conflict, and a file's module entity is
+/// the same shape. Settling the module `--ours` says "the whole file is ours",
+/// which is exactly the claim a `--theirs` on one function inside it overrides.
+///
+/// Containment is read from span enclosure within one side, and this is a
+/// different use of the field than the one `entities_agree` refuses. An
+/// absolute offset is a projection fact and cannot say whether two sides agree.
+/// One span enclosing another INSIDE one side is a structural fact about that
+/// side's own text, and it is the only containment the graph carries here:
+/// measured on the stranger's fixture, a commit of that file produced four
+/// entities and zero relations, so a rule keyed on a `Contains` edge could
+/// never have fired.
+fn split_specific_from_bulk<'a>(
+    inside: &[&'a SettledEntity<'a>],
+    base_state: &kin_model::graph::ResolvedGraphState,
+    ours_state: &kin_model::graph::ResolvedGraphState,
+    theirs_state: &kin_model::graph::ResolvedGraphState,
+) -> (Vec<&'a SettledEntity<'a>>, Vec<&'a SettledEntity<'a>>) {
+    let mut specific = Vec::new();
+    let mut bulk = Vec::new();
+    for outer in inside {
+        let contains_another = inside.iter().any(|inner| {
+            inner.entity != outer.entity
+                && [base_state, ours_state, theirs_state].iter().any(|state| {
+                    match (
+                        state.entities.get(&outer.entity),
+                        state.entities.get(&inner.entity),
+                    ) {
+                        (Some(outer), Some(inner)) => encloses(outer, inner),
+                        _ => false,
+                    }
+                })
+        });
+        if contains_another {
+            bulk.push(*outer);
+        } else {
+            specific.push(*outer);
+        }
+    }
+    (specific, bulk)
+}
+
+/// Whether one entity's span strictly encloses another's, in one side's own
+/// text. Equal ranges are not enclosure, so two readings of one entity never
+/// make each other bulk.
+fn encloses(outer: &kin_model::Entity, inner: &kin_model::Entity) -> bool {
+    let (Some(outer), Some(inner)) = (outer.span.as_ref(), inner.span.as_ref()) else {
+        return false;
+    };
+    outer.file == inner.file
+        && outer.start_byte <= inner.start_byte
+        && outer.end_byte >= inner.end_byte
+        && (outer.start_byte, outer.end_byte) != (inner.start_byte, inner.end_byte)
 }
 
 /// Name entity decisions the way the caller made them, so a refusal quotes the

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -529,6 +529,33 @@ unknown provider to be refused with the valid names printed and, the assertion
 that matters, with the stub recording zero requests, since a refusal that reaches
 the sign-in page comes back only as a redirect no terminal shows.
 
+`merge_precedence_repro.py` grades the merge defect the rc062a stranger run
+called "a wrong answer reported as a right one" (FIR-2958). Settling one entity
+`--theirs` and then settling the rest `--all-ours` reported all 76 conflicts
+resolved and published the `--ours` bytes, with the merge change recording
+`tree=0`: the source branch contributed nothing while every decision read as
+applied. A settled entity and a settled artifact land in two independent maps and
+only the artifact map becomes file bytes, so both were honoured and the one the
+reader sees won.
+
+Check `precedence` does the stranger's three commands and grades two things at
+once, because either alone passes on a build that merely fails differently: the
+merged file holds the body the entity decision chose, and the published merge
+carries a nonzero tree delta read off `kin log`'s own `Deltas:` line. Check
+`bulk` is the control on that same merge, requiring the file no entity decision
+covers to still hold the `--ours` bytes, so the rule reads as precedence rather
+than as take-theirs. Check `refusal` settles two entities in one file to opposite
+sides, which no side's committed bytes can carry, and requires the merge to
+refuse naming the file and both decisions and to move no ref. Check `uniform` is
+the control that keeps the other three honest: an ordinary `--all-theirs` merge
+must still publish, so a build that refused every merge would satisfy `refusal`
+and lose nothing else.
+
+The self-test drives every grader against one fixture per assertion. A merge log
+reading `tree=0` must fail, a one-parent change must read UNREADABLE rather than
+graded, and a refusal that names the file but neither entity, or both entities
+but only one side, must each fail on their own assertion.
+
 `brownfield_repro.py --self-test` and `response_budget_elisions.py --self-test`
 exercise their verdict graders on fixed payloads and need no binary and no
 corpus. Each case is paired with its inverse, so a grader that cannot tell its
@@ -578,6 +605,10 @@ python3 scripts/acceptance/working_copy_freshness_repro.py \
 python3 scripts/acceptance/bridge_reach_repro.py \
   --kin target/release/kin \
   --json acceptance/bridge_reach.json --verbose
+
+python3 scripts/acceptance/merge_precedence_repro.py \
+  --kin target/release/kin --daemon target/release/kin-daemon \
+  --json acceptance/merge_precedence.json --verbose
 ```
 
 Release, not debug. Release is what ships, so it is what an acceptance answer

--- a/scripts/acceptance/merge_precedence_repro.py
+++ b/scripts/acceptance/merge_precedence_repro.py
@@ -80,13 +80,16 @@ TICKET = "FIR-2958"
 
 print = functools.partial(print, flush=True)
 
-# One function per side of the question, in one file, so an entity decision and
-# an artifact decision can cover the same bytes. `base` is what both branches
-# edit; `mate` is here so the file has a second entity the merge must leave
-# alone.
+# One file whose two entities both conflict. `base` is edited to a DIFFERENT
+# LENGTH on each branch, which moves `mate` to a different byte offset on each
+# branch, so `mate` conflicts too while being semantically identical on both
+# sides. That shape is the whole difficulty and it is what the stranger hit: a
+# bulk settle records a decision about `mate` that only its byte offsets
+# distinguish, and judging the merge on whole entity values would refuse a mix
+# kin can project honestly. The two bodies must not be the same length.
 BASE_LIB = b"pub fn base() {}\npub fn mate() {}\n"
-OURS_LIB = b"pub fn base(value: u64) {}\npub fn mate() {}\n"
-THEIRS_LIB = b"pub fn base(value: i32) {}\npub fn mate() {}\n"
+OURS_LIB = b"pub fn base(count: u64) {}\npub fn mate() {}\n"
+THEIRS_LIB = b"pub fn base(v: i32) {}\npub fn mate() {}\n"
 
 # A second file neither entity decision covers, so the bulk settle has something
 # to keep. Without it "the rule is precedence" and "the rule is take theirs" are
@@ -98,8 +101,8 @@ THEIRS_SHARED = b"feature shared\n"
 # The contradictory fixture: two entities in one file, both moved on both
 # branches, so settling them to opposite sides leaves no side carrying both.
 BASE_PAIR = b"pub fn alpha() {}\npub fn beta() {}\n"
-OURS_PAIR = b"pub fn alpha(value: u64) {}\npub fn beta(value: u64) {}\n"
-THEIRS_PAIR = b"pub fn alpha(value: i32) {}\npub fn beta(value: i32) {}\n"
+OURS_PAIR = b"pub fn alpha(count: u64) {}\npub fn beta(count: u64) {}\n"
+THEIRS_PAIR = b"pub fn alpha(v: i32) {}\npub fn beta(v: i32) {}\n"
 
 
 def run(cmd, cwd=None, env=None, timeout=600, stdin=None):

--- a/scripts/acceptance/merge_precedence_repro.py
+++ b/scripts/acceptance/merge_precedence_repro.py
@@ -1,0 +1,767 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove a bulk artifact settle never overrides an entity decision inside it.
+
+FIR-2958. The rc062a stranger run settled one entity `--theirs`, settled the rest
+`--all-ours`, and was told every conflict was resolved:
+
+    $ kin resolve --theirs 0ce7fbfa-...              # format_report
+    Settled 1 conflict(s); ... has 1 of 76 conflict(s) settled
+    $ kin resolve --all-ours --expect db9836e0...
+    Settled 75 conflict(s); ... has 76 of 76 conflict(s) settled
+    $ kin resolve --do-continue
+    Merged refs/heads/pretty into refs/heads/main as change 5f3cd725...
+
+Every line reported success and 1 + 75 = 76 reconciles. The merged file was the
+`--ours` version, and the merge change recorded `Deltas: entities=1 relations=0
+tree=0`: a tree delta of zero, meaning the source branch contributed no bytes at
+all. The entity decision was recorded, reported settled, and discarded.
+
+The mechanism is that a settled entity and a settled artifact land in two
+independent maps, and only the artifact map becomes file bytes. Both decisions
+were honoured, in different dimensions, and the one the reader sees won.
+
+The rule this suite grades is the founder's ruling of 2026-08-30: entity beats
+artifact, specific beats bulk. The artifact is re-taken from whichever side's
+published bytes carry every entity decision inside that file, and where no side
+carries all of them the merge refuses and names both decisions. Nothing is
+synthesized, because kin has no textual line merge to build a third body from,
+so a projection is a choice among sides this merge already bound.
+
+Four checks, three repositories, run in order because two of them are
+destructive: they publish the merge the earlier assertions are about.
+
+  precedence  the entity settled `--theirs` decides the bytes of the artifact
+              holding it, even though a later `--all-ours` settled that artifact,
+              and the published merge carries a nonzero tree delta
+  bulk        the control on the same merge: `--all-ours` still owns every
+              artifact no entity decision contradicts, so the rule is precedence
+              and not "take theirs"
+  refusal     two entities in one file settled to opposite sides have no
+              publishable projection, so the merge refuses, names the file and
+              both decisions, moves no ref, and leaves the resolutions parked
+  uniform     the control that keeps the other three honest: an ordinary
+              `--all-theirs` merge still publishes, with the source bytes on
+              disk and a nonzero tree delta. Without it a product that refused
+              every merge would satisfy the refusal check and lose nothing else.
+
+Exit status is 0 when every check passed, 1 when one failed, 2 when one could not
+be read, and 3 when the run could not be set up. `--self-test` exercises every
+grader against a payload that must pass and one that must fail, and needs no
+binary, so a grader that cannot fail is a failure here rather than a silent pass
+in CI.
+
+The binary under test
+---------------------
+    cargo build --release --locked --bin kin --bin kin-daemon
+    python3 scripts/acceptance/merge_precedence_repro.py --kin target/release/kin
+
+`--kin` may also come from KIN_BIN. The kin-daemon beside it is used when one
+exists. No binary is built by this script.
+"""
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+TICKET = "FIR-2958"
+
+print = functools.partial(print, flush=True)
+
+# One function per side of the question, in one file, so an entity decision and
+# an artifact decision can cover the same bytes. `base` is what both branches
+# edit; `mate` is here so the file has a second entity the merge must leave
+# alone.
+BASE_LIB = b"pub fn base() {}\npub fn mate() {}\n"
+OURS_LIB = b"pub fn base(value: u64) {}\npub fn mate() {}\n"
+THEIRS_LIB = b"pub fn base(value: i32) {}\npub fn mate() {}\n"
+
+# A second file neither entity decision covers, so the bulk settle has something
+# to keep. Without it "the rule is precedence" and "the rule is take theirs" are
+# the same observation.
+BASE_SHARED = b"shared bytes\n"
+OURS_SHARED = b"main shared\n"
+THEIRS_SHARED = b"feature shared\n"
+
+# The contradictory fixture: two entities in one file, both moved on both
+# branches, so settling them to opposite sides leaves no side carrying both.
+BASE_PAIR = b"pub fn alpha() {}\npub fn beta() {}\n"
+OURS_PAIR = b"pub fn alpha(value: u64) {}\npub fn beta(value: u64) {}\n"
+THEIRS_PAIR = b"pub fn alpha(value: i32) {}\npub fn beta(value: i32) {}\n"
+
+
+def run(cmd, cwd=None, env=None, timeout=600, stdin=None):
+    proc = subprocess.Popen(
+        cmd, cwd=cwd, env=env,
+        stdin=subprocess.PIPE if stdin is not None else None,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    try:
+        out, err = proc.communicate(input=stdin, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        out, err = proc.communicate()
+        return 124, out, err
+    return proc.returncode, out, err
+
+
+# -- graders ---------------------------------------------------------------
+#
+# Every grader takes parsed payloads or rendered text and returns (status,
+# detail). Kept apart from the run so `--self-test` can hand each one an input
+# that must pass and one that must fail, with no binary anywhere.
+
+
+def merge_change_of(log_text):
+    """The newest change's parents and delta counts, or None when unreadable.
+
+    `Deltas:` and `Parents:` are `kin log`'s own lines. Reading both is what
+    separates "the merge moved no bytes" from "this is not a merge at all":
+    a one-parent change with tree=0 is an ordinary empty change and says
+    nothing about this defect.
+    """
+    if not isinstance(log_text, str) or "change " not in log_text:
+        return None
+    parents = None
+    deltas = None
+    for line in log_text.splitlines():
+        stripped = line.strip()
+        if parents is None and stripped.startswith("Parents:"):
+            parents = stripped[len("Parents:"):].split()
+        if deltas is None and stripped.startswith("Deltas:"):
+            fields = {}
+            for token in stripped[len("Deltas:"):].split():
+                key, sep, value = token.partition("=")
+                if sep:
+                    fields[key] = value
+            deltas = fields
+    if deltas is None:
+        return None
+    return {"parents": parents or [], "deltas": deltas}
+
+
+def grade_merge_moved_the_tree(log_text):
+    """A merge that took the source branch's entity has to move the tree.
+
+    `tree=0` is the exact signature the stranger recorded: the merged tree is
+    byte-identical to the target branch, so the source branch contributed
+    nothing while all 76 conflicts read as settled.
+    """
+    read = merge_change_of(log_text)
+    if read is None:
+        return UNREADABLE, "the log carries no change with a Deltas line"
+    if len(read["parents"]) != 2:
+        return UNREADABLE, (
+            "the newest change is not a merge, so its deltas say nothing: parents %r"
+            % (read["parents"],)
+        )
+    tree = read["deltas"].get("tree")
+    if tree is None:
+        return UNREADABLE, "the Deltas line carries no tree count: %r" % (read["deltas"],)
+    if tree == "0":
+        return FAIL, (
+            "the merge change records tree=0, so the source branch contributed no bytes "
+            "while every conflict reported settled: %r" % (read["deltas"],)
+        )
+    return PASS, "the merge change records tree=%s beside parents %r" % (tree, read["parents"])
+
+
+def grade_bytes(actual, expected, what):
+    """What is on disk, against what the settled decisions say must be."""
+    if actual is None:
+        return UNREADABLE, "%s could not be read from disk" % (what,)
+    if actual != expected:
+        return FAIL, "%s holds %r, and the settled decisions say %r" % (what, actual, expected)
+    return PASS, "%s holds %r" % (what, actual)
+
+
+def grade_refusal_names_both_decisions(stderr, path, entity_names):
+    """A refusal that does not name both decisions is the defect wearing a
+    refusal costume: the caller still cannot see which two choices collided."""
+    if not isinstance(stderr, str) or not stderr.strip():
+        return UNREADABLE, "the refusal printed nothing at all"
+    if path not in stderr:
+        return FAIL, "the refusal does not name the file %s: %r" % (path, stderr[-400:])
+    missing = [name for name in entity_names if name not in stderr]
+    if missing:
+        return FAIL, (
+            "the refusal does not name the entity decision(s) %s: %r"
+            % (", ".join(missing), stderr[-400:])
+        )
+    absent = [flag for flag in ("--theirs", "--ours") if flag not in stderr]
+    if absent:
+        return FAIL, (
+            "the refusal does not name the %s side(s) that were chosen: %r"
+            % (", ".join(absent), stderr[-400:])
+        )
+    return PASS, "the refusal names %s and both decisions" % (path,)
+
+
+def grade_nothing_published(log_text, before_head):
+    """A refused merge moves no ref. Reading the head back is the only proof;
+    the refusal's own text cannot say what it did not do."""
+    if not isinstance(log_text, str) or "change " not in log_text:
+        return UNREADABLE, "the log could not be read back after the refusal"
+    head = None
+    for line in log_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("change "):
+            head = stripped.split()[1]
+            break
+    if head is None:
+        return UNREADABLE, "the log names no change at all"
+    if head != before_head:
+        return FAIL, "the refused merge still advanced the branch from %s to %s" % (
+            before_head, head)
+    return PASS, "the branch is still at %s" % (head,)
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.home = os.path.join(workdir, "home")
+        os.makedirs(self.home)
+        # kin refuses to invent an author, which is correct product behavior and
+        # not an obstacle. The run isolates HOME so it cannot read the machine's
+        # identity, so it brings one of its own.
+        with open(os.path.join(self.home, ".gitconfig"), "w") as handle:
+            handle.write("[user]\n\tname = merge-precedence-repro\n"
+                         "\temail = repro@example.invalid\n"
+                         "[commit]\n\tgpgsign = false\n")
+        self.env = dict(os.environ)
+        self.env["HOME"] = self.home
+        self.env["USERPROFILE"] = self.home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(self.home, "registry.toml")
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DAEMON_URL", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repos = {}
+
+    def git(self, args, repo):
+        base = ["git", "-c", "core.hooksPath=/dev/null",
+                "-c", "user.email=repro@example.invalid",
+                "-c", "user.name=merge-precedence-repro",
+                "-c", "commit.gpgsign=false"]
+        return run(base + args, cwd=repo, env=self.env)
+
+    def kin_run(self, args, repo, timeout=600):
+        rc, out, err = run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+        if self.verbose:
+            print("  $ kin %s -> rc=%s" % (" ".join(args), rc))
+        return rc, out, err
+
+    def repo(self, name, files):
+        """A converted repository whose `main` and `feature` both moved `files`.
+
+        `files` maps a relative path to its (base, ours, theirs) bodies. main is
+        ours, feature is theirs, which is the orientation `kin merge feature`
+        gives them.
+        """
+        if name in self._repos:
+            return self._repos[name]
+        path = os.path.realpath(os.path.join(self.workdir, name))
+        os.makedirs(path)
+        self.git(["init", "-q", "--initial-branch=main", "."], path)
+        self._write(path, files, 0)
+        self.git(["add", "-A"], path)
+        rc, out, err = self.git(["commit", "-q", "-m", "base"], path)
+        if rc != 0:
+            raise RuntimeError("git commit failed: %s" % (err or out)[-300:])
+
+        self.git(["switch", "-q", "-c", "feature"], path)
+        self._write(path, files, 2)
+        self.git(["add", "-A"], path)
+        rc, out, err = self.git(["commit", "-q", "-m", "feature work"], path)
+        if rc != 0:
+            raise RuntimeError("git commit failed on feature: %s" % (err or out)[-300:])
+
+        self.git(["switch", "-q", "main"], path)
+        self._write(path, files, 1)
+        self.git(["add", "-A"], path)
+        rc, out, err = self.git(["commit", "-q", "-m", "main work"], path)
+        if rc != 0:
+            raise RuntimeError("git commit failed on main: %s" % (err or out)[-300:])
+
+        rc, out, err = self.kin_run(["init", "."], path)
+        if rc != 0:
+            raise RuntimeError("kin init failed in %s: %s" % (path, (err or out)[-300:]))
+        self._repos[name] = path
+        return path
+
+    @staticmethod
+    def _write(path, files, index):
+        for rel, bodies in files.items():
+            full = os.path.join(path, rel)
+            parent = os.path.dirname(full)
+            if parent and not os.path.isdir(parent):
+                os.makedirs(parent)
+            with open(full, "wb") as handle:
+                handle.write(bodies[index])
+
+    def read_bytes(self, repo, rel):
+        try:
+            with open(os.path.join(repo, rel), "rb") as handle:
+                return handle.read()
+        except (IOError, OSError):
+            return None
+
+    def conflicts(self, repo):
+        rc, out, err = self.kin_run(["conflicts", "--json"], repo)
+        if rc != 0:
+            raise RuntimeError("kin conflicts --json failed: %s" % (err or out)[-300:])
+        return json.loads(out)
+
+    def entity_conflict(self, report, name):
+        """The identity of the one parked entity conflict named `name`.
+
+        `kin resolve` takes the uuid, and the listing labels an entity
+        `<name> in <file>`. Asserting there is exactly one keeps a fixture that
+        grew a second entity of that name from settling the wrong conflict.
+        """
+        prefix = "%s in " % name
+        found = []
+        for entry in (report.get("record") or {}).get("entries") or []:
+            subject = entry.get("subject") or {}
+            if subject.get("subject") != "entity":
+                continue
+            label = entry.get("label")
+            if isinstance(label, str) and label.startswith(prefix):
+                found.append(subject.get("entity"))
+        if len(found) != 1:
+            raise RuntimeError(
+                "expected exactly one parked conflict named %s, found %r" % (name, found))
+        return found[0]
+
+    def head_change(self, repo):
+        rc, out, err = self.kin_run(["log", "-n", "1"], repo)
+        if rc != 0:
+            raise RuntimeError("kin log failed: %s" % (err or out)[-300:])
+        for line in out.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("change "):
+                return stripped.split()[1]
+        raise RuntimeError("kin log named no change: %s" % out[-300:])
+
+
+class Result(object):
+    def __init__(self, ident, status, detail):
+        self.ident = ident
+        self.status = status
+        self.detail = detail
+
+
+MIXED_FILES = {
+    "src/lib.rs": (BASE_LIB, OURS_LIB, THEIRS_LIB),
+    "shared.txt": (BASE_SHARED, OURS_SHARED, THEIRS_SHARED),
+}
+PAIR_FILES = {"src/lib.rs": (BASE_PAIR, OURS_PAIR, THEIRS_PAIR)}
+
+
+def _settle_the_mixed_merge(suite):
+    """Do the stranger's three commands once, and cache what they produced."""
+    if hasattr(suite, "_mixed"):
+        return suite._mixed
+    repo = suite.repo("mixed", MIXED_FILES)
+    rc, out, err = suite.kin_run(["merge", "feature"], repo)
+    # A conflicted merge is the state this suite is about, so a nonzero exit is
+    # expected here and is not graded: FIR-2960 grades the exit code itself.
+    del rc, out, err
+    entity = suite.entity_conflict(suite.conflicts(repo), "base")
+    rc, out, err = suite.kin_run(["resolve", "--theirs", entity], repo)
+    if rc != 0:
+        raise RuntimeError("settling the entity failed: %s" % (err or out)[-300:])
+    rc, out, err = suite.kin_run(["resolve", "--all-ours"], repo)
+    if rc != 0:
+        raise RuntimeError("the bulk settle failed: %s" % (err or out)[-300:])
+    rc, out, err = suite.kin_run(["resolve", "--continue"], repo)
+    published = rc == 0
+    log = suite.kin_run(["log", "-n", "1"], repo)[1] if published else ""
+    suite._mixed = {"repo": repo, "published": published, "log": log,
+                    "detail": (err or out)[-400:]}
+    return suite._mixed
+
+
+def check_precedence(suite):
+    state = _settle_the_mixed_merge(suite)
+    if not state["published"]:
+        return Result("precedence", FAIL,
+                      "%s the merge did not publish at all: %s" % (TICKET, state["detail"]))
+    verdicts = [
+        ("bytes", grade_bytes(suite.read_bytes(state["repo"], "src/lib.rs"),
+                              THEIRS_LIB, "src/lib.rs")),
+        ("tree", grade_merge_moved_the_tree(state["log"])),
+    ]
+    return _combine("precedence", verdicts)
+
+
+def check_bulk(suite):
+    state = _settle_the_mixed_merge(suite)
+    if not state["published"]:
+        return Result("bulk", UNREADABLE,
+                      "%s the merge did not publish, so the bulk settle is ungraded" % TICKET)
+    status, detail = grade_bytes(suite.read_bytes(state["repo"], "shared.txt"),
+                                 OURS_SHARED, "shared.txt")
+    return Result("bulk", status, "%s %s" % (TICKET, detail))
+
+
+def check_refusal(suite):
+    repo = suite.repo("pair", PAIR_FILES)
+    before = suite.head_change(repo)
+    suite.kin_run(["merge", "feature"], repo)
+    report = suite.conflicts(repo)
+    alpha = suite.entity_conflict(report, "alpha")
+    beta = suite.entity_conflict(report, "beta")
+    rc, out, err = suite.kin_run(["resolve", "--theirs", alpha], repo)
+    if rc != 0:
+        return Result("refusal", UNREADABLE,
+                      "%s settling alpha failed: %s" % (TICKET, (err or out)[-300:]))
+    rc, out, err = suite.kin_run(["resolve", "--ours", beta], repo)
+    if rc != 0:
+        return Result("refusal", UNREADABLE,
+                      "%s settling beta failed: %s" % (TICKET, (err or out)[-300:]))
+    rc, out, err = suite.kin_run(["resolve", "--all-ours"], repo)
+    if rc != 0:
+        return Result("refusal", UNREADABLE,
+                      "%s the bulk settle failed: %s" % (TICKET, (err or out)[-300:]))
+    rc, out, err = suite.kin_run(["resolve", "--continue"], repo)
+    if rc == 0:
+        return Result("refusal", FAIL,
+                      "%s two contradictory settlements published anyway, with %r on disk"
+                      % (TICKET, suite.read_bytes(repo, "src/lib.rs")))
+    verdicts = [
+        ("named", grade_refusal_names_both_decisions(err or out, "src/lib.rs",
+                                                     ["alpha", "beta"])),
+        ("head", grade_nothing_published(suite.kin_run(["log", "-n", "1"], repo)[1], before)),
+    ]
+    return _combine("refusal", verdicts)
+
+
+def check_uniform(suite):
+    """The control. A rule that refused every mixed merge, or took theirs
+    always, would satisfy the three checks above and lose nothing else."""
+    repo = suite.repo("uniform", MIXED_FILES)
+    suite.kin_run(["merge", "feature"], repo)
+    rc, out, err = suite.kin_run(["resolve", "--all-theirs"], repo)
+    if rc != 0:
+        return Result("uniform", UNREADABLE,
+                      "%s the uniform settle failed: %s" % (TICKET, (err or out)[-300:]))
+    rc, out, err = suite.kin_run(["resolve", "--continue"], repo)
+    if rc != 0:
+        return Result("uniform", FAIL,
+                      "%s an ordinary uniform merge no longer publishes: %s"
+                      % (TICKET, (err or out)[-300:]))
+    verdicts = [
+        ("lib", grade_bytes(suite.read_bytes(repo, "src/lib.rs"), THEIRS_LIB, "src/lib.rs")),
+        ("shared", grade_bytes(suite.read_bytes(repo, "shared.txt"), THEIRS_SHARED,
+                               "shared.txt")),
+        ("tree", grade_merge_moved_the_tree(suite.kin_run(["log", "-n", "1"], repo)[1])),
+    ]
+    return _combine("uniform", verdicts)
+
+
+def _combine(ident, verdicts):
+    """Report every arm, never the first bad one, because knowing which arm
+    broke is the whole value of grading several claims in one check."""
+    detail = "; ".join("%s %s %s" % (name, status, note) for name, (status, note) in verdicts)
+    if any(status == FAIL for _, (status, _) in verdicts):
+        return Result(ident, FAIL, "%s %s" % (TICKET, detail))
+    if any(status == UNREADABLE for _, (status, _) in verdicts):
+        return Result(ident, UNREADABLE, "%s %s" % (TICKET, detail))
+    return Result(ident, PASS, "%s %s" % (TICKET, detail))
+
+
+# Ordered, and the order is load bearing: `precedence` publishes the merge
+# `bulk` reads back.
+CHECKS = [
+    ("precedence", check_precedence),
+    ("bulk", check_bulk),
+    ("refusal", check_refusal),
+    ("uniform", check_uniform),
+]
+
+
+# -- self-test fixtures ----------------------------------------------------
+#
+# One fixture per assertion. Two assertions that can both catch one input hide
+# each other's absence, so every fixture below is caught by exactly one, and
+# deleting that assertion is the only thing that turns this self-test red.
+
+MERGE_LOG_MOVED = (
+    "change 5f3cd725aa\n"
+    "Author: repro <repro@example.invalid>\n"
+    "Parents: 37b6e37b81 3b1d3eeeb7\n"
+    "Deltas: entities=1 relations=0 tree=1 policy=false\n"
+)
+MERGE_LOG_TREE_ZERO = (
+    "change 5f3cd725aa\n"
+    "Parents: 37b6e37b81 3b1d3eeeb7\n"
+    "Deltas: entities=1 relations=0 tree=0 policy=false\n"
+)
+# One parent, so the deltas are an ordinary change's and say nothing here. Only
+# the parent-count arm can catch this.
+LOG_NOT_A_MERGE = (
+    "change 5f3cd725aa\n"
+    "Parents: 37b6e37b81\n"
+    "Deltas: entities=1 relations=0 tree=1 policy=false\n"
+)
+# Two parents and a Deltas line with no tree field, which only the missing-field
+# arm can catch.
+MERGE_LOG_NO_TREE = (
+    "change 5f3cd725aa\n"
+    "Parents: 37b6e37b81 3b1d3eeeb7\n"
+    "Deltas: entities=1 relations=0 policy=false\n"
+)
+LOG_NO_DELTAS = "change 5f3cd725aa\nParents: 37b6e37b81 3b1d3eeeb7\n"
+
+REFUSAL_FULL = (
+    "Error: the recorded resolutions disagree about src/lib.rs: entity alpha (0ce7fbfa) was "
+    "settled `--theirs`, entity beta (899c1130) was settled `--ours`, and artifact src/lib.rs "
+    "(ce183603) was settled `--ours`, whose bytes do not carry 1 decision(s)"
+)
+# Names both decisions and never names the file, which only the path arm catches.
+REFUSAL_NO_PATH = (
+    "Error: the recorded resolutions disagree: entity alpha was settled `--theirs`, entity beta "
+    "was settled `--ours`"
+)
+# Names the file and both flags and neither entity, which only the entity arm catches.
+REFUSAL_NO_ENTITY = (
+    "Error: the recorded resolutions disagree about src/lib.rs: something was settled "
+    "`--theirs` and something else was settled `--ours`"
+)
+# Names the file and both entities and only one flag, which only the flag arm catches.
+REFUSAL_NO_FLAGS = (
+    "Error: the recorded resolutions disagree about src/lib.rs: alpha and beta were settled "
+    "to opposite sides, one of them `--ours`"
+)
+
+
+def report_payload(results):
+    """The report shape `scripts/acceptance/gate.py` reads.
+
+    The key is `results` and not `checks`. That is not a style choice: the gate
+    calls `payload.get("results")` and refuses anything else with "carries no
+    results list". Two sibling suites shipped keyed `checks`, printed green CHECK
+    lines, and produced a verdict the gate could not read. The self-test drives
+    the gate's own loader over this payload rather than a copy of its rules.
+    """
+    return {"suite": "merge_precedence", "ticket": TICKET,
+            "results": [{"id": r.ident, "ticket": TICKET, "status": r.status,
+                         "detail": r.detail} for r in results]}
+
+
+def absolute_binary(path):
+    """A binary path the fixtures can still find after they change directory.
+
+    Every check runs the binary with `cwd=` a fixture repository, so a relative
+    `--kin target/release/kin` resolves against that fixture rather than the
+    caller's directory, and raises `[Errno 2] No such file or directory`. The
+    workflow passes exactly that relative path.
+    """
+    return path and os.path.abspath(os.path.expanduser(path))
+
+
+def self_test():
+    graded = []
+    failures = []
+
+    def expect(label, got, want):
+        graded.append(label)
+        status = got[0]
+        if status != want:
+            failures.append("%s: wanted %s got %s (%s)" % (label, want, status, got[1]))
+
+    expect("tree passes a merge that moved the tree",
+           grade_merge_moved_the_tree(MERGE_LOG_MOVED), PASS)
+    expect("tree fails the shipped tree=0 signature",
+           grade_merge_moved_the_tree(MERGE_LOG_TREE_ZERO), FAIL)
+    expect("tree cannot read a one-parent change",
+           grade_merge_moved_the_tree(LOG_NOT_A_MERGE), UNREADABLE)
+    expect("tree cannot read a Deltas line with no tree field",
+           grade_merge_moved_the_tree(MERGE_LOG_NO_TREE), UNREADABLE)
+    expect("tree cannot read a log with no Deltas line",
+           grade_merge_moved_the_tree(LOG_NO_DELTAS), UNREADABLE)
+    expect("tree cannot read something that is not a log",
+           grade_merge_moved_the_tree("nope"), UNREADABLE)
+
+    expect("bytes pass the body the decisions chose",
+           grade_bytes(THEIRS_LIB, THEIRS_LIB, "src/lib.rs"), PASS)
+    expect("bytes fail the body the decisions rejected",
+           grade_bytes(OURS_LIB, THEIRS_LIB, "src/lib.rs"), FAIL)
+    expect("bytes cannot read a file that is not there",
+           grade_bytes(None, THEIRS_LIB, "src/lib.rs"), UNREADABLE)
+
+    expect("refusal passes text naming the file and both decisions",
+           grade_refusal_names_both_decisions(REFUSAL_FULL, "src/lib.rs", ["alpha", "beta"]),
+           PASS)
+    expect("refusal fails text that names no file",
+           grade_refusal_names_both_decisions(REFUSAL_NO_PATH, "src/lib.rs", ["alpha", "beta"]),
+           FAIL)
+    expect("refusal fails text that names neither entity",
+           grade_refusal_names_both_decisions(REFUSAL_NO_ENTITY, "src/lib.rs", ["alpha", "beta"]),
+           FAIL)
+    expect("refusal fails text that names only one side",
+           grade_refusal_names_both_decisions(REFUSAL_NO_FLAGS, "src/lib.rs", ["alpha", "beta"]),
+           FAIL)
+    expect("refusal cannot read an empty stderr",
+           grade_refusal_names_both_decisions("", "src/lib.rs", ["alpha"]), UNREADABLE)
+
+    expect("head passes a branch that did not move",
+           grade_nothing_published("change 37b6e37b81\n", "37b6e37b81"), PASS)
+    expect("head fails a branch the refusal advanced",
+           grade_nothing_published("change 5f3cd725aa\n", "37b6e37b81"), FAIL)
+    expect("head cannot read something that is not a log",
+           grade_nothing_published("nope", "37b6e37b81"), UNREADABLE)
+
+    # The report shape, driven through the gate's own reader rather than through
+    # a copy of its rules. A suite that runs, grades, prints green CHECK lines
+    # and writes a report the gate cannot read has not passed.
+    import importlib.util
+
+    gate_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gate.py")
+    if not os.path.exists(gate_path):
+        failures.append("gate.py is not beside this file, so the report shape went unchecked")
+    else:
+        spec = importlib.util.spec_from_file_location("acceptance_gate", gate_path)
+        gate = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(gate)
+        scratch = tempfile.mkdtemp(prefix="merge-precedence-selftest-")
+        try:
+            rows = [Result(ident, UNREADABLE, "%s check raised: fabricated" % TICKET)
+                    for ident, _ in CHECKS]
+            good = os.path.join(scratch, "good.json")
+            with open(good, "w") as handle:
+                json.dump(report_payload(rows), handle)
+            try:
+                loaded = gate.load_report(good)
+                expect("the gate reads every row this suite writes",
+                       (sorted(loaded), "loaded"), sorted(ident for ident, _ in CHECKS))
+                expect("the gate reads a status off each row",
+                       (loaded[CHECKS[0][0]].get("status"), "row status"), UNREADABLE)
+            except Exception as exc:  # noqa: BLE001 - a refusal is the finding
+                failures.append("the gate refused this suite's own report: %s" % exc)
+
+            # CONTROL: the shape that broke CI twice must still be refused, or
+            # the two assertions above would pass over any payload at all.
+            bad = os.path.join(scratch, "bad.json")
+            with open(bad, "w") as handle:
+                json.dump({"suite": "merge_precedence", "ticket": TICKET,
+                           "checks": [{"id": ident, "status": UNREADABLE}
+                                      for ident, _ in CHECKS]}, handle)
+            try:
+                gate.load_report(bad)
+                refused = False
+            except Exception:  # noqa: BLE001 - the refusal is what is wanted
+                refused = True
+            expect("CONTROL the gate still refuses the `checks`-keyed shape that broke CI",
+                   (refused, "refused"), True)
+        finally:
+            shutil.rmtree(scratch, ignore_errors=True)
+
+    expect("a relative kin path is absolutized by this suite",
+           (os.path.isabs(absolute_binary("target/release/kin")), "isabs"), True)
+    expect("and an absent binary stays absent rather than becoming the cwd",
+           (absolute_binary(None), "absent"), None)
+
+    for line in failures:
+        print("SELFTEST FAIL %s" % line)
+    # Counted, never written out. A hardcoded total drifts from the assertions
+    # it claims to describe, and it drifts silently downward.
+    print("self-test: %d grader assertions, %d failed" % (len(graded), len(failures)))
+    if len(graded) != len(set(graded)):
+        print("SELFTEST FAIL duplicate assertion labels, so one shadowed another")
+        return 1
+    if not graded:
+        print("SELFTEST FAIL no grader assertion ran")
+        return 1
+    return 1 if failures else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN") or shutil.which("kin"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path")
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    opts = parser.parse_args(argv)
+
+    if opts.self_test:
+        return self_test()
+
+    if not opts.kin:
+        print("SETUP no kin binary: pass --kin or set KIN_BIN")
+        return 3
+    opts.kin = absolute_binary(opts.kin)
+    opts.daemon = absolute_binary(opts.daemon)
+    if not opts.daemon:
+        beside = os.path.join(os.path.dirname(opts.kin), "kin-daemon")
+        if os.path.isfile(beside) and os.access(beside, os.X_OK):
+            opts.daemon = beside
+
+    workdir = tempfile.mkdtemp(prefix="merge-precedence-")
+    suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
+    try:
+        results = []
+        for ident, check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - a setup failure is not a verdict
+                results.append(Result(ident, UNREADABLE, "%s check raised: %s" % (TICKET, error)))
+        for result in results:
+            print("CHECK %s %s %s %s" % (result.ident, TICKET, result.status, result.detail))
+        asked = [ident for ident, _ in CHECKS]
+        answered = [result.ident for result in results]
+        # Written before the asked/answered guard below, not after it. Four
+        # UNREADABLE rows are a verdict the gate can name; a missing report is
+        # one it can only refuse.
+        if opts.json_path:
+            directory = os.path.dirname(os.path.abspath(opts.json_path))
+            if directory:
+                try:
+                    os.makedirs(directory)
+                except OSError:
+                    pass
+            with open(opts.json_path, "w") as handle:
+                json.dump(report_payload(results), handle, indent=2)
+        if answered != asked:
+            print("SETUP asked for %r and %r answered" % (asked, answered))
+            return 3
+        if any(result.status == FAIL for result in results):
+            return 1
+        if any(result.status == UNREADABLE for result in results):
+            return 2
+        return 0
+    finally:
+        for repo in suite._repos.values():
+            try:
+                run([opts.kin, "daemon", "stop"], cwd=repo, env=suite.env, timeout=180)
+            except Exception:  # noqa: BLE001 - teardown must not change the verdict
+                pass
+        if not opts.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+        else:
+            print("kept fixtures under %s" % workdir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -133,6 +133,11 @@ EXPECTED_SUITES = (
         "acceptance/init_budget.json",
     ),
     ExpectedSuite(
+        "scripts/acceptance/coverage_read_open.py",
+        "coverage_read",
+        "acceptance/coverage_read.json",
+    ),
+    ExpectedSuite(
         "scripts/acceptance/bridge_reach_repro.py",
         "bridge_reach",
         "acceptance/bridge_reach.json",
@@ -141,6 +146,11 @@ EXPECTED_SUITES = (
         "scripts/acceptance/prose_query_parity_repro.py",
         "prose_parity",
         "acceptance/prose_parity.json",
+    ),
+    ExpectedSuite(
+        "scripts/acceptance/merge_precedence_repro.py",
+        "merge_precedence",
+        "acceptance/merge_precedence.json",
     ),
 )
 


### PR DESCRIPTION
`kin merge` could settle one entity `--theirs`, settle the enclosing artifact `--ours` in a bulk pass, report every conflict settled, and publish a merge in which the source branch contributed no bytes. Nothing warned. The rc062a stranger run found it and called it "a wrong answer reported as a right one", and it is the one thing that disqualifies Kin as a Git replacement whatever else works.

## Measured before anything was written

The brief said measure first, so the numbers are the stranger's own instrument run on my own release build, adapted for macOS only in its paths and its checksum tool.

| arm | THEIRSMARKER | OURSMARKER | Deltas | every step exit |
|---|---|---|---|---|
| before, my build of origin/main | 0 | 1 | `entities=1 relations=0 tree=0 policy=false` | 0 |
| after, my build with the rule | 1 | 0 | `entities=4 relations=0 tree=1 policy=false` | 0 |
| control, `--all-theirs` on origin/main | 1 | 0 | `entities=4 relations=0 tree=1 policy=false` | 0 |

Only the control row moved before the fix, which is what makes the zero a measurement rather than a broken harness. The merge surface was byte-identical to origin/main when measured, read as blob ids, with a control on a file main had moved so the check could fail.

## The mechanism

`apply_resolution` writes every settled entry into one of three independent maps, and only the artifact map becomes file bytes. Both decisions were honoured, in different dimensions, and the one the reader sees won.

## The rule

`project_artifacts_from_settled_entities` in `crates/kin-daemon/src/repository_merge.rs`, run in `publish_resolved_merge` between applying the resolutions and checking the residue, beside the composition refusals it belongs with. Entity beats artifact, specific beats bulk: the file, and the entities settled inside it, are taken from whichever side carries every one of those entity decisions. Nothing is synthesized, so what publishes is a side's own committed blob, held to history by the same `require_recorded_side` check the settled side got. Where no single side carries every decision the merge refuses and names the artifact decision and every entity decision inside the file, because a kin merge composes at the granularity of a whole entity or artifact and never the line.

This is the founder's ruling of 2026-08-30 00:55Z, built as a decision and not a default: entity beats artifact, a bulk artifact settle never overrides a recorded entity decision inside it, file bytes are projected from settled entities, unprojectable mixes refuse naming both decisions, never silent. The reason is written beside the code so a future reader finds it there and can flip it.

## Two things the measurement changed about the fix

**Agreement is judged on graph content, not on whole entity values.** A span moves whenever anything above it changes length and `created_in` differs on every branch, so a whole-value comparison reports every entity in an edited file as disagreeing when one of them moved. Measured: one edited function produced four entity conflicts, and only one of those entities was edited. Judged that way the rule would have refused the very case it exists to project, so `span`, `file_origin` and `created_in` are excluded by name and the fingerprint decides. One consequence follows and the rule takes it: when the artifact is projected to a side, the entities settled inside that file come from that side too, so the spans graph truth records are the spans the published bytes actually have.

**The artifact is not the only bulk unit of conflict.** The first version refused the stranger's own case, and its refusal named the reason: the file's module entity was settled `--ours` in the same bulk pass, its span covers the whole file and its behaviour hash is the whole file's text, so no side could carry that beside `format_report` settled `--theirs`.

So the rule states the thesis rather than a tie-break between two peers: **a settlement naming a container never overrides a settlement naming something inside it, at both levels.** Specific decisions constrain the projection and bulk ones follow it. The module entity being the same shape as the artifact one level down is exactly why the end state has no artifact layer at all: once the entity is the only unit of conflict, there is nothing at the artifact level left to override with, and this precedence rule stops being a rule and becomes a consequence.

Containment is read from span enclosure within one side, and that needs saying carefully, because it is a different use of the field than the agreement test above refuses. An absolute byte offset is a projection fact and cannot say whether two sides agree, which is why `entities_agree` excludes `span` by name. One span enclosing another INSIDE one side is a structural fact about that side's own text, and it is the only containment the graph actually carries for this shape. Measured: a commit of that fixture reports `(4 entities, 0 relations, 1 artifacts)`, so a rule keyed on `RelationKind::Contains` could never have fired, while `kin graph inspect` reads `reporting (Module) Span: lines 1-11` around `format_report (Function) Span: lines 4-6`.

## What this does not do, and where the rest is written

The end state is that the entity and the relation are the only units of conflict and an artifact conflict row is derived from its entities' conflicts rather than enumerated beside them. Under that shape this precedence rule is not a tie-break between two peers, it falls out, because there is nothing at the artifact level to override with. That derivation is larger than this change, so this PR lands the ruled precedence rule and the refusal, and the derived-conflict design goes to FIR-2960 in the model's vocabulary for the next lane to build toward rather than patch the count.

## Proof

Four scripted acceptance checks in `scripts/acceptance/merge_precedence_repro.py`, reading the product's own output and nothing else: the merged file's bytes off disk and the tree delta off `kin log`'s own `Deltas:` line. `precedence` asserts the entity decision reaches the file and the merge moves the tree. `bulk` is the control on the same merge, so the rule reads as precedence rather than as take-theirs. `refusal` asserts a contradictory mix refuses, names the file and both decisions, and moves no ref. `uniform` is the control that an ordinary `--all-theirs` merge still publishes, so a build that refused every merge would satisfy `refusal` and lose nothing else. Suite exit 0, four asked and four answered.

Registered in all three inventories the acceptance workflow enforces against each other, appended in the same position. Falsified: deleting the gate's `--report` line alone turns the visibility check red naming both the verdict inventory and the one-to-one ordering.

Two integration tests in `crates/kin-cli/tests/repository_merge_resolution.rs`. The first settles one entity `--theirs`, bulk-settles the rest `--ours`, and asserts the published file holds the entity decision, that the file no entity decision covers still holds `--ours`, and that the span recorded for the sibling entity selects that entity inside the bytes kin published. The second settles two entities in one file to opposite sides and asserts the merge refuses, names the file and both decisions, and moves no ref.

The lane report at `.kin-coord/reports/mergetruth-20260830.md` carries the numbers, the blob-id comparison with its control, and the falsification grid.

## The falsification grid

Six arms times three tests, on the tree this PR lands, with a freshly built daemon per arm proved by mtime against the mutated source. Every mutation removes a property of the code, never weakens an assertion.

```
arm  precedence  refusal  container   mutation removes
M0   green       green    green       nothing
M1   red         red      red         the rule's call site
M2   green       red      green       the refusal
M3   red         green    red         semantic agreement, comparing whole entity values
M4   red         green    green       the entity re-take
M5   green       green    red         the container split
```

18 of 18 cells answered. No mutation arm is green all the way across, every arm has its own signature, and each red was traced to its own assertion by source location. M4 is caught only by the span assertion, which is what proves the entity re-take does something. M5 is caught only by the container test.

Two things the grid found that nothing else would have, both worth stating because they are the reason to run one.

**A surviving mutant in this change.** The first complete grid had M5 green across every test. A Rust `src/lib.rs` produces no conflicting module entity, so both the integration tests and the acceptance suite used a shape that cannot exercise the container rule at all. Only a Python file does, which is why the hand reproduction found the container case and the tests did not: the stranger's fixture was Python and mine were not. `a_container_settle_does_not_override_a_settle_inside_it` closes it, and it is the only thing that catches M5.

**An earlier grid that graded nothing and looked like a pass.** `kin-cli` does not depend on `kin-daemon`, only on `kin-daemon-spawn`, so `cargo test -p kin-cli` never rebuilds the daemon these tests spawn, and the harness rebuilds it only when its build stamp is incompatible, which is not a freshness check. One daemon built from the M1 tree served M1 through M5 and printed five identical rows under five different labels, with twelve of twelve cells, a clean tree and exit 0. The tell was that a row RED all the way across is as much a tell as a row green. Asserting the mutation marker is in the SOURCE proves an edit landed and says nothing about which BYTES ran, and when the subject is a separate binary reached over HTTP the mutation and the subject are two different artifacts. The driver now builds the daemon per arm and refuses the arm if the binary is older than the file the mutation edited.

## One registration this PR also completes

Clean `origin/main` fails its own acceptance visibility guard with three violations: the `coverage_read` suite has a step and a gate line, seven occurrences in the workflow, and zero rows in `EXPECTED_SUITES`. Its gate line also sat last while its suite step is third, and the guard requires those two orders to agree, so no single `EXPECTED_SUITES` order could have satisfied both. This PR adds the missing row and moves the gate line up to where the step already is, and the guard now reads "22 suite reports reach one always-running verdict in order". Falsified in both directions: dropping my own gate line turns it red, and dropping the `coverage_read` row turns it red too.

Closes FIR-2958
Refs FIR-2960
