### PR TITLE
Correct the workspace-diff disclosure: relations do reach the overlay

### DIFF
--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -670,22 +670,27 @@ fn endpoint_is_workspace(requested: Option<&str>) -> bool {
     matches!(requested, None | Some("WORKSPACE") | Some("workspace"))
 }
 
-/// What the entity and relation counts above cannot show on a workspace endpoint.
+/// What the ENTITY count above cannot show on a workspace endpoint.
 ///
-/// A workspace endpoint's semantic side is its base change's entities and
-/// relations plus the workspace semantic overlay, and no writer in the daemon
-/// ever puts an entity delta into that overlay. The admission seam publishes
-/// with `semantic_delta: WorkspaceSemanticDelta::default()`, unconditionally,
-/// and the one other overlay writer computes its delta with the authority
-/// entities as BOTH the base and the desired side, so it cannot emit an entity
-/// delta either. `Entities: +0 ~0 -0` on a HEAD-to-WORKSPACE diff is therefore
-/// structural rather than an answer about the edit.
+/// Narrower than it first shipped, and the narrowing matters. A workspace
+/// endpoint's semantic side is its base change's entities and relations plus the
+/// workspace semantic overlay. Nothing ever writes an ENTITY delta into that
+/// overlay: the admission seam publishes
+/// `semantic_delta: WorkspaceSemanticDelta::default()` unconditionally, and the
+/// enrichment writer computes its delta with the authority entities as BOTH the
+/// base and the desired side (`kin-daemon/src/state.rs`), so an entity delta is
+/// structurally impossible from either. RELATION deltas do reach it, from that
+/// same enrichment writer, whose relation arguments are not the same value twice.
 ///
-/// A stranger read the pair as an answer, checked it against a fully settled
-/// graph (`kin graph status`: 78 of 78 embeddings indexed, 8 of 8 files at 100%
-/// coverage), and concluded the semantic layer had silently skipped a rewrite of
-/// a function body (FIR-2961). Naming the scope beside the counts is what tells a
-/// real zero apart from one nothing could have moved.
+/// So `Entities: +0 ~0 -0` beside a moving `Relations` line is not a
+/// contradiction, and saying so is the point. Two independent runs read the pair
+/// as an answer and went looking for a broken semantic layer: one over a
+/// rewritten function body against a fully settled graph (`kin graph status`: 78
+/// of 78 embeddings indexed, 8 of 8 files at 100% coverage), and one over an
+/// appended top-level function that read `Artifacts: +0 ~1 -0`,
+/// `Relations: +0 ~9 -0`, `Entities: +0 ~0 -0`, unchanged twenty seconds later at
+/// the same authority generation, while `kin status` already counted the entity
+/// and the commit that followed recorded ten of them (FIR-2961).
 ///
 /// Silent on a diff between two changes, where the entity delta is computed and
 /// means what it says.
@@ -703,11 +708,10 @@ fn semantic_scope_line(report: &DiffReport) -> Option<String> {
         "The base endpoint is"
     };
     Some(format!(
-        "Semantic scope: {side} the workspace, whose entities and relations are its base \
-         change's plus a workspace semantic overlay that no admission writes entity or relation \
-         deltas into. So semantic movement made in the working copy since its base change \
-         appears in neither count above, whatever the artifact rows show; commit it and diff \
-         change to change to see it."
+        "Semantic scope: {side} the workspace, whose entities are its base change's plus a \
+         workspace semantic overlay that nothing writes an entity delta into, so the entity \
+         count above cannot move for work in the working copy however many artifacts or \
+         relations do; commit it and diff change to change to see entity movement."
     ))
 }
 

--- a/scripts/acceptance/vcs_read_surfaces_repro.py
+++ b/scripts/acceptance/vcs_read_surfaces_repro.py
@@ -481,9 +481,10 @@ DIFF_WITHOUT_SCOPE = (
     "M  ledger/reporting.py -> ledger/reporting.py [ce183603] blob f53cc41c -> blob d712bc3d\n"
 )
 DIFF_WITH_SCOPE = DIFF_WITHOUT_SCOPE + (
-    "Semantic scope: The head endpoint is the workspace, whose entities and relations are its "
-    "base change's plus a workspace semantic overlay that no admission writes entity or "
-    "relation deltas into.\n"
+    "Semantic scope: The head endpoint is the workspace, whose entities are its base change's "
+    "plus a workspace semantic overlay that nothing writes an entity delta into, so the entity "
+    "count above cannot move for work in the working copy however many artifacts or relations "
+    "do; commit it and diff change to change to see entity movement.\n"
 )
 DIFF_NO_ENTITIES_LINE = "Kin repository-v6 diff\nArtifacts: +0 ~1 -0\n"
 


### PR DESCRIPTION
A correction against my own landed wording, plus the cost number kin#1258 owed.

## The wrong sentence

kin#1258 shipped this disclosure on a workspace diff:

> whose entities and relations are its base change's plus a workspace semantic
> overlay that no admission writes entity or relation deltas into

The relations half is wrong, and the greenfield video run refuted it the same
night on an independent tree. Appending one top-level function and reading
`kin diff HEAD WORKSPACE`:

```
Artifacts: +0 ~1 -0
Entities:  +0 ~0 -0
Relations: +0 ~9 -0
```

Relations moved. So something does write relation deltas into that overlay.

## Verified against the code, not taken on the report's word

`crates/kin-daemon/src/state.rs`, the enrichment overlay writer:

```rust
let delta = kin_core::diff_workspace_semantics(
    &authority.entities,
    &authority.relations,
    &authority.entities,
    &desired,
)
```

`authority.entities` is passed as BOTH the base and the desired side, so an entity
delta is structurally impossible from this writer, and the admission seam
publishes `WorkspaceSemanticDelta::default()`, so it emits none either.
`authority.relations` is compared against `desired`, so relation deltas absolutely
can come out of it. That is exactly the shape the video observed.

## Why the corrected line is better rather than merely narrower

`Entities: +0 ~0 -0` beside a moving `Relations` line is not a contradiction, and
the old wording implied it was. Saying so is now the whole point of the line,
because that pair is the exact confusion two independent runs walked into: one
over a rewritten function body against a fully settled graph (`kin graph status`:
78 of 78 embeddings indexed, 8 of 8 files at 100% coverage), and one over an
appended function whose diff read zero entities while `kin status` already counted
it and the commit immediately after recorded ten. The greenfield run also carries
a search control, `kin search zzz_not_a_real_symbol_qqq` answering
`No name matched`, so its positive result means something.

Full evidence: `.kin-coord/reports/greenfieldvideo-20260830.md`.

## How I got it wrong, since the shape repeats

I had the mechanism right and generalized one clause too far, from "cannot emit an
entity delta either" to "entity or relation deltas". Nothing in my own measurement
contradicted it, because my fixture's edit moved no relations, so the wrong half of
the sentence was never exercised. It took a different tree to expose it. That is
the argument for two reproductions on different trees rather than one careful one.

## The cost of read-after-admit, which #1258's body could not carry

#1258 had already squash-landed when the number arrived, so it lands here.

Measured on the binary carrying the clock but NOT the admission, which isolates
the admission's cost rather than comparing two builds that differ in two ways. 130
generated Python modules, 130 artifacts tracked, confirmed from `kin status`'s own
artifact count. Ten timed reads per arm.

The first attempt was not a measurement and said so. Sequential arms, ten reads
each, gave `control` a median of 0.304s and `read-after-admit` 0.242s: the arm
doing strictly MORE work came out faster. At load 80 with a 0.9s outlier on a
0.24s operation, a 0.06s gap between medians measures load drift. The same
explicit `kin admit` on the same shape read 0.208s in one arm and 0.123s in the
other, which calibrates the noise floor at better than 0.08s on a 0.2s operation.

So the arms were interleaved inside one loop, with the leading arm swapped every
round so an ordering effect cancels, and one warm pass each. The paired difference
per round is what survives load drift.

| rounds | control median | read-after-admit median | paired difference, median | slower in |
|---|---|---|---|---|
| 20 | 0.265s | 0.351s | **+0.071s** | 14 of 20 |
| 40 | 0.294s | 0.369s | **+0.115s** | 28 of 40 |

**Read-after-admit costs roughly 70 to 115 milliseconds median on a 130-artifact
tree.** Two replicates, 42 of 60 paired rounds slower, about 0.0015 against a
coin-flip null. The direction comes from the count and the mechanism together; the
magnitude is a range across replicates rather than a point, because that is the
precision this box supports.

`git status` on a tree this size pays its own walk. A tenth of a second buys an
answer about the working copy rather than about a graph that may not have looked
at it. The caveat that matters: this is 130 files, the walk is the term that
grows, and a repository two orders of magnitude larger has not been measured here
and should not be inferred from it.

Timed in Python, not through `/usr/bin/time`, because time writes to the same
stderr the product does and silencing one silences both, which is how the first
run of this measurement reported an empty list of times and a median of zero.

Taken with several builders live and a load average above 80, so these are
loaded-box numbers and the spread says so.

## The paragraph a reviewer stops on: a read now mutates

Checked rather than assumed.

`resolve_daemon_url_if_running_async` reads `KIN_DAEMON_URL` or asks the supervisor
for an ALREADY-published route and spawns nothing, so `kin status` never starts a
daemon. That matters more than it looks: a status that spawned a daemon would
change the cost profile of every scripted call.

The two integration tests that drive `kin status --json`,
`crates/kin-cli/tests/init_json.rs` and
`crates/kin-cli/tests/graph_status_after_admission.rs`, both run with
`env_remove("KIN_DAEMON_URL")` and no daemon up, so the admission returns Skipped,
nothing mutates, and the JSON payload is unchanged. They hold, and CI on #1258
confirmed it.

`init.rs` and `setup.rs` shell out to `git status --porcelain`, not this command.

And the documented byte-identical contract on `StatusReport` is about the report
being derived from ONE immutable authority lease rather than varying with the
filesystem mid-read. The admission completes before the lease is taken, so that
still holds; what moves now is the content, when the working copy moved, which is
the entire point.

Closes FIR-2961
