### PR TITLE
Name a held merge in kin status, where the working copy cannot

### DIFF
--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -39,7 +39,8 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use kin_core::last_admission::LastAdmissionRead;
 use kin_model::{
-    Hash256, RefName, RefTarget, RepositoryId, RootBundle, WorkspaceHead, WorkspaceId,
+    Hash256, MergeTransactionRecord, RefName, RefTarget, RepositoryId, RootBundle, WorkspaceHead,
+    WorkspaceId,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -986,6 +987,7 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
                 crate::daemon_death::recorded_for_store(layout.root()).as_ref(),
                 &kin_core::last_admission::read(&layout),
                 &pass,
+                merge.as_ref()
             )
         );
         // Which projection served the files this status describes. Appended
@@ -1108,8 +1110,17 @@ pub fn build_command_status_response(
     death: Option<&kin_daemon_spawn::DaemonKillRecord>,
     admission: &LastAdmissionRead,
     pass: &StatusAdmission,
+    merge: Option<&MergeInProgress>,
 ) -> Result<CommandStatusResponse> {
-    let text = render_text(&report, build.as_ref(), footprint, death, admission, pass);
+    let text = render_text(
+        &report,
+        build.as_ref(),
+        footprint,
+        death,
+        admission,
+        pass,
+        merge,
+    );
     let json = json
         .then(|| serde_json::to_string(&report))
         .transpose()
@@ -1120,6 +1131,83 @@ pub fn build_command_status_response(
         text,
         json,
     })
+}
+
+/// A merge this workspace is holding open.
+///
+/// Only the fields a status line needs. The full account is `kin conflicts`, and
+/// duplicating it here would give a reader two versions of one merge that can
+/// come to disagree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MergeInProgress {
+    pub source_ref: String,
+    pub target_ref: String,
+    pub transaction: String,
+    pub settled: usize,
+    pub total: usize,
+}
+
+/// The merge this workspace is holding open, when it is holding one.
+///
+/// `kin status` said nothing at all during a merge that had left seventy-six
+/// conflicts unresolved, and reported the tree as matching its base change while
+/// it did (FIR-2961). Kin holds a merge in an authority transaction rather than
+/// smearing conflict markers across the working copy, which is the better design
+/// and is exactly why the working copy cannot tell you a merge is open: there is
+/// nothing on disk to see. Walk away, come back, and the only surface that knows
+/// is one you have to already suspect you need.
+///
+/// Read off the authority lease, from the same durable record `kin conflicts`
+/// reads, so the two cannot disagree and neither needs a daemon or a filesystem
+/// read. A terminated record is not a merge in progress and is skipped here,
+/// because "the last merge" and "a merge waiting on you" are the two states this
+/// line exists to separate.
+pub fn merge_in_progress(
+    binding: &kin_core::LocalRepositoryAuthorityBinding,
+) -> Result<Option<MergeInProgress>> {
+    let authority = ActiveRepositoryAuthority::open(binding)?;
+    let lease = authority.manager().read_authority();
+    let workspace_id = authority.workspace_id;
+    Ok(lease
+        .metadata()
+        .merge_transactions
+        .iter()
+        .find(|record| record.workspace_id == workspace_id && record.state.is_in_progress())
+        .map(summarize_merge))
+}
+
+fn summarize_merge(record: &MergeTransactionRecord) -> MergeInProgress {
+    let unresolved = record.unresolved().count();
+    MergeInProgress {
+        source_ref: record.binding.source_ref.to_string(),
+        target_ref: record.binding.target_ref.to_string(),
+        transaction: record.hash.to_string(),
+        settled: record.entries.len().saturating_sub(unresolved),
+        total: record.entries.len(),
+    }
+}
+
+/// The merge banner, worded so the next command is in the sentence.
+///
+/// Rendered directly under the heading rather than appended at the end, because
+/// the reason this line exists is that a reader who does not already suspect a
+/// merge is open will not scroll for it. `git status` puts "You have unmerged
+/// paths" at the top for the same reason.
+fn merge_line(merge: &MergeInProgress) -> String {
+    let remaining = merge.total.saturating_sub(merge.settled);
+    if remaining == 0 {
+        format!(
+            "Merge in progress: {} into {} as merge transaction {}, every one of {} conflict(s) \
+             settled; publish it with `kin resolve --continue`",
+            merge.source_ref, merge.target_ref, merge.transaction, merge.total
+        )
+    } else {
+        format!(
+            "Merge in progress: {} into {} as merge transaction {}, {} of {} conflict(s) settled; \
+             `kin conflicts` lists what is outstanding, and nothing below describes it",
+            merge.source_ref, merge.target_ref, merge.transaction, merge.settled, merge.total
+        )
+    }
 }
 
 /// Graph truth caught up with the working copy, or the reason it could not be.
@@ -1318,6 +1406,7 @@ fn render_text(
     death: Option<&kin_daemon_spawn::DaemonKillRecord>,
     admission: &LastAdmissionRead,
     pass: &StatusAdmission,
+    merge: Option<&MergeInProgress>,
 ) -> String {
     let workspace_state =
         workspace_state_phrase(report.workspace.dirty, admission, pass, Utc::now());
@@ -1387,6 +1476,9 @@ fn render_text(
     ];
     if let Some(footprint) = footprint {
         lines.push(format!("Store size: {}", footprint.render()));
+    }
+    if let Some(merge) = merge {
+        lines.insert(1, merge_line(merge));
     }
     if let Some(build) = build {
         lines.push(format!(
@@ -1538,7 +1630,8 @@ mod tests {
                 None,
                 None,
                 &LastAdmissionRead::Absent,
-                &skipped_pass()
+                &skipped_pass(),
+                None
             )
             .contains("Authority payload read: "),
             "text status must state the payload the open read"
@@ -1848,6 +1941,7 @@ mod tests {
             None,
             &LastAdmissionRead::Absent,
             &skipped_pass(),
+            None,
         );
         assert!(
             rendered.contains(
@@ -1878,7 +1972,8 @@ mod tests {
                 None,
                 None,
                 &LastAdmissionRead::Absent,
-                &skipped_pass()
+                &skipped_pass(),
+                None
             )
             .contains("Live embedding coverage: 41/57 indexed, 16 pending (live query graph)"),
             "{}",
@@ -1888,7 +1983,8 @@ mod tests {
                 None,
                 None,
                 &LastAdmissionRead::Absent,
-                &skipped_pass()
+                &skipped_pass(),
+                None
             )
         );
     }
@@ -1925,6 +2021,103 @@ mod tests {
 
     fn skipped_pass() -> StatusAdmission {
         StatusAdmission::Skipped("no daemon is running for this repository".to_string())
+    }
+
+    fn merge_fixture(settled: usize, total: usize) -> MergeInProgress {
+        MergeInProgress {
+            source_ref: "refs/heads/pretty".to_string(),
+            target_ref: "refs/heads/main".to_string(),
+            transaction: "1f2f0ae2".to_string(),
+            settled,
+            total,
+        }
+    }
+
+    /// FIR-2961. During a merge that had left seventy-six conflicts unresolved,
+    /// `kin status` said nothing at all and reported the tree as matching its
+    /// base change while it did. Kin holds a merge in an authority transaction
+    /// rather than smearing markers across the working copy, which is the better
+    /// design and is exactly why the working copy cannot tell you: there is
+    /// nothing on disk to see.
+    #[test]
+    fn a_held_merge_is_named_with_what_it_waits_on() {
+        let line = merge_line(&merge_fixture(2, 76));
+        assert!(line.starts_with("Merge in progress:"), "{line}");
+        assert!(line.contains("refs/heads/pretty"), "{line}");
+        assert!(line.contains("refs/heads/main"), "{line}");
+        assert!(line.contains("1f2f0ae2"), "{line}");
+        assert!(line.contains("2 of 76 conflict(s) settled"), "{line}");
+        assert!(line.contains("kin conflicts"), "{line}");
+    }
+
+    /// Every conflict settled is a different state and a different next command.
+    /// A banner that said the same thing in both would send a reader to
+    /// `kin conflicts` to be told there is nothing outstanding.
+    #[test]
+    fn a_fully_settled_merge_names_the_publish_step_instead() {
+        let line = merge_line(&merge_fixture(76, 76));
+        assert!(
+            line.contains("every one of 76 conflict(s) settled"),
+            "{line}"
+        );
+        assert!(line.contains("kin resolve --continue"), "{line}");
+        assert!(
+            !line.contains("kin conflicts"),
+            "a settled merge must not send the reader to a list of nothing: {line}"
+        );
+    }
+
+    /// Placement is half the fix. `git status` puts "You have unmerged paths" at
+    /// the top, and a banner printed at the bottom of forty lines is one a reader
+    /// who does not already suspect a merge will never see. So this grades the
+    /// rendered position, not the wording.
+    #[test]
+    fn the_merge_banner_renders_directly_under_the_heading() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
+        let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
+        let merge = merge_fixture(2, 76);
+
+        let rendered = render_text(
+            &report,
+            None,
+            None,
+            None,
+            &LastAdmissionRead::Absent,
+            &skipped_pass(),
+            Some(&merge),
+        );
+        let lines: Vec<&str> = rendered.lines().collect();
+        assert_eq!(lines[0], "Kin repository-v6 status", "{rendered}");
+        assert!(
+            lines[1].starts_with("Merge in progress:"),
+            "the banner has to be the line under the heading, not somewhere below: {}",
+            lines[1]
+        );
+
+        // The control, and it is the half that matters: no merge, no banner, and
+        // the line under the heading is the one that was always there. A fix that
+        // printed the banner unconditionally would pass the assertion above.
+        let quiet = render_text(
+            &report,
+            None,
+            None,
+            None,
+            &LastAdmissionRead::Absent,
+            &skipped_pass(),
+            None,
+        );
+        assert!(
+            !quiet.contains("Merge in progress:"),
+            "a repository with no held merge must not claim one: {quiet}"
+        );
+        let quiet_lines: Vec<&str> = quiet.lines().collect();
+        assert!(
+            quiet_lines[1].starts_with("Repository: "),
+            "{}",
+            quiet_lines[1]
+        );
     }
 
     /// The arm this PR exists for. A verdict with no admission behind it is not
@@ -2067,11 +2260,19 @@ mod tests {
         let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
 
         let tree_line_of = |pass: &StatusAdmission| {
-            render_text(&report, None, None, None, &LastAdmissionRead::Absent, pass)
-                .lines()
-                .find(|line| line.starts_with("Tree: "))
-                .unwrap_or_default()
-                .to_string()
+            render_text(
+                &report,
+                None,
+                None,
+                None,
+                &LastAdmissionRead::Absent,
+                pass,
+                None,
+            )
+            .lines()
+            .find(|line| line.starts_with("Tree: "))
+            .unwrap_or_default()
+            .to_string()
         };
 
         // Read-after-admit outranks the marker, so with no pass behind it the
@@ -2112,6 +2313,7 @@ mod tests {
             None,
             &LastAdmissionRead::Absent,
             &skipped_pass(),
+            None,
         );
         assert!(
             !without.contains("Store size"),
@@ -2126,6 +2328,7 @@ mod tests {
             None,
             &LastAdmissionRead::Absent,
             &skipped_pass(),
+            None,
         );
         assert!(
             with.contains("Store size: ") && with.contains("under .kin/"),

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -977,6 +977,14 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
+        // A merge Kin is holding open, read off the authority lease. Never fatal:
+        // a status that refuses to print because it could not check for a merge
+        // is worse than one that prints and does not mention it, and this is the
+        // command an operator runs when something is already wrong.
+        let merge = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)
+            .ok()
+            .and_then(|binding| merge_in_progress(&binding).ok())
+            .flatten();
         let footprint = StoreFootprint::measure(&layout);
         print!(
             "{}",

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4374,6 +4374,10 @@ async fn command_status(
         daemon_source_known: daemon_build.source_known,
         daemon_dependency_provenance: daemon_build.dependency_provenance.to_string(),
     };
+    let merge = kin_core::LocalRepositoryAuthorityBinding::from_layout(&state.layout)
+        .ok()
+        .and_then(|binding| kin_cli::commands::status::merge_in_progress(&binding).ok())
+        .flatten();
     let response = kin_cli::commands::status::build_command_status_response(
         report,
         request.json,
@@ -4397,6 +4401,10 @@ async fn command_status(
              `/commands/admit` first for an answer measured against the working copy"
                 .to_string(),
         ),
+        // A merge this workspace is holding open, read off the authority lease.
+        // Never fatal: a status route that 500s because it could not check for a
+        // merge is worse than one that answers and does not mention it.
+        merge.as_ref(),
     )
     .map_err(internal_error)?;
     Ok(Json(response))

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -378,6 +378,16 @@ every answer passes a one-directional check while helping nobody. The
 `--self-test` cases are the literal pre-fix output the stranger saw and the
 post-fix output beside it, so a grader that cannot fail is caught here.
 
+It also covers what `kin status` does NOT say. Kin holds a merge in an authority
+transaction rather than smearing conflict markers across the working copy, which
+is the better design and the stranger preferred it to Git's markers; it is also
+why the working copy cannot tell you a merge is open, so the status line is the
+only place it can live. During a merge that had left seventy-six conflicts
+unresolved, `kin status` said nothing and reported the tree as matching its base
+change. The `held_merge` check opens a real conflicting merge and asks, with
+`kin conflicts` as its positive control so a fixture that never reached that state
+reads UNREADABLE rather than FAIL.
+
 `working_copy_freshness_repro.py` covers what the product says about a working
 copy it has not read, which the v0.6.1 yardstick run caught three surfaces
 getting wrong at once (FIR-2820). The stranger wrote a module, did not commit it,

--- a/scripts/acceptance/vcs_read_surfaces_repro.py
+++ b/scripts/acceptance/vcs_read_surfaces_repro.py
@@ -29,7 +29,7 @@ here, and it grades both directions: a surface that qualifies every answer it
 gives is as useless as one that qualifies none, so the all-clear has its own
 check and must still arrive.
 
-Six checks, one seeded repository, run in order because the experiment is
+Seven checks, one seeded repository, run in order because the experiment is
 destructive: each one sets up the next, and the last stops the daemon.
 
   basis        the `Tree:` line names when graph truth last caught up, rather
@@ -47,6 +47,15 @@ destructive: each one sets up the next, and the last stops the daemon.
                are satisfied by a product that hedges every sentence
   diff_scope   a workspace diff names what its entity and relation counts cannot
                show, rather than printing three zeroes that cannot move
+  held_merge   a real conflicting merge is opened and `kin status` must name it.
+               Kin holds a merge in an authority transaction rather than smearing
+               conflict markers across the files, which is the better design and
+               is exactly why the status line is the only place this can live:
+               there is nothing on disk to see. `kin conflicts` is the positive
+               control, and it is not decoration, because a fixture that never
+               opened a merge must read UNREADABLE rather than FAIL. Runs before
+               `unadmitted`, which stops the daemon both `kin merge` and
+               `kin conflicts` need
   unadmitted   with the daemon stopped, the verdict names itself unmeasured
                instead of borrowing the clock of an older admission. A fresh
                marker beside no admission at all is the most convincing form of
@@ -105,6 +114,31 @@ def total_by(entries, key):
     buckets = {}
     for entry in entries:
         buckets[entry[key]] = round(buckets.get(entry[key], 0) + entry["amount"], 2)
+    return buckets
+'''
+
+
+# Same declaration, two different bodies. A merge of two different FILES is clean
+# and would grade nothing, so both branches rewrite `total_by`.
+MODULE_SIDELINE = '''"""Roll ledger entries up into totals."""
+
+
+def total_by(entries, key):
+    """Sum amounts under one key, in cents."""
+    buckets = {}
+    for entry in entries:
+        buckets[entry[key]] = buckets.get(entry[key], 0) + int(entry["amount"] * 100)
+    return buckets
+'''
+
+MODULE_MAINLINE = '''"""Roll ledger entries up into totals."""
+
+
+def total_by(entries, key):
+    """Sum amounts under one key, with a currency symbol."""
+    buckets = {}
+    for entry in entries:
+        buckets[entry[key]] = "$%.2f" % (buckets.get(entry[key], 0) + entry["amount"])
     return buckets
 '''
 
@@ -216,6 +250,35 @@ def grade_verdict_without_an_admission_says_so(text):
                 "basis as though one had: %s" % line
             )
     return FAIL, "the verdict states no basis at all: %s" % line
+
+
+def grade_status_names_a_held_merge(text, conflicts_text):
+    """A merge Kin is holding cannot be seen from the working copy at all.
+
+    Kin holds a merge in an authority transaction rather than smearing conflict
+    markers across the files, which is the better design and is exactly why the
+    status line is the only place this can live: there is nothing on disk to see.
+    `kin status` said nothing during a merge that had left seventy-six conflicts
+    unresolved (FIR-2961).
+
+    `conflicts_text` is the positive control, and it is not decoration: if
+    `kin conflicts` does not report a merge either, the fixture never reached the
+    state this grades and the answer is UNREADABLE rather than FAIL.
+    """
+    body = text or ""
+    control = conflicts_text or ""
+    if "in progress" not in control.lower() and "merging" not in control.lower():
+        return UNREADABLE, (
+            "kin conflicts reports no held merge, so the fixture never reached the state "
+            "this check is about: %s" % control.strip()[:200]
+        )
+    if "Merge in progress:" in body:
+        line = next(l for l in body.splitlines() if l.startswith("Merge in progress:"))
+        return PASS, "kin status names the held merge: %s" % line
+    return FAIL, (
+        "kin conflicts reports a held merge and kin status says nothing about it, so a "
+        "reader who walks away is told the tree is clean and current"
+    )
 
 
 def grade_diff_discloses_its_semantic_scope(text):
@@ -338,6 +401,9 @@ class Suite(object):
     def edit_tracked_module(self):
         self._write(self.repo(), TRACKED_MODULE, MODULE_AFTER)
 
+    def write_tracked_module(self, body):
+        self._write(self.repo(), TRACKED_MODULE, body)
+
     def status_text(self):
         rc, out, err = self.kin_run(["status"])
         return out if rc == 0 else (out + err)
@@ -360,6 +426,51 @@ def check_saw_the_edit(suite):
     suite.edit_tracked_module()
     status, detail = grade_status_saw_the_edit(before, suite.status_text())
     return Result("saw_the_edit", status, "%s %s" % (TICKET, detail))
+
+
+def check_held_merge(suite):
+    """Open a real conflicting merge and ask kin status about it.
+
+    Destructive and it runs late for that reason: it leaves the workspace holding
+    a merge transaction, which nothing after it would survive.
+    """
+    steps = [
+        ["commit", "-m", "settle before branching"],
+        ["branch", "create", "sideline"],
+        ["branch", "switch", "sideline"],
+    ]
+    for args in steps:
+        rc, out, err = suite.kin_run(args)
+        if rc != 0:
+            return Result("held_merge", UNREADABLE,
+                          "%s `kin %s` exited %s: %s"
+                          % (TICKET, " ".join(args), rc, (err or out)[-200:]))
+    # Same declaration, two different bodies, one on each branch. That is the
+    # shape that conflicts; two different files would merge clean and grade
+    # nothing.
+    suite.write_tracked_module(MODULE_SIDELINE)
+    rc, out, err = suite.kin_run(["commit", "-m", "round on the sideline"])
+    if rc != 0:
+        return Result("held_merge", UNREADABLE,
+                      "%s the sideline commit failed: %s" % (TICKET, (err or out)[-200:]))
+    for args in (["branch", "switch", "main"],):
+        rc, out, err = suite.kin_run(args)
+        if rc != 0:
+            return Result("held_merge", UNREADABLE,
+                          "%s switching back failed: %s" % (TICKET, (err or out)[-200:]))
+    suite.write_tracked_module(MODULE_MAINLINE)
+    rc, out, err = suite.kin_run(["commit", "-m", "round on main"])
+    if rc != 0:
+        return Result("held_merge", UNREADABLE,
+                      "%s the mainline commit failed: %s" % (TICKET, (err or out)[-200:]))
+    # kin merge exits 0 on a conflicted merge today (a separate finding), so the
+    # exit code is not the signal here and kin conflicts is.
+    suite.kin_run(["merge", "sideline"])
+    _, conflicts_out, conflicts_err = suite.kin_run(["conflicts"])
+    status, detail = grade_status_names_a_held_merge(
+        suite.status_text(), conflicts_out or conflicts_err
+    )
+    return Result("held_merge", status, "%s %s" % (TICKET, detail))
 
 
 def check_unadmitted(suite):
@@ -408,6 +519,7 @@ CHECKS = (
     ("content", check_content),
     ("settled", check_settled),
     ("diff_scope", check_diff_scope),
+    ("held_merge", check_held_merge),
     ("unadmitted", check_unadmitted),
 )
 
@@ -486,6 +598,25 @@ DIFF_WITH_SCOPE = DIFF_WITHOUT_SCOPE + (
     "count above cannot move for work in the working copy however many artifacts or relations "
     "do; commit it and diff change to change to see entity movement.\n"
 )
+STATUS_WITH_MERGE = (
+    "Kin repository-v6 status\n"
+    "Merge in progress: refs/heads/sideline into refs/heads/main as merge transaction "
+    "1f2f0ae2, 2 of 76 conflict(s) settled; `kin conflicts` lists what is outstanding, and "
+    "nothing below describes it\n"
+    "Tree: efcc91dc (11 artifacts, matching its base change as admitted 0s ago)\n"
+)
+# The literal shape the stranger saw: a held 76-conflict merge, and a status that
+# reports the tree as current and says nothing else.
+STATUS_SILENT_DURING_MERGE = (
+    "Kin repository-v6 status\n"
+    "Tree: efcc91dc (11 artifacts, matching its base change)\n"
+)
+CONFLICTS_HELD = (
+    "Merging refs/heads/sideline into refs/heads/main is in progress as merge transaction "
+    "1f2f0ae2 (2 of 76 conflict(s) settled)\n"
+)
+CONFLICTS_NONE = "No merge has opened on workspace 004e239e; there is nothing to resolve\n"
+
 DIFF_NO_ENTITIES_LINE = "Kin repository-v6 diff\nArtifacts: +0 ~1 -0\n"
 
 ADMIT_NO_OP_CLAIM = (
@@ -531,6 +662,16 @@ def self_test():
         ("diffscope/present", grade_diff_discloses_its_semantic_scope, DIFF_WITH_SCOPE, PASS),
         ("diffscope/no-entities", grade_diff_discloses_its_semantic_scope,
          DIFF_NO_ENTITIES_LINE, UNREADABLE),
+        # The grader takes a pair, so these rows carry a tuple. The UNREADABLE row
+        # is the one that keeps this check honest: a silent status over a fixture
+        # that never opened a merge is a setup failure, not a product defect, and
+        # scoring it FAIL would make the check fire on its own broken fixture.
+        ("heldmerge/silent", grade_status_names_a_held_merge,
+         (STATUS_SILENT_DURING_MERGE, CONFLICTS_HELD), FAIL),
+        ("heldmerge/named", grade_status_names_a_held_merge,
+         (STATUS_WITH_MERGE, CONFLICTS_HELD), PASS),
+        ("heldmerge/no-merge-opened", grade_status_names_a_held_merge,
+         (STATUS_SILENT_DURING_MERGE, CONFLICTS_NONE), UNREADABLE),
         ("content/no-op-claim", grade_admit_does_not_claim_a_no_op, ADMIT_NO_OP_CLAIM, FAIL),
         ("content/moved", grade_admit_does_not_claim_a_no_op, ADMIT_CONTENT_MOVED, PASS),
         ("content/unmeasured", grade_admit_does_not_claim_a_no_op, ADMIT_UNMEASURED, FAIL),


### PR DESCRIPTION
`kin status` said nothing at all during a merge that had left seventy-six
conflicts unresolved, and reported the tree as `matching its base change` while it
did. Walk away, come back, and the only surface that knows a merge is waiting is
one you have to already suspect you need.

## Measured, with the controls, before a line was written

```
$ command grep -ic merge crates/kin-cli/src/commands/status.rs
0
$ command grep -ic workspace crates/kin-cli/src/commands/status.rs   # POSITIVE CONTROL
60
$ command grep -ic zzznotaword crates/kin-cli/src/commands/status.rs # must be zero
0
```

The needle can find and can miss, and the answer is zero across all 2071 lines:
no code, no comment, no test, no doc string. Meanwhile a merge in progress is a
first-class concept two files away, `conflicts.rs:30`: "the last merge, and 'is a
merge in progress' is a state check."

## Why the working copy cannot tell you

Kin holds a merge in an authority transaction rather than smearing conflict
markers across the working copy. That is the better design and the stranger said
so, preferring it to Git's markers. It is also exactly why there is nothing on
disk to see, which makes the status line the only place this can live.

## The read costs nothing and needs no daemon

Off the same authority lease `kin status` already opens, from the same durable
`MergeTransactionRecord` that `kin conflicts` reads, so the two cannot come to
disagree. `metadata.merge_transactions` is a plain field on the lease. No daemon,
no filesystem read, nothing added to the wire.

A terminated record is skipped. "The last merge" and "a merge waiting on you" are
the two states this line exists to separate, and `MergeTransactionState::is_in_progress`
is the one that answers.

## Placement is half the fix

`git status` puts "You have unmerged paths" at the top. A banner printed at the
bottom of forty lines is one a reader who does not already suspect a merge will
never see, so this renders directly under the heading, and a test grades the
POSITION rather than the wording.

Inserted after the `lines` vec closes rather than into it, so the twenty-odd lines
inside keep their exact shape and no hunk here can reorder them.

## Tests, and the control that is the half that matters

- a held merge names both refs, the transaction, `2 of 76 conflict(s) settled`,
  and sends the reader to `kin conflicts`
- a fully settled merge names `kin resolve --continue` instead and must NOT
  mention `kin conflicts`, because a banner that said the same thing in both would
  send a reader to a list of nothing
- the banner renders at index 1, directly under the heading
- **the control:** with no held merge there is no banner at all, and the line under
  the heading is the one that was always there. A fix that printed the banner
  unconditionally would pass every assertion above and fail this one

## The signature change, audited rather than eyeballed

`render_text` gained a seventh parameter, which touches nine call sites. The last
time a signature moved in this file, one call site kept the old arity and survived
the bulk edit because rustfmt had already wrapped it with a trailing comma, so the
long calls a new argument just made longer are exactly the ones a textual sweep
misses.

So this was closed by walking parens per call and audited by counting ARGUMENTS,
and that caught two bugs before the patch touched the tree: a `, ,` on the four
calls already carrying a trailing comma, and a first audit needle that searched
for the word "merge" when the test sites correctly take `None`, giving seven false
positives. The audit now reads all nine sites at seven arguments and zero double
commas.

Closes FIR-2961
