### PR TITLE
Answer graph status coverage from the authority envelope, and pin kin-db 0.7.75

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.74"
+version = "0.7.75"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "0fa49e0651295a820c6ef4b5ac8d7a569049b8feb875a837ccab45fded75fa33"
+checksum = "084672921e93d32ad910bb934ac46cc9f62c95d2744c46d2afbaaacea8c28d33"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.74", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.75", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.21", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -4305,6 +4305,76 @@ mod tests {
         }
     }
 
+    /// A status report reads the ENVELOPE, and opens no store at all.
+    ///
+    /// `graph status` needs one workspace tree and the bodies its structured
+    /// facets name. It used to get both by opening the whole repository
+    /// authority, which decodes every domain the snapshot carries and
+    /// re-verifies every persisted body; on a converted repository that is the
+    /// repository, and a cold status read took a daemon serving 861 entities
+    /// from 5.8 GiB to 15.9 GiB and got it OOM-killed at 16 (FIR-2955).
+    ///
+    /// Two things make the zero below evidence rather than decoration.
+    ///
+    /// The CONTROL comes first: one deliberate `ActiveRepositoryAuthority::open`
+    /// on this same fixture must move the counter by exactly one. Without it a
+    /// zero is equally consistent with a counter that never moves, which is the
+    /// shape of a check that cannot fail.
+    ///
+    /// And the report has to be REAL. A collector that returned an empty
+    /// coverage would also open nothing, so the assertions below require the
+    /// authority tree it read to carry the fixture's artifacts. A zero over an
+    /// empty report is not the property this test is for.
+    #[test]
+    fn a_status_report_reads_the_envelope_and_opens_no_store() {
+        const SOURCE: &[u8] = b"fn target() {}\n";
+        let fixture = graph_source_fixture(Some(SOURCE));
+        let entity = source_entity("target", fixture.file_id.clone(), 0, SOURCE.len() - 1);
+        commit_source_entity(&fixture, &entity);
+        let opens = super::super::repository_authority::repository_authority_opens_on_this_thread;
+        let entities = fixture
+            .graph
+            .list_all_entities()
+            .expect("the fixture graph lists its entities");
+
+        let before = opens();
+        drop(
+            super::super::repository_authority::ActiveRepositoryAuthority::open(&fixture.binding)
+                .expect("open the whole store once, deliberately"),
+        );
+        assert_eq!(
+            opens() - before,
+            1,
+            "the counter must be able to see a whole-store open on this fixture, or the zero \
+             below proves nothing"
+        );
+
+        let before = opens();
+        let report = super::super::graph_health::inspect_graph_with_entities(
+            &fixture.authority(),
+            &fixture.graph,
+            &entities,
+            None,
+        )
+        .expect("build the status report");
+        assert_eq!(
+            opens() - before,
+            0,
+            "a status report must answer from the authority envelope, never by opening the \
+             whole store"
+        );
+        assert!(
+            report.repository_artifact_coverage.authority_artifact_count > 0,
+            "the report must have read a real authority tree; a zero open over an empty \
+             coverage is not the property under test"
+        );
+        assert!(
+            report.repository_artifact_coverage.repository_tree_in_sync,
+            "the envelope's tree must be the one the graph carries, or the envelope read \
+             resolved the wrong workspace"
+        );
+    }
+
     /// A batch of source resolutions costs ONE authority open, not one each.
     ///
     /// `get_entity_sources` resolves source per entity, and every resolution

--- a/crates/kin-cli/src/commands/graph_health.rs
+++ b/crates/kin-cli/src/commands/graph_health.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use kin_model::{
     ArtifactKind, EntityStore, FilePathId, GraphStats, Hash256, RepoPath, ResolvedTree, TreeEntry,
 };
@@ -188,16 +188,61 @@ struct EnrichmentFacets {
 
 /// Coverage against the authority this request reads at.
 ///
-/// Takes the request's authority rather than its binding because
-/// [`ActiveRepositoryAuthority::open`] re-verifies every persisted body against
-/// its content address, so it costs whatever the whole store is worth. A server
-/// that has already paid for one open at the publication this request reads
-/// hands it over here; a one-shot caller still opens for itself.
+/// This reads two things: one workspace tree out of the authority envelope, and
+/// the bodies its structured facets name, by content address. Neither needs the
+/// history the same snapshot carries, and on a converted repository that history
+/// IS the snapshot: psf/requests at 6493 commits writes 1051.5 MiB whose change
+/// map dominates it. A full [`ActiveRepositoryAuthority::open`] decodes all of
+/// it and re-verifies all 8242 sealed bodies, so a cold `graph status` cost the
+/// whole store to print counters and took a daemon serving 861 entities to
+/// 15.9 GiB (FIR-2955).
+///
+/// So the envelope read comes first. It walks the same bytes, verifies the same
+/// frame checksum, and allocates nothing for the domains it skips, and every
+/// body it returns is verified against its own content address exactly as the
+/// manager's is. The full open stays as the fallback for the cases KinDB
+/// declines to answer cheaply, and it is still the only thing that audits every
+/// persisted body.
+///
+/// A server that can cache one envelope per publication supplies a resolver, so
+/// a warm request pays nothing; without one the envelope is read through the
+/// binding, which costs one parse of the body and no allocation for the domains
+/// it skips.
 fn collect_repository_artifact_coverage(
     authority: &RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
     graph_tree: &ResolvedTree,
 ) -> Result<RepositoryArtifactCoverage> {
+    if let Some(envelope) = authority.open_envelope()? {
+        let binding = authority.binding();
+        let workspace_id = binding.workspace_id();
+        let workspace = envelope
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == workspace_id)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow!(
+                    "repository {} has no workspace {} in its authority",
+                    binding.repository_id(),
+                    workspace_id
+                )
+            })?;
+        workspace.validate()?;
+        return collect_repository_artifact_coverage_for_tree(
+            &workspace.tree,
+            graph,
+            graph_tree,
+            &|hash| {
+                envelope
+                    .load_source_blob(hash)
+                    .with_context(|| format!("load immutable repository source blob {hash}"))?
+                    .ok_or_else(|| anyhow!("immutable repository source blob {hash} is absent"))
+            },
+        );
+    }
+
     let authority = authority.open()?;
     let workspace = authority.workspace()?;
     workspace.validate()?;

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -66,6 +66,7 @@ pub fn repository_authority_opens_on_this_thread() -> u64 {
 pub struct RequestRepositoryAuthority {
     binding: kin_core::LocalRepositoryAuthorityBinding,
     shared: Option<SharedAuthorityResolver>,
+    envelope: Option<SharedEnvelopeResolver>,
 }
 
 /// A server's promise to produce authority for the publication a request reads
@@ -73,12 +74,24 @@ pub struct RequestRepositoryAuthority {
 pub type SharedAuthorityResolver =
     std::sync::Arc<dyn Fn() -> Result<std::sync::Arc<ActiveRepositoryAuthority>> + Send + Sync>;
 
+/// The same promise for the authority ENVELOPE, which is a different and much
+/// smaller read than the authority itself.
+///
+/// `Ok(None)` means KinDB declined to answer the envelope cheaply for these
+/// bytes and the caller must open in full; it is never a wrong answer.
+pub type SharedEnvelopeResolver =
+    std::sync::Arc<dyn Fn() -> Result<Option<std::sync::Arc<AuthorityEnvelope>>> + Send + Sync>;
+
+/// The repository-authority envelope, opened without the history beside it.
+pub type AuthorityEnvelope = kin_db::RepositoryAuthorityMetadata<kin_db::LocalFileBackend>;
+
 impl RequestRepositoryAuthority {
     /// Authority this command opens for itself.
     pub fn pinned(binding: kin_core::LocalRepositoryAuthorityBinding) -> Self {
         Self {
             binding,
             shared: None,
+            envelope: None,
         }
     }
 
@@ -98,6 +111,39 @@ impl RequestRepositoryAuthority {
         Self {
             binding,
             shared: Some(resolve),
+            envelope: None,
+        }
+    }
+
+    /// Let a server resolve the authority ENVELOPE for this request too.
+    ///
+    /// The envelope carries refs, workspaces and the roots, and reading it does
+    /// not decode the history the same snapshot bytes carry. A server that can
+    /// cache one per publication supplies this so a warm request pays nothing;
+    /// without it, [`Self::open_envelope`] reads through the binding, which is
+    /// correct and costs one parse of the snapshot body with no allocation for
+    /// the domains it skips.
+    ///
+    /// The freshness obligation is exactly [`Self::shared`]'s, for the same
+    /// reason and with the same failure mode.
+    #[must_use]
+    pub fn with_envelope_resolver(mut self, resolve: SharedEnvelopeResolver) -> Self {
+        self.envelope = Some(resolve);
+        self
+    }
+
+    /// The authority envelope to read this command from, when one answers.
+    ///
+    /// `None` is KinDB declining to answer cheaply, and the caller's obligation
+    /// is to fall back to [`Self::open`] rather than to report an absence.
+    pub(crate) fn open_envelope(&self) -> Result<Option<std::sync::Arc<AuthorityEnvelope>>> {
+        match &self.envelope {
+            Some(resolve) => resolve(),
+            None => Ok(self
+                .binding
+                .open_authority_metadata()
+                .context("read repository authority envelope")?
+                .map(std::sync::Arc::new)),
         }
     }
 

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -331,6 +331,32 @@ impl LocalRepositoryAuthorityBinding {
         )
         .map(|(manager, payload_stats)| (manager, Some(payload_stats)))
     }
+
+    /// Read the repository-authority envelope without materializing the
+    /// history the same bytes carry.
+    ///
+    /// A full open decodes every domain the snapshot holds, and on a converted
+    /// repository that is the repository: psf/requests at 6493 commits writes a
+    /// 1051.5 MiB snapshot whose change map dominates it. A caller that needs
+    /// the envelope and then some bodies by content address does not need any
+    /// of that, and this is the read for it.
+    ///
+    /// `None` means the envelope cannot be answered cheaply and correctly, so
+    /// the caller must open in full. It is never a wrong answer: KinDB returns
+    /// it when no persisted authority exists, when the acknowledged journal
+    /// head is past the snapshot base, or when the snapshot carries no
+    /// envelope.
+    pub fn open_authority_metadata(
+        &self,
+    ) -> std::result::Result<
+        Option<kin_db::RepositoryAuthorityMetadata<LocalFileBackend>>,
+        kin_db::KinDbError,
+    > {
+        kin_db::RepositoryAuthorityMetadata::open(
+            self.repository_id.clone(),
+            Arc::clone(&self.backend),
+        )
+    }
 }
 
 /// Open an already initialized local repository through one coherent recovery.

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -223,6 +223,12 @@ pub(crate) struct ProjectionAuthorityCache {
     held: std::sync::Mutex<Option<HeldProjectionAuthority>>,
     query: std::sync::Mutex<Option<HeldQueryAuthority>>,
     command: std::sync::Mutex<Option<HeldCommandAuthority>>,
+    /// The authority ENVELOPE, which is not a fourth wrapper over the same
+    /// read: it is a much smaller read of the same bytes, keyed the same way.
+    /// A reader that needs refs, workspaces or the roots and then some bodies
+    /// by content address takes this, and never decodes the history a converted
+    /// repository's snapshot mostly consists of.
+    envelope: std::sync::Mutex<Option<HeldEnvelopeAuthority>>,
     /// Serializes misses so a burst of concurrent cold requests pays for one
     /// full load rather than one per request.
     load_gate: std::sync::Mutex<()>,
@@ -255,6 +261,14 @@ struct HeldCommandAuthority {
     /// [`HeldProjectionAuthority::published`] and for the same reason.
     published: LocalPublicationIdentity,
     authority: Arc<kin_cli::commands::repository_authority::ActiveRepositoryAuthority>,
+}
+
+#[derive(Clone)]
+struct HeldEnvelopeAuthority {
+    /// Read strictly before the envelope it labels was loaded, exactly as for
+    /// [`HeldProjectionAuthority::published`] and for the same reason.
+    published: LocalPublicationIdentity,
+    envelope: Arc<kin_cli::commands::repository_authority::AuthorityEnvelope>,
 }
 
 impl ProjectionAuthorityCache {
@@ -335,10 +349,32 @@ impl ProjectionAuthorityCache {
         });
     }
 
+    fn reuse_envelope(
+        &self,
+        published: &LocalPublicationIdentity,
+    ) -> Option<Arc<kin_cli::commands::repository_authority::AuthorityEnvelope>> {
+        lock_recover(&self.envelope)
+            .as_ref()
+            .filter(|held| &held.published == published)
+            .map(|held| Arc::clone(&held.envelope))
+    }
+
+    fn install_envelope(
+        &self,
+        published: LocalPublicationIdentity,
+        envelope: Arc<kin_cli::commands::repository_authority::AuthorityEnvelope>,
+    ) {
+        *lock_recover(&self.envelope) = Some(HeldEnvelopeAuthority {
+            published,
+            envelope,
+        });
+    }
+
     fn invalidate(&self) {
         *lock_recover(&self.held) = None;
         *lock_recover(&self.query) = None;
         *lock_recover(&self.command) = None;
+        *lock_recover(&self.envelope) = None;
     }
 }
 
@@ -551,6 +587,75 @@ fn command_repository_authority(
         "command repository authority loaded"
     );
     Ok(authority)
+}
+
+/// The repository-authority ENVELOPE for one request, cached per publication.
+///
+/// Every obligation [`command_repository_authority`] discharges, discharged the
+/// same way and in the same order: the pinned namespace is confirmed, the
+/// publication record is read BEFORE the load it labels, the load gate
+/// serializes a burst of cold requests, and the label installed beside the
+/// envelope is the one taken before it.
+///
+/// What differs is what gets loaded. A full open decodes every domain the
+/// snapshot carries and re-verifies every persisted body; on a converted
+/// repository that is the whole store, and a cold `graph status` paid it to
+/// print counters. The envelope read walks the same bytes, verifies the same
+/// frame checksum, and allocates nothing for the history it skips.
+///
+/// `Ok(None)` is KinDB declining to answer the envelope cheaply for these
+/// bytes. The caller falls back to the full open, so this is a cost decision
+/// and never a correctness one. It does not count into
+/// [`ProjectionAuthorityCache::loads`], because that counter means whole-store
+/// opens and an envelope read is not one.
+fn command_repository_envelope(
+    state: &DaemonState,
+) -> Result<
+    Option<Arc<kin_cli::commands::repository_authority::AuthorityEnvelope>>,
+    (StatusCode, String),
+> {
+    let backend = state.local_repository_backend().ok_or_else(|| {
+        repository_authority_error("local daemon is missing its startup storage capability")
+    })?;
+    let binding = state
+        .local_repository_authority_binding()
+        .map_err(repository_authority_error)?;
+    let repository_id = binding.repository_id().clone();
+
+    if let Err(error) = confirm_pinned_projection_namespace(&backend, &repository_id) {
+        state.projection_authority.invalidate();
+        return Err(error);
+    }
+
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(envelope) = state.projection_authority.reuse_envelope(&published) {
+        return Ok(Some(envelope));
+    }
+
+    let _load = lock_recover(&state.projection_authority.load_gate);
+    // Re-read under the gate, for the reason the full open re-reads: the
+    // publication may have moved while this request waited, and the label
+    // installed below must be the one taken before the load it describes.
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(envelope) = state.projection_authority.reuse_envelope(&published) {
+        return Ok(Some(envelope));
+    }
+    let Some(envelope) = binding
+        .open_authority_metadata()
+        .map_err(repository_authority_error)?
+    else {
+        return Ok(None);
+    };
+    let envelope = Arc::new(envelope);
+    state
+        .projection_authority
+        .install_envelope(published, Arc::clone(&envelope));
+    tracing::debug!(
+        repository = %repository_id,
+        generation = envelope.generation(),
+        "command repository authority envelope loaded"
+    );
+    Ok(Some(envelope))
 }
 
 /// Hand a command helper an authority this daemon already resolved.
@@ -4614,6 +4719,7 @@ async fn command_graph(
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
     let resolver_state = Arc::clone(&state);
+    let envelope_state = Arc::clone(&state);
     let repository_authority =
         kin_cli::commands::repository_authority::RequestRepositoryAuthority::shared(
             binding,
@@ -4621,7 +4727,15 @@ async fn command_graph(
                 command_repository_authority(&resolver_state)
                     .map_err(|(_, message)| anyhow::anyhow!(message))
             }),
-        );
+        )
+        // `graph status` reads one workspace tree and then bodies by content
+        // address, and neither needs the history the same snapshot carries.
+        // Without this it resolves the envelope through the binding on every
+        // request; with it, a warm request pays nothing.
+        .with_envelope_resolver(Arc::new(move || {
+            command_repository_envelope(&envelope_state)
+                .map_err(|(_, message)| anyhow::anyhow!(message))
+        }));
     let embedding_runtime = graph_status_embedding_runtime(&state, &graph);
     // Read here rather than inside the renderer, for the reason the freshness
     // marker is read in the CLI: the record is a property of the store on disk,


### PR DESCRIPTION
`kin graph status` opens the whole repository authority to read one workspace tree and a handful of bodies by content address. This routes that one read at kin-db 0.7.75's envelope-only path instead.

## What this is worth, measured, and it is narrower than it first looked

Lane historylimit attributed the opens with `#[track_caller]`, on this lane's converted psf/requests store, with the instrument proved present by `strings` against a fabricated-string control:

| command | kin-db authority opens | attributed to the kin-cli wrapper |
|---|---|---|
| `graph status` #1 | 12 | **1** |
| `graph status` #2 | 12 | **1** |
| `locate session` | 2 | 0 |

**Twenty-four of twenty-six opens never touch `ActiveRepositoryAuthority` at all.** So this change removes **one open of twelve** per status. It is not the answer to the read-time transient, and the other eleven are unattributed until the funnel instrument at `kin_core::open_persisted_local_repository_authority` runs.

Stated so it cannot be misread: **no reduction in peak is claimed here.** The after-measurement, on the same store with the same instrument, is the evidence still owed, and what it should show is the open count moving from twelve to eleven and the peak by that share.

## Why it is worth landing anyway

**Correctness.** kin-db 0.7.75's envelope read walks the acknowledged journal onto the envelope rather than answering from the snapshot base. A read that answered from the base alone would serve a pre-frame workspace tree and report coherence on a store whose worktree moved after admission, which is what `coverage_read_open.py`'s diverged arm exists to catch. That walk is falsified across five mutations in kin-db, with every assertion in its test observed to fire.

**Cost per open, which is bigger than one twelfth of the count.** The envelope read skips the body sweep entirely, and on historylimit's run `bodies_ms` was 423.1 s against `recover_ms` 285.9 s, so body re-verification is the larger half of an open. The time share is unmeasured and is not claimed.

## What it does

`collect_repository_artifact_coverage` resolves the envelope first and falls back to the full open where KinDB declines. `RequestRepositoryAuthority` gains an optional envelope resolver, and the daemon supplies one through a slot in `ProjectionAuthorityCache` keyed on the same publication identity, read before the load it labels, behind the same load gate.

Guarded by `a_status_report_reads_the_envelope_and_opens_no_store`, which counts whole-store opens across a status report and requires zero. Its control is a deliberate open on the same fixture that must move the counter by one, because a zero from a counter that never moves is a check that cannot fail, and it asserts the report actually read an authority tree, because an empty coverage would open nothing either.

## The local gate, and one red that is not this diff

`cargo nextest run --workspace --locked` reads **8102 of 8103 passed, 21 skipped, 1 failed**, and `cargo test --doc --locked` is green.

The one red is `kin-core::init_phase_ladder_contiguous the_admission_ladder_accounts_for_the_whole_of_init`, failing all three retries in each of two full-suite runs and PASSING when run alone. Its own message and the three loaded readings, unchanged, so the shape is visible rather than asserted:

> init_from_git ran for 3442 ms with no admission phase open, 6.7% of its 51339 ms, over the 2.0% this guard allows. The stretch sits immediately before `the end of init, with no phase open`.

```
3141 ms uncovered, 13.1% of its 23979 ms
3423 ms uncovered,  6.6% of its 52190 ms
3442 ms uncovered,  6.7% of its 51339 ms
run alone: init 9.8 s, test PASSES, so the stretch there is under 0.2 s
```

The uncovered stretch is constant at 3.1 to 3.4 seconds while the total ranges 24 to 52 seconds, so it appears under concurrency and then stops scaling. It sits after the last span closes, and nothing in this diff runs inside `init_from_git`: the changes are on the daemon read path and the kin-db pin adds spans, not work. The guard belongs to lane initmem and the message and readings are with them.

One consequence of the same three numbers, for whoever tunes it: because the bar is a FRACTION over a stable absolute stretch, the guard fails harder the faster the run gets. 3141 ms is 13.1 percent at a 24-second total and 6.6 percent at 52.

## One fact this run settled

`replay_ms` is zero on every open across two hosts, two binaries and two lanes' runs. The durable-validation fast path runs every time, so history replay is not the cost on a converted store.

Refs FIR-2955
