### PR TITLE
Write the vcs_read_surfaces report under the key the gate reads

### DIFF
--- a/scripts/acceptance/gate.py
+++ b/scripts/acceptance/gate.py
@@ -43,7 +43,9 @@ import functools
 import io
 import json
 import os
+import shutil
 import sys
+import tempfile
 
 PASS = "PASS"
 FAIL = "FAIL"
@@ -97,6 +99,23 @@ def load_report(path):
         raise GateError("report %s is not JSON: %s" % (path, exc))
     results = payload.get("results")
     if not isinstance(results, list):
+        # Name the remedy in the failing log rather than in a sibling file. Four
+        # suites have now shipped their rows under `checks`: same_owner_call
+        # first, working_copy_freshness second (kin#1205's squash printed four
+        # CHECK lines over a report this loader could not read), init_budget
+        # third under FIR-2929, and vcs_read_surfaces fourth under FIR-2985. Each
+        # author had to rediscover the key from this message, which said only
+        # what was missing and never what to do about it.
+        if isinstance(payload.get("checks"), list):
+            raise GateError(
+                "report %s carries its rows under `checks`; this gate reads "
+                "`results`. Rename the top-level key in that suite's "
+                "`report_payload`, then add the self-test row that loads the "
+                "written report back through this loader, which is what stops "
+                "it drifting again; "
+                "`scripts/acceptance/working_copy_freshness_repro.py`'s "
+                "`report_payload` docstring prescribes both and records the "
+                "earlier occurrences" % path)
         raise GateError("report %s carries no results list" % path)
     if not results:
         raise GateError("report %s carries an empty results list; a suite that "
@@ -267,6 +286,46 @@ def self_test():
         "acceptance gate FAILED on 1 finding(s)" in missing_run_output,
         True,
     )
+
+    # The `checks`-key branch and the no-key branch both refuse, and a field-level
+    # assertion cannot tell them apart, so each arm is asserted on its exact
+    # MESSAGE. A mutation that merely redirects between the two branches leaves
+    # both refusing and would survive a check that only asked whether it raised.
+    scratch = tempfile.mkdtemp(prefix="acceptance-gate-self-test-")
+    try:
+        def write(name, payload):
+            target = os.path.join(scratch, name)
+            with open(target, "w") as handle:
+                json.dump(payload, handle)
+            return target
+
+        rows = [{"id": "one", "status": PASS, "detail": "self-test"}]
+
+        checks_keyed = write("checks.json", {"ticket": "FIR-0", "checks": rows})
+        try:
+            load_report(checks_keyed)
+            problems.append("a `checks`-keyed report was accepted")
+        except GateError as exc:
+            expect("a `checks`-keyed report names the remedy",
+                   "Rename the top-level key" in str(exc), True)
+            expect("a `checks`-keyed report names the prescribing docstring",
+                   "working_copy_freshness_repro.py" in str(exc), True)
+
+        neither = write("neither.json", {"ticket": "FIR-0", "rows": rows})
+        try:
+            load_report(neither)
+            problems.append("a report with neither key was accepted")
+        except GateError as exc:
+            expect("a report with neither key keeps the plain message",
+                   str(exc).endswith("carries no results list"), True)
+            expect("CONTROL the plain message does NOT name the remedy",
+                   "Rename the top-level key" in str(exc), False)
+
+        good = write("good.json", {"ticket": "FIR-0", "results": rows})
+        expect("CONTROL a `results`-keyed report is still accepted",
+               sorted(load_report(good)), ["one"])
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
 
     for line in problems:
         print("SELF-TEST FAIL %s" % line)

--- a/scripts/acceptance/vcs_read_surfaces_repro.py
+++ b/scripts/acceptance/vcs_read_surfaces_repro.py
@@ -72,6 +72,7 @@ from __future__ import print_function
 
 import argparse
 import functools
+import importlib.util
 import json
 import os
 import re
@@ -525,9 +526,15 @@ CHECKS = (
 
 
 def report_payload(results):
+    # The key is `results` because that is the one `gate.py:load_report` reads.
+    # This file shipped it as `checks`, so the gate refused the report with
+    # "carries no results list" and none of the graders below was ever consulted
+    # (FIR-2985, the same class as FIR-2929 in init_budget). The self-test proves
+    # the join by handing this payload to the real loader rather than by naming
+    # the key a second time, because a string written twice drifts the same way.
     return {
         "ticket": TICKET,
-        "checks": [
+        "results": [
             {"id": result.ident, "status": result.status, "detail": result.detail}
             for result in results
         ],
@@ -635,6 +642,84 @@ ADMIT_UNMEASURED = (
 ADMIT_REFUSED = "Complete exact-tree admission failed: host entry changed\n"
 
 
+def check_the_gate_reads_this_suites_report():
+    """Hand this suite's own report to `gate.py`'s loader and require it back.
+
+    FIR-2985. This file emitted its rows under `checks` while `gate.py`'s
+    `load_report` reads `results`, so the gate refused the report with "carries
+    no results list" and every grader above went ungraded from the moment the
+    suite was wired in. The run stayed red, which is the good half, but it was
+    red for a plumbing fault wearing a product failure's clothes.
+
+    The same class had already been fixed once, in init_budget under FIR-2929,
+    and `working_copy_freshness_repro.py` already carries this exact check. It
+    is per-suite, which is precisely why the class came back here. This is that
+    proven check copied, not a new invention.
+
+    Asserting the literal key would write the string twice and drift the same
+    way. Importing the real consumer cannot: if the gate stops reading
+    `results`, or this file stops writing it, this goes red.
+
+    Returns (cases_run, broken).
+    """
+    ran = 0
+    broken = 0
+
+    def expect(name, got, want):
+        nonlocal ran, broken
+        ran += 1
+        ok = got == want
+        if not ok:
+            broken += 1
+        print("SELFTEST %s %s expected=%s got=%s"
+              % (name, "ok" if ok else "BROKEN", want, got))
+
+    gate_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gate.py")
+    if not os.path.exists(gate_path):
+        print("SELFTEST gate/beside BROKEN gate.py is not beside this file, "
+              "so the report shape went unchecked")
+        return 1, 1
+
+    spec = importlib.util.spec_from_file_location("acceptance_gate", gate_path)
+    gate = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gate)
+
+    scratch = tempfile.mkdtemp(prefix="vcs-read-surfaces-selftest-")
+    try:
+        rows = [Result(ident, UNREADABLE, "%s check raised: fabricated" % TICKET)
+                for ident, _ in CHECKS]
+        good = os.path.join(scratch, "good.json")
+        with open(good, "w") as handle:
+            json.dump(report_payload(rows), handle)
+        try:
+            loaded = gate.load_report(good)
+            expect("gate/reads-every-row", sorted(loaded),
+                   sorted(ident for ident, _ in CHECKS))
+            expect("gate/reads-a-status", loaded[CHECKS[0][0]].get("status"), UNREADABLE)
+        except Exception as exc:  # noqa: BLE001 - a refusal is the finding
+            ran += 1
+            broken += 1
+            print("SELFTEST gate/reads-every-row BROKEN the gate refused this "
+                  "suite's own report: %s" % exc)
+
+        # CONTROL: the shape that shipped must still be refused, or the two
+        # assertions above would pass over any payload at all.
+        bad = os.path.join(scratch, "bad.json")
+        with open(bad, "w") as handle:
+            json.dump({"ticket": TICKET,
+                       "checks": [{"id": ident, "status": UNREADABLE}
+                                  for ident, _ in CHECKS]}, handle)
+        try:
+            gate.load_report(bad)
+            refused = False
+        except Exception:  # noqa: BLE001 - the refusal is what is wanted
+            refused = True
+        expect("gate/CONTROL-still-refuses-the-checks-shape", refused, True)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+    return ran, broken
+
+
 def self_test():
     """Drive every grader against a payload that must pass and one that must fail.
 
@@ -698,7 +783,9 @@ def self_test():
             failures += 1
         print("SELFTEST %s %s expected=%s got=%s %s"
               % (name, "ok" if ok else "BROKEN", expected, got, detail))
-    print("SELFTEST %d case(s), %d broken" % (len(cases), failures))
+    gate_cases, gate_broken = check_the_gate_reads_this_suites_report()
+    failures += gate_broken
+    print("SELFTEST %d case(s), %d broken" % (len(cases) + gate_cases, failures))
     return 1 if failures else 0
 
 


### PR DESCRIPTION
`report_payload` emitted its rows under `checks` while `gate.py`'s `load_report` reads `results`, so the gate refused the report with "carries no results list" and **every grader in this suite went ungraded** from the moment it was wired into `acceptance.yml` by #1254 at 2026-08-30T01:57Z. The run stayed red, which is the good half, but it was red for a plumbing fault wearing a product failure's clothes, and it is one of the three findings currently holding main's Acceptance red.

## Checked before renaming, because the rename changes refused into graded

Row shape and status vocabulary were already correct: rows carry `id`, `status` and `detail`, which is what `gate.py:load_report` needs, and PASS, FAIL and UNREADABLE are spelled identically in `gate.py`, `vcs_read_surfaces_repro.py` and `init_budget_refusal.py`. That mattered to confirm first. The rename moves this suite from refused to graded, and a mismatched vocabulary would have converted a loud refusal into a quiet wrong answer, which is strictly worse than the bug being fixed.

## The guard is copied, not invented

The same class was fixed once already in `init_budget` under FIR-2929 (#1240), and `working_copy_freshness_repro.py` already carries a check that catches it: it hands its own report to `gate.py`'s loader, requires the rows back, and keeps a control asserting the `checks`-keyed shape is still refused. That check is per-suite, which is exactly why the class came back here, so this copies the proven one rather than inventing another.

Asserting the literal key would write the string twice and drift the same way. Importing the real consumer cannot: if the gate stops reading `results`, or this file stops writing it, the self-test goes red.

## Falsification

Restoring the shipped bug (`results` back to `checks`):

    SELFTEST gate/reads-every-row BROKEN the gate refused this suite's own report:
      report .../good.json carries no results list
    SELFTEST gate/CONTROL-still-refuses-the-checks-shape ok expected=True got=True
    SELFTEST 28 case(s), 1 broken            rc=1

Restored: `SELFTEST 29 case(s), 0 broken`, rc=0. The mutation reproduces the gate's own error text verbatim, which is how CI reported it. The control arm correctly stays green under that mutation because it grades a different payload, so the two are not hiding each other.

## Local gates

All 14 non-cargo gates from `bin/kin-precheck kin --list`'s enumeration pass. Not run: `fmt` and `clippy`, since the diff is one Python file with zero Rust and two lanes were building.

## Scope

This closes the recurrence and guards this suite. It does not stop a third one: the check lives in two of twenty-one suites and there is no shared report writer, which is tracked as FIR-2986 with the measurement behind it.

Closes FIR-2985

## Second commit: the gate names the remedy, which is the part that covers the class

This is the **fourth** suite to ship rows under `checks`, not the third: `working_copy_freshness_repro.py:579-591`'s docstring records `same_owner_call_repro.py` as the first and itself as the second (kin#1205's squash printed four CHECK lines over a report the verdict step could not read), then `init_budget` under FIR-2929, then this one. Every author had to rediscover the key, because the refusal said only what was missing and never what to do about it, and the prescription lived in a sibling suite's docstring nobody had reason to open.

So `gate.py`'s refusal now names the remedy when it meets a top-level `checks` list: the rename, the self-test row that reads the written report back through this loader, and where both are already written down. The next author reads it in the failing log rather than in a sibling file.

**Why the existing guard did not catch this, which is the sentence worth keeping:** the registration guard checks that the report PATH reaches the gate, not that the gate can READ it. A suite can be correctly registered, run, write a file at the right path, and still be ungraded.

### Falsification of the gate change

Three mutations, each dying on its own named arms:

    M0-baseline                 rc=0   0 failure lines
    M1-delete-checks-branch     rc=1   names the remedy: FAIL / names the docstring: FAIL
    M2-redirect-branch          rc=1   names the remedy: FAIL / names the docstring: FAIL
    M3-leak-remedy-into-plain   rc=1   plain message kept: FAIL / CONTROL not-name-remedy: FAIL

**M2 is the one that matters.** Redirecting the branch to `if False` leaves BOTH branches refusing, so a field-level assertion asking only whether a `GateError` was raised cannot tell them apart and the mutation survives. Each arm therefore asserts its exact message. Controls kept: a report with neither key keeps the plain message, and a `results`-keyed report is still read and its rows returned.

The `vcs_read_surfaces` suite self-test still reads 29 cases, 0 broken against the changed gate, and all 14 non-cargo gates pass.

Also tracked: FIR-2986 for one shared report writer, which is the ceiling this does not reach. Raised to High after re-measuring, and after finding the class has now hit four suites rather than the two I first wrote.
