### PR TITLE
Admit a transfer under the receiving replica's own admission case, so a converted repository can push a new file

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13805,6 +13805,33 @@ fn apply_received_repository_transfer_pack(
         .is_none()
         .then(|| state.local_kindb_capability())
         .flatten();
+    // This replica's OWN admission case, read from the overlay of the workspace
+    // this daemon pinned at startup.
+    //
+    // Which workspace is "this replica's" is the whole difficulty, and it is why
+    // the case cannot be inferred inside the transfer code. Authority is
+    // replicated, so `local_overlays` can hold overlays from several hosts with
+    // different cases: a macOS replica records `FoldAscii`, a Linux one records
+    // `Sensitive`, and both live in one authority record. Only the daemon knows
+    // which of them is its own, because it pinned that workspace id when it
+    // started rather than rediscovering it from mutable control files.
+    //
+    // The recorded case is read rather than the filesystem re-probed, and that is
+    // deliberate. `AdmissionCase` is persisted in the overlay identity so that
+    // reopen and later scans stay on one matcher; a fresh probe could disagree
+    // with the case this replica's own commits are already enforcing, and then one
+    // store would apply two rules depending on whether content arrived locally or
+    // over the wire.
+    //
+    // `None` is a hosted daemon, which has no local `.kin` layout and therefore no
+    // workspace whose case it can honestly claim. kin-db accepts `None` only where
+    // the shared policy has no rule sources, so nothing is ever admitted under a
+    // case nobody chose.
+    let receiver_case = state
+        .local_repository_workspace_id()
+        .and_then(|workspace_id| {
+            kin_remote::repository_transfer::receiver_admission_case(authority, workspace_id)
+        });
     kin_remote::repository_transfer::apply_repository_transfer_pack_with_pre_commit(
         authority,
         repository_id,
@@ -13812,6 +13839,7 @@ fn apply_received_repository_transfer_pack(
         actor,
         pack,
         &configured_transfer_limits(),
+        receiver_case,
         || match local_kindb {
             Some(kindb) => kindb.invalidate_for_unversioned_transfer(),
             None => Ok(()),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13823,15 +13823,27 @@ fn apply_received_repository_transfer_pack(
     // store would apply two rules depending on whether content arrived locally or
     // over the wire.
     //
-    // `None` is a hosted daemon, which has no local `.kin` layout and therefore no
-    // workspace whose case it can honestly claim. kin-db accepts `None` only where
-    // the shared policy has no rule sources, so nothing is ever admitted under a
-    // case nobody chose.
-    let receiver_case = state
-        .local_repository_workspace_id()
-        .and_then(|workspace_id| {
-            kin_remote::repository_transfer::receiver_admission_case(authority, workspace_id)
-        });
+    // A daemon with no workspace overlay to read admits under `Sensitive`, and
+    // that is not a guess. `DaemonState::open_with_backend`, the hosted path,
+    // leaves `cached_workspace_id` unset, so there is no overlay; what a hosted
+    // replica actually stores artifacts in is byte-exact object storage, where two
+    // paths differing only in case are two objects. Case-sensitive matching is
+    // what that store does, so admitting under it describes this replica rather
+    // than choosing on the publisher's behalf.
+    //
+    // Passing `None` here would be the honest-looking answer and the wrong one.
+    // kin-db refuses `None` wherever the shared policy has any rule source, and
+    // one `.gitignore` rule is one source, measured. A hosted receiver claiming no
+    // case would therefore refuse every brownfield push that introduces a file,
+    // which is the defect this change exists to remove.
+    let receiver_case = Some(
+        state
+            .local_repository_workspace_id()
+            .and_then(|workspace_id| {
+                kin_remote::repository_transfer::receiver_admission_case(authority, workspace_id)
+            })
+            .unwrap_or(kin_model::AdmissionCase::Sensitive),
+    );
     kin_remote::repository_transfer::apply_repository_transfer_pack_with_pre_commit(
         authority,
         repository_id,

--- a/crates/kin-daemon/tests/transfer_admission_policy.rs
+++ b/crates/kin-daemon/tests/transfer_admission_policy.rs
@@ -115,3 +115,71 @@ fn both_native_receivers_admit_through_the_wrapper() {
         );
     }
 }
+
+/// The receiver admits under a case, and never under none.
+///
+/// This is the one property of the receiver-own-case change that an end-to-end
+/// run cannot see, and that is measured rather than assumed. The lane's harness
+/// puts a LOCAL kin daemon behind the hosted control plane, so its receiver has a
+/// pinned workspace id and reads its overlay's case; the fallback a hosted
+/// object-storage daemon depends on is never reached. A mutation deleting that
+/// fallback came back GREEN through the whole stack, push included, which is
+/// exactly the shape of a check that cannot fail.
+///
+/// What it protects: kin-db refuses a `None` case wherever the shared admission
+/// policy has any rule source, and one `.gitignore` rule is one source. A hosted
+/// receiver that claimed no case would therefore refuse every push that
+/// introduces a file into a repository converted from git, which is the
+/// brownfield adoption path.
+///
+/// Both halves are asserted as invocations inside the wrapper, not as mentions,
+/// so replacing the whole binding with a bare `None` drops both counts to zero.
+#[test]
+fn the_transfer_receiver_always_admits_under_a_case() {
+    const FALLBACK: &str = ".unwrap_or(kin_model::AdmissionCase::Sensitive)";
+    const OWN_CASE: &str = "kin_remote::repository_transfer::receiver_admission_case(";
+
+    assert_eq!(
+        occurrences(
+            API_SOURCE,
+            "AdmissionCase::NoSuchCaseThisDaemonHasEverCarried"
+        ),
+        0,
+        "the must-miss control matched, so a hit below proves nothing"
+    );
+
+    for (needle, why) in [
+        (
+            OWN_CASE,
+            "the receiver must read the case from the overlay of the workspace this daemon \
+             pinned at startup, because authority is replicated and can hold overlays recorded \
+             on several hosts with different cases",
+        ),
+        (
+            FALLBACK,
+            "a receiver with no workspace overlay must still admit under a case, and Sensitive \
+             is what a hosted replica's byte-exact object storage actually does",
+        ),
+    ] {
+        let count = occurrences(API_SOURCE, needle);
+        assert_eq!(count, 1, "{needle} appears {count} times in api.rs; {why}");
+    }
+
+    let wrapper_start = API_SOURCE
+        .find(WRAPPER)
+        .expect("the wrapper definition was asserted present above");
+    let wrapper_end = API_SOURCE[wrapper_start..]
+        .find("\n}\n")
+        .map(|offset| wrapper_start + offset)
+        .expect("the wrapper definition has no closing brace");
+    for needle in [OWN_CASE, FALLBACK] {
+        let at = API_SOURCE
+            .find(needle)
+            .expect("presence was asserted immediately above");
+        assert!(
+            at > wrapper_start && at < wrapper_end,
+            "{needle} sits outside the admission wrapper (wrapper spans {wrapper_start}..\
+             {wrapper_end}, found at {at}), so the receiver that actually admits may not use it"
+        );
+    }
+}

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -19,12 +19,12 @@ use kin_db::{
     StorageBackend,
 };
 use kin_model::{
-    compute_resolved_tree_hash, validate_semantic_change_id, AuthorId, ChangeOrigin, ChangeStore,
-    DefaultRefExpectation, DefaultRefMutation, ExternalChangeAlias, ExternalObjectId,
+    compute_resolved_tree_hash, validate_semantic_change_id, AdmissionCase, AuthorId, ChangeOrigin,
+    ChangeStore, DefaultRefExpectation, DefaultRefMutation, ExternalChangeAlias, ExternalObjectId,
     ExternalObjectKind, ExternalObjectRecord, GitExternalAuthority, GitExternalAuthorityDelta,
     Hash256, ModelError, OperationId, RefExpectation, RefMutation, RefName, RefTarget,
     RefUpdatePolicy, RepositoryCommitOutcome, RepositoryCommitReceipt, RepositoryId,
-    RepositoryTransaction, RootBundle, SemanticChange, SemanticChangeId, TreeEntry,
+    RepositoryTransaction, RootBundle, SemanticChange, SemanticChangeId, TreeEntry, WorkspaceId,
     REPOSITORY_TRANSACTION_SCHEMA_VERSION,
 };
 use serde::{Deserialize, Serialize};
@@ -66,6 +66,39 @@ impl RepositoryAuthorityMetadata for RepositoryAuthorityState {
     fn committed_authority_metadata(&self) -> Option<&PersistedRepositoryAuthority> {
         self.snapshot().repository_authority.as_ref()
     }
+}
+
+/// The admission case THIS replica already enforces, read from the overlay of the
+/// workspace the caller names as its own.
+///
+/// Exposed because only the caller knows which workspace is its own, and the
+/// traversal belongs here. Authority is replicated, so `local_overlays` can hold
+/// overlays recorded on several hosts with different cases: a macOS replica
+/// records `FoldAscii`, a Linux one records `Sensitive`, and both sit in one
+/// authority record. Nothing inside a transfer can pick between them, which is
+/// exactly why `apply_repository_transfer_pack_with_pre_commit` takes the case
+/// rather than deriving it.
+///
+/// The recorded case is returned rather than a filesystem re-probed.
+/// [`AdmissionCase`] is persisted in the overlay identity so reopen and later
+/// scans stay on one matcher, and a fresh probe could disagree with the case this
+/// replica's own commits already enforce, leaving one store applying two rules
+/// depending on whether content arrived locally or over the wire.
+///
+/// `None` where the named workspace has no overlay, or where authority has never
+/// been written. Both mean this replica has no case of its own to admit under,
+/// and kin-db accepts that only where the shared policy has no rule sources.
+pub fn receiver_admission_case<B: StorageBackend + ?Sized + 'static>(
+    authority: &RepositoryAuthorityManager<B>,
+    workspace_id: WorkspaceId,
+) -> Option<AdmissionCase> {
+    let lease = authority.read_authority();
+    lease
+        .committed_authority_metadata()?
+        .local_overlays
+        .iter()
+        .find(|overlay| overlay.workspace_id == workspace_id)
+        .map(|overlay| overlay.case)
 }
 
 pub const REPOSITORY_TRANSFER_PROTOCOL: &str = "kin-repository-v6-fast-forward";
@@ -1188,6 +1221,11 @@ pub(crate) fn apply_repository_transfer_pack<B: StorageBackend + ?Sized + 'stati
         actor,
         pack,
         limits,
+        // No receiver case. This wrapper exists for the arms that assert the
+        // no-case path, which is what kin-db accepts only where a shared policy
+        // has no rule sources for a matcher to compile. An arm that wants a case
+        // calls `apply_repository_transfer_pack_with_pre_commit` and names one.
+        None,
         || Ok(()),
     )
 }
@@ -1199,6 +1237,22 @@ pub(crate) fn apply_repository_transfer_pack<B: StorageBackend + ?Sized + 'stati
 /// whatever the peer advertised. Passing `RepositoryTransferLimits::default()`
 /// is the compiled behaviour and is what a caller with no deployment
 /// configuration should send.
+///
+/// `receiver_case` is THIS replica's own [`AdmissionCase`], and it is deliberately
+/// not the publisher's. The same policy bytes admit different paths under
+/// case-sensitive and ASCII-folded matching, so somebody has to decide which
+/// semantics govern the transferred history, and the honest answer is the replica
+/// that will hold it: every other admission decision here already runs under this
+/// case, and a transfer deciding differently would leave one store enforcing two
+/// rules. `AdmissionCase`'s own definition says the behaviour is persisted in the
+/// overlay identity precisely to keep reopen and later scans on one matcher, which
+/// is the same reason this reads the recorded case rather than re-probing a
+/// filesystem.
+///
+/// `None` means this receiver has no workspace whose case it can honestly claim,
+/// which is a hosted backend with no local `.kin` layout. kin-db accepts `None`
+/// only where the shared policy has no rule sources, so nothing can be admitted
+/// under a case nobody chose.
 ///
 /// `before_authority_commit` runs exactly once, after every validation and
 /// after the immutable CAS prewrites, immediately before the authority
@@ -1212,6 +1266,10 @@ pub(crate) fn apply_repository_transfer_pack<B: StorageBackend + ?Sized + 'stati
 /// It does not run on an idempotent replay. A replay of a transfer this code
 /// committed already ran the policy before that original commit, and running it
 /// again would mutate local state for a transfer that moves nothing.
+// Eight, because the receiver's own admission case is a distinct receiver-side
+// input from its ceilings and from its commit-boundary policy, and folding it
+// into either would name it wrongly.
+#[allow(clippy::too_many_arguments)]
 pub fn apply_repository_transfer_pack_with_pre_commit<B, P>(
     authority: &RepositoryAuthorityManager<B>,
     expected_repository_id: &RepositoryId,
@@ -1219,6 +1277,7 @@ pub fn apply_repository_transfer_pack_with_pre_commit<B, P>(
     actor: AuthorId,
     pack: &RepositoryTransferPack,
     limits: &RepositoryTransferLimits,
+    receiver_case: Option<AdmissionCase>,
     before_authority_commit: P,
 ) -> Result<RepositoryTransferReceipt>
 where
@@ -1355,13 +1414,17 @@ where
     // transferred history, with the full sensitive-content check run on every
     // introduced artifact because nothing here was already tracked.
     //
-    // `None` is the publisher's admission case not travelling yet. kin-db
-    // accepts that only where it cannot decide anything, which is a shared
-    // policy with no rule sources, and refuses by name otherwise rather than
-    // choosing matching semantics on the publisher's behalf. Carrying the case
-    // in the pack is the follow-on that lifts that limit.
+    // The case is THIS replica's own, supplied by the caller that knows which
+    // workspace is its own. It is not the publisher's and does not travel: the
+    // publisher's case decided what the publisher admitted, and this replica has
+    // to decide what IT holds, under the one case every other admission decision
+    // here already uses.
+    //
+    // A caller with no workspace to speak for passes `None`, and kin-db accepts
+    // that only where the shared policy has no rule sources, refusing by name
+    // otherwise rather than admitting under a case nobody chose.
     let receipt = authority
-        .commit_transferred_repository_transaction(transaction, None)
+        .commit_transferred_repository_transaction(transaction, receiver_case)
         .map_err(repository_commit)?;
     let outcome = match receipt.outcome {
         RepositoryCommitOutcome::Committed => RepositoryTransferApplyOutcome::Committed,
@@ -4384,6 +4447,7 @@ mod tests {
                 AuthorId::new("policy-test"),
                 &fixture.pack,
                 &RepositoryTransferLimits::default(),
+                None,
                 || Err(std::io::Error::other("sentinel policy refusal")),
             )
             .expect_err("a refused policy admitted the pack");
@@ -4420,6 +4484,7 @@ mod tests {
                 AuthorId::new("policy-test"),
                 &fixture.pack,
                 &RepositoryTransferLimits::default(),
+                None,
                 || {
                     calls.set(calls.get() + 1);
                     generation_at_policy
@@ -4459,6 +4524,7 @@ mod tests {
                 AuthorId::new("policy-test"),
                 &wrong_repository,
                 &RepositoryTransferLimits::default(),
+                None,
                 || {
                     calls.set(calls.get() + 1);
                     Ok(())
@@ -4487,6 +4553,7 @@ mod tests {
                 AuthorId::new("policy-test"),
                 &fixture.pack,
                 &RepositoryTransferLimits::default(),
+                None,
                 || {
                     calls.set(calls.get() + 1);
                     Ok(())
@@ -4503,6 +4570,7 @@ mod tests {
                 AuthorId::new("policy-test"),
                 &fixture.pack,
                 &RepositoryTransferLimits::default(),
+                None,
                 || {
                     calls.set(calls.get() + 1);
                     Ok(())

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -1249,10 +1249,13 @@ pub(crate) fn apply_repository_transfer_pack<B: StorageBackend + ?Sized + 'stati
 /// is the same reason this reads the recorded case rather than re-probing a
 /// filesystem.
 ///
-/// `None` means this receiver has no workspace whose case it can honestly claim,
-/// which is a hosted backend with no local `.kin` layout. kin-db accepts `None`
-/// only where the shared policy has no rule sources, so nothing can be admitted
-/// under a case nobody chose.
+/// `None` means the caller speaks for no replica at all, which is the negotiation
+/// convenience wrapper and the test-only entry point beside it. It is NOT what a
+/// hosted receiver passes: a hosted replica has no workspace overlay but it does
+/// have a store, and that store is byte-exact object storage, so it admits under
+/// `Sensitive` because that is what it does. kin-db accepts `None` only where the
+/// shared policy has no rule sources, so a caller that claims no case can never
+/// admit anything under a case nobody chose.
 ///
 /// `before_authority_commit` runs exactly once, after every validation and
 /// after the immutable CAS prewrites, immediately before the authority

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -876,6 +876,12 @@ where
             // creation record it can honestly claim to own. A receiver that
             // does own one supplies its own policy through
             // `pull_from_remote_with`, which is the path the daemon takes.
+            //
+            // The absent receiver case is the same fact a second time. A helper
+            // that cannot claim a local layout cannot claim a workspace either,
+            // and so has no case of its own to admit under. kin-db accepts that
+            // only where the shared policy has no rule sources, which is exactly
+            // the bound this helper should be held to.
             apply_repository_transfer_pack_with_pre_commit(
                 local,
                 repository_id,
@@ -883,6 +889,7 @@ where
                 actor.clone(),
                 pack,
                 &RepositoryTransferLimits::default(),
+                None,
                 || Ok(()),
             )
         },


### PR DESCRIPTION
A repository converted from git with a single `.gitignore` rule could not push a
change that introduces a file. Measured end to end before this change: HTTP 422,
`shared admission policy with 1 rule source(s), and the publisher's admission
case did not travel with it`. Since essentially every real repository has a
`.gitignore`, that is the brownfield adoption path, closed.

A transfer passed no admission case at all, so kin-db refused rather than choose
matching semantics on the publisher's behalf, which was the right refusal and the
wrong end state.

The case a receiver should apply is its own. The same policy bytes admit different
paths under case-sensitive and ASCII-folded matching, so somebody has to decide,
and the honest answer is the replica that will hold the history: every other
admission decision it makes already runs under that case, and a transfer deciding
differently would leave one store enforcing two rules depending on whether content
arrived locally or over the wire.

Only the caller knows which workspace is its own, which is why the case is a
parameter rather than something the transfer derives. Authority is replicated, so
`local_overlays` can hold overlays recorded on several hosts with different cases:
a macOS replica records `FoldAscii`, a Linux one records `Sensitive`, and both sit
in one authority record. The daemon pinned its own workspace id at startup, so it
is the one place that can resolve this.

`kin-remote` gains `receiver_admission_case`, which reads the recorded case from
that workspace's overlay. Recorded rather than re-probed on purpose. `AdmissionCase`
is persisted in the overlay identity so reopen and later scans stay on one matcher,
and a fresh filesystem probe could disagree with the case this replica's own commits
already enforce. It also keeps this out of the filesystem entirely, which both
zero-file-search guards check.

A daemon with no overlay to read admits under `Sensitive`, and that is not a guess.
`DaemonState::open_with_backend`, the hosted path, leaves `cached_workspace_id`
unset; what a hosted replica actually stores artifacts in is byte-exact object
storage, where two paths differing only in case are two objects.

kin-db needs no change. `commit_transferred_repository_transaction` already takes
`Option<AdmissionCase>` and already refuses `None` by name where the policy has
rules.

## The measurement, four rows

Each one a real push through a real KinLab control plane over a real kin daemon,
two replicas seeded from one `kin init`.

| repository | change | before | after |
|---|---|---|---|
| bare `kin init`, no rules | adds a file | admitted | admitted |
| converted git repo, one `.gitignore` rule | adds a file | **refused** | **admitted** |
| converted git repo, one rule | edits an existing artifact | admitted | admitted |
| converted git repo | adds a file the rule matches | never becomes a change | unchanged |

The fourth row is not this change's doing and is worth stating: `kin commit` on a
new file the rule matches reports `nothing to commit: this tree is already
committed`, the same change id as before, because admission never took it. The rule
is enforced where content enters graph truth, before a change exists.

## Falsification, and the arm that proves the end-to-end run is blind

Two grids, because one of them alone would have been a check that cannot fail.

**End to end**, against the built binaries, each arm naming its own sha:

```
M0 baseline                              green  arm3 rc=0  admitted, no refusal
M1 drop the hosted Sensitive fallback    green  arm3 rc=0  admitted, no refusal
M3 supply no case at all                 red    arm3 rc=1  case-guard: shared admission
                                                           policy with 1 rule source(s)
```

**M1 coming back green is the finding, not a miss.** That harness puts a LOCAL kin
daemon behind the control plane, so its receiver has a pinned workspace id and reads
its overlay's case; it never reaches the fallback a hosted object-storage daemon
depends on. A mutation deleting that fallback passed through the whole stack, push
included.

So the property gets a source contract in the file that already pins this daemon's
admission funnel, which lives outside `api.rs` precisely so a guard cannot match
itself. Both halves are asserted as invocations inside the wrapper rather than as
mentions, with a must-miss control first:

```
M0 baseline                        green  ran=4  failed=(none)
M1 delete the Sensitive fallback   red    ran=4  failed=the_transfer_receiver_always_admits_under_a_case
M2 supply no case at all           red    ran=4  failed=the_transfer_receiver_always_admits_under_a_case
```

Every arm lands on its expectation, every red names this test rather than a
neighbour, and both drivers refused a dirty tree before arming their restore trap
and ended with zero mutation markers in the tree.

## Gates

```
bin/kin-precheck kin   16 gates ran, 16 passed, 0 failed, on 7309653592c8
cargo test -p kin-remote                102 passed, 0 failed
cargo test -p kin-daemon --test transfer_admission_policy   4 passed, 0 failed
```

Graded on the rebased tree, because it was 3 commits behind main when first gated
and the tree that lands is the one worth grading.

## What this does NOT do, named rather than left out

**The refusal on a case divergence does not yet name both cases or the deciding
rule.** kin-db's existing message is `{label} artifact {path} is excluded by the
exact graph-owned admission policy`, which names neither. Naming them needs the
matcher, which is kin-db's, so it belongs in the kin-db work at 0.7.76 rather than
in a kin-only change.

**The two arms that need a case divergence are not run here.** A rule pair that
distinguishes the cases, `*.LOG` then `!keep.log`, cannot be exercised in this
harness: its three replicas are copies of one converted seed and share one overlay,
so no divergence is constructible, and `kin clone` speaks only Git transport today.
kin-remote's own fixtures carry no shared policy with rules either. That pair
belongs beside the matcher in kin-db, and it is now worth building, because this
change makes the divergence reachable in production for the first time: a macOS
publisher pushing to a hosted replica that admits under `Sensitive`.

The end state, where admitted-ness is a fact in the graph with a reason attached
rather than re-derived per surface, is filed as FIR-2981 with the authority-schema
migration path named as its prerequisite.

Closes FIR-2982
