### PR TITLE
Put init's capture-staging teardown on the admission ladder

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -87,6 +87,25 @@ path = "junit.xml"
 
 # quarantine: ticket=FIR-2809 since=2026-08-27 last-flake=2026-08-27 source=crates/kin-core/tests/init_phase_ladder_contiguous.rs
 #
+# The dates above are correct and deliberately unchanged. On 2026-08-30 lane
+# daemonmem reproduced this guard red three times, at 3141, 3423 and 3442 ms
+# uncovered against a 2.0 percent bar, but those were LOCAL `cargo test` runs
+# under the full workspace suite, not nextest retries. The field above means the
+# most recent run in which this test needed a RETRY, read off nextest's own
+# summary, and CI has recorded none: runs 33292963787, 33293674768 and
+# 33293776932 on 2026-08-30 each report "test(s) recorded, none needed a retry"
+# with the junit-reporting invocation present. Writing a CI date that no CI run
+# produced would put local evidence into a field defined by the hosted summary.
+#
+# So expect the promotion arm to advise deletion from 2026-09-03, and read that
+# advice against this paragraph rather than acting on the date alone. The cause
+# was found and fixed under FIR-2980: the uncovered stretch was init's own
+# capture-staging teardown, `GitCaptureStaging::drop` calling `remove_dir_all`
+# over the whole Git capture, now inside a `kin.init.release_capture_staging`
+# span. That work measured 141 ms unloaded and 1140 ms under IO contention, and
+# CPU contention does not move it. If this row is still quiet after that fix has
+# had a week on main, the promotion is the right call rather than a premature one.
+#
 # Day-one intake, and the only row. It ejected pull request 1141 for a measured
 # 34 minutes on 2026-08-26. It has the evidence quarantine demands: the guard was
 # confirmed LOAD-SENSITIVE by the control that counts, same bytes, round one red

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -639,6 +639,34 @@ fn init_from_git_with_hooks(
         seal = %sealed_observation.fingerprint,
         "admitted exact Git repository as graph-owned Kin authority"
     );
+
+    // Everything past here is teardown, and it is not free. The ladder guard's
+    // `total_ms` is `started.elapsed()` taken after this function RETURNS, so
+    // every local's Drop runs inside the timed region and outside every span.
+    // Measured on a full-history conversion under contention that stretch was
+    // 3.1 to 3.4 seconds with no phase open, flat across a 2x range of init
+    // totals, and an unnamed stretch is memory a profile charges to no phase
+    // (FIR-2980; the guard's own message records a 6,733-commit measurement
+    // discarded for exactly that).
+    //
+    // The expensive one is `capture_dir`: `GitCaptureStaging::drop` calls
+    // `remove_staging_tree`, a `remove_dir_all` with retries over the whole Git
+    // capture, including the `objects` tree the ephemeral capture blob store
+    // filled. That is filesystem work, not allocator work, which is why 12 cores
+    // of CPU load did not reproduce it. Dropping these explicitly inside a span
+    // is what puts the work on the ladder; it changes no behaviour, since both
+    // would drop at the closing brace a few instructions later.
+    //
+    // This span deliberately does NOT cover the in-memory drops that follow
+    // (`snapshot`, `admitted`, `semantic_plan`, `source_proof`, `transaction`,
+    // `git_authority`), so a residual gap is expected rather than a failure. The
+    // residual is the measurement of the other half.
+    {
+        let _span = info_span!("kin.init.release_capture_staging").entered();
+        drop(capture_store);
+        drop(capture_dir);
+    }
+
     Ok(result)
 }
 


### PR DESCRIPTION
The ladder guard's `total_ms` is `started.elapsed()` taken after `init_from_git` **returns**, so every local's Drop runs inside the timed region and outside every span. Under the full workspace suite that stretch measured 3141, 3423 and 3442 ms with no phase open against a 2.0% bar, essentially constant while the init total ranged from 24 to 52 seconds.

**A conversion's peak can land in its own teardown.** That is what the guard has been reporting, and it is exactly the case that discarded the 6,733-commit psf/requests measurement its own message records, where the peak landed with only `kin.command` and `kin.init` open.

## The mechanism, read rather than assumed

`capture_dir` is bound once and only ever borrowed afterwards, never moved, so `GitCaptureStaging::drop` runs at return and calls `remove_staging_tree`, a `remove_dir_all` with retries over the whole Git capture, including the `objects` tree the ephemeral capture blob store filled. `capture_store` is ruled out by reading it: `BlobStore::drop` only calls `sync()`, which its own doc says issues nothing for an ephemeral store.

## Measured on the span itself, which needs no A/B comparison

    release_capture_staging, unloaded          141 ms
    release_capture_staging, under IO load    1140 ms      (8x)

Six IO workers creating and deleting 1200 small files in a loop. The exact work claimed to be the stretch inflates 8x under filesystem contention. Twelve spinner cores at nice 5 moved init from 9.8 s to 15.1 s and did **not** trip the guard, so CPU contention does not move it. That discriminates between the filesystem reading and an allocator-pressure one.

## Attribution, proved both ways, unloaded

                      phases  coverage  largest gap                                   tail
  WITH the span         22     99.9%    7 ms before kin.init.capture_git_repository   0 ms
  WITHOUT (control)     21     99.6%    33 ms before the end of init, no phase open   33 ms

The span closes at 14298 ms with the total at 14298 ms, so the tail is exactly zero and the largest gap moves off the end of init onto an ordinary between-phases gap. Removing it brings the tail back as the largest gap under its own name. The mutation's absence was asserted (`grep -c` reading 0) before the arm was graded, the run refuses outright on a tree without the span, and the tree was restored on an EXIT/INT/TERM trap and read back.

## What this does NOT prove, stated plainly

- **1140 ms is not 3442 ms.** daemonmem's contention was the full 8103-test suite; mine was six IO workers. Direction and mechanism confirmed, magnitude not matched.
- **Removing the span does not turn the guard red on this fixture.** Unloaded the control's tail is 0.23% of its total, well under the 2.0% bar, so "remove it and read the guard red" cannot be done here. The two arms prove where the stretch is charged, not a red-to-green flip.
- **My IO-load A/B arms are weaker than they look** and I am not resting anything on them: Arm A ran at a 35470 ms total and Arm B at 23001 ms, so I varied the code and the load level together, which is the trap this repo catalogues. The span-duration measurement above is unaffected, since it compares one code under two named conditions.

The fix does not depend on any of that: the span now runs to the end of the function, so whatever teardown costs under any contention lands inside it and the tail is **structurally** zero rather than merely small.

`MAX_GAP_FRACTION` is untouched at 0.02, and the guard is still quarantined under FIR-2809 (`.config/nextest.toml`, `retries = 2`), whose `since` expires 2026-09-11.

Closes FIR-2980

## Second commit: FIR-2809's quarantine row, and why its dates do NOT move

I was asked to bump the row's `last-flake` to 2026-08-30 from daemonmem's three reproductions. **I measured the premise first and it does not hold, so the dates stay and the reason is written beside them instead.**

`last-flake` means, in the config's own words, "the most recent run in which this test actually needed a retry, read off nextest's own `(N flaky)` summary". daemonmem's three reds at 3141, 3423 and 3442 ms are real evidence the test still fails under load, but they were **local `cargo test` runs under the full workspace suite, not nextest retries**. CI has recorded no retry:

    run 33292963787   2682 test(s) recorded, none needed a retry
    run 33293674768   2682 test(s) recorded, none needed a retry
    run 33293776932   2683 test(s) recorded, none needed a retry

All three on 2026-08-30, each with the `--report-junit` invocation present in the log (six occurrences), and a fabricated-string control returning zero so the absence is a real absence rather than a search that could not match. Writing 2026-08-30 into that field would put local evidence into one defined by the hosted summary, and would make the row assert a CI flake the CI record says did not happen.

So the row gains a paragraph, not a new date: what daemonmem measured, why it is not a `last-flake`, that the promotion arm will therefore advise deletion from 2026-09-03, and that the cause is fixed by this PR's first commit. A reader meeting that advice finds the context beside it.

**`since=2026-08-27` stands**, so the row expires 2026-09-11 under `QUARANTINE_MAX_DAYS = 14` and its strictly-greater `age > 14` test.

Comments only: parsed keys counted before and after (2 of each `ticket|since|last-flake|source`, one in the template line and one in the row), zero non-comment lines changed, and `check-quarantine.py` still reports one row, ticketed, dated, inside fourteen days, naming a test that exists.
