### PR TITLE
Name the caller of every daemon authority open, one frame up

### DIFF
--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -45,6 +45,18 @@ impl LocalRepositoryAuthorityContext {
         self.binding.workspace_id()
     }
 
+    /// Open the local repository authority this daemon pinned at startup.
+    ///
+    /// `#[track_caller]` is load-bearing for attribution and changes no
+    /// behaviour. `open_manager` is itself `#[track_caller]` and the kin-core
+    /// funnel logs `Location::caller()` on every open, so without the attribute
+    /// here every one of this method's call sites collapses into the
+    /// `open_manager` line below. Measured on a converted psf/requests store,
+    /// eighteen of twenty opens inside one `kin graph status` reported that one
+    /// line and named no caller, which is an attribution that cannot answer the
+    /// question it exists for. With the attribute the funnel names the site that
+    /// asked for the open.
+    #[track_caller]
     pub(crate) fn open(
         &self,
     ) -> std::result::Result<RepositoryAuthorityManager<LocalFileBackend>, kin_db::KinDbError> {
@@ -301,4 +313,98 @@ pub(crate) fn plan_daemon_semantic_delta(
         target_relations,
     )
     .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod attribution_tests {
+    use super::*;
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    /// Every `caller=` the kin-core authority funnel logged while the capture was live.
+    #[derive(Default)]
+    struct Captured {
+        callers: Vec<String>,
+    }
+
+    struct CaptureLayer(std::sync::Arc<std::sync::Mutex<Captured>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            #[derive(Default)]
+            struct Read {
+                caller: Option<String>,
+            }
+            impl tracing::field::Visit for Read {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "caller" {
+                        // `caller = %format_args!(..)` records through
+                        // `record_debug` with a `std::fmt::Arguments`, whose
+                        // Debug delegates to Display and adds no quotes. The
+                        // trim is there so a future recording change that does
+                        // add them fails this test on the LINE rather than on
+                        // the punctuation.
+                        self.caller = Some(format!("{value:?}").trim_matches('"').to_string());
+                    }
+                }
+            }
+            let mut read = Read::default();
+            event.record(&mut read);
+            if let Some(caller) = read.caller {
+                self.0.lock().unwrap().callers.push(caller);
+            }
+        }
+    }
+
+    /// The funnel names the site that ASKED for an open, not the line inside
+    /// `open` that performs it.
+    ///
+    /// This is the only way `#[track_caller]` on `open` can be falsified, and
+    /// the assertion is exact rather than a substring: the expected value is
+    /// built from `file!()` and the `line!()` of the call below, so removing
+    /// the attribute makes the funnel report the `open_manager` line inside
+    /// `open` and this test fails naming both. A weaker assertion, that the
+    /// caller merely mentions this file, would pass with the attribute removed,
+    /// because the line inside `open` is in this file too.
+    #[test]
+    fn the_funnel_names_the_caller_of_open_rather_than_the_line_inside_it() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let context = LocalRepositoryAuthorityContext::from_layout_for_test(&init.layout).unwrap();
+
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Captured::default()));
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer(std::sync::Arc::clone(
+            &captured,
+        )));
+        let expected_line = {
+            let _capture = crate::capture_events_on_this_thread(subscriber);
+            let line = line!() + 1;
+            context.open().expect("the test store must open");
+            line
+        };
+
+        let callers = captured.lock().unwrap().callers.clone();
+        // A capture that recorded nothing is not a passing test. The funnel logs
+        // at info, so an empty vector here means the event never reached this
+        // subscriber and the assertion below would be vacuous.
+        assert!(
+            !callers.is_empty(),
+            "the authority funnel logged no caller= field at all, so this test graded nothing"
+        );
+
+        let expected = format!("{}:{}", file!(), expected_line);
+        assert!(
+            callers.iter().any(|caller| caller == &expected),
+            "the funnel named {callers:?}, none of them the call site {expected}. Without \
+             #[track_caller] on LocalRepositoryAuthorityContext::open every caller collapses \
+             into the open_manager line inside open, which is what this asserts against."
+        );
+    }
 }

--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -380,9 +380,8 @@ mod attribution_tests {
         let context = LocalRepositoryAuthorityContext::from_layout_for_test(&init.layout).unwrap();
 
         let captured = std::sync::Arc::new(std::sync::Mutex::new(Captured::default()));
-        let subscriber = tracing_subscriber::registry().with(CaptureLayer(std::sync::Arc::clone(
-            &captured,
-        )));
+        let subscriber =
+            tracing_subscriber::registry().with(CaptureLayer(std::sync::Arc::clone(&captured)));
         let expected_line = {
             let _capture = crate::capture_events_on_this_thread(subscriber);
             let line = line!() + 1;


### PR DESCRIPTION
`#[track_caller]` on `open_manager` resolves to `LocalRepositoryAuthorityContext::open`, which is the immediate caller, so every call site collapses into one line and the attribution cannot answer the question it exists for.

## What it costs today, measured

On a converted psf/requests store, one `kin graph status` on `99b6b6f0`:

| caller the funnel named | opens |
|---|---|
| `local_repository_authority.rs:53` | 9 of 12 |
| `state.rs:4677` (daemon startup) | 1 |
| `state.rs:9953` (enrichment publish) | 1 |
| `api.rs:541` (coverage read) | 1 |

On `c1f7d8cc` the first row is 18 of 20. The two `state.rs` rows are useful because those sites call the funnel directly. The dominant row names a method, not a caller.

`repository_commit.rs` alone holds eight non-test open sites, one per pipeline stage: `authority_workspace_tree`, `plan_session_workspace_admission`, `commit_session_workspace_admission`, `publish_workspace_tree`, `plan_native_commit_inner`, `load_native_commit_base`, `load_native_source_blob` and `recover_native_commit`. `load_native_source_blob` decodes the whole persisted authority and re-verifies every body in repository CAS to load one blob. **Which of those the eighteen are is a hypothesis from reading, and it stays one until the funnel can say.**

## What this changes

Nothing at runtime. `#[track_caller]` propagates `Location::caller()` one frame further, so the funnel names the site that asked for the open instead of the line that performs it.

## The test, and why it is shaped this way

The assertion is exact, built from `file!()` and the `line!()` of the call, not a substring:

```rust
let line = line!() + 1;
context.open().expect("the test store must open");
```

**A substring assertion would pass with the attribute removed**, because the `open_manager` line inside `open` lives in this file too, so "the caller mentions this file" is true either way. That is the only falsification this change has, and a check that survives its own mutation is not one.

It also refuses an empty capture. The funnel logs at info, and a capture that recorded nothing would make the assertion vacuous rather than red, which is the shape a passing test and a test that graded nothing share.

## Gate

Pushed for hosted CI to build under the captain's ruling, with the local box held for the release candidate's own build. No local `cargo` run was made against this branch at push time; a local check follows inside the same slot once the candidate build releases it, and this line is here so the PR does not read as locally gated when it was not.

Refs FIR-2955
