### PR TITLE
Pin kin-db 0.7.76, which names the rule and the case a refusal decided under

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.74"
+version = "0.7.76"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "0fa49e0651295a820c6ef4b5ac8d7a569049b8feb875a837ccab45fded75fa33"
+checksum = "03dd5d93e70900752bf8577f1b38a3354e2d4588d2c9de63a176fdfd59495817"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.74", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.76", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.21", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
0.7.76 makes an admission refusal say **which rule** excluded the artifact and
**which case** it matched under, instead of only that the graph-owned policy
excluded it. `AdmissionDecisionReason` already carried the deciding rule's source,
line, pattern and negation, and nothing read them.

It also carries the negation pair as a test, which is the case that refutes the
tidy story that ASCII-folded matching is the stricter one. Against `*.LOG` then
`!keep.log` and an artifact spelled `keep.LOG`, FoldAscii **admits**, because the
negation folds onto the path and re-admits it, and Sensitive **refuses**, because
the negation does not match at all. The folded case is the permissive one there.

That matters to this crate now rather than in the abstract. As of #1274 a receiver
applies its own admission case, so a `FoldAscii` publisher pushing `keep.LOG` to a
replica that admits under `Sensitive`, which is every hosted replica, lands on
exactly that pair.

And it pins that a forged Git-origin label cannot skip the shared admission
policy: a transaction carrying a Git-origin change must also carry that commit's
raw object and its final alias, so the label costs a git object a forger does not
have.

## The version

Taken from the registry INDEX rather than from kin-db's main plus one. The index
lists `0.7.72, 0.7.74, 0.7.75`, so `0.7.73` was never published and neither was
`0.7.45`. The sequence has holes and an increment is not automatically safe.
0.7.76 is strictly greater than the index's newest, and the index was confirmed to
serve it at 06:17:04Z before this was written, three and a half minutes after
kin-db#257 merged. Merged is not published, so the index is what was polled.

## The lock

Exactly two lines, the version and the checksum, with the `sparse+` registry
source preserved:

```
-version = "0.7.74"
+version = "0.7.76"
-checksum = "0fa49e0651295a820c6ef4b5ac8d7a569049b8feb875a837ccab45fded75fa33"
+checksum = "03dd5d93e70900752bf8577f1b38a3354e2d4588d2c9de63a176fdfd59495817"
```

`cargo update -p kin-db --precise 0.7.76` also rewrote a dozen `windows-sys`
entries: thirty changed lines where four were wanted, on a platform this host
cannot build, inside a two-line pin where nobody would have read them. The lock
was restored from HEAD and the kin-db entry re-applied on its own.
`fuzz/Cargo.lock` is the repo's other tracked lock and carries no kin-db, so it is
untouched, and neither lock carries 0.7.74 now.

## The gate

```
cargo check --workspace --locked    rc=0
```

That is the gate a pin needs. The DEV-LOCAL path replaces the crate under test
with a local checkout and cannot validate a registry pin at all, which is why it
was not used.

Branched from `origin/main` at `5d59d16fe`, verified by reading HEAD and the
ahead/behind counts rather than by trusting a printed base line.
