### PR TITLE
Give vcs_read_surfaces:content its own edit to admit

### DIFF
--- a/scripts/acceptance/vcs_read_surfaces_repro.py
+++ b/scripts/acceptance/vcs_read_surfaces_repro.py
@@ -144,6 +144,21 @@ def total_by(entries, key):
 '''
 
 
+# A THIRD body, for `check_content` alone. Same declarations, same count, body
+# only, like MODULE_AFTER; distinct from it so an edit reaches `kin admit` that no
+# earlier status read has already taken.
+MODULE_FOR_ADMIT = '''"""Roll ledger entries up into totals."""
+
+
+def total_by(entries, key):
+    """Sum amounts under one key, rounded to whole units."""
+    buckets = {}
+    for entry in entries:
+        buckets[entry[key]] = round(buckets.get(entry[key], 0) + entry["amount"])
+    return buckets
+'''
+
+
 def run(cmd, cwd=None, env=None, timeout=600):
     process = subprocess.Popen(
         cmd, cwd=cwd, env=env,
@@ -493,6 +508,20 @@ def check_diff_scope(suite):
 
 
 def check_content(suite):
+    """`kin admit` over a content-only edit must not report a no-op.
+
+    Makes its OWN edit, and that is the whole correction. Since kin#1258
+    `kin status` admits before it reads, so `check_saw_the_edit` above does not
+    merely observe the edit, it TAKES it: the tree hash moving is exactly how that
+    check passes. By the time this one ran, there was nothing left to admit and
+    `kin admit` correctly said so, which failed this check on every main
+    Acceptance run after kin#1258 landed.
+
+    The check that proves read-after-admit works was consuming the state the next
+    check grades. A read that mutates has to be treated as a mutation when
+    ordering an experiment around it.
+    """
+    suite.write_tracked_module(MODULE_FOR_ADMIT)
     rc, out, err = suite.kin_run(["admit"])
     if rc != 0:
         return Result("content", UNREADABLE,
@@ -510,10 +539,15 @@ def check_settled(suite):
     return Result("settled", status, "%s %s" % (TICKET, detail))
 
 
-# Order is load-bearing and the experiment is destructive. `saw_the_edit` makes
-# the edit the next two are about, `content` admits it, `settled` re-admits a
-# settled tree, `diff_scope` reads a workspace diff over it, and `unadmitted`
-# stops the daemon, which nothing after it could survive.
+# Order is load-bearing and the experiment is destructive, and since kin#1258
+# every `kin status` in it is a MUTATION: status admits before it reads. So each
+# check that grades an unadmitted state has to create that state itself, after
+# the last status call, rather than inherit one from the check above.
+# `basis` and `saw_the_edit` both read status and therefore both admit;
+# `saw_the_edit` takes the edit it makes, which is exactly how it passes.
+# `content` writes its own edit for that reason, `settled` re-admits the settled
+# tree `content` left, `diff_scope` reads a workspace diff over it, and
+# `unadmitted` stops the daemon, which nothing after it could survive.
 CHECKS = (
     ("basis", check_basis),
     ("saw_the_edit", check_saw_the_edit),


### PR DESCRIPTION
`vcs_read_surfaces:content` has failed on every main Acceptance run since kin#1258. The defect is in the suite, not the product.

## Mechanism, from the run's own two adjacent lines

CI run 33295456256:

```
CHECK saw_the_edit PASS  the tree moved b797a254 -> 3673bc6d, so the answer was measured
                         against the working copy
CHECK content      FAIL  a pass over an edited tracked file reported nothing changed
```

`saw_the_edit` passing is causally why `content` fails. Since #1258 `kin status` admits before it reads, so `check_saw_the_edit` does not observe the edit it makes, it **takes** it. The tree hash moving between its two status reads is exactly how that check passes. `check_content` then ran `kin admit` with nothing outstanding, and `kin admit` correctly reported a no-op.

The check written to prove read-after-admit works is the one that made the next check unreachable.

## Two hypotheses this refutes, on that run's own evidence

**Not a missing daemon.** `held_merge` PASSED and needs `kin merge` plus `kin conflicts` to run. `basis` read "as admitted 0s ago". `diff_scope` PASSED.

**Not a missing live graph.** `unadmitted` PASSED on the same run, with the no-daemon path naming its gap by name.

## The change

`check_content` writes a third module body of its own before admitting, so an edit reaches `kin admit` that no earlier status read has taken. The ordering comment above `CHECKS` described the pre-#1258 world and is corrected with it, because leaving it would invite the next reader to rebuild the same bug.

Suite-only. No product code moves.

## Why it was missed

The suite was validated end to end against a staged binary at `6438c64d1`, which is #1254's content. Read-after-admit arrived in #1258 and the suite was never re-run against a binary carrying it. Measured, not asserted: `git show 6438c64d1:crates/kin-cli/src/commands/status.rs | grep -c admit_before_reading` returns 0, and the same read against `origin/main` finds the call at line 975.

A green taken against a staged binary expires the moment the product moves past it, and nothing about the green says so.

## The class, third instance in one night

Read-after-admit has now broken three acceptance checks by removing the condition each one graded, after the two in `working_copy_freshness` under FIR-2820. A read that mutates has to be ordered like a mutation: a check that grades an unadmitted state has to create it after the last status call, and a suite sharing a fixture across steps has to be read as a sequence of mutations once one of its reads admits.

Closes FIR-2990
