### PR TITLE
Resolve the admission pair once per publication, not once per concurrent task

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -38141,13 +38141,25 @@ mod tests {
             "eight sequential admission reads at one publication must load the authority zero              further times; each load decodes the whole store and re-verifies every CAS body"
         );
 
+        // The concurrent arm gets a COLD state of its own, and that is the
+        // whole point of it. Written against the warm state above, eight tasks
+        // all hit the populated slot and never reach the load gate, so removing
+        // the gate left it green across three runs: an arm that could not fail
+        // for the reason it was written. Cold, the eight race into an empty
+        // slot and only the gate holds them to one load between them.
+        let cold = test_state();
+        install_repository_file(&cold, "src/lib.py", b"def handler():\n    return 1\n");
+        cold.is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let cold_before = cold.projection_authority.loads();
+
         // No join_all: this crate carries futures-util rather than futures, and
         // a hand-rolled join needs no dependency at all here.
         let mut tasks = Vec::new();
         for call in 0..8 {
-            let state = Arc::clone(&state);
+            let cold = Arc::clone(&cold);
             tasks.push(tokio::task::spawn_blocking(move || {
-                cached_authority_admission(&state)
+                cached_authority_admission(&cold)
                     .map(|_| call)
                     .map_err(|(_, message)| format!("concurrent call {call} failed: {message}"))
             }));
@@ -38158,9 +38170,11 @@ mod tests {
                 .expect("every concurrent call must succeed");
         }
         assert_eq!(
-            state.projection_authority.loads(),
-            before,
-            "eight CONCURRENT admission reads at one publication must still load zero further              times; a burst that each misses and opens is the shape this cache exists to stop"
+            cold.projection_authority.loads(),
+            cold_before + 1,
+            "eight CONCURRENT admission reads racing into a COLD slot must pay one load between \
+             them, not one each; the load gate is what makes that true, and this is the only \
+             arm that can watch it go"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -223,6 +223,18 @@ pub(crate) struct ProjectionAuthorityCache {
     held: std::sync::Mutex<Option<HeldProjectionAuthority>>,
     query: std::sync::Mutex<Option<HeldQueryAuthority>>,
     command: std::sync::Mutex<Option<HeldCommandAuthority>>,
+    /// The admission pair every reconcile task needs, which is not a fourth
+    /// wrapper over the authority but two small values read out of one.
+    ///
+    /// `current_authority_admission` wants a root bundle and a compiled
+    /// admission matcher, and neither can differ between tasks inside one
+    /// publication: the matcher's own type is documented as "a compiled,
+    /// immutable admission-policy generation". Before this slot each
+    /// concurrent task opened the whole store for its own copy, and on a
+    /// converted psf/requests store six tokio workers were measured inside
+    /// that function at one instant, serialized at 2.2 seconds per open
+    /// because an open is O(store).
+    admission: std::sync::Mutex<Option<HeldAdmission>>,
     /// Serializes misses so a burst of concurrent cold requests pays for one
     /// full load rather than one per request.
     load_gate: std::sync::Mutex<()>,
@@ -255,6 +267,16 @@ struct HeldCommandAuthority {
     /// [`HeldProjectionAuthority::published`] and for the same reason.
     published: LocalPublicationIdentity,
     authority: Arc<kin_cli::commands::repository_authority::ActiveRepositoryAuthority>,
+}
+
+#[derive(Clone)]
+struct HeldAdmission {
+    /// Read strictly before the authority these values came out of was loaded,
+    /// exactly as for [`HeldProjectionAuthority::published`] and for the same
+    /// reason.
+    published: LocalPublicationIdentity,
+    roots: kin_model::RootBundle,
+    policy: Option<kin_index::ResolvedAdmissionMatcher>,
 }
 
 impl ProjectionAuthorityCache {
@@ -311,6 +333,32 @@ impl ProjectionAuthorityCache {
         *lock_recover(&self.query) = Some(HeldQueryAuthority {
             published,
             authority,
+        });
+    }
+
+    fn reuse_admission(
+        &self,
+        published: &LocalPublicationIdentity,
+    ) -> Option<(
+        kin_model::RootBundle,
+        Option<kin_index::ResolvedAdmissionMatcher>,
+    )> {
+        lock_recover(&self.admission)
+            .as_ref()
+            .filter(|held| &held.published == published)
+            .map(|held| (held.roots.clone(), held.policy.clone()))
+    }
+
+    fn install_admission(
+        &self,
+        published: LocalPublicationIdentity,
+        roots: kin_model::RootBundle,
+        policy: Option<kin_index::ResolvedAdmissionMatcher>,
+    ) {
+        *lock_recover(&self.admission) = Some(HeldAdmission {
+            published,
+            roots,
+            policy,
         });
     }
 
@@ -551,6 +599,75 @@ fn command_repository_authority(
         "command repository authority loaded"
     );
     Ok(authority)
+}
+
+/// The admission pair for the current publication, from one open per
+/// publication rather than one per task.
+///
+/// Same shape as [`command_repository_authority`] above and deliberately so: a
+/// reviewer should be able to diff the two. Read the publication, try the slot,
+/// take the load gate, re-read under it because the publication may have moved
+/// while this request waited, try again, and only then pay for the open.
+///
+/// What this replaces: `loop_runner::current_authority_admission` opened the
+/// whole store on every call, and its three callers reach it independently from
+/// concurrent tasks. Measured on a converted psf/requests store, six tokio
+/// workers sat inside it at one instant, each in a whole-store open serialized
+/// at 2.205 seconds, which is what one open costs warm there. Neither value it
+/// reads can differ between tasks inside one publication, so the cost was paid
+/// per arrival for an answer that could not vary.
+pub(crate) fn cached_authority_admission(
+    state: &DaemonState,
+) -> Result<
+    (
+        kin_model::RootBundle,
+        Option<kin_index::ResolvedAdmissionMatcher>,
+    ),
+    (StatusCode, String),
+> {
+    let backend = state.local_repository_backend().ok_or_else(|| {
+        repository_authority_error("local daemon is missing its startup storage capability")
+    })?;
+    let binding = state
+        .local_repository_authority_binding()
+        .map_err(repository_authority_error)?;
+    let repository_id = binding.repository_id().clone();
+
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(pair) = state.projection_authority.reuse_admission(&published) {
+        return Ok(pair);
+    }
+
+    let _load = lock_recover(&state.projection_authority.load_gate);
+    // Re-read under the gate: the publication may have moved while this request
+    // waited, and the label installed below must be the one taken before the
+    // open it describes.
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(pair) = state.projection_authority.reuse_admission(&published) {
+        return Ok(pair);
+    }
+
+    let context =
+        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
+            .map_err(|error| repository_authority_error(error.to_string()))?;
+    let authority = context
+        .open()
+        .map_err(|error| repository_authority_error(error.to_string()))?;
+    state.projection_authority.record_load();
+    let roots = authority.read_authority().roots().clone();
+    let policy = authority
+        .workspace_admission_snapshot(context.repository_id(), &context.workspace_id())
+        .map_err(|error| repository_authority_error(error.to_string()))?
+        .map(|snapshot| snapshot.matcher);
+    state
+        .projection_authority
+        .install_admission(published, roots.clone(), policy.clone());
+    tracing::debug!(
+        repository = %repository_id,
+        loads = state.projection_authority.loads(),
+        "admission pair loaded"
+    );
+    Ok((roots, policy))
 }
 
 /// Hand a command helper an authority this daemon already resolved.
@@ -37981,6 +38098,69 @@ mod tests {
         assert!(
             state.projection_authority.loads() > before,
             "a focal that resolves still opens the authority its bodies are read through"
+        );
+    }
+
+    /// The admission pair costs one authority open per publication, not one per
+    /// caller, and concurrency does not change that.
+    ///
+    /// `current_authority_admission` has three callers that reach it
+    /// independently from concurrent tasks, and before the cache each opened
+    /// the whole store for its own copy. An open decodes the entire persisted
+    /// authority and re-verifies every body in repository CAS, so on a
+    /// converted psf/requests store six concurrent tasks were measured inside
+    /// that function at once, serialized at 2.205 seconds each.
+    ///
+    /// Two arms because they fail differently. Sequential proves the slot is
+    /// consulted at all; concurrent proves the load gate holds a burst to one
+    /// load rather than admitting a thundering herd that each miss and open.
+    ///
+    /// Every call is asserted to have SUCCEEDED before the count is read. A
+    /// count that did not move is the same reading whether the cache worked or
+    /// every call failed early, and only one of those is the property.
+    #[tokio::test]
+    async fn the_admission_pair_costs_one_open_per_publication() {
+        let state = test_state();
+        install_repository_file(&state, "src/lib.py", b"def handler():\n    return 1\n");
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // Warm the publication once so the count below measures reuse rather
+        // than the first load, which every path has to pay.
+        cached_authority_admission(&state).expect("the fixture store must resolve an admission");
+        let before = state.projection_authority.loads();
+
+        for call in 0..8 {
+            cached_authority_admission(&state)
+                .unwrap_or_else(|(_, message)| panic!("sequential call {call} failed: {message}"));
+        }
+        assert_eq!(
+            state.projection_authority.loads(),
+            before,
+            "eight sequential admission reads at one publication must load the authority zero              further times; each load decodes the whole store and re-verifies every CAS body"
+        );
+
+        // No join_all: this crate carries futures-util rather than futures, and
+        // a hand-rolled join needs no dependency at all here.
+        let mut tasks = Vec::new();
+        for call in 0..8 {
+            let state = Arc::clone(&state);
+            tasks.push(tokio::task::spawn_blocking(move || {
+                cached_authority_admission(&state)
+                    .map(|_| call)
+                    .map_err(|(_, message)| format!("concurrent call {call} failed: {message}"))
+            }));
+        }
+        for task in tasks {
+            task.await
+                .expect("the task must not panic")
+                .expect("every concurrent call must succeed");
+        }
+        assert_eq!(
+            state.projection_authority.loads(),
+            before,
+            "eight CONCURRENT admission reads at one publication must still load zero further              times; a burst that each misses and opens is the shape this cache exists to stop"
         );
     }
 

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -510,24 +510,23 @@ fn mass_deletion_refused(removed: u64, total_graph_files: u64) -> DaemonError {
 /// A repository with no local workspace — a hosted snapshot daemon — has no
 /// policy to resolve and reports `None`. Nothing is filtered in that case, and
 /// nothing is published from a host walk there either.
+///
+/// One open per PUBLICATION rather than one per call, which is the whole cost
+/// of this function. It used to open the whole store every time, and its three
+/// callers reach it independently on concurrent tasks, so a burst paid one
+/// O(store) open each and serialized behind kin-db. Neither value can differ
+/// between tasks inside one publication, so the answer is resolved once and
+/// shared through the daemon's `ProjectionAuthorityCache`, invalidated the way
+/// every other slot there is: by the publication identity moving.
 pub(crate) fn current_authority_admission(
     state: &DaemonState,
 ) -> Result<(
     kin_model::RootBundle,
     Option<kin_index::ResolvedAdmissionMatcher>,
 )> {
-    let authority_context =
-        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
-    let authority = authority_context.open().map_err(DaemonError::Graph)?;
-    let roots = authority.read_authority().roots().clone();
-    let policy = authority
-        .workspace_admission_snapshot(
-            authority_context.repository_id(),
-            &authority_context.workspace_id(),
-        )
-        .map_err(DaemonError::Graph)?
-        .map(|snapshot| snapshot.matcher);
-    Ok((roots, policy))
+    crate::api::cached_authority_admission(state).map_err(|(_status, message)| {
+        DaemonError::Io(std::io::Error::other(message))
+    })
 }
 
 /// Measure host content graph truth does not carry, right now.

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -524,9 +524,8 @@ pub(crate) fn current_authority_admission(
     kin_model::RootBundle,
     Option<kin_index::ResolvedAdmissionMatcher>,
 )> {
-    crate::api::cached_authority_admission(state).map_err(|(_status, message)| {
-        DaemonError::Io(std::io::Error::other(message))
-    })
+    crate::api::cached_authority_admission(state)
+        .map_err(|(_status, message)| DaemonError::Io(std::io::Error::other(message)))
 }
 
 /// Measure host content graph truth does not carry, right now.

--- a/scripts/acceptance/capped_brownfield_init.py
+++ b/scripts/acceptance/capped_brownfield_init.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Convert psf/requests inside a memory-capped container and grade the kills.
+
+Why a container
+---------------
+The other memory suites read `memory.max` through this process's own binding
+cgroup, and a hosted runner has no cap, so `Acceptance` has never measured
+anything at 16 GB on any runner: every one of them read a ceiling far above the
+demand and passed. That is why this class was found by a stranger in a capped
+container and by nothing in CI.
+
+So this suite does not read the host's ceiling. It CREATES one, runs the
+conversion inside a `docker --memory <cap>` container, and reads
+`memory.max`, `memory.peak` and `memory.events` from that container's own
+cgroup at the end. A run on a 64 GB host and a run on a 16 GB host therefore
+grade the same thing, and the cap is printed beside every result so a reader
+never has to infer which was measured.
+
+What it grades
+--------------
+On a converted psf/requests store at the documented 16 GB minimum, the daemon
+serving enrichment must not be killed by the memory limit.
+
+    CHECK capped_init_no_oom_kill FIR-2988 PASS|FAIL|UNREADABLE <detail>
+    CHECK capped_init_no_kill_line FIR-2988 PASS|FAIL|UNREADABLE <detail>
+
+Two checks rather than one because they fail differently. The cgroup counter is
+the fact; the product's own sentence is what a partner reads. A build that
+stopped emitting the sentence while still dying would pass the second alone,
+and a build that emitted it spuriously would pass the first alone.
+
+`memory.peak` is reported but NOT graded. On the arm that produced this suite it
+read 13.56 GiB against a 16.00 GiB cap, which is 2.44 GiB below the ceiling on a
+run that was nonetheless killed by the cgroup's own OOM killer, so peak equal to
+max is sufficient evidence of a cap kill and not necessary. The `oom_kill`
+counter decides, because only the cgroup's OOM killer increments it.
+
+Cost
+----
+About twelve minutes: a full clone of psf/requests, a conversion of its whole
+history, and the enrichment pass that follows. Too heavy for the per-PR gate, so
+it runs behind `--run`, which the preflight's host leg and the stranger both
+pass. Without `--run` it prints what it would do and exits 0.
+
+Falsification
+-------------
+Point `--archive` at a build predating the fix and the first check must FAIL
+with `oom_kill 1`. That arm is what produced this suite rather than a thing
+invented for it.
+
+Exit status is 1 when any check FAILs, 2 when none fail but some are UNREADABLE,
+0 only when every check passes, 3 on a setup error.
+"""
+
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import uuid
+
+REPO = "https://github.com/psf/requests"
+# Pinned so the corpus cannot move underneath the number. This is the revision
+# the v0.6.2 stranger's brownfield arm converted.
+REVISION = "5460f467b02e49471c0fd6cfc9ca0adab6351f98"
+IMAGE_DEFAULT = "kin-stranger:1"
+DEFAULT_CAP = "16g"
+KILL_SENTENCE = "killed by the memory limit"
+GIB = float(1 << 30)
+
+
+EMITTED = []
+
+
+def emit(check_id, status, detail):
+    """Print one check line and record its status.
+
+    The exit code is computed from this list rather than recomputed from the
+    same inputs, because two readings of one fact drift: a check could print
+    FAIL while the status arithmetic below read the value differently and
+    returned 0. There is one reading and the tally is over it.
+    """
+    EMITTED.append(status)
+    print("CHECK %s FIR-2988 %s %s" % (check_id, status, detail))
+
+
+def run(argv, **kw):
+    return subprocess.run(argv, capture_output=True, text=True, **kw)
+
+
+def docker(name, script):
+    return run(["docker", "exec", name, "bash", "-lc", script])
+
+
+def read_cgroup(name):
+    """The cap and the counters from INSIDE the container, never from the flag.
+
+    A container's limits at the end are not the flags it was created with, and
+    a workload can raise them, so the flag is recorded separately and compared
+    rather than trusted.
+    """
+    out = docker(name, "cat /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.peak; "
+                       "cat /sys/fs/cgroup/memory.events")
+    if out.returncode != 0:
+        return None
+    lines = [l.strip() for l in out.stdout.splitlines() if l.strip()]
+    read = {}
+    for line in lines:
+        parts = line.split()
+        if len(parts) == 1 and parts[0].isdigit():
+            read.setdefault("_numbers", []).append(int(parts[0]))
+        elif len(parts) == 2 and parts[1].lstrip("-").isdigit():
+            read[parts[0]] = int(parts[1])
+    numbers = read.get("_numbers", [])
+    if len(numbers) >= 2:
+        read["memory.max"], read["memory.peak"] = numbers[0], numbers[1]
+    return read
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--run", action="store_true",
+                        help="actually run the twelve-minute conversion")
+    parser.add_argument("--archive", default=os.environ.get("KIN_ARCHIVE"),
+                        help="a kin-linux-*.tar.gz whose kin and kin-daemon are installed")
+    parser.add_argument("--cap", default=os.environ.get("KIN_CAPPED_INIT_CAP", DEFAULT_CAP))
+    parser.add_argument("--image", default=os.environ.get("KIN_CAPPED_INIT_IMAGE", IMAGE_DEFAULT))
+    parser.add_argument("--keep", action="store_true",
+                        help="leave the container after the run (default: leave it)")
+    parser.add_argument("--json", dest="json_path", default=None)
+    args = parser.parse_args(argv)
+
+    if not args.run:
+        print("capped_brownfield_init: not run. Pass --run to spend about twelve minutes "
+              "converting psf/requests at %s inside a docker --memory %s container."
+              % (REVISION[:12], args.cap))
+        return 0
+    if not args.archive or not os.path.isfile(args.archive):
+        print("capped_brownfield_init: SETUP --archive must name a kin release archive", file=sys.stderr)
+        return 3
+    if run(["docker", "info"]).returncode != 0:
+        print("capped_brownfield_init: SETUP docker is not available on this host", file=sys.stderr)
+        return 3
+
+    name = "kin-capped-init-%s" % uuid.uuid4().hex[:10]
+    archive_dir = os.path.dirname(os.path.abspath(args.archive))
+    archive_base = os.path.basename(args.archive)
+    # Never --rm: it deletes the only record of why a capped run died, and exit
+    # 137 cannot separate an OOM kill from any other kill.
+    started = run(["docker", "run", "-d", "--name", name,
+                   "--memory", args.cap, "--cpus", "5",
+                   "-v", "%s:/dist:ro" % archive_dir,
+                   args.image, "sleep", "infinity"])
+    if started.returncode != 0:
+        print("capped_brownfield_init: SETUP container would not start: %s"
+              % started.stderr.strip(), file=sys.stderr)
+        return 3
+
+    result = {"cap_flag": args.cap, "revision": REVISION, "container": name}
+    try:
+        cap = read_cgroup(name)
+        if not cap or "memory.max" not in cap:
+            emit("capped_init_no_oom_kill", "UNREADABLE",
+                 "the container's cgroup could not be read, so no cap was measured")
+            emit("capped_init_no_kill_line", "UNREADABLE", "no run was made")
+            return 2
+        result["memory.max_at_start"] = cap["memory.max"]
+        print("cap read from the container's cgroup: %d bytes (%.2f GiB), flag was %s"
+              % (cap["memory.max"], cap["memory.max"] / GIB, args.cap))
+
+        install = docker(name,
+            "set -e; mkdir -p /work/dist && cp /dist/%s /work/dist/ && cd /work/dist && "
+            "tar xzf %s && d=$(dirname $(find /work/dist -name kin -type f | head -1)) && "
+            "mkdir -p /work/bin && cp $d/kin $d/kin-daemon /work/bin/ && "
+            "chmod +x /work/bin/kin /work/bin/kin-daemon && ls -l /work/bin"
+            % (archive_base, archive_base))
+        if install.returncode != 0 or not docker(name, "test -x /work/bin/kin-daemon").returncode == 0:
+            # Without kin-daemon beside kin, init SKIPS enrichment and exits 0
+            # with a plausible peak, which is a null result wearing a pass.
+            emit("capped_init_no_oom_kill", "UNREADABLE",
+                 "kin-daemon is not beside kin in the container, so enrichment would be skipped "
+                 "and this run would measure nothing")
+            emit("capped_init_no_kill_line", "UNREADABLE", "no run was made")
+            return 2
+        version = docker(name, "/work/bin/kin --version").stdout.strip()
+        result["kin_version"] = version
+        print("binary under test: %s" % version)
+
+        clone = docker(name, "rm -rf /work/req && git clone -q %s /work/req && "
+                             "git -C /work/req checkout -q %s && git -C /work/req rev-parse HEAD"
+                             % (REPO, REVISION))
+        if clone.returncode != 0 or REVISION not in clone.stdout:
+            emit("capped_init_no_oom_kill", "UNREADABLE",
+                 "the corpus could not be cloned at %s" % REVISION[:12])
+            emit("capped_init_no_kill_line", "UNREADABLE", "no run was made")
+            return 2
+
+        began = time.time()
+        init = docker(name, "cd /work/req && timeout 2700 /work/bin/kin init 2>&1")
+        result["init_rc"] = init.returncode
+        result["init_wall_s"] = round(time.time() - began, 1)
+        print("init rc=%d wall=%ss" % (init.returncode, result["init_wall_s"]))
+
+        end = read_cgroup(name) or {}
+        result.update({k: v for k, v in end.items() if not k.startswith("_")})
+        peak = end.get("memory.peak")
+        oom_kill = end.get("oom_kill")
+        if peak is not None:
+            print("memory.peak %d (%.2f GiB) against memory.max %d (%.2f GiB), reported not graded"
+                  % (peak, peak / GIB, end.get("memory.max", 0), end.get("memory.max", 0) / GIB))
+
+        if oom_kill is None:
+            emit("capped_init_no_oom_kill", "UNREADABLE",
+                 "memory.events carried no oom_kill field, so no kill count was read")
+        elif oom_kill == 0:
+            emit("capped_init_no_oom_kill", "PASS",
+                 "oom_kill 0 under a %.2f GiB cap read from the cgroup" % (end.get("memory.max", 0) / GIB))
+        else:
+            emit("capped_init_no_oom_kill", "FAIL",
+                 "oom_kill %d under a %.2f GiB cap read from the cgroup; peak %.2f GiB"
+                 % (oom_kill, end.get("memory.max", 0) / GIB, (peak or 0) / GIB))
+
+        text = init.stdout or ""
+        if not text.strip():
+            emit("capped_init_no_kill_line", "UNREADABLE", "init produced no output to read")
+        elif KILL_SENTENCE in text:
+            line = next((l.strip() for l in text.splitlines() if KILL_SENTENCE in l), KILL_SENTENCE)
+            emit("capped_init_no_kill_line", "FAIL", line[:240])
+        else:
+            emit("capped_init_no_kill_line", "PASS",
+                 "the product reported no daemon killed by the memory limit")
+        result["init_tail"] = text[-4000:]
+    finally:
+        if args.json_path:
+            with open(args.json_path, "w") as handle:
+                json.dump(result, handle, indent=2, sort_keys=True)
+        print("container %s left in place; remove it yourself once its evidence is read" % name)
+
+    # Refuse a tally over the wrong number of checks. A suite that emitted one
+    # line grades half of what it claims, and its exit code would not say so.
+    if len(EMITTED) != 2:
+        print("capped_brownfield_init: SETUP emitted %d check lines, expected 2"
+              % len(EMITTED), file=sys.stderr)
+        return 3
+    if "FAIL" in EMITTED:
+        return 1
+    if "UNREADABLE" in EMITTED:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
`current_authority_admission` opened the whole repository authority on every call, and its three callers reach it independently from concurrent tasks. An open decodes the entire persisted authority and re-verifies every body in repository CAS, so on a converted psf/requests store this was the dominant cost of `kin graph status` and it is what kills the daemon at the documented 16 GB minimum.

## What was measured before the change

`sample` on the repo daemon during the cadence, seven funnel callers in one four-second sample:

```
6  kin_daemon::loop_runner::current_authority_admission
1  kin_daemon::daemon::run_with_authority_on
```

**Six tokio worker threads inside that one function at the same instant**, each below it in `open_persisted_local_repository_authority`. The opens arrive at a fixed 2.205 second cadence, which is not a timer: kin-daemon has no such constant, and `GRAPH_STATUS_ATTEMPT_BACKOFF` caps at 400 ms over three attempts. 2.205 s is what one whole-store open costs warm there, so the events are concurrent requests serialized one at a time.

Cold `kin graph status`, funnel opens by caller, candidate `9375a2450`, two runs from fresh store copies:

| run | status #1 opens | elapsed | at `lra.rs:53` |
|---|---|---|---|
| cand1 | 12 | 60.7 s | 9 |
| cand2 | 37 | 158.0 s | 34 |

The count is a draw from a distribution, not a figure, and the PR does not claim a delta on it.

At the documented 16 GB minimum, converting psf/requests at `5460f467b0` from the v0.6.2 candidate archive: **`memory.peak` 13.56 GiB against a 16.00 GiB cap read from the cgroup, `oom_kill 1`, `OOMKilled=true`**, init rc 7, and the product's own sentence, "The daemon for this store was killed by the memory limit 1 time(s)". `kin doctor` reads Memory floor DEGRADED and Daemon kills DEGRADED.

## What this does

The admission pair is resolved once per PUBLICATION and shared, rather than once per task. `ProjectionAuthorityCache` gains a fourth slot beside its three wrappers, keyed on `LocalPublicationIdentity` and invalidated the way every other slot there is.

Correctness rests on a property the design already states: `ResolvedAdmissionMatcher` documents itself as **"A compiled, immutable admission-policy generation"**, and a root bundle cannot differ between tasks inside one publication either. So the cost was being paid per arrival for an answer that could not vary.

`cached_authority_admission` is written beside `command_repository_authority` **in the same shape on purpose**, so a reviewer can diff the two rather than take the ordering on trust: read the publication, try the slot, take the load gate, re-read under it because the publication may have moved while the request waited, try again, then open once and install.

## Falsification

Two arms, each killed by its own mutation:

| mutation | sequential arm | concurrent arm |
|---|---|---|
| **M1** `reuse_admission` always misses | **RED** `left: 9 right: 1` | not reached |
| **M2** no load gate, no re-read | green | **RED** `left: 8 right: 1`, three runs |

**M2 first survived, three runs green**, and that is why the test looks the way it does. The concurrent arm was written against the warm state the sequential arm leaves behind, so all eight tasks hit a populated slot and never reached the load gate. It was a second reading of the sequential assertion wearing the name of a burst test. Rewritten to start on a cold state of its own, it dies to M2 every time. The comment in the test says so, so the next reader does not reuse the state above it.

## The acceptance suite creates its own cap

`scripts/acceptance/capped_brownfield_init.py`, behind `--run`, about twelve minutes, for the preflight's host leg and the stranger rather than the per-PR gate.

The other memory suites read `memory.max` through this process's binding cgroup, and a hosted runner has no cap, so **Acceptance has never measured anything at 16 GB on any runner**. That is why a stranger in a capped container found this and CI did not. This suite does not read a ceiling, it creates one, and prints the cap beside every result so a 64 GB host and a 16 GB host grade the same thing.

Two checks because they fail differently: the cgroup's `oom_kill` counter is the fact, the product's sentence is what a partner reads. `memory.peak` is reported and **not** graded, because the arm that produced this suite read 13.56 GiB under a 16.00 GiB cap on a run the cgroup's own OOM killer killed. Peak equal to max is sufficient evidence of a cap kill and not necessary; only `oom_kill` decides.

## The capped 16 GiB arm, before and after

Same VM with nothing else running, same `--memory 16g` with the cap read from the cgroup rather than the flag, same psf/requests at `5460f467b0`, both from a linux-aarch64 release archive with the version string read back before each clock started.

|  | BEFORE `65d07b1d1` | AFTER `badc2134c` |
|---|---|---|
| `memory.max` | 16.00 GiB | 16.00 GiB |
| **`memory.peak`** | **16.00 GiB**, the cap to the byte | **7.74 GiB** |
| `max` | 6517 | **0** |
| `oom` | 1 | **0** |
| `oom_kill` | 1 | **0** |
| init | **rc 7**, 859 s | **rc 0**, 1006 s |
| `OOMKilled` | true | **false** |

`max` going 6517 to zero is the strongest number here: the patched run's cgroup never once blocked an allocation, and it finished 8.26 GiB below its ceiling.

The product's own sentences agree. Before: *"and a daemon serving this store was killed"*, plus *"The daemon for this store was killed by the memory limit 1 time(s); cap 16.0 GiB"*. After: neither, count zero. `kin doctor` moves from **Daemon kills DEGRADED** to **Daemon kills ok, "no daemon serving this store has been killed"**.

### What this does NOT fix

Enrichment still reads **partial, "completion not attested"**, and doctor still reads **Reference edge coverage STALE**. Doctor names the cause and it is not memory: *"no language server found for rust (rust-analyzer), python (pyright-langserver or pylsp), typescript, javascript"*. That gap is present at any cap and has its own ticket. **This change does not close it.**

### Three things this does not claim

The longer wall time is **not** a regression. The before arm exited early because it died at 859 seconds; a run that finishes takes longer than one that is killed.

**One run each.** The open counts on this path vary 2.6x on identical bytes, and the container arm has not been repeated, so 7.74 GiB is a reading rather than a range.

**The arm graded `badc2134c`; this PR's head is `9b4acca4d`.** They differ by exactly two characters, the braces rustfmt removed from around a single-expression closure body, checked with all whitespace stripped and with a control proving the comparison can detect a real difference. The arm did not grade the head and this body does not imply it did.

Refs FIR-2988
