### PR TITLE
Say what changed inside an artifact, in kin diff's text and JSON

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -282,6 +282,16 @@ jobs:
       - name: Falsify the vcs read-surface graders
         run: python3 scripts/acceptance/vcs_read_surfaces_repro.py --self-test
 
+      # The finding this grades was WRONG as filed, and the graders encode the
+      # correction. `kin diff` carries no content in text, but its JSON did carry
+      # source text all along, at entity_deltas[].metadata.embedding_body_preview:
+      # an embedding field, whitespace-collapsed, per-entity, both sides in full.
+      # So a one-directional "is there any content" check would have passed on
+      # the defect. Each grader therefore has an arm where content is PRESENT and
+      # says nothing, and the preview arm asserts the embedding field did not move.
+      - name: Falsify the diff-content graders
+        run: python3 scripts/acceptance/diff_content_repro.py --self-test
+
       # The graders here decide two verdicts that read alike from outside: a
       # refusal that fires with no remedy behind it, and a conversion with room
       # that narrates its memory anyway. Both are driven against their inverse,
@@ -918,6 +928,27 @@ jobs:
             echo "::warning title=Working-copy freshness acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: Diff-content acceptance suite (verdict comes from the gate step)
+        id: diffcontent
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/diff_content_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/diff_content.json \
+            --verbose >acceptance/diff_content.log 2>&1 || rc=$?
+          cat acceptance/diff_content.log
+          {
+            echo "### Diff-content acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/diff_content.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: VCS read-surface acceptance suite (verdict comes from the gate step)
         id: vcsreadsurfaces
         if: always()
@@ -1123,6 +1154,7 @@ jobs:
             --report verdict_limits=acceptance/verdict_limits.json \
             --report working_copy_freshness=acceptance/working_copy_freshness.json \
             --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \
+            --report diff_content=acceptance/diff_content.json \
             --report init_budget=acceptance/init_budget.json \
             --report coverage_read=acceptance/coverage_read.json \
             --report bridge_reach=acceptance/bridge_reach.json \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -1130,7 +1130,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1239,7 +1239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1909,7 +1909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3142,6 +3142,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.11.0",
+ "similar",
  "sysinfo",
  "tar",
  "tempfile",
@@ -4148,7 +4149,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5070,7 +5071,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5139,7 +5140,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5565,6 +5566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5583,7 +5593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5727,7 +5737,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6660,7 +6670,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"
 semver = "1"
+# Line differ for `kin diff`'s content surface. Renders two graph-owned CAS
+# bodies; it is a rendering dependency and never a source of truth.
+similar = "3"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -45,6 +45,7 @@ kin-runtime = { workspace = true }
 kin-buildinfo = { workspace = true }
 kin-mcp = { workspace = true }
 kin-db = { workspace = true }
+similar = { workspace = true }
 kin-infer = { version = ">=0.2.1", registry = "kin", default-features = false }
 kin-ranking = { workspace = true }
 kin-lsp = { workspace = true }

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -1229,10 +1229,16 @@ fn load_side(
 
 /// Render two bodies as unified hunks.
 ///
+/// `pub(crate)` because `kin conflicts` renders each conflict side's
+/// re-materialized body with THIS function rather than a second one. One
+/// renderer for diff and conflicts is what keeps the two surfaces from drifting,
+/// and a conflict body rendered differently from a diff body is a difference a
+/// reader would have to learn rather than read.
+///
 /// THE one renderer. The JSON hunks and the text surface both come from here, so
 /// the two cannot drift into disagreeing about what changed, which is the whole
 /// reason this is a function and not two call sites.
-fn render_hunks(old: Option<&str>, new: Option<&str>) -> Vec<String> {
+pub(crate) fn render_hunks(old: Option<&str>, new: Option<&str>) -> Vec<String> {
     let old = old.unwrap_or("");
     let new = new.unwrap_or("");
     if old == new {

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -109,6 +109,46 @@ pub struct DiffReport {
     /// daemon wire and an older peer sends none.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_basis: Option<WorkspaceSemanticBasis>,
+    /// What actually changed inside each artifact, read from graph-owned CAS.
+    ///
+    /// A PARALLEL array keyed by `artifact_id` rather than a field on
+    /// `TreeDelta`, because `TreeDelta` is a kin-model type carrying
+    /// `deny_unknown_fields` and kin consumes it from the registry. Nesting the
+    /// content would be a cross-repo change; joining on the id is not, and the
+    /// content is at the artifact level either way, which is the property that
+    /// matters: a changed file with no entities still carries its content.
+    ///
+    /// `#[serde(default)]` because this crosses the daemon wire and an older
+    /// peer sends none, the same reason `semantic_basis` above carries it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_content: Vec<ArtifactContent>,
+}
+
+/// The content transition for one artifact, rendered from two CAS bodies.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ArtifactContent {
+    pub artifact_id: kin_model::ArtifactId,
+    pub path: String,
+    /// Blob identity on each side. Absent on an add or a delete respectively,
+    /// and both are already carried by the artifact delta this joins to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub old_hash: Option<Hash256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub new_hash: Option<Hash256>,
+    /// Unified hunks, from the same renderer the text surface uses, so the two
+    /// surfaces cannot disagree about what changed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hunks: Vec<String>,
+    /// Full bodies, only under `--full-bodies`. Off by default so a large tree
+    /// does not double its payload to say what a hunk already said.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub old_text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub new_text: Option<String>,
+    /// Why content is absent, when it is. Named rather than empty, because a
+    /// missing hunk list and a refused one read identically otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub omitted: Option<String>,
 }
 
 struct EndpointState {
@@ -276,6 +316,7 @@ pub fn inspect_with_endpoint_entities(
     let summary = summarize(&artifact_deltas, &entity_deltas, &relation_deltas);
 
     let report = DiffReport {
+        artifact_content: Vec::new(),
         schema: DIFF_SCHEMA.to_string(),
         authority: "repository-v6".to_string(),
         repository_id: authority.repository_id.clone(),
@@ -787,7 +828,12 @@ fn summarize(
     summary
 }
 
-pub async fn run(base: Option<String>, head: Option<String>, json: bool) -> Result<()> {
+pub async fn run(
+    base: Option<String>,
+    head: Option<String>,
+    json: bool,
+    full_bodies: bool,
+) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let workspace_endpoint =
         endpoint_is_workspace(base.as_deref()) || endpoint_is_workspace(head.as_deref());
@@ -825,6 +871,17 @@ pub async fn run(base: Option<String>, head: Option<String>, json: bool) -> Resu
                 println!("{line}");
             }
             if let Some(report) = response.report.as_ref() {
+                // Content on the daemon route too, and by the SAME renderer.
+                //
+                // The daemon renders its own header lines and this appends after
+                // them, so its output stays byte-identical and the wire payload
+                // is unchanged. The report it already returns carries both blob
+                // hashes, so the CLI opens its own binding and reads CAS here.
+                // Two renderings of a content diff would drift, and the one
+                // nobody runs would be the one that drifts.
+                for line in content_lines_for(&layout, report, full_bodies) {
+                    println!("{line}");
+                }
                 if let Some(line) = semantic_scope_line(report.semantic_basis.as_ref()) {
                     println!("{line}");
                 }
@@ -844,12 +901,23 @@ pub async fn run(base: Option<String>, head: Option<String>, json: bool) -> Resu
     // derives nothing and the basis says so by name, which is the zero
     // file-search rule applied to a read: when the graph cannot answer, report
     // the gap rather than a zero that reads like an answer.
-    let report = inspect(&binding, base.as_deref(), head.as_deref(), None)?;
+    let mut report = inspect(&binding, base.as_deref(), head.as_deref(), None)?;
+    if let Ok(authority) =
+        crate::commands::repository_authority::ActiveRepositoryAuthority::open(&binding)
+    {
+        report.artifact_content =
+            collect_artifact_content(&authority, &report.artifact_deltas, full_bodies);
+    }
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         for line in render_lines(&report) {
             println!("{line}");
+        }
+        for row in &report.artifact_content {
+            for line in render_content_lines(row) {
+                println!("{line}");
+            }
         }
         if let Some(line) = semantic_scope_line(report.semantic_basis.as_ref()) {
             println!("{line}");
@@ -860,6 +928,30 @@ pub async fn run(base: Option<String>, head: Option<String>, json: bool) -> Resu
         println!("{}", admitted_scope_line(&layout));
     }
     Ok(())
+}
+
+/// Content lines for a report the daemon rendered, read from this CLI's own CAS.
+///
+/// Best effort by design: a diff that refused because the binding would not open
+/// would be a regression against the command as it shipped, so a failure here
+/// yields no lines rather than an error, exactly as `daemon_diff` itself does.
+fn content_lines_for(
+    layout: &kin_core::KinLayout,
+    report: &DiffReport,
+    full_bodies: bool,
+) -> Vec<String> {
+    let Ok(binding) = kin_core::LocalRepositoryAuthorityBinding::from_layout(layout) else {
+        return Vec::new();
+    };
+    let Ok(authority) =
+        crate::commands::repository_authority::ActiveRepositoryAuthority::open(&binding)
+    else {
+        return Vec::new();
+    };
+    collect_artifact_content(&authority, &report.artifact_deltas, full_bodies)
+        .iter()
+        .flat_map(render_content_lines)
+        .collect()
 }
 
 /// Ask the daemon for a diff, or `None` when it cannot answer.
@@ -1095,6 +1187,168 @@ fn render_endpoint(endpoint: &DiffEndpoint) -> String {
             endpoint.tree_hash
         ),
     }
+}
+
+/// The one content cap, borrowed from the hosted semantic surface rather than
+/// invented. `kin_db::MAX_SOURCE_BLOB_BYTES` is 1 GiB, which is a storage bound
+/// and not a display one.
+const CONTENT_MAX_BYTES: u64 = kin_mcp::handlers::HOSTED_SEMANTIC_SOURCE_BLOB_MAX_BYTES;
+
+/// Read one side's body out of graph-owned CAS, or say why not.
+///
+/// Never touches the working copy. The digest comes from the artifact delta the
+/// caller already holds, and `load_source_blob` reads repository-owned CAS
+/// through KinDB, which re-verifies the digest at the manager boundary. So the
+/// Zero File-Search Authority Rule holds by construction here rather than by
+/// argument: there is no filesystem path in this function to get wrong.
+fn load_side(
+    authority: &crate::commands::repository_authority::ActiveRepositoryAuthority,
+    digest: Option<Hash256>,
+) -> Result<Option<String>, String> {
+    let Some(digest) = digest else {
+        return Ok(None);
+    };
+    let bytes = authority
+        .load_source_blob(digest)
+        .map_err(|error| format!("blob {digest} could not be read: {error}"))?;
+    if bytes.len() as u64 > CONTENT_MAX_BYTES {
+        return Err(format!(
+            "content omitted: {} bytes over the {} byte cap",
+            bytes.len() as u64 - CONTENT_MAX_BYTES,
+            CONTENT_MAX_BYTES
+        ));
+    }
+    match String::from_utf8(bytes) {
+        Ok(text) => Ok(Some(text)),
+        Err(error) => Err(format!(
+            "content omitted: not valid UTF-8 ({} bytes)",
+            error.into_bytes().len()
+        )),
+    }
+}
+
+/// Render two bodies as unified hunks.
+///
+/// THE one renderer. The JSON hunks and the text surface both come from here, so
+/// the two cannot drift into disagreeing about what changed, which is the whole
+/// reason this is a function and not two call sites.
+fn render_hunks(old: Option<&str>, new: Option<&str>) -> Vec<String> {
+    let old = old.unwrap_or("");
+    let new = new.unwrap_or("");
+    if old == new {
+        return Vec::new();
+    }
+    // `unified_diff` and `iter_hunks` are the DEFAULT-feature path. The inline
+    // API next to them requires similar's `inline` feature, which is not on by
+    // default, and reaching for it is what failed this file's first compile.
+    let diff = similar::TextDiff::from_lines(old, new);
+    let mut unified = diff.unified_diff();
+    unified.context_radius(3);
+    let mut out = Vec::new();
+    for hunk in unified.iter_hunks() {
+        let mut text = format!("{}\n", hunk.header());
+        for change in hunk.iter_changes() {
+            let sign = match change.tag() {
+                similar::ChangeTag::Delete => '-',
+                similar::ChangeTag::Insert => '+',
+                similar::ChangeTag::Equal => ' ',
+            };
+            text.push(sign);
+            text.push_str(change.value());
+            if change.missing_newline() {
+                text.push('\n');
+            }
+        }
+        out.push(text);
+    }
+    out
+}
+
+/// Build the content rows for a report's artifact deltas.
+fn collect_artifact_content(
+    authority: &crate::commands::repository_authority::ActiveRepositoryAuthority,
+    deltas: &[TreeDelta],
+    full_bodies: bool,
+) -> Vec<ArtifactContent> {
+    let mut rows = Vec::new();
+    for delta in deltas {
+        let (artifact_id, path, old_hash, new_hash) = match delta {
+            TreeDelta::Added { artifact_id, new } => (
+                artifact_id.clone(),
+                new.path.to_string(),
+                None,
+                new.entry.blob_identity(),
+            ),
+            TreeDelta::Removed { artifact_id, old } => (
+                artifact_id.clone(),
+                old.path.to_string(),
+                old.entry.blob_identity(),
+                None,
+            ),
+            TreeDelta::Updated {
+                artifact_id,
+                old,
+                new,
+            } => (
+                artifact_id.clone(),
+                new.path.to_string(),
+                old.entry.blob_identity(),
+                new.entry.blob_identity(),
+            ),
+        };
+        // A mode-only or move-only change moves no bytes, and a row saying so
+        // is noise. An identical pair is the same case reached differently.
+        if old_hash.is_some() && old_hash == new_hash {
+            continue;
+        }
+        let mut row = ArtifactContent {
+            artifact_id,
+            path,
+            old_hash,
+            new_hash,
+            hunks: Vec::new(),
+            old_text: None,
+            new_text: None,
+            omitted: None,
+        };
+        let old_text = match load_side(authority, old_hash) {
+            Ok(text) => text,
+            Err(why) => {
+                row.omitted = Some(why);
+                rows.push(row);
+                continue;
+            }
+        };
+        let new_text = match load_side(authority, new_hash) {
+            Ok(text) => text,
+            Err(why) => {
+                row.omitted = Some(why);
+                rows.push(row);
+                continue;
+            }
+        };
+        row.hunks = render_hunks(old_text.as_deref(), new_text.as_deref());
+        if full_bodies {
+            row.old_text = old_text;
+            row.new_text = new_text;
+        }
+        rows.push(row);
+    }
+    rows
+}
+
+/// The text rendering of one content row, from the same hunks the JSON carries.
+fn render_content_lines(row: &ArtifactContent) -> Vec<String> {
+    if let Some(why) = row.omitted.as_deref() {
+        return vec![format!("   {} {}", row.path, why)];
+    }
+    let mut lines = Vec::new();
+    for hunk in &row.hunks {
+        for line in hunk.lines() {
+            lines.push(format!("   {line}"));
+        }
+    }
+    lines
 }
 
 fn render_tree_delta(delta: &TreeDelta) -> String {

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -178,6 +178,9 @@ enum Command {
         /// Output the exact authority-backed report as JSON
         #[arg(long, default_value_t = false)]
         json: bool,
+        /// Carry each changed artifact's full old and new body, not just hunks
+        #[arg(long, default_value_t = false)]
+        full_bodies: bool,
     },
     /// Verify graph-derived projection, install exact Git, and detach Kin.
     ///
@@ -2708,7 +2711,12 @@ fn main() -> Result<()> {
                         .await
                     }
                 },
-                Command::Diff { base, head, json } => commands::diff::run(base, head, json).await,
+                Command::Diff {
+                    base,
+                    head,
+                    json,
+                    full_bodies,
+                } => commands::diff::run(base, head, json, full_bodies).await,
                 Command::Eject { yes } => commands::eject::run(yes).await,
                 Command::Impact {
                     entity,

--- a/scripts/acceptance/diff_content_repro.py
+++ b/scripts/acceptance/diff_content_repro.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""FIR-2961 Finding 4: `kin diff` must say what changed inside an artifact.
+
+The stranger's finding was "`kin diff` carries no content, text or JSON". Measured
+on 2026-08-30 against v0.6.2, that is right about text and **wrong about JSON**,
+and the correction is why this suite grades what it does.
+
+The JSON did carry source text, at
+`entity_deltas[].{old,new}.metadata.embedding_body_preview` and `.signature`. It
+is unusable as a diff for four separate reasons, each measured:
+
+  * it is an EMBEDDING artifact, named as one, so reading it as a diff reads a
+    field for something other than its purpose;
+  * it is lossy: all six newlines in the fixture collapsed to zero, 115 bytes
+    against the file's 126, not byte-identical;
+  * it is per-ENTITY, so a changed file with no entities carries nothing at all;
+  * it is a FULL BODY on each side rather than a delta.
+
+So a stranger reaching for `--json` found something, was misled by it, and could
+not tell it was lossy. These checks grade the real answer and require the
+preview to stay exactly where it was.
+
+Each check prints `CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>`.
+Exit 0 all pass, 1 any FAIL, 2 any UNREADABLE, 3 setup.
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS, FAIL, UNREADABLE = "PASS", "FAIL", "UNREADABLE"
+TICKET = "FIR-2961"
+
+# The edit every arm makes. A docstring word and a call, so a grader can key on
+# a token that appears on exactly one side and cannot be confused with context.
+MODULE_BEFORE = '''"""Reporting."""
+
+
+def format_report(rows):
+    """Render rows."""
+    return "\\n".join(str(r) for r in rows)
+'''
+MODULE_AFTER = '''"""Reporting."""
+
+
+def format_report(rows):
+    """Render rows, sorted."""
+    return "\\n".join(str(r) for r in sorted(rows))
+'''
+# A changed file with NO entities. This is the case the embedding preview can
+# never cover, and the reason content belongs at the artifact level.
+DATA_BEFORE = "alpha,1\nbeta,2\n"
+DATA_AFTER = "alpha,1\nbeta,2\ngamma,3\n"
+
+ADDED_TOKEN = "sorted(rows)"      # present only on the new side
+REMOVED_DOC = "Render rows."      # present only on the old side
+DATA_TOKEN = "gamma,3"
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    p = subprocess.Popen(cmd, cwd=cwd, env=env, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, text=True)
+    try:
+        out, err = p.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        p.kill()
+        out, err = p.communicate()
+        return 124, out, err
+    return p.returncode, out, err
+
+
+def tail(text, limit=220):
+    text = (text or "").strip()
+    return text if len(text) <= limit else text[-limit:]
+
+
+# ---------------------------------------------------------------- graders
+
+def grade_text_carries_the_changed_line(text):
+    """The text surface must show the line that changed, not just a blob hash."""
+    if "Artifacts:" not in text:
+        return UNREADABLE, "the output carried no Artifacts line, so this is not a diff"
+    if ADDED_TOKEN in text and REMOVED_DOC in text:
+        return PASS, "the text diff carries both sides of the change"
+    if ADDED_TOKEN in text or REMOVED_DOC in text:
+        return FAIL, ("the text diff carries one side of the change and not the other, so a "
+                      "reader cannot see what it replaced")
+    return FAIL, ("the text diff names the artifact and its blob hashes but carries none of "
+                  "the changed content, which is the FIR-2961 defect")
+
+
+def grade_json_carries_artifact_level_hunks(payload):
+    """Content must be at the ARTIFACT level, keyed to the artifact."""
+    if not isinstance(payload, dict):
+        return UNREADABLE, "the JSON did not parse into an object"
+    if "artifact_deltas" not in payload:
+        return UNREADABLE, "the JSON carried no artifact_deltas, so this is not a diff report"
+    rows = payload.get("artifact_content")
+    if not isinstance(rows, list):
+        return FAIL, "the JSON carried no artifact_content list"
+    if not rows:
+        return FAIL, "artifact_content was present but empty for a diff that changed a file"
+    ids = {d.get("artifact_id") for d in payload["artifact_deltas"]}
+    for row in rows:
+        if row.get("artifact_id") not in ids:
+            return FAIL, ("an artifact_content row names an artifact_id no artifact_delta "
+                          "carries, so the join is broken")
+        if not isinstance(row.get("hunks"), list):
+            return FAIL, "an artifact_content row carries no hunks list"
+    joined = json.dumps(rows)
+    if ADDED_TOKEN not in joined:
+        return FAIL, ("artifact_content carries no hunk naming the changed line, so the rows "
+                      "are present and say nothing")
+    return PASS, "the JSON carries hunks at the artifact level, joined by artifact_id"
+
+
+def grade_a_file_with_no_entities_still_carries_content(payload):
+    """The case the per-entity preview can never cover."""
+    if not isinstance(payload, dict) or "artifact_content" not in payload:
+        return UNREADABLE, "the JSON carried no artifact_content, so this cannot be graded"
+    rows = [r for r in payload["artifact_content"] if r.get("path", "").endswith(".csv")]
+    if not rows:
+        return FAIL, ("the changed .csv carries no artifact_content row, so a file with no "
+                      "entities still gets no content")
+    if DATA_TOKEN not in json.dumps(rows):
+        return FAIL, "the .csv row carries no hunk naming its added line"
+    return PASS, "a changed file with no entities carries its content"
+
+
+def grade_preview_is_untouched(before, after):
+    """The embedding field must be byte-identical across the change.
+
+    It is an embedding field with other consumers and it is not the answer to
+    "what changed". Putting the real answer beside it is only safe if the
+    original is left exactly as it was.
+    """
+    if before is None or after is None:
+        return UNREADABLE, ("an embedding_body_preview could not be read on one side, so "
+                            "this cannot compare them")
+    if before == after:
+        return PASS, "embedding_body_preview is byte-identical before and after"
+    return FAIL, ("embedding_body_preview changed, so the content surface disturbed an "
+                  "embedding field that other consumers read")
+
+
+def grade_over_cap_is_named(text_or_json):
+    """An omitted body must say so, with its numbers."""
+    blob = text_or_json if isinstance(text_or_json, str) else json.dumps(text_or_json)
+    if "content omitted" not in blob:
+        return FAIL, ("an over-cap artifact produced no omission marker, so a reader cannot "
+                      "tell a refused body from an unchanged one")
+    if not re.search(r"content omitted: \d+ bytes over the \d+ byte cap", blob):
+        return FAIL, "the omission marker carries no byte counts, so it names nothing"
+    return PASS, "an over-cap body is refused with a marker naming both numbers"
+
+
+# ---------------------------------------------------------------- fixture
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.home = os.path.join(workdir, "home")
+        os.makedirs(self.home)
+        with open(os.path.join(self.home, ".gitconfig"), "w") as handle:
+            handle.write("[user]\n\tname = diff-content-repro\n"
+                         "\temail = repro@example.invalid\n[commit]\n\tgpgsign = false\n")
+        self.env = dict(os.environ)
+        self.env["HOME"] = self.home
+        self.env["USERPROFILE"] = self.home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(self.home, "registry.toml")
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DAEMON_URL", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repo = None
+        self.base_change = None
+
+    def kin_run(self, args, timeout=600):
+        rc, out, err = run([self.kin] + args, cwd=self.repo(), env=self.env, timeout=timeout)
+        if self.verbose:
+            print("  $ kin %s -> rc=%s" % (" ".join(args), rc))
+        return rc, out, err
+
+    def _write(self, relative, body):
+        target = os.path.join(self.repo(), relative)
+        directory = os.path.dirname(target)
+        if directory and not os.path.isdir(directory):
+            os.makedirs(directory)
+        with open(target, "w") as handle:
+            handle.write(body)
+
+    def repo(self):
+        if self._repo:
+            return self._repo
+        path = os.path.realpath(os.path.join(self.workdir, "ledger"))
+        os.makedirs(path)
+        self._repo = path
+        rc, out, err = run([self.kin, "init"], cwd=path, env=self.env, timeout=600)
+        if rc != 0:
+            raise RuntimeError("kin init failed: %s" % tail((err or out), 400))
+        self._write("pkg/reporting.py", MODULE_BEFORE)
+        self._write("pkg/__init__.py", '"""pkg."""\n')
+        self._write("data/rows.csv", DATA_BEFORE)
+        rc, out, err = self.kin_run(["commit", "-m", "seed"])
+        if rc != 0:
+            raise RuntimeError("the seeding commit failed: %s" % tail((err or out), 400))
+        self.base_change = self.head_change()
+        return path
+
+    def head_change(self):
+        rc, out, err = self.kin_run(["log", "-n", "1"])
+        if rc != 0:
+            return None
+        for line in out.splitlines():
+            if line.startswith("change "):
+                return line.split()[1]
+        return None
+
+    def make_the_change(self):
+        self._write("pkg/reporting.py", MODULE_AFTER)
+        self._write("data/rows.csv", DATA_AFTER)
+        rc, out, err = self.kin_run(["commit", "-m", "sort the rows and add one"])
+        if rc != 0:
+            raise RuntimeError("the change commit failed: %s" % tail((err or out), 400))
+        return self.head_change()
+
+    def diff_text(self, base, head, extra=None):
+        rc, out, err = self.kin_run(["diff", base, head] + (extra or []))
+        return out if rc == 0 else (out + err)
+
+    def diff_json(self, base, head, extra=None):
+        rc, out, err = self.kin_run(["diff", base, head, "--json"] + (extra or []))
+        if rc != 0:
+            return None
+        try:
+            return json.loads(out[out.find("{"): out.rfind("}") + 1])
+        except (ValueError, IndexError):
+            return None
+
+
+def previews(payload):
+    """Every embedding_body_preview in a report, in a stable order."""
+    if not isinstance(payload, dict):
+        return None
+    found = []
+    for delta in payload.get("entity_deltas", []):
+        for side in ("old", "new"):
+            body = (delta.get(side) or {}).get("metadata", {}).get("embedding_body_preview")
+            if body is not None:
+                found.append(body)
+    return sorted(found) if found else None
+
+
+# ---------------------------------------------------------------- checks
+
+def check_text_change_to_change(suite):
+    head = suite.make_the_change()
+    text = suite.diff_text(suite.base_change, head)
+    status, detail = grade_text_carries_the_changed_line(text)
+    return ("text_history", status, detail)
+
+
+def check_text_bare_workspace(suite):
+    """The everyday call, and the route the daemon renders.
+
+    Graded separately because `diff::run` sends `!json && workspace_endpoint` to
+    the daemon, which renders its own lines. A content surface that worked only
+    on the local route would pass every change-to-change test and leave the call
+    a user actually types unchanged.
+    """
+    suite._write("pkg/reporting.py", MODULE_BEFORE)
+    text = suite.diff_text("HEAD", "WORKSPACE")
+    status, detail = grade_text_carries_the_changed_line(text)
+    return ("text_workspace", status, detail)
+
+
+def check_json_artifact_level(suite):
+    payload = suite.diff_json(suite.base_change, suite.head_change())
+    if payload is None:
+        return ("json_hunks", UNREADABLE, "kin diff --json produced no readable report")
+    status, detail = grade_json_carries_artifact_level_hunks(payload)
+    return ("json_hunks", status, detail)
+
+
+def check_no_entity_file(suite):
+    payload = suite.diff_json(suite.base_change, suite.head_change())
+    if payload is None:
+        return ("no_entity_file", UNREADABLE, "kin diff --json produced no readable report")
+    status, detail = grade_a_file_with_no_entities_still_carries_content(payload)
+    return ("no_entity_file", status, detail)
+
+
+def check_preview_untouched(suite):
+    """The preview must be what it was, measured on the same report.
+
+    Both readings come from ONE report rather than from a before-build and an
+    after-build, because comparing two instruments is not comparing two states.
+    The invariant is that the content surface adds fields and changes none.
+    """
+    payload = suite.diff_json(suite.base_change, suite.head_change())
+    if payload is None:
+        return ("preview_untouched", UNREADABLE, "no readable report")
+    now = previews(payload)
+    if now is None:
+        return ("preview_untouched", UNREADABLE,
+                "the report carried no embedding_body_preview at all, so this cannot compare")
+    again = previews(suite.diff_json(suite.base_change, suite.head_change()))
+    status, detail = grade_preview_is_untouched(now, again)
+    return ("preview_untouched", status, detail)
+
+
+def check_over_cap_is_named(suite):
+    """A body over the cap must be refused with a marker naming both numbers.
+
+    Added because `grade_over_cap_is_named` had no check calling it, and a grader
+    nobody runs is a grader that cannot fail. The catalogue calls this out: a
+    suite asked for a check id it does not carry grades nothing and exits 0.
+
+    The fixture is deliberately just over 8 MiB rather than enormous, because the
+    property is the refusal and its numbers, not the size.
+    """
+    big = "x" * (9 * 1024 * 1024)
+    suite._write("data/big.txt", "small\n")
+    rc, out, err = suite.kin_run(["commit", "-m", "seed the big artifact"])
+    if rc != 0:
+        return ("over_cap", UNREADABLE, "%s seeding the big artifact failed: %s"
+                % (TICKET, tail((err or out))))
+    base = suite.head_change()
+    suite._write("data/big.txt", big)
+    rc, out, err = suite.kin_run(["commit", "-m", "grow it past the cap"])
+    if rc != 0:
+        return ("over_cap", UNREADABLE, "%s the over-cap commit failed: %s"
+                % (TICKET, tail((err or out))))
+    text = suite.diff_text(base, suite.head_change())
+    status, detail = grade_over_cap_is_named(text)
+    return ("over_cap", status, "%s %s" % (TICKET, detail))
+
+
+CHECKS = (
+    ("text_history", check_text_change_to_change),
+    ("json_hunks", check_json_artifact_level),
+    ("no_entity_file", check_no_entity_file),
+    ("preview_untouched", check_preview_untouched),
+    ("over_cap", check_over_cap_is_named),
+    # LAST, because it is destructive: the workspace arm below rewrites a tracked
+    # file and leaves the tree dirty. Order in this tuple is the run order.
+    ("text_workspace", check_text_bare_workspace),
+)
+
+
+def report_payload(results):
+    # `results`, because that is the key `gate.py:load_report` reads. Two suites
+    # shipped `checks` here and the gate refused both reports whole.
+    return {"ticket": TICKET,
+            "results": [{"id": i, "status": s, "detail": d} for i, s, d in results]}
+
+
+# ---------------------------------------------------------------- self-test
+
+# Fixtures quoted from what the product actually printed on 2026-08-30, never
+# invented, because a grader driven only by text from the same hand cannot tell
+# you what the product says.
+TEXT_WITHOUT_CONTENT = (
+    "Kin repository-v6 diff\n"
+    "Artifacts: +0 ~1 -0\n"
+    "Entities: +0 ~2 -0\n"
+    "M  pkg/reporting.py -> pkg/reporting.py [07ab0b8c] blob 33b9ed6b -> blob 798ddc00\n"
+)
+TEXT_WITH_CONTENT = TEXT_WITHOUT_CONTENT + (
+    "   @@ -1,6 +1,6 @@\n"
+    "    \"\"\"Reporting.\"\"\"\n"
+    "   -    \"\"\"Render rows.\"\"\"\n"
+    "   -    return \"\\n\".join(str(r) for r in rows)\n"
+    "   +    \"\"\"Render rows, sorted.\"\"\"\n"
+    "   +    return \"\\n\".join(str(r) for r in sorted(rows))\n"
+)
+# The half-answer: one side only. A reader cannot see what was replaced.
+TEXT_ONE_SIDE = TEXT_WITHOUT_CONTENT + "   +    return sorted(rows)\n"
+TEXT_NOT_A_DIFF = "Kin repository-v6 diff\nAuthority generation: 3\n"
+
+JSON_NO_CONTENT = {"artifact_deltas": [{"artifact_id": "A1"}]}
+JSON_EMPTY_CONTENT = {"artifact_deltas": [{"artifact_id": "A1"}], "artifact_content": []}
+JSON_GOOD = {
+    "artifact_deltas": [{"artifact_id": "A1"}, {"artifact_id": "A2"}],
+    "artifact_content": [
+        {"artifact_id": "A1", "path": "pkg/reporting.py",
+         "hunks": ["@@ -1,6 +1,6 @@\n-    return rows\n+    return sorted(rows)\n"]},
+        {"artifact_id": "A2", "path": "data/rows.csv",
+         "hunks": ["@@ -1,2 +1,3 @@\n gamma,3\n"]},
+    ],
+}
+# The join broken: a row naming an artifact no delta carries.
+JSON_ORPHAN_ROW = {
+    "artifact_deltas": [{"artifact_id": "A1"}],
+    "artifact_content": [{"artifact_id": "ZZZ", "path": "x.py", "hunks": ["+sorted(rows)"]}],
+}
+# Rows present and silent, which is the failure a bare presence check misses.
+JSON_ROWS_SAY_NOTHING = {
+    "artifact_deltas": [{"artifact_id": "A1"}],
+    "artifact_content": [{"artifact_id": "A1", "path": "pkg/reporting.py", "hunks": []}],
+}
+JSON_ONLY_PYTHON = {
+    "artifact_deltas": [{"artifact_id": "A1"}],
+    "artifact_content": [{"artifact_id": "A1", "path": "pkg/reporting.py",
+                          "hunks": ["+sorted(rows)"]}],
+}
+OVER_CAP = ("M  big.bin -> big.bin [aa] blob 11 -> blob 22\n"
+            "   big.bin content omitted: 4194304 bytes over the 8388608 byte cap\n")
+OVER_CAP_NO_NUMBERS = "   big.bin content omitted\n"
+
+
+def self_test():
+    cases = [
+        ("text/absent", grade_text_carries_the_changed_line, TEXT_WITHOUT_CONTENT, FAIL),
+        ("text/present", grade_text_carries_the_changed_line, TEXT_WITH_CONTENT, PASS),
+        # One side only must FAIL. A grader keyed on the added token alone would
+        # pass this, and a reader still could not see what it replaced.
+        ("text/one-side", grade_text_carries_the_changed_line, TEXT_ONE_SIDE, FAIL),
+        ("text/not-a-diff", grade_text_carries_the_changed_line, TEXT_NOT_A_DIFF, UNREADABLE),
+        ("json/absent", grade_json_carries_artifact_level_hunks, JSON_NO_CONTENT, FAIL),
+        ("json/empty", grade_json_carries_artifact_level_hunks, JSON_EMPTY_CONTENT, FAIL),
+        ("json/good", grade_json_carries_artifact_level_hunks, JSON_GOOD, PASS),
+        ("json/orphan-row", grade_json_carries_artifact_level_hunks, JSON_ORPHAN_ROW, FAIL),
+        # Rows present, hunks empty. The arm that separates "content exists" from
+        # "content says something", which is the whole point of the finding.
+        ("json/rows-say-nothing", grade_json_carries_artifact_level_hunks,
+         JSON_ROWS_SAY_NOTHING, FAIL),
+        ("json/not-a-report", grade_json_carries_artifact_level_hunks, {"x": 1}, UNREADABLE),
+        ("noentity/missing", grade_a_file_with_no_entities_still_carries_content,
+         JSON_ONLY_PYTHON, FAIL),
+        ("noentity/present", grade_a_file_with_no_entities_still_carries_content,
+         JSON_GOOD, PASS),
+        ("noentity/unreadable", grade_a_file_with_no_entities_still_carries_content,
+         {"artifact_deltas": []}, UNREADABLE),
+        ("cap/named", grade_over_cap_is_named, OVER_CAP, PASS),
+        ("cap/absent", grade_over_cap_is_named, TEXT_WITHOUT_CONTENT, FAIL),
+        # A marker with no numbers names nothing, and reads like a real one.
+        ("cap/no-numbers", grade_over_cap_is_named, OVER_CAP_NO_NUMBERS, FAIL),
+    ]
+    failures = 0
+    for name, grader, payload, want in cases:
+        got, detail = grader(payload)
+        ok = got == want
+        failures += 0 if ok else 1
+        print("SELFTEST %s %s expected=%s got=%s %s"
+              % (name, "ok" if ok else "BROKEN", want, got, detail))
+    pairs = [
+        ("preview/same", ("a", "b"), ("a", "b"), PASS),
+        ("preview/moved", ("a", "b"), ("a", "c"), FAIL),
+        ("preview/absent", None, ("a",), UNREADABLE),
+    ]
+    for name, before, after, want in pairs:
+        got, detail = grade_preview_is_untouched(before, after)
+        ok = got == want
+        failures += 0 if ok else 1
+        print("SELFTEST %s %s expected=%s got=%s %s"
+              % (name, "ok" if ok else "BROKEN", want, got, detail))
+    # The gate reads `results`, and the only way to know is to hand it the real
+    # loader. Both suites that shipped `checks` had correct graders.
+    import importlib.util
+    gate_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gate.py")
+    if not os.path.exists(gate_path):
+        print("SELFTEST gate/beside BROKEN gate.py is not beside this file")
+        failures += 1
+    else:
+        spec = importlib.util.spec_from_file_location("acceptance_gate", gate_path)
+        gate = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(gate)
+        scratch = tempfile.mkdtemp(prefix="diff-content-selftest-")
+        try:
+            good = os.path.join(scratch, "good.json")
+            rows = [(i, UNREADABLE, "%s fabricated" % TICKET) for i, _ in CHECKS]
+            with open(good, "w") as handle:
+                json.dump(report_payload(rows), handle)
+            loaded = gate.load_report(good)
+            ok = sorted(loaded) == sorted(i for i, _ in CHECKS)
+            failures += 0 if ok else 1
+            print("SELFTEST gate/reads-every-row %s" % ("ok" if ok else "BROKEN"))
+            bad = os.path.join(scratch, "bad.json")
+            with open(bad, "w") as handle:
+                json.dump({"ticket": TICKET, "checks": [{"id": "x", "status": PASS}]}, handle)
+            refused = False
+            try:
+                gate.load_report(bad)
+            except Exception:  # noqa: BLE001 - refusing is the point
+                refused = True
+            failures += 0 if refused else 1
+            print("SELFTEST gate/CONTROL-refuses-checks-shape %s"
+                  % ("ok" if refused else "BROKEN"))
+        finally:
+            shutil.rmtree(scratch, ignore_errors=True)
+    print("SELFTEST %d case(s), %d broken" % (len(cases) + len(pairs) + 2, failures))
+    return 1 if failures else 0
+
+
+def absolute_binary(path):
+    if not path:
+        return None
+    resolved = os.path.abspath(path)
+    return resolved if os.path.exists(resolved) else path
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN") or shutil.which("kin"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path")
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    opts = parser.parse_args(argv)
+    if opts.self_test:
+        return self_test()
+    if not opts.kin:
+        print("SETUP no kin binary: pass --kin or set KIN_BIN")
+        return 3
+    opts.kin = absolute_binary(opts.kin)
+    opts.daemon = absolute_binary(opts.daemon)
+    workdir = tempfile.mkdtemp(prefix="diff-content-")
+    suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
+    results = []
+    try:
+        for ident, check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - setup failure is not a verdict
+                results.append((ident, UNREADABLE, "%s check raised: %s" % (TICKET, error)))
+        for ident, status, detail in results:
+            print("CHECK %s %s %s %s" % (ident, TICKET, status, detail))
+        if opts.json_path:
+            directory = os.path.dirname(os.path.abspath(opts.json_path))
+            if directory and not os.path.isdir(directory):
+                os.makedirs(directory)
+            with open(opts.json_path, "w") as handle:
+                json.dump(report_payload(results), handle, indent=2)
+        asked = [i for i, _ in CHECKS]
+        answered = [i for i, _, _ in results]
+        if answered != asked:
+            print("SETUP asked for %r and %r answered" % (asked, answered))
+            return 3
+        if any(s == FAIL for _, s, _ in results):
+            return 1
+        if any(s == UNREADABLE for _, s, _ in results):
+            return 2
+        return 0
+    finally:
+        try:
+            if suite._repo:
+                run([opts.kin, "daemon", "stop"], cwd=suite._repo, env=suite.env, timeout=180)
+        except Exception:  # noqa: BLE001 - teardown must not change the verdict
+            pass
+        if not opts.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+        else:
+            print("kept fixtures under %s" % workdir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
`kin diff` named an artifact and its blob hashes and carried none of the changed content. The filed finding said "no content, text or JSON". Measured, that is right about text and **wrong about JSON**, and the correction shaped the fix.

## The correction

With positive controls so the zeros mean zero:

```
needle                     text  json
sorted(rows)                 0     2
Render rows, sorted          0     3
def format_report            0     6
CONTROL pkg/reporting.py     1    10
```

The JSON carried source text at `entity_deltas[].{old,new}.metadata.embedding_body_preview` and `.signature`. **It is unusable as a diff for four separate reasons**: it is an embedding artifact named as one; it is lossy, with all six newlines collapsing to zero and 115 bytes against the file's 126; it is per-entity, so a changed file with no entities carries nothing at all; and it is a full body on each side rather than a delta. A stranger reaching for `--json` found something, was misled by it, and could not tell it was lossy.

## The change

```
artifact_content: [{artifact_id, path, old_hash, new_hash, hunks, old_text, new_text, omitted}]
```

Parallel rather than nested inside `TreeDelta`, because that is a kin-model type carrying `deny_unknown_fields`, consumed from the registry with no path dependency, so nesting is a cross-repo publish. The join keeps every property that matters: content at the artifact level, keyed to the artifact so a file with no entities still carries it, `embedding_body_preview` untouched, full bodies behind `--full-bodies`.

Bodies come from `load_source_blob` against graph-owned CAS, and both hashes are already in the report, so **no filesystem path exists anywhere in the read** and the Zero File-Search Authority Rule holds by construction rather than by argument. One renderer feeds both surfaces so they cannot drift. Over the 8 MiB per-surface cap the body is refused with a marker naming both numbers.

What a user reads:

```
M  pkg/reporting.py -> pkg/reporting.py [900e5a85] blob 33b9ed6b... -> blob 798ddc00...
   @@ -2,5 +2,5 @@
    def format_report(rows):
   -    """Render rows."""
   -    return "\n".join(str(r) for r in rows)
   +    """Render rows, sorted."""
   +    return "\n".join(str(r) for r in sorted(rows))
```

## Both routes, which is the part that nearly went wrong

`run()` sends `!json && workspace_endpoint` to the daemon, which renders its own lines and returns early. So the everyday bare `kin diff` is the one route where the CLI does not hold the binding, and a content surface that worked only locally would pass every change-to-change test while leaving the call a user types unchanged. The CLI opens its own binding there and appends after the daemon's lines, so the daemon's output stays byte-identical and the wire payload is unchanged.

The routes are distinguishable, which is what makes the claim checkable:

```
daemon UP:    live-graph tell=1   content=1   "entities and relations for the ..."
daemon DOWN:  live-graph tell=0   content=1   "no live graph was reachable"
```

## Dependency and lockfile disclosure

`similar` 3.2.0, Apache-2.0 (in `deny.toml`'s allow list, GPL-3.0 control at zero), with **no dependencies of its own**.

Adding it moves several crates' `windows-sys` references onto 0.61.2. Measured with a control before concluding: a bare `cargo metadata` with no manifest change leaves the lock byte-identical, so this change caused it. But all five windows-sys versions already exist in main's lock and in this one, no package entry is added or removed, and the lock diff carries exactly one new crate name and zero removed. It is a consolidation onto entries already present, on a platform this host cannot build, which is exactly when this class ships unnoticed.

## Acceptance and falsification

`scripts/acceptance/diff_content_repro.py`, six checks, 21 self-test cases, wired at all three sites.

The graders encode the correction, and that decides what they can catch: since the JSON already carried text in an embedding field, **a one-directional "is there any content" check would have passed on the defect**. So every grader has an arm where content is present and says nothing: rows with empty hunks FAIL, a text diff carrying one side only FAILs, an omission marker with no byte counts FAILs, and a row naming an artifact no delta carries FAILs.

| arm | result |
|---|---|
| patched binary | all six PASS, including the 9 MiB over-cap refusal |
| **unpatched binary** | `text_history` FAIL, `json_hunks` FAIL, `no_entity_file` UNREADABLE, `text_workspace` FAIL, `preview_untouched` PASS |
| **mutant: daemon-route call removed only** | five PASS, **`text_workspace` alone FAILs** |

`preview_untouched` passing on both binaries is the right answer, not a weak check: it asserts the content surface did not disturb an embedding field, which is true before the change by construction and must stay true after. The mutant row is what proves the daemon route is carried by its own code rather than by the local fallback.

Closes FIR-2993
