### PR TITLE
Pin kin-db 0.7.77, which makes the kin-search substring floor mandatory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.76"
+version = "0.7.77"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "03dd5d93e70900752bf8577f1b38a3354e2d4588d2c9de63a176fdfd59495817"
+checksum = "bb78d778724f05b4409c43c48c7a47abdb653c048435fe416a974293d3e98e06"
 dependencies = [
  "bincode",
  "bstr",
@@ -3711,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "kin-search"
-version = "0.1.5"
+version = "0.1.6"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "90b1943f2fa86bf338b63f662229f2fc009dff069a5851b928db1f7c0ebab5c1"
+checksum = "e84e12c18955d50c27efb5f36aaf4b64b076022f87a7c4760d5de91691a4bd16"
 dependencies = [
  "bincode",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.76", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.77", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.21", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -38434,25 +38434,29 @@ mod tests {
         let result: kin_cli::commands::search::DaemonSearchResponse =
             serde_json::from_slice(&body).unwrap();
 
-        // FIR-2918. This assertion used to read `records.is_empty()`, and it
-        // held for the wrong reason: the fixture's lexical index was never
-        // committed, so every query returned nothing. Now that the query path
-        // brings the index current, the disjunctive fallback answers with the
-        // index's NEAREST document rather than a match, measured here as
-        // `definitelyNoSuchSymbol` retrieving `present` at 0.45 because `def`
-        // occurs in `def present()` and is a substring of `definitely`, over a
-        // corpus holding no token of the query.
+        // This assertion has been right, then wrong, then right again, and the
+        // reason matters more than the line.
         //
-        // So the property this test is about is unchanged and is now stated
-        // directly: nothing matched BY NAME. `text_fallback` is the product's
-        // own name for that, and it is true only when the answer is non-empty
-        // and every row is a fallback row. The qualifier assertions below are
-        // untouched, and they are what this test exists for; making them survive
-        // a labelled-fallback answer is the fix this change carries.
+        // Originally `records.is_empty()`, and it held for the WRONG reason: the
+        // fixture's lexical index was never committed, so every query returned
+        // nothing (FIR-2918). Bringing the index current at query time made the
+        // disjunctive fallback answer with the index's nearest document, and
+        // this assertion moved to `text_fallback` to state the property it
+        // always meant, that nothing matched BY NAME.
+        //
+        // kin-search 0.1.6 then removed the thing that produced that row. It
+        // refuses a reverse substring match carrying too little of the query, so
+        // `definitelyNoSuchSymbol` no longer reaches `def present()` through
+        // `def` sitting inside `definitely` (FIR-2968). Measured on this pin:
+        // `text_fallback: false, total_matches: 0, records: []`. So the original
+        // assertion is correct again, and now for the reason it always claimed:
+        // the query matches nothing because the index holds nothing for it.
+        //
+        // The `|| text_fallback` half of the absence gate is no longer exercised
+        // here, which is why the sibling below exists.
         assert!(
-            result.text_fallback,
-            "nothing may match this query by name; an answer with a name match would make the \
-             qualifier assertions below vacuous: {result:?}"
+            result.records.is_empty(),
+            "a query whose terms the index does not hold must match nothing: {result:?}"
         );
         let qualifier = result.absence_qualifier.join(" ");
         assert!(
@@ -38470,6 +38474,75 @@ mod tests {
         assert!(
             !qualifier.contains("cross-file"),
             "a scope-gated surface must not claim an edge class: {qualifier:?}"
+        );
+    }
+
+    /// An all-fallback answer is an absence and must qualify like one.
+    ///
+    /// This exists because the pin to kin-search 0.1.6 took the coverage away
+    /// from the test above. That test used to reach the `|| text_fallback` half
+    /// of the absence gate through a WRONG answer, a nearest document returned
+    /// for a query the index held nothing for; 0.1.6 refuses that, so it now
+    /// reaches the `records.is_empty()` half instead and the other half would
+    /// ship unguarded.
+    ///
+    /// So this drives the same gate through a RIGHT answer. `socket` is not any
+    /// entity's name here, so nothing matches by name, but it is a real token in
+    /// one doc summary, so the text pass answers with a labelled fallback row.
+    /// That is a legitimate all-fallback answer, it is still an absence as far
+    /// as the caller's query is concerned, and the degradation has to reach the
+    /// verdict rather than being silenced by the presence of a row.
+    #[tokio::test]
+    async fn an_all_fallback_search_still_carries_the_degradation() {
+        let state = test_state();
+        let mut described = test_entity("handler", "src/net.py");
+        described.doc_summary =
+            Some("Opens a socket and speaks to a server over the network.".to_string());
+        state.graph.upsert_entity(&described).unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state
+            .embed_worker_failed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/search")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "query": "socket" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let result: kin_cli::commands::search::DaemonSearchResponse =
+            serde_json::from_slice(&body).unwrap();
+
+        // The fixture has to actually produce the state under test, or the
+        // assertion below is about a case that never happened.
+        assert!(
+            result.text_fallback,
+            "this fixture must produce an ALL-FALLBACK answer, or it is not exercising the \
+             half of the absence gate it exists for: {result:?}"
+        );
+        assert!(
+            !result.records.is_empty(),
+            "an all-fallback answer is non-empty by definition: {result:?}"
+        );
+        let qualifier = result.absence_qualifier.join(" ");
+        assert!(
+            qualifier.contains("Kin cannot rule out"),
+            "a row that matched nothing by name must not silence the degradation: {qualifier:?}"
+        );
+        assert!(
+            qualifier.contains("embed_worker_failed"),
+            "the line names the signal the verdict disclosed: {qualifier:?}"
         );
     }
 


### PR DESCRIPTION
This is the landing that puts the FIR-2968 fix in kin's shipped bytes. kin-search 0.1.6 refuses a reverse substring match that carries too little of the query, and kin-db 0.7.77 raises its own requirement from the caret `0.1.5` to `0.1.6` so a consumer re-locking cannot resolve the broken version. Both moved here together, because kin's lock held `kin-search 0.1.5` directly and a kin-db pin alone would have left it there.

The defect, measured rather than argued: `definitelyNoSuchSymbol` retrieved an entity whose only text is `present`, `def present()` and `src/a.py`, with `match_kind: TextFallback` and score 0.45207196, over a corpus holding no token of the query. `def` is in that vocabulary because of the signature, and `def` sits inside `definitely`.

The lock diff is exactly four lines, two versions and two checksums, with both `sparse+` sources untouched:

```
kin-db      0.7.76 -> 0.7.77   03dd5d93e7090075... -> bb78d778724f05b4...
kin-search  0.1.5  -> 0.1.6    90b1943f2fa86bf3... -> e84e12c18955d50c...
```

`cargo update --precise` wanted thirty-two lines, dragging a dozen `windows-sys` entries across platforms this host cannot build, which is invisible inside a pin nobody reads closely. That was restored with `git restore --source=HEAD --worktree Cargo.lock`, not a bare checkout, and the four lines applied by hand. Both checksums were read from the sparse index rather than taken from cargo's output, and the two readings agree.

## The interaction this pin exposed, which is most of the diff

The pin turned `api::tests::a_degraded_daemon_reaches_the_search_cli_through_the_route` red, and the same assertion has now been right, wrong, and right again for three different reasons.

It began as `records.is_empty()` and held for the WRONG reason: the fixture's lexical index was never committed, so every query returned nothing. FIR-2918 made the index current at query time, the disjunctive fallback began answering with the index's nearest document, and the assertion moved to `text_fallback`, which states the property it always meant, that nothing matched BY NAME. kin-search 0.1.6 then removed the thing producing that row. Measured on this pin: `text_fallback: false, total_matches: 0, records: []`. So the original assertion is correct again, and now for the reason it always claimed, and it is restored.

That restoration leaves a hole this PR would otherwise ship. The `|| text_fallback` half of the absence gate, added under FIR-2918 so a labelled-fallback answer still discloses its degradation, was reached only through the WRONG answer. With 0.1.6 refusing that answer, the clause has no test at all.

So `an_all_fallback_search_still_carries_the_degradation` drives the same gate through a RIGHT answer. `socket` is no entity's name in its fixture, so nothing matches by name, but it is a real token in one doc summary, so the text pass answers with a labelled fallback row. That is a legitimate all-fallback answer, it is still an absence as far as the caller's query is concerned, and the degradation has to reach the verdict rather than being silenced by the presence of a row. It asserts the fixture actually produced an all-fallback answer BEFORE asserting the qualifier survived it, so a fixture that stops exercising the case cannot pass quietly.

## Gates

`cargo check --workspace --locked` rc 0. `cargo nextest run --workspace --locked`: 8127 tests run, 8127 passed, 21 skipped. `cargo fmt --all -- --check` clean. `cargo test --doc --workspace --locked` rc 0 across 23 result blocks, which graded the workspace's single doctest; that is what it covers, stated rather than reported as a green.

DEV-LOCAL cannot validate a registry pin at all, since it replaces the crate under test with a local checkout, which is why every gate above is `--locked`.

Rebased onto `9f026c617` immediately before pushing, since kin is a classic repo and nothing re-grades a squash onto a main that moved. That commit touched `crates/kin-daemon/src/api.rs` as this branch does; both sides were checked present afterwards, with a line neither side wrote as the negative control.

Closes FIR-2968
Refs FIR-2918
