### PR TITLE
Install a published merge into the running daemon's graph

### DIFF
--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -1097,6 +1097,27 @@ pub(crate) fn publish_resolved_merge(
         ))
         .into());
     }
+    // The repository transaction is durable authority. The in-process graph is a
+    // derived query view, and a published merge never reached it: the two
+    // `create_change` calls in this file both go into a detached
+    // `InMemoryGraph::from_snapshot` replay copy that exists to prove the merge
+    // replays to the desired tree, and `state.graph.create_change` appeared
+    // nowhere in this file or in `repository_merge_state.rs`.
+    //
+    // So after the CAS the authority held the merge change and the running
+    // daemon's graph did not. `kin log`, `kin diff` and `kin status` answered
+    // anyway because they read authority, while `kin blame` and `kin history`
+    // went through the live projection and failed, first with "the active graph
+    // projection does not hold" and then with a bare `change not found`, until a
+    // restart rebuilt the graph from authority. A later commit installed only
+    // its own change and did not heal it.
+    //
+    // Install the exact immutable changes only after the authority CAS
+    // succeeds, which is what the commit path does at `command_commit_after_admission`
+    // under this same named phase. Captured before the CAS because the
+    // transaction is moved into it. A fast-forward carries no change and
+    // installs nothing.
+    let published_changes = transaction.changes.clone();
     let (materialized, receipt, authority_freeze) =
         kin_core::tree::transition_repository_workspace_tree_and_commit_repository_transaction(
             state.layout.working_dir(),
@@ -1111,6 +1132,17 @@ pub(crate) fn publish_resolved_merge(
                 record.binding.source_ref, record.binding.target_ref
             )
         })?;
+    for change in &published_changes {
+        crate::mcp_commit::timed_commit_phase("install_live_graph", || {
+            state.graph.create_change(change)
+        })
+        .with_context(|| {
+            format!(
+                "install published change {} into the live query graph",
+                change.id
+            )
+        })?;
+    }
 
     let resolved_count = terminated.entries.len();
     let report = kin_cli::commands::resolve::ResolveReport {
@@ -2032,6 +2064,27 @@ fn publish(
         ))
         .into());
     }
+    // The repository transaction is durable authority. The in-process graph is a
+    // derived query view, and a published merge never reached it: the two
+    // `create_change` calls in this file both go into a detached
+    // `InMemoryGraph::from_snapshot` replay copy that exists to prove the merge
+    // replays to the desired tree, and `state.graph.create_change` appeared
+    // nowhere in this file or in `repository_merge_state.rs`.
+    //
+    // So after the CAS the authority held the merge change and the running
+    // daemon's graph did not. `kin log`, `kin diff` and `kin status` answered
+    // anyway because they read authority, while `kin blame` and `kin history`
+    // went through the live projection and failed, first with "the active graph
+    // projection does not hold" and then with a bare `change not found`, until a
+    // restart rebuilt the graph from authority. A later commit installed only
+    // its own change and did not heal it.
+    //
+    // Install the exact immutable changes only after the authority CAS
+    // succeeds, which is what the commit path does at `command_commit_after_admission`
+    // under this same named phase. Captured before the CAS because the
+    // transaction is moved into it. A fast-forward carries no change and
+    // installs nothing.
+    let published_changes = transaction.changes.clone();
     let (materialized, receipt, authority_freeze) =
         kin_core::tree::transition_repository_workspace_tree_and_commit_repository_transaction(
             state.layout.working_dir(),
@@ -2046,6 +2099,17 @@ fn publish(
                 request.source, plan.target_ref
             )
         })?;
+    for change in &published_changes {
+        crate::mcp_commit::timed_commit_phase("install_live_graph", || {
+            state.graph.create_change(change)
+        })
+        .with_context(|| {
+            format!(
+                "install published change {} into the live query graph",
+                change.id
+            )
+        })?;
+    }
     let line = match outcome {
         MergeOutcome::FastForward => format!(
             "Fast-forwarded {} to change {} ({} projected entries, authority generation {})",


### PR DESCRIPTION
A published merge never reached the running daemon's in-process query graph, so `kin blame` and `kin history` failed on it until the daemon was restarted. `kin log`, `kin diff` and `kin status` answered anyway, because they read authority. Four surfaces said the merge was there and two said it was not, which is what made it hard to see.

## The mechanism

`repository_merge.rs` calls `create_change` twice and both go into a detached `InMemoryGraph::from_snapshot` replay copy that exists to prove the merge replays to the desired tree. `state.graph.create_change` appeared nowhere in that file or in `repository_merge_state.rs`, with a control at four other uses of `state.graph` in the same file so the zero is a real zero.

The commit path does install, at `command_commit_after_admission`, under `timed_commit_phase("install_live_graph", ...)`, with the comment that says why: the repository transaction is durable authority and the in-process graph is a derived query view, so the exact immutable change is installed only after the authority CAS succeeds. The merge path never did.

Diagnosis by historylimit, verified here from source rather than taken on the message.

## Both publish paths, not one

The stopper was found through `resolve --continue`, which publishes via `publish_resolved_merge`. A plain `kin merge` that authors a change publishes via `publish` and had the same gap. Both are fixed.

The transaction is moved into the CAS, so its changes are captured before it and installed after it succeeds. A fast-forward carries no change and installs nothing. The replay copies are untouched, and this does not invalidate-and-rebuild.

## Measured

Distinct subjects, a merge proven by its two parents, and no daemon restart between the publish and the reads, because a restart rebuilds the graph from authority and hides exactly the defect under test.

```
                    pre-merge blame   log    status   blame   history   blame reports
before  03495221    answers 7b704fd0  rc=0   rc=0     rc=1    rc=1      nothing
after   e85dd8df    answers 75069e11  rc=0   rc=0     rc=0    rc=0      the merge change
```

**The pre-merge blame is the control the whole thing rests on.** Without it, a blame that fails after the merge cannot be told from a blame that never worked in this fixture, and the arm would be measuring the fixture rather than the defect. The probe refuses to grade at all if blame does not answer first, and both arms show it answering. So the sequence each arm proves is: blame works, a merge publishes, blame stops working, same daemon, no restart.

The probe asserts the live projection holds the **merge change** rather than merely answering, because a blame that answers at an older change is the defect still present. Probe at `.kin-coord/reports/mergeinstall-repro/probe.sh`.

## Two ways this probe lied to me first, both now guarded

Its first version published no merge at all. `kin init` leaves a pending semantic overlay and `kin merge` refuses one, so I was grading blame and history against a repo with no merge in it. The probe now commits the overlay and **refuses to grade unless the newest change carries two parents**.

Its second version asked `kin blame src/lib.py`. Blame takes an entity, not a path, so it answered "No entity matching 'src/lib.py' found" on both builds and I read a working fix as broken. The probe now asks for an entity, and the comment says why.

Both are the same shape: the right output read from the wrong question.

## Not done here

Neither merge path calls `record_repository_authority_commit`, which the commit path does at `api.rs:6111` and which advances `snapshot_generation` and refuses if it does not advance. That is the same class of gap one field over. I did not add it because it can refuse and I have not measured that, and a refusal added blind to the merge path is worse than a gap that is named.

Refs FIR-2960
