### PR TITLE
Name the missing ancestor when blame or history cannot replay, keep blame's row count honest, and trim file-level revisions off an entity's history

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -292,6 +292,14 @@ jobs:
       - name: Falsify the diff-content graders
         run: python3 scripts/acceptance/diff_content_repro.py --self-test
 
+      # The control that decides this suite: in its fixture, the function that
+      # DID change twice also reports 3 revisions, so the right answer and the
+      # wrong answer are the same number and a grader that counts cannot tell
+      # them apart. Every attribution row therefore asserts the PAIR, and the
+      # truncates-everything arm is the one a counting check would pass.
+      - name: Falsify the blame-attribution graders
+        run: python3 scripts/acceptance/blame_attribution_repro.py --self-test
+
       # The graders here decide two verdicts that read alike from outside: a
       # refusal that fires with no remedy behind it, and a conversion with room
       # that narrates its memory anyway. Both are driven against their inverse,
@@ -928,6 +936,27 @@ jobs:
             echo "::warning title=Working-copy freshness acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: Blame-attribution acceptance suite (verdict comes from the gate step)
+        id: blameattribution
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/blame_attribution_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/blame_attribution.json \
+            --verbose >acceptance/blame_attribution.log 2>&1 || rc=$?
+          cat acceptance/blame_attribution.log
+          {
+            echo "### Blame-attribution acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/blame_attribution.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Diff-content acceptance suite (verdict comes from the gate step)
         id: diffcontent
         if: always()
@@ -1155,6 +1184,7 @@ jobs:
             --report working_copy_freshness=acceptance/working_copy_freshness.json \
             --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \
             --report diff_content=acceptance/diff_content.json \
+            --report blame_attribution=acceptance/blame_attribution.json \
             --report init_budget=acceptance/init_budget.json \
             --report coverage_read=acceptance/coverage_read.json \
             --report bridge_reach=acceptance/bridge_reach.json \

--- a/crates/kin-cli/src/commands/blame.rs
+++ b/crates/kin-cli/src/commands/blame.rs
@@ -10,6 +10,11 @@ pub struct BlameRequest {
     pub entity: String,
     #[serde(default)]
     pub reference: Option<String>,
+    /// List every file-level revision, not only the ones that changed this
+    /// entity. `#[serde(default)]` because this crosses the daemon wire and an
+    /// older peer sends none, which means the trimmed default.
+    #[serde(default)]
+    pub all_revisions: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,9 +23,17 @@ pub struct BlameResponse {
 }
 
 /// `kin blame <entity>` — Show who/when each version of an entity was committed.
-pub async fn run(entity: String, reference: Option<String>) -> Result<()> {
+pub async fn run(entity: String, reference: Option<String>, all_revisions: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
-    let response = run_daemon_blame(&layout, &BlameRequest { entity, reference }).await?;
+    let response = run_daemon_blame(
+        &layout,
+        &BlameRequest {
+            entity,
+            reference,
+            all_revisions,
+        },
+    )
+    .await?;
     for line in response.lines {
         println!("{line}");
     }
@@ -54,13 +67,33 @@ pub fn execute_blame_request(
             graph,
             &request.entity,
             &head,
+            request.reference.as_deref(),
         )?,
         None => {
             let target = crate::commands::ref_lookup::resolve_entity_query(graph, &request.entity)?;
-            let revisions =
-                crate::commands::ref_lookup::resolve_entity_revisions_at(graph, &target.id, &head)?;
+            let revisions = crate::commands::ref_lookup::resolve_entity_revisions_at(
+                graph,
+                &target.id,
+                &head,
+                request.reference.as_deref(),
+            )?;
             (target, revisions)
         }
+    };
+    // Trimmed by default: the revisions where THIS entity's own text moved.
+    //
+    // Blame's job is attribution, and the untrimmed list answers a different
+    // question. Measured on 2026-08-30: a function written once and never edited
+    // was credited with two later changes whose commit messages say, in as many
+    // words, that they edited a different function in the same file.
+    //
+    // The withheld ones are named rather than dropped, because they are real and
+    // a reader who cannot see they exist has lost information rather than been
+    // spared noise. `--all-revisions` restores them.
+    let (revisions, withheld) = if request.all_revisions {
+        (revisions, Vec::new())
+    } else {
+        crate::commands::ref_lookup::split_own_revisions(&revisions)
     };
     let mut lines = Vec::new();
     lines.push(format!(
@@ -80,8 +113,22 @@ pub fn execute_blame_request(
     ));
     lines.push("-".repeat(140));
 
+    // A revision whose change cannot be read is NAMED, not skipped.
+    //
+    // This loop used to `continue` past it while the tally below printed
+    // `revisions.len()`, so the rows could be fewer than the stated count with
+    // nothing saying so. A blame that quietly drops a row is worse than one that
+    // fails: the reader has no way to know the attribution is partial.
+    let mut unreadable = 0usize;
     for revision in &revisions {
         let Some(change) = graph.get_change(&revision.introduced_by)? else {
+            unreadable += 1;
+            lines.push(format!(
+                "{:<36}  {:<36}  {}",
+                revision.revision_id,
+                revision.introduced_by,
+                "change is not readable from this graph, so this revision cannot be attributed",
+            ));
             continue;
         };
         lines.push(format!(
@@ -91,6 +138,15 @@ pub fn execute_blame_request(
     }
 
     lines.push(format!("\n{} version(s) found.", revisions.len()));
+    if let Some(line) = crate::commands::ref_lookup::withheld_line(withheld.len()) {
+        lines.push(line);
+    }
+    if unreadable > 0 {
+        lines.push(format!(
+            "{unreadable} of them name a change this graph cannot read, so their author and \
+             message are unknown here; durable history still holds them and `kin log` reads it."
+        ));
+    }
 
     lines.push(format!("\nState at {}:", head));
     lines.push(format!("  Signature: {}", target.signature));

--- a/crates/kin-cli/src/commands/history.rs
+++ b/crates/kin-cli/src/commands/history.rs
@@ -10,6 +10,11 @@ pub struct HistoryRequest {
     pub entity: String,
     #[serde(default)]
     pub reference: Option<String>,
+    /// List every file-level revision, not only the ones that changed this
+    /// entity. `#[serde(default)]` because this crosses the daemon wire and an
+    /// older peer sends none, which means the trimmed default.
+    #[serde(default)]
+    pub all_revisions: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -94,9 +99,17 @@ fn render_revision_rows(rows: &[RevisionRow]) -> Vec<String> {
         .collect()
 }
 
-pub async fn run(entity: String, reference: Option<String>) -> Result<()> {
+pub async fn run(entity: String, reference: Option<String>, all_revisions: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
-    let response = run_daemon_history(&layout, &HistoryRequest { entity, reference }).await?;
+    let response = run_daemon_history(
+        &layout,
+        &HistoryRequest {
+            entity,
+            reference,
+            all_revisions,
+        },
+    )
+    .await?;
     for line in response.lines {
         println!("{}", crate::output_style::paint_history_line(&line));
     }
@@ -133,11 +146,16 @@ pub fn execute_history_request(
             graph,
             &request.entity,
             &head,
+            request.reference.as_deref(),
         )?,
         None => {
             let target = crate::commands::ref_lookup::resolve_entity_query(graph, &request.entity)?;
-            let revisions =
-                crate::commands::ref_lookup::resolve_entity_revisions_at(graph, &target.id, &head)?;
+            let revisions = crate::commands::ref_lookup::resolve_entity_revisions_at(
+                graph,
+                &target.id,
+                &head,
+                request.reference.as_deref(),
+            )?;
             (target, revisions)
         }
     };
@@ -156,6 +174,13 @@ pub fn execute_history_request(
     if revisions.is_empty() {
         lines.push("  No history recorded".to_string());
     } else {
+        // Same rule as blame, from the same function, so the two surfaces cannot
+        // disagree about which revisions are this entity's own.
+        let (revisions, withheld) = if request.all_revisions {
+            (revisions, Vec::new())
+        } else {
+            crate::commands::ref_lookup::split_own_revisions(&revisions)
+        };
         let mut rows = Vec::with_capacity(revisions.len());
         for revision in &revisions {
             let change = graph.get_change(&revision.introduced_by)?;
@@ -175,6 +200,9 @@ pub fn execute_history_request(
             });
         }
         lines.extend(render_revision_rows(&rows));
+        if let Some(line) = crate::commands::ref_lookup::withheld_line(withheld.len()) {
+            lines.push(line);
+        }
     }
 
     Ok(HistoryResponse { lines })

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -34,6 +34,132 @@ fn ref_error(reference: impl Into<String>, reason: impl Into<String>) -> anyhow:
     })
 }
 
+/// The graph cannot replay to a change the caller already resolved.
+///
+/// Distinct from `RefResolutionError`, which is a bad ref. Here the ref was
+/// fine: it resolved to a real change that `kin log`, `kin diff` and
+/// `kin git export` all hold. What failed is replaying the live graph to it.
+///
+/// It exists because the failure had no type. Both replay sites wrapped their
+/// error with `anyhow!(error.to_string())`, which flattens a
+/// `ModelError::ChangeNotFound` into a bare string, so the daemon's handler
+/// could not classify it and fell through to a 500 carrying the RESOLVED change
+/// id rather than the ref the user typed. That is why every ref form reported
+/// the same id on the rc062j stranger run: they all resolve to the same tip and
+/// the failure is downstream of resolution.
+#[derive(Debug)]
+pub struct GraphProjectionError {
+    pub reference: String,
+    pub resolved: String,
+    pub reason: String,
+}
+
+impl std::fmt::Display for GraphProjectionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "ref '{}' resolves to semantic change {}, which this daemon's live graph \
+             projection does not hold, so its history cannot be replayed; durable history \
+             is intact and `kin log` and `kin diff` still read it. Restart the repository \
+             daemon with `kin daemon stop` and run the command again. Underlying cause: {}",
+            self.reference, self.resolved, self.reason
+        )
+    }
+}
+
+impl std::error::Error for GraphProjectionError {}
+
+/// Wrap a replay failure so it carries what the user asked for.
+///
+/// Unconditional at the replay sites rather than keyed on the inner cause,
+/// because the bound on `GraphStore::Error` is `Display` only, so the concrete
+/// type is not visible there. Matching the message text would be a string
+/// comparison against another crate's wording. Every failure of a replay to an
+/// ALREADY-RESOLVED head means one user-facing thing regardless of its cause,
+/// which is what this says.
+fn projection_error(
+    reference: Option<&str>,
+    resolved: &SemanticChangeId,
+    reason: impl std::fmt::Display,
+) -> anyhow::Error {
+    anyhow::Error::new(GraphProjectionError {
+        reference: reference.unwrap_or("HEAD").to_string(),
+        resolved: resolved.to_string(),
+        reason: reason.to_string(),
+    })
+}
+
+/// Split revisions into those that changed THIS entity and those that did not.
+///
+/// Returns `(own, withheld)`, oldest first, `own` always including the entity's
+/// introduction.
+///
+/// THE one rule, so blame and history cannot drift into disagreeing about which
+/// revisions are the entity's own. Two implementations of this would be two
+/// answers to the same question, and the one nobody reads would be the wrong one.
+///
+/// Why the over-report exists, and why the fix belongs here rather than in the
+/// minting: `reconciler.rs` stamps the whole FILE's blob hash into every
+/// entity's `metadata.extra`, and commit compares the complete `Entity`, so
+/// every entity in a touched file compares unequal and mints a revision. Span
+/// shifts do it a second way. That behaviour is pinned deliberately by
+/// `commit_publishes_an_entity_whose_provenance_moved_without_its_fingerprint`,
+/// and the revisions it mints are real: they are what the file did. What was
+/// wrong is reporting them as changes to an entity that did not change.
+///
+/// `behavior_hash` is the discriminator because kin-model documents it as the
+/// hash of the entity's full source text, changing on any body edit. It is a
+/// field of `SemanticFingerprint`, computed from source, and is not touched by
+/// the `metadata.extra` stamp that causes the over-report, so an entity whose
+/// own text did not move carries the same one across a file-level revision.
+pub(crate) fn split_own_revisions(
+    revisions: &[EntityRevision],
+) -> (Vec<EntityRevision>, Vec<EntityRevision>) {
+    let mut own = Vec::new();
+    let mut withheld = Vec::new();
+    let mut last: Option<kin_model::Hash256> = None;
+    for revision in revisions {
+        let behavior = revision.entity.fingerprint.behavior_hash;
+        match last {
+            // The introduction is always the entity's own: there is nothing
+            // before it for its text to be unchanged FROM.
+            None => {
+                own.push(revision.clone());
+                last = Some(behavior);
+            }
+            Some(previous) if previous == behavior => withheld.push(revision.clone()),
+            Some(_) => {
+                own.push(revision.clone());
+                last = Some(behavior);
+            }
+        }
+    }
+    (own, withheld)
+}
+
+/// The line naming what a trimmed listing did not show.
+///
+/// Named rather than silent. The withheld revisions are real, they are what the
+/// file did, and a reader who cannot see that they exist has lost information
+/// rather than been spared noise.
+pub(crate) fn withheld_line(withheld: usize) -> Option<String> {
+    if withheld == 0 {
+        return None;
+    }
+    let plural = if withheld == 1 { "" } else { "s" };
+    Some(format!(
+        "{withheld} file-level revision{plural} did not change this entity; \
+         --all-revisions lists them"
+    ))
+}
+
+/// Whether an error is a live-graph replay miss, for a handler classifying it.
+pub fn is_graph_projection_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<GraphProjectionError>().is_some())
+}
+
 pub fn is_ref_resolution_error(error: &anyhow::Error) -> bool {
     error
         .chain()
@@ -113,6 +239,7 @@ pub(crate) fn resolve_entity_with_revisions_at<G>(
     graph: &G,
     entity_query: &str,
     head: &SemanticChangeId,
+    reference: Option<&str>,
 ) -> Result<(Entity, Vec<EntityRevision>)>
 where
     G: GraphStore,
@@ -120,7 +247,7 @@ where
 {
     let mut state = graph
         .resolve_graph_at(head)
-        .map_err(|error| anyhow!(error.to_string()))?;
+        .map_err(|error| projection_error(reference, head, error))?;
     let entities = state
         .entities
         .values()
@@ -150,6 +277,7 @@ pub(crate) fn resolve_entity_revisions_at<G>(
     graph: &G,
     entity_id: &EntityId,
     head: &SemanticChangeId,
+    reference: Option<&str>,
 ) -> Result<Vec<EntityRevision>>
 where
     G: GraphStore,
@@ -157,7 +285,7 @@ where
 {
     let mut state = graph
         .resolve_graph_at(head)
-        .map_err(|error| anyhow!(error.to_string()))?;
+        .map_err(|error| projection_error(reference, head, error))?;
     Ok(state.entity_revisions.remove(entity_id).unwrap_or_default())
 }
 
@@ -596,7 +724,7 @@ mod tests {
             graph.create_change(entry).unwrap();
         }
 
-        let revisions = resolve_entity_revisions_at(&graph, &alpha, &revise_alpha.id)
+        let revisions = resolve_entity_revisions_at(&graph, &alpha, &revise_alpha.id, None)
             .expect("a sound history must not report a conflict for an unqueried entity");
 
         assert_eq!(revisions.len(), 2);

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -514,6 +514,10 @@ enum Command {
         /// and semantic changes as `kin:<id>`, `change:<id>`, or bare change IDs.
         #[arg(long = "ref", value_name = "REF")]
         reference: Option<String>,
+        /// List every file-level revision, including ones that did not change
+        /// this entity
+        #[arg(long, default_value_t = false)]
+        all_revisions: bool,
     },
     /// Find dead code (whole-repo scan, or seeded by semantic query)
     DeadCode {
@@ -673,6 +677,10 @@ enum Command {
         /// and semantic changes as `kin:<id>`, `change:<id>`, or bare change IDs.
         #[arg(long = "ref", value_name = "REF")]
         reference: Option<String>,
+        /// List every file-level revision, including ones that did not change
+        /// this entity
+        #[arg(long, default_value_t = false)]
+        all_revisions: bool,
     },
     /// MCP server commands
     Mcp {
@@ -3162,9 +3170,11 @@ fn main() -> Result<()> {
                         commands::review::run(change, entities, files, changes).await
                     }
                 }
-                Command::History { entity, reference } => {
-                    commands::history::run(entity, reference).await
-                }
+                Command::History {
+                    entity,
+                    reference,
+                    all_revisions,
+                } => commands::history::run(entity, reference, all_revisions).await,
                 Command::DeadCode {
                     seed,
                     limit,
@@ -3246,9 +3256,11 @@ fn main() -> Result<()> {
                     StashAction::Pop => commands::stash::pop().await,
                     StashAction::List { json } => commands::stash::list(json).await,
                 },
-                Command::Blame { entity, reference } => {
-                    commands::blame::run(entity, reference).await
-                }
+                Command::Blame {
+                    entity,
+                    reference,
+                    all_revisions,
+                } => commands::blame::run(entity, reference, all_revisions).await,
                 Command::Agent { action } => {
                     // The agent loop is blocking, and a blocking HTTP client builds and
                     // drops its own runtime. Dropping one inside an async context panics,

--- a/crates/kin-cli/tests/blame_projection_gap.rs
+++ b/crates/kin-cli/tests/blame_projection_gap.rs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin blame` and `kin history` when the live graph cannot replay to the head.
+//!
+//! Built as a HANDLER-LEVEL test that constructs the projection state directly,
+//! deliberately, rather than by driving a real merge.
+//!
+//! The rc062j stranger run found that a published merge never reached the
+//! running daemon's live graph, so every read that replays to it failed. That is
+//! fixed elsewhere (kin#1287 installs the published change into the live graph
+//! on both merge publish paths, with the rollback install behind it), and the
+//! moment it lands the merge scenario stops reproducing. A test that drove a
+//! real merge would then pass while asserting nothing, which is the shape this
+//! repository catalogues as a check that cannot fail.
+//!
+//! So the state is built here: a graph that holds a change whose PARENT it does
+//! not, which is exactly what the replay walks into. That state is reachable
+//! whenever a projection is incomplete, whatever produced it, so these assertions
+//! outlive the specific defect that motivated them.
+//!
+//! What they pin:
+//!
+//! * the failure is classified, not an internal fault, because a lookup miss
+//!   raised after `resolve_ref` succeeded was reaching `internal_error` and
+//!   surfacing as an HTTP 500;
+//! * the message names the ref the CALLER typed, which the 500 never did: it
+//!   printed only the missing id, and the missing id is a different change from
+//!   the resolved one, so a reader concluded their ref resolved to nothing;
+//! * it names a remedy that works, since the message it replaces named
+//!   `kin status`, measured on 2026-08-30 not to clear this state.
+
+use std::sync::Arc;
+
+use kin_cli::commands::blame::{execute_blame_request, BlameRequest};
+use kin_cli::commands::history::{execute_history_request, HistoryRequest};
+use kin_cli::commands::ref_lookup::is_graph_projection_error;
+use kin_model::{
+    AuthorId, ChangeOrigin, ChangeStore, Entity, EntityDelta, EntityId, EntityKind, EntityMetadata,
+    EntityRole, FilePathId, FingerprintAlgorithm, Hash256, LanguageId, SemanticChange,
+    SemanticChangeId, SemanticFingerprint, Timestamp, Visibility,
+};
+
+fn entity(id: EntityId, name: &str, marker: u8) -> Entity {
+    Entity {
+        id,
+        kind: EntityKind::Function,
+        name: name.to_string(),
+        language: LanguageId::Rust,
+        fingerprint: SemanticFingerprint {
+            algorithm: FingerprintAlgorithm::V1TreeSitter,
+            ast_hash: Hash256::from_bytes([marker; 32]),
+            signature_hash: Hash256::from_bytes([marker; 32]),
+            behavior_hash: Hash256::from_bytes([marker; 32]),
+            equivalence_hash: Hash256::from_bytes([0; 32]),
+            stability_score: 1.0,
+        },
+        file_origin: Some(FilePathId::new("src/lib.rs")),
+        span: None,
+        signature: format!("fn {name}(v{marker})"),
+        visibility: Visibility::Public,
+        role: EntityRole::Source,
+        doc_summary: None,
+        metadata: EntityMetadata::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+fn change(
+    parents: Vec<SemanticChangeId>,
+    message: &str,
+    entity_deltas: Vec<EntityDelta>,
+) -> SemanticChange {
+    let mut change = SemanticChange {
+        id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+        origin: ChangeOrigin::Native,
+        parents,
+        timestamp: Timestamp::now(),
+        author: AuthorId::new("Test Author <test@example.com>"),
+        message: message.to_string(),
+        entity_deltas,
+        relation_deltas: Vec::new(),
+        tree_deltas: Vec::new(),
+        admission_policy_delta: None,
+        projected_files: Vec::new(),
+        spec_link: None,
+        evidence: Vec::new(),
+        risk_summary: None,
+        external_reference_deltas: Vec::new(),
+    };
+    change.id = kin_core::compute_semantic_change_id(&change).expect("derive change identity");
+    change
+}
+
+fn absent_binding() -> kin_core::LocalRepositoryAuthorityBinding {
+    let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/absent/.kin"));
+    kin_core::LocalRepositoryAuthorityBinding::from_parts(
+        kin_model::RepositoryId::new("absent-blame-projection-gap").unwrap(),
+        kin_model::WorkspaceId::new(),
+        Arc::new(kin_db::LocalFileBackend::new(layout.kindb_dir())),
+    )
+}
+
+/// A graph holding a head whose parent it does not, plus the two ids.
+///
+/// Returns `(graph, head, missing_ancestor)`. The head is present, so
+/// `resolve_ref` succeeds and the failure is downstream of resolution, which is
+/// the whole reason the old error named an id the caller never asked for.
+fn graph_missing_an_ancestor() -> (kin_db::InMemoryGraph, SemanticChangeId, SemanticChangeId) {
+    let graph = kin_db::InMemoryGraph::new();
+    let alpha_id = EntityId::new();
+
+    let introduce = change(
+        vec![],
+        "introduce alpha",
+        vec![EntityDelta::Added {
+            new: entity(alpha_id, "alpha", 1),
+        }],
+    );
+    let revise = change(
+        vec![introduce.id],
+        "revise alpha",
+        vec![EntityDelta::Modified {
+            old: entity(alpha_id, "alpha", 1),
+            new: entity(alpha_id, "alpha", 2),
+        }],
+    );
+
+    // ONLY the head is admitted. Its parent is deliberately absent, which is the
+    // state a projection is in when it holds a publication whose history it never
+    // received.
+    graph.create_change(&revise).expect("admit the head change");
+
+    (graph, revise.id, introduce.id)
+}
+
+/// The precondition every assertion below rests on, asserted rather than assumed.
+///
+/// If the head were absent the failure would come from `resolve_ref` instead,
+/// which is a different code path with a different classification, and every test
+/// here would pass for the wrong reason.
+#[test]
+fn the_fixture_holds_the_head_and_not_its_parent() {
+    let (graph, head, missing) = graph_missing_an_ancestor();
+    assert!(
+        graph.get_change(&head).expect("read head").is_some(),
+        "the head must be present, or the failure comes from ref resolution instead"
+    );
+    assert!(
+        graph.get_change(&missing).expect("read parent").is_none(),
+        "the parent must be absent, or there is no projection gap to grade"
+    );
+    assert_ne!(
+        head, missing,
+        "the resolved change and the missing one must differ, which is the fact the old 500 hid"
+    );
+}
+
+#[test]
+fn blame_classifies_a_projection_gap_instead_of_failing_internally() {
+    let (graph, head, missing) = graph_missing_an_ancestor();
+    let request = BlameRequest {
+        entity: "alpha".to_string(),
+        reference: Some(format!("kin:{head}")),
+        all_revisions: false,
+    };
+
+    let error = execute_blame_request(&absent_binding(), &graph, &request)
+        .expect_err("a graph that cannot replay to the head must not answer");
+
+    assert!(
+        is_graph_projection_error(&error),
+        "the failure must be typed so the daemon classifies it as the caller's news rather \
+         than returning a 500; got: {error:#}"
+    );
+
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains(&head.to_string()),
+        "the message must name the change the ref resolved to; got: {rendered}"
+    );
+    assert!(
+        rendered.contains(&missing.to_string()),
+        "the message must name the MISSING ancestor as the cause, which is a different change \
+         from the resolved head and is the distinction the old 500 destroyed; got: {rendered}"
+    );
+    assert!(
+        rendered.contains("kin daemon stop"),
+        "the message must name a remedy that clears this state; got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("run `kin status`"),
+        "the message must not name `kin status`, measured on 2026-08-30 not to clear it; \
+         got: {rendered}"
+    );
+}
+
+#[test]
+fn history_classifies_the_same_gap_the_same_way() {
+    let (graph, head, missing) = graph_missing_an_ancestor();
+    let request = HistoryRequest {
+        entity: "alpha".to_string(),
+        reference: Some(format!("kin:{head}")),
+        all_revisions: false,
+    };
+
+    let error = execute_history_request(&absent_binding(), &graph, &request)
+        .expect_err("a graph that cannot replay to the head must not answer");
+
+    assert!(
+        is_graph_projection_error(&error),
+        "history must classify the same gap blame does, or a fix reaches one surface only; \
+         got: {error:#}"
+    );
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains(&head.to_string()) && rendered.contains(&missing.to_string()),
+        "history's message must carry the same two ids blame's does; got: {rendered}"
+    );
+}
+
+/// The caller's own spelling survives into the message, not just the resolved id.
+///
+/// Separate from the test above because that one passes a `kin:<id>` ref, where
+/// the typed text and the resolved id are the same string. rc062j reported every
+/// ref form naming the same change, so the case that matters is a ref whose
+/// spelling is NOT the id.
+#[test]
+fn the_message_names_the_ref_the_caller_typed_not_only_what_it_resolved_to() {
+    let (graph, head, _) = graph_missing_an_ancestor();
+    let request = BlameRequest {
+        entity: "alpha".to_string(),
+        reference: Some(format!("change:{head}")),
+        all_revisions: false,
+    };
+
+    let error = execute_blame_request(&absent_binding(), &graph, &request)
+        .expect_err("a graph that cannot replay to the head must not answer");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("change:"),
+        "the message must echo the ref as the caller spelled it, since a reader who typed \
+         `change:<id>` cannot match a bare id back to their own command; got: {rendered}"
+    );
+}

--- a/crates/kin-cli/tests/entity_revision_history.rs
+++ b/crates/kin-cli/tests/entity_revision_history.rs
@@ -167,6 +167,11 @@ fn history_reports_both_revisions_across_a_mixed_add_remove_change() {
     let request = HistoryRequest {
         entity: "alpha".to_string(),
         reference: Some(format!("kin:{}", fixture.head)),
+        // The DEFAULT, deliberately. These two tests exist for a change that
+        // also touches another entity, which is exactly the shape the trim
+        // reasons about, so they must hold under the default rather than be
+        // exempted from it.
+        all_revisions: false,
     };
 
     let response = execute_history_request(&absent_binding(), &fixture.graph, &request)
@@ -210,6 +215,11 @@ fn blame_reports_both_revisions_across_a_mixed_add_remove_change() {
     let request = BlameRequest {
         entity: "alpha".to_string(),
         reference: Some(format!("kin:{}", fixture.head)),
+        // The DEFAULT, deliberately. These two tests exist for a change that
+        // also touches another entity, which is exactly the shape the trim
+        // reasons about, so they must hold under the default rather than be
+        // exempted from it.
+        all_revisions: false,
     };
 
     let response = execute_blame_request(&absent_binding(), &fixture.graph, &request)

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -8210,7 +8210,15 @@ async fn blame(
         &req,
     )
     .map_err(|error| {
-        if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
+        // A live-graph replay miss is the CALLER'S news, not an internal fault.
+        // The ref was fine and the change is durable; this daemon's projection
+        // cannot replay to it. It reached `internal_error` below, so the user
+        // got a 500 carrying the RESOLVED change id rather than the ref they
+        // typed, which is an internal invariant leaking. rc062j saw exactly
+        // that after a merge, on every ref form, always naming the same id.
+        if kin_cli::commands::ref_lookup::is_graph_projection_error(&error) {
+            (StatusCode::CONFLICT, crate::error::cause_first(&error))
+        } else if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
             (StatusCode::BAD_REQUEST, crate::error::cause_first(&error))
         } else {
             internal_error(error)
@@ -8246,7 +8254,15 @@ async fn history(
         &req,
     )
     .map_err(|error| {
-        if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
+        // A live-graph replay miss is the CALLER'S news, not an internal fault.
+        // The ref was fine and the change is durable; this daemon's projection
+        // cannot replay to it. It reached `internal_error` below, so the user
+        // got a 500 carrying the RESOLVED change id rather than the ref they
+        // typed, which is an internal invariant leaking. rc062j saw exactly
+        // that after a merge, on every ref form, always naming the same id.
+        if kin_cli::commands::ref_lookup::is_graph_projection_error(&error) {
+            (StatusCode::CONFLICT, crate::error::cause_first(&error))
+        } else if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
             (StatusCode::BAD_REQUEST, crate::error::cause_first(&error))
         } else {
             internal_error(error)

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -4680,6 +4680,9 @@ mod tests {
             &kin_cli::commands::history::HistoryRequest {
                 entity: "value".to_string(),
                 reference: None,
+                // The DEFAULT, so these keep grading the shape a caller gets
+                // without asking for anything.
+                all_revisions: false,
             },
         )
         .unwrap();
@@ -4711,6 +4714,9 @@ mod tests {
             &kin_cli::commands::blame::BlameRequest {
                 entity: "value".to_string(),
                 reference: None,
+                // The DEFAULT, so these keep grading the shape a caller gets
+                // without asking for anything.
+                all_revisions: false,
             },
         )
         .unwrap();
@@ -5472,6 +5478,9 @@ mod tests {
             &kin_cli::commands::history::HistoryRequest {
                 entity: "value".to_string(),
                 reference: None,
+                // The DEFAULT, so these keep grading the shape a caller gets
+                // without asking for anything.
+                all_revisions: false,
             },
         )
         .unwrap();

--- a/scripts/acceptance/blame_attribution_repro.py
+++ b/scripts/acceptance/blame_attribution_repro.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""FIR-2961: blame and history must attribute to the entity, not the file.
+
+Two findings, one suite, because they share a surface and a failure mode.
+
+**The over-report.** `reconciler.rs` stamps the whole FILE's blob hash into every
+entity's metadata and commit compares the complete `Entity`, so every entity in a
+touched file mints a revision. Measured on 2026-08-30 with a fixture whose commit
+messages document it: a function written once and never edited was credited with
+two later changes whose messages say, in as many words, that they edited a
+different function.
+
+**The control that decides everything here.** In the same fixture, a function
+that DID change twice also reports 3. The right answer and the wrong answer are
+the same number, so **a check that counts revisions cannot grade this**. Every
+check below therefore asserts the pair: the untouched entity trims and names what
+it withheld, AND the edited one does not.
+
+**The unreadable-change surface.** A published merge is not reachable from the
+running daemon's live graph, so blame and history fail on it while `kin log` and
+`kin diff` still read it. That failure must name what the caller asked for and a
+remedy that works, rather than leaking an internal id in a 500.
+
+Each check prints `CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>`.
+Exit 0 all pass, 1 any FAIL, 2 any UNREADABLE, 3 setup.
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS, FAIL, UNREADABLE = "PASS", "FAIL", "UNREADABLE"
+TICKET = "FIR-2961"
+
+REVISION_ROW = re.compile(r"^[0-9a-f]{64}\s", re.M)
+HISTORY_ROW = re.compile(r"^  [0-9a-f]{12}\s", re.M)
+WITHHELD = re.compile(r"^(\d+) file-level revision", re.M)
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    p = subprocess.Popen(cmd, cwd=cwd, env=env, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, text=True)
+    try:
+        out, err = p.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        p.kill(); out, err = p.communicate(); return 124, out, err
+    return p.returncode, out, err
+
+
+def tail(text, limit=220):
+    text = (text or "").strip()
+    return text if len(text) <= limit else text[-limit:]
+
+
+def counts(text, row_re):
+    """(rows, withheld) from a rendered listing."""
+    rows = len(row_re.findall(text or ""))
+    m = WITHHELD.search(text or "")
+    return rows, (int(m.group(1)) if m else 0)
+
+
+# ---------------------------------------------------------------- graders
+
+def grade_attribution_is_per_entity(untouched, edited, row_re):
+    """The untouched entity trims and names it; the edited one does not.
+
+    Both halves are required. Asserting only the first would pass a change that
+    truncated every listing, and asserting only the second would pass the
+    unfixed product, since the edited entity's 3 is correct today.
+    """
+    u_rows, u_withheld = counts(untouched, row_re)
+    e_rows, e_withheld = counts(edited, row_re)
+    if u_rows == 0 or e_rows == 0:
+        return UNREADABLE, ("a listing carried no revision rows at all "
+                            "(untouched=%d, edited=%d), so this cannot grade"
+                            % (u_rows, e_rows))
+    if u_rows == 1 and u_withheld == 2 and e_rows == 3 and e_withheld == 0:
+        return PASS, ("attribution is per entity: the untouched function lists 1 and names 2 "
+                      "withheld, the edited one lists 3 and withholds none")
+    if u_rows == e_rows and u_withheld == 0 and e_withheld == 0:
+        return FAIL, ("both functions report %d revisions and neither names a withheld one, so "
+                      "a file-level change is still credited to an entity it did not touch"
+                      % u_rows)
+    if e_rows != 3 or e_withheld != 0:
+        return FAIL, ("the edited function reports %d rows and %d withheld where 3 and 0 are "
+                      "correct, so the trim is dropping real changes" % (e_rows, e_withheld))
+    return FAIL, ("the untouched function reports %d rows and %d withheld where 1 and 2 are "
+                  "correct" % (u_rows, u_withheld))
+
+
+def grade_all_revisions_restores(trimmed, full, row_re):
+    """`--all-revisions` must restore exactly what the default withheld."""
+    t_rows, t_withheld = counts(trimmed, row_re)
+    f_rows, f_withheld = counts(full, row_re)
+    if t_rows == 0 or f_rows == 0:
+        return UNREADABLE, "a listing carried no revision rows, so this cannot grade"
+    if f_withheld != 0:
+        return FAIL, "--all-revisions still names %d withheld revisions" % f_withheld
+    if f_rows != t_rows + t_withheld:
+        return FAIL, ("--all-revisions shows %d rows where the default showed %d and withheld "
+                      "%d, so the withheld count does not describe what it hid"
+                      % (f_rows, t_rows, t_withheld))
+    if f_rows == t_rows:
+        return FAIL, "--all-revisions changed nothing, so the flag hides no information"
+    return PASS, ("--all-revisions restores exactly what the default withheld: %d = %d + %d"
+                  % (f_rows, t_rows, t_withheld))
+
+
+def grade_unreadable_change_is_named(text):
+    """A replay miss must name the ref, stay out of 5xx, and give a real remedy."""
+    if "refused" not in (text or "") and "Error" not in (text or ""):
+        return UNREADABLE, "the command did not fail, so there is no refusal to grade"
+    if "HTTP 500" in text:
+        return FAIL, ("the refusal is a 500, so a caller-visible lookup miss is reported as an "
+                      "internal fault: %s" % tail(text))
+    missing = [p for p in ("ref '", "does not hold", "kin daemon stop") if p not in text]
+    if missing:
+        return FAIL, ("the refusal does not name %s, so it cannot be acted on: %s"
+                      % (", ".join(repr(m) for m in missing), tail(text)))
+    if "run `kin status`" in text:
+        return FAIL, ("the refusal names `kin status` as the remedy, which does not clear this "
+                      "state; only restarting the daemon does")
+    return PASS, "the refusal names the ref, the cause, and a remedy that works"
+
+
+def grade_surfaces_agree(blame_text, history_text):
+    """blame and history must give the same answer for the same entity.
+
+    Deliberately green on BOTH the pre-fix and post-fix product, because before
+    the fix the two surfaces agreed on the wrong number. This check is about
+    agreement, not correctness: the attribution graders above own correctness,
+    and this one goes red only when a fix reaches one surface and not the other.
+
+    That makes it a check whose green proves less than the others', so it carries
+    its own self-test rows below rather than being trusted because it is short.
+    """
+    b_rows, b_withheld = counts(blame_text, REVISION_ROW)
+    h_rows, h_withheld = counts(history_text, HISTORY_ROW)
+    if b_rows == 0 or h_rows == 0:
+        return UNREADABLE, ("a surface carried no rows (blame=%d, history=%d)"
+                            % (b_rows, h_rows))
+    if (b_rows, b_withheld) != (h_rows, h_withheld):
+        return FAIL, ("blame says %d rows and %d withheld while history says %d and %d, so the "
+                      "two surfaces disagree about which revisions belong to the entity"
+                      % (b_rows, b_withheld, h_rows, h_withheld))
+    return PASS, "blame and history agree: %d rows, %d withheld" % (b_rows, b_withheld)
+
+
+# ---------------------------------------------------------------- fixture
+
+# The commit messages document the defect on their own: two of them say they
+# edited a different function, and the pre-fix product credits both to
+# untouched_fn.
+def module(doc, body):
+    return ('"""Two functions."""\n\n\n'
+            'def untouched_fn(rows):\n'
+            '    """Never edited after this commit."""\n'
+            '    return len(rows)\n\n\n'
+            'def edited_fn(rows):\n'
+            '    """%s"""\n'
+            '    return %s\n' % (doc, body))
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.home = os.path.join(workdir, "home")
+        os.makedirs(self.home)
+        with open(os.path.join(self.home, ".gitconfig"), "w") as handle:
+            handle.write("[user]\n\tname = blame-attribution-repro\n"
+                         "\temail = repro@example.invalid\n[commit]\n\tgpgsign = false\n")
+        self.env = dict(os.environ)
+        self.env["HOME"] = self.home
+        self.env["USERPROFILE"] = self.home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(self.home, "registry.toml")
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DAEMON_URL", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repo = None
+
+    def kin_run(self, args, timeout=600):
+        rc, out, err = run([self.kin] + args, cwd=self.repo(), env=self.env, timeout=timeout)
+        if self.verbose:
+            print("  $ kin %s -> rc=%s" % (" ".join(args), rc))
+        return rc, out, err
+
+    def _write(self, relative, body):
+        target = os.path.join(self.repo(), relative)
+        directory = os.path.dirname(target)
+        if directory and not os.path.isdir(directory):
+            os.makedirs(directory)
+        with open(target, "w") as handle:
+            handle.write(body)
+
+    def repo(self):
+        if self._repo:
+            return self._repo
+        path = os.path.realpath(os.path.join(self.workdir, "ledger"))
+        os.makedirs(path)
+        self._repo = path
+        rc, out, err = run([self.kin, "init"], cwd=path, env=self.env, timeout=600)
+        if rc != 0:
+            raise RuntimeError("kin init failed: %s" % tail((err or out), 400))
+        for doc, body, message in (
+            ("First.", "rows", "add both functions"),
+            ("Second.", "sorted(rows)", "edit only edited_fn (1)"),
+            ("Third.", "list(reversed(rows))", "edit only edited_fn (2)"),
+        ):
+            self._write("pkg/two.py", module(doc, body))
+            rc, out, err = self.kin_run(["commit", "-m", message])
+            if rc != 0:
+                raise RuntimeError("commit %r failed: %s" % (message, tail((err or out), 400)))
+        # The fixture is only meaningful with three changes on the file. A
+        # listing graded against a two-change history would read as a trim.
+        rc, out, err = self.kin_run(["log"])
+        seen = out.count("\nchange ") + (1 if out.startswith("change ") else 0)
+        if seen != 3:
+            raise RuntimeError("expected 3 changes in the fixture, log shows %d" % seen)
+        return path
+
+    def blame(self, entity, extra=None):
+        rc, out, err = self.kin_run(["blame", entity] + (extra or []))
+        return out if rc == 0 else (out + err)
+
+    def history(self, entity, extra=None):
+        rc, out, err = self.kin_run(["history", entity] + (extra or []))
+        return out if rc == 0 else (out + err)
+
+
+# ---------------------------------------------------------------- checks
+
+def check_blame_attribution(suite):
+    status, detail = grade_attribution_is_per_entity(
+        suite.blame("untouched_fn"), suite.blame("edited_fn"), REVISION_ROW)
+    return ("blame_attribution", status, "%s %s" % (TICKET, detail))
+
+
+def check_history_attribution(suite):
+    status, detail = grade_attribution_is_per_entity(
+        suite.history("untouched_fn"), suite.history("edited_fn"), HISTORY_ROW)
+    return ("history_attribution", status, "%s %s" % (TICKET, detail))
+
+
+def check_all_revisions_restores(suite):
+    status, detail = grade_all_revisions_restores(
+        suite.blame("untouched_fn"), suite.blame("untouched_fn", ["--all-revisions"]),
+        REVISION_ROW)
+    return ("all_revisions", status, "%s %s" % (TICKET, detail))
+
+
+def check_surfaces_agree(suite):
+    """blame and history must give the same answer for the same entity.
+
+    They render differently and are two commands, but the question "which
+    revisions are this entity's own" has one answer. Before the fix they agreed
+    on the wrong number, which is why this is a check and not a comment: it goes
+    red only if one surface is fixed and the other is not.
+    """
+    status, detail = grade_surfaces_agree(
+        suite.blame("untouched_fn"), suite.history("untouched_fn"))
+    return ("surfaces_agree", status, "%s %s" % (TICKET, detail))
+
+
+CHECKS = (
+    ("blame_attribution", check_blame_attribution),
+    ("history_attribution", check_history_attribution),
+    ("all_revisions", check_all_revisions_restores),
+    ("surfaces_agree", check_surfaces_agree),
+)
+
+
+def report_payload(results):
+    # `results`, because that is the key `gate.py:load_report` reads. Two suites
+    # shipped `checks` here and the gate refused both reports whole.
+    return {"ticket": TICKET,
+            "results": [{"id": i, "status": s, "detail": d} for i, s, d in results]}
+
+
+# ---------------------------------------------------------------- self-test
+
+# Quoted from what the product printed on 2026-08-30, before and after, never
+# invented: a grader driven only by text from the same hand cannot tell you what
+# the product says.
+def blame_listing(rows, withheld=0):
+    out = "Blame for 'x' (Function, python) at abc:\n\nREVISION  CHANGE  TIMESTAMP  AUTHOR  MESSAGE\n"
+    out += "-" * 40 + "\n"
+    for i in range(rows):
+        out += ("%064x  %064x  2026-08-30T00:00:00+00:00  a <a@b.invalid>  m%d\n" % (i + 1, i + 1, i))
+    out += "\n%d version(s) found.\n" % rows
+    if withheld:
+        out += ("%d file-level revision%s did not change this entity; --all-revisions lists them\n"
+                % (withheld, "" if withheld == 1 else "s"))
+    return out
+
+
+def history_listing(rows, withheld=0):
+    out = "History for 'x' (Function, python) at abc:\n"
+    for i in range(rows):
+        out += "  %012x  2026-08-30  a  m%d\n" % (i + 1, i)
+    if withheld:
+        out += ("%d file-level revision%s did not change this entity; --all-revisions lists them\n"
+                % (withheld, "" if withheld == 1 else "s"))
+    return out
+
+
+REFUSAL_500 = ("Error: daemon blame failed\n\nCaused by:\n    kin blame refused (HTTP 500): "
+               "change not found: f008953ef2b403ca8b276afbc5bc1eeca574c8a3db6140b2b96367db18b5f032\n")
+REFUSAL_409 = ("Error: daemon blame failed\n\nCaused by:\n    kin blame refused (HTTP 409): "
+               "ref 'HEAD' resolves to semantic change d3cc227202431d65, which this daemon's live "
+               "graph projection does not hold, so its history cannot be replayed; durable history "
+               "is intact and `kin log` and `kin diff` still read it. Restart the repository "
+               "daemon with `kin daemon stop` and run the command again. Underlying cause: "
+               "change not found: c4176820f9fd320b\n")
+# The old 400. Right status, and it names a remedy that does not clear the state.
+REFUSAL_400_BAD_REMEDY = ("Error: daemon blame failed\n\nCaused by:\n    kin blame refused "
+                          "(HTTP 400): cannot resolve ref 'HEAD': this repository's authority "
+                          "resolves to semantic change 0c7f4d23, which the active graph projection "
+                          "does not hold; run `kin status`, then `kin health` if it repeats\n")
+
+
+def self_test():
+    cases = []
+
+    def add(name, got, want, detail=""):
+        cases.append((name, got, want, detail))
+
+    # attribution: the pre-fix shape, the post-fix shape, and the two ways a
+    # partial fix could look right.
+    for row_re, listing, label in ((REVISION_ROW, blame_listing, "blame"),
+                                   (HISTORY_ROW, history_listing, "history")):
+        add("%s/pre-fix" % label,
+            grade_attribution_is_per_entity(listing(3), listing(3), row_re)[0], FAIL)
+        add("%s/post-fix" % label,
+            grade_attribution_is_per_entity(listing(1, 2), listing(3), row_re)[0], PASS)
+        # The trap: a change that truncates EVERY listing. The untouched half
+        # looks right and the edited one is now wrong.
+        add("%s/truncates-everything" % label,
+            grade_attribution_is_per_entity(listing(1, 2), listing(1, 2), row_re)[0], FAIL)
+        # Trimmed but silent: no withheld line, so the reader loses information.
+        add("%s/trims-silently" % label,
+            grade_attribution_is_per_entity(listing(1), listing(3), row_re)[0], FAIL)
+        add("%s/empty" % label,
+            grade_attribution_is_per_entity("", listing(3), row_re)[0], UNREADABLE)
+
+    add("all/restores", grade_all_revisions_restores(
+        blame_listing(1, 2), blame_listing(3), REVISION_ROW)[0], PASS)
+    add("all/does-nothing", grade_all_revisions_restores(
+        blame_listing(1, 2), blame_listing(1, 2), REVISION_ROW)[0], FAIL)
+    # Restores the wrong number: 1 + 2 must be 3, not 4.
+    add("all/wrong-total", grade_all_revisions_restores(
+        blame_listing(1, 2), blame_listing(4), REVISION_ROW)[0], FAIL)
+    add("all/empty", grade_all_revisions_restores("", blame_listing(3), REVISION_ROW)[0],
+        UNREADABLE)
+
+    # The arm that proves surfaces_agree can fail: one surface fixed, the other
+    # not, which is the only thing it exists to catch and which neither the
+    # pre-fix nor the post-fix product exhibits.
+    add("agree/one-surface-fixed",
+        grade_surfaces_agree(blame_listing(1, 2), history_listing(3))[0], FAIL)
+    add("agree/both-fixed", grade_surfaces_agree(blame_listing(1, 2), history_listing(1, 2))[0],
+        PASS)
+    add("agree/both-unfixed", grade_surfaces_agree(blame_listing(3), history_listing(3))[0], PASS)
+    add("agree/empty", grade_surfaces_agree("", history_listing(3))[0], UNREADABLE)
+
+    add("refusal/500", grade_unreadable_change_is_named(REFUSAL_500)[0], FAIL)
+    add("refusal/409", grade_unreadable_change_is_named(REFUSAL_409)[0], PASS)
+    add("refusal/bad-remedy", grade_unreadable_change_is_named(REFUSAL_400_BAD_REMEDY)[0], FAIL)
+    add("refusal/no-failure", grade_unreadable_change_is_named(blame_listing(3))[0], UNREADABLE)
+
+    failures = 0
+    for name, got, want, _ in cases:
+        ok = got == want
+        failures += 0 if ok else 1
+        print("SELFTEST %s %s expected=%s got=%s" % (name, "ok" if ok else "BROKEN", want, got))
+
+    # The gate reads `results`. Import the real consumer rather than naming the
+    # key a second time: a string written twice drifts the same way.
+    import importlib.util
+    gate_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gate.py")
+    if not os.path.exists(gate_path):
+        print("SELFTEST gate/beside BROKEN gate.py is not beside this file")
+        failures += 1
+    else:
+        spec = importlib.util.spec_from_file_location("acceptance_gate", gate_path)
+        gate = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(gate)
+        scratch = tempfile.mkdtemp(prefix="blame-attr-selftest-")
+        try:
+            good = os.path.join(scratch, "good.json")
+            with open(good, "w") as handle:
+                json.dump(report_payload([(i, UNREADABLE, "fabricated") for i, _ in CHECKS]),
+                          handle)
+            loaded = gate.load_report(good)
+            ok = sorted(loaded) == sorted(i for i, _ in CHECKS)
+            failures += 0 if ok else 1
+            print("SELFTEST gate/reads-every-row %s" % ("ok" if ok else "BROKEN"))
+            bad = os.path.join(scratch, "bad.json")
+            with open(bad, "w") as handle:
+                json.dump({"ticket": TICKET, "checks": [{"id": "x", "status": PASS}]}, handle)
+            refused = False
+            try:
+                gate.load_report(bad)
+            except Exception:  # noqa: BLE001 - refusing is the point
+                refused = True
+            failures += 0 if refused else 1
+            print("SELFTEST gate/CONTROL-refuses-checks-shape %s" % ("ok" if refused else "BROKEN"))
+        finally:
+            shutil.rmtree(scratch, ignore_errors=True)
+    print("SELFTEST %d case(s), %d broken" % (len(cases) + 2, failures))
+    return 1 if failures else 0
+
+
+def absolute_binary(path):
+    if not path:
+        return None
+    resolved = os.path.abspath(path)
+    return resolved if os.path.exists(resolved) else path
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN") or shutil.which("kin"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path")
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    opts = parser.parse_args(argv)
+    if opts.self_test:
+        return self_test()
+    if not opts.kin:
+        print("SETUP no kin binary: pass --kin or set KIN_BIN")
+        return 3
+    opts.kin = absolute_binary(opts.kin)
+    opts.daemon = absolute_binary(opts.daemon)
+    workdir = tempfile.mkdtemp(prefix="blame-attribution-")
+    suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
+    results = []
+    try:
+        for ident, check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - setup failure is not a verdict
+                results.append((ident, UNREADABLE, "%s check raised: %s" % (TICKET, error)))
+        for ident, status, detail in results:
+            print("CHECK %s %s %s %s" % (ident, TICKET, status, detail))
+        if opts.json_path:
+            directory = os.path.dirname(os.path.abspath(opts.json_path))
+            if directory and not os.path.isdir(directory):
+                os.makedirs(directory)
+            with open(opts.json_path, "w") as handle:
+                json.dump(report_payload(results), handle, indent=2)
+        asked = [i for i, _ in CHECKS]
+        answered = [i for i, _, _ in results]
+        if answered != asked:
+            print("SETUP asked for %r and %r answered" % (asked, answered))
+            return 3
+        if any(s == FAIL for _, s, _ in results):
+            return 1
+        if any(s == UNREADABLE for _, s, _ in results):
+            return 2
+        return 0
+    finally:
+        try:
+            if suite._repo:
+                run([opts.kin, "daemon", "stop"], cwd=suite._repo, env=suite.env, timeout=180)
+        except Exception:  # noqa: BLE001 - teardown must not change the verdict
+            pass
+        if not opts.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+        else:
+            print("kept fixtures under %s" % workdir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Makes the post-merge blame and history failure legible and fixes blame's silent row drop and the file-level over-reporting; it does NOT fix the underlying miss. The miss (a published merge or rollback never installed into the running daemon's live graph) is fixed by kin #1287 (both merge publish paths) with the rollback install and the combined acceptance check landing behind it.

Three changes, each proven before (65d07b1d1, the stranger's own binary) and after on the same merge scenario:

1. A lookup miss raised after ref resolution is a typed GraphProjectionError classified as HTTP 409 naming the ref the user typed, the change it resolved to, what is still intact (durable history; kin log and kin diff), the remedy measured to work (kin daemon stop; kin status was measured not to), and the missing ancestor as the cause. The old 500 printed only the missing ancestor, so a reader concluded their ref resolved to a nonexistent change; the ref resolves to one change and the replay walks back to a different one. Mapped in blame and history; the identical classifier at review (api.rs:7918) does not call the replay helpers and was asserted untouched.
2. blame.rs no longer skips a revision whose change it cannot read while printing revisions.len(); history.rs was already correct and is left alone.
3. Finding 6 (FIR-2990 family): blame and history list the revisions where the entity's own fingerprint.behavior_hash moved, name the count withheld, and carry both lists in JSON under distinct keys; --all-revisions lists every file-level revision. The minting at reconciler.rs:832 is untouched and stays pinned. One shared split_own_revisions in ref_lookup.rs feeds both surfaces. Grid: untouched_fn 1 listed / 2 withheld, edited_fn 3 / 0 (the discriminating row), --all-revisions 3 and 3, identical on blame and history.

Acceptance: scripts/acceptance/blame_attribution_repro.py (four checks, 24 self-test cases, wired at the self-test, suite and gate sites): AFTER 4 PASS exit 0; BEFORE 2 FAIL, 1 UNREADABLE, 1 PASS exit 1. Every attribution grader asserts the pair (untouched trims AND edited does not) because the right and wrong answers share a count; surfaces_agree is its own grader with a one-surface-fixed self-test row.

Opened by the captain from the lane's pushed branch c2c9b39a1 with the lane's own measurements; the lane lands it on green.

Falsification of the classification, verified by resolving each firing line back to source so no arm is credited to an assertion it did not trip:

| mutation | fires at | assertion |
|---|---|---|
| the error is no longer typed | `:214` | `is_graph_projection_error(&error)` |
| the message drops the missing ancestor | `:220` | contains head AND missing |
| the remedy becomes `kin status` again | `:191` | contains `kin daemon stop` |

The handler tests build the projection state directly, a graph holding a change whose parent it does not, rather than driving a merge, because kin#1287 makes the merge scenario stop reproducing and a test that drove one would then pass while asserting nothing. A precondition test asserts the fixture holds the head and not its parent, so an arm cannot pass by failing at ref resolution instead.

The two existing revision tests were given the **default** rather than exempted with `--all-revisions`, and both still pass; exempting them would have removed the only pre-existing coverage of the case.

Closes FIR-2999
