### PR TITLE
Stop reporting a conflicted identity as a removal, and name which clause refused a merge

### DIFF
--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -1211,3 +1211,112 @@ fn contradictory_settlements_inside_one_artifact_refuse_and_name_both() {
         .state
         .is_in_progress());
 }
+
+/// Name every field on which two versions of one entity disagree.
+///
+/// Written as a list of every field the model declares rather than a derived
+/// comparison, so a field added to `Entity` later fails to compile here and has
+/// to be classified deliberately as semantic or as provenance.
+fn entity_field_differences(ours: &kin_model::Entity, theirs: &kin_model::Entity) -> Vec<&'static str> {
+    let kin_model::Entity {
+        id,
+        kind,
+        name,
+        language,
+        fingerprint,
+        file_origin,
+        span,
+        signature,
+        visibility,
+        role,
+        doc_summary,
+        metadata,
+        lineage_parent,
+        created_in,
+        superseded_by,
+    } = ours;
+    let mut differing = Vec::new();
+    for (label, differs) in [
+        ("id", *id != theirs.id),
+        ("kind", *kind != theirs.kind),
+        ("name", *name != theirs.name),
+        ("language", *language != theirs.language),
+        ("fingerprint", *fingerprint != theirs.fingerprint),
+        ("file_origin", *file_origin != theirs.file_origin),
+        ("span", *span != theirs.span),
+        ("signature", *signature != theirs.signature),
+        ("visibility", *visibility != theirs.visibility),
+        ("role", *role != theirs.role),
+        ("doc_summary", *doc_summary != theirs.doc_summary),
+        ("metadata", *metadata != theirs.metadata),
+        ("lineage_parent", *lineage_parent != theirs.lineage_parent),
+        ("created_in", *created_in != theirs.created_in),
+        ("superseded_by", *superseded_by != theirs.superseded_by),
+    ] {
+        if differs {
+            differing.push(label);
+        }
+    }
+    differing
+}
+
+/// The one entity named `name` in a resolved graph state.
+fn entity_named(state: &kin_model::graph::ResolvedGraphState, name: &str) -> kin_model::Entity {
+    let mut found: Vec<kin_model::Entity> = state
+        .entities
+        .values()
+        .filter(|entity| entity.name == name)
+        .cloned()
+        .collect();
+    assert_eq!(found.len(), 1, "exactly one entity named {name}");
+    found.pop().expect("checked immediately above")
+}
+
+/// An entity NEITHER branch edited still differs between the branches, and the
+/// measurement says on which field.
+///
+/// Measured rather than assumed, and the measurement corrected the guess that
+/// produced it. `beta` is untouched by both sides, so provenance looked like the
+/// likely difference; `created_in` is in fact EQUAL, because nothing re-minted
+/// the record. The one field that differs is `span`, and the reason is that the
+/// two edits to `alpha` above it are different LENGTHS, so every byte offset
+/// below shifts by a different amount on each side.
+///
+/// That is why one changed function reports three entity conflicts here and
+/// nine in the rc062j stranger run. A byte offset is a projection of whichever
+/// bytes the merge publishes, not an independent decision, so the operator is
+/// being asked a question whose answer is already determined by another answer.
+/// Removing that question is the derived-conflict design, which is FIR-2960 and
+/// not this change: this test records the premise, and the count it explains.
+///
+/// The assertion is an equality against the exact measured set rather than a
+/// subset check, so an entity that starts differing on a SEMANTIC field fails
+/// here rather than being quietly folded into the same explanation.
+#[test]
+fn an_untouched_entity_differs_between_branches_only_in_its_span() {
+    let root = tempdir().expect("temp root");
+    let repo = container_settle_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let init = run_kin_without_enrichment(&runtime, &repo, &["init", ".", "--json"]);
+    ok(&init, "kin init");
+    let layout = kin_core::KinLayout::discover(&repo).expect("discover exact layout");
+
+    let ours = graph_at(&layout, &branch_change(&layout, "main"));
+    let theirs = graph_at(&layout, &branch_change(&layout, "feature"));
+
+    let untouched = entity_field_differences(&entity_named(&ours, "beta"), &entity_named(&theirs, "beta"));
+    assert_eq!(
+        untouched,
+        vec!["span"],
+        "an entity neither side edited differs only in its byte offsets; it actually differed on {untouched:?}"
+    );
+
+    // The control that keeps the reading honest: the entity both sides DID edit
+    // must differ on a semantic field too, or the comparison above is measuring
+    // nothing and would report the same set for every entity in the file.
+    let edited = entity_field_differences(&entity_named(&ours, "alpha"), &entity_named(&theirs, "alpha"));
+    assert!(
+        edited.contains(&"fingerprint"),
+        "the entity both sides edited must differ semantically; it differed on {edited:?}"
+    );
+}

--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -1217,7 +1217,10 @@ fn contradictory_settlements_inside_one_artifact_refuse_and_name_both() {
 /// Written as a list of every field the model declares rather than a derived
 /// comparison, so a field added to `Entity` later fails to compile here and has
 /// to be classified deliberately as semantic or as provenance.
-fn entity_field_differences(ours: &kin_model::Entity, theirs: &kin_model::Entity) -> Vec<&'static str> {
+fn entity_field_differences(
+    ours: &kin_model::Entity,
+    theirs: &kin_model::Entity,
+) -> Vec<&'static str> {
     let kin_model::Entity {
         id,
         kind,
@@ -1304,7 +1307,8 @@ fn an_untouched_entity_differs_between_branches_only_in_its_span() {
     let ours = graph_at(&layout, &branch_change(&layout, "main"));
     let theirs = graph_at(&layout, &branch_change(&layout, "feature"));
 
-    let untouched = entity_field_differences(&entity_named(&ours, "beta"), &entity_named(&theirs, "beta"));
+    let untouched =
+        entity_field_differences(&entity_named(&ours, "beta"), &entity_named(&theirs, "beta"));
     assert_eq!(
         untouched,
         vec!["span"],
@@ -1314,7 +1318,10 @@ fn an_untouched_entity_differs_between_branches_only_in_its_span() {
     // The control that keeps the reading honest: the entity both sides DID edit
     // must differ on a semantic field too, or the comparison above is measuring
     // nothing and would report the same set for every entity in the file.
-    let edited = entity_field_differences(&entity_named(&ours, "alpha"), &entity_named(&theirs, "alpha"));
+    let edited = entity_field_differences(
+        &entity_named(&ours, "alpha"),
+        &entity_named(&theirs, "alpha"),
+    );
     assert!(
         edited.contains(&"fingerprint"),
         "the entity both sides edited must differ semantically; it differed on {edited:?}"

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -252,8 +252,59 @@ fn read_merge_plan(
         )));
     }
     if workspace.is_dirty() {
+        // `is_dirty` is two clauses and the old refusal named neither, so a
+        // caller met "has graph-owned changes" while `kin status` and the
+        // workspace tree both read clean, with nothing to act on. The rc062j
+        // stranger hit that twice. Say which clause refused and what clears it,
+        // because the two readers disagreeing is only a problem when the
+        // disagreement is invisible.
+        // Mirrors `WorkspaceState::is_dirty` clause for clause. Its second arm
+        // is a `map_or`, so an unborn head with any tree at all is dirty for a
+        // third reason that neither of the others names.
+        let overlay_pending = !workspace.semantic_overlay.is_empty();
+        let tree_moved = workspace
+            .base_tree_hash
+            .is_some_and(|base| base != workspace.tree_hash);
+        let unborn_with_tree = workspace.base_tree_hash.is_none() && !workspace.tree.is_empty();
+        let commit_or_stash = "commit it with `kin commit`, or set it aside with `kin stash`";
+        let (what, remedy) = match (overlay_pending, tree_moved, unborn_with_tree) {
+            (true, true, _) => (
+                "a pending semantic overlay AND a working tree that has moved off its base change"
+                    .to_string(),
+                "commit them with `kin commit`, or set them aside with `kin stash`",
+            ),
+            (true, false, false) => (
+                "a pending semantic overlay, while its working tree still matches its base \
+                 change, which is why a tree-only reader such as `kin status` can call this \
+                 workspace clean at the same moment"
+                    .to_string(),
+                commit_or_stash,
+            ),
+            (true, _, true) => (
+                "a pending semantic overlay on a branch with no commit yet".to_string(),
+                commit_or_stash,
+            ),
+            (false, true, _) => (
+                "a working tree that has moved off its base change".to_string(),
+                commit_or_stash,
+            ),
+            (false, false, true) => (
+                "a working tree on a branch with no commit yet".to_string(),
+                commit_or_stash,
+            ),
+            // Unreachable while `is_dirty` is those clauses. A wrong sentence
+            // here would be worse than an honest one, so it says so instead.
+            (false, false, false) => (
+                "graph-owned changes this refusal could not attribute to the semantic overlay, \
+                 the working tree or an unborn head, which is a defect in the refusal rather \
+                 than in your repository; please report it"
+                    .to_string(),
+                "read `kin graph status`",
+            ),
+        };
         return Err(merge_conflict(format!(
-            "workspace {} has graph-owned changes; commit or discard them before merging",
+            "workspace {} holds {what}; a merge publishes into a workspace that holds neither, \
+             so {remedy}, then merge again",
             workspace.workspace_id
         )));
     }
@@ -1834,6 +1885,48 @@ fn collect_dangling_endpoints(
     theirs: &kin_model::graph::ResolvedGraphState,
     conflicts: &mut Vec<MergeConflictEntry>,
 ) -> Result<()> {
+    // An identity that CONFLICTED is absent from the composed maps for a reason
+    // that is not removal: `compose` records the conflict and continues without
+    // inserting. Reading that absence as a removal is what turned one changed
+    // function into forty-five relation rows on the rc062j store, every one of
+    // them saying "one branch removed summarize" about a removal neither branch
+    // performed, and the stranger's note is that believing it resolves the merge
+    // wrongly.
+    //
+    // A value conflict exists on BOTH sides, so whichever side settles it the
+    // endpoint survives and the edge is never dangling. Only an identity absent
+    // from the side actually taken can strand an edge, and that is decided after
+    // `apply_resolution`, which is what the publish-time call of this function
+    // sees. That call passes an empty vec, so `unsettled` is empty there and its
+    // behaviour is unchanged: this narrowing applies to the opening composition
+    // and the recomposition, which must move together or `require_same_conflicts`
+    // refuses every merge.
+    // Narrower than "conflicted", on purpose. An identity present on BOTH sides
+    // survives whichever side is settled, so its edge can never strand and the
+    // row is always false. An identity absent from one side, a
+    // `ChangedOursRemovedTheirs` or its mirror, genuinely strands if the
+    // settlement takes the side that lacks it, so its row is predictive and
+    // stays. Where a row is dropped the publish-time call of this function is
+    // the net that still catches it, because by then `apply_resolution` has put
+    // the settled values in the maps and the answer actually exists.
+    let mut survives_either_side_entities: BTreeSet<kin_model::EntityId> = BTreeSet::new();
+    let mut survives_either_side_artifacts: BTreeSet<kin_model::ArtifactId> = BTreeSet::new();
+    for entry in conflicts.iter() {
+        match &entry.subject {
+            MergeConflictSubject::Entity { entity } => {
+                if ours.entities.contains_key(entity) && theirs.entities.contains_key(entity) {
+                    survives_either_side_entities.insert(*entity);
+                }
+            }
+            MergeConflictSubject::Artifact { artifact } => {
+                if ours.tree.get(artifact).is_some() && theirs.tree.get(artifact).is_some() {
+                    survives_either_side_artifacts.insert(*artifact);
+                }
+            }
+            MergeConflictSubject::Relation { .. } | MergeConflictSubject::Path { .. } => {}
+        }
+    }
+
     let mut dangling: BTreeMap<kin_model::RelationId, (kin_model::GraphNodeId, String)> =
         BTreeMap::new();
     for (id, relation) in relations {
@@ -1842,7 +1935,7 @@ fn collect_dangling_endpoints(
                 let survives = entities.contains_key(&entity);
                 let existed =
                     ours.entities.contains_key(&entity) || theirs.entities.contains_key(&entity);
-                if !survives && existed {
+                if !survives && existed && !survives_either_side_entities.contains(&entity) {
                     dangling.entry(*id).or_insert_with(|| {
                         let name = describe_entity(&ours.entities, &theirs.entities, &entity);
                         (
@@ -1860,7 +1953,7 @@ fn collect_dangling_endpoints(
                 let survives = artifacts.contains_key(&artifact);
                 let existed =
                     ours.tree.get(&artifact).is_some() || theirs.tree.get(&artifact).is_some();
-                if !survives && existed {
+                if !survives && existed && !survives_either_side_artifacts.contains(&artifact) {
                     dangling.entry(*id).or_insert_with(|| {
                         let path = ours
                             .tree
@@ -2930,11 +3023,18 @@ mod tests {
             artifact(anchor_id, "src/anchor.rs", 0x20),
             relation.clone(),
         );
-        let theirs_state = graph_state(
-            artifact(target_id, "src/target.rs", 0x12),
-            artifact(anchor_id, "src/anchor.rs", 0x20),
-            relation.clone(),
-        );
+        // The source branch REMOVES the target, which is the divergence that can
+        // actually strand this edge. It used to be enough to change the target on
+        // both sides, but an identity present on both sides survives whichever
+        // side is settled, so that shape reported a removal neither branch
+        // performed. The rc062j stranger met forty-five of those rows for one
+        // changed function.
+        let theirs_state = ResolvedGraphState {
+            relations: [(relation.id, relation.clone())].into(),
+            tree: ResolvedTree::from_artifacts([artifact(anchor_id, "src/anchor.rs", 0x20)])
+                .unwrap(),
+            ..ResolvedGraphState::default()
+        };
 
         let base_artifacts = artifacts_by_id(&base_state.tree);
         let ours_artifacts = artifacts_by_id(&ours_state.tree);
@@ -3010,6 +3110,118 @@ mod tests {
         )
         .unwrap();
         assert_eq!(merged_relations.get(&relation.id), Some(&relation));
+    }
+
+    /// An identity CONFLICTED on both sides is not a removal, and an edge to it
+    /// never strands.
+    ///
+    /// `compose` records a conflict and continues without inserting, so a
+    /// conflicted identity is absent from the composed map for a reason that is
+    /// not removal. Reading that absence as a removal is what turned one changed
+    /// function into forty-five relation rows on the rc062j store, each one
+    /// saying "one branch removed `summarize`" about a removal neither branch
+    /// performed, and the stranger's note is that believing them resolves the
+    /// merge wrongly.
+    #[test]
+    fn an_endpoint_conflicted_on_both_sides_reports_no_removal() {
+        let target_id = ArtifactId::new();
+        let anchor_id = ArtifactId::new();
+        let relation = Relation {
+            id: RelationId::new(),
+            kind: RelationKind::References,
+            src: GraphNodeId::Artifact(anchor_id),
+            dst: GraphNodeId::Artifact(target_id),
+            confidence: 1.0,
+            origin: RelationOrigin::Manual,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        };
+        // Changed on both sides and removed by neither, which is the shape the
+        // stranger's one edited function produced.
+        let base_state = graph_state(
+            artifact(target_id, "src/target.rs", 0x10),
+            artifact(anchor_id, "src/anchor.rs", 0x20),
+            relation.clone(),
+        );
+        let ours_state = graph_state(
+            artifact(target_id, "src/target.rs", 0x11),
+            artifact(anchor_id, "src/anchor.rs", 0x20),
+            relation.clone(),
+        );
+        let theirs_state = graph_state(
+            artifact(target_id, "src/target.rs", 0x12),
+            artifact(anchor_id, "src/anchor.rs", 0x20),
+            relation.clone(),
+        );
+
+        let base_artifacts = artifacts_by_id(&base_state.tree);
+        let ours_artifacts = artifacts_by_id(&ours_state.tree);
+        let theirs_artifacts = artifacts_by_id(&theirs_state.tree);
+        let mut conflicts = Vec::new();
+        let merged_artifacts = compose(
+            &base_artifacts,
+            &ours_artifacts,
+            &theirs_artifacts,
+            |artifact| MergeConflictSubject::Artifact {
+                artifact: *artifact,
+            },
+            MergeSideValue::artifact,
+            |_| None,
+            &mut conflicts,
+        )
+        .unwrap();
+        let merged_relations = compose(
+            &base_state.relations,
+            &ours_state.relations,
+            &theirs_state.relations,
+            |relation| MergeConflictSubject::Relation {
+                relation: *relation,
+            },
+            MergeSideValue::relation,
+            |_| None,
+            &mut conflicts,
+        )
+        .unwrap();
+
+        // The artifact really did conflict, so the fixture is the case it claims
+        // to be rather than a merge with nothing in it.
+        assert_eq!(
+            conflicts.len(),
+            1,
+            "exactly one conflict, the artifact itself: {conflicts:#?}"
+        );
+        assert!(matches!(
+            conflicts[0].subject,
+            MergeConflictSubject::Artifact { .. }
+        ));
+        assert!(!merged_artifacts.contains_key(&target_id));
+
+        collect_dangling_endpoints(
+            &merged_relations,
+            &HashMap::new(),
+            &merged_artifacts,
+            &base_state,
+            &ours_state,
+            &theirs_state,
+            &mut conflicts,
+        )
+        .unwrap();
+
+        let removals: Vec<&MergeConflictEntry> = conflicts
+            .iter()
+            .filter(|entry| matches!(entry.divergence, MergeDivergence::DanglingEndpoint { .. }))
+            .collect();
+        assert!(
+            removals.is_empty(),
+            "an endpoint present on both sides survives whichever side settles, so no row may \
+             describe a removal: {removals:#?}"
+        );
+        assert_eq!(
+            conflicts.len(),
+            1,
+            "the one real conflict is still the only one reported: {conflicts:#?}"
+        );
     }
 
     fn rule_source_fixture() -> (

--- a/scripts/acceptance/merge_precedence_repro.py
+++ b/scripts/acceptance/merge_precedence_repro.py
@@ -30,8 +30,10 @@ carries all of them the merge refuses and names both decisions. Nothing is
 synthesized, because kin has no textual line merge to build a third body from,
 so a projection is a choice among sides this merge already bound.
 
-Four checks, three repositories, run in order because two of them are
-destructive: they publish the merge the earlier assertions are about.
+Six checks over five repositories, run in order because two of them are
+destructive: they publish the merge the earlier assertions are about. The first
+four grade FIR-2958's precedence rule; the last two grade rc062j finding (2),
+which is the same authority reporting conflicts that are not conflicts.
 
   precedence  the entity settled `--theirs` decides the bytes of the artifact
               holding it, even though a later `--all-ours` settled that artifact,
@@ -46,6 +48,12 @@ destructive: they publish the merge the earlier assertions are about.
               `--all-theirs` merge still publishes, with the source bytes on
               disk and a nonzero tree delta. Without it a product that refused
               every merge would satisfy the refusal check and lose nothing else.
+  removals    one changed function parks no row saying a branch removed an
+              identity it did not remove. Measured at 18 such rows of 22 before
+              the fix, on this same fixture
+  genuine     the control for `removals`: a real removal, still pointed at by
+              the other side, is still reported. Without it a merge that dropped
+              every relation row would satisfy `removals` and lose nothing else
 
 Exit status is 0 when every check passed, 1 when one failed, 2 when one could not
 be read, and 3 when the run could not be set up. `--self-test` exercises every
@@ -77,6 +85,10 @@ FAIL = "FAIL"
 UNREADABLE = "UNREADABLE"
 
 TICKET = "FIR-2958"
+# The granularity checks are rc062j finding (2), a different ticket in the same
+# merge authority, graded here rather than in a second suite because a second
+# copy of this scaffolding is only ever wrong in a way that looks like a pass.
+GRANULARITY_TICKET = "FIR-2960"
 
 print = functools.partial(print, flush=True)
 
@@ -100,6 +112,40 @@ THEIRS_SHARED = b"feature shared\n"
 
 # The contradictory fixture: two entities in one file, both moved on both
 # branches, so settling them to opposite sides leaves no side carrying both.
+# The granularity fixtures, rc062j finding (2). Python, because a Rust
+# `src/lib.rs` produces no module entity and no import edges, so it has nothing
+# to strand. `summarize` is called from three sibling modules, so it carries real
+# incoming edges, and both sides edit it to a DIFFERENT LENGTH, which is what
+# moves `helper` below it to a different byte offset on each side.
+GRAN_CORE_BASE = b"def summarize(rows):\n    return len(rows)\n\n\ndef helper(x):\n    return x + 1\n"
+GRAN_CORE_OURS = b"def summarize(rows):\n    return len(rows) + 100\n\n\ndef helper(x):\n    return x + 1\n"
+GRAN_CORE_THEIRS = b"def summarize(rows):\n    return len(rows) * 2\n\n\ndef helper(x):\n    return x + 1\n"
+
+
+def _gran_module(name):
+    return ("from pkg.core import summarize, helper\n\n\n"
+            "def use_%s(rows):\n    return summarize(rows) + helper(1)\n" % name).encode()
+
+
+GRAN_FILES = {"pkg/core.py": (GRAN_CORE_BASE, GRAN_CORE_OURS, GRAN_CORE_THEIRS)}
+for _name in ("a", "b", "c"):
+    _body = _gran_module(_name)
+    GRAN_FILES["pkg/mod_%s.py" % _name] = (_body, _body, _body)
+
+# The control fixture: one side genuinely REMOVES `helper` while the other side
+# adds an edge to it. That endpoint is absent from one side, so its row is
+# predictive rather than false, and it must survive. Without this check a merge
+# that dropped every relation row would pass `removals` and lose nothing else.
+GENUINE_CORE_BASE = GRAN_CORE_BASE
+GENUINE_CORE_OURS = b"def summarize(rows):\n    return len(rows)\n"
+GENUINE_CORE_THEIRS = GRAN_CORE_BASE
+GENUINE_MOD_BASE = b"from pkg.core import summarize\n\n\ndef use_a(rows):\n    return summarize(rows)\n"
+GENUINE_MOD_THEIRS = _gran_module("a")
+GENUINE_FILES = {
+    "pkg/core.py": (GENUINE_CORE_BASE, GENUINE_CORE_OURS, GENUINE_CORE_THEIRS),
+    "pkg/mod_a.py": (GENUINE_MOD_BASE, GENUINE_MOD_BASE, GENUINE_MOD_THEIRS),
+}
+
 BASE_PAIR = b"pub fn alpha() {}\npub fn beta() {}\n"
 OURS_PAIR = b"pub fn alpha(count: u64) {}\npub fn beta(count: u64) {}\n"
 THEIRS_PAIR = b"pub fn alpha(v: i32) {}\npub fn beta(v: i32) {}\n"
@@ -307,6 +353,14 @@ class Suite(object):
         rc, out, err = self.kin_run(["init", "."], path)
         if rc != 0:
             raise RuntimeError("kin init failed in %s: %s" % (path, (err or out)[-300:]))
+        # `kin init` can leave a pending semantic overlay, and a merge refuses to
+        # publish into a workspace holding one. It happens on the Python fixtures
+        # and not on the Rust ones, so a builder that skipped this worked for
+        # four checks and made the other two UNREADABLE. Not graded: a workspace
+        # with nothing pending reports nothing to commit, which is the same clean
+        # state under another name, and a merge that still refuses says so in the
+        # check's own detail line.
+        self.kin_run(["commit", "-m", "settle the post-init overlay"], path)
         self._repos[name] = path
         return path
 
@@ -366,10 +420,19 @@ class Suite(object):
 
 
 class Result(object):
-    def __init__(self, ident, status, detail):
+    """One graded check.
+
+    `ticket` defaults to this suite's own. It exists because the CHECK line and
+    the detail string used to be able to disagree: the printer hardcoded the
+    suite ticket while `_combine` wrote whichever ticket the check passed, so a
+    granularity row announced FIR-2958 and then explained FIR-2960.
+    """
+
+    def __init__(self, ident, status, detail, ticket=None):
         self.ident = ident
         self.status = status
         self.detail = detail
+        self.ticket = ticket or TICKET
 
 
 MIXED_FILES = {
@@ -481,15 +544,127 @@ def check_uniform(suite):
     return _combine("uniform", verdicts)
 
 
-def _combine(ident, verdicts):
+ROW_ENTITY_CHANGED = '{"subject": {"subject": "entity"}, "divergence": {"divergence": "changed_both_sides"}}'
+ROW_ARTIFACT_CHANGED = '{"subject": {"subject": "artifact"}, "divergence": {"divergence": "changed_both_sides"}}'
+ROW_RELATION_DANGLING = '{"subject": {"subject": "relation"}, "divergence": {"divergence": "dangling_endpoint"}}'
+ROW_RELATION_CHANGED = '{"subject": {"subject": "relation"}, "divergence": {"divergence": "changed_both_sides"}}'
+
+def dangling_rows(conflicts_json_text):
+    """Every parked conflict row whose divergence is a stranded endpoint.
+
+    Returns None when the listing cannot be read or names no parked merge,
+    because "no rows describing a removal" and "no merge at all" are the same
+    empty list and only one of them is the property being graded.
+    """
+    if not isinstance(conflicts_json_text, str) or not conflicts_json_text.strip():
+        return None
+    try:
+        payload = json.loads(conflicts_json_text)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    record = payload.get("record")
+    if not isinstance(record, dict):
+        return None
+    entries = record.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return None
+    rows = []
+    for entry in entries:
+        divergence = (entry or {}).get("divergence")
+        if isinstance(divergence, dict) and divergence.get("divergence") == "dangling_endpoint":
+            rows.append(entry)
+    return rows
+
+
+def grade_no_false_removals(conflicts_json_text):
+    """rc062j (2). One changed function must strand nothing.
+
+    Every identity in this fixture survives whichever side settles, so a row
+    saying one branch removed something is false on its face.
+    """
+    rows = dangling_rows(conflicts_json_text)
+    if rows is None:
+        return (UNREADABLE, "no readable parked merge to count rows in")
+    if rows:
+        return (FAIL, "%d row(s) describe a removal neither branch performed" % len(rows))
+    return (PASS, "no row describes a removal neither branch performed")
+
+
+def grade_reports_a_genuine_removal(conflicts_json_text):
+    """The control. A real removal the other side still points at must be named."""
+    rows = dangling_rows(conflicts_json_text)
+    if rows is None:
+        return (UNREADABLE, "no readable parked merge to count rows in")
+    if not rows:
+        return (FAIL, "a genuine stranded endpoint went unreported")
+    return (PASS, "%d genuine stranded endpoint row(s) reported" % len(rows))
+
+
+def grade_conflict_kinds(conflicts_json_text, forbidden):
+    """The kinds of subject the parked listing names, and whether `forbidden`
+    is among them. Read beside the row count so "zero removal rows" and "zero
+    relation rows of any kind" stay distinguishable."""
+    if not isinstance(conflicts_json_text, str) or not conflicts_json_text.strip():
+        return (UNREADABLE, "no listing to read subject kinds from")
+    try:
+        payload = json.loads(conflicts_json_text)
+        entries = (payload.get("record") or {}).get("entries") or []
+    except (ValueError, AttributeError):
+        return (UNREADABLE, "the listing did not parse")
+    if not entries:
+        return (UNREADABLE, "the listing names no parked merge")
+    kinds = {}
+    for entry in entries:
+        kind = ((entry or {}).get("subject") or {}).get("subject")
+        kinds[kind] = kinds.get(kind, 0) + 1
+    if forbidden in kinds:
+        return (FAIL, "the listing still carries %d %s row(s): %s"
+                % (kinds[forbidden], forbidden, kinds))
+    return (PASS, "subject kinds are %s" % kinds)
+
+
+def check_removals(suite):
+    """rc062j (2). One changed function, and no row claiming a removal.
+
+    Measured before the fix on this exact fixture: 22 rows, of which 18 said one
+    branch removed an identity the other still relates to, and every one of those
+    identities is present on both sides.
+    """
+    repo = suite.repo("granularity", GRAN_FILES)
+    suite.kin_run(["merge", "feature"], repo)
+    listing = suite.kin_run(["conflicts", "--json"], repo)[1]
+    return _combine("removals", [
+        ("rows", grade_no_false_removals(listing)),
+        ("kinds", grade_conflict_kinds(listing, "relation")),
+    ], ticket=GRANULARITY_TICKET)
+
+
+def check_genuine(suite):
+    """The control for `removals`. A real removal must still be reported."""
+    repo = suite.repo("genuine", GENUINE_FILES)
+    suite.kin_run(["merge", "feature"], repo)
+    listing = suite.kin_run(["conflicts", "--json"], repo)[1]
+    return _combine("genuine", [
+        ("rows", grade_reports_a_genuine_removal(listing)),
+    ], ticket=GRANULARITY_TICKET)
+
+
+def _combine(ident, verdicts, ticket=None):
     """Report every arm, never the first bad one, because knowing which arm
-    broke is the whole value of grading several claims in one check."""
+    broke is the whole value of grading several claims in one check.
+
+    `ticket` defaults to this suite's own, and the granularity checks pass
+    their own, so a detail line never cites a ticket the row is not about.
+    """
+    ticket = ticket or TICKET
     detail = "; ".join("%s %s %s" % (name, status, note) for name, (status, note) in verdicts)
     if any(status == FAIL for _, (status, _) in verdicts):
-        return Result(ident, FAIL, "%s %s" % (TICKET, detail))
+        return Result(ident, FAIL, detail, ticket=ticket)
     if any(status == UNREADABLE for _, (status, _) in verdicts):
-        return Result(ident, UNREADABLE, "%s %s" % (TICKET, detail))
-    return Result(ident, PASS, "%s %s" % (TICKET, detail))
+        return Result(ident, UNREADABLE, detail, ticket=ticket)
+    return Result(ident, PASS, detail, ticket=ticket)
 
 
 # Ordered, and the order is load bearing: `precedence` publishes the merge
@@ -499,6 +674,8 @@ CHECKS = [
     ("bulk", check_bulk),
     ("refusal", check_refusal),
     ("uniform", check_uniform),
+    ("removals", check_removals),
+    ("genuine", check_genuine),
 ]
 
 
@@ -567,7 +744,7 @@ def report_payload(results):
     the gate's own loader over this payload rather than a copy of its rules.
     """
     return {"suite": "merge_precedence", "ticket": TICKET,
-            "results": [{"id": r.ident, "ticket": TICKET, "status": r.status,
+            "results": [{"id": r.ident, "ticket": r.ticket, "status": r.status,
                          "detail": r.detail} for r in results]}
 
 
@@ -679,6 +856,45 @@ def self_test():
         finally:
             shutil.rmtree(scratch, ignore_errors=True)
 
+    # rc062j (2). Every granularity grader gets an input that must pass and one
+    # that must fail, so a grader that answers PASS over anything is caught here
+    # rather than in CI with no binary to blame.
+    clean = '{"record": {"entries": [%s, %s]}}' % (
+        ROW_ENTITY_CHANGED, ROW_ARTIFACT_CHANGED)
+    stranded = '{"record": {"entries": [%s, %s]}}' % (
+        ROW_ENTITY_CHANGED, ROW_RELATION_DANGLING)
+    expect("removals passes a listing with no stranded row",
+           grade_no_false_removals(clean), PASS)
+    expect("removals fails the shipped listing carrying stranded rows",
+           grade_no_false_removals(stranded), FAIL)
+    expect("removals cannot read an empty listing",
+           grade_no_false_removals(""), UNREADABLE)
+    expect("removals cannot read a listing with no parked merge",
+           grade_no_false_removals('{"record": {"entries": []}}'), UNREADABLE)
+    expect("removals cannot read text that is not json",
+           grade_no_false_removals("nope"), UNREADABLE)
+
+    expect("genuine passes a listing that reports a real stranded endpoint",
+           grade_reports_a_genuine_removal(stranded), PASS)
+    expect("genuine fails a listing that reports none",
+           grade_reports_a_genuine_removal(clean), FAIL)
+    expect("genuine cannot read an empty listing",
+           grade_reports_a_genuine_removal(""), UNREADABLE)
+
+    expect("kinds passes a listing carrying no relation row",
+           grade_conflict_kinds(clean, "relation"), PASS)
+    expect("kinds fails a listing that still carries one",
+           grade_conflict_kinds(stranded, "relation"), FAIL)
+    expect("kinds cannot read a listing with no parked merge",
+           grade_conflict_kinds('{"record": {"entries": []}}', "relation"), UNREADABLE)
+    # CONTROL: the two graders must not be the same reading. A relation row that
+    # is NOT a stranded endpoint is fine by `removals` and named by `kinds`.
+    plain_relation = '{"record": {"entries": [%s]}}' % ROW_RELATION_CHANGED
+    expect("CONTROL removals accepts a relation row that strands nothing",
+           grade_no_false_removals(plain_relation), PASS)
+    expect("CONTROL kinds still names that same relation row",
+           grade_conflict_kinds(plain_relation, "relation"), FAIL)
+
     expect("a relative kin path is absolutized by this suite",
            (os.path.isabs(absolute_binary("target/release/kin")), "isabs"), True)
     expect("and an absent binary stays absent rather than becoming the cwd",
@@ -731,7 +947,8 @@ def main(argv):
             except Exception as error:  # noqa: BLE001 - a setup failure is not a verdict
                 results.append(Result(ident, UNREADABLE, "%s check raised: %s" % (TICKET, error)))
         for result in results:
-            print("CHECK %s %s %s %s" % (result.ident, TICKET, result.status, result.detail))
+            print("CHECK %s %s %s %s" % (result.ident, result.ticket, result.status,
+                                         result.detail))
         asked = [ident for ident, _ in CHECKS]
         answered = [result.ident for result in results]
         # Written before the asked/answered guard below, not after it. Four


### PR DESCRIPTION
Two rc062j findings from the vcs stranger's merge and resolve workflow. Each has a before-and-after measured on distinct subjects, and each is falsified.

The third finding from that run, the `kin branch switch` race, was in this PR and is **withdrawn from it**. The fix admitted the pending edit before the switch read the graph, and CI caught that admission also absorbing an UNTRACKED file: `command_branch_returns_conflict_for_untracked_target_path_without_mutation` went from an "untracked working-copy path" refusal to a "pending changes cannot move" one, because `selected/Dockerfile` had become tracked pending work that the user never asked to track. Both refuse and neither corrupts, but silently admitting an untracked file as a side effect of a branch switch is a worse behaviour than the race it fixes. The commit is parked at `chore/mergetruth-switch-admit-parked` and comes back as a retry on the specific refusal rather than an unconditional pre-pass, with the untracked case as its own arm.

## (2) 22 conflict rows for one changed function, 18 of them describing a removal that never happened

| | total rows | entity | relation | artifact | rows describing a removal |
|---|---|---|---|---|---|
| before, kin `7682e500` | 22 | 3 | 18 | 1 | **18** |
| after, kin `ee7ad56c` | **4** | 3 | **0** | 1 | **0** |

`collect_dangling_endpoints` decided dangling on `!entities.contains_key(&entity)` against the COMPOSED map, and `compose` records a conflict and continues **without inserting**. So every conflicted identity looked removed and every edge incident on it became a false row saying "one branch removed X, which the other branch still relates to".

The narrowing is deliberately smaller than "skip conflicted". An identity present on **both** sides survives whichever side settles, so its row is always false. An identity absent from one side genuinely strands if the settlement takes the side that lacks it, so its row is predictive and stays. Where a row is dropped, the publish-time call of the same function is the net, because by then `apply_resolution` has put the settled values in the maps and the answer actually exists. The conflict set is read from the vec the function already receives, so no signatures change and the opening composition and the recomposition move together, which `require_same_conflicts` demands.

Falsified:

```
arm  noremoval  genuine   removes
N0   green      green     nothing
N1   red        green     the guard
```

`dangling_relation_records_and_accepts_its_present_base_side` asserted the defect on purpose, with a sentence saying so. Its second half is worth keeping, so its fixture is now a genuine removal by the source branch and that half still runs.

## (4) A merge refused for "graph-owned changes" while other surfaces called the workspace clean

`WorkspaceState::is_dirty` is three distinguishable states, not one: a pending semantic overlay, a working tree moved off its base change, and through its `map_or` an unborn head with any tree at all. The refusal named none of them. It now mirrors the predicate clause for clause and says what clears each, and the overlay-only arm states outright that a tree-only reader such as `kin status` can call the same workspace clean at the same moment, which is the disagreement the stranger met. The unreachable arm says it is a defect in the refusal rather than in the repository.

This fix paid for itself within the hour: it is what caught a later probe of mine that was publishing no merge at all, by naming the overlay clause instead of saying "has graph-owned changes".

## Acceptance and falsification for (2)

Two checks join `scripts/acceptance/merge_precedence_repro.py` rather than a second suite, because a second copy of that scaffolding is only ever wrong in a way that looks like a passing run, and the file is already registered in the workflow, the gate and the visibility guard.

```
CHECK removals FIR-2960 PASS rows PASS no row describes a removal neither branch
  performed; kinds PASS subject kinds are {'entity': 3, 'artifact': 1}
CHECK genuine  FIR-2960 PASS rows PASS 2 genuine stranded endpoint row(s) reported
```

Falsified:

```
arm  removals  genuine  removes
N0   PASS      PASS     nothing
N1   FAIL      PASS     the narrowing
```

N1's own detail reproduces the before-arm independently, from a different fixture path and a different reader: `18 row(s) describe a removal neither branch performed ... {'entity': 3, 'relation': 18, 'artifact': 1}`. `genuine` is green all the way across on purpose: it is the control that separates "stopped reporting false removals" from "stopped reporting relation rows".

The suite's self-test went from 22 grader assertions to 35, each new grader given an input that must pass and one that must fail, plus a control pair proving `removals` and `kinds` are not one reading.

Two things the run corrected on the way. The fixture builder now settles the overlay `kin init` leaves, which the Python fixtures hold and the Rust ones do not, so skipping it worked for four checks and made the other two UNREADABLE; the refusal that caught it is the one this PR rewrites, and it named the overlay clause and the command that clears it. And `Result` now carries its own ticket, because the printer hardcoded the suite's while the combiner wrote the check's, so a granularity row announced FIR-2958 and then explained FIR-2960.

## Why three entity rows remain, measured

The acceptance shape asked for "exactly one entity conflict" too. That half is not in this PR, and the measurement is why.

`an_untouched_entity_differs_between_branches_only_in_its_span` compares two versions of an entity NEITHER side edits, field by field across every field the model declares. Provenance was the guess, and the measurement refuted it: `created_in` is EQUAL, because nothing re-minted the record. The field that differs is `span`. Both edits to the function above it are different lengths, so every byte offset below shifts by a different amount on each side.

So the three entity rows are one real conflict and two byte-offset shifts. A byte offset is a projection of whichever bytes the merge publishes, not an independent decision. Removing that question means choosing a span at compose time, before the artifact settlement decides which bytes publish, and taking the wrong one records spans that point at the wrong lines. That is the derived-conflict design, FIR-2960, and not this change. The removal narrowing has no such hazard, because a row it drops has no decision behind it at all.

The test asserts the exact set rather than a subset, so an entity that starts differing on a SEMANTIC field fails there rather than being folded into the same explanation, and its control asserts the edited entity differs on `fingerprint`.

## Instruments

`.kin-coord/reports/mergetruth-rc062j-repro/` carries `granularity.sh` for (2), `falsify2.sh` for the (2) unit grid and `falsify-acceptance.sh` for the acceptance grid, plus `measure.sh` and `five-hundred.sh` from the withdrawn (3) work. Every arm copies the stranger's store or builds its own fixture; their original is never touched.

Refs FIR-2960
