### PR TITLE
Give both new suite steps the visibility shape, and restore the gate's order

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -956,6 +956,10 @@ jobs:
             grep -E '^CHECK ' acceptance/blame_attribution.log || echo '(no CHECK line was printed)'
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Blame-attribution acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
 
       - name: Diff-content acceptance suite (verdict comes from the gate step)
         id: diffcontent
@@ -977,6 +981,10 @@ jobs:
             grep -E '^CHECK ' acceptance/diff_content.log || echo '(no CHECK line was printed)'
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Diff-content acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
 
       - name: VCS read-surface acceptance suite (verdict comes from the gate step)
         id: vcsreadsurfaces
@@ -1182,9 +1190,9 @@ jobs:
             --report first_query=acceptance/first_query.json \
             --report verdict_limits=acceptance/verdict_limits.json \
             --report working_copy_freshness=acceptance/working_copy_freshness.json \
-            --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \
-            --report diff_content=acceptance/diff_content.json \
             --report blame_attribution=acceptance/blame_attribution.json \
+            --report diff_content=acceptance/diff_content.json \
+            --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \
             --report init_budget=acceptance/init_budget.json \
             --report coverage_read=acceptance/coverage_read.json \
             --report bridge_reach=acceptance/bridge_reach.json \

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -123,6 +123,16 @@ EXPECTED_SUITES = (
         "acceptance/working_copy_freshness.json",
     ),
     ExpectedSuite(
+        "scripts/acceptance/blame_attribution_repro.py",
+        "blame_attribution",
+        "acceptance/blame_attribution.json",
+    ),
+    ExpectedSuite(
+        "scripts/acceptance/diff_content_repro.py",
+        "diff_content",
+        "acceptance/diff_content.json",
+    ),
+    ExpectedSuite(
         "scripts/acceptance/vcs_read_surfaces_repro.py",
         "vcs_read_surfaces",
         "acceptance/vcs_read_surfaces.json",


### PR DESCRIPTION
**Main's Acceptance has run zero suites since kin#1284 landed.** The job stops at "Falsify and enforce the workflow step visibility rule", so every suite after it reports "no report" and the gate grades nothing. #1284 broke it and #1288 added the second violation. Both are mine.

This is the check-that-cannot-fail shape arriving through the front door of two new checks being added.

## Three causes

**1. Both new suite steps omit the visibility shape**, missing the trailing:

```yaml
echo "rc=$rc" >> "$GITHUB_OUTPUT"
if [ "$rc" -ne 0 ]; then
  echo "::warning title=<suite> returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
fi
```

I copied the sibling step's body down to its `GITHUB_STEP_SUMMARY` block and stopped four lines short of where that body ends. The steps read correct beside their siblings and were not.

**2. The gate's `--report` order did not match the step order.** Steps run `blame_attribution`, `diff_content`, `vcs_read_surfaces`; the gate listed them reversed. The guard requires suite outputs and gate inputs to be one-to-one **in order**, which is what makes a report provably reach the verdict that grades it rather than merely existing somewhere.

**3. `EXPECTED_SUITES` was stale**, so the inventory the guard pins was wrong the moment either suite landed.

## Verification

Run with the two commands the step itself runs, in its order, rather than an approximation:

```
--self-test   all 2 controls clean, all 24 adversarial mutants caught
(guard)       workflow authority holds: 24 suite reports reach one always-running verdict in order
```

Both suites' own self-tests still pass, 24 and 21 cases.

**Falsified:** removing one of the two annotations returns the guard to exactly one violation, so it still catches the shape it exists for.

## The rule

Second instance tonight of one shape. The first was a compile error in `kin-daemon`'s test targets that a narrower `cargo test` could not see after the wide check had found its siblings.

**A new entry in a list that something else pins is not finished until the pin is updated and the pinning check is run.** The guard existed, it was correct, and it was never invoked locally against either change.

Closes FIR-3000
