### PR TITLE
Give the diff-content and blame-attribution suite steps the visibility shape the guard enforces

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -936,48 +936,6 @@ jobs:
             echo "::warning title=Working-copy freshness acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
-      - name: Blame-attribution acceptance suite (verdict comes from the gate step)
-        id: blameattribution
-        if: always()
-        run: |
-          set -uo pipefail
-          mkdir -p acceptance
-          rc=0
-          python3 scripts/acceptance/blame_attribution_repro.py \
-            --kin target/release/kin \
-            --daemon target/release/kin-daemon \
-            --json acceptance/blame_attribution.json \
-            --verbose >acceptance/blame_attribution.log 2>&1 || rc=$?
-          cat acceptance/blame_attribution.log
-          {
-            echo "### Blame-attribution acceptance suite (exit $rc)"
-            echo ''
-            echo '```'
-            grep -E '^CHECK ' acceptance/blame_attribution.log || echo '(no CHECK line was printed)'
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Diff-content acceptance suite (verdict comes from the gate step)
-        id: diffcontent
-        if: always()
-        run: |
-          set -uo pipefail
-          mkdir -p acceptance
-          rc=0
-          python3 scripts/acceptance/diff_content_repro.py \
-            --kin target/release/kin \
-            --daemon target/release/kin-daemon \
-            --json acceptance/diff_content.json \
-            --verbose >acceptance/diff_content.log 2>&1 || rc=$?
-          cat acceptance/diff_content.log
-          {
-            echo "### Diff-content acceptance suite (exit $rc)"
-            echo ''
-            echo '```'
-            grep -E '^CHECK ' acceptance/diff_content.log || echo '(no CHECK line was printed)'
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: VCS read-surface acceptance suite (verdict comes from the gate step)
         id: vcsreadsurfaces
         if: always()
@@ -1001,6 +959,56 @@ jobs:
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
           if [ "$rc" -ne 0 ]; then
             echo "::warning title=VCS read-surface acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
+      - name: Diff-content acceptance suite (verdict comes from the gate step)
+        id: diffcontent
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/diff_content_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/diff_content.json \
+            --verbose >acceptance/diff_content.log 2>&1 || rc=$?
+          cat acceptance/diff_content.log
+          {
+            echo "### Diff-content acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/diff_content.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Diff-content acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
+      - name: Blame-attribution acceptance suite (verdict comes from the gate step)
+        id: blameattribution
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/blame_attribution_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/blame_attribution.json \
+            --verbose >acceptance/blame_attribution.log 2>&1 || rc=$?
+          cat acceptance/blame_attribution.log
+          {
+            echo "### Blame-attribution acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/blame_attribution.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Blame-attribution acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
       - name: Init budget acceptance suite (verdict comes from the gate step)

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -128,6 +128,16 @@ EXPECTED_SUITES = (
         "acceptance/vcs_read_surfaces.json",
     ),
     ExpectedSuite(
+        "scripts/acceptance/diff_content_repro.py",
+        "diff_content",
+        "acceptance/diff_content.json",
+    ),
+    ExpectedSuite(
+        "scripts/acceptance/blame_attribution_repro.py",
+        "blame_attribution",
+        "acceptance/blame_attribution.json",
+    ),
+    ExpectedSuite(
         "scripts/acceptance/init_budget_refusal.py",
         "init_budget",
         "acceptance/init_budget.json",


### PR DESCRIPTION
Both suite steps added tonight (#1284 diff-content, #1288 blame-attribution) landed without the `rc` output line and the nonzero warning branch every sibling suite step carries, and they sat before the VCS read-surface step while the verdict gate lists them after it. The visibility guard (`Falsify and enforce the workflow step visibility rule`) refused on all three counts, so every Acceptance run on `main` since c0f48536 graded zero suites: run 33306567951 on e47556dd is the specimen, and #1286 and #1289 are the alarm's issues for it.

This moves the two steps after the VCS read-surface step in the gate's order, adds the `rc` output and the one-annotation warning branch to each, and registers both in the guard's expected suite table in step order. No suite logic changes.

Evidence, all from this branch's tree at 39cc79f7:
- `python3 scripts/acceptance/test_workflow_step_visibility.py --self-test`: all 2 controls clean, all 24 adversarial mutants caught.
- `python3 scripts/acceptance/test_workflow_step_visibility.py`: `workflow authority holds: 24 suite reports reach one always-running verdict in order`, rc 0.
- Falsified against the committed tree: deleting the diff-content warning branch turns the guard red on both of that step's assertions (rc 1); swapping the two steps back out of gate order turns it red on the inventory and one-to-one order assertions (rc 1). Each restore read tree == HEAD.

The alarm closes #1289 on its own once a main run grades green.
