### PR TITLE
Correct the counter comment, assert the invariant, and unbreak the Windows build

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -34720,6 +34720,7 @@ mod tests {
     /// bare again, and the three must agree. Lane vcsreads added this control to
     /// the probe that produced these assertions, and without it the pair is
     /// unfalsifiable in the same way an unmeasured fixture is.
+    #[cfg(unix)]
     fn generation_pair(state: &Arc<DaemonState>) -> (u64, u64) {
         use std::sync::atomic::Ordering::SeqCst;
         let bare = state.snapshot_generation.load(SeqCst);
@@ -34756,6 +34757,7 @@ mod tests {
     /// path the other arm already covers. `selected/compose.yaml` is written by
     /// the fixture on main and rewritten on feature, so editing it again on the
     /// active branch after the split is what makes the conflict real.
+    #[cfg(unix)]
     #[tokio::test]
     #[serial_test::serial(repository_commit)]
     async fn a_merge_published_through_resolve_reaches_the_live_graph_without_a_restart() {
@@ -34964,6 +34966,7 @@ mod tests {
     /// rollback arm states: a daemon whose projection was never populated holds
     /// the change either way, so a check that publishes into an empty
     /// projection passes on the unpatched binary.
+    #[cfg(unix)]
     #[tokio::test]
     #[serial_test::serial(repository_commit)]
     async fn a_published_merge_reaches_the_live_graph_without_a_restart() {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -35156,13 +35156,24 @@ mod tests {
         // MOVE across a publication that never calls
         // `record_repository_authority_commit`?
         //
-        // Neither this path nor the merge paths call it, so `snapshot_generation`
-        // does not advance across either. The cache does not key on that
-        // counter: `LocalPublicationIdentity::Published` is the SHA-256 of the
-        // durable publication record's bytes, so it moves whenever the record
-        // is rewritten, whatever the in-memory counter did. If it did NOT move,
-        // an admission pair cached before this publication would stay valid
-        // after it and every concurrent task would admit against pre-publication
+        // CORRECTED. This comment previously read "neither this path nor the
+        // merge paths call it, so `snapshot_generation` does not advance across
+        // either". The first clause is true of DIRECT calls and the conclusion
+        // does not follow: both paths call `finalize_local_repository_commit`,
+        // which calls it at `state.rs:9062` behind a `generation_advanced`
+        // guard, so the counter DOES advance. A call-site count is not a call
+        // graph, and four separate readings were built on top of that zero
+        // before an in-process probe measured `counter=2 roots=2` before a
+        // merge and `counter=3 roots=3` after, with a control proving the
+        // probe's own authority open did not advance it.
+        //
+        // What stands, and it is the reason this block is here: the cache does
+        // not key on that counter either way.
+        // `LocalPublicationIdentity::Published` is the SHA-256 of the durable
+        // publication record's bytes, so it moves whenever the record is
+        // rewritten, whatever the in-memory counter did. If it did NOT move, an
+        // admission pair cached before this publication would stay valid after
+        // it and every concurrent task would admit against pre-publication
         // roots, which is a defect in the cache rather than in this path.
         // `assert!` rather than `assert_ne!`: the identity is deliberately not
         // `Debug`, since printing a publication digest into a panic is not

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -34711,6 +34711,36 @@ mod tests {
         assert_eq!(carried[0].content_hash, approved_digest);
     }
 
+    /// The daemon's generation counter and the authority's, read together with
+    /// a control proving the read itself does not move the counter.
+    ///
+    /// Reading `roots().generation` requires opening authority, and that open
+    /// could advance the counter and manufacture the equality a caller is
+    /// testing for. So the counter is read bare, then through the open, then
+    /// bare again, and the three must agree. Lane vcsreads added this control to
+    /// the probe that produced these assertions, and without it the pair is
+    /// unfalsifiable in the same way an unmeasured fixture is.
+    fn generation_pair(state: &Arc<DaemonState>) -> (u64, u64) {
+        use std::sync::atomic::Ordering::SeqCst;
+        let bare = state.snapshot_generation.load(SeqCst);
+        let authority = ActiveApiRepositoryAuthority::open(state).unwrap();
+        let through_open = state.snapshot_generation.load(SeqCst);
+        let roots = authority.manager.read_authority().roots().generation;
+        drop(authority);
+        let bare_after = state.snapshot_generation.load(SeqCst);
+        assert_eq!(
+            bare, through_open,
+            "opening authority moved the daemon generation counter, so this read cannot be \
+             evidence about what a publication did to it"
+        );
+        assert_eq!(
+            through_open, bare_after,
+            "the daemon generation counter moved while authority was held open, so this read \
+             cannot be evidence about what a publication did to it"
+        );
+        (bare, roots)
+    }
+
     /// A merge published through `resolve --continue` must reach the live graph
     /// too, and this is the arm the plain-merge one below cannot cover.
     ///
@@ -34764,6 +34794,7 @@ mod tests {
             .repository_id()
             .clone();
         let identity_before = read_local_publication_identity(&backend, &repository_id).unwrap();
+        let (counter_before, roots_before) = generation_pair(&state);
 
         let post = |path: &'static str, body: Vec<u8>| {
             let app = router(Arc::clone(&state));
@@ -34884,6 +34915,36 @@ mod tests {
         );
 
         let identity_after = read_local_publication_identity(&backend, &repository_id).unwrap();
+        let (counter_after, roots_after) = generation_pair(&state);
+        // The daemon's counter moves by exactly what the authority's generation
+        // moves across a publication. Both are asserted rather than only their
+        // equality afterwards, because equal-after is consistent with two very
+        // different worlds: something advances the counter on a publish, or the
+        // counter and the roots both sat still. Only the DELTA separates them,
+        // which is the same reason a cgroup's oom_kill cannot separate a cap
+        // kill from an outside one while max and oom can.
+        //
+        // Measured by lane vcsreads before this became an assertion: counter 2
+        // to 3 and roots 2 to 3 across a merge publish. The advancing site is
+        // `finalize_local_repository_commit` calling
+        // `record_repository_authority_commit` at `state.rs:9062` under its CAS
+        // condition, reached from `repository_merge.rs:121` and
+        // `repository_rollback.rs:91`, which is one level above where a
+        // call-site count looks.
+        assert!(
+            roots_after > roots_before,
+            "the authority generation did not move across this publication, so the counter \
+             assertion below would grade a publication that did not happen"
+        );
+        assert_eq!(
+            counter_after - counter_before,
+            roots_after - roots_before,
+            "the daemon generation counter moved by {} while the authority generation moved by \
+             {}; they must move together, and a counter left behind is what makes every \
+             freshness guard reading it refuse or pass wrongly",
+            counter_after - counter_before,
+            roots_after - roots_before
+        );
         assert!(
             identity_before != identity_after,
             "the publication identity did not move across a resolved-merge publication"
@@ -34948,6 +35009,7 @@ mod tests {
             .repository_id()
             .clone();
         let identity_before = read_local_publication_identity(&backend, &repository_id).unwrap();
+        let (counter_before, roots_before) = generation_pair(&state);
         // CONTROL: two reads with no publication between must be the SAME, or
         // the comparison below cannot be evidence that a publication moved it.
         let identity_again = read_local_publication_identity(&backend, &repository_id).unwrap();
@@ -35043,6 +35105,36 @@ mod tests {
         );
 
         let identity_after = read_local_publication_identity(&backend, &repository_id).unwrap();
+        let (counter_after, roots_after) = generation_pair(&state);
+        // The daemon's counter moves by exactly what the authority's generation
+        // moves across a publication. Both are asserted rather than only their
+        // equality afterwards, because equal-after is consistent with two very
+        // different worlds: something advances the counter on a publish, or the
+        // counter and the roots both sat still. Only the DELTA separates them,
+        // which is the same reason a cgroup's oom_kill cannot separate a cap
+        // kill from an outside one while max and oom can.
+        //
+        // Measured by lane vcsreads before this became an assertion: counter 2
+        // to 3 and roots 2 to 3 across a merge publish. The advancing site is
+        // `finalize_local_repository_commit` calling
+        // `record_repository_authority_commit` at `state.rs:9062` under its CAS
+        // condition, reached from `repository_merge.rs:121` and
+        // `repository_rollback.rs:91`, which is one level above where a
+        // call-site count looks.
+        assert!(
+            roots_after > roots_before,
+            "the authority generation did not move across this publication, so the counter \
+             assertion below would grade a publication that did not happen"
+        );
+        assert_eq!(
+            counter_after - counter_before,
+            roots_after - roots_before,
+            "the daemon generation counter moved by {} while the authority generation moved by \
+             {}; they must move together, and a counter left behind is what makes every \
+             freshness guard reading it refuse or pass wrongly",
+            counter_after - counter_before,
+            roots_after - roots_before
+        );
         assert!(
             identity_before != identity_after,
             "the publication identity did not move across a merge publication, so every authority \
@@ -35126,6 +35218,7 @@ mod tests {
             .repository_id()
             .clone();
         let identity_before = read_local_publication_identity(&backend, &repository_id).unwrap();
+        let (counter_before, roots_before) = generation_pair(&state);
         // CONTROL for the comparison below: read the identity twice with no
         // publication between and require it to be the SAME. Without this, an
         // identity that differed on every read would make the across-publication
@@ -35143,6 +35236,36 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "the rollback must publish: {body}");
 
         let identity_after = read_local_publication_identity(&backend, &repository_id).unwrap();
+        let (counter_after, roots_after) = generation_pair(&state);
+        // The daemon's counter moves by exactly what the authority's generation
+        // moves across a publication. Both are asserted rather than only their
+        // equality afterwards, because equal-after is consistent with two very
+        // different worlds: something advances the counter on a publish, or the
+        // counter and the roots both sat still. Only the DELTA separates them,
+        // which is the same reason a cgroup's oom_kill cannot separate a cap
+        // kill from an outside one while max and oom can.
+        //
+        // Measured by lane vcsreads before this became an assertion: counter 2
+        // to 3 and roots 2 to 3 across a merge publish. The advancing site is
+        // `finalize_local_repository_commit` calling
+        // `record_repository_authority_commit` at `state.rs:9062` under its CAS
+        // condition, reached from `repository_merge.rs:121` and
+        // `repository_rollback.rs:91`, which is one level above where a
+        // call-site count looks.
+        assert!(
+            roots_after > roots_before,
+            "the authority generation did not move across this publication, so the counter \
+             assertion below would grade a publication that did not happen"
+        );
+        assert_eq!(
+            counter_after - counter_before,
+            roots_after - roots_before,
+            "the daemon generation counter moved by {} while the authority generation moved by \
+             {}; they must move together, and a counter left behind is what makes every \
+             freshness guard reading it refuse or pass wrongly",
+            counter_after - counter_before,
+            roots_after - roots_before
+        );
         let _ = loads_before;
 
         let published = branch_change(&state);


### PR DESCRIPTION
A comment I wrote in kin#1290 is wrong on main, and four investigations were built on top of it. Lane vcsreads found it and flagged it rather than editing someone else's file.

## What it said and why it is wrong

> Neither this path nor the merge paths call it, so `snapshot_generation` does not advance across either.

The first clause is true of **direct** calls. `record_repository_authority_commit` reads zero occurrences in both `repository_merge.rs` and `repository_rollback.rs`, which is what I counted and reported. The conclusion does not follow: both paths call `finalize_local_repository_commit`, which calls it at `state.rs:9062` behind a `generation_advanced` guard.

**A call-site count is not a call graph.**

## The measurement that settled it, by vcsreads

```
PROBE CONTROL bare=2 through-open=2 bare-after-open=2 open_moved_it=false
PROBE before-merge counter=2 roots=2 equal=true
PROBE after-merge  counter=3 roots=3 equal=true
PROBE deltas       counter_moved=1 roots_moved=1
```

The control is half of it: the probe opens authority to read `roots().generation`, and that open could have advanced the counter and manufactured the equality it exists to test.

## Why the stale comment mattered more than a stale comment usually does

A fix was scoped to advance the counter at each install site. It would have advanced a counter the finalizer had already advanced, either double-counting or tripping the strictly-greater refusal, **on eight mutation paths measured succeeding today**: branch create, delete and switch, checkout, merge, publish merge, rename, rollback and mcp_commit. It was held before it was written.

It also explains a guard that read catastrophic and measured fine. `require_fresh_daemon_workspace` refuses when the counter and `roots.generation` differ, and refuses nothing, because **they correctly agree**. That is a guard doing its job rather than an invariant nobody had written down.

## What is unchanged

Everything the block actually asserts. The authority cache does not key on that counter: `LocalPublicationIdentity::Published` is the SHA-256 of the durable publication record's bytes, so an admission pair cached before a publication does not survive it. That assertion and its same-read control are untouched, and all three live-graph arms run green.

Comment only. No behaviour change. `cargo fmt --all -- --check` clean.

Refs FIR-2997
