### PR TITLE
Show a conflict's three sides as source, checked back against the digests the merge recorded

### DIFF
--- a/crates/kin-cli/src/commands/conflicts.rs
+++ b/crates/kin-cli/src/commands/conflicts.rs
@@ -16,7 +16,15 @@ pub const CONFLICTS_REPORT_SCHEMA: &str = "kin.conflicts.v1";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct ConflictsRequest {}
+pub struct ConflictsRequest {
+    /// Materialize each conflict subject's three sides as source.
+    ///
+    /// Defaulted, so a client that sends `{}` keeps today's behaviour and
+    /// today's cost. Reading bodies resolves the graph at three changes and
+    /// reads a blob per side, which a listing does not otherwise do.
+    #[serde(default)]
+    pub bodies: bool,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConflictsReport {
@@ -38,6 +46,42 @@ pub struct ConflictsReport {
     pub record_hash: Option<String>,
     pub unresolved_count: usize,
     pub resolved_count: usize,
+    /// One entry per conflict subject whose sides could be materialized, in the
+    /// listing's own order. Empty unless the request asked for bodies.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bodies: Vec<ConflictBody>,
+}
+
+/// One conflict subject's three sides, as the source each side actually holds.
+///
+/// The record itself carries only a `Hash256` per side, which is a digest of
+/// the model value and not a content address: it cannot be resolved to bytes by
+/// any lookup. These are re-materialized from the graph at the three changes the
+/// merge bound, which is why each side is checked back against its recorded
+/// digest before it is offered.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConflictBody {
+    /// The subject as the listing names it, so a reader can pair a body with
+    /// the row it belongs to without re-deriving the identity.
+    pub subject: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// `None` means the identity is absent on that side, which is a real
+    /// answer. A side that could not be verified is named in `unverified` and
+    /// is `None` here too, so the two are never confused by a reader that only
+    /// looks at the body.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ours: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theirs: Option<String>,
+    /// Sides whose re-materialized value did not hash back to the digest the
+    /// record holds, or whose bytes could not be read. Named rather than
+    /// silently omitted, because a body that is quietly missing reads exactly
+    /// like an identity that is absent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unverified: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,8 +92,8 @@ pub struct ConflictsResponse {
     pub report: Option<ConflictsReport>,
 }
 
-pub async fn run(json: bool) -> Result<()> {
-    let response = execute(ConflictsRequest {}).await?;
+pub async fn run(json: bool, show: bool) -> Result<()> {
+    let response = execute(ConflictsRequest { bodies: show }).await?;
     if json {
         let report = response
             .report
@@ -59,8 +103,48 @@ pub async fn run(json: bool) -> Result<()> {
         for line in response.lines {
             println!("{line}");
         }
+        if show {
+            let report = response.report.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("daemon conflicts response omitted its report")
+            })?;
+            for body in &report.bodies {
+                print_body(body);
+            }
+        }
     }
     Ok(())
+}
+
+/// Print one subject's two decisions as diffs against the base.
+///
+/// Rendered against base rather than against each other because the question a
+/// settlement answers is which side's departure from the common ancestor to
+/// keep, and a diff of ours against theirs shows neither departure.
+fn print_body(body: &ConflictBody) {
+    println!();
+    match &body.label {
+        Some(label) => println!("{} ({})", label, body.subject),
+        None => println!("{}", body.subject),
+    }
+    for side in &body.unverified {
+        println!(
+            "  {side}: not shown, because the value re-read from the graph did not hash back to \
+             the digest this merge recorded"
+        );
+    }
+    for (name, side) in [("ours", &body.ours), ("theirs", &body.theirs)] {
+        if side.is_none() && body.unverified.iter().any(|entry| entry == name) {
+            continue;
+        }
+        println!("  base -> {name}:");
+        if body.base.is_none() && side.is_none() {
+            println!("    (absent on both sides)");
+            continue;
+        }
+        for line in crate::commands::diff::render_hunks(body.base.as_deref(), side.as_deref()) {
+            println!("    {line}");
+        }
+    }
 }
 
 async fn execute(request: ConflictsRequest) -> Result<ConflictsResponse> {

--- a/crates/kin-cli/src/commands/conflicts.rs
+++ b/crates/kin-cli/src/commands/conflicts.rs
@@ -141,8 +141,15 @@ fn print_body(body: &ConflictBody) {
             println!("    (absent on both sides)");
             continue;
         }
+        // Split on newlines rather than printing each returned element whole.
+        // The renderer returns a hunk header as one element and that hunk's
+        // body as another carrying embedded newlines, so indenting per element
+        // indented the header and left every `-` and `+` line at column zero,
+        // outside the block it belongs to.
         for line in crate::commands::diff::render_hunks(body.base.as_deref(), side.as_deref()) {
-            println!("    {line}");
+            for physical in line.split('\n') {
+                println!("    {physical}");
+            }
         }
     }
 }

--- a/crates/kin-cli/src/commands/conflicts.rs
+++ b/crates/kin-cli/src/commands/conflicts.rs
@@ -104,9 +104,10 @@ pub async fn run(json: bool, show: bool) -> Result<()> {
             println!("{line}");
         }
         if show {
-            let report = response.report.as_ref().ok_or_else(|| {
-                anyhow::anyhow!("daemon conflicts response omitted its report")
-            })?;
+            let report = response
+                .report
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("daemon conflicts response omitted its report"))?;
             for body in &report.bodies {
                 print_body(body);
             }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -613,6 +613,10 @@ enum Command {
         /// Emit the machine-readable merge transaction record
         #[arg(long)]
         json: bool,
+        /// Print each conflict subject's three sides as source, diffed against
+        /// the common ancestor
+        #[arg(long)]
+        show: bool,
     },
     /// Resolve repository-v6 merge conflicts
     ///
@@ -3218,9 +3222,9 @@ fn main() -> Result<()> {
                     commands::capabilities::require_ready("merge")?;
                     commands::merge::run(branch, json).await
                 }
-                Command::Conflicts { json } => {
+                Command::Conflicts { json, show } => {
                     commands::capabilities::require_ready("conflicts")?;
-                    commands::conflicts::run(json).await
+                    commands::conflicts::run(json, show).await
                 }
                 Command::Resolve {
                     ours,

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -21,7 +21,9 @@ use kin_cli::commands::resolve::{
     ResolveAction, ResolveChoice, ResolveDirective, ResolveReport, ResolveRequest, ResolveResponse,
     RESOLVE_REPORT_SCHEMA,
 };
-use kin_db::{LocalFileBackend, LocalRepositoryAuthorityFreeze, RepositoryAuthorityManager};
+use kin_db::{
+    ChangeStore, LocalFileBackend, LocalRepositoryAuthorityFreeze, RepositoryAuthorityManager,
+};
 use kin_model::{
     MergeConflictSubject, MergeEntryResolution, MergeResolutionPayload, MergeResolutionProvenance,
     MergeSide, MergeTransactionDelta, MergeTransactionRecord, MergeTransactionState,
@@ -71,14 +73,18 @@ pub(crate) fn commit_and_freeze_exact(
 
 pub(crate) fn execute_conflicts(
     state: &DaemonState,
-    _request: &ConflictsRequest,
+    request: &ConflictsRequest,
 ) -> std::result::Result<ConflictsResponse, (StatusCode, String)> {
     let authority =
         ActiveLocalRepositoryAuthority::open_bound(state).map_err(merge_bind_refusal)?;
-    read_conflicts(&authority).map_err(classify_merge_error)
+    read_conflicts(state, &authority, request).map_err(classify_merge_error)
 }
 
-fn read_conflicts(authority: &ActiveLocalRepositoryAuthority) -> Result<ConflictsResponse> {
+fn read_conflicts(
+    state: &DaemonState,
+    authority: &ActiveLocalRepositoryAuthority,
+    request: &ConflictsRequest,
+) -> Result<ConflictsResponse> {
     let lease = authority.manager.read_authority();
     let generation = lease.roots().generation;
     let metadata = lease.metadata();
@@ -137,6 +143,10 @@ fn read_conflicts(authority: &ActiveLocalRepositoryAuthority) -> Result<Conflict
         }
     };
     let record_hash = record.as_ref().map(|record| record.hash.to_string());
+    let bodies = match (&record, request.bodies) {
+        (Some(record), true) => materialize_bodies(state, record),
+        _ => Vec::new(),
+    };
     Ok(ConflictsResponse {
         lines,
         report: Some(ConflictsReport {
@@ -149,8 +159,174 @@ fn read_conflicts(authority: &ActiveLocalRepositoryAuthority) -> Result<Conflict
             record_hash,
             unresolved_count,
             resolved_count,
+            bodies,
         }),
     })
+}
+
+/// Re-materialize each conflict subject's three sides as source.
+///
+/// The record holds one `Hash256` per side, and it is a digest of the model
+/// value rather than a content address, so nothing can be looked up from it. The
+/// bytes come from the graph at the three changes this merge bound, which is the
+/// only place they exist, and each side is hashed back to the recorded digest
+/// before it is offered. That check is what makes the rendering an account of
+/// the merge rather than an account of the graph as it stands now: a side whose
+/// value has moved is named, not shown.
+///
+/// A side that cannot be read is named too. A body quietly missing reads exactly
+/// like an identity that is absent on that side, and those are opposite facts.
+fn materialize_bodies(
+    state: &DaemonState,
+    record: &MergeTransactionRecord,
+) -> Vec<kin_cli::commands::conflicts::ConflictBody> {
+    let sides = [
+        ("base", &record.binding.base_change),
+        ("ours", &record.binding.ours_change),
+        ("theirs", &record.binding.theirs_change),
+    ];
+    let resolved: Vec<(&str, Option<kin_model::graph::ResolvedGraphState>)> = sides
+        .iter()
+        .map(|(name, change)| (*name, state.graph.resolve_graph_at(change).ok()))
+        .collect();
+
+    let mut out = Vec::new();
+    for entry in record.entries.iter() {
+        if !matches!(
+            entry.subject,
+            MergeConflictSubject::Entity { .. } | MergeConflictSubject::Artifact { .. }
+        ) {
+            // A relation has no source of its own. Rendering its endpoints here
+            // would print the same bodies twice under a different name.
+            continue;
+        }
+        let mut body = kin_cli::commands::conflicts::ConflictBody {
+            subject: render_subject_identity(&entry.subject),
+            label: entry.label.clone(),
+            base: None,
+            ours: None,
+            theirs: None,
+            unverified: Vec::new(),
+        };
+        for (name, state_at) in resolved.iter() {
+            let recorded = match *name {
+                "base" => &entry.base,
+                "ours" => &entry.ours,
+                _ => &entry.theirs,
+            };
+            match side_source(state, state_at.as_ref(), &entry.subject, recorded) {
+                SideSource::Absent => {}
+                SideSource::Source(text) => match *name {
+                    "base" => body.base = Some(text),
+                    "ours" => body.ours = Some(text),
+                    _ => body.theirs = Some(text),
+                },
+                SideSource::Unverified => body.unverified.push((*name).to_string()),
+            }
+        }
+        out.push(body);
+    }
+    out
+}
+
+/// What one side of one conflict subject could be read as.
+enum SideSource {
+    /// The identity does not exist on this side, which the record agrees with.
+    Absent,
+    Source(String),
+    /// The value did not hash back to the recorded digest, or its bytes could
+    /// not be read. Never rendered, always named.
+    Unverified,
+}
+
+fn side_source(
+    state: &DaemonState,
+    state_at: Option<&kin_model::graph::ResolvedGraphState>,
+    subject: &MergeConflictSubject,
+    recorded: &kin_model::MergeSideValue,
+) -> SideSource {
+    let Some(state_at) = state_at else {
+        return SideSource::Unverified;
+    };
+    match subject {
+        MergeConflictSubject::Entity { entity } => {
+            let held = state_at.entities.get(entity);
+            match (held, recorded) {
+                (None, kin_model::MergeSideValue::Absent) => SideSource::Absent,
+                (Some(held), _) => {
+                    match kin_model::MergeSideValue::entity(Some(held)) {
+                        Ok(recomputed) if &recomputed == recorded => {}
+                        _ => return SideSource::Unverified,
+                    }
+                    let Some(span) = held.span.as_ref() else {
+                        return SideSource::Unverified;
+                    };
+                    // `FilePathId` already holds a UTF-8 path, so this crossing
+                    // adds no new failure mode; a path it cannot express is
+                    // reported rather than approximated.
+                    let Ok(path) = kin_model::RepoPath::from_utf8(span.file.0.clone()) else {
+                        return SideSource::Unverified;
+                    };
+                    let Some(artifact) = state_at.tree.artifact_at_path(&path) else {
+                        return SideSource::Unverified;
+                    };
+                    match blob_text(state, artifact) {
+                        Some(text) => slice_span(&text, span.start_byte, span.end_byte)
+                            .map(SideSource::Source)
+                            .unwrap_or(SideSource::Unverified),
+                        None => SideSource::Unverified,
+                    }
+                }
+                _ => SideSource::Unverified,
+            }
+        }
+        MergeConflictSubject::Artifact { artifact } => {
+            let held = state_at.tree.get(artifact);
+            match (held, recorded) {
+                (None, kin_model::MergeSideValue::Absent) => SideSource::Absent,
+                (Some(held), _) => {
+                    match kin_model::MergeSideValue::artifact(Some(held)) {
+                        Ok(recomputed) if &recomputed == recorded => {}
+                        _ => return SideSource::Unverified,
+                    }
+                    match blob_text(state, held) {
+                        Some(text) => SideSource::Source(text),
+                        None => SideSource::Unverified,
+                    }
+                }
+                _ => SideSource::Unverified,
+            }
+        }
+        _ => SideSource::Unverified,
+    }
+}
+
+/// The artifact's bytes as text, or `None` when it is not a readable blob.
+///
+/// A symlink and a gitlink are deliberately not text: their tree entries carry
+/// a target rather than a body, and printing one as source would be a fiction.
+fn blob_text(state: &DaemonState, artifact: &kin_model::ResolvedArtifact) -> Option<String> {
+    let kin_model::TreeEntry::Blob { hash, .. } = &artifact.entry else {
+        return None;
+    };
+    let context =
+        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
+            .ok()?;
+    let bytes = crate::repository_commit::load_native_source_blob(&context, *hash).ok()?;
+    String::from_utf8(bytes).ok()
+}
+
+/// The entity's own bytes inside its file.
+///
+/// Refuses rather than clamps. A span that does not lie on character boundaries
+/// or runs past the end of the blob means the span and the bytes disagree, and a
+/// clamped slice would render a body that is not the entity's while looking
+/// exactly like one that is.
+fn slice_span(text: &str, start: usize, end: usize) -> Option<String> {
+    if end < start || end > text.len() {
+        return None;
+    }
+    text.get(start..end).map(|slice| slice.to_string())
 }
 
 pub(crate) fn execute_resolve(

--- a/scripts/acceptance/merge_precedence_repro.py
+++ b/scripts/acceptance/merge_precedence_repro.py
@@ -30,7 +30,7 @@ carries all of them the merge refuses and names both decisions. Nothing is
 synthesized, because kin has no textual line merge to build a third body from,
 so a projection is a choice among sides this merge already bound.
 
-Six checks over five repositories, run in order because two of them are
+Seven checks over six repositories, run in order because two of them are
 destructive: they publish the merge the earlier assertions are about. The first
 four grade FIR-2958's precedence rule; the last two grade rc062j finding (2),
 which is the same authority reporting conflicts that are not conflicts.
@@ -54,6 +54,9 @@ which is the same authority reporting conflicts that are not conflicts.
   genuine     the control for `removals`: a real removal, still pointed at by
               the other side, is still reported. Without it a merge that dropped
               every relation row would satisfy `removals` and lose nothing else
+  bodies      rc062j finding (1): a conflict's three sides render as source,
+              every printed side hashed back to its recorded digest, and the
+              listing that did not ask for bodies still carries none
 
 Exit status is 0 when every check passed, 1 when one failed, 2 when one could not
 be read, and 3 when the run could not be set up. `--self-test` exercises every
@@ -89,6 +92,8 @@ TICKET = "FIR-2958"
 # merge authority, graded here rather than in a second suite because a second
 # copy of this scaffolding is only ever wrong in a way that looks like a pass.
 GRANULARITY_TICKET = "FIR-2960"
+# rc062j finding (1), the conflict bodies. Same authority, same suite.
+BODIES_TICKET = "FIR-2960"
 
 print = functools.partial(print, flush=True)
 
@@ -126,6 +131,11 @@ def _gran_module(name):
     return ("from pkg.core import summarize, helper\n\n\n"
             "def use_%s(rows):\n    return summarize(rows) + helper(1)\n" % name).encode()
 
+
+BODY_CORE_BASE = b"def summarize(rows):\n    return len(rows)\n"
+BODY_CORE_OURS = b"def summarize(rows):\n    return OURSMARKER(rows)\n"
+BODY_CORE_THEIRS = b"def summarize(rows):\n    return THEIRSMARKER(rows)\n"
+BODY_FILES = {"pkg/core.py": (BODY_CORE_BASE, BODY_CORE_OURS, BODY_CORE_THEIRS)}
 
 GRAN_FILES = {"pkg/core.py": (GRAN_CORE_BASE, GRAN_CORE_OURS, GRAN_CORE_THEIRS)}
 for _name in ("a", "b", "c"):
@@ -651,6 +661,76 @@ def check_genuine(suite):
     ], ticket=GRANULARITY_TICKET)
 
 
+def grade_show_renders_both_sides(show_text):
+    """rc062j (1). Both branches' source must appear, as a diff against base.
+
+    Keyed on source the fixture wrote rather than on the presence of a hunk
+    header, because a renderer that emitted headers over empty bodies would
+    satisfy a header check and show the reader nothing.
+    """
+    if not isinstance(show_text, str) or not show_text.strip():
+        return (UNREADABLE, "`kin conflicts --show` printed nothing")
+    missing = [marker for marker in ("OURSMARKER", "THEIRSMARKER")
+               if marker not in show_text]
+    if missing:
+        return (FAIL, "the rendering never shows %s" % ", ".join(missing))
+    if "base -> ours" not in show_text or "base -> theirs" not in show_text:
+        return (FAIL, "both sides appear but neither is labelled as a departure from base")
+    return (PASS, "both sides render as a diff against the common ancestor")
+
+
+def grade_every_printed_side_was_verified(show_text):
+    """Every side offered was hashed back to the digest the record holds.
+
+    A side that failed that check is named rather than printed, so the property
+    is that the rendering carries no such line WHILE carrying real source. The
+    two halves are graded together on purpose: a run that printed nothing at all
+    would also carry no refusal line.
+    """
+    if not isinstance(show_text, str) or not show_text.strip():
+        return (UNREADABLE, "`kin conflicts --show` printed nothing")
+    if "OURSMARKER" not in show_text and "THEIRSMARKER" not in show_text:
+        return (UNREADABLE, "nothing was rendered, so nothing was verified")
+    refusals = show_text.count("not shown, because")
+    if refusals:
+        return (FAIL, "%d side(s) failed the digest re-check on a healthy merge" % refusals)
+    return (PASS, "every rendered side hashed back to its recorded digest")
+
+
+def grade_default_listing_carries_no_bodies(json_text):
+    """The control on cost. Reading bodies resolves three graphs and reads a
+    blob per side, so a listing that did it unasked would have changed what
+    every existing caller pays."""
+    if not isinstance(json_text, str) or not json_text.strip():
+        return (UNREADABLE, "the default listing printed nothing")
+    try:
+        payload = json.loads(json_text)
+    except ValueError:
+        return (UNREADABLE, "the default listing did not parse")
+    bodies = payload.get("bodies")
+    if bodies:
+        return (FAIL, "the default listing carried %d body row(s) nobody asked for" % len(bodies))
+    return (PASS, "the default listing carries no bodies")
+
+
+def check_bodies(suite):
+    """rc062j (1). A conflict's three sides, readable.
+
+    Measured before the change on the same shape: all three sides read as 32
+    bytes of digest, the JSON listing carried zero bytes of source, and
+    `kin conflicts` had no flag that would print one.
+    """
+    repo = suite.repo("bodies", BODY_FILES)
+    suite.kin_run(["merge", "feature"], repo)
+    show = suite.kin_run(["conflicts", "--show"], repo)[1]
+    plain = suite.kin_run(["conflicts", "--json"], repo)[1]
+    return _combine("bodies", [
+        ("render", grade_show_renders_both_sides(show)),
+        ("verified", grade_every_printed_side_was_verified(show)),
+        ("default", grade_default_listing_carries_no_bodies(plain)),
+    ], ticket=BODIES_TICKET)
+
+
 def _combine(ident, verdicts, ticket=None):
     """Report every arm, never the first bad one, because knowing which arm
     broke is the whole value of grading several claims in one check.
@@ -676,6 +756,7 @@ CHECKS = [
     ("uniform", check_uniform),
     ("removals", check_removals),
     ("genuine", check_genuine),
+    ("bodies", check_bodies),
 ]
 
 
@@ -894,6 +975,37 @@ def self_test():
            grade_no_false_removals(plain_relation), PASS)
     expect("CONTROL kinds still names that same relation row",
            grade_conflict_kinds(plain_relation, "relation"), FAIL)
+
+    # rc062j (1). Each body grader gets a payload that must pass and one that
+    # must fail, so a grader that answers PASS over anything is caught here.
+    good_show = ("summarize in pkg/core.py (entity 1)\n"
+                 "  base -> ours:\n    -x\n    +OURSMARKER(rows)\n"
+                 "  base -> theirs:\n    -x\n    +THEIRSMARKER(rows)\n")
+    refused_show = good_show + "  ours: not shown, because the value re-read from the graph\n"
+    headers_only = ("summarize in pkg/core.py (entity 1)\n"
+                    "  base -> ours:\n    @@ -1,1 +1,1 @@\n"
+                    "  base -> theirs:\n    @@ -1,1 +1,1 @@\n")
+    expect("render passes a rendering carrying both sides' source",
+           grade_show_renders_both_sides(good_show), PASS)
+    expect("render fails a rendering of hunk headers over empty bodies",
+           grade_show_renders_both_sides(headers_only), FAIL)
+    expect("render cannot read empty output",
+           grade_show_renders_both_sides(""), UNREADABLE)
+    expect("verified passes a rendering with no refused side",
+           grade_every_printed_side_was_verified(good_show), PASS)
+    expect("verified fails a rendering that refused a side on a healthy merge",
+           grade_every_printed_side_was_verified(refused_show), FAIL)
+    # CONTROL: a run that rendered nothing must not read as verified. Without
+    # this, "no refusal line" would pass over silence.
+    expect("CONTROL verified cannot read a rendering that shows no source at all",
+           grade_every_printed_side_was_verified(headers_only), UNREADABLE)
+    expect("default passes a listing with no bodies",
+           grade_default_listing_carries_no_bodies('{"unresolved_count": 3}'), PASS)
+    expect("default fails a listing that carried bodies unasked",
+           grade_default_listing_carries_no_bodies('{"bodies": [{"subject": "entity 1"}]}'),
+           FAIL)
+    expect("default cannot read text that is not json",
+           grade_default_listing_carries_no_bodies("nope"), UNREADABLE)
 
     expect("a relative kin path is absolutized by this suite",
            (os.path.isabs(absolute_binary("target/release/kin")), "isabs"), True)


### PR DESCRIPTION
rc062j finding (1). A parked conflict tells you a decision is needed and nothing about what the decision is between.

## Before, measured on clean main `7682e5005c4fa7fd`

One two-line Python file edited on both branches. One entity row's three sides:

```
base    value=present   32 bytes of digest
ours    value=present   32 bytes of digest
theirs  value=present   32 bytes of digest

source text 'OURSMARKER'    anywhere in the JSON listing: NO
source text 'THEIRSMARKER'  anywhere in the JSON listing: NO
source text 'def summarize' anywhere in the JSON listing: NO
```

And `kin conflicts` carried no flag that would print one: `--json`, `--profile-out`, `--profile-summary`, `--help`.

## After

```
summarize in pkg/core.py (entity d4912d97-520c-4315-9da0-fb58d4ab9b6e)
  base -> ours:
    @@ -1,2 +1,2 @@
     def summarize(rows):
    -    return len(rows)
    +    return OURSMARKER(rows)
  base -> theirs:
    @@ -1,2 +1,2 @@
     def summarize(rows):
    -    return len(rows)
    +    return THEIRSMARKER(rows)
```

Marker counts in the rendering went from 0/0/0 to OURSMARKER 3, THEIRSMARKER 3, `def summarize` 6, with 0 sides refused.

## Why it needs re-materializing at all

`MergeSideValue::Present` carries `Hash256` of the model value, not a content address, so nothing can be looked up from it. The bytes exist only in the graph at the three changes the merge bound. So `--show` resolves the graph at base, ours and theirs, takes the entity's span inside its artifact's blob, and prints each side's departure from the common ancestor through the diff command's own `render_hunks`. Rendered against base rather than against each other, because the question a settlement answers is which side's departure to keep, and a diff of ours against theirs shows neither departure.

Every side is hashed back to the digest the record holds before it is offered, which is what makes this an account of the merge rather than of the graph as it stands now. A side whose value has moved is named in `unverified` and not printed, and so is one whose bytes cannot be read, because a body that is quietly missing reads exactly like an identity that is absent, and those are opposite facts.

Three refusals rather than approximations: a span off character boundaries or past the end of its blob (a clamped slice would render a body that is not the entity's while looking exactly like one that is); a symlink or gitlink, which carries a target rather than a body; and a relation, which has no source of its own, so rendering its endpoints would print the same bodies twice under another name.

The request field is defaulted, so a client sending `{}` keeps today's behaviour and today's cost. Reading bodies resolves three graphs and reads a blob per side, which a listing does not otherwise do, and `default` is the acceptance arm that holds that line.

## Acceptance

```
CHECK bodies FIR-2960 PASS render PASS both sides render as a diff against the
  common ancestor; verified PASS every rendered side hashed back to its recorded
  digest; default PASS the default listing carries no bodies
```

Seven checks, exit 0. The suite's self-test goes from 35 grader assertions to 44, each new grader given an input that must pass and one that must fail, plus a control that a rendering showing no source at all reads UNREADABLE rather than verified.

## Falsification

```
arm  bodies  removes
B0   PASS    nothing
B1   FAIL    the digest re-check, made unable to pass
B2   PASS    the digest re-check, DELETED
```

B1's detail shows the check gating the output path rather than sitting beside it: `render FAIL the rendering never shows OURSMARKER, THEIRSMARKER; verified UNREADABLE nothing was rendered, so nothing was verified`. The `verified` grader answered UNREADABLE rather than PASS on that silence, which is the control built for exactly this arm.

**B2 is green and that is a finding, not an oversight.** Deleting the verification outright changes nothing a healthy fixture can see, because a merge whose three sides all still hash to their recorded digests cannot distinguish "checked and passed" from "not checked". Catching a genuine divergence needs a record whose digest disagrees with the graph, and I could not construct one through the product's own surfaces without corrupting state by hand. So what is proven is that the check gates the rendering. What is NOT proven is that it fires on a real divergence in the wild.

Three arms, three distinct binaries, tree restored with zero mutation markers.

Refs FIR-2960
