### PR TITLE
Name commands the CLI has in doctor fix lines, and guard the whole class

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -3614,8 +3614,9 @@ pub(crate) fn reference_edge_coverage_health(
         ))
     }
     .with_manual_fix(
-        "re-admit the repository so relation extraction runs again (`kin reconcile --admit`), and \
-         treat any \"unused\" answer as unverified until cross-file edges resolve",
+        "ask this repository's daemon to enrich again once the servers are installed (`kin \
+         daemon sweep`), and treat any \"unused\" answer as unverified until cross-file edges \
+         resolve",
     )
 }
 

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -3143,8 +3143,8 @@ pub fn background_work_health_from_state(
         format!("{cpu}; {}{notice_detail}", reasons.join("; ")),
     )
     .with_manual_fix(
-        "restart the daemon (`kin daemon restart`) to retry the stopped pass, and report the \
-         reason above if it stops again",
+        "stop the daemon (`kin daemon stop`) so the next kin command starts one that retries \
+         the stopped pass, and report the reason above if it stops again",
     )
 }
 
@@ -3233,7 +3233,7 @@ async fn check_reference_edge_coverage(graph_status: &RunGraphStatus) -> HealthC
             HealthStatus::Stale,
             "the daemon serving this repository does not report relation-graph completeness; it \
              predates the measurement",
-            "restart the daemon with `kin daemon restart` to pick up this build",
+            "stop the daemon (`kin daemon stop`) so the next kin command starts one on this build",
             &missing_servers,
         );
     };
@@ -3412,7 +3412,9 @@ async fn check_relation_census(graph_status: &RunGraphStatus) -> HealthCheck {
             "the daemon serving this repository does not report a relation census; it predates \
              the measurement",
         )
-        .with_manual_fix("restart the daemon with `kin daemon restart` to pick up this build");
+        .with_manual_fix(
+            "stop the daemon (`kin daemon stop`) so the next kin command starts one on this build",
+        );
     };
     relation_census_health(comparison)
 }
@@ -3614,9 +3616,10 @@ pub(crate) fn reference_edge_coverage_health(
         ))
     }
     .with_manual_fix(
-        "ask this repository's daemon to enrich again once the servers are installed (`kin \
-         daemon sweep`), and treat any \"unused\" answer as unverified until cross-file edges \
-         resolve",
+        "install the servers, then stop this daemon (`kin daemon stop`) because a daemon \
+         discovers language servers once at startup and the next command starts one that finds \
+         them, then ask it to enrich (`kin daemon sweep`), and treat any \"unused\" answer as \
+         unverified until cross-file edges resolve",
     )
 }
 
@@ -4754,7 +4757,9 @@ async fn check_parse_coverage(graph_status: &RunGraphStatus) -> HealthCheck {
             "the daemon serving this repository does not report parse coverage; it predates the \
              measurement",
         )
-        .with_manual_fix("restart the daemon with `kin daemon restart` to pick up this build");
+        .with_manual_fix(
+            "stop the daemon (`kin daemon stop`) so the next kin command starts one on this build",
+        );
     };
     parse_coverage_health(census)
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -4145,6 +4145,102 @@ mod tests {
     use super::*;
     use clap::CommandFactory;
 
+    /// Every flag a doctor fix line tells a user to type must exist.
+    ///
+    /// `kin doctor` shipped a fix line reading "`kin reconcile --admit`" from
+    /// v0.6.0 (FIR-3003). `reconcile` takes `session` and
+    /// `--confirm-mass-deletion`, so clap rejects `--admit` outright: the one
+    /// action the report offered could not be performed, and nothing noticed
+    /// for three minor versions because a fix line is prose to every test that
+    /// reads it.
+    ///
+    /// This asserts the prose against the parser. The strings live in the lib
+    /// and the clap definition lives in this binary, so the test reads
+    /// `health.rs` from disk rather than importing it; that is also why it
+    /// checks its own reading, since a scan that found nothing would pass.
+    #[test]
+    fn every_flag_a_doctor_fix_line_names_exists_in_the_cli() {
+        // `Cli::command()` builds the whole derive tree at once and overflows a
+        // test thread's default 2 MiB stack on this CLI, which ABORTS the
+        // process. An abort is a red that graded nothing, and from an exit code
+        // alone it reads exactly like a caught bug, so the body runs on a
+        // thread with room and the assertions below are actually reached.
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(fix_line_flags_exist)
+            .expect("spawn the checking thread")
+            .join()
+            .expect("the fix-line check must not panic in the harness thread");
+    }
+
+    fn fix_line_flags_exist() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/commands/health.rs"
+        ))
+        .expect("health.rs is readable from the crate it lives in");
+
+        // Backticked `kin ...` spans are how every fix line names a command.
+        let mut commands: Vec<String> = Vec::new();
+        for span in source.split('`').skip(1).step_by(2) {
+            let span = span.trim();
+            if let Some(rest) = span.strip_prefix("kin ") {
+                commands.push(rest.to_string());
+            }
+        }
+
+        // The scan must find something, or every assertion below is vacuous.
+        // Pinned by count rather than by emptiness so a refactor that quietly
+        // drops most of them is visible too.
+        assert!(
+            commands.len() >= 10,
+            "the scan found only {} backticked `kin ...` spans in health.rs, which is too few \
+             to be reading the file it thinks it is",
+            commands.len()
+        );
+
+        let root = Cli::command();
+        let mut offenders: Vec<String> = Vec::new();
+        for command in &commands {
+            // Walk the subcommand path, then check every flag against the
+            // command that path resolved to. A word that is not a known
+            // subcommand ends the path: it is a positional value, like the `.`
+            // in `kin init .`.
+            let mut node = &root;
+            let mut flags: Vec<&str> = Vec::new();
+            for word in command.split_whitespace() {
+                if let Some(flag) = word.strip_prefix("--") {
+                    let flag =
+                        flag.trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '-');
+                    if !flag.is_empty() {
+                        flags.push(flag);
+                    }
+                    continue;
+                }
+                if flags.is_empty() {
+                    if let Some(next) = node.find_subcommand(word) {
+                        node = next;
+                    }
+                }
+            }
+            for flag in flags {
+                let known = node.get_arguments().any(|arg| arg.get_long() == Some(flag));
+                if !known {
+                    offenders.push(format!(
+                        "`kin {command}` names --{flag}, which `{}` does not take",
+                        node.get_name()
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "a doctor fix line tells a user to type a flag the CLI rejects:\n  {}",
+            offenders.join("\n  ")
+        );
+    }
+
     /// The admission commands must carry every configured target without
     /// `RUST_LOG` being set.
     #[test]

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -4181,8 +4181,18 @@ mod tests {
         .expect("health.rs is readable from the crate it lives in");
 
         // Backticked `kin ...` spans are how every fix line names a command.
+        // Comment lines are dropped whole, before the split, because a doc
+        // comment quotes commands it is not telling anyone to run: the prose
+        // `kin 0.5.40` is a version and `kin health` is a surface name, and
+        // grading either reports a defect that does not exist. Dropping the
+        // lines rather than the spans keeps backtick parity self-consistent.
+        let graded: String = source
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
         let mut commands: Vec<String> = Vec::new();
-        for span in source.split('`').skip(1).step_by(2) {
+        for span in graded.split('`').skip(1).step_by(2) {
             let span = span.trim();
             if let Some(rest) = span.strip_prefix("kin ") {
                 commands.push(rest.to_string());
@@ -4218,8 +4228,25 @@ mod tests {
                     continue;
                 }
                 if flags.is_empty() {
-                    if let Some(next) = node.find_subcommand(word) {
-                        node = next;
+                    match node.find_subcommand(word) {
+                        Some(next) => node = next,
+                        // A node that HAS subcommands expects one, so an
+                        // unknown word there is a command that does not exist
+                        // rather than a positional value. Checking only flags
+                        // would pass `kin daemon zzz` silently, which is the
+                        // same defect this guard exists for wearing a
+                        // subcommand instead of a flag. A node with no
+                        // subcommands takes positionals, like the `.` in
+                        // `kin init .`, so the check does not apply there.
+                        None if node.has_subcommands() => {
+                            offenders.push(format!(
+                                "`kin {command}` names the subcommand {word}, which `{}` does \
+                                 not have",
+                                node.get_name()
+                            ));
+                            break;
+                        }
+                        None => {}
                     }
                 }
             }
@@ -4236,7 +4263,7 @@ mod tests {
 
         assert!(
             offenders.is_empty(),
-            "a doctor fix line tells a user to type a flag the CLI rejects:\n  {}",
+            "a doctor fix line tells a user to type a command the CLI rejects:\n  {}",
             offenders.join("\n  ")
         );
     }


### PR DESCRIPTION
The language-server fix line told users to run `kin reconcile --admit`, a flag the binary rejects. It now names the sequence that works: install the servers, stop this daemon with `kin daemon stop` so the next command starts one that discovers them, then ask it to enrich with `kin daemon sweep`.

A fix line naming a command that does not exist fails in front of the operator at the moment they are already blocked, so the class gets a check rather than a one-line repair. `every_flag_a_doctor_fix_line_names_exists_in_the_cli` reads health.rs, collects every backticked `kin ...` span and walks clap's real command tree, asserting both that each named flag exists on the node the path resolved to and that each word handed to a node with subcommands is one of them. Validating flags alone misses the larger half of the class, because an unknown word reads as a positional value and `kin daemon zzz` would pass.

## The check found four more instances on its first clean run

health.rs told users to run `kin daemon restart` in four places. `DaemonAction` has exactly `Status`, `Stop` and `Sweep`. `language_servers.rs` already carried a test whose own comment says restart does not exist, but it read one constant and could not see the four sibling strings. All four now name `kin daemon stop` and state the mechanism, that the next kin command starts a fresh daemon.

The scan drops comment lines before splitting on backticks, whole lines rather than spans so backtick parity stays self-consistent. A doc comment quotes commands it is not telling anyone to run, and grading them reported two defects that do not exist.

The walk runs on a 32 MiB thread because clap's tree overflows the default test stack, and that abort reads like a caught bug rather than a harness limit.

## Falsification

Every arm was read for which assertion fired, not merely that it went red.

| Arm | Result |
|---|---|
| clean tree | guard green, 148 health tests pass |
| fabricated flag | red: ``kin daemon stop --zzz-flag`` names --zzz-flag, which `stop` does not take |
| fabricated subcommand | red: ``kin daemon zzzsweep`` names the subcommand zzzsweep, which `daemon` does not have |
| real defect reinstated | red: ``kin daemon restart`` names the subcommand restart, which `daemon` does not have |

The last arm is the one that matters: it is drawn from a defect that was really in the tree, so it shows the guard catches the wild case and not only the fixture. Zero markers left in the tree afterward.

## Found, not fixed

`embed.rs:175`, `ref_lookup.rs:443` and `status.rs:799` tell users to run `kin health`. The top-level command enum carries `Doctor` and no `Health`, so these are real and the same class. They sit outside health.rs, which is all this guard reads. Broadening it to all of `commands/` is the follow-up that fixes them with a check rather than by hand, which is how the four restart lines survived in the first place.

Closes FIR-3003
