### PR TITLE
Ungate generation_pair so the rollback arm still compiles on Windows

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -34720,7 +34720,15 @@ mod tests {
     /// bare again, and the three must agree. Lane vcsreads added this control to
     /// the probe that produced these assertions, and without it the pair is
     /// unfalsifiable in the same way an unmeasured fixture is.
-    #[cfg(unix)]
+    ///
+    /// Deliberately NOT `#[cfg(unix)]`. Two of its three callers are, because
+    /// they build fixtures through `universal_branch_test_state`, which is;
+    /// the rollback arm builds its own and has compiled on Windows since it
+    /// was written. Gating this helper alongside the two made the third arm
+    /// call a function that is absent on Windows, which is a compile error
+    /// rather than a test failure, so the whole leg graded nothing. Both
+    /// symbols it touches are ungated: `DaemonState::snapshot_generation`
+    /// and `ActiveApiRepositoryAuthority::open`.
     fn generation_pair(state: &Arc<DaemonState>) -> (u64, u64) {
         use std::sync::atomic::Ordering::SeqCst;
         let bare = state.snapshot_generation.load(SeqCst);


### PR DESCRIPTION
Main is red on `Windows authority tests` since a930eb44c, and this is the fix.

## What broke

Step "Compile and run native Windows core authority tests", two
`error[E0425]: cannot find function generation_pair in this scope`, then
`could not compile kin-daemon (lib test)`. A compile error rather than a test
failure, so the leg graded nothing at all.

`generation_pair` was gated `#[cfg(unix)]` alongside the two arms that build
fixtures through `universal_branch_test_state`, which is unix-only. The third
caller, the rollback arm, builds its own fixture and has compiled on Windows
since it was written. So on Windows the helper vanished while its caller stayed.

## Why ungate the helper rather than gate the third arm

Both would go green. Gating the arm would silently delete Windows coverage that
has existed since the arm was written, which is a worse outcome than the red.
Both symbols the helper touches are ungated: `DaemonState::snapshot_generation`
at `state.rs:2618` and `ActiveApiRepositoryAuthority::open` at `api.rs:67`.

The gap that let this land is filed as FIR-3005, not closed by this PR: the three
Windows authority legs carry `if: github.event_name != 'pull_request'`, ci.yml has
no `workflow_dispatch`, and kin has had no `merge_group` since the 2026-08-27
classic flip, so no event reaching a PR head can start them.

## What graded this, and what did not

**The Windows leg can only be proven on this PR's squash's own main run.**
`windows-authority-tests` carries `if: github.event_name != 'pull_request'`, so
all four Windows checks read `skipped` here and can say nothing. That is exactly
how the break shipped.

**A local Windows compile could not grade it either, and it failed in a way that
reads like success.** `cargo check --target x86_64-pc-windows-msvc -p kin-daemon
--tests` exited 101 in 13 seconds, dead in `ring`'s C build script for want of an
MSVC toolchain: `error: failed to run custom build command for ring v0.17.14`,
E0425 count 0. It never reached Kin source. A red arm that graded nothing.

**So the check that graded this is structural, not a compile,** and it is
labelled that way rather than implying the compiler agreed. It reads the
definition's `cfg` attributes and each call site's enclosing fn, and fails when a
caller lacks a gate its callee has:

| tree | result |
|---|---|
| main (unfixed) | FAIL, 2 gaps, both in the rollback arm, matching CI's 2 errors |
| this branch | PASS, all 6 call sites |
| M1: re-add the gate | FAIL rc 1 on its own assertion, restored to 0 markers |
| fabricated helper name | REFUSES rc 2 rather than passing |

A whole-file sweep of every gated fn against every caller reads 24 entries on
main and 22 here; the differential is exactly `generation_pair` removed and
nothing added. The absolute count is not a gate, because most of the remaining 22
are false positives where the gate is inherited from an enclosing `mod` or
`impl` that the walker does not read.

Unix side: `cargo check -p kin-daemon --tests` rc 0 and `--all-targets` rc 0,
`cargo fmt --all -- --check` rc 0, all through `heavy-slot.sh`.
