### PR TITLE
Give the conflict-body digest check an arm that can fail, and correct the sha #1296 cited

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -49228,6 +49228,211 @@ mod tests {
         );
         assert_eq!(mcp_result_text(&after), text);
     }
+
+    /// The digest re-check must be able to FAIL, or it is a check nothing grades.
+    ///
+    /// On a healthy merge every side hashes back to its recorded digest, so
+    /// deleting the verification entirely changes nothing a fixture built
+    /// through the product can observe. That is a green arm proving nothing.
+    /// Here the record is handed a digest that disagrees with the graph, which
+    /// is the state the check exists for, and the assertions separate the three
+    /// outcomes that matter: the bad side is NAMED, the bad side is NOT PRINTED,
+    /// and the good sides are UNAFFECTED, so a blanket refusal cannot pass.
+    #[cfg(unix)]
+    #[test]
+    fn an_artifact_side_that_does_not_hash_back_to_the_record_is_named_and_not_printed() {
+        let (state, _layout, _repository, main_change, feature_change) =
+            universal_branch_test_state("bodies-artifact-digest");
+        let at_main = state.graph.resolve_graph_at(&main_change).unwrap();
+        let at_feature = state.graph.resolve_graph_at(&feature_change).unwrap();
+
+        let path = kin_model::RepoPath::from_utf8("selected/compose.yaml".to_string()).unwrap();
+        let on_main = at_main
+            .tree
+            .artifact_at_path(&path)
+            .expect("the fixture tracks selected/compose.yaml on main");
+        let on_feature = at_feature
+            .tree
+            .artifact_at_path(&path)
+            .expect("the fixture tracks selected/compose.yaml on feature");
+        let main_side = kin_model::MergeSideValue::artifact(Some(on_main)).unwrap();
+        let feature_side = kin_model::MergeSideValue::artifact(Some(on_feature)).unwrap();
+        // The precondition, asserted rather than assumed: if the two sides
+        // hashed the same, swapping one for the other below would be no
+        // tampering at all and the arm would pass while grading nothing.
+        assert_ne!(
+            main_side, feature_side,
+            "the fixture must hold this artifact differently on the two branches"
+        );
+
+        let entry = |ours: kin_model::MergeSideValue| kin_model::MergeConflictEntry {
+            subject: kin_model::MergeConflictSubject::Artifact {
+                artifact: on_main.artifact_id,
+            },
+            divergence: kin_model::MergeDivergence::ChangedBothSides,
+            base: main_side.clone(),
+            ours,
+            theirs: feature_side.clone(),
+            label: Some("selected/compose.yaml".to_string()),
+            resolution: kin_model::MergeEntryResolution::Unresolved,
+        };
+
+        let intact = crate::repository_merge_state::materialize_bodies_at(
+            &state,
+            &main_change,
+            &main_change,
+            &feature_change,
+            &[entry(main_side.clone())],
+        );
+        assert_eq!(intact.len(), 1);
+        assert!(
+            intact[0].unverified.is_empty(),
+            "a record that agrees with the graph refuses nothing: {:?}",
+            intact[0].unverified
+        );
+        assert!(
+            intact[0].ours.is_some(),
+            "the control arm must render, or the tampered arm's silence means nothing"
+        );
+
+        // The tampering: the record claims `ours` holds what THEIRS holds, so
+        // the value re-read at the ours change cannot hash back to it. A real
+        // digest from the same repository rather than a fabricated one, so the
+        // arm cannot pass because the value was merely unparseable.
+        let tampered = crate::repository_merge_state::materialize_bodies_at(
+            &state,
+            &main_change,
+            &main_change,
+            &feature_change,
+            &[entry(feature_side.clone())],
+        );
+        assert_eq!(tampered.len(), 1);
+        assert_eq!(
+            tampered[0].unverified,
+            vec!["ours".to_string()],
+            "the side whose digest disagrees must be named"
+        );
+        assert!(
+            tampered[0].ours.is_none(),
+            "and it must not be printed: {:?}",
+            tampered[0].ours
+        );
+        assert!(
+            tampered[0].base.is_some() && tampered[0].theirs.is_some(),
+            "while the sides that still agree are unaffected, so the refusal is \
+             scoped to the side that failed rather than to the whole subject"
+        );
+    }
+
+    /// A side whose stored bytes are GONE is named too, not quietly omitted.
+    ///
+    /// This grades the other refusal in the same materializer, and it can only
+    /// be graded here. Removing a source blob and going back through the CLI
+    /// does not reach the rendering at all: the daemon refuses to start, with
+    /// "Git external authority body validation failed", so the store's own
+    /// startup validation makes the CLI route unreachable and this path is
+    /// defensive code that only an already-open state can exercise.
+    ///
+    /// It matters because a body quietly missing reads exactly like an identity
+    /// that is absent on that side, and those are opposite facts.
+    #[cfg(unix)]
+    #[test]
+    fn a_side_whose_stored_bytes_are_gone_is_named_and_not_printed() {
+        let (state, _layout, _repository, main_change, feature_change) =
+            universal_branch_test_state("bodies-missing-blob");
+        let at_main = state.graph.resolve_graph_at(&main_change).unwrap();
+        let at_feature = state.graph.resolve_graph_at(&feature_change).unwrap();
+        let path = kin_model::RepoPath::from_utf8("selected/compose.yaml".to_string()).unwrap();
+        let on_main = at_main.tree.artifact_at_path(&path).unwrap();
+        let on_feature = at_feature.tree.artifact_at_path(&path).unwrap();
+        let kin_model::TreeEntry::Blob { hash, .. } = &on_main.entry else {
+            panic!("the fixture tracks this path as a blob");
+        };
+        let digest = hash.to_string();
+
+        let entry = kin_model::MergeConflictEntry {
+            subject: kin_model::MergeConflictSubject::Artifact {
+                artifact: on_main.artifact_id,
+            },
+            divergence: kin_model::MergeDivergence::ChangedBothSides,
+            base: kin_model::MergeSideValue::artifact(Some(on_main)).unwrap(),
+            ours: kin_model::MergeSideValue::artifact(Some(on_main)).unwrap(),
+            theirs: kin_model::MergeSideValue::artifact(Some(on_feature)).unwrap(),
+            label: Some("selected/compose.yaml".to_string()),
+            resolution: kin_model::MergeEntryResolution::Unresolved,
+        };
+
+        let intact = crate::repository_merge_state::materialize_bodies_at(
+            &state,
+            &main_change,
+            &main_change,
+            &feature_change,
+            std::slice::from_ref(&entry),
+        );
+        assert!(
+            intact[0].ours.is_some() && intact[0].unverified.is_empty(),
+            "the control arm must render before the bytes are removed: {:?}",
+            intact[0]
+        );
+
+        // Remove the blob this side's bytes live in. Named by its own digest,
+        // found by walking rather than by composing a path, because the store's
+        // layout is not this test's to encode.
+        let mut removed = 0_usize;
+        let mut stack = vec![state.layout.kindb_dir()];
+        while let Some(dir) = stack.pop() {
+            let Ok(read) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for item in read.flatten() {
+                let item_path = item.path();
+                if item_path.is_dir() {
+                    stack.push(item_path);
+                } else if item_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name == digest)
+                {
+                    std::fs::remove_file(&item_path).unwrap();
+                    removed += 1;
+                }
+            }
+        }
+        // The precondition, asserted: with nothing removed the arm below would
+        // pass for the wrong reason, since both sides would still render.
+        assert_eq!(
+            removed, 1,
+            "exactly one stored body named {digest} should have been removed"
+        );
+
+        let after = crate::repository_merge_state::materialize_bodies_at(
+            &state,
+            &main_change,
+            &main_change,
+            &feature_change,
+            std::slice::from_ref(&entry),
+        );
+        // Every side is named, including the one whose own bytes are intact.
+        // That is not sloppiness in the materializer: the store validates its
+        // bodies when it is opened, so one missing body refuses every read
+        // against that store. Measured here rather than assumed, and it is the
+        // same validation that stops the daemon starting at all, which is why
+        // the CLI cannot reach this path.
+        //
+        // Scoping is graded by the digest test above, where the refusal really
+        // is per side and `base` and `theirs` keep rendering. Asserting scoping
+        // here as well would assert a property this input does not have.
+        assert_eq!(
+            after[0].unverified,
+            vec!["base".to_string(), "ours".to_string(), "theirs".to_string()],
+            "a store that cannot open names every side rather than omitting any"
+        );
+        assert!(
+            after[0].base.is_none() && after[0].ours.is_none() && after[0].theirs.is_none(),
+            "and prints none of them, because a body quietly missing reads exactly \
+             like an identity that is absent on that side"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -180,10 +180,33 @@ fn materialize_bodies(
     state: &DaemonState,
     record: &MergeTransactionRecord,
 ) -> Vec<kin_cli::commands::conflicts::ConflictBody> {
+    materialize_bodies_at(
+        state,
+        &record.binding.base_change,
+        &record.binding.ours_change,
+        &record.binding.theirs_change,
+        &record.entries,
+    )
+}
+
+/// The half of [`materialize_bodies`] that needs only the three bound changes
+/// and the entries.
+///
+/// Split out so a test can hand it a record whose recorded digest disagrees
+/// with the graph. Without that seam the verification below is a check nothing
+/// can fail: on a healthy merge every side hashes back, so deleting the check
+/// changes nothing any fixture built through the product can observe.
+pub(crate) fn materialize_bodies_at(
+    state: &DaemonState,
+    base_change: &kin_db::SemanticChangeId,
+    ours_change: &kin_db::SemanticChangeId,
+    theirs_change: &kin_db::SemanticChangeId,
+    entries: &[kin_model::MergeConflictEntry],
+) -> Vec<kin_cli::commands::conflicts::ConflictBody> {
     let sides = [
-        ("base", &record.binding.base_change),
-        ("ours", &record.binding.ours_change),
-        ("theirs", &record.binding.theirs_change),
+        ("base", base_change),
+        ("ours", ours_change),
+        ("theirs", theirs_change),
     ];
     let resolved: Vec<(&str, Option<kin_model::graph::ResolvedGraphState>)> = sides
         .iter()
@@ -191,7 +214,7 @@ fn materialize_bodies(
         .collect();
 
     let mut out = Vec::new();
-    for entry in record.entries.iter() {
+    for entry in entries.iter() {
         if !matches!(
             entry.subject,
             MergeConflictSubject::Entity { .. } | MergeConflictSubject::Artifact { .. }
@@ -229,6 +252,21 @@ fn materialize_bodies(
     out
 }
 
+/// Whether the value re-read from the graph is the one the record bound.
+///
+/// One site, deliberately. An entity and an artifact reach this by different
+/// routes and hash different model values, but the decision they make is the
+/// same one, and a decision written twice can be deleted once: a mutation
+/// removing only the entity copy would survive a test that grades only the
+/// artifact, which is the shape where two branches reporting the same field
+/// hide each other's absence.
+fn side_agrees(
+    recomputed: std::result::Result<kin_model::MergeSideValue, kin_model::ModelError>,
+    recorded: &kin_model::MergeSideValue,
+) -> bool {
+    matches!(recomputed, Ok(value) if &value == recorded)
+}
+
 /// What one side of one conflict subject could be read as.
 enum SideSource {
     /// The identity does not exist on this side, which the record agrees with.
@@ -254,9 +292,8 @@ fn side_source(
             match (held, recorded) {
                 (None, kin_model::MergeSideValue::Absent) => SideSource::Absent,
                 (Some(held), _) => {
-                    match kin_model::MergeSideValue::entity(Some(held)) {
-                        Ok(recomputed) if &recomputed == recorded => {}
-                        _ => return SideSource::Unverified,
+                    if !side_agrees(kin_model::MergeSideValue::entity(Some(held)), recorded) {
+                        return SideSource::Unverified;
                     }
                     let Some(span) = held.span.as_ref() else {
                         return SideSource::Unverified;
@@ -285,9 +322,8 @@ fn side_source(
             match (held, recorded) {
                 (None, kin_model::MergeSideValue::Absent) => SideSource::Absent,
                 (Some(held), _) => {
-                    match kin_model::MergeSideValue::artifact(Some(held)) {
-                        Ok(recomputed) if &recomputed == recorded => {}
-                        _ => return SideSource::Unverified,
+                    if !side_agrees(kin_model::MergeSideValue::artifact(Some(held)), recorded) {
+                        return SideSource::Unverified;
                     }
                     match blob_text(state, held) {
                         Some(text) => SideSource::Source(text),


### PR DESCRIPTION
Two defects in what #1296 shipped. Neither is in the rendering; both are in what graded it.

## The sha #1296 cited does not exist

That PR's Before section, and therefore the squash message now on main at `211f914a8`, reads "measured on clean main 7682e5005c4fa7fd". **There is no such commit in this repository.** `7682e5005c4fa7fd` is the first sixteen hex characters of the sha256 of the `kin` BINARY the before-arm ran, printed by the probe's own `shasum -a 256 "$K" | cut -c1-16`, and I labelled it as a commit in prose. A binary digest and a git sha are both hex and both look like a commit id, so the label read as checkoutable and was not.

The correct before-arm, re-measured on this PR's real base:

```
base commit:   e5bf7bf1d85248b50b07cefd98a9fa80aff5ba2d   (#1291's squash, checkoutable)
binary sha256: 18318c7bcacfdda4...
command:       .kin-coord/reports/mergetruth-bodies-repro/bodies.sh <bindir> beforereal

  one entity row's three sides:
    base    value=present   32 bytes of digest
    ours    value=present   32 bytes of digest
    theirs  value=present   32 bytes of digest
  source text 'OURSMARKER'    anywhere in the JSON listing: NO
  source text 'THEIRSMARKER'  anywhere in the JSON listing: NO
  source text 'def summarize' anywhere in the JSON listing: NO
  kin conflicts flags: --json, --profile-out, --profile-summary, --help
```

Measuring on the real base also isolates the finding: 3 conflict rows here, where the old before-arm showed 5, because that binary predated #1291 and so still carried the two false removal rows. The old number mixed two changes.

## The digest check had no arm that could fail

My own B2 line in #1296 said it: deleting the verification outright changes nothing a healthy fixture can see, because a merge whose sides all still hash correctly cannot distinguish "checked and passed" from "not checked". That arm was green and proved nothing.

`materialize_bodies_at` is now split out of `materialize_bodies`, taking the three bound changes and the entries rather than a whole record, so a test can hand it a record whose digest disagrees with the graph. The tampering uses a real digest from the same repository, the one THEIRS holds, rather than a fabricated value, so the arm cannot pass merely because the value was unparseable.

```
arm  digest arm  missing-blob arm  removes
D0   rc 0        rc 0              nothing
D1   rc 101      rc 0              the digest verification
```

D1's fired assertion, read rather than inferred:

```
crates/kin-daemon/src/api.rs:49310
assertion `left == right` failed: the side whose digest disagrees must be named
  left: []
 right: ["ours"]
```

The missing-blob arm staying green under D1 is correct and is the separation that matters: it grades the blob path, not the digest path, so a mutation of one must not move the other.

## The verification is now one site, not two

An entity and an artifact reach it by different routes and hash different model values, but they make the same decision. A decision written twice can be deleted once, so a mutation removing only the entity copy would have survived a test that grades only the artifact. `side_agrees` is that one site, and D1 mutates it.

## The missing-body arm, and why it can only live at the unit level

Removing a source blob and going back through the CLI does not reach the rendering at all. The daemon refuses to start:

```
failed to acquire daemon authority or open state: Graph error: invalid operation:
Git external authority body validation failed: body for ExternalObjectId { kind: Blob, ... }
```

So the store's own validation makes that route unreachable, and the two acceptance checks that tried to tamper through the CLI are removed rather than left passing vacuously. The same validation is why the unit arm asserts that EVERY side is named when one body is gone, rather than only the sides that read it: one missing body refuses every read against that store. Scoping is graded by the digest arm, where the refusal really is per side and `base` and `theirs` keep rendering; asserting it here too would assert a property this input does not have.

## Gates

`cargo fmt --all -- --check` rc 0 as the last command before the push. Suite self-test 44 grader assertions, 0 failed; seven checks, exit 0.

Refs FIR-2960
