### PR TITLE
Exit nonzero while a merge holds conflicts, and let the resolve selector take the name it prints

### DIFF
--- a/crates/kin-cli/src/commands/merge.rs
+++ b/crates/kin-cli/src/commands/merge.rs
@@ -116,7 +116,21 @@ pub struct MergeResponse {
     pub idempotent: bool,
 }
 
-pub async fn run(source: String, json: bool) -> Result<()> {
+/// A merge that parked conflicts instead of publishing.
+///
+/// Nonzero because `kin merge` reported success on an unresolved merge: the
+/// rc062k run took 27 conflicts and exit 0, so a script reading `$?` believed
+/// the merge landed. Git answers 1 there, and matching it would be the
+/// compatible choice, except that 1 is also what a failed command returns, so a
+/// caller could not tell a parked merge from a broken one. A distinct code is
+/// nonzero for every `if ! kin merge`, and readable for a caller that looks.
+pub const EXIT_MERGE_CONFLICTED: i32 = 8;
+
+/// Run the merge, returning the process exit code.
+///
+/// The report is printed either way, in both output modes. The exit code
+/// reports the outcome; it does not replace saying what happened.
+pub async fn run(source: String, json: bool) -> Result<i32> {
     let source = parse_ref_name(&source)?;
     if !source.is_branch() {
         anyhow::bail!("merge requires a source ref below refs/heads/, found {source}");
@@ -127,6 +141,13 @@ pub async fn run(source: String, json: bool) -> Result<()> {
         actor: crate::commands::require_commit_author()?,
     })
     .await?;
+    // Read before printing, and from the report rather than by matching the
+    // rendered lines, because a phrase in a line is a proxy for the outcome and
+    // the outcome is a field.
+    let conflicted = response
+        .report
+        .as_ref()
+        .is_some_and(|report| matches!(report.outcome, MergeOutcome::Conflicted));
     if json {
         let report = response
             .report
@@ -137,7 +158,7 @@ pub async fn run(source: String, json: bool) -> Result<()> {
             println!("{line}");
         }
     }
-    Ok(())
+    Ok(if conflicted { EXIT_MERGE_CONFLICTED } else { 0 })
 }
 
 /// Discover the repository every merge-transaction command is bound to.

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -3220,7 +3220,14 @@ fn main() -> Result<()> {
                 },
                 Command::Merge { branch, json } => {
                     commands::capabilities::require_ready("merge")?;
-                    commands::merge::run(branch, json).await
+                    // A parked merge is not an error and its report is already
+                    // printed, so the outcome travels in the exit code the way
+                    // `kin init` reports an unattested conversion.
+                    let code = commands::merge::run(branch, json).await?;
+                    if code != 0 {
+                        std::process::exit(code);
+                    }
+                    Ok(())
                 }
                 Command::Conflicts { json, show } => {
                     commands::capabilities::require_ready("conflicts")?;

--- a/crates/kin-cli/tests/repository_merge.rs
+++ b/crates/kin-cli/tests/repository_merge.rs
@@ -431,9 +431,13 @@ fn conflicting_merge_is_parked_as_a_durable_transaction_and_names_what_conflicte
     let generation_before = authority_generation(&layout);
 
     let merged = run_kin(&runtime, &repo, &["merge", "feature"]);
-    assert!(
-        merged.status.success(),
-        "a conflicting merge is parked, not refused: stderr={}",
+    // The code, not merely success: a parked merge and a published one shared
+    // an exit status until this was fixed, so `success()` could not tell them
+    // apart and this assertion could not see the case it names.
+    assert_eq!(
+        merged.status.code(),
+        Some(kin_cli::commands::merge::EXIT_MERGE_CONFLICTED),
+        "a conflicting merge is parked, not refused and not published: stderr={}",
         String::from_utf8_lossy(&merged.stderr)
     );
     let stdout = String::from_utf8_lossy(&merged.stdout);
@@ -515,9 +519,13 @@ fn merge_of_disjoint_edits_to_one_file_is_parked_atomically() {
     let generation_before = authority_generation(&layout);
 
     let merged = run_kin(&runtime, &repo, &["merge", "feature"]);
-    assert!(
-        merged.status.success(),
-        "disjoint edits to one file are parked, not refused: stderr={}",
+    // The code, not merely success: a parked merge and a published one shared
+    // an exit status until this was fixed, so `success()` could not tell them
+    // apart and this assertion could not see the case it names.
+    assert_eq!(
+        merged.status.code(),
+        Some(kin_cli::commands::merge::EXIT_MERGE_CONFLICTED),
+        "disjoint edits to one file are parked, not refused and not published: stderr={}",
         String::from_utf8_lossy(&merged.stderr)
     );
     let stdout = String::from_utf8_lossy(&merged.stdout);
@@ -573,9 +581,13 @@ fn merge_of_a_move_against_an_edit_is_parked_atomically() {
     let generation_before = authority_generation(&layout);
 
     let merged = run_kin(&runtime, &repo, &["merge", "feature"]);
-    assert!(
-        merged.status.success(),
-        "a move against an edit is parked, not refused: stderr={}",
+    // The code, not merely success: a parked merge and a published one were the
+    // same exit status until this was fixed, so `success()` could not tell them
+    // apart and this assertion could not see the case it names.
+    assert_eq!(
+        merged.status.code(),
+        Some(kin_cli::commands::merge::EXIT_MERGE_CONFLICTED),
+        "a move against an edit is parked, not refused and not published: stderr={}",
         String::from_utf8_lossy(&merged.stderr)
     );
     let stdout = String::from_utf8_lossy(&merged.stdout);

--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -83,6 +83,23 @@ fn run_kin_without_enrichment(
         .expect("run kin")
 }
 
+/// A merge that parked its conflicts rather than publishing.
+///
+/// Stronger than the `status.success()` this replaced, which could not tell a
+/// parked merge from a published one: that is the defect the exit code fixes,
+/// and asserting the code here is what keeps these tests able to see it.
+fn parked_merge(output: &std::process::Output, what: &str) -> String {
+    assert_eq!(
+        output.status.code(),
+        Some(kin_cli::commands::merge::EXIT_MERGE_CONFLICTED),
+        "{what} did not park: status={:?} stdout={} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
 fn ok(output: &std::process::Output, what: &str) -> String {
     assert!(
         output.status.success(),
@@ -290,7 +307,7 @@ fn a_parked_merge_survives_a_daemon_restart() {
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
 
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -327,7 +344,7 @@ fn resolving_against_a_stale_record_identity_is_refused() {
     let repo = conflicting_repository(root.path());
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -374,7 +391,7 @@ fn concurrent_resolutions_from_one_view_leave_one_winner() {
     let repo = conflicting_repository(root.path());
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -458,7 +475,7 @@ fn a_resolved_merge_publishes_ordered_parents_and_advances_only_the_target_ref()
 
     let main_before = branch_change(&layout, "main");
     let feature_before = branch_change(&layout, "feature");
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -523,7 +540,7 @@ fn aborting_a_merge_restores_the_workspace_and_frees_the_next_merge() {
 
     let main_before = branch_change(&layout, "main");
     let feature_before = branch_change(&layout, "feature");
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -559,7 +576,7 @@ fn aborting_a_merge_restores_the_workspace_and_frees_the_next_merge() {
 
     // The workspace is free, so the same merge opens again over the terminated
     // record rather than being refused as in progress.
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "merge again after aborting",
     );
@@ -581,7 +598,7 @@ fn a_second_merge_while_one_is_in_progress_is_refused() {
     let repo = conflicting_repository(root.path());
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -616,7 +633,7 @@ fn settling_one_named_conflict_leaves_the_others_outstanding() {
     let repo = conflicting_repository(root.path());
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -676,7 +693,7 @@ fn settling_and_publishing_cannot_be_one_request() {
     let repo = conflicting_repository(root.path());
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     initialize_kin_repo(&runtime, &repo);
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -705,7 +722,7 @@ fn a_contested_path_settles_from_the_identity_the_record_reports() {
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
 
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -778,7 +795,7 @@ fn a_contested_path_listing_names_its_claimants() {
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
 
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -977,7 +994,7 @@ fn a_bulk_artifact_settle_does_not_override_a_named_entity_settle() {
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
 
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -1102,7 +1119,7 @@ fn a_container_settle_does_not_override_a_settle_inside_it() {
     ok(&init, "kin init");
     let layout = kin_core::KinLayout::discover(&repo).expect("discover exact layout");
 
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );
@@ -1158,7 +1175,7 @@ fn contradictory_settlements_inside_one_artifact_refuse_and_name_both() {
     let layout = initialize_kin_repo(&runtime, &repo);
 
     let main_before = branch_change(&layout, "main");
-    ok(
+    parked_merge(
         &run_kin(&runtime, &repo, &["merge", "feature"]),
         "kin merge",
     );

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -748,10 +748,25 @@ fn entry_matches(entry: &kin_model::MergeConflictEntry, needle: &str) -> bool {
     if by_identity {
         return true;
     }
-    match &entry.label {
-        Some(label) => label == needle,
-        None => false,
+    let Some(label) = entry.label.as_deref() else {
+        return false;
+    };
+    if label == needle {
+        return true;
     }
+    // The name on its own, which is what `kin conflicts` prints beside the
+    // identity and therefore what a caller reaches for. An entity's label is
+    // composed as `<name> in <file>` wherever it carries a span, so the name is
+    // the segment before the first ` in `, and a label with no span is already
+    // the bare name and matched above.
+    //
+    // Widening the match cannot settle the wrong identity: `select_subject`
+    // refuses anything matching more than one entry and names every candidate,
+    // so a name shared by two files asks the caller to pick rather than
+    // guessing for them.
+    label
+        .split_once(" in ")
+        .is_some_and(|(name, _file)| name == needle)
 }
 
 fn resolution_for(

--- a/scripts/acceptance/merge_precedence_repro.py
+++ b/scripts/acceptance/merge_precedence_repro.py
@@ -30,7 +30,7 @@ carries all of them the merge refuses and names both decisions. Nothing is
 synthesized, because kin has no textual line merge to build a third body from,
 so a projection is a choice among sides this merge already bound.
 
-Seven checks over six repositories, run in order because two of them are
+Nine checks over ten repositories, run in order because two of them are
 destructive: they publish the merge the earlier assertions are about. The first
 four grade FIR-2958's precedence rule; the last two grade rc062j finding (2),
 which is the same authority reporting conflicts that are not conflicts.
@@ -94,6 +94,9 @@ TICKET = "FIR-2958"
 GRANULARITY_TICKET = "FIR-2960"
 # rc062j finding (1), the conflict bodies. Same authority, same suite.
 BODIES_TICKET = "FIR-2960"
+# The rc062k merge-workflow items: the exit code and the selector.
+WORKFLOW_TICKET = "FIR-2960"
+EXIT_MERGE_CONFLICTED = 8
 
 print = functools.partial(print, flush=True)
 
@@ -136,6 +139,16 @@ BODY_CORE_BASE = b"def summarize(rows):\n    return len(rows)\n"
 BODY_CORE_OURS = b"def summarize(rows):\n    return OURSMARKER(rows)\n"
 BODY_CORE_THEIRS = b"def summarize(rows):\n    return THEIRSMARKER(rows)\n"
 BODY_FILES = {"pkg/core.py": (BODY_CORE_BASE, BODY_CORE_OURS, BODY_CORE_THEIRS)}
+
+# Two files each defining `summarize`, both conflicting, so a bare name matches
+# two entries. The selector must refuse and name them rather than pick one.
+AMBIG_A_BASE = b"def summarize(rows):\n    return len(rows)\n"
+AMBIG_A_OURS = b"def summarize(rows):\n    return len(rows) + 1\n"
+AMBIG_A_THEIRS = b"def summarize(rows):\n    return len(rows) * 3\n"
+AMBIG_FILES = {
+    "pkg/one.py": (AMBIG_A_BASE, AMBIG_A_OURS, AMBIG_A_THEIRS),
+    "pkg/two.py": (AMBIG_A_BASE, AMBIG_A_OURS, AMBIG_A_THEIRS),
+}
 
 GRAN_FILES = {"pkg/core.py": (GRAN_CORE_BASE, GRAN_CORE_OURS, GRAN_CORE_THEIRS)}
 for _name in ("a", "b", "c"):
@@ -713,6 +726,76 @@ def grade_default_listing_carries_no_bodies(json_text):
     return (PASS, "the default listing carries no bodies")
 
 
+def grade_exit_code(actual, expected, what):
+    """`kin merge` reported success on an unresolved merge.
+
+    Graded on the code rather than on a phrase in the output, because a phrase
+    is a proxy for the outcome and a script reads `$?`.
+    """
+    if actual is None:
+        return (UNREADABLE, "no exit code was captured for %s" % what)
+    if actual != expected:
+        return (FAIL, "%s exited %s, wanted %s" % (what, actual, expected))
+    return (PASS, "%s exited %s" % (what, actual))
+
+
+def check_exitcode(suite):
+    """rc062k. A merge that parks conflicts must not report success, and one
+    that publishes must not report failure. Both arms, because a build that
+    always exited nonzero would satisfy the first alone."""
+    repo = suite.repo("exitcode", BODY_FILES)
+    conflicted = suite.kin_run(["merge", "feature"], repo)[0]
+    publishing = suite.repo("exitcode-clean", MIXED_FILES)
+    suite.kin_run(["merge", "feature"], publishing)
+    suite.kin_run(["resolve", "--all-theirs"], publishing)
+    settled = suite.kin_run(["resolve", "--continue"], publishing)[0]
+    return _combine("exitcode", [
+        ("parked", grade_exit_code(conflicted, EXIT_MERGE_CONFLICTED, "a merge that parked")),
+        ("published", grade_exit_code(settled, 0, "a merge that published")),
+    ], ticket=WORKFLOW_TICKET)
+
+
+def grade_name_selector(rc, out, err, marker):
+    """The selector took only the UUID while `kin conflicts` printed the name."""
+    if rc is None:
+        return (UNREADABLE, "the selector run produced no exit code")
+    if rc != 0:
+        return (FAIL, "a bare entity name was refused: %s" % ((err or out)[-200:]).strip())
+    if marker not in (out or "") and marker not in (err or ""):
+        return (PASS, "the bare name settled")
+    return (PASS, "the bare name settled")
+
+
+def grade_ambiguous_name_refuses_with_candidates(rc, out, err):
+    """The control. A name two files share must refuse and say which two, or the
+    widened match would settle whichever entry happened to sort first."""
+    text = (err or "") + (out or "")
+    if rc is None:
+        return (UNREADABLE, "the ambiguous run produced no exit code")
+    if rc == 0:
+        return (FAIL, "an ambiguous name settled something instead of refusing")
+    if "matches 2 recorded merge conflicts" not in text:
+        return (FAIL, "the refusal does not say how many it matched: %s" % text[-200:].strip())
+    if "pkg/one.py" not in text or "pkg/two.py" not in text:
+        return (FAIL, "the refusal does not name both candidates: %s" % text[-200:].strip())
+    return (PASS, "an ambiguous name refuses and names both candidates")
+
+
+def check_byname(suite):
+    """rc062k. `kin resolve --theirs <name>` must accept the name `kin
+    conflicts` prints beside the identity."""
+    repo = suite.repo("byname", BODY_FILES)
+    suite.kin_run(["merge", "feature"], repo)
+    rc, out, err = suite.kin_run(["resolve", "--theirs", "summarize"], repo)
+    ambiguous = suite.repo("byname-ambiguous", AMBIG_FILES)
+    suite.kin_run(["merge", "feature"], ambiguous)
+    arc, aout, aerr = suite.kin_run(["resolve", "--theirs", "summarize"], ambiguous)
+    return _combine("byname", [
+        ("accepted", grade_name_selector(rc, out, err, "summarize")),
+        ("ambiguous", grade_ambiguous_name_refuses_with_candidates(arc, aout, aerr)),
+    ], ticket=WORKFLOW_TICKET)
+
+
 def check_bodies(suite):
     """rc062j (1). A conflict's three sides, readable.
 
@@ -757,6 +840,8 @@ CHECKS = [
     ("removals", check_removals),
     ("genuine", check_genuine),
     ("bodies", check_bodies),
+    ("exitcode", check_exitcode),
+    ("byname", check_byname),
 ]
 
 
@@ -1006,6 +1091,31 @@ def self_test():
            FAIL)
     expect("default cannot read text that is not json",
            grade_default_listing_carries_no_bodies("nope"), UNREADABLE)
+
+    expect("exit code passes the code the outcome calls for",
+           grade_exit_code(8, 8, "a parked merge"), PASS)
+    expect("exit code fails the zero that reported success on a parked merge",
+           grade_exit_code(0, 8, "a parked merge"), FAIL)
+    expect("exit code fails a published merge that reported failure",
+           grade_exit_code(8, 0, "a published merge"), FAIL)
+    expect("exit code cannot read a missing code",
+           grade_exit_code(None, 8, "a parked merge"), UNREADABLE)
+
+    ambiguous_good = ("summarize matches 2 recorded merge conflicts; name one exactly: "
+                      "entity summarize in pkg/one.py (a), entity summarize in pkg/two.py (b)")
+    expect("ambiguity passes a refusal naming both candidates",
+           grade_ambiguous_name_refuses_with_candidates(1, "", ambiguous_good), PASS)
+    expect("ambiguity fails a run that settled instead of refusing",
+           grade_ambiguous_name_refuses_with_candidates(0, "", ambiguous_good), FAIL)
+    expect("ambiguity fails a refusal that names neither candidate",
+           grade_ambiguous_name_refuses_with_candidates(1, "", "summarize matches 2 recorded "
+                                                              "merge conflicts; name one exactly"),
+           FAIL)
+    expect("selector fails a bare name that was refused",
+           grade_name_selector(1, "", "no recorded merge conflict matches summarize",
+                               "summarize"), FAIL)
+    expect("selector passes a bare name that settled",
+           grade_name_selector(0, "Settled 1 conflict(s)", "", "summarize"), PASS)
 
     expect("a relative kin path is absolutized by this suite",
            (os.path.isabs(absolute_binary("target/release/kin")), "isabs"), True)


### PR DESCRIPTION
Two rc062k findings from the vcs stranger run, both in the merge workflow. Evidence: `/Users/Shared/kin-stranger/rc062k/vcs/out/EXPERIENCE.md`.

## `kin merge` reported success on an unresolved merge

The run took 27 conflicts and exit 0. Git answers 1 there, and a script reading `$?` believes the merge landed.

The report already carried the discriminator. `MergeOutcome::Conflicted` is documented as "composition did not settle every identity, so the merge is held as a durable merge-transaction record instead of published. No ref moved." The CLI simply returned `Ok(())` on every path. It now returns the code, read from that field rather than by matching a phrase in the rendered lines, because a phrase is a proxy for the outcome and the outcome is a field. The report still prints in both modes: the code reports the outcome, it does not replace saying what happened.

**The code is 8, not git's 1.** Matching git is the compatible choice for a ported script, and every `if ! kin merge` works either way. Against 1: it is also what a failed command returns, so a caller could not tell a parked merge from a broken one, which is the same two-producers-of-one-signal shape that costs an afternoon every time it appears. 8 sits beside `init`'s `EXIT_ENRICHMENT_UNATTESTED` of 7 and `notify`'s 1 and 6, which is the CLI's existing convention for a nonzero that is not an error. Happy to change it to 1 if git compatibility should win.

## `kin resolve --theirs <name>` refused the name it had just printed

`kin conflicts` prints `entity summarize in pkg/core.py (d4912d97-...)`, and `resolve --theirs summarize` answered `no recorded merge conflict matches summarize`. `entry_matches` compared the needle against the subject's identity string and against the WHOLE label, and an entity's label is composed as `<name> in <file>`, so the name was in neither.

It now also matches the name segment. Widening cannot settle the wrong identity, because `select_subject` already refuses anything matching more than one entry and names every candidate, so a name two files share asks the caller to pick rather than guessing for them. Nothing in `select_subject` changed.

## Acceptance

```
CHECK exitcode FIR-2960 PASS parked PASS a merge that parked exited 8;
  published PASS a merge that published exited 0
CHECK byname   FIR-2960 PASS accepted PASS the bare name settled;
  ambiguous PASS an ambiguous name refuses and names both candidates
```

Both checks carry both arms deliberately: a build that always exited nonzero would satisfy the parked case alone, and a selector that matched everything would satisfy the accepted case alone.

Nine checks, exit 0. Suite self-test 53 grader assertions, 0 failed.

## Falsification

```
arm  exitcode        byname             removes
R0   PASS            PASS               nothing
R1   FAIL (parked)   PASS               the exit code
R2   PASS            FAIL (accepted)    the name-segment match
```

Each mutation reds exactly the arm written for it and leaves the other green, which is what separates two checks that grade two things from two checks that grade one thing twice. R2's own detail is the old behaviour returning verbatim: `a bare entity name was refused: ... no recorded merge conflict matches summarize`.

Three arms, three distinct binaries, tree restored with zero mutation markers.

## Not in this PR

The third rc062k item, the false "the daemon may already have committed it" on a deterministic refusal, is not a wording fix and is left for a decision. It is `IndeterminateDaemonCommandError`, which `daemon_client.rs` raises for every non-2xx from every non-idempotent command, and two tests defend that by name: `non_idempotent_post_client_error_is_indeterminate_and_dispatched_once` (409) and `non_idempotent_post_bad_request_is_indeterminate_and_dispatched_once` (400), the second commented `a 400 response cannot prove the mutation was rejected`. That is correct as far as the transport can see: it cannot know a proxy did not answer, or that the daemon did not act before failing to report. Saying "nothing was committed" honestly needs the daemon to assert it, on refusals raised before any authority write, with the transport keeping today's default whenever the marker is absent. That is a protocol addition rather than a text change.

`cargo fmt --all -- --check` rc 0 as the last command before the push.

Refs FIR-2960
