### PR TITLE
Name the parked merge's exit code where a reader meets it

### DIFF
--- a/crates/kin-cli/src/commands/merge.rs
+++ b/crates/kin-cli/src/commands/merge.rs
@@ -157,6 +157,16 @@ pub async fn run(source: String, json: bool) -> Result<i32> {
         for line in response.lines {
             println!("{line}");
         }
+        if conflicted {
+            // Printed by the CLI rather than composed into the daemon's lines,
+            // because the exit code is the CLI's to name and the daemon has no
+            // business knowing it. A reader meets the number where it fires,
+            // which is the only place they can act on it.
+            println!(
+                "Exit {EXIT_MERGE_CONFLICTED}: the merge is parked with conflicts; \
+                 `kin conflicts` lists them"
+            );
+        }
     }
     Ok(if conflicted { EXIT_MERGE_CONFLICTED } else { 0 })
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -601,6 +601,11 @@ enum Command {
         action: SpecAction,
     },
     /// Merge semantic and exact-tree changes from another branch
+    ///
+    /// Exits 0 when the merge published or was already up to date, and 8 when it
+    /// is parked with conflicts: no ref moved, the record is durable, and `kin
+    /// conflicts` lists what is outstanding. A script can tell those apart from
+    /// a failed command, which exits 1.
     Merge {
         /// Branch to merge from
         branch: String,

--- a/scripts/acceptance/merge_precedence_repro.py
+++ b/scripts/acceptance/merge_precedence_repro.py
@@ -739,12 +739,28 @@ def grade_exit_code(actual, expected, what):
     return (PASS, "%s exited %s" % (what, actual))
 
 
+def grade_parked_output_names_its_code(out, err, code):
+    """A code a reader never sees is not documentation.
+
+    Asserts the exact sentence rather than the bare number, because the number
+    alone appears in paths, hashes and counts all over this output, and a phrase
+    satisfied by a different producer is a check on a proxy.
+    """
+    text = (out or "") + (err or "")
+    if not text.strip():
+        return (UNREADABLE, "the parked merge printed nothing to read")
+    wanted = "Exit %d: the merge is parked with conflicts" % code
+    if wanted not in text:
+        return (FAIL, "the parked merge never names its own exit code")
+    return (PASS, "the parked merge names exit %d where it fires" % code)
+
+
 def check_exitcode(suite):
     """rc062k. A merge that parks conflicts must not report success, and one
     that publishes must not report failure. Both arms, because a build that
     always exited nonzero would satisfy the first alone."""
     repo = suite.repo("exitcode", BODY_FILES)
-    conflicted = suite.kin_run(["merge", "feature"], repo)[0]
+    conflicted, parked_out, parked_err = suite.kin_run(["merge", "feature"], repo)
     publishing = suite.repo("exitcode-clean", MIXED_FILES)
     suite.kin_run(["merge", "feature"], publishing)
     suite.kin_run(["resolve", "--all-theirs"], publishing)
@@ -752,6 +768,8 @@ def check_exitcode(suite):
     return _combine("exitcode", [
         ("parked", grade_exit_code(conflicted, EXIT_MERGE_CONFLICTED, "a merge that parked")),
         ("published", grade_exit_code(settled, 0, "a merge that published")),
+        ("named", grade_parked_output_names_its_code(parked_out, parked_err,
+                                                     EXIT_MERGE_CONFLICTED)),
     ], ticket=WORKFLOW_TICKET)
 
 
@@ -1116,6 +1134,16 @@ def self_test():
                                "summarize"), FAIL)
     expect("selector passes a bare name that settled",
            grade_name_selector(0, "Settled 1 conflict(s)", "", "summarize"), PASS)
+
+    expect("named passes output carrying the exact sentence",
+           grade_parked_output_names_its_code(
+               "Exit 8: the merge is parked with conflicts; `kin conflicts` lists them",
+               "", 8), PASS)
+    expect("named fails output that carries the number but not the sentence",
+           grade_parked_output_names_its_code("merged 8 entities into refs/heads/main", "", 8),
+           FAIL)
+    expect("named cannot read empty output",
+           grade_parked_output_names_its_code("", "", 8), UNREADABLE)
 
     expect("a relative kin path is absolutized by this suite",
            (os.path.isabs(absolute_binary("target/release/kin")), "isabs"), True)


### PR DESCRIPTION
The captain's ruling on the parked exit code asked for two things #1303 did not carry: the code named in the parked message and in the merge help text, so a reader learns it where it fires.

## What a parked merge prints now

```
Merging refs/heads/feature into refs/heads/main left 3 unresolved conflict(s); the merge is
held as merge transaction 543e157f... (authority generation 4)
  - artifact pkg/core.py (...): changed on both branches with different content
  ...
Settle each conflict with `kin resolve`, then `kin resolve --continue`, or discard the merge
with `kin resolve --abort`
Exit 8: the merge is parked with conflicts; `kin conflicts` lists them
```

## What `kin merge --help` says

```
Exits 0 when the merge published or was already up to date, and 8 when it is parked with
conflicts: no ref moved, the record is durable, and `kin conflicts` lists what is
outstanding. A script can tell those apart from a failed command, which exits 1.
```

The line is printed by the CLI rather than composed into the daemon's lines, because the exit code is the CLI's to name and the daemon has no business knowing it. It is formatted from `EXIT_MERGE_CONFLICTED` so the sentence cannot drift from the code it announces.

## Grading

```
CHECK exitcode FIR-2960 PASS parked PASS a merge that parked exited 8;
  published PASS a merge that published exited 0;
  named PASS the parked merge names exit 8 where it fires
```

The arm asserts the exact sentence, not the bare number. Digits appear in paths, hashes and conflict counts all over that output, so a check keyed on `8` would be satisfied by a different producer, which is the assert-on-a-proxy shape. Its self-test hands it output carrying the number without the sentence and requires a FAIL. Suite self-test is 56 grader assertions, 0 failed; nine checks, exit 0.

`repository_merge_resolution` 23 of 23, `repository_merge` 18 of 18 and `repository_log` 11 of 11 ran locally before the push, because this changes what `kin merge` prints and a test asserting exact stdout would only have said so in CI. `cargo fmt --all -- --check` rc 0 as the last command.

Refs FIR-2960
