### PR TITLE
Let the daemon say a refusal wrote nothing, and believe it only where that is safe

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -361,6 +361,51 @@ impl fmt::Display for IndeterminateDaemonCommandError {
 
 impl std::error::Error for IndeterminateDaemonCommandError {}
 
+/// A refusal the daemon raised before it wrote anything, and said so.
+///
+/// Separate from [`IndeterminateDaemonCommandError`] on purpose. That one is
+/// correct whenever the transport is guessing, which is every case but this
+/// one: the daemon marked this refusal in its own body, so the caller is told
+/// what is true rather than warned about a write that did not happen.
+///
+/// Nothing in this Display suggests a write may have occurred, because the
+/// whole point of the marker is that none did.
+#[derive(Debug)]
+pub(crate) struct RefusedBeforeWriteError {
+    pub(crate) operation_id: OperationId,
+    path: String,
+    status: reqwest::StatusCode,
+    reason: String,
+}
+
+impl RefusedBeforeWriteError {
+    fn new(
+        operation_id: OperationId,
+        path: &str,
+        status: reqwest::StatusCode,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            operation_id,
+            path: path.to_string(),
+            status,
+            reason: reason.into(),
+        }
+    }
+}
+
+impl fmt::Display for RefusedBeforeWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "daemon refused operation {} at {} with HTTP {} and published nothing: {}",
+            self.operation_id, self.path, self.status, self.reason
+        )
+    }
+}
+
+impl std::error::Error for RefusedBeforeWriteError {}
+
 /// Proof carried by a successful acknowledgement of a non-idempotent command.
 ///
 /// Requiring this trait at the one-dispatch transport boundary makes it
@@ -932,6 +977,24 @@ impl DaemonClient {
                 .text()
                 .await
                 .unwrap_or_else(|error| format!("<response body unavailable: {error}>"));
+            // Honoured only on a client error, and only when the daemon itself
+            // put the marker in the body. A 5xx can leave work in flight
+            // whatever any body says, and a 5xx from a proxy is not this daemon
+            // speaking at all, so both keep the indeterminate answer they have
+            // always had. Anything that does not parse keeps it too, which is
+            // what an older daemon's plain-text refusal reads as.
+            if status.is_client_error() {
+                if let Some(refusal) = crate::daemon_error::DaemonErrorBody::parse(&body) {
+                    if refusal.refused_before_write {
+                        return Err(anyhow::Error::new(RefusedBeforeWriteError::new(
+                            operation_id,
+                            path,
+                            status,
+                            refusal.message,
+                        )));
+                    }
+                }
+            }
             return Err(anyhow::Error::new(IndeterminateDaemonCommandError::new(
                 operation_id,
                 path,
@@ -8050,6 +8113,161 @@ mod tests {
         assert_indeterminate(&error, operation_id);
         assert_eq!(requests.load(std::sync::atomic::Ordering::SeqCst), 1);
         assert!(format!("{error:#}").contains("409 Conflict: stale merge record"));
+    }
+
+    fn assert_refused_before_write(error: &anyhow::Error, operation_id: OperationId, reason: &str) {
+        let refusal = error
+            .downcast_ref::<RefusedBeforeWriteError>()
+            .unwrap_or_else(|| panic!("the refusal must be typed, not indeterminate: {error:#}"));
+        assert_eq!(refusal.operation_id, operation_id);
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains(reason),
+            "the daemon's reason verbatim: {rendered}"
+        );
+        // The whole point of the marker. Asserted on the rendered Display
+        // rather than on the type, because a future edit to the sentence is
+        // exactly what this must catch.
+        assert!(
+            !rendered.contains("may already have committed"),
+            "a refusal the daemon says wrote nothing must not warn about a write: {rendered}"
+        );
+        assert!(
+            !rendered.contains("indeterminate"),
+            "and must not call itself indeterminate: {rendered}"
+        );
+    }
+
+    /// The marker's whole purpose: a 4xx the daemon marked is reported as what
+    /// it is, once, with the daemon's reason carried through.
+    #[tokio::test]
+    async fn a_marked_client_error_is_a_refusal_that_wrote_nothing_and_dispatched_once() {
+        let body = crate::daemon_error::DaemonErrorBody::before_write(
+            "merging refs/heads/pretty into refs/heads/main still has 27 unresolved conflict(s)",
+        )
+        .to_wire();
+        let (base_url, requests, server) = spawn_fixed_response_server_at(
+            "/commands/test",
+            axum::http::StatusCode::CONFLICT,
+            body,
+        )
+        .await;
+        let client =
+            DaemonClient::from_base_url_with_explicit_authority(base_url, None, None).unwrap();
+        let operation_id = stable_test_operation_id();
+
+        let error = client
+            .post_non_idempotent_json::<_, serde_json::Value>(
+                "/commands/test",
+                &serde_json::json!({"operation_id": operation_id}),
+                operation_id,
+                "test one-dispatch post",
+            )
+            .await
+            .expect_err("a refusal is still an error");
+        server.abort();
+
+        assert_refused_before_write(&error, operation_id, "27 unresolved conflict(s)");
+        assert_eq!(
+            requests.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "one dispatch, exactly as before"
+        );
+    }
+
+    /// A 5xx is ignored even when it carries the marker.
+    ///
+    /// A server error can leave work in flight whatever the body says, and a
+    /// 5xx from a proxy is not the daemon speaking at all. This is the arm that
+    /// keeps the marker from becoming a way to talk the transport out of its
+    /// one real safety property.
+    #[tokio::test]
+    async fn a_marked_server_error_is_still_indeterminate() {
+        let body =
+            crate::daemon_error::DaemonErrorBody::before_write("nothing was committed").to_wire();
+        let (base_url, requests, server) = spawn_fixed_response_server_at(
+            "/commands/test",
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            body,
+        )
+        .await;
+        let client =
+            DaemonClient::from_base_url_with_explicit_authority(base_url, None, None).unwrap();
+        let operation_id = stable_test_operation_id();
+
+        let error = client
+            .post_non_idempotent_json::<_, serde_json::Value>(
+                "/commands/test",
+                &serde_json::json!({"operation_id": operation_id}),
+                operation_id,
+                "test one-dispatch post",
+            )
+            .await
+            .expect_err("a 5xx cannot prove the mutation was rejected");
+        server.abort();
+
+        assert_indeterminate(&error, operation_id);
+        assert_eq!(requests.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    /// An older daemon's plain-text refusal, which is what every daemon sent
+    /// before this field existed. It parses as nothing, so the caller keeps the
+    /// indeterminate answer, which is the compatibility direction that matters:
+    /// a new CLI must not read silence as a promise.
+    #[tokio::test]
+    async fn an_unmarked_client_error_body_is_still_indeterminate() {
+        let (base_url, requests, server) = spawn_fixed_response_server(
+            axum::http::StatusCode::CONFLICT,
+            "repository projection conflict: tracked working-copy path differs",
+        )
+        .await;
+        let client =
+            DaemonClient::from_base_url_with_explicit_authority(base_url, None, None).unwrap();
+        let operation_id = stable_test_operation_id();
+
+        let error = client
+            .post_non_idempotent_json::<_, serde_json::Value>(
+                "/commands/test",
+                &serde_json::json!({"operation_id": operation_id}),
+                operation_id,
+                "test one-dispatch post",
+            )
+            .await
+            .expect_err("an unmarked refusal proves nothing");
+        server.abort();
+
+        assert_indeterminate(&error, operation_id);
+        assert_eq!(requests.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    /// A body that parses but says `false` is the same as saying nothing.
+    ///
+    /// Separate from the plain-text arm because they fail at different steps,
+    /// and a fix that made an unparseable body honoured would leave this one
+    /// green while breaking the other.
+    #[tokio::test]
+    async fn a_client_error_marked_false_is_still_indeterminate() {
+        let (base_url, _requests, server) = spawn_fixed_response_server(
+            axum::http::StatusCode::BAD_REQUEST,
+            r#"{"message":"no recorded merge conflict matches summarize","refused_before_write":false}"#,
+        )
+        .await;
+        let client =
+            DaemonClient::from_base_url_with_explicit_authority(base_url, None, None).unwrap();
+        let operation_id = stable_test_operation_id();
+
+        let error = client
+            .post_non_idempotent_json::<_, serde_json::Value>(
+                "/commands/test",
+                &serde_json::json!({"operation_id": operation_id}),
+                operation_id,
+                "test one-dispatch post",
+            )
+            .await
+            .expect_err("a refusal is still an error");
+        server.abort();
+
+        assert_indeterminate(&error, operation_id);
     }
 
     #[tokio::test]

--- a/crates/kin-cli/src/daemon_error.rs
+++ b/crates/kin-cli/src/daemon_error.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The body a daemon returns when it refuses a non-idempotent command.
+//!
+//! A transport cannot tell a refusal from a half-done write. It sees a status
+//! and some bytes, and it cannot know whether a proxy answered, or whether the
+//! daemon acted and then failed to report. That is why every non-2xx from a
+//! non-idempotent command is treated as indeterminate, and why the caller is
+//! told the daemon may already have committed.
+//!
+//! For an ordinary refusal that is alarming and false. `kin resolve --continue`
+//! with conflicts outstanding is a decision the daemon reached and acted on in
+//! no way, and it was reported as a possible write.
+//!
+//! The daemon is the only party that knows. So it says so, in this body, and
+//! the transport believes it only where believing it is safe. The field is
+//! absent by default and absence means indeterminate, which is today's
+//! behaviour: a proxy can strip a field, which is safe, and nothing can add one.
+
+use serde::{Deserialize, Serialize};
+
+/// The JSON schema this body is validated against.
+pub const DAEMON_ERROR_SCHEMA: &str = "kin://contracts/daemon-error";
+
+/// One refusal, as the daemon describes it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DaemonErrorBody {
+    /// The refusal in the daemon's own words, rendered to the caller verbatim.
+    pub message: String,
+    /// True only when the daemon raised this refusal before its first authority
+    /// write, so nothing was published and a caller may act on that.
+    ///
+    /// Defaulted, so a daemon that predates this field parses as `false`, which
+    /// is the safe answer and today's behaviour.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub refused_before_write: bool,
+}
+
+impl DaemonErrorBody {
+    /// A refusal raised before anything was written.
+    pub fn before_write(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            refused_before_write: true,
+        }
+    }
+
+    /// A refusal that says nothing about what was written.
+    pub fn unknown(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            refused_before_write: false,
+        }
+    }
+
+    /// Read a refusal out of a response body, or `None` when it is not one.
+    ///
+    /// `None` covers an older daemon's plain-text body, a proxy's HTML, and a
+    /// truncated read, and every one of them means the caller learns nothing
+    /// and keeps the indeterminate answer. Unknown fields are refused so a
+    /// body shaped like something else cannot be read as this.
+    pub fn parse(body: &str) -> Option<Self> {
+        serde_json::from_str::<Self>(body).ok()
+    }
+
+    /// The body as the daemon puts it on the wire.
+    pub fn to_wire(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| self.message.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_absent_marker_reads_as_unknown_rather_than_before_write() {
+        let parsed = DaemonErrorBody::parse(r#"{"message":"refused"}"#)
+            .expect("a body with only a message is still a refusal body");
+        assert!(
+            !parsed.refused_before_write,
+            "an older daemon says nothing, and nothing must not read as a promise"
+        );
+    }
+
+    #[test]
+    fn a_plain_text_body_is_not_a_refusal_body() {
+        assert_eq!(
+            DaemonErrorBody::parse("repository projection conflict: tracked path differs"),
+            None,
+            "today's plain-text refusals must not parse into a marker"
+        );
+    }
+
+    #[test]
+    fn the_marker_survives_a_round_trip_and_is_omitted_when_false() {
+        let before = DaemonErrorBody::before_write("nothing was committed");
+        let wire = before.to_wire();
+        assert!(wire.contains("refused_before_write"));
+        assert_eq!(DaemonErrorBody::parse(&wire), Some(before));
+
+        // Omitted rather than written as false, so a body carrying the field at
+        // all is a body some daemon meant to set it in.
+        let unknown = DaemonErrorBody::unknown("nothing was committed");
+        assert!(!unknown.to_wire().contains("refused_before_write"));
+        assert_eq!(DaemonErrorBody::parse(&unknown.to_wire()), Some(unknown));
+    }
+}

--- a/crates/kin-cli/src/lib.rs
+++ b/crates/kin-cli/src/lib.rs
@@ -6,6 +6,7 @@ pub mod capability;
 pub mod commands;
 pub mod daemon_client;
 pub mod daemon_death;
+pub mod daemon_error;
 pub mod embed_model;
 pub mod model_residency;
 pub mod output_style;

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -5235,30 +5235,30 @@ async fn command_merge(
     headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<kin_cli::commands::merge::MergeRequest>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, crate::repository_merge::CommandRefusal> {
     if !state
         .is_initialized
         .load(std::sync::atomic::Ordering::Relaxed)
     {
-        return Err((
+        return Err(crate::repository_merge::CommandRefusal::from((
             StatusCode::SERVICE_UNAVAILABLE,
             "daemon not fully initialized".to_string(),
-        ));
+        )));
     }
     if state.storage_backend.is_some() {
-        return Err((
+        return Err(crate::repository_merge::CommandRefusal::from((
             StatusCode::CONFLICT,
             "local repository merge authority is unavailable for hosted snapshot authority"
                 .to_string(),
-        ));
+        )));
     }
     if extract_session_id_from_headers(&headers)?.is_some() {
-        return Err((
+        return Err(crate::repository_merge::CommandRefusal::from((
             StatusCode::CONFLICT,
             "merge does not accept X-Kin-Session because it mutates the primary repository \
              workspace and its active branch"
                 .to_string(),
-        ));
+        )));
     }
 
     let _coordination = state.coordination_gate.lock().await;
@@ -5305,30 +5305,30 @@ async fn command_resolve(
     headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<kin_cli::commands::resolve::ResolveRequest>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, crate::repository_merge::CommandRefusal> {
     if !state
         .is_initialized
         .load(std::sync::atomic::Ordering::Relaxed)
     {
-        return Err((
+        return Err(crate::repository_merge::CommandRefusal::from((
             StatusCode::SERVICE_UNAVAILABLE,
             "daemon not fully initialized".to_string(),
-        ));
+        )));
     }
     if state.storage_backend.is_some() {
-        return Err((
+        return Err(crate::repository_merge::CommandRefusal::from((
             StatusCode::CONFLICT,
             "local repository merge authority is unavailable for hosted snapshot authority"
                 .to_string(),
-        ));
+        )));
     }
     if extract_session_id_from_headers(&headers)?.is_some() {
-        return Err((
+        return Err(crate::repository_merge::CommandRefusal::from((
             StatusCode::CONFLICT,
             "resolve does not accept X-Kin-Session because it mutates the primary repository \
              workspace and its active branch"
                 .to_string(),
-        ));
+        )));
     }
 
     let _coordination = state.coordination_gate.lock().await;

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -93,21 +93,81 @@ pub(crate) fn merge_bad_request(message: impl Into<String>) -> anyhow::Error {
     anyhow::Error::new(MergeBadRequest(message.into()))
 }
 
+/// A refusal from a non-idempotent command, and whether anything was written.
+///
+/// A transport sees a status and some bytes. It cannot know whether a proxy
+/// answered, or whether this daemon acted and then failed to report, so it
+/// treats every non-2xx as an indeterminate write and tells the caller the
+/// daemon may already have committed. For an ordinary refusal that is alarming
+/// and false, and the daemon is the only party that can say otherwise.
+///
+/// So it says so here. `From<(StatusCode, String)>` produces the silent form,
+/// which is today's behaviour, and a site marks itself with `before_write` only
+/// when it is reached before this command's first authority write. Silence is
+/// the default in both directions: a body with no marker, a body that does not
+/// parse, and a proxy that replaced the body all mean the caller learns nothing.
+pub(crate) struct CommandRefusal {
+    status: StatusCode,
+    body: kin_cli::daemon_error::DaemonErrorBody,
+}
+
+impl CommandRefusal {
+    /// A refusal raised before this command's first authority write.
+    ///
+    /// Only correct above the `finalize_local_repository_commit` call, which is
+    /// where both of these commands publish. Applying it below that line is the
+    /// mutation the tests for this exist to catch.
+    pub(crate) fn before_write((status, message): (StatusCode, String)) -> Self {
+        Self {
+            status,
+            body: kin_cli::daemon_error::DaemonErrorBody::before_write(message),
+        }
+    }
+}
+
+impl From<(StatusCode, String)> for CommandRefusal {
+    fn from((status, message): (StatusCode, String)) -> Self {
+        Self {
+            status,
+            body: kin_cli::daemon_error::DaemonErrorBody::unknown(message),
+        }
+    }
+}
+
+impl axum::response::IntoResponse for CommandRefusal {
+    fn into_response(self) -> axum::response::Response {
+        (
+            self.status,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/json; charset=utf-8",
+            )],
+            self.body.to_wire(),
+        )
+            .into_response()
+    }
+}
+
 pub(crate) fn execute(
     state: &DaemonState,
     request: &MergeRequest,
-) -> std::result::Result<MergeResponse, (StatusCode, String)> {
+) -> std::result::Result<MergeResponse, CommandRefusal> {
     let graph_mutation = state.begin_graph_authority_mutation();
     let persistence = state.persist_lock.lock().map_err(|_| {
-        (
+        CommandRefusal::from((
             StatusCode::INTERNAL_SERVER_ERROR,
             "daemon persistence lock poisoned".to_string(),
-        )
+        ))
     })?;
     let previous_graph_root = hex::encode(state.graph.compute_root_hash());
-    let authority =
-        ActiveLocalRepositoryAuthority::open_bound(state).map_err(merge_bind_refusal)?;
-    let outcome = plan_and_publish(state, &authority, request).map_err(classify_merge_error)?;
+    // Everything from here to `finalize_local_repository_commit` below runs
+    // before this command's first authority write, so a refusal raised in it
+    // published nothing and says so. Below that call the marker is never
+    // applied, because by then the daemon cannot promise it.
+    let authority = ActiveLocalRepositoryAuthority::open_bound(state)
+        .map_err(|refusal| CommandRefusal::before_write(merge_bind_refusal(refusal)))?;
+    let outcome = plan_and_publish(state, &authority, request)
+        .map_err(|error| CommandRefusal::before_write(classify_merge_error(error)))?;
     let execution = match outcome {
         MergeCommandOutcome::Commit(execution) => execution,
         MergeCommandOutcome::ReadOnly(response) => {

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -368,18 +368,25 @@ fn slice_span(text: &str, start: usize, end: usize) -> Option<String> {
 pub(crate) fn execute_resolve(
     state: &DaemonState,
     request: &ResolveRequest,
-) -> std::result::Result<ResolveResponse, (StatusCode, String)> {
+) -> std::result::Result<ResolveResponse, crate::repository_merge::CommandRefusal> {
+    use crate::repository_merge::CommandRefusal;
     let graph_mutation = state.begin_graph_authority_mutation();
     let persistence = state.persist_lock.lock().map_err(|_| {
-        (
+        CommandRefusal::from((
             StatusCode::INTERNAL_SERVER_ERROR,
             "daemon persistence lock poisoned".to_string(),
-        )
+        ))
     })?;
     let previous_graph_root = hex::encode(state.graph.compute_root_hash());
-    let authority =
-        ActiveLocalRepositoryAuthority::open_bound(state).map_err(merge_bind_refusal)?;
-    let execution = plan_resolution(state, &authority, request).map_err(classify_merge_error)?;
+    // Same boundary as the merge: everything to `finalize_local_repository_commit`
+    // below runs before this command's first authority write. `plan_resolution`
+    // is where a settlement is refused and where `resolve --continue` refuses
+    // with conflicts outstanding, which is the refusal that was being reported
+    // as a possible write.
+    let authority = ActiveLocalRepositoryAuthority::open_bound(state)
+        .map_err(|refusal| CommandRefusal::before_write(merge_bind_refusal(refusal)))?;
+    let execution = plan_resolution(state, &authority, request)
+        .map_err(|error| CommandRefusal::before_write(classify_merge_error(error)))?;
     let finalization = state
         .finalize_local_repository_commit(
             &execution.receipt,

--- a/crates/kin-daemon/tests/refusal_marker_placement.rs
+++ b/crates/kin-daemon/tests/refusal_marker_placement.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The refusal marker may only be applied before a command writes.
+//!
+//! `CommandRefusal::before_write` tells a caller nothing was published, and a
+//! caller may act on that. Its correctness is a property of WHERE it is applied:
+//! above the `finalize_local_repository_commit` call it is true by control flow,
+//! and below that call it is a lie the transport would faithfully relay.
+//!
+//! That is a source-level property, so this is a source-level check, which is
+//! the right layer for it and not a proxy for something else. The mutation it
+//! exists to catch is moving a marker below the write, which no behavioural
+//! test in this repository can reach: a post-write refusal needs a finalize
+//! failure, and nothing in a fixture can make one happen on demand.
+//!
+//! This file is never one of the files it scans, so it cannot match itself.
+
+use std::path::PathBuf;
+
+// The needles are the INVOCATIONS, with their opening parenthesis, and comment
+// lines are skipped before matching. Both names appear in prose in the files
+// this scans, including in the comment that explains the rule, so a needle that
+// matched a mention would have found the explanation and graded that. It did,
+// on the first run: the write "call" it found was a sentence about the write.
+const MARKER: &str = "CommandRefusal::before_write(";
+const WRITE: &str = ".finalize_local_repository_commit(";
+
+fn crate_file(relative: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+/// The lines of one function, as (line number, text), one-indexed.
+fn function_lines(source: &str, signature: &str) -> Vec<(usize, String)> {
+    let lines: Vec<&str> = source.lines().collect();
+    let start = lines
+        .iter()
+        .position(|line| line.contains(signature))
+        .unwrap_or_else(|| panic!("no function matching {signature}"));
+    let end = (start..lines.len())
+        .find(|index| lines[*index] == "}")
+        .unwrap_or_else(|| panic!("{signature} never closes at column zero"));
+    (start..=end)
+        .filter(|index| !lines[*index].trim_start().starts_with("//"))
+        .map(|index| (index + 1, lines[index].to_string()))
+        .collect()
+}
+
+fn assert_marker_precedes_the_write(relative: &str, signature: &str) {
+    let source = crate_file(relative);
+    let body = function_lines(&source, signature);
+
+    let write_line = body
+        .iter()
+        .find(|(_, text)| text.contains(WRITE))
+        .map(|(number, _)| *number);
+    // The scan proves nothing without this. A function whose write call was
+    // renamed would have no line to compare against, and every marker would
+    // pass by vacuum.
+    let write_line = write_line.unwrap_or_else(|| {
+        panic!("{relative}: {signature} has no {WRITE} call, so this check graded nothing")
+    });
+
+    let markers: Vec<usize> = body
+        .iter()
+        .filter(|(_, text)| text.contains(MARKER))
+        .map(|(number, _)| *number)
+        .collect();
+    assert!(
+        !markers.is_empty(),
+        "{relative}: {signature} applies no marker, so this check graded nothing"
+    );
+
+    for marker in &markers {
+        assert!(
+            *marker < write_line,
+            "{relative}: {signature} marks a refusal at line {marker} as pre-write, but the \
+             authority write is at line {write_line}. A refusal raised at or below that line \
+             cannot promise nothing was published."
+        );
+    }
+}
+
+#[test]
+fn the_merge_command_marks_only_refusals_raised_before_its_write() {
+    assert_marker_precedes_the_write("src/repository_merge.rs", "pub(crate) fn execute(");
+}
+
+#[test]
+fn the_resolve_command_marks_only_refusals_raised_before_its_write() {
+    assert_marker_precedes_the_write(
+        "src/repository_merge_state.rs",
+        "pub(crate) fn execute_resolve(",
+    );
+}
+
+/// The control. A needle that cannot exist must find nothing, or the two checks
+/// above are matching on something other than what they name.
+#[test]
+fn a_marker_that_does_not_exist_is_found_nowhere() {
+    for relative in ["src/repository_merge.rs", "src/repository_merge_state.rs"] {
+        let source = crate_file(relative);
+        assert!(
+            !source.contains("CommandRefusal::after_a_write_that_cannot_exist("),
+            "{relative} matched a fabricated marker, so the scan matches too loosely"
+        );
+        // And the real needle must be present, so a scan that found nothing at
+        // all cannot read as a clean pass.
+        assert!(
+            source.contains(MARKER),
+            "{relative} carries no {MARKER}, so the checks above have no subject"
+        );
+    }
+}

--- a/packages/boundary-contracts/schemas/daemon-error.schema.json
+++ b/packages/boundary-contracts/schemas/daemon-error.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kin://contracts/daemon-error",
+  "title": "DaemonError",
+  "description": "The body a daemon returns when it refuses a non-idempotent command. `refused_before_write` is present only when the daemon raised the refusal before its first authority write; absent means the daemon says nothing, which a caller must read as indeterminate.",
+  "type": "object",
+  "required": ["message"],
+  "properties": {
+    "message": {
+      "type": "string",
+      "description": "The refusal in the daemon's own words, rendered to the caller verbatim."
+    },
+    "refused_before_write": {
+      "type": "boolean",
+      "description": "True only when nothing was published. Absent is the safe default and means unknown."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/boundary-contracts/src/index.js
+++ b/packages/boundary-contracts/src/index.js
@@ -17,6 +17,7 @@ const schemaFiles = {
   directoryList: 'directory-list.schema.json',
   fileContent: 'file-content.schema.json',
   commandAck: 'command-ack.schema.json',
+  daemonError: 'daemon-error.schema.json',
   kinCommandResult: 'kin-command-result.schema.json',
   scmSnapshot: 'scm-snapshot.schema.json',
   scmResourceGroups: 'scm-resource-groups.schema.json',

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -31,6 +31,37 @@ test('all schemas load', async () => {
   assert.ok(schemas.repoScopedSemanticToolResponse);
   assert.ok(schemas.repoScopedSemanticToolError);
   assert.ok(schemas.shadowGateReport);
+  assert.ok(schemas.daemonError);
+});
+
+test('a daemon refusal body carries its marker only when the daemon set it', async () => {
+  // The marker is the whole point: a caller may act on "nothing was written",
+  // so a body that never says it must not be readable as if it had.
+  assert.equal(
+    (await validateContract('daemonError', { message: 'nothing was committed' })).ok,
+    true,
+    'a refusal with no marker is valid, and means unknown'
+  );
+  assert.equal(
+    (await validateContract('daemonError', {
+      message: 'nothing was committed',
+      refused_before_write: true
+    })).ok,
+    true
+  );
+
+  // Fails closed on the three shapes that would let a wrong body through.
+  for (const bad of [
+    { refused_before_write: true },
+    { message: 'refused', refused_before_write: 'true' },
+    { message: 'refused', refused_before_write: true, committed: true }
+  ]) {
+    assert.equal(
+      (await validateContract('daemonError', bad)).ok,
+      false,
+      `this body must be refused: ${JSON.stringify(bad)}`
+    );
+  }
 });
 
 test('repo-scoped semantic contracts bind the path authority and fail closed', async () => {

--- a/scripts/acceptance/merge_precedence_repro.py
+++ b/scripts/acceptance/merge_precedence_repro.py
@@ -30,7 +30,7 @@ carries all of them the merge refuses and names both decisions. Nothing is
 synthesized, because kin has no textual line merge to build a third body from,
 so a projection is a choice among sides this merge already bound.
 
-Nine checks over ten repositories, run in order because two of them are
+Ten checks over eleven repositories, run in order because two of them are
 destructive: they publish the merge the earlier assertions are about. The first
 four grade FIR-2958's precedence rule; the last two grade rc062j finding (2),
 which is the same authority reporting conflicts that are not conflicts.
@@ -96,6 +96,7 @@ GRANULARITY_TICKET = "FIR-2960"
 BODIES_TICKET = "FIR-2960"
 # The rc062k merge-workflow items: the exit code and the selector.
 WORKFLOW_TICKET = "FIR-2960"
+REFUSAL_TICKET = "FIR-3018"
 EXIT_MERGE_CONFLICTED = 8
 
 print = functools.partial(print, flush=True)
@@ -755,6 +756,50 @@ def grade_parked_output_names_its_code(out, err, code):
     return (PASS, "the parked merge names exit %d where it fires" % code)
 
 
+def grade_refusal_says_what_is_true(rc, out, err, published_before, published_after):
+    """rc062k F-25. An ordinary refusal must not warn about a write.
+
+    Four claims graded together, because three of them pass on their own for
+    the wrong reasons: a run that printed nothing carries no false warning, and
+    a run that never refused publishes nothing either.
+    """
+    text = (err or "") + (out or "")
+    if rc is None or not text.strip():
+        return (UNREADABLE, "`kin resolve --continue` produced nothing to read")
+    problems = []
+    if rc == 0:
+        problems.append("the refusal did not refuse")
+    if "may already have committed" in text:
+        problems.append("it still warns the daemon may have committed")
+    if "indeterminate" in text:
+        problems.append("it still calls a determinate refusal indeterminate")
+    if "unresolved conflict" not in text:
+        problems.append("it does not carry the daemon's own reason")
+    if published_before != published_after:
+        problems.append("something WAS published, so the marker would be a lie")
+    if problems:
+        return (FAIL, "; ".join(problems))
+    return (PASS, "the refusal names its reason, warns of no write, and published nothing")
+
+
+def check_wrotenothing(suite):
+    """FIR-3018. The daemon says it wrote nothing and the CLI says so too.
+
+    Not called `refusal`: FIR-2958's check already owns that id, and two checks
+    sharing one collapse in the gate's map so only the later is graded. The
+    suite's own self-test caught it, which is what that gate-shape assertion is
+    for.
+    """
+    repo = suite.repo("wrotenothing", BODY_FILES)
+    suite.kin_run(["merge", "feature"], repo)
+    before = suite.kin_run(["log", "-n", "1"], repo)[1]
+    rc, out, err = suite.kin_run(["resolve", "--continue"], repo)
+    after = suite.kin_run(["log", "-n", "1"], repo)[1]
+    return _combine("wrotenothing", [
+        ("said", grade_refusal_says_what_is_true(rc, out, err, before, after)),
+    ], ticket=REFUSAL_TICKET)
+
+
 def check_exitcode(suite):
     """rc062k. A merge that parks conflicts must not report success, and one
     that publishes must not report failure. Both arms, because a build that
@@ -860,6 +905,7 @@ CHECKS = [
     ("bodies", check_bodies),
     ("exitcode", check_exitcode),
     ("byname", check_byname),
+    ("wrotenothing", check_wrotenothing),
 ]
 
 
@@ -1144,6 +1190,24 @@ def self_test():
            FAIL)
     expect("named cannot read empty output",
            grade_parked_output_names_its_code("", "", 8), UNREADABLE)
+
+    good_refusal = ("Error: merging refs/heads/feature into refs/heads/main still has 3 "
+                    "unresolved conflict(s): entity summarize in pkg/core.py")
+    old_refusal = ("Error: daemon command outcome is indeterminate for operation abc at "
+                   "/commands/resolve: daemon returned HTTP 409: still has 3 unresolved "
+                   "conflict(s); the daemon may already have committed it")
+    expect("refusal passes a refusal that names its reason and warns of no write",
+           grade_refusal_says_what_is_true(1, "", good_refusal, "change a", "change a"), PASS)
+    expect("refusal fails the shipped indeterminate wrapper",
+           grade_refusal_says_what_is_true(1, "", old_refusal, "change a", "change a"), FAIL)
+    expect("refusal fails a run that did not refuse",
+           grade_refusal_says_what_is_true(0, "", good_refusal, "change a", "change a"), FAIL)
+    # CONTROL: the marker is a claim about the repository, so a run that DID
+    # publish must fail even when every word of the message is right.
+    expect("CONTROL refusal fails when something was published after all",
+           grade_refusal_says_what_is_true(1, "", good_refusal, "change a", "change b"), FAIL)
+    expect("refusal cannot read empty output",
+           grade_refusal_says_what_is_true(1, "", "", "change a", "change a"), UNREADABLE)
 
     expect("a relative kin path is absolutized by this suite",
            (os.path.isabs(absolute_binary("target/release/kin")), "isabs"), True)


### PR DESCRIPTION
rc062k's F-25, the last of FIR-2960's six. An ordinary refusal was reported as a possible write: `kin resolve --continue` with conflicts outstanding answered "the daemon may already have committed it, so do not retry automatically", with nothing committed and `kin log` unchanged.

## Why the transport was not the place to fix it

The sentence is not a resolve string. It is `IndeterminateDaemonCommandError`, raised for every non-2xx from every non-idempotent command, which is why the same wrapper appears on a bad selector's 400 and on a merge refusal. Two tests defend that by name, one commented `a 400 response cannot prove the mutation was rejected`, and both are right about what a transport can see: it cannot know a proxy did not answer, nor that the daemon did not act and then fail to report. Reclassifying 4xx there would have deleted a safety property, not fixed a message.

So the daemon says it, and the transport believes it only where that is safe.

## Condition 1: a body field, under a contract

`packages/boundary-contracts/schemas/daemon-error.schema.json`, additive, `additionalProperties: false`, registered in `src/index.js` and validated in `test/contracts.test.js`. A body field rather than a header because a proxy can strip a field, which yields absent, which yields indeterminate, which is safe, and nothing can add one. `refused_before_write` is omitted when false, so a body carrying it at all is one some daemon meant to set.

The contracts test fails closed on the three shapes that would let a wrong body through: no message, a string where the boolean belongs, and an unknown sibling field.

## Condition 2: only above the write, enumerated and checked

| site | file:line | that command's write |
|---|---|---|
| merge, authority bind | `repository_merge.rs:168` | `:181` |
| merge, plan refusal | `repository_merge.rs:170` | `:181` |
| resolve, authority bind | `repository_merge_state.rs:387` | `:391` |
| resolve, plan refusal | `repository_merge_state.rs:389` | `:391` |

`From<(StatusCode, String)>` produces the silent form, so silence is the default everywhere and a site opts in deliberately. The handler guards stay silent: they are trivially pre-write, but every claim here carries a check and fewer claims beat unverified ones.

`crates/kin-daemon/tests/refusal_marker_placement.rs` asserts every marker sits above its command's `finalize_local_repository_commit(`. The marker's correctness is a property of WHERE it is applied, so this is a source check by design, and it is the only thing that can catch the required mutation: a post-write refusal needs a finalize failure and no fixture can make one on demand.

## Condition 3: 4xx only, 5xx byte-for-byte unchanged

Four transport arms, all in `daemon_client.rs`:

- a marked 4xx yields `RefusedBeforeWriteError` carrying the daemon's reason verbatim, dispatched once, with the assertion that its Display contains neither "may already have committed" nor "indeterminate"
- a marked **5xx** is still indeterminate, because a server error can leave work in flight whatever the body says and a proxy's 5xx is not the daemon speaking
- an unmarked plain-text 4xx is still indeterminate
- a 4xx marked `false` is still indeterminate, kept separate from the plain-text arm because they fail at different steps

The two existing tests are untouched and still green: 141 of 141 in `daemon_client`.

## Condition 4: compatibility both ways

Old daemon, new CLI: plain text parses as nothing, so the caller keeps the indeterminate answer rather than reading silence as a promise. That is the third arm above, driven through the real fixture. New daemon, old CLI: the field is additive and an old CLI ignores unknown JSON, so it reads the body as it does today. No schema version bump.

## Condition 5

Main landing for the next release. v0.6.2 shipped and is Latest at `510be53f9`; nothing here touches it.

## End to end

```
CHECK wrotenothing FIR-3018 PASS said PASS the refusal names its reason,
  warns of no write, and published nothing
```

Five claims graded together, because three of them pass alone for the wrong reasons: it refused, it does not warn about a write, it does not call itself indeterminate, it carries the daemon's own reason, and `kin log` is byte identical either side. That last one is the control that matters, because the marker is a claim about the repository rather than about wording, so a run that published something must fail even when every word is right.

## Falsification

```
arm  placement  wrotenothing  removes
P0   rc 0       PASS          nothing
P1   rc 101     n/a           the marker, moved below the write (merge path)
P2   rc 0       PASS          the marker on the MERGE plan refusal
P2b  n/a        FAIL          the marker on the RESOLVE plan refusal
```

P1 is condition 2's mutation and the placement check names both numbers: `marks a refusal at line 188 as pre-write, but the authority write is at line 181`.

**P2's green is a finding about the grid, not the code, and it is reported rather than tidied away.** I predicted the end-to-end check would go red and it did not, because `wrotenothing` drives `kin resolve --continue`, which is `execute_resolve` in `repository_merge_state.rs`, while that mutation edited `repository_merge.rs`. The arm was aimed at the wrong subject and came back green having graded nothing. P2b repeats it against the file the check exercises and goes red with both reasons named: `it still warns the daemon may have committed; it still calls a determinate refusal indeterminate`.

Two more things the checks caught before any binary was built. The placement check first matched its own explanatory comment and reported the authority write at line 163, which is a sentence about the write; the needles are now invocations with their opening parenthesis and comment lines are skipped, with controls that refuse rather than pass when a function has no write call or no marker. And the suite's self-test caught an id collision: `refusal` already belongs to FIR-2958, and two checks sharing an id collapse in the gate's map so only the later would have been graded.

## Gates

Ten checks, exit 0. Suite self-test 61 grader assertions, 0 failed. `repository_merge_resolution` 23 of 23, `repository_merge` 18 of 18, `refusal_marker_placement` 3 of 3, boundary contracts 0 failures, `daemon_client` 141 of 141, all run locally before this was opened. `bin/kin-precheck` 16 of 16 on `0e2fc629f`, and `cargo fmt --all -- --check` rc 0 as the last command before the push.

Closes FIR-3018
Closes FIR-2960
