### PR TITLE
Put the heavy-job runner behind a switch that falls back to ubuntu-latest

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -104,7 +104,10 @@ jobs:
     # mint refuses a sha whose required checks are not green, so what this
     # proves still has to be true before a tag, only later than it used to be.
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: kin-16core
+    # The heavy-runner switch, matching ci.yml's compile-heavy jobs.
+    # `vars.KIN_HEAVY_RUNNER` names the runner; unset or empty resolves to
+    # `ubuntu-latest`, so this workflow is always runnable without the variable.
+    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -902,7 +902,21 @@ jobs:
   # string GitHub publishes or the string a ruleset has to name.
   fast-gate-lint:
     name: Fast gate lint and policy
-    runs-on: ubuntu-latest
+    # The heavy-runner switch, and the one place its value is chosen.
+    # `vars.KIN_HEAVY_RUNNER` names the runner every compile-heavy job in this
+    # workflow uses. When it is unset or empty this resolves to `ubuntu-latest`,
+    # so the workflow is always runnable without it, and flipping the whole set
+    # between runners is a variable edit rather than a workflow change.
+    #
+    # That indirection is the availability half, and it was bought the hard way:
+    # on 2026-08-30 the `kin-16core` pool stopped assigning runners at 14:54:39Z
+    # and every job pinned to it queued with no runner and no error, including
+    # main's Product Acceptance, which is the only grader kin has. A hardcoded
+    # label has no way back from that; this has one.
+    #
+    # Read the runner a run actually resolved from the jobs API `labels` field,
+    # never from this line.
+    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     # FIR-2744. This job shares `check`'s cargo cache key, and with
     # `add-rust-environment-hash-key` off nothing else would notice the two
@@ -1102,7 +1116,8 @@ jobs:
     name: Fast gate test shard
     needs: changes
     if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
-    runs-on: ubuntu-latest
+    # The heavy-runner switch; see `fast-gate-lint` for what it resolves to.
+    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     env:
       CARGO_INCREMENTAL: "0"
@@ -1226,6 +1241,12 @@ jobs:
     name: Fast gate build and tests
     needs: [changes, fast-gate-tests]
     if: ${{ !cancelled() }}
+    # Deliberately a literal `ubuntu-latest` rather than the heavy-runner switch,
+    # for the reason `check-aggregate` is not on one either. This job compiles
+    # nothing and decides in a two-second shell `if`, but it sits directly on the
+    # required context's critical path, so a larger runner's provisioning wait
+    # would raise the one number this gate is measured on. Measured same-run,
+    # that wait was 4 to 99 seconds against `ubuntu-latest`'s 4 to 20.
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -1309,7 +1330,8 @@ jobs:
       ${{ !cancelled()
       && needs.changes.outputs.docs_only != 'true'
       && github.event_name != 'pull_request' }}
-    runs-on: kin-16core
+    # The heavy-runner switch; see `fast-gate-lint` for what it resolves to.
+    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 60
     # The all-features clippy/build/test sequence can otherwise retain more
     # than a hosted runner's available disk in incremental objects and debug
@@ -2311,7 +2333,8 @@ jobs:
     # sha release-tag.yml sweeps, where a non-required failure is terminal even
     # though nothing gated on it. A job that never starts cannot conclude.
     if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
-    runs-on: kin-16core
+    # The heavy-runner switch; see `fast-gate-lint` for what it resolves to.
+    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
@@ -2372,7 +2395,8 @@ jobs:
       ${{ !cancelled()
       && needs.changes.outputs.docs_only != 'true'
       && github.event_name != 'pull_request' }}
-    runs-on: kin-16core
+    # The heavy-runner switch; see `fast-gate-lint` for what it resolves to.
+    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -524,7 +524,7 @@ REAL_CHECK_JOB_AUTHORITY = textwrap.dedent(
         ${{ !cancelled()
         && needs.changes.outputs.docs_only != 'true'
         && github.event_name != 'pull_request' }}
-      runs-on: kin-16core
+      runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
       timeout-minutes: 60
       env:
         CARGO_INCREMENTAL: "0"
@@ -563,10 +563,14 @@ UBUNTU_SHARD_AGGREGATE_AUTHORITY = textwrap.dedent(
 # The `check` job runner, pinned here as well as inside
 # REAL_CHECK_JOB_AUTHORITY, because `shards` binds to blocks.get("check"),
 # so one job is pinned in two places and both have to move together.
-# Moved to the larger runner under the founder's 2026-08-26 ruling. The
-# aggregate is deliberately NOT moved: it compiles nothing and runs in
-# seconds, so it stays on ubuntu-latest.
-UBUNTU_SHARD_RUNNER = "  runs-on: kin-16core"
+# The value is the heavy-runner switch rather than a label: the job reads
+# `vars.KIN_HEAVY_RUNNER` and falls back to ubuntu-latest when it is unset,
+# so what is pinned here is that the shards keep reading the switch. A
+# hardcoded label cannot fall back, and on 2026-08-30 the kin-16core pool
+# stopped assigning runners and left every job pinned to it queued forever.
+# The aggregate is deliberately NOT on the switch: it compiles nothing and
+# runs in seconds, so it stays on ubuntu-latest.
+UBUNTU_SHARD_RUNNER = "  runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}"
 UBUNTU_SHARD_INDEPENDENT_LEGS = "    fail-fast: false"
 UBUNTU_SHARD_MATRIX = "      shard: [1, 2]"
 UBUNTU_SHARD_PARTITION = (
@@ -13877,7 +13881,7 @@ def main() -> None:
             # has always meant is "the shards leave their pinned runner", so it
             # names the pinned value rather than the historical one.
             "the ubuntu shards leave their pinned runner",
-            "    runs-on: kin-16core",
+            "    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}",
             "    runs-on: macos-latest",
         ),
         (
@@ -14098,7 +14102,7 @@ def main() -> None:
             # stub above did not, which is why only this arm changes and the
             # stub's two arms still name ubuntu-latest.
             "real Check & Test runner detached from its shard matrix",
-            "    runs-on: kin-16core",
+            "    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}",
             "    runs-on: ${{ matrix.os }}",
         ),
         (


### PR DESCRIPTION
Availability first. A hardcoded runner label has no way back when its pool stops serving, and that is not hypothetical: it happened today and it stopped kin's only grader.

## What happened

`kin-16core` made its last job assignment at **14:54:39Z** and then stopped. Read from the jobs API, one queued job beside one that was served:

| | queued, run 33319605727 | control, run 33318156420 |
| -- | -- | -- |
| job | Product Acceptance | Product Acceptance |
| `labels` | `["kin-16core"]` | `["kin-16core"]` |
| `runner_name` | **(none)** | `kin-16core-1000123825` |
| `runner_id` | **(none)** | `1000123825` |
| status | queued | completed, success |
| `started_at` | 2026-08-30T15:25:43Z | 2026-08-30T14:54:40Z |

Same workflow, same job, same requested label. One was served and one has waited since 15:25:43Z. Fourteen jobs were queued on that pool at 16:47Z with no runner, across two main shas and this PR. `Product Acceptance` on main is kin's only grader, since the job carries `github.event_name != 'pull_request'` and kin has had no merge_group since the classic flip, so a pool that stops serving stops the grader.

A second control puts the fault on the pool rather than on the repo or the workflow: in run 33319605892, the same run whose four `kin-16core` jobs have waited over an hour, **every fast-gate job completed success** on a `GitHub Actions <n>` runner. One run, one minute, two runner classes, opposite outcomes.

GitHub's status page read all systems operational with zero incidents, verified against a twelve-component control, so this is not a declared outage.

## The change

Six compile-heavy jobs now read one switch: `fast-gate-lint`, `fast-gate-tests`, `check`, `coverage` and `install-proof-pr-build` in `ci.yml`, and `acceptance` in `acceptance.yml`.

```yaml
runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
```

When `vars.KIN_HEAVY_RUNNER` is unset or empty the expression resolves to `ubuntu-latest`, so the workflow is always runnable without it. Flipping the whole set between runners is then a variable edit with no workflow change and no PR.

**This lands with the variable unset**, so all six resolve to `ubuntu-latest` and run while the pool is down. That is the point: merging this makes main's `check`, `coverage`, `install-proof` and `acceptance` runnable again, which they are not today.

`runs-on` accepts the `vars` context but not `env`, which is why this is a repository variable rather than a top-level workflow env. `${{ matrix.os }}` already appears as an unquoted `runs-on` expression in this file, and `vars.` is already used in `release.yml` and `publish-release-installers.yml`, so neither half of the form is new here.

## The switch, proven on this PR's own runs

Same branch, same three jobs, two heads. The only thing that changed is the runner expression.

| head | `runs-on` | `labels` reported | runner assigned |
| -- | -- | -- | -- |
| `a599f9e66` | hardcoded `kin-16core` | `['kin-16core']` | **(none)**, on all three, never assigned |
| `cb20f74b5` | the switch, variable unset | `['ubuntu-latest']` | `GitHub Actions 1000124450`, `...451`, `...452` |

The first head's shards sat with no runner until the force-push cancelled them. The second head's
were assigned in 15 to 17 seconds and ran. So the expression evaluates, the unset variable resolves
to `ubuntu-latest`, and the fallback is what makes these jobs runnable while the pool is down. The
same reading holds for the other switched jobs on this run: `Check & Test ubuntu shard`,
`Code Coverage` and `Install Proof (PR) Build` all report `labels: ['ubuntu-latest']` where they read
`kin-16core` before, and they are `skipped` on a pull request by design rather than stuck.

### The variable itself, proven with a fabricated value and its control

The fallback resolving is not proof the variable is read: a typo in the name would fall back to `ubuntu-latest` forever and look perfect until a flip did nothing. Both arms through `acceptance.yml`'s `workflow_dispatch` on this branch, so the PR's own checks were untouched:

| `KIN_HEAVY_RUNNER` | run | `labels` | runner |
| -- | -- | -- | -- |
| `zzz-fabricated-fastgate16` | 33324651015 | `["zzz-fabricated-fastgate16"]` | **(none)**, queued |
| unset | 33324673142 | `["ubuntu-latest"]` | `GitHub Actions 1000124494`, in_progress |

Same workflow, same job, same branch, one minute apart, and the only thing that varied is the variable. The workflow parses with an arbitrary label, the value reaches `runs-on`, and unset genuinely falls back to a runner that is actually assigned. Both runs were cancelled and the variable deleted; it now reads 404 and the repository's variable list holds only `RELEASE_FOLLOWUP_READY`.

This was safe to run before landing because `origin/main` references `KIN_HEAVY_RUNNER` zero times in both workflow files, while this branch references it six times. A `pull_request` run uses the PR's own workflow, so until this lands the variable is read by exactly one branch.

## What deliberately does not move

`fast-gate-tests-aggregate` keeps a literal `ubuntu-latest`. It compiles nothing and decides in a two-second shell `if`, but it sits directly on the required context's critical path, so a larger runner's provisioning wait would raise the one number the gate is measured on. Measured same-run, that wait was 4 to 99 seconds on `kin-16core` against 4 to 20 on `ubuntu-latest`. Same call `check-aggregate` already carries.

## The pin, moved with the workflow

`check`'s runner is pinned twice in `scripts/test-release-workflow-authority.py`, inside `REAL_CHECK_JOB_AUTHORITY` and again as `UBUNTU_SHARD_RUNNER`, because the shard authority binds `blocks.get("check")`. Two falsification arms also name the value. All four move to the switch together, so what the guard now pins is that `check` keeps reading the switch rather than any particular label.

| arm | rc | which assertion answered |
| -- | -- | -- |
| M0 unmutated, six jobs on the switch | 0 | passes |
| F1 aggregate admits a non-success shard | 1 | ``admit only `success` `` |
| F2 both fast-gate `runs-on` off the switch to a literal | 0 | stays green, the fast-gate runner is not pinned here |
| F3 required context renamed | 1 | `required-check producer census` |
| F4 `check` detached from the switch | 1 | shard/consumer authority |
| F5 guard's `UBUNTU_SHARD_RUNNER` put back to a hard label | 1 | ubuntu shard authority |

F1 is what makes M0 mean anything. F4 and F5 are the pair that matters for this shape: the workflow and the guard have to agree, so neither side can be quietly re-hardcoded on its own.

## Not changed

No required context changes name. The three display names are byte-identical to `origin/main` and the aggregate keeps `needs: [changes, fast-gate-tests]`. The rules endpoint was read before and is read again after landing. Both workflow files parse, and the resolved values were read back from a real YAML parse rather than from the text.

## Why the fast gate is in the set

Measured across five consecutive main push runs, run start to `Fast gate build and tests` going green: 10.08, 10.20, 10.30, 10.93 and 11.17 minutes. All five over the under-ten-minutes bar. That is FIR-3011, and the switch is what will let it be tested: once the pool returns, setting the variable moves the fast gate and the three heavy jobs together, and the three after-runs follow from there.

One number to carry into that decision. `Actions Linux` is fully covered by included minutes at net $0.00, while `Actions Linux 16-core` is billable at a measured $0.0420 per minute, and the org runs a $100/month Actions budget with `prevent_further_usage: true`. The fast gate is 30.2 job-minutes per CI run over 72.7 CI runs a day, so putting it on the paid runner costs on the order of $1,100 to $2,800 per thirty days. The switch does not decide that; it makes it a dial instead of a commitment.

Closes FIR-3025
