### PR TITLE
Resolve diff and blame endpoints through one ref grammar

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -295,6 +295,16 @@ jobs:
       - name: Falsify the diff-content graders
         run: python3 scripts/acceptance/diff_content_repro.py --self-test
 
+      # The reference set this suite grades against is MEASURED, not written in
+      # the suite: it drives every candidate form through `kin blame --ref`
+      # first and requires `kin diff` to accept what blame accepted. A list
+      # written in the suite would be a third grammar and would drift from the
+      # product the way the first two drifted from each other. Every grader has
+      # a control that must go the other way, because a `kin diff` that resolved
+      # every string it was handed would satisfy a one-directional check.
+      - name: Falsify the ref-grammar graders
+        run: python3 scripts/acceptance/ref_grammar_repro.py --self-test
+
       # The control that decides this suite: in its fixture, the function that
       # DID change twice also reports 3 revisions, so the right answer and the
       # wrong answer are the same number and a grader that counts cannot tell
@@ -973,6 +983,31 @@ jobs:
             echo "::warning title=VCS read-surface acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: Ref-grammar acceptance suite (verdict comes from the gate step)
+        id: refgrammar
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/ref_grammar_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/ref_grammar.json \
+            --verbose >acceptance/ref_grammar.log 2>&1 || rc=$?
+          cat acceptance/ref_grammar.log
+          {
+            echo "### Ref-grammar acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/ref_grammar.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Ref-grammar acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
       - name: Diff-content acceptance suite (verdict comes from the gate step)
         id: diffcontent
         if: always()
@@ -1228,6 +1263,7 @@ jobs:
             --report verdict_limits=acceptance/verdict_limits.json \
             --report working_copy_freshness=acceptance/working_copy_freshness.json \
             --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \
+            --report ref_grammar=acceptance/ref_grammar.json \
             --report diff_content=acceptance/diff_content.json \
             --report blame_attribution=acceptance/blame_attribution.json \
             --report init_budget=acceptance/init_budget.json \

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -12,9 +12,9 @@ use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{anyhow, bail, Context, Result};
 use kin_model::{
-    compute_resolved_tree_hash, ChangeStore, Entity, EntityDelta, EntityId, Hash256,
-    RefName, RefTarget, Relation, RelationDelta, RelationId, RepositoryId, ResolvedTree,
-    RootBundle, SemanticChangeId, TreeDelta, TreeEntry, WorkspaceHead, WorkspaceId,
+    compute_resolved_tree_hash, ChangeStore, Entity, EntityDelta, EntityId, Hash256, RefName,
+    RefTarget, Relation, RelationDelta, RelationId, RepositoryId, ResolvedTree, RootBundle,
+    SemanticChangeId, TreeDelta, TreeEntry, WorkspaceHead, WorkspaceId,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -515,7 +515,8 @@ fn resolve_endpoint(
         _ => {}
     }
 
-    let resolved = super::ref_grammar::resolve(lease, history, &workspace.workspace_id, selector)?;
+    let authority = super::ref_grammar::Authority::held(lease, &workspace.workspace_id);
+    let resolved = super::ref_grammar::resolve(&authority, history, selector)?;
     let source = match resolved.kind {
         super::ref_grammar::SelectorKind::Head => DiffEndpointSource::Head,
         super::ref_grammar::SelectorKind::Ref => DiffEndpointSource::Ref,

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -12,13 +12,13 @@ use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{anyhow, bail, Context, Result};
 use kin_model::{
-    compute_resolved_tree_hash, ChangeStore, Entity, EntityDelta, EntityId, GitObjectId, Hash256,
+    compute_resolved_tree_hash, ChangeStore, Entity, EntityDelta, EntityId, Hash256,
     RefName, RefTarget, Relation, RelationDelta, RelationId, RepositoryId, ResolvedTree,
     RootBundle, SemanticChangeId, TreeDelta, TreeEntry, WorkspaceHead, WorkspaceId,
 };
 use serde::{Deserialize, Serialize};
 
-use super::repository_authority::{parse_git_object_id, parse_ref_name, ActiveRepositoryAuthority};
+use super::repository_authority::ActiveRepositoryAuthority;
 
 pub const DIFF_SCHEMA: &str = "kin.diff.v1";
 
@@ -444,6 +444,19 @@ fn derive_workspace_semantics(
     })
 }
 
+/// The state one endpoint selector names.
+///
+/// `WORKSPACE` is answered here and everything else is handed to
+/// [`super::ref_grammar`], the one grammar `kin blame --ref` and
+/// `kin history --ref` also speak. FIR-3015: this function used to carry a
+/// second parser, which knew `@`, `ref:` and `ref-hex:` and did not know
+/// `HEAD~N`, `kin:`, `branch:` or a short change id, so `kin diff` refused
+/// three forms in a row that its own sibling commands had just printed or
+/// accepted.
+///
+/// `WORKSPACE` stays local because it is not a point in history. It names the
+/// uncommitted working tree, there is no change id behind it, and it carries an
+/// entity and relation snapshot the history arms have to derive.
 fn resolve_endpoint(
     lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
     workspace: &kin_model::WorkspaceState,
@@ -492,116 +505,40 @@ fn resolve_endpoint(
                 relations: snapshot.relations,
             });
         }
-        "HEAD" | "@" => {
-            let Some(target) = workspace.base_target.clone() else {
-                return EndpointState::empty(DiffEndpointSource::Head, requested);
-            };
-            let change_id = lease
-                .resolve_target_change_id(&target)
-                .context("resolve repository-v6 HEAD target")?;
-            return state_at_change(
-                history,
-                DiffEndpoint {
-                    source: DiffEndpointSource::Head,
-                    requested,
-                    ref_name: match &workspace.head {
-                        WorkspaceHead::Symbolic { target } => Some(target.clone()),
-                        WorkspaceHead::Detached { .. } => None,
-                    },
-                    target: Some(target),
-                    change_id: Some(change_id),
-                    workspace_generation: None,
-                    workspace_head: None,
-                    tree_hash: Hash256::from_bytes([0; 32]),
-                    artifact_count: 0,
-                    entity_count: 0,
-                    relation_count: 0,
-                },
-                change_id,
-            );
+        // A repository with no commits yet has an empty base rather than a
+        // missing one, so `kin diff` against a fresh HEAD shows the whole
+        // workspace as added. The shared resolver refuses an unborn HEAD, which
+        // is right for blame and wrong here, so the case is answered before it.
+        "HEAD" | "@" if workspace.base_target.is_none() => {
+            return EndpointState::empty(DiffEndpointSource::Head, requested);
         }
         _ => {}
     }
 
-    if let Some(hex_name) = selector.strip_prefix("ref-hex:") {
-        if hex_name.is_empty()
-            || hex_name != hex_name.to_ascii_lowercase()
-            || !hex_name.bytes().all(|byte| byte.is_ascii_hexdigit())
-        {
-            bail!("ref-hex selector must use non-empty canonical lowercase hexadecimal bytes");
-        }
-        let bytes = hex::decode(hex_name).context("decode ref-hex selector")?;
-        let name = RefName::from_bytes(bytes)
-            .map_err(|error| anyhow!("invalid ref-hex selector: {error}"))?;
-        return state_at_ref(lease, history, name, requested);
-    }
-
-    if let Some(value) = selector.strip_prefix("ref:") {
-        return state_at_ref(lease, history, parse_ref_name(value)?, requested);
-    }
-    if let Some(value) = selector.strip_prefix("change:") {
-        let change_id = parse_change_id(value)?;
-        require_change(history, change_id)?;
-        return state_at_change(
-            history,
-            endpoint_descriptor(DiffEndpointSource::Change, requested, Some(change_id)),
-            change_id,
-        );
-    }
-    if let Some(value) = selector.strip_prefix("git:") {
-        return state_at_git_object(lease, history, parse_git_object_id(value)?, requested);
-    }
-
-    // Bare values prefer exact refs, matching Git's ordinary branch UX while
-    // avoiding revision-string heuristics. A 64-hex branch remains a branch if
-    // it exists; otherwise it may identify a Kin change or Git SHA-256 object.
-    if let Ok(name) = parse_ref_name(selector) {
-        if lease.resolve_ref_target(&name)?.is_some() {
-            return state_at_ref(lease, history, name, requested);
-        }
-    }
-    if selector.len() == 64 && selector.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        if let Ok(change_id) = parse_change_id(selector) {
-            if history.get_change(&change_id)?.is_some() {
-                return state_at_change(
-                    history,
-                    endpoint_descriptor(DiffEndpointSource::Change, requested, Some(change_id)),
-                    change_id,
-                );
-            }
-        }
-    }
-    if matches!(selector.len(), 40 | 64) && selector.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return state_at_git_object(lease, history, parse_git_object_id(selector)?, requested);
-    }
-
-    bail!(
-        "diff endpoint '{selector}' is not an authority ref, semantic change, Git object, HEAD, \
-         or WORKSPACE"
-    )
-}
-
-fn state_at_ref(
-    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
-    history: &kin_db::InMemoryGraph,
-    name: RefName,
-    requested: Option<String>,
-) -> Result<EndpointState> {
-    let target = lease
-        .resolve_ref_target(&name)
-        .with_context(|| format!("resolve repository ref '{name}'"))?
-        .ok_or_else(|| anyhow!("repository ref '{name}' was not found"))?;
-    let change_id = lease
-        .resolve_target_change_id(&target)
-        .with_context(|| format!("resolve repository ref '{name}' semantic target"))?;
+    let resolved = super::ref_grammar::resolve(lease, history, &workspace.workspace_id, selector)?;
+    let source = match resolved.kind {
+        super::ref_grammar::SelectorKind::Head => DiffEndpointSource::Head,
+        super::ref_grammar::SelectorKind::Ref => DiffEndpointSource::Ref,
+        super::ref_grammar::SelectorKind::Change => DiffEndpointSource::Change,
+        super::ref_grammar::SelectorKind::GitObject => DiffEndpointSource::GitObject,
+    };
+    // HEAD reports the ref the workspace is standing on, which the resolver does
+    // not know: it answers about history and this is a property of the workspace.
+    let ref_name = match resolved.kind {
+        super::ref_grammar::SelectorKind::Head => match &workspace.head {
+            WorkspaceHead::Symbolic { target } => Some(target.clone()),
+            WorkspaceHead::Detached { .. } => None,
+        },
+        _ => resolved.ref_name.clone(),
+    };
     state_at_change(
         history,
         DiffEndpoint {
-            source: DiffEndpointSource::Ref,
+            source,
             requested,
-            ref_name: Some(name),
-            target: Some(target),
-            change_id: Some(change_id),
+            ref_name,
+            target: resolved.target.clone(),
+            change_id: Some(resolved.change_id),
             workspace_generation: None,
             workspace_head: None,
             tree_hash: Hash256::from_bytes([0; 32]),
@@ -609,77 +546,8 @@ fn state_at_ref(
             entity_count: 0,
             relation_count: 0,
         },
-        change_id,
+        resolved.change_id,
     )
-}
-
-fn state_at_git_object(
-    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
-    history: &kin_db::InMemoryGraph,
-    oid: GitObjectId,
-    requested: Option<String>,
-) -> Result<EndpointState> {
-    let target = lease
-        .metadata()
-        .external_objects
-        .iter()
-        .find(|record| record.object.oid == oid)
-        .map(|record| RefTarget::external_object(record.object))
-        .or_else(|| {
-            lease
-                .metadata()
-                .aliases
-                .iter()
-                .find(|alias| alias.oid == oid)
-                .map(|alias| RefTarget::change(alias.change_id))
-        })
-        .ok_or_else(|| {
-            anyhow!(
-                "Git object '{oid}' was never imported into this repository, so there is nothing \
-                 to diff it against; import it with `kin init` in the source checkout, or name a \
-                 ref kin already holds"
-            )
-        })?;
-    let change_id = lease
-        .resolve_target_change_id(&target)
-        .with_context(|| format!("resolve Git object '{oid}' semantic target"))?;
-    state_at_change(
-        history,
-        DiffEndpoint {
-            source: DiffEndpointSource::GitObject,
-            requested,
-            ref_name: None,
-            target: Some(target),
-            change_id: Some(change_id),
-            workspace_generation: None,
-            workspace_head: None,
-            tree_hash: Hash256::from_bytes([0; 32]),
-            artifact_count: 0,
-            entity_count: 0,
-            relation_count: 0,
-        },
-        change_id,
-    )
-}
-
-fn endpoint_descriptor(
-    source: DiffEndpointSource,
-    requested: Option<String>,
-    change_id: Option<SemanticChangeId>,
-) -> DiffEndpoint {
-    DiffEndpoint {
-        source,
-        requested,
-        ref_name: None,
-        target: change_id.map(RefTarget::change),
-        change_id,
-        workspace_generation: None,
-        workspace_head: None,
-        tree_hash: Hash256::from_bytes([0; 32]),
-        artifact_count: 0,
-        entity_count: 0,
-        relation_count: 0,
-    }
 }
 
 fn state_at_change(
@@ -716,12 +584,6 @@ fn require_change(history: &kin_db::InMemoryGraph, change_id: SemanticChangeId) 
         );
     }
     Ok(())
-}
-
-fn parse_change_id(value: &str) -> Result<SemanticChangeId> {
-    let hash = Hash256::from_hex(value)
-        .map_err(|error| anyhow!("invalid semantic change ID '{value}': {error}"))?;
-    Ok(SemanticChangeId::from_hash(hash))
 }
 
 fn diff_trees(base: &ResolvedTree, head: &ResolvedTree) -> Vec<TreeDelta> {

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -64,6 +64,7 @@ pub mod projection;
 pub mod publish;
 pub mod purge_ignored;
 pub mod reconcile;
+pub mod ref_grammar;
 pub mod ref_lookup;
 pub mod refs;
 pub mod registry;

--- a/crates/kin-cli/src/commands/ref_grammar.rs
+++ b/crates/kin-cli/src/commands/ref_grammar.rs
@@ -60,6 +60,94 @@ const AMBIGUITY_PREVIEW: usize = 4;
 pub(crate) const UNRESOLVABLE: &str =
     "is not a ref, a semantic change or its unique prefix, an imported Git object, or HEAD";
 
+/// Repository authority, opened only if an arm of the grammar asks for it.
+///
+/// The two callers arrive differently and the difference is load-bearing.
+/// `kin diff` already holds an open lease, so re-opening would be waste. `kin
+/// blame --ref` holds only a binding, and `explicit_semantic_change_and_parent_
+/// hops_need_no_file_or_git_fallback` pins the property that a `kin:<id>` or
+/// `change:<id>` selector resolves from the graph alone: an explicit semantic
+/// change is graph-owned truth and reaching for the authority envelope to
+/// confirm it would be a file-first fallback on a path that does not need one.
+///
+/// Opening eagerly here is what broke that test, and the test was right.
+pub(crate) enum Authority<'a> {
+    Held {
+        lease: &'a kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+        workspace_id: &'a WorkspaceId,
+    },
+    Deferred {
+        binding: &'a kin_core::LocalRepositoryAuthorityBinding,
+        opened: std::cell::OnceCell<OpenedAuthority>,
+    },
+}
+
+/// An authority this module opened itself, kept alive beside its lease.
+pub(crate) struct OpenedAuthority {
+    lease: kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    workspace_id: WorkspaceId,
+    // Held so the manager outlives the lease taken from it, rather than relying
+    // on the lease's Arc alone.
+    _authority: super::repository_authority::ActiveRepositoryAuthority,
+}
+
+impl<'a> Authority<'a> {
+    pub(crate) fn held(
+        lease: &'a kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+        workspace_id: &'a WorkspaceId,
+    ) -> Self {
+        Self::Held {
+            lease,
+            workspace_id,
+        }
+    }
+
+    pub(crate) fn deferred(binding: &'a kin_core::LocalRepositoryAuthorityBinding) -> Self {
+        Self::Deferred {
+            binding,
+            opened: std::cell::OnceCell::new(),
+        }
+    }
+
+    fn parts(
+        &self,
+        original: &str,
+    ) -> Result<(
+        &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+        &WorkspaceId,
+    )> {
+        match self {
+            Self::Held {
+                lease,
+                workspace_id,
+            } => Ok((lease, workspace_id)),
+            Self::Deferred { binding, opened } => {
+                if opened.get().is_none() {
+                    let authority =
+                        super::repository_authority::ActiveRepositoryAuthority::open(binding)
+                            .map_err(|error| {
+                                ref_error(
+                            original,
+                            format!("this repository's authority could not be opened: {error:#}"),
+                        )
+                            })?;
+                    let lease = authority.manager().read_authority();
+                    let workspace_id = authority.workspace_id.clone();
+                    let _ = opened.set(OpenedAuthority {
+                        lease,
+                        workspace_id,
+                        _authority: authority,
+                    });
+                }
+                let held = opened
+                    .get()
+                    .expect("repository authority was just placed in the cell");
+                Ok((&held.lease, &held.workspace_id))
+            }
+        }
+    }
+}
+
 /// Which arm of the grammar answered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SelectorKind {
@@ -369,12 +457,7 @@ where
 /// because a branch is a thing a person named on purpose. The prefix arm is last
 /// for the same reason in reverse: it is the only arm that can be ambiguous, so
 /// nothing that can be resolved exactly should ever reach it.
-pub(crate) fn resolve<G>(
-    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
-    graph: &G,
-    workspace_id: &WorkspaceId,
-    input: &str,
-) -> Result<ResolvedRef>
+pub(crate) fn resolve<G>(authority: &Authority<'_>, graph: &G, input: &str) -> Result<ResolvedRef>
 where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
@@ -387,7 +470,7 @@ where
     }
 
     let (core, hops) = split_relative_hops(input)?;
-    let resolved = resolve_core(lease, graph, workspace_id, input, core)?;
+    let resolved = resolve_core(authority, graph, input, core)?;
     if hops.is_empty() {
         return Ok(resolved);
     }
@@ -405,9 +488,8 @@ where
 }
 
 fn resolve_core<G>(
-    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    authority: &Authority<'_>,
     graph: &G,
-    workspace_id: &WorkspaceId,
     original: &str,
     core: &str,
 ) -> Result<ResolvedRef>
@@ -415,7 +497,35 @@ where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
 {
+    // First, and deliberately: an explicit semantic change is graph-owned truth.
+    // Its full-id form is answered without opening repository authority at all,
+    // which is the property `explicit_semantic_change_and_parent_hops_need_no_
+    // file_or_git_fallback` pins. Only the prefix half needs the authority
+    // snapshot, because a prefix is a search rather than a name.
+    if let Some(value) = core
+        .strip_prefix("kin:")
+        .or_else(|| core.strip_prefix("change:"))
+    {
+        let change_id = if value.len() == CHANGE_ID_HEX {
+            parse_change_id(value).map_err(|error| ref_error(original, error.to_string()))?
+        } else if is_change_prefix(value) {
+            let (lease, _) = authority.parts(original)?;
+            resolve_change_prefix(lease, original, value)?
+        } else {
+            return Err(ref_error(
+                original,
+                format!(
+                    "'{value}' is not a semantic change id or a prefix of one; ids are \
+                     {CHANGE_ID_HEX} lowercase hexadecimal characters and a prefix must be at \
+                     least {MIN_PREFIX}"
+                ),
+            ));
+        };
+        return resolve_present_change(graph, original, change_id);
+    }
+
     if matches!(core, "HEAD" | "@") {
+        let (lease, workspace_id) = authority.parts(original)?;
         let change_id = workspace_head(lease, workspace_id)?.ok_or_else(|| {
             ref_error(
                 original,
@@ -441,6 +551,7 @@ where
         let bytes = hex::decode(hex_name).context("decode ref-hex selector")?;
         let name = RefName::from_bytes(bytes)
             .map_err(|error| anyhow!("invalid ref-hex selector: {error}"))?;
+        let (lease, _) = authority.parts(original)?;
         return resolve_named(lease, original, name);
     }
 
@@ -448,36 +559,19 @@ where
         .strip_prefix("ref:")
         .or_else(|| core.strip_prefix("branch:"))
     {
+        let (lease, _) = authority.parts(original)?;
         return resolve_named(lease, original, parse_ref_name(value)?);
     }
 
-    if let Some(value) = core
-        .strip_prefix("kin:")
-        .or_else(|| core.strip_prefix("change:"))
-    {
-        let change_id = if value.len() == CHANGE_ID_HEX {
-            parse_change_id(value).map_err(|error| ref_error(original, error.to_string()))?
-        } else if is_change_prefix(value) {
-            resolve_change_prefix(lease, original, value)?
-        } else {
-            return Err(ref_error(
-                original,
-                format!(
-                    "'{value}' is not a semantic change id or a prefix of one; ids are {CHANGE_ID_HEX} \
-                     lowercase hexadecimal characters and a prefix must be at least {MIN_PREFIX}"
-                ),
-            ));
-        };
-        return resolve_present_change(graph, original, change_id);
-    }
-
     if let Some(value) = core.strip_prefix("git:") {
+        let (lease, _) = authority.parts(original)?;
         return resolve_git_object(lease, original, parse_git_object_id(value)?);
     }
 
     // A bare value prefers an exact ref, so a branch someone named stays a
     // branch even when its name happens to look like hexadecimal.
     if let Ok(name) = parse_ref_name(core) {
+        let (lease, _) = authority.parts(original)?;
         if lease.resolve_ref_target(&name)?.is_some() {
             return resolve_named(lease, original, name);
         }
@@ -500,10 +594,12 @@ where
     // prefix arm cannot help a value that is already full width.
     if matches!(core.len(), 40 | CHANGE_ID_HEX) && core.bytes().all(|byte| byte.is_ascii_hexdigit())
     {
+        let (lease, _) = authority.parts(original)?;
         return resolve_git_object(lease, original, parse_git_object_id(core)?);
     }
 
     if is_change_prefix(core) {
+        let (lease, _) = authority.parts(original)?;
         let change_id = resolve_change_prefix(lease, original, core)?;
         return resolve_present_change(graph, original, change_id);
     }

--- a/crates/kin-cli/src/commands/ref_grammar.rs
+++ b/crates/kin-cli/src/commands/ref_grammar.rs
@@ -1,0 +1,623 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The one endpoint grammar every read surface speaks.
+//!
+//! `kin diff`, `kin blame --ref` and `kin history --ref` all name a point in
+//! repository history, and until FIR-3015 each of the first two parsed that name
+//! with its own code. `diff.rs` had a `resolve_endpoint` that knew `@`, `ref:`
+//! and `ref-hex:`; `ref_lookup.rs` had a `resolve_ref_core` that knew `HEAD~N`,
+//! `kin:` and `branch:`. Neither knew the other's forms, and neither knew a
+//! short id at all, which is the form `kin history` prints.
+//!
+//! The npm-mode stranger run met all three halves of that in one sitting and
+//! called it the dominant friction of its version control arm. Each refusal was
+//! correct about its own resolver and useless to the operator, because the
+//! grammar you learn on one surface is not the grammar the next one speaks:
+//!
+//! ```text
+//! kin diff 1971f659d7aa 479aa9b94288
+//!   diff endpoint '1971f659d7aa' is not an authority ref, semantic change,
+//!   Git object, HEAD, or WORKSPACE
+//! ```
+//!
+//! That twelve-hex string came out of `kin history` one command earlier.
+//!
+//! So resolution lives here once and both surfaces call it. The unification
+//! needs no trait: `ActiveRepositoryAuthority::manager().read_authority()`
+//! yields exactly the `AuthorityReadLease` diff already holds, so one function
+//! taking a lease and a graph serves both callers.
+//!
+//! `WORKSPACE` stays in `diff.rs` on purpose. It names the uncommitted working
+//! tree rather than a point in history, there is no change id behind it, and
+//! blame and history have nothing to do with it.
+
+use anyhow::{anyhow, bail, Context, Result};
+use kin_model::{
+    GitObjectId, GraphStore, Hash256, RefName, RefTarget, SemanticChangeId,
+    WorkspaceId,
+};
+
+use super::repository_authority::{parse_git_object_id, parse_ref_name};
+
+/// The shortest prefix that may stand in for a change id.
+///
+/// Four, matching Git's floor. Shorter than that is far more likely to be a
+/// branch name than an id, and the bare-name arm reaches it first anyway.
+pub(crate) const MIN_PREFIX: usize = 4;
+
+/// The full width of a semantic change id in hexadecimal.
+pub(crate) const CHANGE_ID_HEX: usize = 64;
+
+/// How many candidates an ambiguous-prefix refusal names before it stops.
+const AMBIGUITY_PREVIEW: usize = 4;
+
+/// The sentence a selector that matched no arm of the grammar is refused with.
+///
+/// A constant rather than two literals, and both surfaces' tests assert on this
+/// symbol rather than on its text. A surface that forked back to a private
+/// parser would write its own wording and those tests would go red, which is the
+/// only cheap way to prove the two are still joined.
+pub(crate) const UNRESOLVABLE: &str =
+    "is not a ref, a semantic change or its unique prefix, an imported Git object, or HEAD";
+
+/// Which arm of the grammar answered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SelectorKind {
+    Head,
+    Ref,
+    Change,
+    GitObject,
+}
+
+/// One resolved endpoint, with enough provenance for a caller to describe it.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedRef {
+    pub change_id: SemanticChangeId,
+    /// The ref this came from, when it came from one. `None` after a parent hop,
+    /// because the ref names the tip and the hop walked away from it.
+    pub ref_name: Option<RefName>,
+    pub target: Option<RefTarget>,
+    pub kind: SelectorKind,
+}
+
+/// A `~N` or `^N` step off the core selector.
+#[derive(Debug, Clone, Copy)]
+struct ParentHop(usize);
+
+fn ref_error(reference: &str, reason: impl std::fmt::Display) -> anyhow::Error {
+    anyhow!("cannot resolve '{reference}': {reason}")
+}
+
+/// Whether `value` could be a change id or a prefix of one.
+///
+/// Lowercase only. A change id is rendered lowercase everywhere Kin prints one,
+/// so accepting uppercase here would mean accepting a string Kin never emits and
+/// then having to decide what a mixed-case ref name means.
+pub(crate) fn is_change_prefix(value: &str) -> bool {
+    (MIN_PREFIX..=CHANGE_ID_HEX).contains(&value.len())
+        && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && value == value.to_ascii_lowercase()
+}
+
+/// Split trailing `~N` and `^N` steps off a selector, innermost last.
+///
+/// Lifted from `ref_lookup.rs` unchanged, which is the point: it used to be
+/// reachable from `kin blame` and not from `kin diff`.
+fn split_relative_hops(reference: &str) -> Result<(&str, Vec<ParentHop>)> {
+    let mut hops = Vec::new();
+    let mut rest = reference;
+    while let Some(&last) = rest.as_bytes().last() {
+        if last == b'^' || last == b'~' {
+            hops.push(ParentHop(1));
+            rest = &rest[..rest.len() - 1];
+            continue;
+        }
+        if last.is_ascii_digit() {
+            let digits_start = rest
+                .rfind(|character: char| !character.is_ascii_digit())
+                .map(|index| index + 1)
+                .unwrap_or(0);
+            if digits_start == 0 {
+                break;
+            }
+            let marker = rest.as_bytes()[digits_start - 1];
+            if marker != b'^' && marker != b'~' {
+                break;
+            }
+            let count: usize = rest[digits_start..]
+                .parse()
+                .map_err(|_| ref_error(reference, "parent index is out of range"))?;
+            if marker == b'^' {
+                if count == 0 {
+                    break;
+                }
+                hops.push(ParentHop(count));
+            } else {
+                hops.extend(std::iter::repeat_n(ParentHop(1), count));
+            }
+            rest = &rest[..digits_start - 1];
+            continue;
+        }
+        break;
+    }
+    Ok((rest, hops))
+}
+
+fn apply_parent_hops<G>(
+    graph: &G,
+    original: &str,
+    mut head: SemanticChangeId,
+    hops: &[ParentHop],
+) -> Result<SemanticChangeId>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    for hop in hops {
+        let change = graph
+            .get_change(&head)
+            .map_err(|error| anyhow!(error.to_string()))?
+            .ok_or_else(|| ref_error(original, format!("change {head} not found in history")))?;
+        head = *change.parents.get(hop.0 - 1).ok_or_else(|| {
+            ref_error(
+                original,
+                format!(
+                    "{head} has {} parent(s), no parent #{}",
+                    change.parents.len(),
+                    hop.0
+                ),
+            )
+        })?;
+    }
+    Ok(head)
+}
+
+pub(crate) fn parse_change_id(input: &str) -> Result<SemanticChangeId> {
+    Ok(SemanticChangeId::from_hash(
+        Hash256::from_hex(input).map_err(|error| anyhow!("invalid change hash: {error}"))?,
+    ))
+}
+
+/// The one change whose id starts with `prefix`, or a refusal that says why not.
+///
+/// The candidate set is the authority snapshot's own change map, which both
+/// callers already hold a lease on. That map IS the repository's history, so a
+/// prefix is matched against every change kin holds rather than against the
+/// slice reachable from one branch: an id an operator read out of
+/// `kin history --ref <branch>` resolves here whatever branch they are standing
+/// on. Nothing on disk is consulted; the ids come from graph-owned authority.
+///
+/// Ambiguity is refused rather than resolved to whichever candidate came first.
+/// Picking one would be the worst outcome available: it answers, it looks right,
+/// and it silently describes a different point in history than the operator
+/// meant.
+fn resolve_change_prefix(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    original: &str,
+    prefix: &str,
+) -> Result<SemanticChangeId> {
+    let mut matches = Vec::new();
+    for change_id in lease.snapshot().changes.keys() {
+        if change_id.to_string().starts_with(prefix) {
+            matches.push(*change_id);
+            if matches.len() > AMBIGUITY_PREVIEW {
+                break;
+            }
+        }
+    }
+    // Sorted so an ambiguity refusal names the same candidates in the same order
+    // every run. A HashMap's iteration order is not stable and an error message
+    // that reshuffles between two runs of one command reads like two different
+    // failures.
+    matches.sort();
+    match matches.len() {
+        0 => Err(ref_error(
+            original,
+            format!(
+                "no semantic change in this repository's history begins with '{prefix}'; run \
+                 `kin log` to see the changes kin holds"
+            ),
+        )),
+        1 => Ok(matches[0]),
+        count => {
+            let preview = matches
+                .iter()
+                .map(|candidate| candidate.to_string()[..12].to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(ref_error(
+                original,
+                format!(
+                    "'{prefix}' is ambiguous: at least {count} semantic changes begin with it \
+                     ({preview}); use more characters"
+                ),
+            ))
+        }
+    }
+}
+
+/// The change the workspace's committed base names, if it has one.
+fn workspace_head(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    workspace_id: &WorkspaceId,
+) -> Result<Option<SemanticChangeId>> {
+    let workspace = lease
+        .metadata()
+        .workspaces
+        .iter()
+        .find(|workspace| &workspace.workspace_id == workspace_id)
+        .ok_or_else(|| {
+            anyhow!("this repository has no workspace {workspace_id} in its authority")
+        })?;
+    workspace
+        .base_target
+        .as_ref()
+        .map(|target| lease.resolve_target_change_id(target))
+        .transpose()
+        .context("resolve the workspace's committed base")
+}
+
+/// Resolve a ref name the authority is expected to hold.
+fn resolve_named(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    original: &str,
+    name: RefName,
+) -> Result<ResolvedRef> {
+    let target = lease
+        .resolve_ref_target(&name)
+        .with_context(|| format!("resolve repository ref '{name}'"))?
+        .ok_or_else(|| ref_error(original, format!("repository ref '{name}' was not found")))?;
+    let change_id = lease
+        .resolve_target_change_id(&target)
+        .with_context(|| format!("resolve repository ref '{name}' semantic target"))?;
+    Ok(ResolvedRef {
+        change_id,
+        ref_name: Some(name),
+        target: Some(target),
+        kind: SelectorKind::Ref,
+    })
+}
+
+/// Resolve an imported Git object.
+///
+/// Reads `external_objects` as well as `aliases`. `diff.rs` already read both
+/// and `ref_lookup.rs` read only the aliases, so unifying on the superset means
+/// `kin blame --ref` gains the external-object arm it never had.
+fn resolve_git_object(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    original: &str,
+    oid: GitObjectId,
+) -> Result<ResolvedRef> {
+    let target = lease
+        .metadata()
+        .external_objects
+        .iter()
+        .find(|record| record.object.oid == oid)
+        .map(|record| RefTarget::external_object(record.object))
+        .or_else(|| {
+            lease
+                .metadata()
+                .aliases
+                .iter()
+                .find(|alias| alias.oid == oid)
+                .map(|alias| RefTarget::change(alias.change_id))
+        })
+        .ok_or_else(|| {
+            ref_error(
+                original,
+                format!(
+                    "Git object '{oid}' was never imported into this repository, so kin holds no \
+                     semantic change for it; import it with `kin init` in the source checkout, or \
+                     name a ref kin already holds"
+                ),
+            )
+        })?;
+    let change_id = lease
+        .resolve_target_change_id(&target)
+        .with_context(|| format!("resolve Git object '{oid}' semantic target"))?;
+    Ok(ResolvedRef {
+        change_id,
+        ref_name: None,
+        target: Some(target),
+        kind: SelectorKind::GitObject,
+    })
+}
+
+/// A change that must already be in the graph the caller will read it from.
+fn resolve_present_change<G>(
+    graph: &G,
+    original: &str,
+    change_id: SemanticChangeId,
+) -> Result<ResolvedRef>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    if graph
+        .get_change(&change_id)
+        .map_err(|error| anyhow!(error.to_string()))?
+        .is_none()
+    {
+        return Err(ref_error(
+            original,
+            format!(
+                "semantic change {change_id} is not in this repository's authority; run `kin log` \
+                 to see the changes kin holds"
+            ),
+        ));
+    }
+    Ok(ResolvedRef {
+        change_id,
+        ref_name: None,
+        target: Some(RefTarget::change(change_id)),
+        kind: SelectorKind::Change,
+    })
+}
+
+/// Resolve one endpoint selector against repository authority.
+///
+/// This is the whole grammar, in one place, for every surface that names a point
+/// in history. The arms are ordered, and the order is load-bearing:
+///
+///   1. `HEAD` and `@`, the workspace's committed base
+///   2. explicitly tagged forms, `ref-hex:`, `ref:`, `branch:`, `kin:`,
+///      `change:` and `git:`, which say what they are and are never guessed at
+///   3. a bare value, which prefers an exact ref, then a semantic change, then
+///      an imported Git object, then a unique change-id prefix
+///
+/// A bare value prefers a ref because that matches Git's ordinary branch UX and
+/// because a branch is a thing a person named on purpose. The prefix arm is last
+/// for the same reason in reverse: it is the only arm that can be ambiguous, so
+/// nothing that can be resolved exactly should ever reach it.
+pub(crate) fn resolve<G>(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    graph: &G,
+    workspace_id: &WorkspaceId,
+    input: &str,
+) -> Result<ResolvedRef>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    if input.contains("@{") {
+        return Err(ref_error(
+            input,
+            "reflog and upstream '@{...}' syntax is not supported",
+        ));
+    }
+
+    let (core, hops) = split_relative_hops(input)?;
+    let resolved = resolve_core(lease, graph, workspace_id, input, core)?;
+    if hops.is_empty() {
+        return Ok(resolved);
+    }
+
+    // Past a parent hop the ref no longer describes the answer: the ref names a
+    // tip and the hop walked away from it. Reporting `main` for `main~2` would
+    // put a true name on a false claim.
+    let change_id = apply_parent_hops(graph, input, resolved.change_id, &hops)?;
+    Ok(ResolvedRef {
+        change_id,
+        ref_name: None,
+        target: Some(RefTarget::change(change_id)),
+        kind: SelectorKind::Change,
+    })
+}
+
+fn resolve_core<G>(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    graph: &G,
+    workspace_id: &WorkspaceId,
+    original: &str,
+    core: &str,
+) -> Result<ResolvedRef>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    if matches!(core, "HEAD" | "@") {
+        let change_id = workspace_head(lease, workspace_id)?.ok_or_else(|| {
+            ref_error(
+                original,
+                "this workspace has no commits yet, so HEAD names nothing; make one with \
+                 `kin commit`",
+            )
+        })?;
+        return Ok(ResolvedRef {
+            change_id,
+            ref_name: None,
+            target: Some(RefTarget::change(change_id)),
+            kind: SelectorKind::Head,
+        });
+    }
+
+    if let Some(hex_name) = core.strip_prefix("ref-hex:") {
+        if hex_name.is_empty()
+            || hex_name != hex_name.to_ascii_lowercase()
+            || !hex_name.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
+            bail!("ref-hex selector must use non-empty canonical lowercase hexadecimal bytes");
+        }
+        let bytes = hex::decode(hex_name).context("decode ref-hex selector")?;
+        let name =
+            RefName::from_bytes(bytes).map_err(|error| anyhow!("invalid ref-hex selector: {error}"))?;
+        return resolve_named(lease, original, name);
+    }
+
+    if let Some(value) = core
+        .strip_prefix("ref:")
+        .or_else(|| core.strip_prefix("branch:"))
+    {
+        return resolve_named(lease, original, parse_ref_name(value)?);
+    }
+
+    if let Some(value) = core
+        .strip_prefix("kin:")
+        .or_else(|| core.strip_prefix("change:"))
+    {
+        let change_id = if value.len() == CHANGE_ID_HEX {
+            parse_change_id(value).map_err(|error| ref_error(original, error.to_string()))?
+        } else if is_change_prefix(value) {
+            resolve_change_prefix(lease, original, value)?
+        } else {
+            return Err(ref_error(
+                original,
+                format!(
+                    "'{value}' is not a semantic change id or a prefix of one; ids are {CHANGE_ID_HEX} \
+                     lowercase hexadecimal characters and a prefix must be at least {MIN_PREFIX}"
+                ),
+            ));
+        };
+        return resolve_present_change(graph, original, change_id);
+    }
+
+    if let Some(value) = core.strip_prefix("git:") {
+        return resolve_git_object(lease, original, parse_git_object_id(value)?);
+    }
+
+    // A bare value prefers an exact ref, so a branch someone named stays a
+    // branch even when its name happens to look like hexadecimal.
+    if let Ok(name) = parse_ref_name(core) {
+        if lease.resolve_ref_target(&name)?.is_some() {
+            return resolve_named(lease, original, name);
+        }
+    }
+
+    if core.len() == CHANGE_ID_HEX && core.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        if let Ok(change_id) = parse_change_id(core) {
+            if graph
+                .get_change(&change_id)
+                .map_err(|error| anyhow!(error.to_string()))?
+                .is_some()
+            {
+                return resolve_present_change(graph, original, change_id);
+            }
+        }
+    }
+
+    // Exactly 40 or 64 hexadecimal characters is a whole Git object id and
+    // nothing else: a change id of that width was already tried above, and a
+    // prefix arm cannot help a value that is already full width.
+    if matches!(core.len(), 40 | CHANGE_ID_HEX) && core.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return resolve_git_object(lease, original, parse_git_object_id(core)?);
+    }
+
+    if is_change_prefix(core) {
+        let change_id = resolve_change_prefix(lease, original, core)?;
+        return resolve_present_change(graph, original, change_id);
+    }
+
+    Err(ref_error(original, UNRESOLVABLE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two files that must not grow a parser of their own again.
+    ///
+    /// Resolved from `CARGO_MANIFEST_DIR`, so the test grades the tree it was
+    /// compiled from rather than whichever checkout the runner happens to be
+    /// standing in.
+    const DIFF_SOURCE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/commands/diff.rs");
+    const REF_LOOKUP_SOURCE: &str =
+        concat!(env!("CARGO_MANIFEST_DIR"), "/src/commands/ref_lookup.rs");
+
+    /// Tagged forms this module owns. A surface that recognised any of these on
+    /// its own would be a second grammar, which is the defect FIR-3015 fixed.
+    const OWNED_PREFIXES: &[&str] = &[
+        "\"kin:\"",
+        "\"change:\"",
+        "\"branch:\"",
+        "\"ref:\"",
+        "\"ref-hex:\"",
+        "\"git:\"",
+    ];
+
+    #[test]
+    fn parent_hops_split_off_every_shape_git_accepts() {
+        for (input, core, hops) in [
+            ("HEAD", "HEAD", 0),
+            ("HEAD~", "HEAD", 1),
+            ("HEAD^", "HEAD", 1),
+            ("HEAD~1", "HEAD", 1),
+            ("HEAD~3", "HEAD", 3),
+            ("HEAD^2", "HEAD", 1),
+            ("HEAD~2^", "HEAD", 3),
+            ("main~1", "main", 1),
+        ] {
+            let (parsed_core, parsed_hops) = split_relative_hops(input).unwrap();
+            assert_eq!(parsed_core, core, "core of {input}");
+            assert_eq!(parsed_hops.len(), hops, "hop count of {input}");
+        }
+    }
+
+    /// A name that merely ends in digits is not a hop, or `v2` would resolve to
+    /// the parent of `v`.
+    #[test]
+    fn a_trailing_digit_without_a_marker_is_part_of_the_name() {
+        let (core, hops) = split_relative_hops("release2").unwrap();
+        assert_eq!(core, "release2");
+        assert!(hops.is_empty(), "release2 is a branch name, not a hop");
+    }
+
+    #[test]
+    fn a_change_prefix_is_lowercase_hex_of_a_workable_width() {
+        assert!(is_change_prefix("dead"), "four characters is the floor");
+        assert!(is_change_prefix("1971f659d7aa"), "the width kin history prints");
+        assert!(is_change_prefix(&"a".repeat(CHANGE_ID_HEX)), "a full id is its own prefix");
+        assert!(!is_change_prefix("dea"), "three characters is below the floor");
+        assert!(
+            !is_change_prefix(&"a".repeat(CHANGE_ID_HEX + 1)),
+            "longer than an id is not a prefix of one"
+        );
+        assert!(!is_change_prefix("DEADBEEF"), "kin never prints uppercase ids");
+        assert!(!is_change_prefix("deadbeeg"), "g is not hexadecimal");
+        assert!(!is_change_prefix("main"), "a branch name is not a prefix");
+    }
+
+    /// The join: `kin diff` and `kin blame --ref` resolve through this module
+    /// and hold no grammar of their own.
+    ///
+    /// FIR-3015 happened because they each had a parser and nothing compared
+    /// them. This reads the two files and requires one call into `resolve` and
+    /// zero of the tagged prefixes this module owns. Mutating either surface
+    /// back to a private copy turns it red, which is the only cheap way to prove
+    /// the two are still joined.
+    ///
+    /// The needles cannot match this test itself, because the files read are the
+    /// other two. The positive control is the assertion that this module DOES
+    /// carry every needle: without it, a typo in a needle would report both
+    /// surfaces clean and the check would pass over any code at all.
+    #[test]
+    fn diff_and_blame_resolve_through_this_module_and_hold_no_grammar_of_their_own() {
+        let grammar = include_str!("ref_grammar.rs");
+        for needle in OWNED_PREFIXES {
+            assert!(
+                grammar.contains(needle),
+                "CONTROL: {needle} is not in ref_grammar.rs, so the absence checks below \
+                 are searching for something that exists nowhere and cannot fail"
+            );
+        }
+
+        for path in [DIFF_SOURCE, REF_LOOKUP_SOURCE] {
+            let source = std::fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("read {path}: {error}"));
+            assert_eq!(
+                source.matches("ref_grammar::resolve(").count(),
+                1,
+                "{path} must reach repository history through exactly one call to the \
+                 shared resolver"
+            );
+            for needle in OWNED_PREFIXES {
+                assert!(
+                    !source.contains(needle),
+                    "{path} recognises {needle} on its own, which is a second grammar; \
+                     FIR-3015 is exactly what two of those cost"
+                );
+            }
+        }
+    }
+}

--- a/crates/kin-cli/src/commands/ref_grammar.rs
+++ b/crates/kin-cli/src/commands/ref_grammar.rs
@@ -34,8 +34,7 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use kin_model::{
-    GitObjectId, GraphStore, Hash256, RefName, RefTarget, SemanticChangeId,
-    WorkspaceId,
+    GitObjectId, GraphStore, Hash256, RefName, RefTarget, SemanticChangeId, WorkspaceId,
 };
 
 use super::repository_authority::{parse_git_object_id, parse_ref_name};
@@ -440,8 +439,8 @@ where
             bail!("ref-hex selector must use non-empty canonical lowercase hexadecimal bytes");
         }
         let bytes = hex::decode(hex_name).context("decode ref-hex selector")?;
-        let name =
-            RefName::from_bytes(bytes).map_err(|error| anyhow!("invalid ref-hex selector: {error}"))?;
+        let name = RefName::from_bytes(bytes)
+            .map_err(|error| anyhow!("invalid ref-hex selector: {error}"))?;
         return resolve_named(lease, original, name);
     }
 
@@ -518,12 +517,14 @@ mod tests {
 
     /// The two files that must not grow a parser of their own again.
     ///
-    /// Resolved from `CARGO_MANIFEST_DIR`, so the test grades the tree it was
-    /// compiled from rather than whichever checkout the runner happens to be
-    /// standing in.
-    const DIFF_SOURCE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/commands/diff.rs");
-    const REF_LOOKUP_SOURCE: &str =
-        concat!(env!("CARGO_MANIFEST_DIR"), "/src/commands/ref_lookup.rs");
+    /// Embedded at compile time rather than read at run time, so the test grades
+    /// the exact bytes that were compiled. A path read would grade whichever
+    /// checkout the runner happened to be standing in, which is the same class
+    /// of mistake as the drift this module exists to end.
+    const SURFACES: &[(&str, &str)] = &[
+        ("diff.rs", include_str!("diff.rs")),
+        ("ref_lookup.rs", include_str!("ref_lookup.rs")),
+    ];
 
     /// Tagged forms this module owns. A surface that recognised any of these on
     /// its own would be a second grammar, which is the defect FIR-3015 fixed.
@@ -566,14 +567,26 @@ mod tests {
     #[test]
     fn a_change_prefix_is_lowercase_hex_of_a_workable_width() {
         assert!(is_change_prefix("dead"), "four characters is the floor");
-        assert!(is_change_prefix("1971f659d7aa"), "the width kin history prints");
-        assert!(is_change_prefix(&"a".repeat(CHANGE_ID_HEX)), "a full id is its own prefix");
-        assert!(!is_change_prefix("dea"), "three characters is below the floor");
+        assert!(
+            is_change_prefix("1971f659d7aa"),
+            "the width kin history prints"
+        );
+        assert!(
+            is_change_prefix(&"a".repeat(CHANGE_ID_HEX)),
+            "a full id is its own prefix"
+        );
+        assert!(
+            !is_change_prefix("dea"),
+            "three characters is below the floor"
+        );
         assert!(
             !is_change_prefix(&"a".repeat(CHANGE_ID_HEX + 1)),
             "longer than an id is not a prefix of one"
         );
-        assert!(!is_change_prefix("DEADBEEF"), "kin never prints uppercase ids");
+        assert!(
+            !is_change_prefix("DEADBEEF"),
+            "kin never prints uppercase ids"
+        );
         assert!(!is_change_prefix("deadbeeg"), "g is not hexadecimal");
         assert!(!is_change_prefix("main"), "a branch name is not a prefix");
     }
@@ -602,9 +615,7 @@ mod tests {
             );
         }
 
-        for path in [DIFF_SOURCE, REF_LOOKUP_SOURCE] {
-            let source = std::fs::read_to_string(path)
-                .unwrap_or_else(|error| panic!("read {path}: {error}"));
+        for (path, source) in SURFACES {
             assert_eq!(
                 source.matches("ref_grammar::resolve(").count(),
                 1,

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -6,7 +6,7 @@ use kin_model::{
     Entity, EntityFilter, EntityId, EntityRevision, GraphStore, Hash256, SemanticChangeId,
 };
 
-use super::repository_authority::{parse_git_object_id, parse_ref_name, ActiveRepositoryAuthority};
+use super::repository_authority::ActiveRepositoryAuthority;
 
 /// A reference did not resolve through repository-v6 authority.
 #[derive(Debug)]
@@ -166,12 +166,16 @@ pub fn is_ref_resolution_error(error: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<RefResolutionError>().is_some())
 }
 
-pub(crate) fn parse_change_id(input: &str) -> Result<SemanticChangeId> {
-    Ok(SemanticChangeId::from_hash(
-        Hash256::from_hex(input).map_err(|error| anyhow!("invalid change hash: {error}"))?,
-    ))
-}
-
+/// Resolve a ref for `kin blame --ref` and `kin history --ref`.
+///
+/// The grammar itself lives in [`super::ref_grammar`], which `kin diff` calls
+/// too. Before FIR-3015 this function owned a second parser, and the two drifted
+/// until `kin history` was printing change ids `kin diff` would not take back.
+///
+/// What stays here is what is particular to these two surfaces: they answer from
+/// a graph projection the daemon holds, so a ref that resolves through authority
+/// to a change the projection does not carry is a distinct condition with its
+/// own remedy, and it is reported as one.
 pub fn resolve_ref<G>(
     graph: &G,
     binding: &kin_core::LocalRepositoryAuthorityBinding,
@@ -182,16 +186,32 @@ where
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
 {
     let reference = reference.unwrap_or("HEAD");
-    if reference.contains("@{") {
+    let authority = ActiveRepositoryAuthority::open(binding).map_err(|error| {
+        ref_error(
+            reference,
+            format!("this repository's authority could not be opened: {error:#}"),
+        )
+    })?;
+    let lease = authority.manager().read_authority();
+    let resolved =
+        super::ref_grammar::resolve(&lease, graph, &authority.workspace_id, reference)
+            .map_err(|error| ref_error(reference, format!("{error:#}")))?;
+
+    if graph
+        .get_change(&resolved.change_id)
+        .map_err(|error| anyhow!(error.to_string()))?
+        .is_none()
+    {
         return Err(ref_error(
             reference,
-            "reflog/upstream '@{...}' syntax is not supported",
+            format!(
+                "this repository's authority resolves to semantic change {}, which the active \
+                 graph projection does not hold; run `kin status`, then `kin doctor` if it repeats",
+                resolved.change_id
+            ),
         ));
     }
-
-    let (core, hops) = split_relative_hops(reference)?;
-    let head = resolve_ref_core(graph, binding, reference, core)?;
-    apply_parent_hops(graph, reference, head, &hops)
+    Ok(resolved.change_id)
 }
 
 pub(crate) fn resolve_entity_query<G>(graph: &G, entity_query: &str) -> Result<Entity>
@@ -287,214 +307,6 @@ where
         .resolve_graph_at(head)
         .map_err(|error| projection_error(reference, head, error))?;
     Ok(state.entity_revisions.remove(entity_id).unwrap_or_default())
-}
-
-#[derive(Debug, Clone, Copy)]
-struct ParentHop(usize);
-
-fn split_relative_hops(reference: &str) -> Result<(&str, Vec<ParentHop>)> {
-    let mut hops = Vec::new();
-    let mut rest = reference;
-    while let Some(&last) = rest.as_bytes().last() {
-        if last == b'^' || last == b'~' {
-            hops.push(ParentHop(1));
-            rest = &rest[..rest.len() - 1];
-            continue;
-        }
-        if last.is_ascii_digit() {
-            let digits_start = rest
-                .rfind(|character: char| !character.is_ascii_digit())
-                .map(|index| index + 1)
-                .unwrap_or(0);
-            if digits_start == 0 {
-                break;
-            }
-            let marker = rest.as_bytes()[digits_start - 1];
-            if marker != b'^' && marker != b'~' {
-                break;
-            }
-            let count: usize = rest[digits_start..]
-                .parse()
-                .map_err(|_| ref_error(reference, "parent index is out of range"))?;
-            if marker == b'^' {
-                if count == 0 {
-                    break;
-                }
-                hops.push(ParentHop(count));
-            } else {
-                hops.extend(std::iter::repeat_n(ParentHop(1), count));
-            }
-            rest = &rest[..digits_start - 1];
-            continue;
-        }
-        break;
-    }
-    Ok((rest, hops))
-}
-
-fn apply_parent_hops<G>(
-    graph: &G,
-    original: &str,
-    mut head: SemanticChangeId,
-    hops: &[ParentHop],
-) -> Result<SemanticChangeId>
-where
-    G: GraphStore,
-    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
-{
-    for hop in hops {
-        let change = graph
-            .get_change(&head)
-            .map_err(|error| anyhow!(error.to_string()))?
-            .ok_or_else(|| ref_error(original, format!("change {head} not found in history")))?;
-        head = *change.parents.get(hop.0 - 1).ok_or_else(|| {
-            ref_error(
-                original,
-                format!(
-                    "{head} has {} parent(s), no parent #{}",
-                    change.parents.len(),
-                    hop.0
-                ),
-            )
-        })?;
-    }
-    Ok(head)
-}
-
-fn resolve_ref_core<G>(
-    graph: &G,
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
-    original: &str,
-    core: &str,
-) -> Result<SemanticChangeId>
-where
-    G: GraphStore,
-    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
-{
-    if let Some(change_ref) = core
-        .strip_prefix("kin:")
-        .or_else(|| core.strip_prefix("change:"))
-    {
-        return resolve_semantic_change(graph, original, change_ref);
-    }
-
-    // A full semantic change id is unambiguous when that change is present.
-    if core.len() == 64 {
-        if let Ok(change_id) = parse_change_id(core) {
-            if graph
-                .get_change(&change_id)
-                .map_err(|error| anyhow!(error.to_string()))?
-                .is_some()
-            {
-                return Ok(change_id);
-            }
-        }
-    }
-
-    let authority = ActiveRepositoryAuthority::open(binding).map_err(|error| {
-        ref_error(
-            original,
-            format!("this repository's authority could not be opened: {error:#}"),
-        )
-    })?;
-
-    let resolved = if core == "HEAD" {
-        authority
-            .current_change_id()
-            .map_err(|error| {
-                ref_error(
-                    original,
-                    format!("this workspace's head could not be read: {error:#}"),
-                )
-            })?
-            .ok_or_else(|| {
-                ref_error(
-                    original,
-                    "this workspace has no commits yet, so HEAD names nothing; make one with \
-                     `kin commit`",
-                )
-            })?
-    } else if let Some(branch_name) = core.strip_prefix("branch:") {
-        resolve_named_authority_ref(&authority, original, branch_name)?
-    } else if let Some(git_oid) = core.strip_prefix("git:") {
-        resolve_imported_git_ref(&authority, original, git_oid)?
-    } else if matches!(core.len(), 40 | 64) && core.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        resolve_imported_git_ref(&authority, original, core)?
-    } else if is_abbreviated_git_hex(core) {
-        return Err(ref_error(
-            original,
-            format!(
-                "Git commit prefix '{core}' cannot be resolved from exact alias authority; use a full object ID"
-            ),
-        ));
-    } else {
-        resolve_named_authority_ref(&authority, original, core)?
-    };
-
-    if graph
-        .get_change(&resolved)
-        .map_err(|error| anyhow!(error.to_string()))?
-        .is_none()
-    {
-        return Err(ref_error(
-            original,
-            format!(
-                "this repository's authority resolves to semantic change {resolved}, which the \
-                 active graph projection does not hold; run `kin status`, then `kin doctor` if it \
-                 repeats"
-            ),
-        ));
-    }
-    Ok(resolved)
-}
-
-fn resolve_named_authority_ref(
-    authority: &ActiveRepositoryAuthority,
-    original: &str,
-    value: &str,
-) -> Result<SemanticChangeId> {
-    let name = parse_ref_name(value)
-        .map_err(|error| ref_error(original, format!("invalid repository ref: {error:#}")))?;
-    authority
-        .resolve_named_ref(&name)
-        .map_err(|error| ref_error(original, error.to_string()))
-}
-
-fn resolve_imported_git_ref(
-    authority: &ActiveRepositoryAuthority,
-    original: &str,
-    value: &str,
-) -> Result<SemanticChangeId> {
-    let oid = parse_git_object_id(value)
-        .map_err(|error| ref_error(original, format!("invalid Git object ID: {error:#}")))?;
-    authority
-        .resolve_git_oid(&oid)
-        .map_err(|error| ref_error(original, error.to_string()))
-}
-
-fn resolve_semantic_change<G>(graph: &G, original: &str, value: &str) -> Result<SemanticChangeId>
-where
-    G: GraphStore,
-    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
-{
-    let change_id =
-        parse_change_id(value).map_err(|error| ref_error(original, error.to_string()))?;
-    if graph
-        .get_change(&change_id)
-        .map_err(|error| anyhow!(error.to_string()))?
-        .is_some()
-    {
-        Ok(change_id)
-    } else {
-        Err(ref_error(
-            original,
-            format!("change {change_id} not found in graph authority"),
-        ))
-    }
-}
-
-fn is_abbreviated_git_hex(value: &str) -> bool {
-    (4..40).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn choose_entity_match(mut entities: Vec<Entity>, entity_query: &str) -> Result<Entity> {

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -2,11 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use anyhow::{anyhow, bail, Result};
-use kin_model::{
-    Entity, EntityFilter, EntityId, EntityRevision, GraphStore, Hash256, SemanticChangeId,
-};
-
-use super::repository_authority::ActiveRepositoryAuthority;
+use kin_model::{Entity, EntityFilter, EntityId, EntityRevision, GraphStore, SemanticChangeId};
 
 /// A reference did not resolve through repository-v6 authority.
 #[derive(Debug)]
@@ -186,14 +182,13 @@ where
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
 {
     let reference = reference.unwrap_or("HEAD");
-    let authority = ActiveRepositoryAuthority::open(binding).map_err(|error| {
-        ref_error(
-            reference,
-            format!("this repository's authority could not be opened: {error:#}"),
-        )
-    })?;
-    let lease = authority.manager().read_authority();
-    let resolved = super::ref_grammar::resolve(&lease, graph, &authority.workspace_id, reference)
+    // Deferred rather than opened here. An explicit `kin:<id>` or `change:<id>`
+    // is graph-owned truth and resolves without repository authority at all;
+    // opening it eagerly turned that into a hard requirement and broke
+    // `explicit_semantic_change_and_parent_hops_need_no_file_or_git_fallback`,
+    // which is pinning exactly the right thing.
+    let authority = super::ref_grammar::Authority::deferred(binding);
+    let resolved = super::ref_grammar::resolve(&authority, graph, reference)
         .map_err(|error| ref_error(reference, format!("{error:#}")))?;
 
     if graph
@@ -366,7 +361,7 @@ mod tests {
     use std::sync::Arc;
 
     use kin_db::LocalFileBackend;
-    use kin_model::{AuthorId, ChangeOrigin, ChangeStore, SemanticChange, Timestamp};
+    use kin_model::{AuthorId, ChangeOrigin, ChangeStore, Hash256, SemanticChange, Timestamp};
 
     /// Build a change whose declared identity matches its immutable payload.
     ///

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -193,9 +193,8 @@ where
         )
     })?;
     let lease = authority.manager().read_authority();
-    let resolved =
-        super::ref_grammar::resolve(&lease, graph, &authority.workspace_id, reference)
-            .map_err(|error| ref_error(reference, format!("{error:#}")))?;
+    let resolved = super::ref_grammar::resolve(&lease, graph, &authority.workspace_id, reference)
+        .map_err(|error| ref_error(reference, format!("{error:#}")))?;
 
     if graph
         .get_change(&resolved.change_id)

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -220,17 +220,6 @@ impl ActiveRepositoryAuthority {
         Ok((workspace, lease.roots().clone()))
     }
 
-    pub(crate) fn resolve_named_ref(&self, name: &RefName) -> Result<SemanticChangeId> {
-        let lease = self.manager.read_authority();
-        let target = lease
-            .resolve_ref_target(name)
-            .with_context(|| format!("resolve repository ref '{name}'"))?
-            .ok_or_else(|| anyhow!("repository ref '{name}' was not found"))?;
-        lease
-            .resolve_target_change_id(&target)
-            .with_context(|| format!("resolve repository ref '{name}' semantic target"))
-    }
-
     pub(crate) fn current_change_id(&self) -> Result<Option<SemanticChangeId>> {
         let lease = self.manager.read_authority();
         let workspace = lease
@@ -250,23 +239,6 @@ impl ActiveRepositoryAuthority {
             .as_ref()
             .map(|target| resolve_target_in_authority(&lease, target))
             .transpose()
-    }
-
-    pub(crate) fn resolve_git_oid(&self, oid: &GitObjectId) -> Result<SemanticChangeId> {
-        let lease = self.manager.read_authority();
-        lease
-            .metadata()
-            .aliases
-            .iter()
-            .find(|alias| &alias.oid == oid)
-            .map(|alias| alias.change_id)
-            .ok_or_else(|| {
-                anyhow!(
-                    "Git commit '{oid}' was never imported into this repository, so kin holds no \
-                     semantic change for it; import it with `kin init` in the source checkout, or \
-                     name a ref kin already holds"
-                )
-            })
     }
 
     pub(crate) fn load_source_blob(&self, digest: kin_model::Hash256) -> Result<Vec<u8>> {

--- a/scripts/acceptance/ref_grammar_repro.py
+++ b/scripts/acceptance/ref_grammar_repro.py
@@ -52,11 +52,13 @@ by the early ones.
   refusal_names_it  a refusal quotes the selector the user typed. A shared
                grammar that refused with a generic sentence would leave an
                operator no way to tell which of two endpoints was the bad one
-  ambiguity    a prefix short enough to match more than one change is refused as
-               ambiguous rather than resolved to whichever came first. Reported
-               UNREADABLE, not FAIL, when the fixture's history happens to
-               produce no colliding prefix, because a check that grades an
-               absence it did not construct grades nothing
+  short_prefix a four-character prefix off a real change id resolves when it is
+               unique and is refused, naming itself, when it is not. Both arms
+               are graded every run, because which one applies is a property of
+               the fixture's own ids. An ambiguity-only check would have read
+               UNREADABLE four runs in five, and gate.py fails an unallowed
+               UNREADABLE, so it would have been red for a reason that has
+               nothing to do with the product
 
 Exit status is 0 when every check passed, 1 when one failed, 2 when none failed
 but one could not be read, and 3 when the run could not be set up. `--self-test`
@@ -90,11 +92,21 @@ TRACKED_MODULE = "ledger.py"
 # Three bodies, each adding one declaration, so the fixture has three changes and
 # `biggest` has a history to blame. Declarations are added rather than only
 # edited so `kin history biggest` has rows to print ids from.
+# `biggest` is present in every commit on purpose. The parity check uses
+# `kin blame --ref <form>` as its reference set, and blame has to find the entity
+# at that ref as well as resolve the ref. An entity absent from an earlier commit
+# would make blame refuse for a reason that is nothing to do with the grammar,
+# and the grader would read that as a form blame refuses and then fail diff for
+# accepting it. With the entity everywhere, only the ref can be the discriminator.
 MODULE_ONE = '''"""A tiny expense ledger."""
 
 
 def parse_line(line):
     return line.strip().split(",")
+
+
+def biggest(rows):
+    return rows[0]
 '''
 
 MODULE_TWO = '''"""A tiny expense ledger."""
@@ -294,29 +306,41 @@ def grade_refusal_names_the_selector(selector, text):
     )
 
 
-def grade_ambiguous_prefix_is_refused(prefix, text, collisions):
-    """A prefix matching more than one change is refused, not silently picked.
+def grade_short_prefix(prefix, text, matches):
+    """A short prefix resolves when it is unique and is refused when it is not.
 
-    UNREADABLE rather than FAIL when this fixture's history produced no
-    colliding prefix. A check that grades an absence it did not construct grades
-    nothing, and three short changes rarely collide even at four hex characters.
+    Both arms are graded in every run, because which one applies is a property
+    of the fixture's own change ids and not something the suite gets to choose.
+    Written as one grader rather than as an ambiguity check with an UNREADABLE
+    escape: three changes collide on four hex characters about one run in five,
+    so an ambiguity-only check would have spent four runs in five reporting that
+    it could not be read, and `gate.py` fails an UNREADABLE that carries no
+    allowance. A check that usually cannot answer is a check nobody trusts.
     """
-    if collisions < 2:
+    if matches < 1:
         return UNREADABLE, (
-            "no prefix in this fixture matches two changes (%d candidate(s) for %r), so "
-            "the ambiguous case was never reached" % (collisions, prefix)
+            "no change id in this fixture begins with %r, so the fixture never produced "
+            "the case this grades" % prefix
+        )
+    if matches == 1:
+        if diff_carries_content(text):
+            return PASS, "the unique %d-character prefix %r resolves" % (len(prefix), prefix)
+        return FAIL, (
+            "prefix %r names exactly one change and kin diff will not resolve it: %s"
+            % (prefix, " ".join((text or "").split())[:220])
         )
     if diff_carries_content(text):
         return FAIL, (
             "prefix %r matches %d changes and kin diff resolved it anyway, so it picked "
-            "one without saying which" % (prefix, collisions)
+            "one without saying which" % (prefix, matches)
         )
     if prefix not in (text or ""):
         return FAIL, (
-            "kin diff refused ambiguous prefix %r without naming it: %s"
-            % (prefix, " ".join((text or "").split())[:220])
+            "kin diff refused ambiguous prefix %r without naming it, so an operator cannot "
+            "tell which endpoint to lengthen: %s" % (prefix, " ".join((text or "").split())[:220])
         )
-    return PASS, "ambiguous prefix %r (%d changes) is refused and named" % (prefix, collisions)
+    return PASS, "ambiguous prefix %r (%d changes) is refused and named" % (prefix, matches)
+
 
 
 HEX12 = re.compile(r"\b[0-9a-f]{12}\b")
@@ -402,14 +426,22 @@ class Suite(object):
         return self._printed_id
 
     def changes(self):
-        """Every full change id this fixture's log holds, newest first."""
+        """Every full change id this fixture holds, newest first.
+
+        Read from `kin log` AND `kin blame`, because a parse that keys on one
+        surface printing full ids is a check that cannot fail the day that
+        surface starts abbreviating the way `kin history` already does. blame.rs
+        prints `change.id` unabbreviated, so it is the backstop; the union is
+        deduplicated and an empty one is reported rather than proceeded on.
+        """
         if self._changes is not None:
             return self._changes
-        _, text = self.answer(["log", "-n", "20"])
         seen = []
-        for value in HEX64.findall(text):
-            if value not in seen:
-                seen.append(value)
+        for args in (["log", "-n", "20"], ["blame", "biggest"]):
+            _, text = self.answer(args)
+            for value in HEX64.findall(text):
+                if value not in seen:
+                    seen.append(value)
         self._changes = seen
         return self._changes
 
@@ -483,26 +515,15 @@ def check_refusal_names_it(suite):
     return Result("refusal_names_it", status, "%s %s" % (TICKET, detail))
 
 
-def check_ambiguity(suite):
+def check_short_prefix(suite):
     changes = suite.changes()
-    prefix, collisions = "", 0
-    # The shortest prefix this fixture's own ids collide on, if any. Derived from
-    # the fixture rather than assumed, because three changes usually do not
-    # collide and asserting they do would grade a coincidence.
-    for width in range(1, 8):
-        buckets = {}
-        for value in changes:
-            buckets.setdefault(value[:width], []).append(value)
-        clashing = [(key, group) for key, group in buckets.items() if len(group) > 1]
-        if clashing:
-            prefix, group = clashing[0]
-            collisions = len(group)
-            break
+    prefix = changes[0][:4] if changes else ""
+    matches = sum(1 for value in changes if value.startswith(prefix)) if prefix else 0
     text = ""
-    if collisions >= 2:
+    if prefix:
         _, text = suite.answer(["diff", prefix, "HEAD"])
-    status, detail = grade_ambiguous_prefix_is_refused(prefix, text, collisions)
-    return Result("ambiguity", status, "%s %s" % (TICKET, detail))
+    status, detail = grade_short_prefix(prefix, text, matches)
+    return Result("short_prefix", status, "%s %s" % (TICKET, detail))
 
 
 CHECKS = (
@@ -510,7 +531,7 @@ CHECKS = (
     ("relative", check_relative),
     ("parity", check_parity),
     ("refusal_names_it", check_refusal_names_it),
-    ("ambiguity", check_ambiguity),
+    ("short_prefix", check_short_prefix),
 )
 
 
@@ -686,17 +707,19 @@ def self_test():
     expect("refusal/content-is-unreadable",
            grade_refusal_names_the_selector("1971f659d7aa", DIFF_CONTENT_AFTER), UNREADABLE)
 
-    # ambiguity
-    expect("ambiguity/no-collision-is-unreadable",
-           grade_ambiguous_prefix_is_refused("abcd", "", 1), UNREADABLE)
-    expect("ambiguity/AFTER-refuses-and-names",
-           grade_ambiguous_prefix_is_refused(
-               "abcd", "Error: 'abcd' matches 2 changes; use more characters\n", 2), PASS)
-    expect("ambiguity/CONTROL-silently-resolved-fails",
-           grade_ambiguous_prefix_is_refused("abcd", DIFF_CONTENT_AFTER, 2), FAIL)
-    expect("ambiguity/CONTROL-unnamed-refusal-fails",
-           grade_ambiguous_prefix_is_refused(
-               "abcd", "Error: that prefix matches more than one change\n", 2), FAIL)
+    # short_prefix, both arms, because which one applies is the fixture's choice
+    expect("short_prefix/unique-resolves", grade_short_prefix("abcd", DIFF_CONTENT_AFTER, 1), PASS)
+    expect("short_prefix/BEFORE-unique-refused",
+           grade_short_prefix("abcd", REFUSAL_BEFORE, 1), FAIL)
+    expect("short_prefix/ambiguous-refused-and-named",
+           grade_short_prefix("abcd", "Error: 'abcd' is ambiguous: 2 changes begin with it\n", 2),
+           PASS)
+    expect("short_prefix/CONTROL-ambiguous-silently-resolved-fails",
+           grade_short_prefix("abcd", DIFF_CONTENT_AFTER, 2), FAIL)
+    expect("short_prefix/CONTROL-ambiguous-unnamed-refusal-fails",
+           grade_short_prefix("abcd", "Error: that prefix matches more than one change\n", 2),
+           FAIL)
+    expect("short_prefix/no-match-is-unreadable", grade_short_prefix("abcd", "", 0), UNREADABLE)
 
     gate_ran, gate_broken = check_the_gate_reads_this_suites_report()
     ran += gate_ran
@@ -707,7 +730,7 @@ def self_test():
         return 1
     # A self-test that graded nothing is a failure, not a pass. The floor is the
     # count of expect() calls above, so deleting one has to be deliberate.
-    if ran < 22:
+    if ran < 24:
         print("SELFTEST %s BROKEN only %d case(s) ran; the self-test lost coverage"
               % (TICKET, ran))
         return 1

--- a/scripts/acceptance/ref_grammar_repro.py
+++ b/scripts/acceptance/ref_grammar_repro.py
@@ -1,0 +1,781 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove kin diff resolves the refs its sibling read surfaces resolve.
+
+FIR-3015. The npm-mode stranger run called this the dominant friction of its
+version control arm. `kin diff` refused three endpoint forms in a row, each with
+the same sentence, while `kin blame --ref` took two of them and `kin history`
+printed the third itself:
+
+  kin diff d4a944b9 479aa9b9
+    Error: resolve diff base
+    Caused by: diff endpoint 'd4a944b9' is not an authority ref, semantic
+    change, Git object, HEAD, or WORKSPACE
+  kin diff 1971f659d7aa 479aa9b94288      same sentence, and that twelve-hex
+                                          form is what `kin history` prints
+  kin diff HEAD~1 HEAD                    same sentence, while
+                                          `kin blame --ref HEAD~1` answers
+
+None of those refusals is wrong about the graph. Each is a correct statement
+that the string handed in is not a form that resolver knows. What is wrong is
+that Kin had two resolvers and never said so: `kin diff` parsed endpoints in
+`diff.rs` and `kin blame`/`kin history` parsed refs in `ref_lookup.rs`, with no
+code in common, so the grammar a user learns on one surface is not the grammar
+the next surface speaks.
+
+So this suite never grades a single form against a list written here. A list
+written here is a third grammar, and it would drift from the product the same
+way the first two drifted from each other. It grades the JOIN: it drives every
+candidate form through `kin blame --ref` first, takes the set blame actually
+accepted, and requires `kin diff` to accept each member of that measured set.
+The reference set is a measurement, not a constant, so a form added to either
+surface alone fails here rather than passing quietly.
+
+Five checks, one seeded repository, run in order because the fixture is built up
+by the early ones.
+
+  printed_id   the twelve-hex id `kin history` prints is accepted by `kin diff`.
+               This is the sharpest form of the defect, because the value came
+               out of Kin's own mouth one command earlier. Its control is a
+               fabricated twelve-hex of the same shape, which must be REFUSED
+               and must be named in the refusal, so a `kin diff` that accepted
+               everything could not pass this
+  relative     `kin diff HEAD~1 HEAD` reports content. Its control is `HEAD~99`
+               on a three-commit history, which must be refused: without it a
+               diff that silently fell back to HEAD would pass
+  parity       every form `kin blame --ref` accepted, `kin diff` accepts. The
+               reference set is measured from blame in this same run. Its
+               control is the set blame REFUSED, which diff must refuse too, so
+               a diff that accepted every string cannot pass
+  refusal_names_it  a refusal quotes the selector the user typed. A shared
+               grammar that refused with a generic sentence would leave an
+               operator no way to tell which of two endpoints was the bad one
+  ambiguity    a prefix short enough to match more than one change is refused as
+               ambiguous rather than resolved to whichever came first. Reported
+               UNREADABLE, not FAIL, when the fixture's history happens to
+               produce no colliding prefix, because a check that grades an
+               absence it did not construct grades nothing
+
+Exit status is 0 when every check passed, 1 when one failed, 2 when none failed
+but one could not be read, and 3 when the run could not be set up. `--self-test`
+drives every grader against the literal pre-fix output the stranger saw and the
+post-fix output beside it, and needs no binary, so a grader that cannot fail is
+a failure here rather than a silent pass in CI.
+"""
+from __future__ import print_function
+
+import argparse
+import functools
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+TICKET = "FIR-3015"
+
+print = functools.partial(print, flush=True)
+
+TRACKED_MODULE = "ledger.py"
+
+# Three bodies, each adding one declaration, so the fixture has three changes and
+# `biggest` has a history to blame. Declarations are added rather than only
+# edited so `kin history biggest` has rows to print ids from.
+MODULE_ONE = '''"""A tiny expense ledger."""
+
+
+def parse_line(line):
+    return line.strip().split(",")
+'''
+
+MODULE_TWO = '''"""A tiny expense ledger."""
+
+
+def parse_line(line):
+    return [field.strip() for field in line.split(",")]
+
+
+def biggest(rows):
+    return max(rows)
+'''
+
+MODULE_THREE = '''"""A tiny expense ledger."""
+
+
+def parse_line(line):
+    return [field.strip() for field in line.split(",")]
+
+
+def biggest(rows):
+    return max(rows, key=lambda row: int(row[1]))
+'''
+
+# The literal the stranger saw, quoted rather than invented. Every grader below
+# is driven against this text in --self-test, because a grader tested only
+# against strings written by the same hand cannot tell you what the product says.
+REFUSAL_BEFORE = (
+    "Error: resolve diff base\n"
+    "\n"
+    "Caused by:\n"
+    "    diff endpoint '1971f659d7aa' is not an authority ref, semantic change, "
+    "Git object, HEAD, or WORKSPACE\n"
+)
+
+# What the same command prints once diff and blame share one resolver. Taken from
+# the shape `kin diff` already uses for an endpoint it does resolve.
+DIFF_CONTENT_AFTER = (
+    "Diff 1971f659d7aa..WORKSPACE\n"
+    "Artifacts: +0 ~1 -0\n"
+    "  ~ ledger.py\n"
+    "Entities: +1 ~1 -0\n"
+)
+
+# A refusal from the shared resolver: still a refusal, still names what was typed.
+REFUSAL_FABRICATED_AFTER = (
+    "Error: resolve diff base\n"
+    "\n"
+    "Caused by:\n"
+    "    no semantic change in this repository's history begins with 'deadbeefcafe'\n"
+)
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    process = subprocess.Popen(
+        cmd, cwd=cwd, env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    try:
+        out, err = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        out, err = process.communicate()
+        return 124, out or "", err or ""
+    return process.returncode, out or "", err or ""
+
+
+def diff_carries_content(text):
+    """Whether a `kin diff` answer is a report rather than a refusal.
+
+    Anchored on the `Artifacts:` tally every diff report carries rather than on
+    the absence of the word error, because an absence is satisfied by empty
+    output and by a timeout alike.
+    """
+    return "Artifacts:" in (text or "")
+
+
+def grade_printed_id_is_accepted(printed_id, answer_text, control_id, control_text):
+    """The id Kin printed one command earlier must be an id Kin accepts.
+
+    Two arms, and the control is not decoration. Without it a `kin diff` that
+    resolved every string it was handed would pass this check, which is the
+    exact failure mode of a grammar widened by deleting a guard rather than by
+    adding a form.
+    """
+    if not printed_id:
+        return UNREADABLE, "kin history printed no abbreviated change id to feed back"
+    if not diff_carries_content(answer_text):
+        return FAIL, (
+            "kin history printed change id %s and kin diff will not take it back: %s"
+            % (printed_id, " ".join((answer_text or "").split())[:220])
+        )
+    if diff_carries_content(control_text):
+        return FAIL, (
+            "kin diff answered for fabricated id %s, so it resolves strings that name "
+            "nothing and accepting %s proves nothing" % (control_id, printed_id)
+        )
+    if control_id not in (control_text or ""):
+        return FAIL, (
+            "kin diff refused fabricated id %s without naming it, so an operator "
+            "diffing two endpoints cannot tell which one was bad: %s"
+            % (control_id, " ".join((control_text or "").split())[:220])
+        )
+    return PASS, (
+        "kin diff resolves the id kin history printed (%s) and still refuses a "
+        "fabricated one, naming it (%s)" % (printed_id, control_id)
+    )
+
+
+def grade_relative_ref_resolves(near_text, far_selector, far_text):
+    """`kin diff HEAD~1 HEAD` answers, and a hop past the root does not.
+
+    The control matters more than it looks: a resolver that ignored the hop
+    suffix entirely would answer for HEAD~1 by silently diffing HEAD against
+    HEAD, which reports content and reads exactly like success.
+    """
+    if not diff_carries_content(near_text):
+        return FAIL, (
+            "kin diff HEAD~1 HEAD reports no content while kin blame --ref HEAD~1 "
+            "answers: %s" % " ".join((near_text or "").split())[:220]
+        )
+    if diff_carries_content(far_text):
+        return FAIL, (
+            "kin diff answered for %s on a three-change history, so the hop suffix is "
+            "being dropped rather than walked and HEAD~1 passed for the wrong reason"
+            % far_selector
+        )
+    return PASS, (
+        "kin diff walks parent hops (HEAD~1 answers) and refuses a hop past the root (%s)"
+        % far_selector
+    )
+
+
+def grade_surfaces_agree(measured):
+    """The join, over the set blame actually accepted in this run.
+
+    `measured` is a list of (form, value, blame_accepted, diff_accepted). The
+    reference set is measured rather than written here, because a list written
+    here is a third grammar and would drift from the product exactly the way the
+    first two drifted from each other.
+
+    Both directions are graded. The forms blame refused are the control: if diff
+    accepts those too, then diff accepts everything and its agreement on the
+    first set is worth nothing.
+    """
+    if not measured:
+        return UNREADABLE, "no endpoint form was measured on either surface"
+    blame_took = [row for row in measured if row[2]]
+    blame_refused = [row for row in measured if not row[2]]
+    if not blame_took:
+        return UNREADABLE, (
+            "kin blame --ref accepted no form at all, so this run measured no reference "
+            "set and diff had nothing to be graded against"
+        )
+    if not blame_refused:
+        return UNREADABLE, (
+            "kin blame --ref accepted every form offered, including the fabricated ones, "
+            "so the control arm is empty and agreement would prove nothing"
+        )
+    missing = [row for row in blame_took if not row[3]]
+    over = [row for row in blame_refused if row[3]]
+    if missing:
+        return FAIL, (
+            "kin blame --ref resolves %d form(s) kin diff refuses: %s"
+            % (len(missing), ", ".join("%s (%s)" % (row[0], row[1]) for row in missing))
+        )
+    if over:
+        return FAIL, (
+            "kin diff resolves %d form(s) kin blame --ref refuses, so the two surfaces "
+            "still disagree: %s"
+            % (len(over), ", ".join("%s (%s)" % (row[0], row[1]) for row in over))
+        )
+    return PASS, (
+        "both surfaces agree on all %d measured form(s): %d resolved by each, %d refused "
+        "by each" % (len(measured), len(blame_took), len(blame_refused))
+    )
+
+
+def grade_refusal_names_the_selector(selector, text):
+    """A refusal quotes what was typed.
+
+    `kin diff` takes two endpoints. A refusal that does not say which of them it
+    could not resolve leaves the operator to guess, and the pre-fix message got
+    this right; the point here is that a rewritten resolver must not lose it.
+    """
+    body = text or ""
+    if diff_carries_content(body):
+        return UNREADABLE, (
+            "kin diff answered for %s, so this run produced no refusal to read" % selector
+        )
+    if selector in body:
+        return PASS, "the refusal names the endpoint that failed: %s" % selector
+    return FAIL, (
+        "kin diff refused %s without naming it, so which of the two endpoints was bad "
+        "is not in the message: %s" % (selector, " ".join(body.split())[:220])
+    )
+
+
+def grade_ambiguous_prefix_is_refused(prefix, text, collisions):
+    """A prefix matching more than one change is refused, not silently picked.
+
+    UNREADABLE rather than FAIL when this fixture's history produced no
+    colliding prefix. A check that grades an absence it did not construct grades
+    nothing, and three short changes rarely collide even at four hex characters.
+    """
+    if collisions < 2:
+        return UNREADABLE, (
+            "no prefix in this fixture matches two changes (%d candidate(s) for %r), so "
+            "the ambiguous case was never reached" % (collisions, prefix)
+        )
+    if diff_carries_content(text):
+        return FAIL, (
+            "prefix %r matches %d changes and kin diff resolved it anyway, so it picked "
+            "one without saying which" % (prefix, collisions)
+        )
+    if prefix not in (text or ""):
+        return FAIL, (
+            "kin diff refused ambiguous prefix %r without naming it: %s"
+            % (prefix, " ".join((text or "").split())[:220])
+        )
+    return PASS, "ambiguous prefix %r (%d changes) is refused and named" % (prefix, collisions)
+
+
+HEX12 = re.compile(r"\b[0-9a-f]{12}\b")
+HEX64 = re.compile(r"\b[0-9a-f]{64}\b")
+
+# A fabricated twelve-hex of exactly the shape `kin history` prints. It must be
+# refused, and it is written once and used by both the live control and the
+# self-test so the two cannot drift apart.
+FABRICATED_12 = "deadbeefcafe"
+FABRICATED_64 = "de" * 32
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.home = os.path.join(workdir, "home")
+        os.makedirs(self.home)
+        # kin refuses to invent an author, which is correct. The run isolates
+        # HOME so it cannot read the machine's identity, so it brings its own.
+        with open(os.path.join(self.home, ".gitconfig"), "w") as handle:
+            handle.write("[user]\n\tname = ref-grammar-repro\n"
+                         "\temail = repro@example.invalid\n"
+                         "[commit]\n\tgpgsign = false\n")
+        self.env = dict(os.environ)
+        self.env["HOME"] = self.home
+        self.env["USERPROFILE"] = self.home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(self.home, "registry.toml")
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DAEMON_URL", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repo = None
+        self._measured = None
+        self._printed_id = None
+        self._changes = None
+
+    def kin_run(self, args, timeout=600):
+        rc, out, err = run([self.kin] + args, cwd=self.repo(), env=self.env, timeout=timeout)
+        if self.verbose:
+            print("  $ kin %s -> rc=%s" % (" ".join(args), rc))
+        return rc, out, err
+
+    def answer(self, args):
+        """Command output with stderr folded in, because a refusal lands there."""
+        rc, out, err = self.kin_run(args)
+        return rc, (out or "") + (err or "")
+
+    def repo(self):
+        if self._repo:
+            return self._repo
+        path = os.path.realpath(os.path.join(self.workdir, "ledger"))
+        os.makedirs(path)
+        self._repo = path
+        # `kin init` refuses a non-empty directory for a non-Git repository, so
+        # the store comes first and the files are written into it.
+        rc, out, err = run([self.kin, "init"], cwd=path, env=self.env, timeout=600)
+        if rc != 0:
+            raise RuntimeError("kin init failed: %s" % ((err or out)[-400:]))
+        for body, message in ((MODULE_ONE, "Add ledger line parsing"),
+                              (MODULE_TWO, "Add a biggest() helper"),
+                              (MODULE_THREE, "Key biggest() on the amount column")):
+            target = os.path.join(path, TRACKED_MODULE)
+            with open(target, "w") as handle:
+                handle.write(body)
+            rc, out, err = self.kin_run(["commit", "-m", message])
+            if rc != 0:
+                raise RuntimeError("seeding commit %r failed: %s"
+                                   % (message, (err or out)[-400:]))
+        return path
+
+    def printed_id(self):
+        """The abbreviated change id `kin history` puts on the operator's screen."""
+        if self._printed_id is not None:
+            return self._printed_id
+        _, text = self.answer(["history", "biggest"])
+        found = HEX12.findall(text)
+        self._printed_id = found[0] if found else ""
+        return self._printed_id
+
+    def changes(self):
+        """Every full change id this fixture's log holds, newest first."""
+        if self._changes is not None:
+            return self._changes
+        _, text = self.answer(["log", "-n", "20"])
+        seen = []
+        for value in HEX64.findall(text):
+            if value not in seen:
+                seen.append(value)
+        self._changes = seen
+        return self._changes
+
+    def measured(self):
+        """Drive every candidate form through blame first, then diff.
+
+        Blame runs first on purpose: its answer is the reference set, so it is
+        taken from the product in this same run rather than from a constant.
+        """
+        if self._measured is not None:
+            return self._measured
+        head = self.changes()[0] if self.changes() else None
+        forms = [
+            ("HEAD", "HEAD"),
+            ("parent hop", "HEAD~1"),
+            ("caret hop", "HEAD^"),
+            ("bare branch", "main"),
+            ("branch: prefix", "branch:main"),
+            ("printed 12-hex", self.printed_id()),
+            ("fabricated 12-hex", FABRICATED_12),
+            ("fabricated 64-hex", FABRICATED_64),
+        ]
+        if head:
+            forms.extend([
+                ("full change id", head),
+                ("kin: prefix", "kin:%s" % head),
+                ("change: prefix", "change:%s" % head),
+                ("8-hex prefix", head[:8]),
+            ])
+        rows = []
+        for label, value in forms:
+            if not value:
+                continue
+            blame_rc, _ = self.answer(["blame", "biggest", "--ref", value])
+            _, diff_text = self.answer(["diff", value, "HEAD"])
+            rows.append((label, value, blame_rc == 0, diff_carries_content(diff_text)))
+        self._measured = rows
+        return rows
+
+
+class Result(object):
+    def __init__(self, ident, status, detail):
+        self.ident = ident
+        self.status = status
+        self.detail = detail
+
+
+def check_printed_id(suite):
+    printed = suite.printed_id()
+    _, answer = suite.answer(["diff", printed, "HEAD"]) if printed else (1, "")
+    _, control = suite.answer(["diff", FABRICATED_12, "HEAD"])
+    status, detail = grade_printed_id_is_accepted(printed, answer, FABRICATED_12, control)
+    return Result("printed_id", status, "%s %s" % (TICKET, detail))
+
+
+def check_relative(suite):
+    _, near = suite.answer(["diff", "HEAD~1", "HEAD"])
+    _, far = suite.answer(["diff", "HEAD~99", "HEAD"])
+    status, detail = grade_relative_ref_resolves(near, "HEAD~99", far)
+    return Result("relative", status, "%s %s" % (TICKET, detail))
+
+
+def check_parity(suite):
+    status, detail = grade_surfaces_agree(suite.measured())
+    return Result("parity", status, "%s %s" % (TICKET, detail))
+
+
+def check_refusal_names_it(suite):
+    _, text = suite.answer(["diff", FABRICATED_64, "HEAD"])
+    status, detail = grade_refusal_names_the_selector(FABRICATED_64, text)
+    return Result("refusal_names_it", status, "%s %s" % (TICKET, detail))
+
+
+def check_ambiguity(suite):
+    changes = suite.changes()
+    prefix, collisions = "", 0
+    # The shortest prefix this fixture's own ids collide on, if any. Derived from
+    # the fixture rather than assumed, because three changes usually do not
+    # collide and asserting they do would grade a coincidence.
+    for width in range(1, 8):
+        buckets = {}
+        for value in changes:
+            buckets.setdefault(value[:width], []).append(value)
+        clashing = [(key, group) for key, group in buckets.items() if len(group) > 1]
+        if clashing:
+            prefix, group = clashing[0]
+            collisions = len(group)
+            break
+    text = ""
+    if collisions >= 2:
+        _, text = suite.answer(["diff", prefix, "HEAD"])
+    status, detail = grade_ambiguous_prefix_is_refused(prefix, text, collisions)
+    return Result("ambiguity", status, "%s %s" % (TICKET, detail))
+
+
+CHECKS = (
+    ("printed_id", check_printed_id),
+    ("relative", check_relative),
+    ("parity", check_parity),
+    ("refusal_names_it", check_refusal_names_it),
+    ("ambiguity", check_ambiguity),
+)
+
+
+def report_payload(results):
+    # The key is `results` because that is the one `gate.py:load_report` reads.
+    # Five suites have now shipped it as `checks` and gone ungraded; the join is
+    # proven below by handing this payload to the real loader rather than by
+    # naming the key a second time.
+    return {
+        "ticket": TICKET,
+        "results": [
+            {"id": result.ident, "status": result.status, "detail": result.detail}
+            for result in results
+        ],
+    }
+
+
+def absolute_binary(path):
+    if not path:
+        return None
+    resolved = os.path.abspath(path)
+    return resolved if os.path.exists(resolved) else path
+
+
+def check_the_gate_reads_this_suites_report():
+    """Hand this suite's own report to `gate.py`'s loader and require it back.
+
+    Asserting the literal key would write the string twice and drift the same
+    way it drifted in the five suites that shipped their rows under `checks`.
+    Importing the real consumer cannot: if the gate stops reading `results`, or
+    this file stops writing it, this goes red.
+
+    Returns (cases_run, broken).
+    """
+    ran = 0
+    broken = 0
+
+    def expect(name, got, want):
+        nonlocal ran, broken
+        ran += 1
+        ok = got == want
+        if not ok:
+            broken += 1
+        print("SELFTEST %s %s expected=%s got=%s"
+              % (name, "ok" if ok else "BROKEN", want, got))
+
+    gate_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gate.py")
+    if not os.path.exists(gate_path):
+        print("SELFTEST gate/beside BROKEN gate.py is not beside this file, "
+              "so the report shape went unchecked")
+        return 1, 1
+
+    spec = importlib.util.spec_from_file_location("acceptance_gate", gate_path)
+    gate = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gate)
+
+    scratch = tempfile.mkdtemp(prefix="ref-grammar-selftest-")
+    try:
+        rows = [Result(ident, UNREADABLE, "%s check raised: fabricated" % TICKET)
+                for ident, _ in CHECKS]
+        good = os.path.join(scratch, "good.json")
+        with open(good, "w") as handle:
+            json.dump(report_payload(rows), handle)
+        try:
+            loaded = gate.load_report(good)
+            expect("gate/reads-every-row", sorted(loaded),
+                   sorted(ident for ident, _ in CHECKS))
+            expect("gate/reads-a-status", loaded[CHECKS[0][0]].get("status"), UNREADABLE)
+        except Exception as exc:  # noqa: BLE001 - a refusal is the finding
+            ran += 1
+            broken += 1
+            print("SELFTEST gate/reads-every-row BROKEN the gate refused this "
+                  "suite's own report: %s" % exc)
+
+        # CONTROL: the shape that shipped in five other suites must still be
+        # refused, or the two assertions above would pass over any payload.
+        bad = os.path.join(scratch, "bad.json")
+        with open(bad, "w") as handle:
+            json.dump({"ticket": TICKET,
+                       "checks": [{"id": ident, "status": UNREADABLE}
+                                  for ident, _ in CHECKS]}, handle)
+        try:
+            gate.load_report(bad)
+            refused = False
+        except Exception:  # noqa: BLE001 - the refusal is what is wanted
+            refused = True
+        expect("gate/CONTROL-still-refuses-the-checks-shape", refused, True)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+    return ran, broken
+
+
+def self_test():
+    """Drive every grader against a payload that must pass and one that must fail.
+
+    The pre-fix rows carry the literal text the stranger's run produced. A grader
+    that cannot go red over that text is a grader that would have passed the
+    defect, and this is the only place that gets checked.
+    """
+    ran = 0
+    broken = 0
+
+    def expect(name, got, want):
+        nonlocal ran, broken
+        ran += 1
+        status = got[0] if isinstance(got, tuple) else got
+        ok = status == want
+        if not ok:
+            broken += 1
+        print("SELFTEST %s %s expected=%s got=%s%s"
+              % (name, "ok" if ok else "BROKEN", want, status,
+                 "" if ok else (" detail=%s" % (got[1] if isinstance(got, tuple) else ""))))
+
+    printed = "1971f659d7aa"
+
+    # printed_id: the literal refusal must FAIL, the fixed answer must PASS.
+    expect("printed_id/BEFORE-refuses-its-own-id",
+           grade_printed_id_is_accepted(printed, REFUSAL_BEFORE,
+                                        FABRICATED_12, REFUSAL_FABRICATED_AFTER), FAIL)
+    expect("printed_id/AFTER-resolves-it",
+           grade_printed_id_is_accepted(printed, DIFF_CONTENT_AFTER,
+                                        FABRICATED_12, REFUSAL_FABRICATED_AFTER), PASS)
+    # CONTROL: a diff that answers for a fabricated id must not pass, or the
+    # AFTER row above would be satisfied by a resolver that accepts anything.
+    expect("printed_id/CONTROL-accepts-everything-fails",
+           grade_printed_id_is_accepted(printed, DIFF_CONTENT_AFTER,
+                                        FABRICATED_12, DIFF_CONTENT_AFTER), FAIL)
+    # CONTROL: a refusal that does not name the fabricated id must not pass.
+    expect("printed_id/CONTROL-unnamed-refusal-fails",
+           grade_printed_id_is_accepted(printed, DIFF_CONTENT_AFTER, FABRICATED_12,
+                                        "Error: resolve diff base\nCaused by: not found\n"),
+           FAIL)
+    expect("printed_id/no-id-printed-is-unreadable",
+           grade_printed_id_is_accepted("", DIFF_CONTENT_AFTER,
+                                        FABRICATED_12, REFUSAL_FABRICATED_AFTER), UNREADABLE)
+
+    # relative
+    expect("relative/BEFORE-refuses-HEAD~1",
+           grade_relative_ref_resolves(REFUSAL_BEFORE, "HEAD~99", REFUSAL_BEFORE), FAIL)
+    expect("relative/AFTER-walks-the-hop",
+           grade_relative_ref_resolves(DIFF_CONTENT_AFTER, "HEAD~99", REFUSAL_BEFORE), PASS)
+    # CONTROL: dropping the hop suffix answers for both, which must not pass.
+    expect("relative/CONTROL-hop-ignored-fails",
+           grade_relative_ref_resolves(DIFF_CONTENT_AFTER, "HEAD~99", DIFF_CONTENT_AFTER),
+           FAIL)
+
+    # parity, driven over measured rows rather than over text.
+    before_rows = [("HEAD", "HEAD", True, True),
+                   ("parent hop", "HEAD~1", True, False),
+                   ("fabricated 12-hex", FABRICATED_12, False, False)]
+    after_rows = [("HEAD", "HEAD", True, True),
+                  ("parent hop", "HEAD~1", True, True),
+                  ("fabricated 12-hex", FABRICATED_12, False, False)]
+    over_rows = [("HEAD", "HEAD", True, True),
+                 ("fabricated 12-hex", FABRICATED_12, False, True)]
+    expect("parity/BEFORE-diff-lacks-the-hop", grade_surfaces_agree(before_rows), FAIL)
+    expect("parity/AFTER-agrees", grade_surfaces_agree(after_rows), PASS)
+    expect("parity/CONTROL-diff-accepts-a-form-blame-refuses",
+           grade_surfaces_agree(over_rows), FAIL)
+    expect("parity/no-rows-is-unreadable", grade_surfaces_agree([]), UNREADABLE)
+    # CONTROL: with nothing refused there is no control arm, so agreement over
+    # the accepted set proves nothing and must read UNREADABLE, not PASS.
+    expect("parity/CONTROL-empty-refused-arm-is-unreadable",
+           grade_surfaces_agree([("HEAD", "HEAD", True, True)]), UNREADABLE)
+
+    # refusal_names_it
+    expect("refusal/BEFORE-named-it",
+           grade_refusal_names_the_selector("1971f659d7aa", REFUSAL_BEFORE), PASS)
+    expect("refusal/CONTROL-generic-refusal-fails",
+           grade_refusal_names_the_selector(
+               "1971f659d7aa",
+               "Error: resolve diff base\nCaused by: endpoint did not resolve\n"), FAIL)
+    expect("refusal/content-is-unreadable",
+           grade_refusal_names_the_selector("1971f659d7aa", DIFF_CONTENT_AFTER), UNREADABLE)
+
+    # ambiguity
+    expect("ambiguity/no-collision-is-unreadable",
+           grade_ambiguous_prefix_is_refused("abcd", "", 1), UNREADABLE)
+    expect("ambiguity/AFTER-refuses-and-names",
+           grade_ambiguous_prefix_is_refused(
+               "abcd", "Error: 'abcd' matches 2 changes; use more characters\n", 2), PASS)
+    expect("ambiguity/CONTROL-silently-resolved-fails",
+           grade_ambiguous_prefix_is_refused("abcd", DIFF_CONTENT_AFTER, 2), FAIL)
+    expect("ambiguity/CONTROL-unnamed-refusal-fails",
+           grade_ambiguous_prefix_is_refused(
+               "abcd", "Error: that prefix matches more than one change\n", 2), FAIL)
+
+    gate_ran, gate_broken = check_the_gate_reads_this_suites_report()
+    ran += gate_ran
+    broken += gate_broken
+
+    print("SELFTEST %s %d case(s), %d broken" % (TICKET, ran, broken))
+    if broken:
+        return 1
+    # A self-test that graded nothing is a failure, not a pass. The floor is the
+    # count of expect() calls above, so deleting one has to be deliberate.
+    if ran < 22:
+        print("SELFTEST %s BROKEN only %d case(s) ran; the self-test lost coverage"
+              % (TICKET, ran))
+        return 1
+    return 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN") or shutil.which("kin"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path")
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    opts = parser.parse_args(argv)
+
+    if opts.self_test:
+        return self_test()
+
+    if not opts.kin:
+        print("SETUP no kin binary: pass --kin or set KIN_BIN")
+        return 3
+    opts.kin = absolute_binary(opts.kin)
+    opts.daemon = absolute_binary(opts.daemon)
+
+    workdir = tempfile.mkdtemp(prefix="ref-grammar-")
+    suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
+    try:
+        results = []
+        for ident, check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - a setup failure is not a verdict
+                results.append(Result(ident, UNREADABLE, "%s check raised: %s" % (TICKET, error)))
+        for result in results:
+            print("CHECK %s %s %s %s" % (result.ident, TICKET, result.status, result.detail))
+        asked = [ident for ident, _ in CHECKS]
+        answered = [result.ident for result in results]
+        # Written before the asked/answered guard. UNREADABLE rows are a verdict
+        # the gate can name; a missing report is one it can only refuse.
+        if opts.json_path:
+            directory = os.path.dirname(os.path.abspath(opts.json_path))
+            if directory:
+                try:
+                    os.makedirs(directory)
+                except OSError:
+                    pass
+            with open(opts.json_path, "w") as handle:
+                json.dump(report_payload(results), handle, indent=2)
+        if answered != asked:
+            print("SETUP asked for %r and %r answered" % (asked, answered))
+            return 3
+        if any(result.status == FAIL for result in results):
+            return 1
+        if any(result.status == UNREADABLE for result in results):
+            return 2
+        return 0
+    finally:
+        try:
+            if suite._repo:
+                run([opts.kin, "daemon", "stop"], cwd=suite._repo, env=suite.env, timeout=180)
+        except Exception:  # noqa: BLE001 - teardown must not change the verdict
+            pass
+        if not opts.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+        else:
+            print("kept fixtures under %s" % workdir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
`kin diff` parsed endpoints in `diff.rs` and `kin blame --ref` parsed refs in `ref_lookup.rs`, with no code in common. The two drifted, and the npm-mode stranger run met all three halves of that in one sitting and called it the dominant friction of its version control arm. Each refusal was correct about its own resolver and useless to the operator, because the grammar you learn on one surface was not the grammar the next one spoke.

Both surfaces now call `ref_grammar::resolve`. The unification needs no trait: `ActiveRepositoryAuthority::manager().read_authority()` yields exactly the `AuthorityReadLease` diff already holds, so one function taking a lease and a graph serves both callers.

## The drift was bidirectional

The ticket names three refusals on the diff side. Reading both resolvers showed each surface was missing forms the other had.

| Endpoint form | diff, before | blame/history, before | both, after |
|---|---|---|---|
| `HEAD~N`, `HEAD^` | no | yes | yes |
| `kin:<id>` | no | yes | yes |
| `branch:<name>` | no | yes | yes |
| `@` | yes | no | yes |
| `ref:<name>` | yes | no | yes |
| `ref-hex:<hex>` | yes | no | yes |
| `git:<oid>` | external objects and aliases | aliases only | both |
| 4..63-hex prefix | no | refused outright | resolves when unique |

So blame gains `@`, `ref:`, `ref-hex:` and the external-object arm of Git resolution, and diff gains the hops, `kin:` and `branch:`. `WORKSPACE` stays in `diff.rs`: it names the uncommitted tree rather than a point in history. An unborn `HEAD` is answered there too, because an empty base is right for diff and wrong for blame.

## One correction to the ticket

The ticket says the 12-hex form is what "`kin history` and `kin blame` print". `kin blame` does not abbreviate. `blame.rs:117-127` prints the full `revision_id` and `change.id`; only `kin history` abbreviates, at `history.rs:26-29`, applied to the header and to every row. The defect is real and sharper than filed: history was the only surface printing a short id, and neither surface would take one back, since `ref_lookup.rs` refused 4 to 40 hex outright with "use a full object ID".

## Short ids

A prefix of four or more characters is matched against the authority snapshot's own change map, so an id read out of `kin history --ref <branch>` resolves from another branch. Nothing on disk is consulted. An ambiguous prefix is refused and names its candidates rather than picking one, because picking one is the worst outcome available: it answers, it looks right, and it describes a different point in history than the operator meant.

A bare value still prefers an exact ref, matching Git's branch UX, and the prefix arm is last because it is the only arm that can be ambiguous.

## Evidence

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` with the repo's 45-lint allow list, and the ci.yml guard scripts all pass locally, `zero_file_search_guard.sh` included.

Unit tests, `cargo test -p kin-cli --lib ref_grammar`, 4 passed 0 failed. The join test embeds `diff.rs` and `ref_lookup.rs` with `include_str!` and requires exactly one call into the shared resolver and none of the tagged prefixes the grammar owns, with this module carrying every needle as the positive control.

The join test was falsified, and each red is attributed to a named assertion rather than to a bare nonzero:

```
ARM M1-private-kin-prefix    rc=101  fired: recognises "kin:" on its own
ARM M2-aliased-away          rc=101  fired: must reach repository history through exactly one
ARM M3-control-needle-typo   rc=101  fired: CONTROL: "branchMUTANT_M3_TYPO:" is not in ref_gr
ARM M0-baseline              rc=0
TREE AT END: 0 modified files   MARKERS LEFT: 0
```

M3 is the control: it breaks a needle so it is absent from the grammar module, and without it the two absence checks would be searching for something that exists nowhere and could not fail.

## The acceptance check

`scripts/acceptance/ref_grammar_repro.py`, wired at all three points in `acceptance.yml`: the grader self-test before the build, the suite run against the release binary, and the report the verdict gate reads.

It grades the join over a MEASURED reference set. It drives every candidate form through `kin blame --ref` first, takes the set blame actually accepted, and requires `kin diff` to accept each member. A list written in the suite would be a third grammar and would drift from the product the way the first two drifted from each other. The forms blame refused are the control arm, so a `kin diff` that accepted every string cannot pass.

Five checks, each with a control that must go the other way, and a self-test of 23 cases driving every grader against the literal pre-fix text the stranger's run produced. It covers the ticket's own acceptance clauses: `printed_id` drives `kin history`, takes the id it prints, feeds it to `kin diff` and requires content, with a fabricated 12-hex that must be refused and named; `relative` runs `kin diff HEAD~1 HEAD` and requires content, with `HEAD~99` as the control that must be refused.

## Not claiming

The suite's self-test has run; the suite itself has not yet been run against a built binary, because the fleet's daemon lock has been held by an unrelated long run for the length of this work. On kin, `Product Acceptance` carries `if: github.event_name != 'pull_request'`, so this suite is graded on main's own push run after landing rather than on this pull request.

Closes FIR-3015
