### PR TITLE
Split the fast gate into five shards and pin the denominator to the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1129,7 +1129,21 @@ jobs:
       # aggregate report one cause where there may be three.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+      # Five, not three, because the gate's wall time is its slowest shard and
+      # three put the required context at 10.08 to 11.17 minutes end to end
+      # across five consecutive main runs, all of them over the bar. Measured
+      # per step across nine shard jobs, a shard costs 34 s of job setup plus
+      # 168 s of `cargo nextest list`, which compiles the whole selection and
+      # so does NOT shrink when shards are added, against 930 to 989 s of test
+      # work per run that does. Five is where that 201 s floor stops paying:
+      # six buys about 0.6 min more and eight about 1.4, so the count is
+      # chosen on the floor rather than on how far it can be pushed.
+      #
+      # This list and the `--partition count:.../5` denominator below are one
+      # fact in two places. The guard checks them against each other, because
+      # a matrix SHORTER than the denominator runs that fraction of the
+      # selection and still reports success.
+        shard: [1, 2, 3, 4, 5]
     steps:
       # The scope read diffs a base against a head, so it needs both.
       - uses: actions/checkout@v7
@@ -1222,7 +1236,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t SCOPE < "$RUNNER_TEMP/scope.args"
-          cargo nextest run --locked "${SCOPE[@]}" --partition count:${{ matrix.shard }}/3
+          cargo nextest run --locked "${SCOPE[@]}" --partition count:${{ matrix.shard }}/5
 
       # The reporting verdict. The run above graded a quarantined flake as
       # passing, which is what keeps it off the critical path; this reads the

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -4394,7 +4394,7 @@ FAST_GATE_SHARD_STEPS = (
     "cargo nextest run --locked",
     "run: python3 scripts/check-quarantine.py --report-junit",
 )
-FAST_GATE_SHARD_MATRIX = "shard: [1, 2, 3]"
+FAST_GATE_SHARD_MATRIX = "shard: [1, 2, 3, 4, 5]"
 FAST_GATE_SHARD_INDEPENDENT_LEGS = "fail-fast: false"
 FAST_GATE_AGGREGATE_ALWAYS_RUNS = "if: ${{ !cancelled() }}"
 FAST_GATE_AGGREGATE_NEEDS = "needs: [changes, fast-gate-tests]"
@@ -4455,6 +4455,45 @@ def assert_fast_gate_authority(workflow: str) -> None:
                 "shard cancelling its siblings makes the aggregate report one "
                 "cause where there may be three"
             )
+
+    # The matrix list and the partition denominator are one fact written in two
+    # places, so they are checked against EACH OTHER rather than both pinned to
+    # a number. Pinning both would let a reviewer satisfy the guard by writing
+    # the same digit twice while the two lines still disagreed about what ran.
+    #
+    # Only one direction is dangerous. A denominator BELOW the matrix length
+    # fails loudly, because nextest refuses a partition index above the count.
+    # A denominator ABOVE it is silent: `shard: [1, 2, 3]` against
+    # `count:${{ matrix.shard }}/5` runs three fifths of the selection, every
+    # shard passes, and the aggregate reports the required context green. That
+    # is the same grades-nothing-and-exits-0 shape the listing assertion above
+    # exists to catch, arriving through the matrix instead of through a filter.
+    shard_text = "\n".join(shard_lines)
+    matrix_match = re.search(r"shard: \[([0-9,\s]+)\]", shard_text)
+    if matrix_match is None:
+        raise AssertionError(
+            "the admission core's shards lost their matrix list, so the "
+            "selection no longer has a declared number of parts"
+        )
+    shards = [int(value) for value in matrix_match.group(1).split(",")]
+    partition_match = re.search(
+        r"--partition count:\$\{\{ matrix\.shard \}\}/([0-9]+)", shard_text
+    )
+    if partition_match is None:
+        raise AssertionError(
+            "the admission core's shards must partition by their matrix index; "
+            "without `--partition count:${{ matrix.shard }}/<n>` every shard "
+            "runs the whole selection and the gate pays for it N times over"
+        )
+    denominator = int(partition_match.group(1))
+    if shards != list(range(1, len(shards) + 1)) or denominator != len(shards):
+        raise AssertionError(
+            "the admission core's shard matrix and partition denominator are "
+            f"one fact in two places and they disagree: matrix {shards} against "
+            f"denominator {denominator}. A denominator above the matrix length "
+            "silently drops that fraction of the selection and still reports "
+            "success"
+        )
 
     aggregate = jobs["fast-gate-tests-aggregate"]
     aggregate_lines = active_lines(aggregate)
@@ -13715,6 +13754,23 @@ def main() -> None:
             "        run: python3 scripts/check-quarantine.py\n",
             "        run: true\n",
             "lint and policy half must keep running",
+        ),
+        (
+            # The DENOMINATOR moves and the matrix does not, which is the
+            # mutation only the join can catch. Mutating the matrix instead
+            # would red on FAST_GATE_SHARD_MATRIX one assertion earlier and
+            # prove nothing about this one; that arm was written first and the
+            # falsification loop's own wrong-reason check rejected it.
+            #
+            # Its effect is the silent kind. Matrix [1..5] against
+            # `count:${{ matrix.shard }}/7` means parts 6 and 7 are never
+            # dispatched, so two sevenths of the selection never runs, all five
+            # shards pass, and the required context reports success.
+            "the partition denominator drifts above the shard matrix",
+            "fast-gate-tests",
+            "--partition count:${{ matrix.shard }}/5",
+            "--partition count:${{ matrix.shard }}/7",
+            "one fact in two places and they disagree",
         ),
     ):
         # Scoped to the owning job block rather than the whole file: two jobs


### PR DESCRIPTION
The fast gate is over its under-ten-minutes bar and more shards is the lever that costs nothing.

## What it costs today

Run start to `Fast gate build and tests` going green, five consecutive main push runs: **10.08, 10.20, 10.30, 10.93 and 11.17 minutes**. All five over. On the narrower slowest-shard measure, two of five.

## Why shards rather than a bigger runner

August Actions usage says `Actions Linux` is 349,324 minutes at gross $2,095.94 and **net $0.00**, fully covered by included minutes, while `Actions Linux 16-core` is billable at a measured **$0.0420 per minute** against a $100/month org budget with `prevent_further_usage: true`. Parallelism on `ubuntu-latest` is free to this org; speed on the larger runner is not.

## The measurement behind the count

Per step across **nine shard jobs in three runs**:

| run | shard | fixed s | list/compile s | test s | total min |
| -- | -- | -- | -- | -- | -- |
| 33318156529 | (1) | 36 | 183 | 379 | 9.97 |
| 33318156529 | (2) | 33 | 156 | 308 | 8.28 |
| 33318156529 | (3) | 28 | 172 | 243 | 7.38 |
| 33317266759 | (1) | 34 | 175 | 379 | 9.80 |
| 33317266759 | (2) | 39 | 163 | 334 | 8.93 |
| 33317266759 | (3) | 44 | 172 | 241 | 7.62 |
| 33316714790 | (1) | 27 | 171 | 381 | 9.65 |
| 33316714790 | (2) | 28 | 167 | 389 | 9.73 |
| 33316714790 | (3) | 34 | 151 | 219 | 6.73 |

Means: 34 s of job setup and 168 s of `cargo nextest list`, so **201 s per shard that does not shrink**, against 930 to 989 s of test work per run that does. The mechanism is that the list step compiles the whole selection and only the following `cargo nextest run --partition` is divided.

Modelled slowest shard, carrying each run's own observed imbalance factor forward:

| run | run work s | N=3 observed | N=5 | N=6 | N=8 |
| -- | -- | -- | -- | -- | -- |
| 33318156529 | 930 | 9.97 | 7.15 | 6.52 | 5.73 |
| 33317266759 | 954 | 9.80 | 7.15 | 6.52 | 5.73 |
| 33316714790 | 989 | 9.73 | 7.25 | 6.60 | 5.79 |

Five is chosen on where that 201 s floor stops paying: six buys about 0.6 minutes more and eight about 1.4.

**That was a model and it has since been partly refuted; see the correction below.** `--partition count:` splits by test COUNT rather than duration, and the 1.18 to 1.22 imbalance factor extrapolated from three shards turned out to be 1.43 at five.

## The model's imbalance assumption is REFUTED by this PR's own run

The first five-shard run exists now, so the model is corrected here rather than left to the reader.

PR run 33325452898, five shards on `ubuntu-latest`: walls of 8.33, 9.80, 5.18, 5.50 and 9.23 minutes, slowest **9.80**, required context end to end **10.17**. That is nowhere near the modelled 7.15 to 7.25, and it did not clear the bar.

Two separate reasons, and only one of them is a defect in the model.

**The run is not like-for-like.** Its total test work is 1326 s against the three-shard main run 33325123491's 957 s, a ratio of **1.39x**, because the scope selector picked a larger set for a diff touching a workflow and a guard script. So this run cannot be compared to the before table directly.

**The imbalance assumption is genuinely wrong, and in the direction that hurts.** The model carried the three-shard figure forward. Measured on test time alone: three shards ran 378 s slowest against a 319 s mean, **1.18x**; five shards ran 380 s slowest against a 265 s mean, **1.43x**. Splitting by test count rather than duration concentrates the slow tests as the partitions get smaller, which is exactly the caveat the model named and could not quantify until now.

**The floor held.** Per-shard fixed plus list cost 191 s at five shards against 192 s at three, so the 201 s figure the count was chosen on is confirmed.

Correcting the model with the measured imbalance and normalising to the three-shard run's workload: slowest test 274 s plus a 191 s floor is **7.76 minutes**, against the three-shard run's measured 9.70. So the gain is about two minutes rather than the two and a half modelled, and it still clears the bar with margin. The three main runs after landing are what settle it, and the revert condition below stands unchanged.

Two more shards also added 341 s of extra `cargo nextest list` compute across the run. That is free on this SKU and it is still real.

## Concurrency headroom, checked before picking five over six

There is **no API surface that reports a concurrency limit**: `/orgs/firelock-ai/actions/permissions` and the repository equivalent return only `enabled_repositories`, `allowed_actions` and `sha_pinning_required`. So the limit itself is documentation and I am not quoting a number I cannot fetch. The plan reads `enterprise`.

What is measurable is what kin actually reaches. Sweeping every run created since 13:00Z, 200 runs and 500 ubuntu-labelled job intervals, and taking the running maximum over start and completion events: **peak concurrent ubuntu jobs is 35**, at 14:24:06Z. Five shards adds two per CI run, so tens against an enterprise plan. Stated as a measured peak plus a plan name, not a fetched limit.

## The gap this closes

`check` pins its partition denominator with `UBUNTU_SHARD_PARTITION`, the whole line including `/2`. The fast gate pinned only the substring `cargo nextest run --locked` inside `FAST_GATE_SHARD_STEPS`, so **its denominator was not pinned at all** and the matrix and the denominator were free to disagree.

Only one direction is dangerous. A denominator BELOW the matrix length fails loudly, because nextest refuses a partition index above the count. A denominator ABOVE it is silent: matrix `[1..5]` against `count:${{ matrix.shard }}/7` never dispatches parts 6 and 7, so two sevenths of the selection never runs, all five shards pass, and the required context reports success. That is the grades-nothing-and-exits-0 shape this job's listing assertion already exists to catch, arriving through the matrix instead of through a filter.

The guard now **derives the denominator from the matrix and requires them equal**, rather than pinning both to a number, so writing the same digit twice cannot satisfy it.

## Falsification

| arm | rc | which assertion answered |
| -- | -- | -- |
| M0 unmutated, matrix `[1..5]` and denominator `/5` | 0 | passes |
| F1 denominator drifts ABOVE the matrix, `/5` to `/7`, the silent case | 1 | `one fact in two places and they disagree` |
| F2 denominator drifts BELOW, `/5` to `/3`, the loud case | 1 | same join assertion |
| F3 the `--partition` flag removed entirely | 1 | `must partition by their matrix index` |
| F4 the matrix shrinks to `[1, 2, 3]` | 1 | the literal pin, recorded because it SHADOWS the join |
| F5 aggregate admits a non-success shard | 1 | ``admit only `success` ``, so the guard is alive here |

F4 is why the shipped arm mutates the denominator rather than the matrix. The obvious arm, shrinking the matrix, reds on `FAST_GATE_SHARD_MATRIX` one assertion earlier and proves nothing about the new check. That arm was written first, and the guard's own falsification loop rejected it with `falsification failed for the wrong reason`, which is the machinery working.

## Not changed

No required context changes name, the aggregate keeps `needs: [changes, fast-gate-tests]`, and `check` and `check-macos` keep their own `/2` denominators untouched. Read back from a real YAML parse rather than from the text.

## Acceptance, measured after landing

Three consecutive main runs, three columns each: run start to `Fast gate build and tests` green, the slowest shard, and the queue wait per shard job, so more shards competing for the free pool is measured rather than assumed. If the slowest shard does not move, this reverts as a measured no-gain.

Closes FIR-3029
