### PR TITLE
Check every command hint against clap, not just doctor's fix lines

### DIFF
--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -172,7 +172,7 @@ fn embed_completion_line(
     // than picking one, since neither is established here.
     format!(
         "Done. This run embedded nothing and the daemon reports nothing pending, but this store \
-         reads {indexed_after}/{total} indexed. Run `kin health` to see why coverage and the \
+         reads {indexed_after}/{total} indexed. Run `kin doctor` to see why coverage and the \
          queue disagree"
     )
 }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -6588,7 +6588,7 @@ mod tests {
         );
     }
 
-    /// The failing-admission shape at the `kin health` surface. No pass is
+    /// The failing-admission shape at the `kin doctor` surface. No pass is
     /// stopped — the reconcile loop is waking, failing, and sleeping on
     /// schedule, which is exactly why the supervisor never stopped it — and the
     /// check still must not answer healthy.

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -440,7 +440,7 @@ where
             original,
             format!(
                 "this repository's authority resolves to semantic change {resolved}, which the \
-                 active graph projection does not hold; run `kin status`, then `kin health` if it \
+                 active graph projection does not hold; run `kin status`, then `kin doctor` if it \
                  repeats"
             ),
         ));

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -796,7 +796,7 @@ pub fn inspect(
         anyhow::bail!(
             "this repository's store reported two different root generations for one lease, which \
              means another process wrote it while this command was reading; re-run `kin status`, \
-             and run `kin health` if it repeats"
+             and run `kin doctor` if it repeats"
         );
     }
 
@@ -840,7 +840,7 @@ pub fn inspect(
     report.validate().map_err(|error| {
         anyhow::anyhow!(
             "kin built a status report this build considers invalid ({error}), so it refused \
-                 to print it; run `kin health`, and `kin --version` against `kin daemon status` if \
+                 to print it; run `kin doctor`, and `kin --version` against `kin daemon status` if \
                  the two are on different builds"
         )
     })?;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -4190,28 +4190,79 @@ mod tests {
     }
 
     fn fix_line_flags_exist() {
-        let source = std::fs::read_to_string(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/src/commands/health.rs"
-        ))
-        .expect("health.rs is readable from the crate it lives in");
+        // Every command surface, not just health.rs. The narrow scan was written
+        // for doctor's fix lines and found four more defects in that one file on
+        // its first run; three more sit in files it never read, so the scope is
+        // the whole commands directory (FIR-3009).
+        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/commands");
+        let mut sources: Vec<(String, String)> = Vec::new();
+        let mut stack = vec![std::path::PathBuf::from(dir)];
+        while let Some(at) = stack.pop() {
+            for entry in std::fs::read_dir(&at).expect("the commands directory is readable") {
+                let path = entry.expect("a readable directory entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    let name = path
+                        .strip_prefix(dir)
+                        .unwrap_or(&path)
+                        .to_string_lossy()
+                        .into_owned();
+                    sources.push((
+                        name,
+                        std::fs::read_to_string(&path).expect("a readable source file"),
+                    ));
+                }
+            }
+        }
+        // A scan that reads no files passes every assertion below for the wrong
+        // reason, and the count is pinned rather than the emptiness so a walk
+        // that quietly stops descending is visible too.
+        assert!(
+            sources.len() >= 40,
+            "the walk found only {} source files under {dir}, which is too few to be reading \
+             the directory it thinks it is",
+            sources.len()
+        );
 
-        // Backticked `kin ...` spans are how every fix line names a command.
+        // Backticked `kin ...` spans are how a fix line or hint names a command.
         // Comment lines are dropped whole, before the split, because a doc
         // comment quotes commands it is not telling anyone to run: the prose
         // `kin 0.5.40` is a version and `kin health` is a surface name, and
         // grading either reports a defect that does not exist. Dropping the
         // lines rather than the spans keeps backtick parity self-consistent.
-        let graded: String = source
-            .lines()
-            .filter(|line| !line.trim_start().starts_with("//"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let mut commands: Vec<String> = Vec::new();
-        for span in graded.split('`').skip(1).step_by(2) {
-            let span = span.trim();
-            if let Some(rest) = span.strip_prefix("kin ") {
-                commands.push(rest.to_string());
+        let mut commands: Vec<(String, String)> = Vec::new();
+        for (file, source) in &sources {
+            // A Rust string literal continues across lines with a trailing
+            // backslash, which eats the newline and the next line's indent. A
+            // backticked span split that way reads as `kin \` and gets reported
+            // as a command nobody wrote, so the continuation is rejoined first.
+            let mut graded = String::with_capacity(source.len());
+            let mut continuing = false;
+            for line in source.lines() {
+                if !continuing && line.trim_start().starts_with("//") {
+                    continue;
+                }
+                let piece = if continuing { line.trim_start() } else { line };
+                let joins = piece.ends_with('\\');
+                graded.push_str(piece.strip_suffix('\\').unwrap_or(piece));
+                if !joins {
+                    graded.push('\n');
+                }
+                continuing = joins;
+            }
+            for span in graded.split('`').skip(1).step_by(2) {
+                let span = span.trim();
+                let Some(rest) = span.strip_prefix("kin ") else {
+                    continue;
+                };
+                // A format placeholder is not a command. `kin {}` is a template
+                // whose subcommand arrives at runtime, so there is nothing here
+                // to check against clap and reporting it is a false finding.
+                if rest.contains('{') || rest.contains('}') {
+                    continue;
+                }
+                commands.push((file.clone(), rest.to_string()));
             }
         }
 
@@ -4219,15 +4270,15 @@ mod tests {
         // Pinned by count rather than by emptiness so a refactor that quietly
         // drops most of them is visible too.
         assert!(
-            commands.len() >= 10,
-            "the scan found only {} backticked `kin ...` spans in health.rs, which is too few \
-             to be reading the file it thinks it is",
+            commands.len() >= 200,
+            "the scan found only {} backticked `kin ...` spans under the commands directory, \
+             which is too few to be reading the tree it thinks it is",
             commands.len()
         );
 
         let root = Cli::command();
         let mut offenders: Vec<String> = Vec::new();
-        for command in &commands {
+        for (file, command) in &commands {
             // Walk the subcommand path, then check every flag against the
             // command that path resolved to. A word that is not a known
             // subcommand ends the path: it is a positional value, like the `.`
@@ -4256,8 +4307,8 @@ mod tests {
                         // `kin init .`, so the check does not apply there.
                         None if node.has_subcommands() => {
                             offenders.push(format!(
-                                "`kin {command}` names the subcommand {word}, which `{}` does \
-                                 not have",
+                                "{file}: `kin {command}` names the subcommand {word}, which \
+                                 `{}` does not have",
                                 node.get_name()
                             ));
                             break;
@@ -4267,10 +4318,24 @@ mod tests {
                 }
             }
             for flag in flags {
-                let known = node.get_arguments().any(|arg| arg.get_long() == Some(flag));
+                // `help` and `version` are clap's own, generated from
+                // `#[command(version = ...)]` rather than declared as fields, so
+                // they are absent from get_arguments() and a check that only
+                // walks that list calls the working `kin --version` a defect.
+                let builtin = flag == "help" || flag == "version";
+                // A long ALIAS is a real spelling of the flag: `--continue` is
+                // declared as `#[arg(long, alias = "continue")] do_continue`, so
+                // reading get_long() alone rejects a command that runs.
+                let known = builtin
+                    || node.get_arguments().any(|arg| {
+                        arg.get_long() == Some(flag)
+                            || arg
+                                .get_all_aliases()
+                                .is_some_and(|aliases| aliases.contains(&flag))
+                    });
                 if !known {
                     offenders.push(format!(
-                        "`kin {command}` names --{flag}, which `{}` does not take",
+                        "{file}: `kin {command}` names --{flag}, which `{}` does not take",
                         node.get_name()
                     ));
                 }
@@ -4279,7 +4344,7 @@ mod tests {
 
         assert!(
             offenders.is_empty(),
-            "a doctor fix line tells a user to type a command the CLI rejects:\n  {}",
+            "a user-facing string tells a user to type a command the CLI rejects:\n  {}",
             offenders.join("\n  ")
         );
     }


### PR DESCRIPTION
The guard added under FIR-3003 read `health.rs` alone and found four defects in that one file on its first run. Three more sat in files it never read. This widens it to every source under `crates/kin-cli/src/commands/`, 327 backticked `kin ...` spans across 53 files rather than a handful.

## Measuring first changed the work

The widened scan's first run reported **14 offenders. Ten were the scan's own fault.**

| count | shape | why it is not a defect |
|---|---|---|
| 2 | `` `kin {}` `` in capabilities.rs | a format placeholder whose subcommand arrives at runtime |
| 5 | `` `kin \` `` across five files | a Rust string continues across lines with a trailing backslash that eats the newline and the next line's indent |
| 2 | `kin resolve --continue` | a real long ALIAS, `#[arg(long, alias = "continue")] do_continue` |
| 1 | `kin --version` | clap's own, generated from `#[command(version = ...)]`, so never in `get_arguments()` |

Going straight to fixing would have "corrected" seven working commands and shipped a guard that flags valid advice, which is the risk FIR-3009 names in its own text. All four causes are handled in the scan.

## The four that were real

`embed.rs`, `ref_lookup.rs` and `status.rs` twice told users to run `kin health`. The top-level command enum carries `Doctor` and has no `Health`. After correcting them the scan reports zero.

A fifth, a test's doc comment describing "the `kin health` surface", is corrected **by hand**. The guard drops comment lines deliberately, so nothing enforces that one and it should not be read as covered.

## Falsification

Seven arms, each read for which assertion fired rather than only that it went red.

| arm | expected | result |
|---|---|---|
| clean tree | GREEN | green |
| fabricated flag, in CODE | RED | red, names `--zzzflag` |
| the SAME flag, in a COMMENT | GREEN | green, names nothing |
| fabricated subcommand | RED | red, names `zzzsweep` |
| fabricated sub-subcommand | RED | red, names `zzzstatus` |
| a real `kin health` reinstated | RED | red, names `health` |
| fabricated command inside a doc comment | GREEN | green |

The two green arms are the ones that matter for a widened scope, because a scan that reads 53 files is most likely to fail by grading prose. The last two form a **twin**: separately they conflate "the guard checks flags" with "the guard ignores comments", and only paired can they fail if it stops distinguishing them.

That twin exists because the first grid read 7 of 7 green while one arm graded nothing. Two faults compounded: an expectation passed positionally was silently swapped with the grep needle, and the mutation replaced the *first* occurrence of `kin status`, which is on line 63 and is a comment, so the guard's green was correct behaviour. An arm that mutates "the first occurrence" must assert which occurrence it took, because in a self-documenting file the first one is usually prose.

## Gate

`bin/kin-precheck kin` reports 16 gates ran, 16 passed, 0 failed on `391c4135dbf1e98e7eba452f994e500a32d4e6a2`, the sha pushed here. Rebased onto origin/main past `9dd63f471` so the heavy jobs land on free runners.

Closes FIR-3009
