### PR TITLE
Let a workspace parked on its own base commit, by advancing that head

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -350,6 +350,15 @@ jobs:
       - name: Falsify the coverage read graders
         run: python3 scripts/acceptance/coverage_read_open.py --self-test
 
+      # FIR-3012. The two mutations that survived the first version of these
+      # graders are why this step exists rather than being taken on trust: each
+      # was caught one line later by a different check in the same grader, which
+      # left the arm red and the mutant alive. The fixtures now carry the phrase
+      # the shadowing check wanted, and each arm asserts WHICH assertion fired,
+      # so a red for the wrong reason is not a pass.
+      - name: Falsify the detached-head commit graders
+        run: python3 scripts/acceptance/detached_head_commit_repro.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -1144,6 +1153,31 @@ jobs:
             echo "::warning title=Merge precedence acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: Detached-head commit acceptance suite (verdict comes from the gate step)
+        id: detachedhead
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/detached_head_commit_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/detached_head.json \
+            --verbose >acceptance/detached_head.log 2>&1 || rc=$?
+          cat acceptance/detached_head.log
+          {
+            echo "### Detached-head commit acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/detached_head.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Detached-head commit acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
       # Always, including on a cancelled or timed-out run: the reports are how a
       # failure is diagnosed without re-running the job.
       - name: Upload the acceptance reports
@@ -1198,4 +1232,5 @@ jobs:
             --report bridge_reach=acceptance/bridge_reach.json \
             --report prose_parity=acceptance/prose_parity.json \
             --report merge_precedence=acceptance/merge_precedence.json \
+            --report detached_head=acceptance/detached_head.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk is truncated on ubuntu-latest, and its clipped_steps metadata confirms dropped callee and cross-file rows. This check therefore cannot distinguish an absent required edge from one the walk dropped. Any FAIL or other UNREADABLE still fails the gate, and the moment this check passes the allowance announces itself stale and can go.'

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -3,7 +3,9 @@
 
 use anyhow::{Context, Result};
 
-use super::commit_progress::{daemon_death_explanation, PhaseTail, AUTHORITY_NOT_GIT_NOTE};
+use super::commit_progress::{
+    daemon_death_explanation, PhaseTail, AUTHORITY_NOT_GIT_NOTE, DETACHED_HEAD_NOTE,
+};
 
 pub async fn run(message: String, quiet: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
@@ -145,14 +147,22 @@ impl Drop for CommitAnnouncement {
 /// Without it a brownfield user commits all day and reads `git status` as proof
 /// that nothing happened.
 fn render_commit_summary(result: &DaemonCommitResult, pending: Option<&str>) -> String {
+    let landed = match &result.branch {
+        Some(branch) => format!("on branch '{branch}'"),
+        None => "on a detached HEAD, which no branch names".to_string(),
+    };
     let summary = format!(
-        "Created semantic change {} on branch '{}' ({} entities, {} relations, {} artifacts)\n{}",
+        "Created semantic change {} {} ({} entities, {} relations, {} artifacts)\n{}{}",
         result.change_id,
-        result.branch,
+        landed,
         result.entity_count,
         result.relation_count,
         result.file_count,
         AUTHORITY_NOT_GIT_NOTE,
+        match &result.branch {
+            Some(_) => String::new(),
+            None => format!("\n{DETACHED_HEAD_NOTE}"),
+        },
     );
     match pending {
         Some(pending) => format!("{summary}\n{pending}"),
@@ -169,7 +179,15 @@ fn render_commit_summary(result: &DaemonCommitResult, pending: Option<&str>) -> 
 #[derive(Debug, serde::Deserialize)]
 struct DaemonCommitResult {
     change_id: String,
-    branch: String,
+    /// The branch this change was published onto.
+    ///
+    /// Absent when the workspace head is detached, which is a repository
+    /// converted while Git's own HEAD was detached and never moved onto a
+    /// branch since. The daemon advances that head to the new change and moves
+    /// no ref, so there is no branch to name and inventing one here would be a
+    /// worse answer than saying so.
+    #[serde(default)]
+    branch: Option<String>,
     entity_count: usize,
     relation_count: usize,
     file_count: usize,
@@ -491,14 +509,14 @@ fn landed_commit_for_operation(
     else {
         return Ok(None);
     };
-    let Some((branch, change_id)) = receipt.operation.ref_mutations.iter().find_map(|mutation| {
-        match mutation.new_target.as_ref() {
-            Some(kin_model::RefTarget::Change { change_id }) => {
-                Some((mutation.name.clone(), *change_id))
-            }
-            _ => None,
-        }
-    }) else {
+    let Some((branch, change_id)) = landed_change_in(
+        &receipt.operation.ref_mutations,
+        receipt
+            .operation
+            .workspace_mutation
+            .as_ref()
+            .map(|workspace| &workspace.new_head),
+    ) else {
         return Ok(None);
     };
     let change = lease.snapshot().changes.get(&change_id).ok_or_else(|| {
@@ -508,11 +526,48 @@ fn landed_commit_for_operation(
     })?;
     Ok(Some(DaemonCommitResult {
         change_id: change_id.to_string(),
-        branch: branch.to_string(),
+        branch,
         entity_count: change.entity_deltas.len(),
         relation_count: change.relation_deltas.len(),
         file_count: change.tree_deltas.len(),
     }))
+}
+
+/// The change one operation record published, and the branch it published onto.
+///
+/// Two shapes, because a commit publishes in two ways and only one of them
+/// moves a ref. A commit on a branch fast-forwards the branch its head names,
+/// so the ref mutation carries both the branch and the change. A commit on a
+/// detached head moves no ref at all and advances the workspace head instead,
+/// so reading only the ref mutations would report a landed change as one that
+/// never happened. That is the one answer this lookup must never give: every
+/// caller reaching it has already lost the reply and is deciding whether to
+/// commit again.
+///
+/// Takes the two fields it reads rather than the whole record, so the decision
+/// can be exercised without building a `RepositoryOperationRecord`, which needs
+/// a real store to be meaningful. The shape it is given here is the shape the
+/// daemon writes, and `a_detached_workspace_head_advances_to_the_change_it_commits`
+/// in `kin-daemon` asserts that shape on the receipt itself, so the two sides
+/// meet at a fact one of them proved rather than at a string written twice.
+fn landed_change_in(
+    ref_mutations: &[kin_model::RefMutation],
+    new_head: Option<&kin_model::WorkspaceHead>,
+) -> Option<(Option<String>, kin_model::SemanticChangeId)> {
+    ref_mutations
+        .iter()
+        .find_map(|mutation| match mutation.new_target.as_ref() {
+            Some(kin_model::RefTarget::Change { change_id }) => {
+                Some((Some(mutation.name.to_string()), *change_id))
+            }
+            _ => None,
+        })
+        .or(match new_head {
+            Some(kin_model::WorkspaceHead::Detached {
+                target: kin_model::RefTarget::Change { change_id },
+            }) => Some((None, *change_id)),
+            _ => None,
+        })
 }
 
 /// Await `work`, printing the phases the daemon reaches while it runs.
@@ -652,10 +707,105 @@ mod tests {
         })
     }
 
+    fn change_id_fixture() -> kin_model::SemanticChangeId {
+        kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([7; 32]))
+    }
+
+    fn branch_ref_mutation(change_id: kin_model::SemanticChangeId) -> Vec<kin_model::RefMutation> {
+        vec![kin_model::RefMutation {
+            name: kin_model::RefName::from_bytes(b"refs/heads/main".to_vec()).unwrap(),
+            expected: kin_model::RefExpectation::MustNotExist,
+            new_target: Some(kin_model::RefTarget::change(change_id)),
+            policy: kin_model::RefUpdatePolicy::FastForwardOnly,
+        }]
+    }
+
+    /// The control. A commit on a branch is recovered from its ref mutation and
+    /// names the branch it moved.
+    #[test]
+    fn a_branch_commit_is_recovered_from_its_ref_mutation() {
+        let change_id = change_id_fixture();
+        assert_eq!(
+            landed_change_in(&branch_ref_mutation(change_id), None),
+            Some((Some("refs/heads/main".to_string()), change_id)),
+            "a ref mutation naming a change is the branch this commit published onto"
+        );
+    }
+
+    /// FIR-3012. A commit on a detached head moves no ref, so the only record of
+    /// where it went is the head the workspace mutation advanced. Reading only
+    /// ref mutations reported a landed change as one that never happened, to a
+    /// caller already deciding whether to commit again.
+    #[test]
+    fn a_detached_commit_is_recovered_from_the_head_it_advanced() {
+        let change_id = change_id_fixture();
+        let head = kin_model::WorkspaceHead::Detached {
+            target: kin_model::RefTarget::change(change_id),
+        };
+        assert_eq!(
+            landed_change_in(&[], Some(&head)),
+            Some((None, change_id)),
+            "a detached commit landed, and no branch names it"
+        );
+    }
+
+    /// The must-be-absent arm, so the two above are answers rather than a
+    /// function that says yes to everything. A workspace mutation that moved no
+    /// head onto a change, which is what an admission or a branch switch
+    /// records, published nothing.
+    #[test]
+    fn an_operation_that_published_no_change_is_recovered_as_nothing() {
+        let head = kin_model::WorkspaceHead::Symbolic {
+            target: kin_model::RefName::from_bytes(b"refs/heads/main".to_vec()).unwrap(),
+        };
+        assert_eq!(landed_change_in(&[], Some(&head)), None);
+        assert_eq!(landed_change_in(&[], None), None);
+    }
+
+    /// The commit line says where the change went, and on a detached head it
+    /// says so in words plus the one command that puts the work on a branch.
+    #[test]
+    fn the_commit_summary_names_a_detached_head_and_how_to_leave_it() {
+        let mut result = landed_result();
+        result.branch = None;
+        let text = render_commit_summary(&result, None);
+        assert!(
+            text.contains("on a detached HEAD"),
+            "a detached commit must say so rather than name a branch: {text}"
+        );
+        assert!(
+            !text.contains("on branch"),
+            "no branch moved, so none may be named: {text}"
+        );
+        assert!(
+            text.contains("kin branch create"),
+            "the reader is told how to put this change on a branch: {text}"
+        );
+        // The line above this one ends in "push this branch to a Kin remote".
+        // On a detached head there is no branch, so the pair has to resolve
+        // itself rather than leave a reader holding two sentences that
+        // disagree.
+        assert!(
+            text.contains("nothing to push yet"),
+            "the detached note must settle the push sentence above it: {text}"
+        );
+
+        // The control, same renderer, same fixture but for the one field.
+        let on_branch = render_commit_summary(&landed_result(), None);
+        assert!(
+            on_branch.contains("on branch 'refs/heads/main'"),
+            "a branch commit still names its branch: {on_branch}"
+        );
+        assert!(
+            !on_branch.contains("kin branch create"),
+            "a commit already on a branch is not told how to make one: {on_branch}"
+        );
+    }
+
     fn landed_result() -> DaemonCommitResult {
         DaemonCommitResult {
             change_id: "5b8ca7b7".to_string(),
-            branch: "refs/heads/main".to_string(),
+            branch: Some("refs/heads/main".to_string()),
             entity_count: 32,
             relation_count: 4,
             file_count: 1,
@@ -903,7 +1053,7 @@ mod tests {
         let summary = render_commit_summary(
             &DaemonCommitResult {
                 change_id: "9ade4452cd80".to_string(),
-                branch: "refs/heads/main".to_string(),
+                branch: Some("refs/heads/main".to_string()),
                 entity_count: 0,
                 relation_count: 0,
                 file_count: 1,
@@ -994,7 +1144,7 @@ mod tests {
     fn the_pending_line_is_added_beneath_the_summary_and_replaces_none_of_it() {
         let result = DaemonCommitResult {
             change_id: "9ade4452cd80".to_string(),
-            branch: "refs/heads/main".to_string(),
+            branch: Some("refs/heads/main".to_string()),
             entity_count: 0,
             relation_count: 0,
             file_count: 2,

--- a/crates/kin-cli/src/commands/commit_progress.rs
+++ b/crates/kin-cli/src/commands/commit_progress.rs
@@ -516,6 +516,26 @@ macro_rules! authority_not_git_note {
 /// reads as a commit that silently did nothing.
 pub const AUTHORITY_NOT_GIT_NOTE: &str = authority_not_git_note!();
 
+/// The extra line a `kin commit` prints when the workspace head is detached.
+///
+/// A repository converted while Git's own HEAD was detached, which is where
+/// `git checkout <tag>` and every bisect leaves you, carries a detached Kin
+/// workspace head from admission onward. Committing there advances that head
+/// and moves no branch, exactly as it would with no Git in the picture at all.
+///
+/// The change is not adrift: the workspace head names it, and the workspace is
+/// durable authority rather than a ref that a later checkout forgets. It is
+/// still worth one sentence, because a reader who types `kin branch list` will
+/// find nothing there and should be told where the work went and how to give it
+/// a name.
+/// It also settles the line above it. `AUTHORITY_NOT_GIT_NOTE` ends in "push
+/// this branch to a Kin remote", and on a detached head there is no branch, so
+/// the two read as a contradiction unless this one says so outright. Measured
+/// on the shipped output before it did.
+pub const DETACHED_HEAD_NOTE: &str =
+    "The workspace head advanced to this change and no branch names it, so there is nothing \
+     to push yet. `kin branch create <name>` puts it on a branch.";
+
 /// The long help `kin commit --help` prints, ending in the line above.
 ///
 /// The commit-time line was the only surface carrying the fact, and a commit is

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -5965,7 +5965,9 @@ struct CommandCommitRequest {
 #[derive(Debug, Serialize)]
 struct CommandCommitResponse {
     change_id: String,
-    branch: String,
+    /// The branch this change was published onto, or `null` when the workspace
+    /// head is detached and the head itself advanced instead.
+    branch: Option<String>,
     entity_count: usize,
     relation_count: usize,
     file_count: usize,
@@ -6111,7 +6113,7 @@ fn command_commit_after_admission(
         return Err(refusal);
     }
     let change_id = plan.change.id;
-    let branch_name = plan.branch.clone();
+    let branch_name = plan.target.branch().map(|name| name.to_string());
     let entity_count = plan.entity_count;
     let relation_count = plan.relation_count;
     let file_count = plan.file_count;
@@ -6224,7 +6226,7 @@ fn command_commit_after_admission(
 
     Ok(Json(CommandCommitResponse {
         change_id: change_id.to_string(),
-        branch: branch_name.to_string(),
+        branch: branch_name,
         entity_count,
         relation_count,
         file_count,

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -28,6 +28,37 @@ use crate::source_cas::read_publishable_source;
 
 type ProjectionEntry = (kin_model::RepoPath, kin_model::TreeEntry, Arc<[u8]>);
 
+/// Where one native commit publishes.
+///
+/// A workspace whose head names a branch publishes onto that branch: the branch
+/// is what moves, and the head goes on naming it. A workspace whose head is
+/// detached owns its own head, because nothing else in the repository names
+/// where it stands, so the head itself advances to the new change and no ref is
+/// invented on the author's behalf.
+///
+/// This is graph vocabulary rather than a Git shape borrowed for convenience. A
+/// workspace parked at a change with no branch is expressible with no file and
+/// no Git in the picture, `kin_model::WorkspaceHead::Detached` already accepts a
+/// `RefTarget::Change`, and the change keeps its parent, so provenance is
+/// unbroken either way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeCommitTarget {
+    /// The branch the workspace head names, which this commit fast-forwards.
+    Branch(RefName),
+    /// The workspace's own detached head, which this commit advances.
+    DetachedHead,
+}
+
+impl NativeCommitTarget {
+    /// The branch this commit moves, or `None` on a detached head.
+    pub fn branch(&self) -> Option<&RefName> {
+        match self {
+            Self::Branch(name) => Some(name),
+            Self::DetachedHead => None,
+        }
+    }
+}
+
 /// Complete immutable plan for one native repository transaction.
 ///
 /// `source_hashes` name bodies already present in the daemon's admitted blob
@@ -46,7 +77,7 @@ type ProjectionEntry = (kin_model::RepoPath, kin_model::TreeEntry, Arc<[u8]>);
 pub struct NativeCommitPlan {
     pub change: SemanticChange,
     pub transaction: RepositoryTransaction,
-    pub branch: RefName,
+    pub target: NativeCommitTarget,
     pub entity_count: usize,
     pub relation_count: usize,
     pub file_count: usize,
@@ -68,7 +99,7 @@ pub struct NativeCommitPlan {
 pub struct NativeCommitResult {
     pub change: SemanticChange,
     pub receipt: RepositoryCommitReceipt,
-    pub branch: RefName,
+    pub target: NativeCommitTarget,
     pub entity_count: usize,
     pub relation_count: usize,
     pub file_count: usize,
@@ -804,8 +835,8 @@ fn plan_native_commit_inner(
         )));
     }
 
-    let (branch, current_ref_target, parent) =
-        resolve_symbolic_commit_base(metadata, &workspace.head, workspace.base_target.as_ref())?;
+    let (commit_target, current_ref_target, parent) =
+        resolve_commit_base(metadata, &workspace.head, workspace.base_target.as_ref())?;
     let parent_policy = match parent {
         Some(parent) => Some(
             metadata
@@ -935,6 +966,28 @@ fn plan_native_commit_inner(
         ))
     })?;
     let new_target = RefTarget::change(change.id);
+    // A branch commit leaves the head naming its branch and moves the branch. A
+    // detached commit moves the head itself and touches no ref, which is what
+    // keeps the head equal to the base that advanced beneath it.
+    let (new_head, ref_mutations) = match &commit_target {
+        NativeCommitTarget::Branch(branch) => (
+            workspace.head.clone(),
+            vec![RefMutation {
+                name: branch.clone(),
+                expected: current_ref_target
+                    .map(|target| RefExpectation::MustEqual { target })
+                    .unwrap_or(RefExpectation::MustNotExist),
+                new_target: Some(new_target.clone()),
+                policy: RefUpdatePolicy::FastForwardOnly,
+            }],
+        ),
+        NativeCommitTarget::DetachedHead => (
+            WorkspaceHead::Detached {
+                target: new_target.clone(),
+            },
+            Vec::new(),
+        ),
+    };
     let workspace_mutation = WorkspaceMutation {
         workspace_id,
         expected: WorkspaceExpectation::MustEqual {
@@ -947,7 +1000,7 @@ fn plan_native_commit_inner(
             admission_policy: workspace.admission_policy,
         },
         new_generation: workspace_generation,
-        new_head: workspace.head.clone(),
+        new_head,
         new_base_target: Some(new_target.clone()),
         new_base_tree_hash: Some(tree_hash),
         tree_deltas: workspace_tree_deltas,
@@ -958,14 +1011,6 @@ fn plan_native_commit_inner(
             shared: shared_policy.stamp(),
             local: workspace.admission_policy.local,
         },
-    };
-    let ref_mutation = RefMutation {
-        name: branch.clone(),
-        expected: current_ref_target
-            .map(|target| RefExpectation::MustEqual { target })
-            .unwrap_or(RefExpectation::MustNotExist),
-        new_target: Some(new_target),
-        policy: RefUpdatePolicy::FastForwardOnly,
     };
     let transaction = RepositoryTransaction {
         schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
@@ -979,7 +1024,7 @@ fn plan_native_commit_inner(
         git_authority_delta: None,
         changes: vec![change.clone()],
         aliases: Vec::new(),
-        ref_mutations: vec![ref_mutation],
+        ref_mutations,
         default_ref_mutation: None,
         workspace_mutation: Some(workspace_mutation),
         local_overlay_delta: None,
@@ -1005,7 +1050,7 @@ fn plan_native_commit_inner(
     Ok(NativeCommitPlan {
         change,
         transaction,
-        branch,
+        target: commit_target,
         entity_count,
         relation_count,
         file_count,
@@ -1103,19 +1148,38 @@ pub(crate) fn recover_native_commit(
         .ref_mutations
         .iter()
         .filter_map(|mutation| match mutation.new_target.as_ref() {
-            Some(RefTarget::Change { change_id }) => Some((mutation.name.clone(), *change_id)),
+            Some(RefTarget::Change { change_id }) => Some((
+                NativeCommitTarget::Branch(mutation.name.clone()),
+                *change_id,
+            )),
             _ => None,
         });
-    let (branch, change_id) = native_targets.next().ok_or_else(|| {
-        invalid(format!(
-            "repository receipt for MCP operation {operation_id} has no native change target"
-        ))
-    })?;
-    if native_targets.next().is_some() {
+    let first = native_targets.next();
+    if first.is_some() && native_targets.next().is_some() {
         return Err(invalid(format!(
             "repository receipt for MCP operation {operation_id} has multiple native change targets"
         )));
     }
+    // A detached commit moves no ref, so its change is named by the head the
+    // workspace mutation advanced rather than by a ref mutation. Reading only
+    // the ref mutations here would make an operation that landed look like one
+    // that never ran, which is precisely the reading this recovery exists to
+    // prevent.
+    let (target, change_id) = first
+        .or(match &receipt.operation.workspace_mutation {
+            Some(workspace) => match &workspace.new_head {
+                WorkspaceHead::Detached {
+                    target: RefTarget::Change { change_id },
+                } => Some((NativeCommitTarget::DetachedHead, *change_id)),
+                _ => None,
+            },
+            None => None,
+        })
+        .ok_or_else(|| {
+            invalid(format!(
+                "repository receipt for MCP operation {operation_id} has no native change target"
+            ))
+        })?;
     let change = lease
         .snapshot()
         .changes
@@ -1132,7 +1196,7 @@ pub(crate) fn recover_native_commit(
         file_count: change.tree_deltas.len(),
         change,
         receipt,
-        branch,
+        target,
     }))
 }
 
@@ -1166,7 +1230,7 @@ pub(crate) fn commit_native_plan(
     Ok(NativeCommitResult {
         change: plan.change,
         receipt,
-        branch: plan.branch,
+        target: plan.target,
         entity_count: plan.entity_count,
         relation_count: plan.relation_count,
         file_count: plan.file_count,
@@ -1372,7 +1436,7 @@ fn commit_native_plan_with_working_copy_proof(
     Ok(NativeCommitResult {
         change: plan.change,
         receipt,
-        branch: plan.branch,
+        target: plan.target,
         entity_count: plan.entity_count,
         relation_count: plan.relation_count,
         file_count: plan.file_count,
@@ -1429,50 +1493,91 @@ fn materializable_artifact_count(tree: &kin_model::ResolvedTree) -> Result<usize
     Ok(count)
 }
 
-fn resolve_symbolic_commit_base(
+/// Where a prospective native commit publishes, and what its parent is.
+///
+/// The second element is the compare-and-swap expectation for the branch ref a
+/// symbolic commit fast-forwards, and is always `None` on a detached head,
+/// which moves no ref at all.
+///
+/// A detached workspace used to be refused here outright. It is not refused any
+/// more, because the refusal answered a question the model had already
+/// answered: `kin_model`'s `validate_head_base` accepts a detached head whose
+/// target is a `RefTarget::Change`, and requires that head to equal the
+/// workspace base. A commit advances the base to the new change, so a detached
+/// head that stayed put would contradict its own base and the transaction would
+/// be refused one layer down. That is what made the old refusal load-bearing,
+/// and it is also what says the fix: the head moves with the base.
+fn resolve_commit_base(
     metadata: &kin_db::PersistedRepositoryAuthority,
     head: &WorkspaceHead,
     workspace_base: Option<&RefTarget>,
-) -> Result<(RefName, Option<RefTarget>, Option<SemanticChangeId>)> {
-    let WorkspaceHead::Symbolic { target: branch } = head else {
-        return Err(invalid(
-            "native repository commit requires a symbolic workspace HEAD",
-        ));
-    };
-    let current = metadata
-        .ref_state
-        .refs
-        .iter()
-        .find(|repository_ref| repository_ref.name == *branch)
-        .map(|repository_ref| repository_ref.target.clone());
-    if current.as_ref() != workspace_base {
-        return Err(invalid(format!(
-            "workspace base does not match current symbolic ref {branch}; refresh or rebase before commit"
-        )));
-    }
-    let parent = match current.as_ref() {
-        None => None,
-        Some(RefTarget::Change { change_id }) => Some(*change_id),
-        Some(RefTarget::ExternalObject { object }) => Some(
-            metadata
-                .aliases
+) -> Result<(
+    NativeCommitTarget,
+    Option<RefTarget>,
+    Option<SemanticChangeId>,
+)> {
+    match head {
+        WorkspaceHead::Symbolic { target: branch } => {
+            let current = metadata
+                .ref_state
+                .refs
                 .iter()
-                .find(|alias| alias.oid == object.oid)
-                .map(|alias| alias.change_id)
-                .ok_or_else(|| {
-                    invalid(format!(
-                        "workspace base external commit {} has no semantic alias",
-                        object.oid
-                    ))
-                })?,
-        ),
-        Some(RefTarget::Symbolic { target }) => {
-            return Err(invalid(format!(
-                "native commit does not yet mutate symbolic ref chain {branch} -> {target}"
-            )));
+                .find(|repository_ref| repository_ref.name == *branch)
+                .map(|repository_ref| repository_ref.target.clone());
+            if current.as_ref() != workspace_base {
+                return Err(invalid(format!(
+                    "workspace base does not match current symbolic ref {branch}; refresh or rebase before commit"
+                )));
+            }
+            let parent = match current.as_ref() {
+                None => None,
+                Some(target) => Some(parent_change_at(metadata, target)?),
+            };
+            Ok((NativeCommitTarget::Branch(branch.clone()), current, parent))
         }
-    };
-    Ok((branch.clone(), current, parent))
+        WorkspaceHead::Detached { target } => {
+            // Durable authority already binds these two together, so a
+            // disagreement is a store nobody should commit onto rather than a
+            // choice between two readings of where the workspace stands.
+            if workspace_base != Some(target) {
+                return Err(invalid(
+                    "detached workspace HEAD does not match the workspace base; refresh before commit",
+                ));
+            }
+            let parent = parent_change_at(metadata, target)?;
+            Ok((NativeCommitTarget::DetachedHead, None, Some(parent)))
+        }
+    }
+}
+
+/// The semantic change one resolved authority target names.
+///
+/// A change names itself. An external Git commit names the change it was
+/// admitted as, and a commit with no alias is a store that cannot describe its
+/// own base. A symbolic target is not resolved at all, which durable authority
+/// already refuses for both a workspace base and a detached head, so this arm
+/// is a refusal rather than an assumption.
+fn parent_change_at(
+    metadata: &kin_db::PersistedRepositoryAuthority,
+    target: &RefTarget,
+) -> Result<SemanticChangeId> {
+    match target {
+        RefTarget::Change { change_id } => Ok(*change_id),
+        RefTarget::ExternalObject { object } => metadata
+            .aliases
+            .iter()
+            .find(|alias| alias.oid == object.oid)
+            .map(|alias| alias.change_id)
+            .ok_or_else(|| {
+                invalid(format!(
+                    "workspace base external commit {} has no semantic alias",
+                    object.oid
+                ))
+            }),
+        RefTarget::Symbolic { target } => Err(invalid(format!(
+            "native commit does not yet mutate symbolic ref chain ending at {target}"
+        ))),
+    }
 }
 
 fn invalid(message: impl Into<String>) -> DaemonError {
@@ -2306,7 +2411,13 @@ mod tests {
         );
         assert_eq!(
             authority
-                .get_repository_ref(&init.repository_id, &result.branch)
+                .get_repository_ref(
+                    &init.repository_id,
+                    result
+                        .target
+                        .branch()
+                        .expect("a workspace on a branch publishes onto that branch"),
+                )
                 .unwrap()
                 .unwrap()
                 .target,
@@ -2379,12 +2490,333 @@ mod tests {
         );
         assert_eq!(
             authority
-                .get_repository_ref(&init.repository_id, &result.branch)
+                .get_repository_ref(
+                    &init.repository_id,
+                    result
+                        .target
+                        .branch()
+                        .expect("a workspace on a branch publishes onto that branch"),
+                )
                 .unwrap()
                 .unwrap()
                 .target,
             RefTarget::change(result.change.id)
         );
+    }
+
+    /// Park the workspace on its own base with no branch naming it.
+    ///
+    /// This is where a repository converted while Git's HEAD was detached
+    /// stands from admission onward: `init.rs` maps a direct raw Git HEAD onto
+    /// `WorkspaceHead::Detached`, and nothing re-reads Git afterwards. Reaching
+    /// that state through an ordinary workspace mutation rather than through a
+    /// Git conversion keeps these tests in one crate, and the state is the same
+    /// state because durable authority is what both produce.
+    fn detach_workspace_head(layout: &kin_core::KinLayout) {
+        let context = test_authority_context(layout);
+        let authority = context.open().unwrap();
+        let lease = authority.read_authority();
+        let metadata = lease.metadata();
+        let workspace = metadata
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == context.workspace_id())
+            .expect("the test repository has one workspace")
+            .clone();
+        let base = workspace
+            .base_target
+            .clone()
+            .expect("a detached head binds a base, so commit at least once first");
+        let base_change = lease.resolve_target_change_id(&base).unwrap();
+        let shared = metadata
+            .admission_policies
+            .iter()
+            .find(|resolved| resolved.change_id == base_change)
+            .and_then(|resolved| resolved.policy.clone())
+            .expect("the base change carries a resolved shared admission policy");
+        let roots = lease.roots().clone();
+        drop(lease);
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: OperationId::new(),
+            repository_id: context.repository_id().clone(),
+            expected_generation: roots.generation,
+            expected_roots: roots,
+            actor: AuthorId::new("detach"),
+            reason: "park this workspace on its base with no branch".to_string(),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: Vec::new(),
+            aliases: Vec::new(),
+            ref_mutations: Vec::new(),
+            default_ref_mutation: None,
+            workspace_mutation: Some(WorkspaceMutation {
+                workspace_id: workspace.workspace_id,
+                expected: WorkspaceExpectation::MustEqual {
+                    generation: workspace.generation,
+                    head: workspace.head.clone(),
+                    base_target: workspace.base_target.clone(),
+                    base_tree_hash: workspace.base_tree_hash,
+                    tree_hash: workspace.tree_hash,
+                    semantic_overlay_hash: workspace.semantic_overlay_hash,
+                    admission_policy: workspace.admission_policy,
+                },
+                new_generation: workspace.generation + 1,
+                new_head: WorkspaceHead::Detached {
+                    target: base.clone(),
+                },
+                new_base_target: Some(base),
+                new_base_tree_hash: workspace.base_tree_hash,
+                tree_deltas: Vec::new(),
+                new_tree_hash: workspace.tree_hash,
+                semantic_delta: WorkspaceSemanticDelta::default(),
+                new_shared_admission_policy: shared.clone(),
+                new_admission_policy: EffectiveAdmissionPolicyStamp {
+                    shared: shared.stamp(),
+                    local: workspace.admission_policy.local,
+                },
+            }),
+            local_overlay_delta: None,
+            merge_transaction_delta: None,
+            sealed_observation: None,
+        };
+        authority
+            .commit_repository_transaction(transaction)
+            .expect("parking a workspace on its own base is a legal workspace mutation");
+    }
+
+    /// The state both arms below start from: one committed change on
+    /// `refs/heads/main`, with a second artifact staged for the commit under
+    /// test.
+    fn repository_with_one_change() -> (
+        tempfile::TempDir,
+        kin_core::InitResult,
+        kin_blobs::BlobStore,
+        kin_db::InMemoryGraph,
+        SemanticChangeId,
+    ) {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        add_artifact(&graph, &blobs, b"first.txt", b"one\n", |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("author"),
+            "first change".to_string(),
+        )
+        .unwrap();
+        let first_change = commit_native_plan_with_projection(&init.layout, &blobs, plan)
+            .unwrap()
+            .change
+            .id;
+        (root, init, blobs, graph, first_change)
+    }
+
+    /// Stage a second artifact and plan the commit under test.
+    fn plan_second_commit(
+        init: &kin_core::InitResult,
+        blobs: &kin_blobs::BlobStore,
+        graph: &kin_db::InMemoryGraph,
+    ) -> Result<NativeCommitPlan> {
+        add_artifact(graph, blobs, b"second.txt", b"two\n", |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        plan_native_commit(
+            &init.layout,
+            graph,
+            blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("author"),
+            "second change".to_string(),
+        )
+    }
+
+    fn workspace_state(init: &kin_core::InitResult) -> kin_model::WorkspaceState {
+        let authority = reopen(init);
+        let lease = authority.read_authority();
+        let state = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == init.workspace_id)
+            .unwrap()
+            .clone();
+        state
+    }
+
+    /// The control. A workspace whose head names a branch keeps naming it, and
+    /// the branch is what moves.
+    ///
+    /// It is written beside the detached arm on purpose: the two differ in
+    /// exactly the three facts asserted here, and a change that moved a branch
+    /// commit onto the detached path would pass every assertion in the arm
+    /// below while failing this one.
+    #[test]
+    fn a_commit_on_a_branch_moves_the_branch_and_leaves_the_head_naming_it() {
+        let (_root, init, blobs, graph, first_change) = repository_with_one_change();
+        let plan = plan_second_commit(&init, &blobs, &graph).unwrap();
+        assert_eq!(
+            plan.target,
+            NativeCommitTarget::Branch(
+                kin_model::RefName::from_bytes(b"refs/heads/main".to_vec()).unwrap()
+            ),
+            "a workspace head naming a branch publishes onto that branch"
+        );
+        assert_eq!(
+            plan.transaction.ref_mutations.len(),
+            1,
+            "a branch commit fast-forwards exactly one ref"
+        );
+        let result = commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+        let workspace = workspace_state(&init);
+        assert_eq!(
+            workspace.head,
+            WorkspaceHead::Symbolic {
+                target: kin_model::RefName::from_bytes(b"refs/heads/main".to_vec()).unwrap()
+            },
+            "the head goes on naming its branch"
+        );
+        assert_eq!(
+            reopen(&init)
+                .get_repository_ref(
+                    &init.repository_id,
+                    &kin_model::RefName::from_bytes(b"refs/heads/main".to_vec()).unwrap()
+                )
+                .unwrap()
+                .unwrap()
+                .target,
+            RefTarget::change(result.change.id),
+            "the branch advanced to the new change"
+        );
+        assert_eq!(result.change.parents, vec![first_change]);
+    }
+
+    /// FIR-3012. A workspace parked on its own base commits, advancing that
+    /// head to the change it just made and moving no branch.
+    ///
+    /// This is the everyday state after `git clone` then `git checkout <tag>`
+    /// then `kin init`, which used to refuse every commit forever with
+    /// `native repository commit requires a symbolic workspace HEAD`, after
+    /// paying the whole planning cost first.
+    #[test]
+    fn a_detached_workspace_head_advances_to_the_change_it_commits() {
+        let (_root, init, blobs, graph, first_change) = repository_with_one_change();
+        detach_workspace_head(&init.layout);
+        let before = workspace_state(&init);
+        assert_eq!(
+            before.head,
+            WorkspaceHead::Detached {
+                target: RefTarget::change(first_change)
+            },
+            "the fixture must actually be detached, or this test asserts about nothing"
+        );
+
+        let plan = plan_second_commit(&init, &blobs, &graph).unwrap();
+        assert_eq!(
+            plan.target,
+            NativeCommitTarget::DetachedHead,
+            "a detached workspace publishes onto its own head"
+        );
+        assert!(
+            plan.transaction.ref_mutations.is_empty(),
+            "a detached commit invents no ref on the author's behalf"
+        );
+        let result = commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+
+        assert_eq!(
+            result.change.parents,
+            vec![first_change],
+            "the detached commit descends from the change the head stood on"
+        );
+        let workspace = workspace_state(&init);
+        assert_eq!(
+            workspace.head,
+            WorkspaceHead::Detached {
+                target: RefTarget::change(result.change.id)
+            },
+            "the detached head advanced to the change it just made"
+        );
+        assert_eq!(
+            workspace.base_target,
+            Some(RefTarget::change(result.change.id)),
+            "the base advanced with the head, which is the invariant validate_head_base binds"
+        );
+        assert_eq!(
+            reopen(&init)
+                .get_repository_ref(
+                    &init.repository_id,
+                    &kin_model::RefName::from_bytes(b"refs/heads/main".to_vec()).unwrap()
+                )
+                .unwrap()
+                .unwrap()
+                .target,
+            RefTarget::change(first_change),
+            "no branch moved, so the branch the fixture left behind is where it was"
+        );
+
+        // The join with kin-cli. `landed_change_in` there reads exactly these
+        // two fields off the operation record to answer "did my commit land",
+        // and it can only be right if this is the shape a detached commit
+        // writes. Asserting it here means neither side is trusting a string the
+        // other side also wrote down.
+        assert!(
+            result.receipt.operation.ref_mutations.is_empty(),
+            "the record a recovery reads carries no ref mutation"
+        );
+        assert_eq!(
+            result
+                .receipt
+                .operation
+                .workspace_mutation
+                .as_ref()
+                .map(|workspace| workspace.new_head.clone()),
+            Some(WorkspaceHead::Detached {
+                target: RefTarget::change(result.change.id)
+            }),
+            "the record names the change on the head the workspace mutation advanced"
+        );
+    }
+
+    /// A detached commit is recoverable by the operation id that made it.
+    ///
+    /// The recovery path used to read only ref mutations, so a detached commit,
+    /// which has none, would have read as an operation that never landed. That
+    /// is the worst possible answer here: the caller reaching this code has
+    /// already lost the reply and is deciding whether to commit again.
+    #[test]
+    fn a_detached_commit_is_recovered_by_its_operation_id() {
+        let (_root, init, blobs, graph, _first_change) = repository_with_one_change();
+        detach_workspace_head(&init.layout);
+        add_artifact(&graph, &blobs, b"second.txt", b"two\n", |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let operation_id = OperationId::new();
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            operation_id,
+            fixed_timestamp(),
+            AuthorId::new("author"),
+            "second change".to_string(),
+        )
+        .unwrap();
+        let committed = commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+
+        let recovered =
+            super::recover_native_commit(&test_authority_context(&init.layout), operation_id)
+                .unwrap()
+                .expect("a landed detached commit is recoverable by its operation id");
+        assert_eq!(recovered.change.id, committed.change.id);
+        assert_eq!(recovered.target, NativeCommitTarget::DetachedHead);
     }
 
     #[test]

--- a/scripts/acceptance/detached_head_commit_repro.py
+++ b/scripts/acceptance/detached_head_commit_repro.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove a repository converted at a detached Git HEAD can commit.
+
+FIR-3012. `git clone` then `git checkout <rev>` leaves Git's HEAD detached, and
+that is where a user stands after checking out a tag, a release sha or a bisect
+point. A `kin init` there records a detached Kin workspace head, faithfully,
+because `init.rs` maps a direct raw Git HEAD onto `WorkspaceHead::Detached`.
+Every `kin commit` afterwards then died on
+
+    HTTP 400: native repository commit requires a symbolic workspace HEAD
+
+after paying the whole planning cost first, and a later `git switch -c` did not
+repair it, because nothing re-reads Git's HEAD once the graph owns the head.
+
+The fix advances the workspace's own head to the change it just made and moves
+no ref, which is the shape `kin_model`'s `validate_head_base` already binds: a
+detached head must equal its base, and a commit advances the base.
+
+Five checks, two seeded repositories, ordered so the control runs first. A suite
+that could only ever prove the new behaviour would pass just as well on a build
+that routed every commit down the detached path, so the branch arm is not
+decoration.
+
+  branch_control   the control that must keep passing. A repository converted on
+                   a branch commits, says which branch it published onto, and
+                   the branch is where the change is. This is the arm a fix that
+                   over-reached would break
+  head_visible     `kin status` names the workspace head on the detached
+                   repository BEFORE any commit. The ticket reported no HEAD
+                   line at all, and a user who cannot see the head cannot see
+                   the thing being refused
+  detached_commits the defect itself. `kin commit` on the detached repository
+                   succeeds, where it used to refuse
+  head_advanced    the head moved to the change that commit made, read as two
+                   different head lines rather than as prose, because no wording
+                   can fake a head line changing
+  no_branch_moved  no branch was invented on the author's behalf, and the branch
+                   the conversion left behind is where it was
+
+Exit status is 0 when every check passed, 1 when one failed, 2 when none failed
+but one could not be read, and 3 when the run could not be set up. `--self-test`
+drives every grader against the literal pre-fix output and the post-fix output
+beside it, and needs no binary, so a grader that cannot fail is a failure here
+rather than a silent pass in CI.
+"""
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+TICKET = "FIR-3012"
+
+print = functools.partial(print, flush=True)
+
+# The literal refusal this suite exists to keep gone. Matched as the sentence
+# rather than as a status code, because a 400 is also what a dozen healthy
+# refusals return and only this wording names the defect.
+PRE_FIX_REFUSAL = (
+    "Error: daemon native commit failed (HTTP 400 Bad Request):\n"
+    "Core error: model error: invalid operation:\n"
+    "native repository commit requires a symbolic workspace HEAD\n"
+)
+
+MODULE_FIRST = '"""A tiny ledger."""\n\n\ndef total(entries):\n    return sum(entries)\n'
+MODULE_SECOND = (
+    '"""A tiny ledger."""\n\n\ndef total(entries):\n    return sum(entries)\n\n\n'
+    "def count(entries):\n    return len(entries)\n"
+)
+MODULE_THIRD = (
+    '"""A tiny ledger."""\n\n\ndef total(entries):\n    return sum(entries)\n\n\n'
+    "def count(entries):\n    return len(entries)\n\n\n"
+    "def mean(entries):\n    return total(entries) / max(count(entries), 1)\n"
+)
+MODULE_EDIT = (
+    '"""A tiny ledger."""\n\n\ndef total(entries):\n    return sum(entries)\n\n\n'
+    "def count(entries):\n    return len(entries)\n\n\n"
+    "def mean(entries):\n    return total(entries) / max(count(entries), 1)\n\n\n"
+    "def spread(entries):\n    return max(entries) - min(entries)\n"
+)
+
+
+class Result(object):
+    def __init__(self, cid, status, detail):
+        self.id = cid
+        self.status = status
+        self.detail = detail
+
+
+def run(cmd, cwd=None, env=None, timeout=900):
+    process = subprocess.Popen(
+        cmd, cwd=cwd, env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    try:
+        out, err = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        out, err = process.communicate()
+        return 124, out or "", err or ""
+    return process.returncode, out or "", err or ""
+
+
+# ── graders ──
+#
+# Pure functions, so --self-test can drive every one against the input that must
+# produce the opposite verdict.
+
+def head_line(text):
+    """The `Head:` line `kin status` printed, or None when it printed none.
+
+    None rather than "" so a caller cannot mistake output that never reached
+    this line for a line that was blank. The ticket's report was that no such
+    line exists, and that reading has to be expressible.
+    """
+    if not isinstance(text, str):
+        return None
+    for line in text.splitlines():
+        if line.startswith("Head: "):
+            return line
+    return None
+
+
+def grade_head_is_visible(status_text):
+    """The head has to be readable before a refusal about it means anything."""
+    line = head_line(status_text)
+    if line is None:
+        return (FAIL, "kin status printed no Head line, so the head cannot be seen")
+    if line.strip() == "Head:":
+        return (FAIL, "the Head line named nothing: %r" % line)
+    return (PASS, "kin status named the head: %s" % line.strip())
+
+
+def grade_commit_refused_the_old_way(commit_text):
+    """Whether this output is the pre-fix refusal, named by its own sentence."""
+    text = commit_text or ""
+    return "requires a symbolic workspace HEAD" in text
+
+
+def grade_detached_commit_landed(rc, commit_text):
+    if grade_commit_refused_the_old_way(commit_text):
+        return (FAIL, "the pre-fix refusal is still shipping: %s"
+                % " ".join((commit_text or "").split())[-160:])
+    if rc != 0:
+        return (FAIL, "kin commit exited %s: %s"
+                % (rc, " ".join((commit_text or "").split())[-160:]))
+    if "Created semantic change" not in (commit_text or ""):
+        return (UNREADABLE,
+                "kin commit exited 0 but named no change, so nothing can be read from it")
+    if "on branch" in commit_text:
+        return (FAIL,
+                "a detached commit named a branch, so a branch was invented: %s"
+                % " ".join(commit_text.split())[:160])
+    if "detached HEAD" not in commit_text:
+        return (FAIL,
+                "a detached commit did not say where it went: %s"
+                % " ".join(commit_text.split())[:160])
+    return (PASS, "the commit landed and named the detached head")
+
+
+def grade_branch_commit_landed(rc, commit_text, branch):
+    """The control's grader. A branch commit still names its branch.
+
+    Deliberately not the negation of the one above. A build that routed every
+    commit onto the detached path would satisfy "did not refuse", so this asks
+    for the branch by name.
+    """
+    if rc != 0:
+        return (FAIL, "kin commit exited %s: %s"
+                % (rc, " ".join((commit_text or "").split())[-160:]))
+    if "on branch '%s'" % branch not in (commit_text or ""):
+        return (FAIL, "a commit on %s did not name it: %s"
+                % (branch, " ".join((commit_text or "").split())[:160]))
+    if "detached HEAD" in commit_text:
+        return (FAIL, "a commit on a branch reported a detached head: %s"
+                % " ".join(commit_text.split())[:160])
+    return (PASS, "the commit landed on %s and said so" % branch)
+
+
+def grade_head_advanced(before, after):
+    """The check prose could never make: the head line has to have MOVED.
+
+    Both readings are of the same surface in the same repository minutes apart,
+    so a suite that only asserted the wording would pass on a product whose head
+    never moves, which is the exact defect a detached commit would have if the
+    head were left cloned.
+    """
+    if before is None or after is None:
+        return (UNREADABLE, "one of the two status reads carried no Head line")
+    if before == after:
+        return (FAIL, "the head did not move across a commit; both read %s" % before.strip())
+    if "detached" not in after:
+        return (FAIL, "the head stopped being detached without anyone switching: %s"
+                % after.strip())
+    if "change " not in after:
+        return (FAIL, "the head moved but names no change: %s" % after.strip())
+    return (PASS, "the head moved from %r to %r" % (before.strip(), after.strip()))
+
+
+BRANCH_ROW = re.compile(r"^\s*\*?\s*(refs/\S+)")
+
+
+def branch_targets(branch_list_text):
+    """Every branch the repository holds, as a set of ref names.
+
+    None when the output carries no ref row at all, which is different from a
+    repository with no branches: a failed command and an empty repository look
+    identical once both are reduced to an empty set.
+    """
+    if not isinstance(branch_list_text, str) or not branch_list_text.strip():
+        return None
+    saw_row = False
+    names = set()
+    for line in branch_list_text.splitlines():
+        match = BRANCH_ROW.match(line)
+        if not match:
+            continue
+        saw_row = True
+        names.add(match.group(1))
+    if not saw_row:
+        return None
+    return names
+
+
+def grade_no_branch_moved(before, after):
+    if before is None or after is None:
+        return (UNREADABLE, "kin branch list printed no ref row, so no branch could be read")
+    added = sorted(after - before)
+    if added:
+        return (FAIL, "a detached commit invented branch(es) %s" % ", ".join(added))
+    removed = sorted(before - after)
+    if removed:
+        return (FAIL, "a detached commit removed branch(es) %s" % ", ".join(removed))
+    return (PASS, "the branch set held still at %s" % (sorted(after) or "none"))
+
+
+def report_payload(results, label):
+    """The report shape `scripts/acceptance/gate.py` reads.
+
+    The key is `results` and not `checks`; the gate calls `payload.get("results")`
+    and refuses anything else with "carries no results list".
+    """
+    return {
+        "label": label,
+        "ticket": TICKET,
+        "results": [
+            {"id": r.id, "ticket": TICKET, "status": r.status, "detail": r.detail}
+            for r in results
+        ],
+    }
+
+
+# ── fixture ──
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.home = os.path.join(workdir, "home")
+        os.makedirs(self.home)
+        # kin refuses to invent an author, which is correct. The run isolates
+        # HOME so it cannot read the machine's identity, so it brings one.
+        with open(os.path.join(self.home, ".gitconfig"), "w") as handle:
+            handle.write("[user]\n\tname = detached-head-commit-repro\n"
+                         "\temail = repro@example.invalid\n"
+                         "[commit]\n\tgpgsign = false\n")
+        self.env = dict(os.environ)
+        self.env["HOME"] = self.home
+        self.env["USERPROFILE"] = self.home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(self.home, "registry.toml")
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DAEMON_URL", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repos = {}
+
+    def kin_run(self, repo, args, timeout=900):
+        rc, out, err = run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+        if self.verbose:
+            print("  $ kin %s -> rc=%s" % (" ".join(args), rc))
+        return rc, out, err
+
+    def git(self, repo, args, timeout=300):
+        rc, out, err = run(["git"] + args, cwd=repo, env=self.env, timeout=timeout)
+        if rc != 0:
+            raise RuntimeError("git %s failed: %s" % (" ".join(args), (err or out)[-300:]))
+        return out
+
+    def repo(self, name, detach):
+        """A three-commit Git repository, converted with `kin init`.
+
+        `detach` decides the one fact under test: whether Git's HEAD is on a
+        branch or on a commit when the conversion happens. Everything else about
+        the two repositories is identical, so a difference between the arms is
+        that fact and not the fixture.
+        """
+        if name in self._repos:
+            return self._repos[name]
+        path = os.path.realpath(os.path.join(self.workdir, name))
+        os.makedirs(path)
+        self.git(path, ["init", "-q", "-b", "main", "."])
+        # The fixture's own hooks path, so a machine-wide commit-msg hook cannot
+        # decide whether this suite can build its input.
+        self.git(path, ["config", "core.hooksPath", os.path.join(self.home, "no-hooks")])
+        self.git(path, ["config", "user.email", "repro@example.invalid"])
+        self.git(path, ["config", "user.name", "detached-head-commit-repro"])
+        for body, message in ((MODULE_FIRST, "first"),
+                              (MODULE_SECOND, "second"),
+                              (MODULE_THIRD, "third")):
+            self._write(path, "ledger/reporting.py", body)
+            self.git(path, ["add", "-A"])
+            self.git(path, ["commit", "-q", "-m", message])
+        if detach:
+            second = self.git(path, ["rev-parse", "HEAD~1"]).strip()
+            self.git(path, ["checkout", "-q", second])
+            # The fixture assertion. A detached arm that quietly stayed on a
+            # branch would pass every grader below for the wrong reason.
+            rc, _, _ = run(["git", "symbolic-ref", "-q", "HEAD"],
+                           cwd=path, env=self.env, timeout=60)
+            if rc == 0:
+                raise RuntimeError("the detached fixture is still on a branch")
+        rc, out, err = self.kin_run(path, ["init", "."])
+        if rc != 0:
+            raise RuntimeError("kin init failed: %s" % ((err or out)[-400:]))
+        self._repos[name] = path
+        return path
+
+    @staticmethod
+    def _write(root, relative, body):
+        target = os.path.join(root, relative)
+        directory = os.path.dirname(target)
+        if directory and not os.path.isdir(directory):
+            os.makedirs(directory)
+        with open(target, "w") as handle:
+            handle.write(body)
+
+    def stop_daemons(self):
+        for path in self._repos.values():
+            run([self.kin, "daemon", "stop"], cwd=path, env=self.env, timeout=180)
+
+
+# ── checks ──
+#
+# The two arms share one dict so a later check can read what an earlier one saw
+# without running the fixture twice. Every entry is written by the check that
+# measured it and read by name, never by position.
+OBSERVED = {}
+
+
+def check_branch_control(suite):
+    repo = suite.repo("on-branch", detach=False)
+    suite._write(repo, "ledger/reporting.py", MODULE_EDIT)
+    rc, out, err = suite.kin_run(repo, ["commit", "-m", "add a spread helper"])
+    status, detail = grade_branch_commit_landed(rc, (out or "") + (err or ""),
+                                                "refs/heads/main")
+    return Result("branch_control", status, detail)
+
+
+def check_head_visible(suite):
+    repo = suite.repo("detached", detach=True)
+    rc, out, err = suite.kin_run(repo, ["status"])
+    if rc != 0:
+        return Result("head_visible", UNREADABLE,
+                      "kin status exited %s: %s" % (rc, (err or out)[-200:]))
+    OBSERVED["head_before"] = head_line(out)
+    status, detail = grade_head_is_visible(out)
+    return Result("head_visible", status, detail)
+
+
+def check_detached_commits(suite):
+    repo = suite.repo("detached", detach=True)
+    rc, out, err = suite.kin_run(repo, ["branch", "list"])
+    OBSERVED["branches_before"] = branch_targets(out) if rc == 0 else None
+    suite._write(repo, "ledger/reporting.py", MODULE_EDIT)
+    rc, out, err = suite.kin_run(repo, ["commit", "-m", "add a spread helper"])
+    OBSERVED["commit_rc"] = rc
+    OBSERVED["commit_text"] = (out or "") + (err or "")
+    status, detail = grade_detached_commit_landed(rc, OBSERVED["commit_text"])
+    return Result("detached_commits", status, detail)
+
+
+def check_head_advanced(suite):
+    if "commit_rc" not in OBSERVED:
+        return Result("head_advanced", UNREADABLE,
+                      "the commit check never ran, so there is no transition to read")
+    if OBSERVED["commit_rc"] != 0:
+        return Result("head_advanced", UNREADABLE,
+                      "the commit did not land, so no head could have moved")
+    repo = suite.repo("detached", detach=True)
+    rc, out, err = suite.kin_run(repo, ["status"])
+    if rc != 0:
+        return Result("head_advanced", UNREADABLE,
+                      "kin status exited %s: %s" % (rc, (err or out)[-200:]))
+    OBSERVED["head_after"] = head_line(out)
+    status, detail = grade_head_advanced(OBSERVED.get("head_before"),
+                                         OBSERVED.get("head_after"))
+    return Result("head_advanced", status, detail)
+
+
+def check_no_branch_moved(suite):
+    if OBSERVED.get("commit_rc") != 0:
+        return Result("no_branch_moved", UNREADABLE,
+                      "the commit did not land, so no branch could have moved")
+    repo = suite.repo("detached", detach=True)
+    rc, out, err = suite.kin_run(repo, ["branch", "list"])
+    if rc != 0:
+        return Result("no_branch_moved", UNREADABLE,
+                      "kin branch list exited %s: %s" % (rc, (err or out)[-200:]))
+    status, detail = grade_no_branch_moved(OBSERVED.get("branches_before"),
+                                           branch_targets(out))
+    return Result("no_branch_moved", status, detail)
+
+
+CHECKS = (
+    ("branch_control", check_branch_control),
+    ("head_visible", check_head_visible),
+    ("detached_commits", check_detached_commits),
+    ("head_advanced", check_head_advanced),
+    ("no_branch_moved", check_no_branch_moved),
+)
+
+
+# ── self-test ──
+
+def self_test():
+    problems = []
+
+    def expect(what, got, want):
+        if got != want:
+            problems.append("%s: got %r, wanted %r" % (what, got, want))
+
+    # head_line separates absent from blank from present.
+    expect("a status with a head", head_line("Workspace: w\nHead: detached Commit abc\nTree: t"),
+           "Head: detached Commit abc")
+    expect("a status with no head line", head_line("Workspace: w\nTree: t"), None)
+    expect("a non-string status", head_line(None), None)
+
+    # The pre-fix refusal must be recognised, and an unrelated 400 must not be.
+    if not grade_commit_refused_the_old_way(PRE_FIX_REFUSAL):
+        problems.append("the pre-fix refusal was not recognised as itself")
+    if grade_commit_refused_the_old_way(
+            "Error: daemon native commit failed (HTTP 400 Bad Request):\n"
+            "Core error: model error: invalid operation:\n"
+            "native commit message must not be empty\n"):
+        problems.append("an unrelated 400 was read as the pre-fix refusal")
+
+    # The detached grader fails on the shipped defect and passes on the fix.
+    expect("the pre-fix refusal fails",
+           grade_detached_commit_landed(1, PRE_FIX_REFUSAL)[0], FAIL)
+    expect("a detached commit passes",
+           grade_detached_commit_landed(0,
+               "Created semantic change 37cfc298 on a detached HEAD, which no branch names "
+               "(3 entities, 1 relations, 1 artifacts)\nRecorded in Kin authority, not in git.\n"
+               "The workspace head advanced to this change and no branch moved. "
+               "`kin branch create <name>` puts it on a branch.")[0], PASS)
+    # The mutation that matters: a fix that quietly put the change on an
+    # invented branch would exit 0 and name a change, and only the branch
+    # sentence tells the two apart. The fixture carries BOTH phrases on
+    # purpose. Without the detached note, deleting the branch check leaves the
+    # missing-note check to fail the same input one line later, for a different
+    # reason, and the mutation survives while the arm still reads red. The
+    # detail is asserted for the same reason: a red arm naming another
+    # assertion is not this arm passing.
+    invented = grade_detached_commit_landed(0,
+        "Created semantic change 37cfc298 on branch 'refs/heads/detached-work' "
+        "(3 entities, 1 relations, 1 artifacts)\n"
+        "The workspace head advanced to this change and no branch moved.")
+    expect("a commit that invented a branch fails", invented[0], FAIL)
+    if "a branch was invented" not in invented[1]:
+        problems.append("the invented-branch case failed for another reason: %r" % invented[1])
+    # And the note's own check, with an input only it can catch: no branch
+    # named and no note either.
+    silent = grade_detached_commit_landed(0,
+        "Created semantic change 37cfc298 (3 entities, 1 relations, 1 artifacts)")
+    expect("a commit that said nothing about where it went fails", silent[0], FAIL)
+    if "did not say where it went" not in silent[1]:
+        problems.append("the silent-commit case failed for another reason: %r" % silent[1])
+    # An exit 0 with no change named is unreadable, never a pass.
+    expect("an empty success is unreadable",
+           grade_detached_commit_landed(0, "")[0], UNREADABLE)
+
+    # The control's grader asks for the branch by name, so a build that routed
+    # every commit down the detached path breaks it.
+    expect("a branch commit passes",
+           grade_branch_commit_landed(0,
+               "Created semantic change 37cfc298 on branch 'refs/heads/main' "
+               "(3 entities, 1 relations, 1 artifacts)", "refs/heads/main")[0], PASS)
+    expect("a branch commit routed onto the detached path fails",
+           grade_branch_commit_landed(0,
+               "Created semantic change 37cfc298 on a detached HEAD, which no branch names "
+               "(3 entities, 1 relations, 1 artifacts)", "refs/heads/main")[0], FAIL)
+    expect("a branch commit naming another branch fails",
+           grade_branch_commit_landed(0,
+               "Created semantic change 37cfc298 on branch 'refs/heads/other' "
+               "(3 entities, 1 relations, 1 artifacts)", "refs/heads/main")[0], FAIL)
+
+    # The head has to MOVE, and a head that stayed put is the defect this fix is
+    # about, not a wording problem.
+    # Both readings name a CHANGE, so the only thing wrong with this pair is
+    # that they are equal. With an external-commit fixture the "names no
+    # change" check catches it one line later and the equality check can be
+    # deleted without the arm noticing.
+    stuck = grade_head_advanced("Head: detached change 37cfc298",
+                                "Head: detached change 37cfc298")
+    expect("a head that never moved fails", stuck[0], FAIL)
+    if "did not move" not in stuck[1]:
+        problems.append("the stuck-head case failed for another reason: %r" % stuck[1])
+    expect("a head that advanced to a change passes",
+           grade_head_advanced("Head: detached Commit 9e7b7dd",
+                               "Head: detached change 37cfc298")[0], PASS)
+    expect("a head that silently became symbolic fails",
+           grade_head_advanced("Head: detached Commit 9e7b7dd",
+                               "Head: symbolic refs/heads/main")[0], FAIL)
+    expect("a missing head reading is unreadable",
+           grade_head_advanced(None, "Head: detached change 37cfc298")[0], UNREADABLE)
+
+    # branch_targets separates "no branches" from "the command said nothing".
+    expect("a branch listing", branch_targets("  refs/heads/main  change abc\n"),
+           {"refs/heads/main"})
+    expect("an empty listing is unreadable", branch_targets(""), None)
+    expect("a listing with no ref row is unreadable",
+           branch_targets("no branches yet\n"), None)
+    expect("an unchanged branch set passes",
+           grade_no_branch_moved({"refs/heads/main"}, {"refs/heads/main"})[0], PASS)
+    expect("an invented branch fails",
+           grade_no_branch_moved({"refs/heads/main"},
+                                 {"refs/heads/main", "refs/heads/detached-work"})[0], FAIL)
+    expect("an unreadable listing is unreadable",
+           grade_no_branch_moved(None, {"refs/heads/main"})[0], UNREADABLE)
+
+    # The report the gate reads, driven through the gate's own reader rather
+    # than through a copy of its rules.
+    payload = report_payload([Result("x", PASS, "ok")], "selftest")
+    if not payload.get("results"):
+        problems.append("the report carries no results list, which the gate refuses")
+    if payload["results"][0]["status"] != PASS:
+        problems.append("the report lost a row's status")
+
+    for problem in problems:
+        print("SELFTEST FAIL %s" % problem)
+    print("detached-head-commit-repro self-test: %d problem(s)" % len(problems))
+    return 1 if problems else 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"))
+    parser.add_argument("--daemon", default=None)
+    parser.add_argument("--workdir", default=None)
+    parser.add_argument("--label", default="local")
+    parser.add_argument("--only", default=None)
+    parser.add_argument("--json", default=None)
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if not args.kin:
+        print("error: --kin (or KIN_BIN) is required", file=sys.stderr)
+        return 3
+    # Absolutized here, before anything reads it: every probe runs with `cwd` set
+    # to a fixture repository, so a relative `--kin target/release/kin` would
+    # validate from the caller's directory and fail from the fixture's.
+    kin = os.path.abspath(args.kin)
+    if not os.path.isfile(kin) or not os.access(kin, os.X_OK):
+        print("error: %s is not an executable kin binary" % kin, file=sys.stderr)
+        return 3
+
+    daemon = os.path.abspath(args.daemon) if args.daemon else None
+    if not daemon:
+        beside = os.path.join(os.path.dirname(kin), "kin-daemon")
+        if os.path.isfile(beside) and os.access(beside, os.X_OK):
+            daemon = beside
+
+    selected = None
+    if args.only:
+        selected = {part.strip() for part in args.only.split(",") if part.strip()}
+
+    workdir = args.workdir or tempfile.mkdtemp(prefix="detached-head-commit-")
+    os.makedirs(workdir, exist_ok=True)
+    suite = Suite(kin, workdir, daemon=daemon, verbose=args.verbose)
+
+    results = []
+    try:
+        for cid, fn in CHECKS:
+            if selected is not None and cid not in selected:
+                continue
+            try:
+                results.append(fn(suite))
+            except Exception as exc:  # a crashed probe is UNREADABLE, never a verdict
+                results.append(Result(cid, UNREADABLE, "the probe raised: %s" % exc))
+    finally:
+        suite.stop_daemons()
+        if not args.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    for res in results:
+        print("CHECK %s %s %s %s" % (res.id, TICKET, res.status, res.detail))
+
+    failed = [r for r in results if r.status == FAIL]
+    unreadable = [r for r in results if r.status == UNREADABLE]
+    print("detached-head-commit-repro: %d checks, %d passed, %d failed, %d unreadable (%s)"
+          % (len(results), len(results) - len(failed) - len(unreadable),
+             len(failed), len(unreadable), args.label))
+
+    if args.json:
+        with open(args.json, "w") as handle:
+            json.dump(report_payload(results, args.label), handle, indent=2, sort_keys=True)
+
+    if failed:
+        return 1
+    if unreadable:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -162,6 +162,11 @@ EXPECTED_SUITES = (
         "merge_precedence",
         "acceptance/merge_precedence.json",
     ),
+    ExpectedSuite(
+        "scripts/acceptance/detached_head_commit_repro.py",
+        "detached_head",
+        "acceptance/detached_head.json",
+    ),
 )
 
 


### PR DESCRIPTION
A repository converted while Git's HEAD was detached could never accept a native commit. `git clone` then `git checkout <rev>` is where a user stands after checking out a tag, a release sha or a bisect point, `kin init` records that faithfully as a detached workspace head, and every `kin commit` afterwards died on `native repository commit requires a symbolic workspace HEAD`. A later `git switch -c` did not repair it, because nothing re-reads Git's HEAD once the graph owns it.

The commit now publishes onto whichever the workspace head names. On a branch nothing changes: the branch fast-forwards and the head goes on naming it. On a detached head the head itself advances to the change and no ref moves, so nothing is invented in a namespace other people read.

## Why this remedy and not the other two

kin-model decides the shape. `validate_head_base` already accepts a detached head whose target is a `RefTarget::Change` and already requires a detached head to equal its base, and a commit advances the base. So the old refusal was load-bearing rather than gratuitous: dropping it and changing nothing else builds a transaction the model refuses one layer down with `new workspace detached HEAD must bind its exact target and tree`, which is what the P2 falsification arm measures. The head has to move with the base.

Refusing at `kin init` was rejected. It answers the Git question and leaves the graph one open, since a workspace parked at a change is a state the model already permits, and it costs a read-only user the whole conversion for a commit they may never make. Re-reading Git's HEAD at commit time was rejected twice over: it is the raw file-first authority the Zero File-Search Authority Rule bars, and after admission the graph owns the head, so honouring a Git ref would mean two systems disagreeing about where the workspace stands.

## The second defect the sweep found

Both recovery paths read only ref mutations to answer "did my commit land", and a detached commit has none. `recover_native_commit` in the daemon and `landed_commit_for_operation` in the CLI would both have told a caller who had already lost the reply that a recorded change never happened, and the retry would then have been refused as an empty successor. They now fall back to the head the workspace mutation advanced. The daemon test asserts the record shape the CLI reads, so the two sides meet at a fact one of them proved rather than at a string written twice.

## Measured

Against the shipped `@kinlab/kin@0.6.2` binary, version `0.6.2 (510be53f9…)`, on a three-commit fixture with a scratch HOME:

```
CHECK branch_control    PASS   the commit landed on refs/heads/main and said so
CHECK head_visible      PASS   Head: detached Commit 1f875816…
CHECK detached_commits  FAIL   the pre-fix refusal is still shipping
CHECK head_advanced     UNREADABLE
CHECK no_branch_moved   UNREADABLE
```

Against this tree, same suite and same fixture: 5 passed, 0 failed, 0 unreadable, with the head reading `detached Commit 8def4f38…` before and `detached change db963ccf…` after, and the branch set holding still.

Two corrections to the ticket fell out of the reproduction. `kin status` does print a Head line on a detached store; the excerpt in the ticket stops three lines before it. And the refusal costs one second on a small store, since it sits early in the planner at `repository_commit.rs:808`; the 45 to 90 seconds in the ticket is the planning phase on a psf/requests-scale store, which measures store size rather than this refusal.

The work is never stranded. After a detached commit, `kin log` shows the change with its parent, `kin status` names it, `kin branch create <name>` builds a ref at that change and `kin branch switch` moves onto it, and the next commit is an ordinary branch commit. The commit line says so and names the first of those commands.

## Falsification

Five product mutations, each recompiled and graded on three tests, with an unmutated baseline green and the tree left clean with zero markers. Restoring the old refusal reds both detached tests and leaves the branch control green. Cloning the head instead of advancing it reds on the model's own invariant. Fast-forwarding a ref anyway reds on the named assertion. Routing a branch commit down the detached path reds the control. Removing the recovery fallback reds exactly one test.

Seven grader mutations of the acceptance suite, every one red and naming its own assertion. Two survived the first pass, both because a later check inside the same grader failed the same fixture one line on for a different reason, so each arm now carries an input only its target can catch and asserts which detail came back.

Local gates on this exact sha: `bin/kin-precheck kin` reports 16 gates ran, 16 passed, 0 failed, on a clean tree.

Closes FIR-3012
