### PR TITLE
Give a projection conflict its kind, and retry a switch only on the one an admission clears

### DIFF
--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -936,7 +936,10 @@ fn branch_switch_admits_and_carries_an_unadmitted_edit_the_branches_agree_about(
     initialize_git_repo(&repo);
     add_feature_branch(&repo);
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
-    let layout = initialize_kin_repo(&runtime, &repo);
+    // Bound to `_` rather than dropped: the call converts the repository, and
+    // this test no longer reads the layout because the authority assertions it
+    // used to make moved to the refusal test named in the comment above.
+    let _layout = initialize_kin_repo(&runtime, &repo);
     // Written straight to the working copy and never admitted, which is the
     // whole point: no `admit_uncommitted_workspace_edit` here, unlike the test
     // below that is otherwise the same scenario.

--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -909,32 +909,55 @@ fn branch_switch_projects_complete_polyglot_and_non_code_tree_from_repository_ca
         .is_symlink());
 }
 
+/// An edit the daemon has not admitted yet carries exactly as an admitted one
+/// does, because the switch admits it.
+///
+/// This test asserted the opposite until the rc062j stranger run, where the
+/// same shape refused seven times in nine and `kin admit` then carried it every
+/// time. Nothing about the edit differs between those two moments: the only
+/// difference is whether the daemon had got to it yet, which is a race the
+/// caller cannot see and did not cause.
+///
+/// So admission state no longer decides. What decides is the question the two
+/// tests below already ask: whether the branches agree about the member being
+/// changed. This is the Git rule, and it is now the whole rule.
+///
+/// The property this test used to carry, that a REFUSED switch must not advance
+/// repository authority, is not lost. It lives in
+/// `branch_switch_refuses_an_admitted_edit_to_a_member_the_branches_disagree_about`,
+/// which still refuses and still asserts the roots are unchanged. Moving it
+/// there rather than deleting it is deliberate: this input stopped refusing, so
+/// it can no longer say anything about what a refusal does.
 #[cfg(unix)]
 #[test]
-fn branch_switch_rejects_local_tracked_edits_and_preserves_authority() {
+fn branch_switch_admits_and_carries_an_unadmitted_edit_the_branches_agree_about() {
     let root = tempdir().expect("temp root");
     let repo = root.path().join("repo");
     initialize_git_repo(&repo);
     add_feature_branch(&repo);
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
-    let (_, manager) = open_authority(&layout);
-    let before = manager.read_authority().roots().clone();
+    // Written straight to the working copy and never admitted, which is the
+    // whole point: no `admit_uncommitted_workspace_edit` here, unlike the test
+    // below that is otherwise the same scenario.
     fs::write(repo.join("unchanged.txt"), b"local uncommitted edit\n").expect("write local edit");
 
     let switched = run_kin(&runtime, &repo, &["branch", "switch", "feature"]);
-    assert!(!switched.status.success());
     assert!(
-        String::from_utf8_lossy(&switched.stderr).contains("differs from prior workspace source")
+        switched.status.success(),
+        "an unadmitted edit to a member both branches share must carry: stdout={} stderr={}",
+        String::from_utf8_lossy(&switched.stdout),
+        String::from_utf8_lossy(&switched.stderr)
     );
     assert_eq!(
         fs::read(repo.join("unchanged.txt")).unwrap(),
-        b"local uncommitted edit\n"
+        b"local uncommitted edit\n",
+        "the carried edit must survive on disk"
     );
     assert_eq!(
-        manager.read_authority().roots(),
-        &before,
-        "rejected projection advanced repository authority"
+        fs::read(repo.join("compose.yaml")).unwrap(),
+        b"services:\n  api:\n    build: .\n",
+        "members the workspace never touched must take the destination's content"
     );
 }
 

--- a/crates/kin-core/src/error.rs
+++ b/crates/kin-core/src/error.rs
@@ -3,6 +3,59 @@
 
 use thiserror::Error;
 
+/// Which kind of projection conflict a refusal is.
+///
+/// The message alone cannot carry this. Two of these refusals are answered very
+/// differently by a caller and were distinguishable only by their wording, and
+/// a predicate on wording is a check a copy edit breaks in silence.
+///
+/// `Other` exists so every site with no opinion keeps its behaviour rather than
+/// being made to claim one, and so a new site cannot pick a kind by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectionConflictKind {
+    /// A path the repository TRACKS whose working-copy content has moved away
+    /// from the projection. The graph has not been told yet, and an admission
+    /// pass resolves it, which is why this one is worth naming.
+    TrackedDrift,
+    /// A path the repository does NOT track standing where a member must go. No
+    /// admission makes this carry; the caller has to move or remove the file.
+    UntrackedBlocks,
+    /// Every other projection conflict, which is most of them.
+    Other,
+}
+
+/// A projection conflict, with its kind beside the sentence.
+///
+/// Displays as the message alone, so every existing rendering of this error is
+/// byte identical to what it was.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectionConflictDetail {
+    pub kind: ProjectionConflictKind,
+    pub message: String,
+}
+
+impl ProjectionConflictDetail {
+    pub fn new(kind: ProjectionConflictKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ProjectionConflictDetail {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+/// Every site that says nothing about the kind keeps saying nothing.
+impl From<String> for ProjectionConflictDetail {
+    fn from(message: String) -> Self {
+        Self::new(ProjectionConflictKind::Other, message)
+    }
+}
+
 /// Unified error type for `kin-core`.
 #[derive(Debug, Error)]
 pub enum KinError {
@@ -37,7 +90,7 @@ pub enum KinError {
     RepositoryConflict(String),
 
     #[error("repository projection conflict: {0}")]
-    ProjectionConflict(String),
+    ProjectionConflict(ProjectionConflictDetail),
 
     /// The working projection will not open until a person acts on the file
     /// the message names.
@@ -88,6 +141,41 @@ impl KinError {
         Self::Io {
             path: path.as_ref().display().to_string(),
             source,
+        }
+    }
+
+    /// A projection conflict whose kind this site does not claim.
+    pub fn projection_conflict(message: impl Into<String>) -> Self {
+        Self::ProjectionConflict(ProjectionConflictDetail::new(
+            ProjectionConflictKind::Other,
+            message,
+        ))
+    }
+
+    /// A TRACKED path whose working-copy content moved away from the projection.
+    pub fn tracked_projection_drift(message: impl Into<String>) -> Self {
+        Self::ProjectionConflict(ProjectionConflictDetail::new(
+            ProjectionConflictKind::TrackedDrift,
+            message,
+        ))
+    }
+
+    /// An UNTRACKED path standing where a member must go.
+    pub fn untracked_path_blocks(message: impl Into<String>) -> Self {
+        Self::ProjectionConflict(ProjectionConflictDetail::new(
+            ProjectionConflictKind::UntrackedBlocks,
+            message,
+        ))
+    }
+
+    /// The kind of projection conflict this is, or `None` when it is not one.
+    ///
+    /// Read by a caller that answers two of these differently. Everything else
+    /// keeps matching the variant and rendering the message, which is unchanged.
+    pub fn projection_conflict_kind(&self) -> Option<ProjectionConflictKind> {
+        match self {
+            Self::ProjectionConflict(detail) => Some(detail.kind),
+            _ => None,
         }
     }
 }

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -73,7 +73,7 @@ pub use config::{
     RemoteHostKind, RemoteRefConfig, RemoteTransportKind, ResourcesConfig, WorldConfig,
     WorldPreset, RESOURCE_PROFILE_NAMES,
 };
-pub use error::{KinError, Result};
+pub use error::{KinError, ProjectionConflictDetail, ProjectionConflictKind, Result};
 pub use exact_tree::{
     exact_tree_correction, plan_artifact_copy, plan_artifact_move, plan_artifact_operations,
     plan_observed_tree_deltas, ArtifactTreeOperation,

--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -662,8 +662,13 @@ pub fn report_repository_workspace_projection_drift(
         for entry in &entries {
             match projection.projection.validate_frozen_entry_unchanged(entry) {
                 Ok(_) => {}
-                Err(KinError::ProjectionConflict(message)) => {
-                    drift.push(message);
+                Err(KinError::ProjectionConflict(detail)) => {
+                    // The message alone, exactly as before. This collector is
+                    // why the kind rides INSIDE the variant rather than in a new
+                    // one: a second variant would have fallen through to the
+                    // `Err(error)` arm below and turned every tracked drift into
+                    // a hard failure instead of a collected one.
+                    drift.push(detail.message);
                     drifted_paths.push(entry.file_id.clone());
                 }
                 Err(error) => return Err(error),
@@ -9306,7 +9311,7 @@ impl ProjectionRoot {
                         break;
                     }
                     Ok(_) => {
-                        return Err(KinError::ProjectionConflict(format!(
+                        return Err(KinError::untracked_path_blocks(format!(
                             "untracked working-copy path {} blocks exact workspace target {}",
                             self.display_root.join(&relative).display(),
                             entry.file_id
@@ -9332,7 +9337,7 @@ impl ProjectionRoot {
                     if previous.relation(&relative) != TrackedPathRelation::Ancestor
                         || removed.relation(&relative) != TrackedPathRelation::Ancestor
                     {
-                        return Err(KinError::ProjectionConflict(format!(
+                        return Err(KinError::projection_conflict(format!(
                             "untracked working-copy directory {} conflicts with exact workspace target {}",
                             self.display_root.join(&relative).display(),
                             entry.file_id
@@ -9347,7 +9352,7 @@ impl ProjectionRoot {
                 }
                 Ok(_) if previous.relation(&relative) == TrackedPathRelation::Exact => {}
                 Ok(_) => {
-                    return Err(KinError::ProjectionConflict(format!(
+                    return Err(KinError::untracked_path_blocks(format!(
                         "untracked working-copy path {} conflicts with exact workspace target {}",
                         self.display_root.join(&relative).display(),
                         entry.file_id
@@ -9381,7 +9386,7 @@ impl ProjectionRoot {
                 .map_err(|error| KinError::io(self.display_root.join(&relative), error))?;
             if metadata.is_dir() && !metadata_is_reparse(&metadata) {
                 if removed.relation(&relative) != TrackedPathRelation::Ancestor {
-                    return Err(KinError::ProjectionConflict(format!(
+                    return Err(KinError::projection_conflict(format!(
                         "untracked working-copy directory {} blocks exact workspace reconciliation",
                         self.display_root.join(&relative).display()
                     )));
@@ -9389,7 +9394,7 @@ impl ProjectionRoot {
                 let child = self.open_existing_directory(directory, &name, &relative)?;
                 self.validate_removable_directory_contents(&child, &relative, removed)?;
             } else if removed.relation(&relative) != TrackedPathRelation::Exact {
-                return Err(KinError::ProjectionConflict(format!(
+                return Err(KinError::untracked_path_blocks(format!(
                     "untracked working-copy path {} blocks exact workspace reconciliation",
                     self.display_root.join(&relative).display()
                 )));
@@ -9433,7 +9438,7 @@ impl ProjectionRoot {
                     )?;
                 }
                 Ok(_) => {
-                    return Err(KinError::ProjectionConflict(format!(
+                    return Err(KinError::projection_conflict(format!(
                         "selected checkout path {} is blocked by a non-directory working-copy ancestor {}; select that ancestor explicitly",
                         file_id,
                         self.display_root.join(&relative).display()
@@ -9452,7 +9457,7 @@ impl ProjectionRoot {
             Ok(metadata) => metadata,
         };
         if metadata.is_dir() && !metadata_is_reparse(&metadata) {
-            return Err(KinError::ProjectionConflict(format!(
+            return Err(KinError::projection_conflict(format!(
                 "selected tracked checkout path {} became a real directory; refusing to remove possibly untracked descendants",
                 self.display_root.join(&relative).display()
             )));
@@ -9462,7 +9467,7 @@ impl ProjectionRoot {
         } else if metadata.is_file() {
             ExistingObjectKind::File
         } else {
-            return Err(KinError::ProjectionConflict(format!(
+            return Err(KinError::projection_conflict(format!(
                 "selected checkout path {} has an unsupported working-copy object kind",
                 self.display_root.join(&relative).display()
             )));
@@ -9510,7 +9515,7 @@ impl ProjectionRoot {
                             )?;
                         }
                         Ok(_) => {
-                            return Err(KinError::ProjectionConflict(format!(
+                            return Err(KinError::projection_conflict(format!(
                                 "working-copy ancestor {} appeared after selected checkout preflight",
                                 self.display_root.join(&relative).display()
                             )));
@@ -9521,7 +9526,7 @@ impl ProjectionRoot {
                 match parent.symlink_metadata(name) {
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
                     Err(error) => Err(KinError::io(self.display_root.join(path), error)),
-                    Ok(_) => Err(KinError::ProjectionConflict(format!(
+                    Ok(_) => Err(KinError::projection_conflict(format!(
                         "working-copy path {} appeared after selected checkout preflight",
                         self.display_root.join(path).display()
                     ))),
@@ -9546,7 +9551,7 @@ impl ProjectionRoot {
                     &self.display_root.join(relative),
                 )?;
                 if actual_identity != *identity || actual_state != *state {
-                    return Err(KinError::ProjectionConflict(format!(
+                    return Err(KinError::projection_conflict(format!(
                         "selected working-copy path {} changed after exact checkout preflight",
                         self.display_root.join(relative).display()
                     )));
@@ -9569,7 +9574,7 @@ impl ProjectionRoot {
         for (entry, expected_identity) in entries.iter().zip(expected_identities) {
             let actual_identity = self.validate_tracked_entry_unchanged(entry)?;
             if actual_identity != *expected_identity {
-                return Err(KinError::ProjectionConflict(format!(
+                return Err(KinError::projection_conflict(format!(
                     "tracked working-copy path {} changed object identity after exact workspace preflight; reconciliation refused",
                     self.display_root
                         .join(projection_path(entry.file_id)?)
@@ -9604,7 +9609,7 @@ impl ProjectionRoot {
             let actual_identity = self.validate_frozen_entry_unchanged(entry)?;
             if actual_identity != *expected_identity {
                 let path = validate_projection_proof_path(entry.file_id)?;
-                return Err(KinError::ProjectionConflict(format!(
+                return Err(KinError::projection_conflict(format!(
                     "tracked working-copy path {} changed object identity after exact projection verification",
                     self.display_root.join(path.relative).display()
                 )));
@@ -9647,14 +9652,14 @@ impl ProjectionRoot {
                     .metadata()
                     .map_err(|error| KinError::io(display, error))?;
                 if !metadata.is_file() {
-                    return Err(KinError::ProjectionConflict(format!(
+                    return Err(KinError::projection_conflict(format!(
                         "exact-source object {} changed kind",
                         display.display()
                     )));
                 }
                 #[cfg(windows)]
                 if metadata_is_reparse(&metadata) {
-                    return Err(KinError::ProjectionConflict(format!(
+                    return Err(KinError::projection_conflict(format!(
                         "exact-source object {} became a reparse point",
                         display.display()
                     )));
@@ -9664,7 +9669,7 @@ impl ProjectionRoot {
                     use std::os::unix::fs::PermissionsExt;
 
                     if (metadata.permissions().mode() & 0o111 != 0) != executable {
-                        return Err(KinError::ProjectionConflict(format!(
+                        return Err(KinError::projection_conflict(format!(
                             "exact-source object {} changed executable mode",
                             display.display()
                         )));
@@ -9675,7 +9680,7 @@ impl ProjectionRoot {
                 if !reader_matches_bytes(&mut file, entry.content)
                     .map_err(|error| KinError::io(display, error))?
                 {
-                    return Err(KinError::ProjectionConflict(format!(
+                    return Err(KinError::projection_conflict(format!(
                         "exact-source object {} changed content",
                         display.display()
                     )));
@@ -9696,7 +9701,7 @@ impl ProjectionRoot {
                         .symlink_metadata(name)
                         .map_err(|error| KinError::io(display, error))?;
                     if !metadata_is_reparse(&metadata) {
-                        return Err(KinError::ProjectionConflict(format!(
+                        return Err(KinError::projection_conflict(format!(
                             "exact-source object {} changed kind",
                             display.display()
                         )));
@@ -9704,7 +9709,7 @@ impl ProjectionRoot {
                     let target = rustix::fs::readlinkat(parent, name, Vec::new())
                         .map_err(|error| KinError::io(display, error.into()))?;
                     if target.as_bytes() != entry.content {
-                        return Err(KinError::ProjectionConflict(format!(
+                        return Err(KinError::projection_conflict(format!(
                             "exact-source symbolic link {} changed target",
                             display.display()
                         )));
@@ -11222,7 +11227,7 @@ impl ProjectionRoot {
     ) -> Result<TrackedEntryIdentity> {
         let display = self.display_root.join(&path.relative);
         let conflict = |reason: &str| {
-            KinError::ProjectionConflict(format!(
+            KinError::tracked_projection_drift(format!(
                 "tracked working-copy path {} differs from prior workspace source ({reason}); exact workspace reconciliation refused",
                 display.display()
             ))

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -35,7 +35,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use socket2::{Domain, Protocol, Socket, Type};
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 static BOOTSTRAP_EXPORTS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
@@ -5220,13 +5220,57 @@ async fn command_branch(
 
     let requires_authority_gate =
         !matches!(&request, kin_cli::commands::branch::BranchRequest::List);
-    let _coordination = if requires_authority_gate {
-        Some(state.coordination_gate.lock().await)
-    } else {
-        None
+    let attempt = |state: &Arc<DaemonState>| crate::repository_branch::execute(state, &request);
+
+    // Scoped so the gate is RELEASED before any admission runs below. The
+    // admission seam takes this same gate and the mutex is not reentrant, so a
+    // retry that held it would deadlock rather than admit.
+    let first = {
+        let _coordination = if requires_authority_gate {
+            Some(state.coordination_gate.lock().await)
+        } else {
+            None
+        };
+        attempt(&state)
     };
 
-    let response = crate::repository_branch::execute(&state, &request)?;
+    let response = match first {
+        Ok(response) => response,
+        // Retried only for the one refusal an admission clears: a TRACKED path
+        // whose working copy moved away from the projection the graph holds, so
+        // the switch refused on a view of the workspace that was simply not
+        // current. Read from the refusal's typed kind, not from its wording.
+        //
+        // An untracked path standing where a member must go never reaches here,
+        // which is the whole reason this is a retry on a named refusal rather
+        // than an admission ahead of the command: admitting first also absorbed
+        // untracked files, turning a user's own file into tracked pending work
+        // as a side effect of changing branches.
+        Err(refusal)
+            if refusal.clears_with_admission
+                && matches!(
+                    &request,
+                    kin_cli::commands::branch::BranchRequest::Switch { .. }
+                )
+                && admission_seam_would_skip(&state).is_none() =>
+        {
+            if let Err(error) = crate::repository_admit::execute(&state).await {
+                // A pass that established no outcome does not get to change the
+                // answer. The switch already refused, and that refusal stands.
+                warn!(%error, "the admission before a retried switch reported no outcome");
+                return Err(refusal.into());
+            }
+            let _coordination = if requires_authority_gate {
+                Some(state.coordination_gate.lock().await)
+            } else {
+                None
+            };
+            // Once. A second refusal is the answer, whatever its kind, because
+            // an admission that did not clear it will not clear it next time.
+            attempt(&state)?
+        }
+        Err(refusal) => return Err(refusal.into()),
+    };
     Ok(Json(response))
 }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -28377,6 +28377,57 @@ mod tests {
         );
     }
 
+    /// The third arm of the switch retry: a refusal the retry cannot clear must
+    /// survive it, and must be the NEXT question rather than the same one.
+    ///
+    /// The workspace edits a path both branches track and both hold
+    /// differently. The first attempt refuses for drift, the retry admits, and
+    /// the second attempt gets far enough to ask the real question, which is
+    /// whether that pending work can replay onto the destination. It cannot, so
+    /// it refuses again and that refusal stands.
+    ///
+    /// The assertion that matters is the one on WHICH refusal comes back. A
+    /// retry that never ran would return the drift message again, and a retry
+    /// that ran but did not stop would return success, so the carry refusal is
+    /// the only answer that means both halves worked.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_switch_retry_stops_at_a_refusal_no_admission_can_clear() {
+        let (state, _layout, repository, _main, _feature) =
+            universal_branch_test_state("branch-retry-stops");
+        let authority = ActiveApiRepositoryAuthority::open(&state).unwrap();
+        let generation_before = authority.manager.read_authority().roots().generation;
+        std::fs::write(
+            repository.join("selected/compose.yaml"),
+            b"services:\n  api:\n    image: local-edit\n",
+        )
+        .unwrap();
+        let request = kin_cli::commands::branch::BranchRequest::Switch {
+            name: kin_model::RefName::branch(b"feature").unwrap(),
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("branch-retry-stops-test"),
+        };
+
+        let (status, body) = post_branch_request(Arc::clone(&state), &request, None).await;
+        let rendered = String::from_utf8_lossy(&body).to_string();
+
+        assert_eq!(status, StatusCode::CONFLICT, "{rendered}");
+        assert!(
+            rendered.contains("cannot move onto"),
+            "the retry must reach the carry question and refuse there: {rendered}"
+        );
+        assert!(
+            !rendered.contains("diverge from the graph-owned workspace projection"),
+            "returning the drift refusal again means the retry never ran: {rendered}"
+        );
+        // The admission the retry ran is allowed to publish, so the generation
+        // may move. What must not move is the ref, because the switch refused.
+        assert!(
+            authority.manager.read_authority().roots().generation >= generation_before,
+            "an admission may advance the generation; nothing may move it backwards"
+        );
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn command_branch_returns_conflict_for_untracked_target_path_without_mutation() {

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -961,6 +961,18 @@ fn switch(
                 &workspace.tree,
                 &authority.manager,
             )
+            // A switch to the ref this workspace already tracks is not a
+            // transition, so there is nothing for pending work to carry onto and
+            // an admission clears nothing the caller asked for. It would still
+            // publish, moving the authority generation as a side effect of a
+            // command that changes nothing, so the drift refusal keeps its plain
+            // kind here and the retry never sees it.
+            //
+            // Measured, not assumed: this is where the same-target drift refusal
+            // is actually raised. `preflight_switch_delta` above never refuses
+            // on it, which a probe said and a reading of the two call sites did
+            // not.
+            .map_err(forget_that_admission_would_clear_it)
             .with_context(|| format!("verify exact projection for already-active branch {name}"))?;
         let generation = authority_freeze.roots().generation;
         drop(authority_freeze);
@@ -1531,6 +1543,21 @@ fn projection_conflict_kind(error: &anyhow::Error) -> Option<kin_core::Projectio
         .chain()
         .find_map(|cause| cause.downcast_ref::<kin_core::KinError>())
         .and_then(kin_core::KinError::projection_conflict_kind)
+}
+
+/// Drop the claim that one admission pass would clear this refusal.
+///
+/// For a refusal raised where no transition is being made, the claim is true
+/// and useless: admitting would publish and change the generation while the
+/// caller's command still does nothing. Everything else about the error, its
+/// status and its sentence, is untouched.
+fn forget_that_admission_would_clear_it(error: kin_core::KinError) -> kin_core::KinError {
+    match error {
+        kin_core::KinError::ProjectionConflict(detail) => {
+            kin_core::KinError::projection_conflict(detail.message)
+        }
+        other => other,
+    }
 }
 
 fn classify_branch_error(error: anyhow::Error) -> WorkspaceMutationRefusal {

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -150,20 +150,13 @@ impl From<BranchRefusal> for (StatusCode, String) {
 }
 
 impl WorkspaceMutationRefusal {
-    /// Answer a client. A branch command always transitions under
-    /// `TransitionPolicy::Switch`, which never raises the tracks-another-ref
-    /// case, so this arm is unreachable from a branch route; it maps to a
-    /// conflict rather than panicking, because an answer that is merely wrong
-    /// beats one that takes the daemon down.
-    fn into_client_response(self) -> (StatusCode, String) {
-        match self {
-            Self::Client(status, message) => (status, message),
-            Self::ClientClearsWithAdmission(status, message) => (status, message),
-            Self::TracksAnotherRef(detail) => (StatusCode::CONFLICT, detail),
-        }
-    }
-
-    /// The same answer, carrying whether one admission pass would clear it.
+    /// Answer a client, carrying whether one admission pass would clear it.
+    ///
+    /// A branch command always transitions under `TransitionPolicy::Switch`,
+    /// which never raises the tracks-another-ref case, so that arm is
+    /// unreachable from a branch route; it maps to a conflict rather than
+    /// panicking, because an answer that is merely wrong beats one that takes
+    /// the daemon down.
     fn into_client_refusal(self) -> BranchRefusal {
         match self {
             Self::Client(status, message) => BranchRefusal {

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -105,6 +105,9 @@ impl std::error::Error for WorkspaceTracksAnotherRef {}
 enum WorkspaceMutationRefusal {
     /// A refusal a client is told, as the status and message it is told with.
     Client(StatusCode, String),
+    /// The same, for the one refusal an admission pass clears: a TRACKED path
+    /// whose working copy moved away from the projection the graph holds.
+    ClientClearsWithAdmission(StatusCode, String),
     /// This workspace stands on a different ref than the one a transfer moved.
     TracksAnotherRef(String),
 }
@@ -112,6 +115,37 @@ enum WorkspaceMutationRefusal {
 impl From<(StatusCode, String)> for WorkspaceMutationRefusal {
     fn from((status, message): (StatusCode, String)) -> Self {
         Self::Client(status, message)
+    }
+}
+
+/// A refusal a branch command answers with, and whether one admission clears it.
+///
+/// The flag is read from the projection conflict's own kind rather than from
+/// its wording. A predicate on the sentence is a check a copy edit breaks in
+/// silence, and these two refusals differ by exactly one word in a paragraph.
+pub(crate) struct BranchRefusal {
+    pub(crate) status: StatusCode,
+    pub(crate) message: String,
+    /// True only for a TRACKED path whose content moved away from the
+    /// projection: the graph has not been told, and one admission pass tells
+    /// it. An untracked path standing where a member must go is never this, and
+    /// no admission makes it carry.
+    pub(crate) clears_with_admission: bool,
+}
+
+impl From<(StatusCode, String)> for BranchRefusal {
+    fn from((status, message): (StatusCode, String)) -> Self {
+        Self {
+            status,
+            message,
+            clears_with_admission: false,
+        }
+    }
+}
+
+impl From<BranchRefusal> for (StatusCode, String) {
+    fn from(refusal: BranchRefusal) -> Self {
+        (refusal.status, refusal.message)
     }
 }
 
@@ -124,7 +158,29 @@ impl WorkspaceMutationRefusal {
     fn into_client_response(self) -> (StatusCode, String) {
         match self {
             Self::Client(status, message) => (status, message),
+            Self::ClientClearsWithAdmission(status, message) => (status, message),
             Self::TracksAnotherRef(detail) => (StatusCode::CONFLICT, detail),
+        }
+    }
+
+    /// The same answer, carrying whether one admission pass would clear it.
+    fn into_client_refusal(self) -> BranchRefusal {
+        match self {
+            Self::Client(status, message) => BranchRefusal {
+                status,
+                message,
+                clears_with_admission: false,
+            },
+            Self::ClientClearsWithAdmission(status, message) => BranchRefusal {
+                status,
+                message,
+                clears_with_admission: true,
+            },
+            Self::TracksAnotherRef(detail) => BranchRefusal {
+                status: StatusCode::CONFLICT,
+                message: detail,
+                clears_with_admission: false,
+            },
         }
     }
 }
@@ -239,11 +295,11 @@ pub(crate) fn workspace_behind_ref(state: &DaemonState, name: &RefName) -> Resul
 pub(crate) fn execute(
     state: &DaemonState,
     request: &BranchRequest,
-) -> std::result::Result<BranchResponse, (StatusCode, String)> {
+) -> std::result::Result<BranchResponse, BranchRefusal> {
     if matches!(request, BranchRequest::List) {
-        let authority =
-            ActiveLocalRepositoryAuthority::open_bound(state).map_err(branch_bind_refusal)?;
-        return list(&authority).map_err(internal_branch_error);
+        let authority = ActiveLocalRepositoryAuthority::open_bound(state)
+            .map_err(|refusal| BranchRefusal::from(branch_bind_refusal(refusal)))?;
+        return list(&authority).map_err(|error| BranchRefusal::from(internal_branch_error(error)));
     }
 
     run_workspace_mutation(state, |state, authority| match request {
@@ -271,7 +327,7 @@ pub(crate) fn execute(
             TransitionPolicy::Switch,
         ),
     })
-    .map_err(WorkspaceMutationRefusal::into_client_response)
+    .map_err(WorkspaceMutationRefusal::into_client_refusal)
 }
 
 /// Move the graph-owned workspace onto the current target of the ref it already
@@ -313,6 +369,13 @@ pub(crate) fn follow_moved_ref(
             WorkspaceFollow::NotApplicable { detail }
         }
         Err(WorkspaceMutationRefusal::Client(_, detail)) => WorkspaceFollow::Behind { detail },
+        // A follow is not a switch and never admits, so the one refusal an
+        // admission would clear is reported here exactly as any other client
+        // refusal is. Spelled out rather than folded into the arm above, because
+        // the compiler asking this question is the point of the variant.
+        Err(WorkspaceMutationRefusal::ClientClearsWithAdmission(_, detail)) => {
+            WorkspaceFollow::Behind { detail }
+        }
     }
 }
 
@@ -989,7 +1052,7 @@ fn switch(
     )
     .with_context(|| format!("validate exact workspace projection before moving onto {name}"))?;
     if let Some(first) = drift.first() {
-        return Err(kin_core::KinError::ProjectionConflict(format!(
+        return Err(kin_core::KinError::projection_conflict(format!(
             "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; \
              reconcile them into graph authority or discard them {}",
             drift.len(),
@@ -1459,7 +1522,29 @@ fn render_target(target: &RefTarget) -> String {
     }
 }
 
+/// The projection conflict's kind, wherever in the chain it sits.
+///
+/// Walks the causes rather than reading only the head, because these errors
+/// travel wrapped in context by the time a route classifies them.
+fn projection_conflict_kind(error: &anyhow::Error) -> Option<kin_core::ProjectionConflictKind> {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<kin_core::KinError>())
+        .and_then(kin_core::KinError::projection_conflict_kind)
+}
+
 fn classify_branch_error(error: anyhow::Error) -> WorkspaceMutationRefusal {
+    // Read the kind BEFORE the error is flattened to a status and a sentence,
+    // because that is the last moment it exists. Tracked drift is the one
+    // refusal an admission pass clears; every other projection conflict, and
+    // every other error, keeps the answer it has always had.
+    if matches!(
+        projection_conflict_kind(&error),
+        Some(kin_core::ProjectionConflictKind::TrackedDrift)
+    ) {
+        let (status, message) = client_branch_refusal(error);
+        return WorkspaceMutationRefusal::ClientClearsWithAdmission(status, message);
+    }
     // Nothing to do is not a failure, and a follow tells it apart from one by
     // the variant rather than by reading a message it would have to
     // pattern-match. It is raised only under `TransitionPolicy::FollowMovedRef`,

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -1064,7 +1064,13 @@ fn switch(
     )
     .with_context(|| format!("validate exact workspace projection before moving onto {name}"))?;
     if let Some(first) = drift.first() {
-        return Err(kin_core::KinError::projection_conflict(format!(
+        // Tracked drift by construction, which the comment above states as this
+        // reader's contract: it reads only paths the workspace tree already
+        // tracks, and untracked host paths are never read. Naming the kind here
+        // is what lets one admission pass clear this refusal, and the aggregate
+        // is where it has to be named, because the per-path kinds are collected
+        // as messages and this error is a new one built from them.
+        return Err(kin_core::KinError::tracked_projection_drift(format!(
             "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; \
              reconcile them into graph authority or discard them {}",
             drift.len(),

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -1201,7 +1201,7 @@ pub(crate) fn publish_resolved_merge(
     )
     .context("validate exact workspace projection before publishing the merge")?;
     if let Some(first) = drift.first() {
-        return Err(kin_core::KinError::ProjectionConflict(format!(
+        return Err(kin_core::KinError::projection_conflict(format!(
             "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; \
              reconcile them into graph authority or discard them before publishing this merge",
             drift.len()
@@ -2210,7 +2210,7 @@ fn publish(
     )
     .context("validate exact workspace projection before merging")?;
     if let Some(first) = drift.first() {
-        return Err(kin_core::KinError::ProjectionConflict(format!(
+        return Err(kin_core::KinError::projection_conflict(format!(
             "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; \
              reconcile them into graph authority or discard them before merging",
             drift.len()

--- a/crates/kin-daemon/src/repository_rollback.rs
+++ b/crates/kin-daemon/src/repository_rollback.rs
@@ -424,7 +424,7 @@ fn plan_and_commit(
     )
     .context("validate the exact workspace projection before rolling back")?;
     if let Some(first) = drift.first() {
-        return Err(kin_core::KinError::ProjectionConflict(format!(
+        return Err(kin_core::KinError::projection_conflict(format!(
             "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; \
              reconcile them into graph authority or discard them before rolling back",
             drift.len()

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -639,7 +639,7 @@ fn return_to_base(
     )
     .context("validate the exact workspace projection before returning it to its base")?;
     if let Some(first) = drift.first() {
-        return Err(kin_core::KinError::ProjectionConflict(format!(
+        return Err(kin_core::KinError::projection_conflict(format!(
             "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; the \
              workspace state is already sealed as {}",
             drift.len(),
@@ -854,7 +854,7 @@ fn pop(
     )
     .context("validate the exact workspace projection before restoring a stash")?;
     if let Some(first) = drift.first() {
-        return Err(kin_core::KinError::ProjectionConflict(format!(
+        return Err(kin_core::KinError::projection_conflict(format!(
             "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; \
              reconcile them into graph authority before restoring a stash",
             drift.len()
@@ -1299,7 +1299,7 @@ fn classify_stash_error(error: anyhow::Error) -> (StatusCode, String) {
     if let Some(kin_core::KinError::ProjectionConflict(message)) =
         error.downcast_ref::<kin_core::KinError>()
     {
-        return (StatusCode::CONFLICT, message.clone());
+        return (StatusCode::CONFLICT, message.message.clone());
     }
     for cause in error.chain() {
         if let Some(model) = cause.downcast_ref::<kin_model::ModelError>() {


### PR DESCRIPTION
rc062j finding (3), the last open item from that stranger run. `kin branch switch` refused a pending edit that `kin admit` carries fine, seven times in nine for the stranger and three of three on my own fixture.

## Why the first attempt was withdrawn

An earlier fix admitted before the switch. CI caught that admission also absorbing UNTRACKED files: a user's own file became tracked pending work as a side effect of changing branches, and `command_branch_returns_conflict_for_untracked_target_path_without_mutation` said so. That commit was parked rather than argued with.

Reading the refusal site rather than the symptom gives the real discriminator. Three refusals reach this path from three producers and only one is the stranger's, and they were distinguishable only by their wording.

## The typed distinction, in kin-core as ruled

`ProjectionConflict` now carries a kind beside its sentence: `TrackedDrift`, `UntrackedBlocks`, and `Other` for the twenty-odd sites with no opinion, which are not made to claim one.

**The kind rides inside the variant rather than in new variants, and that is not a style choice.** `tree.rs` collects drift by matching `ProjectionConflict` and pushing the message; a second variant would have fallen through to the `Err(error)` arm beside it and turned every tracked drift from a collected finding into a hard failure, which is the exact path this change is about. The detail Displays as its message alone, so every existing rendering is byte identical.

`WorkspaceMutationRefusal` gains one variant, which the compiler then forces every match to answer without a wildcard. The follow path answers it explicitly and reports it as any other client refusal, because a follow is not a switch and never admits.

**The crossing:** this touches `crates/kin-core/src/error.rs`, `crates/kin-core/src/lib.rs` and `crates/kin-core/src/tree.rs`, which are outside this lane's usual files. No other lane held them.

## The retry

`command_branch` scopes the coordination gate so it is released before any admission runs, since the admission seam takes that same gate and the mutex is not reentrant. On a refusal whose typed kind says one pass would clear it, and only on a switch, it admits once and tries once more. A pass that establishes no outcome leaves the original refusal standing, and a second refusal is the answer whatever its kind.

## Two wrong sites, both found by running rather than reading

The retry was correct and fired in the wrong place twice.

`preflight_switch_delta` looked like the producer of the same-target drift refusal, and a scoping placed there changed nothing. A probe showed it never refuses on that input: the refusal comes from the already-active branch's own projection verification further down.

Then, with the scoping correct, arm 1 still measured 0 of 3. The kind was being dropped at the aggregate: `report_repository_workspace_projection_drift` collects per-path conflicts as MESSAGES, and the branch path builds a NEW error from them with the neutral constructor. Naming that aggregate as tracked drift, which its own reader's comment states as its contract, took the same fixture to 3 of 3.

Three plausible readings of the right code, wrong about which code runs, in one day on one lane. Every one was caught by printing.

## The three arms

```
arm                                              before   after
1  un-admitted tracked file, stranger's store    0 of 3   3 of 3
2  untracked collision keeps its own refusal     green    green
3  genuine carry conflict still refuses          absent   green
```

Arm 2 is the existing test the withdrawn fix broke. Arm 3 is new and asserts WHICH refusal comes back: a retry that never ran would return the drift message again, and one that ran without stopping would return success, so the carry refusal is the only answer meaning both halves worked. It asserts the drift sentence is absent for exactly that reason.

A fourth behaviour the ruling did not name also had to be held. A switch to the ref the workspace already tracks is not a transition, so an admission clears nothing the caller asked for while still publishing and moving the generation, which `command_branch_same_target_validates_dirty_projection_before_generation_change` holds. The downgrade sits on the call that raises that refusal, where no transition is being made by construction.

## Not claimed

The HTTP 500 the stranger saw five times in nine. Zero of ten on every build I ran, before and after, so these arms say nothing about it.

## Gates

kin-core 782 of 782, `command_branch` 10 of 10, `repository_merge_resolution` 23 of 23, `repository_merge` 18 of 18, all run locally before this was opened. `bin/kin-precheck` 16 of 16, and `cargo fmt --all -- --check` rc 0 as the last command before the push.

Refs FIR-2960
