### PR TITLE
Take the fast gate back to three shards; the count was not the lever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1129,21 +1129,30 @@ jobs:
       # aggregate report one cause where there may be three.
       fail-fast: false
       matrix:
-      # Five, not three, because the gate's wall time is its slowest shard and
-      # three put the required context at 10.08 to 11.17 minutes end to end
-      # across five consecutive main runs, all of them over the bar. Measured
-      # per step across nine shard jobs, a shard costs 34 s of job setup plus
-      # 168 s of `cargo nextest list`, which compiles the whole selection and
-      # so does NOT shrink when shards are added, against 930 to 989 s of test
-      # work per run that does. Five is where that 201 s floor stops paying:
-      # six buys about 0.6 min more and eight about 1.4, so the count is
-      # chosen on the floor rather than on how far it can be pushed.
+      # Three, and five was tried and measured back out. Do not raise this
+      # count expecting the gate to get faster; the numbers are below and they
+      # say the shard count is not the lever.
       #
-      # This list and the `--partition count:.../5` denominator below are one
+      # Five ran on main for three consecutive pushes. Slowest shard went from
+      # a 12-run mean of 10.14 min to 9.78, which is 3.5 percent and exactly
+      # one before-side standard deviation, and the required context stayed
+      # over ten minutes on two of the three. What settles it is narrower than
+      # the mean: the SLOWEST partition's test time did not move at all, 386 s
+      # mean at three shards against 392 s at five.
+      #
+      # The reason is a floor that does not divide. Per shard: 34 s of job
+      # setup, 166 s of `cargo nextest list`, which compiles the whole
+      # selection, and 235 s inside the `Test` step itself, measured as the
+      # 470 s that two extra shards added to the run's total test time while
+      # the selection stayed constant. That is 435 s, 7.25 min, at any count.
+      # On top of it the slowest partition holds something indivisible worth
+      # about 390 s, so no count brings that partition below roughly 9.8 min.
+      #
+      # This list and the `--partition count:.../3` denominator below are one
       # fact in two places. The guard checks them against each other, because
       # a matrix SHORTER than the denominator runs that fraction of the
       # selection and still reports success.
-        shard: [1, 2, 3, 4, 5]
+        shard: [1, 2, 3]
     steps:
       # The scope read diffs a base against a head, so it needs both.
       - uses: actions/checkout@v7
@@ -1236,7 +1245,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t SCOPE < "$RUNNER_TEMP/scope.args"
-          cargo nextest run --locked "${SCOPE[@]}" --partition count:${{ matrix.shard }}/5
+          cargo nextest run --locked "${SCOPE[@]}" --partition count:${{ matrix.shard }}/3
 
       # The reporting verdict. The run above graded a quarantined flake as
       # passing, which is what keeps it off the critical path; this reads the

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -4394,7 +4394,7 @@ FAST_GATE_SHARD_STEPS = (
     "cargo nextest run --locked",
     "run: python3 scripts/check-quarantine.py --report-junit",
 )
-FAST_GATE_SHARD_MATRIX = "shard: [1, 2, 3, 4, 5]"
+FAST_GATE_SHARD_MATRIX = "shard: [1, 2, 3]"
 FAST_GATE_SHARD_INDEPENDENT_LEGS = "fail-fast: false"
 FAST_GATE_AGGREGATE_ALWAYS_RUNS = "if: ${{ !cancelled() }}"
 FAST_GATE_AGGREGATE_NEEDS = "needs: [changes, fast-gate-tests]"
@@ -13762,13 +13762,13 @@ def main() -> None:
             # prove nothing about this one; that arm was written first and the
             # falsification loop's own wrong-reason check rejected it.
             #
-            # Its effect is the silent kind. Matrix [1..5] against
-            # `count:${{ matrix.shard }}/7` means parts 6 and 7 are never
-            # dispatched, so two sevenths of the selection never runs, all five
-            # shards pass, and the required context reports success.
+            # Its effect is the silent kind. Matrix [1, 2, 3] against
+            # `count:${{ matrix.shard }}/7` means parts 4 through 7 are never
+            # dispatched, so four sevenths of the selection never runs, all
+            # three shards pass, and the required context reports success.
             "the partition denominator drifts above the shard matrix",
             "fast-gate-tests",
-            "--partition count:${{ matrix.shard }}/5",
+            "--partition count:${{ matrix.shard }}/3",
             "--partition count:${{ matrix.shard }}/7",
             "one fact in two places and they disagree",
         ),


### PR DESCRIPTION
Five shards ran on main for three consecutive pushes and bought nothing measurable. This takes the count back to three and keeps the guard that shipped beside it.

## The measurement

Three consecutive main runs on five shards, against every main run since 12:00Z on three:

| run | sha | shards | slowest shard | required context end to end | queue s |
| -- | -- | -- | -- | -- | -- |
| 33326164513 | `3481be9c9` | 5 | 9.25 | 9.57 | 14, 14, 15, 14, 14 |
| 33326549732 | `1c2b7d5aa` | 5 | 10.07 | 10.45 | 18, 18, 18, 18, 18 |
| 33326915763 | `32234f8c0` | 5 | 10.03 | 10.38 | 14, 15, 15, 14, 15 |
| **mean** | | | **9.78** | **10.13** | |

| | before, 12 runs, 3 shards | after, 3 runs, 5 shards | change |
| -- | -- | -- | -- |
| slowest shard | 10.14 | 9.78 | **-0.35 min, -3.5%** |
| required context end to end | 10.51 | 10.13 | -0.38 min, -3.6% |
| runs over ten minutes | 12 of 12 | 2 of 3 | |

**The shift is exactly one before-side standard deviation.** That side's deviation is 0.36 minutes and the shift is 0.36 minutes, at n=3. The one run that came in under the bar, 9.57, sits inside the before side's own range, and against the immediate 9.70 baseline on `9dd63f471` the after mean of 9.78 is slightly worse.

## What actually settles it, and it does not depend on the sample size

**The slowest partition's own test time did not move.**

| | slowest shard's TEST seconds |
| -- | -- |
| three shards | 378, 401, 379, mean **386** |
| five shards | 375, 403, 398, mean **392** |

Flat, +1.6 percent. Adding two shards did nothing to the one number the gate is measured on. Six runs, and the reading does not rest on a mean of three.

**Total test work grew 49 percent for the same selection.** Summed across shards, 964 s at three against 1434 s at five, so two extra shards added 470 s. That is **235 s per extra shard of overhead inside the `Test` step**. The selection staying constant is checked rather than assumed: per-shard `cargo nextest list` seconds, which compile the whole selection and so proxy its size, went 153 to 166, up 8 percent, nowhere near 49.

**So the per-shard floor does not divide, and it is more than double what the five-shard change was modelled on:**

| component | seconds | divides with more shards? |
| -- | -- | -- |
| job setup | 34 | no |
| `cargo nextest list` | 166 | no, it compiles the whole selection |
| inside the `Test` step | 235 | no |
| **floor** | **435 s = 7.25 min** | |

The measured slowest shard is 587 s; the floor accounts for 435 of that and only 152 s is divisible at all. The earlier model built the floor from the two steps it could see and treated everything inside `Test` as divisible, and the term hiding there was larger than everything it did measure.

There is a second floor above the first. The slowest partition holds something indivisible worth about 390 s of test time, flat across both counts, so no shard count brings that partition below roughly 9.8 minutes.

## What is kept, deliberately

The join assertion stays. It derives the partition denominator from the matrix and requires them equal, rather than pinning both to a number, so a matrix SHORTER than the denominator cannot silently run a fraction of the selection and report success. That defect is real at any shard count and nothing else in the tree can see it.

Its falsification arm moves with the count, mutating `/3` to `/7` rather than `/5` to `/7`, so it still tests the silent direction: matrix `[1, 2, 3]` against `count:${{ matrix.shard }}/7` never dispatches parts 4 through 7, so four sevenths of the selection never runs, all three shards pass, and the required context reports success.

## Falsification

| arm | rc | which assertion answered |
| -- | -- | -- |
| M0 unmutated, matrix `[1..3]`, denominator `/3` | 0 | passes |
| F1 denominator `/3` to `/7`, the silent case | 1 | `one fact in two places and they disagree` |
| F2 denominator `/3` to `/2`, the loud case | 1 | same join assertion |
| F3 `--partition` removed entirely | 1 | `must partition by their matrix index` |
| F4 matrix shrinks to `[1, 2]` | 1 | the literal pin, which SHADOWS the join |
| F5 aggregate admits a non-success shard | 1 | ``admit only `success` `` |

## Not changed

No required context changes name, the aggregate keeps `needs: [changes, fast-gate-tests]`, and `check` and `check-macos` keep their own `[1, 2]` matrices and `/2` denominators, verified untouched. The runner switch is untouched. Read back from a real YAML parse rather than from the text.

## What this does not do

It does not get the gate under ten minutes, and it does not claim to. The count was never the lever. The floor is, and naming what sits inside the 235 s of `Test` overhead and the 390 s indivisible chunk is the next measurement rather than the next change.

Reverts the shard count from kin#1308, squash `3481be9c9a0adfe2b112b98b1c88ccd5c8dad3b5`, and keeps its guard.
