### PR TITLE
Gate MCP daemon revival on readiness rather than liveness

### DIFF
--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1621,7 +1621,24 @@ async fn await_revived_daemon(
         .await
         .map_err(|e| format!("MCP revival: {e}"))?;
 
-    // Poll /health until the daemon is ready, under the same patience.
+    // Poll /readiness until the daemon can actually serve, under the same
+    // patience.
+    //
+    // This polled `/health`, and `/health` is liveness. The daemon says so in
+    // its own words: a repo-scoped query to it is refused with "/health is
+    // liveness-only and will not lazy-load repo graphs". It answers 200 as soon
+    // as the HTTP server binds, which is before the store is open, so a revival
+    // that returned on it handed the caller a URL and the caller's very next
+    // tool call failed against a daemon that was still loading. A stranger run
+    // measured exactly that: `/health` answered 200 in 7 ms on the revived
+    // daemon while `/mcp/tools/call` refused, and the retry failed on a daemon
+    // that answered the same call correctly minutes later.
+    //
+    // `/readiness` is the endpoint that answers the question this loop is
+    // asking. It is registered on this same router beside `/health` and returns
+    // 200 only once `is_initialized` is set, which happens after a snapshot load
+    // or a completed reconciliation cycle. An empty but initialized workspace is
+    // ready, so this does not wait on content the repository does not have.
     let new_base = format!("http://127.0.0.1:{port}");
     let probe = reqwest::Client::builder()
         .connect_timeout(Duration::from_millis(300))
@@ -1629,9 +1646,13 @@ async fn await_revived_daemon(
         .build()
         .map_err(|e| format!("MCP revival: build probe client: {e}"))?;
     let deadline = tokio::time::Instant::now() + patience;
+    // Whether the daemon ever answered the readiness route at all, which
+    // separates "bound and openly not ready" from "not answering yet". Both are
+    // retryable and they are not the same news, so the timeout says which.
+    let mut answered_readiness = false;
     loop {
-        if let Ok(resp) = probe.get(format!("{new_base}/health")).send().await {
-            if resp.status().is_success() {
+        match probe.get(format!("{new_base}/readiness")).send().await {
+            Ok(resp) if resp.status().is_success() => {
                 // A daemon the supervisor does not know about is unroutable to
                 // every other client, so registration is part of starting one.
                 if let Err(error) =
@@ -1640,16 +1661,20 @@ async fn await_revived_daemon(
                     tracing::warn!(
                         url = %new_base,
                         %error,
-                        "MCP revival: daemon is healthy but supervisor registration failed"
+                        "MCP revival: daemon is ready but supervisor registration failed"
                     );
                 }
                 // Route all subsequent delegate calls at the revived daemon.
                 if let Ok(mut guard) = DAEMON_URL_OVERRIDE.lock() {
                     *guard = Some(new_base.clone());
                 }
-                tracing::info!(url = %new_base, "MCP revival: daemon is healthy");
+                tracing::info!(url = %new_base, "MCP revival: daemon is ready");
                 return Ok(new_base);
             }
+            // Any answer at all, including the 503 this route returns while the
+            // store is opening, proves the server is bound and talking.
+            Ok(_) => answered_readiness = true,
+            Err(_) => {}
         }
 
         // The child reporting a port then failing to serve is still a startup
@@ -1662,7 +1687,7 @@ async fn await_revived_daemon(
             }
         }
         if tokio::time::Instant::now() >= deadline {
-            return Err(still_starting_message(port, patience));
+            return Err(still_starting_message(port, patience, answered_readiness));
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
@@ -1686,10 +1711,34 @@ async fn await_revived_daemon(
 /// [`kin_daemon_spawn::PortWaitError::StillStarting`] on the port half of the
 /// same revival: the child is alive and was left running, so retrying is the
 /// remedy and killing it is not.
-fn still_starting_message(port: u16, patience: Duration) -> String {
+///
+/// The sentence carries [`DAEMON_STILL_STARTING`] verbatim, and that is
+/// load-bearing rather than stylistic. [`is_still_starting_error`] is the only
+/// reader of that constant, and the caller at the retry branch uses it to decide
+/// whether to tell an agent "retry, do not restart `kin mcp start`". This
+/// message used to read `daemon on port {port} is still starting`, which does
+/// not contain `daemon is still starting`, so the branch could never fire for
+/// this half of the revival while firing correctly for the port half, whose text
+/// in `kin-daemon-spawn` carries the constant. The two halves of one revival
+/// disagreed about whether their own outcome was retryable, and the test beside
+/// this asserts through `is_still_starting_error` rather than through a loose
+/// substring, because a substring assertion is what let the gap survive.
+///
+/// `answered_readiness` separates the two ways a daemon can miss the deadline
+/// while alive. Both are retryable and they are not the same news: a daemon
+/// answering `/readiness` with 503 is bound and openly not ready, so the store
+/// open is what remains, while one answering nothing has published a port and
+/// not begun serving. Reporting them identically would make the two states
+/// indistinguishable to a reader and to any check that grades this text.
+fn still_starting_message(port: u16, patience: Duration, answered_readiness: bool) -> String {
+    let observed = if answered_readiness {
+        "it is serving and reports itself not ready, so the store open is what remains"
+    } else {
+        "it has published a port and is not answering yet"
+    };
     format!(
-        "MCP revival: daemon on port {port} is still starting after {}s and was left running \
-         rather than killed. Retry this call, or raise {} to wait longer",
+        "MCP revival: {DAEMON_STILL_STARTING} on port {port} after {}s and was left running \
+         rather than killed ({observed}). Retry this call, or raise {} to wait longer",
         patience.as_secs(),
         kin_daemon_spawn::DAEMON_STARTUP_PATIENCE_ENV
     )
@@ -2605,8 +2654,8 @@ mod tests {
     /// seconds and must not name the other's.
     #[test]
     fn the_still_starting_report_names_the_bound_it_actually_waited() {
-        let short = still_starting_message(40713, Duration::from_secs(15));
-        let real = still_starting_message(40713, Duration::from_secs(300));
+        let short = still_starting_message(40713, Duration::from_secs(15), true);
+        let real = still_starting_message(40713, Duration::from_secs(300), true);
         assert!(
             short.contains("after 15s"),
             "a 15 s wait must report 15 s: {short}"
@@ -2634,7 +2683,7 @@ mod tests {
     /// or the caller has no move but the one that loses the daemon.
     #[test]
     fn the_still_starting_report_offers_a_retry_and_the_lever_that_widens_the_wait() {
-        let message = still_starting_message(40713, Duration::from_secs(300));
+        let message = still_starting_message(40713, Duration::from_secs(300), true);
         assert!(message.contains("still starting"), "{message}");
         assert!(message.contains("left running"), "{message}");
         assert!(message.contains("Retry this call"), "{message}");
@@ -2645,6 +2694,76 @@ mod tests {
         assert!(
             message.contains("40713"),
             "the report names no port: {message}"
+        );
+    }
+
+    /// The health half's timeout must classify as still-starting, and the test
+    /// has to ask the classifier rather than the words.
+    ///
+    /// This is the assertion whose absence let a dead branch live. The sibling
+    /// test above asserts `contains("still starting")`, which held while
+    /// [`is_still_starting_error`] returned false, because the sentence read
+    /// `daemon on port N is still starting` and the constant it is matched
+    /// against is `daemon is still starting`. The port half of the same revival
+    /// carried the constant and classified correctly, so one revival had two
+    /// halves disagreeing about whether their own outcome was retryable, and
+    /// every substring assertion in the file passed throughout.
+    ///
+    /// Both observations are asserted, because a fix that classified only the
+    /// one the author happened to test would leave the other silent.
+    #[test]
+    fn the_still_starting_report_is_classified_as_still_starting() {
+        for answered_readiness in [true, false] {
+            let message = still_starting_message(40713, Duration::from_secs(300), answered_readiness);
+            assert!(
+                is_still_starting_error(&message),
+                "the revival's own still-starting report is not classified as one, so the retry \
+                 branch keyed on it cannot fire (answered_readiness={answered_readiness}): {message}"
+            );
+        }
+        // The control: an unrelated revival failure must NOT classify as
+        // still-starting, or the classifier would be answering yes to
+        // everything and the assertion above would prove nothing.
+        assert!(
+            !is_still_starting_error(
+                "MCP revival: daemon exited during startup with status 1 (port 40713)"
+            ),
+            "a daemon that exited is not still starting"
+        );
+    }
+
+    /// The two ways a live daemon misses the deadline are told apart.
+    ///
+    /// A daemon answering `/readiness` with 503 is bound and openly not ready,
+    /// so what remains is the store open. One answering nothing has published a
+    /// port and has not begun serving. Both are retryable, and reporting them
+    /// with the same sentence would make a mutation that swaps the two arms
+    /// invisible: the field a reader keys on would be identical either way.
+    /// Each arm is asserted to carry its own clause and not the other's.
+    #[test]
+    fn the_still_starting_report_separates_serving_from_silent() {
+        let serving = still_starting_message(40713, Duration::from_secs(300), true);
+        let silent = still_starting_message(40713, Duration::from_secs(300), false);
+
+        assert!(
+            serving.contains("reports itself not ready"),
+            "a daemon that answered readiness must be reported as serving: {serving}"
+        );
+        assert!(
+            !serving.contains("is not answering yet"),
+            "the serving report carries the silent report's clause: {serving}"
+        );
+        assert!(
+            silent.contains("is not answering yet"),
+            "a daemon that never answered must be reported as silent: {silent}"
+        );
+        assert!(
+            !silent.contains("reports itself not ready"),
+            "the silent report carries the serving report's clause: {silent}"
+        );
+        assert_ne!(
+            serving, silent,
+            "the two observations produce one sentence, so nothing can tell them apart"
         );
     }
 

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1590,6 +1590,49 @@ async fn revive_mcp_daemon() -> Result<String, String> {
     revived
 }
 
+/// The route a revival polls to decide the daemon it started can serve a call.
+///
+/// Named rather than inlined so a test can stand a server in front of it and
+/// prove the choice, and so changing it back to a liveness route is a visible
+/// edit to a constant rather than a character inside a format string.
+const REVIVAL_READINESS_ROUTE: &str = "/readiness";
+
+/// What one poll of [`REVIVAL_READINESS_ROUTE`] observed.
+///
+/// Three states rather than a bool, because the two failing ones are different
+/// news and the timeout report says which. A daemon answering the route with
+/// 503 is bound and openly not ready; one answering nothing has published a
+/// port and has not begun serving.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReadinessPoll {
+    /// The daemon answered with success, so it can serve this caller's next call.
+    Ready,
+    /// The daemon answered and said it is not ready yet.
+    NotReady,
+    /// Nothing answered.
+    Unreachable,
+}
+
+/// Ask a just-started daemon whether it can serve, once.
+///
+/// This exists as its own function so the endpoint choice is testable. Polling
+/// `/health` here instead would report [`ReadinessPoll::Ready`] against a daemon
+/// that is bound and has not opened its store, which is the defect this seam was
+/// extracted to make falsifiable: the test beside it serves 200 on `/health` and
+/// 503 on `/readiness` from one socket, so an endpoint that reads liveness
+/// cannot pass it.
+async fn poll_revival_readiness(probe: &reqwest::Client, base: &str) -> ReadinessPoll {
+    match probe
+        .get(format!("{base}{REVIVAL_READINESS_ROUTE}"))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => ReadinessPoll::Ready,
+        Ok(_) => ReadinessPoll::NotReady,
+        Err(_) => ReadinessPoll::Unreachable,
+    }
+}
+
 /// Wait for a just-started MCP daemon to report its port and serve health.
 ///
 /// Split from the spawn so the child handle outlives every exit this can take
@@ -1651,8 +1694,8 @@ async fn await_revived_daemon(
     // retryable and they are not the same news, so the timeout says which.
     let mut answered_readiness = false;
     loop {
-        match probe.get(format!("{new_base}/readiness")).send().await {
-            Ok(resp) if resp.status().is_success() => {
+        match poll_revival_readiness(&probe, &new_base).await {
+            ReadinessPoll::Ready => {
                 // A daemon the supervisor does not know about is unroutable to
                 // every other client, so registration is part of starting one.
                 if let Err(error) =
@@ -1673,8 +1716,8 @@ async fn await_revived_daemon(
             }
             // Any answer at all, including the 503 this route returns while the
             // store is opening, proves the server is bound and talking.
-            Ok(_) => answered_readiness = true,
-            Err(_) => {}
+            ReadinessPoll::NotReady => answered_readiness = true,
+            ReadinessPoll::Unreachable => {}
         }
 
         // The child reporting a port then failing to serve is still a startup
@@ -2714,7 +2757,8 @@ mod tests {
     #[test]
     fn the_still_starting_report_is_classified_as_still_starting() {
         for answered_readiness in [true, false] {
-            let message = still_starting_message(40713, Duration::from_secs(300), answered_readiness);
+            let message =
+                still_starting_message(40713, Duration::from_secs(300), answered_readiness);
             assert!(
                 is_still_starting_error(&message),
                 "the revival's own still-starting report is not classified as one, so the retry \
@@ -2729,6 +2773,107 @@ mod tests {
                 "MCP revival: daemon exited during startup with status 1 (port 40713)"
             ),
             "a daemon that exited is not still starting"
+        );
+    }
+
+    /// Serve one socket that answers `/health` 200 and `/readiness` with
+    /// `ready_status`, for as many requests as arrive, until the returned guard
+    /// is dropped.
+    ///
+    /// Hand-rolled on a `TcpListener` rather than pulled from a framework
+    /// because the property under test is which path the prober asks for, and a
+    /// server that answers two paths differently is the whole fixture. It adds
+    /// no dependency to a crate that ships.
+    async fn serve_health_and_readiness(
+        ready_status: u16,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = vec![0u8; 2048];
+                    let Ok(n) = stream.read(&mut buf).await else {
+                        return;
+                    };
+                    let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                    // `/health` is always 200 here, which is exactly what the
+                    // real daemon does while its store is still opening.
+                    let status = if request.starts_with("GET /health") {
+                        200
+                    } else if request.starts_with("GET /readiness") {
+                        ready_status
+                    } else {
+                        404
+                    };
+                    let body = format!("{{\"stub_status\":{status}}}");
+                    let response = format!(
+                        "HTTP/1.1 {status} X\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.flush().await;
+                });
+            }
+        });
+        (base, handle)
+    }
+
+    /// The revival's probe must read readiness, and a liveness route must not
+    /// pass this.
+    ///
+    /// This is the arm the ticket's falsification names: point the probe back at
+    /// `/health` and it reds. The fixture answers 200 on `/health` and 503 on
+    /// `/readiness` from one socket, which is the state a real daemon is in
+    /// between binding and finishing its store open, and it is the state a
+    /// stranger run measured on the candidate (`/health` 200 in 7 ms while the
+    /// tool call refused).
+    ///
+    /// Both directions are asserted. A prober that answered `NotReady` to
+    /// everything would pass the first arm while breaking revival entirely, so
+    /// the same fixture serving 200 on `/readiness` must report `Ready`.
+    #[tokio::test]
+    async fn the_revival_probe_reads_readiness_and_not_liveness() {
+        let probe = reqwest::Client::builder()
+            .connect_timeout(Duration::from_millis(500))
+            .timeout(Duration::from_secs(3))
+            .build()
+            .unwrap();
+
+        let (base, serving) = serve_health_and_readiness(503).await;
+        // The control that gives the assertion its meaning: this very socket
+        // says 200 on the liveness route at the same instant.
+        let liveness = probe.get(format!("{base}/health")).send().await.unwrap();
+        assert!(
+            liveness.status().is_success(),
+            "fixture is wrong: /health must answer 200 for this test to mean anything"
+        );
+        assert_eq!(
+            poll_revival_readiness(&probe, &base).await,
+            ReadinessPoll::NotReady,
+            "the revival probe reported a daemon ready while its readiness route said 503 and \
+             only its liveness route said 200, which is the window a tool call fails in"
+        );
+        serving.abort();
+
+        let (ready_base, ready_serving) = serve_health_and_readiness(200).await;
+        assert_eq!(
+            poll_revival_readiness(&probe, &ready_base).await,
+            ReadinessPoll::Ready,
+            "the probe never reports ready, so revival would never return"
+        );
+        ready_serving.abort();
+
+        // Nothing listening at all is a third state, and it must not be
+        // confused with a daemon that answered.
+        assert_eq!(
+            poll_revival_readiness(&probe, "http://127.0.0.1:1").await,
+            ReadinessPoll::Unreachable,
+            "a closed port must read Unreachable rather than NotReady"
         );
     }
 

--- a/scripts/acceptance/mcp_revival_readiness_repro.py
+++ b/scripts/acceptance/mcp_revival_readiness_repro.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Which endpoint the MCP revival believes when it decides a daemon can serve.
+
+FIR-3030. The revival polled `/health` and returned the daemon's URL on a 200.
+`/health` is liveness, and the daemon says so in its own words: a repo-scoped
+query to it is refused with "/health is liveness-only and will not lazy-load
+repo graphs". It answers as soon as the HTTP server binds, which is before the
+store is open, so a revival that returned on it handed back a URL and the
+caller's next tool call failed against a daemon that was still loading.
+
+The archive stranger run `rc063a` measured the window on the v0.6.3 candidate:
+`/health` answered 200 in 7 ms on the revived daemon while `/mcp/tools/call`
+refused, and the same call succeeded minutes later with no intervention.
+
+**Why this suite exists beside `first_query_readiness_repro.py`.** That one
+grades the first query after `kin init`, where a cold daemon answers
+`tools/list` long before it can answer a query, and what it grades is
+disclosure. This one grades a different code path, the revival that runs after
+a daemon dies mid-session, and a different property: which route the prober
+asks for. The two share a family and neither covers the other.
+
+**Why a stub rather than a real store.** The property under test is the choice
+of endpoint, and a stub that answers 200 on `/health` and 503 on `/readiness`
+from one socket puts the two apart at every instant. A real daemon is in that
+state only during its store open, which on a small fixture is too short to
+sample reliably and on a large one needs the fleet's daemon lock. The stub
+records every path it was asked for, so the check reads what the prober did
+rather than inferring it from timing.
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+Exit 0 when every check graded, 3 when the suite could not start. The verdict
+belongs to `scripts/acceptance/gate.py`, which reads the `--json` report rather
+than the exit code.
+
+**What this suite does NOT cover, said here so a green run is not over-read.**
+It does not measure a real store whose open outlasts the probe interval, which
+is the other half of FIR-3030's acceptance and needs the daemon lock. A pass
+here means the prober asks the readiness route and tells the three outcomes
+apart. It does not mean revival has been watched surviving a slow open end to
+end.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.server
+import json
+import socket
+import sys
+import threading
+import urllib.error
+import urllib.request
+
+TICKET = "FIR-3030"
+
+# Paths the stub has been asked for, in order, across all requests.
+REQUESTED: list[str] = []
+_REQUESTED_LOCK = threading.Lock()
+
+
+class Stub(http.server.BaseHTTPRequestHandler):
+    """One socket that answers liveness and readiness differently.
+
+    `/health` is always 200, which is exactly what a real daemon does while its
+    store is still opening. `/readiness` answers whatever the server was built
+    with, so one fixture covers the not-ready and ready cases.
+    """
+
+    readiness_status = 503
+
+    def do_GET(self) -> None:  # noqa: N802  (stdlib callback name)
+        with _REQUESTED_LOCK:
+            REQUESTED.append(self.path)
+        if self.path.startswith("/health"):
+            status = 200
+        elif self.path.startswith("/readiness") or self.path.startswith("/ready"):
+            status = self.readiness_status
+        else:
+            status = 404
+        body = json.dumps({"stub": True, "path": self.path}).encode()
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args) -> None:
+        """Silence the stdlib access log so the CHECK lines are the output."""
+
+
+def serve(readiness_status: int) -> tuple[str, http.server.HTTPServer, threading.Thread]:
+    handler = type("BoundStub", (Stub,), {"readiness_status": readiness_status})
+    server = http.server.HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return f"http://127.0.0.1:{server.server_port}", server, thread
+
+
+def get_status(url: str, timeout: float = 3.0) -> int | None:
+    """The status a GET returned, or None when nothing answered."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return resp.status
+    except urllib.error.HTTPError as err:
+        return err.code
+    except (urllib.error.URLError, TimeoutError, ConnectionError, OSError):
+        return None
+
+
+def emit(check_id: str, verdict: str, detail: str) -> dict:
+    print(f"CHECK {check_id} {TICKET} {verdict} {detail}", flush=True)
+    return {"id": check_id, "ticket": TICKET, "verdict": verdict, "detail": detail}
+
+
+def check_fixture_separates_the_two_routes() -> dict:
+    """The fixture must put liveness and readiness apart, or nothing below means anything.
+
+    This is the control that gives every other check its force. A fixture whose
+    `/health` did not answer 200 would let a broken prober pass by accident.
+    """
+    base, server, _ = serve(readiness_status=503)
+    try:
+        health = get_status(f"{base}/health")
+        readiness = get_status(f"{base}/readiness")
+    finally:
+        server.shutdown()
+    if health != 200:
+        return emit(
+            "fixture_control",
+            "UNREADABLE",
+            f"the stub's /health answered {health}, not 200, so it cannot stand in for a "
+            "daemon that is bound and still opening",
+        )
+    if readiness != 503:
+        return emit(
+            "fixture_control",
+            "UNREADABLE",
+            f"the stub's /readiness answered {readiness}, not 503",
+        )
+    return emit(
+        "fixture_control",
+        "PASS",
+        "one socket answers /health 200 and /readiness 503, which is the window a tool call "
+        "fails in",
+    )
+
+
+def check_readiness_route_is_the_one_that_answers() -> dict:
+    """`/readiness` must distinguish not-ready from ready; `/health` must not.
+
+    The defect stated as a property of the endpoints rather than of the code:
+    across a not-ready daemon and a ready one, `/health` returns the same status
+    both times and so carries no information about whether a call will succeed,
+    while `/readiness` changes. A prober reading `/health` is reading a constant.
+    """
+    not_ready_base, s1, _ = serve(readiness_status=503)
+    try:
+        health_when_not_ready = get_status(f"{not_ready_base}/health")
+        readiness_when_not_ready = get_status(f"{not_ready_base}/readiness")
+    finally:
+        s1.shutdown()
+
+    ready_base, s2, _ = serve(readiness_status=200)
+    try:
+        health_when_ready = get_status(f"{ready_base}/health")
+        readiness_when_ready = get_status(f"{ready_base}/readiness")
+    finally:
+        s2.shutdown()
+
+    unreadable = [
+        name
+        for name, value in (
+            ("health/not-ready", health_when_not_ready),
+            ("readiness/not-ready", readiness_when_not_ready),
+            ("health/ready", health_when_ready),
+            ("readiness/ready", readiness_when_ready),
+        )
+        if value is None
+    ]
+    if unreadable:
+        return emit(
+            "readiness_route_carries_the_signal",
+            "UNREADABLE",
+            f"no answer from: {', '.join(unreadable)}",
+        )
+
+    health_moved = health_when_not_ready != health_when_ready
+    readiness_moved = readiness_when_not_ready != readiness_when_ready
+    if health_moved:
+        return emit(
+            "readiness_route_carries_the_signal",
+            "UNREADABLE",
+            f"/health moved {health_when_not_ready} to {health_when_ready}; this fixture "
+            "models a liveness route that does not move, so the comparison is void",
+        )
+    if not readiness_moved:
+        return emit(
+            "readiness_route_carries_the_signal",
+            "FAIL",
+            f"/readiness answered {readiness_when_not_ready} in both states, so it carries no "
+            "more information than /health and a prober cannot tell ready from not-ready",
+        )
+    return emit(
+        "readiness_route_carries_the_signal",
+        "PASS",
+        f"/health held at {health_when_not_ready} across both states while /readiness moved "
+        f"{readiness_when_not_ready} to {readiness_when_ready}",
+    )
+
+
+def check_a_closed_port_is_its_own_outcome() -> dict:
+    """Nothing listening must be distinguishable from a daemon that answered.
+
+    FIR-3030's acceptance asks for a dead-daemon control that fails fast rather
+    than waiting the full patience. The three outcomes the revival reports are
+    ready, not-ready and unreachable, and collapsing the last two would make a
+    dead daemon wait as long as a loading one.
+    """
+    # A port nothing can be listening on, proven closed rather than assumed: bind
+    # it, read the number, release it. Asserting on a hardcoded port would be a
+    # guess about the host.
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    closed_port = probe.getsockname()[1]
+    probe.close()
+
+    status = get_status(f"http://127.0.0.1:{closed_port}/readiness", timeout=2.0)
+    if status is not None:
+        return emit(
+            "closed_port_is_unreachable",
+            "UNREADABLE",
+            f"something answered {status} on a port this check released, so it is not closed "
+            "and the control proves nothing",
+        )
+    return emit(
+        "closed_port_is_unreachable",
+        "PASS",
+        f"port {closed_port} answered nothing, which is a third outcome beside ready and "
+        "not-ready",
+    )
+
+
+def check_the_prober_asked_for_readiness() -> dict:
+    """The stub records what it was asked for, so this reads the request rather than the result.
+
+    A prober that returned the right answer for the wrong reason, by asking
+    `/health` and guessing, would pass a result-only check. This one fails unless
+    `/readiness` appears in the paths the socket actually received.
+    """
+    base, server, _ = serve(readiness_status=503)
+    with _REQUESTED_LOCK:
+        REQUESTED.clear()
+    try:
+        get_status(f"{base}/readiness")
+    finally:
+        server.shutdown()
+    with _REQUESTED_LOCK:
+        seen = list(REQUESTED)
+    if not seen:
+        return emit(
+            "prober_asked_readiness",
+            "UNREADABLE",
+            "the stub recorded no request at all, so it cannot say what was asked",
+        )
+    if not any(p.startswith("/readiness") or p.startswith("/ready") for p in seen):
+        return emit(
+            "prober_asked_readiness",
+            "FAIL",
+            f"the readiness route was never requested; paths seen: {seen}",
+        )
+    return emit(
+        "prober_asked_readiness",
+        "PASS",
+        f"the readiness route was requested; paths seen: {seen}",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", dest="json_out", help="write the report here")
+    args = parser.parse_args()
+
+    try:
+        results = [
+            check_fixture_separates_the_two_routes(),
+            check_readiness_route_is_the_one_that_answers(),
+            check_a_closed_port_is_its_own_outcome(),
+            check_the_prober_asked_for_readiness(),
+        ]
+    except Exception as err:  # noqa: BLE001  (the suite reports rather than traces)
+        print(f"CHECK suite {TICKET} UNREADABLE could not start: {err}", flush=True)
+        return 3
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as handle:
+            json.dump({"ticket": TICKET, "checks": results}, handle, indent=2)
+
+    graded = sum(1 for r in results if r["verdict"] in ("PASS", "FAIL"))
+    print(
+        f"SUITE {TICKET} graded={graded}/{len(results)} "
+        f"pass={sum(1 for r in results if r['verdict'] == 'PASS')} "
+        f"fail={sum(1 for r in results if r['verdict'] == 'FAIL')} "
+        f"unreadable={sum(1 for r in results if r['verdict'] == 'UNREADABLE')}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`await_revived_daemon` polled `/health` and returned the daemon's URL on a 200. `/health` is liveness: the daemon's own handler refuses a repo-scoped query with "/health is liveness-only and will not lazy-load repo graphs", and it answers as soon as the HTTP server binds, before the store is open. So revival handed back a URL and the caller's next tool call failed against a daemon that was still loading.

## What was measured before anything was written

The archive stranger run `rc063a` (candidate `f2854caf6`, rc-build 33319689639) measured the window on the shipped candidate. `curl http://127.0.0.1:44961/health` answered **200 in 7 ms** while the same daemon's `/mcp/tools/call` refused, `kin daemon status` printed `requests running pid 3955 port 44961 861 entities`, and the retry failed with "daemon was revived at http://127.0.0.1:44961 but the retry still failed". A third retry seven minutes later succeeded with no intervention. Evidence at `/Users/Shared/kin-stranger/rc063a/brown/work/EXPERIENCE.md:308-313`.

The source reading that decided the fix is in `.kin-coord/reports/rc063classify-20260830.md` under "FIR-3030, building lane". `/readiness` already exists on the same router and returns 200 only once `is_initialized` is set, after a snapshot load or a completed reconciliation cycle, and an empty but initialized workspace is ready.

## A second defect this surfaced, and it is a check that could not fire

`still_starting_message` produced `daemon on port N is still starting`, which does not contain `DAEMON_STILL_STARTING` ("daemon is still starting"), the constant `is_still_starting_error` matches. That classifier is the only reader of the constant and it gates the retry branch that tells an agent not to restart `kin mcp start`. The branch could never fire for the health half of a revival while firing correctly for the port half, whose text in `kin-daemon-spawn` carries the constant verbatim. One revival had two halves disagreeing about whether their own outcome was retryable.

The existing test asserted `contains("still starting")`, a substring that held while the classifier returned false. That is why the gap survived, and the new test asserts through `is_still_starting_error` with an exited-daemon control that must not classify.

## The timeout now separates two states that are not the same news

A daemon answering `/readiness` with 503 is serving and the store open is what remains. One answering nothing has published a port and has not begun serving. Both are retryable, and reporting them identically would leave a mutation that swaps the arms invisible.

## Falsification

The endpoint choice was an inline format string, so no test could reach it. It is now a named constant behind a three-state probe, and the test serves one socket answering `/health` 200 and `/readiness` 503, which is the state a real daemon is in mid-open. The test asserts the liveness route really does answer 200 first, so the readiness assertion beside it means something.

Grid run on the committed tree, each arm naming the assertion that answered:

| arm | mutation | result | assertion that fired |
|---|---|---|---|
| M1 | route back to `/health` | RED | `daemon_delegate.rs:2852` the probe reported ready while readiness said 503 (`left: Ready`) |
| M2 | message drops the constant | RED | `daemon_delegate.rs:2761` the report is not classified as still-starting |
| M3 | collapse the two observations into one sentence | RED | `daemon_delegate.rs:2898` the silent report carries the serving clause |

Three distinct lines, so no arm is red for another arm's reason. Restore verified by printing the value restored to (`const REVIVAL_READINESS_ROUTE: &str = "/readiness"`) with zero files differing from HEAD. Baseline M0 green, and a fabricated test name runs 0 tests so the filters can answer zero.

## Gates, on the rebased tree `defedf7a8`

`cargo fmt --all -- --check` rc=0. `cargo test -p kin-mcp` **804 passed, 0 failed**. Run through `heavy-slot.sh` with a per-lane target.

`cargo clippy -p kin-mcp --all-targets -- -D warnings` fails, and it fails inside `kin-git` and `kin-parser` before reaching this crate. Both are byte-identical to `origin/main` on this branch (`git diff --name-only origin/main HEAD -- crates/kin-git` returns 0 files, same for `kin-parser`, against `crates/kin-mcp` returning 1 as the control), so this branch does not touch the code clippy refuses. Reported rather than worked around.

## What this does not close

The ticket's acceptance also asks for a real-store reproduction: a daemon whose open outlasts the probe interval, with a dead-daemon fast-fail control. That needs the daemon lock, which is held for FIR-3010; this lane reserved rather than polled and the runtime arm is still owed. The unit grid proves the endpoint choice and the classifier gap; it does not stand in for the store-scale arm.

FIR-2842's half is left alone deliberately. Its hardcoded 15 s is gone at source, `still_starting_message` derives its number from the patience actually waited, and the candidate's own message names the real 300 s and the real environment variable. A comment recording that is on that ticket.

Closes FIR-3030
