### PR TITLE
Grade the graph holding the edit, and name when the tree became current

### DIFF
--- a/crates/kin-cli/src/commands/admit.rs
+++ b/crates/kin-cli/src/commands/admit.rs
@@ -111,6 +111,17 @@ pub struct AdmitReport {
     /// the two answers this field exists to keep apart.
     #[serde(default)]
     pub tree_moved: Option<bool>,
+    /// Wall-clock time of the admission that ran BEFORE this pass, RFC 3339.
+    ///
+    /// Read on the daemon before this pass records its own success, because the
+    /// probes keep one last-success clock and this pass overwrites it. Present
+    /// so a settled answer can name what settled it: the watch loop admits on a
+    /// 100ms poll, so an operator who edits a file and immediately runs
+    /// `kin admit` is often told nothing changed by a pass that is correct and
+    /// unhelpful. `None` means no earlier admission is recorded, which is not
+    /// the same as one having happened at an unknown time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prior_admission_at: Option<String>,
     /// False when the pass itself failed. The request still returns its report
     /// so the operator sees the counters and the recorded cause; the CLI exits
     /// nonzero.
@@ -202,11 +213,25 @@ pub fn summary_lines(report: &AdmitReport) -> Vec<String> {
                  added or removed. {} tracked artifacts, {} entities.",
                 report.tracked_after, report.entities_after
             )),
-            Some(false) => lines.push(format!(
-                "Admitted the complete exact tree; nothing changed. {} tracked artifacts, {} \
-                 entities.",
-                report.tracked_after, report.entities_after
-            )),
+            Some(false) => lines.push(match report.prior_admission_at.as_deref() {
+                // Naming the basis rather than only the verdict, the way
+                // kin#1254 did for the `Tree:` line. "Nothing changed" is true
+                // and reads as "your edit was not taken" to the one reader most
+                // likely to see it: someone who just edited a file. What settles
+                // that is WHEN the tree became current, so say it.
+                Some(at) => format!(
+                    "Admitted the complete exact tree; nothing was left to admit, because the \
+                     working copy was already admitted at {at}. {} tracked artifacts, {} \
+                     entities.",
+                    report.tracked_after, report.entities_after
+                ),
+                None => format!(
+                    "Admitted the complete exact tree; nothing changed, and no earlier \
+                     admission is recorded to say when the tree became current. {} tracked \
+                     artifacts, {} entities.",
+                    report.tracked_after, report.entities_after
+                ),
+            }),
             None => lines.push(format!(
                 "Admitted the complete exact tree. {} tracked artifacts, {} entities, and \
                  neither count moved; this daemon does not report whether content moved, so \
@@ -468,6 +493,7 @@ mod tests {
             embeddings_total: 14187,
             reconcile: ReconcileHealth::default(),
             tree_moved: Some(true),
+            prior_admission_at: None,
             admitted,
             failure: (!admitted)
                 .then(|| "host entry changed after exact-tree admission".to_string()),
@@ -512,6 +538,48 @@ mod tests {
         let text = summary_lines(&content_only_pass(Some(false))).join("\n");
         assert!(text.contains("nothing changed"), "{text}");
         assert!(!text.contains("content changed"), "{text}");
+    }
+
+    /// A settled pass names WHEN the tree became current.
+    ///
+    /// "Nothing changed" is true and reads as "your edit was not taken" to the
+    /// one reader most likely to see it, someone who edited a file a second
+    /// earlier. Measured on kin 0.6.2 at 510be53f9: the watch loop drains its
+    /// file watcher every 100ms and admits what it finds, so an admit issued
+    /// 1.0s after a write reported nothing changed 6 times out of 6, while one
+    /// issued immediately reported the content change 6 out of 6. The pass was
+    /// right both times. What was missing was the basis, so this asserts the
+    /// clock is named AND that the bare wording is gone, because a branch that
+    /// appended a time without replacing the sentence would pass a weaker test.
+    #[test]
+    fn a_settled_pass_names_when_the_tree_became_current() {
+        let mut settled = content_only_pass(Some(false));
+        settled.prior_admission_at = Some("2026-08-30T20:04:00Z".to_string());
+        let text = summary_lines(&settled).join("\n");
+        assert!(
+            text.contains("already admitted at 2026-08-30T20:04:00Z"),
+            "a settled pass must name when the tree became current: {text}"
+        );
+        assert!(
+            !text.contains("nothing changed"),
+            "the basis replaces the bare wording rather than sitting beside it: {text}"
+        );
+    }
+
+    /// And the third answer stays three-way. No recorded admission is not the
+    /// same as one at an unknown time, so the absence is named rather than
+    /// rendered as a bare "nothing changed" that a reader would take for a
+    /// basis it does not have.
+    #[test]
+    fn a_settled_pass_with_no_recorded_admission_says_so_rather_than_inventing_one() {
+        let settled = content_only_pass(Some(false));
+        assert!(settled.prior_admission_at.is_none(), "fixture precondition");
+        let text = summary_lines(&settled).join("\n");
+        assert!(
+            text.contains("no earlier admission is recorded"),
+            "an absent clock must be named as absent: {text}"
+        );
+        assert!(!text.contains("already admitted at"), "{text}");
     }
 
     /// An unmeasured tree is the third answer and must render as neither of the

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -2022,6 +2022,7 @@ mod tests {
             embeddings_total: 6,
             reconcile: crate::commands::resources::ReconcileHealth::default(),
             tree_moved: Some(false),
+            prior_admission_at: None,
             admitted: true,
             failure: None,
         }))

--- a/crates/kin-daemon/src/repository_admit.rs
+++ b/crates/kin-daemon/src/repository_admit.rs
@@ -218,6 +218,19 @@ async fn run_pass(state: &DaemonState) -> Result<AdmitResponse> {
     // outcome on the surfaces that answer for the store.
     let now = Instant::now();
     let probes = state.background_work.reconcile();
+
+    // Read the PREVIOUS admission's clock before this pass records its own.
+    // `record_admission_success` below overwrites it and the report is built
+    // afterwards, so reading it there names this very pass at an age of zero,
+    // which says nothing about why there was nothing left to admit. The watch
+    // loop drains its file watcher every 100ms and admits what it finds, so a
+    // write can be admitted between an operator's edit and the `kin admit` they
+    // run about it; this is the clock that lets the summary say so.
+    let prior_admission_at = state
+        .background_work
+        .reconcile_report(now)
+        .last_admission_success_at;
+
     let failure = match &outcome {
         Ok(()) => {
             probes.record_admission_success(now);
@@ -262,6 +275,7 @@ async fn run_pass(state: &DaemonState) -> Result<AdmitResponse> {
         // identically.
         reconcile: state.background_work.reconcile_report(now),
         tree_moved: tree_moved(&before, &after),
+        prior_admission_at,
         admitted: failure.is_none(),
         failure,
     };

--- a/scripts/acceptance/vcs_read_surfaces_repro.py
+++ b/scripts/acceptance/vcs_read_surfaces_repro.py
@@ -318,21 +318,42 @@ def grade_diff_discloses_its_semantic_scope(text):
     return PASS, "the workspace diff names what its semantic counts cannot show"
 
 
-def grade_admit_does_not_claim_a_no_op(text):
-    body = text or ""
-    if "Admitted the complete exact tree" not in body:
-        return UNREADABLE, "kin admit printed no admission line: %s" % body.strip()[:200]
-    if "nothing changed" in body:
+def grade_admit_left_the_graph_holding_the_edit(before_text, after_text):
+    """Whether the graph holds the edit once the pass is done, read as two hashes.
+
+    This graded the admission's WORDING until it was measured. The wording cannot
+    carry the property: `content` and `settled` print the identical sentence,
+    "Admitted the complete exact tree; nothing changed", and only one of them is a
+    defect, so no reading of that string separates the two states it grades.
+
+    Worse, the sentence was a true statement about a pass that correctly admitted
+    nothing. The daemon's watch loop drains its file watcher every 100ms and
+    admits what it finds (`loop_runner.rs`, `run_loop_armed`), and it is armed
+    before `.kin/daemon.port` is published, so a write races an explicit
+    `kin admit` and the loop usually wins. Measured on kin 0.6.2 at 510be53f9,
+    six repetitions per arm: admitting immediately reported the content change 6
+    of 6, and waiting 1.0s or 3.0s reported nothing changed 6 of 6. A stat-keyed
+    cache predicts the opposite, since a staleness window shrinks as an mtime
+    ages, and a write preserving both size and mtime was still seen 6 of 6, so
+    nothing on this path trusts stat.
+
+    So the property is that the graph ends up holding the new bytes, whoever
+    admitted them. Read as two hashes for the reason `grade_status_saw_the_edit`
+    gives one check above: no wording can fake a hash moving.
+    """
+    before = tree_hash(before_text)
+    after = tree_hash(after_text)
+    if before is None or after is None:
+        return UNREADABLE, "kin status printed no Tree: line on one of the two reads"
+    if before == after:
         return FAIL, (
-            "a pass over an edited tracked file reported nothing changed: %s"
-            % body.strip().splitlines()[0]
+            "the tree is still %s after a tracked file was edited and admitted, so the "
+            "graph does not hold the edit" % before[:16]
         )
-    if "content changed" not in body:
-        return FAIL, (
-            "the pass neither claimed a no-op nor named the content change: %s"
-            % body.strip().splitlines()[0]
-        )
-    return PASS, "the pass named the content change: %s" % body.strip().splitlines()[0]
+    return PASS, (
+        "the graph holds the edit: the tree moved %s -> %s across the write and its "
+        "admission" % (before[:16], after[:16])
+    )
 
 
 def grade_admit_still_reports_a_true_no_op(text):
@@ -521,12 +542,13 @@ def check_content(suite):
     check grades. A read that mutates has to be treated as a mutation when
     ordering an experiment around it.
     """
+    before = suite.status_text()
     suite.write_tracked_module(MODULE_FOR_ADMIT)
     rc, out, err = suite.kin_run(["admit"])
     if rc != 0:
         return Result("content", UNREADABLE,
                       "%s kin admit exited %s: %s" % (TICKET, rc, (err or out)[-200:]))
-    status, detail = grade_admit_does_not_claim_a_no_op(out)
+    status, detail = grade_admit_left_the_graph_holding_the_edit(before, suite.status_text())
     return Result("content", status, "%s %s" % (TICKET, detail))
 
 
@@ -791,10 +813,6 @@ def self_test():
          (STATUS_WITH_MERGE, CONFLICTS_HELD), PASS),
         ("heldmerge/no-merge-opened", grade_status_names_a_held_merge,
          (STATUS_SILENT_DURING_MERGE, CONFLICTS_NONE), UNREADABLE),
-        ("content/no-op-claim", grade_admit_does_not_claim_a_no_op, ADMIT_NO_OP_CLAIM, FAIL),
-        ("content/moved", grade_admit_does_not_claim_a_no_op, ADMIT_CONTENT_MOVED, PASS),
-        ("content/unmeasured", grade_admit_does_not_claim_a_no_op, ADMIT_UNMEASURED, FAIL),
-        ("content/refused", grade_admit_does_not_claim_a_no_op, ADMIT_REFUSED, UNREADABLE),
         ("settled/no-op-claim", grade_admit_still_reports_a_true_no_op, ADMIT_NO_OP_CLAIM, PASS),
         ("settled/moved", grade_admit_still_reports_a_true_no_op, ADMIT_CONTENT_MOVED, FAIL),
         ("settled/unmeasured", grade_admit_still_reports_a_true_no_op, ADMIT_UNMEASURED, FAIL),
@@ -807,6 +825,16 @@ def self_test():
         ("sawedit/moved", grade_status_saw_the_edit, (STATUS_BARE, STATUS_BARE_AHEAD), PASS),
         ("sawedit/unmoved", grade_status_saw_the_edit, (STATUS_BARE, STATUS_BARE), FAIL),
         ("sawedit/no-tree-line", grade_status_saw_the_edit,
+         (STATUS_BARE, STATUS_NO_TREE), UNREADABLE),
+        # `content` grades the same property one step later: the graph holding
+        # the edit after the admission, rather than the admission's sentence.
+        # The unmoved row is what keeps FIR-2961's original finding covered,
+        # because it is the arm that reds when the graph does NOT hold the bytes.
+        ("content/moved", grade_admit_left_the_graph_holding_the_edit,
+         (STATUS_BARE, STATUS_BARE_AHEAD), PASS),
+        ("content/unmoved", grade_admit_left_the_graph_holding_the_edit,
+         (STATUS_BARE, STATUS_BARE), FAIL),
+        ("content/no-tree-line", grade_admit_left_the_graph_holding_the_edit,
          (STATUS_BARE, STATUS_NO_TREE), UNREADABLE),
     ])
     failures = 0


### PR DESCRIPTION
Fixes the intermittent `vcs_read_surfaces:content` FAIL that reddens main Acceptance. `kin admit` reported "nothing changed" over a fresh 277-byte write. **The pass was right. The check was wrong, and the sentence was unhelpful.**

## The mechanism, measured rather than argued

The daemon's watch loop drains its file watcher every 100ms and admits what it finds (`loop_runner.rs:3046`, inside `run_loop_armed`), and it is armed before `.kin/daemon.port` is published, by its own doc under FIR-2466. So a write races an explicit `kin admit`, the loop usually wins, and the pass correctly reports nothing left to admit.

`tree_moved` compares the GRAPH's resolved tree before and after the pass (`repository_admit.rs:143`), not the filesystem, so `false` has two producers: the pass failed to see the write, or the graph already held it.

Measured on kin 0.6.2 at `510be53f9`, six repetitions per arm, fresh repo and isolated `KIN_HOME` each, under the daemon lock:

| arm | delay | mtime | content changed | nothing changed |
|---|---|---|---|---|
| L0 | 0 | untouched | **6** | 0 |
| L1 | 1.0s | untouched | 0 | **6** |
| L2 | 3.0s | untouched | 0 | **6** |
| S1 | 0 | **pinned back, size preserved** | **6** | 0 |

**The delay flips the answer, and only one hypothesis predicts that direction.** A stat-keyed fast path predicts the opposite, because a staleness window shrinks as an mtime ages, so waiting would make the write more visible rather than less.

**S1 buries the stat hypothesis.** It writes a body the same length as the one it replaces, 58 bytes both, and pins the mtime back with `touch -t`. That is the worst case any size-plus-mtime or mtime-only key can be given. The admit reported the content change **6 of 6**. Nothing on this path trusts stat.

The same-code control agrees it is a race: run `33314932504` on `4661f9223`, attempt 1 failure, attempt 2 success.

## What changes

**The check grades the property, not the wording.** `content` and `settled` printed the identical sentence, "Admitted the complete exact tree; nothing changed", so no reading of that string could separate the two states it graded. It now reads two tree hashes, the way `grade_status_saw_the_edit` already does one check above, because no wording can fake a hash moving. `content/unmoved` is the row that keeps FIR-2961's original finding covered: it reds when the graph does NOT hold the bytes.

**The summary names its basis**, which kin#1254 started for the `Tree:` line. `run_pass` reads the previous admission's clock before recording its own, since the probes keep one last-success value and this pass overwrites it. Absence stays a third answer rather than collapsing into a claim.

## Falsification, with the two halves kept separate

```
M0  unmutated                     selftest 0   rust 0
A1  grader always returns PASS    selftest 1   rust 0   content/unmoved expected FAIL got PASS
A2  grader ignores the after side selftest 1   rust 0   content/moved, content/no-tree-line
B1  sentence drops the basis      selftest 0   rust 1   a_settled_pass_names_when_the_tree_became_current
B2  none-branch invents a basis   selftest 0   rust 1   a_settled_pass_with_no_recorded_admission_says_so_rather_than_inventing_one
```

Neither half's mutation reds the other's assertion, which is the property that makes the grid mean anything.

**A2 was wrong on its first run and the correction is worth having.** Its anchor matched the FIRST `after = tree_hash(after_text)` in the file, which belongs to `grade_status_saw_the_edit`, so it reddened the sibling's rows instead of this change's. Re-anchored on text unique to the new grader, it reds `content/moved` and `content/no-tree-line` while `sawedit/*` stay green. Reading WHICH assertion fired is what caught it.

Tree restored from saved copies and verified: zero mutation markers, selftest 28 of 28, admit tests 13 of 13.

## One thing deliberately not claimed

The sentence says "already admitted at <time>", not "already admitted by the watch loop". A prior admission has several producers, the loop and `kin status` and `/commands/commit` among them, and the report carries a timestamp rather than an author. Naming the loop would be a claim the data does not support.

Closes FIR-3010
