### PR TITLE
Register the ref-grammar suite in the workflow step-visibility guard

### DIFF
--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -128,6 +128,11 @@ EXPECTED_SUITES = (
         "acceptance/vcs_read_surfaces.json",
     ),
     ExpectedSuite(
+        "scripts/acceptance/ref_grammar_repro.py",
+        "ref_grammar",
+        "acceptance/ref_grammar.json",
+    ),
+    ExpectedSuite(
         "scripts/acceptance/diff_content_repro.py",
         "diff_content",
         "acceptance/diff_content.json",


### PR DESCRIPTION
kin#1307 wired the FIR-3015 acceptance suite into `acceptance.yml` at the three points a suite needs, the grader self-test, the run, and the report the verdict gate reads. There is a fourth, and I missed it: `EXPECTED_SUITES` in `scripts/acceptance/test_workflow_step_visibility.py`, the list that says every suite report reaches the always-running verdict in order.

So the guard has been correctly red on main since `bf8453fad`. It is the guard working, not a broken guard.

## What the guard says

Its message names the omission exactly. The workflow's actual inventory carries `('ref_grammar', 'acceptance/ref_grammar.json')` between `vcs_read_surfaces` and `diff_content`; the expected inventory does not. The entry goes in that same position rather than at the end, because the guard grades order as well as membership.

## Evidence

With the entry, against the real workflow:

```
workflow authority holds: 26 suite reports reach one always-running verdict in order
rc 0
```

The guard's own self-test: `all 2 controls clean, all 24 adversarial mutants caught`, rc 0.

Falsified by removing the entry, which reproduces main's current failure rather than inventing one:

```
MUTANT applied: ref_grammar entry removed
marker check: 0 occurrences
rc 1
VIOLATION: Acceptance verdict report inventory or order changed
  actual   ... ('vcs_read_surfaces', ...), ('ref_grammar', ...), ('diff_content', ...)
  expected ... ('vcs_read_surfaces', ...), ('diff_content', ...)
restored: 3 occurrences, rc 0
```

Both directions, with the marker asserted absent under the mutation and present after restore, so the red is the mutation's and the green is not a stale tree's.

## Scope

One entry, three lines. No product code, no workflow change, no test behaviour change beyond the registration this should have carried in #1307.
