### PR TITLE
Read a receipt's published change in one place, and only when history moved

### DIFF
--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -509,16 +509,17 @@ fn landed_commit_for_operation(
     else {
         return Ok(None);
     };
-    let Some((branch, change_id)) = landed_change_in(
-        &receipt.operation.ref_mutations,
-        receipt
-            .operation
-            .workspace_mutation
-            .as_ref()
-            .map(|workspace| &workspace.new_head),
-    ) else {
+    // The daemon's own recovery asks this of the same record, so the rule lives
+    // in kin-core rather than once in each crate. A second copy is only ever
+    // wrong in a way that looks like a passing run: both suites stay green while
+    // one side writes a shape the other stopped reading.
+    let Some(published) = kin_core::published_change(&receipt.operation) else {
         return Ok(None);
     };
+    let (branch, change_id) = (
+        published.branch.map(|name| name.to_string()),
+        published.change_id,
+    );
     let change = lease.snapshot().changes.get(&change_id).ok_or_else(|| {
         anyhow::anyhow!(
             "repository receipt for operation {operation_id} references missing change {change_id}"
@@ -531,43 +532,6 @@ fn landed_commit_for_operation(
         relation_count: change.relation_deltas.len(),
         file_count: change.tree_deltas.len(),
     }))
-}
-
-/// The change one operation record published, and the branch it published onto.
-///
-/// Two shapes, because a commit publishes in two ways and only one of them
-/// moves a ref. A commit on a branch fast-forwards the branch its head names,
-/// so the ref mutation carries both the branch and the change. A commit on a
-/// detached head moves no ref at all and advances the workspace head instead,
-/// so reading only the ref mutations would report a landed change as one that
-/// never happened. That is the one answer this lookup must never give: every
-/// caller reaching it has already lost the reply and is deciding whether to
-/// commit again.
-///
-/// Takes the two fields it reads rather than the whole record, so the decision
-/// can be exercised without building a `RepositoryOperationRecord`, which needs
-/// a real store to be meaningful. The shape it is given here is the shape the
-/// daemon writes, and `a_detached_workspace_head_advances_to_the_change_it_commits`
-/// in `kin-daemon` asserts that shape on the receipt itself, so the two sides
-/// meet at a fact one of them proved rather than at a string written twice.
-fn landed_change_in(
-    ref_mutations: &[kin_model::RefMutation],
-    new_head: Option<&kin_model::WorkspaceHead>,
-) -> Option<(Option<String>, kin_model::SemanticChangeId)> {
-    ref_mutations
-        .iter()
-        .find_map(|mutation| match mutation.new_target.as_ref() {
-            Some(kin_model::RefTarget::Change { change_id }) => {
-                Some((Some(mutation.name.to_string()), *change_id))
-            }
-            _ => None,
-        })
-        .or(match new_head {
-            Some(kin_model::WorkspaceHead::Detached {
-                target: kin_model::RefTarget::Change { change_id },
-            }) => Some((None, *change_id)),
-            _ => None,
-        })
 }
 
 /// Await `work`, printing the phases the daemon reaches while it runs.
@@ -705,61 +669,6 @@ mod tests {
             "message": "publish one docstring edit",
             "author": "Ada Lovelace <ada@example.com>",
         })
-    }
-
-    fn change_id_fixture() -> kin_model::SemanticChangeId {
-        kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([7; 32]))
-    }
-
-    fn branch_ref_mutation(change_id: kin_model::SemanticChangeId) -> Vec<kin_model::RefMutation> {
-        vec![kin_model::RefMutation {
-            name: kin_model::RefName::from_bytes(b"refs/heads/main".to_vec()).unwrap(),
-            expected: kin_model::RefExpectation::MustNotExist,
-            new_target: Some(kin_model::RefTarget::change(change_id)),
-            policy: kin_model::RefUpdatePolicy::FastForwardOnly,
-        }]
-    }
-
-    /// The control. A commit on a branch is recovered from its ref mutation and
-    /// names the branch it moved.
-    #[test]
-    fn a_branch_commit_is_recovered_from_its_ref_mutation() {
-        let change_id = change_id_fixture();
-        assert_eq!(
-            landed_change_in(&branch_ref_mutation(change_id), None),
-            Some((Some("refs/heads/main".to_string()), change_id)),
-            "a ref mutation naming a change is the branch this commit published onto"
-        );
-    }
-
-    /// FIR-3012. A commit on a detached head moves no ref, so the only record of
-    /// where it went is the head the workspace mutation advanced. Reading only
-    /// ref mutations reported a landed change as one that never happened, to a
-    /// caller already deciding whether to commit again.
-    #[test]
-    fn a_detached_commit_is_recovered_from_the_head_it_advanced() {
-        let change_id = change_id_fixture();
-        let head = kin_model::WorkspaceHead::Detached {
-            target: kin_model::RefTarget::change(change_id),
-        };
-        assert_eq!(
-            landed_change_in(&[], Some(&head)),
-            Some((None, change_id)),
-            "a detached commit landed, and no branch names it"
-        );
-    }
-
-    /// The must-be-absent arm, so the two above are answers rather than a
-    /// function that says yes to everything. A workspace mutation that moved no
-    /// head onto a change, which is what an admission or a branch switch
-    /// records, published nothing.
-    #[test]
-    fn an_operation_that_published_no_change_is_recovered_as_nothing() {
-        let head = kin_model::WorkspaceHead::Symbolic {
-            target: kin_model::RefName::from_bytes(b"refs/heads/main".to_vec()).unwrap(),
-        };
-        assert_eq!(landed_change_in(&[], Some(&head)), None);
-        assert_eq!(landed_change_in(&[], None), None);
     }
 
     /// The commit line says where the change went, and on a detached head it

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -129,6 +129,6 @@ pub use ref_view::{
 };
 pub use repository_authority::{
     durable_semantic_enrichment_summary, open_persisted_local_repository_authority,
-    revalidate_pinned_local_namespace, DurableSemanticEnrichmentSummary,
-    LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal,
+    published_change, revalidate_pinned_local_namespace, DurableSemanticEnrichmentSummary,
+    LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal, PublishedChange,
 };

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -17,10 +17,83 @@ use kin_db::{
     RepositoryAuthorityState, StorageBackend,
 };
 use kin_model::{
-    EntityDelta, EntityId, RelationDelta, RelationId, RepositoryId, SemanticChangeId, WorkspaceId,
+    EntityDelta, EntityId, RefName, RefTarget, RelationDelta, RelationId, RepositoryId,
+    RepositoryOperationRecord, SemanticChangeId, WorkspaceHead, WorkspaceId,
 };
 
 use crate::{KinError, KinLayout, KinManifest, Result};
+
+/// The change one repository operation published, and where it published it.
+///
+/// `branch` is `None` when the operation moved no ref, which is what a commit on
+/// a detached workspace head does: it advances the head itself. On a branch the
+/// commit fast-forwards the branch its head names and this carries that name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishedChange {
+    /// The branch this operation moved, absent on a detached head.
+    pub branch: Option<RefName>,
+    pub change_id: SemanticChangeId,
+}
+
+/// The change one operation record published, or `None` if it published none.
+///
+/// Two callers ask this of the same record and neither can afford a different
+/// answer: the daemon's own recovery after a restart, and the CLI's recovery
+/// when the daemon has stopped answering. Both run only after a caller has lost
+/// the reply and is deciding whether to commit again, so the wrong answer here
+/// does not degrade, it inverts. It tells someone their work is gone while it
+/// sits in authority, and the retry that reading invites is then refused as an
+/// empty successor.
+///
+/// It lives here, in the crate both already depend on, rather than once in each,
+/// because a second copy of this rule is only ever wrong in a way that looks
+/// like a passing run. A commit shape that moved no ref was added under
+/// FIR-3012, and both copies had to learn it; had one been missed, both crates'
+/// suites would have stayed green and the disagreement would have surfaced only
+/// to a user who had already lost a reply.
+///
+/// The ref mutation is preferred over the head because a branch commit writes
+/// both: the workspace mutation on that path leaves the head naming its branch
+/// rather than a change, so the head arm cannot fire, but reading the branch
+/// first keeps the answer's `branch` populated without depending on that.
+///
+/// The history root is read before either shape, and that is not belt and
+/// braces. Both shapes are inferences: a ref moved onto a change, or a head
+/// moved onto one. Neither is a claim that THIS operation published the change
+/// it names, and two ordinary operations produce exactly those shapes while
+/// publishing nothing. `kin branch create` builds a ref at the workspace base,
+/// which on a native store is a change; parking a workspace on its own base
+/// moves its head onto a change. Either would be reported as a landed commit by
+/// the shapes alone. The change history root is the fact rather than the
+/// inference: it moves when and only when a transaction publishes into history,
+/// so an operation that left it standing published nothing, whatever its ref and
+/// head look like.
+pub fn published_change(record: &RepositoryOperationRecord) -> Option<PublishedChange> {
+    if record.roots_before.history == record.roots_after.history {
+        return None;
+    }
+    record
+        .ref_mutations
+        .iter()
+        .find_map(|mutation| match mutation.new_target.as_ref() {
+            Some(RefTarget::Change { change_id }) => Some(PublishedChange {
+                branch: Some(mutation.name.clone()),
+                change_id: *change_id,
+            }),
+            _ => None,
+        })
+        .or(
+            match record.workspace_mutation.as_ref().map(|w| &w.new_head) {
+                Some(WorkspaceHead::Detached {
+                    target: RefTarget::Change { change_id },
+                }) => Some(PublishedChange {
+                    branch: None,
+                    change_id: *change_id,
+                }),
+                _ => None,
+            },
+        )
+}
 
 /// Exact semantic counts derived from one immutable repository-authority lease.
 ///

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1143,43 +1143,33 @@ pub(crate) fn recover_native_commit(
     else {
         return Ok(None);
     };
-    let mut native_targets = receipt
+    // Reading the record's two shapes belongs to kin-core, because the CLI's own
+    // recovery asks the same question of the same record and the two cannot
+    // afford different answers. The multiple-targets refusal stays here: it is
+    // this path's own consistency check on a receipt it is about to report as a
+    // single native commit, not part of what the record says.
+    if receipt
         .operation
         .ref_mutations
         .iter()
-        .filter_map(|mutation| match mutation.new_target.as_ref() {
-            Some(RefTarget::Change { change_id }) => Some((
-                NativeCommitTarget::Branch(mutation.name.clone()),
-                *change_id,
-            )),
-            _ => None,
-        });
-    let first = native_targets.next();
-    if first.is_some() && native_targets.next().is_some() {
+        .filter(|mutation| matches!(mutation.new_target, Some(RefTarget::Change { .. })))
+        .count()
+        > 1
+    {
         return Err(invalid(format!(
             "repository receipt for MCP operation {operation_id} has multiple native change targets"
         )));
     }
-    // A detached commit moves no ref, so its change is named by the head the
-    // workspace mutation advanced rather than by a ref mutation. Reading only
-    // the ref mutations here would make an operation that landed look like one
-    // that never ran, which is precisely the reading this recovery exists to
-    // prevent.
-    let (target, change_id) = first
-        .or(match &receipt.operation.workspace_mutation {
-            Some(workspace) => match &workspace.new_head {
-                WorkspaceHead::Detached {
-                    target: RefTarget::Change { change_id },
-                } => Some((NativeCommitTarget::DetachedHead, *change_id)),
-                _ => None,
-            },
-            None => None,
-        })
-        .ok_or_else(|| {
-            invalid(format!(
-                "repository receipt for MCP operation {operation_id} has no native change target"
-            ))
-        })?;
+    let published = kin_core::published_change(&receipt.operation).ok_or_else(|| {
+        invalid(format!(
+            "repository receipt for MCP operation {operation_id} has no native change target"
+        ))
+    })?;
+    let change_id = published.change_id;
+    let target = match published.branch {
+        Some(branch) => NativeCommitTarget::Branch(branch),
+        None => NativeCommitTarget::DetachedHead,
+    };
     let change = lease
         .snapshot()
         .changes
@@ -2512,7 +2502,7 @@ mod tests {
     /// that state through an ordinary workspace mutation rather than through a
     /// Git conversion keeps these tests in one crate, and the state is the same
     /// state because durable authority is what both produce.
-    fn detach_workspace_head(layout: &kin_core::KinLayout) {
+    fn detach_workspace_head(layout: &kin_core::KinLayout) -> RepositoryCommitReceipt {
         let context = test_authority_context(layout);
         let authority = context.open().unwrap();
         let lease = authority.read_authority();
@@ -2582,7 +2572,7 @@ mod tests {
         };
         authority
             .commit_repository_transaction(transaction)
-            .expect("parking a workspace on its own base is a legal workspace mutation");
+            .expect("parking a workspace on its own base is a legal workspace mutation")
     }
 
     /// The state both arms below start from: one committed change on
@@ -2620,12 +2610,18 @@ mod tests {
     }
 
     /// Stage a second artifact and plan the commit under test.
-    fn plan_second_commit(
+    /// The path is a parameter because a test that commits twice must add two
+    /// different files. Adding the same path twice does not fail at the add; it
+    /// fails much later, inside the transaction, with `repository path
+    /// second.txt remains occupied after applying the transaction`, which reads
+    /// like a product defect rather than a fixture that asked for the impossible.
+    fn plan_next_commit(
         init: &kin_core::InitResult,
         blobs: &kin_blobs::BlobStore,
         graph: &kin_db::InMemoryGraph,
+        path: &[u8],
     ) -> Result<NativeCommitPlan> {
-        add_artifact(graph, blobs, b"second.txt", b"two\n", |hash| {
+        add_artifact(graph, blobs, path, b"more\n", |hash| {
             TreeEntry::blob(hash, false)
         });
         plan_native_commit(
@@ -2662,7 +2658,7 @@ mod tests {
     #[test]
     fn a_commit_on_a_branch_moves_the_branch_and_leaves_the_head_naming_it() {
         let (_root, init, blobs, graph, first_change) = repository_with_one_change();
-        let plan = plan_second_commit(&init, &blobs, &graph).unwrap();
+        let plan = plan_next_commit(&init, &blobs, &graph, b"second.txt").unwrap();
         assert_eq!(
             plan.target,
             NativeCommitTarget::Branch(
@@ -2709,7 +2705,7 @@ mod tests {
     #[test]
     fn a_detached_workspace_head_advances_to_the_change_it_commits() {
         let (_root, init, blobs, graph, first_change) = repository_with_one_change();
-        detach_workspace_head(&init.layout);
+        let _ = detach_workspace_head(&init.layout);
         let before = workspace_state(&init);
         assert_eq!(
             before.head,
@@ -2719,7 +2715,7 @@ mod tests {
             "the fixture must actually be detached, or this test asserts about nothing"
         );
 
-        let plan = plan_second_commit(&init, &blobs, &graph).unwrap();
+        let plan = plan_next_commit(&init, &blobs, &graph, b"second.txt").unwrap();
         assert_eq!(
             plan.target,
             NativeCommitTarget::DetachedHead,
@@ -2785,6 +2781,97 @@ mod tests {
         );
     }
 
+    /// FIR-3038. `kin_core::published_change` reads a REAL receipt of every
+    /// shape a commit writes, and refuses one that only looks like a commit.
+    ///
+    /// Both recovery paths, the daemon's here and the CLI's in `kin-cli`, call
+    /// that one function to answer "did my commit land" after a caller lost the
+    /// reply. Before this it was written twice, and both copies were tested
+    /// against inputs their own authors wrote down, so nothing proved either
+    /// answered correctly for a record a real commit produced. This drives it
+    /// from the durable receipts three real transactions leave behind.
+    ///
+    /// The third arm is the one that decides the test. A workspace parked on its
+    /// own base publishes nothing, and its record carries a head moved onto a
+    /// change, which is byte-identical in shape to what a detached commit
+    /// writes. A reader that keyed on the shapes alone would report that park as
+    /// a landed commit, and a suite whose absent arm used something obviously
+    /// different would never see it.
+    #[test]
+    fn a_receipt_names_the_change_its_operation_published_and_nothing_else() {
+        let (_root, init, blobs, graph, first_change) = repository_with_one_change();
+
+        // Arm one, a real commit on a branch.
+        let plan = plan_next_commit(&init, &blobs, &graph, b"second.txt").unwrap();
+        let on_branch = commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+        let branch_published = kin_core::published_change(&on_branch.receipt.operation)
+            .expect("a branch commit published a change");
+        assert_eq!(
+            branch_published.change_id, on_branch.change.id,
+            "the receipt names the change this commit actually made"
+        );
+        assert_eq!(
+            branch_published.branch,
+            Some(kin_model::RefName::from_bytes(b"refs/heads/main".to_vec()).unwrap()),
+            "and the branch it moved"
+        );
+
+        // Arm three, the park. Taken before the detached commit so its receipt
+        // is graded on its own, and it is where the head-onto-a-change shape
+        // appears without a change behind it.
+        let parked = detach_workspace_head(&init.layout);
+        assert!(
+            matches!(
+                parked
+                    .operation
+                    .workspace_mutation
+                    .as_ref()
+                    .map(|workspace| &workspace.new_head),
+                Some(WorkspaceHead::Detached {
+                    target: RefTarget::Change { .. }
+                })
+            ),
+            "the park must write the same head shape a detached commit does, or this arm \
+             grades nothing"
+        );
+        assert_eq!(
+            kin_core::published_change(&parked.operation),
+            None,
+            "a workspace parked on its own base published no change, whatever its head looks like"
+        );
+        assert_eq!(
+            parked.operation.roots_before.history, parked.operation.roots_after.history,
+            "and the reason is readable in the record: it left change history standing"
+        );
+
+        // Arm two, a real commit on that detached head. A different path,
+        // because the branch arm above already published second.txt.
+        let plan = plan_next_commit(&init, &blobs, &graph, b"third.txt");
+        let detached = match plan {
+            Ok(plan) => commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap(),
+            Err(error) => panic!("a detached workspace must commit: {error}"),
+        };
+        let detached_published = kin_core::published_change(&detached.receipt.operation)
+            .expect("a detached commit published a change");
+        assert_eq!(
+            detached_published.change_id, detached.change.id,
+            "the receipt names the change the detached commit made"
+        );
+        assert_eq!(
+            detached_published.branch, None,
+            "and says no branch names it"
+        );
+        assert_ne!(
+            detached.receipt.operation.roots_before.history,
+            detached.receipt.operation.roots_after.history,
+            "a published change moves change history, which is what separates it from the park"
+        );
+
+        // The three answers are distinct, so no arm is satisfied by another's.
+        assert_ne!(branch_published.change_id, detached_published.change_id);
+        assert_ne!(branch_published.change_id, first_change);
+    }
+
     /// A detached commit is recoverable by the operation id that made it.
     ///
     /// The recovery path used to read only ref mutations, so a detached commit,
@@ -2794,7 +2881,7 @@ mod tests {
     #[test]
     fn a_detached_commit_is_recovered_by_its_operation_id() {
         let (_root, init, blobs, graph, _first_change) = repository_with_one_change();
-        detach_workspace_head(&init.layout);
+        let _ = detach_workspace_head(&init.layout);
         add_artifact(&graph, &blobs, b"second.txt", b"two\n", |hash| {
             TreeEntry::blob(hash, false)
         });


### PR DESCRIPTION
## The ticket's original acceptance was refuted by measurement, and this is what replaced it

FIR-3038 asked for a scripted check under `scripts/acceptance/` that commits on a detached head, **drops the reply**, and requires both recovery paths to report the commit as landed. Two of those five points cannot be reached from a script, measured on `origin/main` before any code was written.

A script cannot ask whether an operation landed. `landed_commit_for_operation` is private and keyed on an operation id the CLI mints internally, and no `kin` subcommand accepts one. Read with two positive controls and a fabricated needle, because a first version of this read had a broken control and a bare zero proves nothing:

```
positive control "no-enrich"            : 1
positive control "adopt-repository-id"  : 1
fabricated "zzz-not-a-flag" (must be 0) : 0
any operation-id argument               : 0
```

And dropping the reply needs a lever the product does not have. `resolve_commit_after_lost_reply` runs only on a transport error with the request in flight; a script can kill the daemon but cannot hit that window deterministically, and a racy acceptance check is worse than none. A `KIN_*_TEST_*` fault injection would make the literal script possible and was refused: daemon surface that exists only so a test can run is the demo-state class the workspace rules bar, and the classification it would exercise is already covered five ways in `classify_lost_reply`.

A new user-facing surface for asking "did operation X land" was considered and rejected on its own premise: the operation id is printed only inside the lost-reply handler, so a user who hits ctrl-C never sees one and would have nothing to type, and what they need, did my last commit land, `kin log` already answers.

What replaced it is below: one reader instead of two, driven from real receipts. FIR-3038's body carries the same two refutations so the scripted version is not resurrected.

## The change

Two paths answer "did my commit land" after a caller loses the daemon's reply: `recover_native_commit` in kin-daemon, the daemon's own recovery after a restart, and `landed_commit_for_operation` in kin-cli, the CLI's when the daemon has stopped answering. Both read the same operation record, both carried their own copy of the rule, and both were tested only against shapes their authors wrote down. Nothing proved either answered correctly for a record a real commit produced.

The rule now lives once, in kin-core, as `published_change`. That matters because a second copy is only ever wrong in a way that looks like a passing run. The commit shape that moves no ref, added under FIR-3012, had to be learned by both; had one been missed, both crates' suites would have stayed green and the disagreement would have surfaced only to a user who had already lost a reply and was deciding whether to commit again.

## The defect the must-be-absent arm found

Both shapes the reader keys on are inferences. A ref moved onto a change, or a head moved onto one. Neither says THIS operation published the change it names, and two ordinary operations produce exactly those shapes while publishing nothing: `kin branch create` builds a ref at the workspace base, which on a native store is a change, and parking a workspace on its own base moves its head onto a change. Either would have been reported as a landed commit. The branch side had that hole already.

`RepositoryOperationRecord` does not retain the transaction's changes, which is why both readers inferred in the first place. It does carry `roots_before` and `roots_after`, and `RootBundle.history` is the replicated semantic change history root, so the fact is available: an operation published a change if and only if it moved that root. The reader reads it first and answers `None` when it stands.

## The test

`a_receipt_names_the_change_its_operation_published_and_nothing_else` in kin-daemon, where the fixture that commits for real already works. Three real transactions against one durable store:

1. a real branch commit, which must answer with its own change id and `refs/heads/main`
2. a workspace parked on its own base, which must answer `None`
3. a real detached commit, which must answer with its own change id and no branch

Arm 2 decides the test and asserts its own fixture first: the park must write a head moved onto a change, shape-identical to a detached commit, or the arm grades nothing. An absent arm built from something obviously different would never have caught the draft above. It asserts the history premise too, the park's receipt leaving history standing and the detached commit's moving it, rather than trusting the doc comment.

`landed_change_in` and its three hand-built-shape tests are gone, replaced by this.

## Falsification

Four mutations of the shared reader, each recompiled, graded on three tests, restored, baseline green, tree clean with zero markers.

| arm | real-receipt test | daemon recovery | branch control |
|---|---|---|---|
| M0 unmutated | green | green | green |
| history-root guard removed | RED `a workspace parked on its own base published no change` | green | green |
| ref-mutation arm removed | RED `a branch commit published a change` | green | green |
| detached-head arm removed | RED `a detached commit published a change` | RED | green |
| branch name dropped | RED `and the branch it moved` | green | green |

Every arm names a different assertion and the branch control is green across all of them, which is what says the mutations reach the reader rather than the fixture.

One process note. The detached-head arm failed to apply on its first run, because the needle was written before `cargo fmt` reflowed the block, so it matched zero times and the arm printed three greens over a mutation that was never in the tree. The driver's own `MUTATION DID NOT APPLY` line is the only reason that was not read as a surviving mutant.

## Gates on this sha

`bin/kin-precheck kin`: 16 gates ran, 16 passed, 0 failed, clean tree. `cargo test -p kin-core -p kin-daemon -p kin-cli`: exit 0, zero failures, 782 + 1284 + 1969 passed. Hosted CI: 45 checks, 0 failed, every required context present by name.

Closes FIR-3038
