### PR TITLE
Stop kin-buildinfo's build script invalidating itself through the git index

### DIFF
--- a/crates/kin-buildinfo/build.rs
+++ b/crates/kin-buildinfo/build.rs
@@ -178,6 +178,28 @@ fn git_allow_empty(cwd: &Path, args: &[&str]) -> Option<String> {
     let output = Command::new("git")
         .args(args)
         .current_dir(cwd)
+        // Every git call this script makes goes through here, which is why the
+        // switch is set once at the chokepoint rather than per subcommand.
+        //
+        // `git status` performs an OPTIONAL index refresh: when the cached stat
+        // data is stale it rewrites `.git/index` as a side effect of reporting.
+        // This script declares that same index as one of its own
+        // `rerun-if-changed` inputs, so a plain status makes the build script
+        // invalidate itself for the next cargo invocation in the same job.
+        //
+        // Measured on CI: the fast-gate shard's `cargo nextest list` compiled 24
+        // crates, and the `cargo nextest run` that followed recompiled exactly
+        // four, kin-buildinfo and its three dependents, for 1m48s. That is 108
+        // seconds per shard per run buying nothing.
+        //
+        // GIT_OPTIONAL_LOCKS=0 is git's own switch for exactly this: it skips
+        // the optional write while returning the identical answer. Measured
+        // locally against a deliberately staled index, a plain status rewrote
+        // it and this one did not, with both reporting the same porcelain.
+        //
+        // It is set for every subcommand rather than only `status` so a future
+        // call that also takes an optional lock cannot reintroduce this.
+        .env("GIT_OPTIONAL_LOCKS", "0")
         .output()
         .ok()?;
     if !output.status.success() {


### PR DESCRIPTION
`kin-buildinfo`'s build script declares the git index as one of its `rerun-if-changed` inputs and then runs `git status --porcelain`, which performs an **optional index refresh**: when the cached stat data is stale it rewrites `.git/index` as a side effect of reporting. So the script mutates an input it watches, and the next cargo invocation in the same job reruns it.

## The evidence, from a fast-gate shard's own log

Splitting the job log on its two ``Finished `test` profile`` lines attributes every compile:

| invocation | duration | crates compiled |
| -- | -- | -- |
| `cargo nextest list` | 2m 45s | **24**, including kin-buildinfo |
| `cargo nextest run` | 1m 48s | **4**: kin-buildinfo, kin-cli, kin-daemon, kin-integration-tests |

`kin-buildinfo` is in **both**, so it was fresh when the list step ended and something invalidated it before the run step. Of the 24 crates the list step built, exactly one was invalidated on its own, and the other three are its dependents: `kin-cli` and `kin-daemon` depend on it directly, `tests/integration` through `kin-daemon`.

It is also the only crate that can be doing this. The workspace contains exactly two `build.rs` files, this one and `kin-cli`'s, and only this one references git state, five times against `kin-cli`'s zero. Cargo's own recorded output at `target/debug/build/kin-buildinfo-*/output` lists 50 registered path inputs including `.git/worktrees/<lane>/index`.

## The change

One line: `GIT_OPTIONAL_LOCKS=0` on the single `Command` chokepoint every git call in this script goes through. Everything else in the diff is the comment explaining why.

It is set at the chokepoint rather than as a flag on `status` alone so a later call that also takes an optional lock cannot reintroduce this. The declared inputs are unchanged; what changes is that the script stops writing one of them.

## Falsification, against a deliberately staled index

| arm | index mtime | result |
| -- | -- | -- |
| plain `git status --porcelain` | 1788122617 to 1788122619 | **REWRITTEN**, reproduces the defect |
| `git --no-optional-locks status --porcelain` | unchanged | fixed |
| `GIT_OPTIONAL_LOCKS=0 git status --porcelain` | unchanged | fixed |
| does the answer change? | both print `M src/f1.rs` | identical porcelain |

The first arm is the control that makes the other two mean anything: it shows the staleness setup actually triggers the write. The fourth is the control that the fix does not change what the script reads.

## Acceptance is on CI, not here

After this lands, a trivial no-op commit's run must show the `cargo nextest run` step compiling **zero** crates, against the four in the before log above. The falsification for that is to remove the switch on a third commit of the same shape, which must bring the four back.

I am not claiming that acceptance yet. This PR is the change and the local falsification; the CI reading follows it.

## Worth

108 seconds per shard per run. The fast gate runs three shards on every pull request, and `check`, `coverage` and `install-proof-pr-build` pay the same cost.

## Not claimed

Which source of staleness fires in CI, whether the fresh `actions/checkout`, the `rust-cache` restore, or an mtime under one of the 50 watched paths. The fix is correct under all of them, because it stops the script writing the input at all, so identifying the producer buys nothing.

Closes FIR-3045
