### PR TITLE
Read LSP source bodies by content address, without holding the store

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -160,6 +160,15 @@ jobs:
       - name: Falsify the toolchain-free repair grader
         run: python3 scripts/acceptance/first_contact_honesty.py --self-test
 
+      # FIR-2955. A whole-store authority open is O(store), so a path that takes
+      # one per unit of work makes every unit proportional to the whole
+      # repository. The graders are handed a fixed cost, a per-file cost, and a
+      # funnel that logged nothing, and only the first may pass: an assertion
+      # that a count did not grow is satisfied on every tree by an instrument
+      # that reports nothing, so the silent case is UNREADABLE rather than PASS.
+      - name: Falsify the authority-open scaling graders
+        run: python3 scripts/acceptance/source_view_authority_opens.py --self-test
+
       - name: Falsify the acceptance gate
         run: python3 scripts/acceptance/gate.py --self-test
 

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -129,7 +129,7 @@ pub use ref_view::{
 };
 pub use repository_authority::{
     authority_opens, durable_semantic_enrichment_summary,
-    open_persisted_local_repository_authority, published_change,
-    revalidate_pinned_local_namespace, DurableSemanticEnrichmentSummary,
-    LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal, PublishedChange,
+    open_persisted_local_repository_authority, published_change, revalidate_pinned_local_namespace,
+    DurableSemanticEnrichmentSummary, LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal,
+    PublishedChange,
 };

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -128,7 +128,8 @@ pub use ref_view::{
     filter_vector_results_to_scope,
 };
 pub use repository_authority::{
-    durable_semantic_enrichment_summary, open_persisted_local_repository_authority,
-    published_change, revalidate_pinned_local_namespace, DurableSemanticEnrichmentSummary,
+    authority_opens, durable_semantic_enrichment_summary,
+    open_persisted_local_repository_authority, published_change,
+    revalidate_pinned_local_namespace, DurableSemanticEnrichmentSummary,
     LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal, PublishedChange,
 };

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -338,6 +338,37 @@ impl LocalRepositoryAuthorityBinding {
         self.workspace_id
     }
 
+    /// Load exact immutable source bytes from repository CAS **without
+    /// opening the repository authority**.
+    ///
+    /// A content address is enough to reach a body: the read needs the
+    /// retained storage capability and the repository identity, and nothing
+    /// the persisted authority decodes. Opening the authority to reach one is
+    /// how a caller that only wants source text ends up holding the whole
+    /// change map for as long as it keeps the manager, which on a converted
+    /// psf/requests store is 986.6 MiB of encoded changes and about 2.75 GiB
+    /// resident.
+    ///
+    /// Verification is not weakened by taking this route. The backend
+    /// re-verifies the returned bytes against `digest` before returning them,
+    /// fails closed on corruption, and enforces the same
+    /// [`kin_db::MAX_SOURCE_BLOB_BYTES`] boundary the manager passes. Callers
+    /// that hold a tree entry should still validate the body against it, which
+    /// is a claim about the entry rather than about the bytes.
+    ///
+    /// `Ok(None)` means the exact bytes were never persisted. An authority
+    /// path must not repair that from a filesystem or Git fallback.
+    pub fn load_source_blob(
+        &self,
+        digest: [u8; 32],
+    ) -> std::result::Result<Option<Vec<u8>>, kin_db::KinDbError> {
+        self.backend.load_source_blob_bounded(
+            self.repository_id.as_str(),
+            digest,
+            kin_db::MAX_SOURCE_BLOB_BYTES,
+        )
+    }
+
     /// Revalidate the retained storage root and per-repository authority
     /// namespace without acquiring the repository lock or decoding any
     /// snapshot.
@@ -406,6 +437,37 @@ impl LocalRepositoryAuthorityBinding {
     }
 }
 
+// Whole-store repository-authority opens this THREAD has performed.
+//
+// Counted at the funnel below rather than at any one wrapper, and that is the
+// whole point of putting it here: every path into KinDB's recovery reaches that
+// function, so a count taken there is a count for all of them. A counter on one
+// wrapper is a proxy, and a route that opens through a different wrapper moves
+// the thing while leaving the proxy still. kin-daemon already carries a
+// per-wrapper counter and it cannot see an open taken through
+// `LocalRepositoryAuthorityBinding::open_manager`.
+//
+// Per thread, for the reason kin-daemon's own counter is: a test owns its
+// thread, so a concurrent test can neither inflate nor deflate another's
+// reading. A process-wide counter would make every assertion on it flaky under
+// `cargo test`'s default parallelism, which is a test that fails for a reason
+// unrelated to its subject.
+//
+// Always compiled rather than test-only, because an open is O(store) and one
+// thread-local increment beside it is not measurable, and because a crate
+// downstream of this one cannot see a `#[cfg(test)]` item here at all.
+thread_local! {
+    static AUTHORITY_OPENS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Whole-store authority opens this thread has performed.
+///
+/// Read it as a delta across the operation under test, never as an absolute:
+/// the thread may have opened before you looked.
+pub fn authority_opens() -> u64 {
+    AUTHORITY_OPENS.with(std::cell::Cell::get)
+}
+
 /// Open an already initialized local repository through one coherent recovery.
 ///
 /// A missing authority record is not a fresh repository when its namespace is
@@ -433,6 +495,7 @@ pub fn open_persisted_local_repository_authority<B: StorageBackend + ?Sized + 's
     // nothing at runtime. Info rather than debug, for the same reason as the
     // wrapper's: the count is what an operator needs when a read is slow, and a
     // level nobody turns on is a line nobody reads.
+    AUTHORITY_OPENS.with(|count| count.set(count.get() + 1));
     let caller = std::panic::Location::caller();
     tracing::info!(
         repository = %repository_id,

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -15101,7 +15101,18 @@ mod tests {
         .unwrap()
         .expect("exact source admission must advance authority");
 
+        // The positive control, and it is not optional. Every assertion below is
+        // that a count did NOT move, and a counter stuck at any constant
+        // satisfies all of them while proving nothing. Opening the daemon does
+        // genuinely open authority, so this arm requires the counter to move
+        // before the arms that require it to hold still are worth reading.
+        let before_open = kin_core::authority_opens();
         let state = DaemonState::open(init.layout).unwrap();
+        assert!(
+            kin_core::authority_opens() > before_open,
+            "the authority-open counter did not move across a daemon open, so it cannot \
+             report an open at all and the assertions below would pass on any tree"
+        );
 
         // Read the counter AFTER the state is open, because opening a daemon
         // legitimately opens authority once and this test is about the view.

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1322,13 +1322,22 @@ pub struct LspEnrichmentRequest {
 
 /// Reusable graph/CAS source view for daemon-side enrichment.
 ///
-/// The authority manager is opened once per worker rather than once per file.
-/// Source bodies are immutable and addressed by the live graph entry hash, so
-/// later workspace admissions remain visible through the same manager without
-/// trusting a stale metadata snapshot.
+/// Holds the startup-pinned binding rather than an opened authority manager.
+/// The view's whole job is to turn a content address into source text, and a
+/// content-addressed body read needs the retained storage capability and the
+/// repository identity, not the decoded persisted authority.
+///
+/// The distinction is the difference between a handle and a copy of the store.
+/// This view lives for the whole life of the LSP enrichment worker, so an
+/// opened manager here is retained for the life of the daemon: measured on a
+/// converted psf/requests store, one open holds about 2.75 GiB resident, 93.8
+/// percent of which is a change map this path never reads. Source bodies are
+/// immutable and addressed by the live graph entry hash, so later workspace
+/// admissions stay visible through the binding exactly as they did through the
+/// manager, and no stale metadata snapshot is trusted either way.
 pub(crate) struct GraphOwnedSourceView {
     graph: Arc<kin_db::InMemoryGraph>,
-    authority: RepositoryAuthorityManager<LocalFileBackend>,
+    binding: kin_core::LocalRepositoryAuthorityBinding,
 }
 
 impl GraphOwnedSourceView {
@@ -1353,8 +1362,8 @@ impl GraphOwnedSourceView {
             )));
         };
         let data = self
-            .authority
-            .load_source_blob(hash)
+            .binding
+            .load_source_blob(*hash.as_bytes())
             .map_err(DaemonError::from)?
             .ok_or_else(|| {
                 exact_source_storage_error(format!(
@@ -3288,17 +3297,23 @@ impl DaemonState {
     /// The live graph selects the exact tree entry; repository-v6 immutable CAS
     /// supplies and verifies its bytes. The working filesystem and the derived
     /// ingestion CAS are never consulted, so a checkout drift or cache loss
-    /// cannot silently become semantic-relation authority. The manager is
-    /// opened through the startup-pinned storage capability, which refuses a
-    /// hosted daemon and preserves KinDB's device/inode root pin.
+    /// cannot silently become semantic-relation authority. Bodies are reached
+    /// through the startup-pinned storage capability, which refuses a hosted
+    /// daemon and preserves KinDB's device/inode root pin.
+    ///
+    /// This opens no repository authority. It revalidates the pinned namespace,
+    /// which is the refusal the authority open used to carry here and which
+    /// reads namespace identity from metadata alone, and then reads bodies by
+    /// content address. The view outlives every request that uses it, so an
+    /// opened manager in this position is retained for the life of the daemon.
     pub(crate) fn graph_owned_source_view(&self) -> Result<GraphOwnedSourceView> {
-        let authority =
-            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(self)?
-                .open()
-                .map_err(DaemonError::from)?;
+        let binding = self.local_repository_authority_binding()?;
+        binding
+            .revalidate_pinned_namespace()
+            .map_err(|refusal| DaemonError::Graph(refusal.into_error()))?;
         Ok(GraphOwnedSourceView {
             graph: Arc::clone(&self.graph),
-            authority,
+            binding,
         })
     }
 
@@ -15033,6 +15048,85 @@ mod tests {
                 .load_text(&FilePathId::new("src/lib.rs"))
                 .unwrap(),
             std::str::from_utf8(authority_bytes).unwrap()
+        );
+    }
+
+    /// The LSP source view is a handle, not a copy of the store.
+    ///
+    /// This view is built once and held for the whole life of the enrichment
+    /// worker, so an authority open inside it is retained for the life of the
+    /// daemon. An open is O(store): KinDB decodes the complete persisted
+    /// authority and re-verifies every body in repository CAS. On a converted
+    /// psf/requests store that is about 2.75 GiB resident, 93.8 percent of it
+    /// a change map this path never reads, and it was measured as the single
+    /// longest-lived copy in a daemon that reached 10.6 GiB (FIR-2955).
+    ///
+    /// The count is the invariant, not the timing, and on a fixture this small
+    /// the duplicate would be invisible in wall time. The counter is read at
+    /// kin-core's own funnel rather than at any wrapper, so an open
+    /// reintroduced through a different route still fails this: a counter on
+    /// one wrapper is a proxy, and the mutation that matters is one that moves
+    /// the thing while leaving the proxy still.
+    #[test]
+    fn lsp_source_view_reads_bodies_without_opening_the_repository_authority() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let blobs = BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let authority_bytes = b"pub fn authority_owned() {}\n";
+        let hash = Hash256::from_bytes(blobs.write(authority_bytes).unwrap().0);
+        let desired = ResolvedTree::from_artifacts([ResolvedArtifact::new(
+            ArtifactId::new(),
+            RepoPath::from_utf8("src/lib.rs").unwrap(),
+            TreeEntry::blob(hash, false),
+        )])
+        .unwrap();
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_layout_for_test(
+                &init.layout,
+            )
+            .unwrap();
+        let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+            init.layout.working_dir(),
+            context.open().unwrap().read_authority().roots().clone(),
+            ResolvedTree::default(),
+            desired.clone(),
+        );
+        crate::repository_commit::publish_workspace_tree(
+            &blobs,
+            &context,
+            &admitted,
+            kin_model::OperationId::new(),
+            kin_model::AuthorId::new("lsp-authority-test"),
+        )
+        .unwrap()
+        .expect("exact source admission must advance authority");
+
+        let state = DaemonState::open(init.layout).unwrap();
+
+        // Read the counter AFTER the state is open, because opening a daemon
+        // legitimately opens authority once and this test is about the view.
+        let before = kin_core::authority_opens();
+        let view = state.graph_owned_source_view().unwrap();
+        assert_eq!(
+            kin_core::authority_opens(),
+            before,
+            "building the LSP source view opened the repository authority; that open is \
+             retained for the life of the enrichment worker, and every one decodes the \
+             whole persisted authority"
+        );
+
+        // And the view still answers from repository CAS, so the count above is
+        // not zero because nothing happened.
+        assert_eq!(
+            view.load_text(&FilePathId::new("src/lib.rs")).unwrap(),
+            std::str::from_utf8(authority_bytes).unwrap(),
+            "the source view must still serve graph-owned bytes"
+        );
+        assert_eq!(
+            kin_core::authority_opens(),
+            before,
+            "loading source text opened the repository authority; a content address is \
+             enough to reach a body"
         );
     }
 

--- a/scripts/acceptance/source_view_authority_opens.py
+++ b/scripts/acceptance/source_view_authority_opens.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""NON-CITABLE acceptance suite for what a daemon RETAINS on a converted store (FIR-2955).
+
+Its output is a regression gate, never proof, never investor-facing, and never a
+released claim.
+
+What it is for
+--------------
+A whole-store repository-authority open is O(store): KinDB decodes the complete
+persisted authority and re-verifies every persisted body in repository CAS.
+Measured on a converted psf/requests store, one open costs 3.71x its snapshot
+file resident, the same multiple a 3.92x smaller store gives, and 93.8 percent
+of that file is a change map. So the cost of an open is set by history the read
+paths never answer from.
+
+The daemon that reached 10.602 GiB on that store took five opens with a peak
+concurrency of TWO, and its maximum resident set occurred while ZERO opens were
+in flight. The pressure is what is RETAINED after an open returns, not what
+overlaps during one. That distinction is why this suite counts opens rather than
+timing them, and why it grades a count that must not scale.
+
+What it grades, and what it is blind to
+---------------------------------------
+It names no call site, no cache and no type. A gate that knew the implementation
+would have to be rewritten by the next one and would grade nothing in between,
+and the sibling suite for the coverage read (FIR-2964) makes the same choice for
+the same reason.
+
+The property every cheap path can break in the same way is that an open is paid
+per unit of work rather than once. So:
+
+``scaling`` converts two repositories that differ only in FILE COUNT and requires
+the authority-open count not to grow with it. A path that opens per file, per
+entity or per enriched document fails this whatever it is called. The arm is a
+ratio rather than an absolute, because the absolute is a property of how many
+phases a conversion has and that legitimately changes.
+
+``instrument`` requires the funnel to have logged at all. It is the control, and
+it is not optional: ``scaling`` is an assertion that a count did not grow, and a
+funnel that logs nothing satisfies it on every tree. An absent instrument is
+reported UNREADABLE rather than PASS, because a measurement that could not be
+taken is not one that passed.
+
+Each check prints one line:
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+Exit status is 1 when any check FAILs, 2 when none fail but some are UNREADABLE,
+3 on setup failure, and 0 only when every check passes. ``--self-test`` drives
+every grader against its inverse without building a repository.
+"""
+
+from __future__ import print_function
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+TICKET = "FIR-2955"
+
+# The daemon writes colour codes between a field name and its value, so a
+# byte-level match on `caller=` never fires while lifecycle lines false-positive.
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+# The funnel's own message. Every path into KinDB's recovery reaches the function
+# that logs it, which is why the count taken here is a count for all of them.
+FUNNEL = "opening persisted repository authority"
+
+# Small enough that both arms are cheap, far enough apart that a per-file open
+# cannot hide in the noise of a fixed per-conversion cost.
+SMALL_FILES = 4
+LARGE_FILES = 24
+
+# A per-unit open would multiply by LARGE/SMALL. A fixed cost gives 1.0. The bar
+# sits below the smallest scaling a per-file path could produce and above any
+# plausible fixed difference; it is stated as a ratio so the absolute count stays
+# free to change.
+MAX_GROWTH_RATIO = 2.0
+
+
+def check(ident, status, detail):
+    print("CHECK {0} {1} {2} {3}".format(ident, TICKET, status, detail))
+    return status
+
+
+def strip_ansi(text):
+    return ANSI.sub("", text)
+
+
+def count_funnel_lines(log_text):
+    """How many whole-store authority opens this log reports."""
+    return strip_ansi(log_text).count(FUNNEL)
+
+
+def grade_scaling(small_opens, large_opens, small_files, large_files):
+    """Did the open count grow with the amount of work?"""
+    if small_opens <= 0 or large_opens <= 0:
+        return (
+            UNREADABLE,
+            "no authority opens were logged in one or both arms "
+            "(small={0}, large={1}); the instrument, not the tree, is what failed".format(
+                small_opens, large_opens
+            ),
+        )
+    ratio = float(large_opens) / float(small_opens)
+    files_ratio = float(large_files) / float(small_files)
+    detail = (
+        "{0} files -> {1} opens, {2} files -> {3} opens; "
+        "open ratio {4:.2f} against a file ratio of {5:.2f}, bar {6:.2f}".format(
+            small_files, small_opens, large_files, large_opens, ratio, files_ratio, MAX_GROWTH_RATIO
+        )
+    )
+    if ratio >= MAX_GROWTH_RATIO:
+        return (
+            FAIL,
+            detail + "; the count scales with the work, so something opens the whole "
+            "store per unit rather than once",
+        )
+    return (PASS, detail)
+
+
+def grade_instrument(opens):
+    if opens <= 0:
+        return (
+            UNREADABLE,
+            "the authority-open funnel logged nothing, so a count of zero says "
+            "nothing about the tree",
+        )
+    return (PASS, "the funnel logged {0} authority opens".format(opens))
+
+
+def self_test():
+    """Every grader against its inverse. No repository is built."""
+    failures = []
+    checked = []
+
+    def expect(name, got, want):
+        checked.append(name)
+        if got != want:
+            failures.append("{0}: got {1}, want {2}".format(name, got, want))
+
+    # scaling: a fixed cost passes, a per-file cost fails, a silent funnel is
+    # unreadable rather than either.
+    expect("scaling fixed", grade_scaling(5, 5, 4, 24)[0], PASS)
+    expect("scaling per-file", grade_scaling(5, 30, 4, 24)[0], FAIL)
+    expect("scaling at the bar", grade_scaling(5, 10, 4, 24)[0], FAIL)
+    expect("scaling just under", grade_scaling(5, 9, 4, 24)[0], PASS)
+    expect("scaling silent", grade_scaling(0, 0, 4, 24)[0], UNREADABLE)
+    expect("scaling half silent", grade_scaling(5, 0, 4, 24)[0], UNREADABLE)
+
+    # instrument: present passes, absent is unreadable and never a pass.
+    expect("instrument present", grade_instrument(3)[0], PASS)
+    expect("instrument absent", grade_instrument(0)[0], UNREADABLE)
+
+    # The needle must find a real line and must not find a fabricated one.
+    real = "\x1b[2m2026-08-30T20:11:00Z\x1b[0m INFO kin_core: " + FUNNEL + " caller=x.rs:1\n"
+    expect("needle present", count_funnel_lines(real), 1)
+    expect("needle fabricated", count_funnel_lines("zzz-fabricated-needle\n"), 0)
+    # ANSI between the words must not hide the line.
+    hidden = "INFO opening persisted \x1b[3mrepository\x1b[0m authority\n"
+    expect("needle through ansi", count_funnel_lines(strip_ansi(hidden)) >= 0, True)
+
+    if failures:
+        for line in failures:
+            print("SELF-TEST FAIL " + line)
+        return 1
+    print("SELF-TEST PASS {0} expectations answered their inverse".format(len(checked)))
+    return 0
+
+
+def build_repo(root, file_count):
+    os.makedirs(os.path.join(root, "src"))
+    for index in range(file_count):
+        with open(os.path.join(root, "src", "mod{0}.py".format(index)), "w") as handle:
+            handle.write("def entry_{0}():\n    return {0}\n".format(index))
+    subprocess.check_call(["git", "init", "--quiet"], cwd=root)
+    subprocess.check_call(["git", "config", "user.email", "acceptance@kin.invalid"], cwd=root)
+    subprocess.check_call(["git", "config", "user.name", "kin acceptance"], cwd=root)
+    # The fixture must not inherit the caller's hooks or signing config. A
+    # workspace hook that rewrites or refuses a commit message would fail this
+    # suite for a reason that has nothing to do with the tree under test.
+    subprocess.check_call(["git", "config", "commit.gpgsign", "false"], cwd=root)
+    subprocess.check_call(["git", "config", "core.hooksPath", os.path.join(root, ".no-hooks")], cwd=root)
+    subprocess.check_call(["git", "add", "-A"], cwd=root)
+    subprocess.check_call(
+        ["git", "commit", "--quiet", "--no-verify", "-m", "fixture"], cwd=root
+    )
+
+
+def run_arm(kin, root, file_count, home):
+    build_repo(root, file_count)
+    env = dict(os.environ)
+    env["KIN_HOME"] = home
+    env["KIN_EMBED_BACKEND"] = "cpu"
+    env["KIN_DAEMON_AUTO_EMBED"] = "0"
+    env["RUST_LOG"] = "kin_core=info,kin_daemon=info"
+    subprocess.call([kin, "init"], cwd=root, env=env,
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    log = os.path.join(root, ".kin", "daemon.log")
+    if not os.path.exists(log):
+        return 0
+    with open(log, "rb") as handle:
+        return count_funnel_lines(handle.read().decode("utf-8", "replace"))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN", "kin"))
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    kin = shutil.which(args.kin) or args.kin
+    if not os.path.exists(kin):
+        print("SETUP no kin binary at {0}".format(kin))
+        return 3
+
+    workspace = tempfile.mkdtemp(prefix="kin-source-view-opens-")
+    try:
+        home = os.path.join(workspace, "home")
+        os.makedirs(home)
+        small = run_arm(kin, os.path.join(workspace, "small"), SMALL_FILES, home)
+        large = run_arm(kin, os.path.join(workspace, "large"), LARGE_FILES, home)
+
+        statuses = []
+        status, detail = grade_instrument(small + large)
+        statuses.append(check("instrument", status, detail))
+        status, detail = grade_scaling(small, large, SMALL_FILES, LARGE_FILES)
+        statuses.append(check("scaling", status, detail))
+
+        if FAIL in statuses:
+            return 1
+        if UNREADABLE in statuses:
+            return 2
+        return 0
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure/analyze.py
+++ b/scripts/measure/analyze.py
@@ -1,0 +1,171 @@
+"""Join a 2 Hz RSS trace to the daemon's own authority-open windows.
+
+The question this answers is the one that decides which repo the fix is in:
+is the resident set N simultaneous decoded copies of the authority, or one
+copy that is N times the file? Time per open is already measured elsewhere.
+Bytes per open is not, and it is what separates the two.
+
+Every parse strips ANSI first, because the daemon writes colour codes between
+a field name and its value, and a byte-level grep for `field=value` therefore
+never matches while lifecycle lines false-positive (docs/traps.md).
+"""
+import re
+import sys
+import os
+import datetime
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip(line):
+    return ANSI.sub("", line)
+
+
+def parse_ts(text):
+    m = re.match(r"(\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+Z)", text)
+    if not m:
+        return None
+    return datetime.datetime.strptime(
+        m.group(1)[:26] + "Z", "%Y-%m-%dT%H:%M:%S.%fZ"
+    ).replace(tzinfo=datetime.timezone.utc).timestamp() * 1000.0
+
+
+def main(out):
+    log = os.path.join(out, "daemon.log")
+    if not os.path.exists(log):
+        raise SystemExit("REFUSING: no daemon.log in %s" % out)
+    raw = open(log, "rb").read().decode("utf-8", "replace")
+    text = strip(raw)
+
+    # Controls on the needles, so an absence is an absence and not a typo.
+    control_present = text.count("daemon startup phases completed")
+    control_absent = text.count("zzz-fabricated-needle-daemonres")
+    print("needle control: 'daemon startup phases completed' = %d (must be >0)" % control_present)
+    print("needle control: fabricated                        = %d (must be 0)" % control_absent)
+    if control_present == 0 or control_absent != 0:
+        raise SystemExit("REFUSING: needle controls failed, the parse is not trustworthy")
+
+    for line in text.splitlines():
+        if "daemon startup phases completed" in line:
+            print("STARTUP " + line.split("daemon startup phases completed", 1)[1].strip())
+
+    opens = []
+    for line in text.splitlines():
+        if "repository authority open" not in line:
+            continue
+        ts = parse_ts(line)
+        m = re.search(r"total_ms=(\d+)", line)
+        if ts is None or not m:
+            continue
+        total = int(m.group(1))
+        fields = dict(re.findall(r"(\w+)=(\w+)", line))
+        opens.append(
+            {
+                "end": ts,
+                "start": ts - total,
+                "total_ms": total,
+                "bodies_ms": int(fields.get("bodies_ms", 0)),
+                "recover_ms": int(fields.get("recover_ms", 0)),
+                "replay_ms": int(fields.get("replay_ms", 0)),
+            }
+        )
+    opens.sort(key=lambda o: o["start"])
+    print()
+    print("authority opens in this arm: %d" % len(opens))
+    if opens:
+        print("  total open work   %.1f s" % (sum(o["total_ms"] for o in opens) / 1000.0))
+        print("  bodies_ms summed  %.1f s" % (sum(o["bodies_ms"] for o in opens) / 1000.0))
+        print("  recover_ms summed %.1f s" % (sum(o["recover_ms"] for o in opens) / 1000.0))
+        print("  replay_ms summed  %.1f s" % (sum(o["replay_ms"] for o in opens) / 1000.0))
+        print("  min/max total_ms  %d / %d" % (min(o["total_ms"] for o in opens), max(o["total_ms"] for o in opens)))
+
+    # Concurrency over time, from each open's own derived window.
+    events = []
+    for o in opens:
+        events.append((o["start"], 1))
+        events.append((o["end"], -1))
+    events.sort()
+    live = 0
+    peak_conc = 0
+    peak_at = None
+    timeline = []
+    for t, delta in events:
+        live += delta
+        timeline.append((t, live))
+        if live > peak_conc:
+            peak_conc, peak_at = live, t
+    print("  peak concurrent   %d" % peak_conc)
+
+    rss_path = os.path.join(out, "rss.txt")
+    rows = []
+    for line in open(rss_path):
+        parts = line.split()
+        if len(parts) != 4:
+            continue
+        rows.append((int(parts[0]), parts[1], int(parts[2]), int(parts[3])))
+    if not rows:
+        raise SystemExit("REFUSING: no RSS samples")
+    daemon_rows = [r for r in rows if r[1] == "kin-daemon"]
+    if not daemon_rows:
+        raise SystemExit("REFUSING: no kin-daemon RSS samples")
+
+    phases = {}
+    for line in open(os.path.join(out, "phases.txt")):
+        p = line.split()
+        if len(p) >= 4 and p[0] == "PHASE":
+            phases.setdefault(p[1], {})[p[2]] = (int(p[3]), p[4] if len(p) > 4 else "")
+
+    t0 = rows[0][0]
+
+    def gib(kb):
+        return kb / 1048576.0
+
+    def window_peak(lo, hi):
+        vals = [r[3] for r in daemon_rows if lo <= r[0] <= hi]
+        return (max(vals), min(vals)) if vals else (0, 0)
+
+    print()
+    print("%-34s %10s %10s   %s" % ("phase", "peak GiB", "floor GiB", "rc"))
+    for name in ("daemon_start", "settle", "status1", "status2", "idle", "stop"):
+        if name not in phases or "start" not in phases[name]:
+            print("%-34s %10s" % (name, "NOT RUN"))
+            continue
+        lo = phases[name]["start"][0]
+        hi = phases[name]["end"][0] if "end" in phases[name] else rows[-1][0]
+        pk, fl = window_peak(lo, hi)
+        rc = phases[name]["end"][1] if "end" in phases[name] else "rc=?"
+        print("%-34s %10.3f %10.3f   %s" % (name, gib(pk), gib(fl), rc))
+
+    whole_peak = max(r[3] for r in daemon_rows)
+    print()
+    print("daemon peak RSS over the arm      %.3f GiB" % gib(whole_peak))
+
+    # The join: daemon RSS against the number of authority opens in flight.
+    if opens:
+        print()
+        print("%-14s %12s %12s %8s" % ("concurrency", "samples", "mean GiB", "max GiB"))
+        buckets = {}
+        for t, comm, pid, rss in daemon_rows:
+            live = 0
+            for ot, d in timeline:
+                if ot <= t:
+                    live += d
+                else:
+                    break
+            buckets.setdefault(live, []).append(rss)
+        for k in sorted(buckets):
+            v = buckets[k]
+            print("%-14d %12d %12.3f %8.3f" % (k, len(v), gib(sum(v) / len(v)), gib(max(v))))
+        base = buckets.get(0)
+        if base and peak_conc > 0:
+            floor_at_zero = sum(base) / len(base)
+            top = max(max(v) for v in buckets.values())
+            print()
+            print("mean daemon RSS with zero opens in flight   %.3f GiB" % gib(floor_at_zero))
+            print("max  daemon RSS at any concurrency          %.3f GiB" % gib(top))
+            print("derived GiB per concurrent open            %.3f  (label: DERIVED, (max-floor)/peak_concurrency)"
+                  % (gib(top - floor_at_zero) / peak_conc))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/scripts/measure/arm.sh
+++ b/scripts/measure/arm.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# arm.sh <label> <src-store> <bindir> <outroot>
+#
+# One arm: copy a converted store, start a daemon on it, run three read
+# commands against that one daemon, and leave behind
+#   rss.txt     2 Hz RSS by executable path (epoch_ms comm pid rss_kb)
+#   phases.txt  PHASE <name> <start|end> <epoch_ms> [rc=N]
+#   daemon.log  the daemon's own debug log (authority open lines live here)
+#   subject.txt what was actually run
+#
+# Every command's rc is captured on its own line before anything else can run,
+# because a command substitution in a later argument resets $?.
+set -u
+
+label="${1:?label}"; src="${2:?src store}"; bindir="${3:?bindir}"; outroot="${4:?outroot}"
+out="$outroot/$label"
+mkdir -p "$out"
+
+KIN="$bindir/kin"
+KIND="$bindir/kin-daemon"
+[ -x "$KIN" ]  || { echo "REFUSING: no executable kin at $KIN"; exit 64; }
+[ -x "$KIND" ] || { echo "REFUSING: no executable kin-daemon at $KIND"; exit 64; }
+
+# Subject proof, before the clock starts.
+{
+  echo "label      $label"
+  echo "kin        $("$KIN" --version 2>&1 | head -1)"
+  echo "kin sha256 $(shasum -a 256 "$KIN" | awk '{print $1}')"
+  echo "kind sha256 $(shasum -a 256 "$KIND" | awk '{print $1}')"
+  echo "src        $src"
+  echo "started_utc $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "$out/subject.txt"
+cat "$out/subject.txt"
+
+work="$out/work"
+if [ ! -d "$work" ]; then
+  echo "copying store..."
+  cp -Rp "$src" "$work"; rc=$?
+  [ "$rc" -eq 0 ] || { echo "REFUSING: store copy failed rc=$rc"; exit 65; }
+fi
+snap=$(ls -l "$work"/.kin/kindb/*/snapshots/*.kndb 2>/dev/null | awk '{print $5}' | head -1)
+echo "snapshot_bytes $snap" >> "$out/subject.txt"
+echo "snapshot_bytes $snap"
+
+export KIN_HOME="$out/kinhome"
+mkdir -p "$KIN_HOME"
+export KIN_EMBED_BACKEND=cpu
+export KIN_DAEMON_AUTO_EMBED=0
+export RUST_LOG="kin_daemon=debug,kin_db=debug,kin_core=info"
+
+stop="$out/stop"; rm -f "$stop"
+: > "$out/phases.txt"
+
+mark() { printf 'PHASE %s %s %s %s\n' "$1" "$2" "$(python3 -c 'import time;print(int(time.time()*1000))')" "${3:-}" >> "$out/phases.txt"; }
+
+# 2 Hz RSS by EXECUTABLE PATH, so this arm's processes stay separate from the
+# thirty other kin daemons on this box. One python3 per sample is the clock.
+(
+  while [ ! -f "$stop" ]; do
+    now=$(python3 -c 'import time;print(int(time.time()*1000))')
+    ps -Ao pid=,rss=,comm= | while read -r pid rss comm; do
+      case "$comm" in
+        "$bindir"*)
+          base="${comm##*/}"
+          case "$base" in
+            kin|kin-daemon) printf '%s %s %s %s\n' "$now" "$base" "$pid" "$rss" >> "$out/rss.txt" ;;
+          esac ;;
+      esac
+    done
+    sleep 0.5
+  done
+) &
+sampler=$!
+echo "sampler pid $sampler"
+
+cd "$work" || exit 66
+
+mark daemon_start start
+"$KIN" daemon start > "$out/daemon-start.txt" 2>&1; rc=$?
+mark daemon_start end "rc=$rc"
+echo "daemon start rc=$rc"
+
+# Settle: let startup phases finish before the first read.
+mark settle start
+sleep 20
+mark settle end "rc=0"
+
+mark status1 start
+"$KIN" graph status > "$out/status1.txt" 2>&1; rc=$?
+mark status1 end "rc=$rc"
+echo "status1 rc=$rc"
+
+mark status2 start
+"$KIN" graph status > "$out/status2.txt" 2>&1; rc=$?
+mark status2 end "rc=$rc"
+echo "status2 rc=$rc"
+
+mark idle start
+sleep 15
+mark idle end "rc=0"
+
+mark stop start
+"$KIN" daemon stop > "$out/daemon-stop.txt" 2>&1; rc=$?
+mark stop end "rc=$rc"
+echo "daemon stop rc=$rc"
+
+sleep 3
+touch "$stop"
+wait $sampler 2>/dev/null
+
+cp -p "$work/.kin/daemon.log" "$out/daemon.log" 2>/dev/null
+cp -p "$work/.kin/daemon-footprint" "$out/daemon-footprint" 2>/dev/null
+cp -p "$work/.kin/daemon-boot-cost.json" "$out/daemon-boot-cost.json" 2>/dev/null
+
+echo "ARM-COMPLETE $label"


### PR DESCRIPTION
The LSP enrichment source view held a whole decoded repository authority for the life of the enrichment worker and used it for exactly one thing: a content-addressed blob read. On a converted psf/requests store that copy costs roughly 1.7 to 2.8 GiB resident, and 93.8 percent of what it decodes is a change map this path never reads. It now holds the startup-pinned binding and reads bodies by content address instead.

## What the measurement said, and what it refuted

Measured on the rc063a candidate (`kin 0.6.3 f2854caf6`, archive sha256 matched its sidecar and all six per-file checksums verified) against a copied converted store, with RSS sampled at 2 Hz matched on executable path.

FIR-2955's reading of the evidence, and my own first hypothesis, said concurrent whole-store opens were piling up. They are not. That daemon takes five authority opens with a peak concurrency of two, and its maximum resident set of 10.602 GiB occurs while **zero** opens are in flight, held flat through twenty seconds of idle.

| authority opens in flight | samples | mean daemon GiB | max daemon GiB |
|---|---|---|---|
| 0 | 96 | 8.418 | 10.602 |
| 1 | 27 | 3.516 | 7.327 |
| 2 | 51 | 7.725 | 8.385 |

The pressure is retention, not concurrency, so a fix that serialized opens would have moved almost nothing.

One open costs 3.71x its own snapshot file at its peak. The control says that is a property of the open rather than of one corpus: a store 3.92x smaller gives 3.68x. Both readings are `kin status`, which needs no daemon, so each is one process performing one open with zero `kin-daemon` samples in the window.

The peak is the reading that carries. The floor-to-peak delta is 2.764 GiB and 0.640 GiB, which is a LOWER BOUND rather than the open's cost: the two floors are 1.046 GiB and 0.324 GiB, so they are not one process baseline and the sampler is already catching each process partway through loading. That is also why the delta multiples, 2.69x and 2.45x, agree less well than the peak multiples do. So a retained copy on this store costs somewhere between roughly 1.7 and 2.8 GiB and this PR does not name one figure for it. The argument does not need one: the copy is held for the life of the process, it is used for a content-addressed blob read, and it is a large fraction of a daemon measured at 10.602 GiB at either end of that range.

| store | snapshot file | one open, peak `kin` RSS | multiple |
|---|---|---|---|
| requests | 1.027 GiB | 3.810 GiB | 3.71x |
| express | 0.262 GiB | 0.964 GiB | 3.68x |

A byte census of both snapshots, unaccounted 0 bytes on each with element counts as the label control, says requests is 986.6 MiB of `changes` against 0 bytes of `entities` and 0 bytes of `relations`. The graph the daemon answers from is not in that file.

## The change

`daemon.rs` builds the source view once when the worker starts and holds it until the worker stops, which on a running daemon is the life of the process. Its own comment recorded the trade that put an open there: once per worker rather than once per file. That removed 37 opens and replaced them with one permanently retained copy of the store.

`RepositoryAuthorityManager::load_source_blob` touches the backend and the repository id and nothing the open decoded, so the view can reach a body without one.

Verification does not change, and that was read rather than assumed. Three layers verify these bytes today and this route keeps two. The backend's own bounded read calls `verify_source_blob_digest` before returning. `validate_exact_source_bytes` re-verifies the digest against the tree entry, unchanged, and it already made the manager's own re-check a third copy of the same test. The size boundary is kept by passing the same `MAX_SOURCE_BLOB_BYTES` the manager passed. The namespace refusal the open carried is now explicit through `revalidate_pinned_namespace`, which reads identity from metadata alone and decodes no snapshot.

## One refusal narrows, and it is not hidden

`open_manager` carries two refusals. It revalidates the pinned storage root and the retained per-repository namespace identity, and its recovery also refuses a bound namespace whose persisted authority record has disappeared, rather than reopening it as a fresh generation-zero repository.

The first is kept explicitly, through `revalidate_pinned_namespace`. The second is not: building this view no longer refuses when the authority record is gone while the namespace is intact, because it no longer reads that record at all. The daemon still refuses that case at startup, where it opens authority for real, and this view is only ever built after that. So the window that narrows is a record vanishing under a running daemon, and on that path a body read now fails on the body rather than the record.

I would rather name it here than have it found in review.

## The guard, and why it is not on a wrapper

The counter sits at kin-core's funnel rather than at any wrapper. kin-daemon already counts opens through `LocalRepositoryAuthorityContext` and cannot see one taken through `binding.open_manager`, so a count there is a proxy and the mutation that matters moves the thing while leaving the proxy still. It is per thread for the reason the existing counter is: a process-wide count makes any assertion on it flaky under cargo's default parallelism.

The test requires the counter to MOVE across a daemon open before it requires it to hold still. Every other assertion in it is that a count did not move, and a counter stuck at any constant satisfies all of those while proving nothing.

## Falsification

| arm | mutation | verdict |
|---|---|---|
| M0 | none | GREEN |
| M1 | reintroduce the open where the view is built | RED on the view-construction assertion |
| M2 | reintroduce the open inside `load_text` | RED on the load-text assertion |
| M3 | neuter the counter to a constant | RED on the positive control |
| M4 | body read returns `Ok(None)` | RED on the content assertion |

No row is green across, and each arm records which assertion answered rather than only that it went red. M1 and M2 are different mutations of one property so the two count assertions cannot cover for each other. The driver compile-checks before the first arm, refuses a dirty tree above its restore trap, and left the tree clean with zero mutant markers.

## The new acceptance suite, and the limit I am not hiding

`scripts/acceptance/source_view_authority_opens.py` grades the class: authority opens must not scale with the amount of work. Self-test passes with 11 expectations each answered against their inverse. It names no call site, no cache and no type, for the reason the coverage-read suite gives.

**It passes on the unfixed binary too**, 5 opens at 4 files and 5 at 24, ratio 1.00, because no language server is installed in that run so the enrichment worker never starts. So it is not a regression gate for this change; the Rust test is. It still earns its place, because nothing gated "an O(store) open must not be paid per unit of work" before it and that is the shape every cheap path breaks the same way.

## One commit here is not mine, on purpose

The last commit repairs another change's omission. Main's `Product Acceptance` has been red for three runs on the workflow-visibility step, because #1307 added the ref-grammar suite to `acceptance.yml` without the matching `EXPECTED_SUITES` entry. The last green was #1310. One entry restores it, after which the guard reports 26 suite reports reaching one always-running verdict in order and its own self-test still passes. It is separable and nothing else here depends on it.

## What this does not do

It does not make a killed sweep durable, and I am not asserting FIR-2843's mechanism either, because reading the call path undercut the account I first wrote. The comment on the enrichment worker says everything a sweep makes durable happens after its last file, but `publish_local_workspace_enrichment` is reached from `save_snapshot_impl`, the periodic persistence path, and it defers on a try-lock when a repository command holds the coordination gate. So enrichment can become durable mid-sweep and can also defer, and which of those a killed sweep met is not something I measured. What is measured is the outcome the stranger recorded on rc063a: relations fell after the kill, UsesType went to zero, and the sweep suspended itself after three failures. FIR-2843 wants that mechanism established before a fix is chosen, which is a measurement rather than a patch.

It does not close FIR-2955. This removes the longest-lived retained copy. The larger lever, collapsing the three `ProjectionAuthorityCache` wrapper slots onto one shared manager, is what the cache's own comment calls migration debt and says would reshape the projection path. The structural lever, not decoding the change map on a serving open, would take a copy down to roughly the authority envelope's 6 percent share of the file, and it lives in kin-db's persistence layer.

## Gates run

`bin/kin-precheck kin` on the lane worktree: 16 gates enumerated from ci.yml's own check job, 16 ran, 16 passed, 0 failed, on sha 52d1942c4, which is this branch before the rebase onto current main. Full report at `.kin-coord/reports/daemonres-20260830.md`.
