### PR TITLE
Say the true thing in five agent-facing surfaces (FIR-3031, 3033, 3035, 3036, 3037)

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2160,13 +2160,40 @@ fn record_vector_index_degradation(
             ),
             "run 'kin embed' until kin status reports full embedding coverage".to_string(),
         )
+    } else if kin_daemon_spawn::auto_embed_enabled_from(
+        std::env::var(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV)
+            .ok()
+            .as_deref(),
+    ) {
+        // An attached index reading zero is a fill that has started and not yet
+        // landed a vector, which is what the doc comment above already says and
+        // what the message used to deny. A stranger followed the old
+        // remediation, ran `kin embed`, and got "already fully covered at 53/53
+        // when this pass started, so the work was finished before it ran" in
+        // 0.059 s: the index was not empty, the query had sampled it about eight
+        // seconds after a commit, and the advice was spent before it was read
+        // (FIR-3035). Naming the command here is the defect, not a detail, so
+        // this arm names the wait and the counter instead.
+        (
+            "filling",
+            format!(
+                "vector index still filling: 0/{} entities embedded at the instant this query \
+                 sampled it, so semantic ranking is off for this answer and only lexical and \
+                 graph signals ranked it",
+                coverage.total
+            ),
+            "the background embedding pass is building this index; re-run the query once it \
+             finishes, and 'kin status' reports the coverage it has reached"
+                .to_string(),
+        )
     } else {
         (
             "empty",
             format!(
-                "vector index empty: 0/{} entities embedded, so semantic ranking is off \
-                 and only lexical and graph signals ranked this query",
-                coverage.total
+                "vector index empty: 0/{} entities embedded, and {} opts out of the background \
+                 embedding pass, so nothing will fill it on its own",
+                coverage.total,
+                kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV
             ),
             "run 'kin embed' until kin status reports full embedding coverage".to_string(),
         )
@@ -22477,13 +22504,107 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             reasons,
-            vec!["absent", "empty", "partial"],
-            "the same 0/12 counters must read as absent or empty depending on the index"
+            vec!["absent", "filling", "partial"],
+            "the same 0/12 counters must read as absent, filling or partial depending on the \
+             index and on whether a pass is coming"
         );
         assert!(
             sink[0].remediation.contains("kin embed"),
             "an unbuilt index must name the command that builds it: {}",
             sink[0].remediation
+        );
+    }
+
+    /// FIR-3035. An attached index reading zero is being FILLED, and saying
+    /// "empty" beside a `kin embed` remediation sends the reader to a command
+    /// that is already a no-op.
+    ///
+    /// A stranger followed that advice on a 53-entity store and `kin embed`
+    /// answered in 0.059 s: "already fully covered at 53/53 indexed when this
+    /// pass started, so the work was finished before it ran". The envelope was
+    /// honest about the instant it sampled and wrong as guidance, because the
+    /// state model had no value between never-built and done.
+    ///
+    /// The three arms are the whole point. Only the middle one changes, and the
+    /// two either side must keep naming `kin embed`, because a fill nothing is
+    /// driving really does need it.
+    #[cfg(feature = "vector")]
+    #[test]
+    #[serial_test::serial]
+    fn a_mid_fill_index_names_the_fill_and_not_a_command_that_would_no_op() {
+        let unfilled = kin_db::EmbeddingStatus {
+            pending: 53,
+            indexed: 0,
+            total: 53,
+        };
+
+        // The arm under test: attached, zero indexed, a pass on its way.
+        let mut filling = Vec::new();
+        {
+            let _on =
+                kin_core::test_env::EnvVarGuard::unset(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV);
+            record_vector_index_degradation(
+                &coverage_from_status(&unfilled, true),
+                true,
+                &mut filling,
+            );
+        }
+        assert_eq!(filling[0].reason, "filling", "{:?}", filling[0]);
+        assert!(
+            filling[0].detail.contains("still filling"),
+            "the reader has to learn a pass is running: {}",
+            filling[0].detail
+        );
+        assert!(
+            !filling[0].remediation.contains("kin embed"),
+            "naming a command that has already finished is the defect: {}",
+            filling[0].remediation
+        );
+
+        // Control one, named by the ticket: an index nothing has built. `absent`
+        // and the `kin embed` remediation must both survive.
+        let mut absent = Vec::new();
+        {
+            let _on =
+                kin_core::test_env::EnvVarGuard::unset(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV);
+            record_vector_index_degradation(
+                &coverage_from_status(&unfilled, false),
+                false,
+                &mut absent,
+            );
+        }
+        assert_eq!(absent[0].reason, "absent", "{:?}", absent[0]);
+        assert!(
+            absent[0].remediation.contains("kin embed"),
+            "an index nobody built still needs the command that builds it: {}",
+            absent[0].remediation
+        );
+
+        // Control two: attached and zero, with the background pass opted OUT.
+        // Nothing is filling this one, so it is genuinely empty and the old
+        // wording is the right wording.
+        let mut opted_out = Vec::new();
+        {
+            let _off =
+                kin_core::test_env::EnvVarGuard::set(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV, "0");
+            record_vector_index_degradation(
+                &coverage_from_status(&unfilled, true),
+                true,
+                &mut opted_out,
+            );
+        }
+        assert_eq!(opted_out[0].reason, "empty", "{:?}", opted_out[0]);
+        assert!(
+            opted_out[0].remediation.contains("kin embed"),
+            "with no pass coming, the command is the only way out: {}",
+            opted_out[0].remediation
+        );
+        assert!(
+            opted_out[0]
+                .detail
+                .contains(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV),
+            "and the lever that decided it must be named: {}",
+            opted_out[0].detail
         );
     }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -22549,7 +22549,11 @@ mod tests {
                 &mut filling,
             );
         }
-        assert_eq!(filling[0].reason, "filling", "{:?}", filling[0]);
+        assert_eq!(
+            filling[0].reason, "filling",
+            "an attached index at zero is being filled, not empty: {:?}",
+            filling[0]
+        );
         assert!(
             filling[0].detail.contains("still filling"),
             "the reader has to learn a pass is running: {}",

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13692,13 +13692,24 @@ pub(crate) fn decide_language_server_request(
         "Nothing to install. This repository's Reference edge coverage row does not report a \
          language-server gap."
     };
-    LanguageServerDecision::Explain(vec![
+    let mut lines = vec![
         headline.to_string(),
         format!(
             "Read that row above for what it does report. {}.",
             host_language_server_state(&request.missing_on_host)
         ),
-    ])
+    ];
+    // The commands, on the one refusal path that still turns a user away with
+    // servers missing. The stranger who found the loop called printing them the
+    // saving grace, because it made the detour cost a minute rather than an
+    // afternoon; they used to live on the no-gap branch, which now installs.
+    if !request.missing_on_host.is_empty() {
+        lines.push("Install them by hand with:".to_string());
+        for command in language_servers::install_commands_for(&request.missing_on_host) {
+            lines.push(format!("  {command}"));
+        }
+    }
+    LanguageServerDecision::Explain(lines)
 }
 
 /// Print an [`LanguageServerDecision::Explain`], and nothing otherwise.
@@ -23483,6 +23494,10 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         assert!(
             !text.contains("reports no reference-edge gap"),
             "an unread row proves nothing about the gap: {text}"
+        );
+        assert!(
+            text.contains("npm install -g pyright"),
+            "a refusal that still turns the user away owes them the command: {text}"
         );
     }
 

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13591,14 +13591,32 @@ pub(crate) fn decide_language_server_request(
     use crate::commands::health::HealthStatus;
 
     // Pending and Stale are exactly the two states the coverage row takes when
-    // a language-server gap was actually OBSERVED. Every other state either
-    // read the graph and found nothing to close, or never read it at all, and
-    // spending a user's bandwidth off the back of an unread row is the prompt
-    // this gate exists to refuse.
+    // a language-server gap was actually OBSERVED.
     let gap_observed = matches!(
         request.coverage_status,
         Some(HealthStatus::Pending | HealthStatus::Stale)
     );
+
+    // Healthy joins them for the INSTALL decision, and only for that decision.
+    //
+    // Requiring an observed gap made the advice circular: `kin init` closes by
+    // telling the user to run this, and run from that same fresh repository it
+    // answered "run this again from a repository whose Reference edge coverage
+    // row names the gap" -- and a repository only carries that gap after it has
+    // been converted without the servers, which is the outcome the init note was
+    // warning against (FIR-3036). The moment it refused was the only moment the
+    // advice was worth anything.
+    //
+    // What the old gate was really protecting is still protected, in both of its
+    // halves. A row nobody READ is still no reason to spend a user's bandwidth,
+    // so None, Unsupported, Missing, Degraded and Misconfigured install nothing;
+    // Healthy is a row that was read. And the new arm additionally requires that
+    // the user ASKED, because this gate sits above the not-requested return
+    // below and a bare `kin doctor --fix` must not fetch language servers nobody
+    // mentioned. An observed gap keeps its old behaviour under a bare `--fix`,
+    // where closing it is the repair that was requested.
+    let coverage_was_read = gap_observed
+        || (request.requested && matches!(request.coverage_status, Some(HealthStatus::Healthy)));
 
     if !request.fixing {
         // Installing downloads packages into a shared prefix, so it belongs
@@ -13615,7 +13633,7 @@ pub(crate) fn decide_language_server_request(
         ]);
     }
 
-    if gap_observed && !request.missing_on_host.is_empty() {
+    if coverage_was_read && !request.missing_on_host.is_empty() {
         return LanguageServerDecision::Install(request.missing_on_host.clone());
     }
 
@@ -13663,23 +13681,6 @@ pub(crate) fn decide_language_server_request(
     // In a repository, servers missing from the host, and no gap to close. The
     // two ways that happens read differently and are kept apart, because only
     // one of them means the graph was actually consulted.
-    if matches!(request.coverage_status, Some(HealthStatus::Healthy)) {
-        let mut lines = vec![
-            "Nothing to install. This repository's graph reports no reference-edge gap, and that \
-             gap is what the install closes."
-                .to_string(),
-            format!(
-                "This host is still missing a server for {}. Install by hand, or run this again \
-                 from a repository whose Reference edge coverage row names the gap:",
-                language_list(&request.missing_on_host)
-            ),
-        ];
-        for command in language_servers::install_commands_for(&request.missing_on_host) {
-            lines.push(format!("  {command}"));
-        }
-        return LanguageServerDecision::Explain(lines);
-    }
-
     // The row exists and reports something other than a verdict from a graph it
     // read. `Unsupported` is the reachable one, and it is always phrased "n/a"
     // by the health check, so naming it as unread is the row's own claim rather
@@ -23415,27 +23416,52 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         );
     }
 
-    /// The second half of hole two, and the state the two strangers were
-    /// actually in: servers missing from the host, and a repository whose graph
-    /// reported no gap for them to close.
+    /// FIR-3036. The state a stranger is actually in on a fresh repository:
+    /// servers missing from the host, and a coverage row that read the graph and
+    /// found no gap yet. That must INSTALL.
+    ///
+    /// It used to refuse with "run this again from a repository whose Reference
+    /// edge coverage row names the gap", which is a loop: `kin init` sends the
+    /// user here, and a repository only carries that gap once it has been
+    /// converted without the servers, which is what the init note was warning
+    /// against. The refusal was defensible and it arrived at the only moment the
+    /// advice was worth anything.
     #[test]
-    fn a_repository_with_no_gap_names_the_missing_servers_and_the_commands() {
-        let lines = explained(&super::LanguageServerRequest {
-            missing_on_host: vec![LanguageId::Python],
+    fn a_fresh_repository_missing_servers_installs_them() {
+        assert_eq!(
+            super::decide_language_server_request(&super::LanguageServerRequest {
+                coverage_status: Some(HealthStatus::Healthy),
+                missing_on_host: vec![LanguageId::Python],
+                ..request(true, true)
+            }),
+            super::LanguageServerDecision::Install(vec![LanguageId::Python]),
+            "a read row with no gap yet is the moment installing is still free"
+        );
+    }
+
+    /// The control for the test above: the same read row on a host that already
+    /// has every server. Nothing to install, and it says so as a fact about the
+    /// host rather than about the repository.
+    #[test]
+    fn a_fresh_repository_on_a_complete_host_installs_nothing() {
+        let decision = super::decide_language_server_request(&super::LanguageServerRequest {
+            coverage_status: Some(HealthStatus::Healthy),
+            missing_on_host: Vec::new(),
             ..request(true, true)
         });
-        let text = lines.join("\n");
         assert!(
-            text.contains("This repository's graph reports no reference-edge gap"),
+            !matches!(decision, super::LanguageServerDecision::Install(_)),
+            "there is nothing to install: {decision:?}"
+        );
+        let text = explained(&super::LanguageServerRequest {
+            coverage_status: Some(HealthStatus::Healthy),
+            missing_on_host: Vec::new(),
+            ..request(true, true)
+        })
+        .join("\n");
+        assert!(
+            text.contains("Every language this build enriches already has a server on this host"),
             "{text}"
-        );
-        assert!(
-            text.contains("This host is still missing a server for python"),
-            "the host fact and the repository fact are different facts: {text}"
-        );
-        assert!(
-            text.contains("npm install -g pyright"),
-            "the command is the whole value of saying anything here: {text}"
         );
     }
 
@@ -23460,11 +23486,20 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         );
     }
 
-    /// The gate itself still opens on exactly the two observed-gap states, and
-    /// on nothing else. This is the behavior the honesty batch must not spend.
+    /// The gate opens on exactly the states where the coverage row was READ,
+    /// and on nothing else.
+    ///
+    /// Healthy joined Pending and Stale under FIR-3036. What the original gate
+    /// was protecting is the half that must not be spent: a row nobody read is
+    /// no reason to spend a user's bandwidth, so every unread state below still
+    /// installs nothing.
     #[test]
-    fn only_an_observed_gap_installs_anything() {
-        for status in [HealthStatus::Pending, HealthStatus::Stale] {
+    fn only_a_read_coverage_row_installs_anything() {
+        for status in [
+            HealthStatus::Pending,
+            HealthStatus::Stale,
+            HealthStatus::Healthy,
+        ] {
             assert_eq!(
                 super::decide_language_server_request(&super::LanguageServerRequest {
                     coverage_status: Some(status.clone()),
@@ -23472,12 +23507,24 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
                     ..request(true, true)
                 }),
                 super::LanguageServerDecision::Install(vec![LanguageId::Python]),
-                "{status:?} is an observed gap"
+                "{status:?} is a coverage row that was read"
             );
         }
+        // And Healthy installs only for a run that ASKED. This gate sits above
+        // the not-requested return, so without this a bare `kin doctor --fix`
+        // would fetch servers nobody mentioned.
+        assert_eq!(
+            super::decide_language_server_request(&super::LanguageServerRequest {
+                coverage_status: Some(HealthStatus::Healthy),
+                missing_on_host: vec![LanguageId::Python],
+                ..request(false, true)
+            }),
+            super::LanguageServerDecision::Silent,
+            "a bare --fix never raised the subject"
+        );
+
         for status in [
             None,
-            Some(HealthStatus::Healthy),
             Some(HealthStatus::Unsupported),
             Some(HealthStatus::Missing),
             Some(HealthStatus::Degraded),
@@ -23490,7 +23537,7 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
             });
             assert!(
                 !matches!(decision, super::LanguageServerDecision::Install(_)),
-                "{status:?} is not an observed gap, so it must not spend bandwidth"
+                "{status:?} never read the graph, so it must not spend bandwidth"
             );
         }
     }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -7684,8 +7684,18 @@ mod tests {
     #[test]
     fn a_health_change_mid_session_is_announced_again() {
         let repo = "/tmp/fir3037-change";
-        assert!(super::should_report_health(repo, "attention"));
-        assert!(!super::should_report_health(repo, "attention"));
+        // Named, not bare. A silent `assert!` is red under any mutation and
+        // tells the falsification grid nothing about WHICH one it caught, which
+        // is the difference between a mutant that was caught and one that
+        // happened to break something.
+        assert!(
+            super::should_report_health(repo, "attention"),
+            "the first sighting of a degraded daemon is news"
+        );
+        assert!(
+            !super::should_report_health(repo, "attention"),
+            "and repeating it is not"
+        );
 
         // The daemon recovers. `validate_health_repo` clears the memory on any
         // other serving status, which is what this models.

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -4758,7 +4758,10 @@ pub(crate) fn validate_health_repo(health: &HealthResponse, working_dir: &Path) 
         RepoIdentity::Rejected(reason) | RepoIdentity::Indeterminate(reason) => bail!(reason),
     }
     if health.status == "attention" {
-        warn_on_health_change(health.repo_root.as_deref().unwrap_or("<unknown>"), "attention");
+        warn_on_health_change(
+            health.repo_root.as_deref().unwrap_or("<unknown>"),
+            "attention",
+        );
     } else {
         // Any other serving status clears the memory, so a daemon that returns
         // to attention later is announced again. Without this the notice would
@@ -4781,9 +4784,8 @@ pub(crate) fn validate_health_repo(health: &HealthResponse, working_dir: &Path) 
 ///
 /// Keyed by repo root because one process can talk to more than one repository,
 /// and a second repository going degraded is its own news.
-static REPORTED_HEALTH: std::sync::Mutex<
-    Option<std::collections::HashMap<String, &'static str>>,
-> = std::sync::Mutex::new(None);
+static REPORTED_HEALTH: std::sync::Mutex<Option<std::collections::HashMap<String, &'static str>>> =
+    std::sync::Mutex::new(None);
 
 /// Whether this status is news for this repository root.
 ///
@@ -11311,7 +11313,6 @@ mod tests {
     }
 
     #[cfg(windows)]
-
     #[test]
     fn windows_directory_handle_can_preserve_bounded_rollback_timestamp() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -4758,13 +4758,67 @@ pub(crate) fn validate_health_repo(health: &HealthResponse, working_dir: &Path) 
         RepoIdentity::Rejected(reason) | RepoIdentity::Indeterminate(reason) => bail!(reason),
     }
     if health.status == "attention" {
+        warn_on_health_change(health.repo_root.as_deref().unwrap_or("<unknown>"), "attention");
+    } else {
+        // Any other serving status clears the memory, so a daemon that returns
+        // to attention later is announced again. Without this the notice would
+        // be once per process and a real change of state would go unsaid.
+        forget_reported_health(health.repo_root.as_deref().unwrap_or("<unknown>"));
+    }
+    Ok(())
+}
+
+/// The health status last announced for a repository root, so a degraded daemon
+/// is reported when its state CHANGES rather than on every call.
+///
+/// [`validate_health_repo`] has four production call sites and is entered
+/// several times per command, so the notice printed twice inside one `kin
+/// doctor` and, in a stranger's words, "before almost every command after the
+/// daemon restart" (FIR-3037). The decision to keep serving a degraded daemon is
+/// right and is not what changed; a line that prints before every command
+/// teaches the reader to skip it, which is expensive on the day the cause is
+/// different.
+///
+/// Keyed by repo root because one process can talk to more than one repository,
+/// and a second repository going degraded is its own news.
+static REPORTED_HEALTH: std::sync::Mutex<
+    Option<std::collections::HashMap<String, &'static str>>,
+> = std::sync::Mutex::new(None);
+
+/// Whether this status is news for this repository root.
+///
+/// Separated from the `warn!` so the rule can be graded directly. A test that
+/// counted log lines would be asserting on a proxy for the decision; this IS the
+/// decision, and the warning below is its one consequence.
+fn should_report_health(repo_root: &str, status: &'static str) -> bool {
+    match REPORTED_HEALTH.lock() {
+        Ok(mut guard) => {
+            let seen = guard.get_or_insert_with(std::collections::HashMap::new);
+            seen.insert(repo_root.to_string(), status) != Some(status)
+        }
+        // A poisoned lock must not silence a degraded daemon. Warning twice is
+        // the failure this exists to reduce; warning zero times is the one it
+        // must not introduce.
+        Err(_) => true,
+    }
+}
+
+fn warn_on_health_change(repo_root: &str, status: &'static str) {
+    if should_report_health(repo_root, status) {
         warn!(
-            repo_root = health.repo_root.as_deref().unwrap_or("<unknown>"),
+            repo_root = repo_root,
             "daemon is up and serving but reports health=attention (degraded); \
              continuing to use it. Run `kin doctor` for details."
         );
     }
-    Ok(())
+}
+
+fn forget_reported_health(repo_root: &str) {
+    if let Ok(mut guard) = REPORTED_HEALTH.lock() {
+        if let Some(seen) = guard.as_mut() {
+            seen.remove(repo_root);
+        }
+    }
 }
 
 struct StartupLock {
@@ -7597,6 +7651,62 @@ mod urlencoding {
 
 #[cfg(test)]
 mod tests {
+    /// FIR-3037. A degraded daemon is announced when its state CHANGES, not on
+    /// every call.
+    ///
+    /// `validate_health_repo` has four production call sites and is entered
+    /// several times per command, so this line printed twice inside one `kin
+    /// doctor` and before almost every command in a stranger's session. The
+    /// decision to keep serving a degraded daemon is right and is not what
+    /// changed.
+    #[test]
+    fn a_degraded_daemon_is_announced_on_a_change_and_not_per_call() {
+        let repo = "/tmp/fir3037-repeat";
+        assert!(
+            super::should_report_health(repo, "attention"),
+            "the first sighting is news"
+        );
+        for call in 0..4 {
+            assert!(
+                !super::should_report_health(repo, "attention"),
+                "call {call} repeated a state nothing changed about"
+            );
+        }
+    }
+
+    /// The control: a daemon whose health CHANGES mid-session must produce a
+    /// second line.
+    ///
+    /// Without it the rule above is satisfied by a latch that reports once and
+    /// never again, which would hide the very transition the warning exists for.
+    #[test]
+    fn a_health_change_mid_session_is_announced_again() {
+        let repo = "/tmp/fir3037-change";
+        assert!(super::should_report_health(repo, "attention"));
+        assert!(!super::should_report_health(repo, "attention"));
+
+        // The daemon recovers. `validate_health_repo` clears the memory on any
+        // other serving status, which is what this models.
+        super::forget_reported_health(repo);
+
+        assert!(
+            super::should_report_health(repo, "attention"),
+            "a daemon that went degraded again is news again"
+        );
+    }
+
+    /// And a second repository is its own subject, because one process can talk
+    /// to more than one.
+    #[test]
+    fn each_repository_root_is_announced_on_its_own() {
+        assert!(super::should_report_health("/tmp/fir3037-a", "attention"));
+        assert!(
+            super::should_report_health("/tmp/fir3037-b", "attention"),
+            "a different repository going degraded is its own news"
+        );
+        assert!(!super::should_report_health("/tmp/fir3037-a", "attention"));
+    }
+
     use super::*;
 
     /// The startup-phase line the MCP answer-early path injects must track the
@@ -11201,6 +11311,7 @@ mod tests {
     }
 
     #[cfg(windows)]
+
     #[test]
     fn windows_directory_handle_can_preserve_bounded_rollback_timestamp() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1330,9 +1330,12 @@ match across the repo, with nothing at the reference site proving it). A `name_o
 is a candidate, not a fact; do not count it as use, and do not conclude something is \
 unused from the absence of anything but `name_only` rows without confirming. \
 `name_only` rows are held out of `total_upstream` and travel in `candidates`, and \
-`unconfirmed_candidates` beside the headline says how many were held, so a \
-`total_upstream` of 0 with `unconfirmed_candidates` above 0 means this answer is holding \
-rows it could not confirm and the zero may not be read alone. \
+`unconfirmed_candidates` beside the headline says how many were held. ANY \
+`total_upstream` with `unconfirmed_candidates` above 0 is a floor and not a total, the \
+zero no more than the one: `counts.upstream_including_unconfirmed` is the matching \
+ceiling, and the caller set lies between them. Read `references` alone and you get the \
+proven subset, which is the right answer to \"who provably calls this\" and the wrong \
+one to \"who calls this\". \
 `_kin.verdict` is the one verdict for the whole response and outranks every count in it. \
 The response bounds its own size (max_chars, default 45000 serialized characters, ceiling \
 60000): a symbol \
@@ -1575,6 +1578,15 @@ fn reference_counts(rows: &[ReferenceRow], receiver_name_candidates: usize) -> s
         // here so a reader who looks only at `counts` still learns the answer
         // withheld something (FIR-1552).
         "receiver_name_candidates": receiver_name_candidates,
+        // The union, because every other number here is a PROVEN count and a
+        // reader who wants "how many callers might there be" was left to add two
+        // of them together. A stranger read `total_upstream: 1` beside a
+        // `candidates` array holding the second of two real callers and wrote
+        // that reading `references` alone "would have given me a wrong answer
+        // that looked clean" (FIR-3033). This is the ceiling that headline is a
+        // floor of; it is not evidence that the extra rows are callers, which is
+        // what `receiver_name_candidates` above and `candidates` themselves say.
+        "upstream_including_unconfirmed": rows.len() + receiver_name_candidates,
     })
 }
 
@@ -8592,6 +8604,155 @@ mod tests {
             structurally_ready_envelope(),
             "find_references",
         ))
+    }
+
+    /// The psf/requests shape with TWO callers: one proven and one withheld.
+    ///
+    /// `requests_shape_response` moves its single relation between tiers, so it
+    /// can produce a headline of 0-and-1 or 1-and-0 but never the mixed answer a
+    /// stranger actually read. `proven` is the annotated caller
+    /// (`HTTPDigestAuth.handle_401` in the real repository, provable because
+    /// `Response.connection` is typed) and `withheld` is the bare-name receiver
+    /// (`Session.send`, whose adapter no static reader can pin).
+    async fn requests_shape_two_caller_response() -> serde_json::Value {
+        let store = InMemoryGraph::new();
+        let target = make_entity("send", "src/requests/adapters.rs");
+        let proven = make_entity("HTTPDigestAuth.handle_401", "src/requests/auth.rs");
+        let withheld = make_entity("Session.send", "src/requests/sessions.rs");
+        store.upsert_entity(&target).unwrap();
+        store.upsert_entity(&proven).unwrap();
+        store.upsert_entity(&withheld).unwrap();
+
+        for (caller, confidence, line) in [
+            (&proven, 1.0f32, 312u32),
+            (
+                &withheld,
+                kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE,
+                784,
+            ),
+        ] {
+            let mut relation =
+                make_relation_at(caller.id, target.id, RelationKind::Calls, confidence);
+            relation.evidence = vec![RelationEvidence {
+                source_span: Some(kin_model::entity::SourceSpan {
+                    file: FilePathId::new(
+                        caller.file_origin.as_ref().unwrap().to_string().as_str(),
+                    ),
+                    start_byte: 0,
+                    end_byte: 1,
+                    start_line: line - 1,
+                    start_col: 0,
+                    end_line: line - 1,
+                    end_col: 1,
+                }),
+                ..RelationEvidence::default()
+            }];
+            store.upsert_relation(&relation).unwrap();
+        }
+        seed_cross_file_call_witness(&store);
+        let registered_root = graph_root(&store);
+
+        let spine = kin_spine::InMemorySpineBackend::new();
+        spine.register_repo(
+            "requests",
+            vec![spine_entry("requests", &target)],
+            &registered_root,
+        );
+        spine.refresh_cross_repo_edges("requests", &[], &[], &["requests".to_string()]);
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        parsed_response(&crate::finalize_with_envelope(
+            handle_find_references_with_authority(
+                &args,
+                &store,
+                FindReferencesAuthority {
+                    repo_id: "requests",
+                    graph_root: &registered_root,
+                    spine: Some(&spine),
+                },
+                None,
+            )
+            .await
+            .unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ))
+    }
+
+    /// FIR-3033. Two real callers, one provable and one not, and no single count
+    /// in the response may be read as "the number of callers" while omitting
+    /// one.
+    ///
+    /// The stranger's line is the specification: reading `references` alone
+    /// "would have given me a wrong answer that looked clean". The split is
+    /// right and stays; what was missing is a number a reader can take as the
+    /// ceiling, so the pair brackets the truth instead of one number implying
+    /// it.
+    #[tokio::test]
+    async fn a_mixed_answer_publishes_a_ceiling_beside_its_floor() {
+        let response = requests_shape_two_caller_response().await;
+
+        assert_eq!(
+            response["total_upstream"], 1,
+            "the headline still counts only what resolved: {response:#}"
+        );
+        assert_eq!(
+            response["unconfirmed_candidates"], 1,
+            "and it still says how many it is holding: {response:#}"
+        );
+        assert_eq!(
+            response["counts"]["upstream_including_unconfirmed"], 2,
+            "the ceiling is the union of both collections: {}",
+            response["counts"]
+        );
+
+        // The property the ticket asks for, asserted over the counts the
+        // response actually carries rather than over a list written twice: every
+        // top-level count is either the proven floor, the withheld count, or the
+        // union, and the union is the only one that equals the row total.
+        let rows = response["references"].as_array().unwrap().len()
+            + response["candidates"].as_array().unwrap().len();
+        assert_eq!(rows, 2, "{response:#}");
+        assert_eq!(
+            response["counts"]["upstream_including_unconfirmed"]
+                .as_u64()
+                .unwrap() as usize,
+            rows,
+            "the ceiling must account for every row the response carries: {response:#}"
+        );
+        assert!(
+            response["counts"]["referencing_entities"].as_u64().unwrap() < rows as u64,
+            "and it must differ from the floor on this fixture, or the pair proves nothing: {}",
+            response["counts"]
+        );
+    }
+
+    /// The control for the test above: only proven callers, where the floor and
+    /// the ceiling must AGREE.
+    ///
+    /// Without it the assertion above is satisfied by a ceiling that always
+    /// exceeds the floor, which would be a different defect wearing the fix's
+    /// shape.
+    #[tokio::test]
+    async fn an_all_proven_answer_has_a_ceiling_equal_to_its_floor() {
+        let response = requests_shape_response(1.0).await;
+
+        assert_eq!(response["total_upstream"], 1, "{response:#}");
+        assert_eq!(response["unconfirmed_candidates"], 0, "{response:#}");
+        assert_eq!(
+            response["counts"]["upstream_including_unconfirmed"], 1,
+            "nothing was withheld, so the ceiling is the headline: {}",
+            response["counts"]
+        );
+        assert_eq!(
+            response["counts"]["upstream_including_unconfirmed"],
+            response["counts"]["referencing_entities"],
+            "floor and ceiling agree when the answer withheld nothing: {}",
+            response["counts"]
+        );
     }
 
     /// The control for [`a_withheld_caller_refuses_the_zero_it_was_held_out_of`]:

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1459,13 +1459,22 @@ fn focal_resolution_gap(payload: &Value, subject: &str) -> Option<String> {
                 .get("matched")
                 .and_then(Value::as_str)
                 .unwrap_or("exact_focal_name");
+            // A pattern match and a name collision are different situations and
+            // the old wording described the milder one in the vocabulary of the
+            // worse. `find_references("slugify")` reported "3 entities match the
+            // name that was queried" where one entity is NAMED slugify and two
+            // are tests whose names merely contain it, which reads as three
+            // same-named definitions: a much scarier thing than what happened
+            // (FIR-3037). The response already carries the distinction in
+            // `matched`; this says it.
             let clause = if counted == "query_name_pattern" {
-                "match the name that was queried"
+                "matched the queried name as a pattern, which includes entities whose names \
+                 merely contain it,"
             } else {
-                "share the focal's name"
+                "share the focal's name exactly, and"
             };
             Some(format!(
-                "focal_resolution_ambiguous: {candidates} entities {clause} and only one was \
+                "focal_resolution_ambiguous: {candidates} entities {clause} only one was \
                  answered for, so {subject} is not evidence about the others"
             ))
         }
@@ -3200,9 +3209,52 @@ mod tests {
             "the ambiguous resolution must be named: {reason}"
         );
         assert!(
-            reason.contains("match the name that was queried"),
+            reason.contains("matched the queried name as a pattern"),
             "an ambiguous QUERY and an ambiguous graph send a reader to different \
              places, so the gap must say which one this is: {reason}"
+        );
+        assert!(
+            reason.contains("names merely contain it"),
+            "a pattern match is not a name collision, and saying so is the fix: {reason}"
+        );
+        assert!(
+            !reason.contains("share the focal's name"),
+            "the collision wording belongs to the other arm: {reason}"
+        );
+    }
+
+    /// The control for the pattern-match wording: a GENUINE collision, two
+    /// definitions carrying one name, where the collision wording must still
+    /// appear.
+    ///
+    /// Without this, the fix above is satisfied by a message that never says
+    /// "share the focal's name" at all, which would trade a message that
+    /// overstates for one that cannot state the real case.
+    #[test]
+    fn a_real_name_collision_still_reads_as_a_collision() {
+        let mut payload = authoritative_empty_references("function");
+        payload["focal_resolution"] = json!({
+            "addressed_by": "name",
+            "same_name_candidates": 2,
+            "matched": "exact_focal_name",
+            "other_candidates": [
+                {"id": "00000000-0000-0000-0000-000000000002", "name": "resolve"},
+            ],
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("an empty reference list yields a negative");
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("focal_resolution_ambiguous"),
+            "a real collision is still an ambiguity: {reason}"
+        );
+        assert!(
+            reason.contains("share the focal's name exactly"),
+            "two definitions of one name is the case the collision wording is for: {reason}"
+        );
+        assert!(
+            !reason.contains("names merely contain it"),
+            "and it must not borrow the pattern-match wording: {reason}"
         );
     }
 

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -2593,6 +2593,59 @@ mod tests {
     /// branch. That keeps every assertion offline and deterministic: no test
     /// here ever reaches the daemon delegate, which on a machine with a live
     /// `KIN_DAEMON_URL` would open a connection and could spawn a daemon.
+    /// FIR-3031, graded through the handler a client actually reaches rather
+    /// than through the helper it calls.
+    ///
+    /// The helper has its own tests in `tools`. This one exists because a
+    /// correct helper nobody calls is the same observable surface as no fix at
+    /// all: deleting the call in `handle_tools_list` leaves every helper test
+    /// green.
+    #[test]
+    fn tools_list_says_where_a_withheld_tool_is() {
+        let config = McpServerConfig {
+            allowed_tools: Some(
+                crate::agent_default_tool_names()
+                    .iter()
+                    .map(|name| (*name).to_string())
+                    .collect(),
+            ),
+            ..McpServerConfig::default()
+        };
+        let response = handle_tools_list(Some(serde_json::json!(1)), &config);
+        let value = serde_json::to_value(&response).unwrap();
+        let tools = value["result"]["tools"].as_array().expect("a tools array");
+        assert_eq!(tools.len(), crate::agent_default_tool_names().len());
+
+        let find_references = tools
+            .iter()
+            .find(|tool| tool["name"] == "find_references")
+            .expect("find_references is served by the default profile");
+        let description = find_references["description"].as_str().unwrap();
+        assert!(
+            description.contains("bulk_check_references"),
+            "the batch advice survives: {description}"
+        );
+        assert!(
+            description.contains("not served by this tool profile"),
+            "and the served answer says the default profile withholds it: {description}"
+        );
+
+        // The control: the same handler with no profile filter must annotate
+        // nothing, because nothing is withheld.
+        let unfiltered = handle_tools_list(Some(serde_json::json!(2)), &McpServerConfig::default());
+        let unfiltered = serde_json::to_value(&unfiltered).unwrap();
+        for tool in unfiltered["result"]["tools"].as_array().unwrap() {
+            assert!(
+                !tool["description"]
+                    .as_str()
+                    .unwrap()
+                    .contains("not served by this tool profile"),
+                "an unfiltered surface withholds nothing: {}",
+                tool["name"]
+            );
+        }
+    }
+
     async fn drive_daemon_loop(
         client_messages: &[serde_json::Value],
         repo_binder: Option<RepoBinder>,

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -1112,7 +1112,18 @@ fn handle_initialize(
 fn handle_tools_list(id: Option<serde_json::Value>, config: &McpServerConfig) -> JsonRpcResponse {
     let mut tools = tool_definitions();
     if let Some(allowed) = &config.allowed_tools {
+        // Captured before the filter, because the annotation below has to tell a
+        // registered tool this profile withholds from a phrase that is simply
+        // prose. After the retain, the withheld ones are gone and that
+        // distinction is unrecoverable.
+        let registered: Vec<String> = tools.tools.iter().map(|tool| tool.name.clone()).collect();
         tools.tools.retain(|tool| allowed.contains(&tool.name));
+        // A served description that sends the reader to a tool this profile does
+        // not serve is a surface contradicting itself, and it is not rare: the
+        // default profile has five of them naming seven withheld tools
+        // (FIR-3031). Answered here rather than in any description, because this
+        // is the one place the served set is known.
+        crate::tools::annotate_unserved_cross_references(&mut tools, &registered, allowed);
     }
     JsonRpcResponse::success(id, serde_json::to_value(&tools).unwrap_or_default())
 }

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -300,6 +300,100 @@ fn transaction_operation_schema() -> serde_json::Value {
     })
 }
 
+/// Whether `name` occurs in `text` as a whole identifier rather than inside a
+/// longer one.
+///
+/// The distinction is the whole check. `get_entity` is a substring of
+/// `get_entity_source`, so a plain `contains` reports eight served descriptions
+/// as pointing at a tool the profile withholds when five of them merely mention
+/// the tool they are served beside. A word here is `[A-Za-z0-9_]`, which is what
+/// every MCP tool name is spelled from.
+fn names_tool_as_a_word(text: &str, name: &str) -> bool {
+    let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let bytes = text.as_bytes();
+    let mut from = 0;
+    while let Some(offset) = text[from..].find(name) {
+        let start = from + offset;
+        let end = start + name.len();
+        let before_ok = start == 0 || !is_word(bytes[start - 1]);
+        let after_ok = end == bytes.len() || !is_word(bytes[end]);
+        if before_ok && after_ok {
+            return true;
+        }
+        from = start + 1;
+    }
+    false
+}
+
+/// Every tool `description` points the reader at that this profile does not
+/// serve, in name order.
+///
+/// `registered` is the whole surface and `served` is this profile's slice of it,
+/// so a name is only reported when the crate really defines a tool by that name.
+/// That is what keeps ordinary prose out of the answer: a description saying
+/// "kin refs" names a CLI command, and no tool is registered under it.
+pub fn unserved_tools_named_in(
+    description: &str,
+    registered: &[String],
+    served: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    let mut named: Vec<String> = registered
+        .iter()
+        .filter(|name| !served.contains(*name))
+        .filter(|name| names_tool_as_a_word(description, name))
+        .cloned()
+        .collect();
+    named.sort();
+    named.dedup();
+    named
+}
+
+/// The sentence a served description gets when it points at a tool this profile
+/// withholds.
+///
+/// A stranger doing dead-code analysis read `find_references`' own description,
+/// which says not to loop it because `bulk_check_references` does the batch in
+/// one shot, and then could not find that tool: the default profile serves 20 of
+/// 65 and not that one, so the documented right way was unreachable from the
+/// configuration Kin ships (FIR-3031). It cost 13 calls on an eleven-export
+/// file.
+///
+/// This says where the tool is rather than deleting the advice, and it is
+/// computed from the served set rather than written into any description,
+/// because the same run found FIVE served descriptions in this state naming
+/// SEVEN withheld tools. Whether `agent-default` should carry a dead-code tool
+/// is a different question and FIR-2480 owns it; this makes the surface stop
+/// contradicting itself whatever that answer turns out to be.
+fn unserved_cross_reference_note(named: &[String]) -> String {
+    let (subject, object) = if named.len() == 1 {
+        ("This tool is", "it")
+    } else {
+        ("These tools are", "them")
+    };
+    format!(
+        " {subject} named above but not served by this tool profile: {}. \
+         Set KIN_MCP_TOOL_PROFILE=full (or --tool-profile full) to reach {object}.",
+        named.join(", ")
+    )
+}
+
+/// Annotate every served description that points at a withheld tool.
+///
+/// Called after the profile filter, which is the one place both halves are
+/// known. `registered` must be the surface BEFORE filtering.
+pub fn annotate_unserved_cross_references(
+    list: &mut ToolsListResult,
+    registered: &[String],
+    served: &std::collections::HashSet<String>,
+) {
+    for tool in &mut list.tools {
+        let named = unserved_tools_named_in(&tool.description, registered, served);
+        if !named.is_empty() {
+            tool.description.push_str(&unserved_cross_reference_note(&named));
+        }
+    }
+}
+
 /// Build the list of all MCP tools that Kin exposes, in name order.
 ///
 /// The order is part of the contract. A client caches the prompt it builds from
@@ -1564,6 +1658,158 @@ mod tests {
             checked >= 11,
             "the sweep found only {checked} budget parameters, so it is not reaching the schemas"
         );
+    }
+
+    /// The served surface may not point the reader at a tool it withholds
+    /// without saying where that tool is (FIR-3031).
+    ///
+    /// Driven off a real profile rather than a hand-listed pair, because the
+    /// stranger found one instance and the profile has five. Asserting the
+    /// CLASS is the point: a description and a profile can drift apart later
+    /// without either looking wrong on its own.
+    #[test]
+    fn a_served_description_never_points_at_a_withheld_tool_in_silence() {
+        let registered: Vec<String> = tool_definitions()
+            .tools
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect();
+        let served: BTreeSet<&str> = agent_default_tool_names().iter().copied().collect();
+        let served_set: std::collections::HashSet<String> =
+            served.iter().map(|name| (*name).to_string()).collect();
+
+        let mut list = tool_definitions();
+        list.tools.retain(|tool| served_set.contains(&tool.name));
+        assert_eq!(
+            list.tools.len(),
+            served.len(),
+            "the profile filter must serve every name the profile lists"
+        );
+        annotate_unserved_cross_references(&mut list, &registered, &served_set);
+
+        let mut annotated = 0usize;
+        for tool in &list.tools {
+            // The annotation is appended, so the names it reports are in the
+            // text too. Read the base description instead, which is what the
+            // producer wrote.
+            let base = tool
+                .description
+                .split(" This tool is named above but not served")
+                .next()
+                .and_then(|head| {
+                    head.split(" These tools are named above but not served")
+                        .next()
+                })
+                .unwrap_or(&tool.description);
+            let named = unserved_tools_named_in(base, &registered, &served_set);
+            if named.is_empty() {
+                continue;
+            }
+            annotated += 1;
+            for name in &named {
+                assert!(
+                    tool.description.contains(name)
+                        && tool.description.contains("not served by this tool profile"),
+                    "{} points at withheld `{name}` with no note saying where it is: {}",
+                    tool.name,
+                    tool.description
+                );
+            }
+        }
+        assert!(
+            annotated >= 1,
+            "the sweep annotated nothing, so it is not reaching the descriptions"
+        );
+
+        // The instance the stranger paid for, named outright so a reword that
+        // drops it fails here rather than silently.
+        let find_references = list
+            .tools
+            .iter()
+            .find(|tool| tool.name == "find_references")
+            .expect("find_references is in agent-default");
+        assert!(
+            find_references.description.contains("bulk_check_references"),
+            "the batch advice is worth keeping: {}",
+            find_references.description
+        );
+        assert!(
+            find_references
+                .description
+                .contains("not served by this tool profile"),
+            "and it must say the default profile does not serve it: {}",
+            find_references.description
+        );
+    }
+
+    /// The controls for the guard above, as a pair through the same call.
+    ///
+    /// A fabricated name must be FOUND when it is genuinely registered and
+    /// withheld, and a name that is merely a prefix of a served one must NOT be,
+    /// which is the case that broke the first measurement of this defect:
+    /// `get_entity` is a substring of `get_entity_source`, and a plain
+    /// `contains` reported eight offenders where five exist.
+    #[test]
+    fn the_withheld_tool_scan_separates_a_whole_name_from_a_prefix() {
+        let registered: Vec<String> = ["get_entity", "get_entity_source", "bulk_check_references"]
+            .iter()
+            .map(|name| (*name).to_string())
+            .collect();
+        let served: std::collections::HashSet<String> =
+            ["get_entity_source".to_string()].into_iter().collect();
+
+        // Positive: a withheld tool named as a whole word is found.
+        assert_eq!(
+            unserved_tools_named_in(
+                "don't loop this call, because bulk_check_references does the batch.",
+                &registered,
+                &served,
+            ),
+            vec!["bulk_check_references".to_string()],
+        );
+
+        // Negative: `get_entity` inside `get_entity_source` is not a mention of
+        // `get_entity`, and `get_entity_source` is served anyway.
+        assert!(
+            unserved_tools_named_in(
+                "drill to any row's entity_id with get_entity_source.",
+                &registered,
+                &served,
+            )
+            .is_empty(),
+            "a prefix of a served name is not a mention of the withheld tool"
+        );
+
+        // And a name nothing registers is prose, not a tool.
+        assert!(
+            unserved_tools_named_in(
+                "the same unit `kin refs` prints, per zzz_fab_tool.",
+                &registered,
+                &served,
+            )
+            .is_empty(),
+        );
+    }
+
+    /// The other control: a profile that withholds nothing gets no note at all.
+    #[test]
+    fn the_full_profile_annotates_nothing() {
+        let registered: Vec<String> = tool_definitions()
+            .tools
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect();
+        let served: std::collections::HashSet<String> = registered.iter().cloned().collect();
+        let mut list = tool_definitions();
+        annotate_unserved_cross_references(&mut list, &registered, &served);
+        for tool in &list.tools {
+            assert!(
+                !tool.description.contains("not served by this tool profile"),
+                "{} was annotated on a profile that withholds nothing: {}",
+                tool.name,
+                tool.description
+            );
+        }
     }
 
     #[test]

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -389,7 +389,8 @@ pub fn annotate_unserved_cross_references(
     for tool in &mut list.tools {
         let named = unserved_tools_named_in(&tool.description, registered, served);
         if !named.is_empty() {
-            tool.description.push_str(&unserved_cross_reference_note(&named));
+            tool.description
+                .push_str(&unserved_cross_reference_note(&named));
         }
     }
 }
@@ -1729,7 +1730,9 @@ mod tests {
             .find(|tool| tool.name == "find_references")
             .expect("find_references is in agent-default");
         assert!(
-            find_references.description.contains("bulk_check_references"),
+            find_references
+                .description
+                .contains("bulk_check_references"),
             "the batch advice is worth keeping: {}",
             find_references.description
         );
@@ -1781,14 +1784,12 @@ mod tests {
         );
 
         // And a name nothing registers is prose, not a tool.
-        assert!(
-            unserved_tools_named_in(
-                "the same unit `kin refs` prints, per zzz_fab_tool.",
-                &registered,
-                &served,
-            )
-            .is_empty(),
-        );
+        assert!(unserved_tools_named_in(
+            "the same unit `kin refs` prints, per zzz_fab_tool.",
+            &registered,
+            &served,
+        )
+        .is_empty(),);
     }
 
     /// The other control: a profile that withholds nothing gets no note at all.


### PR DESCRIPTION
Five Medium findings from the rc063a stranger run, all output honesty in the surfaces an
agent reads first. Each one cost that stranger minutes and a wrong turn, and none of them
is a wrong answer: in every case Kin knew the right thing and said something else.

Measured before any code was written, against a release build of `origin/main` at
`bf8453fadc490888dba1bce244b8e1fb934d9e0d`. None of the five was already fixed. Full table
in the lane report at `.kin-coord/reports/friction-20260830.md`.

## One of them is wider than it was filed

FIR-3031 records `find_references` telling an agent to use `bulk_check_references` while
the `agent-default` profile does not serve it. A real `tools/list` handshake says the class
is five of the twenty served tools, naming seven withheld tools between them:

```
find_references      -> bulk_check_references
impact_analysis      -> semantic_diff, semantic_review
kin_provenance_query -> entity_history
kin_session_start    -> kin_register_intent, register_session
trace_data_flow      -> trace_computation
```

A first pass over the same handshake reported eight, because `get_entity` is a substring of
`get_entity_source` and the match had no word boundary. The five is the word-boundary
number, with a served name that must not be reported and a fabricated name that must not
match as its two controls.

So the fix is a guard in `handle_tools_list`, the one place the served set is known, rather
than a reword of one sentence. **I chose to stop recommending it there rather than to serve
`bulk_check_references` in `agent-default`**, because adding a dead-code tool to that
profile is exactly the design question FIR-2480 owns and this lane has no standing to
settle it. The advice survives and now says where the tool is:

```
before:  ... don't loop this call per entity, because bulk_check_references does the batch in one shot.
after:   ... (unchanged) ... This tool is named above but not served by this tool profile:
         bulk_check_references. Set KIN_MCP_TOOL_PROFILE=full (or --tool-profile full) to reach it.
```

Measured end to end: 0 descriptions carried a note before, 5 after, on the same fixture
through the same handshake.

## The other four

**FIR-3033.** `total_upstream` counts proven callers and holds `name_only` rows in
`candidates`. The split is right and stays. What was missing is a ceiling, so a reader who
takes the headline as the caller count gets an answer that is wrong and looks clean.
`counts.upstream_including_unconfirmed` is the union, and the served description's floor
caveat used to fire only on a headline of zero:

```
before:  ... so a `total_upstream` of 0 with `unconfirmed_candidates` above 0 means this
         answer is holding rows it could not confirm and the zero may not be read alone.
after:   ... ANY `total_upstream` with `unconfirmed_candidates` above 0 is a floor and not
         a total, the zero no more than the one: `counts.upstream_including_unconfirmed`
         is the matching ceiling, and the caller set lies between them.
```

**FIR-3035.** An attached vector index reading zero was reported `empty` with a `kin embed`
remediation, and on a store whose background pass was running that command returned in
0.059 s saying the work had finished before it ran. The `empty` arm now branches on the
background-pass lever the `absent` arm above it already reads:

```
before:  vector index empty: 0/53 entities embedded, so semantic ranking is off ...
         remediation: run 'kin embed' until kin status reports full embedding coverage
after:   vector index still filling: 0/53 entities embedded at the instant this query
         sampled it, so semantic ranking is off for this answer ...
         remediation: the background embedding pass is building this index; re-run the
         query once it finishes, and 'kin status' reports the coverage it has reached
```

This is what the function's own doc comment already claimed. With the pass opted out the
index really is empty and keeps both the old wording and the command.

**FIR-3036.** `kin init` closes by telling the user to run
`kin doctor --fix --install-language-servers`, and from that same fresh repository the
command refused, asking for a repository whose coverage row already names a gap. A
repository only carries that gap once it has been converted without the servers, which is
what the init note was warning against. The gate now opens on a coverage row that was READ
rather than only one reporting a gap. Reproduced under a restricted PATH, which is what
makes this host look like the stranger's container:

```
before:  Nothing to install. This repository's graph reports no reference-edge gap, and
         that gap is what the install closes.
         This host is still missing a server for rust, python, typescript, javascript.
         Install by hand, or run this again from a repository whose Reference edge
         coverage row names the gap: ...
after:   (attempts the install, and reports per language why it cannot proceed here)
         ✗ `npm` is not installed and Kin has no other route to the python language
           server on this host, so it cannot run `npm install -g pyright`
```

Both halves of what the old gate protected survive. A row nobody read still installs
nothing, and the new arm additionally requires an explicit `--install-language-servers`,
because this gate sits above the not-requested return and a bare `kin doctor --fix` must
not fetch servers nobody mentioned. That second half was found by an existing test going
red rather than by review. The three exact install commands moved to the refusal that still
turns a user away, because the stranger called printing them the saving grace.

**FIR-3037.** Two wording defects.

```
before:  focal_resolution_ambiguous: 3 entities match the name that was queried and only
         one was answered for, ...
after:   focal_resolution_ambiguous: 3 entities matched the queried name as a pattern,
         which includes entities whose names merely contain it, only one was answered for, ...
```

One entity is named `slugify`; the other two are tests whose names contain it. The response
already carried the distinction under `matched`. A genuine collision keeps the collision
wording, and that is a test.

The degraded-health notice printed twice inside one `kin doctor`, 62 ms apart, because
`validate_health_repo` warns on every call and has four production call sites. It now fires
on a change of state. A daemon that recovers and degrades again is announced again, and
each repository root is its own subject.

## Checks

Every fix has a scripted check in the crate that fails on the literal and passes on the
fix, each with a control that a neighbouring correct output does not change: the full
profile annotates nothing; an all-proven answer's ceiling equals its floor; an index nobody
built keeps `absent` and `kin embed`; a complete host still reports nothing to install; a
real name collision keeps the collision wording.

Falsification grid of nine mutants run after committing, baseline green first, restored on
an EXIT/INT/TERM trap with the dirty-tree refusal above the trap. Every mutant went red on
its own named assertion, and the grid prints which assertion answered rather than only the
exit code. Three defects in the grid itself were caught and fixed on the way: an arm whose
test name did not exist graded zero tests and read as a SURVIVING mutant, so the driver now
refuses any arm that grades nothing; two expectations named an assertion's predicate where
a panic prints its message; and the listing control caught a test of mine that had landed
under a `#[cfg(windows)]`, which gated it off macOS and stole the attribute from the
Windows test below it.

`bin/kin-precheck kin` green on the rebased tree, 16 of 16 gates. Its clippy leg is what
caught `install_commands_for` going dead.

Closes FIR-3031
Closes FIR-3033
Closes FIR-3035
Closes FIR-3036
Closes FIR-3037
