### PR TITLE
Let a merge be abandoned from a workspace that moved, because abandoning restores nothing

### DIFF
--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -530,6 +530,78 @@ fn a_resolved_merge_publishes_ordered_parents_and_advances_only_the_target_ref()
 }
 
 /// Aborting proves the workspace equals the restore point the merge recorded,
+/// Abandoning a merge works from a workspace that has moved, because it
+/// restores nothing.
+///
+/// The rc063a stranger hand-edited a conflicted file and every exit refused:
+/// `resolve --continue`, `resolve --abort` and `merge` all answered 409 while
+/// `status` and `conflicts` kept advertising the merge, and `stash push --yes`
+/// followed by `stash pop` both succeeded and left it exactly as parked. The
+/// only recovery was `kin checkout --change`.
+///
+/// The gate that refused the abort compared the whole restore point, and it was
+/// protecting a sentence rather than an operation: abort's transaction carries
+/// no workspace mutation, no ref mutation and no changes, and its execution
+/// hands the finalizer the same tree twice with an empty delta.
+///
+/// So this asserts the property that makes unblocking it safe, rather than
+/// asserting that it now succeeds and stopping there: the bytes on disk are
+/// untouched, and the line says the workspace moved instead of claiming it is
+/// unchanged. A version that abandoned the merge AND reverted the caller's edit
+/// would pass a success-only test and lose their work.
+#[test]
+fn aborting_a_merge_from_a_moved_workspace_abandons_it_and_restores_nothing() {
+    let root = tempdir().expect("temp root");
+    let repo = conflicting_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+    parked_merge(
+        &run_kin(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+    let parked = persisted_record(&layout).expect("the merge is parked");
+
+    // Move the workspace the way a caller does: edit the conflicted file by
+    // hand, then let the daemon see it. `kin status` is what the stranger ran.
+    let edited = b"pub fn base(count: u64) {}\npub fn mate() {}\n// hand merged\n";
+    fs::write(repo.join("src/lib.rs"), edited).expect("hand edit the conflicted file");
+    ok(&run_kin(&runtime, &repo, &["status"]), "kin status");
+    let moved = persisted_record(&layout).expect("the merge is still parked after the edit");
+    assert_eq!(
+        moved.restore, parked.restore,
+        "the record's saved restore point never moves; the WORKSPACE is what moved"
+    );
+
+    let aborted_output = ok(
+        &run_kin(&runtime, &repo, &["resolve", "--abort"]),
+        "kin resolve --abort from a moved workspace",
+    );
+
+    let aborted = persisted_record(&layout).expect("the record is retained as the merge's account");
+    assert!(
+        matches!(
+            aborted.state,
+            kin_model::MergeTransactionState::Aborted { .. }
+        ),
+        "the record terminates as abandoned: {:?}",
+        aborted.state
+    );
+    assert_eq!(
+        fs::read(repo.join("src/lib.rs")).unwrap(),
+        edited,
+        "abandoning a merge must not touch the caller's own edit"
+    );
+    assert!(
+        aborted_output.contains("has moved since the merge opened"),
+        "the line must say the workspace moved rather than claim it is unchanged: \
+         {aborted_output}"
+    );
+    assert!(
+        !aborted_output.contains("is unchanged at the recorded restore point"),
+        "and must not claim the restore point still holds: {aborted_output}"
+    );
+}
+
 /// moves no ref, and frees the workspace for the next merge.
 #[test]
 fn aborting_a_merge_restores_the_workspace_and_frees_the_next_merge() {

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -587,7 +587,25 @@ fn settle(
     ))
 }
 
-/// Abandon the merge, proving the workspace still equals its restore point.
+/// Abandon the merge, whatever the workspace has done since it opened.
+///
+/// This used to refuse unless the workspace still equalled the restore point,
+/// on the reasoning that abandoning could not prove the workspace it restores.
+/// It restores no workspace. The transaction below is documented as moving only
+/// the merge record, and it is: `workspace_mutation: None`, no ref mutations and
+/// no changes, and `record_execution` hands the finalizer the same tree for
+/// `previous_tree` and `desired_tree` with an empty delta, so nothing is
+/// projected either. The gate was keeping one sentence true, not guarding an
+/// operation, and it refused the one command whose whole job is getting out.
+///
+/// Measured on the rc063a stranger's shape: hand-edit a conflicted file and
+/// `resolve --continue`, `resolve --abort` and `merge` all answer 409 while
+/// `status` and `conflicts` keep advertising the merge. `stash push --yes` and
+/// `stash pop` both succeed and leave the merge exactly as parked, so they are
+/// not a way out either. The only recovery was `kin checkout --change`.
+///
+/// So it abandons, and the line it prints says what is true rather than what
+/// used to be. What it must never do is claim to have put anything back.
 fn abort(
     authority: &ActiveLocalRepositoryAuthority,
     request: &ResolveRequest,
@@ -595,15 +613,7 @@ fn abort(
     workspace: WorkspaceState,
     record: MergeTransactionRecord,
 ) -> Result<ResolveExecution> {
-    let current = restore_point(&workspace);
-    if current != record.restore {
-        return Err(merge_conflict(format!(
-            "workspace {} no longer equals the restore point this merge recorded, so abandoning \
-             it cannot prove the workspace it restores; reconcile the workspace into graph \
-             authority first",
-            workspace.workspace_id
-        )));
-    }
+    let workspace_moved = restore_point(&workspace) != record.restore;
     let next = record
         .terminate(MergeTransactionState::Aborted {
             operation_id: request.operation_id,
@@ -623,14 +633,26 @@ fn abort(
         .context("validate the merge abort transaction")?;
     let (receipt, authority_freeze) = commit_and_freeze_exact(&authority.manager, transaction)
         .context("abandon the merge transaction")?;
-    let lines = vec![format!(
-        "Abandoned the merge of {} into {}; workspace {} is unchanged at the recorded restore \
-         point (authority generation {})",
-        record.binding.source_ref,
-        record.binding.target_ref,
-        workspace.workspace_id,
-        receipt.generation
-    )];
+    let lines = vec![if workspace_moved {
+        format!(
+            "Abandoned the merge of {} into {}; workspace {} has moved since the merge opened \
+             and is left exactly as it is, because abandoning a merge restores nothing \
+             (authority generation {})",
+            record.binding.source_ref,
+            record.binding.target_ref,
+            workspace.workspace_id,
+            receipt.generation
+        )
+    } else {
+        format!(
+            "Abandoned the merge of {} into {}; workspace {} is unchanged at the recorded \
+             restore point (authority generation {})",
+            record.binding.source_ref,
+            record.binding.target_ref,
+            workspace.workspace_id,
+            receipt.generation
+        )
+    }];
     Ok(record_execution(
         lines,
         workspace,

--- a/scripts/acceptance/merge_precedence_repro.py
+++ b/scripts/acceptance/merge_precedence_repro.py
@@ -30,7 +30,7 @@ carries all of them the merge refuses and names both decisions. Nothing is
 synthesized, because kin has no textual line merge to build a third body from,
 so a projection is a choice among sides this merge already bound.
 
-Ten checks over eleven repositories, run in order because two of them are
+Eleven checks over twelve repositories, run in order because two of them are
 destructive: they publish the merge the earlier assertions are about. The first
 four grade FIR-2958's precedence rule; the last two grade rc062j finding (2),
 which is the same authority reporting conflicts that are not conflicts.
@@ -97,6 +97,8 @@ BODIES_TICKET = "FIR-2960"
 # The rc062k merge-workflow items: the exit code and the selector.
 WORKFLOW_TICKET = "FIR-2960"
 REFUSAL_TICKET = "FIR-3018"
+# The parked-merge wedge: every exit refused once the workspace moved.
+WEDGE_TICKET = "FIR-3023"
 EXIT_MERGE_CONFLICTED = 8
 
 print = functools.partial(print, flush=True)
@@ -397,6 +399,15 @@ class Suite(object):
                 os.makedirs(parent)
             with open(full, "wb") as handle:
                 handle.write(bodies[index])
+
+    def write_bytes(self, repo, rel, content):
+        """Write into a fixture's working copy the way a caller edits a file."""
+        path = os.path.join(repo, rel)
+        directory = os.path.dirname(path)
+        if directory and not os.path.isdir(directory):
+            os.makedirs(directory)
+        with open(path, "wb") as handle:
+            handle.write(content)
 
     def read_bytes(self, repo, rel):
         try:
@@ -782,6 +793,66 @@ def grade_refusal_says_what_is_true(rc, out, err, published_before, published_af
     return (PASS, "the refusal names its reason, warns of no write, and published nothing")
 
 
+def grade_abort_frees_a_moved_workspace(rc, out, err, edited_after):
+    """FIR-3023. Abandoning must work from a workspace that moved.
+
+    Four claims together, because each passes alone for a wrong reason: an abort
+    that refuses everything fails the first, one that reverts the caller's edit
+    fails the third, and one that claims a restore point it no longer has fails
+    the second while doing the right thing.
+    """
+    text = (out or "") + (err or "")
+    if rc is None:
+        return (UNREADABLE, "`kin resolve --abort` produced no exit code")
+    problems = []
+    if rc != 0:
+        problems.append("abandoning was refused: %s" % text[-160:].strip())
+    if "has moved since the merge opened" not in text:
+        problems.append("it does not say the workspace moved")
+    if "is unchanged at the recorded restore point" in text:
+        problems.append("it still claims a restore point that no longer holds")
+    if not edited_after:
+        problems.append("the caller's own edit did not survive the abort")
+    if problems:
+        return (FAIL, "; ".join(problems))
+    return (PASS, "the merge is abandoned, the edit survives, and the line says what is true")
+
+
+def grade_continue_still_refuses(rc, out, err):
+    """The control. Abandoning got a door; settling did not, and must not.
+
+    Without this arm a build that accepted every resolve command would satisfy
+    the check above and lose the whole gate.
+    """
+    text = (out or "") + (err or "")
+    if rc is None:
+        return (UNREADABLE, "`kin resolve --continue` produced no exit code")
+    if rc == 0:
+        return (FAIL, "settling was accepted while conflicts were still outstanding")
+    if "unresolved conflict" not in text:
+        return (FAIL, "the refusal does not name what is outstanding: %s" % text[-160:].strip())
+    return (PASS, "settling still refuses while conflicts remain, and says how many")
+
+
+def check_wedge(suite):
+    """FIR-3023. Hand-edit a conflicted file and there must still be a way out."""
+    repo = suite.repo("wedge", BODY_FILES)
+    suite.kin_run(["merge", "feature"], repo)
+    hand = b"def summarize(rows):\n    return HAND_MERGED(rows)\n"
+    suite.write_bytes(repo, "pkg/core.py", hand)
+    suite.kin_run(["status"], repo)
+    # The control runs FIRST, because the abort below abandons the merge it
+    # needs. The first version of the probe behind this check made exactly that
+    # mistake and read "no merge in progress" as the wedge.
+    crc, cout, cerr = suite.kin_run(["resolve", "--continue"], repo)
+    rc, out, err = suite.kin_run(["resolve", "--abort"], repo)
+    survived = suite.read_bytes(repo, "pkg/core.py") == hand
+    return _combine("wedge", [
+        ("control", grade_continue_still_refuses(crc, cout, cerr)),
+        ("abandoned", grade_abort_frees_a_moved_workspace(rc, out, err, survived)),
+    ], ticket=WEDGE_TICKET)
+
+
 def check_wrotenothing(suite):
     """FIR-3018. The daemon says it wrote nothing and the CLI says so too.
 
@@ -906,6 +977,7 @@ CHECKS = [
     ("exitcode", check_exitcode),
     ("byname", check_byname),
     ("wrotenothing", check_wrotenothing),
+    ("wedge", check_wedge),
 ]
 
 
@@ -1208,6 +1280,31 @@ def self_test():
            grade_refusal_says_what_is_true(1, "", good_refusal, "change a", "change b"), FAIL)
     expect("refusal cannot read empty output",
            grade_refusal_says_what_is_true(1, "", "", "change a", "change a"), UNREADABLE)
+
+    good_abort = ("Abandoned the merge of refs/heads/feature into refs/heads/main; workspace "
+                  "8d34 has moved since the merge opened and is left exactly as it is")
+    old_abort = "Error: workspace 8d34 no longer equals the restore point this merge recorded"
+    lying_abort = ("Abandoned the merge; workspace 8d34 is unchanged at the recorded restore "
+                   "point")
+    expect("wedge passes an abort that frees a moved workspace",
+           grade_abort_frees_a_moved_workspace(0, good_abort, "", True), PASS)
+    expect("wedge fails the shipped refusal",
+           grade_abort_frees_a_moved_workspace(1, "", old_abort, True), FAIL)
+    expect("wedge fails an abort that reverted the caller's edit",
+           grade_abort_frees_a_moved_workspace(0, good_abort, "", False), FAIL)
+    # CONTROL: succeeding is not enough. An abort that works but still claims the
+    # restore point holds is telling the caller something false about their tree.
+    expect("CONTROL wedge fails an abort that claims a restore point it no longer has",
+           grade_abort_frees_a_moved_workspace(0, lying_abort, "", True), FAIL)
+    expect("wedge cannot read a missing exit code",
+           grade_abort_frees_a_moved_workspace(None, "", "", True), UNREADABLE)
+
+    expect("continue-control passes a refusal naming what is outstanding",
+           grade_continue_still_refuses(1, "", "still has 3 unresolved conflict(s)"), PASS)
+    expect("continue-control fails a settle accepted with conflicts outstanding",
+           grade_continue_still_refuses(0, "Merged", ""), FAIL)
+    expect("continue-control fails a refusal that names nothing",
+           grade_continue_still_refuses(1, "", "no"), FAIL)
 
     expect("a relative kin path is absolutized by this suite",
            (os.path.isabs(absolute_binary("target/release/kin")), "isabs"), True)


### PR DESCRIPTION
The rc063a stranger hand-edited a conflicted file and every exit refused. `resolve --continue`, `resolve --abort` and `merge` all answered 409 while `status` and `conflicts` kept advertising the merge. The only recovery was `kin checkout --change`.

## Measured before writing anything, and three of the ticket's four claims did not survive

Fresh fixture per arm, instruments in `.kin-coord/reports/mergetruth-wedge-repro/`:

| ticket claim | on the fixture |
|---|---|
| the wedge: continue, abort and merge all refuse | **reproduced** |
| the enrichment sweep moves the counter | **not reproduced**, a daemon restart left it at 2 and abort succeeded |
| `kin stash pop` fails on the same comparison | **not reproduced**, `stash push --yes` and `stash pop` both succeed |
| "compare the tree hash, not the counter" would fix it | **refuted**, the tree hash moved too, `8365b4a85299` to `01d76e767d51` |

The two that did not reproduce may still be real at the stranger's scale, whose sweep moved 181 relations against this fixture's one Python file. Absence here is not absence there and this PR does not claim otherwise.

Worth having on the record: `stash push --yes` and `stash pop` both succeed and leave the merge **exactly as parked**, so stash is not a door out either.

## The gate was protecting a sentence, not an operation

Abort's transaction is documented as moving only the merge record, and it is: `workspace_mutation: None`, no ref mutations, no changes. `record_execution` then hands the finalizer the same tree for `previous_tree` and `desired_tree` with an empty delta, so nothing is projected.

**Abort restores nothing.** The comparison existed to keep one sentence true, "workspace ... is unchanged at the recorded restore point", and it refused the one command whose whole job is getting out in order to protect a claim about a workspace nobody was going to touch. That is also why the ticket's fix reads plausible and does nothing: swapping which field the assertion keys on leaves it an assertion.

So abort proceeds, and where the workspace has moved it says so and says the workspace is left exactly as it is.

## Before and after

```
exit                 before              after
resolve --continue   rc 1, 409           rc 1, 409  (correct, conflicts remain)
resolve --abort      rc 1, 409           rc 0, "has moved since the merge opened"
conflicts after      still parked        "was abandoned; no merge is in progress"
```

## Acceptance

```
CHECK wedge FIR-3023 PASS
  control   PASS settling still refuses while conflicts remain, and says how many
  abandoned PASS the merge is abandoned, the edit survives, and the line says what is true
```

Four claims graded together in the `abandoned` arm, because each passes alone for a wrong reason: an abort that reverted the caller's edit satisfies the first two, and one that succeeds while repeating the old sentence tells the caller something false about their tree. The control is `resolve --continue`, which must still refuse; the ticket's control was to be a tracked-file mutation refused by the abort gate, and since that gate is what this removes, the control moved to the command that still holds the line. The control runs FIRST, because the abort abandons the merge it needs.

The integration test asserts the same property rather than asserting success: the caller's bytes are still on disk afterwards, and the line does not claim a restore point that no longer holds. A version that abandoned the merge and reverted the edit would pass a success-only test and lose the work.

## Falsification

```
arm  abandoned  control  removes
W0   PASS       PASS     nothing
W1   FAIL       PASS     the abort's freedom, gate restored
```

Which is the ticket's own wording: restoring the counter comparison reds the first arm and leaves the control green. Two arms, two distinct binaries, tree restored with zero mutation markers.

## Gates

`repository_merge_resolution` 24 of 24, `repository_merge` 18 of 18, `repository_branches` 25 of 25, `command_branch` 10 of 10, eleven acceptance checks at exit 0, suite self-test 69 grader assertions. `bin/kin-precheck` 16 of 16 including clippy, and `cargo fmt --all -- --check` rc 0 as the last command before the push.

Closes FIR-3023
