### PR TITLE
Register the git paths absolutely, so cargo stops watching a file that is not there

### DIFF
--- a/crates/kin-buildinfo/build.rs
+++ b/crates/kin-buildinfo/build.rs
@@ -34,15 +34,44 @@ fn main() {
         .or_else(|| find_workspace_root(&manifest_dir))
         .unwrap_or_else(|| manifest_dir.clone());
 
+    // `git rev-parse --git-path` answers RELATIVE to the repository in a normal
+    // checkout and ABSOLUTE in a linked worktree, and cargo resolves a relative
+    // `rerun-if-changed` against the PACKAGE manifest directory rather than the
+    // repository root. So a bare `.git/HEAD` here registers
+    // `crates/kin-buildinfo/.git/HEAD`, which does not exist, and a
+    // rerun-if-changed on a missing file makes cargo treat this unit as dirty on
+    // every invocation.
+    //
+    // Measured on CI before this was joined: cargo said
+    //   stale: missing ".../crates/kin-buildinfo/.git/HEAD"
+    //   dirty: FsStatusOutdated(StaleItem(MissingFile { path: ... }))
+    // and kin-cli, kin-daemon and kin-integration-tests followed as
+    // StaleDepFingerprint on this build script's unit. That is a whole recompile
+    // of four crates in every cargo invocation after the first, measured at 108
+    // seconds per fast-gate shard.
+    //
+    // It is invisible in a linked worktree, where the path comes back absolute
+    // and resolves, which is every lane checkout in the fleet and is why this
+    // survived so long.
+    let watch = |path: String| {
+        let path = PathBuf::from(path);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            root.join(path)
+        };
+        println!("cargo:rerun-if-changed={}", path.display());
+    };
+
     if let Some(head) = git(&root, &["rev-parse", "--git-path", "HEAD"]) {
-        println!("cargo:rerun-if-changed={head}");
+        watch(head);
     }
     if let Some(index) = git(&root, &["rev-parse", "--git-path", "index"]) {
-        println!("cargo:rerun-if-changed={index}");
+        watch(index);
     }
     if let Some(reference) = git(&root, &["symbolic-ref", "-q", "HEAD"]) {
         if let Some(path) = git(&root, &["rev-parse", "--git-path", &reference]) {
-            println!("cargo:rerun-if-changed={path}");
+            watch(path);
         }
     }
 


### PR DESCRIPTION
`kin-buildinfo`'s build script was rebuilt on every cargo invocation, taking `kin-cli`, `kin-daemon` and `kin-integration-tests` with it, for **108 seconds in every fast-gate shard**. `check`, `coverage` and `install-proof-pr-build` run the same script and paid the same.

## Cargo named the input when asked

On run 33335619683, with `CARGO_LOG=cargo::core::compiler::fingerprint=info` on the shard's Test step:

```
stale: missing "/home/runner/work/kin/kin/crates/kin-buildinfo/.git/HEAD"
dirty: FsStatusOutdated(StaleItem(MissingFile { path: ... }))
```

The dirty input is a file that **does not exist**, and its path points at `crates/kin-buildinfo/.git/HEAD` rather than the repository's `.git/HEAD`. The other three crates followed as `dirty: FsStatusOutdated(StaleDepFingerprint { unit: UnitIndex(287) })`, 287 being this build script.

`git rev-parse --git-path` answers **relative** in a normal checkout and **absolute** in a linked worktree, and cargo resolves a relative `rerun-if-changed` against the **package manifest directory** rather than the repository root. So the script said `.git/HEAD` meaning the repository and cargo heard `crates/kin-buildinfo/.git/HEAD`. A `rerun-if-changed` on a missing file makes cargo treat the unit as dirty on every invocation.

## The change

Join each `--git-path` result onto the repository root before registering it. A relative answer becomes the real file; an absolute one passes through unchanged. Verified in both checkout kinds before this was pushed: in a normal clone the old path does not exist and the new one does, and in a linked worktree git already answers absolutely so the join is a no-op.

## The acceptance, measured as a single-variable A/B

Same branch, same `CARGO_LOG` diagnostic held fixed, one variable:

| run | commit | phase 1, `nextest list` | phase 2, `nextest run` |
| -- | -- | -- | -- |
| 33335619683 | probe only, no fix | 24 crates, 2m 15s | **4 crates, 1m 39s** |
| 33336196295 | same probe plus this fix | 24 crates, 1m 45s | **0 crates, 0.26 s** |

Three earlier runs put the four-crate before side on record independently: 33326549732 on main before anything, 33335063224 after kin#1319, and 33335132217 on a no-op commit. All four crates, every time.

**One reading I am deliberately not citing.** The `stale: missing` line is absent on the after run, and that absence proves nothing, because the positive control fails: `cargo::core::compiler::fingerprint` went 194 to 1, ` INFO ` 165 to 0, and `prepare_target` 165 to 0, so cargo emitted no fingerprint logging at all when the step finished in 0.26 s with nothing to prepare. That single remaining hit is the workflow echoing the env var. The acceptance rests only on the phase-2 count and duration, which are ordinary cargo output present in every run.

## Why this survived

It is **invisible in a linked worktree**, where `--git-path` returns an absolute path that resolves. Every lane checkout in this fleet is a linked worktree, so no local investigation could reproduce it, and cargo's own recorded output read from a lane's target directory shows the absolute paths and looks correct.

## Not changed

`kin#1319`'s `GIT_OPTIONAL_LOCKS=0` stays. It prevents a real index rewrite that local controls proved, it is correct hygiene, and it is not what fixed this.

Closes FIR-3045
