### PR TITLE
Dispatch the image promotion when a release completes

### DIFF
--- a/.github/workflows/publish-release-installers.yml
+++ b/.github/workflows/publish-release-installers.yml
@@ -266,6 +266,52 @@ jobs:
             echo "- install.ps1: \`${INSTALL_PS1_SHA256}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # The third dispatch, beside the two above and under the same token, which
+      # already carries kin-infra in its repositories list.
+      #
+      # Getting a promoted release's daemon into production took a person
+      # resolving nine inputs by hand on 2026-08-30, three failed dispatches, and
+      # a five-minute outage when a shortcut was tried instead. Every one of
+      # those nine is knowable from the API, so this sends the trigger and the
+      # receiver resolves them.
+      #
+      # The payload carries the TAG only, deliberately. kin-infra's
+      # promote-release-images.yml refuses a schema_version it does not know,
+      # requires the tag to equal exact GitHub Latest, and resolves the commit,
+      # the release run, the GHCR digest and both main heads itself. That is the
+      # rule publish-install.yml states for this repository pair: payload fields
+      # are never trusted without independent API verification. Sending less is
+      # what makes that enforceable.
+      - name: Request promoted release image promotion
+        id: image-promotion-dispatch
+        env:
+          DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          payload="$(jq -n \
+            --arg tag "$KIN_TAG" \
+            '{event_type:"promote-release-images",client_payload:{schema_version:1,kin_tag:$tag}}')"
+          code="$(curl -sS -o /tmp/image-promotion-dispatch-response -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/firelock-ai/kin-infra/dispatches \
+            -d "$payload")"
+          if [ "$code" != 204 ]; then
+            echo "::error::image promotion repository dispatch returned HTTP $code"
+            cat /tmp/image-promotion-dispatch-response
+            exit 1
+          fi
+          echo "dispatched_at=$dispatched_at" >> "$GITHUB_OUTPUT"
+          {
+            echo "Requested release image promotion:"
+            echo ""
+            echo "- release: \`${KIN_TAG}\`"
+            echo "- receiver resolves the tuple itself and refuses a tag that is not exact Latest"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Prove Homebrew workflow and public formula
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -12722,6 +12722,19 @@ def main() -> None:
         "actions/workflows/publish-install.yml/runs?event=repository_dispatch",
         "the workflow may still be disabled",
         'python3 scripts/verify_installer_parity.py "$KIN_TAG" --expected-sha "$KIN_SHA"',
+        # The image-promotion dispatch, third beside the two above and under the
+        # same token, whose repositories list already carries kin-infra.
+        #
+        # The payload is pinned to the TAG ALONE on purpose. kin-infra's receiver
+        # resolves the commit, the release run, the GHCR digest and both main
+        # heads itself and refuses a tag that is not exact GitHub Latest, which is
+        # the rule publish-install.yml states for this pair: payload fields are
+        # never trusted without independent API verification. Sending more would
+        # be sending a caller-supplied identity for a production image, so the
+        # exact payload text is pinned rather than only the event type.
+        'event_type:"promote-release-images"',
+        "client_payload:{schema_version:1,kin_tag:$tag}",
+        "image promotion repository dispatch returned HTTP $code",
     ):
         require(installer_callback, policy, "completed-release follow-up callback")
 


### PR DESCRIPTION
Third dispatch, beside the two already in this job, under the same token, whose `repositories` list already carries `kin-infra`. kin-infra's receiver landed in #242 and #243 and has been waiting for a sender.

This is the sender half of FIR-3021.

## The pattern being copied, not invented

This job already sends two repository dispatches. The new one is the same shape, line for line. From the existing installer dispatch:

```bash
payload="$(jq -n \
  --arg tag "$KIN_TAG" \
  ...
  '{event_type:"publish-install",client_payload:{schema_version:1,kin_tag:$tag,...}}')"
code="$(curl -sS -o /tmp/installer-dispatch-response -w '%{http_code}' \
  -X POST \
  -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/firelock-ai/kin-infra/dispatches \
  -d "$payload")"
if [ "$code" != 204 ]; then
  echo "::error::installer repository dispatch returned HTTP $code"
  cat /tmp/installer-dispatch-response
  exit 1
fi
```

The addition uses the same token, the same two headers, the same 204 check with the response body printed on failure, and the same step-summary shape. Three dispatches now, in order:

| line | event_type | target |
| --- | --- | --- |
| 213 | `kin-release` | `firelock-ai/homebrew-kin` |
| 245 | `publish-install` | `firelock-ai/kin-infra` |
| 294 | `promote-release-images` | `firelock-ai/kin-infra` |

## Why the payload carries the tag alone

That is the design, not an economy. `publish-install.yml` states the rule for this repository pair in its own header:

> payload fields are never trusted without independent API verification

kin-infra's `promote-release-images.yml` refuses a `schema_version` it does not recognise, requires the tag to equal **exact GitHub Latest**, and resolves the commit, the release run, the GHCR digest and both `main` heads itself, shape-checking each. Sending less is what makes that enforceable. Sending a commit or a digest would hand a production image's identity to its caller.

## Why it needs no new credential or scope

The App token minted in this job is already scoped to both repositories:

```yaml
repositories: |
  homebrew-kin
  kin-infra
permission-actions: read
permission-contents: write
```

No secret, no scope and no permission changes.

## The guard is extended, not added

`scripts/test-release-workflow-authority.py` already pins both existing dispatches by event type, target and payload text, so the new one joins that list. **The payload text is pinned in full rather than only the event type**, because the tag-only shape is the property that matters and an added field would sail past an event-type-only assertion.

## Falsification

Delete the step from the workflow and the guard goes red on its own name:

```
AssertionError: completed-release follow-up callback is missing required policy:
  event_type:"promote-release-images"
```

Green again when restored. The mutation was asserted present first: `event_type:"promote-release-images"` counts **0** in the workflow after deletion, against **1** before, with a fabricated event type counting 0 in both as the control. `actionlint` clean.

## Not falsifiable here, named rather than skipped

The end-to-end arm, that a completed release produces a `promote-image` run and that a watcher separates **"no run"** from **"could not read"**, needs a real release to fire. It cannot be run from a pull request. It is owed on FIR-3021 and stays owed.

## What lands with this

Nothing changes until the next release tag. When one publishes, this fires, the receiver checks the tag against Latest and resolves the tuple, and `promote-image.yml` runs with inputs no person typed. `promote-image` itself is untouched by both halves.