### PR TITLE
Prove the public onboarding path

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -11,6 +11,7 @@ on:
       - "SECURITY.md"
       - "docs/quickstart.md"
       - "lychee.toml"
+      - "scripts/fixtures/public-doc-links/**"
       - ".github/workflows/link-check.yml"
   push:
     branches: [main]
@@ -20,6 +21,7 @@ on:
       - "SECURITY.md"
       - "docs/quickstart.md"
       - "lychee.toml"
+      - "scripts/fixtures/public-doc-links/**"
       - ".github/workflows/link-check.yml"
   schedule:
     - cron: "17 13 * * 1"
@@ -63,3 +65,47 @@ jobs:
             ./docs/quickstart.md
           fail: true
           lycheeVersion: v0.24.2
+
+      # The action installs its pinned lychee into RUNNER_TEMP and publishes it
+      # on GITHUB_PATH. Exercise the same binary and config against one fixture
+      # per false-green class. Checking that each failing output names its own
+      # target prevents a shared config error from satisfying every arm.
+      - name: Falsify every public-link policy arm
+        shell: bash
+        run: |
+          set -euo pipefail
+          expect_failure() {
+            label="$1"
+            fixture="$2"
+            target="$3"
+            set +e
+            output="$(lychee --config lychee.toml "$fixture" 2>&1)"
+            rc=$?
+            set -e
+            printf '%s\n' "$output"
+            if [[ "$rc" -eq 0 ]]; then
+              echo "::error title=Link falsifier passed::$label returned success"
+              exit 1
+            fi
+            if ! grep -Fq "$target" <<<"$output"; then
+              echo "::error title=Wrong link falsified::$label did not report $target"
+              exit 1
+            fi
+          }
+
+          expect_failure \
+            "missing Markdown anchor" \
+            ./scripts/fixtures/public-doc-links/missing-anchor.md \
+            "anchor-that-does-not-exist"
+          expect_failure \
+            "missing relative file" \
+            ./scripts/fixtures/public-doc-links/missing-relative.md \
+            "relative-file-that-does-not-exist.md"
+          expect_failure \
+            "dead public HTTP link" \
+            ./scripts/fixtures/public-doc-links/dead-http.md \
+            "kin-link-check-http"
+          expect_failure \
+            "dead URL inside a code block" \
+            ./scripts/fixtures/public-doc-links/dead-verbatim.md \
+            "kin-link-check-verbatim"

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ exec "$SHELL" -l
 kin setup --intent agent
 ```
 
+Use `kin setup --intent editor` for the VS Code path. Confirm the resulting
+machine-readable health checklist with `kin setup status --json`.
+
 The installer resolves the [latest stable release](https://github.com/firelock-ai/kin/releases/latest),
 verifies its published SHA-256 checksum, installs the managed binaries under
 `~/.kin`, and launches setup. Running the explicit `agent` intent configures the
@@ -309,6 +312,7 @@ Lua, R, Zig, Haskell, and Nix. If your language is on that list, `locate` and
 kin locate "where are webhook retries handled"
 kin refs ExactEntityName
 kin trace ExactEntityName
+kin overview
 ```
 
 Replace `ExactEntityName` with a symbol returned by `locate`. `locate` finds the

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2463,6 +2463,10 @@ enum HostedReleaseAction {
 /// more than no suggestion at all.
 const RETIRED_COMMANDS: &[(&[&str], &str)] = &[
     (
+        &["setup", "editor"],
+        "`kin setup --intent editor` selects the editor onboarding path; setup intents are options, not subcommands.",
+    ),
+    (
         &["import"],
         "`kin clone <source>` admits a repository from elsewhere, and `kin init` admits one in place.",
     ),
@@ -4756,6 +4760,125 @@ mod tests {
             .expect("spawn cli validation thread")
             .join()
             .expect("cli definition validation must succeed");
+    }
+
+    /// Public first-run commands are executable contracts, not examples the
+    /// parser is allowed to drift away from.
+    ///
+    /// These are the exact command shapes named by README.md and
+    /// docs/quickstart.md. Parsing only `kin setup` or only the leaf actions is
+    /// weaker than the contract: the intent value, JSON flag, review range and
+    /// default option values are all part of what a new developer copies.
+    #[test]
+    fn documented_onboarding_commands_parse_to_their_public_contract() {
+        on_cli_test_stack(|| {
+            let editor = Cli::try_parse_from(["kin", "setup", "--intent", "editor"])
+                .expect("the documented editor intent must parse");
+            assert!(matches!(
+                editor.command,
+                Command::Setup {
+                    action: None,
+                    intent: Some(intent),
+                    ..
+                } if intent == "editor"
+            ));
+
+            let setup_status = Cli::try_parse_from(["kin", "setup", "status", "--json"])
+                .expect("the documented setup status command must parse");
+            assert!(matches!(
+                setup_status.command,
+                Command::Setup {
+                    action: Some(SetupAction::Status { json: true }),
+                    ..
+                }
+            ));
+
+            let status = Cli::try_parse_from(["kin", "status"])
+                .expect("the documented status command must parse");
+            assert!(matches!(
+                status.command,
+                Command::Status {
+                    json: false,
+                    wait_quiesce: 0
+                }
+            ));
+
+            let overview = Cli::try_parse_from(["kin", "overview"])
+                .expect("the documented overview command must parse");
+            assert!(matches!(
+                overview.command,
+                Command::Overview {
+                    compact: false,
+                    json: false
+                }
+            ));
+
+            let review = Cli::try_parse_from(["kin", "review", "shadow", "BASE_BRANCH..HEAD"])
+                .expect("the documented shadow-review range must parse");
+            assert!(matches!(
+                review.command,
+                Command::Review {
+                    change: None,
+                    json: false,
+                    entities: None,
+                    files: None,
+                    changes: None,
+                    action: Some(ReviewAction::Shadow {
+                        range: Some(range),
+                        base: None,
+                        head: None,
+                        title: None,
+                        source_url: None,
+                        author: None,
+                        json: false,
+                    }),
+                } if range == "BASE_BRANCH..HEAD"
+            ));
+
+            let quickstart = include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../docs/quickstart.md"
+            ));
+            let readme = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../README.md"));
+            for command in [
+                "kin setup --intent editor",
+                "kin setup status --json",
+                "kin status",
+                "kin overview",
+                "kin review shadow",
+            ] {
+                assert!(
+                    quickstart.contains(command),
+                    "docs/quickstart.md must carry the parser-checked `{command}` surface"
+                );
+                assert!(
+                    readme.contains(command),
+                    "README.md must carry the parser-checked `{command}` surface"
+                );
+            }
+        });
+    }
+
+    /// The formerly documented subcommand spelling stays rejected and the
+    /// production signpost points at the canonical option spelling instead of
+    /// clap's edit-distance suggestion of the unrelated `doctor` subcommand.
+    #[test]
+    fn stale_setup_editor_form_is_rejected_with_the_canonical_replacement() {
+        on_cli_test_stack(|| {
+            let error = Cli::try_parse_from(["kin", "setup", "editor"])
+                .err()
+                .expect("setup intents must not become compatibility subcommands");
+            assert_eq!(error.kind(), clap::error::ErrorKind::InvalidSubcommand);
+
+            let args = vec!["setup".to_string(), "editor".to_string()];
+            let (path, guidance) = retired_command_signpost(&args)
+                .expect("production must replace clap's misleading suggestion");
+            assert_eq!(path, "setup editor");
+            assert!(
+                guidance.contains("`kin setup --intent editor`"),
+                "the rejection must name the command a developer can run: {guidance}"
+            );
+        });
     }
 
     #[test]

--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -989,6 +989,15 @@ impl IsolatedDaemonRuntime {
         fresh_daemon_bin(self)
     }
 
+    /// Resolve or build the compatible daemon without outliving `deadline`.
+    ///
+    /// A smoke test with one total wall-clock budget must include harness
+    /// preparation. Otherwise the compatibility probe or fallback Cargo build
+    /// can wait longer than the product sequence the test claims to bound.
+    pub fn daemon_bin_before(&self, deadline: Instant) -> PathBuf {
+        fresh_daemon_bin_before(self, deadline)
+    }
+
     pub fn daemon_command(&self) -> Command<'_> {
         self.command(self.daemon_bin())
     }
@@ -1030,9 +1039,11 @@ impl IsolatedDaemonRuntime {
         scrub_inherited_kin_authority(command);
         command
             .env("KIN_REGISTRY_PATH", &self.registry_path)
-            // The explicit registry is authoritative. HOME/USERPROFILE are a
-            // fail-closed fallback for any child boundary that intentionally
-            // rebuilds its environment instead of inheriting the override.
+            // Bind the managed install and store root explicitly. HOME and
+            // USERPROFILE remain a fail-closed fallback for any child boundary
+            // that intentionally rebuilds its environment instead of
+            // inheriting the override.
+            .env("KIN_HOME", self.home_path.join(".kin"))
             .env("HOME", &self.home_path)
             .env("USERPROFILE", &self.home_path)
             .env("XDG_CONFIG_HOME", self.home_path.join(".config"))
@@ -1698,6 +1709,7 @@ fn is_allowed_runtime_override(key: &OsStr) -> bool {
         "KIN_SUPERVISOR_IDLE_TIMEOUT_SECS",
         "KIN_DAEMON_READY_TIMEOUT_SECS",
         "KIN_BYPASS_EMBEDDING_COVERAGE_CHECK",
+        "KIN_EMBED_BACKEND",
         // A runtime-bound command that sets this and is not carried proves the
         // opposite of what its test asserts: the child embeds, and the test
         // reads that as the product ignoring an operator. That is how the
@@ -3218,13 +3230,21 @@ pub fn daemon_compat_mismatch(
 }
 
 fn daemon_compat(runtime: &IsolatedDaemonRuntime, path: &Path) -> Result<(), String> {
+    daemon_compat_within(runtime, path, COMMAND_TIMEOUT)
+}
+
+fn daemon_compat_within(
+    runtime: &IsolatedDaemonRuntime,
+    path: &Path,
+    timeout: Duration,
+) -> Result<(), String> {
     if !path.exists() {
         return Err(format!("{} does not exist", path.display()));
     }
     let mut command = runtime.command(path);
     let output = command
         .arg("--compat-json")
-        .output()
+        .output_within(timeout)
         .map_err(|error| format!("could not run {} --compat-json: {error}", path.display()))?;
     if !output.status.success() {
         return Err(format!(
@@ -3303,9 +3323,41 @@ fn daemon_rebuild_follows_the_layout_its_own_binary_was_written_into() {
 }
 
 fn fresh_daemon_bin(runtime: &IsolatedDaemonRuntime) -> PathBuf {
+    fresh_daemon_bin_with_deadline(runtime, None)
+}
+
+fn fresh_daemon_bin_before(runtime: &IsolatedDaemonRuntime, deadline: Instant) -> PathBuf {
+    fresh_daemon_bin_with_deadline(runtime, Some(deadline))
+}
+
+fn daemon_preparation_budget(
+    deadline: Option<Instant>,
+    default: Duration,
+    label: &str,
+) -> Duration {
+    deadline
+        .map(|deadline| {
+            deadline
+                .checked_duration_since(Instant::now())
+                .filter(|remaining| !remaining.is_zero())
+                .unwrap_or_else(|| panic!("daemon preparation deadline expired before {label}"))
+        })
+        .unwrap_or(default)
+}
+
+fn fresh_daemon_bin_with_deadline(
+    runtime: &IsolatedDaemonRuntime,
+    deadline: Option<Instant>,
+) -> PathBuf {
     let kin_bin = PathBuf::from(env!("CARGO_BIN_EXE_kin"));
     let daemon_bin = kin_bin.with_file_name(format!("kin-daemon{}", std::env::consts::EXE_SUFFIX));
-    if daemon_compat(runtime, &daemon_bin).is_ok() {
+    if daemon_compat_within(
+        runtime,
+        &daemon_bin,
+        daemon_preparation_budget(deadline, COMMAND_TIMEOUT, "the compatibility probe"),
+    )
+    .is_ok()
+    {
         return daemon_bin;
     }
 
@@ -3325,7 +3377,11 @@ fn fresh_daemon_bin(runtime: &IsolatedDaemonRuntime) -> PathBuf {
         let output = build
             .args(&args)
             .current_dir(workspace_root)
-            .output_within(BUILD_TIMEOUT)
+            .output_within(daemon_preparation_budget(
+                deadline,
+                BUILD_TIMEOUT,
+                "the fallback Cargo build",
+            ))
             .expect("run cargo build -p kin-daemon");
         assert!(
             output.status.success(),
@@ -3335,7 +3391,11 @@ fn fresh_daemon_bin(runtime: &IsolatedDaemonRuntime) -> PathBuf {
         );
     });
 
-    if let Err(reason) = daemon_compat(runtime, &daemon_bin) {
+    if let Err(reason) = daemon_compat_within(
+        runtime,
+        &daemon_bin,
+        daemon_preparation_budget(deadline, COMMAND_TIMEOUT, "the final compatibility probe"),
+    ) {
         panic!(
             "kin-daemon at {} is unusable after rebuild: {reason}.\n\
              This test binary carries build identity {}. A daemon built from a \

--- a/crates/kin-cli/tests/fixtures/quickstart/checkout.py
+++ b/crates/kin-cli/tests/fixtures/quickstart/checkout.py
@@ -1,0 +1,13 @@
+"""Tiny source fixture for the public quickstart smoke."""
+
+
+def apply_quickstart_discount(subtotal_cents: int) -> int:
+    """Apply the fixture's one deterministic checkout rule."""
+    if subtotal_cents >= 5_000:
+        return subtotal_cents - 500
+    return subtotal_cents
+
+
+def quickstart_checkout_total(subtotal_cents: int) -> int:
+    """Return the checkout total through the rule the smoke locates."""
+    return apply_quickstart_discount(subtotal_cents)

--- a/crates/kin-cli/tests/quickstart_smoke.rs
+++ b/crates/kin-cli/tests/quickstart_smoke.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Bounded proof of the public local quickstart against a controlled repository.
+//!
+//! The source lives under `tests/fixtures`, and every product read in this test
+//! goes through Kin's repository-v6 authority and daemon-owned graph. No test
+//! oracle reads the temporary working file after `kin init`, and background
+//! embedding is off so the default suite never asks for a model or GPU.
+
+use serial_test::serial;
+use std::path::Path;
+use std::process::Output;
+use std::time::{Duration, Instant};
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+const FIXTURE_SOURCE: &str = include_str!("fixtures/quickstart/checkout.py");
+const LOCATE_QUERY: &str = "apply_quickstart_discount";
+const CALLER_NAME: &str = "quickstart_checkout_total";
+const SMOKE_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn remaining(deadline: Instant, label: &str) -> Duration {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .unwrap_or_else(|| {
+            panic!("the {SMOKE_TIMEOUT:?} quickstart deadline expired before {label}")
+        })
+}
+
+fn run(command: &mut Command<'_>, deadline: Instant, label: &str) -> Output {
+    command
+        .output_within(remaining(deadline, label))
+        .unwrap_or_else(|error| panic!("run {label}: {error}"))
+}
+
+fn require_success(output: Output, label: &str) -> Output {
+    assert!(
+        output.status.success(),
+        "{label} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn git(repo: &Path, args: &[&str], deadline: Instant) {
+    let output = run(
+        Command::new("git").args(args).current_dir(repo),
+        deadline,
+        &format!("git {args:?}"),
+    );
+    require_success(output, &format!("git {args:?}"));
+}
+
+fn kin_command<'runtime>(
+    runtime: &'runtime common::IsolatedDaemonRuntime,
+    daemon_bin: &Path,
+) -> Command<'runtime> {
+    let mut command = runtime.kin_command();
+    command
+        .env("KIN_DAEMON_BIN", daemon_bin)
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
+        .env("KIN_EMBED_BACKEND", "cpu")
+        .env("KIN_DAEMON_AUTO_EMBED", "0");
+    command
+}
+
+#[test]
+#[serial]
+fn public_quickstart_reads_one_fixture_from_graph_authority() {
+    let started = Instant::now();
+    let deadline = started + SMOKE_TIMEOUT;
+    let repo = tempdir().expect("create quickstart repository");
+    let repo_path = repo.path().to_path_buf();
+    std::fs::write(repo.path().join("checkout.py"), FIXTURE_SOURCE)
+        .expect("write the checked-in quickstart fixture");
+
+    let runtime = common::IsolatedDaemonRuntime::new(repo.path());
+    // The compatibility probe and its one-time fallback build share the same
+    // deadline as the public command sequence. Harness preparation cannot sit
+    // outside the smoke's claimed wall-clock cap.
+    let daemon_bin = runtime.daemon_bin_before(deadline);
+
+    git(
+        repo.path(),
+        &["init", "-q", "--initial-branch", "main"],
+        deadline,
+    );
+    git(repo.path(), &["add", "checkout.py"], deadline);
+    git(
+        repo.path(),
+        &[
+            "-c",
+            "user.name=kin-ci",
+            "-c",
+            "user.email=ci@kin.dev",
+            "commit",
+            "-q",
+            "-m",
+            "quickstart fixture",
+        ],
+        deadline,
+    );
+
+    let init = run(
+        kin_command(&runtime, &daemon_bin)
+            .args(["init", "."])
+            .current_dir(repo.path()),
+        deadline,
+        "kin init",
+    );
+    require_success(init, "kin init");
+
+    let status = require_success(
+        run(
+            kin_command(&runtime, &daemon_bin)
+                .args(["status", "--json"])
+                .current_dir(repo.path()),
+            deadline,
+            "kin status --json",
+        ),
+        "kin status --json",
+    );
+    let status: serde_json::Value =
+        serde_json::from_slice(&status.stdout).expect("status is one JSON document");
+    assert_eq!(status["authority"], "repository-v6");
+    assert_eq!(status["workspace"]["dirty"], false);
+    assert!(
+        status["semantic_enrichment"]["entity_count"]
+            .as_u64()
+            .is_some_and(|count| count >= 2),
+        "the admitted fixture must carry both functions in durable authority: {status}"
+    );
+
+    let overview = require_success(
+        run(
+            kin_command(&runtime, &daemon_bin)
+                .args(["overview", "--json"])
+                .current_dir(repo.path()),
+            deadline,
+            "kin overview --json",
+        ),
+        "kin overview --json",
+    );
+    let overview: serde_json::Value =
+        serde_json::from_slice(&overview.stdout).expect("overview is one JSON document");
+    assert_eq!(overview["files"], 1);
+    assert!(
+        overview["entities"]
+            .as_u64()
+            .is_some_and(|count| count >= 2),
+        "overview must read the fixture's graph entities: {overview}"
+    );
+
+    let locate = require_success(
+        run(
+            kin_command(&runtime, &daemon_bin)
+                .args(["locate", LOCATE_QUERY, "--json", "--no-snippets"])
+                .current_dir(repo.path()),
+            deadline,
+            "kin locate",
+        ),
+        "kin locate",
+    );
+    let locate: serde_json::Value =
+        serde_json::from_slice(&locate.stdout).expect("locate is one JSON document");
+    assert_eq!(
+        locate["semantic_coverage"]["graph_bodies"],
+        serde_json::json!({"source_paths": 1, "with_body": 1, "gap_paths": 0}),
+        "the locate answer must account for the fixture through graph-owned source bodies: {locate}"
+    );
+    let hit = locate["entities"]
+        .as_array()
+        .and_then(|entities| {
+            entities
+                .iter()
+                .find(|entity| entity["name"] == LOCATE_QUERY)
+        })
+        .unwrap_or_else(|| panic!("locate did not return the fixture entity: {locate}"));
+    assert_eq!(hit["provenance"]["file"], "checkout.py");
+    let entity_id = hit["entity_id"]
+        .as_str()
+        .expect("the graph entity hit carries its stable id");
+
+    let refs = require_success(
+        run(
+            kin_command(&runtime, &daemon_bin)
+                .args(["refs", entity_id])
+                .current_dir(repo.path()),
+            deadline,
+            "kin refs",
+        ),
+        "kin refs",
+    );
+    let refs = String::from_utf8(refs.stdout).expect("refs output is utf-8");
+    assert!(
+        refs.contains(CALLER_NAME) && refs.contains("checkout.py"),
+        "refs must report the fixture caller from graph relations: {refs}"
+    );
+
+    // The runtime owns every daemon/supervisor child. Drop it before removing
+    // the repository, then require the temporary repository to disappear.
+    drop(runtime);
+    repo.close().expect("remove the quickstart repository");
+    assert!(!repo_path.exists(), "the quickstart fixture leaked files");
+    assert!(
+        started.elapsed() <= SMOKE_TIMEOUT,
+        "the public quickstart and its cleanup exceeded the {SMOKE_TIMEOUT:?} hard deadline"
+    );
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -133,6 +133,12 @@ for your **intent** rather than a bag of independent toggles:
 | **Hosted / KinLab** | Local setup, plus this machine's KinLab sign-in state and the commands that change it (see below). |
 | **Advanced / manual** | Choose shell, per-client MCP, and daemon options yourself. |
 
+To configure the editor path directly:
+
+```sh
+kin setup --intent editor
+```
+
 You can pre-select non-interactively (handy in scripts / CI):
 
 ```sh
@@ -334,6 +340,12 @@ derived runtime enrichment that has not become repository authority.
 kin status
 ```
 
+### Orient to the graph
+
+```sh
+kin overview
+```
+
 ### Commit changes
 
 Save a new semantic change snapshot:
@@ -410,6 +422,30 @@ Rank the files most relevant to a problem description:
 ```sh
 kin locate "users can't reset their password" --explain
 ```
+
+### Run the checked fixture query
+
+Kin's bounded onboarding smoke copies the readable
+[quickstart checkout fixture](../crates/kin-cli/tests/fixtures/quickstart/checkout.py)
+into a temporary repository, initializes it, and uses this exact graph query:
+
+```sh
+kin locate "apply_quickstart_discount"
+kin refs apply_quickstart_discount
+```
+
+The smoke then resolves `refs` from the entity ID returned by `locate`. It runs
+without background embedding and has a 120-second wall-clock limit. This is an
+onboarding check, not benchmark evidence or a performance claim.
+
+### Review a branch range
+
+```sh
+kin review shadow "$(git rev-parse BASE_BRANCH)..$(git rev-parse HEAD)"
+```
+
+Replace `BASE_BRANCH` with the branch you want to compare, and run `kin init`
+after both commits exist so the exact SHAs are part of Kin's imported graph.
 
 ---
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -2,9 +2,21 @@
 timeout = 30
 max_retries = 3
 max_concurrency = 8
+include_fragments = "anchor-only"
+include_verbatim = true
 
 # Badge images are decorative and frequently rate-limited. Their destination
 # links remain checked because only the image host is excluded.
+#
+# The local model endpoint and GitHub release asset prefix are exact code
+# examples rather than public destinations. GitHub's issue chooser redirects
+# anonymous checks to a login page, so a 200 there cannot prove the chooser.
+# Cursor's application deep link is not HTTP and lychee otherwise labels it
+# unsupported. Each is excluded by exact route rather than by host.
 exclude = [
-  "^https://img\\.shields\\.io/"
+  "^https://img\\.shields\\.io/",
+  "^http://localhost:1234/v1$",
+  "^https://github\\.com/firelock-ai/kin/releases/latest/download/$",
+  "^https://github\\.com/firelock-ai/kin/issues/new/choose$",
+  "^cursor://"
 ]

--- a/scripts/fixtures/public-doc-links/dead-http.md
+++ b/scripts/fixtures/public-doc-links/dead-http.md
@@ -1,0 +1,3 @@
+# Dead public HTTP link
+
+[This endpoint must fail](http://127.0.0.1:9/kin-link-check-http)

--- a/scripts/fixtures/public-doc-links/dead-verbatim.md
+++ b/scripts/fixtures/public-doc-links/dead-verbatim.md
@@ -1,0 +1,5 @@
+# Dead URL inside a code block
+
+```sh
+curl http://127.0.0.1:9/kin-link-check-verbatim
+```

--- a/scripts/fixtures/public-doc-links/missing-anchor.md
+++ b/scripts/fixtures/public-doc-links/missing-anchor.md
@@ -1,0 +1,3 @@
+# Existing anchor
+
+[This anchor must fail](#anchor-that-does-not-exist)

--- a/scripts/fixtures/public-doc-links/missing-relative.md
+++ b/scripts/fixtures/public-doc-links/missing-relative.md
@@ -1,0 +1,3 @@
+# Missing relative file
+
+[This file must fail](relative-file-that-does-not-exist.md)


### PR DESCRIPTION
## Outcome

Proves the first public Kin path end to end: checked first-contact links, parser-accurate onboarding commands, a useful stale-form signpost, and one deterministic graph-owned quickstart fixture covering init, status, overview, locate, and refs under a shared 120-second deadline.

The smoke binds temporary Kin and user state, disables background embedding and VFS, forces CPU fallback, and takes its locate and refs answers only from repository-v6 graph authority.

## Proof

- Pinned Lychee 0.24.2 corpus: 86 total, 64 unique, 77 OK, 0 errors, with four independent red falsifiers
- Focused parser and stale-form tests: pass
- `quickstart_smoke`: 10 passed, including graph authority and cleanup
- `cargo fmt --all -- --check`: pass
- CI-equivalent clippy: pass
- `bin/kin-precheck kin`: 16 of 16, including both Zero File-Search guards
- `bin/kin-parity`: PASS-WITH-ALLOWANCES on exact head, magic 25 of 25; only checked pre-existing FIR-2464, FIR-2501, and FIR-2580 allowances
- Independent diff review: pass, no blocker

Closes #324
Closes #325
Closes #326