### PR TITLE
Migrate dev images to GitHub-hosted builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
       - name: Test release ordering and npm provenance policy
         run: |
           python3 ./scripts/test-release-workflow-authority.py
+          bash ./scripts/test-publish-dev-container.sh
+          bash ./scripts/kin-dev-image.test.sh
           python3 ./scripts/test-kin-registry-release-receiver.py
           python3 ./scripts/test_install_optional_vfs.py
           python3 ./scripts/test_installer_parity.py
@@ -169,6 +171,10 @@ jobs:
           node --check ./scripts/verify-capability-proof.mjs
           node --check ./scripts/verify-npm-attestation.mjs
           bash -n ./scripts/publish-npm-release.sh
+          bash -n ./scripts/publish-dev-container.sh
+          bash -n ./scripts/kin-dev-image
+          bash -n ./scripts/test-publish-dev-container.sh
+          bash -n ./scripts/kin-dev-image.test.sh
           bash -n ./scripts/verify-npm-release.sh
           bash -n ./scripts/assert-windows-init-contract.sh
           bash -n ./scripts/windows-authority-legs.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
     # above is untouched, so every commit that reaches main still runs it. A
     # manual dispatch from any other ref is skipped before it can mint GCP
     # identity; the supported helper always dispatches the workflow on main.
-    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,12 +2,30 @@
 # Copyright 2026 Firelock, LLC
 
 name: Docker
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Dev image {0} {1}', github.event.inputs.mode || 'canary', github.event.inputs.commit || github.sha) || format('Dev image main {0}', github.sha) }}
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  # Fix-forward path for an exact commit already on main. The workflow file and
+  # OIDC identity still resolve from main; the input selects only the reviewed
+  # source commit to rebuild and publish.
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: Full 40-hex commit reachable from main (defaults to main HEAD)
+        required: false
+        type: string
+      mode:
+        description: Canary proves GitHub upload; publish writes the supported dev image
+        required: true
+        default: canary
+        type: choice
+        options:
+          - canary
+          - publish
 
 # The sha suffix is empty off main, so every pull request and merge-queue ref
 # keeps one group per ref and `cancel-in-progress` supersedes an older push
@@ -19,7 +37,11 @@ on:
 # absent rather than failed. The hosted merge queue lands PRs back to back, so
 # that window is the ordinary case here, not a rare one.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  # Pushes and manual replays of the same commit share one serial group. That
+  # closes the only first-publish race: two builders cannot both observe the
+  # immutable full-SHA tag missing and then push independently built manifests
+  # to it. Different main commits retain independent groups.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.commit || github.sha) || github.sha }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
@@ -27,19 +49,93 @@ permissions:
 
 jobs:
   build-image:
-    name: Docker Image Build (no push)
+    name: Build and publish dev daemon image
     # Off the pull-request path as of FIR-2815. This job gates nothing on a pull
     # request and never did, but `merge_pr_ready` in the umbrella refuses while
     # ANY check is still pending, required or not, so an advisory leg sets the
     # lane's clock exactly as a required one does. Moving only the required legs
     # would have left the pull-request clock at this job's measured 20.1 minutes
     # and read like the idea did not work. The `push: branches: [main]` trigger
-    # above is untouched, so every commit that reaches main still runs it.
-    if: ${{ github.event_name != 'pull_request' }}
+    # above is untouched, so every commit that reaches main still runs it. A
+    # manual dispatch from any other ref is skipped before it can mint GCP
+    # identity; the supported helper always dispatches the workflow on main.
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # Never interpolate the input into shell source. A dispatch runs this
+      # workflow from main, and may select only the exact full commit that main
+      # already contains. That makes a manual rebuild a replay of reviewed
+      # source rather than package-write authority for an arbitrary ref.
+      - name: Resolve exact main source
+        id: source
+        shell: bash
+        env:
+          REQUESTED_COMMIT: ${{ github.event.inputs.commit || '' }}
+          REQUESTED_MODE: ${{ github.event.inputs.mode || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          requested="${REQUESTED_COMMIT:-$GITHUB_SHA}"
+          if ! printf '%s\n' "$requested" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::source must be a full lowercase 40-hex commit"
+            exit 1
+          fi
+          git fetch --quiet origin main
+          commit="$(git rev-parse "${requested}^{commit}")"
+          if [ "$commit" != "$requested" ]; then
+            echo "::error::$requested resolved to $commit instead of itself"
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$commit" origin/main; then
+            echo "::error::$commit is not reachable from origin/main"
+            exit 1
+          fi
+          # Keep every host-executed helper from the workflow's current main
+          # checkout. A manual fix-forward may rebuild an older main commit,
+          # but historical shell must never run in a job whose permission set
+          # exposes the OIDC request endpoint. The old Dockerfile runs isolated
+          # inside BuildKit and the resulting container receives no runner OIDC
+          # environment; source bytes still come from the selected commit.
+          for helper in \
+            publish-dev-container.sh \
+            verify-container-build-info.sh \
+            test-entrypoint-workspace-mount.sh \
+            test-compose-published-port.sh \
+            test-gcs-emulator-endpoint.sh; do
+            install -m 0755 "scripts/${helper}" "$RUNNER_TEMP/${helper}"
+          done
+          # The compose guard interpolates its input before it calls Docker.
+          # Keep that data file on current workflow main too, so an older source
+          # checkout cannot reference runner credentials or privileged mounts.
+          install -m 0644 docker-compose.yml "$RUNNER_TEMP/docker-compose.yml"
+          git checkout --detach "$commit"
+          test "$(git rev-parse HEAD)" = "$commit"
+          test -z "$(git status --porcelain --untracked-files=all)"
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "branch=main" >> "$GITHUB_OUTPUT"
+          mode=publish
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            mode="$REQUESTED_MODE"
+          fi
+          if [ "$mode" != canary ] && [ "$mode" != publish ]; then
+            echo "::error::mode must be canary or publish"
+            exit 1
+          fi
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+          if [ "$mode" = canary ]; then
+            echo "publish_tag=gha-canary-${commit}" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_tag=${commit}" >> "$GITHUB_OUTPUT"
+          fi
 
       # Resolve the Dockerfile's digest-pinned base images through a mirror
       # first. This job publishes a check-run against every commit that reaches
@@ -57,12 +153,13 @@ jobs:
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
 
-      # Build-only gate: this job NEVER pushes an image. It proves the
-      # multi-stage Dockerfile still builds end to end, with kin-* dependencies
-      # resolved from the Kin sparse registry, then a release build of the
-      # `kin` and `kin-daemon` binaries into a slim runtime image. Layer cache
-      # is persisted across runs via the GitHub Actions cache backend so the
-      # heavy release compile stays affordable on repeat runs.
+      # Build once into the local Docker daemon. Every smoke below exercises
+      # this exact image before the supported GCP exchange runs; only after the
+      # checks pass does the final step push these already-tested bytes. The job
+      # has OIDC permission throughout, as GitHub permissions are job-scoped,
+      # but the provider grants only development-repository image writes.
+      # Layer cache stays in GitHub Actions, so the public repository pays no
+      # Cloud Build CPU/RAM charge and writes no Artifact Registry buildcache.
       - name: Build image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -74,22 +171,24 @@ jobs:
           load: true
           tags: kin:ci
           build-args: |
-            KIN_BUILD_GIT_SHA=${{ github.sha }}
+            KIN_DB_REF=main
+            KIN_BUILD_GIT_SHA=${{ steps.source.outputs.commit }}
             KIN_BUILD_DIRTY=false
-            KIN_BUILD_BRANCH=${{ github.ref_name }}
+            KIN_BUILD_BRANCH=${{ steps.source.outputs.branch }}
+            # Preserve the release image's fat-LTO link on every main build.
+            # GitHub-hosted compute removes the 8 GB Cloud Build constraint
+            # that forced only the legacy trigger down to thin LTO.
+            KIN_LTO=fat
           cache-from: type=gha
-          # Export layers only from main. A pull request's Actions cache scope
-          # is private to that pull request, so exporting mode=max from every
-          # round wrote layers only that same branch could reread, while
-          # spending the shared repository cache budget. Pull requests still
-          # import main's layers, and skipping the export also removes the
-          # mode=max upload from every pull-request round.
-          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=max' || '' }}
+          # The job runs only from main. One main-scoped cache replaces Cloud
+          # Build's Artifact Registry buildcache tag and remains reusable by a
+          # manual exact-SHA replay without storing a second paid registry copy.
+          cache-to: type=gha,mode=max
 
       - name: Verify container build provenance
         env:
-          EXPECTED_SHA: ${{ github.sha }}
-        run: bash scripts/verify-container-build-info.sh kin:ci "$EXPECTED_SHA"
+          EXPECTED_SHA: ${{ steps.source.outputs.commit }}
+        run: bash "$RUNNER_TEMP/verify-container-build-info.sh" kin:ci "$EXPECTED_SHA"
 
       # Container-level smoke on the freshly built image. Proves the entrypoint
       # boots the daemon in local mode with NO /workspace volume, the case that
@@ -196,14 +295,16 @@ jobs:
       # entrypoint leaves a mounted volume alone and refuses rather than deleting
       # through it, and that it still re-initializes when nothing is at risk.
       - name: Entrypoint contract with a volume mounted inside .kin
-        run: bash scripts/test-entrypoint-workspace-mount.sh kin:ci
+        run: bash "$RUNNER_TEMP/test-entrypoint-workspace-mount.sh" kin:ci
 
       # Every probe above runs inside the container's own network namespace, so
       # none of them can see whether the port compose publishes actually reaches
       # the daemon. This one curls the published mapping from the runner, with
       # the unset-bind-host arm first as a negative control.
       - name: Published port reachable from outside the container namespace
-        run: bash scripts/test-compose-published-port.sh kin:ci
+        env:
+          KIN_COMPOSE_FILE: ${{ runner.temp }}/docker-compose.yml
+        run: bash "$RUNNER_TEMP/test-compose-published-port.sh" kin:ci
 
       # FIR-2668's acceptance, against a real fake-gcs-server. The image this
       # job just built carries `--features gcs`, so the emulator round trip runs
@@ -213,4 +314,118 @@ jobs:
       # Cloud Storage, which is the arm that stops the happy path from passing
       # for a lever that is being ignored.
       - name: GCS emulator endpoint acceptance
-        run: bash scripts/test-gcs-emulator-endpoint.sh kin:ci
+        run: bash "$RUNNER_TEMP/test-gcs-emulator-endpoint.sh" kin:ci
+
+      # The repository variables are non-secret routing configuration. Refuse
+      # an empty or drifted contract before the supported OIDC exchange, so a
+      # misconfigured repository fails with one local, actionable line.
+      - name: Validate development registry identity
+        id: publisher-config
+        env:
+          PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          SERVICE_ACCOUNT: ${{ vars.GCP_BUILD_SERVICE_ACCOUNT }}
+          REGISTRY: ${{ vars.GCP_ARTIFACT_REGISTRY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PROVIDER" ] && [ -z "$SERVICE_ACCOUNT" ] && [ -z "$REGISTRY" ]; then
+            echo "::warning::development image OIDC is not activated; build and smoke passed, publish skipped"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          test "$PROVIDER" = "projects/642331057243/locations/global/workloadIdentityPools/github-actions/providers/kin-build-oidc"
+          test "$SERVICE_ACCOUNT" = "kin-github-builder@kin-ecosystem.iam.gserviceaccount.com"
+          test "$REGISTRY" = "us-central1-docker.pkg.dev/kin-ecosystem/kin-dev"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      # OIDC is minted only after the built image passes every local smoke. The
+      # provider admits this public repository's numeric identity, this exact
+      # workflow on refs/heads/main, and only push/workflow_dispatch events.
+      - name: Authenticate development image writer
+        if: steps.publisher-config.outputs.ready == 'true'
+        id: gcp-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_BUILD_SERVICE_ACCOUNT }}
+          token_format: access_token
+          create_credentials_file: false
+
+      - name: Log in to Artifact Registry
+        if: steps.publisher-config.outputs.ready == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Publish immutable development image
+        id: publish
+        if: steps.publisher-config.outputs.ready == 'true'
+        env:
+          REGISTRY: ${{ vars.GCP_ARTIFACT_REGISTRY }}
+          COMMIT: ${{ steps.source.outputs.commit }}
+          MODE: ${{ steps.source.outputs.mode }}
+          PUBLISH_TAG: ${{ steps.source.outputs.publish_tag }}
+          KIN_DEV_IMAGE_VERIFIER: ${{ runner.temp }}/verify-container-build-info.sh
+        run: |
+          set -euo pipefail
+          bash "$RUNNER_TEMP/publish-dev-container.sh" \
+            kin:ci "${REGISTRY}/kin-daemon" "$COMMIT" "$PUBLISH_TAG"
+
+      - name: Record development image proof
+        if: steps.publisher-config.outputs.ready == 'true'
+        env:
+          REGISTRY: ${{ vars.GCP_ARTIFACT_REGISTRY }}
+          COMMIT: ${{ steps.source.outputs.commit }}
+          MODE: ${{ steps.source.outputs.mode }}
+          DIGEST: ${{ steps.publish.outputs.digest }}
+          ALIASES_PROMOTED: ${{ steps.publish.outputs.aliases_promoted }}
+          REFERENCE: ${{ steps.publish.outputs.reference }}
+          PUBLICATION: ${{ steps.publish.outputs.publication }}
+          READBACK: ${{ steps.publish.outputs.readback }}
+          EMBEDDED_SHA: ${{ steps.publish.outputs.embedded_sha }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s\n' "$DIGEST" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+            echo "::error::publisher did not return an immutable digest"
+            exit 1
+          fi
+          if [ "$READBACK" != true ] || [ "$EMBEDDED_SHA" != true ]; then
+            echo "::error::publisher did not prove registry readback and embedded source"
+            exit 1
+          fi
+          if [ "$PUBLICATION" != published ] && [ "$PUBLICATION" != verified_existing ]; then
+            echo "::error::publisher returned an unknown publication result"
+            exit 1
+          fi
+          if [ "$ALIASES_PROMOTED" != false ]; then
+            echo "::error::GitHub publisher must never write mutable aliases"
+            exit 1
+          fi
+          if [ "$MODE" = canary ]; then
+            expected_reference="${REGISTRY}/kin-daemon:gha-canary-${COMMIT}"
+            if [ "$REFERENCE" != "$expected_reference" ]; then
+              echo "::error::manual canary escaped its immutable tag"
+              exit 1
+            fi
+          else
+            expected_reference="${REGISTRY}/kin-daemon:${COMMIT}"
+            if [ "$REFERENCE" != "$expected_reference" ]; then
+              echo "::error::publisher escaped the immutable full-SHA tag"
+              exit 1
+            fi
+          fi
+          echo "KIN_DEV_IMAGE_PROOF mode=${MODE} source=${COMMIT} reference=${REFERENCE} digest=${DIGEST} publication=${PUBLICATION} aliases_promoted=${ALIASES_PROMOTED} readback=${READBACK} embedded_sha=${EMBEDDED_SHA} transport=github-hosted"
+          {
+            echo "## Development image proof"
+            echo
+            echo "- mode: \`${MODE}\`"
+            echo "- source: \`${COMMIT}\`"
+            echo "- reference: \`${REFERENCE}\`"
+            echo "- digest: \`${DIGEST}\`"
+            echo "- publication: \`${PUBLICATION}\`"
+            echo "- aliases promoted: \`${ALIASES_PROMOTED}\`"
+            echo "- registry readback: \`${READBACK}\`"
+            echo "- embedded source verified: \`${EMBEDDED_SHA}\`"
+            echo "- transport: standard GitHub-hosted runner with GCP OIDC"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # release.yml), and falls back to docker.io when the mirror cannot serve the
 # digest, so neither registry is a single point of failure.
 #
-# This matters beyond reproducibility. `Docker Image Build (no push)` publishes
+# This matters beyond reproducibility. `Build and publish dev daemon image` publishes
 # a check-run against every commit that reaches main, and release-tag.yml's
 # second sweep refuses a release commit carrying any non-green check-run,
 # required or not. A registry blip lasting minutes therefore refuses a release
@@ -16,8 +16,10 @@
 # Dependency compilation is split away from workspace compilation. `cargo chef
 # prepare` distills the workspace manifests into a recipe whose bytes change
 # only when a dependency changes, so the `cook` layer in the builder keys on
-# dependencies alone and survives across source-only commits in the
-# registry-backed BuildKit cache that cloudbuild.yaml imports and exports.
+# dependencies alone and survives across source-only commits. The normal
+# GitHub-hosted development builder carries that layer in its Actions cache;
+# legacy cloudbuild.yaml carries the same layer in a registry cache only when
+# an operator deliberately invokes that fallback.
 # Before the split, `COPY . /build/kin` preceded the only cargo invocation, so
 # every push to main recompiled the entire dependency graph from scratch and
 # each hosted build burned 11-20 minutes on E2_HIGHCPU_8.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Firelock, LLC
 #
-# Cloud Build config for kin repo.
+# Legacy manual Cloud Build fallback for the kin repo. The normal development
+# image path is `.github/workflows/docker.yml`: the public repository builds on
+# a standard GitHub-hosted runner, smokes the image, and pushes that exact image
+# through a least-privilege OIDC writer. Keep this file for provider recovery,
+# but do not attach it to a per-push trigger.
 #
 # Tagging strategy:
 #   Every push:    {image}:{COMMIT_SHA} + {image}:{sanitized-branch}  (candidate)
@@ -12,8 +16,8 @@
 # GitHub release workflow so package publication follows the release path rather
 # than the push-to-main dev build path.
 #
-# Build cache: each hosted build runs on a fresh VM, so the local layer cache is
-# always empty and every push recompiled the whole Rust dependency graph. The
+# Fallback cache: each Cloud Build VM is fresh, so the local layer cache is
+# empty and an invocation would recompile the whole Rust dependency graph. The
 # Dockerfile now splits dependency compilation into a `cargo chef cook` layer
 # keyed only on the dependency recipe, and the buildx registry cache below is
 # what carries that layer between builds. The two changes are one mechanism:

--- a/scripts/kin-dev-image
+++ b/scripts/kin-dev-image
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+# Local-first daemon image loop plus a narrow exact-SHA hosted publisher.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GIT="${KIN_DEV_IMAGE_GIT:-git}"
+DOCKER="${KIN_DEV_IMAGE_DOCKER:-docker}"
+GH="${KIN_DEV_IMAGE_GH:-gh}"
+UPSTREAM_REPOSITORY="firelock-ai/kin"
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  scripts/kin-dev-image local [image-tag]
+  scripts/kin-dev-image canary [40-hex-commit]
+  scripts/kin-dev-image hosted [40-hex-commit]
+
+local   Build the current checkout locally (default tag: kin:dev). Clean
+        checkouts carry exact source identity; dirty checkouts stay explicitly
+        unknown/dirty.
+canary Dispatch a fresh gha-canary-<commit> upload for cutover proof. It never
+        promotes main or staging-latest.
+hosted Dispatch the GitHub-hosted dev image publisher for an exact commit
+        already reachable from origin/main. The workflow itself always runs
+        from main. It uses the immutable full-SHA tag and returns the exact
+        digest operators should consume. Neither hosted mode writes aliases.
+EOF
+  exit 2
+}
+
+command="${1:-}"
+case "$command" in
+  local)
+    if [ "$#" -gt 2 ]; then usage; fi
+    image="${2:-kin:dev}"
+    sha="$($GIT -C "$ROOT" rev-parse HEAD)"
+    branch="$($GIT -C "$ROOT" symbolic-ref --quiet --short HEAD 2>/dev/null || printf 'detached')"
+    dirty="$($GIT -C "$ROOT" status --porcelain --untracked-files=all)"
+    build_args=(
+      buildx build
+      --load
+      --file "$ROOT/Dockerfile"
+      --tag "$image"
+      --build-arg KIN_DB_REF=main
+      --build-arg KIN_LTO=thin
+    )
+    if [ -z "$dirty" ]; then
+      build_args+=(
+        --build-arg "KIN_BUILD_GIT_SHA=${sha}"
+        --build-arg "KIN_BUILD_DIRTY=false"
+        --build-arg "KIN_BUILD_BRANCH=${branch}"
+      )
+    else
+      echo "Building dirty checkout with unknown/dirty embedded source identity" >&2
+    fi
+    "$DOCKER" "${build_args[@]}" "$ROOT"
+    if [ -z "$dirty" ]; then
+      (cd "$ROOT" && bash scripts/verify-container-build-info.sh "$image" "$sha")
+    fi
+    echo "Built local daemon image: $image"
+    ;;
+
+  canary|hosted)
+    if [ "$#" -gt 2 ]; then usage; fi
+    if [ "$command" = canary ]; then
+      mode=canary
+    else
+      mode=publish
+    fi
+    requested="${2:-$($GIT -C "$ROOT" rev-parse HEAD)}"
+    if ! printf '%s\n' "$requested" | grep -Eq '^[0-9a-f]{40}$'; then
+      echo "error: hosted publish requires a full lowercase 40-hex commit" >&2
+      exit 2
+    fi
+
+    origin="$($GIT -C "$ROOT" remote get-url origin)"
+    case "$origin" in
+      git@github.com:firelock-ai/kin.git|https://github.com/firelock-ai/kin.git|https://github.com/firelock-ai/kin)
+        ;;
+      *)
+        echo "error: origin '$origin' is not the canonical $UPSTREAM_REPOSITORY repository" >&2
+        exit 1
+        ;;
+    esac
+
+    "$GIT" -C "$ROOT" fetch --quiet origin main
+    resolved="$($GIT -C "$ROOT" rev-parse "${requested}^{commit}")"
+    if [ "$resolved" != "$requested" ]; then
+      echo "error: requested commit resolved to $resolved instead of itself" >&2
+      exit 1
+    fi
+    if ! "$GIT" -C "$ROOT" merge-base --is-ancestor "$resolved" origin/main; then
+      echo "error: $resolved is not reachable from origin/main; push and land it first" >&2
+      exit 1
+    fi
+
+    prior_runs="$(mktemp)"
+    "$GH" run list \
+      --repo "$UPSTREAM_REPOSITORY" \
+      --workflow docker.yml \
+      --event workflow_dispatch \
+      --limit 100 \
+      --json databaseId \
+      --jq '.[].databaseId' > "$prior_runs"
+
+    "$GH" workflow run docker.yml \
+      --repo "$UPSTREAM_REPOSITORY" \
+      --ref main \
+      -f "commit=${resolved}" \
+      -f "mode=${mode}"
+    echo "Dispatched ${mode} GitHub-hosted dev image run for $resolved"
+
+    run_id=""
+    run_url=""
+    expected_title="Dev image ${mode} ${resolved}"
+    for _ in $(seq 1 30); do
+      rows="$($GH run list \
+        --repo "$UPSTREAM_REPOSITORY" \
+        --workflow docker.yml \
+        --event workflow_dispatch \
+        --limit 100 \
+        --json databaseId,displayTitle,url,status \
+        --jq '.[] | [.databaseId, .displayTitle, .url, .status] | @tsv')"
+      while IFS=$'\t' read -r candidate_id candidate_title candidate_url _status; do
+        [ "$candidate_title" = "$expected_title" ] || continue
+        if ! grep -Fxq "$candidate_id" "$prior_runs"; then
+          run_id="$candidate_id"
+          run_url="$candidate_url"
+          break
+        fi
+      done <<< "$rows"
+      [ -z "$run_id" ] || break
+      sleep 2
+    done
+    rm -f "$prior_runs"
+    if [ -z "$run_id" ] || [ -z "$run_url" ]; then
+      echo "error: dispatched workflow did not surface as '$expected_title'" >&2
+      exit 1
+    fi
+
+    echo "KIN_DEV_IMAGE_RUN id=$run_id url=$run_url"
+    if ! "$GH" run watch "$run_id" \
+      --repo "$UPSTREAM_REPOSITORY" \
+      --exit-status \
+      --interval 10; then
+      echo "error: hosted dev image run failed: $run_url" >&2
+      exit 1
+    fi
+
+    proof=""
+    for _ in $(seq 1 5); do
+      logs="$($GH run view "$run_id" --repo "$UPSTREAM_REPOSITORY" --log)"
+      proof_line="$(printf '%s\n' "$logs" \
+        | grep -F "KIN_DEV_IMAGE_PROOF mode=${mode} source=${resolved} " \
+        | tail -1 || true)"
+      if [ -n "$proof_line" ]; then
+        proof="${proof_line#*KIN_DEV_IMAGE_PROOF }"
+        break
+      fi
+      sleep 2
+    done
+    if [ "$mode" = canary ]; then
+      expected_reference="us-central1-docker.pkg.dev/kin-ecosystem/kin-dev/kin-daemon:gha-canary-${resolved}"
+      proof_pattern="^mode=canary source=${resolved} reference=${expected_reference} digest=sha256:[0-9a-f]{64} publication=published aliases_promoted=false readback=true embedded_sha=true transport=github-hosted$"
+      proof_error="a fresh GitHub canary publication"
+    else
+      expected_reference="us-central1-docker.pkg.dev/kin-ecosystem/kin-dev/kin-daemon:${resolved}"
+      proof_pattern="^mode=publish source=${resolved} reference=${expected_reference} digest=sha256:[0-9a-f]{64} publication=(published|verified_existing) aliases_promoted=false readback=true embedded_sha=true transport=github-hosted$"
+      proof_error="an exact-SHA GitHub publication"
+    fi
+    if ! printf '%s\n' "$proof" | grep -Eq "$proof_pattern"; then
+      echo "error: hosted run completed without ${proof_error} proof: $run_url" >&2
+      exit 1
+    fi
+    echo "KIN_DEV_IMAGE_PROOF $proof"
+    ;;
+
+  *) usage ;;
+esac

--- a/scripts/kin-dev-image.test.sh
+++ b/scripts/kin-dev-image.test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+COMMIT="0123456789abcdef0123456789abcdef01234567"
+LOCK_SHA="$(sha256sum "$ROOT/Cargo.lock" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$ROOT/Cargo.lock" | awk '{print $1}')"
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/git" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_GIT_LOG"
+args="$*"
+case "$args" in
+  *" rev-parse HEAD") printf '%s\n' "$TEST_COMMIT" ;;
+  *" symbolic-ref --quiet --short HEAD") printf '%s\n' main ;;
+  *" status --porcelain --untracked-files=all") printf '%s' "${TEST_DIRTY:-}" ;;
+  *" remote get-url origin") printf '%s\n' "${TEST_ORIGIN:-https://github.com/firelock-ai/kin.git}" ;;
+  *" fetch --quiet origin main") ;;
+  *" rev-parse ${TEST_COMMIT}^{commit}") printf '%s\n' "$TEST_COMMIT" ;;
+  *" merge-base --is-ancestor ${TEST_COMMIT} origin/main") exit "${TEST_ANCESTOR_STATUS:-0}" ;;
+  *) echo "unexpected git command: $args" >&2; exit 90 ;;
+esac
+SH
+
+cat > "$TMP/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_DOCKER_LOG"
+if [ "${1:-}" = buildx ] && [ "${2:-}" = build ]; then exit 0; fi
+if [ "${1:-}" = run ]; then
+  printf '{"sha":"%s","dirty":false,"source_known":true,"dependency_provenance":"%s"}\n' \
+    "$TEST_COMMIT" "$TEST_LOCK_SHA"
+  exit 0
+fi
+echo "unexpected docker command: $*" >&2
+exit 91
+SH
+
+cat > "$TMP/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_GH_LOG"
+case "$*" in
+  "run list "*"--json databaseId --jq "*)
+    [ ! -f "$TEST_GH_STATE" ] || printf '%s\n' 123
+    ;;
+  "workflow run docker.yml "*)
+    touch "$TEST_GH_STATE"
+    ;;
+  "run list "*"--json databaseId,displayTitle,url,status "*)
+    [ ! -f "$TEST_GH_STATE" ] || printf '123\tDev image %s %s\thttps://github.com/firelock-ai/kin/actions/runs/123\tqueued\n' "$TEST_MODE" "$TEST_COMMIT"
+    ;;
+  "run watch 123 "*)
+    exit "${TEST_WATCH_STATUS:-0}"
+    ;;
+  "run view 123 "*" --log")
+    if [ "${TEST_NO_PROOF:-0}" != 1 ]; then
+      publication="${TEST_PUBLICATION:-published}"
+      printf 'publish\tKIN_DEV_IMAGE_PROOF mode=%s source=%s reference=us-central1-docker.pkg.dev/kin-ecosystem/kin-dev/kin-daemon:%s digest=sha256:%064d publication=%s aliases_promoted=%s readback=true embedded_sha=true transport=github-hosted\n' \
+        "$TEST_MODE" "$TEST_COMMIT" "$TEST_REFERENCE_TAG" 0 "$publication" "$TEST_ALIASES"
+    fi
+    ;;
+  *) echo "unexpected gh command: $*" >&2; exit 92 ;;
+esac
+SH
+cat > "$TMP/bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$TMP/bin/git" "$TMP/bin/docker" "$TMP/bin/gh" "$TMP/bin/sleep"
+
+export TEST_COMMIT="$COMMIT"
+export TEST_LOCK_SHA="$LOCK_SHA"
+export TEST_GIT_LOG="$TMP/git.log"
+export TEST_DOCKER_LOG="$TMP/docker.log"
+export TEST_GH_LOG="$TMP/gh.log"
+export TEST_GH_STATE="$TMP/gh.state"
+export TEST_MODE=canary
+export TEST_REFERENCE_TAG="gha-canary-${COMMIT}"
+export TEST_ALIASES=false
+export PATH="$TMP/bin:$PATH"
+export KIN_DEV_IMAGE_GIT="$TMP/bin/git"
+export KIN_DEV_IMAGE_DOCKER="$TMP/bin/docker"
+export KIN_DEV_IMAGE_GH="$TMP/bin/gh"
+
+cd "$ROOT"
+
+echo "==> clean local build carries exact identity and thin LTO"
+: > "$TEST_GIT_LOG"; : > "$TEST_DOCKER_LOG"
+TEST_DIRTY= bash scripts/kin-dev-image local kin:test
+grep -Fq -- "--build-arg KIN_BUILD_GIT_SHA=${COMMIT}" "$TEST_DOCKER_LOG"
+grep -Fq -- "--build-arg KIN_BUILD_DIRTY=false" "$TEST_DOCKER_LOG"
+grep -Fq -- "--build-arg KIN_LTO=thin" "$TEST_DOCKER_LOG"
+
+echo "==> dirty local build cannot claim a clean source identity"
+: > "$TEST_DOCKER_LOG"
+TEST_DIRTY=' M src/lib.rs' bash scripts/kin-dev-image local kin:dirty
+if grep -Fq "KIN_BUILD_GIT_SHA=" "$TEST_DOCKER_LOG"; then
+  echo "dirty local build received a trusted source override" >&2
+  exit 1
+fi
+
+echo "==> canary proves a fresh namespaced upload for one exact commit"
+: > "$TEST_GIT_LOG"; : > "$TEST_GH_LOG"
+rm -f "$TEST_GH_STATE"
+bash scripts/kin-dev-image canary "$COMMIT"
+grep -Fxq "workflow run docker.yml --repo firelock-ai/kin --ref main -f commit=${COMMIT} -f mode=canary" "$TEST_GH_LOG"
+grep -Fq "merge-base --is-ancestor ${COMMIT} origin/main" "$TEST_GIT_LOG"
+grep -Fq "run watch 123 --repo firelock-ai/kin --exit-status" "$TEST_GH_LOG"
+
+echo "==> an existing canary cannot masquerade as fresh cutover proof"
+: > "$TEST_GH_LOG"
+rm -f "$TEST_GH_STATE"
+if TEST_PUBLICATION=verified_existing bash scripts/kin-dev-image canary "$COMMIT" \
+  >"$TMP/existing-canary.out" 2>&1; then
+  echo "existing canary unexpectedly passed as a fresh publication" >&2
+  exit 1
+fi
+grep -Fq "without a fresh GitHub canary publication proof" \
+  "$TMP/existing-canary.out"
+
+echo "==> hosted publish uses the full-SHA tag and accepts proven replay"
+: > "$TEST_GH_LOG"
+rm -f "$TEST_GH_STATE"
+TEST_MODE=publish TEST_REFERENCE_TAG="$COMMIT" TEST_ALIASES=false \
+  TEST_PUBLICATION=verified_existing \
+  bash scripts/kin-dev-image hosted "$COMMIT"
+grep -Fxq "workflow run docker.yml --repo firelock-ai/kin --ref main -f commit=${COMMIT} -f mode=publish" "$TEST_GH_LOG"
+
+echo "==> non-main commit is refused before GitHub dispatch"
+: > "$TEST_GH_LOG"
+if TEST_ANCESTOR_STATUS=1 bash scripts/kin-dev-image hosted "$COMMIT" \
+  >"$TMP/non-main.out" 2>&1; then
+  echo "non-main commit unexpectedly dispatched" >&2
+  exit 1
+fi
+grep -Fq "not reachable from origin/main" "$TMP/non-main.out"
+test ! -s "$TEST_GH_LOG"
+
+echo "==> abbreviated commit and non-canonical origin are refused"
+if bash scripts/kin-dev-image hosted deadbeef >"$TMP/short.out" 2>&1; then
+  echo "abbreviated commit unexpectedly dispatched" >&2
+  exit 1
+fi
+grep -Fq "full lowercase 40-hex" "$TMP/short.out"
+if TEST_ORIGIN=https://github.com/example/fork.git bash scripts/kin-dev-image hosted "$COMMIT" \
+  >"$TMP/origin.out" 2>&1; then
+  echo "fork origin unexpectedly dispatched upstream" >&2
+  exit 1
+fi
+grep -Fq "not the canonical firelock-ai/kin" "$TMP/origin.out"
+
+echo "==> a green run without digest proof is refused"
+: > "$TEST_GH_LOG"
+rm -f "$TEST_GH_STATE"
+if TEST_NO_PROOF=1 bash scripts/kin-dev-image canary "$COMMIT" \
+  >"$TMP/no-proof.out" 2>&1; then
+  echo "proofless hosted run unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq "without a fresh GitHub canary publication proof" "$TMP/no-proof.out"
+
+echo "kin-dev-image tests passed"

--- a/scripts/publish-dev-container.sh
+++ b/scripts/publish-dev-container.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+# Publish one already-tested local image to the development Artifact Registry.
+# A main push owns the full commit tag. A manual cutover canary owns the separate
+# gha-canary-<commit> namespace so a Cloud Build tag from the migration overlap
+# cannot masquerade as proof that GitHub published its locally smoked bytes.
+
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <local-image> <registry-image> <40-hex-commit> <publish-tag>" >&2
+  exit 2
+fi
+
+local_image="$1"
+registry_image="${2%:}"
+commit="$3"
+publish_tag="$4"
+verifier="${KIN_DEV_IMAGE_VERIFIER:-scripts/verify-container-build-info.sh}"
+
+if [ -z "$local_image" ] || [ -z "$registry_image" ]; then
+  echo "error: local and registry image names must not be empty" >&2
+  exit 2
+fi
+if ! printf '%s\n' "$commit" | grep -Eq '^[0-9a-f]{40}$'; then
+  echo "error: commit must be a full lowercase 40-hex id" >&2
+  exit 2
+fi
+canary_tag="gha-canary-${commit}"
+if [ "$publish_tag" != "$commit" ] && [ "$publish_tag" != "$canary_tag" ]; then
+  echo "error: publish tag must be the full commit or its gha-canary-<commit> identity" >&2
+  exit 2
+fi
+
+source_ref="${registry_image}:${publish_tag}"
+
+inspect_digest() {
+  local reference="$1"
+  local output
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if output="$(docker buildx imagetools inspect "$reference" \
+      --format '{{.Manifest.Digest}}' 2>&1)"; then
+      printf '%s\n' "$output"
+      return 0
+    fi
+    if [ "$output" = "ERROR: ${reference}: not found" ]; then
+      return 44
+    fi
+    if [ "$attempt" -eq 5 ]; then
+      printf '%s\n' "$output" >&2
+      echo "error: could not establish registry state for $reference" >&2
+      return 1
+    fi
+    sleep $(( attempt * 2 ))
+  done
+}
+
+if source_digest="$(inspect_digest "$source_ref")"; then
+  # Never overwrite an exact identity. Cloud Build may already have moved the
+  # legacy full-SHA tag during migration overlap, while a canary retry may see
+  # its own earlier success. Both are verification, not proof this run pushed.
+  bash "$verifier" \
+    "${registry_image}@${source_digest}" "$commit"
+  publication="verified_existing"
+else
+  inspect_status=$?
+  if [ "$inspect_status" -ne 44 ]; then
+    exit "$inspect_status"
+  fi
+
+  docker image inspect "$local_image" >/dev/null
+  docker image tag "$local_image" "$source_ref"
+  docker push "$source_ref"
+  source_digest="$(inspect_digest "$source_ref")"
+  publication="published"
+fi
+
+if ! printf '%s\n' "$source_digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+  echo "error: $source_ref did not resolve to an immutable sha256 digest" >&2
+  exit 1
+fi
+
+references=("$source_ref")
+
+for reference in "${references[@]}"; do
+  actual_digest="$(inspect_digest "$reference")"
+  if [ "$actual_digest" != "$source_digest" ]; then
+    echo "error: $reference resolved to $actual_digest, expected $source_digest" >&2
+    exit 1
+  fi
+done
+
+# Pull and execute by digest after the registry writes. This is the served
+# Artifact Registry object, not merely the local image that passed smoke.
+bash "$verifier" \
+  "${registry_image}@${source_digest}" "$commit"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "digest=$source_digest"
+    echo "aliases_promoted=false"
+    echo "reference=$source_ref"
+    echo "publication=$publication"
+    echo "readback=true"
+    echo "embedded_sha=true"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+if [ "$publication" = published ]; then
+  action="Published"
+else
+  action="Verified existing"
+fi
+echo "$action immutable development image: ${source_ref}"
+echo "Published no mutable aliases; consume ${registry_image}@${source_digest}"

--- a/scripts/test-compose-published-port.sh
+++ b/scripts/test-compose-published-port.sh
@@ -30,7 +30,7 @@ set -euo pipefail
 
 IMAGE="${1:?usage: test-compose-published-port.sh <image-ref> [host-port]}"
 HOST_PORT="${2:-14219}"
-COMPOSE_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/docker-compose.yml"
+COMPOSE_FILE="${KIN_COMPOSE_FILE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/docker-compose.yml}"
 CID=""
 
 cleanup() {

--- a/scripts/test-publish-dev-container.sh
+++ b/scripts/test-publish-dev-container.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+COMMIT="0123456789abcdef0123456789abcdef01234567"
+DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+OTHER_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+IMAGE="us-central1-docker.pkg.dev/kin-ecosystem/kin-dev/kin-daemon"
+LOCK_SHA="$(sha256sum "$ROOT/Cargo.lock" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$ROOT/Cargo.lock" | awk '{print $1}')"
+
+mkdir -p "$TMP/bin" "$TMP/state"
+cat > "$TMP/bin/git" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$*" = "ls-remote origin refs/heads/main" ]; then
+  printf '%s\trefs/heads/main\n' "$TEST_MAIN_SHA"
+  exit 0
+fi
+echo "unexpected git command: $*" >&2
+exit 92
+SH
+cat > "$TMP/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_LOG"
+
+if [ "${1:-}" = buildx ] && [ "${2:-}" = imagetools ] && [ "${3:-}" = inspect ]; then
+  ref="$4"
+  case "$ref" in
+    *:"${TEST_PUBLISH_TAG:-$TEST_COMMIT}") marker=source ;;
+    *@sha256:*) printf '%s\n' "$TEST_DIGEST"; exit 0 ;;
+    *) echo "unexpected inspect reference: $ref" >&2; exit 90 ;;
+  esac
+  if [ -f "$TEST_STATE/$marker" ]; then
+    printf '%s\n' "${TEST_SOURCE_DIGEST:-$TEST_DIGEST}"
+    exit 0
+  fi
+  echo "ERROR: ${ref}: not found" >&2
+  exit 1
+fi
+
+if [ "${1:-}" = image ] && [ "${2:-}" = inspect ]; then exit 0; fi
+if [ "${1:-}" = image ] && [ "${2:-}" = tag ]; then exit 0; fi
+if [ "${1:-}" = push ]; then touch "$TEST_STATE/source"; exit 0; fi
+if [ "${1:-}" = run ]; then
+  printf '{"sha":"%s","dirty":false,"source_known":true,"dependency_provenance":"%s"}\n' \
+    "${TEST_RUN_SHA:-$TEST_COMMIT}" "$TEST_LOCK_SHA"
+  exit 0
+fi
+echo "unexpected docker command: $*" >&2
+exit 91
+SH
+chmod +x "$TMP/bin/git" "$TMP/bin/docker"
+
+export PATH="$TMP/bin:$PATH"
+export TEST_LOG="$TMP/docker.log"
+export TEST_STATE="$TMP/state"
+export TEST_COMMIT="$COMMIT"
+export TEST_DIGEST="$DIGEST"
+export TEST_OTHER_DIGEST="$OTHER_DIGEST"
+export TEST_LOCK_SHA="$LOCK_SHA"
+export TEST_MAIN_SHA="$COMMIT"
+
+cd "$ROOT"
+
+echo "==> new full-commit tag is published once with no mutable aliases"
+: > "$TEST_LOG"
+rm -f "$TEST_STATE"/*
+: > "$TMP/full.output"
+GITHUB_OUTPUT="$TMP/full.output" bash scripts/publish-dev-container.sh \
+  kin:ci "$IMAGE" "$COMMIT" "$COMMIT" | tee "$TMP/full.stdout"
+grep -Fxq "push ${IMAGE}:${COMMIT}" "$TEST_LOG"
+grep -Fxq "reference=${IMAGE}:${COMMIT}" "$TMP/full.output"
+grep -Fxq "publication=published" "$TMP/full.output"
+grep -Fxq "aliases_promoted=false" "$TMP/full.output"
+grep -Fq "Published immutable development image: ${IMAGE}:${COMMIT}" \
+  "$TMP/full.stdout"
+if grep -Eq "imagetools create|:main|:staging-latest" "$TEST_LOG"; then
+  echo "immutable full-SHA publish wrote a mutable alias" >&2
+  exit 1
+fi
+
+echo "==> a fresh GitHub canary uses its own tag and never moves aliases"
+: > "$TEST_LOG"
+rm -f "$TEST_STATE"/*
+CANARY_TAG="gha-canary-${COMMIT}"
+: > "$TMP/canary.output"
+TEST_PUBLISH_TAG="$CANARY_TAG" GITHUB_OUTPUT="$TMP/canary.output" \
+  bash scripts/publish-dev-container.sh \
+  kin:ci "$IMAGE" "$COMMIT" "$CANARY_TAG" | tee "$TMP/canary.stdout"
+grep -Fxq "push ${IMAGE}:${CANARY_TAG}" "$TEST_LOG"
+if grep -Eq "imagetools create|:main|:staging-latest" "$TEST_LOG"; then
+  echo "GitHub canary moved mutable aliases" >&2
+  exit 1
+fi
+grep -Fxq "reference=${IMAGE}:${CANARY_TAG}" "$TMP/canary.output"
+grep -Fxq "publication=published" "$TMP/canary.output"
+grep -Fxq "readback=true" "$TMP/canary.output"
+grep -Fxq "embedded_sha=true" "$TMP/canary.output"
+grep -Fq "Published immutable development image: ${IMAGE}:${CANARY_TAG}" \
+  "$TMP/canary.stdout"
+
+echo "==> arbitrary publish tags are rejected before registry access"
+: > "$TEST_LOG"
+if bash scripts/publish-dev-container.sh \
+  kin:ci "$IMAGE" "$COMMIT" "mutable-main" \
+  >"$TMP/arbitrary-tag.out" 2>&1; then
+  echo "arbitrary mutable tag unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq "publish tag must be the full commit" "$TMP/arbitrary-tag.out"
+test ! -s "$TEST_LOG"
+
+echo "==> an existing full-commit tag is verified and never overwritten"
+: > "$TEST_LOG"
+touch "$TEST_STATE/source"
+bash scripts/publish-dev-container.sh kin:ci "$IMAGE" "$COMMIT" "$COMMIT"
+if grep -Eq "^(push|image tag) " "$TEST_LOG"; then
+  echo "existing immutable tag was overwritten" >&2
+  exit 1
+fi
+
+echo "==> a moved legacy full-SHA tag is never claimed as a GitHub upload"
+: > "$TEST_LOG"
+touch "$TEST_STATE/source"
+: > "$TMP/moved.output"
+TEST_SOURCE_DIGEST="$OTHER_DIGEST" GITHUB_OUTPUT="$TMP/moved.output" \
+  bash scripts/publish-dev-container.sh \
+  kin:ci "$IMAGE" "$COMMIT" "$COMMIT"
+grep -Fxq "digest=${OTHER_DIGEST}" "$TMP/moved.output"
+grep -Fxq "publication=verified_existing" "$TMP/moved.output"
+if grep -Eq "^(push|image tag) " "$TEST_LOG"; then
+  echo "moved legacy tag was overwritten or claimed as freshly published" >&2
+  exit 1
+fi
+
+echo "==> abbreviated commit is rejected before registry access"
+: > "$TEST_LOG"
+if bash scripts/publish-dev-container.sh kin:ci "$IMAGE" deadbeef deadbeef \
+  >"$TMP/short.out" 2>&1; then
+  echo "abbreviated commit unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq "full lowercase 40-hex" "$TMP/short.out"
+test ! -s "$TEST_LOG"
+
+echo "publish-dev-container tests passed"

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -150,6 +150,8 @@ EXPECTED_SELECTOR_INVOCATIONS = {
 HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
 SETUP = ROOT / "crates" / "kin-cli" / "src" / "commands" / "setup.rs"
 DOCKERFILE = ROOT / "Dockerfile"
+DEV_IMAGE_PUBLISHER = ROOT / "scripts" / "publish-dev-container.sh"
+DEV_IMAGE_TOOL = ROOT / "scripts" / "kin-dev-image"
 CI_APT_INSTALL = ROOT / "scripts" / "ci-apt-install.sh"
 BASE_IMAGE_REGISTRY = "docker.io"
 BASE_IMAGE_MIRROR = 'mirrors = ["mirror.gcr.io"]'
@@ -746,7 +748,7 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
         "dco": "DCO sign-off",
     },
     ".github/workflows/docker.yml": {
-        "build-image": "Docker Image Build (no push)",
+        "build-image": "Build and publish dev daemon image",
     },
     ".github/workflows/fuzz.yml": {
         "fuzz": "cargo-fuzz (${{ matrix.target }})",
@@ -9406,7 +9408,7 @@ def assert_container_base_image_authority(
 ) -> None:
     """Keep one registry from being able to refuse a release on its own.
 
-    `Docker Image Build (no push)` publishes a check-run against every commit
+    `Build and publish dev daemon image` publishes a check-run against every commit
     that reaches main, and release-tag.yml's second sweep refuses a release
     commit carrying any non-green check-run whether or not a ruleset requires
     it. Minutes of registry unavailability therefore refuse a release
@@ -9492,6 +9494,253 @@ def assert_pin_prover_cannot_refuse_a_release(pins_workflow: str) -> None:
         "pin prover checkout, whose failure would fail the job regardless of "
         "the guard below it",
     )
+
+
+def assert_dev_image_publish_policy(
+    workflow: str,
+    publisher: str,
+    local_tool: str,
+) -> None:
+    """Keep the free hosted builder narrow, exact, and replayable."""
+
+    job = workflow_job_blocks(workflow).get("build-image")
+    if job is None:
+        raise AssertionError("dev image workflow no longer declares build-image")
+
+    required_workflow = (
+        "run-name: ${{ github.event_name == 'workflow_dispatch' && format('Dev image {0} {1}', github.event.inputs.mode || 'canary', github.event.inputs.commit || github.sha) || format('Dev image main {0}', github.sha) }}",
+        "workflow_dispatch:",
+        "description: Full 40-hex commit reachable from main",
+        "description: Canary proves GitHub upload; publish writes the supported dev image",
+        "type: choice",
+        "- canary",
+        "- publish",
+        "group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.commit || github.sha) || github.sha }}",
+        "if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}",
+        "runs-on: ubuntu-latest",
+        "id-token: write",
+        "persist-credentials: false",
+        "fetch-depth: 0",
+        "REQUESTED_COMMIT: ${{ github.event.inputs.commit || '' }}",
+        "REQUESTED_MODE: ${{ github.event.inputs.mode || '' }}",
+        "EVENT_NAME: ${{ github.event_name }}",
+        "^[0-9a-f]{40}$",
+        'git merge-base --is-ancestor "$commit" origin/main',
+        'install -m 0755 "scripts/${helper}" "$RUNNER_TEMP/${helper}"',
+        'install -m 0644 docker-compose.yml "$RUNNER_TEMP/docker-compose.yml"',
+        'echo "mode=${mode}" >> "$GITHUB_OUTPUT"',
+        'echo "publish_tag=gha-canary-${commit}" >> "$GITHUB_OUTPUT"',
+        'echo "publish_tag=${commit}" >> "$GITHUB_OUTPUT"',
+        "publish-dev-container.sh",
+        "verify-container-build-info.sh",
+        "test-entrypoint-workspace-mount.sh",
+        "test-compose-published-port.sh",
+        "test-gcs-emulator-endpoint.sh",
+        "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+        "push: false",
+        "load: true",
+        "KIN_BUILD_GIT_SHA=${{ steps.source.outputs.commit }}",
+        "KIN_BUILD_DIRTY=false",
+        "KIN_BUILD_BRANCH=${{ steps.source.outputs.branch }}",
+        "KIN_LTO=fat",
+        "cache-from: type=gha",
+        "cache-to: type=gha,mode=max",
+        "EXPECTED_SHA: ${{ steps.source.outputs.commit }}",
+        'bash "$RUNNER_TEMP/verify-container-build-info.sh" kin:ci "$EXPECTED_SHA"',
+        'bash "$RUNNER_TEMP/test-entrypoint-workspace-mount.sh" kin:ci',
+        'KIN_COMPOSE_FILE: ${{ runner.temp }}/docker-compose.yml',
+        'bash "$RUNNER_TEMP/test-compose-published-port.sh" kin:ci',
+        'bash "$RUNNER_TEMP/test-gcs-emulator-endpoint.sh" kin:ci',
+        "GCP_WORKLOAD_IDENTITY_PROVIDER",
+        "GCP_BUILD_SERVICE_ACCOUNT",
+        "GCP_ARTIFACT_REGISTRY",
+        "projects/642331057243/locations/global/workloadIdentityPools/github-actions/providers/kin-build-oidc",
+        "kin-github-builder@kin-ecosystem.iam.gserviceaccount.com",
+        "us-central1-docker.pkg.dev/kin-ecosystem/kin-dev",
+        "id: publisher-config",
+        "development image OIDC is not activated; build and smoke passed, publish skipped",
+        'echo "ready=false" >> "$GITHUB_OUTPUT"',
+        'echo "ready=true" >> "$GITHUB_OUTPUT"',
+        "if: steps.publisher-config.outputs.ready == 'true'",
+        "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093",
+        "token_format: access_token",
+        "create_credentials_file: false",
+        "docker/login-action@dbcb813823bdd20940b903addbd779551569679f",
+        "username: oauth2accesstoken",
+        "password: ${{ steps.gcp-auth.outputs.access_token }}",
+        "KIN_DEV_IMAGE_VERIFIER: ${{ runner.temp }}/verify-container-build-info.sh",
+        "id: publish",
+        "DIGEST: ${{ steps.publish.outputs.digest }}",
+        "ALIASES_PROMOTED: ${{ steps.publish.outputs.aliases_promoted }}",
+        "REFERENCE: ${{ steps.publish.outputs.reference }}",
+        "PUBLICATION: ${{ steps.publish.outputs.publication }}",
+        "READBACK: ${{ steps.publish.outputs.readback }}",
+        "EMBEDDED_SHA: ${{ steps.publish.outputs.embedded_sha }}",
+        'if [ "$ALIASES_PROMOTED" != false ]',
+        "GitHub publisher must never write mutable aliases",
+        "## Development image proof",
+        "KIN_DEV_IMAGE_PROOF mode=${MODE} source=${COMMIT} reference=${REFERENCE} digest=${DIGEST} publication=${PUBLICATION} aliases_promoted=${ALIASES_PROMOTED} readback=${READBACK} embedded_sha=${EMBEDDED_SHA} transport=github-hosted",
+        "standard GitHub-hosted runner with GCP OIDC",
+        'kin:ci "${REGISTRY}/kin-daemon" "$COMMIT" "$PUBLISH_TAG"',
+    )
+    for policy in required_workflow:
+        require(workflow, policy, "GitHub-hosted development image publisher")
+
+    # The GCP exchange and mutation must remain after every image smoke, and the
+    # exact source resolver must remain before the one build. This is an order
+    # contract, not merely a census of strings comments could satisfy.
+    ordered_markers = (
+        "      - name: Resolve exact main source",
+        "      - name: Build image",
+        "      - name: Verify container build provenance",
+        "      - name: Entrypoint smoke",
+        "      - name: Entrypoint contract with a volume mounted inside .kin",
+        "      - name: Published port reachable from outside the container namespace",
+        "      - name: GCS emulator endpoint acceptance",
+        "      - name: Validate development registry identity",
+        "      - name: Authenticate development image writer",
+        "      - name: Log in to Artifact Registry",
+        "      - name: Publish immutable development image",
+        "      - name: Record development image proof",
+    )
+    positions = [job.index(marker) for marker in ordered_markers]
+    if positions != sorted(positions):
+        raise AssertionError(
+            "development image auth or publish moved ahead of build provenance smoke"
+        )
+
+    for forbidden in (
+        "packages: write",
+        "contents: write",
+        "secrets.",
+        "gcloud ",
+        "gcloud-builds",
+        "cloudbuild.yaml",
+        "ghcr.io",
+        "github.run_id",
+        "staging-latest",
+        "imagetools create",
+    ):
+        if forbidden in job:
+            raise AssertionError(
+                f"development image publisher contains forbidden authority: {forbidden}"
+            )
+    if job.count("id-token: write") != 1:
+        raise AssertionError(
+            "development image publisher must grant exactly one job-scoped id-token writer"
+        )
+    if job.count("if: steps.publisher-config.outputs.ready == 'true'") != 4:
+        raise AssertionError(
+            "auth, registry login, publish, and proof must all skip before OIDC activation"
+        )
+    if re.search(r"(?m)^\s+run:\s+bash scripts/", job):
+        raise AssertionError(
+            "historical checkout shell must not execute on the OIDC-capable host"
+        )
+
+    required_publisher = (
+        "<40-hex-commit> <publish-tag>",
+        "KIN_DEV_IMAGE_VERIFIER",
+        "^[0-9a-f]{40}$",
+        'canary_tag="gha-canary-${commit}"',
+        'if [ "$publish_tag" != "$commit" ] && [ "$publish_tag" != "$canary_tag" ]',
+        'source_ref="${registry_image}:${publish_tag}"',
+        'if source_digest="$(inspect_digest "$source_ref")"',
+        '"${registry_image}@${source_digest}" "$commit"',
+        'bash "$verifier"',
+        'if [ "$inspect_status" -ne 44 ]',
+        'docker image tag "$local_image" "$source_ref"',
+        'docker push "$source_ref"',
+        "^sha256:[0-9a-f]{64}$",
+        'references=("$source_ref")',
+        'for reference in "${references[@]}"',
+        'if [ "$actual_digest" != "$source_digest" ]',
+        'echo "digest=$source_digest"',
+        'echo "aliases_promoted=false"',
+        'echo "reference=$source_ref"',
+        'echo "publication=$publication"',
+        'publication="verified_existing"',
+        'publication="published"',
+        'echo "readback=true"',
+        'echo "embedded_sha=true"',
+    )
+    for policy in required_publisher:
+        require(publisher, policy, "immutable development image helper")
+
+    existing_start = publisher.index(
+        'if source_digest="$(inspect_digest "$source_ref")"'
+    )
+    first_push = publisher.index('docker push "$source_ref"', existing_start)
+    first_verify = publisher.index(
+        'bash "$verifier"', existing_start
+    )
+    readback = publisher.index(
+        'for reference in "${references[@]}"', first_push
+    )
+    served_verify = publisher.rindex('bash "$verifier"')
+    proof_outputs = publisher.index('echo "readback=true"', served_verify)
+    if not (
+        existing_start
+        < first_verify
+        < first_push
+        < readback
+        < served_verify
+        < proof_outputs
+    ):
+        raise AssertionError(
+            "existing commit provenance must pass before a replay is accepted, "
+            "and the immutable registry reference plus served digest must be "
+            "verified before proof outputs are recorded"
+        )
+    for forbidden in (
+        "docker build ",
+        "docker buildx build",
+        "docker buildx imagetools create",
+        "gcloud ",
+        ":latest",
+        ":main",
+        "staging-latest",
+        "promote_aliases",
+        "branch_ref",
+    ):
+        if forbidden in publisher:
+            raise AssertionError(
+                f"immutable development image helper contains forbidden behavior: {forbidden}"
+            )
+
+    required_tool = (
+        "scripts/kin-dev-image local [image-tag]",
+        "scripts/kin-dev-image canary [40-hex-commit]",
+        "scripts/kin-dev-image hosted [40-hex-commit]",
+        'if [ "$command" = canary ]',
+        "mode=canary",
+        "mode=publish",
+        "KIN_LTO=thin",
+        "KIN_BUILD_DIRTY=false",
+        "full lowercase 40-hex commit",
+        'remote get-url origin',
+        "firelock-ai/kin.git",
+        'merge-base --is-ancestor "$resolved" origin/main',
+        'workflow run docker.yml',
+        '--repo "$UPSTREAM_REPOSITORY"',
+        "--ref main",
+        '-f "commit=${resolved}"',
+        '-f "mode=${mode}"',
+        "--event workflow_dispatch",
+        'expected_title="Dev image ${mode} ${resolved}"',
+        'if ! grep -Fxq "$candidate_id" "$prior_runs"',
+        'run watch "$run_id"',
+        "--exit-status",
+        'run view "$run_id"',
+        'grep -F "KIN_DEV_IMAGE_PROOF mode=${mode} source=${resolved} "',
+        "us-central1-docker.pkg.dev/kin-ecosystem/kin-dev/kin-daemon:gha-canary-${resolved}",
+        "publication=published aliases_promoted=false readback=true embedded_sha=true transport=github-hosted",
+        "publication=(published|verified_existing) aliases_promoted=false readback=true embedded_sha=true transport=github-hosted",
+        'echo "KIN_DEV_IMAGE_RUN id=$run_id url=$run_url"',
+        'echo "KIN_DEV_IMAGE_PROOF $proof"',
+    )
+    for policy in required_tool:
+        require(local_tool, policy, "local-first development image tool")
 
 
 def job_step_active_lines(workflow: str, job: str, marker: str) -> list[str]:
@@ -9657,10 +9906,144 @@ def main() -> None:
     mcp_tools = MCP_TOOLS_DOC.read_text(encoding="utf-8")
     npm_canonical_readme = NPM_CANONICAL_README.read_text(encoding="utf-8")
     docker_workflow = (WORKFLOWS / "docker.yml").read_text(encoding="utf-8")
+    dev_image_publisher = DEV_IMAGE_PUBLISHER.read_text(encoding="utf-8")
+    dev_image_tool = DEV_IMAGE_TOOL.read_text(encoding="utf-8")
     workflow_sources = {
         workflow: workflow.read_text(encoding="utf-8") for workflow in workflow_paths()
     }
     assert_workflow_job_census(workflow_sources)
+
+    assert_dev_image_publish_policy(
+        docker_workflow,
+        dev_image_publisher,
+        dev_image_tool,
+    )
+    for invocation in (
+        "bash ./scripts/test-publish-dev-container.sh",
+        "bash ./scripts/kin-dev-image.test.sh",
+        "bash -n ./scripts/publish-dev-container.sh",
+        "bash -n ./scripts/kin-dev-image",
+    ):
+        require(ci_workflow, invocation, "development image guard reachability")
+    expect_assertion(
+        "same-commit manual publishers stop sharing one serial group",
+        "missing required policy: group:",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow.replace(
+                "(github.event.inputs.commit || github.sha)",
+                "github.run_id",
+                1,
+            ),
+            dev_image_publisher,
+            dev_image_tool,
+        ),
+    )
+    expect_assertion(
+        "manual canary reuses the legacy full-SHA tag",
+        "missing required policy: echo \"publish_tag=gha-canary-",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow.replace(
+                'echo "publish_tag=gha-canary-${commit}"',
+                'echo "publish_tag=${commit}"',
+                1,
+            ),
+            dev_image_publisher,
+            dev_image_tool,
+        ),
+    )
+    expect_assertion(
+        "historical compose data reaches the OIDC-capable runner",
+        "missing required policy: KIN_COMPOSE_FILE:",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow.replace(
+                "KIN_COMPOSE_FILE: ${{ runner.temp }}/docker-compose.yml",
+                "KIN_COMPOSE_FILE: ${{ github.workspace }}/docker-compose.yml",
+                1,
+            ),
+            dev_image_publisher,
+            dev_image_tool,
+        ),
+    )
+    expect_assertion(
+        "registry login runs while the development OIDC contract is inactive",
+        "auth, registry login, publish, and proof must all skip",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow.replace(
+                "        if: steps.publisher-config.outputs.ready == 'true'\n",
+                "",
+                1,
+            ),
+            dev_image_publisher,
+            dev_image_tool,
+        ),
+    )
+    expect_assertion(
+        "historical checkout shell executes on the OIDC-capable runner",
+        "historical checkout shell must not execute",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow.replace(
+                "      - name: Authenticate development image writer\n",
+                "      - name: Execute historical helper\n"
+                "        run: bash scripts/verify-container-build-info.sh kin:ci "
+                '"$GITHUB_SHA"\n\n'
+                "      - name: Authenticate development image writer\n",
+                1,
+            ),
+            dev_image_publisher,
+            dev_image_tool,
+        ),
+    )
+    expect_assertion(
+        "manual image publish accepts a commit outside main",
+        "missing required policy: git merge-base --is-ancestor",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow.replace(
+                'git merge-base --is-ancestor "$commit" origin/main',
+                'git cat-file -e "$commit"',
+                1,
+            ),
+            dev_image_publisher,
+            dev_image_tool,
+        ),
+    )
+    existing_verify_start = dev_image_publisher.index(
+        '  bash "$verifier"'
+    )
+    existing_verify_end = dev_image_publisher.index(
+        '  publication="verified_existing"', existing_verify_start
+    )
+    publisher_without_existing_verify = (
+        dev_image_publisher[:existing_verify_start]
+        + dev_image_publisher[existing_verify_end:]
+    )
+    expect_assertion(
+        "an existing commit tag is accepted before its provenance is checked",
+        "existing commit provenance must pass before a replay is accepted",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow,
+            publisher_without_existing_verify,
+            dev_image_tool,
+        ),
+    )
+    expect_assertion(
+        "the immutable publisher reintroduces a staging alias",
+        "contains forbidden behavior: docker buildx imagetools create",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow,
+            dev_image_publisher
+            + "\ndocker buildx imagetools create --tag image:staging-latest image@sha256:bad\n",
+            dev_image_tool,
+        ),
+    )
+    expect_assertion(
+        "local helper dispatches branch-controlled workflow code",
+        "missing required policy: --ref main",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow,
+            dev_image_publisher,
+            dev_image_tool.replace("--ref main", '--ref "$branch"', 1),
+        ),
+    )
 
     external_context_spoof = dict(workflow_sources)
     external_context_spoof[WORKFLOWS / "required-context-spoof.yaml"] = (
@@ -12794,7 +13177,7 @@ def main() -> None:
         "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
         "Keep polling the bounded log authority even",
         "cache-from: type=gha",
-        "cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=max' || '' }}",
+        "cache-to: type=gha,mode=max",
     ):
         require(docker_workflow, policy, "Docker CI authority and smoke gate")
 
@@ -15329,7 +15712,7 @@ def main() -> None:
             }
         )
         check_runs.append(
-            non_required_check("Docker Image Build (no push)", 303, 31_001)
+            non_required_check("Build and publish dev daemon image", 303, 31_001)
         )
 
     assert_release_gate_admits(
@@ -15337,7 +15720,7 @@ def main() -> None:
         "a red landing-push check that no required context covers",
         (
             "admitting over a red check no required context covers: "
-            "Docker Image Build (no push) (conclusion=failure",
+            "Build and publish dev daemon image (conclusion=failure",
         ),
         add_red_non_required_push_job,
     )
@@ -16039,7 +16422,10 @@ jobs:
             writes = re.findall(
                 r"(?m)^\s+(contents|packages|id-token):\s*write\s*$", content
             )
-            if writes:
+            dev_image_oidc_only = (
+                workflow.name == "docker.yml" and writes == ["id-token"]
+            )
+            if writes and not dev_image_oidc_only:
                 raise AssertionError(
                     f"{workflow.name} grants {sorted(set(writes))} on a main-push workflow"
                 )
@@ -16060,8 +16446,9 @@ jobs:
 
     print(
         "release workflow authority is reviewed-PR to App-tag automatic, "
-        "protected, pinned, GCP-free, cross-platform byte-canonical, and npm "
-        "automatic through short-lived OIDC with post-public proof"
+        "protected, pinned, GCP-free on release writes, cross-platform "
+        "byte-canonical, with dev-only Artifact Registry OIDC and npm automatic "
+        "through short-lived OIDC with post-public proof"
     )
 
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -9516,7 +9516,7 @@ def assert_dev_image_publish_policy(
         "- canary",
         "- publish",
         "group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.commit || github.sha) || github.sha }}",
-        "if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}",
+        "if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}",
         "runs-on: ubuntu-latest",
         "id-token: write",
         "persist-credentials: false",
@@ -9932,6 +9932,19 @@ def main() -> None:
             docker_workflow.replace(
                 "(github.event.inputs.commit || github.sha)",
                 "github.run_id",
+                1,
+            ),
+            dev_image_publisher,
+            dev_image_tool,
+        ),
+    )
+    expect_assertion(
+        "dev image OIDC starts admitting an unreviewed future event",
+        "missing required policy: if:",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow.replace(
+                "if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}",
+                "if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}",
                 1,
             ),
             dev_image_publisher,

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -9516,7 +9516,6 @@ def assert_dev_image_publish_policy(
         "- canary",
         "- publish",
         "group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.commit || github.sha) || github.sha }}",
-        "if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}",
         "runs-on: ubuntu-latest",
         "id-token: write",
         "persist-credentials: false",
@@ -9585,6 +9584,23 @@ def assert_dev_image_publish_policy(
     )
     for policy in required_workflow:
         require(workflow, policy, "GitHub-hosted development image publisher")
+
+    expected_job_if = (
+        "if: ${{ (github.event_name == 'push' || "
+        "github.event_name == 'workflow_dispatch') && "
+        "github.ref == 'refs/heads/main' }}"
+    )
+    active_job_conditions = [
+        line.strip()
+        for line in job.splitlines()
+        if re.match(r"^    if:\s+", line)
+        and not line.lstrip().startswith("#")
+    ]
+    if active_job_conditions != [expected_job_if]:
+        raise AssertionError(
+            "development image OIDC requires exactly one active job-level "
+            "push/workflow_dispatch allowlist on refs/heads/main"
+        )
 
     # The GCP exchange and mutation must remain after every image smoke, and the
     # exact source resolver must remain before the one build. This is an order
@@ -9940,11 +9956,33 @@ def main() -> None:
     )
     expect_assertion(
         "dev image OIDC starts admitting an unreviewed future event",
-        "missing required policy: if:",
+        "requires exactly one active job-level",
         lambda: assert_dev_image_publish_policy(
             docker_workflow.replace(
                 "if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}",
                 "if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}",
+                1,
+            ),
+            dev_image_publisher,
+            dev_image_tool,
+        ),
+    )
+    safe_dev_image_job_if = (
+        "if: ${{ (github.event_name == 'push' || "
+        "github.event_name == 'workflow_dispatch') && "
+        "github.ref == 'refs/heads/main' }}"
+    )
+    unsafe_dev_image_job_if = (
+        "if: ${{ github.event_name != 'pull_request' && "
+        "github.ref == 'refs/heads/main' }}"
+    )
+    expect_assertion(
+        "a commented safe allowlist compensates for an unsafe active job field",
+        "requires exactly one active job-level",
+        lambda: assert_dev_image_publish_policy(
+            docker_workflow.replace(
+                f"    {safe_dev_image_job_if}",
+                f"    {unsafe_dev_image_job_if}\n    # {safe_dev_image_job_if}",
                 1,
             ),
             dev_image_publisher,


### PR DESCRIPTION
## Outcome

Moves the development daemon image build from paid per-main Cloud Build compute to a standard GitHub-hosted runner while preserving the fat-LTO release image shape. The workflow builds and smokes locally before OIDC, then publishes only immutable full-SHA or `gha-canary-<sha>` tags to the isolated `kin-dev` Artifact Registry repository. It writes no mutable image aliases.

The workflow is safe to land before activation. If all three repository variables are absent, build and smoke run but publication is skipped. Partial or drifted configuration fails closed. The existing `kin-build` Cloud Build trigger remains enabled and unchanged. OIDC can start only on an explicit `push` or `workflow_dispatch` event on `refs/heads/main`.

Adds `scripts/kin-dev-image local`, `canary`, and `hosted` for local iteration, fresh cutover proof, and exact-SHA hosted publication. Hosted commands wait for the matching run and require machine-readable source, reference, digest, publication, readback, embedded-SHA, transport, and no-alias proof.

## Verification

- `bin/kin-precheck kin`: 16 gates enumerated from `ci.yml`, 16 passed on `d9bea5b82a19515e53e8fcda1e92fd672d7e7535`
- `bin/kin-parity`: FINAL PASS-WITH-ALLOWANCES; only tracked FIR-2580, FIR-2501, and FIR-2464 allowances
- `python3 scripts/test-release-workflow-authority.py`: passed with event allowlist, canary, no-alias, trusted-helper, historical-compose, identity, and concurrency falsifiers
- `bash scripts/test-publish-dev-container.sh`: passed full-SHA, fresh canary, replay, moved-tag, provenance, and no-alias cases
- `bash scripts/kin-dev-image.test.sh`: passed local, canary, hosted, proofless-run, origin, and ancestry cases
- `actionlint .github/workflows/docker.yml .github/workflows/ci.yml`: passed
- shell syntax and `git diff --check`: passed

Independent review cleared `010a45a366d8aeb6f215bbff659c21d15d16d796` to land inactive. Exact-SHA rereview is requested for the narrow event-allowlist follow-up at `d9bea5b82a19515e53e8fcda1e92fd672d7e7535`. Neither review clears Cloud Build retirement.

## Activation and cutover

This PR is intentionally the inactive landing. A mutable repository variable is not activation authority because deleting every variable could recreate the green skip. Strict activation is a later version-controlled workflow change.

1. Land this inactive workflow while `kin-build` stays enabled.
2. Apply the dedicated `kin-dev` repository, narrow WIF provider, repository-only writer service account, and repository variables. Prove the builder service account has no user-managed keys.
3. Run one `mode=canary` dispatch and retain its fresh `publication=published`, exact tag, digest, readback, embedded-SHA, run URL, and `aliases_promoted=false` proof.
4. Publish one exact full-SHA image, then migrate the local hosted and KinLab development consumers from the absent old `:latest` reference to the returned digest. Prove both consumers.
5. Open and review a second strict-activation PR. It must carry the version-controlled `KIN_GITHUB_BUILD_ACTIVATION=strict-v1` sentinel and make all-empty publisher configuration fatal unconditionally.
6. Land the strict activation while Cloud Build is still enabled. Its ordinary main push must freshly publish its own full-SHA image and return exact source, digest, readback, embedded-SHA, no-alias, run, and workflow-source proof.
7. Inventory and drain all active or queued legacy builds. Only then disable, but do not delete, `kin-build`.

Rollback starts by re-enabling `kin-build`. Immutable GitHub tags remain evidence and require no deletion. A strict-activation revert may happen only while the legacy trigger is active, so the system never returns to a green all-empty skip with no builder behind it.
