### PR TITLE
Materialize graph sections before first reopen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.77"
+version = "0.7.81"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "bb78d778724f05b4409c43c48c7a47abdb653c048435fe416a974293d3e98e06"
+checksum = "81af647f5d6309ff18d9818e33eebc6e7cfcdfad87793df561a1e6d584086780"
 dependencies = [
  "bincode",
  "bstr",
@@ -6670,7 +6670,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.77", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.81", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.21", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -27,6 +27,7 @@ pub struct GraphCommandResponse {
     pub lines: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<GraphSourceRecord>,
     /// Reference-edge completeness, per language, for the status and validate
     /// surfaces.
@@ -5010,6 +5011,20 @@ mod tests {
             graph_wait_label(&GraphCommandRequest::Source {
                 entity: "Router".to_string()
             }),
+        );
+    }
+
+    #[test]
+    fn graph_response_from_an_older_daemon_may_omit_optional_source() {
+        let response: GraphCommandResponse = serde_json::from_value(serde_json::json!({
+            "lines": ["older daemon response"]
+        }))
+        .unwrap();
+        assert!(response.source.is_none());
+        assert_eq!(response.lines, ["older daemon response"]);
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            serde_json::json!({"lines": ["older daemon response"]})
         );
     }
 }

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -27,7 +27,6 @@ pub struct GraphCommandResponse {
     pub lines: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<GraphSourceRecord>,
     /// Reference-edge completeness, per language, for the status and validate
     /// surfaces.
@@ -171,6 +170,22 @@ fn append_hydration_semantics_line(
 pub async fn validate() -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     print_graph_response(run_daemon_graph(&layout, &GraphCommandRequest::Validate).await?)
+}
+
+/// `kin graph materialize` — persist the current workspace base graph section.
+///
+/// This is an explicit representation rewrite. It preserves semantic roots and
+/// logical authority generation while making future workspace-base reopens
+/// reuse the complete graph section instead of folding history again.
+pub async fn materialize(json: bool) -> Result<()> {
+    let layout = crate::commands::require_repository_layout()?;
+    let materialization = super::repository_authority::materialize_workspace_base_offline(&layout)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&materialization)?);
+        return Ok(());
+    }
+    println!("{}", materialization.human_line());
+    Ok(())
 }
 
 /// `kin graph inspect <entity>` — look up an entity (by name or UUID) and show its relations.

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -98,6 +98,51 @@ struct InitResultPayload<'a> {
     /// schema version, so a consumer that does not read it is unaffected.
     #[serde(skip_serializing_if = "Option::is_none")]
     daemon_killed: Option<DaemonKilledPayload>,
+    /// Whether the verified repository was also prepared for its first fast
+    /// workspace-base reopen. This is a representation outcome, not a second
+    /// semantic commit.
+    graph_section_materialization: &'a InitGraphSectionMaterialization,
+}
+
+/// The post-publication graph-section phase can fail without undoing the
+/// verified repository init that preceded it. Keep that degraded result in the
+/// init receipt while the explicit command remains a hard-failing retry.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum InitGraphSectionMaterialization {
+    Complete(super::repository_authority::GraphSectionMaterialization),
+    Failed {
+        schema: &'static str,
+        scope: super::repository_authority::GraphSectionMaterializationScope,
+        state: &'static str,
+        error: String,
+        retry: &'static str,
+    },
+}
+
+impl InitGraphSectionMaterialization {
+    fn failed(error: &anyhow::Error) -> Self {
+        Self::Failed {
+            schema: "kin.graph-section-materialization.v1",
+            scope: super::repository_authority::GraphSectionMaterializationScope::WorkspaceBase,
+            state: "failed",
+            error: format!("{error:#}"),
+            retry: "kin graph materialize",
+        }
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(self, Self::Failed { .. })
+    }
+
+    fn human_line(&self) -> String {
+        match self {
+            Self::Complete(outcome) => outcome.human_line(),
+            Self::Failed { error, retry, .. } => format!(
+                "Graph-section materialization did not complete. Run `{retry}` to retry: {error}"
+            ),
+        }
+    }
 }
 
 /// What one machine-readable result says about a daemon it lost.
@@ -158,6 +203,11 @@ macro_rules! note {
 /// questions; what nobody can attest is that its enrichment finished.
 pub const EXIT_ENRICHMENT_UNATTESTED: i32 = 7;
 
+/// Exit status for a verified init whose reopen-acceleration section did not
+/// persist. The repository exists and remains graph-authoritative; the
+/// explicit graph command retries only the missing representation step.
+pub const EXIT_GRAPH_SECTION_UNMATERIALIZED: i32 = 8;
+
 pub async fn run(
     path: Option<String>,
     json: bool,
@@ -205,6 +255,21 @@ pub async fn run(
             .with_context(|| {
                 format!("initialize unborn Kin-native repository authority adopting {adopted}")
             })?,
+    };
+
+    // Core init has finished publishing and proving semantic authority here.
+    // Reopen that exact persisted authority in a short-lived scope and memoize
+    // its complete workspace base before enrichment starts a daemon. This
+    // keeps the section's capture allocation out of the calibrated publish
+    // peak and lets the first real daemon reopen consume the section.
+    let graph_section_materialization = match materialize_graph_section_after_init(&result.layout) {
+        Ok(outcome) => InitGraphSectionMaterialization::Complete(outcome),
+        Err(error) => {
+            note!(
+                "warning: repository initialization completed, but graph-section materialization did not; run `kin graph materialize` to retry: {error:#}"
+            );
+            InitGraphSectionMaterialization::failed(&error)
+        }
     };
 
     if let Err(error) = exclude_store_from_git(result.layout.working_dir()) {
@@ -271,18 +336,35 @@ pub async fn run(
     let daemon_death = crate::daemon_death::recorded_for_store(result.layout.root());
 
     if json {
-        print_json_result(&result, boundary, enrichment, daemon_death.as_ref())?;
+        print_json_result(
+            &result,
+            boundary,
+            enrichment,
+            &graph_section_materialization,
+            daemon_death.as_ref(),
+        )?;
     } else {
         print_human_result(
             &result,
             boundary,
             &enrichment,
             &cross_file,
+            &graph_section_materialization,
             model_present_before,
             daemon_death.as_ref(),
         )?;
     }
-    Ok(exit_code_for(daemon_death.as_ref()))
+    Ok(exit_code_for(
+        daemon_death.as_ref(),
+        graph_section_materialization.is_failed(),
+    ))
+}
+
+fn materialize_graph_section_after_init(
+    layout: &kin_core::KinLayout,
+) -> Result<super::repository_authority::GraphSectionMaterialization> {
+    super::repository_authority::materialize_workspace_base_offline(layout)
+        .context("prepare the initialized repository's first graph reopen")
 }
 
 /// Exit status for a conversion that finished.
@@ -299,9 +381,13 @@ pub async fn run(
 /// So the degraded outcome gets its own code rather than an error. Exit 1 would
 /// say the conversion failed and invite a re-run, which at the repository size
 /// that causes this is a loop that cannot terminate.
-fn exit_code_for(daemon_death: Option<&kin_daemon_spawn::DaemonKillRecord>) -> i32 {
+fn exit_code_for(
+    daemon_death: Option<&kin_daemon_spawn::DaemonKillRecord>,
+    graph_section_failed: bool,
+) -> i32 {
     match daemon_death {
         Some(_) => EXIT_ENRICHMENT_UNATTESTED,
+        None if graph_section_failed => EXIT_GRAPH_SECTION_UNMATERIALIZED,
         None => 0,
     }
 }
@@ -1110,6 +1196,7 @@ fn print_json_result(
     result: &kin_core::InitResult,
     boundary: InitBoundary,
     semantic_enrichment: SemanticEnrichmentStatus,
+    graph_section_materialization: &InitGraphSectionMaterialization,
     daemon_death: Option<&kin_daemon_spawn::DaemonKillRecord>,
 ) -> Result<()> {
     let workspace = &result.authority.workspace;
@@ -1142,6 +1229,7 @@ fn print_json_result(
             summary: record.summary(),
             exit_code: EXIT_ENRICHMENT_UNATTESTED,
         }),
+        graph_section_materialization,
     };
     emit(&format!("{}\n", serde_json::to_string_pretty(&payload)?))
 }
@@ -1173,6 +1261,7 @@ fn print_human_result(
     boundary: InitBoundary,
     semantic_enrichment: &SemanticEnrichmentStatus,
     cross_file: &CrossFileEnrichment,
+    graph_section_materialization: &InitGraphSectionMaterialization,
     model_present_before: bool,
     daemon_death: Option<&kin_daemon_spawn::DaemonKillRecord>,
 ) -> Result<()> {
@@ -1181,6 +1270,7 @@ fn print_human_result(
         boundary,
         semantic_enrichment,
         cross_file,
+        graph_section_materialization,
         model_present_before,
         daemon_death,
     )?)
@@ -1210,6 +1300,7 @@ fn render_human_result(
     boundary: InitBoundary,
     semantic_enrichment: &SemanticEnrichmentStatus,
     cross_file: &CrossFileEnrichment,
+    graph_section_materialization: &InitGraphSectionMaterialization,
     model_present_before: bool,
     daemon_death: Option<&kin_daemon_spawn::DaemonKillRecord>,
 ) -> Result<String> {
@@ -1241,6 +1332,11 @@ fn render_human_result(
         out,
         "  Workspace head: {}",
         serde_json::to_string(&result.authority.workspace.workspace_head)?
+    )?;
+    writeln!(
+        out,
+        "  Graph reopen: {}",
+        graph_section_materialization.human_line()
     )?;
     match boundary {
         InitBoundary::ExactGit => {
@@ -2311,7 +2407,7 @@ mod tests {
             let summary =
                 render_semantic_enrichment(&status, reading, &CrossFileEnrichment::Produced);
             let names_a_kill = summary.contains("a daemon serving this store was killed");
-            let code = exit_code_for(reading);
+            let code = exit_code_for(reading, false);
             assert_eq!(
                 names_a_kill,
                 code != 0,
@@ -2321,12 +2417,12 @@ mod tests {
         }
 
         assert_eq!(
-            exit_code_for(None),
+            exit_code_for(None, false),
             0,
             "a conversion that lost no daemon must still exit 0"
         );
         assert_eq!(
-            exit_code_for(Some(&record)),
+            exit_code_for(Some(&record), false),
             EXIT_ENRICHMENT_UNATTESTED,
             "a conversion that lost one must exit the degraded code"
         );
@@ -2334,6 +2430,11 @@ mod tests {
             EXIT_ENRICHMENT_UNATTESTED, 1,
             "exit 1 says the conversion failed and invites a re-run, which at the repository \
              size that causes this is a loop that cannot terminate"
+        );
+        assert_eq!(
+            exit_code_for(None, true),
+            EXIT_GRAPH_SECTION_UNMATERIALIZED,
+            "a verified repository whose reopen section failed gets its own degraded code"
         );
     }
 

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -39,8 +39,40 @@ pub struct GraphSectionMaterialization {
     pub workspace_id: WorkspaceId,
     pub state: GraphSectionMaterializationState,
     pub authority_generation: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "optional_semantic_change_id_hex"
+    )]
     pub resolved_at: Option<SemanticChangeId>,
+}
+
+mod optional_semantic_change_id_hex {
+    use kin_model::{Hash256, SemanticChangeId};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &Option<SemanticChangeId>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(value) => serializer.serialize_some(&value.to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<SemanticChangeId>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|value| {
+                Hash256::from_hex(&value)
+                    .map(SemanticChangeId::from_hash)
+                    .map_err(serde::de::Error::custom)
+            })
+            .transpose()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -547,6 +579,25 @@ mod tests {
         assert_eq!(json["state"], "no_base_target");
         assert_eq!(json["authority_generation"], 3);
         assert!(json.get("resolved_at").is_none());
+    }
+
+    #[test]
+    fn graph_section_materialization_json_names_the_base_target_as_hex() {
+        let resolved_at = SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([0x29; 32]));
+        let outcome = GraphSectionMaterialization::from_kin_db(
+            RepositoryId::new("graph-section-test").unwrap(),
+            WorkspaceId::from_uuid(uuid::Uuid::from_u128(0x31)),
+            MaterializedGraphSectionOutcome::AlreadyCurrent {
+                resolved_at,
+                authority_generation: 4,
+            },
+        );
+
+        let json = serde_json::to_value(&outcome).unwrap();
+        assert_eq!(json["resolved_at"], "29".repeat(32));
+
+        let round_trip: GraphSectionMaterialization = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, outcome);
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -9,18 +9,119 @@
 
 use anyhow::{anyhow, Context, Result};
 use kin_db::{
-    AuthorityPayloadStats, LocalFileBackend, RepositoryAuthorityManager, RepositoryAuthorityState,
+    AuthorityPayloadStats, LocalFileBackend, MaterializedGraphSectionOutcome,
+    RepositoryAuthorityManager, RepositoryAuthorityState,
 };
 use kin_model::{
     GitObjectId, RefName, RefTarget, RepositoryId, RootBundle, SemanticChangeId, WorkspaceId,
     WorkspaceState,
 };
+use serde::{Deserialize, Serialize};
 
 pub struct ActiveRepositoryAuthority {
     manager: RepositoryAuthorityManager<LocalFileBackend>,
     payload_stats: Option<AuthorityPayloadStats>,
     pub(crate) repository_id: RepositoryId,
     pub(crate) workspace_id: WorkspaceId,
+}
+
+/// Machine-readable result of explicitly memoizing one workspace base graph.
+///
+/// This is deliberately a representation result rather than a repository
+/// commit receipt. Materialization may advance the storage backend's fenced
+/// publication cursor, but it preserves the logical authority generation and
+/// roots exactly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphSectionMaterialization {
+    pub schema: String,
+    pub scope: GraphSectionMaterializationScope,
+    pub repository_id: RepositoryId,
+    pub workspace_id: WorkspaceId,
+    pub state: GraphSectionMaterializationState,
+    pub authority_generation: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_at: Option<SemanticChangeId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphSectionMaterializationScope {
+    WorkspaceBase,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphSectionMaterializationState {
+    Persisted,
+    AlreadyCurrent,
+    NoBaseTarget,
+}
+
+impl GraphSectionMaterialization {
+    const SCHEMA: &'static str = "kin.graph-section-materialization.v1";
+
+    fn from_kin_db(
+        repository_id: RepositoryId,
+        workspace_id: WorkspaceId,
+        outcome: MaterializedGraphSectionOutcome,
+    ) -> Self {
+        let (state, authority_generation, resolved_at) = match outcome {
+            MaterializedGraphSectionOutcome::Persisted {
+                resolved_at,
+                authority_generation,
+            } => (
+                GraphSectionMaterializationState::Persisted,
+                authority_generation,
+                Some(resolved_at),
+            ),
+            MaterializedGraphSectionOutcome::AlreadyCurrent {
+                resolved_at,
+                authority_generation,
+            } => (
+                GraphSectionMaterializationState::AlreadyCurrent,
+                authority_generation,
+                Some(resolved_at),
+            ),
+            MaterializedGraphSectionOutcome::NoBaseTarget {
+                authority_generation,
+            } => (
+                GraphSectionMaterializationState::NoBaseTarget,
+                authority_generation,
+                None,
+            ),
+        };
+        Self {
+            schema: Self::SCHEMA.to_string(),
+            scope: GraphSectionMaterializationScope::WorkspaceBase,
+            repository_id,
+            workspace_id,
+            state,
+            authority_generation,
+            resolved_at,
+        }
+    }
+
+    pub fn human_line(&self) -> String {
+        match (&self.state, &self.resolved_at) {
+            (GraphSectionMaterializationState::Persisted, Some(resolved_at)) => format!(
+                "Persisted the workspace base graph section at {resolved_at} (authority generation {}).",
+                self.authority_generation
+            ),
+            (GraphSectionMaterializationState::AlreadyCurrent, Some(resolved_at)) => format!(
+                "The workspace base graph section is already current at {resolved_at} (authority generation {}).",
+                self.authority_generation
+            ),
+            (GraphSectionMaterializationState::NoBaseTarget, None) => format!(
+                "No workspace base graph section exists yet because this workspace is unborn (authority generation {}).",
+                self.authority_generation
+            ),
+            // Construction is private and keeps the state and target paired.
+            // This arm still prevents malformed wire input from being rendered
+            // as if it were a trustworthy product outcome.
+            _ => "The graph-section materialization response was internally inconsistent."
+                .to_string(),
+        }
+    }
 }
 
 thread_local! {
@@ -189,6 +290,34 @@ impl ActiveRepositoryAuthority {
         &self.manager
     }
 
+    /// Persist the current workspace base graph as an idempotent acceleration
+    /// section without changing semantic authority.
+    pub(crate) fn materialize_workspace_base_graph_section(
+        &self,
+    ) -> Result<GraphSectionMaterialization> {
+        let outcome = self
+            .manager
+            .materialize_workspace_base_graph_section(&self.repository_id, &self.workspace_id)
+            .with_context(|| {
+                format!(
+                    "materialize workspace {} base graph section for repository {}",
+                    self.workspace_id, self.repository_id
+                )
+            })?
+            .ok_or_else(|| {
+                anyhow!(
+                    "repository {} has no workspace {} in its authority",
+                    self.repository_id,
+                    self.workspace_id
+                )
+            })?;
+        Ok(GraphSectionMaterialization::from_kin_db(
+            self.repository_id.clone(),
+            self.workspace_id,
+            outcome,
+        ))
+    }
+
     /// Payload receipt produced by the same recovery that built this manager.
     ///
     /// `None` only where no persisted authority existed and generation zero was
@@ -255,6 +384,54 @@ impl ActiveRepositoryAuthority {
     }
 }
 
+/// Materialize the current workspace base without starting or sharing a
+/// daemon runtime.
+///
+/// The runtime capability is acquired before the first whole-authority open
+/// and remains held until that manager is dropped. A running daemon therefore
+/// makes the command fail before it can fold history or write representation
+/// bytes, and a daemon cannot begin opening the repository during the rewrite.
+pub(crate) fn materialize_workspace_base_offline(
+    layout: &kin_core::KinLayout,
+) -> Result<GraphSectionMaterialization> {
+    materialize_workspace_base_offline_within(
+        layout,
+        kin_daemon_spawn::REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET,
+    )
+}
+
+fn materialize_workspace_base_offline_within(
+    layout: &kin_core::KinLayout,
+    budget: std::time::Duration,
+) -> Result<GraphSectionMaterialization> {
+    let runtime = crate::daemon_client::acquire_repository_runtime_authority_within(
+        layout.root(),
+        budget,
+    )
+    .with_context(|| {
+        format!(
+            "acquire repository runtime authority for {}",
+            layout.root().display()
+        )
+    })?
+    .ok_or_else(|| {
+        anyhow!(
+            "another Kin process holds repository runtime authority for {}; run `kin daemon stop`, then retry `kin graph materialize`",
+            layout.root().display()
+        )
+    })?;
+
+    let outcome = {
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(layout)
+            .context("bind repository authority for offline graph-section materialization")?;
+        let authority = ActiveRepositoryAuthority::open(&binding)
+            .context("open repository authority for offline graph-section materialization")?;
+        authority.materialize_workspace_base_graph_section()
+    };
+    drop(runtime);
+    outcome
+}
+
 fn resolve_target_in_authority(
     authority: &RepositoryAuthorityState,
     target: &RefTarget,
@@ -299,5 +476,118 @@ pub(crate) fn parse_git_object_id(value: &str) -> Result<GitObjectId> {
         length => anyhow::bail!(
             "invalid Git object ID '{value}': expected 20 or 32 bytes, found {length}"
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graph_section_materialization_keeps_all_three_backend_outcomes_distinct() {
+        let resolved_at = SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([0x29; 32]));
+        let repository_id = RepositoryId::new("graph-section-test").unwrap();
+        let workspace_id = WorkspaceId::from_uuid(uuid::Uuid::from_u128(0x29));
+        let cases = [
+            (
+                MaterializedGraphSectionOutcome::Persisted {
+                    resolved_at,
+                    authority_generation: 7,
+                },
+                GraphSectionMaterializationState::Persisted,
+                Some(resolved_at),
+            ),
+            (
+                MaterializedGraphSectionOutcome::AlreadyCurrent {
+                    resolved_at,
+                    authority_generation: 7,
+                },
+                GraphSectionMaterializationState::AlreadyCurrent,
+                Some(resolved_at),
+            ),
+            (
+                MaterializedGraphSectionOutcome::NoBaseTarget {
+                    authority_generation: 7,
+                },
+                GraphSectionMaterializationState::NoBaseTarget,
+                None,
+            ),
+        ];
+
+        for (backend, state, target) in cases {
+            let mapped = GraphSectionMaterialization::from_kin_db(
+                repository_id.clone(),
+                workspace_id,
+                backend,
+            );
+            assert_eq!(mapped.schema, "kin.graph-section-materialization.v1");
+            assert_eq!(
+                mapped.scope,
+                GraphSectionMaterializationScope::WorkspaceBase
+            );
+            assert_eq!(mapped.state, state);
+            assert_eq!(mapped.authority_generation, 7);
+            assert_eq!(mapped.resolved_at, target);
+            assert_eq!(mapped.repository_id, repository_id);
+            assert_eq!(mapped.workspace_id, workspace_id);
+        }
+    }
+
+    #[test]
+    fn graph_section_materialization_json_names_state_and_omits_unborn_target() {
+        let outcome = GraphSectionMaterialization::from_kin_db(
+            RepositoryId::new("graph-section-test").unwrap(),
+            WorkspaceId::from_uuid(uuid::Uuid::from_u128(0x30)),
+            MaterializedGraphSectionOutcome::NoBaseTarget {
+                authority_generation: 3,
+            },
+        );
+        let json = serde_json::to_value(outcome).unwrap();
+        assert_eq!(json["scope"], "workspace_base");
+        assert_eq!(json["state"], "no_base_target");
+        assert_eq!(json["authority_generation"], 3);
+        assert!(json.get("resolved_at").is_none());
+    }
+
+    #[test]
+    fn offline_materialization_refuses_runtime_contention_before_authority_open() {
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(directory.path()).unwrap();
+        let held = crate::daemon_client::acquire_repository_runtime_authority_within(
+            initialized.layout.root(),
+            std::time::Duration::ZERO,
+        )
+        .unwrap()
+        .expect("test owns repository runtime authority");
+        let opens_before = repository_authority_opens_on_this_thread();
+
+        let error = materialize_workspace_base_offline_within(
+            &initialized.layout,
+            std::time::Duration::ZERO,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("kin daemon stop"), "{error:#}");
+        assert_eq!(
+            repository_authority_opens_on_this_thread(),
+            opens_before,
+            "contention must be decided before a whole repository authority open"
+        );
+
+        drop(held);
+        let outcome = materialize_workspace_base_offline_within(
+            &initialized.layout,
+            std::time::Duration::ZERO,
+        )
+        .unwrap();
+        assert_eq!(
+            outcome.state,
+            GraphSectionMaterializationState::NoBaseTarget
+        );
+        assert_eq!(
+            repository_authority_opens_on_this_thread(),
+            opens_before + 1,
+            "the successful maintenance arm opens authority exactly once"
+        );
     }
 }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2191,6 +2191,44 @@ pub struct ProcessIdentity {
     birth_token: String,
 }
 
+/// The process-lifetime repository authority shared by daemon startup and
+/// one-shot offline maintenance commands.
+pub type RepositoryRuntimeAuthority = kin_daemon_spawn::RepositoryRuntimeAuthority;
+
+/// Marker introducing the existing process-incarnation owner stamp.
+const REPOSITORY_RUNTIME_OWNER_STAMP_V2: &str = "kin-daemon-owner-v2";
+
+/// Render the byte-compatible owner stamp written under `.kin/daemon.lock`.
+///
+/// Process identity stays in this crate while the lower shared crate owns only
+/// the OS capability and treats this value as opaque.
+pub fn current_repository_runtime_owner_stamp() -> String {
+    match current_process_identity() {
+        Ok(identity) => match serde_json::to_string(&identity) {
+            Ok(encoded) => format!("{REPOSITORY_RUNTIME_OWNER_STAMP_V2} {encoded}"),
+            Err(_) => std::process::id().to_string(),
+        },
+        Err(_) => std::process::id().to_string(),
+    }
+}
+
+/// Acquire the repository runtime singleton with the standard bounded retry.
+pub fn acquire_repository_runtime_authority(
+    kin_root: &Path,
+) -> std::io::Result<Option<RepositoryRuntimeAuthority>> {
+    let owner_stamp = current_repository_runtime_owner_stamp();
+    kin_daemon_spawn::acquire_repository_runtime_authority(kin_root, &owner_stamp)
+}
+
+/// Acquire the repository runtime singleton within one caller-owned budget.
+pub fn acquire_repository_runtime_authority_within(
+    kin_root: &Path,
+    budget: Duration,
+) -> std::io::Result<Option<RepositoryRuntimeAuthority>> {
+    let owner_stamp = current_repository_runtime_owner_stamp();
+    kin_daemon_spawn::acquire_repository_runtime_authority_within(kin_root, budget, &owner_stamp)
+}
+
 impl ProcessIdentity {
     /// The PID this identity names. Only a lookup key on its own — compare
     /// whole identities to decide whether it is still the same process.

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1487,6 +1487,12 @@ enum GraphAction {
     Status,
     /// Structural integrity validation
     Validate,
+    /// Persist the current workspace base graph section for faster reopen
+    Materialize {
+        /// Output machine-readable JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Look up an entity by name and show its relations
     Inspect {
         /// Entity name or UUID to inspect
@@ -3567,6 +3573,7 @@ fn main() -> Result<()> {
                 Command::Graph { action } => match action {
                     GraphAction::Status => commands::graph::status().await,
                     GraphAction::Validate => commands::graph::validate().await,
+                    GraphAction::Materialize { json } => commands::graph::materialize(json).await,
                     GraphAction::Inspect { name, json } => {
                         commands::graph::inspect(name, json).await
                     }

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -54,6 +54,18 @@ fn kin_init(repo: &Path, home: &Path, extra: &[&str]) -> std::process::Output {
         .expect("run kin init")
 }
 
+fn kin_graph_materialize(repo: &Path, home: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(["graph", "materialize", "--json"])
+        .env("HOME", home)
+        .env("KIN_EMBED_BACKEND", "cpu")
+        .env("KIN_NO_DAEMON", "1")
+        .env("KIN_SESSION_ID", uuid::Uuid::new_v4().to_string())
+        .current_dir(repo)
+        .output()
+        .expect("run kin graph materialize")
+}
+
 fn git_stdout(path: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
         .args(args)
@@ -171,6 +183,19 @@ fn fresh_native_init_json_reports_exact_unborn_authority() {
     assert_eq!(payload["authority_generation"], 1);
     assert_eq!(payload["workspace_generation"], 0);
     assert!(payload["initial_change_id"].is_null());
+    assert_eq!(
+        payload["graph_section_materialization"]["schema"],
+        "kin.graph-section-materialization.v1"
+    );
+    assert_eq!(
+        payload["graph_section_materialization"]["state"],
+        "no_base_target"
+    );
+    assert_eq!(
+        payload["graph_section_materialization"]["scope"],
+        "workspace_base"
+    );
+    assert!(payload["graph_section_materialization"]["resolved_at"].is_null());
 }
 
 #[test]
@@ -215,6 +240,64 @@ fn fresh_git_init_json_reports_exact_reachable_authority() {
     assert!(
         payload["uncommitted_worktree"].is_null(),
         "a source that matched carries no disclosure: {payload}"
+    );
+    assert_eq!(
+        payload["graph_section_materialization"]["state"],
+        "persisted"
+    );
+    assert_eq!(
+        payload["graph_section_materialization"]["authority_generation"],
+        payload["authority_generation"]
+    );
+    assert!(!payload["graph_section_materialization"]["resolved_at"].is_null());
+}
+
+/// The automatic phase must persist before enrichment can start a daemon, and
+/// the explicit operator verb must observe that same durable section through
+/// the direct offline reopen path without starting or targeting a daemon.
+#[test]
+fn init_materializes_before_the_first_daemon_reopen() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("materialized");
+    fs::create_dir_all(&home).expect("create home");
+    seed_git_repo(&repo);
+
+    let init = kin_init(&repo, &home, &["--json", "--no-enrich"]);
+    assert!(
+        init.status.success(),
+        "init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let initialized: Value =
+        serde_json::from_slice(&init.stdout).expect("init stdout should be JSON");
+    let automatic = &initialized["graph_section_materialization"];
+    assert_eq!(automatic["state"], "persisted", "{initialized}");
+    assert_eq!(automatic["scope"], "workspace_base", "{initialized}");
+    assert!(!repo.join(".kin/daemon.pid").exists());
+    assert!(!repo.join(".kin/daemon.port").exists());
+
+    let explicit = kin_graph_materialize(&repo, &home);
+    assert!(
+        explicit.status.success(),
+        "explicit materialization failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&explicit.stdout),
+        String::from_utf8_lossy(&explicit.stderr)
+    );
+    let reopened: Value =
+        serde_json::from_slice(&explicit.stdout).expect("graph materialize stdout should be JSON");
+    assert_eq!(reopened["schema"], "kin.graph-section-materialization.v1");
+    assert_eq!(reopened["state"], "already_current", "{reopened}");
+    assert_eq!(reopened["scope"], "workspace_base", "{reopened}");
+    assert_eq!(
+        reopened["authority_generation"],
+        automatic["authority_generation"]
+    );
+    assert_eq!(reopened["resolved_at"], automatic["resolved_at"]);
+    assert!(
+        !repo.join(".kin/daemon.pid").exists() && !repo.join(".kin/daemon.port").exists(),
+        "an offline representation rewrite must not leave a daemon endpoint behind"
     );
 }
 

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -275,6 +275,16 @@ fn init_materializes_before_the_first_daemon_reopen() {
     let automatic = &initialized["graph_section_materialization"];
     assert_eq!(automatic["state"], "persisted", "{initialized}");
     assert_eq!(automatic["scope"], "workspace_base", "{initialized}");
+    let automatic_resolved_at = automatic["resolved_at"]
+        .as_str()
+        .expect("init materialization target should be a JSON string");
+    assert_eq!(automatic_resolved_at.len(), 64, "{initialized}");
+    assert!(
+        automatic_resolved_at
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "init materialization target should be lowercase hex: {initialized}"
+    );
     assert!(!repo.join(".kin/daemon.pid").exists());
     assert!(!repo.join(".kin/daemon.port").exists());
 
@@ -290,6 +300,16 @@ fn init_materializes_before_the_first_daemon_reopen() {
     assert_eq!(reopened["schema"], "kin.graph-section-materialization.v1");
     assert_eq!(reopened["state"], "already_current", "{reopened}");
     assert_eq!(reopened["scope"], "workspace_base", "{reopened}");
+    let reopened_resolved_at = reopened["resolved_at"]
+        .as_str()
+        .expect("explicit materialization target should be a JSON string");
+    assert_eq!(reopened_resolved_at.len(), 64, "{reopened}");
+    assert!(
+        reopened_resolved_at
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "explicit materialization target should be lowercase hex: {reopened}"
+    );
     assert_eq!(
         reopened["authority_generation"],
         automatic["authority_generation"]

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -40,6 +40,13 @@ use std::process::Command;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
+mod runtime_authority;
+
+pub use runtime_authority::{
+    acquire_repository_runtime_authority, acquire_repository_runtime_authority_within,
+    RepositoryRuntimeAuthority, REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET,
+};
+
 /// The port argument every daemon spawn passes.
 ///
 /// Zero means "bind an ephemeral port and report it", which is what makes the

--- a/crates/kin-daemon-spawn/src/runtime_authority.rs
+++ b/crates/kin-daemon-spawn/src/runtime_authority.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Exclusive per-repository runtime authority shared by daemon and maintenance
+//! processes.
+//!
+//! This module owns the OS capability and deliberately treats the owner stamp
+//! as opaque. Process-incarnation evidence remains with the caller that mints
+//! the existing wire format.
+
+use fs2::FileExt;
+use std::fs::{File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// How long a contended process retries before reporting the holder.
+pub const REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET: Duration = Duration::from_secs(5);
+
+const REPOSITORY_RUNTIME_AUTHORITY_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Exclusive authority to open one repository as a live runtime.
+///
+/// The capability is an advisory lock on the never-unlinked
+/// `.kin/daemon.lock` inode. It is bound to the canonical `.kin` root so a
+/// caller cannot acquire for repository A and replay it while opening B.
+#[derive(Debug)]
+pub struct RepositoryRuntimeAuthority {
+    file: File,
+    canonical_kin_root: PathBuf,
+}
+
+impl RepositoryRuntimeAuthority {
+    /// Canonical `.kin` root protected by this capability.
+    pub fn canonical_kin_root(&self) -> &Path {
+        &self.canonical_kin_root
+    }
+}
+
+impl Drop for RepositoryRuntimeAuthority {
+    /// Clear the owner stamp while the singleton is still held, then let the
+    /// file handle close and release the advisory lock.
+    fn drop(&mut self) {
+        let _ = self.file.set_len(0);
+        let _ = self.file.flush();
+    }
+}
+
+/// Acquire repository runtime authority with the standard bounded retry.
+pub fn acquire_repository_runtime_authority(
+    kin_root: &Path,
+    owner_stamp: &str,
+) -> std::io::Result<Option<RepositoryRuntimeAuthority>> {
+    acquire_repository_runtime_authority_within(
+        kin_root,
+        REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET,
+        owner_stamp,
+    )
+}
+
+/// Acquire repository runtime authority within one caller-owned budget.
+///
+/// `owner_stamp` is written byte-for-byte only after the singleton lock is
+/// held. The caller owns its schema and process-identity semantics.
+pub fn acquire_repository_runtime_authority_within(
+    kin_root: &Path,
+    budget: Duration,
+    owner_stamp: &str,
+) -> std::io::Result<Option<RepositoryRuntimeAuthority>> {
+    if owner_stamp.is_empty() || owner_stamp.contains(['\n', '\r']) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "repository runtime owner stamp must be one non-empty line",
+        ));
+    }
+    without_blocking_runtime_worker(|| {
+        let deadline = Instant::now() + budget;
+        loop {
+            match try_acquire_repository_runtime_authority(kin_root, deadline, owner_stamp) {
+                Ok(Some(authority)) => return Ok(Some(authority)),
+                Ok(None) => {}
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::WouldBlock
+                        && Instant::now() >= deadline =>
+                {
+                    return Ok(None);
+                }
+                Err(error) => return Err(error),
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return Ok(None);
+            }
+            std::thread::sleep(
+                REPOSITORY_RUNTIME_AUTHORITY_RETRY_INTERVAL
+                    .min(deadline.saturating_duration_since(now)),
+            );
+        }
+    })
+}
+
+fn try_acquire_repository_runtime_authority(
+    kin_root: &Path,
+    deadline: Instant,
+    owner_stamp: &str,
+) -> std::io::Result<Option<RepositoryRuntimeAuthority>> {
+    let canonical_kin_root = kin_root.canonicalize()?;
+    let _coordination = acquire_lifecycle_coordination(&canonical_kin_root, deadline)?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(canonical_kin_root.join("daemon.lock"))?;
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            stamp_owner(&mut file, owner_stamp);
+            Ok(Some(RepositoryRuntimeAuthority {
+                file,
+                canonical_kin_root,
+            }))
+        }
+        Err(error) if error.kind() == fs2::lock_contended_error().kind() => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Serialize runtime acquisition with endpoint publication and stale evidence
+/// handling through the same never-unlinked coordination inode.
+fn acquire_lifecycle_coordination(kin_root: &Path, deadline: Instant) -> std::io::Result<File> {
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(kin_root.join("daemon.lifecycle"))?;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(file),
+            Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+                let now = Instant::now();
+                if now >= deadline {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WouldBlock,
+                        "timed out waiting for daemon lifecycle coordination lock",
+                    ));
+                }
+                std::thread::sleep(
+                    REPOSITORY_RUNTIME_AUTHORITY_RETRY_INTERVAL
+                        .min(deadline.saturating_duration_since(now)),
+                );
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn stamp_owner(file: &mut File, owner_stamp: &str) {
+    if file.set_len(0).is_err() || file.seek(SeekFrom::Start(0)).is_err() {
+        return;
+    }
+    if file.write_all(owner_stamp.as_bytes()).is_err() {
+        return;
+    }
+    let _ = file.flush();
+}
+
+/// Keep synchronous lock waits off a multi-thread Tokio worker.
+fn without_blocking_runtime_worker<T>(work: impl FnOnce() -> T) -> T {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(work)
+        }
+        _ => work(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authority_is_canonical_exclusive_and_never_unlinks_its_inode() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join(".kin");
+        std::fs::create_dir(&root).unwrap();
+
+        let held = acquire_repository_runtime_authority(&root, "owner-a")
+            .unwrap()
+            .expect("the first holder acquires");
+        assert_eq!(held.canonical_kin_root(), root.canonicalize().unwrap());
+        assert!(
+            acquire_repository_runtime_authority_within(&root, Duration::ZERO, "owner-b")
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("daemon.lock")).unwrap(),
+            "owner-a"
+        );
+
+        drop(held);
+        assert!(root.join("daemon.lock").exists());
+        assert_eq!(
+            std::fs::read_to_string(root.join("daemon.lock")).unwrap(),
+            ""
+        );
+        assert!(
+            acquire_repository_runtime_authority_within(&root, Duration::ZERO, "owner-b")
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn owner_stamp_is_opaque_but_must_be_one_nonempty_line() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join(".kin");
+        std::fs::create_dir(&root).unwrap();
+        for invalid in ["", "owner\nnext", "owner\rnext"] {
+            assert_eq!(
+                acquire_repository_runtime_authority_within(&root, Duration::ZERO, invalid)
+                    .unwrap_err()
+                    .kind(),
+                std::io::ErrorKind::InvalidInput
+            );
+        }
+    }
+}

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -30,74 +30,8 @@ pub use kin_cli::daemon_client::AutoStartError;
 
 // ── Daemon Singleton Lock ───────────────────────────────────────────────
 
-/// An exclusive, per-repo daemon lock.
-///
-/// Held for the daemon's entire lifetime to guarantee at most one daemon
-/// process per repo. The lock is an OS-level advisory `flock(2)` on
-/// `.kin/daemon.lock`. Because the kernel ties the lock to the open file
-/// description, it is released automatically when this handle is dropped *or*
-/// when the last process holding that description exits. A forked child can
-/// inherit the description and keep it locked after the stamped daemon dies;
-/// that case is detected and reported, but not automatically unlinked.
-///
-/// Current builds never unlink this pathname automatically. The separate
-/// lifecycle coordination lock serializes all current acquisition and endpoint
-/// publication paths, but it cannot exclude a compatible older writer that
-/// does not participate. Recovery therefore fails closed rather than replacing
-/// an inode that a legacy process could have acquired after a userspace check.
-#[derive(Debug)]
-pub struct DaemonLock {
-    file: std::fs::File,
-    canonical_kin_root: PathBuf,
-}
-
-impl DaemonLock {
-    /// Canonical `.kin` root whose singleton this capability protects.
-    ///
-    /// Carrying the repository identity with the file handle prevents a caller
-    /// from replaying authority acquired for repo A while starting state opened
-    /// from repo B.
-    pub fn canonical_kin_root(&self) -> &Path {
-        &self.canonical_kin_root
-    }
-}
-
-impl Drop for DaemonLock {
-    /// Clear the owner stamp before releasing the lock.
-    ///
-    /// This is what makes the stamp mean something precise: a non-empty
-    /// `daemon.lock` body says a process took the lock and did *not* release it
-    /// cleanly. A clean exit runs this drop; a `SIGKILL` cannot, which is
-    /// exactly the case reclaim needs to identify. Without the clear, every
-    /// ordinary shutdown would leave a dead-owner record and the next startup
-    /// would "reclaim" locks that were never stale.
-    fn drop(&mut self) {
-        let _ = self.file.set_len(0);
-        let _ = self.file.flush();
-    }
-}
-
-/// Stamp the acquiring process's PID into the lock file body.
-///
-/// The flock lives on the open file description, so the file's *contents* are
-/// free real estate. Recording the owner there gives every other process a
-/// piece of evidence about who holds the repo that does not depend on
-/// `daemon.pid` surviving: `daemon.pid` is written by the daemon and can be
-/// removed by any other participant, while this stamp is written under the
-/// lock by the only process that could have taken it.
-fn stamp_lock_owner(file: &mut std::fs::File) {
-    let stamp = current_owner_stamp();
-    if file.set_len(0).is_err() {
-        return;
-    }
-    if file.seek(SeekFrom::Start(0)).is_err() {
-        return;
-    }
-    if write!(file, "{stamp}").is_err() {
-        return;
-    }
-    let _ = file.flush();
-}
+/// Compatibility name for the shared per-repository runtime capability.
+pub type DaemonLock = kin_cli::daemon_client::RepositoryRuntimeAuthority;
 
 /// Marker introducing an owner stamp that carries process identity rather than
 /// a bare PID.
@@ -113,14 +47,9 @@ const OWNER_STAMP_V2: &str = "kin-daemon-owner-v2";
 ///
 /// Falls back to the bare-PID form when identity cannot be read at all, which
 /// is the same evidence the previous format carried and never less.
+#[cfg(test)]
 fn current_owner_stamp() -> String {
-    match kin_cli::daemon_client::current_process_identity() {
-        Ok(identity) => match serde_json::to_string(&identity) {
-            Ok(encoded) => format!("{OWNER_STAMP_V2} {encoded}"),
-            Err(_) => std::process::id().to_string(),
-        },
-        Err(_) => std::process::id().to_string(),
-    }
+    kin_cli::daemon_client::current_repository_runtime_owner_stamp()
 }
 
 /// What a lock file's owner stamp records.
@@ -231,57 +160,7 @@ pub fn singleton_lock_holder(kin_root: &Path) -> Option<SingletonLockHolder> {
 ///   not start a second daemon and should exit cleanly.
 /// - `Err(_)` — an unexpected IO error opening the lock file.
 pub fn acquire_singleton_lock(kin_root: &Path) -> std::io::Result<Option<DaemonLock>> {
-    without_blocking_runtime_worker(|| acquire_singleton_lock_inner(kin_root))
-}
-
-fn acquire_singleton_lock_inner(kin_root: &Path) -> std::io::Result<Option<DaemonLock>> {
-    acquire_singleton_lock_inner_until(kin_root, Instant::now() + SINGLETON_LOCK_RETRY_BUDGET)
-}
-
-fn acquire_singleton_lock_inner_until(
-    kin_root: &Path,
-    deadline: Instant,
-) -> std::io::Result<Option<DaemonLock>> {
-    acquire_singleton_lock_inner_until_with_coordination_hook(kin_root, deadline, || {})
-}
-
-fn acquire_singleton_lock_inner_until_with_coordination_hook<F>(
-    kin_root: &Path,
-    deadline: Instant,
-    on_coordination_contention: F,
-) -> std::io::Result<Option<DaemonLock>>
-where
-    F: FnMut(),
-{
-    let canonical_kin_root = kin_root.canonicalize()?;
-    let _coordination = acquire_singleton_coordination_guard_until_with_hook(
-        &canonical_kin_root,
-        deadline,
-        on_coordination_contention,
-    )?;
-    let path = canonical_kin_root.join("daemon.lock");
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&path)?;
-    match file.try_lock_exclusive() {
-        Ok(()) => {
-            // Record ownership while holding the lock, so a contender that
-            // fails to acquire can always name the process it lost to.
-            stamp_lock_owner(&mut file);
-            Ok(Some(DaemonLock {
-                file,
-                canonical_kin_root,
-            }))
-        }
-        // fs2 reports contention with the platform's "would block" error
-        // (EWOULDBLOCK on Unix). Treat that — and only that — as "already
-        // held"; surface every other IO error to the caller.
-        Err(err) if err.kind() == fs2::lock_contended_error().kind() => Ok(None),
-        Err(err) => Err(err),
-    }
+    kin_cli::daemon_client::acquire_repository_runtime_authority(kin_root)
 }
 
 /// Serialize current daemon acquisition, evidence reads, and endpoint changes.
@@ -355,29 +234,7 @@ pub fn acquire_singleton_lock_within(
     kin_root: &Path,
     budget: Duration,
 ) -> std::io::Result<Option<DaemonLock>> {
-    without_blocking_runtime_worker(|| {
-        let deadline = Instant::now() + budget;
-        loop {
-            match acquire_singleton_lock_inner_until(kin_root, deadline) {
-                Ok(Some(lock)) => return Ok(Some(lock)),
-                Ok(None) => {}
-                Err(error)
-                    if error.kind() == std::io::ErrorKind::WouldBlock
-                        && Instant::now() >= deadline =>
-                {
-                    return Ok(None);
-                }
-                Err(error) => return Err(error),
-            }
-            let now = Instant::now();
-            if now >= deadline {
-                return Ok(None);
-            }
-            std::thread::sleep(
-                SINGLETON_LOCK_RETRY_INTERVAL.min(deadline.saturating_duration_since(now)),
-            );
-        }
-    })
+    kin_cli::daemon_client::acquire_repository_runtime_authority_within(kin_root, budget)
 }
 
 /// Run a blocking step without holding a tokio worker thread hostage.
@@ -406,7 +263,8 @@ pub(crate) fn without_blocking_runtime_worker<T>(work: impl FnOnce() -> T) -> T 
 /// How long a contended starter keeps retrying the singleton lock before it
 /// reports the holder. Long enough to cover an exiting daemon's teardown,
 /// short enough that a genuine second daemon fails fast and loudly.
-pub const SINGLETON_LOCK_RETRY_BUDGET: Duration = Duration::from_secs(5);
+pub const SINGLETON_LOCK_RETRY_BUDGET: Duration =
+    kin_daemon_spawn::REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET;
 
 const SINGLETON_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -7,14 +7,13 @@
 //! The CLI reads those files to connect. If the daemon isn't running, the
 //! CLI spawns it and waits for the port to open.
 
-use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 #[cfg(target_os = "macos")]
 use std::fs::{File, OpenOptions};
 #[cfg(target_os = "macos")]
-use std::io::Read as _;
+use std::io::{Read as _, Seek, SeekFrom, Write};
 #[cfg(target_os = "macos")]
 use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _};
 #[cfg(target_os = "macos")]

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -2534,6 +2534,8 @@ pub(crate) fn unregister_launch_agent(_kin_root: &Path) {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(target_os = "macos"))]
+    use std::io::{Seek as _, SeekFrom, Write as _};
 
     #[cfg(target_os = "macos")]
     const LIFECYCLE_WORKER_MODE: &str = "KINTEST_LIFECYCLE_WORKER_MODE";

--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -4457,7 +4457,12 @@ mod tests {
                     .admit_reader(AdmitReaderRequest {
                         lease: proof(&completed),
                         repositories: completed.target_repositories.clone(),
-                        reader: reader(control.runtime_reader_identity(), ttl_seconds),
+                        reader: ReaderAdmissionInput {
+                            identity: control.runtime_reader_identity().to_string(),
+                            min_snapshot_schema: record.reader.min_snapshot_schema,
+                            max_snapshot_schema: record.reader.max_snapshot_schema,
+                            valid_for_seconds: ttl_seconds,
+                        },
                         legacy_writer_drain_proof_sha256: None,
                     })
                     .unwrap();

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -54,6 +54,11 @@ the consumer leaves the row bare while the reading still says the arrival could
 not be accounted for, and the two halves contradict. Which branch of the join
 runs is a property of the store, and the result names it. Every check names the
 ticket it is about, so a failure is attributable without reading the code.
+Check 25 covers FIR-2955. It initializes a committed Git repository with
+`--no-enrich`, then runs `kin graph materialize --json` twice. The first call
+must report `already_current`, proving init persisted the section before any
+daemon reopen, and the second must keep the same repository, workspace,
+authority generation and base target, proving the explicit verb is idempotent.
 
 `parse_hole_repro.py` covers what the others cannot see: a file the
 repository admits that produced no entity at all. It builds a JavaScript library

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -367,6 +367,30 @@ class Suite(object):
             raise RuntimeError("git commit failed: %s" % (err or out)[-300:])
         self._kin_init(repo)
 
+    def _build_graphsection(self, repo):
+        """A committed Git base whose first daemon reopen must be prepared.
+
+        `--no-enrich` is load-bearing: no daemon may open the store before the
+        check asks the explicit materialize verb whether init already wrote the
+        section.
+        """
+        rc, out, err = self.git(["init", "-q", "."], repo)
+        if rc != 0:
+            raise RuntimeError("git init failed: %s" % (err or out)[-300:])
+        self._write(repo, "src/lib.py", "def graph_truth():\n    return 29\n")
+        rc, out, err = self.git(["add", "-A"], repo)
+        if rc != 0:
+            raise RuntimeError("git add failed: %s" % (err or out)[-300:])
+        rc, out, err = self.git(
+            ["commit", "-q", "-m", "graph section fixture"], repo)
+        if rc != 0:
+            raise RuntimeError("git commit failed: %s" % (err or out)[-300:])
+        rc, out, err = self.kin_run(["init", ".", "--no-enrich"], repo)
+        if rc != 0:
+            raise RuntimeError(
+                "kin init --no-enrich failed in %s: %s"
+                % (repo, (err or out)[-300:]))
+
     def _build_threestate(self, repo):
         """A store converted from Git holding one file of each parse outcome.
 
@@ -3588,6 +3612,109 @@ def check_24(suite):
     return res
 
 
+def check_25(suite):
+    """FIR-2955: init prepares the first workspace-base reopen.
+
+    The explicit verb runs twice. `persisted` on its first run proves init
+    omitted the phase; `already_current` twice proves both the init tail and
+    the operator retry are durable and idempotent.
+    """
+    res = Result("25", "FIR-2955",
+                 "init leaves the workspace base graph section materialized")
+    repo = suite.fixture("graphsection")
+
+    endpoint_files = [os.path.join(repo, ".kin", name)
+                      for name in ("daemon.pid", "daemon.port")]
+    present = [path for path in endpoint_files if os.path.exists(path)]
+    if present:
+        res.bad("init --no-enrich left a daemon endpoint before the offline retry: %s" %
+                ", ".join(present))
+        return res
+
+    def materialize(label):
+        rc, out, err = suite.kin_run(
+            ["graph", "materialize", "--json"], repo)
+        if rc != 0:
+            res.bad("%s exited %d: %s" %
+                    (label, rc, (err or out).strip()[-300:]))
+            return None
+        try:
+            payload = json.loads(out)
+        except ValueError:
+            res.unknown("%s printed non-JSON stdout: %r" %
+                        (label, out.strip()[-300:]))
+            return None
+        required = {
+            "schema": str,
+            "scope": str,
+            "repository_id": str,
+            "workspace_id": str,
+            "state": str,
+            "authority_generation": int,
+            "resolved_at": str,
+        }
+        malformed = [
+            "%s:%s" % (field, type(payload.get(field)).__name__)
+            for field, expected in required.items()
+            if not isinstance(payload.get(field), expected)
+            or (expected is str and not payload.get(field))
+        ]
+        if malformed:
+            res.unknown("%s response has an unreadable contract (%s): %s" %
+                        (label, ", ".join(malformed),
+                         json.dumps(payload, sort_keys=True)[:400]))
+            return None
+        if payload["schema"] != "kin.graph-section-materialization.v1":
+            res.unknown("%s returned unknown schema %r" %
+                        (label, payload["schema"]))
+            return None
+        if payload["scope"] != "workspace_base":
+            res.bad("%s materialized scope %r instead of workspace_base" %
+                    (label, payload["scope"]))
+            return None
+        if payload["authority_generation"] < 0:
+            res.unknown("%s returned a negative authority generation" % label)
+            return None
+        return payload
+
+    first = materialize("first explicit materialize after init")
+    if first is None:
+        return res
+    if first["state"] == "persisted":
+        res.bad("the first explicit materialize persisted the section, proving kin init "
+                "omitted its post-publication materialization phase")
+        return res
+    if first["state"] != "already_current":
+        res.bad("the first explicit materialize returned %r, not already_current" %
+                first["state"])
+        return res
+    res.ok("the first explicit retry found init's durable section already current")
+
+    second = materialize("second explicit materialize")
+    if second is None:
+        return res
+    if second["state"] != "already_current":
+        res.bad("the idempotent retry returned %r, not already_current" %
+                second["state"])
+        return res
+    stable = ["repository_id", "workspace_id", "authority_generation", "resolved_at"]
+    changed = [field for field in stable if second[field] != first[field]]
+    if changed:
+        res.bad("the second retry changed %s: first=%s second=%s" %
+                (", ".join(changed), json.dumps(first, sort_keys=True),
+                 json.dumps(second, sort_keys=True)))
+    else:
+        res.ok("the second retry stayed already_current at the same identity, generation, "
+               "and base target")
+    present = [path for path in endpoint_files if os.path.exists(path)]
+    if present:
+        res.bad("offline materialization created a daemon endpoint: %s" %
+                ", ".join(present))
+    else:
+        res.ok("both explicit retries completed without starting a daemon")
+    return res
+
+
 CHECKS = [
     ("0", check_0),
     ("1", check_1),
@@ -3614,6 +3741,7 @@ CHECKS = [
     ("22", check_22),
     ("23", check_23),
     ("24", check_24),
+    ("25", check_25),
 ]
 
 

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -3664,6 +3664,10 @@ def check_25(suite):
                         (label, ", ".join(malformed),
                          json.dumps(payload, sort_keys=True)[:400]))
             return None
+        if not re.fullmatch(r"[0-9a-f]{64}", payload["resolved_at"]):
+            res.unknown("%s returned a non-canonical base target %r" %
+                        (label, payload["resolved_at"]))
+            return None
         if payload["schema"] != "kin.graph-section-materialization.v1":
             res.unknown("%s returned unknown schema %r" %
                         (label, payload["schema"]))

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -319,15 +319,21 @@
       ]
     },
     {
+      "file": "crates/kin-daemon-spawn/src/runtime_authority.rs",
+      "reason": "Shared per-repository runtime capability boundary. try_acquire_repository_runtime_authority canonicalizes the exact .kin root before it opens the never-unlinked daemon.lock and daemon.lifecycle inodes, so a capability acquired for one repository cannot be replayed while opening another. It writes only the caller-owned opaque process stamp after the exclusive lock is held and answers no repository query. Function-scoped so the owner-stamp validation, retry policy, public wrappers, Drop behavior, and any newly added filesystem access remain scanned by default.",
+      "owner": "kin-daemon-spawn",
+      "expiration": "2026-12-31",
+      "allow_fn": [
+        "try_acquire_repository_runtime_authority"
+      ]
+    },
+    {
       "file": "crates/kin-daemon/src/lifecycle.rs",
-      "reason": "Daemon lifecycle boundary: starting, finding, and stopping the process that holds graph authority. Five classes, all excused per function. Singleton coordination: the lock file, its owner stamp, and the guards that decide whether this process may become the daemon. Endpoint publication and ownership: the pid, port, and owner components are written atomically, read back, and removed only after owner-bound proof; the named ownership helpers make that proof independently testable without adding query authority. Binary resolution and liveness: locating and validating the exact kin-daemon executable and probing whether an endpoint is answering before spawning another. Bounded macOS process ownership: the private launchctl capture, stable process-group guardian, deadline, and cleanup helpers. Platform registration and migration: the digest-addressed LaunchAgent plist, exact legacy-authority inspection, staged replacement, rollback, and non-macOS no-op counterparts, which is why two public names carry a count of two. Every path here reaches, supervises, or registers the authority and answers no repository query. The expression pins are process/file handle declarations and the capture file's Drop cleanup; none produces an answer. Function-scoped so the remainder of the module stays scanned.",
+      "reason": "Daemon lifecycle boundary: starting, finding, and stopping the process that holds graph authority. Five classes, all excused per function. Singleton coordination: the lock owner reader and short-lived lifecycle guards that serialize endpoint operations beside the shared runtime capability. Endpoint publication and ownership: the pid, port, and owner components are written atomically, read back, and removed only after owner-bound proof; the named ownership helpers make that proof independently testable without adding query authority. Binary resolution and liveness: locating and validating the exact kin-daemon executable and probing whether an endpoint is answering before spawning another. Bounded macOS process ownership: the private launchctl capture, stable process-group guardian, deadline, and cleanup helpers. Platform registration and migration: the digest-addressed LaunchAgent plist, exact legacy-authority inspection, staged replacement, rollback, and non-macOS no-op counterparts, which is why two public names carry a count of two. Every path here reaches, supervises, or registers the authority and answers no repository query. The expression pins are the process handle declaration and the capture file's Drop cleanup; neither produces an answer. Function-scoped so the remainder of the module stays scanned.",
       "owner": "kin-daemon",
       "expiration": "2026-12-31",
       "allow_fn": [
-        "stamp_lock_owner",
-        "current_owner_stamp",
         "read_lock_owner_stamp",
-        "acquire_singleton_lock_inner_until_with_coordination_hook",
         "acquire_singleton_coordination_guard",
         "acquire_singleton_coordination_guard_until",
         "acquire_singleton_coordination_guard_until_with_hook",
@@ -371,8 +377,7 @@
       ],
       "allow_match": [
         "use std::process::{Child, Command, ExitStatus, Output, Stdio};",
-        "let _ = std::fs::remove_file(&self.path);",
-        "file: std::fs::File,"
+        "let _ = std::fs::remove_file(&self.path);"
       ]
     },
     {


### PR DESCRIPTION
## Outcome

Kin now materializes the workspace-base graph section at the tail of `kin init`, before the first daemon reopen. Developers also get an explicit offline `kin graph materialize --json` repair verb with a stable, typed receipt.

## What changed

- Pin the published registry dependency `kin-db = 0.7.81`.
- Share the exact per-repository OS runtime authority between daemon startup and offline maintenance without changing process-identity ownership.
- Run graph-section materialization after verified init publication and before enrichment or daemon autostart.
- Keep materialization out of daemon HTTP and ordinary publish paths.
- Return canonical 64-character lowercase semantic-change IDs in the v1 JSON receipt.
- Preserve optional `source` wire compatibility for older daemon responses.
- Add the FIR-2955 acceptance check and focused init, contention, idempotence, JSON, and compatibility coverage.
- Move only the lifecycle filesystem exemption that the shared runtime authority extraction moved.

## Verification

- `bin/kin-parity`: PASS-WITH-ALLOWANCES. Magic 26 of 26 passed, including FIR-2955. The only allowances are the existing FIR-2464, FIR-2501, and FIR-2580 entries.
- `bin/kin-precheck kin`: 16 of 16 passed.
- Shared runtime authority: 2 of 2 passed.
- Daemon lifecycle: 78 of 78 passed.
- Graph materialization mapping and JSON: 3 of 3 passed.
- Init then explicit reopen: 1 of 1 passed.
- Older daemon response compatibility: 1 of 1 passed.
- Publication lease registry-pin regression: 1 of 1 passed.
- Zero file-search verifier and poisoned-tree falsifier: passed.

Falsification removed each guarded behavior independently. The init test failed when init skipped materialization, the contention test failed when authority opened before the shared lock, JSON tests failed when `resolved_at` reverted to a byte array, and the old-daemon response test failed when optional-field omission was removed.

## Boundaries

This change does not add a daemon materialization route, modify ordinary publication, or claim to resolve the separate revision-map divergence observed in kin-db measurement. Fold-produced and separately re-derived revision timelines remain a distinct correctness investigation.

Supersedes #1261 and #1333. The latter carried an identical reviewed tree but retained the dependency automation's reserved commit marker on a normal product branch, which the registry admission guard correctly refused.

Closes FIR-2955
