### PR TITLE
Harden stranger proof coverage gate

### DIFF
--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -37,6 +37,12 @@ export const EVIDENCE_REF = 'release-evidence';
 export const PREFLIGHT_SCHEMA = 'kin.release-preflight.v1';
 export const PREFLIGHT_RECORD = 'preflight.json';
 export const STRANGER_RECORD = 'stranger.env';
+// A primetime release must make it through the three distinct first-contact
+// surfaces Kin asks a developer to trust: a new repository, a brownfield
+// repository, and the version-control replacement path. `kin-stranger` writes
+// these names into run.env, so this is a contract with the proof harness rather
+// than a prose convention in a release note.
+export const REQUIRED_STRANGER_ARMS = Object.freeze(['green', 'brown', 'vcs']);
 // The release train's version bump branch, and the ONLY branch whose head ever
 // carried proof records. It bounds the bridge below. release-train.yml declares
 // the same literal, and the authority suite pins the two together so they
@@ -45,6 +51,24 @@ export const BUMP_BRANCH = 'automation/release-next';
 
 const COMMIT_SHA = /^[0-9a-f]{40}$/;
 const ARCHIVE_SHA = /^[0-9a-f]{64}$/;
+
+function armList(env, field, { allowEmpty = false } = {}) {
+  if (!Object.prototype.hasOwnProperty.call(env ?? {}, field)) {
+    throw new Error(`stranger record carries no ${field}, so its arm coverage is unknown`);
+  }
+  const raw = env[field];
+  if (typeof raw !== 'string') {
+    throw new Error(`stranger record carries non-text ${field}, so its arm coverage is unknown`);
+  }
+  const arms = raw.split(',').map((arm) => arm.trim()).filter(Boolean);
+  if (!allowEmpty && arms.length === 0) {
+    throw new Error(`stranger record carries no ${field}, so its arm coverage is unknown`);
+  }
+  if (new Set(arms).size !== arms.length) {
+    throw new Error(`stranger record repeats an arm in ${field}, so its coverage is ambiguous`);
+  }
+  return arms;
+}
 
 export function evidencePath(sha, name) {
   if (typeof sha !== 'string' || !COMMIT_SHA.test(sha)) {
@@ -70,7 +94,13 @@ export function parseRunEnv(text) {
     if (eq <= 0) {
       continue;
     }
-    out[line.slice(0, eq)] = line.slice(eq + 1);
+    const key = line.slice(0, eq);
+    if (Object.prototype.hasOwnProperty.call(out, key)) {
+      throw new Error(
+        `stranger record repeats key "${key}", so its evidence is ambiguous`,
+      );
+    }
+    out[key] = line.slice(eq + 1);
   }
   return out;
 }
@@ -138,29 +168,17 @@ export function judgePreflight(record, sha) {
 
 // What a satisfied gate does and does not say.
 //
-// This accepts a record from a stranger run that FAILED, and that is deliberate.
-// The tests are that the run finished and that it ran the bytes a preflight leg
-// judged; the arm's own result is not a test, because the doctrine is that the
-// report must EXIST, and "the run found nothing" is a finding about the run
-// rather than about the build. The first real back-fill proves the point rather
-// than leaving it theoretical: rc0545's run.env finished at 2026-08-20T21:35:26Z
-// with its brown arm having exited rc=30, and this function accepts it.
+// A record may still contain useful findings. This gate does not decide that
+// Kin is defect-free. It does decide that all three required first-contact arms
+// completed their two phases on the same archived bytes the preflight judged.
+// That distinction is intentional: an unfinished arm cannot be treated as a
+// finding, because it has not supplied a result that a human can review.
 //
-// So a gate that passes means A STRANGER RUN HAPPENED ON THESE BYTES. It never
-// means the stranger passed. Those two readings are one careless sentence apart
-// in a status update, and only one of them is true. Anyone quoting this gate as
-// evidence of a good release is quoting it wrong.
-//
-// It also never means the stranger ran EVERYTHING. Nothing below reads the
-// `arms` field, deliberately: a green-only run.env satisfies this function
-// exactly as a two-arm one does, because a gate that demanded every arm would
-// block every budget-constrained release, which is the deferred-instrument
-// problem arriving by another door. The consequence is that a release evidenced
-// by one arm carries less coverage than one evidenced by two, and this gate
-// cannot tell you which you are holding. Where that difference matters it goes
-// in the release note, not here. The two halves of this misreading are
-// neighbours and a reader will meet them together, so they are written
-// together.
+// `finished_at` alone is insufficient. The v0.6.3 record reached that terminal
+// field with `arms_complete=` and all three arms in `arms_incomplete`; accepting
+// it let a partial local-model run look like release evidence. Require the
+// harness's explicit coverage fields, refuse any incomplete arm, and preserve
+// the complete arm set in the returned result for callers and logs.
 export function judgeStranger(env, sha, archives) {
   const where = evidencePath(sha, STRANGER_RECORD);
   const archive = env?.archive_sha256;
@@ -183,7 +201,52 @@ export function judgeStranger(env, sha, archives) {
       'these bytes',
     );
   }
-  return { archive };
+
+  const requested = armList(env, 'arms');
+  // An empty completed list is distinct from an absent field: the latter
+  // makes coverage unknowable, while the former is an explicit statement that
+  // none completed. Keep it long enough to name an incomplete arm when one is
+  // recorded, then reject it below if no arm is complete.
+  const completed = armList(env, 'arms_complete', { allowEmpty: true });
+  const incomplete = armList(env, 'arms_incomplete', { allowEmpty: true });
+  const requestedSet = new Set(requested);
+
+  const missingRequired = REQUIRED_STRANGER_ARMS.filter((arm) => !requestedSet.has(arm));
+  if (missingRequired.length > 0) {
+    throw new Error(
+      `${where} omits required stranger arm(s) ${missingRequired.join(', ')}, ` +
+      'so the release lacks complete first-contact coverage',
+    );
+  }
+
+  const unexpectedCompleted = completed.filter((arm) => !requestedSet.has(arm));
+  if (unexpectedCompleted.length > 0) {
+    throw new Error(
+      `${where} marks undeclared arm(s) ${unexpectedCompleted.join(', ')} complete, ` +
+      'so its coverage record is inconsistent',
+    );
+  }
+  const unexpectedIncomplete = incomplete.filter((arm) => !requestedSet.has(arm));
+  if (unexpectedIncomplete.length > 0) {
+    throw new Error(
+      `${where} marks undeclared arm(s) ${unexpectedIncomplete.join(', ')} incomplete, ` +
+      'so its coverage record is inconsistent',
+    );
+  }
+  if (incomplete.length > 0) {
+    throw new Error(
+      `${where} records incomplete stranger arm(s) ${incomplete.join(', ')}, ` +
+      'so the stranger proof did not finish',
+    );
+  }
+  const missingCompleted = requested.filter((arm) => !completed.includes(arm));
+  if (missingCompleted.length > 0) {
+    throw new Error(
+      `${where} does not mark requested arm(s) ${missingCompleted.join(', ')} complete, ` +
+      'so the stranger proof did not finish',
+    );
+  }
+  return { archive, arms: requested };
 }
 
 // Fails closed. An unreadable record is not a passing check, so a transport
@@ -424,11 +487,11 @@ export async function main({
   const { archives } = judgePreflight(preflight, sha);
 
   const strangerText = await fetchEvidence(sha, STRANGER_RECORD, options);
-  const { archive } = judgeStranger(parseRunEnv(strangerText), sha, archives);
+  const { archive, arms } = judgeStranger(parseRunEnv(strangerText), sha, archives);
 
   log(
     `Verified release proof artifacts for ${sha}: preflight PASS across ` +
-    `${archives.length} leg(s), stranger ran archive sha256 ${archive}`,
+    `${archives.length} leg(s), stranger completed ${arms.join(', ')} on archive sha256 ${archive}`,
   );
   return { sha, archives, archive };
 }

--- a/scripts/check-release-proof-artifacts.test.mjs
+++ b/scripts/check-release-proof-artifacts.test.mjs
@@ -60,8 +60,14 @@ const strangerEnv = (over = {}) => ({
   archive_name: 'kin-linux-aarch64.tar.gz',
   archive_sha256: ARCHIVE_A,
   finished_at: '2026-08-18T21:53:25Z',
+  arms: 'green,brown,vcs',
+  arms_complete: 'green,brown,vcs',
+  arms_incomplete: '',
   ...over,
 });
+
+const strangerRecordText = (over = {}) =>
+  `${Object.entries(strangerEnv(over)).map(([key, value]) => `${key}=${value}`).join('\n')}\n`;
 
 const throwsWith = (fn, fragment) =>
   assert.throws(fn, (error) => {
@@ -97,6 +103,13 @@ test('parseRunEnv reads the stranger key=value record', () => {
   assert.equal(parsed.continue_mission, '');
   // Values may contain '=': split on the first one only.
   assert.equal(parsed.image_id, 'sha256:881ca213=weird');
+});
+
+test('parseRunEnv refuses a duplicated proof-record key', () => {
+  throwsWith(
+    () => parseRunEnv('arms_incomplete=green\narms_incomplete=\n'),
+    /repeats key "arms_incomplete", so its evidence is ambiguous/,
+  );
 });
 
 test('judgePreflight accepts a well-formed record and returns its archives', () => {
@@ -182,6 +195,7 @@ test('judgePreflight refuses a leg with no archive to link a stranger run to', (
 test('judgeStranger accepts a run on bytes a preflight leg judged', () => {
   assert.deepEqual(judgeStranger(strangerEnv(), SHA, [ARCHIVE_A, ARCHIVE_B]), {
     archive: ARCHIVE_A,
+    arms: ['green', 'brown', 'vcs'],
   });
 });
 
@@ -205,6 +219,76 @@ test('judgeStranger refuses a real run on bytes no preflight leg judged', () => 
       ARCHIVE_B,
     ]),
     /the stranger ran, but not on these bytes/,
+  );
+});
+
+test('judgeStranger refuses missing, partial, and internally inconsistent arm coverage', () => {
+  throwsWith(
+    () => judgeStranger(strangerEnv({ arms: 'green,brown' }), SHA, [ARCHIVE_A]),
+    /omits required stranger arm\(s\) vcs/,
+  );
+  throwsWith(
+    () => judgeStranger(strangerEnv({ arms_incomplete: 'green,brown,vcs' }), SHA, [ARCHIVE_A]),
+    /records incomplete stranger arm\(s\) green, brown, vcs/,
+  );
+  throwsWith(
+    () => judgeStranger(
+      strangerEnv({ arms_complete: '', arms_incomplete: 'green,brown,vcs' }),
+      SHA,
+      [ARCHIVE_A],
+    ),
+    /records incomplete stranger arm\(s\) green, brown, vcs/,
+  );
+  throwsWith(
+    () => judgeStranger(strangerEnv({ arms_complete: 'green,brown' }), SHA, [ARCHIVE_A]),
+    /does not mark requested arm\(s\) vcs complete/,
+  );
+  throwsWith(
+    () => judgeStranger(strangerEnv({ arms_complete: '', arms_incomplete: '' }), SHA, [ARCHIVE_A]),
+    /does not mark requested arm\(s\) green, brown, vcs complete/,
+  );
+  throwsWith(
+    () => judgeStranger(strangerEnv({ arms_complete: 'green,brown,vcs,other' }), SHA, [ARCHIVE_A]),
+    /marks undeclared arm\(s\) other complete/,
+  );
+  throwsWith(
+    () => judgeStranger(strangerEnv({ arms_incomplete: 'other' }), SHA, [ARCHIVE_A]),
+    /marks undeclared arm\(s\) other incomplete/,
+  );
+  throwsWith(
+    () => judgeStranger(strangerEnv({ arms_complete: 'green,brown,vcs,vcs' }), SHA, [ARCHIVE_A]),
+    /repeats an arm in arms_complete/,
+  );
+  throwsWith(
+    () => judgeStranger(strangerEnv({ arms: 'green,green,brown,vcs' }), SHA, [ARCHIVE_A]),
+    /repeats an arm in arms/,
+  );
+  throwsWith(
+    () => judgeStranger(strangerEnv({ arms_incomplete: 'green,green' }), SHA, [ARCHIVE_A]),
+    /repeats an arm in arms_incomplete/,
+  );
+});
+
+test('judgeStranger refuses a record that never declares its coverage fields', () => {
+  const withoutRequested = strangerEnv();
+  delete withoutRequested.arms;
+  throwsWith(
+    () => judgeStranger(withoutRequested, SHA, [ARCHIVE_A]),
+    /carries no arms, so its arm coverage is unknown/,
+  );
+
+  const withoutCompleted = strangerEnv();
+  delete withoutCompleted.arms_complete;
+  throwsWith(
+    () => judgeStranger(withoutCompleted, SHA, [ARCHIVE_A]),
+    /carries no arms_complete, so its arm coverage is unknown/,
+  );
+
+  const withoutIncomplete = strangerEnv();
+  delete withoutIncomplete.arms_incomplete;
+  throwsWith(
+    () => judgeStranger(withoutIncomplete, SHA, [ARCHIVE_A]),
+    /carries no arms_incomplete, so its arm coverage is unknown/,
   );
 });
 
@@ -272,12 +356,29 @@ test('main proceeds when both records exist for the exact candidate', async () =
     log: (line) => lines.push(line),
     fetchImpl: stubFetch({
       [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
-      [STRANGER_RECORD]: ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`),
+      [STRANGER_RECORD]: ok(strangerRecordText()),
     }),
   });
   assert.equal(result.archive, ARCHIVE_A);
   assert.deepEqual(result.archives, [ARCHIVE_A, ARCHIVE_B]);
   assert.match(lines.join('\n'), /Verified release proof artifacts/);
+});
+
+test('main refuses a duplicate key that tries to hide an incomplete stranger arm', async () => {
+  const duplicateIncomplete = `${strangerRecordText({ arms_incomplete: 'green' })}arms_incomplete=\n`;
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+        [STRANGER_RECORD]: ok(duplicateIncomplete),
+      }),
+    }),
+    /repeats key "arms_incomplete", so its evidence is ambiguous/,
+  );
 });
 
 test('main holds a candidate with no preflight record', async () => {
@@ -317,7 +418,7 @@ test('main holds when the records exist but describe a different build', async (
       log: () => {},
       fetchImpl: stubFetch({
         [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
-        [STRANGER_RECORD]: ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`),
+        [STRANGER_RECORD]: ok(strangerRecordText()),
       }),
     }),
     /the record exists but is about a different build/,
@@ -473,7 +574,7 @@ test('main bridges a landed commit to the candidate that was proven', async () =
         });
         return ok(JSON.stringify(record));
       }
-      return ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`);
+      return ok(strangerRecordText());
     },
   });
   assert.equal(result.sha, RC_HEAD);
@@ -504,7 +605,7 @@ test('main answers from the direct key without asking about pull requests', asyn
       if (url.includes(PREFLIGHT_RECORD)) {
         return ok(JSON.stringify(preflightRecord()));
       }
-      return ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`);
+      return ok(strangerRecordText());
     },
   });
   assert.equal(result.sha, SHA);
@@ -541,7 +642,7 @@ test('main bridges when the direct key is absent and a commit is given', async (
         });
         return ok(JSON.stringify(record));
       }
-      return ok(`archive_sha256=${ARCHIVE_A}\nfinished_at=2026-08-18T21:53:25Z\n`);
+      return ok(strangerRecordText());
     },
   });
   assert.equal(result.sha, RC_HEAD);


### PR DESCRIPTION
## Summary

- Require complete green, brown, and vcs stranger coverage before a release proof can pass.
- Reject incomplete, missing, contradictory, duplicate-arm, and duplicate-key records.
- Add regressions for the v0.6.3 partial-record shape.

## Verification

- node --test scripts/check-release-proof-artifacts.test.mjs
- CI release-policy Node selection, 186 passing
- python3 scripts/test-release-workflow-authority.py