### PR TITLE
Keep documentation out of the release provenance inventory so kin update can move again

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -731,12 +731,16 @@ jobs:
             sha256: sha256(name),
             size_bytes: fs.statSync(name).size,
           });
-          // The content inventory covers the archive's component files. The macOS
-          // notification bundle is a sealed directory rather than a component, so
-          // it is classified and shape-checked here but stays out of the manifest:
-          // an installed updater refuses any inventory name outside its managed
-          // component list, and the bundle's bytes are already covered by the
-          // archive digest, its code signature, and its stapled notarization.
+          // The content inventory covers the archive's component files and nothing
+          // else. An installed updater refuses any inventory name outside its
+          // managed component list, so the macOS notification bundle, a sealed
+          // directory rather than a component, and the three documentation
+          // members are classified and shape-checked here but stay out of the
+          // manifest. v0.6.2 refused the v0.6.3 manifest on `checksums-sha256.txt`,
+          // the first documentation record in it, and no managed install could
+          // update across any release from v0.5.45 on. Their bytes are covered by
+          // the archive digest; the bundle's also by its code signature and
+          // stapled notarization, the docs' also by the in-archive checksum file.
           const contents = classifyReleaseArchiveRoot(artifact, { target })
             .files
             .map((name) => {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1215,12 +1215,16 @@ jobs:
             sha256: sha256(name),
             size_bytes: fs.statSync(name).size,
           });
-          // The content inventory covers the archive's component files. The macOS
-          // notification bundle is a sealed directory rather than a component, so
-          // it is classified and shape-checked here but stays out of the manifest:
-          // an installed updater refuses any inventory name outside its managed
-          // component list, and the bundle's bytes are already covered by the
-          // archive digest, its code signature, and its stapled notarization.
+          // The content inventory covers the archive's component files and nothing
+          // else. An installed updater refuses any inventory name outside its
+          // managed component list, so the macOS notification bundle, a sealed
+          // directory rather than a component, and the three documentation
+          // members are classified and shape-checked here but stay out of the
+          // manifest. v0.6.2 refused the v0.6.3 manifest on `checksums-sha256.txt`,
+          // the first documentation record in it, and no managed install could
+          // update across any release from v0.5.45 on. Their bytes are covered by
+          // the archive digest; the bundle's also by its code signature and
+          // stapled notarization, the docs' also by the in-archive checksum file.
           const contents = classifyReleaseArchiveRoot(artifact, { target })
             .files
             .map((name) => {
@@ -1516,6 +1520,7 @@ jobs:
           const path = require("path");
           const { readUpdateBuildIdentity } = require("./scripts/read-update-build-identity.cjs");
           const {
+            DOC_FILES,
             assertReleaseArchiveMemberPaths,
             classifyReleaseArchiveRoot,
           } = require("./scripts/release-archive-shape.cjs");
@@ -1672,11 +1677,22 @@ jobs:
             try {
               // Component files carry per-file provenance; the macOS notification
               // bundle is admitted as a sealed directory and is inventoried by the
-              // archive digest instead. Everything else is refused.
-              const actualNames = classifyReleaseArchiveRoot(contentRoot, {
+              // archive digest instead, and so are the documentation members. An
+              // installed updater judges the inventory with its own frozen
+              // component list and refuses any other name, so a manifest naming
+              // a doc file is not a fuller description of the archive, it is a
+              // release no managed install can update to: v0.6.2 refused v0.6.3
+              // on the first such record. Everything else is refused.
+              const classified = classifyReleaseArchiveRoot(contentRoot, {
                 target: spec.target,
-              }).files;
+              });
+              const actualNames = classified.files;
               const manifestNames = manifest.archive_contents.map((entry) => entry.name).sort();
+              const documented = manifestNames.filter((name) => DOC_FILES.includes(name));
+              fail(documented.length === 0,
+                `${manifestPath} names documentation the installed updater refuses: ${documented.join(", ")}`);
+              fail(JSON.stringify(classified.docs) === JSON.stringify([...DOC_FILES].sort()),
+                `${spec.archive} does not carry every documentation member`);
               fail(JSON.stringify(actualNames) === JSON.stringify(manifestNames),
                 `${manifestPath} content inventory does not match ${spec.archive}`);
               const records = new Map(manifest.archive_contents.map((entry) => [entry.name, entry]));

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -6514,6 +6514,18 @@ fn validate_notifier_bundle_shape(members: &[BundleMember]) -> Result<()> {
 ///
 /// Adding a name here without adding it to the archive shape (or the reverse)
 /// is the failure this pair exists to prevent, so the two lists name each other.
+///
+/// They are archive members, not inventory records. The provenance manifest's
+/// `archive_contents` names only platform components, because an updater that
+/// is already installed judges the manifest with its own frozen component list
+/// and refuses any other name (`validate_artifact_provenance_metadata`): the
+/// v0.6.2 updater refused the v0.6.3 manifest on `checksums-sha256.txt`, the
+/// first documentation record in it, and every manifest from v0.5.45 on carried
+/// the same three, so no managed install could update across that range. The
+/// release side keeps them out of the manifest (`classifyReleaseArchiveRoot`
+/// returns them as `docs`, never `files`), and this side sets them aside
+/// wherever an archive or a manifest names them, so a manifest that names one
+/// again can never strand another release for the updaters built from here on.
 pub(crate) const RELEASE_ARCHIVE_DOC_FILES: &[&str] =
     &["README.md", "INSTALL.md", "checksums-sha256.txt"];
 
@@ -7785,6 +7797,14 @@ where
         let Some(name) = file_name.to_str() else {
             anyhow::bail!("release zip contains a non-UTF-8 file name");
         };
+        if RELEASE_ARCHIVE_DOC_FILES.contains(&name) {
+            // The same documentation skip the tar walker applies, for the same
+            // reason. The Windows zip has carried these members since the docs
+            // were added, and without this skip every such zip was refused
+            // below as an unexpected file before any component was looked at.
+            // Any other unmanaged name still aborts the staging.
+            continue;
+        }
         let Some(component) = spec.iter().copied().find(|item| item.name == name) else {
             anyhow::bail!("release archive contains unexpected file '{name}'");
         };
@@ -10701,6 +10721,7 @@ fn validate_artifact_provenance_metadata(
     let (cli_name, daemon_name) = static_identity_component_names(spec)?;
 
     let mut verified_identities = VerifiedStagedIdentities::new();
+    let mut documented = HashSet::new();
     let mut static_graph_version = None;
     for record in &provenance.archive_contents {
         validate_hex(
@@ -10708,6 +10729,29 @@ fn validate_artifact_provenance_metadata(
             64,
             &format!("component '{}' SHA-256", record.name),
         )?;
+        if RELEASE_ARCHIVE_DOC_FILES.contains(&record.name.as_str()) {
+            // Documentation travels in the archive and is installed nowhere, so
+            // a manifest that inventories it is describing the archive rather
+            // than smuggling a component. The record is accepted and set aside:
+            // it never enters the verified identity set, because every later
+            // count compares that set against the components actually staged
+            // and a doc file is never staged. It may not carry a static build
+            // identity, which only the CLI and daemon authorities have, and it
+            // may not appear twice.
+            if record.build_identity.is_some() {
+                anyhow::bail!(
+                    "artifact provenance carries a static build identity for documentation file '{}'",
+                    record.name
+                );
+            }
+            if !documented.insert(record.name.as_str()) {
+                anyhow::bail!(
+                    "artifact provenance contains duplicate documentation file '{}'",
+                    record.name
+                );
+            }
+            continue;
+        }
         if !spec
             .iter()
             .any(|component| component.name == record.name.as_str())
@@ -13923,6 +13967,57 @@ cwd = {:?}
         );
     }
 
+    /// The Windows archive is a zip and carries the same three documentation
+    /// members as the tarballs. The zip walker had no skip for them, so every
+    /// zip that carried them was refused as an unexpected file before any
+    /// component was looked at.
+    #[test]
+    fn documentation_members_are_skipped_in_a_zip_and_unknown_names_still_abort() {
+        let tmp = tempfile::tempdir().unwrap();
+        let archive = make_zip(&[
+            ("kin.exe", b"kin"),
+            ("kin-daemon.exe", b"daemon"),
+            ("README.md", b"# Kin"),
+            ("INSTALL.md", b"# Install"),
+            ("checksums-sha256.txt", b"abc  kin.exe"),
+        ]);
+        stage_archive(
+            &archive,
+            "kin-windows-x86_64.zip",
+            tmp.path(),
+            WINDOWS_COMPONENTS,
+        )
+        .expect("a zip carrying its own documentation must stage");
+        for doc in RELEASE_ARCHIVE_DOC_FILES {
+            assert!(
+                !tmp.path().join("bin").join(doc).exists(),
+                "{doc} was installed as a binary"
+            );
+            assert!(
+                !tmp.path().join("lib").join(doc).exists(),
+                "{doc} was installed as a library"
+            );
+        }
+        assert_eq!(fs::read(tmp.path().join("bin/kin.exe")).unwrap(), b"kin");
+
+        let stray = make_zip(&[
+            ("kin.exe", b"kin"),
+            ("kin-daemon.exe", b"daemon"),
+            ("NOTES.md", b"stray"),
+        ]);
+        let error = stage_archive(
+            &stray,
+            "kin-windows-x86_64.zip",
+            tempfile::tempdir().unwrap().path(),
+            WINDOWS_COMPONENTS,
+        )
+        .expect_err("an unmanaged zip member must still abort the staging");
+        assert!(
+            format!("{error:#}").contains("unexpected file"),
+            "error: {error:#}"
+        );
+    }
+
     /// A macOS release archive carries KinNotifier.app as a directory. The
     /// stager materializes it under the staging tree's `lib`, preserving the
     /// executable bit its executable needs to be launchable at all.
@@ -15819,6 +15914,194 @@ cwd = {:?}
         assert!(format!("{err:#}").contains("does not match artifact provenance"));
         assert_bundle_matches(&kin_home, LINUX_COMPONENTS, &old);
         assert!(transaction_dirs(&kin_home).unwrap().is_empty());
+    }
+
+    /// A release manifest may inventory the documentation members beside the
+    /// components, and an updater must set those records aside rather than
+    /// refuse them or count them against the staged bundle. The order mirrors
+    /// the published manifests, which sort case-insensitively and so put
+    /// `checksums-sha256.txt` first: that is the record the v0.6.2 updater
+    /// named when it refused every manifest from v0.5.45 to v0.6.3.
+    #[test]
+    fn documentation_records_in_the_provenance_inventory_are_set_aside() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stage = tmp.path().join("stage");
+        let identity = test_static_build_identity();
+        let cli = bytes_with_static_build_identity(b"new-kin", &identity);
+        let daemon = bytes_with_static_build_identity(b"new-daemon", &identity);
+        let docs = RELEASE_ARCHIVE_DOC_FILES
+            .iter()
+            .map(|doc| {
+                (
+                    format!("kin-linux-x86_64/{doc}"),
+                    format!("words in {doc}\n").into_bytes(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut entries: Vec<(&str, &[u8])> = vec![
+            ("kin-linux-x86_64/kin", cli.as_slice()),
+            ("kin-linux-x86_64/kin-daemon", daemon.as_slice()),
+            ("kin-linux-x86_64/kin-vfs", b"new-vfs".as_slice()),
+            (
+                "kin-linux-x86_64/libkin_vfs_shim.so",
+                b"new-shim".as_slice(),
+            ),
+        ];
+        entries.extend(
+            docs.iter()
+                .map(|(name, bytes)| (name.as_str(), bytes.as_slice())),
+        );
+        let archive = make_tar_gz(&entries);
+        stage_archive(
+            &archive,
+            "kin-linux-x86_64.tar.gz",
+            &stage,
+            LINUX_COMPONENTS,
+        )
+        .unwrap();
+        let mut provenance = test_provenance(
+            &stage,
+            LINUX_COMPONENTS,
+            "kin-linux-x86_64.tar.gz",
+            &archive,
+        );
+        for (name, bytes) in &docs {
+            provenance.archive_contents.push(ProvenanceFile {
+                name: name.rsplit('/').next().unwrap().to_string(),
+                sha256: hex::encode(Sha256::digest(bytes)),
+                size_bytes: bytes.len() as u64,
+                build_identity: None,
+            });
+        }
+        provenance
+            .archive_contents
+            .sort_by_key(|record| record.name.to_lowercase());
+        assert_eq!(
+            provenance.archive_contents[0].name, "checksums-sha256.txt",
+            "the fixture must lead with the record the field refusal named"
+        );
+        let release = GithubRelease {
+            tag_name: "v0.2.22".to_string(),
+            prerelease: false,
+            assets: Vec::new(),
+        };
+        let asset = GithubAsset {
+            name: "kin-linux-x86_64.tar.gz".to_string(),
+            browser_download_url: "https://example.invalid/archive".to_string(),
+        };
+        let validate = |provenance: &ArtifactProvenance| {
+            validate_artifact_provenance(
+                provenance,
+                &release,
+                &"a".repeat(40),
+                &asset,
+                &archive,
+                &stage,
+                LINUX_COMPONENTS,
+                true,
+            )
+        };
+
+        let identities = validate(&provenance)
+            .expect("a manifest inventorying the archive's documentation must be accepted");
+        let mut verified = identities.keys().cloned().collect::<Vec<_>>();
+        verified.sort();
+        assert_eq!(
+            verified,
+            ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"],
+            "documentation records must not enter the verified identity set"
+        );
+        for doc in RELEASE_ARCHIVE_DOC_FILES {
+            assert!(
+                !stage.join("bin").join(doc).exists() && !stage.join("lib").join(doc).exists(),
+                "{doc} was staged as a component"
+            );
+        }
+
+        // The skip is not a side door: a documentation record may neither claim
+        // a static build identity nor appear twice.
+        let mut with_identity = provenance.clone();
+        with_identity
+            .archive_contents
+            .iter_mut()
+            .find(|record| record.name == "README.md")
+            .unwrap()
+            .build_identity = Some(test_static_build_identity());
+        let err = validate(&with_identity)
+            .expect_err("a documentation record carrying a build identity must be refused");
+        assert!(
+            format!("{err:#}").contains("static build identity for documentation file 'README.md'"),
+            "error: {err:#}"
+        );
+        let mut duplicated = provenance.clone();
+        let readme = duplicated
+            .archive_contents
+            .iter()
+            .find(|record| record.name == "README.md")
+            .unwrap()
+            .clone();
+        duplicated.archive_contents.push(readme);
+        let err =
+            validate(&duplicated).expect_err("a duplicate documentation record must be refused");
+        assert!(
+            format!("{err:#}").contains("duplicate documentation file 'README.md'"),
+            "error: {err:#}"
+        );
+    }
+
+    /// The tolerance above must not turn the inventory guard off: a name that is
+    /// neither a component nor a documentation member still stops the update,
+    /// and the refusal names it.
+    #[test]
+    fn unknown_provenance_inventory_names_are_still_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stage = tmp.path().join("stage");
+        let archive = full_linux_static_archive("kin-linux-x86_64");
+        stage_archive(
+            &archive,
+            "kin-linux-x86_64.tar.gz",
+            &stage,
+            LINUX_COMPONENTS,
+        )
+        .unwrap();
+        let mut provenance = test_provenance(
+            &stage,
+            LINUX_COMPONENTS,
+            "kin-linux-x86_64.tar.gz",
+            &archive,
+        );
+        provenance.archive_contents.push(ProvenanceFile {
+            name: "NOTES.md".to_string(),
+            sha256: hex::encode(Sha256::digest(b"stray")),
+            size_bytes: 5,
+            build_identity: None,
+        });
+        let release = GithubRelease {
+            tag_name: "v0.2.22".to_string(),
+            prerelease: false,
+            assets: Vec::new(),
+        };
+        let asset = GithubAsset {
+            name: "kin-linux-x86_64.tar.gz".to_string(),
+            browser_download_url: "https://example.invalid/archive".to_string(),
+        };
+        let err = validate_artifact_provenance(
+            &provenance,
+            &release,
+            &"a".repeat(40),
+            &asset,
+            &archive,
+            &stage,
+            LINUX_COMPONENTS,
+            true,
+        )
+        .expect_err("an inventory record outside the platform bundle must be refused");
+        assert!(
+            format!("{err:#}").contains(
+                "artifact provenance inventory contains file 'NOTES.md' outside the managed platform bundle"
+            ),
+            "error: {err:#}"
+        );
     }
 
     #[cfg(unix)]

--- a/scripts/release-archive-shape.cjs
+++ b/scripts/release-archive-shape.cjs
@@ -59,6 +59,14 @@ const MAX_BUNDLE_DEPTH = 6;
 // They are members of the archive and nothing installs them: `kin update` skips
 // them by name (see RELEASE_ARCHIVE_DOC_FILES in the updater) and `scripts/
 // install.sh` moves a fixed list of binaries, so neither changes behaviour.
+//
+// They are archive members and not inventory records. `classifyReleaseArchiveRoot`
+// returns them as `docs`, never in `files`, because `files` becomes the
+// provenance manifest's `archive_contents` and an installed updater judges that
+// list with its own frozen component list, refusing any other name. Every
+// manifest from v0.5.45 to v0.6.3 carried these three, and the v0.6.2 updater
+// refused v0.6.3 on `checksums-sha256.txt`, the first of them in sort order, so
+// no managed install could update across that whole range.
 const DOC_FILES = Object.freeze(["README.md", "INSTALL.md", "checksums-sha256.txt"]);
 
 const ROOT_FILES_BY_FAMILY = {
@@ -267,18 +275,27 @@ function assertNotifierBundle(bundleRoot, bundleName) {
   }
 }
 
-// Classify the extracted root of a release archive into its component files and
-// its sanctioned bundles, refusing every other shape.
+// Classify the extracted root of a release archive into its component files,
+// its documentation members and its sanctioned bundles, refusing every other
+// shape.
 //
-// The returned file list is the release's content inventory: it is what the
+// The returned `files` list is the release's content inventory: it is what the
 // build job hashes into the per-artifact provenance manifest and what the
 // publish job compares that manifest against, so both sides agree on which
-// entries carry per-file provenance and which travel as a sealed bundle.
+// entries carry per-file provenance. Documentation is admitted at the root and
+// returned separately as `docs`, never in `files`. An installed updater refuses
+// any inventory name outside its managed component list and only ever installs
+// components, so a doc record in the manifest does not describe the archive
+// more fully, it stops every update on that platform: v0.6.2 refused the v0.6.3
+// manifest on `checksums-sha256.txt`, the first foreign name in it. The docs'
+// bytes stay covered by the archive digest and by the in-archive checksum
+// manifest, the same way the notification bundle's are covered by the digest.
 function classifyReleaseArchiveRoot(contentRoot, options) {
   const { target } = options ?? {};
   const bundleAllowed = targetCarriesNotifierBundle(target);
   const rootFiles = releaseArchiveRootFiles(target);
   const files = [];
+  const docs = [];
   const bundles = [];
   for (const entry of fs.readdirSync(contentRoot, { withFileTypes: true })) {
     if (entry.isSymbolicLink()) {
@@ -290,7 +307,11 @@ function classifyReleaseArchiveRoot(contentRoot, options) {
           `release archive root for ${target} holds unexpected file '${entry.name}'`
         );
       }
-      files.push(entry.name);
+      if (DOC_FILES.includes(entry.name)) {
+        docs.push(entry.name);
+      } else {
+        files.push(entry.name);
+      }
       continue;
     }
     if (!entry.isDirectory()) {
@@ -312,8 +333,9 @@ function classifyReleaseArchiveRoot(contentRoot, options) {
     throw new Error(`release archive root for ${target} is missing ${NOTIFIER_BUNDLE_DIR}`);
   }
   files.sort();
+  docs.sort();
   bundles.sort();
-  return { files, bundles };
+  return { files, docs, bundles };
 }
 
 module.exports = {

--- a/scripts/release-archive-shape.test.cjs
+++ b/scripts/release-archive-shape.test.cjs
@@ -9,6 +9,7 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const {
+  DOC_FILES: SHAPE_DOC_FILES,
   MAX_BUNDLE_ENTRIES,
   NOTIFIER_BUNDLE_DIR,
   assertReleaseArchiveMemberPaths,
@@ -59,20 +60,20 @@ const LINUX_LISTING = [
 // artifact prefix at all.
 const WINDOWS_LISTING = ["kin.exe", "kin-daemon.exe", "kin-vfs.exe"];
 
-// Documentation members ride on every family, so the per-family expectations
-// below are the executables plus these, sorted.
-const DOC_FILES = ["INSTALL.md", "README.md", "checksums-sha256.txt"];
-const MACOS_FILES = ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.dylib", ...DOC_FILES].sort();
-const LINUX_FILES = ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so", ...DOC_FILES].sort();
+// Documentation members ride on every family, so the per-family admitted root
+// sets below are the components plus these, sorted. They are admitted at the
+// root and kept out of the provenance inventory: an installed updater judges the
+// inventory by its own component list and refuses any other name, which is how
+// v0.6.2 refused v0.6.3 on `checksums-sha256.txt`.
+const DOC_FILES = ["INSTALL.md", "README.md", "checksums-sha256.txt"].sort();
+const MACOS_COMPONENTS = ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.dylib"].sort();
+const LINUX_COMPONENTS = ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"].sort();
 // Sorted the way the classifier returns names, which puts the bare CLI between
 // the hyphenated binaries and the underscored shim.
-const WINDOWS_FILES = [
-  "kin-daemon.exe",
-  "kin-vfs.exe",
-  "kin.exe",
-  "kin_vfs_shim.dll",
-  ...DOC_FILES,
-].sort();
+const WINDOWS_COMPONENTS = ["kin-daemon.exe", "kin-vfs.exe", "kin.exe", "kin_vfs_shim.dll"].sort();
+const MACOS_FILES = [...MACOS_COMPONENTS, ...DOC_FILES].sort();
+const LINUX_FILES = [...LINUX_COMPONENTS, ...DOC_FILES].sort();
+const WINDOWS_FILES = [...WINDOWS_COMPONENTS, ...DOC_FILES].sort();
 
 function tempRoot() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "release-archive-shape-"));
@@ -219,21 +220,66 @@ test("the bundle is required on macOS listings and refused on every other target
 
 test("the extracted macOS root yields exactly the four provenance-bearing files", () => {
   const root = macosRoot();
-  const { files, bundles } = classifyReleaseArchiveRoot(root, { target: MACOS_TARGET });
-  assert.deepEqual(files, MACOS_FILES);
+  const { files, docs, bundles } = classifyReleaseArchiveRoot(root, { target: MACOS_TARGET });
+  assert.deepEqual(files, MACOS_COMPONENTS);
+  assert.deepEqual(docs, DOC_FILES);
   assert.deepEqual(bundles, [NOTIFIER_BUNDLE_DIR]);
 });
 
 test("the extracted Linux root yields its files and no bundle", () => {
-  const { files, bundles } = classifyReleaseArchiveRoot(linuxRoot(), { target: LINUX_TARGET });
-  assert.deepEqual(files, LINUX_FILES);
+  const { files, docs, bundles } = classifyReleaseArchiveRoot(linuxRoot(), {
+    target: LINUX_TARGET,
+  });
+  assert.deepEqual(files, LINUX_COMPONENTS);
+  assert.deepEqual(docs, DOC_FILES);
   assert.deepEqual(bundles, []);
 });
 
 test("the extracted Windows root yields its files and no bundle", () => {
-  const { files, bundles } = classifyReleaseArchiveRoot(windowsRoot(), { target: WINDOWS_TARGET });
-  assert.deepEqual(files, WINDOWS_FILES);
+  const { files, docs, bundles } = classifyReleaseArchiveRoot(windowsRoot(), {
+    target: WINDOWS_TARGET,
+  });
+  assert.deepEqual(files, WINDOWS_COMPONENTS);
+  assert.deepEqual(docs, DOC_FILES);
   assert.deepEqual(bundles, []);
+});
+
+// The `files` list the classifier returns is what the build job writes into the
+// provenance manifest's `archive_contents`, and an installed updater then judges
+// that list with its own frozen component list. Every manifest from v0.5.45 to
+// v0.6.3 carried the three documentation members, and the v0.6.2 updater refused
+// v0.6.3 on the first of them, so no managed install could update across that
+// range. The documentation stays a sanctioned root member; it is the inventory
+// it must never reach.
+test("documentation members are admitted at the root and never enter the inventory", () => {
+  assert.deepEqual([...SHAPE_DOC_FILES].sort(), DOC_FILES);
+  for (const [root, target, components] of [
+    [macosRoot(), MACOS_TARGET, MACOS_COMPONENTS],
+    [linuxRoot(), LINUX_TARGET, LINUX_COMPONENTS],
+    [windowsRoot(), WINDOWS_TARGET, WINDOWS_COMPONENTS],
+  ]) {
+    const { files, docs } = classifyReleaseArchiveRoot(root, { target });
+    assert.deepEqual(
+      files.filter((name) => DOC_FILES.includes(name)),
+      [],
+      `${target}: the provenance inventory names documentation the installed updater refuses`
+    );
+    assert.deepEqual(files, components, `${target}: the inventory is not exactly the components`);
+    assert.deepEqual(docs, DOC_FILES, `${target}: a documentation member was dropped`);
+    assert.ok(
+      DOC_FILES.every((name) => releaseArchiveRootFiles(target).includes(name)),
+      `${target}: documentation is no longer admitted at the archive root`
+    );
+  }
+  // An archive without its documentation still classifies. Whether the docs are
+  // mandatory is the packaging step's presence assertion, not the classifier's.
+  const bare = linuxRoot();
+  for (const name of DOC_FILES) {
+    fs.rmSync(path.join(bare, name));
+  }
+  const { files, docs } = classifyReleaseArchiveRoot(bare, { target: LINUX_TARGET });
+  assert.deepEqual(files, LINUX_COMPONENTS);
+  assert.deepEqual(docs, []);
 });
 
 test("the sanctioned root files are read per target family", () => {

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -13829,6 +13829,19 @@ def main() -> None:
         "classifyReleaseArchiveRoot(contentRoot, {",
     ):
         require(publish_job, policy, "sanctioned release archive shape at publish")
+    # The inventory is what an installed updater judges the release by, with its
+    # own frozen component list, and it refuses any other name. Every manifest
+    # from v0.5.45 to v0.6.3 named the three documentation members, and v0.6.2
+    # refused v0.6.3 on checksums-sha256.txt, the first of them. The classifier
+    # now keeps documentation out of `files`, and the publish job must both read
+    # the doc list from the shared module and refuse a manifest that names one by
+    # that defect's name rather than as a generic inventory mismatch.
+    for policy in (
+        "DOC_FILES,",
+        "names documentation the installed updater refuses",
+        "does not carry every documentation member",
+    ):
+        require(publish_job, policy, "documentation kept out of the provenance inventory")
     for forbidden in (
         "entries.every((entry) => entry.isFile())",
         ".filter((entry) => entry.isFile())",


### PR DESCRIPTION
`kin update` works again from the next release onward, on every install whose updater is already in the field, and the release build can no longer produce a manifest those updaters refuse.

## What was wrong

On this machine the managed v0.6.2 install downloaded `kin-macos-aarch64.tar.gz` for v0.6.3, verified the SHA-256, then refused with `artifact provenance inventory contains file 'checksums-sha256.txt' outside the managed platform bundle`. The updater judges the manifest's `archive_contents` with its own platform component list (`validate_artifact_provenance_metadata`) and refuses any other name; that rule has been in place since July 19 (#351). The archive docs (README.md, INSTALL.md, checksums-sha256.txt) were added on August 19 (#941) and the release build inventoried them because `classifyReleaseArchiveRoot(...).files` included them. The generator's own comment says an installed updater refuses any inventory name outside its component list, and keeps the notifier bundle out for that reason; the docs came in through the same door.

Two details matter for the fix. The published manifests sort case-insensitively, so `checksums-sha256.txt` is the first record and the one the error named; INSTALL.md and README.md are equally outside the spec and would be named next, so removing only the checksum file from the archive changes nothing. And the docs are fine as archive members: the tar walker has skipped them by name since #941. Every `kin-macos-aarch64.provenance.json` from v0.5.45 through v0.6.3 carries the three doc records, so no managed install has been able to update across any release pair in that range.

## Field compatibility, the constraint that decides the shape

The v0.6.2 updater is frozen. It accepts an inventory whose names are all platform components, and a tarball whose members are components plus the three docs (plus the notifier bundle on macOS). So the release side moves and the archive shape stays:

- `scripts/release-archive-shape.cjs` now returns documentation as `docs` and never in `files`, which is the list release.yml and rc-build.yml write into `archive_contents` and the list the publish job compares the manifest against. The archive keeps its three doc files, so PR #1336's generated Windows guidance and `scripts/install.sh` are unchanged.
- The publish job additionally refuses a manifest that names a doc file, by that name rather than as a generic inventory mismatch, and asserts every doc member is present in the archive. `scripts/test-release-workflow-authority.py` pins both.
- On main's updater, `validate_artifact_provenance_metadata` now sets documentation records aside instead of refusing them, without letting them into the verified identity set that four later counts compare against staged components, and refuses a doc record that carries a static build identity or appears twice. `stage_zip` gets the same doc skip the tar walker has had; without it every Windows zip since #941 was refused as an unexpected file, so Windows updaters built before this change cannot update through the zip and a Windows install on 0.6.x reinstalls once through install.ps1.

Neither Rust change helps a binary already installed. Both stop this class from recurring for the updaters built from here on.

## Tests and falsification

- `documentation_records_in_the_provenance_inventory_are_set_aside`: a Linux archive carrying all three docs, staged, with a manifest that inventories components and docs in the published sort order (checksums first); `validate_artifact_provenance` accepts it and returns exactly the four component identities, and a doc record with a build identity or a duplicate doc record is refused.
- `unknown_provenance_inventory_names_are_still_refused`: a `NOTES.md` record is still refused with the original message, so the tolerance does not turn the guard off.
- `documentation_members_are_skipped_in_a_zip_and_unknown_names_still_abort`: the zip counterpart of the existing tar test.
- `release-archive-shape.test.cjs`: `files` is exactly the components and `docs` exactly the three names on all three families, docs stay admitted at the root, and a root without docs still classifies.

Falsifications (each reverted before the commit): removing the inventory skip, the `documented` set and the zip skip (32 lines) turned `documentation_records_in_the_provenance_inventory_are_set_aside` red with `a manifest inventorying the archive's documentation must be accepted: artifact provenance inventory contains file 'checksums-sha256.txt' outside the managed platform bundle` (the field error verbatim) and `documentation_members_are_skipped_in_a_zip_and_unknown_names_still_abort` red with `release archive contains unexpected file 'README.md'`, while `unknown_provenance_inventory_names_are_still_refused` stayed green; putting docs back into the classifier's `files` turned four shape tests red, the new one on `the provenance inventory names documentation the installed updater refuses`.

## Commands run

- `cargo test -p kin-cli update -- --list`: 176 tests listed, the three new names among them, a control name that cannot exist matched 0.
- `cargo test -p kin-cli update`: 175 passed in the kin-cli lib plus 1 in an integration target, 0 failed.
- `node --test scripts/release-archive-shape.test.cjs scripts/write-release-archive-docs.test.mjs`: 28 pass, 0 fail.
- `node scripts/check-rc-build-drift.mjs`: rc-build.yml mirrors release.yml's build job, exit 0.
- `python3 scripts/test-release-workflow-authority.py`: exit 0.
- `cargo fmt --all -- --check`: exit 0.
- `bin/kin-precheck kin` through `bin/kin-lane run updatefix kin`, which runs clippy exactly as ci.yml does plus the fourteen guard scripts: `16 gates ran, 16 passed, 0 failed, on kin 1a517b6cca567c81b3396a7ee2b006669091386e`, branch `chore/lane-updatefix-kin`, 0 behind origin/main.

Every cargo command ran through the fleet's heavy-slot wrapper, one at a time, with CARGO_BUILD_JOBS=6.

## Release note

The v0.6.4 mint waits for this change: its version bump (#1338) is on main, and a v0.6.4 built without this fix would carry the same seven-record inventory and be refused by every installed updater exactly as v0.6.3 was.
