### PR TITLE
Advance the immutable kin-vfs pin to v0.4.23 beside the registry refresh

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -191,7 +191,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 2cab0e11e9b1ae0adc422ef8e0d09c24d296d370
+          ref: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -665,7 +665,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 2cab0e11e9b1ae0adc422ef8e0d09c24d296d370
+          EXPECTED_VFS_COMMIT: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -523,7 +523,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 2cab0e11e9b1ae0adc422ef8e0d09c24d296d370
+          ref: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -1149,7 +1149,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 2cab0e11e9b1ae0adc422ef8e0d09c24d296d370
+          EXPECTED_VFS_COMMIT: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1441,7 +1441,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: 2cab0e11e9b1ae0adc422ef8e0d09c24d296d370
+          ref: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1509,7 +1509,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: 2cab0e11e9b1ae0adc422ef8e0d09c24d296d370
+          EXPECTED_VFS_COMMIT: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1883,7 +1883,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: 2cab0e11e9b1ae0adc422ef8e0d09c24d296d370
+      expected_vfs_commit: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.4.22"
+version = "0.4.23"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "307a2cf1a2ba510dcf28d8fb6b770c9b8dc48cabc75cad8147d3679f72d5d1f7"
+checksum = "e8cb6f31620f6f3cd83b99ad81f354c8fa6cfac827ec19944e5b8bc51e5e629f"
 dependencies = [
  "lru",
  "parking_lot",
@@ -6670,7 +6670,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "=0.7.81", registry = "kin", default-features = false }
-kin-vfs-core = { version = "=0.4.22", registry = "kin" }
+kin-vfs-core = { version = "=0.4.23", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -16622,7 +16622,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: 2cab0e11e9b1ae0adc422ef8e0d09c24d296d370",
+        "expected_vfs_commit: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
kin#1339, the release bot's dependency refresh, is red on "Verify Kin/kin-vfs compatibility at the pinned release input": Kin resolves kin-vfs-core 0.4.23 from the registry while release.yml and rc-build.yml still pin the kin-vfs checkout at 2cab0e11, which builds 0.4.22. This PR carries the bot's commit unchanged and advances the three pins to ff59dfeb, the commit v0.4.23 points at (kin-vfs #141), so the registry version and the pinned release input agree.

Verified locally: `git show ff59dfeb:Cargo.toml` in kin-vfs reads version 0.4.23 and the old pin reads 0.4.22; `node scripts/check-release-version.mjs`, `node scripts/check-rc-build-drift.mjs` and `node scripts/check-kin-vfs-compat.mjs` results are in the lane report; `cargo metadata --locked` accepts the lock; no em dashes. Hosted CI grades the cargo gates. Supersedes kin#1339, which the captain closes once this lands. Part of FIR-3057.
