### PR TITLE
Send every print through a closed-pipe sink instead of exiting on EPIPE

### DIFF
--- a/crates/kin-cli/src/broken_pipe.rs
+++ b/crates/kin-cli/src/broken_pipe.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! How the CLI ends when the process reading its output has gone away.
+//! What the CLI does when the process reading its output has gone away.
 //!
 //! Rust starts every binary with `SIGPIPE` ignored, so a write into a pipe
 //! whose reader has closed comes back as `EPIPE` instead of ending the process,
-//! and the `print!` family turns that error into a panic. `kin diff HEAD
+//! and std's `print!` family turns that error into a panic. `kin diff HEAD
 //! WORKSPACE | head -5` therefore ended in `thread 'main' panicked at ...
 //! failed printing to stdout: Broken pipe` and exit 101 on every command that
 //! writes more than its reader takes, and a `kin commit ... 2>&1 | head -3`
@@ -15,24 +15,42 @@
 //! write: eleven of twelve commands exited 101, and only `--help` survived,
 //! because clap discards its write errors.
 //!
-//! The CLI has over a thousand print sites, so this is handled once, at the
-//! two places a failed write can leave the process: the panic hook, for the
-//! `print!` family, and the top of `main`, for an `io::Error` that came back
-//! through `?`. This module decides; `main.rs`, the process boundary, holds
-//! the hook and performs the exits.
+//! The rule is that a reader going away changes what a command prints and
+//! never what it does. The CLI has over a thousand print sites, so the four
+//! macros are redefined once for the whole crate, here, and `main.rs` imports
+//! the same definitions. Each one writes through [`print_stdout`] or
+//! [`print_stderr`]: the first write that meets a closed pipe marks that
+//! stream gone, every later write to it is skipped before it reaches the OS,
+//! and the command runs to its end and exits with the status its work earned.
+//! On Unix the first `EPIPE` also points the descriptor at `/dev/null`, so a
+//! print in a crate this one calls into, a library writing its own
+//! diagnostics, or a child process that inherits the stream finds a sink where
+//! the pipe was instead of the same `EPIPE`. A write that fails for any other
+//! reason is still the panic std would have raised, with std's own message, so
+//! a full disk under `kin log > file` is reported exactly as before.
 //!
-//! Which stream broke decides the status. stdout carries a command's result
-//! and is written once the work is done, so a reader that stopped taking it
-//! has everything it wanted and the command exits 0. stderr carries progress
-//! and warnings while the work is still running, so a reader gone there cut
-//! the command off before its result, and the exit says so with the status a
-//! shell reports for a process `SIGPIPE` ended. `kin commit 2>&1 | head -3`
-//! shows why the two must differ. On a cold daemon, head closes after the
-//! startup lines and the next progress write fails before the commit request
-//! is sent, so nothing was recorded; on a warm daemon the same pipeline fails
-//! on the summary line, after the change is in authority. Both exited 101
-//! before. Now the first exits 141 and the second exits 0, and a caller keying
-//! on the code reads each one right.
+//! `kin init 2>&1 | head -1` is the case that fixed the design. Both streams
+//! are one pipe that closes after one line, and init's contract, pinned in
+//! `tests/init_non_tty_output.rs`, is that its status reports the admission
+//! and not the pipe: progress is advisory, the admission is not. An earlier
+//! shape of this module ended the process from a panic hook on the first
+//! failed print, 0 for stdout and 141 for stderr. That stopped init at a
+//! progress line with its store half written and reported 141 for an
+//! admission that had every right to finish, and because the hook ran before
+//! the unwind it also defeated the task boundary init keeps around its own
+//! advisory writes. A cut reader is never a reason to report a failed
+//! admission, and never a reason to report a successful one that did not
+//! happen; the only way to satisfy both is to keep working.
+//!
+//! One write can still end a command early: an `io::Error` of kind
+//! `BrokenPipe` that reached `main` through `?` from a write this module did
+//! not make. [`exit_status`] answers that with [`CUT_OFF_STATUS`], 141, the
+//! status a shell reports for a process `SIGPIPE` ended and the status this
+//! process would have had under the default disposition, and prints nothing,
+//! because the command stopped at that write and everything after it did not
+//! run. 141 cannot be read as success of work that never happened, which is
+//! what makes ending early acceptable there; 0 could be, which is why this
+//! module's own writes never end anything.
 //!
 //! Resetting `SIGPIPE` to its default disposition would have been one line and
 //! was rejected. The daemon transport is a socket, std sets `SO_NOSIGPIPE`
@@ -41,7 +59,9 @@
 //! instead of returning the error `kin commit` reads to find out whether its
 //! change landed anyway.
 
+use std::fmt;
 use std::io::{self, Write as _};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// The status a shell reports for a process that `SIGPIPE` ended, 128 + 13,
 /// and the status this process would have had under the default disposition.
@@ -49,159 +69,335 @@ use std::io::{self, Write as _};
 /// command failed", which is exactly the news.
 pub const CUT_OFF_STATUS: i32 = 141;
 
-#[cfg(unix)]
-const BROKEN_PIPE_OS_ERRORS: &[i32] = &[libc::EPIPE];
-/// `ERROR_BROKEN_PIPE` and `ERROR_NO_DATA`: the two codes a write into a pipe
-/// the other side has closed comes back with, and the two std decodes to
-/// `ErrorKind::BrokenPipe`.
-#[cfg(windows)]
-const BROKEN_PIPE_OS_ERRORS: &[i32] = &[109, 232];
+/// Set by the first write to meet a closed pipe on each stream, and read
+/// before every write after it.
+static STDOUT_GONE: AtomicBool = AtomicBool::new(false);
+static STDERR_GONE: AtomicBool = AtomicBool::new(false);
 
-/// The status a panic earns when it is a std print into a closed pipe, for
-/// the hook `main` installs; `None` for every other panic, which the hook
-/// hands on to the one that was installed before it, so a real panic still
-/// prints its message and still exits 101.
-pub fn exit_status_for_panic(info: &std::panic::PanicHookInfo<'_>) -> Option<i32> {
-    let payload = info.payload();
-    let message = payload
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| payload.downcast_ref::<&str>().copied())?;
-    exit_status_for_print_failure(message)
+/// `print!` for this crate: std's arguments, written through [`print_stdout`].
+///
+/// `#[macro_export]` places the four macros at the crate root so `main.rs`
+/// imports them by name, and `#[macro_use]` on this module in `lib.rs` puts
+/// them in textual scope for every module declared after it, which is why the
+/// module is declared first there. A print site in this crate that reached
+/// std's macro instead would panic on a closed pipe exactly as before.
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {
+        $crate::broken_pipe::print_stdout(::std::format_args!($($arg)*))
+    };
 }
 
-/// The status a failed std print earns, when the failure is a closed pipe.
+/// `println!` for this crate; see [`print!`].
+#[macro_export]
+macro_rules! println {
+    () => {
+        $crate::broken_pipe::print_stdout(::std::format_args!("\n"))
+    };
+    ($($arg:tt)*) => {
+        $crate::broken_pipe::print_stdout(::std::format_args!(
+            "{}\n",
+            ::std::format_args!($($arg)*)
+        ))
+    };
+}
+
+/// `eprint!` for this crate; see [`print!`].
+#[macro_export]
+macro_rules! eprint {
+    ($($arg:tt)*) => {
+        $crate::broken_pipe::print_stderr(::std::format_args!($($arg)*))
+    };
+}
+
+/// `eprintln!` for this crate; see [`print!`].
+#[macro_export]
+macro_rules! eprintln {
+    () => {
+        $crate::broken_pipe::print_stderr(::std::format_args!("\n"))
+    };
+    ($($arg:tt)*) => {
+        $crate::broken_pipe::print_stderr(::std::format_args!(
+            "{}\n",
+            ::std::format_args!($($arg)*)
+        ))
+    };
+}
+
+/// Write one formatted print to stdout, tolerating a reader that has gone.
 ///
-/// std's `print_to` panics with `failed printing to {stream}: {error}` and
-/// nothing else carries the stream, so the message is the evidence. The error
-/// half is compared against what the OS itself says for a broken pipe, built
-/// here rather than written down, so the check holds on every platform and in
-/// every locale the process runs in. A print that failed for any other reason
-/// is still a panic.
-pub fn exit_status_for_print_failure(message: &str) -> Option<i32> {
-    let descriptions = broken_pipe_descriptions();
-    for (stream, status) in [("stdout", 0), ("stderr", CUT_OFF_STATUS)] {
-        let Some(error) = message.strip_prefix(&format!("failed printing to {stream}: ")) else {
-            continue;
-        };
-        if descriptions.iter().any(|description| description == error) {
-            return Some(status);
-        }
+/// Under this crate's own unit tests the write goes to std's macro instead, so
+/// libtest's per-test capture keeps working; the sink is exercised through the
+/// fake streams in this module's tests and through the real binary in
+/// `tests/cli_broken_pipe.rs` and `tests/commit_broken_pipe_exit.rs`. The
+/// switch is a runtime `cfg!` rather than a `#[cfg]` so both arms compile in
+/// every build and the test build carries no unreferenced sink.
+#[doc(hidden)]
+pub fn print_stdout(args: fmt::Arguments<'_>) {
+    if cfg!(test) {
+        std::print!("{args}");
+        return;
     }
-    None
+    write_through(
+        &STDOUT_GONE,
+        "stdout",
+        || io::stdout().lock(),
+        |out| out.write_fmt(args),
+        stdout_reader_gone,
+    );
 }
 
-fn broken_pipe_descriptions() -> Vec<String> {
-    BROKEN_PIPE_OS_ERRORS
-        .iter()
-        .map(|code| io::Error::from_raw_os_error(*code).to_string())
-        .collect()
+/// Write one formatted print to stderr, tolerating a reader that has gone.
+#[doc(hidden)]
+pub fn print_stderr(args: fmt::Arguments<'_>) {
+    if cfg!(test) {
+        std::eprint!("{args}");
+        return;
+    }
+    write_through(
+        &STDERR_GONE,
+        "stderr",
+        || io::stderr().lock(),
+        |err| err.write_fmt(args),
+        stderr_reader_gone,
+    );
 }
 
-/// The status an error that reached `main` earns when it is a closed pipe.
+/// Write a result that was rendered whole to stdout, tolerating a reader that
+/// has gone.
 ///
-/// `Some(0)` for an `io::Error` of kind `BrokenPipe` that is the error itself,
-/// under however many layers of context were added on the way up: that is
-/// what a write to stdout returns through `?`, and the CLI's stderr writes go
-/// through `eprint!`, which panics rather than returns. The error's source
-/// chain is deliberately not walked. A daemon request that failed carries an
-/// io error underneath its transport error, and a commit whose reply was lost
-/// must stay an error the caller can read, never a quiet success.
-pub fn broken_pipe_exit_status(error: &anyhow::Error) -> Option<i32> {
+/// For a command whose output is its work, such as `kin completions`: a reader
+/// that took one line of it and left has what it wanted, and the command ends
+/// as it would have had the reader stayed.
+pub fn write_stdout(bytes: &[u8]) {
+    write_through(
+        &STDOUT_GONE,
+        "stdout",
+        || io::stdout().lock(),
+        |out| out.write_all(bytes).and_then(|()| out.flush()),
+        stdout_reader_gone,
+    );
+}
+
+/// Perform one write to a stream this module guards.
+///
+/// The stream is skipped outright once its reader is known to be gone. The
+/// first write to meet a closed pipe marks it so and runs `on_gone` exactly
+/// once, and the caller carries on as if the write had landed. Any other
+/// failure is the panic std raises for a failed print, with std's own message,
+/// so nothing about a full disk or a bad descriptor changes here.
+///
+/// Generic over the writer, and handed the flag and the redirect as arguments,
+/// so the unit tests below drive every arm against a fake stream without
+/// touching the process's own.
+fn write_through<W: io::Write>(
+    gone: &AtomicBool,
+    label: &str,
+    open: impl FnOnce() -> W,
+    write: impl FnOnce(&mut W) -> io::Result<()>,
+    on_gone: impl FnOnce(),
+) {
+    if gone.load(Ordering::Acquire) {
+        return;
+    }
+    let mut writer = open();
+    match write(&mut writer) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {
+            if !gone.swap(true, Ordering::AcqRel) {
+                on_gone();
+            }
+        }
+        Err(error) => panic!("failed printing to {label}: {error}"),
+    }
+}
+
+/// What happens to stdout once its reader is known to be gone.
+fn stdout_reader_gone() {
+    #[cfg(unix)]
+    redirect_to_dev_null(libc::STDOUT_FILENO);
+}
+
+/// What happens to stderr once its reader is known to be gone.
+fn stderr_reader_gone() {
+    #[cfg(unix)]
+    redirect_to_dev_null(libc::STDERR_FILENO);
+}
+
+/// Point a standard stream whose reader has gone at `/dev/null`.
+///
+/// This module's own writes already stop at the flag. The redirect is for
+/// everything else that writes the same descriptor: a `println!` in a crate
+/// this one calls into, a library that writes its own diagnostics, and a child
+/// process that inherits the stream and would otherwise die of `SIGPIPE` or
+/// meet the same `EPIPE`. A failure leaves the descriptor as it was, which is
+/// no worse than before this ran.
+#[cfg(unix)]
+fn redirect_to_dev_null(fd: libc::c_int) {
+    // SAFETY: plain libc calls on descriptors this process owns. `open`
+    // returns a fresh descriptor or -1, `dup2` replaces one of the two
+    // standard descriptors with it, and the fresh one is closed again. The
+    // path is a NUL-terminated literal and no pointer outlives the call.
+    unsafe {
+        let null = libc::open(c"/dev/null".as_ptr(), libc::O_WRONLY);
+        if null < 0 {
+            return;
+        }
+        libc::dup2(null, fd);
+        libc::close(null);
+    }
+}
+
+/// The status `main` ends with when the command returned an error, and the
+/// report that goes with it.
+///
+/// An `io::Error` of kind `BrokenPipe` that is the error itself, under however
+/// many layers of context were added on the way up, is a write this module did
+/// not make meeting a reader that had gone. The command stopped at that write,
+/// so the status is [`CUT_OFF_STATUS`] and nothing is printed: the one stream
+/// that might still be open would only be told that the other one closed. The
+/// error's source chain is deliberately not walked. A daemon request that
+/// failed carries an io error underneath its transport error, and a commit
+/// whose reply was lost must stay an error the caller can read, never a cut
+/// reader.
+///
+/// Every other error is rendered the way std renders a `main` that returns
+/// `Err`, `Error: {err:?}`, through [`print_stderr`], so a refusal nobody
+/// reads any more still exits 1 rather than becoming a second broken-pipe
+/// panic.
+pub fn exit_status(error: &anyhow::Error) -> i32 {
+    if is_cut_off(error) {
+        return CUT_OFF_STATUS;
+    }
+    print_stderr(format_args!("Error: {error:?}\n"));
+    1
+}
+
+fn is_cut_off(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<io::Error>()
-        .filter(|error| error.kind() == io::ErrorKind::BrokenPipe)
-        .map(|_| 0)
-}
-
-/// Report the error a `main` is about to exit 1 on, the way std would have.
-///
-/// A `main` that returns `Err` prints `Error: {err:?}` through `eprintln!`, so
-/// a refusal whose stderr nobody reads any more was a second broken-pipe
-/// panic and exit 101 in place of exit 1. The rendering here is the same and
-/// the write's failure is dropped, so the exit status stays the refusal's own.
-pub fn report_error(error: &anyhow::Error) {
-    let _ = writeln!(io::stderr().lock(), "Error: {error:?}");
+        .is_some_and(|error| error.kind() == io::ErrorKind::BrokenPipe)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
 
-    /// Exactly what std's `print_to` formats for a broken pipe on this host.
-    fn print_failure(stream: &str) -> String {
-        format!(
-            "failed printing to {stream}: {}",
-            io::Error::from_raw_os_error(BROKEN_PIPE_OS_ERRORS[0])
-        )
+    /// A stream whose reader has gone: every write is `EPIPE`.
+    struct ClosedPipe;
+
+    impl io::Write for ClosedPipe {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
     }
 
-    #[test]
-    fn every_listed_os_error_decodes_to_a_broken_pipe() {
-        for code in BROKEN_PIPE_OS_ERRORS {
-            assert_eq!(
-                io::Error::from_raw_os_error(*code).kind(),
-                io::ErrorKind::BrokenPipe,
-                "os error {code}"
-            );
+    /// A stream that fails for a reason that is not the reader leaving.
+    struct FullDisk;
+
+    impl io::Write for FullDisk {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("the disk is full"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
         }
     }
 
     #[test]
-    fn a_print_into_a_closed_stdout_is_a_clean_exit() {
-        assert_eq!(
-            exit_status_for_print_failure(&print_failure("stdout")),
-            Some(0)
+    fn the_first_write_into_a_closed_pipe_marks_the_stream_gone_and_redirects_once() {
+        let gone = AtomicBool::new(false);
+        let redirects = Cell::new(0);
+        let opened = Cell::new(0);
+        let open = || {
+            opened.set(opened.get() + 1);
+            ClosedPipe
+        };
+
+        write_through(
+            &gone,
+            "stdout",
+            open,
+            |out| out.write_all(b"first"),
+            || redirects.set(redirects.get() + 1),
         );
+        assert!(
+            gone.load(Ordering::Acquire),
+            "the write that met the closed pipe must mark the stream gone"
+        );
+        assert_eq!(redirects.get(), 1, "the redirect runs on that first write");
+        assert_eq!(opened.get(), 1);
+
+        // The reader is known to be gone, so the stream is not even opened.
+        write_through(
+            &gone,
+            "stdout",
+            open,
+            |out| out.write_all(b"second"),
+            || redirects.set(redirects.get() + 1),
+        );
+        assert_eq!(opened.get(), 1, "a later write skips the stream entirely");
+        assert_eq!(redirects.get(), 1, "and the redirect runs once per stream");
     }
 
     #[test]
-    fn a_print_into_a_closed_stderr_is_the_cut_off_status() {
-        assert_eq!(
-            exit_status_for_print_failure(&print_failure("stderr")),
-            Some(CUT_OFF_STATUS)
+    fn a_write_that_landed_leaves_the_stream_in_use() {
+        let gone = AtomicBool::new(false);
+        let mut sink = Vec::new();
+        let redirected = Cell::new(false);
+        write_through(
+            &gone,
+            "stdout",
+            || &mut sink,
+            |out| out.write_all(b"the result\n"),
+            || redirected.set(true),
         );
+        assert_eq!(sink, b"the result\n");
+        assert!(!gone.load(Ordering::Acquire));
+        assert!(!redirected.get());
     }
 
     #[test]
-    fn a_print_that_failed_for_any_other_reason_stays_a_panic() {
-        // Code 2 is ENOENT on Unix and ERROR_FILE_NOT_FOUND on Windows, so this
-        // is a real OS message on both and a broken pipe on neither.
-        let other = format!(
-            "failed printing to stdout: {}",
-            io::Error::from_raw_os_error(2)
+    fn a_write_that_failed_for_any_other_reason_is_still_a_panic() {
+        let gone = AtomicBool::new(false);
+        let redirected = Cell::new(false);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            write_through(
+                &gone,
+                "stdout",
+                || FullDisk,
+                |out| out.write_all(b"the result\n"),
+                || redirected.set(true),
+            );
+        }));
+        let payload = outcome.expect_err("a full disk is still a failed print");
+        let message = payload
+            .downcast_ref::<String>()
+            .expect("the panic carries std's own message");
+        assert_eq!(message, "failed printing to stdout: the disk is full");
+        assert!(
+            !gone.load(Ordering::Acquire),
+            "only a closed pipe marks a stream gone"
         );
-        assert_eq!(exit_status_for_print_failure(&other), None);
-        // The kind's own description, which std never prints for a stdout
-        // write, is not accepted in place of the OS message.
-        assert_eq!(
-            exit_status_for_print_failure("failed printing to stdout: broken pipe"),
-            None
-        );
-        assert_eq!(
-            exit_status_for_print_failure("index out of bounds: the len is 1 but the index is 1"),
-            None
-        );
-        // A library's own write panic carries the stream nowhere and is not
-        // read as one either; the completions arm renders into memory for
-        // exactly this reason.
-        let foreign = format!(
-            "failed to write completion file: {:?}",
-            io::Error::from_raw_os_error(BROKEN_PIPE_OS_ERRORS[0])
-        );
-        assert_eq!(exit_status_for_print_failure(&foreign), None);
+        assert!(!redirected.get());
     }
 
     #[test]
-    fn a_broken_pipe_that_reached_main_as_itself_is_a_clean_exit() {
+    fn a_broken_pipe_that_reached_main_as_itself_is_cut_off_not_a_success() {
         let bare: anyhow::Error = io::Error::from(io::ErrorKind::BrokenPipe).into();
-        assert_eq!(broken_pipe_exit_status(&bare), Some(0));
+        assert_eq!(exit_status(&bare), CUT_OFF_STATUS);
         let wrapped = anyhow::Error::from(io::Error::from(io::ErrorKind::BrokenPipe))
             .context("write the change log")
             .context("kin log");
-        assert_eq!(broken_pipe_exit_status(&wrapped), Some(0));
+        assert_eq!(exit_status(&wrapped), CUT_OFF_STATUS);
         let other: anyhow::Error = io::Error::from(io::ErrorKind::NotFound).into();
-        assert_eq!(broken_pipe_exit_status(&other), None);
+        assert_eq!(exit_status(&other), 1);
     }
 
     /// A transport error shaped like reqwest's: its own message, with the io
@@ -229,9 +425,9 @@ mod tests {
             source: io::Error::from(io::ErrorKind::BrokenPipe),
         })
         .context("send daemon-owned native commit request");
-        assert_eq!(broken_pipe_exit_status(&error), None);
+        assert_eq!(exit_status(&error), 1);
         // The control: the chain does carry the broken pipe, so a walk down
-        // it would have answered 0, and this test would then be passing on
+        // it would have answered 141, and this test would then be passing on
         // an error that never had one.
         assert!(error.chain().any(|cause| cause
             .downcast_ref::<io::Error>()

--- a/crates/kin-cli/src/broken_pipe.rs
+++ b/crates/kin-cli/src/broken_pipe.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! How the CLI ends when the process reading its output has gone away.
+//!
+//! Rust starts every binary with `SIGPIPE` ignored, so a write into a pipe
+//! whose reader has closed comes back as `EPIPE` instead of ending the process,
+//! and the `print!` family turns that error into a panic. `kin diff HEAD
+//! WORKSPACE | head -5` therefore ended in `thread 'main' panicked at ...
+//! failed printing to stdout: Broken pipe` and exit 101 on every command that
+//! writes more than its reader takes, and a `kin commit ... 2>&1 | head -3`
+//! whose change was already in authority died the same way while printing the
+//! summary, so the caller read a landed commit as a failure (FIR-2846,
+//! FIR-3039). Measured on 489138ec with the reader gone before the first
+//! write: eleven of twelve commands exited 101, and only `--help` survived,
+//! because clap discards its write errors.
+//!
+//! The CLI has over a thousand print sites, so this is handled once, at the
+//! two places a failed write can leave the process: the panic hook, for the
+//! `print!` family, and the top of `main`, for an `io::Error` that came back
+//! through `?`. This module decides; `main.rs`, the process boundary, holds
+//! the hook and performs the exits.
+//!
+//! Which stream broke decides the status. stdout carries a command's result
+//! and is written once the work is done, so a reader that stopped taking it
+//! has everything it wanted and the command exits 0. stderr carries progress
+//! and warnings while the work is still running, so a reader gone there cut
+//! the command off before its result, and the exit says so with the status a
+//! shell reports for a process `SIGPIPE` ended. `kin commit 2>&1 | head -3`
+//! shows why the two must differ. On a cold daemon, head closes after the
+//! startup lines and the next progress write fails before the commit request
+//! is sent, so nothing was recorded; on a warm daemon the same pipeline fails
+//! on the summary line, after the change is in authority. Both exited 101
+//! before. Now the first exits 141 and the second exits 0, and a caller keying
+//! on the code reads each one right.
+//!
+//! Resetting `SIGPIPE` to its default disposition would have been one line and
+//! was rejected. The daemon transport is a socket, std sets `SO_NOSIGPIPE`
+//! only on Apple platforms and never sends with `MSG_NOSIGNAL`, so on Linux a
+//! write to a daemon that has since gone away would kill this process silently
+//! instead of returning the error `kin commit` reads to find out whether its
+//! change landed anyway.
+
+use std::io::{self, Write as _};
+
+/// The status a shell reports for a process that `SIGPIPE` ended, 128 + 13,
+/// and the status this process would have had under the default disposition.
+/// Scripts already read it as "the reader closed early" rather than "the
+/// command failed", which is exactly the news.
+pub const CUT_OFF_STATUS: i32 = 141;
+
+#[cfg(unix)]
+const BROKEN_PIPE_OS_ERRORS: &[i32] = &[libc::EPIPE];
+/// `ERROR_BROKEN_PIPE` and `ERROR_NO_DATA`: the two codes a write into a pipe
+/// the other side has closed comes back with, and the two std decodes to
+/// `ErrorKind::BrokenPipe`.
+#[cfg(windows)]
+const BROKEN_PIPE_OS_ERRORS: &[i32] = &[109, 232];
+
+/// The status a panic earns when it is a std print into a closed pipe, for
+/// the hook `main` installs; `None` for every other panic, which the hook
+/// hands on to the one that was installed before it, so a real panic still
+/// prints its message and still exits 101.
+pub fn exit_status_for_panic(info: &std::panic::PanicHookInfo<'_>) -> Option<i32> {
+    let payload = info.payload();
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())?;
+    exit_status_for_print_failure(message)
+}
+
+/// The status a failed std print earns, when the failure is a closed pipe.
+///
+/// std's `print_to` panics with `failed printing to {stream}: {error}` and
+/// nothing else carries the stream, so the message is the evidence. The error
+/// half is compared against what the OS itself says for a broken pipe, built
+/// here rather than written down, so the check holds on every platform and in
+/// every locale the process runs in. A print that failed for any other reason
+/// is still a panic.
+pub fn exit_status_for_print_failure(message: &str) -> Option<i32> {
+    let descriptions = broken_pipe_descriptions();
+    for (stream, status) in [("stdout", 0), ("stderr", CUT_OFF_STATUS)] {
+        let Some(error) = message.strip_prefix(&format!("failed printing to {stream}: ")) else {
+            continue;
+        };
+        if descriptions.iter().any(|description| description == error) {
+            return Some(status);
+        }
+    }
+    None
+}
+
+fn broken_pipe_descriptions() -> Vec<String> {
+    BROKEN_PIPE_OS_ERRORS
+        .iter()
+        .map(|code| io::Error::from_raw_os_error(*code).to_string())
+        .collect()
+}
+
+/// The status an error that reached `main` earns when it is a closed pipe.
+///
+/// `Some(0)` for an `io::Error` of kind `BrokenPipe` that is the error itself,
+/// under however many layers of context were added on the way up: that is
+/// what a write to stdout returns through `?`, and the CLI's stderr writes go
+/// through `eprint!`, which panics rather than returns. The error's source
+/// chain is deliberately not walked. A daemon request that failed carries an
+/// io error underneath its transport error, and a commit whose reply was lost
+/// must stay an error the caller can read, never a quiet success.
+pub fn broken_pipe_exit_status(error: &anyhow::Error) -> Option<i32> {
+    error
+        .downcast_ref::<io::Error>()
+        .filter(|error| error.kind() == io::ErrorKind::BrokenPipe)
+        .map(|_| 0)
+}
+
+/// Report the error a `main` is about to exit 1 on, the way std would have.
+///
+/// A `main` that returns `Err` prints `Error: {err:?}` through `eprintln!`, so
+/// a refusal whose stderr nobody reads any more was a second broken-pipe
+/// panic and exit 101 in place of exit 1. The rendering here is the same and
+/// the write's failure is dropped, so the exit status stays the refusal's own.
+pub fn report_error(error: &anyhow::Error) {
+    let _ = writeln!(io::stderr().lock(), "Error: {error:?}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exactly what std's `print_to` formats for a broken pipe on this host.
+    fn print_failure(stream: &str) -> String {
+        format!(
+            "failed printing to {stream}: {}",
+            io::Error::from_raw_os_error(BROKEN_PIPE_OS_ERRORS[0])
+        )
+    }
+
+    #[test]
+    fn every_listed_os_error_decodes_to_a_broken_pipe() {
+        for code in BROKEN_PIPE_OS_ERRORS {
+            assert_eq!(
+                io::Error::from_raw_os_error(*code).kind(),
+                io::ErrorKind::BrokenPipe,
+                "os error {code}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_print_into_a_closed_stdout_is_a_clean_exit() {
+        assert_eq!(
+            exit_status_for_print_failure(&print_failure("stdout")),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn a_print_into_a_closed_stderr_is_the_cut_off_status() {
+        assert_eq!(
+            exit_status_for_print_failure(&print_failure("stderr")),
+            Some(CUT_OFF_STATUS)
+        );
+    }
+
+    #[test]
+    fn a_print_that_failed_for_any_other_reason_stays_a_panic() {
+        // Code 2 is ENOENT on Unix and ERROR_FILE_NOT_FOUND on Windows, so this
+        // is a real OS message on both and a broken pipe on neither.
+        let other = format!(
+            "failed printing to stdout: {}",
+            io::Error::from_raw_os_error(2)
+        );
+        assert_eq!(exit_status_for_print_failure(&other), None);
+        // The kind's own description, which std never prints for a stdout
+        // write, is not accepted in place of the OS message.
+        assert_eq!(
+            exit_status_for_print_failure("failed printing to stdout: broken pipe"),
+            None
+        );
+        assert_eq!(
+            exit_status_for_print_failure("index out of bounds: the len is 1 but the index is 1"),
+            None
+        );
+        // A library's own write panic carries the stream nowhere and is not
+        // read as one either; the completions arm renders into memory for
+        // exactly this reason.
+        let foreign = format!(
+            "failed to write completion file: {:?}",
+            io::Error::from_raw_os_error(BROKEN_PIPE_OS_ERRORS[0])
+        );
+        assert_eq!(exit_status_for_print_failure(&foreign), None);
+    }
+
+    #[test]
+    fn a_broken_pipe_that_reached_main_as_itself_is_a_clean_exit() {
+        let bare: anyhow::Error = io::Error::from(io::ErrorKind::BrokenPipe).into();
+        assert_eq!(broken_pipe_exit_status(&bare), Some(0));
+        let wrapped = anyhow::Error::from(io::Error::from(io::ErrorKind::BrokenPipe))
+            .context("write the change log")
+            .context("kin log");
+        assert_eq!(broken_pipe_exit_status(&wrapped), Some(0));
+        let other: anyhow::Error = io::Error::from(io::ErrorKind::NotFound).into();
+        assert_eq!(broken_pipe_exit_status(&other), None);
+    }
+
+    /// A transport error shaped like reqwest's: its own message, with the io
+    /// error underneath as the source.
+    #[derive(Debug)]
+    struct Transport {
+        source: io::Error,
+    }
+
+    impl std::fmt::Display for Transport {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("error sending request")
+        }
+    }
+
+    impl std::error::Error for Transport {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.source)
+        }
+    }
+
+    #[test]
+    fn a_transport_error_carrying_a_broken_pipe_underneath_stays_an_error() {
+        let error = anyhow::Error::new(Transport {
+            source: io::Error::from(io::ErrorKind::BrokenPipe),
+        })
+        .context("send daemon-owned native commit request");
+        assert_eq!(broken_pipe_exit_status(&error), None);
+        // The control: the chain does carry the broken pipe, so a walk down
+        // it would have answered 0, and this test would then be passing on
+        // an error that never had one.
+        assert!(error.chain().any(|cause| cause
+            .downcast_ref::<io::Error>()
+            .is_some_and(|cause| cause.kind() == io::ErrorKind::BrokenPipe)));
+    }
+}

--- a/crates/kin-cli/src/lib.rs
+++ b/crates/kin-cli/src/lib.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-pub mod backend;
+// Declared first, out of alphabetical order, on purpose: `#[macro_use]` puts
+// this crate's own `print!` family in textual scope for every module declared
+// after it, and a module declared before it would reach std's macros, which
+// panic when the process reading the output has gone away.
+#[macro_use]
 pub mod broken_pipe;
+pub mod backend;
 pub mod capability;
 pub mod commands;
 pub mod daemon_client;

--- a/crates/kin-cli/src/lib.rs
+++ b/crates/kin-cli/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 pub mod backend;
+pub mod broken_pipe;
 pub mod capability;
 pub mod commands;
 pub mod daemon_client;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{self, Shell};
 use kin_cli::commands;
+use kin_cli::{eprintln, println};
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use tracing::Instrument;
@@ -2590,34 +2591,23 @@ fn parse_cli_or_report_retired_command() -> Cli {
     }
 }
 
-/// The process entry. The closed-pipe exit is installed before anything can
-/// print, and the outcome of [`run`] becomes an exit status in one place, so a
-/// refusal is reported the same way whether or not anyone still reads stderr.
-/// `kin_cli::broken_pipe` decides every status here; this is the process
-/// boundary, so it is where the exits happen.
+/// The process entry. The outcome of [`run`] becomes an exit status in one
+/// place, so a refusal is reported the same way whether or not anyone still
+/// reads stderr, and the `println!` and `eprintln!` this file imports from
+/// `kin_cli` are the ones that tolerate a reader going away, so nothing here
+/// ends early because a pipe closed. Two cases, told apart by the status. A
+/// command that ran to its end exits 0, or its own error status, whatever
+/// happened to its streams on the way, because its work is done and the
+/// status reports the work. A command that stopped at a write outside those
+/// macros, an `io::Error` of kind `BrokenPipe` that came back through `?`,
+/// exits 141: its work after that write never ran, and 141 is a status nobody
+/// can read as success of work that never happened. `kin_cli::broken_pipe`
+/// decides the status; this is the process boundary, so it is where the exit
+/// happens.
 fn main() {
-    install_exit_on_broken_pipe();
     if let Err(error) = run() {
-        let status = kin_cli::broken_pipe::broken_pipe_exit_status(&error).unwrap_or_else(|| {
-            kin_cli::broken_pipe::report_error(&error);
-            1
-        });
-        std::process::exit(status);
+        std::process::exit(kin_cli::broken_pipe::exit_status(&error));
     }
-}
-
-/// Install the hook that turns a print into a closed pipe into an exit.
-///
-/// Every other panic reaches the hook that was installed before this one, so
-/// a real panic still prints its message and still exits 101.
-fn install_exit_on_broken_pipe() {
-    let previous = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        if let Some(status) = kin_cli::broken_pipe::exit_status_for_panic(info) {
-            std::process::exit(status);
-        }
-        previous(info);
-    }));
 }
 
 fn run() -> Result<()> {
@@ -3756,15 +3746,13 @@ fn run() -> Result<()> {
                     // Rendered into memory and written from here. clap_complete
                     // writes straight into the sink it is handed and turns a
                     // failed write into a panic of its own, `failed to write
-                    // completion file`, which names no stream and so cannot be
-                    // read as a closed pipe by the exit hook. The write below
-                    // is the one that meets the pipe, and its error comes back
-                    // as the io error the top of `main` ends on.
+                    // completion file`, so the write that can meet a closed
+                    // pipe has to be one this crate makes: a reader that takes
+                    // one line of the script and leaves gets the same clean
+                    // exit as one that takes it all.
                     let mut script = Vec::new();
                     clap_complete::generate(shell, &mut Cli::command(), "kin", &mut script);
-                    let mut stdout = std::io::stdout().lock();
-                    std::io::Write::write_all(&mut stdout, &script)?;
-                    std::io::Write::flush(&mut stdout)?;
+                    kin_cli::broken_pipe::write_stdout(&script);
                     Ok(())
                 }
                 Command::Update {

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2590,7 +2590,37 @@ fn parse_cli_or_report_retired_command() -> Cli {
     }
 }
 
-fn main() -> Result<()> {
+/// The process entry. The closed-pipe exit is installed before anything can
+/// print, and the outcome of [`run`] becomes an exit status in one place, so a
+/// refusal is reported the same way whether or not anyone still reads stderr.
+/// `kin_cli::broken_pipe` decides every status here; this is the process
+/// boundary, so it is where the exits happen.
+fn main() {
+    install_exit_on_broken_pipe();
+    if let Err(error) = run() {
+        let status = kin_cli::broken_pipe::broken_pipe_exit_status(&error).unwrap_or_else(|| {
+            kin_cli::broken_pipe::report_error(&error);
+            1
+        });
+        std::process::exit(status);
+    }
+}
+
+/// Install the hook that turns a print into a closed pipe into an exit.
+///
+/// Every other panic reaches the hook that was installed before this one, so
+/// a real panic still prints its message and still exits 101.
+fn install_exit_on_broken_pipe() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if let Some(status) = kin_cli::broken_pipe::exit_status_for_panic(info) {
+            std::process::exit(status);
+        }
+        previous(info);
+    }));
+}
+
+fn run() -> Result<()> {
     // Select this process's resource profile before anything reads it: the GPU
     // kernel plan and the Metal submission depth are each resolved once per
     // process, and mutating the environment is only safe while the process is
@@ -3723,12 +3753,18 @@ fn main() -> Result<()> {
                     }
                 }
                 Command::Completions { shell } => {
-                    clap_complete::generate(
-                        shell,
-                        &mut Cli::command(),
-                        "kin",
-                        &mut std::io::stdout(),
-                    );
+                    // Rendered into memory and written from here. clap_complete
+                    // writes straight into the sink it is handed and turns a
+                    // failed write into a panic of its own, `failed to write
+                    // completion file`, which names no stream and so cannot be
+                    // read as a closed pipe by the exit hook. The write below
+                    // is the one that meets the pipe, and its error comes back
+                    // as the io error the top of `main` ends on.
+                    let mut script = Vec::new();
+                    clap_complete::generate(shell, &mut Cli::command(), "kin", &mut script);
+                    let mut stdout = std::io::stdout().lock();
+                    std::io::Write::write_all(&mut stdout, &script)?;
+                    std::io::Write::flush(&mut stdout)?;
                     Ok(())
                 }
                 Command::Update {

--- a/crates/kin-cli/tests/cli_broken_pipe.rs
+++ b/crates/kin-cli/tests/cli_broken_pipe.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What `kin` does when the process reading its output has gone, through the
+//! real binary.
+//!
+//! `kin diff HEAD WORKSPACE | head -5` on a release candidate ended in
+//! `thread 'main' panicked at ... failed printing to stdout: Broken pipe (os
+//! error 32)` and exit 101, while the same command into a file exited 0 with
+//! all 135 lines, so the output was right and only the exit was wrong. The
+//! panic is std's, the CLI has over a thousand print sites, and the fix lives
+//! at the process boundary, so these drive the binary itself through a pipe
+//! whose reader is gone: once with no store at all, for the two exit paths the
+//! boundary handles, and once against a daemon for the commands the report
+//! named. Every pipe arm has the file arm beside it as the control that the
+//! output still flows when the reader stays.
+
+use serde_json::Value;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{ExitStatus, Output, Stdio};
+use tempfile::tempdir;
+
+mod common;
+
+use common::{Command, IsolatedDaemonRuntime};
+
+fn run_git(repo: &Path, args: &[&str]) -> Output {
+    Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(repo)
+        .output()
+        .expect("run git")
+}
+
+fn require_git(repo: &Path, args: &[&str]) {
+    let output = run_git(repo, args);
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn kin<'runtime>(
+    runtime: &'runtime IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> Command<'runtime> {
+    let mut command = runtime.kin_command();
+    command
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        // The pipe is the subject; the daemon these start must not touch the
+        // one GPU on a shared host to embed a two-function fixture.
+        .env("KIN_EMBED_BACKEND", "cpu")
+        .current_dir(repo);
+    command
+}
+
+/// The file arm: the same command with its output kept, which is the control
+/// that a fix did not simply stop the command from printing.
+fn run_into_files(runtime: &IsolatedDaemonRuntime, repo: &Path, args: &[&str]) -> Output {
+    kin(runtime, repo, args).output().expect("run kin")
+}
+
+/// Run `kin` with stdout on a pipe whose reader is already gone, so the first
+/// write into it fails, and report the exit status with what stderr said.
+///
+/// The reader is dropped BEFORE the spawn, so there is no window in which the
+/// child could write successfully and the arm could pass on timing alone.
+fn run_with_reader_gone(
+    runtime: &IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+    stderr_path: &Path,
+) -> (ExitStatus, String) {
+    let (reader, writer) = std::io::pipe().expect("create a pipe");
+    drop(reader);
+    let stderr = fs::File::create(stderr_path).expect("create the stderr capture");
+    let mut child = kin(runtime, repo, args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::from(stderr))
+        .spawn_owned()
+        .expect("spawn kin");
+    let status = child.wait().expect("wait for kin");
+    (status, fs::read_to_string(stderr_path).unwrap_or_default())
+}
+
+fn assert_clean_exit(args: &[&str], status: ExitStatus, stderr: &str) {
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "kin {args:?} into a closed pipe must exit 0, not {status:?}: stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "kin {args:?} into a closed pipe must not panic: stderr={stderr}"
+    );
+}
+
+fn assert_full_output(args: &[&str], output: &Output) {
+    assert!(
+        output.status.success(),
+        "kin {args:?} into a file must still succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !output.stdout.is_empty(),
+        "kin {args:?} into a file must still print its result: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// The `print!` path: a reader gone before the first line.
+///
+/// `kin capabilities` needs no store and prints its matrix line by line
+/// through `println!`, so its first write is the one that meets the closed
+/// pipe and std's print panic is the thing under test.
+///
+/// Falsify by removing `install_exit_hook()` from `main`: the pipe arm then
+/// exits 101 with `panicked at` on stderr, and the file arm stays green.
+#[test]
+fn a_print_into_a_pipe_nobody_reads_exits_zero_without_a_panic() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("anywhere");
+    fs::create_dir_all(&repo).expect("create a working directory");
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let args = ["capabilities"];
+
+    let (status, stderr) =
+        run_with_reader_gone(&runtime, &repo, &args, &root.path().join("pipe.stderr"));
+    assert_clean_exit(&args, status, &stderr);
+
+    assert_full_output(&args, &run_into_files(&runtime, &repo, &args));
+}
+
+/// The `?` path: a reader that takes one line of a script larger than the pipe
+/// can hold, which is `| head -1` exactly.
+///
+/// `kin completions zsh` is thousands of lines, so once the reader has its
+/// line and leaves, the child is blocked in a write the kernel then fails.
+/// The completion script is written through `io::Write`, whose error comes
+/// back through `?` to the top of `main`, so this is the other exit path.
+///
+/// Falsify by handing `clap_complete::generate` stdout directly again: its own
+/// `failed to write completion file` panic names no stream, the hook lets it
+/// through, and the arm reads 101. Or by returning the error from `main`
+/// instead of ending on it: the arm then reads exit 1 and an `Error:` line.
+#[test]
+fn a_reader_that_leaves_after_one_line_of_completions_gets_a_clean_exit() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("anywhere");
+    fs::create_dir_all(&repo).expect("create a working directory");
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let args = ["completions", "zsh"];
+
+    let (reader, writer) = std::io::pipe().expect("create a pipe");
+    let stderr_path = root.path().join("completions.stderr");
+    let stderr = fs::File::create(&stderr_path).expect("create the stderr capture");
+    let mut child = kin(&runtime, &repo, &args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::from(stderr))
+        .spawn_owned()
+        .expect("spawn kin");
+    let mut lines = BufReader::new(reader);
+    let mut first = String::new();
+    lines
+        .read_line(&mut first)
+        .expect("read the first line of the script");
+    assert!(
+        first.starts_with("#compdef"),
+        "the first line is the script's own header: {first:?}"
+    );
+    drop(lines);
+    let status = child.wait().expect("wait for kin");
+    let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();
+    assert_clean_exit(&args, status, &stderr);
+
+    let output = run_into_files(&runtime, &repo, &args);
+    assert_full_output(&args, &output);
+    assert!(
+        output.stdout.len() > 64 * 1024,
+        "the script must be larger than a pipe buffer for the pipe arm to mean anything: {} bytes",
+        output.stdout.len()
+    );
+}
+
+fn initialize(runtime: &IsolatedDaemonRuntime, repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    require_git(repo, &["init", "--initial-branch=main"]);
+    require_git(repo, &["config", "commit.gpgsign", "false"]);
+    require_git(repo, &["config", "user.name", "Ada Lovelace"]);
+    require_git(repo, &["config", "user.email", "ada@example.com"]);
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    fs::write(
+        repo.join("src/lib.rs"),
+        b"pub fn shipped() -> u8 { 1 }\n\npub fn shipped_twice() -> u8 { shipped() + shipped() }\n",
+    )
+    .expect("write source");
+    require_git(repo, &["add", "--all"]);
+    require_git(repo, &["commit", "-m", "first commit"]);
+
+    let init = run_into_files(runtime, repo, &["init", ".", "--json"]);
+    assert!(
+        init.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let report: Value = serde_json::from_slice(&init.stdout).expect("kin init reports JSON");
+    assert!(
+        report.get("schema").is_some(),
+        "init must report its schema: {report}"
+    );
+}
+
+/// The commands the report named, each through a pipe whose reader is gone
+/// and each into a file beside it.
+///
+/// One store and one daemon for all of them, because the pipe is the subject
+/// and the store is only there so every command has something to print.
+///
+/// Falsify by removing `install_exit_hook()` from `main`: every pipe arm then
+/// reads 101, and every file arm stays green.
+#[test]
+fn every_repository_command_survives_a_reader_that_is_gone() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+    // A workspace edit that is not yet committed, so `diff HEAD WORKSPACE` has
+    // artifact and semantic changes to print.
+    fs::write(repo.join("src/added.rs"), b"pub fn added() -> u8 { 3 }\n").expect("add source");
+
+    let commands: [&[&str]; 6] = [
+        &["diff", "HEAD", "WORKSPACE"],
+        &["log", "--count", "50"],
+        &["history", "shipped"],
+        &["status"],
+        &["conflicts"],
+        &["search", "shipped"],
+    ];
+    for (index, args) in commands.iter().enumerate() {
+        let stderr_path = root.path().join(format!("pipe-{index}.stderr"));
+        let (status, stderr) = run_with_reader_gone(&runtime, &repo, args, &stderr_path);
+        assert_clean_exit(args, status, &stderr);
+        assert_full_output(args, &run_into_files(&runtime, &repo, args));
+    }
+}

--- a/crates/kin-cli/tests/cli_broken_pipe.rs
+++ b/crates/kin-cli/tests/cli_broken_pipe.rs
@@ -8,12 +8,13 @@
 //! `thread 'main' panicked at ... failed printing to stdout: Broken pipe (os
 //! error 32)` and exit 101, while the same command into a file exited 0 with
 //! all 135 lines, so the output was right and only the exit was wrong. The
-//! panic is std's, the CLI has over a thousand print sites, and the fix lives
-//! at the process boundary, so these drive the binary itself through a pipe
-//! whose reader is gone: once with no store at all, for the two exit paths the
-//! boundary handles, and once against a daemon for the commands the report
-//! named. Every pipe arm has the file arm beside it as the control that the
-//! output still flows when the reader stays.
+//! panic is std's, the CLI has over a thousand print sites, and the fix is the
+//! crate's own `print!` family, which marks a stream gone on its first
+//! closed-pipe write and skips it after, so these drive the binary itself
+//! through a pipe whose reader is gone: once with no store at all, for the
+//! print path and for a result written whole, and once against a daemon for
+//! the commands the report named. Every pipe arm has the file arm beside it as
+//! the control that the output still flows when the reader stays.
 
 use serde_json::Value;
 use std::fs;
@@ -127,8 +128,9 @@ fn assert_full_output(args: &[&str], output: &Output) {
 /// through `println!`, so its first write is the one that meets the closed
 /// pipe and std's print panic is the thing under test.
 ///
-/// Falsify by removing `install_exit_hook()` from `main`: the pipe arm then
-/// exits 101 with `panicked at` on stderr, and the file arm stays green.
+/// Falsify by making the sink raise std's own panic on a closed pipe instead
+/// of marking the stream gone: the pipe arm then exits 101 with `panicked at`
+/// on stderr, and the file arm stays green.
 #[test]
 fn a_print_into_a_pipe_nobody_reads_exits_zero_without_a_panic() {
     let root = tempdir().expect("temp root");
@@ -144,18 +146,18 @@ fn a_print_into_a_pipe_nobody_reads_exits_zero_without_a_panic() {
     assert_full_output(&args, &run_into_files(&runtime, &repo, &args));
 }
 
-/// The `?` path: a reader that takes one line of a script larger than the pipe
-/// can hold, which is `| head -1` exactly.
+/// A result written whole: a reader that takes one line of a script larger
+/// than the pipe can hold, which is `| head -1` exactly.
 ///
 /// `kin completions zsh` is thousands of lines, so once the reader has its
 /// line and leaves, the child is blocked in a write the kernel then fails.
-/// The completion script is written through `io::Write`, whose error comes
-/// back through `?` to the top of `main`, so this is the other exit path.
+/// The script is rendered into memory and written through the crate's own
+/// tolerant write rather than by clap_complete, so this is the path a whole
+/// result takes.
 ///
 /// Falsify by handing `clap_complete::generate` stdout directly again: its own
-/// `failed to write completion file` panic names no stream, the hook lets it
-/// through, and the arm reads 101. Or by returning the error from `main`
-/// instead of ending on it: the arm then reads exit 1 and an `Error:` line.
+/// `failed to write completion file` panic is a panic like any other, and the
+/// arm reads 101.
 #[test]
 fn a_reader_that_leaves_after_one_line_of_completions_gets_a_clean_exit() {
     let root = tempdir().expect("temp root");
@@ -231,8 +233,8 @@ fn initialize(runtime: &IsolatedDaemonRuntime, repo: &Path) {
 /// One store and one daemon for all of them, because the pipe is the subject
 /// and the store is only there so every command has something to print.
 ///
-/// Falsify by removing `install_exit_hook()` from `main`: every pipe arm then
-/// reads 101, and every file arm stays green.
+/// Falsify by making the sink raise std's own panic on a closed pipe: every
+/// pipe arm then reads 101, and every file arm stays green.
 #[test]
 fn every_repository_command_survives_a_reader_that_is_gone() {
     let root = tempdir().expect("temp root");

--- a/crates/kin-cli/tests/commit_broken_pipe_exit.rs
+++ b/crates/kin-cli/tests/commit_broken_pipe_exit.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The exit status of `kin commit` when the process reading it has gone,
+//! through the real binaries.
+//!
+//! A stranger recovering from a wedged daemon ran `kin daemon stop` and then
+//! the commit again as `kin commit -m ... 2>&1 | head -3`, and read `EXIT=101`
+//! from a commit that had recorded its change: `head` closed the pipe after
+//! three warnings, the summary `println!` met a closed pipe, and a failed
+//! print is a panic. The retry was refused with `nothing to commit`, which is
+//! how they learned the first one had worked; a caller keying on the exit
+//! code would have retried or rolled back instead.
+//!
+//! Three arms, each driving `kin` and `kin-daemon`. The change lands and the
+//! reader is gone by the summary: exit 0 and the change in `kin log`. The
+//! commit is refused and nobody reads either stream: exit 1, not 0 and not
+//! 101, because a refusal is the caller's news whether or not it was
+//! delivered. The reader leaves while the daemon is still starting: the commit
+//! never reached authority, nothing is recorded, and the exit is 141 rather
+//! than a 0 that would claim a change that does not exist.
+
+use serde_json::Value;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{ExitStatus, Output, Stdio};
+use tempfile::tempdir;
+
+mod common;
+
+use common::{Command, IsolatedDaemonRuntime};
+
+fn run_git(repo: &Path, args: &[&str]) -> Output {
+    Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(repo)
+        .output()
+        .expect("run git")
+}
+
+fn require_git(repo: &Path, args: &[&str]) {
+    let output = run_git(repo, args);
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn kin<'runtime>(
+    runtime: &'runtime IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> Command<'runtime> {
+    let mut command = runtime.kin_command();
+    command
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        // The pipe is the subject; the daemon these start must not touch the
+        // one GPU on a shared host to embed a two-function fixture.
+        .env("KIN_EMBED_BACKEND", "cpu")
+        .current_dir(repo);
+    command
+}
+
+fn run_kin(runtime: &IsolatedDaemonRuntime, repo: &Path, args: &[&str]) -> Output {
+    kin(runtime, repo, args).output().expect("run kin")
+}
+
+fn require_kin(runtime: &IsolatedDaemonRuntime, repo: &Path, args: &[&str]) -> Output {
+    let output = run_kin(runtime, repo, args);
+    assert!(
+        output.status.success(),
+        "kin {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn initialize(runtime: &IsolatedDaemonRuntime, repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    require_git(repo, &["init", "--initial-branch=main"]);
+    require_git(repo, &["config", "commit.gpgsign", "false"]);
+    require_git(repo, &["config", "user.name", "Ada Lovelace"]);
+    require_git(repo, &["config", "user.email", "ada@example.com"]);
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    fs::write(repo.join("src/lib.rs"), b"pub fn shipped() -> u8 { 1 }\n").expect("write source");
+    require_git(repo, &["add", "--all"]);
+    require_git(repo, &["commit", "-m", "first commit"]);
+
+    let init = run_kin(runtime, repo, &["init", ".", "--json"]);
+    assert!(
+        init.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+}
+
+fn log_entries(runtime: &IsolatedDaemonRuntime, repo: &Path) -> Vec<Value> {
+    let output = require_kin(runtime, repo, &["log", "--json", "--count", "20"]);
+    let report: Value = serde_json::from_slice(&output.stdout).expect("kin log should emit JSON");
+    assert_eq!(report["schema"], "kin.log.v1");
+    report["entries"]
+        .as_array()
+        .expect("log reports its entries")
+        .clone()
+}
+
+fn newest_change(entries: &[Value]) -> Value {
+    let id = entries.first().expect("the log has a change")["change_id"].clone();
+    assert!(
+        !id.is_null(),
+        "every log entry names its change: {entries:?}"
+    );
+    id
+}
+
+/// A pipe whose reader is gone before the child exists, so its first write
+/// into it fails and no timing can make the arm pass.
+fn gone_pipe() -> std::io::PipeWriter {
+    let (reader, writer) = std::io::pipe().expect("create a pipe");
+    drop(reader);
+    writer
+}
+
+/// The stranger's arm, with a warm daemon: the change is recorded, the summary
+/// is the first and only stdout write, and the reader is gone by then.
+///
+/// stderr goes to a file so the arm can also say there was no panic, which the
+/// stranger could not see because their stderr was the same closed pipe.
+///
+/// Falsify by removing `install_exit_hook()` from `main`: the status reads
+/// 101 with `failed printing to stdout` on stderr, and the change is in the
+/// log all the same.
+#[test]
+fn a_commit_recorded_before_its_reader_left_exits_zero() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+    // Warm the daemon and pin the log, so the commit below is measured on its
+    // own and the only stderr writes it can make are warnings.
+    let before = log_entries(&runtime, &repo);
+
+    fs::write(repo.join("src/added.rs"), b"pub fn added() -> u8 { 3 }\n").expect("add source");
+    let stderr_path = root.path().join("commit.stderr");
+    let stderr = fs::File::create(&stderr_path).expect("create the stderr capture");
+    let mut child = kin(&runtime, &repo, &["commit", "-m", "publish added source"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(gone_pipe()))
+        .stderr(Stdio::from(stderr))
+        .spawn_owned()
+        .expect("spawn kin commit");
+    let status = child.wait().expect("wait for kin commit");
+    let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();
+
+    let after = log_entries(&runtime, &repo);
+    assert_eq!(
+        after.len(),
+        before.len() + 1,
+        "the commit must have recorded its change: stderr={stderr}"
+    );
+    assert_ne!(newest_change(&after), newest_change(&before));
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "a commit that recorded its change must exit 0 whether or not its summary was read, \
+         not {status:?}: stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "a closed pipe is not a panic: stderr={stderr}"
+    );
+}
+
+/// A refused commit with nobody reading either stream.
+///
+/// The refusal is printed by the top of `main`, so this is the arm that pins
+/// how `main` ends on an error when stderr is gone: exit 1, the refusal's own
+/// status, and neither the 101 of a second print panic nor a 0.
+///
+/// Falsify by returning the error from `main` again instead of ending on it:
+/// std prints the refusal through `eprintln!`, the closed pipe turns that into
+/// a print panic, and the status reads 101.
+#[test]
+fn a_refused_commit_exits_one_even_when_nobody_reads_it() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+    fs::write(repo.join("src/added.rs"), b"pub fn added() -> u8 { 3 }\n").expect("add source");
+    require_kin(&runtime, &repo, &["commit", "-m", "publish added source"]);
+    let committed = log_entries(&runtime, &repo);
+
+    // The control: with its output kept, the refusal exits 1 and says why.
+    let refused = run_kin(&runtime, &repo, &["commit", "--quiet", "-m", "again"]);
+    assert_eq!(
+        refused.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&refused.stdout),
+        String::from_utf8_lossy(&refused.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&refused.stderr).contains("nothing to commit"),
+        "the refusal must say what it refused: {}",
+        String::from_utf8_lossy(&refused.stderr)
+    );
+
+    let both = gone_pipe();
+    let stderr = both
+        .try_clone()
+        .expect("share the pipe between both streams");
+    let mut child = kin(&runtime, &repo, &["commit", "--quiet", "-m", "again"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(both))
+        .stderr(Stdio::from(stderr))
+        .spawn_owned()
+        .expect("spawn kin commit");
+    let status: ExitStatus = child.wait().expect("wait for kin commit");
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "a refused commit exits 1 whether or not anyone reads the refusal, not {status:?}"
+    );
+
+    let after = log_entries(&runtime, &repo);
+    assert_eq!(
+        after.len(),
+        committed.len(),
+        "a refused commit records nothing"
+    );
+}
+
+/// The stranger's arm on a cold daemon: `2>&1 | head -N` with `head` leaving
+/// while the daemon is still starting.
+///
+/// Both streams share one pipe. The test reads until the daemon-start notice
+/// and then leaves, exactly as `head` does once it has its lines. The next
+/// progress line has nowhere to go, the commit request has not been sent, and
+/// the exit has to say the command was cut off rather than claim a change.
+///
+/// Falsify by giving a closed stderr the same status as a closed stdout: the
+/// status then reads 0 over a log that gained nothing.
+#[test]
+fn a_commit_cut_off_while_its_daemon_starts_records_nothing_and_does_not_exit_zero() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+    fs::write(repo.join("src/added.rs"), b"pub fn added() -> u8 { 3 }\n").expect("add source");
+    require_kin(&runtime, &repo, &["commit", "-m", "publish added source"]);
+    let before = log_entries(&runtime, &repo);
+    require_kin(&runtime, &repo, &["daemon", "stop"]);
+
+    fs::write(repo.join("src/more.rs"), b"pub fn more() -> u8 { 4 }\n").expect("add more source");
+    let (reader, writer) = std::io::pipe().expect("create a pipe");
+    let stderr = writer
+        .try_clone()
+        .expect("share the pipe between both streams");
+    let mut child = kin(&runtime, &repo, &["commit", "-m", "publish more source"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::from(stderr))
+        .spawn_owned()
+        .expect("spawn kin commit");
+    let mut lines = BufReader::new(reader);
+    let mut seen = String::new();
+    loop {
+        let mut line = String::new();
+        let read = lines.read_line(&mut line).expect("read the shared pipe");
+        assert_ne!(
+            read, 0,
+            "the commit must announce the daemon it starts before it ends; it said: {seen}"
+        );
+        seen.push_str(&line);
+        if line.contains("starting the kin daemon") {
+            break;
+        }
+    }
+    drop(lines);
+    let status = child.wait().expect("wait for kin commit");
+
+    let after = log_entries(&runtime, &repo);
+    assert_eq!(
+        after.len(),
+        before.len(),
+        "a commit cut off before it reached authority records nothing"
+    );
+    assert_eq!(newest_change(&after), newest_change(&before));
+    assert_eq!(
+        status.code(),
+        Some(kin_cli::broken_pipe::CUT_OFF_STATUS),
+        "a commit cut off before it ran must say so and never exit 0, not {status:?}; \
+         it said: {seen}"
+    );
+}

--- a/crates/kin-cli/tests/commit_broken_pipe_exit.rs
+++ b/crates/kin-cli/tests/commit_broken_pipe_exit.rs
@@ -12,13 +12,16 @@
 //! how they learned the first one had worked; a caller keying on the exit
 //! code would have retried or rolled back instead.
 //!
-//! Three arms, each driving `kin` and `kin-daemon`. The change lands and the
-//! reader is gone by the summary: exit 0 and the change in `kin log`. The
-//! commit is refused and nobody reads either stream: exit 1, not 0 and not
-//! 101, because a refusal is the caller's news whether or not it was
-//! delivered. The reader leaves while the daemon is still starting: the commit
-//! never reached authority, nothing is recorded, and the exit is 141 rather
-//! than a 0 that would claim a change that does not exist.
+//! Three arms, each driving `kin` and `kin-daemon`, and one doctrine under all
+//! of them: the exit status reports the commit, never the pipe, so a recorded
+//! change is never reported as a failure and a change that was not recorded
+//! is never reported as a success. The change lands and the reader is gone by
+//! the summary: exit 0 and the change in `kin log`. The commit is refused and
+//! nobody reads either stream: exit 1, not 0 and not 101, because a refusal
+//! is the caller's news whether or not it was delivered. The reader leaves
+//! after one line while the daemon is still starting, `2>&1 | head -1` on a
+//! cold daemon: the commit keeps going, the change is in `kin log`, and the
+//! exit is 0.
 
 use serde_json::Value;
 use std::fs;
@@ -138,9 +141,9 @@ fn gone_pipe() -> std::io::PipeWriter {
 /// stderr goes to a file so the arm can also say there was no panic, which the
 /// stranger could not see because their stderr was the same closed pipe.
 ///
-/// Falsify by removing `install_exit_hook()` from `main`: the status reads
-/// 101 with `failed printing to stdout` on stderr, and the change is in the
-/// log all the same.
+/// Falsify by making the sink raise std's own panic on a closed pipe instead
+/// of marking the stream gone: the status reads 101 with `failed printing to
+/// stdout` on stderr, and the change is in the log all the same.
 #[test]
 fn a_commit_recorded_before_its_reader_left_exits_zero() {
     let root = tempdir().expect("temp root");
@@ -188,9 +191,9 @@ fn a_commit_recorded_before_its_reader_left_exits_zero() {
 /// how `main` ends on an error when stderr is gone: exit 1, the refusal's own
 /// status, and neither the 101 of a second print panic nor a 0.
 ///
-/// Falsify by returning the error from `main` again instead of ending on it:
-/// std prints the refusal through `eprintln!`, the closed pipe turns that into
-/// a print panic, and the status reads 101.
+/// Falsify by rendering the refusal through std's `eprintln!` instead of the
+/// sink: the closed pipe turns that print into a panic, and the status reads
+/// 101.
 #[test]
 fn a_refused_commit_exits_one_even_when_nobody_reads_it() {
     let root = tempdir().expect("temp root");
@@ -241,18 +244,25 @@ fn a_refused_commit_exits_one_even_when_nobody_reads_it() {
     );
 }
 
-/// The stranger's arm on a cold daemon: `2>&1 | head -N` with `head` leaving
-/// while the daemon is still starting.
+/// The stranger's arm on a cold daemon, as `2>&1 | head -1`: both streams one
+/// pipe, and the reader leaves after the first line, while the daemon this
+/// commit has to start is still starting.
 ///
-/// Both streams share one pipe. The test reads until the daemon-start notice
-/// and then leaves, exactly as `head` does once it has its lines. The next
-/// progress line has nowhere to go, the commit request has not been sent, and
-/// the exit has to say the command was cut off rather than claim a change.
+/// Every write after that first line meets a closed pipe: the startup ticks,
+/// the ready line, any warning, and the summary. None of them may decide
+/// anything. The doctrine, asserted first, is that the exit status and the log
+/// agree: a 0 over a log that gained nothing would claim a change that does
+/// not exist, and a non-zero over a log that gained one would report a landed
+/// commit as a failure, which is FIR-2846 itself. What this design then
+/// delivers is the first of the two agreeing shapes: the commit runs to its
+/// end, the change is in `kin log`, and the status is 0.
 ///
-/// Falsify by giving a closed stderr the same status as a closed stdout: the
-/// status then reads 0 over a log that gained nothing.
+/// Falsify by ending the process on the first closed-pipe write with the
+/// status the old hook gave a closed stderr, 141: the log gains nothing and
+/// the design assertion reads 141 over an unchanged log. Falsify the doctrine
+/// assertion by ending it with 0 instead: a 0 over a log that gained nothing.
 #[test]
-fn a_commit_cut_off_while_its_daemon_starts_records_nothing_and_does_not_exit_zero() {
+fn a_commit_whose_reader_leaves_after_one_line_still_records_its_change_and_exits_zero() {
     let root = tempdir().expect("temp root");
     let repo = root.path().join("repo");
     let runtime = IsolatedDaemonRuntime::new(&repo);
@@ -273,34 +283,47 @@ fn a_commit_cut_off_while_its_daemon_starts_records_nothing_and_does_not_exit_ze
         .stderr(Stdio::from(stderr))
         .spawn_owned()
         .expect("spawn kin commit");
+    // `head -1`: one line, then gone.
     let mut lines = BufReader::new(reader);
-    let mut seen = String::new();
-    loop {
-        let mut line = String::new();
-        let read = lines.read_line(&mut line).expect("read the shared pipe");
-        assert_ne!(
-            read, 0,
-            "the commit must announce the daemon it starts before it ends; it said: {seen}"
-        );
-        seen.push_str(&line);
-        if line.contains("starting the kin daemon") {
-            break;
-        }
-    }
+    let mut first = String::new();
+    let read = lines
+        .read_line(&mut first)
+        .expect("read the first line of the shared pipe");
+    assert_ne!(
+        read, 0,
+        "the commit must say something before it ends, and on a cold daemon it says it is \
+         starting one"
+    );
     drop(lines);
-    let status = child.wait().expect("wait for kin commit");
+    let status: ExitStatus = child.wait().expect("wait for kin commit");
 
     let after = log_entries(&runtime, &repo);
-    assert_eq!(
-        after.len(),
-        before.len(),
-        "a commit cut off before it reached authority records nothing"
+    let recorded = match after.len().checked_sub(before.len()) {
+        Some(0) => false,
+        Some(1) => true,
+        _ => panic!(
+            "one commit moves the log by at most one entry: {} before, {} after",
+            before.len(),
+            after.len()
+        ),
+    };
+    assert!(
+        (status.code() == Some(0)) == recorded,
+        "the exit status and the log must agree, and they do not: status {status:?}, change \
+         recorded {recorded}. A 0 over a log that gained nothing claims a change that does not \
+         exist, and a failure over a log that gained one reports a landed commit as failed. The \
+         first line it wrote was: {first}"
     );
-    assert_eq!(newest_change(&after), newest_change(&before));
+    assert!(
+        recorded,
+        "a reader leaving after one line is no reason to stop the commit, and this one recorded \
+         nothing; status {status:?}; the first line it wrote was: {first}"
+    );
+    assert_ne!(newest_change(&after), newest_change(&before));
     assert_eq!(
         status.code(),
-        Some(kin_cli::broken_pipe::CUT_OFF_STATUS),
-        "a commit cut off before it ran must say so and never exit 0, not {status:?}; \
-         it said: {seen}"
+        Some(0),
+        "a commit that recorded its change exits 0 whether or not anyone read its summary, not \
+         {status:?}"
     );
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,7 +25,7 @@ These apply to every command.
 | `-h, --help` | Print help. |
 | `-V, --version` | Print the build version. |
 
-Every command also shares one rule for a reader that goes away. When the process reading kin's output closes the pipe, as `kin log | head -1` does once `head` has its line, kin stops writing and exits: `0` when the closed stream is stdout, because the result it was printing was the reader's to take or leave, and `141`, the status a shell reports for a process `SIGPIPE` ended, when the closed stream is stderr, because the progress it was printing stopped being read before the command reached its result and nothing it might have gone on to record should be assumed. Neither is a panic, and a command whose output goes to a file is unaffected.
+Every command also shares one rule for a reader that goes away. When the process reading kin's output closes the pipe, as `kin log | head -1` does once `head` has its line, kin stops writing to that stream, finishes what it was doing, and exits with the status its work earned: `0` for a command that completed and its own error status for one that was refused. A `kin commit -m ... 2>&1 | head -1` still records its change and exits `0`, and a `kin init 2>&1 | head -1` still leaves a complete store. The one exception is a write kin could not skip meeting the closed pipe, which ends the command at that write with `141`, the status a shell reports for a process `SIGPIPE` ended, and never with a `0` for work that did not run. Neither is a panic, and a command whose output goes to a file is unaffected.
 
 ## Contents
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,6 +25,8 @@ These apply to every command.
 | `-h, --help` | Print help. |
 | `-V, --version` | Print the build version. |
 
+Every command also shares one rule for a reader that goes away. When the process reading kin's output closes the pipe, as `kin log | head -1` does once `head` has its line, kin stops writing and exits: `0` when the closed stream is stdout, because the result it was printing was the reader's to take or leave, and `141`, the status a shell reports for a process `SIGPIPE` ended, when the closed stream is stderr, because the progress it was printing stopped being read before the command reached its result and nothing it might have gone on to record should be assumed. Neither is a panic, and a command whose output goes to a file is unaffected.
+
 ## Contents
 
 - [Start here](#start-here): `init`, `clone`, `status`, `commit`, `log`, `diff`


### PR DESCRIPTION
`kin diff HEAD WORKSPACE | head -5` no longer ends in a Rust panic, a `kin commit` whose change is already in authority no longer exits 101 because the process reading it went away, and a `kin init 2>&1 | head -1` still finishes its store and exits 0. Both tickets were one defect: Rust ignores `SIGPIPE`, a write into a closed pipe comes back as `EPIPE`, and std's `print!` family turns that into a panic. The stranger who filed FIR-2846 had run the retry as `kin commit -m ... 2>&1 | head -3` (rc061a, `phase2-work.jsonl` line 503); `head` closed the pipe after the three warnings, the summary `println!` met a closed pipe, and the panic text was invisible because their stderr was the same pipe.

## What changed since the first cut of this PR

The first cut ended the process from a panic hook on the first failed print, 0 for a closed stdout and 141 for a closed stderr. Its own CI run (33578515631) failed the existing guard `init_finishes_its_store_when_the_reader_closes_the_pipe` at `init_non_tty_output.rs:136` with `left: "141"`, `right: "0"`. That test runs `{ kin init <repo> 2>&1; echo $? > status; } | head -1` and its comment is the doctrine: progress is advisory, the admission is not. Exiting from the hook stopped init at a progress line with its store half written, and because a hook runs before the unwind it also defeated init's own defence, the enrichment phase isolated on a `tokio::spawn` task exactly so a panic inside it could not decide init's status. A cut reader is never a reason to report a failed admission, and never a reason to report a successful one that did not happen. The only design that satisfies both is to keep working.

## The change

A reader going away changes what a command prints and never what it does.

`crates/kin-cli/src/broken_pipe.rs` defines `print!`, `println!`, `eprint!` and `eprintln!` for the crate, exported at the crate root and put in textual scope by `#[macro_use]` on the module, which `lib.rs` therefore declares first. `main.rs` imports the two it uses. Every one of the crate's 1086 print sites writes through one sink: a stream already marked gone is skipped before any syscall, the first write to meet `ErrorKind::BrokenPipe` marks it gone and, on Unix, points the descriptor at `/dev/null` so a print in another crate, a library's diagnostics or a child process finds a sink where the pipe was, and any other failure is still std's own panic with std's own message, so a full disk under `kin log > file` reports as before. `kin completions` renders into memory and writes through the same sink.

`main` ends on the status `broken_pipe::exit_status` decides. A command that ran to its end exits 0 or its own error status whatever happened to its streams. An `io::Error` of kind `BrokenPipe` that reached `main` as itself, a write outside the sink meeting a closed pipe, exits 141 and prints nothing: the command stopped at that write, and 141 cannot be read as success of work that never ran. Every other error is rendered `Error: {err:?}` through the stderr sink and exits 1. The source chain is not walked, so a transport error with an io error underneath stays an error the caller can read. The panic hook, the message matcher and the OS-code table are gone.

Resetting `SIGPIPE` to its default disposition stays rejected: std never sends with `MSG_NOSIGNAL` and sets `SO_NOSIGPIPE` only on Apple platforms, so on Linux a socket write to a daemon that has gone away would kill the CLI silently instead of returning the error the lost-reply path in `commit.rs` reads. `docs/cli-reference.md` states the rule under Global flags.

## Tests

The existing init guard `init_finishes_its_store_when_the_reader_closes_the_pipe` passes on the redesign (13 of 13 in its binary) after failing on the same tree minus the redesign, reproduced locally at `init_non_tty_output.rs:136` with `left: "141"`, `right: "0"`. `crates/kin-cli/tests/commit_broken_pipe_exit.rs` pins three shapes: a commit recorded before its reader left exits 0 with the change in `kin log`; a refused commit with both streams gone exits 1 beside the file-arm control that says `nothing to commit`; and the rewritten cold-daemon arm, `2>&1 | head -1` with the reader leaving after the first line while the daemon is still starting, asserts first that the status and the log agree (never a 0 over a log that gained nothing, never a failure over a log that gained one) and then that this design records the change and exits 0. `crates/kin-cli/tests/cli_broken_pipe.rs` drives `kin capabilities` into a pipe whose reader was dropped before the spawn, `kin completions zsh` into a reader that takes one line of a script larger than a pipe buffer, and six repository commands against a daemon, each exiting 0 with no `panicked at` and each still printing into a file. Five unit tests drive the sink against fake streams: the first closed-pipe write marks the stream gone and redirects once, a later write never opens the stream, a landed write leaves it in use, any other failure is still std's panic with std's message, and a bare or context-wrapped `BrokenPipe` at `main` is 141 while a transport error carrying one underneath stays 1, with the control that its chain does carry the pipe.

## Falsifications

Each mutation was applied by an exact-match patch and reverted the same way, with the file read back as original after every revert. Restoring the first cut's design inside the sink (end the process on the first closed-pipe write, 0 for stdout and 141 for stderr) turns the init guard red at `init_non_tty_output.rs:136` with `left: "141"`, `right: "0"`, and the cold-daemon commit test red at `commit_broken_pipe_exit.rs:317` with exit 141 over a log that gained nothing. Ending the process with 0 instead turns that test red at line 310, the doctrine assertion, with a 0 over a log that gained nothing; the init guard stays green under that mutation because `.kin/version` is on disk before the first advisory line, so the commit test is what pins the doctrine. Restoring std's panic in the sink turns `a_print_into_a_pipe_nobody_reads_exits_zero_without_a_panic` red at `cli_broken_pipe.rs:100` (exit 101), `a_commit_recorded_before_its_reader_left_exits_zero` red at `commit_broken_pipe_exit.rs:176` (exit 101 with the change recorded) and the sink's own unit test red. Handing `clap_complete::generate` stdout directly turns the completions test red at `cli_broken_pipe.rs:100` with exit 101 from clap's own panic. Rendering the refusal through std's `eprintln!` turns `a_refused_commit_exits_one_even_when_nobody_reads_it` red at line 233 with `left: Some(101)`, `right: Some(1)`. The restored tree then ran all four targets green again.

The previous cut's 36-arm table was rerun on the redesigned binary with a fresh fixture: every command under `file`, `| head -1` and `| true` exits 0 with no `panicked at`, and the `capabilities`, `completions` and `help` file arms are byte-identical to the pre-fix outputs.

## Gates run

All through the lane worktree (`.kin-coord/worktrees/cliexit-kin`, six commits behind origin/main and touching none of these files), one heavy-slot command at a time, with a scratch KIN_HOME and CPU embedding. The first cut's failure was reproduced on 29342d6ad before any change: `cargo test --locked -p kin-cli --test init_non_tty_output init_finishes_its_store_when_the_reader_closes_the_pipe` listed 1 and failed at line 136 with `left: "141"`, `right: "0"`. On the redesign, with each listing asserted first: `--lib broken_pipe` 5 of 5; `--test init_non_tty_output` 13 of 13; `--test commit_broken_pipe_exit` 12 of 12; `--test cli_broken_pipe` 12 of 12; then the full `cargo test --locked -p kin-cli`, 2810 tests listed, rc=0, 70 result lines all ok. `cargo fmt --all -- --check` clean. `cargo clippy --all-targets --all-features` with CI's 45-lint allow list under `RUSTFLAGS=-D warnings` clean. `bin/kin-precheck kin`: 16 gates enumerated from ci.yml's check job, 16 passed, including the zero-file-search guard. The lane report is `.kin-coord/reports/cliexit-20260902.md`, section "cliexit2: the init regression".

Closes FIR-2846
Closes FIR-3039



CodeQL on this head reports two new rust/cleartext-logging alerts at the sink (broken_pipe.rs:138 and :154). They are re-attributions: the sink is the one write path every print now takes, so the four session-id prints already on main (intent.rs, remote.rs, session_run.rs; deliberate output of the user's own session handles to their terminal) are reported at the sink's lines as if new. The data, the streams and the audience are unchanged; the sink writes to the process stdout and stderr, not a log file. The captain dismissed both as false positives with that rationale on 2026-09-02; the CodeQL rollup recomputed to success on the dismissal (a re-request is refused for that app).

