### PR TITLE
Project a conversion's peak from its own plan and keep phases 11 and 13 speaking

### DIFF
--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -345,6 +345,36 @@ fn init_from_git_with_hooks(
         plan
     };
 
+    // What phase 1 could not see. Its forecast multiplies a per-artifact term
+    // by the commit count, so a one-commit snapshot of a wide tree forecasts
+    // one tree's worth of entries, stays silent, and dies in the phase below.
+    // The plan now holds the head tree it will admit and a recorded size for
+    // every object it captured, so the conversion's width is finally a number
+    // rather than a guess, and reading it costs one pass over structures that
+    // are already in hand.
+    //
+    // Reported as well as judged. The count is the phase's own size and is
+    // worth a line whatever the machine has, because the phase after it is the
+    // one that spends minutes and gigabytes on exactly this many files.
+    {
+        let survey = crate::init_budget::ImportSurvey {
+            commits: semantic_plan.changes.len() as u64,
+            head_artifacts: semantic_plan.workspace_seed.base_tree.len() as u64,
+            object_bytes: semantic_plan
+                .external_objects
+                .iter()
+                .map(|record| record.body_len)
+                .sum(),
+        };
+        progress.detail(format_args!(
+            "{} files, {} commits",
+            survey.head_artifacts, survey.commits
+        ));
+        if let Some(line) = crate::init_budget::project_import(survey).advisory_line() {
+            crate::init_attempt::disclose_line(&line);
+        }
+    }
+
     progress.begin("derive semantic history");
     let semantic_plan = {
         let _span = info_span!(
@@ -406,6 +436,10 @@ fn init_from_git_with_hooks(
     // Consuming the plan is what frees them. The closure carries the facts and
     // never carried the bodies, so a future reader that wants one has to say so
     // rather than be handed silence.
+    // Read before the bodies go, because the closure that replaces the plan
+    // exposes this count only through a trait, and phase 11 wants the number
+    // rather than the trait.
+    let admitted_changes = semantic_plan.changes.len();
     let semantic_plan = {
         let _span = info_span!("kin.init.release_plan_bodies").entered();
         ProvedImportClosure::from_proved_plan(semantic_plan)
@@ -472,6 +506,15 @@ fn init_from_git_with_hooks(
             observed_entries = sealed_observation.observed_entries
         )
         .entered();
+        // Every second of this phase is spent inside two calls that report
+        // nothing: the transaction build below and the workspace-semantics
+        // derivation inside `bind_workspace_authority`. Measured on an
+        // 18,508-file snapshot the pair took 38 seconds and printed no line at
+        // all. The heartbeat cannot see inside either, so it says what it does
+        // know, which is how large the work is and how long it has been going.
+        let _beat = progress.heartbeat(format!(
+            "{admitted_tracked_artifacts} files, {admitted_changes} changes"
+        ));
         let mut transaction = admitted
             .into_generation_zero_repository_transaction(
                 &capture_store,
@@ -504,6 +547,17 @@ fn init_from_git_with_hooks(
     progress.begin("commit bootstrap transaction");
     {
         let _span = info_span!("kin.init.commit_bootstrap_transaction").entered();
+        // The phase that goes quietest. `kin_db::storage::history_replay` is
+        // the only periodic emitter below this call, and it finishes early: on
+        // an 18,508-file snapshot its last line landed at 68 seconds and the
+        // phase then ran for over half an hour in silence. The store's own
+        // commit reports nothing and this crate cannot make it, so the line
+        // that keeps moving is this one.
+        let _beat = progress.heartbeat(format!(
+            "{admitted_tracked_artifacts} files, {} changes, {} objects",
+            transaction.changes.len(),
+            transaction.external_objects.len()
+        ));
         prepared.commit_repository_bootstrap(transaction)?;
     }
 

--- a/crates/kin-core/src/init_budget.rs
+++ b/crates/kin-core/src/init_budget.rs
@@ -589,9 +589,467 @@ pub fn verdict_for_with_allowance(
     }
 }
 
+// ------------------------------------------------- the plan's own projection
+
+/// Bytes a conversion holds for each artifact in the head tree it admits.
+///
+/// The term [`HistorySurvey`] does not have. Its per-artifact coefficient is
+/// multiplied by the commit count, so a one-commit snapshot forecasts one
+/// tree's worth of tree ENTRIES and nothing at all for what deriving semantics
+/// from those artifacts costs. That derivation is where the memory goes: on a
+/// measured 18,508-file snapshot the conversion reached 13.68 GiB inside phase
+/// 5, before a single byte of it had been staged, and the phase-1 forecast for
+/// the same repository was 74 MB.
+///
+/// Same discipline as the coefficients above: the SMALLEST demand per head
+/// artifact measured across snapshot conversions, so the projection understates
+/// every one of them rather than fitting any. Measured on three one-commit
+/// snapshots, peak resident bytes per head artifact: react 254,734 over 7,210
+/// files, redis 947,678 over 1,857, vscode 968,025 over 18,508. React is the
+/// floor and this rounds under it.
+const BYTES_PER_HEAD_ARTIFACT: u64 = 250_000;
+
+/// Bytes a conversion holds for each byte of source it admits.
+///
+/// Paired with [`BYTES_PER_HEAD_ARTIFACT`] and taken as the larger of the two,
+/// because neither alone survives both shapes: a tree of many tiny files is
+/// driven by its file count, and a tree of few large files by its bytes. A
+/// repository that is extreme in either direction is one the other term
+/// forecasts at nothing, and the measured subjects sit on opposite sides of
+/// that line: react's projection comes from its file count and vscode's from
+/// its bytes.
+///
+/// Same floor discipline. Peak resident bytes per byte of captured object:
+/// redis 82.76, react 45.37, vscode 33.69. Vscode is the floor and this rounds
+/// under it.
+const BYTES_PER_SOURCE_BYTE: u64 = 33;
+
+/// What the import plan knows about the conversion it has just planned.
+///
+/// Distinct from [`HistorySurvey`], which is counted from the source before
+/// anything is read and can therefore only see history depth. By phase 4 the
+/// plan holds the head tree it is going to admit and a size for every object it
+/// captured, so the width of the conversion is finally a number rather than a
+/// guess. Both are needed: the survey refuses a deep history before capture
+/// spends minutes on it, and this one describes the shape the survey is blind
+/// to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImportSurvey {
+    /// Changes the plan carries, one per admitted commit.
+    pub commits: u64,
+    /// Artifacts in the head tree the workspace seed admits.
+    pub head_artifacts: u64,
+    /// Bytes of captured Git objects the plan records.
+    pub object_bytes: u64,
+}
+
+impl ImportSurvey {
+    /// Bytes this conversion is projected to hold at its peak.
+    ///
+    /// The largest of three floors rather than their sum, for the reason
+    /// [`HistorySurvey::forecast_peak_bytes`] gives: each coefficient is
+    /// already the smallest any measured conversion justified, and adding
+    /// independently minimised terms is how a floor stops being one.
+    ///
+    /// The first two terms are the history-depth forecast this repeats so a
+    /// deep history is never projected LOWER at phase 4 than it was at phase 1.
+    /// The third is the snapshot term, and it is the one that fires on a
+    /// shallow clone of a wide tree.
+    pub fn projected_peak_bytes(&self) -> u64 {
+        let by_commit = self.commits.saturating_mul(BYTES_PER_COMMIT);
+        let by_tree = self
+            .commits
+            .saturating_mul(self.head_artifacts)
+            .saturating_mul(BYTES_PER_COMMIT_ARTIFACT);
+        let by_head = self
+            .head_artifacts
+            .saturating_mul(BYTES_PER_HEAD_ARTIFACT)
+            .max(self.object_bytes.saturating_mul(BYTES_PER_SOURCE_BYTE));
+        by_commit.max(by_tree).max(by_head)
+    }
+}
+
+/// What the ladder decided about this conversion's peak once it had a plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportProjection {
+    /// The machine could not be measured, so nothing is claimed.
+    Unmeasured { reason: String },
+    /// The projection fits in what the machine still has.
+    Fits {
+        survey: ImportSurvey,
+        projected_bytes: u64,
+        available_bytes: u64,
+    },
+    /// The projection is larger than what the machine still has.
+    Short {
+        survey: ImportSurvey,
+        projected_bytes: u64,
+        available_bytes: u64,
+    },
+}
+
+impl ImportProjection {
+    /// The line an operator sees, or `None` when there is nothing to say.
+    ///
+    /// Silent unless the projection is short, because a memory line on a
+    /// conversion with room to spare is the noise that trains an operator to
+    /// skip the line that matters.
+    ///
+    /// It warns and does not refuse. Phase 1 already owns the refusal, decided
+    /// against a ceiling with a documented calibration and an environment
+    /// variable to override it. This runs four phases later on a conversion
+    /// that has already been admitted and captured, and its own coefficients
+    /// are calibrated on far fewer subjects, so turning it into a second
+    /// refusal would spend a user's completed capture on the least-tested
+    /// number in the module.
+    pub fn advisory_line(&self) -> Option<String> {
+        let Self::Short {
+            survey,
+            projected_bytes,
+            available_bytes,
+        } = self
+        else {
+            return None;
+        };
+        // Names the head tree rather than the history, because that is what
+        // drove the number, and because the remedy differs. A deep history is
+        // helped by a shallow clone. This is not: the measured subject WAS a
+        // shallow clone, one commit deep, and it still needed sixteen
+        // gigabytes. Telling that operator to clone shallower would send them
+        // round a loop they are already standing in.
+        Some(format!(
+            "  this conversion is projected to hold about {}, and this {} has about {} left, \
+             because {} files over {} of source is a wide tree. A shallower clone will not help: \
+             the tree is the size, not the history. It will probably not finish; to be sure, give \
+             it more than {} or convert a smaller subtree",
+            human_bytes(*projected_bytes),
+            ceiling_noun(),
+            human_bytes(*available_bytes),
+            survey.head_artifacts,
+            human_bytes(survey.object_bytes),
+            human_bytes(*projected_bytes),
+        ))
+    }
+}
+
+/// Project this conversion's peak against what it still has to spend.
+///
+/// Reads the machine and the environment, so the pure decision lives in
+/// [`projection_for`] and this is the only part a test cannot run without one.
+pub fn project_import(survey: ImportSurvey) -> ImportProjection {
+    match headroom_bytes() {
+        Ok(available_bytes) => projection_for(survey, available_bytes),
+        Err(reason) => ImportProjection::Unmeasured { reason },
+    }
+}
+
+/// Bytes this conversion still has, judged against the ceiling phase 1 used.
+///
+/// Not simply [`memory_pressure::MemoryReading::available_bytes`], because
+/// [`INIT_MEMORY_CEILING_ENV`] exists and phase 1 already honours it. An
+/// operator sets that variable for one of two reasons, a container whose real
+/// cap Kin reads wrongly or a forecast they have judged wrong for their own
+/// repository, and either way they stated the true ceiling once and phase 1
+/// took them at their word. Reading the machine again four phases later would
+/// warn that same operator with the number they overrode, and this projection
+/// has no second variable to turn it off.
+///
+/// The machine is still asked what is charged against that ceiling, because by
+/// phase 4 the conversion has already spent some of it. With no override set
+/// that arithmetic is `limit_bytes - used_bytes`, which is exactly what
+/// [`memory_pressure::MemoryReading::available_bytes`] returns, so an
+/// unoverridden conversion is judged against the number it was judged against
+/// before.
+fn headroom_bytes() -> Result<u64, String> {
+    let charged_bytes = memory_pressure::read()
+        .reading()
+        .map_or(0, |reading| reading.used_bytes);
+    headroom_for(ceiling(), charged_bytes)
+}
+
+/// The same arithmetic over values, so the override's effect is testable
+/// without a process-wide environment variable.
+fn headroom_for(ceiling: Ceiling, charged_bytes: u64) -> Result<u64, String> {
+    match ceiling {
+        // Saturating, so a machine already charged past its own ceiling
+        // projects against nothing left rather than wrapping to everything.
+        Ceiling::Bytes(bytes) => Ok(bytes.saturating_sub(charged_bytes)),
+        // Unreachable inside a conversion: phase 1 refuses an override it
+        // cannot parse and never reaches this phase. Answered rather than
+        // asserted, so a future caller that arrives here earlier is left
+        // silent instead of panicking.
+        Ceiling::Invalid(raw) => Err(format!(
+            "{INIT_MEMORY_CEILING_ENV} is set to {raw:?}, which is not a byte count, so this \
+             conversion's peak was not projected"
+        )),
+        Ceiling::Unreadable(reason) => Err(reason),
+    }
+}
+
+/// The same decision over numbers, so the threshold is testable without a
+/// machine of any particular size.
+pub fn projection_for(survey: ImportSurvey, available_bytes: u64) -> ImportProjection {
+    let projected_bytes = survey.projected_peak_bytes();
+    if projected_bytes > available_bytes {
+        ImportProjection::Short {
+            survey,
+            projected_bytes,
+            available_bytes,
+        }
+    } else {
+        ImportProjection::Fits {
+            survey,
+            projected_bytes,
+            available_bytes,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Peak resident bytes measured converting a fresh one-commit snapshot of
+    /// each, on kin 0.6.3, `--no-enrich`, with a scratch `KIN_HOME`.
+    ///
+    /// Name, head artifacts, captured object bytes, measured peak. These are
+    /// the subjects both snapshot coefficients were read off, so a change to
+    /// either that stops flooring them is a change that broke its own
+    /// calibration.
+    const MEASURED_SNAPSHOTS: [(&str, u64, u64, u64); 3] = [
+        ("redis", 1_857, 21_264_703, 1_759_838_208),
+        ("react", 7_210, 40_479_046, 1_836_630_016),
+        ("vscode", 18_508, 531_828_795, 17_916_215_296),
+    ];
+
+    fn snapshot(head_artifacts: u64, object_bytes: u64) -> ImportSurvey {
+        ImportSurvey {
+            commits: 1,
+            head_artifacts,
+            object_bytes,
+        }
+    }
+
+    /// The case this projection exists for.
+    ///
+    /// A one-commit snapshot of vscode, which is what `git clone --depth 1`
+    /// leaves behind, measured at 16.69 GiB. On a 16 GB machine that must be
+    /// spoken about before phase 5 spends the memory rather than after the
+    /// kernel spends it for us.
+    #[test]
+    fn a_one_commit_snapshot_of_a_wide_tree_is_projected_over_a_small_machine() {
+        let survey = snapshot(18_508, 531_828_795);
+        let projection = projection_for(survey, 16 * 1000 * 1000 * 1000);
+        assert!(
+            matches!(projection, ImportProjection::Short { .. }),
+            "expected a short projection, got {projection:?}"
+        );
+        assert!(projection.advisory_line().is_some());
+    }
+
+    /// The blindness this was written to cover, pinned so it cannot be argued
+    /// away later.
+    ///
+    /// [`HistorySurvey`] multiplies its per-artifact term by the commit count.
+    /// At one commit that term collapses, and the same repository the
+    /// projection puts at over sixteen gigabytes the phase-1 forecast puts at
+    /// well under one. Both numbers are in this assertion on purpose: a future
+    /// change that fixes the phase-1 forecast makes this test fail loudly
+    /// rather than leaving two forecasts silently disagreeing.
+    #[test]
+    fn the_phase_one_forecast_is_blind_to_the_shape_this_projection_catches() {
+        let head_artifacts = 18_508;
+        let object_bytes = 531_828_795;
+        let forecast = HistorySurvey {
+            commits: 1,
+            tracked_artifacts: head_artifacts,
+        }
+        .forecast_peak_bytes();
+        let projected = snapshot(head_artifacts, object_bytes).projected_peak_bytes();
+        assert!(
+            forecast < 1024 * 1024 * 1024,
+            "the phase-1 forecast for a one-commit snapshot was {forecast}, which is no longer \
+             the blindness this projection covers"
+        );
+        assert!(
+            projected > 16 * 1000 * 1000 * 1000,
+            "the projection has to see what the forecast cannot, got {projected}"
+        );
+    }
+
+    /// Silent when there is room, for the reason the module's own
+    /// `TIGHT_FRACTION` gives: a memory line on a conversion that fits is the
+    /// noise that trains an operator to skip the one that matters.
+    #[test]
+    fn a_projection_that_fits_says_nothing() {
+        let projection = projection_for(snapshot(1_857, 21_264_703), 64 * 1024 * 1024 * 1024);
+        assert!(matches!(projection, ImportProjection::Fits { .. }));
+        assert_eq!(projection.advisory_line(), None);
+    }
+
+    /// The remedy has to be one the reader is not already standing in.
+    ///
+    /// The phase-1 refusal offers `git clone --depth`, which is right for a
+    /// deep history and useless here: the measured subject WAS one commit deep
+    /// and still needed sixteen gigabytes. A line that sent that operator to
+    /// clone shallower would send them round a loop.
+    #[test]
+    fn the_advisory_names_the_tree_and_does_not_offer_a_shallower_clone() {
+        let line = projection_for(snapshot(18_508, 531_828_795), 16 * 1000 * 1000 * 1000)
+            .advisory_line()
+            .expect("a short projection states itself");
+        assert!(line.contains("18508 files"), "line was: {line}");
+        assert!(line.contains("wide tree"), "line was: {line}");
+        assert!(
+            line.contains("shallower clone will not help"),
+            "the one remedy that cannot work here has to be ruled out by name: {line}"
+        );
+        assert!(
+            line.contains("smaller subtree"),
+            "a warning with no remedy is most of the way back to silence: {line}"
+        );
+    }
+
+    /// Every subject the coefficients were read off is still floored by them.
+    ///
+    /// This is the calibration's own guard. Raising either coefficient past a
+    /// measured subject turns the projection from a floor into a guess, and a
+    /// guess that overstates is how a warning starts firing on conversions
+    /// that would have finished.
+    #[test]
+    fn the_projection_floors_every_measured_subject() {
+        for (name, head_artifacts, object_bytes, measured_peak) in MEASURED_SNAPSHOTS {
+            let projected = snapshot(head_artifacts, object_bytes).projected_peak_bytes();
+            assert!(
+                projected <= measured_peak,
+                "{name} projected {projected} over a measured peak of {measured_peak}, so the \
+                 projection is no longer a floor"
+            );
+        }
+    }
+
+    /// A deep history is never projected lower here than it was forecast at
+    /// phase 1.
+    ///
+    /// The two run four phases apart on the same conversion, and a second
+    /// number that undercut the first would read as the danger having passed.
+    /// It has not: the projection adds a term, it does not replace one.
+    #[test]
+    fn a_deep_history_is_never_projected_below_its_phase_one_forecast() {
+        for (commits, tracked) in [(18_514u64, 1_676u64), (6_493, 900), (200, 40), (1, 18_508)] {
+            let forecast = HistorySurvey {
+                commits,
+                tracked_artifacts: tracked,
+            }
+            .forecast_peak_bytes();
+            let projected = ImportSurvey {
+                commits,
+                head_artifacts: tracked,
+                object_bytes: 0,
+            }
+            .projected_peak_bytes();
+            assert!(
+                projected >= forecast,
+                "{commits} commits over {tracked} files projected {projected} against a phase-1 \
+                 forecast of {forecast}"
+            );
+        }
+    }
+
+    /// A repository large enough to overflow the product saturates high rather
+    /// than wrapping to a projection of nothing, which is the direction a
+    /// forecast is allowed to be wrong in.
+    ///
+    /// Each case overflows exactly one of the two terms this projection adds,
+    /// while the terms it inherited stay small. A survey that is `u64::MAX` in
+    /// every field would saturate on the inherited per-commit term alone and
+    /// pass with both new multiplications wrapping, which is a test that cannot
+    /// fail for the code it was written for.
+    #[test]
+    fn a_projection_large_enough_to_overflow_saturates_high() {
+        // Over u64::MAX at 250,000 bytes per artifact, still under it at the
+        // 4,000 the inherited per-commit-artifact term charges.
+        let by_artifact_count = ImportSurvey {
+            commits: 1,
+            head_artifacts: 100_000_000_000_000,
+            object_bytes: 0,
+        };
+        assert_eq!(by_artifact_count.projected_peak_bytes(), u64::MAX);
+        // Over u64::MAX at 33 bytes per source byte, with no artifacts at all,
+        // so nothing but the source-byte term can produce the saturation.
+        let by_source_bytes = ImportSurvey {
+            commits: 1,
+            head_artifacts: 0,
+            object_bytes: 1_000_000_000_000_000_000,
+        };
+        assert_eq!(by_source_bytes.projected_peak_bytes(), u64::MAX);
+        assert!(matches!(
+            projection_for(by_source_bytes, u64::MAX - 1),
+            ImportProjection::Short { .. }
+        ));
+    }
+
+    /// An operator who told this module its real ceiling is not warned four
+    /// phases later with the number they overrode.
+    ///
+    /// [`INIT_MEMORY_CEILING_ENV`] is this module's only lever and phase 1
+    /// honours it. This projection has no lever of its own, so a projection
+    /// that read the machine anyway would fire on precisely the operator who
+    /// has already answered it, with no way to stop it.
+    #[test]
+    fn a_raised_ceiling_is_what_this_projection_is_judged_against() {
+        let survey = snapshot(18_508, 531_828_795);
+        let machine = headroom_for(Ceiling::Bytes(16 * 1000 * 1000 * 1000), 0)
+            .expect("a readable ceiling has a headroom");
+        assert!(
+            projection_for(survey, machine).advisory_line().is_some(),
+            "this subject has to be short against the machine before an override can matter"
+        );
+        let raised = headroom_for(
+            Ceiling::Bytes(64 * 1024 * 1024 * 1024),
+            8 * 1024 * 1024 * 1024,
+        )
+        .expect("an operator's ceiling has a headroom");
+        assert_eq!(raised, 56 * 1024 * 1024 * 1024);
+        assert_eq!(
+            projection_for(survey, raised).advisory_line(),
+            None,
+            "an operator who raised the ceiling past this projection is still being warned by it"
+        );
+    }
+
+    /// The headroom is the ceiling less what is already charged against it.
+    ///
+    /// By phase 4 the conversion has spent four phases of memory, so judging a
+    /// projection against the whole ceiling would compare a peak against room
+    /// that is already gone.
+    #[test]
+    fn the_headroom_is_the_ceiling_less_what_is_already_charged() {
+        assert_eq!(
+            headroom_for(Ceiling::Bytes(16_000_000_000), 15_000_000_000),
+            Ok(1_000_000_000)
+        );
+        // A machine charged past its own ceiling has nothing left rather than
+        // everything, which is what a wrapping subtraction would report.
+        assert_eq!(headroom_for(Ceiling::Bytes(8), 9), Ok(0));
+    }
+
+    /// A ceiling this module cannot read projects nothing and says nothing.
+    ///
+    /// The same discipline as the phase-1 verdict: a check that could not run
+    /// leaves the conversion exactly as it was rather than guessing at it.
+    #[test]
+    fn an_unreadable_ceiling_projects_nothing() {
+        assert!(headroom_for(Ceiling::Unreadable("no ceiling here".to_string()), 0).is_err());
+        assert!(headroom_for(Ceiling::Invalid("twelve".to_string()), 0).is_err());
+        assert_eq!(
+            ImportProjection::Unmeasured {
+                reason: "no ceiling here".to_string(),
+            }
+            .advisory_line(),
+            None
+        );
+    }
 
     fn survey(commits: u64, tracked_artifacts: u64) -> HistorySurvey {
         HistorySurvey {

--- a/crates/kin-core/src/init_progress.rs
+++ b/crates/kin-core/src/init_progress.rs
@@ -17,8 +17,9 @@
 use std::cell::RefCell;
 use std::fmt::Arguments;
 use std::io::{IsTerminal, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::init_attempt::InitAttemptJournal;
 
@@ -130,6 +131,21 @@ impl PhaseProgress {
         Self { ladder }
     }
 
+    /// Tick the open phase with `detail` until the returned handle is dropped.
+    ///
+    /// For a phase whose body is one blocking call this crate cannot
+    /// instrument from the inside. The caller states what the work is; the
+    /// ladder supplies how long it has been going.
+    pub(crate) fn heartbeat(&self, detail: String) -> PhaseHeartbeat {
+        self.heartbeat_every(detail, HEARTBEAT_INTERVAL)
+    }
+
+    /// [`Self::heartbeat`] with the cadence named, so a test can drive one
+    /// without waiting the production interval for a single tick.
+    fn heartbeat_every(&self, detail: String, interval: Duration) -> PhaseHeartbeat {
+        PhaseHeartbeat::start(Arc::clone(&self.ladder), detail, interval)
+    }
+
     fn with<R>(&mut self, act: impl FnOnce(&mut Ladder) -> R) -> Option<R> {
         self.ladder.lock().ok().map(|mut ladder| act(&mut ladder))
     }
@@ -196,6 +212,89 @@ impl PhaseProgress {
     #[cfg(test)]
     pub(crate) fn detail_updates(&self) -> usize {
         self.ladder.lock().expect("ladder lock").detail_updates
+    }
+}
+
+/// How often a heartbeat ticks the phase it was started for.
+///
+/// Short enough that a terminal redraw looks alive, long enough that the
+/// throttle off a terminal still leaves a readable line rate: the ladder
+/// prints the first detail and then every tenth, so this cadence puts a line
+/// in a pipe roughly every fifty seconds.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How finely the heartbeat wakes to check whether it has been stopped.
+///
+/// Separate from the tick interval so dropping the handle does not wait a full
+/// tick to be noticed. A phase that ends promptly must not be held open by its
+/// own progress reporting.
+const HEARTBEAT_POLL: Duration = Duration::from_millis(100);
+
+/// Advance an open phase from another thread while this one blocks.
+///
+/// Several phases spend all of their minutes inside a single call into a crate
+/// below this one, and those crates report through `tracing` or not at all.
+/// `kin_db::storage::history_replay` is the only periodic emitter any of them
+/// has, so a conversion that finishes replay and goes on to commit prints two
+/// lines and then nothing: a measured 18,508-file snapshot sat in phase 13 for
+/// over half an hour with a line that last moved at 68 seconds. Nothing was
+/// wrong, and there was no way to know that from the outside.
+///
+/// A heartbeat does not invent progress it cannot see. It carries the size of
+/// the work, which the caller knows before it blocks, and the phase line's own
+/// elapsed time, which the ladder already keeps. That turns silence into a
+/// statement an operator can act on: this many files, still going, this long.
+///
+/// It takes the ladder by handle rather than through [`ACTIVE_LADDER`],
+/// because that slot belongs to the thread that installed it and a spawned
+/// thread has none. Handing the `Arc` over directly leaves that discipline
+/// exactly as it was.
+pub(crate) struct PhaseHeartbeat {
+    stop: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl PhaseHeartbeat {
+    fn start(ladder: Arc<Mutex<Ladder>>, detail: String, interval: Duration) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&stop);
+        let thread = std::thread::Builder::new()
+            .name("kin-init-heartbeat".to_string())
+            .spawn(move || {
+                let mut waited = Duration::ZERO;
+                while !flag.load(Ordering::Relaxed) {
+                    std::thread::sleep(HEARTBEAT_POLL);
+                    waited += HEARTBEAT_POLL;
+                    if waited < interval {
+                        continue;
+                    }
+                    waited = Duration::ZERO;
+                    // A poisoned ladder means the reporting thread panicked
+                    // mid-redraw. Ticking it again would be writing through a
+                    // lock whose invariant is already broken, so the heartbeat
+                    // simply stops reporting rather than taking the process
+                    // down with a second panic.
+                    let Ok(mut ladder) = ladder.lock() else {
+                        return;
+                    };
+                    ladder.detail(format_args!("{detail}"));
+                }
+            })
+            .ok();
+        Self { stop, thread }
+    }
+}
+
+impl Drop for PhaseHeartbeat {
+    /// Stop ticking and wait for the tick in flight.
+    ///
+    /// Joined rather than detached, so a heartbeat can never draw over the
+    /// phase line after the phase that owns it has closed.
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
     }
 }
 
@@ -327,6 +426,82 @@ impl Ladder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A phase whose body is one blocking call still advances.
+    ///
+    /// The behaviour this guards is the whole point of the type: a conversion
+    /// that sits in phase 13 for half an hour must not look identical to one
+    /// that has hung. Falsified by removing the `ladder.detail` call from the
+    /// heartbeat loop, which leaves the thread running and the count at zero.
+    #[test]
+    fn a_heartbeat_advances_the_phase_it_was_started_for() {
+        let mut progress = PhaseProgress::new(2);
+        progress.begin("commit bootstrap transaction");
+        let before = progress.detail_updates();
+        let beat = progress.heartbeat_every("18508 files".to_string(), Duration::from_millis(20));
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while progress.detail_updates() <= before && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        drop(beat);
+        assert!(
+            progress.detail_updates() > before,
+            "a heartbeat that never ticks leaves a long phase as silent as it was"
+        );
+    }
+
+    /// Dropping the handle stops the ticking, and stops it before the drop
+    /// returns.
+    ///
+    /// A heartbeat that outlived its phase would draw its own line over the
+    /// next phase's, which is worse than the silence it replaced. Falsified by
+    /// dropping the join in `Drop`, which lets a tick in flight land after the
+    /// phase closed.
+    #[test]
+    fn a_dropped_heartbeat_stops_ticking() {
+        let mut progress = PhaseProgress::new(2);
+        progress.begin("commit bootstrap transaction");
+        let beat = progress.heartbeat_every("18508 files".to_string(), Duration::from_millis(20));
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while progress.detail_updates() == 0 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        drop(beat);
+        let settled = progress.detail_updates();
+        assert!(
+            settled > 0,
+            "the heartbeat has to have started to prove it stops"
+        );
+        std::thread::sleep(Duration::from_millis(300));
+        assert_eq!(
+            progress.detail_updates(),
+            settled,
+            "a heartbeat kept ticking after its handle was dropped"
+        );
+    }
+
+    /// The cadence is what makes a piped log readable rather than a flood.
+    ///
+    /// Off a terminal the ladder prints the first detail and then every tenth,
+    /// so the production interval has to be short enough to redraw a terminal
+    /// and long enough that ten of them is not a wall of text. Guarded as a
+    /// range rather than a value, so tuning the cadence does not fail the test
+    /// but replacing it with a per-second tick does.
+    #[test]
+    fn the_heartbeat_cadence_stays_in_the_band_a_piped_log_can_take() {
+        assert!(
+            HEARTBEAT_INTERVAL >= Duration::from_secs(2),
+            "a tick faster than this floods a pipe once the tenth-line throttle lets it through"
+        );
+        assert!(
+            HEARTBEAT_INTERVAL <= Duration::from_secs(15),
+            "ten of these is the gap between piped lines, and past this it reads as a hang again"
+        );
+        assert!(
+            HEARTBEAT_POLL < HEARTBEAT_INTERVAL,
+            "a poll coarser than the interval cannot stop the thread inside one tick"
+        );
+    }
 
     #[test]
     fn a_phase_ladder_numbers_every_phase_it_enters() {


### PR DESCRIPTION
## What this fixes

`kin init` decides at phase 1 whether a conversion will fit. It forecasts the peak
as the larger of commits times 1.2 MB and commits times tracked artifacts times
4,000 B. Both terms are multiplied by the commit count, so on a one-commit
snapshot the forecast collapses. A `git clone --depth 1` of VS Code, 18,508 files
and 531,828,795 bytes of captured Git objects, forecasts **74 MB**. The measured
conversion peaked at **16.69 GiB**. Nothing was printed, and on a 16 GB machine
the run dies with `Killed` and no message, because SIGKILL runs no destructor.

That is FIR-3056. This PR does not fix the allocation. It makes the conversion
say what it is about to do, before it does it, and keeps two silent phases
talking.

## The measurement, which came first

kin 0.6.3 (`8ed98962c0327829a67d7650605472698654eb46`) extracted from the npm
shim's managed install, so the numbers are the product's own bytes. Every run
used `KIN_EMBED_BACKEND=cpu`, a fresh scratch `KIN_HOME`, a fresh copy of the
snapshot, and `kin init --json --no-enrich` under `/usr/bin/time -l`, with a
sampler recording process-tree RSS every 2 s and a timestamper stamping each
`[N/17]` line so RSS could be attributed per phase. Subjects are fresh
one-commit snapshots: tree materialized without `.git`, then `git init`,
`gc.auto 0`, `git add -A`, one signed commit.

Peak confirmed twice: the sampler read 17,916,215,296 bytes, `/usr/bin/time -l`
read 17,915,936,768.

```
ph   label                                      wall_s     peak_RSS
1    check admission blockers                      0.0     0.01 GiB
2    capture Git repository                       32.3     0.28 GiB
3    build Git authority                           1.4            -
4    plan semantic import                          0.2            -
5    derive semantic history                      77.0    13.68 GiB
6    apply admission policy                       30.5    15.18 GiB
7    prove Git source                             32.8    16.48 GiB
8    stage repository layout                       0.0    14.86 GiB
9    copy Git objects                             52.7    14.86 GiB
10   seal staged content                          44.5    14.86 GiB
11   build bootstrap transaction                  38.1    16.67 GiB
12   validate bootstrap transaction                7.1    16.68 GiB
13   commit bootstrap transaction                 OPEN    16.69 GiB
     TOTAL                                      2302.3    16.69 GiB
```

Read that for where the memory goes, not where the time goes. The conversion
holds 0.28 GiB at the end of phase 2 and 13.68 GiB at the end of phase 5. It is
committed to its peak about 110 seconds in, at the fifth of seventeen phases, and
it never gives the memory back. redis (1,857 files) and react (7,210 files) both
completed cleanly at 1.64 and 1.71 GiB, so this is a shape, not a size.

Wall times are upper bounds. This is a shared box and other lanes held the
one-minute load between 10 and 54 throughout. Peak RSS is unaffected by that.
The baseline run took a SIGTERM at 2,304 s from outside the harness with phase 13
still open, after RSS had already fallen back to 0.69 GB, so the peak and the
phase 1 to 13 timings are sound and phases 14 to 17 were not observed on vscode.

## The two forecasts

**Phase 1, unchanged.** Counts commits and index entries before anything is
captured. Refuses past 1.5 times the ceiling, warns past 0.7 of it. On this
snapshot it says 74 MB and stays silent, which is exactly the blindness below.

**Phase 4, new.** By then the plan holds the head tree it will admit, the changes
it carries, and a recorded `body_len` for every object it captured, so the
conversion's width is finally a number rather than a guess. Reading it costs one
pass over structures already in hand.

Two coefficients, both floors, taken as the smallest demand any measured subject
justified rather than fitted to any of them:

| term | measured per unit | shipped |
|---|---|---|
| per head artifact | react 254,734 B, redis 947,678 B, vscode 968,025 B | 250,000 B |
| per source byte | vscode 33.69 B, react 45.37 B, redis 82.76 B | 33 B |

Paired and taken as the larger, because neither survives both shapes on its own:
a tree of many tiny files is driven by its file count, a tree of few large files
by its bytes, and the measured subjects sit on opposite sides of that line.
React's projection comes from its file count and vscode's from its bytes. The
projection is then the largest of the two inherited terms and this one, never
their sum, for the reason the phase-1 forecast already gives: adding
independently minimised terms is how a floor stops being one.

It warns and does not refuse. Phase 1 owns the refusal, decided against a
documented calibration with an environment variable to override it. This runs
four phases later on a conversion already admitted and captured, on coefficients
resting on three subjects, so making it a second refusal would spend a user's
completed capture on the least-tested number in the module.

The warning names the tree and rules out the one remedy that cannot work here.
The phase-1 refusal offers `git clone --depth`, which is right for a deep history
and useless on this shape: the measured subject **was** one commit deep and still
needed sixteen gigabytes. A line sending that operator to clone shallower would
send them round a loop they are already standing in.

It is judged against the ceiling phase 1 was judged against, less what is already
charged. An operator who set `KIN_INIT_MEMORY_CEILING_BYTES` has stated the true
ceiling once and been taken at their word, and warning them again four phases
later with the number they overrode would fire on precisely the person who has
already answered. With no override set the arithmetic is `limit_bytes -
used_bytes`, which is what `MemoryReading::available_bytes` returns, so an
unoverridden conversion is judged against the same number as before.

## The two silent phases

Phases 11 and 13 spend all of their time inside one call into a crate below this
one, and `kin_db::storage::history_replay` is the only periodic emitter any of
them has. On the same snapshot phase 11 ran 38.1 s and printed nothing at all,
and phase 13's last line landed at 68 s and the phase then ran for over half an
hour in silence. Nothing was wrong, and there was no way to know that from
outside.

The heartbeat invents no progress it cannot see. It carries the size of the work,
which the caller knows before it blocks, and the phase line's own elapsed time,
which the ladder already keeps. It ticks every 5 s from a named thread, takes the
ladder by handle rather than through the thread-local slot that belongs to the
installing thread, stops reporting rather than panicking twice on a poisoned
ladder, and joins on drop so it can never draw over the phase that follows.

## What this does not touch

The allocation itself belongs to kin-model, which is pinned from the registry.
It is already tracked: FIR-2692 for `compute_semantic_change_id` cloning its
change and building a `serde_json::Value` tree, which names a borrowed view in
the manner of `CanonicalTransaction` as the fix, and FIR-2335 for the replay
clones, which I re-verified still holds in 0.7.22 at `graph.rs:997-1001` and
`graph.rs:393-400`. Both got the snapshot evidence as comments. No line here goes
near either.

## Gates

Everything below ran through the fleet's heavy slot against this worktree, and
`bin/kin-precheck` printed the path, sha and branch it resolved before grading.

| gate | result |
|---|---|
| `bin/kin-precheck kin --repo-dir` | 16 gates enumerated from ci.yml's own check job, 16 passed, 0 failed |
| `cargo test -p kin-core --lib` | 795 passed, 0 failed |
| `cargo test -p kin-cli --test init_non_tty_output` | 13 passed, 0 failed |

The precheck total includes `cargo fmt -- --check`, `cargo clippy --all-targets
--all-features` with the 45-lint debt allow-list under `RUSTFLAGS=-D warnings`,
and all fourteen guard scripts ci.yml names. Three steps the check job runs are
listed by precheck as deliberately non-local and were not counted.

`init_non_tty_output` is here on purpose rather than incidentally. It is the one
test in the tree that asserts on what `kin init` writes to stderr, and this PR
changes exactly that: it asserts zero carriage-return frames in a captured run
and a total under 16 KB, which is what a new phase-4 detail line and two
heartbeats could have broken. Off a terminal the ladder writes with `writeln`
and no `\r`, and prints the first detail and then every tenth, so a 5 s cadence
puts a line in a pipe roughly every fifty seconds.

`bin/kin-parity` was not run. The change is confined to kin-core with no product
binary behaviour outside the phase ladder, and the ladder's one assertion is
covered above. Hosted CI remains the gate of record.

Thirteen new tests. Every one was falsified by breaking the behaviour it guards,
across ten mutations, each applied to a pristine copy and restored, with both
files hash-checked against the pristine afterwards. Each mutation reddened
exactly the tests predicted for it:

| mutation | tests reddened |
|---|---|
| drop the head-tree term | 5 |
| raise the per-artifact floor past react's measurement | 1 |
| drop the inherited per-commit-artifact term | 1 |
| wrap instead of saturate on the head term | 1 |
| let the advisory speak for a projection that fits | 3 |
| stop subtracting what is already charged | 2 |
| make an unreadable ceiling stop being an error | 1 |
| stop the heartbeat ticking the ladder | 2 |
| neither stop nor join the thread on drop | 1 |
| drop the cadence to a per-second tick | 1 |

One inherited test was rewritten because it could not fail. The overflow case
used a `u64::MAX` survey, which saturates on the inherited per-commit term alone
and passed with both new multiplications wrapping. It now overflows each new term
in isolation, and the wrapping mutation proves it.

Related: FIR-3056, FIR-2692, FIR-2335
