### PR TITLE
Serve the live graph as an export and a delta stream

### DIFF
--- a/crates/kin-cli/src/commands/graph_export.rs
+++ b/crates/kin-cli/src/commands/graph_export.rs
@@ -1,0 +1,1120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The consumer-facing projection of the live graph.
+//!
+//! `kin graph viz` built a render payload by reading a snapshot off disk and
+//! serving it once, so every outside consumer that wanted to draw or follow a
+//! repository had to start that server and scrape it. The payload had no line,
+//! no signature and no cap, and each consumer wrote its own sampling rule, so
+//! two clients drawing "the graph" drew different graphs.
+//!
+//! This module holds the payload shape and the sampling rule in one place, as
+//! pure functions over what the graph reported. The daemon serves them at
+//! `GET /graph/export` against the live graph it already holds, and the CLI
+//! asks that same route, so there is one answer and one sample.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+use kin_model::{Entity, EntityStore, GraphNodeId};
+use serde::{Deserialize, Serialize};
+
+/// Node cap applied when a caller names none.
+///
+/// A caller that asks for no cap gets none: the whole graph is a legitimate
+/// request and the export must be able to answer it. This is the default a
+/// drawing client inherits, chosen because it is the largest node count the
+/// existing force-directed renderers stay interactive at.
+pub const DEFAULT_NODE_LIMIT: usize = 1_400;
+
+/// One drawable node.
+///
+/// `line` and `signature` are absent unless the caller asked for them through
+/// `include`, so the default payload carries exactly the fields the current
+/// renderers read and nothing that would grow it for no drawn pixel.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphExportNode {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+    pub file: Option<String>,
+    pub degree: usize,
+    /// 1-based presentation start line, when the caller asked for it and the
+    /// entity carries a span. A spanless entity has no line to report and
+    /// reporting 0 or 1 for one would be a fabricated position.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
+/// One drawable edge. Both endpoints are ids present in `nodes`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphExportLink {
+    pub source: String,
+    pub target: String,
+    pub kind: String,
+}
+
+/// The export envelope.
+///
+/// The counts describe the population the sample was drawn from, so a client
+/// can say how much of the graph it is showing rather than implying it drew
+/// all of it. `root_hash` names the graph this payload came from, which is what
+/// pairs an export with the delta stream: an event whose root no longer matches
+/// means re-export rather than patch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphExportPayload {
+    /// Hex Merkle root of the graph this payload was built from.
+    pub root_hash: String,
+    /// Position in the delta stream this payload was cut at.
+    ///
+    /// The resync key. A client exports, subscribes to `/graph/events`, and
+    /// discards every event whose `seq` is at or below this one; what is left is
+    /// exactly what happened after the cut. The root hash cannot do this job on
+    /// its own, because a working-tree edit changes the graph without advancing
+    /// the root, so a client reconnecting between commits would see a matching
+    /// hash and a stale picture.
+    pub seq: u64,
+    /// Entities matching `kinds` and `path`, before the node cap.
+    pub entity_count: usize,
+    /// Drawable links among those entities, before the node cap.
+    pub relation_count: usize,
+    /// Relations withheld because an endpoint is not an entity in this graph at
+    /// all. An import of an external crate resolves to a placeholder that is no
+    /// entity here, and a link naming an absent node is not a drawable edge.
+    pub unresolved_links: usize,
+    /// Relations withheld because an endpoint was excluded by `kinds`, `path`
+    /// or the node cap. Counted apart from `unresolved_links` because one is a
+    /// property of the graph and the other is a property of this request.
+    pub filtered_links: usize,
+    /// Whether the node cap dropped anything. False means `nodes` is every
+    /// entity that matched.
+    pub sampled: bool,
+    /// The cap actually applied, absent when the caller asked for no cap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    pub nodes: Vec<GraphExportNode>,
+    pub links: Vec<GraphExportLink>,
+}
+
+/// Which optional node fields a caller asked for.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct IncludeFields {
+    pub line: bool,
+    pub signature: bool,
+}
+
+impl IncludeFields {
+    /// Parse a comma-separated `include` value. Unknown names are ignored
+    /// rather than refused, so a newer client naming a field this build does
+    /// not have still gets its export.
+    pub fn parse(raw: &str) -> Self {
+        let mut fields = Self::default();
+        for token in raw.split(',') {
+            match token.trim().to_ascii_lowercase().as_str() {
+                "line" | "lines" => fields.line = true,
+                "signature" | "signatures" => fields.signature = true,
+                _ => {}
+            }
+        }
+        fields
+    }
+}
+
+/// A resolved export request.
+#[derive(Debug, Clone, Default)]
+pub struct ExportOptions {
+    /// `None` means no cap: emit every matching entity.
+    pub limit: Option<usize>,
+    /// Normalized entity-kind names. Empty means every kind.
+    pub kinds: Vec<String>,
+    /// Repository path prefix a node's file must start with.
+    pub path_prefix: Option<String>,
+    pub include: IncludeFields,
+}
+
+/// Normalize a kind name so `TraitDef`, `trait_def` and `traitdef` are one key.
+///
+/// The payload emits the graph's own `Debug` spelling because that is what the
+/// existing renderers already switch on. A query parameter typed by a human or
+/// a JSON client should not have to guess which spelling this build uses.
+fn normalize_kind(raw: &str) -> String {
+    raw.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+/// Parse a comma-separated `kinds` value into normalized names.
+pub fn parse_kinds(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(normalize_kind)
+        .filter(|k| !k.is_empty())
+        .collect()
+}
+
+/// One node's graph-owned identity, split out from the store so payload
+/// assembly is a pure function over what the graph reported.
+#[derive(Debug, Clone)]
+pub struct NodeMeta {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+    pub file: Option<String>,
+    pub line: Option<u32>,
+    pub signature: Option<String>,
+}
+
+impl NodeMeta {
+    /// Project one graph entity into the export's node identity.
+    pub fn from_entity(entity: &Entity) -> Self {
+        Self {
+            id: entity.id.to_string(),
+            name: entity.name.clone(),
+            kind: format!("{:?}", entity.kind),
+            file: entity.file_origin.as_ref().map(|f| f.0.clone()),
+            line: entity
+                .span
+                .as_ref()
+                .map(|span| span.start_line.saturating_add(1)),
+            signature: if entity.signature.is_empty() {
+                None
+            } else {
+                Some(entity.signature.clone())
+            },
+        }
+    }
+
+    fn matches(&self, options: &ExportOptions) -> bool {
+        if !options.kinds.is_empty() && !options.kinds.contains(&normalize_kind(&self.kind)) {
+            return false;
+        }
+        if let Some(prefix) = options.path_prefix.as_deref() {
+            let Some(file) = self.file.as_deref() else {
+                // A node with no file cannot satisfy a path prefix. Keeping it
+                // would answer "under this directory" with something that is
+                // under no directory at all.
+                return false;
+            };
+            if !file.starts_with(prefix) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// The module a node is sampled within.
+///
+/// A faithful port of the rule the demo renderer already applies client side
+/// (`kin-demo/server/graph-sampling.ts:moduleOf`), moved here so kin serves one
+/// sample instead of every consumer inventing its own. Two clients drawing "the
+/// graph" were drawing different graphs; now they draw the same one.
+///
+/// The two-level case is why the rule is not just "first path segment". A Rust
+/// workspace keeps every crate under `crates/`, a pnpm workspace keeps every
+/// app under `packages/`, and collapsing those into one bucket hands the whole
+/// quota to whichever crate happens to be densest while every other crate
+/// disappears from the picture.
+fn module_of(file: Option<&str>) -> String {
+    let Some(raw) = file.filter(|value| !value.is_empty()) else {
+        // Entities the graph placed in no file are real and are under no
+        // module. They share one bucket rather than vanishing.
+        return UNKNOWN_MODULE.to_string();
+    };
+    let normalized = raw.replace('\\', "/");
+    let normalized = normalized.strip_prefix("./").unwrap_or(&normalized);
+    let parts: Vec<&str> = normalized.split('/').filter(|p| !p.is_empty()).collect();
+    if parts.len() <= 1 {
+        // A file at the repository root is its own module for this purpose.
+        return ROOT_MODULE.to_string();
+    }
+    if CONTAINER_DIRS.contains(&parts[0]) && parts.len() > 2 {
+        return format!("{}/{}", parts[0], parts[1]);
+    }
+    parts[0].to_string()
+}
+
+/// Directories that hold modules rather than being one.
+const CONTAINER_DIRS: &[&str] = &[
+    "app", "apps", "cmd", "crates", "internal", "lib", "modules", "packages", "pkg", "services",
+    "src",
+];
+
+const UNKNOWN_MODULE: &str = "(unknown)";
+const ROOT_MODULE: &str = "(root)";
+
+/// Share of the node cap handed out as per-module quotas.
+///
+/// The rest is filled globally by degree, so the sample is neither "the
+/// densest module only" nor "an even slice of everything". Ported from the
+/// demo's rule rather than re-derived, because matching an already-shipped
+/// picture is worth more here than a marginally better one nobody has seen.
+const QUOTA_SHARE_PERCENT: usize = 60;
+
+/// Rank key within a module: highest degree first, then a stable tiebreak.
+///
+/// The id tiebreak is what makes the sample deterministic, and it is the one
+/// place this deviates from the demo's rule. Degree and name alone leave every
+/// zero-degree same-name node tied, and which of them survived would then
+/// depend on the order the store happened to enumerate entities in, so two
+/// exports of one unchanged graph could disagree.
+fn rank_key(node: &(NodeMeta, usize)) -> (std::cmp::Reverse<usize>, &str, &str) {
+    (
+        std::cmp::Reverse(node.1),
+        node.0.name.as_str(),
+        node.0.id.as_str(),
+    )
+}
+
+/// Reduce `ranked` to at most `limit` nodes: a per-module quota by degree,
+/// then a global fill by degree for whatever budget the quotas left.
+///
+/// Returns the surviving nodes in canonical id order, so the payload's node
+/// order does not leak the order the sample was assembled in.
+fn sample(ranked: Vec<(NodeMeta, usize)>, limit: usize) -> Vec<(NodeMeta, usize)> {
+    if limit == 0 || ranked.len() <= limit {
+        let mut kept = ranked;
+        kept.sort_by(|a, b| a.0.id.cmp(&b.0.id));
+        return kept;
+    }
+
+    // BTreeMap, not a hash map: module iteration order decides who gets the
+    // quota when the budget runs out mid-pass, so it has to be the same order
+    // every time rather than whatever the hasher produced.
+    let mut by_module: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for (index, node) in ranked.iter().enumerate() {
+        by_module
+            .entry(module_of(node.0.file.as_deref()))
+            .or_default()
+            .push(index);
+    }
+    for indices in by_module.values_mut() {
+        indices.sort_by(|a, b| rank_key(&ranked[*a]).cmp(&rank_key(&ranked[*b])));
+    }
+
+    let share = std::cmp::max(
+        1,
+        limit.saturating_mul(QUOTA_SHARE_PERCENT) / 100 / by_module.len(),
+    );
+    let mut chosen: HashSet<usize> = HashSet::with_capacity(limit);
+    'quota: for indices in by_module.values() {
+        for index in indices.iter().take(share) {
+            if chosen.len() >= limit {
+                break 'quota;
+            }
+            chosen.insert(*index);
+        }
+    }
+
+    if chosen.len() < limit {
+        let mut rest: Vec<usize> = (0..ranked.len())
+            .filter(|index| !chosen.contains(index))
+            .collect();
+        rest.sort_by(|a, b| rank_key(&ranked[*a]).cmp(&rank_key(&ranked[*b])));
+        for index in rest {
+            if chosen.len() >= limit {
+                break;
+            }
+            chosen.insert(index);
+        }
+    }
+
+    let mut kept: Vec<(NodeMeta, usize)> = ranked
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, node)| chosen.contains(&index).then_some(node))
+        .collect();
+    kept.sort_by(|a, b| a.0.id.cmp(&b.0.id));
+    kept
+}
+
+/// Assemble the export payload from what the graph reported.
+///
+/// `all_entity_ids` is every entity id in the graph, unfiltered: it is what
+/// separates a relation pointing outside the graph from one pointing at a node
+/// this request excluded. `edges` are the graph's relations as
+/// (source, target, kind) with both endpoints already resolved to entity ids.
+pub fn assemble_payload(
+    root_hash: String,
+    seq: u64,
+    node_meta: Vec<NodeMeta>,
+    all_entity_ids: &HashSet<String>,
+    edges: impl IntoIterator<Item = (String, String, String)>,
+    options: &ExportOptions,
+) -> GraphExportPayload {
+    let matched: Vec<NodeMeta> = node_meta
+        .into_iter()
+        .filter(|meta| meta.matches(options))
+        .collect();
+    let matched_ids: HashSet<&str> = matched.iter().map(|meta| meta.id.as_str()).collect();
+
+    // Collapse to undirected (a, b, kind) keys BEFORE classifying anything.
+    // `read_graph` walks every entity and asks for its relations, so an edge
+    // between two entities is reported twice, once from each end. Classifying
+    // first counted one graph edge as two withheld ones, and the render payload
+    // has always drawn such a pair as a single line anyway.
+    let mut distinct_edges: BTreeSet<(String, String, String)> = BTreeSet::new();
+    for (a, b, kind) in edges {
+        let (a, b) = if a <= b { (a, b) } else { (b, a) };
+        distinct_edges.insert((a, b, kind));
+    }
+
+    let mut link_keys: BTreeSet<(String, String, String)> = BTreeSet::new();
+    let mut unresolved_links = 0usize;
+    let mut filtered_links = 0usize;
+    for (a, b, kind) in distinct_edges {
+        if !all_entity_ids.contains(a.as_str()) || !all_entity_ids.contains(b.as_str()) {
+            unresolved_links += 1;
+            continue;
+        }
+        if !matched_ids.contains(a.as_str()) || !matched_ids.contains(b.as_str()) {
+            filtered_links += 1;
+            continue;
+        }
+        link_keys.insert((a, b, kind));
+    }
+
+    let mut degrees: HashMap<&str, usize> = HashMap::with_capacity(matched.len());
+    for (a, b, _kind) in &link_keys {
+        *degrees.entry(a.as_str()).or_insert(0) += 1;
+        *degrees.entry(b.as_str()).or_insert(0) += 1;
+    }
+
+    let entity_count = matched.len();
+    let relation_count = link_keys.len();
+
+    let ranked: Vec<(NodeMeta, usize)> = matched
+        .into_iter()
+        .map(|meta| {
+            let degree = degrees.get(meta.id.as_str()).copied().unwrap_or(0);
+            (meta, degree)
+        })
+        .collect();
+
+    let (kept, sampled) = match options.limit {
+        Some(limit) if ranked.len() > limit => (sample(ranked, limit), true),
+        _ => {
+            let mut kept = ranked;
+            kept.sort_by(|a, b| a.0.id.cmp(&b.0.id));
+            (kept, false)
+        }
+    };
+
+    let kept_ids: HashSet<&str> = kept.iter().map(|(meta, _)| meta.id.as_str()).collect();
+    let mut links: Vec<GraphExportLink> = Vec::new();
+    for (source, target, kind) in link_keys {
+        if !kept_ids.contains(source.as_str()) || !kept_ids.contains(target.as_str()) {
+            filtered_links += 1;
+            continue;
+        }
+        links.push(GraphExportLink {
+            source,
+            target,
+            kind,
+        });
+    }
+
+    let nodes: Vec<GraphExportNode> = kept
+        .into_iter()
+        .map(|(meta, degree)| GraphExportNode {
+            id: meta.id,
+            name: meta.name,
+            kind: meta.kind,
+            file: meta.file,
+            degree,
+            line: if options.include.line {
+                meta.line
+            } else {
+                None
+            },
+            signature: if options.include.signature {
+                meta.signature
+            } else {
+                None
+            },
+        })
+        .collect();
+
+    GraphExportPayload {
+        root_hash,
+        seq,
+        entity_count,
+        relation_count,
+        unresolved_links,
+        filtered_links,
+        sampled,
+        limit: options.limit,
+        nodes,
+        links,
+    }
+}
+
+/// Read the entities and relations an export needs out of a graph store.
+///
+/// Split from [`assemble_payload`] so the shaping and sampling rules can be
+/// graded without a store, and so the daemon and any offline reader produce the
+/// same payload from the same graph.
+pub fn read_graph<S>(
+    store: &S,
+) -> anyhow::Result<(
+    Vec<NodeMeta>,
+    HashSet<String>,
+    Vec<(String, String, String)>,
+)>
+where
+    S: EntityStore,
+{
+    let entities = store
+        .list_all_entities()
+        .map_err(|error| anyhow::anyhow!("list graph entities: {error}"))?;
+
+    let all_entity_ids: HashSet<String> = entities.iter().map(|e| e.id.to_string()).collect();
+
+    let mut edges: Vec<(String, String, String)> = Vec::new();
+    for entity in &entities {
+        let src_id = entity.id.to_string();
+        let relations = store
+            .get_all_relations_for_entity(&entity.id)
+            .map_err(|error| anyhow::anyhow!("read relations for {src_id}: {error}"))?;
+        for relation in relations {
+            let other_id = match (&relation.src, &relation.dst) {
+                (GraphNodeId::Entity(s), GraphNodeId::Entity(d)) => {
+                    if *s == entity.id {
+                        d.to_string()
+                    } else {
+                        s.to_string()
+                    }
+                }
+                _ => continue,
+            };
+            edges.push((src_id.clone(), other_id, format!("{:?}", relation.kind)));
+        }
+    }
+
+    let node_meta = entities.iter().map(NodeMeta::from_entity).collect();
+    Ok((node_meta, all_entity_ids, edges))
+}
+
+/// How a caller asked for the export on the command line.
+#[derive(Debug, Clone, Default)]
+pub struct ExportArgs {
+    /// `None` uses [`DEFAULT_NODE_LIMIT`]; `Some(0)` means no cap at all.
+    pub limit: Option<usize>,
+    pub kinds: Option<String>,
+    pub path: Option<String>,
+    pub include: Option<String>,
+    pub out: Option<std::path::PathBuf>,
+    pub json: bool,
+}
+
+/// Build the `/graph/export` query string for these arguments.
+///
+/// Split out so the encoding is graded without a daemon: a `path` prefix
+/// holding a space or an `&` has to survive the trip, and a caller who asked
+/// for no cap has to be distinguishable from one who named none.
+pub fn export_query_string(args: &ExportArgs) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    // An explicit 0 is the request for the whole graph. It has to reach the
+    // daemon as a value, because omitting the parameter means "use the default
+    // cap" and those are opposite requests.
+    if let Some(limit) = args.limit {
+        parts.push(format!("limit={limit}"));
+    }
+    for (key, value) in [
+        ("kinds", args.kinds.as_deref()),
+        ("path", args.path.as_deref()),
+        ("include", args.include.as_deref()),
+    ] {
+        if let Some(value) = value.filter(|v| !v.trim().is_empty()) {
+            parts.push(format!(
+                "{key}={}",
+                crate::daemon_client::urlencoding::encode(value)
+            ));
+        }
+    }
+    parts.join("&")
+}
+
+/// `kin graph export`: the drawable projection of the live graph, as JSON.
+pub async fn export(args: ExportArgs) -> anyhow::Result<()> {
+    let layout = crate::commands::require_repository_layout()?;
+    let client =
+        crate::daemon_client::DaemonClient::connect_for_command("graph export", &layout).await?;
+    let payload = client.graph_export(&export_query_string(&args)).await?;
+
+    let body = serde_json::to_string_pretty(&payload)
+        .map_err(|error| anyhow::anyhow!("serialize graph export: {error}"))?;
+
+    if let Some(path) = args.out.as_ref() {
+        std::fs::write(path, format!("{body}\n"))
+            .map_err(|error| anyhow::anyhow!("write {}: {error}", path.display()))?;
+        if !args.json {
+            println!("{}", export_summary_line(&payload, Some(path)));
+        }
+        return Ok(());
+    }
+
+    if args.json {
+        println!("{body}");
+    } else {
+        println!("{}", export_summary_line(&payload, None));
+    }
+    Ok(())
+}
+
+/// One line saying what the export actually contains.
+///
+/// It reports the drawn counts against the population they came from, because
+/// a sampled export that reported only its own size would read as the whole
+/// graph. `sampled` alone does not say how much was left out.
+pub fn export_summary_line(
+    payload: &GraphExportPayload,
+    written_to: Option<&std::path::Path>,
+) -> String {
+    let scope = if payload.sampled {
+        format!(
+            "{} of {} entities and {} of {} relations (sampled)",
+            payload.nodes.len(),
+            payload.entity_count,
+            payload.links.len(),
+            payload.relation_count
+        )
+    } else {
+        format!(
+            "{} entities and {} relations (complete)",
+            payload.nodes.len(),
+            payload.links.len()
+        )
+    };
+    match written_to {
+        Some(path) => format!(
+            "Wrote {scope} at root {} seq {} to {}",
+            payload.root_hash,
+            payload.seq,
+            path.display()
+        ),
+        None => format!("{scope} at root {} seq {}", payload.root_hash, payload.seq),
+    }
+}
+
+/// How a caller asked to watch the graph on the command line.
+#[derive(Debug, Clone, Default)]
+pub struct WatchArgs {
+    /// Event type names to keep. Empty means every type.
+    pub types: Option<String>,
+    pub json: bool,
+}
+
+/// Build the `/graph/events` query string for these arguments.
+pub fn watch_query_string(args: &WatchArgs) -> String {
+    match args.types.as_deref().filter(|v| !v.trim().is_empty()) {
+        Some(types) => format!("types={}", crate::daemon_client::urlencoding::encode(types)),
+        None => String::new(),
+    }
+}
+
+/// Pull the JSON payloads out of one chunk of an SSE body.
+///
+/// SSE frames are separated by a blank line and a frame may arrive split across
+/// TCP reads, so the caller keeps a buffer and hands back whatever tail did not
+/// terminate. Comment lines (the heartbeat) carry no payload and are dropped.
+pub fn drain_sse_frames(buffer: &mut String) -> Vec<String> {
+    let mut payloads = Vec::new();
+    while let Some(end) = buffer.find("\n\n") {
+        let frame: String = buffer.drain(..end + 2).collect();
+        for line in frame.lines() {
+            let line = line.trim_end_matches('\r');
+            if let Some(rest) = line.strip_prefix("data:") {
+                let payload = rest.trim();
+                if !payload.is_empty() {
+                    payloads.push(payload.to_string());
+                }
+            }
+        }
+    }
+    payloads
+}
+
+/// `kin graph watch`: follow the live graph, one event per line.
+pub async fn watch(args: WatchArgs) -> anyhow::Result<()> {
+    use std::io::Write as _;
+
+    let layout = crate::commands::require_repository_layout()?;
+    let client =
+        crate::daemon_client::DaemonClient::connect_for_command("graph watch", &layout).await?;
+    let mut response = client.graph_events(&watch_query_string(&args)).await?;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    let mut buffer = String::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| anyhow::anyhow!("read graph event stream: {error}"))?
+    {
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+        for payload in drain_sse_frames(&mut buffer) {
+            if args.json {
+                writeln!(out, "{payload}")?;
+            } else {
+                writeln!(out, "{}", watch_human_line(&payload))?;
+            }
+            // Flushed per event, not per buffer. A watch piped into another
+            // process is useless if its output arrives in 8 KiB batches minutes
+            // after the change it describes.
+            out.flush()?;
+        }
+    }
+    Ok(())
+}
+
+/// One human-readable line for an event payload.
+///
+/// Falls back to the raw JSON rather than dropping an event whose shape this
+/// build does not know. A watch that silently swallowed a newer daemon's event
+/// would be worse than one that printed something ugly.
+pub fn watch_human_line(payload: &str) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) else {
+        return payload.to_string();
+    };
+    let event_type = value
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("event");
+    let field = |name: &str| value.get(name).and_then(|v| v.as_str()).map(str::to_string);
+    match event_type {
+        "EntityChanged" => format!(
+            "entity {} {} {}",
+            field("change_type").unwrap_or_else(|| "changed".to_string()),
+            field("entity_id").unwrap_or_default(),
+            field("file_path").unwrap_or_default()
+        )
+        .trim_end()
+        .to_string(),
+        "RelationChanged" => format!(
+            "relation {} {} {} -> {}",
+            field("change_type").unwrap_or_else(|| "changed".to_string()),
+            field("kind").unwrap_or_default(),
+            field("source").unwrap_or_default(),
+            field("target").unwrap_or_default()
+        ),
+        "GraphRootChanged" => format!(
+            "graph root -> {}",
+            field("new_root_hash").unwrap_or_default()
+        ),
+        _ => payload.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(id: &str, name: &str, kind: &str, file: Option<&str>) -> NodeMeta {
+        NodeMeta {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: kind.to_string(),
+            file: file.map(str::to_string),
+            line: Some(7),
+            signature: Some(format!("fn {name}()")),
+        }
+    }
+
+    fn ids(payload: &GraphExportPayload) -> Vec<&str> {
+        payload.nodes.iter().map(|n| n.id.as_str()).collect()
+    }
+
+    fn all_ids(metas: &[NodeMeta]) -> HashSet<String> {
+        metas.iter().map(|m| m.id.clone()).collect()
+    }
+
+    /// A file at the repository root, a file one level down, and a file under a
+    /// container directory are three different module answers.
+    ///
+    /// The container case is the one that matters: a Rust workspace keeps every
+    /// crate under `crates/`, so collapsing that to one bucket gives the whole
+    /// quota to the densest crate and erases the rest from the picture.
+    #[test]
+    fn a_container_directory_is_split_one_level_deeper() {
+        assert_eq!(module_of(Some("main.c")), "(root)");
+        assert_eq!(module_of(Some("src/net.c")), "src");
+        assert_eq!(
+            module_of(Some("crates/kin-db/src/graph.rs")),
+            "crates/kin-db"
+        );
+        assert_eq!(module_of(Some("deps/hiredis/net.c")), "deps");
+        assert_eq!(module_of(None), "(unknown)");
+        // A Windows path names the same module as its POSIX spelling.
+        assert_eq!(module_of(Some("src\\modules\\vector.c")), "src/modules");
+        // A leading "./" is not a module.
+        assert_eq!(module_of(Some("./src/net.c")), "src");
+    }
+
+    /// The same graph exports the same sample no matter what order the store
+    /// enumerated it in.
+    ///
+    /// This is the property the demo's client-side rule did not have: it broke
+    /// degree ties on name alone, so two same-name zero-degree entities were
+    /// tied and whichever the store happened to list first survived.
+    #[test]
+    fn the_sample_does_not_depend_on_enumeration_order() {
+        let build = |order: &[usize]| {
+            let pool: Vec<NodeMeta> = (0..40)
+                .map(|i| {
+                    meta(
+                        &format!("id-{i:03}"),
+                        // Deliberately colliding names, so only the id can
+                        // break the tie.
+                        "same",
+                        "Function",
+                        Some(if i % 2 == 0 { "src/a.rs" } else { "lib/b.rs" }),
+                    )
+                })
+                .collect();
+            let reordered: Vec<NodeMeta> = order.iter().map(|i| pool[*i].clone()).collect();
+            let known = all_ids(&pool);
+            assemble_payload(
+                "root".to_string(),
+                0,
+                reordered,
+                &known,
+                Vec::new(),
+                &ExportOptions {
+                    limit: Some(10),
+                    ..Default::default()
+                },
+            )
+        };
+
+        let forward: Vec<usize> = (0..40).collect();
+        let backward: Vec<usize> = (0..40).rev().collect();
+        let shuffled: Vec<usize> = (0..40).map(|i| (i * 17) % 40).collect();
+
+        let a = build(&forward);
+        let b = build(&backward);
+        let c = build(&shuffled);
+        assert_eq!(
+            ids(&a),
+            ids(&b),
+            "reversing the input must not move the sample"
+        );
+        assert_eq!(
+            ids(&a),
+            ids(&c),
+            "shuffling the input must not move the sample"
+        );
+        assert_eq!(a.nodes.len(), 10);
+        assert!(a.sampled);
+    }
+
+    /// A small module is not erased by a large dense one.
+    ///
+    /// Ranking the whole graph by degree hands the entire budget to whichever
+    /// directory happens to be densest. Measured on redis, `utils` holds 97 of
+    /// 23,098 entities; a reader looking for it has to find something drawn.
+    #[test]
+    fn a_small_module_survives_a_dense_one() {
+        let mut metas = Vec::new();
+        let mut edges = Vec::new();
+        // A dense module: 200 entities, all wired to one hub.
+        for i in 0..200 {
+            metas.push(meta(
+                &format!("big-{i:03}"),
+                &format!("big{i}"),
+                "Function",
+                Some("src/big.rs"),
+            ));
+            if i > 0 {
+                edges.push((
+                    "big-000".to_string(),
+                    format!("big-{i:03}"),
+                    "Calls".to_string(),
+                ));
+            }
+        }
+        // A small module: 3 entities, no edges at all, so every one of them
+        // ranks below every node in the dense module on degree.
+        for i in 0..3 {
+            metas.push(meta(
+                &format!("small-{i}"),
+                &format!("small{i}"),
+                "Function",
+                Some("utils/tiny.rs"),
+            ));
+        }
+
+        let known = all_ids(&metas);
+        let payload = assemble_payload(
+            "root".to_string(),
+            0,
+            metas,
+            &known,
+            edges,
+            &ExportOptions {
+                limit: Some(20),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(payload.nodes.len(), 20);
+        let small_kept = payload
+            .nodes
+            .iter()
+            .filter(|n| n.id.starts_with("small-"))
+            .count();
+        assert_eq!(
+            small_kept, 3,
+            "every entity of a 3-entity module fits inside its quota and must be drawn"
+        );
+    }
+
+    /// An edge to something that is not an entity, and an edge to an entity
+    /// this request excluded, are different news and are counted apart.
+    #[test]
+    fn an_absent_endpoint_and_an_excluded_one_are_counted_separately() {
+        let metas = vec![
+            meta("a", "alpha", "Function", Some("src/a.rs")),
+            meta("b", "beta", "Class", Some("src/b.rs")),
+        ];
+        let mut known = all_ids(&metas);
+        // An entity that exists in the graph but is not in this payload's
+        // population, because the caller filtered it out by kind.
+        known.insert("c".to_string());
+        let edges = vec![
+            ("a".to_string(), "b".to_string(), "Calls".to_string()),
+            // Endpoint is no entity at all: an import of an external crate.
+            ("a".to_string(), "outside".to_string(), "Calls".to_string()),
+        ];
+
+        let payload = assemble_payload(
+            "root".to_string(),
+            0,
+            metas,
+            &known,
+            edges,
+            &ExportOptions {
+                kinds: vec!["function".to_string()],
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            payload.nodes.len(),
+            1,
+            "only the Function survives the filter"
+        );
+        assert_eq!(
+            payload.unresolved_links, 1,
+            "the external endpoint is unresolved, a property of the graph"
+        );
+        assert_eq!(
+            payload.filtered_links, 1,
+            "the a->b edge lost its target to the kind filter, a property of this request"
+        );
+        assert!(payload.links.is_empty());
+    }
+
+    /// One graph edge is one edge, however many times the store reported it.
+    ///
+    /// `read_graph` asks every entity for its relations, so an edge between two
+    /// entities comes back twice, once from each end. Counting withheld edges
+    /// before collapsing that pair reported a single dropped edge as two, which
+    /// is how a consumer would have been told a filtered export hid twice as
+    /// much of the graph as it did.
+    #[test]
+    fn an_edge_reported_from_both_ends_is_one_edge() {
+        let metas = vec![
+            meta("a", "alpha", "Function", Some("src/a.rs")),
+            meta("b", "beta", "Function", Some("vendor/b.rs")),
+        ];
+        let known = all_ids(&metas);
+        // Exactly what the store hands back: the same edge, from each end.
+        let edges = vec![
+            ("a".to_string(), "b".to_string(), "Calls".to_string()),
+            ("b".to_string(), "a".to_string(), "Calls".to_string()),
+        ];
+
+        let drawn = assemble_payload(
+            "root".to_string(),
+            0,
+            metas.clone(),
+            &known,
+            edges.clone(),
+            &ExportOptions::default(),
+        );
+        assert_eq!(drawn.links.len(), 1, "one edge draws one line");
+        assert_eq!(drawn.relation_count, 1);
+        assert_eq!(drawn.nodes[0].degree, 1, "and counts once toward degree");
+
+        let filtered = assemble_payload(
+            "root".to_string(),
+            0,
+            metas,
+            &known,
+            edges,
+            &ExportOptions {
+                path_prefix: Some("src/".to_string()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            filtered.filtered_links, 1,
+            "and is withheld once, not once per end"
+        );
+    }
+
+    /// The default payload carries exactly the fields the existing renderers
+    /// read, and nothing that would grow it for no drawn pixel.
+    #[test]
+    fn optional_fields_are_absent_until_asked_for() {
+        let metas = vec![meta("a", "alpha", "Function", Some("src/a.rs"))];
+        let known = all_ids(&metas);
+
+        let plain = assemble_payload(
+            "root".to_string(),
+            0,
+            metas.clone(),
+            &known,
+            Vec::new(),
+            &ExportOptions::default(),
+        );
+        assert_eq!(plain.nodes[0].line, None);
+        assert_eq!(plain.nodes[0].signature, None);
+        let json = serde_json::to_string(&plain.nodes[0]).unwrap();
+        assert!(
+            !json.contains("line"),
+            "an absent field is not on the wire: {json}"
+        );
+        assert!(
+            !json.contains("signature"),
+            "an absent field is not on the wire: {json}"
+        );
+
+        let rich = assemble_payload(
+            "root".to_string(),
+            0,
+            metas,
+            &known,
+            Vec::new(),
+            &ExportOptions {
+                include: IncludeFields::parse("signature,line"),
+                ..Default::default()
+            },
+        );
+        assert_eq!(rich.nodes[0].line, Some(7));
+        assert_eq!(rich.nodes[0].signature.as_deref(), Some("fn alpha()"));
+    }
+
+    /// An unknown `include` name is ignored rather than refused, so a newer
+    /// client naming a field this build does not have still gets its export.
+    #[test]
+    fn an_unknown_include_name_is_ignored() {
+        let fields = IncludeFields::parse("signature,embedding,LINE");
+        assert!(fields.signature);
+        assert!(fields.line);
+    }
+
+    /// `kinds` matches whichever spelling the caller typed.
+    #[test]
+    fn a_kind_filter_matches_every_spelling_of_the_name() {
+        for spelling in ["TraitDef", "trait_def", "traitdef", " TRAIT-DEF "] {
+            let metas = vec![meta("a", "alpha", "TraitDef", Some("src/a.rs"))];
+            let known = all_ids(&metas);
+            let payload = assemble_payload(
+                "root".to_string(),
+                0,
+                metas,
+                &known,
+                Vec::new(),
+                &ExportOptions {
+                    kinds: parse_kinds(spelling),
+                    ..Default::default()
+                },
+            );
+            assert_eq!(
+                payload.nodes.len(),
+                1,
+                "{spelling} must select the TraitDef"
+            );
+        }
+    }
+
+    /// A cap that nothing exceeded is not a sample, and says so.
+    #[test]
+    fn an_uncrossed_cap_reports_a_complete_export() {
+        let metas = vec![meta("a", "alpha", "Function", Some("src/a.rs"))];
+        let known = all_ids(&metas);
+        let payload = assemble_payload(
+            "root".to_string(),
+            0,
+            metas,
+            &known,
+            Vec::new(),
+            &ExportOptions {
+                limit: Some(50),
+                ..Default::default()
+            },
+        );
+        assert!(!payload.sampled);
+        assert_eq!(payload.entity_count, 1);
+        assert_eq!(payload.nodes.len(), 1);
+    }
+
+    /// A caller asking for the whole graph and a caller naming no cap are
+    /// opposite requests, and the query string has to keep them apart.
+    #[test]
+    fn an_explicit_zero_limit_reaches_the_daemon_as_a_value() {
+        let whole = export_query_string(&ExportArgs {
+            limit: Some(0),
+            ..Default::default()
+        });
+        assert_eq!(whole, "limit=0");
+
+        let defaulted = export_query_string(&ExportArgs::default());
+        assert_eq!(defaulted, "", "naming no cap sends no parameter");
+    }
+
+    /// A path prefix holding a separator survives the trip.
+    #[test]
+    fn query_parameters_are_percent_encoded() {
+        let query = export_query_string(&ExportArgs {
+            path: Some("src/a b&c".to_string()),
+            include: Some("line".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(query, "path=src%2Fa%20b%26c&include=line");
+    }
+
+    /// An SSE frame that arrived split across two reads is still one event.
+    #[test]
+    fn a_frame_split_across_reads_is_reassembled() {
+        let mut buffer = String::new();
+        buffer.push_str("data: {\"type\":\"EntityCha");
+        assert!(
+            drain_sse_frames(&mut buffer).is_empty(),
+            "half a frame is not an event"
+        );
+        buffer.push_str("nged\"}\n\n: heartbeat\n\ndata: {\"type\":\"RelationChanged\"}\n\n");
+        let frames = drain_sse_frames(&mut buffer);
+        assert_eq!(
+            frames,
+            vec![
+                "{\"type\":\"EntityChanged\"}".to_string(),
+                "{\"type\":\"RelationChanged\"}".to_string()
+            ],
+            "the heartbeat comment carries no payload and is not an event"
+        );
+        assert!(buffer.is_empty());
+    }
+
+    /// A watch prints something for an event type this build does not know,
+    /// rather than swallowing it.
+    #[test]
+    fn an_unknown_event_type_is_printed_rather_than_dropped() {
+        let raw = r#"{"type":"SomethingNewer","detail":42}"#;
+        assert_eq!(watch_human_line(raw), raw);
+    }
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub mod eject;
 pub mod embed;
 pub mod git;
 pub mod graph;
+pub mod graph_export;
 pub mod graph_health;
 pub mod graph_viz;
 pub mod health;

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1437,6 +1437,58 @@ impl DaemonClient {
             .context("parse daemon graph command response")
     }
 
+    /// `GET /graph/export`: the drawable projection of the live graph.
+    ///
+    /// A GET with query parameters rather than a `GraphCommandRequest`, because
+    /// the graph command family answers in `lines` for a terminal and this
+    /// answers in a payload for a renderer. Routing it through the same client
+    /// keeps daemon discovery, the bearer token and the build-match check
+    /// identical to every other graph command.
+    pub async fn graph_export(
+        &self,
+        query: &str,
+    ) -> Result<crate::commands::graph_export::GraphExportPayload> {
+        let url = if query.is_empty() {
+            format!("{}/graph/export", self.base_url)
+        } else {
+            format!("{}/graph/export?{query}", self.base_url)
+        };
+        let resp = self.send(self.client.get(&url), "graph export").await?;
+        if !resp.status().is_success() {
+            return Err(self.http_refusal("graph export", resp).await);
+        }
+        resp.json().await.context("parse graph export response")
+    }
+
+    /// `GET /graph/events`: the live delta stream, as a still-open response.
+    ///
+    /// Returns the response rather than a parsed body because the body never
+    /// ends: the caller reads frames off it until it decides to stop.
+    pub async fn graph_events(&self, query: &str) -> Result<reqwest::Response> {
+        let url = if query.is_empty() {
+            format!("{}/graph/events", self.base_url)
+        } else {
+            format!("{}/graph/events?{query}", self.base_url)
+        };
+        let resp = self
+            .send(
+                self.client
+                    .get(&url)
+                    // The stream stays open until the caller closes it, so the
+                    // client's ordinary request timeout would end it on a quiet
+                    // graph and read as a daemon failure. A year is not a limit
+                    // anyone reaches; it is the absence of one, spelled.
+                    .timeout(std::time::Duration::from_secs(60 * 60 * 24 * 365))
+                    .header(reqwest::header::ACCEPT, "text/event-stream"),
+                "graph events",
+            )
+            .await?;
+        if !resp.status().is_success() {
+            return Err(self.http_refusal("graph events", resp).await);
+        }
+        Ok(resp)
+    }
+
     pub async fn overview(
         &self,
         request: &crate::commands::overview::OverviewRequest,
@@ -7671,7 +7723,7 @@ async fn resolve_daemon_url_inner(
 }
 
 /// Simple percent-encoding for query parameters.
-mod urlencoding {
+pub(crate) mod urlencoding {
     pub fn encode(s: &str) -> String {
         let mut result = String::with_capacity(s.len());
         for byte in s.bytes() {

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1517,6 +1517,38 @@ enum GraphAction {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    /// Export the drawable projection of the live graph as JSON
+    Export {
+        /// Cap the exported node count, sampled by degree with per-module
+        /// quotas. 0 exports every entity; omitted uses the default cap
+        #[arg(long, value_name = "N")]
+        limit: Option<usize>,
+        /// Keep only these entity kinds (comma-separated, e.g. function,class)
+        #[arg(long, value_name = "KINDS")]
+        kinds: Option<String>,
+        /// Keep only entities whose file starts with this repository path prefix
+        #[arg(long, value_name = "PREFIX")]
+        path: Option<String>,
+        /// Attach optional node fields (comma-separated: signature,line)
+        #[arg(long, value_name = "FIELDS")]
+        include: Option<String>,
+        /// Write the payload to this file instead of stdout
+        #[arg(long, value_name = "FILE")]
+        out: Option<PathBuf>,
+        /// Output machine-readable JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Follow live graph changes, one event per line
+    Watch {
+        /// Keep only these event types (comma-separated, e.g.
+        /// EntityChanged,RelationChanged)
+        #[arg(long, value_name = "TYPES")]
+        types: Option<String>,
+        /// Output machine-readable NDJSON, one event object per line
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Serve an interactive force-directed visualization of the semantic graph
     Viz {
         /// Port to bind the local HTTP server to
@@ -3581,6 +3613,31 @@ fn main() -> Result<()> {
                         commands::graph::source(entity, json).await
                     }
                     GraphAction::Body { entity, json } => commands::graph::body(entity, json).await,
+                    GraphAction::Export {
+                        limit,
+                        kinds,
+                        path,
+                        include,
+                        out,
+                        json,
+                    } => {
+                        commands::graph_export::export(commands::graph_export::ExportArgs {
+                            limit,
+                            kinds,
+                            path,
+                            include,
+                            out,
+                            json,
+                        })
+                        .await
+                    }
+                    GraphAction::Watch { types, json } => {
+                        commands::graph_export::watch(commands::graph_export::WatchArgs {
+                            types,
+                            json,
+                        })
+                        .await
+                    }
                     GraphAction::Viz { port, open } => commands::graph_viz::run(port, open).await,
                 },
                 Command::Git { action } => match action {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1953,6 +1953,8 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/commands/verify", post(command_verify))
         .route("/support", get(support))
         .route("/graph/bootstrap", get(graph_bootstrap))
+        .route("/graph/export", get(graph_export))
+        .route("/graph/events", get(graph_events))
         .route("/graph/mutations", post(graph_mutations))
         .route("/commands/status", post(command_status))
         .route("/commands/resources", post(command_resources))
@@ -6801,6 +6803,204 @@ async fn graph_bootstrap(
     let bytes = export_graph_snapshot_bytes(graph).await?;
 
     Ok(([(header::CONTENT_TYPE, "application/octet-stream")], bytes))
+}
+
+/// Query parameters for `GET /graph/export`.
+#[derive(Debug, Deserialize)]
+struct GraphExportParams {
+    /// Node cap. `0` asks for the whole graph; absent uses the default cap.
+    #[serde(default)]
+    limit: Option<usize>,
+    /// Comma-separated entity kinds to keep.
+    #[serde(default)]
+    kinds: Option<String>,
+    /// Repository path prefix a node's file must start with.
+    #[serde(default)]
+    path: Option<String>,
+    /// Comma-separated optional node fields: `signature`, `line`.
+    #[serde(default)]
+    include: Option<String>,
+}
+
+/// GET /graph/export: the drawable projection of the daemon's live graph.
+///
+/// `/graph/bootstrap` already exports this graph, but as the whole binary
+/// snapshot: measured on a 730-entity repository it is 3.6 MiB against the
+/// 271 KiB a renderer actually draws, and nothing in it is shaped for a
+/// consumer. This is the same graph, projected to nodes and links, capped and
+/// sampled server side so every consumer draws the same picture.
+///
+/// Same session-scope resolution as `graph_bootstrap`: a session holding a
+/// temporal scope exports the graph that scope names.
+async fn graph_export(
+    headers: axum::http::HeaderMap,
+    Query(params): Query<GraphExportParams>,
+    State(state): State<Arc<DaemonState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    use kin_cli::commands::graph_export as export;
+
+    let session_id = extract_session_id_from_headers(&headers)?;
+    let graph = resolve_session_graph(&state, session_id.as_ref()).await;
+
+    let options = export::ExportOptions {
+        limit: match params.limit {
+            // An explicit 0 is the request for every entity. Absent is a
+            // request for a drawable default, which is a different question.
+            Some(0) => None,
+            Some(limit) => Some(limit),
+            None => Some(export::DEFAULT_NODE_LIMIT),
+        },
+        kinds: params
+            .kinds
+            .as_deref()
+            .map(export::parse_kinds)
+            .unwrap_or_default(),
+        path_prefix: params.path.filter(|prefix| !prefix.is_empty()),
+        include: params
+            .include
+            .as_deref()
+            .map(export::IncludeFields::parse)
+            .unwrap_or_default(),
+    };
+
+    // Read BEFORE the payload is built. A client keeps every event above this
+    // number, so reading first can only make it re-apply something the export
+    // already contains, which for an upsert is a no-op. Reading after would let
+    // an event emitted during the build fall into neither, and that one is lost.
+    let seq = state.current_event_seq();
+
+    // Off the request thread. Reading every entity and each one's relations is
+    // real CPU work at repository scale, and doing it inline would stall every
+    // other request this runtime is serving.
+    tokio::task::spawn_blocking(move || {
+        let root_hash = hex::encode(graph.compute_root_hash());
+        let (node_meta, all_entity_ids, edges) = export::read_graph(graph.as_ref())?;
+        Ok::<_, anyhow::Error>(export::assemble_payload(
+            root_hash,
+            seq,
+            node_meta,
+            &all_entity_ids,
+            edges,
+            &options,
+        ))
+    })
+    .await
+    .map_err(internal_error)?
+    .map(Json)
+    .map_err(internal_error)
+}
+
+/// Query parameters for `GET /graph/events`.
+#[derive(Debug, Deserialize)]
+struct GraphEventsParams {
+    /// Comma-separated event type names to keep, e.g.
+    /// `EntityChanged,RelationChanged`. Absent means every type.
+    #[serde(default)]
+    types: Option<String>,
+}
+
+/// GET /graph/events: the graph-facing view of the daemon event bus.
+///
+/// The same broadcast channel `/vfs/subscribe` serves, which is left exactly as
+/// it was because the VFS daemon and the spine depend on its frames. What this
+/// adds is the two things a graph consumer needs and that one does not carry: a
+/// `types` filter, so a renderer is not woken by coordination traffic it will
+/// throw away, and a first frame naming the current `root_hash`, so a client
+/// reconnecting after a gap can tell whether its drawn graph is still the one
+/// the daemon holds or has to be re-exported.
+async fn graph_events(
+    Query(params): Query<GraphEventsParams>,
+    State(state): State<Arc<DaemonState>>,
+) -> impl IntoResponse {
+    let wanted: Option<std::collections::HashSet<String>> = params
+        .types
+        .as_deref()
+        .map(|raw| {
+            raw.split(',')
+                .map(|name| name.trim().to_string())
+                .filter(|name| !name.is_empty())
+                .collect::<std::collections::HashSet<String>>()
+        })
+        .filter(|names| !names.is_empty());
+
+    let mut rx = state.event_tx.subscribe();
+    let root_hash = hex::encode(state.graph.compute_root_hash());
+    let entity_count = state.graph.entity_count();
+    let seq = state.current_event_seq();
+
+    let stream = async_stream::stream! {
+        // The resync anchor. `seq` is the one that works between commits: a
+        // working-tree edit changes the graph without advancing the root, so a
+        // client reconnecting mid-session cannot learn anything from the hash
+        // alone. It exports, reads the export's `seq`, subscribes, and discards
+        // every event at or below it.
+        let connected = json!({
+            "type": "connected",
+            "entity_count": entity_count,
+            "root_hash": root_hash,
+            "seq": seq,
+        });
+        yield Ok::<_, std::convert::Infallible>(format!("data: {connected}\n\n"));
+
+        let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(30));
+        heartbeat.tick().await; // Skip first immediate tick
+
+        loop {
+            tokio::select! {
+                event = rx.recv() => {
+                    match event {
+                        Ok(sequenced) => {
+                            let keep = wanted
+                                .as_ref()
+                                .is_none_or(|names| names.contains(sequenced.event.type_name()));
+                            if keep {
+                                // The sequence is merged into the event object
+                                // rather than wrapping it, so a consumer reads
+                                // one flat frame and an older one that ignores
+                                // the field still parses exactly what it did.
+                                if let Ok(mut value) = serde_json::to_value(&sequenced.event) {
+                                    if let Some(object) = value.as_object_mut() {
+                                        object.insert("seq".to_string(), json!(sequenced.seq));
+                                    }
+                                    yield Ok(format!("data: {value}\n\n"));
+                                }
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            // Never filtered. A gap is not a graph event, it is
+                            // the news that this client's view is now wrong,
+                            // and a filter that swallowed it would leave a
+                            // consumer patching a graph it has already lost.
+                            yield Ok(format!("data: {{\"type\":\"lagged\",\"missed\":{n}}}\n\n"));
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            break;
+                        }
+                    }
+                }
+                _ = heartbeat.tick() => {
+                    yield Ok(": heartbeat\n\n".to_string());
+                }
+            }
+        }
+    };
+
+    let mut response = (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "text/event-stream"),
+            (header::CACHE_CONTROL, "no-cache"),
+            (header::CONNECTION, "keep-alive"),
+        ],
+        axum::body::Body::from_stream(stream),
+    )
+        .into_response();
+    // Prevent nginx from buffering the SSE stream in GKE deployments.
+    response.headers_mut().insert(
+        axum::http::HeaderName::from_static("x-accel-buffering"),
+        axum::http::HeaderValue::from_static("no"),
+    );
+    response
 }
 
 /// POST /locate — run locate against the daemon-resident graph and return the
@@ -15556,8 +15756,12 @@ async fn vfs_subscribe(State(state): State<Arc<DaemonState>>) -> impl IntoRespon
             tokio::select! {
                 event = rx.recv() => {
                     match event {
-                        Ok(daemon_event) => {
-                            if let Ok(json) = serde_json::to_string(&daemon_event) {
+                        // The bare event, without the sequence envelope. The VFS
+                        // daemon and the spine read these exact frames, so this
+                        // stream stays byte-identical; the sequence is a graph
+                        // consumer's concern and rides `/graph/events`.
+                        Ok(sequenced) => {
+                            if let Ok(json) = serde_json::to_string(&sequenced.event) {
                                 yield Ok(format!("data: {json}\n\n"));
                             }
                         }
@@ -27685,7 +27889,7 @@ mod tests {
         assert!(created.operation_id.is_some());
         assert_eq!(state.graph.compute_root_hash(), graph_root_before);
         assert!(matches!(
-            events.recv().await.unwrap(),
+            events.recv().await.unwrap().event,
             DaemonEvent::RepositoryAuthorityChanged {
                 previous_generation,
                 new_generation,
@@ -35656,6 +35860,266 @@ mod tests {
         let _snapshot = kin_db::GraphSnapshot::from_bytes(&body).unwrap();
     }
 
+    /// Ask `/graph/export` and read its payload back.
+    async fn export_payload(
+        state: Arc<DaemonState>,
+        query: &str,
+    ) -> kin_cli::commands::graph_export::GraphExportPayload {
+        let uri = if query.is_empty() {
+            "/graph/export".to_string()
+        } else {
+            format!("/graph/export?{query}")
+        };
+        let response = router(state)
+            .oneshot(Request::get(&uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "GET {uri}");
+        let body = axum::body::to_bytes(response.into_body(), 8 * 1024 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    /// The export answers from the live graph the daemon already holds, in the
+    /// shape a renderer draws.
+    ///
+    /// `/graph/bootstrap` already exports this graph, but as the whole binary
+    /// snapshot: 119.6 MiB against 1.0 MiB on a 23,098-entity repository. This
+    /// is the same truth, projected.
+    #[tokio::test]
+    async fn graph_export_projects_the_live_graph_to_nodes_and_links() {
+        let state = test_state();
+        let caller = test_entity("caller", "src/a.py");
+        let callee = test_entity("callee", "src/b.py");
+        state.graph.upsert_entity(&caller).unwrap();
+        state.graph.upsert_entity(&callee).unwrap();
+        link(&state, &caller, &callee, RelationKind::Calls);
+
+        let payload = export_payload(Arc::clone(&state), "").await;
+
+        assert_eq!(payload.nodes.len(), 2);
+        assert_eq!(payload.links.len(), 1);
+        assert_eq!(payload.entity_count, 2);
+        assert_eq!(payload.relation_count, 1);
+        assert!(!payload.sampled);
+        assert!(
+            !payload.root_hash.is_empty(),
+            "without a root hash a client cannot pair this with the event stream"
+        );
+        assert_eq!(payload.links[0].kind, "Calls");
+        for node in &payload.nodes {
+            assert_eq!(
+                node.degree, 1,
+                "both endpoints of the one edge have degree 1"
+            );
+        }
+    }
+
+    /// A capped export says how much it left out, rather than reading as the
+    /// whole graph.
+    #[tokio::test]
+    async fn a_capped_export_reports_the_population_it_sampled_from() {
+        let state = test_state();
+        for index in 0..6 {
+            let entity = test_entity(&format!("fn{index}"), &format!("src/m{index}.py"));
+            state.graph.upsert_entity(&entity).unwrap();
+        }
+
+        let payload = export_payload(Arc::clone(&state), "limit=2").await;
+
+        assert_eq!(payload.nodes.len(), 2);
+        assert!(payload.sampled);
+        assert_eq!(
+            payload.entity_count, 6,
+            "the count is the population, not the drawing"
+        );
+        assert_eq!(payload.limit, Some(2));
+    }
+
+    /// An explicit `limit=0` asks for every entity, which is a different
+    /// request from naming no cap at all.
+    #[tokio::test]
+    async fn an_explicit_zero_limit_exports_the_whole_graph() {
+        let state = test_state();
+        for index in 0..4 {
+            let entity = test_entity(&format!("fn{index}"), &format!("src/m{index}.py"));
+            state.graph.upsert_entity(&entity).unwrap();
+        }
+
+        let payload = export_payload(Arc::clone(&state), "limit=0").await;
+        assert_eq!(payload.nodes.len(), 4);
+        assert!(!payload.sampled);
+        assert_eq!(payload.limit, None);
+    }
+
+    /// The default payload is exactly what the current renderers read; the
+    /// bigger fields ride along only when asked for.
+    #[tokio::test]
+    async fn line_and_signature_are_opt_in() {
+        let state = test_state();
+        let entity = test_entity("handler", "src/a.py");
+        state.graph.upsert_entity(&entity).unwrap();
+
+        let plain = export_payload(Arc::clone(&state), "").await;
+        assert_eq!(plain.nodes[0].line, None);
+        assert_eq!(plain.nodes[0].signature, None);
+
+        let rich = export_payload(Arc::clone(&state), "include=line,signature").await;
+        assert_eq!(
+            rich.nodes[0].line,
+            Some(2),
+            "the graph's 0-based span row is reported as a 1-based editor line"
+        );
+        assert_eq!(rich.nodes[0].signature.as_deref(), Some("def handler()"));
+    }
+
+    /// A filter that excludes an endpoint withholds its edge, and says which
+    /// kind of withholding it was.
+    #[tokio::test]
+    async fn a_path_filter_reports_its_dropped_edges_apart_from_unresolved_ones() {
+        let state = test_state();
+        let inside = test_entity("inside", "src/a.py");
+        let outside = test_entity("outside", "vendor/b.py");
+        state.graph.upsert_entity(&inside).unwrap();
+        state.graph.upsert_entity(&outside).unwrap();
+        link(&state, &inside, &outside, RelationKind::Calls);
+
+        let payload = export_payload(Arc::clone(&state), "path=src/").await;
+
+        assert_eq!(payload.nodes.len(), 1);
+        assert_eq!(payload.filtered_links, 1, "this request dropped the edge");
+        assert_eq!(
+            payload.unresolved_links, 0,
+            "both endpoints are entities, so nothing here is unresolved"
+        );
+    }
+
+    /// The export names the position it was cut at, and events after the cut
+    /// sort above it.
+    ///
+    /// This is the pair a client resyncs on. The root hash cannot do it: a
+    /// working-tree edit changes the graph and never advances the root, so
+    /// between commits the two hashes match while the picture is stale.
+    #[tokio::test]
+    async fn an_export_is_cut_before_the_events_that_follow_it() {
+        let state = test_state();
+        let entity = test_entity("handler", "src/a.py");
+        state.graph.upsert_entity(&entity).unwrap();
+
+        let first = export_payload(Arc::clone(&state), "").await;
+
+        let mut rx = state.event_tx.subscribe();
+        state.emit_event(crate::state::DaemonEvent::EntityChanged {
+            entity_id: entity.id,
+            node: None,
+            change_type: crate::state::ChangeType::Modified,
+            file_path: Some("src/a.py".to_string()),
+            session_id: None,
+        });
+        let emitted = rx.try_recv().expect("the event reached the bus");
+        assert!(
+            emitted.seq > first.seq,
+            "an event emitted after the cut must sort above it: cut={} event={}",
+            first.seq,
+            emitted.seq
+        );
+
+        let second = export_payload(Arc::clone(&state), "").await;
+        assert!(
+            second.seq >= emitted.seq,
+            "an export taken after the event must include it in its cut"
+        );
+    }
+
+    /// Every frame on the graph stream carries its position.
+    #[tokio::test]
+    async fn graph_events_stamps_a_sequence_on_every_frame() {
+        let state = test_state();
+        let entity = test_entity("handler", "src/a.py");
+        state.graph.upsert_entity(&entity).unwrap();
+
+        let response = router(Arc::clone(&state))
+            .oneshot(Request::get("/graph/events").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let mut body = response.into_body().into_data_stream();
+
+        let read_frame = |chunk: axum::body::Bytes| -> serde_json::Value {
+            let text = String::from_utf8(chunk.to_vec()).unwrap();
+            serde_json::from_str(text.trim_start_matches("data: ").trim()).unwrap()
+        };
+
+        let connected = read_frame(
+            futures_util::StreamExt::next(&mut body)
+                .await
+                .expect("connected frame")
+                .unwrap(),
+        );
+        assert_eq!(connected["type"], json!("connected"));
+        let cut = connected["seq"].as_u64().expect("connected carries a seq");
+
+        // Emitted after the subscription exists, so the stream must deliver it.
+        state.emit_event(crate::state::DaemonEvent::RelationChanged {
+            source: entity.id,
+            target: entity.id,
+            kind: "Calls".to_string(),
+            change_type: crate::state::ChangeType::Created,
+            file_path: Some("src/a.py".to_string()),
+        });
+
+        let frame = read_frame(
+            futures_util::StreamExt::next(&mut body)
+                .await
+                .expect("the emitted event reaches the stream")
+                .unwrap(),
+        );
+        assert_eq!(frame["type"], json!("RelationChanged"));
+        assert!(
+            frame["seq"].as_u64().expect("every frame carries a seq") > cut,
+            "a frame emitted after the connected cut must sort above it: {frame}"
+        );
+        // The sequence is merged into the event object, not wrapped around it,
+        // so an older consumer reads exactly the fields it always did.
+        assert_eq!(frame["kind"], json!("Calls"));
+    }
+
+    /// The stream's first frame is the resync anchor.
+    #[tokio::test]
+    async fn graph_events_opens_with_the_current_root_hash() {
+        let state = test_state();
+        let expected = hex::encode(state.graph.compute_root_hash());
+        let response = router(Arc::clone(&state))
+            .oneshot(Request::get("/graph/events").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream")
+        );
+
+        let mut body = response.into_body().into_data_stream();
+        let first = futures_util::StreamExt::next(&mut body)
+            .await
+            .expect("the connected frame is sent before anything happens")
+            .unwrap();
+        let text = String::from_utf8(first.to_vec()).unwrap();
+        let payload = text.trim_start_matches("data: ").trim();
+        let frame: serde_json::Value = serde_json::from_str(payload).unwrap();
+        assert_eq!(frame["type"], json!("connected"));
+        assert_eq!(
+            frame["root_hash"],
+            json!(expected),
+            "a reconnecting client compares this with the export it drew"
+        );
+    }
+
     #[tokio::test]
     async fn mcp_tools_call_semantic_search_uses_live_graph() {
         let state = test_state();
@@ -39947,7 +40411,7 @@ mod tests {
 
         // Neither handler may broadcast a GraphRootChanged for a read.
         loop {
-            match events.try_recv() {
+            match events.try_recv().map(|sequenced| sequenced.event) {
                 Ok(DaemonEvent::GraphRootChanged { new_root_hash, .. }) => panic!(
                     "warm blame/history must not emit GraphRootChanged, got new_root_hash={new_root_hash:?}"
                 ),

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1426,6 +1426,7 @@ pub(crate) fn evict_enrichment_for_removed_paths(
         for id in cleanup.removed_entities {
             state.emit_event(DaemonEvent::EntityChanged {
                 entity_id: id,
+                node: None,
                 change_type: ChangeType::Deleted,
                 file_path: Some(file_id.0.clone()),
                 session_id: None,
@@ -2943,6 +2944,12 @@ pub async fn run_loop_armed(
         // staging view; there is no second mutable overlay authority.
         let mut reconciler = state.reconciler.write().await;
         let mut graph_changed = false;
+        // What this pass emitted, totalled so the pass can close with one
+        // boundary event. A renderer lays out once per pass on that boundary
+        // rather than once per event: measured, one appended function in
+        // hiredis net.c emits 26 entity events, 25 of them for entities the
+        // edit never touched.
+        let mut pass_delta = crate::state::PassDelta::default();
         // Events this tick admitted without deferring them back to the retry
         // queue. This is the reconcile pass's persisted-progress counter: a tick
         // that re-observes the same paths and defers every one of them scores
@@ -3149,6 +3156,7 @@ pub async fn run_loop_armed(
                                     for id in cleanup.removed_entities {
                                         state.emit_event(DaemonEvent::EntityChanged {
                                             entity_id: id,
+                                            node: None,
                                             change_type: ChangeType::Deleted,
                                             file_path: Some(file_id.0.clone()),
                                             session_id: None,
@@ -3219,6 +3227,7 @@ pub async fn run_loop_armed(
                             for id in cleanup.removed_entities {
                                 state.emit_event(DaemonEvent::EntityChanged {
                                     entity_id: id,
+                                    node: None,
                                     change_type: ChangeType::Deleted,
                                     file_path: Some(file_id.0.clone()),
                                     session_id: None,
@@ -3261,6 +3270,7 @@ pub async fn run_loop_armed(
                                 for id in cleanup.removed_entities {
                                     state.emit_event(DaemonEvent::EntityChanged {
                                         entity_id: id,
+                                        node: None,
                                         change_type: ChangeType::Deleted,
                                         file_path: Some(file_id.0.clone()),
                                         session_id: None,
@@ -3365,9 +3375,16 @@ pub async fn run_loop_armed(
                     } = &outcome
                     {
                         let file_path = path.to_string_lossy().to_string();
+                        pass_delta.nodes_added += added.len();
+                        pass_delta.nodes_modified += modified.len();
+                        pass_delta.nodes_removed += removed.len();
                         for id in added {
                             state.emit_event(DaemonEvent::EntityChanged {
                                 entity_id: *id,
+                                // Read from the graph the transaction just
+                                // applied, so a drawing consumer can place the
+                                // node without asking what it now is.
+                                node: crate::state::graph_node_summary(state.graph.as_ref(), id),
                                 change_type: ChangeType::Created,
                                 file_path: Some(file_path.clone()),
                                 // FS-reconcile loop: a raw filesystem change has
@@ -3378,6 +3395,10 @@ pub async fn run_loop_armed(
                         for id in modified {
                             state.emit_event(DaemonEvent::EntityChanged {
                                 entity_id: *id,
+                                // Read from the graph the transaction just
+                                // applied, so a drawing consumer can place the
+                                // node without asking what it now is.
+                                node: crate::state::graph_node_summary(state.graph.as_ref(), id),
                                 change_type: ChangeType::Modified,
                                 file_path: Some(file_path.clone()),
                                 // FS-reconcile loop: a raw filesystem change has
@@ -3388,6 +3409,7 @@ pub async fn run_loop_armed(
                         for id in removed {
                             state.emit_event(DaemonEvent::EntityChanged {
                                 entity_id: *id,
+                                node: None,
                                 change_type: ChangeType::Deleted,
                                 file_path: Some(file_path.clone()),
                                 // FS-reconcile loop: a raw filesystem change has
@@ -3413,20 +3435,44 @@ pub async fn run_loop_armed(
                         if !changed_ids.is_empty() {
                             lsp_changed.push((file_id.clone(), changed_ids));
                         }
+
+                        // Emitted after the entity events on purpose: an edge
+                        // event naming a node the consumer has not been told
+                        // about yet cannot be applied to a drawn graph.
+                        if should_apply {
+                            for event in crate::state::relation_change_events(
+                                &delta,
+                                Some(file_path.as_str()),
+                            ) {
+                                pass_delta.count(&event);
+                                state.emit_event(event);
+                            }
+                        }
                     } else if let ReconcileOutcome::FileRemoved {
                         removed, file_id, ..
                     } = &outcome
                     {
                         let file_path = path.to_string_lossy().to_string();
+                        pass_delta.nodes_removed += removed.len();
                         for id in removed {
                             state.emit_event(DaemonEvent::EntityChanged {
                                 entity_id: *id,
+                                node: None,
                                 change_type: ChangeType::Deleted,
                                 file_path: Some(file_path.clone()),
                                 // FS-reconcile loop: a raw filesystem change has
                                 // no owning agent, so attribution is honestly None.
                                 session_id: None,
                             });
+                        }
+                        if should_apply {
+                            for event in crate::state::relation_change_events(
+                                &delta,
+                                Some(file_path.as_str()),
+                            ) {
+                                pass_delta.count(&event);
+                                state.emit_event(event);
+                            }
                         }
                         match clear_incompatible_facets(&state, file_id, EnrichmentFacet::None) {
                             Ok(_) => {
@@ -3519,6 +3565,14 @@ pub async fn run_loop_armed(
             if let Err(e) = projection_result {
                 error!(error = %e, "failed to refresh projection after reconciliation");
             }
+        }
+
+        // The pass boundary, after every event this pass produced. A consumer
+        // that has been buffering since the last boundary applies the batch and
+        // lays out once. Silent when the pass emitted nothing, because a
+        // boundary with no delta is not news.
+        if let Some(boundary) = pass_delta.into_event() {
+            state.emit_event(boundary);
         }
 
         pass.advanced(admitted_events, Instant::now());
@@ -8325,6 +8379,7 @@ async fn sync_filesystem_with_graph_publishing_inner(
                                 for id in cleanup.removed_entities {
                                     state.emit_event(DaemonEvent::EntityChanged {
                                         entity_id: id,
+                                        node: None,
                                         change_type: ChangeType::Deleted,
                                         file_path: Some(file_id.0.clone()),
                                         session_id: None,
@@ -8376,6 +8431,7 @@ async fn sync_filesystem_with_graph_publishing_inner(
                         for id in cleanup.removed_entities {
                             state.emit_event(DaemonEvent::EntityChanged {
                                 entity_id: id,
+                                node: None,
                                 change_type: ChangeType::Deleted,
                                 file_path: Some(file_id.0.clone()),
                                 session_id: None,
@@ -8412,6 +8468,7 @@ async fn sync_filesystem_with_graph_publishing_inner(
                             for id in cleanup.removed_entities {
                                 state.emit_event(DaemonEvent::EntityChanged {
                                     entity_id: id,
+                                    node: None,
                                     change_type: ChangeType::Deleted,
                                     file_path: Some(file_id.0.clone()),
                                     session_id: None,
@@ -8499,6 +8556,7 @@ async fn sync_filesystem_with_graph_publishing_inner(
                         for id in removed {
                             state.emit_event(DaemonEvent::EntityChanged {
                                 entity_id: *id,
+                                node: None,
                                 change_type: ChangeType::Deleted,
                                 file_path: Some(file_id.0.clone()),
                                 // FS-reconcile loop: anonymous, no owning session.

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1250,6 +1250,186 @@ impl CoordinationEventLog {
     }
 }
 
+/// What an entity is, carried alongside a change so a consumer can patch a
+/// drawn graph without a round trip.
+///
+/// The same fields a `/graph/export` node carries, minus the id, which the
+/// event already names. Kept deliberately small: this rides every entity
+/// change on a broadcast channel, and a signature or a body would make a
+/// one-file edit a megabyte of stream.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct GraphNodeSummary {
+    pub name: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    /// 1-based presentation start line, absent when the entity carries no span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    pub degree: usize,
+}
+
+/// What one reconcile pass emitted, totalled as it goes.
+///
+/// Kept separate from the event it becomes so the counting can be graded
+/// without a reconcile loop, and so a pass that emitted nothing can say so by
+/// producing no event at all rather than a boundary full of zeroes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PassDelta {
+    pub nodes_added: usize,
+    pub nodes_modified: usize,
+    pub nodes_removed: usize,
+    pub relations_added: usize,
+    pub relations_removed: usize,
+}
+
+impl PassDelta {
+    /// Fold one already-built relation event into the totals.
+    ///
+    /// Counting the event rather than the delta it came from is deliberate: the
+    /// boundary's job is to tell a consumer how much it should have applied, and
+    /// what it applied is what was emitted. A relation delta that named a
+    /// non-entity endpoint produced no event, so it must not appear here either.
+    ///
+    /// A `Modified` edge counts as added: the edge that now exists is the one a
+    /// consumer upserts, and splitting out a fourth counter for it would report
+    /// a distinction no renderer acts on.
+    pub fn count(&mut self, event: &DaemonEvent) {
+        if let DaemonEvent::RelationChanged { change_type, .. } = event {
+            match change_type {
+                ChangeType::Created | ChangeType::Modified => self.relations_added += 1,
+                ChangeType::Deleted => self.relations_removed += 1,
+            }
+        }
+    }
+
+    /// True when this pass emitted nothing at all.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// The boundary event for this pass, or `None` when there was no delta.
+    pub fn into_event(self) -> Option<DaemonEvent> {
+        if self.is_empty() {
+            return None;
+        }
+        Some(DaemonEvent::GraphDeltaApplied {
+            nodes_added: self.nodes_added,
+            nodes_modified: self.nodes_modified,
+            nodes_removed: self.nodes_removed,
+            relations_added: self.relations_added,
+            relations_removed: self.relations_removed,
+        })
+    }
+}
+
+/// Read one entity's node summary out of the live graph.
+///
+/// `None` when the entity is not in the graph, which is the honest answer for
+/// a deletion: there is nothing left to describe. The degree counts distinct
+/// undirected (neighbour, kind) pairs, which is the same quantity an unfiltered
+/// `/graph/export` node reports, so a consumer drawing a whole-repository graph
+/// can use the two interchangeably. An export narrowed by `kinds` or `path`
+/// counts degree within that narrower population and will read lower; the
+/// stream cannot know which narrowing a given consumer asked for. Counting raw
+/// relations here instead would make the two disagree even on the whole graph.
+pub fn graph_node_summary(
+    graph: &kin_db::InMemoryGraph,
+    id: &EntityId,
+) -> Option<GraphNodeSummary> {
+    use kin_model::EntityStore as _;
+
+    let entity = graph.get_entity(id).ok().flatten()?;
+    let degree = graph
+        .get_all_relations_for_entity(id)
+        .map(|relations| {
+            let mut seen: std::collections::HashSet<(String, String)> =
+                std::collections::HashSet::new();
+            for relation in relations {
+                let other = match (&relation.src, &relation.dst) {
+                    (kin_model::GraphNodeId::Entity(src), kin_model::GraphNodeId::Entity(dst)) => {
+                        if src == id {
+                            *dst
+                        } else {
+                            *src
+                        }
+                    }
+                    // An edge to an artifact or an external symbol is not a
+                    // drawable edge, so it is not part of a drawable degree.
+                    _ => continue,
+                };
+                seen.insert((other.to_string(), format!("{:?}", relation.kind)));
+            }
+            seen.len()
+        })
+        .unwrap_or(0);
+
+    Some(GraphNodeSummary {
+        name: entity.name.clone(),
+        kind: format!("{:?}", entity.kind),
+        file: entity.file_origin.as_ref().map(|f| f.0.clone()),
+        line: entity
+            .span
+            .as_ref()
+            .map(|span| span.start_line.saturating_add(1)),
+        degree,
+    })
+}
+
+/// Turn the relation deltas of one applied transaction into stream events.
+///
+/// Only entity-to-entity edges become events: an edge whose endpoint is an
+/// artifact or an external symbol is not a drawable edge, and a consumer
+/// patching a graph cannot place it. A `Modified` delta reports the new state,
+/// because that is the edge that now exists.
+pub fn relation_change_events(
+    delta: &kin_model::TransactionDelta,
+    file_path: Option<&str>,
+) -> Vec<DaemonEvent> {
+    let mut events = Vec::new();
+    for relation_delta in &delta.relation_deltas {
+        let (relation, change_type) = match relation_delta {
+            kin_model::RelationDelta::Added { new } => (new, ChangeType::Created),
+            kin_model::RelationDelta::Modified { new, .. } => (new, ChangeType::Modified),
+            kin_model::RelationDelta::Removed { old } => (old, ChangeType::Deleted),
+        };
+        let (kin_model::GraphNodeId::Entity(source), kin_model::GraphNodeId::Entity(target)) =
+            (&relation.src, &relation.dst)
+        else {
+            continue;
+        };
+        events.push(DaemonEvent::RelationChanged {
+            source: *source,
+            target: *target,
+            kind: format!("{:?}", relation.kind),
+            change_type,
+            file_path: file_path.map(str::to_string),
+        });
+    }
+    events
+}
+
+/// One event and the position in the stream it was emitted at.
+///
+/// The sequence is what makes a reconnect safe. A working-tree edit changes the
+/// graph without advancing the graph root: measured on hiredis, one appended
+/// function produced 26 entity events and zero `GraphRootChanged`. So a client
+/// that reconnects between commits cannot use the root hash to work out what it
+/// missed, because the root it holds is still current and its picture is still
+/// wrong. A monotonic sequence answers that question exactly: export, subscribe,
+/// discard everything at or below the sequence the export was cut at, apply the
+/// rest.
+///
+/// It rides the envelope rather than each variant so every event carries one
+/// without any variant having to remember to, and so `/vfs/subscribe` can keep
+/// serializing the bare event and stay byte-identical for the VFS daemon and
+/// the spine.
+#[derive(Debug, Clone)]
+pub struct SequencedEvent {
+    pub seq: u64,
+    pub event: DaemonEvent,
+}
+
 /// SSE invalidation events pushed to subscribers (VFS daemon, spine, KinLab).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
@@ -1265,6 +1445,31 @@ pub enum DaemonEvent {
         /// default keeps existing payloads and consumers working unchanged.
         #[serde(default)]
         session_id: Option<String>,
+        /// What the entity now is, when the emitting path knew.
+        ///
+        /// Without it this event is an id and a path, and a consumer drawing
+        /// the graph has to ask the daemon what changed before it can redraw
+        /// one node. Additive and optional: `serde` default keeps every
+        /// existing payload and consumer working unchanged, and a path that
+        /// cannot cheaply answer sends `None` rather than a guess.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        node: Option<GraphNodeSummary>,
+    },
+    /// A relation between two entities was added, changed, or removed.
+    ///
+    /// The one thing the stream never reported. `EntityChanged` says a node
+    /// moved; nothing said an edge appeared or vanished, so a drawn graph could
+    /// only be refreshed wholesale. Both endpoints are entity ids, because an
+    /// edge to a non-entity is not a drawable edge.
+    RelationChanged {
+        source: EntityId,
+        target: EntityId,
+        /// The relation kind, in the graph's own spelling (`Calls`, `Contains`).
+        kind: String,
+        change_type: ChangeType,
+        /// The file whose reconcile produced this edge, when there was one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        file_path: Option<String>,
     },
     /// Files were added or removed from the tracked tree.
     TreeChanged {
@@ -1286,6 +1491,44 @@ pub enum DaemonEvent {
     },
     /// Durable coordination lifecycle event, appended before broadcast.
     Coordination { event: CoordinationEventEnvelope },
+    /// One reconcile pass finished, and this is what it did in total.
+    ///
+    /// Emitted after the last entity and relation event of the pass, so a
+    /// renderer can lay out once per pass instead of once per event. The
+    /// measurement that asked for it: one appended function in hiredis `net.c`
+    /// produced 26 `EntityChanged` events, 25 of them for entities the edit
+    /// never touched, because a reconcile re-emits every entity in the file it
+    /// reparsed. A consumer patching per event would relayout 26 times for one
+    /// keystroke.
+    ///
+    /// The counts are of emitted events, so they are what a consumer should
+    /// have applied since the previous boundary.
+    GraphDeltaApplied {
+        nodes_added: usize,
+        nodes_modified: usize,
+        nodes_removed: usize,
+        relations_added: usize,
+        relations_removed: usize,
+    },
+}
+
+impl DaemonEvent {
+    /// The `type` this event serializes as.
+    ///
+    /// Read from the variant rather than from a serialized payload, so the
+    /// `/graph/events` type filter costs nothing on an event it drops and
+    /// cannot disagree with what the wire actually says.
+    pub const fn type_name(&self) -> &'static str {
+        match self {
+            Self::EntityChanged { .. } => "EntityChanged",
+            Self::RelationChanged { .. } => "RelationChanged",
+            Self::TreeChanged { .. } => "TreeChanged",
+            Self::GraphRootChanged { .. } => "GraphRootChanged",
+            Self::RepositoryAuthorityChanged { .. } => "RepositoryAuthorityChanged",
+            Self::Coordination { .. } => "Coordination",
+            Self::GraphDeltaApplied { .. } => "GraphDeltaApplied",
+        }
+    }
 }
 
 /// Authority owning the graph selected for a daemon request.
@@ -2651,7 +2894,10 @@ pub struct DaemonState {
     pub vfs_version: AtomicU64,
     /// Broadcast channel for SSE invalidation events.
     /// Subscribers (VFS daemon, spine, KinLab) receive real-time notifications.
-    pub event_tx: tokio::sync::broadcast::Sender<DaemonEvent>,
+    pub event_tx: tokio::sync::broadcast::Sender<SequencedEvent>,
+    /// Position of the last event emitted. Read by `/graph/export` before it
+    /// cuts a payload, stamped onto every event by [`DaemonState::emit_event`].
+    pub event_seq: std::sync::atomic::AtomicU64,
     /// Per-session temporal scopes. When a session has an active scope,
     /// all queries see the cached historical graph instead of the live graph.
     /// Max MAX_CONCURRENT_SCOPES sessions can have active scopes simultaneously.
@@ -4912,6 +5158,7 @@ impl DaemonState {
             repository_command_enrich_after_authority_once: AtomicBool::new(false),
             vfs_version: AtomicU64::new(persisted_vfs_version),
             event_tx: tokio::sync::broadcast::channel(256).0,
+            event_seq: std::sync::atomic::AtomicU64::new(0),
             session_scopes: RwLock::new(HashMap::new()),
             spine: std::sync::OnceLock::new(),
             spine_initialization_failure: Mutex::new(None),
@@ -5279,6 +5526,7 @@ impl DaemonState {
             repository_command_enrich_after_authority_once: AtomicBool::new(false),
             vfs_version: AtomicU64::new(persisted_vfs_version),
             event_tx: tokio::sync::broadcast::channel(256).0,
+            event_seq: std::sync::atomic::AtomicU64::new(0),
             session_scopes: RwLock::new(HashMap::new()),
             spine: std::sync::OnceLock::new(),
             spine_initialization_failure: Mutex::new(None),
@@ -8443,12 +8691,30 @@ impl DaemonState {
 
     /// Emit an SSE event to all subscribers. Non-blocking — if no subscribers, the event is dropped.
     pub fn emit_event(&self, event: DaemonEvent) {
-        match self.event_tx.send(event) {
+        // Stamped here, not at the subscriber, because subscribers see the
+        // stream at different points and a number derived per subscriber would
+        // not be the same number twice.
+        let seq = self
+            .event_seq
+            .fetch_add(1, Ordering::SeqCst)
+            .saturating_add(1);
+        match self.event_tx.send(SequencedEvent { seq, event }) {
             Ok(_) => {}
             Err(_) => {
                 debug!("broadcast event dropped, no active subscribers");
             }
         }
+    }
+
+    /// The position the stream has reached.
+    ///
+    /// Read BEFORE a payload is built, never after. A client keeps every event
+    /// above the sequence its export was cut at, so reading first can only make
+    /// it re-apply an event the export already contains, which for an upsert is
+    /// a no-op. Reading after would let an event emitted during the build fall
+    /// into neither the export nor the kept range, and that one is lost.
+    pub fn current_event_seq(&self) -> u64 {
+        self.event_seq.load(Ordering::SeqCst)
     }
 
     /// Save the current graph via the storage backend (CAS write).
@@ -12553,6 +12819,7 @@ mod tests {
         // so Mission Control can render "<session> -> entity <id>".
         let event = DaemonEvent::EntityChanged {
             entity_id: kin_model::EntityId::new(),
+            node: None,
             change_type: ChangeType::Modified,
             file_path: Some("crates/kin-daemon/src/api.rs".to_string()),
             session_id: Some("mission-ctl-7".to_string()),
@@ -12722,6 +12989,7 @@ mod tests {
         // Mission Control reads as "unattributed" (never a fabricated guess).
         let event = DaemonEvent::EntityChanged {
             entity_id: kin_model::EntityId::new(),
+            node: None,
             change_type: ChangeType::Created,
             file_path: Some("src/lib.rs".to_string()),
             session_id: None,
@@ -12737,6 +13005,7 @@ mod tests {
         // `#[serde(default)]` additive contract the change relies on.
         let mut payload = serde_json::to_value(DaemonEvent::EntityChanged {
             entity_id: kin_model::EntityId::new(),
+            node: None,
             change_type: ChangeType::Modified,
             file_path: Some("api.rs".to_string()),
             session_id: Some("dropme".to_string()),
@@ -12750,6 +13019,281 @@ mod tests {
         }
     }
 
+    /// Build a relation between two entities.
+    fn relation_between(
+        source: kin_model::EntityId,
+        target: kin_model::EntityId,
+        kind: kin_model::RelationKind,
+    ) -> kin_model::Relation {
+        kin_model::Relation {
+            id: kin_model::RelationId::new(),
+            kind,
+            src: kin_model::GraphNodeId::Entity(source),
+            dst: kin_model::GraphNodeId::Entity(target),
+            confidence: 1.0,
+            origin: kin_model::RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        }
+    }
+
+    /// A reconcile that learned an edge reports both of its endpoints.
+    ///
+    /// This is the thing the stream never said. `EntityChanged` reports that a
+    /// node moved; nothing reported that an edge appeared, so a drawn graph
+    /// could only be refreshed wholesale. Measured before this existed: one
+    /// appended function in hiredis `net.c` produced 26 `EntityChanged` events
+    /// and zero relation events, while the graph gained a `Calls` edge.
+    #[test]
+    fn an_applied_relation_delta_becomes_an_event_naming_both_endpoints() {
+        let caller = kin_model::EntityId::new();
+        let callee = kin_model::EntityId::new();
+        let gone = kin_model::EntityId::new();
+
+        let delta = kin_model::TransactionDelta {
+            entity_deltas: Vec::new(),
+            relation_deltas: vec![
+                kin_model::RelationDelta::Added {
+                    new: relation_between(caller, callee, kin_model::RelationKind::Calls),
+                },
+                kin_model::RelationDelta::Removed {
+                    old: relation_between(caller, gone, kin_model::RelationKind::Calls),
+                },
+            ],
+            tree_deltas: Vec::new(),
+            admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
+        };
+
+        let events = relation_change_events(&delta, Some("src/net.c"));
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            DaemonEvent::RelationChanged {
+                source,
+                target,
+                kind,
+                change_type,
+                file_path,
+            } => {
+                assert_eq!(*source, caller);
+                assert_eq!(*target, callee);
+                assert_eq!(kind, "Calls");
+                assert!(matches!(change_type, ChangeType::Created));
+                assert_eq!(file_path.as_deref(), Some("src/net.c"));
+            }
+            other => panic!("expected RelationChanged, got {other:?}"),
+        }
+        match &events[1] {
+            DaemonEvent::RelationChanged {
+                target,
+                change_type,
+                ..
+            } => {
+                assert_eq!(*target, gone);
+                assert!(matches!(change_type, ChangeType::Deleted));
+            }
+            other => panic!("expected RelationChanged, got {other:?}"),
+        }
+    }
+
+    /// An edge to something that is not an entity produces no event.
+    ///
+    /// A consumer patching a drawn graph cannot place an endpoint that is no
+    /// node, and the export withholds those edges for the same reason. Sending
+    /// one would make the two surfaces disagree about what an edge is.
+    #[test]
+    fn an_edge_to_a_non_entity_produces_no_event() {
+        let entity = kin_model::EntityId::new();
+        let mut relation = relation_between(entity, entity, kin_model::RelationKind::Calls);
+        relation.dst = kin_model::GraphNodeId::Artifact(kin_model::ArtifactId::new());
+
+        let delta = kin_model::TransactionDelta {
+            entity_deltas: Vec::new(),
+            relation_deltas: vec![kin_model::RelationDelta::Added { new: relation }],
+            tree_deltas: Vec::new(),
+            admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
+        };
+
+        assert!(
+            relation_change_events(&delta, None).is_empty(),
+            "an artifact endpoint is not drawable and must produce no frame"
+        );
+    }
+
+    /// A pass that changed nothing says nothing.
+    ///
+    /// The reconcile loop ticks whether or not anything happened, and a
+    /// boundary full of zeroes on every tick would wake every subscribed
+    /// renderer for no reason.
+    #[test]
+    fn a_pass_that_changed_nothing_emits_no_boundary() {
+        assert!(PassDelta::default().is_empty());
+        assert!(PassDelta::default().into_event().is_none());
+    }
+
+    /// The boundary counts the frames the pass emitted, so a consumer knows how
+    /// much it should have applied since the last one.
+    #[test]
+    fn the_boundary_counts_the_frames_the_pass_emitted() {
+        let mut delta = PassDelta {
+            nodes_added: 1,
+            nodes_modified: 25,
+            ..Default::default()
+        };
+        let source = kin_model::EntityId::new();
+        let target = kin_model::EntityId::new();
+        let relation = |change_type| DaemonEvent::RelationChanged {
+            source,
+            target,
+            kind: "Calls".to_string(),
+            change_type,
+            file_path: None,
+        };
+        delta.count(&relation(ChangeType::Created));
+        // A modified edge is the edge that now exists, so a consumer upserts it
+        // exactly as it would an added one.
+        delta.count(&relation(ChangeType::Modified));
+        delta.count(&relation(ChangeType::Deleted));
+        // An entity event is already counted from the reconcile outcome, and
+        // counting it again here would double every node in the boundary.
+        delta.count(&DaemonEvent::EntityChanged {
+            entity_id: source,
+            node: None,
+            change_type: ChangeType::Created,
+            file_path: None,
+            session_id: None,
+        });
+
+        assert!(!delta.is_empty());
+        match delta
+            .into_event()
+            .expect("a pass with a delta has a boundary")
+        {
+            DaemonEvent::GraphDeltaApplied {
+                nodes_added,
+                nodes_modified,
+                nodes_removed,
+                relations_added,
+                relations_removed,
+            } => {
+                assert_eq!(nodes_added, 1);
+                assert_eq!(nodes_modified, 25);
+                assert_eq!(nodes_removed, 0);
+                assert_eq!(relations_added, 2, "created and modified both upsert");
+                assert_eq!(relations_removed, 1);
+            }
+            other => panic!("expected GraphDeltaApplied, got {other:?}"),
+        }
+    }
+
+    /// Every emitted event gets a position, and the positions only go up.
+    ///
+    /// This is what a reconnecting client compares against its export. A
+    /// working-tree edit never advances the graph root, so without this the
+    /// client has nothing to compare at all.
+    #[test]
+    fn every_emitted_event_carries_a_sequence_that_only_advances() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        let mut rx = state.event_tx.subscribe();
+
+        let cut = state.current_event_seq();
+        for _ in 0..3 {
+            state.emit_event(DaemonEvent::EntityChanged {
+                entity_id: kin_model::EntityId::new(),
+                node: None,
+                change_type: ChangeType::Modified,
+                file_path: None,
+                session_id: None,
+            });
+        }
+
+        let mut seen = Vec::new();
+        while let Ok(sequenced) = rx.try_recv() {
+            seen.push(sequenced.seq);
+        }
+        assert_eq!(seen.len(), 3);
+        assert!(
+            seen.iter().all(|seq| *seq > cut),
+            "an event emitted after the cut must sort above it: cut={cut} seen={seen:?}"
+        );
+        assert!(
+            seen.windows(2).all(|pair| pair[1] > pair[0]),
+            "sequences must strictly increase: {seen:?}"
+        );
+        assert_eq!(state.current_event_seq(), *seen.last().unwrap());
+    }
+
+    /// A relation event reaches a subscriber through the real bus.
+    #[test]
+    fn a_relation_event_reaches_an_sse_subscriber() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        let mut rx = state.event_tx.subscribe();
+        let source = kin_model::EntityId::new();
+        let target = kin_model::EntityId::new();
+        state.emit_event(DaemonEvent::RelationChanged {
+            source,
+            target,
+            kind: "Calls".to_string(),
+            change_type: ChangeType::Created,
+            file_path: Some("src/net.c".to_string()),
+        });
+        match rx
+            .try_recv()
+            .expect("event delivered to SSE subscriber")
+            .event
+        {
+            DaemonEvent::RelationChanged {
+                source: got_source,
+                target: got_target,
+                ..
+            } => {
+                assert_eq!(got_source, source);
+                assert_eq!(got_target, target);
+            }
+            other => panic!("expected RelationChanged, got {other:?}"),
+        }
+    }
+
+    /// The type filter reads the variant, and every variant has a name.
+    #[test]
+    fn every_event_variant_names_itself_on_the_wire() {
+        let event = DaemonEvent::RelationChanged {
+            source: kin_model::EntityId::new(),
+            target: kin_model::EntityId::new(),
+            kind: "Calls".to_string(),
+            change_type: ChangeType::Created,
+            file_path: None,
+        };
+        // The name the filter matches on has to be the name the wire carries,
+        // or `--types RelationChanged` silently drops every relation event.
+        let wire = serde_json::to_value(&event).unwrap();
+        assert_eq!(wire["type"], serde_json::json!(event.type_name()));
+        assert_eq!(event.type_name(), "RelationChanged");
+    }
+
+    /// A node summary is absent from the wire when the emitting path had none.
+    #[test]
+    fn an_absent_node_summary_is_absent_from_the_payload() {
+        let payload = serde_json::to_value(DaemonEvent::EntityChanged {
+            entity_id: kin_model::EntityId::new(),
+            node: None,
+            change_type: ChangeType::Modified,
+            file_path: None,
+            session_id: None,
+        })
+        .unwrap();
+        assert!(
+            payload.get("node").is_none(),
+            "an optional summary nobody filled must not appear as null: {payload}"
+        );
+    }
+
     #[test]
     fn emit_event_delivers_session_attribution_to_subscriber() {
         // The real /events emit path: emit_event -> broadcast -> SSE subscriber.
@@ -12760,11 +13304,16 @@ mod tests {
         let mut rx = state.event_tx.subscribe();
         state.emit_event(DaemonEvent::EntityChanged {
             entity_id: kin_model::EntityId::new(),
+            node: None,
             change_type: ChangeType::Modified,
             file_path: Some("crates/kin-daemon/src/api.rs".to_string()),
             session_id: Some("mission-ctl-7".to_string()),
         });
-        match rx.try_recv().expect("event delivered to SSE subscriber") {
+        match rx
+            .try_recv()
+            .expect("event delivered to SSE subscriber")
+            .event
+        {
             DaemonEvent::EntityChanged { session_id, .. } => {
                 assert_eq!(session_id.as_deref(), Some("mission-ctl-7"));
             }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ Kin is pre-1.0 and the command surface moves. Where this page and your build dis
 
 Descriptions are the command's own help text. A `--json` flag switches that command to machine-readable output. Angle brackets mark a required argument, square brackets an optional one, and a trailing `...` an argument that takes the rest of the line.
 
-82 commands are documented below. 4 further commands (`bench-meta`, `contextbench-locate`, `prepared-state`, `semantic-only-guard`) are hidden from `kin --help` because they exist for benchmark and internal orchestration, and they are not part of the supported surface.
+83 commands are documented below. 4 further commands (`bench-meta`, `contextbench-locate`, `prepared-state`, `semantic-only-guard`) are hidden from `kin --help` because they exist for benchmark and internal orchestration, and they are not part of the supported surface.
 
 `kin capabilities` prints the readiness matrix for the Git-replacement command set, and `kin capabilities --json` gives the same inventory to a machine. Reach for it before scripting against a command you have not used.
 
@@ -2251,6 +2251,36 @@ kin graph body <entity> [options]
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--json` |  | Output machine-readable JSON |
+
+#### `kin graph export`
+
+Export the drawable projection of the live graph as JSON. Reads the daemon's live graph, projects it to nodes and links, and samples it server side so every consumer draws the same picture. The payload contract is `graph-export.schema.json` in `packages/boundary-contracts`; `docs/graph-feed.md` explains the sampling rule and how to pair an export with `kin graph watch`.
+
+```
+kin graph export [options]
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--limit <n>` | `1400` | Cap the exported node count, sampled by degree with per-module quotas. `0` exports every entity |
+| `--kinds <kinds>` |  | Keep only these entity kinds, comma-separated (`function,class`). Any spelling of a kind name matches |
+| `--path <prefix>` |  | Keep only entities whose file starts with this repository path prefix |
+| `--include <fields>` |  | Attach optional node fields, comma-separated (`signature,line`) |
+| `--out <file>` |  | Write the payload to this file instead of stdout |
+| `--json` |  | Print the payload instead of a one-line summary |
+
+#### `kin graph watch`
+
+Follow live graph changes, one event per line. Streams the daemon's graph delta events for as long as it runs. `--json` makes it NDJSON, one event object per line, ready to pipe. The frame contract is `graph-event.schema.json` in `packages/boundary-contracts`.
+
+```
+kin graph watch [options]
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--types <types>` |  | Keep only these event types, comma-separated (`EntityChanged,RelationChanged`) |
+| `--json` |  | Output NDJSON, one event object per line |
 
 #### `kin graph viz`
 

--- a/docs/graph-feed.md
+++ b/docs/graph-feed.md
@@ -102,6 +102,15 @@ Server-sent events, one JSON payload per `data:` line, a comment heartbeat every
 30 seconds. The `types` parameter keeps only the named event types. Frames are
 `graph-event.schema.json` in `packages/boundary-contracts`.
 
+A filtered stream has gaps in `seq`, and that is expected: the sequence is
+assigned when an event is emitted, not when it is delivered, so numbers are
+missing for the frames the filter dropped. Measured on hiredis, `--types
+RelationChanged` over an edit that produced 27 entity frames delivered two
+relation frames at seq 62 and 63 behind a connected frame at seq 33. Never read
+consecutive sequence numbers as proof that nothing was missed. What `seq` is for
+is ordering against an export's cut, and it does that whether or not a filter is
+on.
+
 Every frame carries a monotonic `seq`. The first frame is always `connected`,
 carrying `entity_count`, `root_hash` and the `seq` the stream has reached.
 `EntityChanged` carries the entity id, the change type, the file, the session

--- a/docs/graph-feed.md
+++ b/docs/graph-feed.md
@@ -1,0 +1,179 @@
+# The live graph feed
+
+Kin serves its graph to outside consumers two ways: one JSON export shaped for
+drawing, and one event stream that says what changed. Both come off the daemon,
+both are reachable from the CLI, and both carry a sequence number so a consumer
+knows exactly which events its picture already contains.
+
+Before this existed, a consumer that wanted to draw a repository started
+`kin graph viz --port N` and scraped its `/api/graph.json` once. That was a
+snapshot, it needed a subprocess and a port, and on Windows it wedged on pid
+reuse. The other option was `GET /graph/bootstrap`, which is the whole binary
+snapshot: on a 23,098-entity repository that is 119.6 MiB, against the 1.0 MiB a
+renderer actually draws.
+
+## The export
+
+`GET /graph/export` on the daemon, or `kin graph export --json`.
+
+```
+kin graph export --json --limit 1400 --include line
+curl "$KIN_DAEMON_URL/graph/export?limit=1400&include=line,signature"
+```
+
+Query parameters:
+
+| Parameter | Meaning |
+| --- | --- |
+| `limit` | Node cap. Absent uses 1,400. `0` asks for every entity |
+| `kinds` | Comma-separated entity kinds to keep. Any spelling matches: `TraitDef`, `trait_def` and `traitdef` are one filter |
+| `path` | Repository path prefix a node's file must start with |
+| `include` | Comma-separated optional node fields: `signature`, `line` |
+
+The response is `graph-export.schema.json` in `packages/boundary-contracts`.
+It carries `seq`, the position in the delta stream the payload was cut at, which
+is what pairs it with `/graph/events`.
+Nodes carry `id`, `name`, `kind`, `file` and `degree` always, plus `line` and
+`signature` when asked for. Links carry `source`, `target` and `kind`, and both
+endpoints are always ids present in `nodes`.
+
+The envelope says how much of the graph you are looking at. `entity_count` and
+`relation_count` are the population the sample was drawn from, not what came
+back, so a client can report "1,400 of 23,098" rather than implying it drew
+everything. Two counters describe withheld edges and they are deliberately not
+one number: `unresolved_links` counts links whose endpoint is not an entity in
+this graph at all, such as an import of an external crate, which is a property
+of the graph; `filtered_links` counts links dropped because an endpoint was
+excluded by `kinds`, `path` or the node cap, which is a property of your
+request.
+
+Every count is of distinct links. A link is an undirected
+`(source, target, kind)` key, so two relations between the same pair in the same
+kind are one link and draw one line, and an edge the graph reports from both of
+its endpoints is counted once.
+
+A session holding a temporal scope exports the graph that scope names, the same
+resolution `/graph/bootstrap` uses.
+
+## The sampling rule
+
+A repository graph is bigger than any renderer wants. The cap is applied server
+side so a client does not download 9 MiB in order to throw 94 percent of it
+away, and so two consumers drawing the same repository draw the same picture.
+
+Nodes are bucketed by module, each module gets a quota, and whatever the quotas
+leave is filled globally by degree:
+
+1. A node's module is the first segment of its file path. Under a container
+   directory (`app`, `apps`, `cmd`, `crates`, `internal`, `lib`, `modules`,
+   `packages`, `pkg`, `services`, `src`) with more than two segments, it is the
+   first two. A file at the repository root is `(root)`; an entity the graph
+   placed in no file is `(unknown)`.
+2. Each module gets `max(1, (limit * 60 / 100) / module_count)` nodes, taken
+   highest degree first.
+3. The remaining budget is filled from everything not yet chosen, again highest
+   degree first.
+4. Ties break on name, then on entity id.
+
+The module split is what keeps a small module visible. Ranking the whole graph
+by degree hands the entire budget to whichever directory happens to be densest;
+measured on redis, `utils` holds 97 of 23,098 entities and a reader looking for
+it has to find something drawn. At a 1,400-node cap on that repository all eight
+modules survive, and `utils` keeps all 97.
+
+The id tiebreak is what makes the sample deterministic. Without it every
+zero-degree node with the same name is tied, and which one survived would depend
+on the order the store happened to enumerate entities in, so two exports of one
+unchanged graph could disagree.
+
+`degree` is the node's degree across the whole matched population, not
+recomputed for the sampled subgraph. A node whose neighbours were sampled out
+still reports how connected it really is.
+
+## The event stream
+
+`GET /graph/events` on the daemon, or `kin graph watch --json`.
+
+```
+kin graph watch --json --types EntityChanged,RelationChanged
+```
+
+Server-sent events, one JSON payload per `data:` line, a comment heartbeat every
+30 seconds. The `types` parameter keeps only the named event types. Frames are
+`graph-event.schema.json` in `packages/boundary-contracts`.
+
+Every frame carries a monotonic `seq`. The first frame is always `connected`,
+carrying `entity_count`, `root_hash` and the `seq` the stream has reached.
+`EntityChanged` carries the entity id, the change type, the file, the session
+that caused it when there was one, and a `node` summary of what the entity now
+is, so a consumer can patch a drawn node without a second round trip.
+`RelationChanged` carries both endpoint ids, the relation kind and the change
+type. It is emitted after the entity frames of the same reconcile, so an edge
+never names a node the consumer has not been told about yet. Both endpoints are
+always entities: an edge to an artifact or an external symbol is not drawable
+and produces no frame.
+
+`GraphDeltaApplied` closes each reconcile pass, after the last entity and
+relation frame of that pass, and says how much the pass did:
+`nodes_added`, `nodes_modified`, `nodes_removed`, `relations_added`,
+`relations_removed`. Buffer frames and lay out on this one. The reason is
+measured: one appended function at the end of hiredis `net.c` emitted 26
+`EntityChanged` frames, and 25 of them were for entities the edit never
+touched, because a reconcile re-emits every entity in the file it reparsed. A
+consumer laying out per frame would relayout 26 times for one keystroke. A pass
+that changed nothing emits no boundary at all.
+
+`/vfs/subscribe` is unchanged and still carries the same bus. Its frames have no
+`seq` and its `connected` frame has no root hash, because the VFS daemon and the
+spine depend on its exact frames.
+
+## Resyncing
+
+The protocol is:
+
+1. `GET /graph/export`. Keep its `seq`.
+2. Subscribe to `/graph/events`.
+3. Discard every frame whose `seq` is at or below the export's `seq`. Those
+   changes are already in the payload you hold.
+4. Apply the rest, laying out on each `GraphDeltaApplied`.
+
+Order does not matter between steps 1 and 2, which is the point of doing it this
+way. The export reads its sequence before it starts building, so an event
+emitted while the payload is being assembled falls above the cut and is
+delivered. The cost is that a client may re-apply one change it already has, and
+applying a node or edge upsert twice is a no-op. The alternative, reading the
+sequence after the build, would drop that event on the floor instead.
+
+`root_hash` is not the resync key, and cannot be. A working-tree edit changes
+the graph without advancing the graph root: measured on hiredis, one appended
+function produced 26 entity events and zero `GraphRootChanged`. A client
+reconnecting between commits would compare two matching hashes and keep a stale
+picture. Use `root_hash` to tell which committed state you are looking at, and
+`seq` to tell what you have applied.
+
+One signal still means throw the picture away and start at step 1:
+
+- `lagged`. The subscriber fell behind the daemon's broadcast channel and events
+  were dropped before it saw them. It carries no `seq`, because the frames it is
+  telling you about were never delivered and there is no position to name. It is
+  never removed by the `types` filter: it is not a graph event, it is the news
+  that your view is now wrong.
+
+`GraphRootChanged` is not that signal. It means a commit happened, which a
+consumer may want to show, but the entity and relation frames that came with it
+already describe the change.
+
+## Adding an event type
+
+New event types are added additively and older consumers are expected to keep
+working. A consumer must ignore a `type` it does not recognize rather than fail
+on it. Validating a frame against `graph-event.schema.json` answers "is this a
+frame I know", not "is this stream well formed", so a validation failure on an
+unknown type is a signal to skip that frame and nothing more.
+
+## Consumers
+
+`kin-demo` draws the export in its graph pane. `kinlab` mission control reads
+the event stream, and its org graph explorer is the surface the export is shaped
+for. Both import the payload shapes from `@kin/boundary-contracts` so the schema
+is the one contract all three read.

--- a/packages/boundary-contracts/schemas/graph-event.schema.json
+++ b/packages/boundary-contracts/schemas/graph-event.schema.json
@@ -1,0 +1,299 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kin://contracts/graph-event",
+  "description": "One frame of the Kin daemon graph delta stream, as served by GET /graph/events and printed by `kin graph watch --json`. Frames are internally tagged on `type` and carry a monotonic `seq`. The stream may carry types this schema does not list: a consumer must ignore an unrecognized type rather than fail, so validating against this schema is how a consumer decides whether a frame is one it knows, not whether the stream is well formed.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/connected"
+    },
+    {
+      "$ref": "#/$defs/lagged"
+    },
+    {
+      "$ref": "#/$defs/entityChanged"
+    },
+    {
+      "$ref": "#/$defs/relationChanged"
+    },
+    {
+      "$ref": "#/$defs/treeChanged"
+    },
+    {
+      "$ref": "#/$defs/graphRootChanged"
+    },
+    {
+      "$ref": "#/$defs/graphDeltaApplied"
+    }
+  ],
+  "$defs": {
+    "changeType": {
+      "type": "string",
+      "enum": [
+        "created",
+        "modified",
+        "deleted"
+      ]
+    },
+    "nodeSummary": {
+      "type": "object",
+      "description": "What the entity now is, so a consumer can patch a drawn node without a round trip. The same fields a graph-export node carries, minus the id, which the event already names.",
+      "required": [
+        "name",
+        "kind",
+        "degree"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "file": {
+          "type": "string"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "degree": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "connected": {
+      "type": "object",
+      "description": "The first frame on every subscription. Its root_hash is the resync anchor: pair it with the root_hash on the export you drew, and re-export on a mismatch.",
+      "required": [
+        "type",
+        "entity_count",
+        "root_hash",
+        "seq"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "connected"
+        },
+        "entity_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "root_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]*$"
+        },
+        "seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+        }
+      }
+    },
+    "lagged": {
+      "type": "object",
+      "description": "The subscriber fell behind the broadcast channel and missed events. Never filtered out by the types parameter, because it is the news that this client's view is now wrong. Re-export on receipt. Carries no seq: the events it reports were dropped before this subscriber saw them, so there is no position to name. Re-export on receipt.",
+      "required": [
+        "type",
+        "missed"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "lagged"
+        },
+        "missed": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "entityChanged": {
+      "type": "object",
+      "required": [
+        "type",
+        "entity_id",
+        "change_type",
+        "seq"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "EntityChanged"
+        },
+        "entity_id": {
+          "type": "string"
+        },
+        "change_type": {
+          "$ref": "#/$defs/changeType"
+        },
+        "file_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "session_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The session that caused the change, or null for a filesystem reconcile, which has no owning agent."
+        },
+        "node": {
+          "$ref": "#/$defs/nodeSummary"
+        },
+        "seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+        }
+      }
+    },
+    "relationChanged": {
+      "type": "object",
+      "description": "An edge appeared, changed, or went away. Emitted after the EntityChanged frames of the same reconcile, so an edge never names a node the consumer has not been told about yet. Both endpoints are entity ids; an edge to an artifact or an external symbol is not drawable and produces no frame.",
+      "required": [
+        "type",
+        "source",
+        "target",
+        "kind",
+        "change_type",
+        "seq"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "RelationChanged"
+        },
+        "source": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "change_type": {
+          "$ref": "#/$defs/changeType"
+        },
+        "file_path": {
+          "type": "string"
+        },
+        "seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+        }
+      }
+    },
+    "treeChanged": {
+      "type": "object",
+      "required": [
+        "type",
+        "paths_added",
+        "paths_removed",
+        "seq"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "TreeChanged"
+        },
+        "paths_added": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "paths_removed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+        }
+      }
+    },
+    "graphRootChanged": {
+      "type": "object",
+      "description": "The graph root advanced. A drawn graph built at old_root_hash is now stale; re-export.",
+      "required": [
+        "type",
+        "new_root_hash",
+        "seq"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "GraphRootChanged"
+        },
+        "old_root_hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "new_root_hash": {
+          "type": "string"
+        },
+        "seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+        }
+      }
+    },
+    "graphDeltaApplied": {
+      "type": "object",
+      "description": "One reconcile pass finished. Emitted after the last entity and relation frame of that pass, so a renderer lays out once per pass instead of once per event. The counts are of frames emitted since the previous boundary. A modified edge counts as added, because the edge that now exists is the one a consumer upserts.",
+      "required": [
+        "type",
+        "seq",
+        "nodes_added",
+        "nodes_modified",
+        "nodes_removed",
+        "relations_added",
+        "relations_removed"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "GraphDeltaApplied"
+        },
+        "seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+        },
+        "nodes_added": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "nodes_modified": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "nodes_removed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "relations_added": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "relations_removed": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/packages/boundary-contracts/schemas/graph-event.schema.json
+++ b/packages/boundary-contracts/schemas/graph-event.schema.json
@@ -88,7 +88,7 @@
         "seq": {
           "type": "integer",
           "minimum": 0,
-          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+          "description": "Monotonic position in the delta stream, assigned when the event is emitted rather than when it is delivered. Compare against the seq your export was cut at. A stream narrowed by the types parameter has gaps, so consecutive numbers are not proof that nothing was missed."
         }
       }
     },
@@ -148,7 +148,7 @@
         "seq": {
           "type": "integer",
           "minimum": 0,
-          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+          "description": "Monotonic position in the delta stream, assigned when the event is emitted rather than when it is delivered. Compare against the seq your export was cut at. A stream narrowed by the types parameter has gaps, so consecutive numbers are not proof that nothing was missed."
         }
       }
     },
@@ -186,7 +186,7 @@
         "seq": {
           "type": "integer",
           "minimum": 0,
-          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+          "description": "Monotonic position in the delta stream, assigned when the event is emitted rather than when it is delivered. Compare against the seq your export was cut at. A stream narrowed by the types parameter has gaps, so consecutive numbers are not proof that nothing was missed."
         }
       }
     },
@@ -218,7 +218,7 @@
         "seq": {
           "type": "integer",
           "minimum": 0,
-          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+          "description": "Monotonic position in the delta stream, assigned when the event is emitted rather than when it is delivered. Compare against the seq your export was cut at. A stream narrowed by the types parameter has gaps, so consecutive numbers are not proof that nothing was missed."
         }
       }
     },
@@ -247,7 +247,7 @@
         "seq": {
           "type": "integer",
           "minimum": 0,
-          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+          "description": "Monotonic position in the delta stream, assigned when the event is emitted rather than when it is delivered. Compare against the seq your export was cut at. A stream narrowed by the types parameter has gaps, so consecutive numbers are not proof that nothing was missed."
         }
       }
     },
@@ -271,7 +271,7 @@
         "seq": {
           "type": "integer",
           "minimum": 0,
-          "description": "Monotonic position in the delta stream. Compare against the seq your export was cut at."
+          "description": "Monotonic position in the delta stream, assigned when the event is emitted rather than when it is delivered. Compare against the seq your export was cut at. A stream narrowed by the types parameter has gaps, so consecutive numbers are not proof that nothing was missed."
         },
         "nodes_added": {
           "type": "integer",

--- a/packages/boundary-contracts/schemas/graph-export.schema.json
+++ b/packages/boundary-contracts/schemas/graph-export.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kin://contracts/graph-export",
+  "description": "The drawable projection of a Kin repository graph, as served by GET /graph/export on the daemon and by `kin graph export`. Nodes and links are what a renderer draws; the counts describe the population the sample was drawn from, so a consumer can say how much of the graph it is showing.",
+  "type": "object",
+  "required": [
+    "root_hash",
+    "seq",
+    "entity_count",
+    "relation_count",
+    "unresolved_links",
+    "filtered_links",
+    "sampled",
+    "nodes",
+    "links"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "root_hash": {
+      "type": "string",
+      "description": "Hex Merkle root of the graph this payload was built from. Pair it with the root_hash on the /graph/events connected frame: a mismatch means re-export rather than patch.",
+      "pattern": "^[0-9a-f]*$"
+    },
+    "seq": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Position in the delta stream this payload was cut at. The resync key: subscribe to /graph/events, discard every event whose seq is at or below this one, and apply the rest. root_hash cannot do this alone, because a working-tree edit changes the graph without advancing the root."
+    },
+    "entity_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Entities matching the request's kinds and path filters, before the node cap. Not the number of nodes drawn."
+    },
+    "relation_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Distinct drawable links among those entities, before the node cap. Links are undirected (source, target, kind) keys, so two relations between the same pair in the same kind count once and draw one line."
+    },
+    "unresolved_links": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Distinct links withheld because an endpoint is not an entity in this graph at all, such as an import of an external crate. A property of the graph, not of this request."
+    },
+    "filtered_links": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Distinct links withheld because an endpoint was excluded by the kinds or path filter or by the node cap. A property of this request, not of the graph."
+    },
+    "sampled": {
+      "type": "boolean",
+      "description": "Whether the node cap dropped anything. False means nodes holds every entity that matched."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "The node cap actually applied. Absent when the caller asked for no cap."
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/node"
+      }
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/link"
+      }
+    }
+  },
+  "$defs": {
+    "node": {
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "kind",
+        "degree"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Entity UUID."
+        },
+        "name": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "description": "Entity kind in the graph's own spelling, e.g. Function, Class, TraitDef."
+        },
+        "file": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repository-relative path, or null for an entity the graph placed in no file."
+        },
+        "degree": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct undirected (neighbour, kind) pairs across the whole matched population, not recomputed for the sampled subgraph."
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based presentation start line. Present only when the request asked for include=line and the entity carries a span."
+        },
+        "signature": {
+          "type": "string",
+          "description": "Present only when the request asked for include=signature."
+        }
+      }
+    },
+    "link": {
+      "type": "object",
+      "required": [
+        "source",
+        "target",
+        "kind"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Entity UUID, always present in nodes."
+        },
+        "target": {
+          "type": "string",
+          "description": "Entity UUID, always present in nodes."
+        },
+        "kind": {
+          "type": "string",
+          "description": "Relation kind in the graph's own spelling, e.g. Calls, Contains, UsesMacro."
+        }
+      }
+    }
+  }
+}

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -981,3 +981,145 @@ export interface RepoImportedWorkSummary {
   highlightedStatus: string | null;
   highlightedMilestone: string | null;
 }
+
+/**
+ * The drawable projection of a Kin repository graph.
+ *
+ * Served by `GET /graph/export` on the daemon and by `kin graph export`. The
+ * counts describe the population the sample was drawn from, not what was
+ * drawn, so a consumer can say how much of the graph it is showing.
+ */
+export interface GraphExportNode {
+  /** Entity UUID. */
+  id: string;
+  name: string;
+  /** Entity kind in the graph's own spelling, e.g. Function, Class, TraitDef. */
+  kind: string;
+  /** Repository-relative path, or null for an entity the graph placed in no file. */
+  file?: string | null;
+  /**
+   * Distinct undirected (neighbour, kind) pairs across the whole matched
+   * population, not recomputed for the sampled subgraph.
+   */
+  degree: number;
+  /** 1-based start line. Present only when the request asked for include=line. */
+  line?: number;
+  /** Present only when the request asked for include=signature. */
+  signature?: string;
+}
+
+export interface GraphExportLink {
+  /** Entity UUID, always present in nodes. */
+  source: string;
+  /** Entity UUID, always present in nodes. */
+  target: string;
+  /** Relation kind in the graph's own spelling, e.g. Calls, Contains. */
+  kind: string;
+}
+
+export interface GraphExport {
+  /**
+   * Hex Merkle root of the graph this payload came from. Pair it with the
+   * root_hash on the /graph/events connected frame: a mismatch means
+   * re-export rather than patch.
+   */
+  root_hash: string;
+  /**
+   * Position in the delta stream this payload was cut at. The resync key:
+   * subscribe to /graph/events, discard every event whose seq is at or below
+   * this one, and apply the rest. root_hash cannot do this alone, because a
+   * working-tree edit changes the graph without advancing the root.
+   */
+  seq: number;
+  /** Entities matching the kinds and path filters, before the node cap. */
+  entity_count: number;
+  /**
+   * Distinct drawable links among those entities, before the node cap. Links
+   * are undirected (source, target, kind) keys, so two relations between the
+   * same pair in the same kind count once and draw one line.
+   */
+  relation_count: number;
+  /**
+   * Distinct links withheld because an endpoint is not an entity in this graph
+   * at all. A property of the graph, not of the request.
+   */
+  unresolved_links: number;
+  /**
+   * Distinct links withheld because an endpoint was excluded by the kinds or
+   * path filter or by the node cap. A property of the request, not of the
+   * graph.
+   */
+  filtered_links: number;
+  /** Whether the node cap dropped anything. */
+  sampled: boolean;
+  /** The cap actually applied. Absent when the caller asked for no cap. */
+  limit?: number;
+  nodes: GraphExportNode[];
+  links: GraphExportLink[];
+}
+
+/** Change vocabulary shared by entity and relation events. */
+export type GraphChangeType = "created" | "modified" | "deleted";
+
+/**
+ * What an entity now is, carried alongside a change so a consumer can patch a
+ * drawn node without a round trip.
+ */
+export interface GraphNodeSummary {
+  name: string;
+  kind: string;
+  file?: string;
+  line?: number;
+  degree: number;
+}
+
+/**
+ * One frame of the graph delta stream, from `GET /graph/events` or
+ * `kin graph watch --json`.
+ *
+ * The stream may carry types this union does not list. A consumer must ignore
+ * an unrecognized type rather than fail: new variants are added additively and
+ * an older client is expected to keep working.
+ */
+export type GraphEvent =
+  | { type: "connected"; entity_count: number; root_hash: string; seq: number }
+  /**
+   * The subscriber fell behind and events were dropped. Carries no seq: the
+   * events it reports were never delivered, so there is no position to name.
+   * Re-export on receipt.
+   */
+  | { type: "lagged"; missed: number }
+  | {
+      type: "EntityChanged";
+      seq: number;
+      entity_id: string;
+      change_type: GraphChangeType;
+      file_path?: string | null;
+      session_id?: string | null;
+      node?: GraphNodeSummary;
+    }
+  | {
+      type: "RelationChanged";
+      seq: number;
+      source: string;
+      target: string;
+      kind: string;
+      change_type: GraphChangeType;
+      file_path?: string;
+    }
+  | { type: "TreeChanged"; seq: number; paths_added: string[]; paths_removed: string[] }
+  | { type: "GraphRootChanged"; seq: number; old_root_hash?: string | null; new_root_hash: string }
+  /**
+   * One reconcile pass finished. Emitted after the last entity and relation
+   * frame of that pass, so a renderer lays out once per pass rather than once
+   * per event. Counts are of frames emitted since the previous boundary.
+   */
+  | {
+      type: "GraphDeltaApplied";
+      seq: number;
+      nodes_added: number;
+      nodes_modified: number;
+      nodes_removed: number;
+      relations_added: number;
+      relations_removed: number;
+    };

--- a/packages/boundary-contracts/src/index.js
+++ b/packages/boundary-contracts/src/index.js
@@ -29,7 +29,9 @@ const schemaFiles = {
   repoScopedSemanticToolResponse: 'repo-scoped-semantic-tool-response.schema.json',
   repoScopedSemanticToolError: 'repo-scoped-semantic-tool-error.schema.json',
   shadowGateReport: 'shadow-gate-report.schema.json',
-  hostedRepositoryTransfer: 'hosted-repository-transfer.schema.json'
+  hostedRepositoryTransfer: 'hosted-repository-transfer.schema.json',
+  graphExport: 'graph-export.schema.json',
+  graphEvent: 'graph-event.schema.json'
 };
 
 const schemaIdMap = {

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -762,3 +762,302 @@ test('the hosted transfer route is built from the contract, and refuses what it 
   assert.deepEqual(schema.definitions.refusal.required, ['error']);
   assert.equal(schema.definitions.refusal.properties.error.minLength, 1);
 });
+
+test('the graph feed schemas load', async () => {
+  const schemas = await loadAllSchemas();
+  assert.ok(schemas.graphExport);
+  assert.ok(schemas.graphEvent);
+});
+
+const minimalExport = {
+  root_hash: 'a1b2c3',
+  seq: 41,
+  entity_count: 2,
+  relation_count: 1,
+  unresolved_links: 0,
+  filtered_links: 0,
+  sampled: false,
+  nodes: [
+    { id: 'e1', name: 'alpha', kind: 'Function', file: 'src/a.rs', degree: 1 },
+    { id: 'e2', name: 'beta', kind: 'Class', file: null, degree: 1 }
+  ],
+  links: [{ source: 'e1', target: 'e2', kind: 'Calls' }]
+};
+
+test('a graph export states how much of the graph it is showing', async () => {
+  // The counts are the population, not the drawing. A payload that carried
+  // only its own size would read as the whole graph, which is exactly what a
+  // sampled export must never imply.
+  assert.equal((await validateContract('graphExport', minimalExport)).ok, true);
+
+  const { root_hash: _dropped, ...noRoot } = minimalExport;
+  assert.equal(
+    (await validateContract('graphExport', noRoot)).ok,
+    false,
+    'without a root hash a client cannot pair the export with the stream, so it is not an export'
+  );
+
+  const noCounts = { ...minimalExport };
+  delete noCounts.entity_count;
+  assert.equal(
+    (await validateContract('graphExport', noCounts)).ok,
+    false,
+    'a payload that does not say how many entities matched cannot be read as complete or as sampled'
+  );
+});
+
+test('optional export node fields are optional and unknown ones are refused', async () => {
+  const withExtras = structuredClone(minimalExport);
+  withExtras.nodes[0].line = 12;
+  withExtras.nodes[0].signature = 'fn alpha()';
+  assert.equal(
+    (await validateContract('graphExport', withExtras)).ok,
+    true,
+    'line and signature ride along when the caller asked for them'
+  );
+
+  const withUnknown = structuredClone(minimalExport);
+  withUnknown.nodes[0].embedding = [0.1, 0.2];
+  assert.equal(
+    (await validateContract('graphExport', withUnknown)).ok,
+    false,
+    'a field nobody agreed on is how the three copies of this shape drift apart'
+  );
+});
+
+test('a relation event names both endpoints and what happened to the edge', async () => {
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'RelationChanged',
+        seq: 7,
+        source: 'e1',
+        target: 'e2',
+        kind: 'Calls',
+        change_type: 'created'
+      })
+    ).ok,
+    true
+  );
+
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'RelationChanged',
+        seq: 7,
+        source: 'e1',
+        kind: 'Calls',
+        change_type: 'created'
+      })
+    ).ok,
+    false,
+    'an edge with one endpoint cannot be applied to a drawn graph'
+  );
+
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'RelationChanged',
+        seq: 7,
+        source: 'e1',
+        target: 'e2',
+        kind: 'Calls',
+        change_type: 'added'
+      })
+    ).ok,
+    false,
+    'the change vocabulary is shared with entity events and is not per-event'
+  );
+});
+
+test('the connected frame carries the resync anchor', async () => {
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'connected',
+        entity_count: 730,
+        root_hash: 'ab',
+        seq: 41
+      })
+    ).ok,
+    true
+  );
+  assert.equal(
+    (await validateContract('graphEvent', { type: 'connected', entity_count: 730, seq: 41 })).ok,
+    false,
+    'without a root hash a reconnecting client cannot tell whether to patch or re-export'
+  );
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'connected',
+        entity_count: 730,
+        root_hash: 'ab'
+      })
+    ).ok,
+    false,
+    'and without a sequence it cannot tell what it missed between commits'
+  );
+});
+
+test('an entity event may carry the node it now describes', async () => {
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'EntityChanged',
+        seq: 12,
+        entity_id: 'e1',
+        change_type: 'modified',
+        file_path: '/repo/src/a.rs',
+        session_id: null,
+        node: { name: 'alpha', kind: 'Function', file: 'src/a.rs', line: 12, degree: 3 }
+      })
+    ).ok,
+    true
+  );
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'EntityChanged',
+        seq: 12,
+        entity_id: 'e1',
+        change_type: 'modified'
+      })
+    ).ok,
+    true,
+    'the summary is additive: a path that cannot cheaply produce one sends none'
+  );
+});
+
+test('a frame this contract does not describe fails validation rather than passing quietly', async () => {
+  // This is the one result a consumer must not act on as an error. The stream
+  // is additive and an older client will see types it has never heard of, so
+  // validation answers "is this a frame I know", not "is the stream broken".
+  assert.equal(
+    (await validateContract('graphEvent', { type: 'SomethingNewer', detail: 42 })).ok,
+    false,
+    'an unrecognized type is out of contract, and a consumer ignores it rather than failing'
+  );
+});
+
+test('the graph feed shape is one contract the Rust, the schema and the declarations agree on', async () => {
+  const [declarations, exportSource, stateSource, exportSchema, eventSchema] = await Promise.all([
+    fs.readFile(path.join(packageRoot, 'src/index.d.ts'), 'utf8'),
+    fs.readFile(
+      path.join(repositoryRoot, 'crates/kin-cli/src/commands/graph_export.rs'),
+      'utf8'
+    ),
+    fs.readFile(path.join(repositoryRoot, 'crates/kin-daemon/src/state.rs'), 'utf8'),
+    loadSchema('graphExport'),
+    loadSchema('graphEvent')
+  ]);
+
+  // The extractors must be shown to work before an empty result is read as
+  // agreement.
+  assert.equal(
+    rustStructFields(exportSource, 'GraphExportNotAStruct'),
+    null,
+    'the Rust extractor must miss a struct that does not exist'
+  );
+  assert.ok(
+    rustStructFields(exportSource, 'GraphExportNode').fields.includes('degree'),
+    'the Rust extractor must find a field the struct is known to declare'
+  );
+  assert.equal(
+    declaredInterfaceFields(declarations, 'GraphExportNotAnInterface'),
+    null,
+    'the TypeScript extractor must miss an interface that does not exist'
+  );
+
+  const pairs = [
+    ['GraphExportNode', rustStructFields(exportSource, 'GraphExportNode').fields, Object.keys(exportSchema.$defs.node.properties)],
+    ['GraphExportLink', rustStructFields(exportSource, 'GraphExportLink').fields, Object.keys(exportSchema.$defs.link.properties)],
+    ['GraphExport', rustStructFields(exportSource, 'GraphExportPayload').fields, Object.keys(exportSchema.properties)],
+    ['GraphNodeSummary', rustStructFields(stateSource, 'GraphNodeSummary').fields, Object.keys(eventSchema.$defs.nodeSummary.properties)]
+  ];
+
+  for (const [name, rustFields, schemaFields] of pairs) {
+    assert.deepEqual(
+      [...rustFields].sort(),
+      [...schemaFields].sort(),
+      `${name}: the Rust struct and the JSON Schema must carry the same fields`
+    );
+    const declared = declaredInterfaceFields(declarations, name);
+    assert.ok(declared, `${name} must be declared in index.d.ts`);
+    assert.deepEqual(
+      [...declared].sort(),
+      [...rustFields].sort(),
+      `${name}: the TypeScript declaration and the Rust struct must carry the same fields`
+    );
+  }
+});
+
+test('the pass boundary says what the whole reconcile did', async () => {
+  // A renderer lays out on this frame, not on each of the 26 entity events one
+  // appended function produces, so it has to say how much to apply.
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'GraphDeltaApplied',
+        seq: 67,
+        nodes_added: 1,
+        nodes_modified: 25,
+        nodes_removed: 0,
+        relations_added: 3,
+        relations_removed: 1
+      })
+    ).ok,
+    true
+  );
+
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'GraphDeltaApplied',
+        seq: 67,
+        nodes_added: 1,
+        nodes_modified: 25,
+        nodes_removed: 0
+      })
+    ).ok,
+    false,
+    'a boundary that counts only nodes leaves a consumer guessing about its edges'
+  );
+});
+
+test('a delta frame without a sequence is not a delta frame', async () => {
+  // The sequence is what a reconnecting client compares against its export.
+  // A frame that omits it cannot be placed, and between commits the root hash
+  // cannot place it either: a working-tree edit never advances the root.
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'RelationChanged',
+        source: 'e1',
+        target: 'e2',
+        kind: 'Calls',
+        change_type: 'created'
+      })
+    ).ok,
+    false
+  );
+  assert.equal(
+    (
+      await validateContract('graphEvent', {
+        type: 'EntityChanged',
+        entity_id: 'e1',
+        change_type: 'modified'
+      })
+    ).ok,
+    false
+  );
+});
+
+test('a graph export names the sequence it was cut at', async () => {
+  const { seq: _dropped, ...noSeq } = minimalExport;
+  assert.equal(
+    (await validateContract('graphExport', noSeq)).ok,
+    false,
+    'without it a client cannot tell which events it already has'
+  );
+});


### PR DESCRIPTION
An outside consumer that wants to draw or follow a Kin repository has no
first-class way in. It starts `kin graph viz --port N` and scrapes
`/api/graph.json` once, which is a snapshot behind a subprocess and a port and
wedges on Windows pid reuse, or it pulls `GET /graph/bootstrap`, which is the
whole binary snapshot and is not shaped for a consumer at all. This gives kin a
documented graph feed: a JSON export shaped for drawing, a delta stream shaped
for following, both on the daemon and both on the CLI, with the payload contract
published so kin-demo and kinlab consume the same schema.

## What the measurements said

Measured first, on scratch one-commit stores, before any feature code.

On hiredis (730 entities, 1,832 relations) `/graph/bootstrap` is 3,738,112 bytes
and the current viz payload is 277,921. On redis (23,098 entities, 59,629
relations) bootstrap is 125,439,954 bytes in 1.28 s, the viz payload is 9,695,691
with a 6.26 s cold start, and a 1,400-node sampled export of that same graph is
1,061,798. So the only existing way in is 118x what a renderer needs, and
sampling on the client means downloading 9 MiB to discard 94 percent of it.

The stream was the worse half. One appended function at the end of hiredis
`net.c` produced 26 `EntityChanged` events on `/vfs/subscribe`: one created and
25 modified, which is every entity that file already had, because a reconcile
re-emits everything in the file it reparsed. Zero relation events, though the
graph gained a `Calls` edge. Zero `GraphRootChanged`. Every frame carried only an
id, a change type and a path, so a consumer could not patch a drawn node without
a second round trip.

## What this adds

`GET /graph/export` answers from the daemon's live graph with `limit`, `kinds`,
`path` and `include=signature,line`. Nodes carry id, name, kind, file and degree
by default, which is exactly what the current renderers read, plus line and
signature on request. The envelope carries `root_hash`, `seq`, the population
counts, and two separate withheld-edge counters: `unresolved_links` keeps its
meaning of an endpoint that is no entity at all, and `filtered_links` is new and
counts what the request itself excluded. Counts are of distinct undirected links,
because the store reports an edge from both of its ends.

Sampling moves server side and ports the rule kin-demo already applies, so both
draw the same picture and the demo can drop its copy: per-module quotas at 60
percent of the cap by degree, global degree fill for the rest, and a module that
is two path segments deep under a container directory such as `crates` or
`packages`. Entity id joins the tiebreak, which the client-side rule lacks, so
the sample no longer depends on the order the store enumerated entities in. On
redis all eight modules survive a 1,400-node cap, and `utils` keeps all 97 of its
entities.

`GET /graph/events` is the same bus `/vfs/subscribe` serves, with a type filter
and a first frame carrying the current position. `EntityChanged` gains an
optional node summary read from the graph the transaction just applied.
`RelationChanged` reports edge adds and removes from the reconcile delta,
emitted after the entity frames of the same pass so an edge never names a node
the consumer has not been told about. `GraphDeltaApplied` closes each pass with
what it did, so a renderer lays out once per pass instead of 26 times for one
keystroke. `/vfs/subscribe` is unchanged and serializes the bare event, because
the VFS daemon and the spine depend on its exact frames.

The resync key is a monotonic sequence, not the root hash. The measurement is
the reason: a working-tree edit changes the graph and emits no
`GraphRootChanged`, so a client reconnecting between commits compares two
matching hashes over a stale picture. Events travel in a sequenced envelope and
the export returns the position it was cut at. The export reads that counter
before it builds, so an event emitted during the build lands above the cut and is
delivered rather than lost; the cost is one possibly re-applied upsert, which is
a no-op.

`kin graph export` and `kin graph watch` route through the daemon like the other
graph commands. `packages/boundary-contracts` gains
`graph-export.schema.json` and `graph-event.schema.json`, exported from
`index.js` and `index.d.ts`, so kinlab imports the same shapes.
`docs/graph-feed.md` carries the contract, the sampling rule, the resync protocol
and the consumers; `docs/cli-reference.md` gains both commands.

## Proven against a build of this branch

A debug build of this branch on a fresh hiredis store, not a unit test.

`GET /graph/export` answered in 31 ms at 278,097 bytes, against 3,738,112 for
`/graph/bootstrap` on the same repository. `include=line,signature` attached
both. `kinds=macro` narrowed the population to 148 and sampled it to 5.
`limit=0` exported all 730 with no cap. All three payloads validate against the
published schema.

One appended function in `net.c`, watched on `/graph/events`: 26
`EntityChanged` frames, all 26 carrying a node summary, 3 `RelationChanged`
frames with real endpoints, and one `GraphDeltaApplied` reading `nodes_added 1,
nodes_modified 25, nodes_removed 0, relations_added 3, relations_removed 0`.
That is the original measurement reproduced exactly, now in a single frame a
renderer can act on. Every frame carried a sequence, monotonic, relations after
the entity frames, boundary last, and 31 of 31 frames validated against the
published schema. `kin graph watch --json` gave 34 standalone JSON lines with
the boundary last. `/vfs/subscribe` still had zero frames carrying a sequence.

Two findings came out of that run and are documented rather than smoothed over.

A filtered stream has gaps in its sequence, because the number is assigned when
an event is emitted and not when it is delivered. `--types RelationChanged` over
an edit that produced 27 entity frames delivered two relation frames at 62 and
63 behind a connected frame at 33. A consumer must never read consecutive
numbers as proof that nothing was missed, which is exactly the case a renderer
falls into by asking for a filter.

And a watch that printed nothing turned out to be the daemon being right. Raw
`curl` on the same route in the same window saw the same nothing, which ruled the
CLI out, and the daemon log said `broken AST, retaining LKG state, file=sds.c,
errors=25`: the reconciler had refused a file whose parse the test edit broke, so
there was nothing to emit. Re-run against a file that parses it produced the 34
frames above.

## Gates

Run against this tree through the fleet's builder slots:

- `cargo test -p kin-cli --lib graph_export`: 13 passed, 0 failed
- `cargo test -p kin-daemon --lib` filtered to the new tests: 16 passed, 0 failed
- `bin/kin-precheck kin`: 16 gates ran, 16 passed, 0 failed, which is `fmt`,
  `clippy --all-targets --all-features` with ci.yml's own allow list, and the 14
  guard scripts enumerated out of ci.yml's check job
- `npm run lint` and `npm test` in `packages/boundary-contracts`: 19 passed, 0
  failed

Every new test was broken deliberately and the red run recorded, eleven
mutations across two sweeps, each caught by exactly the test written for it, with
a green run before and after. One of them caught a real defect before it shipped:
the store reports an edge from both of its ends, so classifying withheld edges
before collapsing that pair counted one dropped edge as two, and a filtered
export would have claimed it was hiding twice as much of the graph as it was.

Related: FIR-3069
