### PR TITLE
Resolve kin trace targets by identity: uuids, pinned twins, non-zero exit on a miss

### DIFF
--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -125,6 +125,11 @@ pub struct ContextResponse {
     /// human rendering says the same thing on the same run.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub budget_elisions: BTreeMap<String, ContextElision>,
+    /// Set when the query resolved to no entity, so a caller reading the exit
+    /// code is not handed guidance as though it were a pack (FIR-3071). The same
+    /// text stays in `lines` for a client that predates this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// What one pack section lost to the token budget.
@@ -173,8 +178,15 @@ pub async fn run(
                 "the running daemon does not support structured context packs; restart it with the current Kin build"
             );
         }
+        if let Some(error) = response.error {
+            anyhow::bail!(error);
+        }
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
+        // Refuse before printing, so a miss leaves stdout empty.
+        if let Some(error) = response.error {
+            anyhow::bail!(error);
+        }
         for line in response.lines {
             println!("{line}");
         }
@@ -218,8 +230,10 @@ pub fn build_context_response(
             });
 
     let Some(target) = resolve_context_target(graph, &request.entity)? else {
+        let lines = context_not_found_guidance(&request.entity);
         return Ok(ContextResponse {
-            lines: context_not_found_guidance(&request.entity),
+            error: Some(lines.join("\n")),
+            lines,
             // Stamped even here: an unresolved entity is an answer, and leaving
             // this empty would report it as a daemon too old to answer at all.
             schema_version: CONTEXT_RESPONSE_SCHEMA_VERSION.to_string(),
@@ -376,6 +390,7 @@ pub fn build_context_response(
             same_file_dropped: selection.same_file_dropped(),
         }),
         budget_elisions: elisions,
+        error: None,
         pack: Some(pack),
     })
 }
@@ -603,6 +618,50 @@ mod tests {
             "offers search: {joined}"
         );
         assert!(joined.contains("kin locate"), "offers locate: {joined}");
+    }
+
+    /// A miss has to be readable as a miss by a caller that only checks the exit
+    /// code. The prose stays in `lines` for an older client; the discriminator
+    /// beside it is what makes `kin context` refuse (FIR-3071).
+    #[test]
+    fn context_miss_carries_the_discriminator_and_not_just_the_prose() {
+        let graph = kin_db::InMemoryGraph::new();
+        graph.upsert_entity(&test_entity("checkout")).unwrap();
+
+        let response = build_context_response(
+            &graph,
+            &ContextRequest {
+                entity: "definitelyMissingEntity".to_string(),
+                budget: "8k".to_string(),
+                assistant: None,
+            },
+        )
+        .unwrap();
+
+        let joined = response.lines.join("\n");
+        assert!(joined.contains("not found"), "{joined}");
+        assert_eq!(response.error.as_deref(), Some(joined.as_str()));
+        assert!(response.pack.is_none());
+    }
+
+    /// The other side of the same rule: a resolved context must not carry the
+    /// discriminator, or every answer would refuse.
+    #[test]
+    fn a_resolved_context_carries_no_error_discriminator() {
+        let graph = kin_db::InMemoryGraph::new();
+        graph.upsert_entity(&test_entity("checkout")).unwrap();
+
+        let response = build_context_response(
+            &graph,
+            &ContextRequest {
+                entity: "checkout".to_string(),
+                budget: "8k".to_string(),
+                assistant: None,
+            },
+        )
+        .unwrap();
+
+        assert!(response.error.is_none(), "{:?}", response.error);
     }
 
     fn test_entity(name: &str) -> Entity {

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use anyhow::{Context, Result};
-use kin_model::{EntityFilter, EntityId, EntityStore, GraphNodeId};
+use kin_model::{EntityId, EntityStore, GraphNodeId};
 use serde::{Deserialize, Serialize};
 
 pub const IMPACT_RESPONSE_SCHEMA_VERSION: &str = "kin-impact-response-v1";
@@ -118,6 +118,16 @@ pub async fn run(
             anyhow::bail!("impact resolution failed: {}", response.resolution);
         }
     } else {
+        // The same refusal the --json path already made, on the path a person
+        // and a shell script both take. Guidance printed at exit 0 is what let a
+        // caller embed "Entity ... not found" as though it were an analysis
+        // (FIR-3071).
+        if response.resolution != "resolved" && !response.resolution.is_empty() {
+            for line in response.lines {
+                eprintln!("{}", crate::output_style::paint_impact_line(&line));
+            }
+            anyhow::bail!("impact resolution failed: {}", response.resolution);
+        }
         for line in response.lines {
             println!("{}", crate::output_style::paint_impact_line(&line));
         }
@@ -602,85 +612,41 @@ struct ResolvedEntities {
     exact_name: bool,
 }
 
+/// Resolve this request's entity through the one resolver every read command
+/// shares.
+///
+/// The rules here used to live in this function alone, which is why `kin trace`
+/// and `kin xref` could not read an id and no command but this one could take
+/// `--file` (FIR-3071). They now live in [`crate::entity_identity`]; this stays
+/// as the thin adapter between `ImpactRequest` and that resolver.
 fn resolve_entities(
     graph: &kin_db::InMemoryGraph,
     request: &ImpactRequest,
 ) -> Result<ResolvedEntities> {
-    let mut matches = if let Ok(uuid) = uuid::Uuid::parse_str(&request.entity) {
-        graph.get_entity(&EntityId(uuid))?.into_iter().collect()
-    } else {
-        let filter = EntityFilter {
-            name_pattern: Some(request.entity.clone()),
-            ..Default::default()
-        };
-        let mut matches = graph.query_entities(&filter)?;
-        // An external reference target carries the imported symbol's name, so a
-        // name query returns it beside the local declaration that shares that
-        // name. It is never a subject of impact analysis: this repository holds
-        // no definition, no file, and no relations out of it, so nothing can be
-        // said about what changing it would reach. Leaving it in the match set
-        // inflates the count, and under a structured caller's fail-closed
-        // resolution it turns a repository's own `Error` or `Result` into an
-        // ambiguous query answered with no analysis at all.
-        matches.retain(|entity| !kin_index::is_external_reference_target(entity));
-        // Broad matching is for discovery: "resolve" should still find
-        // resolve_binary. But when the query names an entity exactly, substring
-        // cousins (try_resolve_binary alongside resolve_binary) force an
-        // ambiguity note onto an unambiguous ask, so an exact-name hit narrows
-        // the set to the exact matches.
-        //
-        // One rule for both surfaces. A structured caller used to RETAIN the
-        // exact matches here instead, which empties the set for every name that
-        // resolves only inexactly: Python methods are named `HTTPAdapter.send`,
-        // so `kin impact send --json` retained nothing and was then reported as
-        // an entity the graph does not hold, with an empty candidate list,
-        // because the name snapshot below was taken after the retain (FIR-2478).
-        // Fail-closed resolution survives the move: it is enforced where it can
-        // still see what the name found, in `build_impact_response`.
-        let exact: Vec<kin_model::Entity> = matches
-            .iter()
-            .filter(|entity| entity.name == request.entity)
-            .cloned()
-            .collect();
-        if !exact.is_empty() {
-            matches = exact;
-        }
-        matches
-    };
-    let exact_name = matches.iter().any(|entity| entity.name == request.entity);
-    let name_matches = matches.clone();
-    if let Some(file) = request.file.as_deref() {
-        matches.retain(|entity| kin_review::StableEntityIdentity::from_entity(entity).file == file);
-    }
-    if let Some(kind) = request.kind.as_deref() {
-        matches.retain(|entity| kin_review::StableEntityIdentity::from_entity(entity).kind == kind);
-    }
-    if let Some(signature) = request.signature.as_deref() {
-        let normalized = signature.split_whitespace().collect::<Vec<_>>().join(" ");
-        matches.retain(|entity| {
-            kin_review::StableEntityIdentity::from_entity(entity).signature == normalized
-        });
-    }
+    let resolved = crate::entity_identity::resolve_identity(
+        graph,
+        &request.entity,
+        &crate::entity_identity::IdentityQualifiers {
+            file: request.file.clone(),
+            kind: request.kind.clone(),
+            signature: request.signature.clone(),
+        },
+    )?;
     Ok(ResolvedEntities {
-        matches,
-        name_matches,
-        exact_name,
+        matches: resolved.matches,
+        name_matches: resolved.name_matches,
+        exact_name: resolved.exact_name,
     })
 }
 
 /// The qualifiers a request carried, spelled the way the user passed them.
 fn active_qualifiers(request: &ImpactRequest) -> Vec<String> {
-    [
-        request.file.as_deref().map(|v| format!("--file {v}")),
-        request.kind.as_deref().map(|v| format!("--kind {v}")),
-        request
-            .signature
-            .as_deref()
-            .map(|v| format!("--signature {v}")),
-    ]
-    .into_iter()
-    .flatten()
-    .collect()
+    crate::entity_identity::IdentityQualifiers {
+        file: request.file.clone(),
+        kind: request.kind.clone(),
+        signature: request.signature.clone(),
+    }
+    .labels()
 }
 
 /// The answer when a name resolves but the identity qualifiers exclude every

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -74,6 +74,12 @@ pub struct RefsResponse {
     /// the CLI and the MCP tool cannot disagree about one store.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub negative: Option<serde_json::Value>,
+    /// Set when the query resolved to no entity. Without it a caller reading the
+    /// exit code takes the guidance for an answer, which for `kin refs` is an
+    /// empty reference list: the exact shape a "safe to delete?" sweep acts on
+    /// (FIR-3071). The same text stays in `lines` for an older client.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,6 +118,10 @@ pub async fn run(entity: String, kind: String) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "refs").await?;
     let response = run_daemon_refs(&layout, &RefsRequest { entity, kind }).await?;
+    // Refuse before printing, so a miss leaves stdout empty.
+    if let Some(error) = response.error {
+        anyhow::bail!(error);
+    }
     for line in response.lines {
         println!("{}", crate::output_style::paint_refs_line(&line));
     }
@@ -199,8 +209,10 @@ pub fn build_refs_response(
         // Not an absence claim about references: the focal never resolved, so
         // nothing was walked and there is no coverage question to answer. A
         // verdict here would qualify a lookup failure as if it were a finding.
+        let lines = refs_not_found_guidance(&request.entity);
         return Ok(RefsResponse {
-            lines: refs_not_found_guidance(&request.entity),
+            error: Some(lines.join("\n")),
+            lines,
             negative: None,
         });
     };
@@ -238,7 +250,11 @@ pub fn build_refs_response(
         ));
         let neighbors = declaration_neighbors::collect(graph, target, &relation_kinds)?;
         lines.extend(empty_result_context(target, &neighbors));
-        return Ok(RefsResponse { lines, negative });
+        return Ok(RefsResponse {
+            lines,
+            negative,
+            error: None,
+        });
     }
 
     // FIR-1552. A receiver-method call the linker matched on the bare leaf name
@@ -324,6 +340,7 @@ pub fn build_refs_response(
     Ok(RefsResponse {
         lines,
         negative: None,
+        error: None,
     })
 }
 
@@ -1024,6 +1041,62 @@ mod tests {
         parse_relation_kinds, refs_not_found_guidance, BulkRefsRequest, BulkRefsResponse,
         ReferenceLinesAbsent, RefsRequest, RelationResolution,
     };
+
+    /// A miss has to be readable as a miss by a caller that only checks the exit
+    /// code. For `kin refs` the guidance reads as an empty reference list, which
+    /// is the shape a "safe to delete?" sweep acts on, so the discriminator
+    /// beside the prose is what makes the command refuse (FIR-3071).
+    #[test]
+    fn refs_miss_carries_the_discriminator_and_not_just_the_prose() {
+        let (graph, layout, _dir) = orphan_fixture();
+        let healthy = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 3,
+            "graph_generation": 1,
+        }));
+
+        let response = build_refs_response(
+            &layout,
+            &graph,
+            &RefsRequest {
+                entity: "definitelyMissingEntity".to_string(),
+                kind: "all".to_string(),
+            },
+            &healthy,
+        )
+        .expect("refs response");
+
+        let joined = response.lines.join("\n");
+        assert!(joined.contains("not found"), "{joined}");
+        assert_eq!(response.error.as_deref(), Some(joined.as_str()));
+    }
+
+    /// The other side of the same rule: a resolved answer must not carry the
+    /// discriminator, or every `kin refs` would refuse.
+    #[test]
+    fn a_resolved_refs_answer_carries_no_error_discriminator() {
+        let (graph, layout, _dir) = orphan_fixture();
+        let healthy = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 3,
+            "graph_generation": 1,
+        }));
+
+        let response = build_refs_response(
+            &layout,
+            &graph,
+            &RefsRequest {
+                entity: "orphan".to_string(),
+                kind: "all".to_string(),
+            },
+            &healthy,
+        )
+        .expect("refs response");
+
+        assert!(response.error.is_none(), "{:?}", response.error);
+    }
 
     /// THE SPINE (FIR-2524 rung three). A degraded daemon must make `kin refs`
     /// inherit the MCP verdict for that degradation.

--- a/crates/kin-cli/src/commands/trace.rs
+++ b/crates/kin-cli/src/commands/trace.rs
@@ -58,6 +58,22 @@ pub struct TraceRequest {
     pub max_lines: usize,
     pub nearby_limit: usize,
     pub transitive_limit: usize,
+    /// Exact repo-relative file qualifier, as `kin impact` spells it.
+    #[serde(default)]
+    pub file: Option<String>,
+    /// Exact entity-kind qualifier, as `kin impact` spells it.
+    #[serde(default)]
+    pub kind: Option<String>,
+}
+
+impl TraceRequest {
+    fn qualifiers(&self) -> crate::entity_identity::IdentityQualifiers {
+        crate::entity_identity::IdentityQualifiers {
+            file: self.file.clone(),
+            kind: self.kind.clone(),
+            signature: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,7 +82,37 @@ pub struct TraceResponse {
     pub lines: Vec<String>,
     #[serde(default)]
     pub entities: Vec<TraceJsonEntity>,
+    /// Set when the query resolved to no entity. A trace that found nothing is
+    /// not a trace, and a caller that reads only the exit code has no other way
+    /// to tell: the guidance used to arrive as ordinary output lines with a
+    /// success code, and a demo came within one guard of pasting "Entity ... not
+    /// found" into a model prompt as repository material (FIR-3071).
+    ///
+    /// The same text stays in `lines` so a daemon serving an older `kin` keeps
+    /// printing what it printed before. A `kin` new enough to read this field
+    /// refuses before it prints anything.
+    #[serde(default)]
+    pub error: Option<String>,
 }
+
+/// A trace whose query resolved to no entity.
+///
+/// Carried as an error rather than as output so that every seam between the
+/// graph and the caller has to handle it: the in-process builder, the daemon
+/// route, and the exit code. The guidance travels with it, because a miss should
+/// still say what to try next.
+#[derive(Debug)]
+pub struct TraceMiss {
+    pub lines: Vec<String>,
+}
+
+impl std::fmt::Display for TraceMiss {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.lines.join("\n"))
+    }
+}
+
+impl std::error::Error for TraceMiss {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceJsonEntity {
@@ -77,6 +123,7 @@ pub struct TraceJsonEntity {
     pub signature: Option<String>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     entity: String,
     compact: bool,
@@ -85,6 +132,8 @@ pub async fn run(
     max_lines: usize,
     nearby_limit: usize,
     transitive_limit: usize,
+    file: Option<String>,
+    kind: Option<String>,
 ) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "trace").await?;
@@ -99,9 +148,16 @@ pub async fn run(
             max_lines,
             nearby_limit,
             transitive_limit,
+            file,
+            kind,
         },
     )
     .await?;
+    // Refuse before printing, not after: a miss must leave stdout empty so a
+    // caller piping this into a prompt gets nothing rather than an apology.
+    if let Some(error) = response.error {
+        anyhow::bail!(error);
+    }
     for line in response.lines {
         println!("{line}");
     }
@@ -132,25 +188,48 @@ pub fn build_trace_response(
     envelope: &kin_mcp::Envelope,
 ) -> Result<TraceResponse> {
     if request.json {
-        return build_trace_json_response(layout, graph, &request.entity);
+        return build_trace_json_response(layout, graph, request);
     }
 
-    Ok(TraceResponse {
-        lines: build_trace_lines(
-            layout,
-            binding,
-            graph,
-            &request.entity,
-            request.compact,
-            &request.budget,
-            request.assistant.as_deref(),
-            request.max_lines,
-            request.nearby_limit,
-            request.transitive_limit,
-            envelope,
-        )?,
-        entities: Vec::new(),
-    })
+    let built = build_trace_lines(
+        layout,
+        binding,
+        graph,
+        request,
+        request.compact,
+        &request.budget,
+        request.assistant.as_deref(),
+        request.max_lines,
+        request.nearby_limit,
+        request.transitive_limit,
+        envelope,
+    );
+    match built {
+        Ok(lines) => Ok(TraceResponse {
+            lines,
+            entities: Vec::new(),
+            error: None,
+        }),
+        Err(error) => Ok(trace_miss_response(error)?),
+    }
+}
+
+/// Turn a resolution miss into the response shape both eras of client read, and
+/// leave every other error alone.
+///
+/// The guidance goes into `lines` for a `kin` that predates the `error` field
+/// and into `error` for one that does not, so the same daemon serves both and
+/// only the newer one refuses. Anything that is not a miss is a real failure and
+/// keeps propagating.
+fn trace_miss_response(error: anyhow::Error) -> Result<TraceResponse> {
+    match error.downcast::<TraceMiss>() {
+        Ok(miss) => Ok(TraceResponse {
+            lines: miss.lines.clone(),
+            entities: Vec::new(),
+            error: Some(miss.to_string()),
+        }),
+        Err(other) => Err(other),
+    }
 }
 
 /// The absence qualifier for a pack whose dependency walk came back empty.
@@ -194,25 +273,25 @@ fn trace_absence_qualifier(
 pub fn build_trace_json_response(
     layout: &kin_core::KinLayout,
     graph: &impl GraphStore,
-    entity: &str,
+    request: &TraceRequest,
 ) -> Result<TraceResponse> {
+    let entity = request.entity.as_str();
     if looks_like_file_path(entity) {
         return Ok(TraceResponse {
             lines: Vec::new(),
             entities: Vec::new(),
+            error: None,
         });
     }
 
-    let matches = query_trace_matches(graph, entity)?;
-    let mut matches = if matches.is_empty() {
-        fallback_leaf_trace_matches(graph, entity)?
-    } else {
-        matches
+    let resolution = match resolve_trace_target(graph, request) {
+        Ok(resolution) => resolution,
+        Err(error) => return trace_miss_response(error),
     };
+    let mut matches = resolution.candidates;
 
-    if let Some(best_id) = select_best_match_with_layout(entity, &matches).map(|e| e.id) {
-        matches.sort_by_key(|candidate| (candidate.id != best_id, candidate.name.len()));
-    }
+    let best_id = resolution.target.id;
+    matches.sort_by_key(|candidate| (candidate.id != best_id, candidate.name.len()));
 
     let entities = matches
         .iter()
@@ -232,6 +311,7 @@ pub fn build_trace_json_response(
     Ok(TraceResponse {
         lines: Vec::new(),
         entities,
+        error: None,
     })
 }
 
@@ -240,7 +320,7 @@ fn build_trace_lines(
     layout: &kin_core::KinLayout,
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &impl GraphStore,
-    entity: &str,
+    request: &TraceRequest,
     compact: bool,
     budget: &str,
     assistant: Option<&str>,
@@ -251,15 +331,15 @@ fn build_trace_lines(
 ) -> Result<Vec<String>> {
     // Agents sometimes pass file paths instead of entity names; resolve those to
     // the graph-owned entities declared in that file rather than a raw file read.
-    if looks_like_file_path(entity) {
-        return Ok(render_file_path_trace_lines(layout, graph, entity));
+    if looks_like_file_path(&request.entity) {
+        return Ok(render_file_path_trace_lines(layout, graph, &request.entity));
     }
 
     build_trace_lines_with_graph(
         layout,
         binding,
         graph,
-        entity,
+        request,
         compact,
         budget,
         assistant,
@@ -270,6 +350,7 @@ fn build_trace_lines(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_json(
     entity: String,
     _compact: bool,
@@ -278,6 +359,8 @@ pub async fn run_json(
     _max_lines: usize,
     _nearby_limit: usize,
     _transitive_limit: usize,
+    file: Option<String>,
+    kind: Option<String>,
 ) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "trace --json").await?;
@@ -292,9 +375,16 @@ pub async fn run_json(
             max_lines: _max_lines,
             nearby_limit: _nearby_limit,
             transitive_limit: _transitive_limit,
+            file,
+            kind,
         },
     )
     .await?;
+    // An empty array is a lie for a query that resolved nothing, and it is the
+    // shape an editor integration is most likely to trust silently.
+    if let Some(error) = response.error {
+        anyhow::bail!(error);
+    }
     println!("{}", serde_json::to_string(&response.entities)?);
     Ok(())
 }
@@ -304,7 +394,7 @@ fn build_trace_lines_with_graph(
     layout: &kin_core::KinLayout,
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &impl GraphStore,
-    entity: &str,
+    request: &TraceRequest,
     compact: bool,
     budget: &str,
     assistant: Option<&str>,
@@ -313,6 +403,7 @@ fn build_trace_lines_with_graph(
     transitive_limit: usize,
     envelope: &kin_mcp::Envelope,
 ) -> Result<Vec<String>> {
+    let entity = request.entity.trim();
     let token_budget = parse_budget(budget)?;
     let focal_max_lines = if compact {
         max_lines.min(12)
@@ -332,21 +423,8 @@ fn build_trace_lines_with_graph(
         _ => None,
     });
 
-    let matches = query_trace_matches(graph, entity)?;
-    let matches = if matches.is_empty() {
-        fallback_leaf_trace_matches(graph, entity)?
-    } else {
-        matches
-    };
-
-    if matches.is_empty() {
-        return Ok(trace_not_found_guidance(entity));
-    }
-
-    let target = match select_best_match_with_layout(entity, &matches) {
-        Some(target) => target,
-        None => return Ok(trace_not_found_guidance(entity)),
-    };
+    let resolution = resolve_trace_target(graph, request)?;
+    let target = &resolution.target;
 
     let opts = kin_context::ContextOptions {
         budget: token_budget,
@@ -378,6 +456,18 @@ fn build_trace_lines_with_graph(
             "Budget: {}/{} tokens",
             pack.actual_tokens,
             token_budget.max_tokens()
+        ));
+    }
+
+    // Say that a choice was made and what the alternatives are, in both
+    // renderings. The compact one is the rendering an agent reads, and it is the
+    // one that put a header's declaration beside a source file's definition in a
+    // single prompt with nothing marking the difference (FIR-3071).
+    if !resolution.addressed_by_id {
+        lines.extend(crate::entity_identity::twin_note(
+            entity,
+            target,
+            &resolution.candidates,
         ));
     }
 
@@ -845,6 +935,145 @@ fn extract_textual_followups(text: &str) -> Vec<String> {
     out
 }
 
+/// What a trace query resolved to.
+#[derive(Debug)]
+struct TraceResolution {
+    /// The entity the trace describes.
+    target: Entity,
+    /// Every candidate the query reached, after the qualifiers narrowed them.
+    candidates: Vec<Entity>,
+    /// Whether the caller addressed an id. An id names one entity, so there was
+    /// no choice to report.
+    addressed_by_id: bool,
+}
+
+/// Resolve the entity a trace is about, by id or by name, then narrow by the
+/// identity qualifiers.
+///
+/// The id branch is what `kin trace --help` has always promised and never did:
+/// its argument is documented as "Entity name or ID", but resolution went
+/// through the name index alone, so a uuid `kin search --json` had just returned
+/// was matched as a name pattern and reported absent while `kin context`
+/// accepted the same uuid (FIR-3071).
+///
+/// The name branch keeps the qualified-name retry `kin trace` already had, so
+/// `Router::route` still reaches `Router<S>::route` and `cfg.run` still reaches
+/// `run`, and applies the qualifiers to what that found. Every miss leaves as a
+/// [`TraceMiss`], so no caller downstream can mistake one for an answer.
+fn resolve_trace_target(
+    graph: &impl GraphStore,
+    request: &TraceRequest,
+) -> Result<TraceResolution> {
+    let entity = request.entity.trim();
+    let qualifiers = request.qualifiers();
+
+    if let Ok(uuid) = uuid::Uuid::parse_str(entity) {
+        let Some(found) = graph.get_entity(&kin_model::EntityId(uuid))? else {
+            return Err(anyhow::Error::new(TraceMiss {
+                lines: trace_id_not_found_guidance(entity),
+            }));
+        };
+        return Ok(TraceResolution {
+            target: found.clone(),
+            candidates: vec![found],
+            addressed_by_id: true,
+        });
+    }
+
+    let matches = query_trace_matches(graph, entity)?;
+    let matches = if matches.is_empty() {
+        fallback_leaf_trace_matches(graph, entity)?
+    } else {
+        matches
+    };
+    if matches.is_empty() {
+        return Err(anyhow::Error::new(TraceMiss {
+            lines: trace_not_found_guidance(entity),
+        }));
+    }
+
+    let name_candidates = matches.clone();
+    let mut candidates = matches;
+    crate::entity_identity::apply_qualifiers(&mut candidates, &qualifiers);
+    if candidates.is_empty() {
+        return Err(anyhow::Error::new(TraceMiss {
+            lines: trace_qualifier_miss_guidance(entity, &qualifiers.labels(), &name_candidates),
+        }));
+    }
+
+    let Some(target) = select_best_match_with_layout(entity, &candidates).cloned() else {
+        return Err(anyhow::Error::new(TraceMiss {
+            lines: trace_not_found_guidance(entity),
+        }));
+    };
+    Ok(TraceResolution {
+        target,
+        candidates,
+        addressed_by_id: false,
+    })
+}
+
+/// Guidance when the caller addressed an id this graph does not hold.
+///
+/// Kept apart from the name miss because the next step differs: an id is either
+/// stale or from another store, and re-running the search that produced it is
+/// what fixes that, while a name miss wants discovery.
+fn trace_id_not_found_guidance(entity: &str) -> Vec<String> {
+    vec![
+        format!("Entity id '{entity}' is not in this repo's graph."),
+        "hint: ids are per store. Re-run `kin search <name> --json` against this repository and use the id it returns."
+            .to_string(),
+    ]
+}
+
+/// Guidance when the name resolves but the qualifiers exclude every match.
+///
+/// The entity is in the graph, so saying it is absent would be false, and it is
+/// the answer a caller gets by following Kin's own advice to disambiguate by
+/// file. Report the miss as a filter miss and name what the name alone reaches,
+/// so the next command is a copy of one of these lines. Same shape `kin impact`
+/// already uses for the same case.
+fn trace_qualifier_miss_guidance(
+    entity: &str,
+    qualifiers: &[String],
+    candidates: &[Entity],
+) -> Vec<String> {
+    let mut lines = vec![format!(
+        "No entity named '{}' matches {}.",
+        entity,
+        qualifiers.join(" ")
+    )];
+    lines.push(format!(
+        "'{}' resolves in this repo's graph to {} entit{}:",
+        entity,
+        candidates.len(),
+        if candidates.len() == 1 { "y" } else { "ies" }
+    ));
+    for candidate in candidates
+        .iter()
+        .take(crate::commands::declaration_neighbors::MAX_LISTED)
+    {
+        lines.push(format!(
+            "  {} ({}) @ {}",
+            candidate.name,
+            kin_review::StableEntityIdentity::from_entity(candidate).kind,
+            crate::entity_identity::entity_location(candidate)
+        ));
+    }
+    if let Some(more) = crate::commands::declaration_neighbors::and_more_suffix(
+        crate::commands::declaration_neighbors::MAX_LISTED,
+        candidates.len(),
+    ) {
+        lines.push(format!("  {more}"));
+    }
+    lines.push(
+        "hint: qualify with one of the identities above, or drop the qualifier to trace the \
+         preferred match."
+            .to_string(),
+    );
+    lines
+}
+
 /// Actionable guidance when `kin trace <symbol>` resolves nothing — not as a
 /// graph entity and not via the source-symbol fallback. Keep the not-found
 /// signal, then point at discovery commands rather than dead-ending. Honest by
@@ -891,6 +1120,222 @@ mod tests {
             WorkspaceId::new(),
             Arc::new(LocalFileBackend::new(layout.kindb_dir())),
         )
+    }
+
+    /// A request that carries nothing but the entity, so a test naming one
+    /// concern does not restate nine defaults.
+    fn trace_request(entity: &str) -> super::TraceRequest {
+        super::TraceRequest {
+            entity: entity.to_string(),
+            json: false,
+            compact: false,
+            budget: "8k".to_string(),
+            assistant: None,
+            max_lines: 20,
+            nearby_limit: 3,
+            transitive_limit: 0,
+            file: None,
+            kind: None,
+        }
+    }
+
+    /// The FIR-3071 fixture: `buffer_grow` declared in a header and defined in a
+    /// source file, spelled the way the C parser writes each. The declaration
+    /// keeps the terminator its statement ended with; the definition's signature
+    /// stops where its body starts.
+    fn buffer_grow_twin(file: &str, signature: &str, line: u32) -> Entity {
+        let file_id = kin_model::FilePathId::new(file);
+        let mut entity = make_entity("buffer_grow");
+        entity.id = EntityId::from_content(&file_id.0, "buffer_grow", "Function", line);
+        entity.language = LanguageId::C;
+        entity.signature = signature.to_string();
+        entity.span = Some(kin_model::SourceSpan {
+            file: file_id.clone(),
+            start_byte: 0,
+            end_byte: 200,
+            start_line: line,
+            start_col: 0,
+            end_line: line,
+            end_col: 0,
+        });
+        entity.file_origin = Some(file_id);
+        entity
+    }
+
+    fn buffer_grow_declaration() -> Entity {
+        buffer_grow_twin("src/buffer.h", "int buffer_grow(buf_t *b, size_t need);", 5)
+    }
+
+    fn buffer_grow_definition() -> Entity {
+        buffer_grow_twin("src/buffer.c", "int buffer_grow(buf_t *b, size_t need)", 5)
+    }
+
+    /// A store that lists the twins in the given order, which is the only thing
+    /// the six preserved stores differed by.
+    fn twin_store(order: [Entity; 2]) -> InMemoryGraph {
+        let graph = InMemoryGraph::new();
+        for entity in order {
+            graph.upsert_entity(&entity).unwrap();
+        }
+        graph
+    }
+
+    /// The defect itself: six stores built from one tree with differing commit
+    /// dates listed these two entities three ways one way and three the other,
+    /// and `kin trace buffer_grow` answered about whichever came first. The
+    /// choice has to be the same in both listings, and it has to be the
+    /// definition.
+    #[test]
+    fn resolution_does_not_move_with_the_order_the_store_lists_twins_in() {
+        let forward = twin_store([buffer_grow_definition(), buffer_grow_declaration()]);
+        let reversed = twin_store([buffer_grow_declaration(), buffer_grow_definition()]);
+
+        let first = super::resolve_trace_target(&forward, &trace_request("buffer_grow")).unwrap();
+        let second = super::resolve_trace_target(&reversed, &trace_request("buffer_grow")).unwrap();
+
+        assert_eq!(
+            first.target.id, second.target.id,
+            "the traced entity moved with the listing order"
+        );
+        assert_eq!(
+            first.target.file_origin.as_ref().map(|f| f.0.as_str()),
+            Some("src/buffer.c"),
+            "a body should beat a declaration"
+        );
+        assert_eq!(first.candidates.len(), 2, "both twins stay listed");
+        assert!(!first.addressed_by_id);
+    }
+
+    /// What `kin trace --help` has always promised. A uuid used to go through
+    /// the name index and come back absent while `kin context` accepted it.
+    #[test]
+    fn resolution_accepts_an_entity_id_the_way_context_does() {
+        let declaration = buffer_grow_declaration();
+        let graph = twin_store([buffer_grow_definition(), declaration.clone()]);
+
+        let resolved =
+            super::resolve_trace_target(&graph, &trace_request(&declaration.id.to_string()))
+                .unwrap();
+
+        assert_eq!(resolved.target.id, declaration.id);
+        assert!(
+            resolved.addressed_by_id,
+            "an id names one entity, so nothing was chosen"
+        );
+    }
+
+    #[test]
+    fn resolution_refuses_an_entity_id_this_graph_does_not_hold() {
+        let graph = twin_store([buffer_grow_definition(), buffer_grow_declaration()]);
+        let absent = EntityId::new().to_string();
+
+        let error = super::resolve_trace_target(&graph, &trace_request(&absent)).unwrap_err();
+        let miss = error.downcast::<super::TraceMiss>().expect("a trace miss");
+
+        assert!(miss.to_string().contains("is not in this repo's graph"));
+    }
+
+    /// The caller that knows which twin it means can now say so, and the
+    /// qualifier wins over the definition preference.
+    #[test]
+    fn a_file_qualifier_pins_the_declaration_over_the_preferred_definition() {
+        let graph = twin_store([buffer_grow_definition(), buffer_grow_declaration()]);
+        let mut request = trace_request("buffer_grow");
+        request.file = Some("src/buffer.h".to_string());
+        request.kind = Some("function".to_string());
+
+        let resolved = super::resolve_trace_target(&graph, &request).unwrap();
+
+        assert_eq!(
+            resolved.target.file_origin.as_ref().map(|f| f.0.as_str()),
+            Some("src/buffer.h"),
+            "the qualifier must decide"
+        );
+        assert_eq!(resolved.candidates.len(), 1);
+    }
+
+    /// A qualifier that excludes everything is a filter miss, not an absent
+    /// entity, and saying otherwise about an entity the name had just found is
+    /// the mistake `kin impact` already paid for.
+    #[test]
+    fn a_qualifier_that_matches_nothing_reports_a_filter_miss() {
+        let graph = twin_store([buffer_grow_definition(), buffer_grow_declaration()]);
+        let mut request = trace_request("buffer_grow");
+        request.file = Some("src/nowhere.c".to_string());
+
+        let error = super::resolve_trace_target(&graph, &request).unwrap_err();
+        let miss = error.downcast::<super::TraceMiss>().expect("a trace miss");
+        let text = miss.to_string();
+
+        assert!(text.contains("matches --file src/nowhere.c"), "{text}");
+        assert!(
+            text.contains("resolves in this repo's graph to 2"),
+            "{text}"
+        );
+        assert!(text.contains("src/buffer.c"), "{text}");
+        assert!(
+            !text.contains("not found"),
+            "a filter miss is not a miss: {text}"
+        );
+    }
+
+    /// The miss discriminator, on a test that cannot skip.
+    ///
+    /// `trace_graph_miss_returns_guidance_without_disk_fallback` below returns
+    /// early when `KinLayout::discover` finds no repository, so under `cargo
+    /// test` from a checkout without a `.kin` it passes having asserted nothing:
+    /// setting `error: None` in `trace_miss_response` left it green. This builds
+    /// its own layout, so the only way it passes is by the response being right.
+    #[test]
+    fn a_trace_miss_response_carries_the_discriminator_beside_the_guidance() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let binding = absent_binding(&layout);
+        let graph = twin_store([buffer_grow_definition(), buffer_grow_declaration()]);
+
+        let response = super::build_trace_response(
+            &layout,
+            &binding,
+            &graph,
+            &trace_request("definitelyMissingEntity"),
+            &healthy_trace_envelope(),
+        )
+        .expect("a miss is an answer, not a failure of the builder");
+
+        let joined = response.lines.join("\n");
+        assert!(joined.contains("not found"), "{joined}");
+        assert_eq!(
+            response.error.as_deref(),
+            Some(joined.as_str()),
+            "the guidance must travel in both fields, or the CLI cannot refuse"
+        );
+        assert!(response.entities.is_empty());
+    }
+
+    /// The other side of it: a resolved query must carry no discriminator, or
+    /// every trace would refuse.
+    ///
+    /// Asserted on the `--json` builder rather than the rendered one. The
+    /// rendered path reads the focal's source through the repository authority,
+    /// which this test's binding does not hold, so it would fail for a reason it
+    /// is not about. The `--json` path runs the same resolution and is the
+    /// surface an editor integration reads.
+    #[test]
+    fn a_resolved_trace_carries_no_error_discriminator() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let graph = twin_store([buffer_grow_definition(), buffer_grow_declaration()]);
+
+        let response =
+            super::build_trace_json_response(&layout, &graph, &trace_request("buffer_grow"))
+                .expect("trace json response");
+
+        assert!(response.error.is_none(), "{:?}", response.error);
+        assert_eq!(response.entities.len(), 2, "both twins are listed");
+        assert_eq!(
+            response.entities[0].file, "src/buffer.c",
+            "the definition must be ranked first, not the header's declaration"
+        );
     }
 
     #[test]
@@ -1103,16 +1548,7 @@ issues.map((iss) => util.finalizeItem(iss, ctx, core.config()));
             &layout,
             &binding,
             &graph,
-            &super::TraceRequest {
-                entity: "definitelyMissingEntity".to_string(),
-                json: false,
-                compact: false,
-                budget: "8k".to_string(),
-                assistant: None,
-                max_lines: 20,
-                nearby_limit: 3,
-                transitive_limit: 0,
-            },
+            &trace_request("definitelyMissingEntity"),
             &healthy_trace_envelope(),
         )
         .unwrap();
@@ -1124,6 +1560,13 @@ issues.map((iss) => util.finalizeItem(iss, ctx, core.config()));
         assert!(
             joined.contains("kin search definitelyMissingEntity"),
             "offers search instead of disk fallback: {joined}"
+        );
+        // The guidance still travels in `lines` for an older client, and the
+        // discriminator beside it is what makes the CLI refuse (FIR-3071).
+        assert_eq!(
+            response.error.as_deref(),
+            Some(joined.as_str()),
+            "a miss must carry the discriminator, not just the prose"
         );
     }
 }

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -20,11 +20,20 @@ pub struct XrefResponse {
     /// authority, revision, roots, and anchor information at this boundary.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spine: Option<::kin_spine::SpineXrefResponse>,
+    /// Set when the query resolved to no entity, so a caller reading the exit
+    /// code is not handed guidance as though it were an anchor listing
+    /// (FIR-3071). The same text stays in `lines` for an older client.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 pub async fn run(entity: String) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_xref(&layout, &XrefRequest { entity }).await?;
+    // Refuse before printing, so a miss leaves stdout empty.
+    if let Some(error) = response.error {
+        anyhow::bail!(error);
+    }
     for line in response.lines {
         println!("{line}");
     }
@@ -61,13 +70,34 @@ pub async fn build_xref_response(
     let matches = graph.query_entities(&filter)?;
 
     if matches.is_empty() {
+        let lines = xref_not_found_guidance(&request.entity);
         return Ok(XrefResponse {
-            lines: xref_not_found_guidance(&request.entity),
+            error: Some(lines.join("\n")),
+            lines,
             spine: None,
         });
     }
 
-    let target = &matches[0];
+    // Not `&matches[0]`. The graph returns name matches in an order decided at
+    // ingest, so taking the first made `kin xref` answer about whichever twin
+    // the store happened to list first, the same defect `kin trace` carried:
+    // six stores built from one tree split three and three on which of
+    // `buffer_grow`'s two entities came first (FIR-3071). `select_best_match`
+    // ranks by name quality and breaks its ties on facts read off the entity
+    // record, so the answer is a property of the candidates.
+    let target = match kin_core::select_best_match(&request.entity, &matches, |entity, hint| {
+        kin_core::normalize_symbol_hint(&entity.name).contains(hint)
+    }) {
+        Some(target) => target,
+        None => {
+            let lines = xref_not_found_guidance(&request.entity);
+            return Ok(XrefResponse {
+                error: Some(lines.join("\n")),
+                lines,
+                spine: None,
+            });
+        }
+    };
     let mut lines = vec![format!(
         "Cross-repo references (xrefs) for '{}':",
         target.name
@@ -106,7 +136,11 @@ pub async fn build_xref_response(
         spine = Some(response);
     }
 
-    Ok(XrefResponse { lines, spine })
+    Ok(XrefResponse {
+        lines,
+        spine,
+        error: None,
+    })
 }
 
 fn spine_xref_lines(
@@ -314,6 +348,7 @@ mod tests {
         let response = XrefResponse {
             lines: vec!["partial".to_string()],
             spine: Some(kin_spine::SpineXrefResponse::new(Vec::new(), Vec::new())),
+            error: None,
         };
         let encoded = serde_json::to_vec(&response).unwrap();
         let decoded: XrefResponse = serde_json::from_slice(&encoded).unwrap();
@@ -321,6 +356,93 @@ mod tests {
         assert!(!spine.authority_complete);
         assert!(spine.authority_revision.is_none());
         assert!(spine.authority_roots.is_empty());
+    }
+
+    /// A miss has to be readable as a miss by a caller that only checks the exit
+    /// code. The prose stays in `lines` for an older client; the discriminator
+    /// beside it is what makes `kin xref` refuse (FIR-3071).
+    /// The same store-order defect `kin trace` carried, on the other command
+    /// that resolved a name to a listing position.
+    ///
+    /// Asserting only that two insertion orders agree would prove nothing here:
+    /// the store returns name matches sorted by entity id, so insertion order
+    /// never reaches the caller and such a test passes with the defect in place.
+    /// It has to assert WHICH twin is chosen. The header's declaration sorts
+    /// first by id (a9988b12 against b477cab2), so `matches.first()` answers
+    /// about the declaration while the ranked choice answers about the
+    /// definition, and the spine anchor is where that choice is observable.
+    #[tokio::test]
+    async fn xref_resolves_the_definition_rather_than_the_first_listed_twin() {
+        fn twin(file: &str, signature: &str, line: u32) -> Entity {
+            let file_id = FilePathId::new(file);
+            let mut e = entity("buffer_grow");
+            e.id = EntityId::from_content(&file_id.0, "buffer_grow", "Function", line);
+            e.signature = signature.to_string();
+            e.file_origin = Some(file_id);
+            e
+        }
+        let declaration = twin("src/buffer.h", "int buffer_grow(buf_t *b, size_t need);", 5);
+        let definition = twin("src/buffer.c", "int buffer_grow(buf_t *b, size_t need)", 5);
+        assert!(
+            declaration.id < definition.id,
+            "fixture precondition: the declaration must sort first, or this test cannot catch \
+             a resolver that takes the first listed match"
+        );
+
+        let graph = kin_db::InMemoryGraph::new();
+        graph.upsert_entity(&declaration).unwrap();
+        graph.upsert_entity(&definition).unwrap();
+        let root = graph_root(&graph);
+
+        let spine = kin_spine::InMemorySpineBackend::new();
+        spine.register_repo(
+            "repo",
+            vec![entry("repo", &declaration), entry("repo", &definition)],
+            &root,
+        );
+        spine.refresh_cross_repo_edges("repo", &[], &[], &["repo".to_string()]);
+
+        let response = build_xref_response(
+            &graph,
+            &XrefRequest {
+                entity: "buffer_grow".to_string(),
+            },
+            "repo",
+            &root,
+            Some(&spine),
+        )
+        .await
+        .expect("xref response");
+
+        assert!(response.error.is_none(), "{:?}", response.error);
+        let payload = response.spine.expect("typed spine response");
+        assert!(
+            payload.authority_complete_for("repo", &definition.id),
+            "xref answered about the twin the store listed first, not the definition"
+        );
+    }
+
+    #[tokio::test]
+    async fn xref_miss_carries_the_discriminator_and_not_just_the_prose() {
+        let graph = kin_db::InMemoryGraph::new();
+        graph.upsert_entity(&entity("target")).unwrap();
+        let root = graph_root(&graph);
+
+        let response = build_xref_response(
+            &graph,
+            &XrefRequest {
+                entity: "definitelyMissingEntity".to_string(),
+            },
+            "repo",
+            &root,
+            None::<&dyn kin_spine::SpineBackend>,
+        )
+        .await
+        .unwrap();
+
+        let joined = response.lines.join("\n");
+        assert!(joined.contains("not found"), "{joined}");
+        assert_eq!(response.error.as_deref(), Some(joined.as_str()));
     }
 
     #[tokio::test]

--- a/crates/kin-cli/src/entity_identity.rs
+++ b/crates/kin-cli/src/entity_identity.rs
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! One way to name an entity, for every read command that takes one.
+//!
+//! A caller addresses an entity three ways: by the id `kin search --json`
+//! handed back, by a name, or by a name plus the qualifiers that pin which of
+//! several same-named entities it meant. Before this module each command spelled
+//! that out for itself, and they disagreed. `kin context` and `kin impact` read
+//! an id; `kin trace` and `kin xref` matched the id string as a name pattern and
+//! reported the entity absent, while `kin trace --help` advertised "Entity name
+//! or ID". Only `kin impact` accepted `--file`, `--kind` and `--signature`, so a
+//! caller that knew which twin it meant could say so to one command out of five
+//! (FIR-3071).
+//!
+//! Resolution answers in two stages and keeps them apart. `name_matches` is what
+//! the name alone reaches; `matches` is what survives the qualifiers. A command
+//! that collapses them reports "not found" about an entity the unqualified
+//! lookup had just returned, which is what `kin impact Error --file
+//! src/error.rs` used to do.
+//!
+//! Nothing here reads the filesystem. Every fact is read from the graph's own
+//! entity records, and the qualifiers compare against
+//! [`kin_review::StableEntityIdentity`], the same normalized identity the note
+//! this module prints suggests, so a `--file`/`--kind` pair copied out of that
+//! note is the pair the filter compares.
+
+use anyhow::Result;
+use kin_model::{Entity, EntityFilter, EntityId, GraphStore};
+
+/// The qualifiers that pin one entity when a name reaches several.
+#[derive(Debug, Clone, Default)]
+pub struct IdentityQualifiers {
+    /// Exact repo-relative file path.
+    pub file: Option<String>,
+    /// Exact entity kind, spelled as `StableEntityIdentity` spells it.
+    pub kind: Option<String>,
+    /// Whitespace-normalized declaration signature, for overloads.
+    pub signature: Option<String>,
+}
+
+impl IdentityQualifiers {
+    pub fn is_empty(&self) -> bool {
+        self.file.is_none() && self.kind.is_none() && self.signature.is_none()
+    }
+
+    /// The qualifiers as the caller typed them, for a message that has to name
+    /// what excluded everything.
+    pub fn labels(&self) -> Vec<String> {
+        [
+            self.file.as_deref().map(|v| format!("--file {v}")),
+            self.kind.as_deref().map(|v| format!("--kind {v}")),
+            self.signature
+                .as_deref()
+                .map(|v| format!("--signature {v}")),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    }
+}
+
+/// What a query resolved to, at both stages of resolution.
+pub struct ResolvedIdentity {
+    /// After `--file`, `--kind` and `--signature`.
+    pub matches: Vec<Entity>,
+    /// Before them: what the name or id alone reaches.
+    pub name_matches: Vec<Entity>,
+    /// Whether the query is some entity's name exactly, rather than a fragment
+    /// of one. A structured caller resolves only on an exact name, so this is
+    /// what separates "the graph holds nothing by that name" from "the name you
+    /// gave is part of several entities' names".
+    pub exact_name: bool,
+    /// Whether the query parsed as an entity id. An id names one entity, so a
+    /// caller that passed one has already disambiguated and gets no twin note.
+    pub addressed_by_id: bool,
+}
+
+/// Resolve `query` to the entities it can mean, then narrow by `qualifiers`.
+///
+/// An id resolves to at most one entity and skips name matching entirely. A
+/// name goes through the graph's name index, drops external reference targets,
+/// and narrows to exact-name hits when the query is exactly some entity's name.
+///
+/// An external reference target carries an imported symbol's name while standing
+/// for a definition another repository owns. This repository holds no file and
+/// no relations for it, so it can never be the subject of a trace or an impact
+/// walk; leaving it in inflates the count and turns a repository's own `Error`
+/// into an ambiguous query.
+pub fn resolve_identity<G: GraphStore>(
+    graph: &G,
+    query: &str,
+    qualifiers: &IdentityQualifiers,
+) -> Result<ResolvedIdentity> {
+    let trimmed = query.trim();
+    let addressed_by_id = uuid::Uuid::parse_str(trimmed).is_ok();
+
+    let mut matches: Vec<Entity> = if let Ok(uuid) = uuid::Uuid::parse_str(trimmed) {
+        graph.get_entity(&EntityId(uuid))?.into_iter().collect()
+    } else {
+        let filter = EntityFilter {
+            name_pattern: Some(trimmed.to_string()),
+            ..Default::default()
+        };
+        let mut matches = graph.query_entities(&filter)?;
+        matches.retain(|entity| !kin_index::is_external_reference_target(entity));
+        // Broad matching is for discovery: "resolve" should still reach
+        // resolve_binary. But when the query names an entity exactly, substring
+        // cousins force an ambiguity note onto an unambiguous ask, so an
+        // exact-name hit narrows the set to the exact matches.
+        let exact: Vec<Entity> = matches
+            .iter()
+            .filter(|entity| entity.name == trimmed)
+            .cloned()
+            .collect();
+        if !exact.is_empty() {
+            matches = exact;
+        }
+        matches
+    };
+
+    let exact_name = matches.iter().any(|entity| entity.name == trimmed);
+    let name_matches = matches.clone();
+    apply_qualifiers(&mut matches, qualifiers);
+
+    Ok(ResolvedIdentity {
+        matches,
+        name_matches,
+        exact_name,
+        addressed_by_id,
+    })
+}
+
+/// Narrow `matches` to the entities the qualifiers admit.
+///
+/// Split out from [`resolve_identity`] so a command that gathers its candidates
+/// its own way still filters them by exactly these rules. `kin trace` is one:
+/// its name lookup retries a qualified name against its leaf, so `Router::route`
+/// reaches `Router<S>::route`, and that retry has to happen before the
+/// qualifiers narrow what it found.
+///
+/// Compared against [`kin_review::StableEntityIdentity`], the normalized
+/// identity, so `--file` takes the repo-relative path the answer prints and
+/// `--kind` takes the lowercase kind, not a `Debug` spelling.
+pub fn apply_qualifiers(matches: &mut Vec<Entity>, qualifiers: &IdentityQualifiers) {
+    if let Some(file) = qualifiers.file.as_deref() {
+        matches.retain(|entity| kin_review::StableEntityIdentity::from_entity(entity).file == file);
+    }
+    if let Some(kind) = qualifiers.kind.as_deref() {
+        matches.retain(|entity| kin_review::StableEntityIdentity::from_entity(entity).kind == kind);
+    }
+    if let Some(signature) = qualifiers.signature.as_deref() {
+        let normalized = signature.split_whitespace().collect::<Vec<_>>().join(" ");
+        matches.retain(|entity| {
+            kin_review::StableEntityIdentity::from_entity(entity).signature == normalized
+        });
+    }
+}
+
+/// The entity to answer about when several share a name and nothing pins one.
+///
+/// Ordered by [`kin_core::definition_identity_key`]: a body beats a declaration,
+/// then the file path, then the start line, then the id. Every term is read off
+/// the entity record, so the choice is a property of the candidates and not of
+/// the order the store listed them in, which is what made the same question
+/// answer two ways across six stores built from one tree (FIR-3071).
+pub fn choose_definition(matches: &[Entity]) -> Option<&Entity> {
+    matches.iter().min_by(|a, b| {
+        kin_core::definition_identity_key(a).cmp(&kin_core::definition_identity_key(b))
+    })
+}
+
+/// How many candidates a note lists before it stops.
+const MAX_LISTED_TWINS: usize = 4;
+
+/// What the answer has to say when the name reached more than one entity.
+///
+/// Says which entity was chosen and why, then names the others and the flags
+/// that pin them. Without this a caller cannot tell an unambiguous answer from a
+/// coin flip the command already made on its behalf, which is how a demo put a
+/// header's declaration and a source file's definition into one prompt as though
+/// they were the same entity.
+///
+/// Silent when the caller passed an id or when the name reached one entity,
+/// because there was nothing to choose.
+pub fn twin_note(query: &str, chosen: &Entity, matches: &[Entity]) -> Vec<String> {
+    if matches.len() < 2 {
+        return Vec::new();
+    }
+    let chosen_identity = kin_review::StableEntityIdentity::from_entity(chosen);
+    let mut lines = vec![format!(
+        "note: '{}' names {} entities in this graph; traced the {} at {}.",
+        query,
+        matches.len(),
+        if kin_core::carries_body(chosen) {
+            "definition"
+        } else {
+            "declaration"
+        },
+        entity_location(chosen),
+    )];
+    let others: Vec<&Entity> = matches
+        .iter()
+        .filter(|candidate| candidate.id != chosen.id)
+        .collect();
+    for candidate in others.iter().take(MAX_LISTED_TWINS) {
+        let identity = kin_review::StableEntityIdentity::from_entity(candidate);
+        lines.push(format!(
+            "note: also {} ({}).",
+            entity_location(candidate),
+            identity.kind
+        ));
+    }
+    if others.len() > MAX_LISTED_TWINS {
+        lines.push(format!(
+            "note: and {} more.",
+            others.len() - MAX_LISTED_TWINS
+        ));
+    }
+    lines.push(format!(
+        "note: pin one with --file <path> --kind <kind>, for example --file {} --kind {}.",
+        if chosen_identity.file.is_empty() {
+            "<path>".to_string()
+        } else {
+            chosen_identity.file.clone()
+        },
+        chosen_identity.kind
+    ));
+    lines
+}
+
+/// `path:line` for an entity, or `unknown` when the graph carries no file for
+/// it. Presentation only; resolution is keyed on graph identity, never on paths.
+pub fn entity_location(entity: &Entity) -> String {
+    crate::commands::declaration_neighbors::entity_location(entity)
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_db::InMemoryGraph;
+    use kin_model::{
+        EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId, FingerprintAlgorithm,
+        Hash256, LanguageId, SemanticFingerprint, SourceSpan, Visibility,
+    };
+
+    /// The FIR-3071 fixture in miniature: one name, a declaration in a header
+    /// and a definition in a source file, exactly as the C parser writes them.
+    /// The declaration keeps its terminator because nothing clamped its
+    /// signature; the definition's stops where its body starts.
+    fn twin(name: &str, file: &str, line: u32, signature: &str, span_len: usize) -> Entity {
+        let file_id = FilePathId::new(file);
+        Entity {
+            id: EntityId::from_content(&file_id.0, name, "Function", line),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::C,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([1; 32]),
+                signature_hash: Hash256::from_bytes([2; 32]),
+                behavior_hash: Hash256::from_bytes([3; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(file_id.clone()),
+            span: Some(SourceSpan {
+                file: file_id,
+                start_byte: 0,
+                end_byte: span_len,
+                start_line: line,
+                start_col: 0,
+                end_line: line,
+                end_col: 0,
+            }),
+            signature: signature.to_string(),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn declaration() -> Entity {
+        twin(
+            "buffer_grow",
+            "src/buffer.h",
+            5,
+            "int buffer_grow(buf_t *b, size_t need);",
+            39,
+        )
+    }
+
+    fn definition() -> Entity {
+        twin(
+            "buffer_grow",
+            "src/buffer.c",
+            5,
+            "int buffer_grow(buf_t *b, size_t need)",
+            220,
+        )
+    }
+
+    /// The property the six preserved stores broke: the choice must be the same
+    /// whichever order the store lists the twins in.
+    #[test]
+    fn choose_definition_ignores_the_order_the_store_listed_the_twins_in() {
+        let forward = vec![definition(), declaration()];
+        let reversed = vec![declaration(), definition()];
+
+        let first = choose_definition(&forward).expect("a candidate");
+        let second = choose_definition(&reversed).expect("a candidate");
+
+        assert_eq!(
+            first.id, second.id,
+            "the choice moved with the listing order"
+        );
+        assert_eq!(
+            first.file_origin.as_ref().map(|f| f.0.as_str()),
+            Some("src/buffer.c"),
+            "the definition should win over the header's declaration"
+        );
+    }
+
+    #[test]
+    fn twin_note_names_the_choice_and_the_flags_that_pin_the_other() {
+        let matches = vec![definition(), declaration()];
+        let chosen = choose_definition(&matches).expect("a candidate");
+        let note = twin_note("buffer_grow", chosen, &matches).join("\n");
+
+        assert!(note.contains("names 2 entities"), "{note}");
+        assert!(note.contains("traced the definition"), "{note}");
+        assert!(note.contains("src/buffer.h"), "{note}");
+        assert!(note.contains("--file src/buffer.c"), "{note}");
+    }
+
+    #[test]
+    fn twin_note_is_silent_when_the_name_reaches_one_entity() {
+        let matches = vec![definition()];
+        let chosen = choose_definition(&matches).expect("a candidate");
+        assert!(twin_note("buffer_grow", chosen, &matches).is_empty());
+    }
+
+    #[test]
+    fn resolve_identity_reads_an_entity_id_the_way_context_and_impact_do() {
+        let graph = InMemoryGraph::new();
+        let target = definition();
+        graph.upsert_entity(&target).unwrap();
+        graph.upsert_entity(&declaration()).unwrap();
+
+        let resolved = resolve_identity(
+            &graph,
+            &target.id.to_string(),
+            &IdentityQualifiers::default(),
+        )
+        .unwrap();
+
+        assert!(resolved.addressed_by_id);
+        assert_eq!(resolved.matches.len(), 1);
+        assert_eq!(resolved.matches[0].id, target.id);
+    }
+
+    #[test]
+    fn resolve_identity_pins_a_twin_by_file_and_kind() {
+        let graph = InMemoryGraph::new();
+        graph.upsert_entity(&definition()).unwrap();
+        graph.upsert_entity(&declaration()).unwrap();
+
+        let resolved = resolve_identity(
+            &graph,
+            "buffer_grow",
+            &IdentityQualifiers {
+                file: Some("src/buffer.h".to_string()),
+                kind: Some("function".to_string()),
+                signature: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(resolved.name_matches.len(), 2, "both twins carry the name");
+        assert_eq!(resolved.matches.len(), 1, "the file pins one");
+        assert_eq!(
+            resolved.matches[0]
+                .file_origin
+                .as_ref()
+                .map(|f| f.0.as_str()),
+            Some("src/buffer.h"),
+            "the qualifier must win over the definition preference"
+        );
+    }
+
+    /// A qualifier that excludes everything is a filter miss, not an absent
+    /// entity, and the two stages have to stay distinguishable for the command
+    /// to say so.
+    #[test]
+    fn resolve_identity_keeps_a_qualifier_miss_apart_from_a_name_miss() {
+        let graph = InMemoryGraph::new();
+        graph.upsert_entity(&definition()).unwrap();
+
+        let resolved = resolve_identity(
+            &graph,
+            "buffer_grow",
+            &IdentityQualifiers {
+                file: Some("src/nowhere.c".to_string()),
+                kind: None,
+                signature: None,
+            },
+        )
+        .unwrap();
+
+        assert!(resolved.matches.is_empty());
+        assert_eq!(resolved.name_matches.len(), 1);
+        assert!(resolved.exact_name);
+    }
+}

--- a/crates/kin-cli/src/lib.rs
+++ b/crates/kin-cli/src/lib.rs
@@ -14,6 +14,7 @@ pub mod daemon_client;
 pub mod daemon_death;
 pub mod daemon_error;
 pub mod embed_model;
+pub mod entity_identity;
 pub mod model_residency;
 pub mod output_style;
 pub mod profile;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -243,6 +243,12 @@ enum Command {
     Trace {
         /// Entity name or ID
         entity: String,
+        /// Exact repo-relative file qualifier for stable identity resolution
+        #[arg(long)]
+        file: Option<String>,
+        /// Exact entity-kind qualifier (for example: function or method)
+        #[arg(long)]
+        kind: Option<String>,
         /// Output machine-readable JSON for editor integrations
         #[arg(long, default_value_t = false)]
         json: bool,
@@ -2818,6 +2824,8 @@ fn run() -> Result<()> {
                 } => commands::contextbench_locate::run(task_file, json, debug).await,
                 Command::Trace {
                     entity,
+                    file,
+                    kind,
                     json,
                     compact,
                     show_body: _,
@@ -2837,6 +2845,8 @@ fn run() -> Result<()> {
                             max_lines,
                             limit.unwrap_or(nearby),
                             transitive,
+                            file,
+                            kind,
                         )
                         .await
                     } else {
@@ -2848,6 +2858,8 @@ fn run() -> Result<()> {
                             max_lines,
                             limit.unwrap_or(nearby),
                             transitive,
+                            file,
+                            kind,
                         )
                         .await
                     }

--- a/crates/kin-core/src/disambiguation.rs
+++ b/crates/kin-core/src/disambiguation.rs
@@ -60,6 +60,65 @@ pub fn query_trace_matches(graph: &impl GraphStore, query: &str) -> Result<Vec<E
     Ok(matches)
 }
 
+/// Whether an entity's own record shows it carries a body, rather than only
+/// declaring one.
+///
+/// The parser writes `signature` by clamping the declaration where its body
+/// begins: `kin_parser::adapter::declaration_signature` stops at the `body`
+/// field, at a `function_body` or `class_body` child, and at the first comment,
+/// then trims a trailing `{` or `:`. A definition therefore stores a signature
+/// that ends where its body starts, while a declaration stores its whole
+/// statement, terminator included. The terminator is the tell: a signature that
+/// still ends in `;` is the entire declaration, because the language closed the
+/// statement instead of opening a body.
+///
+/// This holds wherever a language spells a declaration as a terminated
+/// statement, which is every language Kin parses that has the distinction at
+/// all: a C prototype, a Rust trait method without a default, a TypeScript
+/// `declare` or interface member. A definition's signature ends at its
+/// parameter list or return type and never at a terminator.
+///
+/// Read off the entity alone, so it answers the same way for a store built
+/// today and one built from the same tree six commits ago, and nothing here
+/// consults the filesystem.
+pub fn carries_body(entity: &Entity) -> bool {
+    !entity.signature.trim_end().ends_with(';')
+}
+
+/// The order two entities sharing a name are chosen in when nothing the caller
+/// passed pins one.
+///
+/// Every term is read off the entity record, so the order is a property of the
+/// entities and never of the order a store happened to list them in. That is
+/// the whole point. `buffer_grow` declared in `buffer.h` and defined in
+/// `buffer.c` is one name over two entities; six stores built from one tree
+/// with differing commit dates listed the pair one way three times and the
+/// other way three times, while twenty consecutive reads of any single store
+/// agreed with themselves. A picker that stopped at the first match therefore
+/// traced the declaration on half the stores and the definition on the other
+/// half, with nothing in the answer saying which (FIR-3071).
+///
+/// Lower sorts first: a body beats a declaration, then the file path, then the
+/// start line, then the id, which `EntityId::from_content` derives from file,
+/// name, kind and line and which is therefore stable across rebuilds of the
+/// same tree rather than freshly random per store.
+pub fn definition_identity_key(entity: &Entity) -> (bool, String, u32, kin_model::EntityId) {
+    (
+        !carries_body(entity),
+        entity
+            .file_origin
+            .as_ref()
+            .map(|origin| origin.0.clone())
+            .unwrap_or_default(),
+        entity
+            .span
+            .as_ref()
+            .map(|span| span.start_line)
+            .unwrap_or(0),
+        entity.id,
+    )
+}
+
 /// Whether the name index rules out every resolver match for `query`.
 ///
 /// `find_references` and `trace_data_flow` both resolve a caller's name through

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -114,7 +114,8 @@ pub use workspace_semantics::diff_workspace_semantics;
 
 pub use diff::{compute_semantic_change_id, content_identity_from_deltas};
 pub use disambiguation::{
-    fallback_leaf_trace_matches, name_resolution_certainly_misses, query_trace_matches,
+    carries_body, definition_identity_key, fallback_leaf_trace_matches,
+    name_resolution_certainly_misses, query_trace_matches,
 };
 pub use identity::{
     resolve_commit_identity, unresolved_identity_message, CommitIdentity, IdentitySource,

--- a/crates/kin-core/src/ranking.rs
+++ b/crates/kin-core/src/ranking.rs
@@ -17,6 +17,16 @@ use kin_model::Entity;
 /// 4. Method-style hint (both query and name use `::` or neither does)
 /// 5. Has file origin (prefer entities with known source locations)
 /// 6. Shorter name (prefer less-qualified names as more specific)
+/// 7. Definition identity: a body beats a declaration, then file, line, id
+///
+/// Criterion 7 exists so the answer is a property of the candidates rather than
+/// of the order the store listed them in. Everything above it can tie exactly:
+/// two entities sharing one name, one kind and one length tie on all six, and
+/// `min_by_key` then keeps whichever the store happened to yield first. Six
+/// stores built from one tree with differing commit dates split three and three
+/// on which of `buffer_grow`'s two entities came first, so `kin trace` answered
+/// about the header's declaration on half of them (FIR-3071). The tail terms
+/// are read off the entity record, so they cannot vary that way.
 ///
 /// The `qualifier_checker` callback is used to check whether an entity
 /// matches a qualifier hint. This allows the caller to provide file-based
@@ -66,6 +76,7 @@ where
             !method_hint,
             !file_rank,
             e.name.len(),
+            crate::disambiguation::definition_identity_key(e),
         )
     })
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -220,6 +220,8 @@ kin trace <entity> [options]
 
 | Flag | Default | Description |
 | --- | --- | --- |
+| `--file <file>` |  | Exact repo-relative file qualifier for stable identity resolution |
+| `--kind <kind>` |  | Exact entity-kind qualifier (for example: function or method) |
 | `--json` |  | Output machine-readable JSON for editor integrations |
 | `--compact` |  | Render a smaller, cheaper trace tuned for assistant workflows |
 | `--show-body` |  | Compatibility no-op: trace already shows the focal body by default |
@@ -229,6 +231,28 @@ kin trace <entity> [options]
 | `--max-lines <max-lines>` | `40` | Max lines to print for any single source snippet |
 | `--nearby <nearby>` | `4` | Max nearby entries to print |
 | `--transitive <transitive>` | `2` | Max transitive entries to print |
+
+The argument takes either form. An entity id, exactly as `kin search --json` prints it, names one
+entity and needs no qualifier. A name may reach several: a C function declared in a header and
+defined in a source file is two entities under one name, and so is an overload set.
+
+When a name reaches several and nothing pins one, `kin trace` prefers the definition over the
+declaration, then the earlier file path, then the earlier line, then the id. Every one of those is
+read off the entity record, so the same tree answers the same way in every store built from it.
+The trace then says which entity it chose and names the others, so you can pin one:
+
+```
+kin trace buffer_grow --file src/buffer.h --kind function
+```
+
+`--file` takes the repo-relative path the answer prints and `--kind` the lowercase kind, the same
+spellings `kin impact` takes.
+
+A query that resolves to no entity exits non-zero and puts the message on stderr, leaving stdout
+empty. That holds for the name form, for an id this repository's graph does not hold, and for a
+qualifier that excludes every match, which reports what the name alone does reach rather than
+claiming the entity is absent. `kin context`, `kin refs`, `kin xref` and `kin impact` refuse the
+same way.
 
 ### `kin impact`
 


### PR DESCRIPTION
`kin trace` now answers about the entity you meant. It takes the entity id its help has always
advertised, takes `--file` and `--kind` to pin one of several same-named entities, prefers the
definition over a declaration by a rule that cannot move with store order, says which one it chose
and what the others are, and exits non-zero with the message on stderr when it resolves nothing.

## The order bug, and what was actually causing it

The ticket names three defects and its comment adds a fourth: the same question answered two ways
across six stores built from one tree. That fourth one is a single line.

`kin_core::select_best_match` picks with `min_by_key` over six terms: exact name, qualifier support,
qualified leaf, method hint, has-file-origin, name length. A C function declared in a header and
defined in a source file is two entities that tie on all six, and `min_by_key` keeps the first
minimum, so the winner was whichever the store listed first. That is why twenty consecutive traces
against one store agreed twenty times while six stores split three and three: it was never sampling
noise, it was the listing order, fixed at ingest.

Nothing else told them apart. `EntityRole` has no declaration variant, and the C parser gives a
`function_definition` and a prototype the same `EntityKind::Function`.

## How a body is now told from a declaration

The parser writes an entity's `signature` by clamping the declaration where its body begins. So a
definition's stored signature stops at its parameter list, and a declaration's is the whole
statement, terminator included. A signature that still ends in a semicolon is a declaration, because
the language closed the statement instead of opening a body. That holds for a C prototype, a Rust
trait method with no default, and a TypeScript `declare` or interface member alike.

The ordering is that, then file path, then start line, then id. Every term is read off the entity
record, so the choice is a property of the candidates rather than of the store. `EntityId` is derived
from file, name, kind and line with no commit date in it, so the id tiebreak is stable across stores
built from one tree. No filesystem read anywhere in it, and it works on stores built before this
change.

The tail is appended to `select_best_match` itself, so every caller of that function becomes
deterministic, not just trace.

## One resolver instead of five spellings

`kin context` and `kin impact` read an entity id; `kin trace` and `kin xref` matched the id string as
a name pattern and reported the entity absent. Only `kin impact` accepted `--file` and `--kind`. The
new `crates/kin-cli/src/entity_identity.rs` holds the one resolver, and `kin impact`'s own resolution
is now a thin adapter onto it. It compares against `kin_review::StableEntityIdentity`, so the
`--file` and `--kind` values the twin note suggests are the values the filter compares.

## A miss is an error now

A query that resolves nothing exits non-zero with the message on stderr and leaves stdout empty. The
same fix went to `kin context`, `kin refs`, `kin xref` and `kin impact`'s text path. `kin
trace-data-flow`, `kin graph` and the MCP tools already had it right.

The daemon keeps returning a structured response and the CLI converts it, which is what
`kin impact --json` and `kin graph source` already do. Returning a 500 would have reached the user as
`kin trace refused (HTTP 500)`. The guidance travels in both `lines` and a new `error` field, so a
daemon serving an older `kin` keeps printing what it printed before and a newer one refuses.

## Verification

- `cargo test -p kin-core --lib` 782 passed, `cargo test -p kin-cli --lib` 2034 passed,
  `cargo check -p kin-daemon --all-targets` clean.
- `bin/kin-precheck kin`: 16 gates enumerated from this repo's own ci.yml check job, 16 passed, on
  this PR's sha over a clean tree.
- Nine mutations, nine red, baseline green. One of them stripped the new deterministic tail back
  off the ranking key, which is what proves the order test guards anything.
- The six preserved stores, each served by a daemon built from this branch: `kin search` still lists
  the twins header-first on three of them and source-first on the other three, and `kin trace
  buffer_grow` now answers `src/buffer.c` on all six. `--file src/buffer.h --kind function` pins the
  header twin on all six, and a miss exits 1 with zero bytes on stdout on all six.

Two mutations caught tests of mine that could not fail, which is the reason to run them. One rode
inside an existing test that returns early when no repository layout is found, so it passed having
asserted nothing; it now builds its own layout. The other is the `xref` insertion-order test
described above. Both were rewritten until their mutation went red.

## `kin xref` had the same defect, and is fixed here too

`kin xref` resolved a name to `matches[0]` with no ranking at all, so it answered about whichever
twin the store listed first. Same class, same shape, so it is closed in this landing rather than
left for a second one. It now ranks its candidates through the same `select_best_match`, which
carries the deterministic tail.

Its test is worth a note, because the first version could not fail. Asserting that two insertion
orders agree proves nothing: the store returns name matches sorted by entity id, so insertion order
never reaches the caller and the test passed with the defect in place. The test now asserts which
twin is chosen, observed through the spine anchor, and the fixture asserts its own precondition
that the declaration sorts first by id. The mutation that reverts `xref` to `matches.first()` turns
it red.

## Not in this change

There is no `name@file:line` entity grammar anywhere in the CLI to reuse (`ref_grammar.rs` is
history endpoints, `resolve.rs` is merge conflicts), so adding that form would mean inventing a
second way to say what `--file` and `--kind` already say. The multi-focal lane is adding exactly
that parser on top of this resolver, where it earns its keep, because `kin context A B C` cannot
carry per-focal flags.

Related: FIR-3071
