### PR TITLE
Add kin path, a graph-native route between two entities

### DIFF
--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -59,6 +59,7 @@ pub mod migrate;
 pub mod note;
 pub mod notify;
 pub mod overview;
+pub mod path;
 pub mod pipeline;
 pub mod prepared_state;
 pub mod projection;

--- a/crates/kin-cli/src/commands/path.rs
+++ b/crates/kin-cli/src/commands/path.rs
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin path <from> <to>`: the shortest routes between two entities.
+//!
+//! The walk itself lives in `kin_mcp::handlers::path` and runs in the daemon
+//! behind `POST /commands/path`, so this command, the daemon route and the
+//! `trace_path` MCP tool answer from one implementation. What this module owns
+//! is the rendering and the exit code: a route found is 0, an end that did not
+//! resolve is an error, and no route inside the bound is
+//! [`NO_ROUTE_EXIT_CODE`] with the gap on stderr, so a script that captures
+//! stdout never captures something that reads like a route.
+
+use anyhow::{Context, Result};
+use kin_mcp::handlers::path::{render_compact, PathDirection, PathRequest, PathResponse};
+
+/// The graph holds no route inside the bound. Kept apart from 1, which is an
+/// error, so a caller can tell "the question was answered, negatively" from
+/// "the question was not answered".
+pub const NO_ROUTE_EXIT_CODE: i32 = 3;
+
+/// CLI entry: build the request, ask the daemon, render, and hand back the
+/// exit code.
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    from: String,
+    to: String,
+    from_file: Option<String>,
+    to_file: Option<String>,
+    max_depth: Option<usize>,
+    limit: Option<usize>,
+    direction: Option<String>,
+    include_type_edges: bool,
+    json: bool,
+    compact: bool,
+) -> Result<i32> {
+    let direction = match direction {
+        Some(value) => {
+            Some(PathDirection::parse(&value).map_err(|message| anyhow::anyhow!(message))?)
+        }
+        None => None,
+    };
+    let request = PathRequest {
+        from,
+        to,
+        from_file,
+        to_file,
+        max_depth,
+        limit,
+        direction,
+        include_type_edges: include_type_edges.then_some(true),
+    };
+    let layout = crate::commands::require_repository_layout()?;
+    let payload = run_daemon_path(&layout, &request).await?;
+    let response: PathResponse =
+        serde_json::from_value(payload.clone()).context("parse daemon path response")?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else if response.found {
+        if compact {
+            print!("{}", render_compact(&response));
+        } else {
+            print!("{}", render_report(&response, &payload));
+        }
+    } else {
+        eprint!("{}", render_report(&response, &payload));
+    }
+    Ok(if response.found {
+        0
+    } else {
+        NO_ROUTE_EXIT_CODE
+    })
+}
+
+async fn run_daemon_path(
+    layout: &kin_core::KinLayout,
+    request: &PathRequest,
+) -> Result<serde_json::Value> {
+    let daemon_url = std::env::var("KIN_DAEMON_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(Some)
+        .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("path", layout))?;
+    let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
+    client
+        .path(request)
+        .await
+        .context("daemon path command failed")
+}
+
+/// The readable form: the compact route lines, then what the walk covered, how
+/// each end resolved, and the envelope's verdict when the daemon attached one.
+pub fn render_report(response: &PathResponse, payload: &serde_json::Value) -> String {
+    let mut out = String::new();
+    if response.found {
+        out.push_str(&render_compact(response));
+    } else if let Some(gap) = &response.gap {
+        out.push_str(&format!(
+            "no route: {}\n  {}\n",
+            gap.detail, gap.remediation
+        ));
+    } else {
+        out.push_str("no route\n");
+    }
+    for walk in &response.explored {
+        out.push_str(&format!(
+            "explored: {} walk, {} entities, {} edges, depth {}, {} in {} ms\n",
+            walk.sense,
+            walk.nodes,
+            walk.edges,
+            walk.depth_reached,
+            walk.stopped_by,
+            walk.elapsed_ms
+        ));
+    }
+    for (which, end) in [("from", &response.from), ("to", &response.to)] {
+        let location = match (&end.file, end.start_line) {
+            (Some(file), Some(line)) => format!("{file}:{line}"),
+            (Some(file), None) => file.clone(),
+            (None, _) => "(no file)".to_string(),
+        };
+        out.push_str(&format!(
+            "{which}: {} [{}] {} ({}",
+            end.name,
+            end.kind.to_lowercase(),
+            location,
+            end.addressed_by.replace('_', " ")
+        ));
+        if end.same_name_candidates > 1 {
+            let others: Vec<String> = end
+                .other_candidates
+                .iter()
+                .map(|candidate| {
+                    format!(
+                        "{}:{}",
+                        candidate.file.as_deref().unwrap_or("(no file)"),
+                        candidate
+                            .start_line
+                            .map(|line| line.to_string())
+                            .unwrap_or_else(|| "?".to_string())
+                    )
+                })
+                .collect();
+            out.push_str(&format!(
+                "; one of {} named {}, others at {}; pin with {}@<file>",
+                end.same_name_candidates,
+                end.name,
+                others.join(", "),
+                end.name
+            ));
+        }
+        out.push_str(")\n");
+    }
+    for degradation in &response.degradations {
+        out.push_str(&format!(
+            "note: {} ({}): {}\n",
+            degradation.component, degradation.reason, degradation.detail
+        ));
+    }
+    let verdict = &payload[kin_mcp::ENVELOPE_KEY][kin_mcp::VERDICT_KEY];
+    if let Some(state) = verdict["state"].as_str() {
+        match verdict["limiting_factor"].as_str() {
+            Some(factor) => out.push_str(&format!("verdict: {state} ({factor})\n")),
+            None => out.push_str(&format!("verdict: {state}\n")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_mcp::handlers::path::{
+        PathCandidate, PathEndpoint, PathExplored, PathGap, PathHop, PathRoute,
+    };
+
+    fn end(name: &str, file: &str, line: u32) -> PathEndpoint {
+        PathEndpoint {
+            entity_id: "00000000-0000-0000-0000-000000000001".to_string(),
+            name: name.to_string(),
+            kind: "Function".to_string(),
+            file: Some(file.to_string()),
+            start_line: Some(line),
+            end_line: Some(line + 3),
+            external: false,
+            addressed_by: "name".to_string(),
+            same_name_candidates: 1,
+            other_candidates: Vec::new(),
+            members_expanded: 0,
+        }
+    }
+
+    fn hop(name: &str, file: &str, line: u32, relation: Option<&str>) -> PathHop {
+        PathHop {
+            entity_id: "00000000-0000-0000-0000-000000000002".to_string(),
+            name: name.to_string(),
+            kind: "Function".to_string(),
+            file: Some(file.to_string()),
+            start_line: Some(line),
+            end_line: Some(line + 3),
+            external: false,
+            relation: relation.map(str::to_string),
+            edge: relation.map(|_| "outgoing".to_string()),
+            resolution: relation.map(|_| "type_resolved".to_string()),
+            site_lines: relation.map(|_| vec![line + 1]).unwrap_or_default(),
+            site_lines_absent_reason: None,
+        }
+    }
+
+    fn response(found: bool) -> PathResponse {
+        PathResponse {
+            from: end("edit", "src/editor.rs", 4),
+            to: end("write", "src/model.rs", 9),
+            direction_requested: "either".to_string(),
+            direction: found.then(|| "forward".to_string()),
+            max_depth: 6,
+            limit: 3,
+            walked_kinds: vec!["Calls".to_string()],
+            include_type_edges: false,
+            found,
+            routes: if found {
+                vec![PathRoute {
+                    direction: "forward".to_string(),
+                    hops: 2,
+                    walked_hops: 2,
+                    steps: vec![
+                        hop("edit", "src/editor.rs", 4, Some("Calls")),
+                        hop("push", "src/model.rs", 1, Some("Calls")),
+                        hop("write", "src/model.rs", 9, None),
+                    ],
+                }]
+            } else {
+                Vec::new()
+            },
+            routes_total: usize::from(found),
+            routes_truncated: false,
+            explored: vec![PathExplored {
+                sense: "forward".to_string(),
+                nodes: 3,
+                edges: 2,
+                depth_reached: 2,
+                stopped_by: if found {
+                    "route_found"
+                } else {
+                    "frontier_exhausted"
+                }
+                .to_string(),
+                elapsed_ms: 1,
+            }],
+            gap: (!found).then(|| PathGap {
+                reason: "frontier_exhausted".to_string(),
+                detail: "no route between 'edit' and 'write' within 6 hops".to_string(),
+                remediation: "check both ends".to_string(),
+            }),
+            degradations: Vec::new(),
+            edge_coverage: serde_json::Value::Null,
+        }
+    }
+
+    /// The report leads with the route, one line per hop, and closes with the
+    /// verdict the daemon attached.
+    #[test]
+    fn the_report_leads_with_the_route_and_ends_with_the_verdict() {
+        let payload = serde_json::json!({
+            "_kin": { "verdict": { "state": "certified", "limiting_factor": null } }
+        });
+        let report = render_report(&response(true), &payload);
+        let lines: Vec<&str> = report.lines().collect();
+        assert!(
+            lines[0].starts_with("route 1 of 1 (forward, 2 hops): edit -> write"),
+            "{report}"
+        );
+        assert_eq!(lines[1].trim(), "edit [function] src/editor.rs:4");
+        assert!(
+            lines[2]
+                .trim()
+                .starts_with("-Calls@5-> push [function] src/model.rs:1"),
+            "{report}"
+        );
+        assert!(
+            lines[3]
+                .trim()
+                .starts_with("-Calls@2-> write [function] src/model.rs:9"),
+            "{report}"
+        );
+        assert!(
+            report.contains("explored: forward walk, 3 entities, 2 edges"),
+            "{report}"
+        );
+        assert!(report.ends_with("verdict: certified\n"), "{report}");
+    }
+
+    /// No route renders the gap, never a route-shaped line, and names a twin
+    /// the caller could pin.
+    #[test]
+    fn a_no_route_report_names_the_gap_and_the_twin() {
+        let mut response = response(false);
+        response.from.same_name_candidates = 2;
+        response.from.other_candidates = vec![PathCandidate {
+            entity_id: "00000000-0000-0000-0000-000000000003".to_string(),
+            name: "edit".to_string(),
+            kind: "Function".to_string(),
+            file: Some("src/other.rs".to_string()),
+            start_line: Some(70),
+        }];
+        let payload = serde_json::json!({
+            "_kin": { "verdict": { "state": "inconclusive", "limiting_factor": "from_ambiguous" } }
+        });
+        let report = render_report(&response, &payload);
+        assert!(
+            report.starts_with("no route: no route between 'edit' and 'write'"),
+            "{report}"
+        );
+        assert!(!report.contains("route 1"), "{report}");
+        assert!(
+            report.contains("one of 2 named edit, others at src/other.rs:70; pin with edit@<file>"),
+            "{report}"
+        );
+        assert!(
+            report.ends_with("verdict: inconclusive (from_ambiguous)\n"),
+            "{report}"
+        );
+    }
+}

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1565,6 +1565,26 @@ impl DaemonClient {
             .context("parse daemon trace-data-flow response")
     }
 
+    /// `POST /commands/path`: the shortest routes between two entities, answered
+    /// as the annotated JSON the daemon built, envelope and negative included.
+    pub async fn path(
+        &self,
+        request: &kin_mcp::handlers::path::PathRequest,
+    ) -> Result<serde_json::Value> {
+        let resp = self
+            .send(
+                self.client
+                    .post(format!("{}/commands/path", self.base_url))
+                    .json(request),
+                "path",
+            )
+            .await?;
+        if !resp.status().is_success() {
+            return Err(self.http_refusal("path", resp).await);
+        }
+        resp.json().await.context("parse daemon path response")
+    }
+
     pub async fn refs(
         &self,
         request: &crate::commands::refs::RefsRequest,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -277,6 +277,43 @@ enum Command {
         #[arg(long, default_value_t = 2)]
         transitive: usize,
     },
+    /// Find the shortest routes from one entity to another over the graph's
+    /// call, instantiation, reference, import and include edges.
+    ///
+    /// Each end is an entity name, an entity id, or `name@file` to pin one of
+    /// two same-named entities. A class stands for its members, so a route
+    /// between two classes runs through the methods that carry it. Exits 3 when
+    /// the graph holds no route inside the depth bound, with the gap on stderr.
+    Path {
+        /// Source entity: name, id, or name@file
+        from: String,
+        /// Target entity: name, id, or name@file
+        to: String,
+        /// Pin the source to the entity of that name in this file (path or path suffix)
+        #[arg(long = "from-file", value_name = "FILE")]
+        from_file: Option<String>,
+        /// Pin the target the same way
+        #[arg(long = "to-file", value_name = "FILE")]
+        to_file: Option<String>,
+        /// Hops walked between the two ends (default 6, ceiling 12); containment hops are not counted
+        #[arg(long = "max-depth", value_name = "N")]
+        max_depth: Option<usize>,
+        /// Routes printed, shortest first (default 3, ceiling 25)
+        #[arg(long, value_name = "K")]
+        limit: Option<usize>,
+        /// `forward` (from reaches to), `reverse` (to reaches from), or `either` (default; forward first, reports which held)
+        #[arg(long, value_name = "DIR")]
+        direction: Option<String>,
+        /// Walk through type-annotation edges too
+        #[arg(long = "include-type-edges", default_value_t = false)]
+        include_type_edges: bool,
+        /// Output machine-readable JSON, `_kin` envelope included
+        #[arg(long, default_value_t = false)]
+        json: bool,
+        /// One line per hop and nothing else, sized for a prompt
+        #[arg(long, default_value_t = false)]
+        compact: bool,
+    },
     /// Search entities in the graph
     Search {
         /// Search pattern (use '|' for OR, e.g. "save|load|persist")
@@ -2822,6 +2859,38 @@ fn run() -> Result<()> {
                     json,
                     debug,
                 } => commands::contextbench_locate::run(task_file, json, debug).await,
+                Command::Path {
+                    from,
+                    to,
+                    from_file,
+                    to_file,
+                    max_depth,
+                    limit,
+                    direction,
+                    include_type_edges,
+                    json,
+                    compact,
+                } => {
+                    // No route is an answer, not an error, and it travels in
+                    // the exit code the way a parked merge does.
+                    let code = commands::path::run(
+                        from,
+                        to,
+                        from_file,
+                        to_file,
+                        max_depth,
+                        limit,
+                        direction,
+                        include_type_edges,
+                        json,
+                        compact,
+                    )
+                    .await?;
+                    if code != 0 {
+                        std::process::exit(code);
+                    }
+                    Ok(())
+                }
                 Command::Trace {
                     entity,
                     file,

--- a/crates/kin-cli/tests/path_query.rs
+++ b/crates/kin-cli/tests/path_query.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin path` end to end: a real `kin init`, the daemon's `/commands/path`
+//! route, and the three output shapes a caller reads (JSON, the readable
+//! report, and the compact one-line-per-hop form), plus the exit code a script
+//! reads when the graph holds no route.
+
+use serial_test::serial;
+use std::fs;
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+/// Commit everything so `kin init` sees a clean migration source.
+fn commit_worktree(repo: &std::path::Path, message: &str) {
+    let add = Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(repo)
+        .output()
+        .expect("git add");
+    assert!(
+        add.status.success(),
+        "git add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let commit = Command::new("git")
+        .args([
+            "-c",
+            "user.name=kin-ci",
+            "-c",
+            "user.email=ci@kin.dev",
+            "commit",
+            "-q",
+            "-m",
+            message,
+        ])
+        .current_dir(repo)
+        .output()
+        .expect("git commit");
+    assert!(
+        commit.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+}
+
+fn kin_command(runtime: &common::IsolatedDaemonRuntime) -> Command<'_> {
+    let mut cmd = runtime.kin_command();
+    cmd.env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
+        .env("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", "1");
+    cmd
+}
+
+/// A three-link chain in one Rust file: `edit` calls `push`, `push` calls
+/// `write`, and `orphan` calls nothing and is called by nothing.
+fn seed_repository(repo: &std::path::Path) {
+    fs::create_dir_all(repo.join("src")).expect("create src dir");
+    fs::write(
+        repo.join("src/lib.rs"),
+        "pub fn edit() {\n    push();\n}\n\npub fn push() {\n    write();\n}\n\npub fn write() {}\n\npub fn orphan() {}\n",
+    )
+    .expect("write source");
+    let git_init = Command::new("git")
+        .arg("init")
+        .arg("-q")
+        .current_dir(repo)
+        .output()
+        .expect("git init");
+    assert!(
+        git_init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&git_init.stderr)
+    );
+    commit_worktree(repo, "seed");
+}
+
+#[test]
+#[serial]
+fn path_answers_json_report_and_compact_and_exits_three_on_no_route() {
+    let repo = tempdir().expect("temp repo");
+    let runtime = common::IsolatedDaemonRuntime::new(repo.path());
+    seed_repository(repo.path());
+
+    let init = kin_command(&runtime)
+        .arg("init")
+        .arg(".")
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin init");
+    assert!(
+        init.status.success(),
+        "kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // JSON: one document on stdout, the route in order, the envelope beside it.
+    let json = kin_command(&runtime)
+        .args(["path", "edit", "write", "--json"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin path --json");
+    assert!(
+        json.status.success(),
+        "kin path --json failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&json.stdout),
+        String::from_utf8_lossy(&json.stderr)
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&json.stdout).expect("path --json stdout is one JSON document");
+    assert_eq!(payload["found"], serde_json::json!(true), "{payload}");
+    assert_eq!(
+        payload["direction"],
+        serde_json::json!("forward"),
+        "{payload}"
+    );
+    let steps = payload["routes"][0]["steps"]
+        .as_array()
+        .expect("the first route has steps");
+    let names: Vec<&str> = steps
+        .iter()
+        .map(|step| step["name"].as_str().unwrap_or("?"))
+        .collect();
+    assert_eq!(names, vec!["edit", "push", "write"], "{payload}");
+    assert_eq!(
+        steps[0]["relation"],
+        serde_json::json!("Calls"),
+        "{payload}"
+    );
+    assert_eq!(
+        steps[0]["file"],
+        serde_json::json!("src/lib.rs"),
+        "{payload}"
+    );
+    assert_eq!(steps[0]["start_line"], serde_json::json!(1), "{payload}");
+    // Whether this build's Rust extraction records a syntax site on a call edge
+    // is a fact about the parser, not about the route; the contract is that an
+    // empty list always says why.
+    let site_lines = steps[0]["site_lines"]
+        .as_array()
+        .expect("site_lines is always an array");
+    if site_lines.is_empty() {
+        assert_eq!(
+            steps[0]["site_lines_absent_reason"],
+            serde_json::json!("no_evidence_span"),
+            "{payload}"
+        );
+    } else {
+        assert_eq!(site_lines, &vec![serde_json::json!(2)], "{payload}");
+        assert!(steps[0]["site_lines_absent_reason"].is_null(), "{payload}");
+    }
+    assert!(steps[2]["relation"].is_null(), "{payload}");
+    assert!(
+        payload.get("_kin").is_some() && payload.get("negative").is_some(),
+        "the daemon annotates the answer with its envelope and negative: {payload}"
+    );
+    assert_eq!(
+        payload["from"]["same_name_candidates"],
+        serde_json::json!(1),
+        "{payload}"
+    );
+
+    // Compact: a header and one line per hop, nothing else.
+    let compact = kin_command(&runtime)
+        .args(["path", "edit", "write", "--compact"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin path --compact");
+    assert!(compact.status.success());
+    let stdout = String::from_utf8_lossy(&compact.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 4, "header plus one line per hop: {stdout}");
+    assert!(
+        lines[0].starts_with("route 1 of 1 (forward, 2 hops): edit -> write"),
+        "{stdout}"
+    );
+    assert!(
+        lines[1].trim().starts_with("edit [function] src/lib.rs:1"),
+        "{stdout}"
+    );
+    assert!(
+        lines[2].trim().starts_with("-Calls") && lines[2].contains("push [function] src/lib.rs:5"),
+        "{stdout}"
+    );
+    assert!(
+        lines[3].trim().starts_with("-Calls") && lines[3].contains("write [function] src/lib.rs:9"),
+        "{stdout}"
+    );
+
+    // The readable report carries the route, the walk, both ends and the verdict.
+    let report = kin_command(&runtime)
+        .args(["path", "edit", "write"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin path");
+    assert!(report.status.success());
+    let stdout = String::from_utf8_lossy(&report.stdout);
+    assert!(stdout.contains("explored: forward walk"), "{stdout}");
+    assert!(
+        stdout.contains("from: edit [function] src/lib.rs:1"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("verdict: "), "{stdout}");
+
+    // Pinned the wrong way round, forward holds nothing: exit 3, the gap on
+    // stderr, and nothing route-shaped on stdout.
+    let none = kin_command(&runtime)
+        .args(["path", "write", "edit", "--direction", "forward"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin path with no route");
+    assert_eq!(
+        none.status.code(),
+        Some(3),
+        "no route exits 3: stdout={} stderr={}",
+        String::from_utf8_lossy(&none.stdout),
+        String::from_utf8_lossy(&none.stderr)
+    );
+    assert!(
+        none.stdout.is_empty(),
+        "{}",
+        String::from_utf8_lossy(&none.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&none.stderr);
+    assert!(stderr.contains("no route"), "{stderr}");
+    assert!(stderr.contains("frontier_exhausted"), "{stderr}");
+
+    // Either sense finds the reverse route and says so.
+    let reverse = kin_command(&runtime)
+        .args(["path", "write", "edit", "--json"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin path either");
+    assert!(reverse.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&reverse.stdout).unwrap();
+    assert_eq!(
+        payload["direction"],
+        serde_json::json!("reverse"),
+        "{payload}"
+    );
+
+    // An end that does not resolve is an error, not a route and not a gap.
+    let missing = kin_command(&runtime)
+        .args(["path", "nowhere", "write"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin path with a missing end");
+    assert_eq!(missing.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&missing.stderr);
+    assert!(stderr.contains("nowhere"), "{stderr}");
+
+    // A disconnected pair with no depth bound in the way is a frontier gap in
+    // both senses, and the JSON says so with an empty route list.
+    let orphan = kin_command(&runtime)
+        .args(["path", "edit", "orphan", "--json"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin path to an orphan");
+    assert_eq!(orphan.status.code(), Some(3));
+    let payload: serde_json::Value = serde_json::from_slice(&orphan.stdout).unwrap();
+    assert_eq!(payload["found"], serde_json::json!(false), "{payload}");
+    assert_eq!(payload["routes"], serde_json::json!([]), "{payload}");
+    assert_eq!(
+        payload["gap"]["reason"],
+        serde_json::json!("frontier_exhausted"),
+        "{payload}"
+    );
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1963,6 +1963,7 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/commands/dead-code", post(command_dead_code))
         .route("/commands/dead-code-seeded", post(command_dead_code_seeded))
         .route("/commands/trace-data-flow", post(command_trace_data_flow))
+        .route("/commands/path", post(command_path))
         .route("/commands/refs", post(command_refs))
         .route("/commands/bulk-refs", post(command_bulk_refs))
         .route("/commands/xref", post(command_xref))
@@ -4967,6 +4968,95 @@ async fn run_trace_data_flow_off_runtime(
 struct CancelOnDrop(kin_cli::commands::trace_data_flow::TraceCancel);
 
 impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
+}
+
+/// POST /commands/path: the shortest routes from one entity to another over the
+/// relation graph, the query `kin path` and the `trace_path` MCP tool share.
+///
+/// Reads no bodies, so it opens no repository authority: every hop is identity
+/// and location, and the walk runs off the runtime under the same cancel-on-drop
+/// seam as trace-data-flow. The answer carries the `_kin` envelope and its
+/// negative, so a client that prints `found: false` prints the verdict beside it
+/// and the CLI's JSON is byte-for-byte the MCP tool's payload.
+async fn command_path(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<kin_mcp::handlers::path::PathRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if !state
+        .is_initialized
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "daemon not fully initialized".to_string(),
+        ));
+    }
+    let session_id = extract_session_id_from_headers(&headers)?;
+    let graph = resolve_session_graph(&state, session_id.as_ref()).await;
+    let cancel = kin_mcp::handlers::path::PathCancel::new();
+    let _abandon = PathCancelOnDrop(cancel.clone());
+    let budget = kin_mcp::handlers::path::PathBudget::cancellable(cancel);
+    let outcome = tokio::task::spawn_blocking(move || {
+        kin_mcp::handlers::path::build_path_response_within(graph.as_ref(), &request, budget)
+    })
+    .await
+    .map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("path worker failed: {error}"),
+        )
+    })?;
+    let response = match outcome {
+        Ok(response) => response,
+        Err(error) => return Err(path_refusal(error)),
+    };
+    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state).await);
+    let text = serde_json::to_string(&response)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+    let finalized = kin_mcp::finalize_with_envelope(
+        kin_mcp::ToolCallResult::text(text),
+        envelope,
+        kin_mcp::handlers::path::TOOL_NAME,
+    );
+    let payload = finalized
+        .content
+        .into_iter()
+        .find_map(|block| {
+            let kin_mcp::ContentBlock::Text { text } = block;
+            serde_json::from_str::<serde_json::Value>(&text).ok()
+        })
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "path response could not be annotated".to_string(),
+            )
+        })?;
+    Ok(Json(payload))
+}
+
+/// An end that did not resolve is the caller's to fix, and says so with 422
+/// rather than hiding behind a 500 the client would retry.
+fn path_refusal(error: kin_mcp::handlers::path::PathError) -> (StatusCode, String) {
+    use kin_mcp::handlers::path::PathError;
+    let status = match &error {
+        PathError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
+        PathError::EndpointNotFound { .. } | PathError::EndpointAmbiguous { .. } => {
+            StatusCode::UNPROCESSABLE_ENTITY
+        }
+        PathError::Graph(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (status, error.to_string())
+}
+
+/// Cancels the route walk when the request future is dropped, for the reason
+/// [`CancelOnDrop`] does the same for a trace.
+struct PathCancelOnDrop(kin_mcp::handlers::path::PathCancel);
+
+impl Drop for PathCancelOnDrop {
     fn drop(&mut self) {
         self.0.cancel();
     }

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -782,6 +782,18 @@ fn shape_for(tool: &str) -> Option<ResponseShape> {
             bulk_keys: &[],
             narrow_param: "depth",
         },
+        // The route query carries no bodies at all: a hop is identity, location
+        // and the edge into the next hop, so the only layer the ladder can
+        // shed is a whole route, and `limit` is what a caller narrows.
+        crate::handlers::path::TOOL_NAME => ResponseShape {
+            collections: &["routes"],
+            body_keys: &[],
+            explain_keys: &[],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            bulk_keys: &[],
+            narrow_param: "limit",
+        },
         "get_context_pack" | "trace_computation" => ResponseShape {
             // `dependents` sheds beside `dependencies`: it is the same section
             // split by direction, and a group the budget cannot trim is a group

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1476,6 +1476,10 @@ fn counted_for(tool: &str, payload: &Value) -> Option<Value> {
             payload.get("total_upstream").and_then(Value::as_u64)?,
         ),
         "trace_data_flow" => ("steps", payload.get("total_steps").and_then(Value::as_u64)?),
+        crate::handlers::path::TOOL_NAME => (
+            "shortest_routes",
+            payload.get("routes_total").and_then(Value::as_u64)?,
+        ),
         "bulk_check_references" => (
             "entities",
             payload
@@ -1489,7 +1493,11 @@ fn counted_for(tool: &str, payload: &Value) -> Option<Value> {
     // A response that says it stopped early is a floor whatever its substrate
     // looked like, so the payload's own truncation flag outranks the class
     // verdict for this field.
-    let truncated = payload.get("truncated").and_then(Value::as_bool) == Some(true);
+    // The route query spells its cut `routes_truncated`, because `truncated`
+    // on a walk means the walk stopped early and a route set cut to `limit`
+    // did not.
+    let truncated = payload.get("truncated").and_then(Value::as_bool) == Some(true)
+        || payload.get("routes_truncated").and_then(Value::as_bool) == Some(true);
     // FIR-1552: same rule, other cause. An answer that held same-name candidates
     // out of its headline reports a number some of those candidates may belong
     // in, so the number is a floor and this object has to say so with the count

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -11,6 +11,7 @@ pub mod common;
 pub mod bench;
 pub mod entities;
 pub mod file_entities;
+pub mod path;
 pub mod provenance;
 pub(crate) mod repository_authority;
 pub mod review;
@@ -66,6 +67,7 @@ pub async fn handle_tool_call<G: GraphStore>(
             entities::handle_trace_computation(arguments, store, sessions, repository_authority)
         }
         "trace_data_flow" => entities::handle_trace_data_flow(arguments, store),
+        path::TOOL_NAME => path::handle_trace_path(arguments, store),
         "find_references" => {
             entities::handle_find_references(arguments, store, repository_authority).await
         }

--- a/crates/kin-mcp/src/handlers/path.rs
+++ b/crates/kin-mcp/src/handlers/path.rs
@@ -1,0 +1,2456 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `trace_path`: the route from one entity to another over the relation graph.
+//!
+//! Every other query in Kin is rooted at one entity. `trace_data_flow` walks out
+//! from a focal, `find_references` walks in, `get_context_pack` packs one
+//! neighbourhood, and `impact_analysis` fans out from a change. The ordinary
+//! shape of a code question is a route between two named things, "how does an
+//! edit typed into the editor reach the text model", and a single-rooted walk
+//! sits at one end of that chain and never meets the other (FIR-3070). This
+//! walker answers that question in one call: it resolves both ends, runs a
+//! breadth-first search from the source over the reference edges the graph
+//! records, and returns up to K shortest routes with every hop named, located
+//! and joined to the next by the relation the graph holds.
+//!
+//! One implementation serves three surfaces. The module is generic over
+//! [`GraphStore`], so the offline MCP arm, the daemon's `/commands/path` route
+//! and the daemon-served MCP tool all run this code, and `kin path` is a client
+//! of the daemon route. The crates sit in that order (this one under `kin-cli`
+//! under `kin-daemon`), which is why the walker lives here rather than beside
+//! `trace_data_flow`'s CLI arm.
+//!
+//! A class stands for its members. Each endpoint expands downward over
+//! `Contains` edges before the walk starts, so a route between two classes runs
+//! through the methods that carry it and is reported with those containment
+//! hops in place. The expansion goes down only: walking up from a method to its
+//! class and down to a sibling would claim that the method reaches whatever its
+//! sibling reaches, which is not a route the code has.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use kin_index::RelationResolution;
+use kin_model::graph::{EntityFilter, GraphStore};
+use kin_model::ids::EntityId;
+use kin_model::relation::Relation;
+use kin_model::{Entity, RelationKind};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{McpError, Result};
+use crate::handlers::common::{
+    get_optional_string_param, get_string_param, presentation_line, presentation_span_lines,
+    ReferenceLinesAbsent,
+};
+use crate::types::ToolCallResult;
+
+/// The MCP tool name, and the name every registry keyed by tool uses for it.
+pub const TOOL_NAME: &str = "trace_path";
+
+/// Written for a small model: the first sentence says when to call it.
+pub const TRACE_PATH_DESC: &str = "\
+Call this when the question is how one thing reaches another: it returns the shortest \
+routes from entity A to entity B over the graph's call, instantiation, reference, import \
+and include edges, every hop named with its kind, file and line and the relation that \
+joins it to the next hop, in one call. Address each end by exact name, by entity id, or by \
+name@file to pin one of two same-named entities. A class stands for its members, so a \
+route between two classes runs through the methods that carry it. `direction` defaults to \
+`either`: the forward sense (A reaches B) is tried first, and the answer says which sense \
+held. When no route exists the answer says so with `found: false`, a `gap` naming what \
+stopped the walk and how much of the graph it explored, and the same-name twin count on \
+each end, so read `_kin.verdict` before concluding that A never reaches B.";
+
+const DEFAULT_MAX_DEPTH: usize = 6;
+const MAX_MAX_DEPTH: usize = 12;
+const DEFAULT_LIMIT: usize = 3;
+const MAX_LIMIT: usize = 25;
+/// Relations examined before the walk stops regardless of the clock, so a
+/// pathological fan-out is cut at the same place every run.
+const DEFAULT_MAX_EDGES_SCANNED: usize = 250_000;
+/// Wall-clock ceiling for one call, both senses included.
+const DEFAULT_TIME_BUDGET: Duration = Duration::from_secs(10);
+/// How far an endpoint expands over `Contains` edges, and how many members it
+/// may stand for. A module names every declaration it holds; past the cap the
+/// endpoint is disclosed as partial rather than silently narrowed.
+const CONTAINMENT_DEPTH: usize = 4;
+const CONTAINMENT_CAP: usize = 5_000;
+const OTHER_CANDIDATES_SHOWN: usize = 5;
+/// Shortest routes counted before the count itself is reported as a floor.
+const ROUTE_COUNT_CEILING: usize = 1_000;
+
+/// The edge classes a cross-file coverage observation is measured against,
+/// the same three every other reference query declares.
+const REFERENCE_KINDS: [RelationKind; 3] = [
+    RelationKind::Calls,
+    RelationKind::Imports,
+    RelationKind::References,
+];
+
+/// Which way a route may run between the two ends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PathDirection {
+    /// `from` reaches `to`: every edge runs from the source side to the target side.
+    Forward,
+    /// `to` reaches `from`.
+    Reverse,
+    /// Forward first; reverse only when forward finds nothing. The answer says
+    /// which sense held.
+    #[default]
+    Either,
+}
+
+impl PathDirection {
+    pub fn parse(value: &str) -> std::result::Result<Self, String> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "forward" | "out" | "outgoing" => Ok(Self::Forward),
+            "reverse" | "back" | "backward" | "backwards" | "in" | "incoming" => Ok(Self::Reverse),
+            "either" | "any" | "both" | "" => Ok(Self::Either),
+            other => Err(format!(
+                "invalid direction '{other}': expected forward, reverse, or either"
+            )),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Forward => "forward",
+            Self::Reverse => "reverse",
+            Self::Either => "either",
+        }
+    }
+}
+
+/// One sense of a walk. Both walk outgoing edges; they differ in which end is
+/// the seed set, so a reverse route is listed from `to` to `from`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Sense {
+    Forward,
+    Reverse,
+}
+
+impl Sense {
+    fn as_str(self) -> &'static str {
+        match self {
+            Sense::Forward => "forward",
+            Sense::Reverse => "reverse",
+        }
+    }
+}
+
+/// Request shape for the route query, shared by the CLI, the daemon route and
+/// the MCP tool.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PathRequest {
+    /// Source end: an entity uuid, an exact name, or `name@file`.
+    pub from: String,
+    /// Target end, in the same forms.
+    pub to: String,
+    /// Pins `from` to the entity of that name whose file matches this path or
+    /// path suffix. The `name@file` spelling is the same request.
+    #[serde(default)]
+    pub from_file: Option<String>,
+    #[serde(default)]
+    pub to_file: Option<String>,
+    /// Hops walked between the two endpoint closures (default 6, ceiling 12).
+    /// Containment hops that join a class to its members are not counted.
+    #[serde(default)]
+    pub max_depth: Option<usize>,
+    /// Routes returned (default 3, ceiling 25). Shortest first.
+    #[serde(default)]
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub direction: Option<PathDirection>,
+    /// Walk through `UsesType` edges too (default false). Off for the reason
+    /// `trace_data_flow` keeps it off: a shared type name joins every entity that
+    /// annotates with it to every other one.
+    #[serde(default)]
+    pub include_type_edges: Option<bool>,
+}
+
+/// A caller's standing answer to "does anyone still want this result?".
+#[derive(Debug, Clone, Default)]
+pub struct PathCancel(Arc<AtomicBool>);
+
+impl PathCancel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// Work ceilings for one call.
+#[derive(Debug, Clone)]
+pub struct PathBudget {
+    pub max_edges: usize,
+    pub time: Duration,
+    cancel: Option<PathCancel>,
+}
+
+impl Default for PathBudget {
+    fn default() -> Self {
+        Self {
+            max_edges: DEFAULT_MAX_EDGES_SCANNED,
+            time: DEFAULT_TIME_BUDGET,
+            cancel: None,
+        }
+    }
+}
+
+impl PathBudget {
+    /// Caller-supplied ceilings, so the bounds are testable at a scale a test
+    /// can reach.
+    pub fn bounded(max_edges: usize, time: Duration) -> Self {
+        Self {
+            max_edges,
+            time,
+            cancel: None,
+        }
+    }
+
+    /// The shipped ceilings plus a cancellation flag the walk reads at every
+    /// checkpoint.
+    pub fn cancellable(cancel: PathCancel) -> Self {
+        Self {
+            cancel: Some(cancel),
+            ..Self::default()
+        }
+    }
+}
+
+/// Why a walk stopped, in the vocabulary the response reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stop {
+    RouteFound,
+    FrontierExhausted,
+    DepthBound,
+    EdgeCeiling,
+    TimeBudget,
+    Cancelled,
+}
+
+impl Stop {
+    fn as_str(self) -> &'static str {
+        match self {
+            Stop::RouteFound => "route_found",
+            Stop::FrontierExhausted => "frontier_exhausted",
+            Stop::DepthBound => "depth_bound",
+            Stop::EdgeCeiling => "edge_ceiling",
+            Stop::TimeBudget => "time_budget",
+            Stop::Cancelled => "cancelled",
+        }
+    }
+
+    /// A stop the walk did not choose: the frontier was not empty and the
+    /// depth bound was not reached, so the answer is bounded by work rather
+    /// than by the graph.
+    fn is_ceiling(self) -> bool {
+        matches!(self, Stop::EdgeCeiling | Stop::TimeBudget | Stop::Cancelled)
+    }
+
+    /// Ordered by how much of the answer the stop takes away, so a gap over two
+    /// walks names the more limiting one.
+    fn severity(self) -> u8 {
+        match self {
+            Stop::RouteFound => 0,
+            Stop::FrontierExhausted => 1,
+            Stop::DepthBound => 2,
+            Stop::EdgeCeiling => 3,
+            Stop::TimeBudget => 4,
+            Stop::Cancelled => 5,
+        }
+    }
+}
+
+struct Meter {
+    budget: PathBudget,
+    started: Instant,
+    edges: usize,
+}
+
+impl Meter {
+    fn new(budget: PathBudget) -> Self {
+        Self {
+            budget,
+            started: Instant::now(),
+            edges: 0,
+        }
+    }
+
+    fn charge_edge(&mut self) -> Option<Stop> {
+        self.edges += 1;
+        self.ceiling()
+    }
+
+    fn ceiling(&self) -> Option<Stop> {
+        if self
+            .budget
+            .cancel
+            .as_ref()
+            .is_some_and(PathCancel::is_cancelled)
+        {
+            return Some(Stop::Cancelled);
+        }
+        if self.edges >= self.budget.max_edges {
+            return Some(Stop::EdgeCeiling);
+        }
+        if self.started.elapsed() >= self.budget.time {
+            return Some(Stop::TimeBudget);
+        }
+        None
+    }
+}
+
+/// One entity the caller could have meant instead of the one chosen.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathCandidate {
+    pub entity_id: String,
+    pub name: String,
+    pub kind: String,
+    pub file: Option<String>,
+    pub start_line: Option<u32>,
+}
+
+/// One end of the route as it was resolved.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathEndpoint {
+    pub entity_id: String,
+    pub name: String,
+    pub kind: String,
+    pub file: Option<String>,
+    pub start_line: Option<u32>,
+    pub end_line: Option<u32>,
+    /// True when the graph holds no file for this symbol.
+    pub external: bool,
+    /// `entity_id`, `name`, or `name_and_file`: which form the caller used, so
+    /// a reader can tell a pinned end from one the ranking chose.
+    pub addressed_by: String,
+    /// Entities carrying exactly this name, the chosen one included. Above one
+    /// and not pinned, an empty route set answers for one twin a question that
+    /// was asked of any of them.
+    pub same_name_candidates: usize,
+    /// The other same-named entities, bounded, never including the chosen one,
+    /// each addressable by id or by `name@file`.
+    pub other_candidates: Vec<PathCandidate>,
+    /// Members reached through `Contains` edges that stand for this end.
+    pub members_expanded: usize,
+}
+
+/// One entity on a route, with the edge that joins it to the next hop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathHop {
+    pub entity_id: String,
+    pub name: String,
+    pub kind: String,
+    pub file: Option<String>,
+    pub start_line: Option<u32>,
+    pub end_line: Option<u32>,
+    pub external: bool,
+    /// Relation kind joining this hop to the next one; null on the last hop.
+    pub relation: Option<String>,
+    /// `outgoing` when the edge runs from this hop to the next, `incoming` when
+    /// it runs from the next hop into this one (a member joined to the class
+    /// that contains it); null on the last hop.
+    pub edge: Option<String>,
+    /// How the edge was resolved (`type_resolved`, `import_scoped`,
+    /// `name_only`); null on containment hops and on the last hop. A route is
+    /// only as trustworthy as its weakest hop.
+    pub resolution: Option<String>,
+    /// 1-based lines of the syntax that produced the edge, in the file of the
+    /// edge's source entity. Empty when the graph carries no site for it.
+    pub site_lines: Vec<u32>,
+    /// Why `site_lines` is empty, in the vocabulary `find_references` uses
+    /// (`no_evidence_span`, `span_outside_caller_file`), and null when at
+    /// least one line is present or the hop carries no edge.
+    pub site_lines_absent_reason: Option<String>,
+}
+
+/// One route, listed in the direction its edges run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathRoute {
+    /// `forward` (listed from `from` to `to`) or `reverse` (from `to` to `from`).
+    pub direction: String,
+    /// Edges in `steps`, containment hops included.
+    pub hops: usize,
+    /// Edges walked between the two endpoint closures, the number `max_depth`
+    /// bounds.
+    pub walked_hops: usize,
+    pub steps: Vec<PathHop>,
+}
+
+/// What one walk covered and why it stopped.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathExplored {
+    pub sense: String,
+    pub nodes: usize,
+    pub edges: usize,
+    pub depth_reached: usize,
+    /// `route_found`, `frontier_exhausted`, `depth_bound`, `edge_ceiling`,
+    /// `time_budget` or `cancelled`.
+    pub stopped_by: String,
+    pub elapsed_ms: u64,
+}
+
+/// Why no route came back, stated so that the absence can be acted on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathGap {
+    /// The most limiting stop across the walks that ran.
+    pub reason: String,
+    pub detail: String,
+    pub remediation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathDegradation {
+    pub component: String,
+    pub reason: String,
+    pub detail: String,
+    pub remediation: String,
+}
+
+/// The whole answer.
+///
+/// Every key is always serialized. The optional-on-read defaults exist because
+/// the envelope annotator lifts some payload keys (`degradations` among them)
+/// into `_kin` when it stamps a daemon answer, and the CLI reads that stamped
+/// form back into this struct.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathResponse {
+    pub from: PathEndpoint,
+    pub to: PathEndpoint,
+    pub direction_requested: String,
+    /// The sense the routes run in, null when none was found.
+    #[serde(default)]
+    pub direction: Option<String>,
+    pub max_depth: usize,
+    pub limit: usize,
+    #[serde(default)]
+    pub walked_kinds: Vec<String>,
+    #[serde(default)]
+    pub include_type_edges: bool,
+    pub found: bool,
+    #[serde(default)]
+    pub routes: Vec<PathRoute>,
+    /// Shortest routes that exist, of which `routes` holds the first `limit`.
+    #[serde(default)]
+    pub routes_total: usize,
+    #[serde(default)]
+    pub routes_truncated: bool,
+    #[serde(default)]
+    pub explored: Vec<PathExplored>,
+    #[serde(default)]
+    pub gap: Option<PathGap>,
+    #[serde(default)]
+    pub degradations: Vec<PathDegradation>,
+    /// Whether the graph links references across files for the source end's
+    /// language, the fact an absence rests on.
+    #[serde(default)]
+    pub edge_coverage: serde_json::Value,
+}
+
+/// What can go wrong before a walk starts.
+#[derive(Debug)]
+pub enum PathError {
+    InvalidRequest(String),
+    EndpointNotFound {
+        which: &'static str,
+        spec: String,
+        detail: String,
+    },
+    EndpointAmbiguous {
+        which: &'static str,
+        spec: String,
+        candidates: Vec<PathCandidate>,
+    },
+    Graph(String),
+}
+
+impl PathError {
+    /// A miss on one of the two names, which the negative classifier reports
+    /// as a resolution miss rather than as an absent route.
+    pub fn is_resolution_miss(&self) -> bool {
+        matches!(
+            self,
+            PathError::EndpointNotFound { .. } | PathError::EndpointAmbiguous { .. }
+        )
+    }
+}
+
+impl fmt::Display for PathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathError::InvalidRequest(message) => write!(f, "{message}"),
+            PathError::EndpointNotFound {
+                which,
+                spec,
+                detail,
+            } => write!(f, "no entity found for {which} '{spec}': {detail}"),
+            PathError::EndpointAmbiguous {
+                which,
+                spec,
+                candidates,
+            } => {
+                write!(
+                    f,
+                    "{which} '{spec}' names {} entities; pin one by id or name@file:",
+                    candidates.len()
+                )?;
+                for candidate in candidates {
+                    write!(
+                        f,
+                        " [{} {} {}:{} {}]",
+                        candidate.kind,
+                        candidate.name,
+                        candidate.file.as_deref().unwrap_or("<no file>"),
+                        candidate
+                            .start_line
+                            .map(|line| line.to_string())
+                            .unwrap_or_else(|| "?".to_string()),
+                        candidate.entity_id
+                    )?;
+                }
+                Ok(())
+            }
+            PathError::Graph(message) => write!(f, "graph store error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for PathError {}
+
+fn graph_error<E: fmt::Display>(error: E) -> PathError {
+    PathError::Graph(error.to_string())
+}
+
+/// The relation kinds a route may run over.
+fn walked_kinds(include_type_edges: bool) -> Vec<RelationKind> {
+    let mut kinds = vec![
+        RelationKind::Calls,
+        RelationKind::Instantiates,
+        RelationKind::Imports,
+        RelationKind::Includes,
+        RelationKind::UsesMacro,
+        RelationKind::References,
+    ];
+    if include_type_edges {
+        kinds.push(RelationKind::UsesType);
+    }
+    kinds
+}
+
+/// Preference among several edges joining the same two hops: a call is a
+/// stronger claim than a reference, so the route names the call.
+fn kind_rank(kind: RelationKind) -> u8 {
+    match kind {
+        RelationKind::Calls => 0,
+        RelationKind::Instantiates => 1,
+        RelationKind::Imports => 2,
+        RelationKind::Includes => 3,
+        RelationKind::UsesMacro => 4,
+        RelationKind::References => 5,
+        RelationKind::UsesType => 6,
+        _ => 7,
+    }
+}
+
+fn kind_label(entity: &Entity) -> String {
+    format!("{:?}", entity.kind)
+}
+
+fn span_lines(entity: &Entity) -> (Option<u32>, Option<u32>) {
+    match entity.span.as_ref() {
+        Some(span) => {
+            let (start, end) = presentation_span_lines(span);
+            (Some(start), Some(end))
+        }
+        None => (None, None),
+    }
+}
+
+fn candidate_record(entity: &Entity) -> PathCandidate {
+    PathCandidate {
+        entity_id: entity.id.to_string(),
+        name: entity.name.clone(),
+        kind: kind_label(entity),
+        file: entity.file_origin.as_ref().map(|file| file.0.clone()),
+        start_line: span_lines(entity).0,
+    }
+}
+
+/// Deterministic order for a candidate list: file, then line, then id.
+fn sort_candidates(list: &mut [Entity]) {
+    list.sort_by(|a, b| {
+        let file_a = a.file_origin.as_ref().map(|file| file.0.as_str());
+        let file_b = b.file_origin.as_ref().map(|file| file.0.as_str());
+        file_a
+            .cmp(&file_b)
+            .then_with(|| span_lines(a).0.cmp(&span_lines(b).0))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+}
+
+/// Entities carrying exactly `name`, in a stable order.
+fn exact_name_matches<G: GraphStore>(
+    store: &G,
+    name: &str,
+) -> std::result::Result<Vec<Entity>, PathError> {
+    let filter = EntityFilter {
+        name_pattern: Some(name.to_string()),
+        ..Default::default()
+    };
+    let mut matches: Vec<Entity> = store
+        .query_entities(&filter)
+        .map_err(graph_error)?
+        .into_iter()
+        .filter(|entity| entity.name == name)
+        .collect();
+    sort_candidates(&mut matches);
+    Ok(matches)
+}
+
+/// Whether `entity` lives in the file `hint` names: the exact path, a path
+/// suffix (`sessions.py`, `requests/sessions.py`), or a longer path that ends
+/// in the graph's relative one.
+fn file_matches(entity: &Entity, hint: &str) -> bool {
+    let Some(path) = entity.file_origin.as_ref() else {
+        return false;
+    };
+    let path = path.0.replace('\\', "/");
+    let hint = hint.trim().replace('\\', "/");
+    let hint = hint.trim_start_matches("./");
+    if hint.is_empty() {
+        return false;
+    }
+    path == hint || path.ends_with(&format!("/{hint}")) || hint.ends_with(&format!("/{path}"))
+}
+
+/// `name@file` split at the last `@`, when both halves are present.
+fn split_pinned(spec: &str) -> (&str, Option<&str>) {
+    match spec.rsplit_once('@') {
+        Some((name, file)) if !name.trim().is_empty() && !file.trim().is_empty() => {
+            (name.trim(), Some(file.trim()))
+        }
+        _ => (spec, None),
+    }
+}
+
+/// Among same-named candidates the caller already narrowed, the one `kin trace`
+/// would choose: a body beats a declaration, then the file path, then the
+/// start line, then the id (`kin_core::definition_identity_key`, FIR-3071).
+/// Read off the entity records, so the same tree answers the same way in
+/// every store built from it.
+fn strongest_definition<G: GraphStore>(
+    _store: &G,
+    candidates: Vec<Entity>,
+) -> std::result::Result<Entity, PathError> {
+    candidates
+        .into_iter()
+        .min_by_key(kin_core::definition_identity_key)
+        .ok_or_else(|| PathError::Graph("no candidate to rank".to_string()))
+}
+
+struct ResolvedEnd {
+    entity: Entity,
+    endpoint: PathEndpoint,
+}
+
+fn endpoint_record(entity: &Entity, addressed_by: &str, twins: &[Entity]) -> PathEndpoint {
+    let (start_line, end_line) = span_lines(entity);
+    let same_name_candidates = twins
+        .iter()
+        .filter(|twin| twin.name == entity.name)
+        .count()
+        .max(1);
+    let other_candidates = twins
+        .iter()
+        .filter(|twin| twin.id != entity.id)
+        .take(OTHER_CANDIDATES_SHOWN)
+        .map(candidate_record)
+        .collect();
+    PathEndpoint {
+        entity_id: entity.id.to_string(),
+        name: entity.name.clone(),
+        kind: kind_label(entity),
+        file: entity.file_origin.as_ref().map(|file| file.0.clone()),
+        start_line,
+        end_line,
+        external: kin_ranking::entity_ranking::trace_entity_is_external(entity),
+        addressed_by: addressed_by.to_string(),
+        same_name_candidates,
+        other_candidates,
+        members_expanded: 0,
+    }
+}
+
+/// Resolve one end by uuid, by `name@file` or `file_hint`, or by name through
+/// the same ranking `trace_data_flow` resolves its focal with.
+///
+/// Public so the trace surface can address a twin the same way once it grows
+/// a `--file` (FIR-3071): one resolver, one disclosure shape.
+pub fn resolve_endpoint<G: GraphStore>(
+    store: &G,
+    which: &'static str,
+    spec: &str,
+    file_hint: Option<&str>,
+) -> std::result::Result<ResolvedEndpoint, PathError> {
+    let end = resolve_end(store, which, spec, file_hint)?;
+    Ok(ResolvedEndpoint {
+        entity: end.entity,
+        endpoint: end.endpoint,
+    })
+}
+
+/// A resolved end as the public resolver hands it back.
+pub struct ResolvedEndpoint {
+    pub entity: Entity,
+    pub endpoint: PathEndpoint,
+}
+
+fn resolve_end<G: GraphStore>(
+    store: &G,
+    which: &'static str,
+    spec: &str,
+    file_hint: Option<&str>,
+) -> std::result::Result<ResolvedEnd, PathError> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return Err(PathError::InvalidRequest(format!(
+            "{which} must name an entity"
+        )));
+    }
+    if let Ok(uuid) = uuid::Uuid::parse_str(spec) {
+        let entity = store
+            .get_entity(&EntityId(uuid))
+            .map_err(graph_error)?
+            .ok_or_else(|| PathError::EndpointNotFound {
+                which,
+                spec: spec.to_string(),
+                detail: "no entity carries this id".to_string(),
+            })?;
+        let twins = exact_name_matches(store, &entity.name)?;
+        let endpoint = endpoint_record(&entity, "entity_id", &twins);
+        return Ok(ResolvedEnd { entity, endpoint });
+    }
+
+    let (name, hint) = match file_hint.map(str::trim).filter(|hint| !hint.is_empty()) {
+        Some(hint) => (spec, Some(hint)),
+        None => split_pinned(spec),
+    };
+    let matches = kin_core::query_trace_matches(store, name).map_err(graph_error)?;
+    let exact: Vec<Entity> = matches
+        .iter()
+        .filter(|entity| entity.name == name)
+        .cloned()
+        .collect();
+    // A qualified name that names no entity falls back to its bare leaf, the
+    // way `kin trace` does through `kin_core::fallback_leaf_trace_matches`,
+    // but never silently onto one of several: a unique leaf is accepted and
+    // reported as `leaf_name`, and leaf twins are refused with the candidates
+    // listed so the caller pins one by file or id. Measured on ripgrep, where
+    // `SearchWorker::search` was refused outright while three entities named
+    // `search` sat in the graph.
+    let leaf_only = matches.is_empty();
+    let mut pool = if leaf_only {
+        let leaf = name
+            .rfind("::")
+            .map(|index| &name[index + 2..])
+            .or_else(|| name.rfind('.').map(|index| &name[index + 1..]))
+            .unwrap_or(name);
+        let mut leaf_pool: Vec<Entity> =
+            kin_core::fallback_leaf_trace_matches(store, name).map_err(graph_error)?;
+        leaf_pool.retain(|entity| {
+            entity.file_origin.is_some() || entity.role != kin_model::entity::EntityRole::External
+        });
+        let exact_leaf: Vec<Entity> = leaf_pool
+            .iter()
+            .filter(|entity| entity.name == leaf)
+            .cloned()
+            .collect();
+        if exact_leaf.is_empty() {
+            leaf_pool
+        } else {
+            exact_leaf
+        }
+    } else if exact.is_empty() {
+        matches
+    } else {
+        exact
+    };
+    sort_candidates(&mut pool);
+
+    if let Some(hint) = hint {
+        let pinned: Vec<Entity> = pool
+            .iter()
+            .filter(|entity| file_matches(entity, hint))
+            .cloned()
+            .collect();
+        if pinned.is_empty() {
+            let detail = if pool.is_empty() {
+                "no entity carries this name".to_string()
+            } else {
+                let mut files: Vec<String> = pool
+                    .iter()
+                    .filter_map(|entity| entity.file_origin.as_ref().map(|file| file.0.clone()))
+                    .collect();
+                files.dedup();
+                files.truncate(OTHER_CANDIDATES_SHOWN);
+                format!(
+                    "'{name}' is not in a file matching '{hint}'; it is in: {}",
+                    files.join(", ")
+                )
+            };
+            return Err(PathError::EndpointNotFound {
+                which,
+                spec: spec.to_string(),
+                detail,
+            });
+        }
+        let chosen = strongest_definition(store, pinned)?;
+        let twins = exact_name_matches(store, &chosen.name)?;
+        let endpoint = endpoint_record(&chosen, "name_and_file", &twins);
+        return Ok(ResolvedEnd {
+            entity: chosen,
+            endpoint,
+        });
+    }
+
+    if pool.is_empty() {
+        return Err(PathError::EndpointNotFound {
+            which,
+            spec: spec.to_string(),
+            detail: "no entity carries this name".to_string(),
+        });
+    }
+    if leaf_only {
+        if pool.len() > 1 {
+            return Err(PathError::EndpointAmbiguous {
+                which,
+                spec: spec.to_string(),
+                candidates: pool.iter().map(candidate_record).collect(),
+            });
+        }
+        let chosen = pool.remove(0);
+        let twins = exact_name_matches(store, &chosen.name)?;
+        let endpoint = endpoint_record(&chosen, "leaf_name", &twins);
+        return Ok(ResolvedEnd {
+            entity: chosen,
+            endpoint,
+        });
+    }
+    let chosen =
+        match kin_ranking::entity_ranking::select_best_entity(store, name).map_err(graph_error)? {
+            Some(entity) => entity,
+            None => strongest_definition(store, pool)?,
+        };
+    let twins = exact_name_matches(store, &chosen.name)?;
+    let endpoint = endpoint_record(&chosen, "name", &twins);
+    Ok(ResolvedEnd {
+        entity: chosen,
+        endpoint,
+    })
+}
+
+/// An endpoint and every member it stands for, with the `Contains` edge that
+/// admitted each member so the route can show the hop.
+struct Closure {
+    /// Member to `(parent, relation)`; the root maps to `None`.
+    parents: HashMap<EntityId, Option<(EntityId, Relation)>>,
+    capped: bool,
+}
+
+impl Closure {
+    fn contains(&self, id: &EntityId) -> bool {
+        self.parents.contains_key(id)
+    }
+
+    /// Ids from the root down to `member`, both inclusive.
+    fn chain_to(&self, member: EntityId) -> Vec<EntityId> {
+        let mut chain = vec![member];
+        let mut current = member;
+        while let Some(Some((parent, _))) = self.parents.get(&current) {
+            chain.push(*parent);
+            current = *parent;
+        }
+        chain.reverse();
+        chain
+    }
+}
+
+fn containment_closure<G: GraphStore>(
+    store: &G,
+    root: &Entity,
+    meter: &mut Meter,
+) -> std::result::Result<Closure, PathError> {
+    let mut closure = Closure {
+        parents: HashMap::new(),
+        capped: false,
+    };
+    closure.parents.insert(root.id, None);
+    let mut frontier = vec![root.id];
+    for _ in 0..CONTAINMENT_DEPTH {
+        let mut next = Vec::new();
+        'frontier: for node in frontier.drain(..) {
+            let relations = store
+                .get_all_relations_for_entity(&node)
+                .map_err(graph_error)?;
+            for relation in relations {
+                meter.charge_edge();
+                if relation.kind != RelationKind::Contains || relation.src.as_entity() != Some(node)
+                {
+                    continue;
+                }
+                let Some(child) = relation.dst.as_entity() else {
+                    continue;
+                };
+                if child == node || closure.parents.contains_key(&child) {
+                    continue;
+                }
+                if closure.parents.len() >= CONTAINMENT_CAP {
+                    closure.capped = true;
+                    break 'frontier;
+                }
+                closure.parents.insert(child, Some((node, relation)));
+                next.push(child);
+            }
+        }
+        if next.is_empty() || closure.capped {
+            break;
+        }
+        next.sort();
+        frontier = next;
+    }
+    Ok(closure)
+}
+
+/// One shortest-path predecessor of a node, with the edge that reached it.
+#[derive(Debug, Clone)]
+struct ParentEdge {
+    parent: EntityId,
+    kind: RelationKind,
+    resolution: RelationResolution,
+    /// `(file, 1-based line)` of every syntax site the edge's evidence records.
+    sites: Vec<(String, u32)>,
+}
+
+fn evidence_sites(relation: &Relation) -> Vec<(String, u32)> {
+    let mut sites: Vec<(String, u32)> = relation
+        .evidence
+        .iter()
+        .filter_map(|evidence| evidence.source_span.as_ref())
+        .map(|span| (span.file.0.clone(), presentation_line(span.start_line)))
+        .collect();
+    sites.sort();
+    sites.dedup();
+    sites
+}
+
+/// Merge a second edge from the same predecessor: the stronger kind names the
+/// hop, and every site is kept.
+fn record_parent(parents: &mut Vec<ParentEdge>, edge: ParentEdge) {
+    if let Some(existing) = parents.iter_mut().find(|known| known.parent == edge.parent) {
+        if kind_rank(edge.kind) < kind_rank(existing.kind) {
+            existing.kind = edge.kind;
+            existing.resolution = edge.resolution;
+        }
+        existing.sites.extend(edge.sites);
+        existing.sites.sort();
+        existing.sites.dedup();
+    } else {
+        parents.push(edge);
+    }
+}
+
+struct Walk {
+    depth_of: HashMap<EntityId, usize>,
+    parents: HashMap<EntityId, Vec<ParentEdge>>,
+    /// Goal members reached at the first depth any goal member appeared.
+    hits: Vec<EntityId>,
+    hit_depth: usize,
+    stop: Stop,
+    nodes: usize,
+    edges: usize,
+    elapsed: Duration,
+}
+
+impl Walk {
+    fn explored(&self, sense: Sense) -> PathExplored {
+        PathExplored {
+            sense: sense.as_str().to_string(),
+            nodes: self.nodes,
+            edges: self.edges,
+            depth_reached: self.depth_of.values().copied().max().unwrap_or(0),
+            stopped_by: self.stop.as_str().to_string(),
+            elapsed_ms: self.elapsed.as_millis() as u64,
+        }
+    }
+}
+
+/// Breadth-first over outgoing edges from every member of `seeds`, level by
+/// level, recording every shortest-path predecessor, until a level holds a
+/// member of `goals`, the frontier empties, the depth bound is reached, or the
+/// meter stops it.
+///
+/// A level is finished before it is judged, so every goal member at the hit
+/// depth is collected and every route of that length can be enumerated.
+fn walk_outgoing<G: GraphStore>(
+    store: &G,
+    seeds: &Closure,
+    goals: &Closure,
+    allowed: &HashSet<RelationKind>,
+    max_depth: usize,
+    meter: &mut Meter,
+) -> std::result::Result<Walk, PathError> {
+    let started = Instant::now();
+    let edges_before = meter.edges;
+    let mut depth_of: HashMap<EntityId, usize> = HashMap::new();
+    let mut parents: HashMap<EntityId, Vec<ParentEdge>> = HashMap::new();
+    let mut frontier: Vec<EntityId> = seeds.parents.keys().copied().collect();
+    frontier.sort();
+    for id in &frontier {
+        depth_of.insert(*id, 0);
+    }
+    let mut hits: Vec<EntityId> = frontier
+        .iter()
+        .filter(|id| goals.contains(id))
+        .copied()
+        .collect();
+    let mut nodes = 0usize;
+    let mut depth = 0usize;
+    let stop;
+    if !hits.is_empty() {
+        stop = Stop::RouteFound;
+    } else {
+        loop {
+            if depth >= max_depth {
+                stop = Stop::DepthBound;
+                break;
+            }
+            let mut next: Vec<EntityId> = Vec::new();
+            let mut level_hits: Vec<EntityId> = Vec::new();
+            let mut ceiling: Option<Stop> = None;
+            'level: for node in &frontier {
+                if let Some(reason) = meter.ceiling() {
+                    ceiling = Some(reason);
+                    break 'level;
+                }
+                let relations = store
+                    .get_all_relations_for_entity(node)
+                    .map_err(graph_error)?;
+                nodes += 1;
+                for relation in &relations {
+                    if let Some(reason) = meter.charge_edge() {
+                        ceiling = Some(reason);
+                        break 'level;
+                    }
+                    if !allowed.contains(&relation.kind) || relation.src.as_entity() != Some(*node)
+                    {
+                        continue;
+                    }
+                    let Some(neighbor) = relation.dst.as_entity() else {
+                        continue;
+                    };
+                    if neighbor == *node {
+                        continue;
+                    }
+                    let edge = ParentEdge {
+                        parent: *node,
+                        kind: relation.kind,
+                        resolution: RelationResolution::of(relation),
+                        sites: evidence_sites(relation),
+                    };
+                    match depth_of.get(&neighbor).copied() {
+                        None => {
+                            depth_of.insert(neighbor, depth + 1);
+                            parents.entry(neighbor).or_default().push(edge);
+                            next.push(neighbor);
+                            if goals.contains(&neighbor) {
+                                level_hits.push(neighbor);
+                            }
+                        }
+                        Some(known) if known == depth + 1 => {
+                            record_parent(parents.entry(neighbor).or_default(), edge);
+                        }
+                        Some(_) => {}
+                    }
+                }
+            }
+            depth += 1;
+            if let Some(reason) = ceiling {
+                hits = level_hits;
+                stop = reason;
+                break;
+            }
+            if !level_hits.is_empty() {
+                hits = level_hits;
+                stop = Stop::RouteFound;
+                break;
+            }
+            if next.is_empty() {
+                stop = Stop::FrontierExhausted;
+                break;
+            }
+            next.sort();
+            next.dedup();
+            frontier = next;
+        }
+    }
+    hits.sort();
+    hits.dedup();
+    let hit_depth = hits
+        .first()
+        .and_then(|id| depth_of.get(id).copied())
+        .unwrap_or(depth);
+    Ok(Walk {
+        depth_of,
+        parents,
+        hits,
+        hit_depth,
+        stop,
+        nodes,
+        edges: meter.edges - edges_before,
+        elapsed: started.elapsed(),
+    })
+}
+
+/// A route between the closures: `nodes[i]` is joined to `nodes[i + 1]` by
+/// `edges[i]`.
+struct CoreRoute {
+    nodes: Vec<EntityId>,
+    edges: Vec<ParentEdge>,
+}
+
+/// Every shortest route from a seed to a hit, enumerated backwards through the
+/// predecessor lists, up to [`ROUTE_COUNT_CEILING`]. Returns the routes, how
+/// many were counted, and whether the count stopped at the ceiling.
+fn enumerate_routes(walk: &Walk) -> (Vec<CoreRoute>, usize, bool) {
+    let mut routes: Vec<CoreRoute> = Vec::new();
+    let mut ceiling_hit = false;
+    'hits: for goal in &walk.hits {
+        let mut stack: Vec<(EntityId, Vec<EntityId>, Vec<ParentEdge>)> =
+            vec![(*goal, vec![*goal], Vec::new())];
+        while let Some((node, path_nodes, path_edges)) = stack.pop() {
+            if routes.len() >= ROUTE_COUNT_CEILING {
+                ceiling_hit = true;
+                break 'hits;
+            }
+            if walk.depth_of.get(&node).copied().unwrap_or(0) == 0 {
+                let mut nodes = path_nodes;
+                let mut edges = path_edges;
+                nodes.reverse();
+                edges.reverse();
+                routes.push(CoreRoute { nodes, edges });
+                continue;
+            }
+            let Some(predecessors) = walk.parents.get(&node) else {
+                continue;
+            };
+            let mut ordered: Vec<&ParentEdge> = predecessors.iter().collect();
+            ordered.sort_by_key(|edge| (kind_rank(edge.kind), edge.parent));
+            for edge in ordered.into_iter().rev() {
+                if path_nodes.contains(&edge.parent) {
+                    continue;
+                }
+                let mut nodes = path_nodes.clone();
+                nodes.push(edge.parent);
+                let mut edges = path_edges.clone();
+                edges.push(edge.clone());
+                stack.push((edge.parent, nodes, edges));
+            }
+        }
+    }
+    let total = routes.len();
+    (routes, total, ceiling_hit)
+}
+
+struct EntityCache<'a, G: GraphStore> {
+    store: &'a G,
+    seen: HashMap<EntityId, Option<Entity>>,
+}
+
+impl<'a, G: GraphStore> EntityCache<'a, G> {
+    fn new(store: &'a G) -> Self {
+        Self {
+            store,
+            seen: HashMap::new(),
+        }
+    }
+
+    fn get(&mut self, id: EntityId) -> std::result::Result<Option<Entity>, PathError> {
+        if let Some(known) = self.seen.get(&id) {
+            return Ok(known.clone());
+        }
+        let entity = self.store.get_entity(&id).map_err(graph_error)?;
+        self.seen.insert(id, entity.clone());
+        Ok(entity)
+    }
+}
+
+/// The edge leaving one hop toward the next.
+struct HopEdge {
+    kind: RelationKind,
+    outgoing: bool,
+    resolution: Option<&'static str>,
+    sites: Vec<(String, u32)>,
+}
+
+fn hop_record(
+    entity: Option<&Entity>,
+    id: EntityId,
+    edge: Option<&HopEdge>,
+    next_file: Option<&str>,
+) -> PathHop {
+    let (start_line, end_line) = entity.map(span_lines).unwrap_or((None, None));
+    let file = entity.and_then(|entity| entity.file_origin.as_ref().map(|file| file.0.clone()));
+    // Sites are reported in the file of the edge's source entity: this hop's
+    // file for an outgoing edge, the next hop's for an incoming one.
+    let site_file = edge.and_then(|edge| {
+        if edge.outgoing {
+            file.as_deref()
+        } else {
+            next_file
+        }
+    });
+    let site_lines: Vec<u32> = edge
+        .map(|edge| {
+            edge.sites
+                .iter()
+                .filter(|(site_file_name, _)| Some(site_file_name.as_str()) == site_file)
+                .map(|(_, line)| *line)
+                .collect()
+        })
+        .unwrap_or_default();
+    let site_lines_absent_reason = match edge {
+        Some(_) if !site_lines.is_empty() => None,
+        Some(edge) if edge.sites.is_empty() => {
+            Some(ReferenceLinesAbsent::NoEvidenceSpan.as_str().to_string())
+        }
+        Some(_) => Some(
+            ReferenceLinesAbsent::SpanOutsideCallerFile
+                .as_str()
+                .to_string(),
+        ),
+        None => None,
+    };
+    PathHop {
+        entity_id: id.to_string(),
+        name: entity
+            .map(|entity| entity.name.clone())
+            .unwrap_or_else(|| "<missing entity>".to_string()),
+        kind: entity
+            .map(kind_label)
+            .unwrap_or_else(|| "Unknown".to_string()),
+        file,
+        start_line,
+        end_line,
+        external: entity.is_some_and(kin_ranking::entity_ranking::trace_entity_is_external),
+        relation: edge.map(|edge| format!("{:?}", edge.kind)),
+        edge: edge.map(|edge| {
+            let label = if edge.outgoing {
+                "outgoing"
+            } else {
+                "incoming"
+            };
+            label.to_string()
+        }),
+        resolution: edge.and_then(|edge| edge.resolution.map(str::to_string)),
+        site_lines,
+        site_lines_absent_reason,
+    }
+}
+
+/// A core route with its containment prefix and suffix, rendered to hops.
+fn render_route<G: GraphStore>(
+    route: &CoreRoute,
+    sense: Sense,
+    seeds: &Closure,
+    goals: &Closure,
+    cache: &mut EntityCache<'_, G>,
+) -> std::result::Result<PathRoute, PathError> {
+    let first = *route.nodes.first().expect("a route has at least one node");
+    let last = *route.nodes.last().expect("a route has at least one node");
+    let mut chain: Vec<(EntityId, Option<HopEdge>)> = Vec::new();
+    let prefix = seeds.chain_to(first);
+    for node in prefix.iter().take(prefix.len().saturating_sub(1)) {
+        chain.push((
+            *node,
+            Some(HopEdge {
+                kind: RelationKind::Contains,
+                outgoing: true,
+                resolution: None,
+                sites: Vec::new(),
+            }),
+        ));
+    }
+    for (index, node) in route.nodes.iter().enumerate() {
+        let edge = route.edges.get(index).map(|edge| HopEdge {
+            kind: edge.kind,
+            outgoing: true,
+            resolution: Some(edge.resolution.as_str()),
+            sites: edge.sites.clone(),
+        });
+        chain.push((*node, edge));
+    }
+    let suffix = goals.chain_to(last);
+    for node in suffix.iter().rev().skip(1) {
+        if let Some((_, tail_edge)) = chain.last_mut() {
+            *tail_edge = Some(HopEdge {
+                kind: RelationKind::Contains,
+                outgoing: false,
+                resolution: None,
+                sites: Vec::new(),
+            });
+        }
+        chain.push((*node, None));
+    }
+    let hops = chain.len().saturating_sub(1);
+    let mut steps = Vec::with_capacity(chain.len());
+    for (index, (id, edge)) in chain.iter().enumerate() {
+        let entity = cache.get(*id)?;
+        let next_file = match chain.get(index + 1) {
+            Some((next_id, _)) => cache
+                .get(*next_id)?
+                .and_then(|next| next.file_origin.as_ref().map(|file| file.0.clone())),
+            None => None,
+        };
+        steps.push(hop_record(
+            entity.as_ref(),
+            *id,
+            edge.as_ref(),
+            next_file.as_deref(),
+        ));
+    }
+    Ok(PathRoute {
+        direction: sense.as_str().to_string(),
+        hops,
+        walked_hops: route.edges.len(),
+        steps,
+    })
+}
+
+fn route_key(route: &PathRoute) -> Vec<String> {
+    route.steps.iter().map(|step| step.name.clone()).collect()
+}
+
+fn degradation(
+    component: &str,
+    reason: &str,
+    detail: String,
+    remediation: &str,
+) -> PathDegradation {
+    PathDegradation {
+        component: component.to_string(),
+        reason: reason.to_string(),
+        detail,
+        remediation: remediation.to_string(),
+    }
+}
+
+fn stop_phrase(stopped_by: &str) -> &'static str {
+    match stopped_by {
+        "frontier_exhausted" => "ran out of reachable entities before meeting the target",
+        "depth_bound" => "stopped at the depth bound",
+        "edge_ceiling" => "stopped at the edge ceiling",
+        "time_budget" => "stopped at the time budget",
+        "cancelled" => "was cancelled",
+        _ => "stopped",
+    }
+}
+
+fn compose_gap(
+    from: &PathEndpoint,
+    to: &PathEndpoint,
+    max_depth: usize,
+    explored: &[PathExplored],
+) -> PathGap {
+    let most_limiting = explored
+        .iter()
+        .map(|walk| walk.stopped_by.as_str())
+        .max_by_key(|stopped_by| match *stopped_by {
+            "frontier_exhausted" => Stop::FrontierExhausted.severity(),
+            "depth_bound" => Stop::DepthBound.severity(),
+            "edge_ceiling" => Stop::EdgeCeiling.severity(),
+            "time_budget" => Stop::TimeBudget.severity(),
+            "cancelled" => Stop::Cancelled.severity(),
+            _ => 0,
+        })
+        .unwrap_or("frontier_exhausted")
+        .to_string();
+    let walks: Vec<String> = explored
+        .iter()
+        .map(|walk| {
+            format!(
+                "the {} walk explored {} entities over {} edges and {}",
+                walk.sense,
+                walk.nodes,
+                walk.edges,
+                stop_phrase(&walk.stopped_by)
+            )
+        })
+        .collect();
+    let mut detail = format!(
+        "no route between '{}' and '{}' within {max_depth} hops: {}",
+        from.name,
+        to.name,
+        walks.join("; ")
+    );
+    for (which, end) in [("from", from), ("to", to)] {
+        if end.same_name_candidates > 1 && end.addressed_by == "name" {
+            detail.push_str(&format!(
+                ". '{}' is one of {} entities with that name and the {which} end was the one at {}:{}; the others were not walked",
+                end.name,
+                end.same_name_candidates,
+                end.file.as_deref().unwrap_or("<no file>"),
+                end.start_line
+                    .map(|line| line.to_string())
+                    .unwrap_or_else(|| "?".to_string())
+            ));
+        }
+    }
+    let remediation = match most_limiting.as_str() {
+        "depth_bound" => format!(
+            "raise max_depth (now {max_depth}, ceiling {MAX_MAX_DEPTH}), or name a pair that sits closer together"
+        ),
+        "edge_ceiling" | "time_budget" | "cancelled" => {
+            "narrow the walk with a smaller max_depth or a closer pair; the graph beyond the ceiling was not explored".to_string()
+        }
+        _ => "check that both ends resolved to the entities you meant (same_name_candidates and other_candidates on from and to), pin a twin with name@file or its entity id, or pass include_type_edges to walk type annotations too".to_string(),
+    };
+    PathGap {
+        reason: most_limiting,
+        detail,
+        remediation,
+    }
+}
+
+/// Build the answer under the shipped ceilings.
+pub fn build_path_response<G: GraphStore>(
+    store: &G,
+    request: &PathRequest,
+) -> std::result::Result<PathResponse, PathError> {
+    build_path_response_within(store, request, PathBudget::default())
+}
+
+/// The same walk under caller-supplied ceilings.
+pub fn build_path_response_within<G: GraphStore>(
+    store: &G,
+    request: &PathRequest,
+    budget: PathBudget,
+) -> std::result::Result<PathResponse, PathError> {
+    let max_depth = request
+        .max_depth
+        .unwrap_or(DEFAULT_MAX_DEPTH)
+        .clamp(1, MAX_MAX_DEPTH);
+    let limit = request.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let direction = request.direction.unwrap_or_default();
+    let include_type_edges = request.include_type_edges.unwrap_or(false);
+    let mut meter = Meter::new(budget);
+    let mut degradations: Vec<PathDegradation> = Vec::new();
+
+    let ResolvedEnd {
+        entity: from_entity,
+        endpoint: mut from,
+    } = resolve_end(store, "from", &request.from, request.from_file.as_deref())?;
+    let ResolvedEnd {
+        entity: to_entity,
+        endpoint: mut to,
+    } = resolve_end(store, "to", &request.to, request.to_file.as_deref())?;
+
+    let kinds = walked_kinds(include_type_edges);
+    let allowed: HashSet<RelationKind> = kinds.iter().copied().collect();
+    let from_closure = containment_closure(store, &from_entity, &mut meter)?;
+    let to_closure = containment_closure(store, &to_entity, &mut meter)?;
+    from.members_expanded = from_closure.parents.len().saturating_sub(1);
+    to.members_expanded = to_closure.parents.len().saturating_sub(1);
+    for (which, closure) in [("from", &from_closure), ("to", &to_closure)] {
+        if closure.capped {
+            degradations.push(degradation(
+                "endpoint_members",
+                "members_capped",
+                format!(
+                    "the {which} end stands for more than {CONTAINMENT_CAP} members and only the first {CONTAINMENT_CAP} were walked, so a route through a later member was not looked for"
+                ),
+                "name a member of that end directly rather than the container",
+            ));
+        }
+    }
+
+    let senses: &[Sense] = match direction {
+        PathDirection::Forward => &[Sense::Forward],
+        PathDirection::Reverse => &[Sense::Reverse],
+        PathDirection::Either => &[Sense::Forward, Sense::Reverse],
+    };
+    let mut explored: Vec<PathExplored> = Vec::new();
+    let mut routes: Vec<PathRoute> = Vec::new();
+    let mut routes_total = 0usize;
+    let mut routes_truncated = false;
+    let mut sense_held: Option<Sense> = None;
+    let mut cache = EntityCache::new(store);
+    for (index, sense) in senses.iter().enumerate() {
+        let (seeds, goals) = match sense {
+            Sense::Forward => (&from_closure, &to_closure),
+            Sense::Reverse => (&to_closure, &from_closure),
+        };
+        let walk = walk_outgoing(store, seeds, goals, &allowed, max_depth, &mut meter)?;
+        let bounded = walk.stop.is_ceiling();
+        explored.push(walk.explored(*sense));
+        if !walk.hits.is_empty() {
+            let (core, total, ceiling_hit) = enumerate_routes(&walk);
+            let mut rendered = Vec::with_capacity(core.len());
+            for route in &core {
+                rendered.push(render_route(route, *sense, seeds, goals, &mut cache)?);
+            }
+            rendered.sort_by(|a, b| {
+                a.hops
+                    .cmp(&b.hops)
+                    .then_with(|| route_key(a).cmp(&route_key(b)))
+            });
+            routes_total = total;
+            routes_truncated = total > limit || ceiling_hit;
+            rendered.truncate(limit);
+            routes = rendered;
+            sense_held = Some(*sense);
+            if bounded {
+                degradations.push(degradation(
+                    "route_enumeration",
+                    "walk_bounded",
+                    format!(
+                        "the {} walk {} while expanding the level that reached the target, so other routes of {} hops may be missing",
+                        sense.as_str(),
+                        stop_phrase(walk.stop.as_str()),
+                        walk.hit_depth
+                    ),
+                    "re-run with a smaller max_depth to spend the budget closer to the pair",
+                ));
+            }
+            if ceiling_hit {
+                degradations.push(degradation(
+                    "route_enumeration",
+                    "route_count_ceiling",
+                    format!(
+                        "more than {ROUTE_COUNT_CEILING} shortest routes exist and only the first {ROUTE_COUNT_CEILING} were counted, so routes_total is a floor"
+                    ),
+                    "name a member of each end rather than the container to narrow the pair",
+                ));
+            }
+            break;
+        }
+        if bounded {
+            if index + 1 < senses.len() {
+                degradations.push(degradation(
+                    "direction",
+                    "reverse_not_walked",
+                    format!(
+                        "the forward walk {} before the reverse sense could run, so no reverse route was looked for",
+                        stop_phrase(walk.stop.as_str())
+                    ),
+                    "re-run with direction=reverse to walk that sense on its own budget",
+                ));
+            }
+            break;
+        }
+    }
+
+    let found = !routes.is_empty();
+    let gap = if found {
+        None
+    } else {
+        Some(compose_gap(&from, &to, max_depth, &explored))
+    };
+    let edge_coverage = crate::edge_coverage::observe_cross_file_reference_coverage(
+        store,
+        &from_entity,
+        &REFERENCE_KINDS,
+    );
+    Ok(PathResponse {
+        from,
+        to,
+        direction_requested: direction.as_str().to_string(),
+        direction: sense_held.map(|sense| sense.as_str().to_string()),
+        max_depth,
+        limit,
+        walked_kinds: kinds.iter().map(|kind| format!("{kind:?}")).collect(),
+        include_type_edges,
+        found,
+        routes,
+        routes_total,
+        routes_truncated,
+        explored,
+        gap,
+        degradations,
+        edge_coverage,
+    })
+}
+
+/// One line per hop, sized for a prompt: the first line names the start, and
+/// every line after it is one edge and the entity it reaches.
+pub fn render_route_lines(route: &PathRoute) -> Vec<String> {
+    let mut lines = Vec::with_capacity(route.steps.len());
+    let mut pending: Option<String> = None;
+    for step in &route.steps {
+        let location = match (&step.file, step.start_line) {
+            (Some(file), Some(line)) => format!("{file}:{line}"),
+            (Some(file), None) => file.clone(),
+            (None, _) => "(no file)".to_string(),
+        };
+        let node = format!("{} [{}] {}", step.name, step.kind.to_lowercase(), location);
+        lines.push(match pending.take() {
+            Some(arrow) => format!("{arrow} {node}"),
+            None => node,
+        });
+        if let (Some(relation), Some(edge)) = (&step.relation, &step.edge) {
+            let sites = if step.site_lines.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "@{}",
+                    step.site_lines
+                        .iter()
+                        .map(|line| line.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            };
+            pending = Some(if edge == "outgoing" {
+                format!("-{relation}{sites}->")
+            } else {
+                format!("<-{relation}{sites}-")
+            });
+        }
+    }
+    lines
+}
+
+/// The compact form: a header per route and one line per hop, nothing else.
+pub fn render_compact(response: &PathResponse) -> String {
+    if !response.found {
+        let gap = response
+            .gap
+            .as_ref()
+            .map(|gap| gap.detail.clone())
+            .unwrap_or_else(|| "no route".to_string());
+        return format!("no route: {gap}\n");
+    }
+    let mut out = String::new();
+    let shown = response.routes.len();
+    for (index, route) in response.routes.iter().enumerate() {
+        let first = route
+            .steps
+            .first()
+            .map(|step| step.name.as_str())
+            .unwrap_or("?");
+        let last = route
+            .steps
+            .last()
+            .map(|step| step.name.as_str())
+            .unwrap_or("?");
+        out.push_str(&format!(
+            "route {} of {} ({}, {} hops): {} -> {}\n",
+            index + 1,
+            if response.routes_truncated {
+                format!("{shown} shown of {}", response.routes_total)
+            } else {
+                shown.to_string()
+            },
+            route.direction,
+            route.hops,
+            first,
+            last
+        ));
+        for line in render_route_lines(route) {
+            out.push_str("  ");
+            out.push_str(&line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Parse the MCP tool arguments into a request.
+pub fn request_from_args(args: &HashMap<String, serde_json::Value>) -> Result<PathRequest> {
+    let from = get_string_param(args, "from")?;
+    let to = get_string_param(args, "to")?;
+    let direction = match get_optional_string_param(args, "direction") {
+        Some(value) => Some(PathDirection::parse(&value).map_err(McpError::InvalidParams)?),
+        None => None,
+    };
+    let usize_param = |key: &str| {
+        args.get(key)
+            .and_then(serde_json::Value::as_u64)
+            .map(|value| value as usize)
+    };
+    Ok(PathRequest {
+        from,
+        to,
+        from_file: get_optional_string_param(args, "from_file"),
+        to_file: get_optional_string_param(args, "to_file"),
+        max_depth: usize_param("max_depth"),
+        limit: usize_param("limit"),
+        direction,
+        include_type_edges: args
+            .get("include_type_edges")
+            .and_then(serde_json::Value::as_bool),
+    })
+}
+
+/// The MCP tool: the same walk, answered as JSON text. A name that resolves to
+/// nothing is a tool error rather than a transport error, so the envelope can
+/// carry a resolution-miss negative beside it.
+pub fn handle_trace_path<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<ToolCallResult> {
+    let request = request_from_args(args)?;
+    match build_path_response(store, &request) {
+        Ok(response) => {
+            let json = serde_json::to_string_pretty(&response).map_err(McpError::Json)?;
+            Ok(ToolCallResult::text(json))
+        }
+        Err(PathError::InvalidRequest(message)) => Err(McpError::InvalidParams(message)),
+        Err(error) if error.is_resolution_miss() => {
+            Ok(ToolCallResult::error(format!("{TOOL_NAME}: {error}")))
+        }
+        Err(error) => Err(McpError::GraphStore(error.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_db::InMemoryGraph;
+    use kin_model::entity::{
+        EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
+        SourceSpan, Visibility,
+    };
+    use kin_model::ids::{FilePathId, Hash256, LanguageId, RelationId};
+    use kin_model::relation::{RelationEvidence, RelationOrigin};
+    use kin_model::{EntityStore, GraphNodeId};
+
+    fn make_entity(name: &str, file: &str, kind: EntityKind, line: u32) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            kind,
+            name: name.to_string(),
+            language: LanguageId::TypeScript,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file)),
+            span: Some(SourceSpan {
+                file: FilePathId::new(file),
+                start_byte: 0,
+                end_byte: 32,
+                start_line: line,
+                start_col: 0,
+                end_line: line + 10,
+                end_col: 1,
+            }),
+            signature: format!("function {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn function(name: &str, file: &str) -> Entity {
+        make_entity(name, file, EntityKind::Function, 4)
+    }
+
+    fn relation(src: &Entity, dst: &Entity, kind: RelationKind) -> Relation {
+        Relation {
+            id: RelationId::new(),
+            kind,
+            src: GraphNodeId::Entity(src.id),
+            dst: GraphNodeId::Entity(dst.id),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![],
+        }
+    }
+
+    /// A relation whose evidence records the syntax site, in `src`'s file.
+    fn call_at(src: &Entity, dst: &Entity, row: u32) -> Relation {
+        let mut rel = relation(src, dst, RelationKind::Calls);
+        rel.evidence = vec![RelationEvidence {
+            source_span: Some(SourceSpan {
+                file: src.file_origin.clone().unwrap(),
+                start_byte: 0,
+                end_byte: 1,
+                start_line: row,
+                start_col: 0,
+                end_line: row,
+                end_col: 1,
+            }),
+            ..RelationEvidence::default()
+        }];
+        rel
+    }
+
+    fn seed(store: &InMemoryGraph, entities: &[&Entity], relations: &[Relation]) {
+        for entity in entities {
+            store.upsert_entity(entity).unwrap();
+        }
+        for rel in relations {
+            store.upsert_relation(rel).unwrap();
+        }
+    }
+
+    fn request(from: &str, to: &str) -> PathRequest {
+        PathRequest {
+            from: from.to_string(),
+            to: to.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn names(route: &PathRoute) -> Vec<&str> {
+        route.steps.iter().map(|step| step.name.as_str()).collect()
+    }
+
+    /// A three-link chain answers with the chain, in order, with every hop
+    /// located and joined by the relation the graph holds.
+    #[test]
+    fn a_route_is_listed_from_source_to_target_with_every_hop_located() {
+        let store = InMemoryGraph::new();
+        let a = function("edit", "src/editor.ts");
+        let b = function("apply", "src/view.ts");
+        let c = function("push", "src/model.ts");
+        seed(
+            &store,
+            &[&a, &b, &c],
+            &[call_at(&a, &b, 11), call_at(&b, &c, 21)],
+        );
+
+        let response = build_path_response(&store, &request("edit", "push")).unwrap();
+
+        assert!(response.found, "{response:?}");
+        assert_eq!(response.direction.as_deref(), Some("forward"));
+        assert_eq!(response.routes.len(), 1);
+        assert_eq!(response.routes_total, 1);
+        assert!(!response.routes_truncated);
+        let route = &response.routes[0];
+        assert_eq!(route.hops, 2);
+        assert_eq!(route.walked_hops, 2);
+        assert_eq!(names(route), vec!["edit", "apply", "push"]);
+        assert_eq!(route.steps[0].relation.as_deref(), Some("Calls"));
+        assert_eq!(route.steps[0].edge.as_deref(), Some("outgoing"));
+        assert_eq!(route.steps[0].site_lines, vec![12]);
+        assert!(route.steps[0].site_lines_absent_reason.is_none());
+        assert_eq!(route.steps[0].file.as_deref(), Some("src/editor.ts"));
+        assert_eq!(route.steps[0].start_line, Some(5));
+        assert_eq!(route.steps[1].site_lines, vec![22]);
+        assert!(route.steps[2].relation.is_none() && route.steps[2].edge.is_none());
+        assert_eq!(response.explored[0].stopped_by, "route_found");
+        assert!(response.gap.is_none());
+        assert_eq!(response.from.entity_id, a.id.to_string());
+        assert_eq!(response.to.entity_id, c.id.to_string());
+    }
+
+    /// A one-hop route beats every two-hop one, and the two-hop ones are never
+    /// enumerated because the walk stops at the level that met the target.
+    #[test]
+    fn the_shortest_route_comes_first_and_nothing_longer_is_listed() {
+        let store = InMemoryGraph::new();
+        let a = function("a", "src/a.ts");
+        let b1 = function("b1", "src/b.ts");
+        let b2 = function("b2", "src/b.ts");
+        let c = function("c", "src/c.ts");
+        seed(
+            &store,
+            &[&a, &b1, &b2, &c],
+            &[
+                relation(&a, &b1, RelationKind::Calls),
+                relation(&b1, &c, RelationKind::Calls),
+                relation(&a, &b2, RelationKind::Calls),
+                relation(&b2, &c, RelationKind::Calls),
+                relation(&a, &c, RelationKind::References),
+            ],
+        );
+
+        let response = build_path_response(&store, &request("a", "c")).unwrap();
+        assert_eq!(response.routes.len(), 1, "{response:?}");
+        assert_eq!(response.routes[0].hops, 1);
+        assert_eq!(
+            response.routes[0].steps[0].relation.as_deref(),
+            Some("References")
+        );
+        assert_eq!(response.routes_total, 1);
+        // An edge recorded without a syntax site says so rather than printing
+        // an empty list a reader cannot tell from "no site in this file".
+        assert!(response.routes[0].steps[0].site_lines.is_empty());
+        assert_eq!(
+            response.routes[0].steps[0]
+                .site_lines_absent_reason
+                .as_deref(),
+            Some("no_evidence_span")
+        );
+        assert!(response.routes[0].steps[1]
+            .site_lines_absent_reason
+            .is_none());
+    }
+
+    /// Parallel shortest routes are all counted, listed in a stable order, and
+    /// cut to `limit` with the cut disclosed.
+    #[test]
+    fn the_limit_cuts_parallel_routes_and_says_how_many_exist() {
+        let store = InMemoryGraph::new();
+        let a = function("a", "src/a.ts");
+        let b1 = function("b1", "src/b.ts");
+        let b2 = function("b2", "src/b.ts");
+        let c = function("c", "src/c.ts");
+        seed(
+            &store,
+            &[&a, &b1, &b2, &c],
+            &[
+                relation(&a, &b1, RelationKind::Calls),
+                relation(&b1, &c, RelationKind::Calls),
+                relation(&a, &b2, RelationKind::Calls),
+                relation(&b2, &c, RelationKind::Calls),
+            ],
+        );
+
+        let both = build_path_response(
+            &store,
+            &PathRequest {
+                limit: Some(2),
+                ..request("a", "c")
+            },
+        )
+        .unwrap();
+        assert_eq!(both.routes.len(), 2);
+        assert_eq!(names(&both.routes[0]), vec!["a", "b1", "c"]);
+        assert_eq!(names(&both.routes[1]), vec!["a", "b2", "c"]);
+        assert_eq!(both.routes_total, 2);
+        assert!(!both.routes_truncated);
+
+        let one = build_path_response(
+            &store,
+            &PathRequest {
+                limit: Some(1),
+                ..request("a", "c")
+            },
+        )
+        .unwrap();
+        assert_eq!(one.routes.len(), 1);
+        assert_eq!(names(&one.routes[0]), vec!["a", "b1", "c"]);
+        assert_eq!(one.routes_total, 2);
+        assert!(one.routes_truncated);
+    }
+
+    /// The depth bound is a bound on walked hops, and a walk that stopped
+    /// there says so rather than reporting the target unreachable.
+    #[test]
+    fn the_depth_bound_is_honest_about_what_it_did_not_walk() {
+        let store = InMemoryGraph::new();
+        let a = function("a", "src/a.ts");
+        let b = function("b", "src/b.ts");
+        let c = function("c", "src/c.ts");
+        let d = function("d", "src/d.ts");
+        seed(
+            &store,
+            &[&a, &b, &c, &d],
+            &[
+                relation(&a, &b, RelationKind::Calls),
+                relation(&b, &c, RelationKind::Calls),
+                relation(&c, &d, RelationKind::Calls),
+            ],
+        );
+
+        let bounded = build_path_response(
+            &store,
+            &PathRequest {
+                max_depth: Some(2),
+                direction: Some(PathDirection::Forward),
+                ..request("a", "d")
+            },
+        )
+        .unwrap();
+        assert!(!bounded.found);
+        assert!(bounded.routes.is_empty());
+        let gap = bounded
+            .gap
+            .as_ref()
+            .expect("a gap on every no-route answer");
+        assert_eq!(gap.reason, "depth_bound");
+        assert!(gap.remediation.contains("max_depth"), "{gap:?}");
+        assert_eq!(bounded.explored[0].stopped_by, "depth_bound");
+        assert_eq!(bounded.explored[0].depth_reached, 2);
+
+        let reached = build_path_response(
+            &store,
+            &PathRequest {
+                max_depth: Some(3),
+                direction: Some(PathDirection::Forward),
+                ..request("a", "d")
+            },
+        )
+        .unwrap();
+        assert!(reached.found);
+        assert_eq!(reached.routes[0].hops, 3);
+    }
+
+    /// The answer says which sense held, and a pinned sense is honoured.
+    #[test]
+    fn direction_is_reported_and_can_be_pinned() {
+        let store = InMemoryGraph::new();
+        let a = function("a", "src/a.ts");
+        let b = function("b", "src/b.ts");
+        seed(&store, &[&a, &b], &[relation(&b, &a, RelationKind::Calls)]);
+
+        let either = build_path_response(&store, &request("a", "b")).unwrap();
+        assert!(either.found, "{either:?}");
+        assert_eq!(either.direction.as_deref(), Some("reverse"));
+        assert_eq!(either.direction_requested, "either");
+        assert_eq!(names(&either.routes[0]), vec!["b", "a"]);
+        assert_eq!(either.routes[0].direction, "reverse");
+        assert_eq!(either.explored.len(), 2);
+        assert_eq!(either.explored[0].sense, "forward");
+        assert_eq!(either.explored[0].stopped_by, "frontier_exhausted");
+        assert_eq!(either.explored[1].sense, "reverse");
+        assert_eq!(either.explored[1].stopped_by, "route_found");
+
+        let forward = build_path_response(
+            &store,
+            &PathRequest {
+                direction: Some(PathDirection::Forward),
+                ..request("a", "b")
+            },
+        )
+        .unwrap();
+        assert!(!forward.found);
+        assert_eq!(forward.explored.len(), 1);
+        assert_eq!(forward.gap.as_ref().unwrap().reason, "frontier_exhausted");
+
+        let reverse = build_path_response(
+            &store,
+            &PathRequest {
+                direction: Some(PathDirection::Reverse),
+                ..request("a", "b")
+            },
+        )
+        .unwrap();
+        assert!(reverse.found);
+        assert_eq!(reverse.direction.as_deref(), Some("reverse"));
+    }
+
+    /// No route is an explicit answer: empty routes, a gap that names both
+    /// ends and both walks, and nothing plausible in their place.
+    #[test]
+    fn no_route_fails_loud_with_the_gap() {
+        let store = InMemoryGraph::new();
+        let a = function("a", "src/a.ts");
+        let x = function("x", "src/x.ts");
+        let b = function("b", "src/b.ts");
+        seed(
+            &store,
+            &[&a, &x, &b],
+            &[relation(&a, &x, RelationKind::Calls)],
+        );
+
+        let response = build_path_response(&store, &request("a", "b")).unwrap();
+        assert!(!response.found);
+        assert!(response.routes.is_empty());
+        assert_eq!(response.routes_total, 0);
+        assert!(response.direction.is_none());
+        let gap = response.gap.as_ref().unwrap();
+        assert_eq!(gap.reason, "frontier_exhausted");
+        assert!(
+            gap.detail.contains("'a'") && gap.detail.contains("'b'"),
+            "{gap:?}"
+        );
+        assert!(gap.detail.contains("forward walk") && gap.detail.contains("reverse walk"));
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["found"], serde_json::json!(false));
+        assert_eq!(json["routes"], serde_json::json!([]));
+        assert!(json["gap"]["detail"].is_string());
+    }
+
+    /// A twin is pinned by `name@file` or `from_file`, the choice is disclosed
+    /// either way, and a no-route answer across a twin names the twin.
+    #[test]
+    fn a_twin_is_pinned_by_file_and_disclosed_by_name() {
+        let store = InMemoryGraph::new();
+        let declared = make_entity("run", "src/main.c", EntityKind::Function, 3);
+        let defined = make_entity("run", "src/mod1.c", EntityKind::Function, 40);
+        let target = function("target", "src/mod2.c");
+        seed(
+            &store,
+            &[&declared, &defined, &target],
+            &[relation(&defined, &target, RelationKind::Calls)],
+        );
+
+        let pinned = build_path_response(&store, &request("run@mod1.c", "target")).unwrap();
+        assert!(pinned.found, "{pinned:?}");
+        assert_eq!(pinned.from.entity_id, defined.id.to_string());
+        assert_eq!(pinned.from.addressed_by, "name_and_file");
+        assert_eq!(pinned.from.same_name_candidates, 2);
+        assert_eq!(pinned.from.other_candidates.len(), 1);
+        assert_eq!(
+            pinned.from.other_candidates[0].entity_id,
+            declared.id.to_string()
+        );
+
+        let by_flag = build_path_response(
+            &store,
+            &PathRequest {
+                from_file: Some("src/mod1.c".to_string()),
+                ..request("run", "target")
+            },
+        )
+        .unwrap();
+        assert_eq!(by_flag.from.entity_id, defined.id.to_string());
+        assert_eq!(by_flag.from.addressed_by, "name_and_file");
+
+        let wrong_twin = build_path_response(&store, &request("run@main.c", "target")).unwrap();
+        assert!(!wrong_twin.found);
+        assert_eq!(wrong_twin.from.entity_id, declared.id.to_string());
+
+        let by_name = build_path_response(&store, &request("run", "target")).unwrap();
+        assert_eq!(by_name.from.addressed_by, "name");
+        assert_eq!(by_name.from.same_name_candidates, 2);
+
+        let missing = build_path_response(&store, &request("run@nowhere.c", "target"));
+        let error = missing.expect_err("a file that holds no twin is a miss");
+        assert!(error.is_resolution_miss());
+        let message = error.to_string();
+        assert!(
+            message.contains("src/main.c") && message.contains("src/mod1.c"),
+            "the miss names the files the twins live in: {message}"
+        );
+    }
+
+    /// A name-addressed twin that hides the route is named in the gap.
+    #[test]
+    fn a_no_route_answer_names_a_twin_it_did_not_walk() {
+        let store = InMemoryGraph::new();
+        let declared = make_entity("run", "src/main.c", EntityKind::Function, 3);
+        let defined = make_entity("run", "src/mod1.c", EntityKind::Function, 40);
+        let target = function("target", "src/mod2.c");
+        seed(
+            &store,
+            &[&declared, &defined, &target],
+            &[relation(&defined, &target, RelationKind::Calls)],
+        );
+        let response = build_path_response(&store, &request("run@main.c", "target")).unwrap();
+        assert!(!response.found);
+        // Pinned by file, so the gap does not claim ambiguity; the twin count
+        // is on the endpoint for the reader instead.
+        assert_eq!(response.from.same_name_candidates, 2);
+
+        let mut by_name = build_path_response(&store, &request("run", "target")).unwrap();
+        // Force the by-name choice onto the declaration to exercise the clause.
+        by_name.from.addressed_by = "name".to_string();
+        by_name.from.file = Some("src/main.c".to_string());
+        let gap = compose_gap(&by_name.from, &by_name.to, 6, &by_name.explored);
+        assert!(
+            gap.detail.contains("one of 2 entities with that name"),
+            "{gap:?}"
+        );
+    }
+
+    /// A class stands for its members: the route runs through the method that
+    /// carries it, and the containment hops are shown with their direction.
+    #[test]
+    fn a_class_reaches_through_its_members() {
+        let store = InMemoryGraph::new();
+        let widget = make_entity("CodeEditorWidget", "src/widget.ts", EntityKind::Class, 20);
+        let execute = make_entity(
+            "CodeEditorWidget.executeEdits",
+            "src/widget.ts",
+            EntityKind::Method,
+            300,
+        );
+        let push = make_entity(
+            "TextModel.pushEditOperations",
+            "src/model.ts",
+            EntityKind::Method,
+            900,
+        );
+        let model = make_entity("TextModel", "src/model.ts", EntityKind::Class, 50);
+        seed(
+            &store,
+            &[&widget, &execute, &push, &model],
+            &[
+                relation(&widget, &execute, RelationKind::Contains),
+                call_at(&execute, &push, 310),
+                relation(&model, &push, RelationKind::Contains),
+            ],
+        );
+
+        let response =
+            build_path_response(&store, &request("CodeEditorWidget", "TextModel")).unwrap();
+        assert!(response.found, "{response:?}");
+        assert_eq!(response.from.members_expanded, 1);
+        assert_eq!(response.to.members_expanded, 1);
+        let route = &response.routes[0];
+        assert_eq!(route.hops, 3);
+        assert_eq!(route.walked_hops, 1);
+        assert_eq!(
+            names(route),
+            vec![
+                "CodeEditorWidget",
+                "CodeEditorWidget.executeEdits",
+                "TextModel.pushEditOperations",
+                "TextModel"
+            ]
+        );
+        assert_eq!(route.steps[0].relation.as_deref(), Some("Contains"));
+        assert_eq!(route.steps[0].edge.as_deref(), Some("outgoing"));
+        assert_eq!(route.steps[1].relation.as_deref(), Some("Calls"));
+        assert_eq!(route.steps[1].site_lines, vec![311]);
+        assert_eq!(route.steps[2].relation.as_deref(), Some("Contains"));
+        assert_eq!(route.steps[2].edge.as_deref(), Some("incoming"));
+        assert!(route.steps[3].relation.is_none());
+
+        let lines = render_route_lines(route);
+        assert_eq!(lines.len(), 4, "one line per hop plus the start: {lines:?}");
+        assert!(lines[1].starts_with("-Contains->"), "{lines:?}");
+        assert!(lines[2].starts_with("-Calls@311->"), "{lines:?}");
+        assert!(lines[3].starts_with("<-Contains-"), "{lines:?}");
+        let compact = render_compact(&response);
+        assert!(
+            compact.starts_with("route 1 of 1 (forward, 3 hops): CodeEditorWidget -> TextModel\n")
+        );
+    }
+
+    /// A method never reaches its siblings through its class: the expansion
+    /// runs down from an endpoint only.
+    #[test]
+    fn a_member_does_not_reach_its_sibling_through_the_class() {
+        let store = InMemoryGraph::new();
+        let class = make_entity("A", "src/a.ts", EntityKind::Class, 1);
+        let m = make_entity("A.m", "src/a.ts", EntityKind::Method, 10);
+        let k = make_entity("A.k", "src/a.ts", EntityKind::Method, 20);
+        let target = function("target", "src/t.ts");
+        seed(
+            &store,
+            &[&class, &m, &k, &target],
+            &[
+                relation(&class, &m, RelationKind::Contains),
+                relation(&class, &k, RelationKind::Contains),
+                relation(&k, &target, RelationKind::Calls),
+            ],
+        );
+        let from_method = build_path_response(
+            &store,
+            &PathRequest {
+                direction: Some(PathDirection::Forward),
+                ..request("A.m", "target")
+            },
+        )
+        .unwrap();
+        assert!(!from_method.found, "{from_method:?}");
+        let from_class = build_path_response(&store, &request("A", "target")).unwrap();
+        assert!(from_class.found);
+        assert_eq!(names(&from_class.routes[0]), vec!["A", "A.k", "target"]);
+    }
+
+    /// A work ceiling stops the walk and the answer says the graph beyond it
+    /// was not explored.
+    #[test]
+    fn a_work_ceiling_stops_the_walk_and_says_so() {
+        let store = InMemoryGraph::new();
+        let hub = function("hub", "src/hub.ts");
+        let far = function("far", "src/far.ts");
+        let mut entities = vec![hub.clone(), far.clone()];
+        let mut relations = Vec::new();
+        for index in 0..40 {
+            let spoke = function(&format!("spoke{index}"), "src/spokes.ts");
+            relations.push(relation(&hub, &spoke, RelationKind::Calls));
+            entities.push(spoke);
+        }
+        let refs: Vec<&Entity> = entities.iter().collect();
+        seed(&store, &refs, &relations);
+
+        let response = build_path_response_within(
+            &store,
+            &PathRequest {
+                direction: Some(PathDirection::Forward),
+                ..request("hub", "far")
+            },
+            PathBudget::bounded(10, Duration::from_secs(30)),
+        )
+        .unwrap();
+        assert!(!response.found);
+        assert_eq!(response.explored[0].stopped_by, "edge_ceiling");
+        let gap = response.gap.as_ref().unwrap();
+        assert_eq!(gap.reason, "edge_ceiling");
+        assert!(gap.detail.contains("edge ceiling"), "{gap:?}");
+    }
+
+    /// The handler answers JSON with the keys the negative classifier and the
+    /// envelope read, refuses a missing end as a tool error, and refuses a
+    /// missing parameter as invalid params.
+    #[test]
+    fn the_handler_answers_json_and_refuses_a_missing_end() {
+        let store = InMemoryGraph::new();
+        let a = function("a", "src/a.ts");
+        let b = function("b", "src/b.ts");
+        seed(&store, &[&a, &b], &[relation(&a, &b, RelationKind::Calls)]);
+
+        let args: HashMap<String, serde_json::Value> = [
+            ("from".to_string(), serde_json::json!("a")),
+            ("to".to_string(), serde_json::json!("b")),
+        ]
+        .into_iter()
+        .collect();
+        let result = handle_trace_path(&args, &store).unwrap();
+        assert_ne!(result.is_error, Some(true));
+        let crate::types::ContentBlock::Text { text } = &result.content[0];
+        let payload: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(payload["found"], serde_json::json!(true));
+        assert_eq!(payload["routes"].as_array().unwrap().len(), 1);
+        assert_eq!(payload["routes_total"], serde_json::json!(1));
+        assert_eq!(
+            payload["from"]["same_name_candidates"],
+            serde_json::json!(1)
+        );
+        assert!(
+            payload
+                .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
+                .is_some(),
+            "the payload carries the coverage observation under the key the classifier reads"
+        );
+
+        let enveloped =
+            crate::finalize_with_envelope(result, crate::Envelope::offline(), TOOL_NAME);
+        let crate::types::ContentBlock::Text { text } = &enveloped.content[0];
+        let annotated: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert!(annotated.get(crate::ENVELOPE_KEY).is_some(), "{annotated}");
+        assert!(annotated.get(crate::NEGATIVE_KEY).is_some(), "{annotated}");
+
+        let missing: HashMap<String, serde_json::Value> = [
+            ("from".to_string(), serde_json::json!("nope")),
+            ("to".to_string(), serde_json::json!("b")),
+        ]
+        .into_iter()
+        .collect();
+        let refused = handle_trace_path(&missing, &store).unwrap();
+        assert_eq!(refused.is_error, Some(true));
+        let crate::types::ContentBlock::Text { text } = &refused.content[0];
+        assert!(text.contains("nope"), "{text}");
+
+        let no_to: HashMap<String, serde_json::Value> =
+            [("from".to_string(), serde_json::json!("a"))]
+                .into_iter()
+                .collect();
+        assert!(matches!(
+            handle_trace_path(&no_to, &store),
+            Err(McpError::InvalidParams(_))
+        ));
+    }
+
+    /// An absent route carries a negative whose kind names the route, so an
+    /// agent calibrates the absence instead of reading an empty list.
+    #[test]
+    fn a_no_route_answer_carries_a_no_route_negative() {
+        let store = InMemoryGraph::new();
+        let a = function("a", "src/a.ts");
+        let b = function("b", "src/b.ts");
+        seed(&store, &[&a, &b], &[]);
+        let args: HashMap<String, serde_json::Value> = [
+            ("from".to_string(), serde_json::json!("a")),
+            ("to".to_string(), serde_json::json!("b")),
+        ]
+        .into_iter()
+        .collect();
+        let result = handle_trace_path(&args, &store).unwrap();
+        let enveloped =
+            crate::finalize_with_envelope(result, crate::Envelope::offline(), TOOL_NAME);
+        let crate::types::ContentBlock::Text { text } = &enveloped.content[0];
+        let annotated: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(annotated["found"], serde_json::json!(false));
+        assert_eq!(
+            annotated[crate::NEGATIVE_KEY]["kind"],
+            serde_json::json!("no_route")
+        );
+        assert!(annotated[crate::NEGATIVE_KEY]["safe_to_conclude_absent"].is_boolean());
+    }
+
+    /// A qualified name that names no entity resolves to its leaf when one
+    /// entity carries it, and is refused with the candidates listed when
+    /// several do, so a twin is never chosen silently under a qualifier.
+    #[test]
+    fn a_qualified_name_takes_a_unique_leaf_and_refuses_leaf_twins() {
+        let store = InMemoryGraph::new();
+        let run = function("run", "src/core/main.rs");
+        let search_a = function("search", "src/core/main.rs");
+        let search_b = function("search", "src/core/search.rs");
+        seed(
+            &store,
+            &[&run, &search_a, &search_b],
+            &[
+                relation(&run, &search_a, RelationKind::Calls),
+                relation(&search_a, &search_b, RelationKind::Calls),
+            ],
+        );
+
+        let unique =
+            build_path_response(&store, &request("Worker::run", "search@search.rs")).unwrap();
+        assert!(unique.found, "{unique:?}");
+        assert_eq!(unique.from.entity_id, run.id.to_string());
+        assert_eq!(unique.from.addressed_by, "leaf_name");
+
+        let refused = build_path_response(&store, &request("Worker::run", "Worker::search"));
+        let error = refused.expect_err("two leaf twins under a qualifier are refused");
+        assert!(error.is_resolution_miss());
+        let message = error.to_string();
+        assert!(message.contains("names 2 entities"), "{message}");
+        assert!(
+            message.contains("src/core/main.rs") && message.contains("src/core/search.rs"),
+            "the refusal lists the twins so the caller can pin one: {message}"
+        );
+
+        let pinned =
+            build_path_response(&store, &request("Worker::run", "Worker::search@search.rs"))
+                .unwrap();
+        assert_eq!(pinned.to.entity_id, search_b.id.to_string());
+        assert_eq!(pinned.to.addressed_by, "name_and_file");
+    }
+
+    #[test]
+    fn direction_parse_accepts_aliases_and_refuses_nonsense() {
+        assert_eq!(
+            PathDirection::parse("Forward").unwrap(),
+            PathDirection::Forward
+        );
+        assert_eq!(PathDirection::parse("in").unwrap(), PathDirection::Reverse);
+        assert_eq!(PathDirection::parse("").unwrap(), PathDirection::Either);
+        assert!(PathDirection::parse("sideways").is_err());
+    }
+
+    #[test]
+    fn file_hints_match_suffixes_and_longer_paths() {
+        let entity = function("f", "src/requests/sessions.py");
+        assert!(file_matches(&entity, "sessions.py"));
+        assert!(file_matches(&entity, "requests/sessions.py"));
+        assert!(file_matches(&entity, "src/requests/sessions.py"));
+        assert!(file_matches(&entity, "/workspace/src/requests/sessions.py"));
+        assert!(!file_matches(&entity, "models.py"));
+        assert!(!file_matches(&entity, "s.py"));
+        assert_eq!(split_pinned("run@src/a.c"), ("run", Some("src/a.c")));
+        assert_eq!(split_pinned("run"), ("run", None));
+        assert_eq!(split_pinned("@a.c"), ("@a.c", None));
+    }
+}

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -63,6 +63,8 @@ pub const NEGATIVE_KEY: &str = "negative";
 /// The file-enumeration tool, named once here so the spec, the gate and the
 /// dependency declaration below cannot drift from the registry that serves it.
 const FILE_ENTITIES_TOOL: &str = crate::handlers::file_entities::TOOL_NAME;
+/// The route query, named from the handler that defines it for the same reason.
+const TRACE_PATH_TOOL: &str = crate::handlers::path::TOOL_NAME;
 
 /// Why a file enumeration cannot be certified as the file's whole entity set,
 /// or `None` when nothing stops it.
@@ -268,6 +270,17 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
             always: false,
             class: NegativeClass::Structural,
         },
+        // The route query. Its empty answer is the sharpest absence a graph
+        // walk can claim, "A never reaches B", and it rests on the same typed
+        // reference edges the walkers above read, so it is gated by the same
+        // coverage facts plus the two-ended resolution gaps `path_gaps` adds.
+        TRACE_PATH_TOOL => RetrievalSpec {
+            field: "routes",
+            kind: "no_route",
+            subject: "no route was found between the two entities that were named",
+            always: false,
+            class: NegativeClass::Structural,
+        },
         // Bare-array payloads (wrapped under `result` by the annotator).
         "dead_code" => RetrievalSpec {
             field: "",
@@ -369,7 +382,9 @@ pub(crate) fn absence_cross_file_classes(tool: &str, payload: &Value) -> Vec<Str
                     .collect()
             })
             .unwrap_or_else(reference_classes),
-        "trace_data_flow" | "impact_analysis" | "get_context_pack" => reference_classes(),
+        "trace_data_flow" | "impact_analysis" | "get_context_pack" | TRACE_PATH_TOOL => {
+            reference_classes()
+        }
         _ => Vec::new(),
     }
 }
@@ -410,6 +425,7 @@ fn absence_is_language_scoped(tool: &str) -> bool {
             | "find_dead_code_seeded"
             | "graph_neighborhood"
             | "get_context_pack"
+            | TRACE_PATH_TOOL
     )
 }
 
@@ -2558,6 +2574,16 @@ pub fn negative_for(
         }
     }
 
+    // A route has two ends and a bound, and each is a way an empty answer can
+    // be true of something other than what was asked: a twin that was never
+    // walked, or a depth the walk stopped at before its frontier emptied.
+    if tool == TRACE_PATH_TOOL {
+        let gaps = path_gaps(payload);
+        if !gaps.is_empty() {
+            push_gap(&mut trustworthy, &mut trust_reason, gaps.join("; "));
+        }
+    }
+
     // The payload's own `degradations[]` is a report about THIS query, and the
     // verdict has to consume it or contradict it. A page that names an active
     // degradation beside a negative claiming none is the shape this whole
@@ -2680,6 +2706,58 @@ pub fn negative_for(
 /// see them at all: there is no payload to count, and the response used to
 /// arrive as a bare `{"message": ...}` with the envelope but no negative beside
 /// it, which is the one shape an agent cannot calibrate.
+/// Every reason an empty route set is unsafe to read as "A never reaches B",
+/// in a stable order.
+///
+/// The walker publishes both ends with `addressed_by` and the count of entities
+/// carrying the same exact name. An end the caller pinned (by id or by file)
+/// was chosen by the caller and is no gap whatever the count says; an end the
+/// ranking chose among several is, because the walk ran from one twin and the
+/// others were never seeds or goals. The stop reason is the other half: a walk
+/// that emptied its frontier explored everything reachable inside `max_depth`,
+/// while one that stopped at the bound or at a work ceiling did not.
+fn path_gaps(payload: &Value) -> Vec<String> {
+    let mut gaps = Vec::new();
+    for which in ["from", "to"] {
+        let end = payload.get(which).unwrap_or(&Value::Null);
+        let pinned = matches!(
+            end.get("addressed_by").and_then(Value::as_str),
+            Some("entity_id") | Some("name_and_file")
+        );
+        match end.get("same_name_candidates").and_then(Value::as_u64) {
+            None => gaps.push(format!(
+                "{which}_resolution_unreported: this answer did not report how many entities its \
+                 '{which}' end could have been resolved from, so an empty route set may describe \
+                 a same-named sibling rather than the entity that was asked about"
+            )),
+            Some(candidates) if candidates > 1 && !pinned => gaps.push(format!(
+                "{which}_ambiguous: {candidates} entities carry the name '{}' and the walk used one \
+                 of them, so no route from or to the others was looked for; pin the one you mean \
+                 with name@file or its entity id",
+                end.get("name").and_then(Value::as_str).unwrap_or("?")
+            )),
+            _ => {}
+        }
+    }
+    match payload
+        .get("gap")
+        .and_then(|gap| gap.get("reason"))
+        .and_then(Value::as_str)
+    {
+        Some("depth_bound") => gaps.push(
+            "walk_depth_bounded: the walk stopped at max_depth before its frontier emptied, so a \
+             longer route may exist; raise max_depth"
+                .to_string(),
+        ),
+        Some(reason @ ("edge_ceiling" | "time_budget" | "cancelled")) => gaps.push(format!(
+            "walk_bounded: the walk stopped at its {reason} before its frontier emptied, so a route \
+             may exist beyond what was explored"
+        )),
+        _ => {}
+    }
+    gaps
+}
+
 fn resolution_miss_spec(tool: &str) -> Option<(&'static str, &'static str)> {
     match tool {
         // The review family's files mode resolves each named path to the
@@ -2699,6 +2777,10 @@ fn resolution_miss_spec(tool: &str) -> Option<(&'static str, &'static str)> {
         "trace_data_flow" => Some((
             "focal_not_resolved",
             "the focal that was asked about could not be resolved, so no data-flow chain was walked",
+        )),
+        TRACE_PATH_TOOL => Some((
+            "endpoint_not_resolved",
+            "one of the two entities that were named could not be resolved, so no route was walked",
         )),
         // An unknown id and an entity with no recorded history are the same
         // shape on this tool's success path — change_count 0, latest_change
@@ -7268,5 +7350,78 @@ mod tests {
         let gap = absence_coverage_gap("trace_data_flow", &unlinked)
             .expect("a graph holding no cross-file calls cannot complete a call chain");
         assert!(gap.starts_with("cross_file_edges_absent"), "{gap}");
+    }
+
+    /// A route query's empty answer is a claim about two names. A twin the
+    /// ranking chose among makes it inconclusive; a twin the caller pinned by
+    /// file does not, because the caller chose.
+    #[test]
+    fn a_no_route_answer_across_an_unpinned_twin_is_inconclusive() {
+        let payload = json!({
+            "from": {"name": "run", "addressed_by": "name", "same_name_candidates": 2},
+            "to": {"name": "target", "addressed_by": "name", "same_name_candidates": 1},
+            "found": false,
+            "routes": [],
+            "routes_total": 0,
+            "gap": {"reason": "frontier_exhausted", "detail": "", "remediation": ""},
+            "degradations": [],
+        });
+        let negative = negative_for(
+            crate::handlers::path::TOOL_NAME,
+            &payload,
+            &structural_ready_envelope(),
+        )
+        .expect("a route query is negative-capable");
+        assert_eq!(negative["kind"], json!("no_route"));
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("from_ambiguous"), "{reason}");
+        assert!(!reason.contains("to_ambiguous"), "{reason}");
+
+        let mut pinned = payload.clone();
+        pinned["from"]["addressed_by"] = json!("name_and_file");
+        let negative = negative_for(
+            crate::handlers::path::TOOL_NAME,
+            &pinned,
+            &structural_ready_envelope(),
+        )
+        .unwrap();
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(!reason.contains("from_ambiguous"), "{reason}");
+    }
+
+    /// A walk that stopped at its depth bound did not explore the graph it
+    /// claims nothing about, and the verdict says so.
+    #[test]
+    fn a_depth_bounded_no_route_answer_is_inconclusive() {
+        let payload = json!({
+            "from": {"name": "a", "addressed_by": "entity_id", "same_name_candidates": 1},
+            "to": {"name": "b", "addressed_by": "entity_id", "same_name_candidates": 1},
+            "found": false,
+            "routes": [],
+            "routes_total": 0,
+            "gap": {"reason": "depth_bound", "detail": "", "remediation": ""},
+            "degradations": [],
+        });
+        let negative = negative_for(
+            crate::handlers::path::TOOL_NAME,
+            &payload,
+            &structural_ready_envelope(),
+        )
+        .unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("walk_depth_bounded"), "{reason}");
+
+        let mut exhausted = payload.clone();
+        exhausted["gap"]["reason"] = json!("frontier_exhausted");
+        let negative = negative_for(
+            crate::handlers::path::TOOL_NAME,
+            &exhausted,
+            &structural_ready_envelope(),
+        )
+        .unwrap();
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(!reason.contains("walk_depth_bounded"), "{reason}");
     }
 }

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -676,6 +676,31 @@ fn registered_tools() -> ToolsListResult {
                 }),
             },
             ToolDefinition {
+                name: crate::handlers::path::TOOL_NAME.into(),
+                description: crate::handlers::path::TRACE_PATH_DESC.into(),
+                annotations: read_only("Trace path"),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "from": { "type": "string", "description": "Source end: entity UUID, exact name, or name@file to pin one of two same-named entities." },
+                        "to": { "type": "string", "description": "Target end, in the same forms." },
+                        "from_file": { "type": "string", "description": "Pin `from` to the entity of that name in the file this path or path suffix names. Same request as the name@file spelling." },
+                        "to_file": { "type": "string", "description": "Pin `to` the same way." },
+                        "max_depth": { "type": "integer", "description": "Hops walked between the two ends (default 6, ceiling 12). Containment hops joining a class to its members are not counted.", "default": 6, "minimum": 1, "maximum": 12 },
+                        "limit": { "type": "integer", "description": "Routes returned, shortest first (default 3, ceiling 25). `routes_total` says how many shortest routes exist.", "default": 3, "minimum": 1, "maximum": 25 },
+                        "direction": {
+                            "type": "string",
+                            "enum": ["either", "forward", "reverse"],
+                            "description": "'forward' means from reaches to, 'reverse' means to reaches from, 'either' (default) tries forward first and says which sense held.",
+                            "default": "either"
+                        },
+                        "include_type_edges": { "type": "boolean", "description": "Walk through UsesType edges too (default false).", "default": false },
+                        "max_chars": max_chars_property()
+                    },
+                    "required": ["from", "to"]
+                }),
+            },
+            ToolDefinition {
                 name: "find_references".into(),
                 description: crate::handlers::entities::FIND_REFERENCES_DESC.into(),
                 annotations: read_only("Find references"),
@@ -1549,6 +1574,10 @@ pub fn agent_default_tool_names() -> &'static [&'static str] {
         // that turns an id into the exact graph-owned body.
         "get_entity_source",
         "trace_data_flow",
+        // The route between two named things is the ordinary shape of a code
+        // question, and no single-rooted walk can answer it (FIR-3070). It is
+        // one call where the locate-then-trace loop cost five.
+        crate::handlers::path::TOOL_NAME,
         "find_references",
         "graph_neighborhood",
         // The enumeration half of discovery. Every other retrieval tool in this
@@ -2251,8 +2280,8 @@ mod tests {
         let list = tool_definitions();
         // 54 + 5 transaction tools + 1 semantic_locate + 1 shadow_gate_report
         // + 1 get_entity_sources + 2 exact artifact tools
-        // + 1 list_file_entities = 65
-        assert_eq!(list.tools.len(), 65);
+        // + 1 list_file_entities + 1 trace_path = 66
+        assert_eq!(list.tools.len(), 66);
     }
 
     /// The reference lists each category's members on a line opening with this
@@ -2480,8 +2509,11 @@ The Kin MCP server exposes 2 semantic tools to AI assistants.
             list.tools.iter().map(|t| t.name.as_str()).collect();
         let profile = agent_default_tool_names();
 
+        // 21 since trace_path joined: a route query between two entities is the
+        // question the wedge is asked most, and it was the one tool the belt
+        // could not answer with fewer than five calls.
         assert!(
-            profile.len() >= 10 && profile.len() <= 20,
+            profile.len() >= 10 && profile.len() <= 21,
             "agent-default should be small but cover the wedge; got {}",
             profile.len()
         );
@@ -2514,6 +2546,9 @@ The Kin MCP server exposes 2 semantic tools to AI assistants.
             // change affects cannot do the thing Kin is described as doing, and
             // the CLI answering it is no help to the agent surface.
             "impact_analysis",
+            // The route question. Without it an agent asked "how does A reach
+            // B" spends five calls on single-rooted walks (FIR-3070).
+            crate::handlers::path::TOOL_NAME,
         ] {
             assert!(
                 profile.contains(&required),

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ Kin is pre-1.0 and the command surface moves. Where this page and your build dis
 
 Descriptions are the command's own help text. A `--json` flag switches that command to machine-readable output. Angle brackets mark a required argument, square brackets an optional one, and a trailing `...` an argument that takes the rest of the line.
 
-83 commands are documented below. 4 further commands (`bench-meta`, `contextbench-locate`, `prepared-state`, `semantic-only-guard`) are hidden from `kin --help` because they exist for benchmark and internal orchestration, and they are not part of the supported surface.
+84 commands are documented below. 4 further commands (`bench-meta`, `contextbench-locate`, `prepared-state`, `semantic-only-guard`) are hidden from `kin --help` because they exist for benchmark and internal orchestration, and they are not part of the supported surface.
 
 `kin capabilities` prints the readiness matrix for the Git-replacement command set, and `kin capabilities --json` gives the same inventory to a machine. Reach for it before scripting against a command you have not used.
 
@@ -30,7 +30,7 @@ Every command also shares one rule for a reader that goes away. When the process
 ## Contents
 
 - [Start here](#start-here): `init`, `clone`, `status`, `commit`, `log`, `diff`
-- [Ask the graph](#ask-the-graph): `locate`, `search`, `trace`, `impact`, `refs`, `context`
+- [Ask the graph](#ask-the-graph): `locate`, `search`, `trace`, `path`, `impact`, `refs`, `context`
 - [More graph queries](#more-graph-queries): `history`, `blame`, `overview`, `deps`, `xref`, `dead-code`, `trace-data-flow`, `security`, `languages`, `scope`, `locate-debug`
 - [Branches, merges, and exact trees](#branches-merges-and-exact-trees): `branch`, `checkout`, `merge`, `conflicts`, `resolve`, `stash`, `rollback`, `tag`, `semver`, `purge-ignored`, `admit`, `reconcile`, `migrate`, `eject`, `git`
 - [Review and verification](#review-and-verification): `review`, `approvals`, `verify`, `spec`, `audit`, `rename`
@@ -253,6 +253,32 @@ empty. That holds for the name form, for an id this repository's graph does not 
 qualifier that excludes every match, which reports what the name alone does reach rather than
 claiming the entity is absent. `kin context`, `kin refs`, `kin xref` and `kin impact` refuse the
 same way.
+
+### `kin path`
+
+Find the shortest routes from one entity to another over the graph's call, instantiation, reference, import and include edges. Each end is an entity name, an entity id, or `name@file` to pin one of two same-named entities. A class stands for its members, so a route between two classes runs through the methods that carry it. Exits 3 when the graph holds no route inside the depth bound, with the gap on stderr.
+
+```
+kin path <from> <to> [options]
+```
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<from>` | yes | Source entity: name, id, or name@file |
+| `<to>` | yes | Target entity: name, id, or name@file |
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--from-file <file>` |  | Pin the source to the entity of that name in this file (path or path suffix) |
+| `--to-file <file>` |  | Pin the target the same way |
+| `--max-depth <n>` |  | Hops walked between the two ends (default 6, ceiling 12); containment hops are not counted |
+| `--limit <k>` |  | Routes printed, shortest first (default 3, ceiling 25) |
+| `--direction <dir>` |  | `forward` (from reaches to), `reverse` (to reaches from), or `either` (default; forward first, reports which held) |
+| `--include-type-edges` |  | Walk through type-annotation edges too |
+| `--json` |  | Output machine-readable JSON, `_kin` envelope included |
+| `--compact` |  | One line per hop and nothing else, sized for a prompt |
+
+Every hop names the entity, its kind, its file and line, the relation that joins it to the next hop and the 1-based lines of the syntax that produced that edge (or, when the graph recorded no site, why under `site_lines_absent_reason`). The answer says which sense held (`direction`), how many shortest routes exist (`routes_total`), what each walk explored and why it stopped (`explored`), and how each end resolved, including how many entities carry the same exact name (`same_name_candidates`). A qualified name (`Worker::search`) that names no entity resolves to its bare leaf when exactly one entity carries it, and is refused with the candidates listed when several do, so a twin is never chosen silently under a qualifier. A no-route answer is explicit: `found: false`, an empty `routes`, and a `gap` naming what stopped the walk (`frontier_exhausted`, `depth_bound`, `edge_ceiling`, `time_budget`) with the remedy, and the `_kin.verdict` beside it says whether that absence can be trusted. The same query is served to agents as the `trace_path` MCP tool.
 
 ### `kin impact`
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # Model Context Protocol (MCP) Tool Surface Reference
 
-The Kin MCP server exposes 65 semantic tools to AI assistants (Claude, Cursor, Gemini,
+The Kin MCP server exposes 66 semantic tools to AI assistants (Claude, Cursor, Gemini,
 Codex, etc.). These tools bridge the gap between traditional file-first navigation and
 Kin's graph-first semantic substrate: instead of issuing raw shell commands or reading raw
 files, an assistant interacts with the codebase through entity-level primitives.
@@ -197,10 +197,11 @@ reported rather than served as a confident answer.
 ---
 
 ## 2. Tracing & References
-*Tools:* `trace_computation`, `trace_data_flow`, `find_references`, `bulk_check_references`, `entity_history`
+*Tools:* `trace_computation`, `trace_data_flow`, `trace_path`, `find_references`, `bulk_check_references`, `entity_history`
 
 - **`trace_computation`**: Get a focal entity together with its control-/data-flow neighborhood in one structured response (a flat snapshot, not an ordered walk). The response carries its body plus callers, callees, and imports.
 - **`trace_data_flow`**: Walk the directional call/data-flow chain rooted at a focal entity and return it as an ordered list of steps (the path-walk counterpart to `trace_computation`'s flat neighborhood).
+- **`trace_path`**: The route between two named entities, for the question "how does A reach B" that no single-rooted walk answers. It resolves both ends (by exact name, entity id, or `name@file` to pin a twin; a qualified name that matches nothing takes its bare leaf when that is unique and is refused with the candidates listed when it is not), searches breadth-first over call, instantiation, reference, import and include edges, and returns up to `limit` shortest routes, every hop carrying its kind, file, line, the relation into the next hop and the syntax lines that produced it. A class stands for its members, so a route between two classes runs through the methods that carry it, and those containment hops are shown. `direction` defaults to `either`: forward (A reaches B) is tried first and the answer says which sense held. No route is explicit rather than plausible: `found: false`, `routes: []`, a `gap` naming what stopped the walk and how much of the graph it explored, and the same-name twin count on each end; the `negative` and `_kin.verdict` beside it say whether the absence can be trusted. In the `agent-default` profile.
 - **`find_references`**: Find all entities that import, call, or reference a target symbol. One row is one referencing entity, so two callers in one file are two rows, and `total_upstream` counts those entities, the same unit `kin refs` prints. The `counts` object names the unit and adds the file and reference-site totals beside it. A row's `reference_lines` gives the lines inside that caller which reference the target, and names why under `reference_lines_absent_reason` when the graph does not carry them. Rows omit the caller's body by default; pass `include_snippets=true` for it.
 - **`bulk_check_references`**: Classify many entities by reachability in one call.
 - **`entity_history`**: Retrieve version changes scoped to a specific entity.


### PR DESCRIPTION
`kin path <from> <to>` answers "how does A reach B" in one call, and the same query ships on the daemon as `POST /commands/path` and to agents as the `trace_path` MCP tool in the agent-default profile. Until now every Kin query was rooted at one entity, so the ordinary shape of a code question, a route between two named things, cost an agent five locate-and-trace calls and 30,196 tokens on the VS Code editor subtree (FIR-3070), and a pack built from one end refused the question outright.

One walker serves all three surfaces. It lives in `kin_mcp::handlers::path`, generic over `GraphStore`, because the crates stack kin-mcp under kin-cli under kin-daemon and the MCP crate already walks a generic store for `trace_data_flow`. Both ends resolve by exact name, entity id, or `name@file` (also `--from-file` and `--to-file`) through the same ranking `trace_data_flow` uses, and each end reports how it was addressed and how many entities carry the same exact name. A class stands for its members: each end expands downward over `Contains` before the walk, never upward, so a route between two classes runs through the methods that carry it and a method never reaches a sibling through its class. The walk is breadth-first over the graph's call, instantiation, import, include, macro and reference edges (type edges opt in), records every shortest-path predecessor, and stops at the first level holding a member of the far end, so it returns up to `--limit` shortest routes with `routes_total` and `routes_truncated` beside them. `--direction` defaults to `either`: forward first, then reverse, and the answer says which sense held. Every hop carries id, name, kind, file, lines, the relation into the next hop, its direction and resolution class, and the syntax lines that produced the edge. `--compact` prints one line per hop for a prompt.

No route fails loud. The answer is `found: false` with empty `routes`, a `gap` naming what stopped the walk (`frontier_exhausted`, `depth_bound`, `edge_ceiling`, `time_budget`) with nodes and edges explored and a remedy, twin counts on both ends, exit code 3 on the CLI with the gap on stderr, and a `no_route` negative that `_kin.verdict` reads: an unpinned twin or a bounded walk makes the absence inconclusive. `trace_path` joins the retrieval spec, cross-file coverage classes, language scoping, resolution-miss spec, envelope count unit and response-budget shape, and both docs pages.

Tests: twelve walker tests on a synthetic graph (route found and located, shortest first, the limit with `routes_total`, the depth bound, direction pinned and reported, no route with the gap, a twin pinned by `name@file` and by `--from-file`, a twin named in the gap, a class reaching through its members, a member never reaching a sibling through its class, a work ceiling, the handler's JSON and envelope, the leaf rule), two classifier tests, two report tests and an end-to-end test that inits a repository and drives `kin path` through the daemon. Slotted runs: kin-mcp lib 828 passed, kin-cli path unit tests 2, kin-daemon built, `path_query` 10 passed; `bin/kin-precheck` 16 of 16 gates. Every test was falsified by a mutant that weakens the behaviour it guards (21 mutants, all red, files restored byte for byte; the table is in the lane report).

Measured on fresh stores built by this branch's debug binary under a scratch `KIN_HOME` with `KIN_EMBED_BACKEND=cpu`, whole-process times from a warm daemon, the walk's own clock 0 to 1 ms throughout. hiredis (730 entities): `redisCommand` to `redisBufferWrite` is one forward route of 4 hops in 108 to 135 ms over 18 nodes and 423 edges; `redisCommand` to `sdscatlen` is 2 routes of 4 hops in 94 ms; `redisGetReply` to `redisCommand` is found in the reverse sense in 164 ms; `redisConnect` to `redisContextConnectTcp` is no route in 128 ms, and that is the truth, since `redisConnect` reaches the socket through `redisContextConnectBindTcp` (found in 2 hops). ripgrep (3,808 entities): `main@crates/core/main.rs` to `search@crates/core/main.rs` is 2 hops in 292 ms, `main` to `SearchWorker<W>::search` is 3 hops in 270 ms, and `main` to `search` by bare name is no route within 6 with both ends flagged ambiguous (5 and 3 twins) in 204 ms. The `CodeEditorWidget` to `TextModel` question is unmeasured: the demo container's VS Code store was out of bounds tonight.

Twins on C stores, read against hiredis: the linker attaches `Calls` edges to the header declaration, so `redisConnect` reaches `redisContextConnectBindTcp` at its net.h declaration in 2 hops while the definition in net.c is a same-named twin with no edge joining the pair. The answer says which twin it chose (`file:line`, `same_name_candidates`, `other_candidates`) and the verdict stays inconclusive, and a pin by `name@file` chooses by #1350's shared rule (a body beats a declaration, then file, line, id). Bridging a declaration to its definition inside the walk is a follow-up with its own shape test, so that `main` in five crates never bridges.

Related: FIR-3070. `get_context_pack` is untouched; the multi-focal pack lane has the one-line seam for a `route` block in the lane report.
