### PR TITLE
Read C types through extern C blocks and name typedefs by their identifier

### DIFF
--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -40,13 +40,34 @@ impl LanguageAdapter for CAdapter {
         };
 
         let mut entities = Vec::new();
+        let mut forward_decls = Vec::new();
         let mut relations = Vec::new();
         let mut imports = Vec::new();
         let root = tree.root_node();
         let mut cursor = root.walk();
 
         for child in root.children(&mut cursor) {
-            extract_c_node(&child, source, file_id, &mut entities, &mut relations);
+            extract_c_node(
+                &child,
+                source,
+                file_id,
+                &mut entities,
+                &mut forward_decls,
+                &mut relations,
+            );
+        }
+
+        // A forward declaration names a type whose members are spelled out somewhere
+        // else. Keep it only when this file never spells them out, so an opaque handle
+        // still reaches the graph while `struct redisContext;` does not shadow the
+        // definition that follows it further down the same header.
+        for candidate in forward_decls {
+            let defined_here = entities
+                .iter()
+                .any(|entity| entity.kind == candidate.kind && entity.name == candidate.name);
+            if !defined_here {
+                entities.push(candidate);
+            }
         }
 
         // Recursively extract all includes and ALL_CAPS macro usages across the whole file
@@ -90,6 +111,7 @@ fn extract_c_node(
     source: &[u8],
     file_id: &FilePathId,
     entities: &mut Vec<ExtractedEntity>,
+    forward_decls: &mut Vec<ExtractedEntity>,
     relations: &mut Vec<ExtractedRelation>,
 ) {
     match node.kind() {
@@ -109,66 +131,33 @@ fn extract_c_node(
             }
         }
         "declaration" => {
-            extract_declaration(node, source, file_id, entities);
+            extract_declaration(node, source, file_id, entities, forward_decls);
         }
         "type_definition" => {
-            extract_type_definition(node, source, file_id, entities);
+            extract_type_definition(node, source, file_id, entities, forward_decls);
         }
-        "struct_specifier" => {
-            if let Some(name_node) = node.child_by_field_name("name") {
-                let name = name_node.utf8_text(source).unwrap_or("").to_string();
-                if !name.is_empty() {
-                    entities.push(ExtractedEntity {
-                        kind: EntityKind::Class,
-                        name,
-                        signature: node_signature(node, source),
-                        visibility: Visibility::Public,
-                        doc_summary: extract_preceding_comment(node, source),
-                        fingerprint: compute_fingerprint(node, source),
-                        span: span_from_node(node, file_id),
-                    });
-                }
-            }
-        }
-        // A union is modeled as a Class, mirroring struct handling.
-        "union_specifier" => {
-            if let Some(name_node) = node.child_by_field_name("name") {
-                let name = name_node.utf8_text(source).unwrap_or("").to_string();
-                if !name.is_empty() {
-                    entities.push(ExtractedEntity {
-                        kind: EntityKind::Class,
-                        name,
-                        signature: node_signature(node, source),
-                        visibility: Visibility::Public,
-                        doc_summary: extract_preceding_comment(node, source),
-                        fingerprint: compute_fingerprint(node, source),
-                        span: span_from_node(node, file_id),
-                    });
-                }
-            }
-        }
-        "enum_specifier" => {
-            if let Some(name_node) = node.child_by_field_name("name") {
-                let name = name_node.utf8_text(source).unwrap_or("").to_string();
-                if !name.is_empty() {
-                    entities.push(ExtractedEntity {
-                        kind: EntityKind::EnumDef,
-                        name,
-                        signature: node_signature(node, source),
-                        visibility: Visibility::Public,
-                        doc_summary: extract_preceding_comment(node, source),
-                        fingerprint: compute_fingerprint(node, source),
-                        span: span_from_node(node, file_id),
-                    });
-                }
-            }
+        "struct_specifier" | "union_specifier" | "enum_specifier" => {
+            extract_type_specifier(node, node, source, file_id, entities, forward_decls);
         }
         // Recurse into preprocessor conditional blocks (#ifdef, #ifndef, #if, etc.)
         // so that code inside header guards is still extracted.
-        "preproc_ifdef" | "preproc_if" | "preproc_else" | "preproc_elif" => {
+        //
+        // `extern "C" { ... }` is a linkage_specification whose declaration_list body
+        // holds the rest of the header. The C header idiom opens that brace inside one
+        // `#ifdef __cplusplus` and closes it inside another, so tree-sitter puts every
+        // declaration between them in the body rather than at the top level. An ERROR
+        // node likewise keeps the well-formed subtrees error recovery salvaged. Walk
+        // through all of them, or a header's entire public API stays invisible.
+        "preproc_ifdef"
+        | "preproc_if"
+        | "preproc_else"
+        | "preproc_elif"
+        | "linkage_specification"
+        | "declaration_list"
+        | "ERROR" => {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
-                extract_c_node(&child, source, file_id, entities, relations);
+                extract_c_node(&child, source, file_id, entities, forward_decls, relations);
             }
         }
         "preproc_def" | "preproc_function_def" => {
@@ -239,64 +228,25 @@ fn extract_declaration(
     source: &[u8],
     file_id: &FilePathId,
     entities: &mut Vec<ExtractedEntity>,
+    forward_decls: &mut Vec<ExtractedEntity>,
 ) {
     let text = node.utf8_text(source).unwrap_or("");
 
-    // Check for enum_specifier inside the declaration
-    if let Some(enum_node) = find_child_of_kind(node, "enum_specifier") {
-        if let Some(name_node) = enum_node.child_by_field_name("name") {
-            let name = name_node.utf8_text(source).unwrap_or("").to_string();
-            if !name.is_empty() {
-                entities.push(ExtractedEntity {
-                    kind: EntityKind::EnumDef,
-                    name,
-                    signature: node_signature(node, source),
-                    visibility: Visibility::Public,
-                    doc_summary: extract_preceding_comment(node, source),
-                    fingerprint: compute_fingerprint(node, source),
-                    span: span_from_node(node, file_id),
-                });
-                return;
-            }
+    // A declaration can carry the type it defines: `struct Point { int x; } origin;`.
+    // It can also merely name one: `struct timeval tv;` or
+    // `struct redisReply *redisCommand(...);`. A forward declaration is neither, and
+    // always parses as a bare specifier rather than as a declaration, so a bodyless
+    // specifier here is only this declaration's type. Keep reading past it, because
+    // there may still be a prototype to record.
+    for kind in ["enum_specifier", "struct_specifier", "union_specifier"] {
+        let Some(specifier) = find_child_of_kind(node, kind) else {
+            continue;
+        };
+        if specifier.child_by_field_name("body").is_none() {
+            break;
         }
-    }
-
-    // Check for struct_specifier inside the declaration
-    if let Some(struct_node) = find_child_of_kind(node, "struct_specifier") {
-        if let Some(name_node) = struct_node.child_by_field_name("name") {
-            let name = name_node.utf8_text(source).unwrap_or("").to_string();
-            if !name.is_empty() {
-                entities.push(ExtractedEntity {
-                    kind: EntityKind::Class,
-                    name,
-                    signature: node_signature(node, source),
-                    visibility: Visibility::Public,
-                    doc_summary: extract_preceding_comment(node, source),
-                    fingerprint: compute_fingerprint(node, source),
-                    span: span_from_node(node, file_id),
-                });
-                return;
-            }
-        }
-    }
-
-    // Check for union_specifier inside the declaration (mirrors struct handling)
-    if let Some(union_node) = find_child_of_kind(node, "union_specifier") {
-        if let Some(name_node) = union_node.child_by_field_name("name") {
-            let name = name_node.utf8_text(source).unwrap_or("").to_string();
-            if !name.is_empty() {
-                entities.push(ExtractedEntity {
-                    kind: EntityKind::Class,
-                    name,
-                    signature: node_signature(node, source),
-                    visibility: Visibility::Public,
-                    doc_summary: extract_preceding_comment(node, source),
-                    fingerprint: compute_fingerprint(node, source),
-                    span: span_from_node(node, file_id),
-                });
-                return;
-            }
-        }
+        extract_type_specifier(&specifier, node, source, file_id, entities, forward_decls);
+        return;
     }
 
     // Check for function declarations/prototypes (including macro-prefixed).
@@ -336,90 +286,208 @@ fn extract_declaration(
     }
 }
 
+/// Record the struct, union or enum a `struct_specifier`, `union_specifier` or
+/// `enum_specifier` node introduces.
+///
+/// `span_node` supplies the span, signature and doc comment, so a declaration can
+/// attribute the whole statement while a bare specifier attributes itself. A specifier
+/// with no `body` field is a forward declaration or a bare type reference such as
+/// `struct timeval tv;`. It names a type defined elsewhere, so it goes to
+/// `forward_decls` and is admitted only if nothing in the file defines that name.
+fn extract_type_specifier(
+    specifier: &tree_sitter::Node,
+    span_node: &tree_sitter::Node,
+    source: &[u8],
+    file_id: &FilePathId,
+    entities: &mut Vec<ExtractedEntity>,
+    forward_decls: &mut Vec<ExtractedEntity>,
+) {
+    let Some(kind) = specifier_entity_kind(specifier) else {
+        return;
+    };
+    let Some(name) = node_field_text(specifier, "name", source) else {
+        return;
+    };
+    let entity = ExtractedEntity {
+        kind,
+        name,
+        signature: node_signature(span_node, source),
+        visibility: Visibility::Public,
+        doc_summary: extract_preceding_comment(span_node, source),
+        fingerprint: compute_fingerprint(span_node, source),
+        span: span_from_node(span_node, file_id),
+    };
+    if specifier.child_by_field_name("body").is_some() {
+        entities.push(entity);
+    } else {
+        forward_decls.push(entity);
+    }
+}
+
+/// A union is modeled as a Class, mirroring struct handling, because kin-model carries
+/// no separate record kind for either.
+fn specifier_entity_kind(specifier: &tree_sitter::Node) -> Option<EntityKind> {
+    match specifier.kind() {
+        "struct_specifier" | "union_specifier" => Some(EntityKind::Class),
+        "enum_specifier" => Some(EntityKind::EnumDef),
+        _ => None,
+    }
+}
+
+/// Read a named field's text, treating an empty field as absent.
+fn node_field_text(node: &tree_sitter::Node, field: &str, source: &[u8]) -> Option<String> {
+    let child = node.child_by_field_name(field)?;
+    let text = child.utf8_text(source).unwrap_or("").trim().to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+/// How far to follow a declarator chain before giving up. Real C nests a handful of
+/// pointers and parentheses; anything deeper is malformed input, not a name.
+const MAX_DECLARATOR_DEPTH: usize = 16;
+
+/// Resolve the name a declarator introduces.
+///
+/// A typedef alias arrives wrapped in whatever declarator syntax names it: `foo_t`,
+/// `*foo_p`, `arr_t[10]` or `(*cb_t)(int, void *)`. Follow the chain down through
+/// pointers, arrays, functions and parentheses to the name at the bottom, so a
+/// function-pointer typedef is stored as `cb_t` and not as the text of its declarator.
+fn declarator_name(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    let mut current = *node;
+    for _ in 0..MAX_DECLARATOR_DEPTH {
+        // A parenthesized declarator holds its inner declarator as an unnamed child.
+        let next = current
+            .child_by_field_name("declarator")
+            .or_else(|| current.named_child(0));
+        let Some(next) = next else {
+            // The chain bottoms out at the name. Read the leaf's text rather than
+            // trusting its kind: the grammar calls most aliases `type_identifier` but
+            // spells the ones it already knows, such as `size_t`, `primitive_type`.
+            let text = current.utf8_text(source).unwrap_or("").trim().to_string();
+            return if text.is_empty() { None } else { Some(text) };
+        };
+        current = next;
+    }
+    None
+}
+
+/// One name a typedef introduces.
+struct TypedefAlias {
+    name: String,
+    /// True when the declarator is the bare name. `typedef struct dict { ... } dict,
+    /// *dictPtr;` introduces `dict` as another name for the record and `dictPtr` as a
+    /// pointer to it, so only the first is the record itself.
+    names_the_type_itself: bool,
+}
+
+/// Collect every alias a `type_definition` introduces.
+///
+/// One typedef can name several: `typedef struct X { ... } A, *Ap;` carries two
+/// `declarator` fields, and reading only the first loses `Ap`.
+fn typedef_aliases(node: &tree_sitter::Node, source: &[u8]) -> Vec<TypedefAlias> {
+    let mut aliases: Vec<TypedefAlias> = Vec::new();
+    for i in 0..node.child_count() {
+        let Ok(child_index) = i.try_into() else {
+            continue;
+        };
+        if node.field_name_for_child(child_index) != Some("declarator") {
+            continue;
+        }
+        let Some(child) = node.child(child_index) else {
+            continue;
+        };
+        // A pointer, array or function declarator derives a new type from the record;
+        // only a bare name is another name for the record itself.
+        let names_the_type_itself =
+            child.child_by_field_name("declarator").is_none() && child.named_child_count() == 0;
+        if let Some(name) = declarator_name(&child, source) {
+            if !aliases.iter().any(|alias| alias.name == name) {
+                aliases.push(TypedefAlias {
+                    name,
+                    names_the_type_itself,
+                });
+            }
+        }
+    }
+    aliases
+}
+
 /// Extract entities from a `type_definition` (typedef) node.
 ///
-/// If the typedef wraps a struct_specifier or enum_specifier, extract the
-/// appropriate entity kind. Otherwise treat it as a type alias.
+/// A typedef that wraps a struct, union or enum yields that record's kind; anything
+/// else is a type alias. When the wrapped specifier carries a tag whose spelling
+/// differs from the alias, both names are recorded against the same span, because C
+/// code reaches the type either way: `struct redisReader *r` and `redisReader *r` name
+/// the same thing, and an agent asking about a codebase uses whichever the source uses.
 fn extract_type_definition(
     node: &tree_sitter::Node,
     source: &[u8],
     file_id: &FilePathId,
     entities: &mut Vec<ExtractedEntity>,
+    forward_decls: &mut Vec<ExtractedEntity>,
 ) {
-    // The typedef name is in the `declarator` field (the alias name).
-    let typedef_name = node.child_by_field_name("declarator").and_then(|d| {
-        let text = d.utf8_text(source).unwrap_or("").to_string();
-        if text.is_empty() {
-            None
-        } else {
-            Some(text)
-        }
-    });
+    let mut aliases = typedef_aliases(node, source);
 
-    // Check if the typedef wraps a struct_specifier
-    if let Some(struct_node) = find_child_of_kind(node, "struct_specifier") {
-        // Prefer the typedef name, fall back to the struct tag name
-        let name = typedef_name.clone().or_else(|| {
-            struct_node.child_by_field_name("name").and_then(|n| {
-                let t = n.utf8_text(source).unwrap_or("").to_string();
-                if t.is_empty() {
-                    None
-                } else {
-                    Some(t)
-                }
-            })
-        });
-        if let Some(name) = name {
+    let mut wrapped = None;
+    for kind in ["struct_specifier", "union_specifier", "enum_specifier"] {
+        if let Some(specifier) = find_child_of_kind(node, kind) {
+            wrapped = Some(specifier);
+            break;
+        }
+    }
+
+    let Some(specifier) = wrapped else {
+        // Plain typedef, such as `typedef unsigned long size_t;`.
+        for alias in aliases {
             entities.push(ExtractedEntity {
-                kind: EntityKind::Class,
-                name,
+                kind: EntityKind::TypeAlias,
+                name: alias.name,
                 signature: node_signature(node, source),
                 visibility: Visibility::Public,
                 doc_summary: extract_preceding_comment(node, source),
                 fingerprint: compute_fingerprint(node, source),
                 span: span_from_node(node, file_id),
             });
-            return;
         }
-    }
+        return;
+    };
 
-    // Check if the typedef wraps an enum_specifier
-    if let Some(enum_node) = find_child_of_kind(node, "enum_specifier") {
-        let name = typedef_name.clone().or_else(|| {
-            enum_node.child_by_field_name("name").and_then(|n| {
-                let t = n.utf8_text(source).unwrap_or("").to_string();
-                if t.is_empty() {
-                    None
-                } else {
-                    Some(t)
-                }
-            })
-        });
-        if let Some(name) = name {
-            entities.push(ExtractedEntity {
-                kind: EntityKind::EnumDef,
-                name,
-                signature: node_signature(node, source),
-                visibility: Visibility::Public,
-                doc_summary: extract_preceding_comment(node, source),
-                fingerprint: compute_fingerprint(node, source),
-                span: span_from_node(node, file_id),
+    let Some(record_kind) = specifier_entity_kind(&specifier) else {
+        return;
+    };
+    // The tag is a name C code can spell on its own: `struct redisReader *r`.
+    if let Some(tag) = node_field_text(&specifier, "name", source) {
+        if !aliases.iter().any(|alias| alias.name == tag) {
+            aliases.push(TypedefAlias {
+                name: tag,
+                names_the_type_itself: true,
             });
-            return;
         }
     }
 
-    // Plain typedef (e.g., `typedef unsigned long size_t;`)
-    if let Some(name) = typedef_name {
-        entities.push(ExtractedEntity {
-            kind: EntityKind::TypeAlias,
-            name,
+    let defined_here = specifier.child_by_field_name("body").is_some();
+    for alias in aliases {
+        let entity = ExtractedEntity {
+            kind: if alias.names_the_type_itself {
+                record_kind
+            } else {
+                EntityKind::TypeAlias
+            },
+            name: alias.name,
             signature: node_signature(node, source),
             visibility: Visibility::Public,
             doc_summary: extract_preceding_comment(node, source),
             fingerprint: compute_fingerprint(node, source),
             span: span_from_node(node, file_id),
-        });
+        };
+        if defined_here {
+            entities.push(entity);
+        } else {
+            forward_decls.push(entity);
+        }
     }
 }
 
@@ -942,6 +1010,279 @@ int compute(Point p) { return internal_helper() + p.x; }
             .collect();
         assert_eq!(unions.len(), 1);
         assert_eq!(unions[0].name, "Data");
+    }
+
+    /// A header shaped like hiredis's `read.h`: one `#ifdef __cplusplus` opens the
+    /// `extern "C"` brace and a second one closes it, so tree-sitter puts the entire
+    /// public API inside a single linkage_specification.
+    const HIREDIS_SHAPED_HEADER: &[u8] = br#"
+#ifndef __EXAMPLE_READ_H
+#define __EXAMPLE_READ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define REDIS_READER_MAX_BUF (1024*16)
+
+typedef struct redisReadTask {
+    int type;
+    struct redisReadTask *parent;
+} redisReadTask;
+
+typedef struct {
+    int fd;
+    void *loop;
+} redisRunLoop;
+
+struct redisSSLContext {
+    void *ssl_ctx;
+};
+
+enum redisConnectionType {
+    REDIS_CONN_TCP,
+    REDIS_CONN_UNIX
+};
+
+typedef union redisValue {
+    long long integer;
+    double dval;
+} redisValue;
+
+typedef void (redisPushFn)(void *, void *);
+typedef void (*redisDisconnectFn)(struct redisReadTask *, int);
+
+typedef struct redisReader {
+    int err;
+    char *buf;
+    redisReadTask **task;
+} redisReader;
+
+redisReader *redisReaderCreate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+"#;
+
+    fn c_entities(source: &[u8]) -> Vec<ExtractedEntity> {
+        let adapter = CAdapter;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.h");
+        adapter.extract(&tree, source, &file_id).unwrap().entities
+    }
+
+    fn names_of(entities: &[ExtractedEntity], kind: EntityKind) -> Vec<String> {
+        entities
+            .iter()
+            .filter(|entity| entity.kind == kind)
+            .map(|entity| entity.name.clone())
+            .collect()
+    }
+
+    #[test]
+    fn extern_c_block_does_not_hide_the_public_api() {
+        let entities = c_entities(HIREDIS_SHAPED_HEADER);
+        let classes = names_of(&entities, EntityKind::Class);
+        for expected in [
+            "redisReadTask",
+            "redisRunLoop",
+            "redisSSLContext",
+            "redisValue",
+            "redisReader",
+        ] {
+            assert!(
+                classes.iter().any(|name| name == expected),
+                "{expected} missing from {classes:?}"
+            );
+        }
+        assert!(
+            names_of(&entities, EntityKind::EnumDef)
+                .iter()
+                .any(|name| name == "redisConnectionType"),
+            "the enum inside the extern C block was dropped"
+        );
+        assert!(
+            names_of(&entities, EntityKind::Function)
+                .iter()
+                .any(|name| name == "redisReaderCreate"),
+            "the prototype inside the extern C block was dropped"
+        );
+        assert!(
+            names_of(&entities, EntityKind::Macro)
+                .iter()
+                .any(|name| name == "REDIS_READER_MAX_BUF"),
+            "the macro inside the extern C block was dropped"
+        );
+    }
+
+    #[test]
+    fn redis_reader_carries_the_span_of_its_definition() {
+        let entities = c_entities(HIREDIS_SHAPED_HEADER);
+        let reader = entities
+            .iter()
+            .find(|entity| entity.name == "redisReader" && entity.kind == EntityKind::Class)
+            .expect("redisReader should be a Class");
+        let text = std::str::from_utf8(
+            &HIREDIS_SHAPED_HEADER[reader.span.start_byte..reader.span.end_byte],
+        )
+        .unwrap();
+        assert!(
+            text.contains("char *buf;"),
+            "the span should cover the members, got: {text}"
+        );
+    }
+
+    #[test]
+    fn function_pointer_typedef_is_named_by_its_identifier() {
+        let aliases = names_of(&c_entities(HIREDIS_SHAPED_HEADER), EntityKind::TypeAlias);
+        assert!(
+            aliases.iter().any(|name| name == "redisPushFn"),
+            "{aliases:?}"
+        );
+        assert!(
+            aliases.iter().any(|name| name == "redisDisconnectFn"),
+            "{aliases:?}"
+        );
+        assert!(
+            aliases.iter().all(|name| !name.contains('(')),
+            "a raw declarator leaked into a name: {aliases:?}"
+        );
+    }
+
+    #[test]
+    fn typedef_union_is_a_class_and_not_an_alias() {
+        let entities = c_entities(b"typedef union ffc_value { double d; long long i; } ffc_value;");
+        assert_eq!(names_of(&entities, EntityKind::Class), vec!["ffc_value"]);
+        assert!(names_of(&entities, EntityKind::TypeAlias).is_empty());
+    }
+
+    #[test]
+    fn typedef_struct_records_the_tag_alongside_a_differing_alias() {
+        let entities = c_entities(b"typedef struct foo_s { int a; } foo_t;");
+        assert_eq!(
+            names_of(&entities, EntityKind::Class),
+            vec!["foo_t", "foo_s"]
+        );
+        let starts: Vec<usize> = entities
+            .iter()
+            .map(|entity| entity.span.start_byte)
+            .collect();
+        assert_eq!(
+            starts[0], starts[1],
+            "the tag and the alias should point at the same definition"
+        );
+    }
+
+    #[test]
+    fn a_typedef_records_every_alias_it_declares() {
+        let entities = c_entities(b"typedef struct dict { int size; } dict, *dictPtr;");
+        assert_eq!(names_of(&entities, EntityKind::Class), vec!["dict"]);
+        assert_eq!(names_of(&entities, EntityKind::TypeAlias), vec!["dictPtr"]);
+    }
+
+    #[test]
+    fn a_forward_declaration_does_not_shadow_the_definition_below_it() {
+        let entities = c_entities(
+            b"struct redisContext;\n\nstruct redisContext {\n    int fd;\n    char *obuf;\n};\n",
+        );
+        assert_eq!(names_of(&entities, EntityKind::Class), vec!["redisContext"]);
+        let context = &entities[0];
+        assert!(
+            context.span.end_line > context.span.start_line,
+            "the surviving entity should be the multi-line definition"
+        );
+    }
+
+    #[test]
+    fn an_opaque_type_declared_but_never_defined_still_reaches_the_graph() {
+        let entities = c_entities(b"struct redisSSLContext;\nint use(struct redisSSLContext *c);");
+        assert_eq!(
+            names_of(&entities, EntityKind::Class),
+            vec!["redisSSLContext"]
+        );
+    }
+
+    #[test]
+    fn a_bare_type_reference_is_not_recorded_as_a_definition() {
+        let entities = c_entities(b"struct timeval tv;\nint elapsed(void) { return 0; }");
+        assert!(
+            names_of(&entities, EntityKind::Class).is_empty(),
+            "a variable of an external type must not claim to define it"
+        );
+    }
+
+    #[test]
+    fn a_prototype_returning_a_struct_is_still_recorded() {
+        let entities = c_entities(b"struct redisReply *redisCommand(void *c, const char *fmt);");
+        assert!(
+            names_of(&entities, EntityKind::Function)
+                .iter()
+                .any(|name| name == "redisCommand"),
+            "{:?}",
+            entities
+                .iter()
+                .map(|entity| (entity.kind, entity.name.as_str()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// hiredis's `adapters/libuv.h` shape: a `#if` arm opens a function body, the
+    /// `#else` arm opens a second signature, and one closing brace serves both. The
+    /// braces never balance, so tree-sitter makes the whole file a single ERROR node
+    /// and hangs every well-formed declaration off it.
+    const UNBALANCED_CONDITIONAL_HEADER: &[u8] = br#"
+#ifndef __EXAMPLE_LIBUV_H
+#define __EXAMPLE_LIBUV_H
+
+typedef struct redisLibuvEvents {
+    int events;
+} redisLibuvEvents;
+
+#if UV_VERSION_MINOR < 11
+static void redisLibuvTimeout(void *timer, int status) {
+    (void)status;
+#else
+static void redisLibuvTimeout(void *timer) {
+#endif
+    (void)timer;
+}
+
+static void redisLibuvCleanup(void *privdata) {
+    (void)privdata;
+}
+
+#endif
+"#;
+
+    #[test]
+    fn declarations_recovered_from_a_top_level_parse_error_are_kept() {
+        let tree = CAdapter.parse(UNBALANCED_CONDITIONAL_HEADER).unwrap();
+        let root = tree.root_node();
+        assert_eq!(
+            (root.child_count(), root.child(0).map(|node| node.kind())),
+            (1, Some("ERROR")),
+            "the fixture must reproduce the single top-level ERROR node, or this test \
+             proves nothing about error recovery"
+        );
+
+        let entities = c_entities(UNBALANCED_CONDITIONAL_HEADER);
+        assert!(
+            names_of(&entities, EntityKind::Class)
+                .iter()
+                .any(|name| name == "redisLibuvEvents"),
+            "{:?}",
+            names_of(&entities, EntityKind::Class)
+        );
+        assert!(
+            names_of(&entities, EntityKind::Function)
+                .iter()
+                .any(|name| name == "redisLibuvCleanup"),
+            "{:?}",
+            names_of(&entities, EntityKind::Function)
+        );
     }
 }
 


### PR DESCRIPTION
On the demo's hiredis store an agent named `redisReader` correctly and the verifier could not resolve it, so the demo blamed Kin for a name that is in the source at `read.h:98`. It was not just that type. The C adapter never entered a `linkage_specification`, which is where tree-sitter puts the body of the standard C header idiom, because `#ifdef __cplusplus / extern "C" { / #endif` opens the brace inside one conditional and closes it inside another. That hid the entire public API of eight hiredis files.

## Measured first

Read-only against the demo's store on 2026-09-02, `kin graph export --json --limit 5000`: 730 entities, 1659 relations, of which Function 532, Macro 148, Class 28, Method 12, TypeAlias 8, EnumDef 2. Enumerating every `typedef struct`, named struct, union, enum and typedef alias in the tracked sources gives 78 declarations, and 29 of them were in the graph.

`read.h` contributed 26 entities and every one was a Macro: no types, no prototypes. The three Class nodes attributed to `hiredis.h` were all bodyless forward declarations at `:41`, `:107` and `:108`, not definitions, so the graph claimed hiredis defines `timeval` while the real 40-line `redisContext` at `:258` was absent. Two of the eight TypeAlias nodes carried a raw declarator as their name, such as `(redisPushFn)(void *, void *)`, which no query can reach.

## Change

`extract_c_node` now walks into `linkage_specification`, `declaration_list` and `ERROR`. The last one matters for `adapters/libuv.h`, where a `#if` arm opens a function body and the `#else` arm opens a second signature, so the braces never balance and the whole file becomes one ERROR node whose children are well formed.

Four narrower defects the walk exposes are fixed with it. A `typedef union` had no branch and was filed as a TypeAlias; it is a Class now, mirroring struct and bare-union handling. The typedef name came from the raw text of the declarator field, so the chain is followed to the name at the bottom instead, reading the leaf's text rather than trusting its kind, because the grammar spells `size_t` as a `primitive_type`. Only the first declarator field was read, so `typedef struct X {} A, *Ap;` lost `Ap`; every declarator is read now, and a name introduced through a pointer or array declarator becomes a TypeAlias rather than another name for the record. The struct, union or enum tag is recorded alongside the alias when the two differ, because C reaches the type either way.

A specifier with no body is a forward declaration or a bare type reference, so it no longer counts as a definition on sight. It is held back and admitted only when nothing in the file defines that name. That keeps an opaque handle in the graph, stops a forward declaration from shadowing the definition further down the same header, and stops `struct timeval tv;` from claiming the file defines `timeval`. A declaration that merely names a type no longer ends the read either, so `struct redisReply *redisCommand(...);` records its prototype.

## Proof

Eleven new tests in the adapter's test module, on a hiredis-shaped header carrying a tagged typedef struct, an anonymous typedef struct, a plain named struct, an enum, a union and two function-pointer typedefs. Each was falsified by breaking the production behavior once: ten mutations, each turning exactly the tests written for it red, then restored to 28 of 28 green. The ERROR test asserts the fixture actually produces a single top-level ERROR node, because the first fixture I wrote passed without the ERROR arm and proved nothing.

A fresh `git clone` of hiredis at the demo's own commit `29ea279`, indexed with `kin init --no-enrich` from this branch's build into a scratch KIN_HOME:

| Kind | before | after |
|---|---|---|
| Function | 532 | 814 |
| Macro | 148 | 278 |
| Class | 28 | 59 |
| TypeAlias | 8 | 24 |
| EnumDef | 2 | 10 |
| Constant | 0 | 9 |
| Method | 12 | 12 |
| **total** | **730** | **1206** |

All 78 declarations now resolve. `read.h` goes 26 to 36, `hiredis.h` 27 to 86, `async.h` 1 to 31, `sds.h` 5 to 66, `ffc.h` 1 to 277, `adapters/libuv.h` 0 to 13. `dict.h` and `net.h` are unchanged at 29 and 13, which is the control: files with no linkage specification do not move.

`kin locate redisReader` now returns `read.h` first with an `entity_resolve` signal and a named match, and the entity's span is `read.h` lines 98 to 118, the definition itself. Before, `read.h` ranked seventh on an embedding signal with no entity resolution.

`bin/kin-precheck kin`: 16 gates enumerated from ci.yml's check job, 16 ran, 16 passed, 0 failed, on tree `4cca04073` with this change applied. `cargo test -p kin-parser` is green across all 13 targets, and the round-trip fuzz suite in `kin-integration-tests` is green.

No UsesType edges move: `ENRICHABLE_LANGUAGES` in `crates/kin-core/src/reference_coverage.rs:53` covers Rust, Python, TypeScript and JavaScript only, and `lsp_adapter_for` in `crates/kin-daemon/src/daemon.rs:415` returns None for C, so no C entity has ever carried one.

Related: FIR-3085
