### PR TITLE
Bump kin-model to 0.7.23 and kin-db to 0.7.83

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2844,7 +2844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.81"
+version = "0.7.83"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "81af647f5d6309ff18d9818e33eebc6e7cfcdfad87793df561a1e6d584086780"
+checksum = "74c3a324e925851004fa1abd00e5e37f335bdf6952f5c4bc3cb890efc3f8b395"
 dependencies = [
  "bincode",
  "bstr",
@@ -3317,6 +3317,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reqwest 0.12.28",
+ "rmp",
  "rmp-serde",
  "rustc-hash 2.1.3",
  "safetensors",
@@ -3507,9 +3508,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.22"
+version = "0.7.23"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "3550abd2115b4885d7594e8d1cfe045f68ff1b62c374217bbf0e7f24c81a7a86"
+checksum = "f8fa9147250a6ed0344f4b4d6e9503972f3a119d8034e26a23728b2d5baa62a2"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -4667,7 +4668,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ pretty_assertions = "1"
 serial_test = "4"
 
 # Internal crates
-kin-model = { version = "=0.7.22", registry = "kin" }
+kin-model = { version = "=0.7.23", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.81", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.83", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.23", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-core/dependency_env_allowlist.txt
+++ b/crates/kin-core/dependency_env_allowlist.txt
@@ -84,3 +84,11 @@ KIN_CLOCKHALF_COMMITS
 KIN_CLOCKHALF_FILES
 KIN_CLOCKHALF_FLAT
 KIN_CLOCKHALF_CHURN
+
+# kin-db storage/repository.rs: the two inputs to its FIR-3064 open-cost
+# harness, a `#[cfg(test)] mod fir3064_open_cost` whose only test is `#[ignore]`d
+# because it opens a real on-disk store by hand to read the resident set after
+# each step of a daemon startup. Same shape as the FIR-2334 pair above, and
+# nothing in a kin process reads either name.
+KIN_FIR3064_STORE
+KIN_FIR3064_REPO

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -816,7 +816,14 @@ pub fn count_repository_transfer_packs<B: StorageBackend + ?Sized + 'static>(
 
 /// Everything one coherent authority lease contributes to a pack.
 struct TransferSourceContext {
-    all_changes: std::collections::HashMap<SemanticChangeId, SemanticChange>,
+    /// Held as `ChangeMap` rather than the `HashMap` it derefs to, so a
+    /// converted store's history stays on disk. The map decodes on first use
+    /// and its clone shares the encoded source, so building this context costs
+    /// a pointer; converting to the inner `HashMap` here would force the whole
+    /// history into memory for every transfer, including the ones whose
+    /// closure touches a handful of changes. Every read below reaches the map
+    /// through `Deref`, so the sites are unchanged.
+    all_changes: kin_db::storage::ChangeMap,
     source_head: SemanticChangeId,
     source_git_authority_hash: Option<Hash256>,
     /// The authority this transfer will ESTABLISH, present only when the

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.22"
+version = "0.7.23"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "3550abd2115b4885d7594e8d1cfe045f68ff1b62c374217bbf0e7f24c81a7a86"
+checksum = "f8fa9147250a6ed0344f4b4d6e9503972f3a119d8034e26a23728b2d5baa62a2"
 dependencies = [
  "chrono",
  "gix-hash",


### PR DESCRIPTION
Takes kin-model 0.7.23, published to the kin registry today, and the kin-db 0.7.83 that
accepts it.

## What 0.7.23 carries

Deriving a change's identity no longer materializes the change, and replaying a history no
longer copies it. The old `compute_semantic_change_id` cloned the deltas to validate them,
cloned the whole change to sort it, and built a `serde_json::Value` tree of that copy, on
every call, and an admission calls it a dozen times because kin-git recomputes and
validates the id at every phase. The identity is now written one field and one delta at a
time through the sinks `RepositoryTransaction::transaction_hash` already used, over a
borrowed view. The bytes are unchanged and kin-model pins the digest against the old walk
as an oracle. Separately, `resolve_graph_at` stopped copying the one-change history it
replays twice beyond the copy the store hands over.

Measured on the kin-model lane, both ladders DEV-LOCAL rather than citable:

| subject | phase | before | after |
|---|---|---|---|
| React, 7,210 files, 25,772 entities | apply admission policy | 1.58 GiB | 0.48 GiB |
| React | prove Git source | 1.71 GiB | 0.51 GiB |
| VS Code, 18,508 files, 221,553 entities | derive semantic history | 13.68 GiB | 4.55 GiB |
| VS Code | apply admission policy | 15.18 GiB | 4.81 GiB |
| VS Code | prove Git source | 16.48 GiB | 5.06 GiB |

The VS Code run completes where the before run was killed at 2,304 seconds with phase 13
still open. That pair crosses a kin version as well as the kin-model change, unlike the
React pair.

## Why kin-db moves in the same PR

It has to. kin-db pins kin-model exactly, and every published kin-db through 0.7.82
requires `=0.7.22`. kin pins kin-db exactly in turn. Two exact pins cannot co-resolve, so
bumping kin-model alone fails to resolve rather than failing to compile:

```
error: failed to select a version for `kin-model`.
    ... required by package `kin-db v0.7.81 (registry `kin`)`
versions that meet the requirements `=0.7.22` are: 0.7.22
```

kin-db 0.7.83 is the first release that accepts kin-model 0.7.23.

## The one type this crosses

kin was on kin-db 0.7.81, so this also crosses 0.7.82, where a snapshot's `changes` became
a `ChangeMap`. That type decodes on first use and its clone shares the encoded source, so a
history that a converted store left on disk stays there. Every kin caller but one reaches
`snapshot().changes` through `Deref` and needed no change. The exception is
`TransferSourceContext` in kin-remote, which stores it in a typed field, so that field
becomes `kin_db::storage::ChangeMap`.

The compiler suggests `.into()` at that site. That is the wrong fix here: `From<ChangeMap>`
calls `into_inner`, which forces the decode and pulls the whole history into memory for
every transfer, including ones whose closure touches a handful of changes. That is exactly
the cost kin-db had just moved off the open path, so the field keeps the lazy type instead.

## Lockfiles

Refreshed with `--precise`, so the resolve moves the two crates, kin-db's new `rmp`
dependency, and three edges cargo re-unified onto versions already present in the lock
(gix-imara-diff, io-extras, quinn-udp). `fuzz/Cargo.lock` is a separate detached-workspace
lockfile that the Fuzz workflow enforces with `cargo metadata --locked`, and that workflow
triggers on the root manifest, so a pin moved without it goes red there rather than here.

## Gates

Through the fleet slot on the lane worktree. `bin/kin-precheck kin`: 16 gates enumerated
from ci.yml's own check job, 16 ran, 16 passed, 0 failed. `cargo test -p kin-remote`: 102
passed, 0 failed, including the whole `repository_transfer_negotiation` suite that drives
the changed field.

Related: FIR-3056, FIR-3064
