### PR TITLE
Read a resolution miss off the exit code and stderr in the rename check

### DIFF
--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -3209,13 +3209,32 @@ def check_22(suite):
     else:
         res.ok("`canonical_title` resolves after one commit")
 
-    rc, out, _ = suite.kin_run(["refs", "normalize_title"], repo)
-    old_name = strip_ansi(out)
-    if "not found" not in old_name:
+    # A resolution miss is an error, not an answer: it exits non-zero with the
+    # message on stderr and leaves stdout empty (FIR-3071). This arm used to read
+    # stdout alone for "not found", which stopped being able to tell "the name is
+    # gone" from "the name resolved" the moment the message moved, because both
+    # are silent on stdout. It read the empty string as a live resolution and
+    # failed the gate on a product that had just got stricter.
+    #
+    # Reading all three facts is what makes it a check rather than a coincidence:
+    # the exit code says a miss happened, stderr says it was a RESOLUTION miss
+    # and not some other refusal, and the empty stdout is the property a caller
+    # piping this into a prompt depends on.
+    rc, out, err = suite.kin_run(["refs", "normalize_title"], repo)
+    old_out = strip_ansi(out)
+    old_err = strip_ansi(err)
+    if rc == 0:
         res.bad("the old name still resolves after the rename, so the graph is carrying a "
-                "declaration the file no longer has: %r" % old_name[:300])
+                "declaration the file no longer has: rc=0 %r" % old_out[:300])
+    elif "not found" not in old_err:
+        res.bad("the old name was refused, but not as a resolution miss, so this check cannot "
+                "say the rename landed: rc=%d stderr=%r" % (rc, old_err[:300]))
+    elif old_out.strip():
+        res.bad("a resolution miss must leave stdout empty, or a caller pipes the apology into "
+                "a prompt as repository material: %r" % old_out[:300])
     else:
-        res.ok("the old name is gone from the graph")
+        res.ok("the old name is gone from the graph, refused at rc=%d with the message on "
+               "stderr and nothing on stdout" % rc)
 
     # The callers. Both files that called it were edited in the same commit, so
     # a rename that landed has both edges; the rc061a run had none.


### PR DESCRIPTION
Main's Acceptance went red on `9edbf082` and this is the fix. The product is fine; the check was
reading the wrong stream.

`magic:22` asserts that a renamed-away symbol stops resolving, by running `kin refs <old name>` and
looking for "not found" in its **stdout**. #1350 moved a resolution miss to stderr with a non-zero
exit and left stdout empty, on purpose, so that a caller piping the command into a prompt gets
nothing rather than an apology. After that, stdout is silent whether the name resolved or not, so
the check could no longer tell those apart. It saw the empty string, concluded the old name still
resolved, and failed the gate. The failure line carries the evidence: it printed the value it judged
and the value was `''`.

That is my miss from #1350. The suite encodes the contract, I changed the contract, and I should have
changed the suite in the same landing.

The check now reads all three facts rather than one:

- the exit code, which says a miss happened at all,
- stderr, which says it was a *resolution* miss and not some other refusal,
- an empty stdout, which is the property the change was for.

Each wrong outcome gets its own sentence, so the next failure here names which of the three broke
instead of pointing at the old name. This is strictly stronger than what it replaces, which could be
satisfied by one phrase appearing anywhere in one stream.

I checked the other three acceptance call sites that run these commands. Two of them concatenate
stdout and stderr before matching, so they were never exposed, and the third asserts on a name that
resolves. This was the only affected check.

Related: FIR-3071
