### PR TITLE
Bump kin-db to 0.7.84

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.83"
+version = "0.7.84"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "74c3a324e925851004fa1abd00e5e37f335bdf6952f5c4bc3cb890efc3f8b395"
+checksum = "7f72d12b426a54d459e31d1834b9e23eaf84d5a5c110ea23cce959b861ec1c90"
 dependencies = [
  "bincode",
  "bstr",
@@ -6671,7 +6671,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.83", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.84", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.23", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
Takes kin-db 0.7.84, published to the kin registry at 08:25Z, beside the kin-model 0.7.23 pin that landed in #1356.

## What 0.7.84 carries

The head-revision vector carry (kin-db #266): `kin embed` stops embedding every entity twice. A head-revision key now copies its live entity's vector instead of computing a near-identical one. Measured on hiredis with the embed cache off, same store either side: forward passes 1,485 down to 757, wall 481.8 s down to 254.5 s, identical coverage and identical vector count. Vectors written are unchanged, so no persisted store needs rebuilding.

## Shape

Cargo.toml and Cargo.lock only. The fuzz lockfile carries no kin-db entry, and 0.7.84 adds no environment names, so the dependency allowlist is unchanged. Not fixed by this bump: FIR-3096 (embed progress retired on a daemon reopen), which is in flight on kin-db.
