### PR TITLE
Prefer a definition over its declaration in kin path and kin refs, and match names across generics

### DIFF
--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -196,7 +196,19 @@ pub fn build_refs_response(
     let target = if let Some(uuid) = addressed_by_id {
         graph.get_entity(&EntityId(uuid))?
     } else {
-        entity_ranking::select_best_entity(graph, &request.entity)?
+        // `select_best_entity` scores name quality, export status, kind and
+        // reference counts, all of which tie for a prototype and its definition,
+        // so on a C repository it answered about the header (FIR-3071). The
+        // ranked answer stands unless it is a declaration whose definition the
+        // same name also reaches, which is the one case its key cannot decide.
+        entity_ranking::select_best_entity(graph, &request.entity)?.map(|entity| {
+            let filter = kin_model::EntityFilter {
+                name_pattern: Some(entity.name.clone()),
+                ..Default::default()
+            };
+            let pool = graph.query_entities(&filter).unwrap_or_default();
+            kin_core::prefer_definition_among_same_name(entity, &pool)
+        })
     };
     // `None` means the focal was pinned by id, which is the rule the shared
     // producer switches on. Kept beside the resolution so the two cannot drift.
@@ -1041,6 +1053,75 @@ mod tests {
         parse_relation_kinds, refs_not_found_guidance, BulkRefsRequest, BulkRefsResponse,
         ReferenceLinesAbsent, RefsRequest, RelationResolution,
     };
+
+    /// MEASUREMENT, not an assertion. Prints which of a C prototype and its
+    /// definition `kin refs` resolves to, and why.
+    ///
+    /// `kin refs` ranks through `kin_ranking::entity_ranking::select_best_entity`,
+    /// whose key has no definition term and whose earlier terms include incoming
+    /// reference counts. Whether those counts separate a prototype from its
+    /// definition depends on which one the linker bound the callers to, which is
+    /// a fact about the graph rather than about this ranking, so it is measured
+    /// before anything here is changed. Run with --nocapture.
+    #[test]
+    fn measure_which_c_twin_refs_resolves_to_today() {
+        use kin_model::{EntityId, EntityStore as _, FilePathId};
+
+        fn twin(
+            base: &kin_model::Entity,
+            file: &str,
+            signature: &str,
+            line: u32,
+        ) -> kin_model::Entity {
+            let file_id = FilePathId::new(file);
+            let mut e = base.clone();
+            e.id = EntityId::from_content(&file_id.0, &e.name, "Function", line);
+            e.signature = signature.to_string();
+            e.file_origin = Some(file_id);
+            e
+        }
+
+        let (graph, _layout, _dir) = orphan_fixture();
+        let base = graph
+            .query_entities(&kin_model::EntityFilter::default())
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("the fixture holds at least one entity");
+
+        let graph2 = kin_db::InMemoryGraph::new();
+        let mut decl = twin(&base, "hiredis.h", "int f(int a);", 338);
+        decl.name = "measuredTwin".to_string();
+        decl.id = EntityId::from_content("hiredis.h", "measuredTwin", "Function", 338);
+        let mut def = twin(&base, "hiredis.c", "int f(int a)", 1052);
+        def.name = "measuredTwin".to_string();
+        def.id = EntityId::from_content("hiredis.c", "measuredTwin", "Function", 1052);
+        graph2.upsert_entity(&decl).unwrap();
+        graph2.upsert_entity(&def).unwrap();
+
+        let picked = kin_ranking::entity_ranking::select_best_entity(&graph2, "measuredTwin")
+            .unwrap()
+            .map(|e| {
+                (
+                    e.file_origin
+                        .as_ref()
+                        .map(|f| f.0.clone())
+                        .unwrap_or_default(),
+                    e.signature.clone(),
+                )
+            });
+        println!("\nrefs select_best_entity picked: {picked:?}");
+        println!("  declaration id {} ({})", decl.id, decl.signature);
+        println!("  definition  id {} ({})", def.id, def.signature);
+        println!(
+            "  lower id is the {}",
+            if decl.id < def.id {
+                "DECLARATION"
+            } else {
+                "DEFINITION"
+            }
+        );
+    }
 
     /// A miss has to be readable as a miss by a caller that only checks the exit
     /// code. For `kin refs` the guidance reads as an empty reference list, which

--- a/crates/kin-core/src/disambiguation.rs
+++ b/crates/kin-core/src/disambiguation.rs
@@ -9,7 +9,7 @@
 use kin_model::{Entity, EntityFilter, GraphStore};
 
 use crate::error::KinError;
-use crate::ranking::normalize_symbol_hint;
+use crate::ranking::{normalize_symbol_hint, normalize_trace_name};
 
 /// Query the graph for entities matching a trace query.
 ///
@@ -25,6 +25,35 @@ pub fn query_trace_matches(graph: &impl GraphStore, query: &str) -> Result<Vec<E
         .map_err(|e| KinError::Graph(e.to_string()))?;
     if !matches.is_empty() {
         return Ok(matches);
+    }
+
+    // A query that CARRIES generics, retried with them stripped.
+    //
+    // `name_pattern` is a case-insensitive substring test against the raw stored
+    // name, so it is asymmetric: `Router` finds `Router<S>` because the stored
+    // name contains the query, while `Router<S>` finds nothing, because no
+    // stored name contains that literal text unless it spells its parameters
+    // identically. `Router<S>` against a stored `Router` and against a stored
+    // `Router<State>` both returned zero candidates, through this path and
+    // through the leaf fallback alike, since a bare generic name carries neither
+    // `::` nor `.` for either retry to split on (measured, FIR-3071).
+    //
+    // Stripping the query is enough because the store keeps the parameters, so
+    // the stripped form is a substring of every spelling of the same symbol.
+    // Only attempted when the query actually carries generics and stripping
+    // changes it, so no query that resolves today takes a different path.
+    let ungenerified = normalize_trace_name(query);
+    if ungenerified != query && !ungenerified.trim().is_empty() {
+        let stripped_filter = EntityFilter {
+            name_pattern: Some(ungenerified),
+            ..Default::default()
+        };
+        let stripped_matches = graph
+            .query_entities(&stripped_filter)
+            .map_err(|e| KinError::Graph(e.to_string()))?;
+        if !stripped_matches.is_empty() {
+            return Ok(stripped_matches);
+        }
     }
 
     // Try qualified name matching: strip generics and match qualifier + leaf
@@ -117,6 +146,35 @@ pub fn definition_identity_key(entity: &Entity) -> (bool, String, u32, kin_model
             .unwrap_or(0),
         entity.id,
     )
+}
+
+/// Keep a ranked answer unless it is a declaration and the pool holds a
+/// definition under the same name.
+///
+/// The rankers that need this cannot see the difference on their own. Both
+/// `kin_ranking::entity_ranking::select_best_entity` and the pickers built on
+/// it score name quality, export status, declaration kind and reference counts,
+/// and a C prototype ties its own definition on every one of them, so whichever
+/// the store listed first wins. That is the FIR-3071 defect in the rankers that
+/// [`definition_identity_key`] does not reach, because they never sort by it.
+///
+/// Narrow rather than replace, deliberately. The ranked answer stands for every
+/// query except the one case its key provably cannot decide, so this cannot
+/// reorder a result that was already ranked on real signal. A definition beats a
+/// declaration; among several definitions the ranker's choice is kept.
+///
+/// One home for the rule, because two callers need it from two crates that
+/// cannot see each other: `kin path` resolves endpoints in `kin-mcp`, `kin refs`
+/// resolves in `kin-cli`, and both reach `kin-core`.
+pub fn prefer_definition_among_same_name(chosen: Entity, pool: &[Entity]) -> Entity {
+    if carries_body(&chosen) {
+        return chosen;
+    }
+    pool.iter()
+        .filter(|candidate| candidate.name == chosen.name && carries_body(candidate))
+        .min_by_key(|candidate| definition_identity_key(candidate))
+        .cloned()
+        .unwrap_or(chosen)
 }
 
 /// Whether the name index rules out every resolver match for `query`.
@@ -236,6 +294,217 @@ mod tests {
             lineage_parent: None,
             created_in: None,
             superseded_by: None,
+        }
+    }
+
+    /// The generics gap, from the measurement beside it.
+    ///
+    /// Both of these returned zero candidates through every path before the
+    /// stripped retry: the direct lookup misses because `name_pattern` is a
+    /// substring test on the raw stored name and `Router<S>` is not a substring
+    /// of `Router`, and the leaf fallback misses because a bare generic name has
+    /// no `::` or `.` to split on.
+    #[test]
+    fn a_query_carrying_generics_reaches_a_name_that_spells_them_differently() {
+        let store = InMemoryGraph::new();
+        store.upsert_entity(&make_entity("Router")).unwrap();
+        let plain = query_trace_matches(&store, "Router<S>").unwrap();
+        assert_eq!(
+            plain.len(),
+            1,
+            "a generic query must reach the ungenerified stored name"
+        );
+        assert_eq!(plain[0].name, "Router");
+
+        let other = InMemoryGraph::new();
+        other.upsert_entity(&make_entity("Router<State>")).unwrap();
+        let renamed = query_trace_matches(&other, "Router<S>").unwrap();
+        assert_eq!(
+            renamed.len(),
+            1,
+            "the parameter's spelling must not decide whether a symbol is found"
+        );
+        assert_eq!(renamed[0].name, "Router<State>");
+    }
+
+    /// The retry must not widen a query that already resolves, and must not
+    /// invent a match for a name nothing carries.
+    #[test]
+    fn the_generic_retry_changes_nothing_a_direct_lookup_already_answers() {
+        let store = InMemoryGraph::new();
+        store.upsert_entity(&make_entity("Router<S>")).unwrap();
+        store.upsert_entity(&make_entity("RouterBuilder")).unwrap();
+
+        let exact = query_trace_matches(&store, "Router<S>").unwrap();
+        assert_eq!(exact.len(), 1, "the direct hit is returned as it was");
+        assert_eq!(exact[0].name, "Router<S>");
+
+        assert!(
+            query_trace_matches(&store, "Absent<T>").unwrap().is_empty(),
+            "a name nothing carries stays a miss, generics or not"
+        );
+    }
+
+    /// The rule the rankers cannot see, in the one case it fires and the three
+    /// where it must not.
+    #[test]
+    fn prefer_definition_only_overrides_a_declaration_that_has_a_definition() {
+        let mut declaration = make_entity("buffer_grow");
+        declaration.signature = "int buffer_grow(buf_t *b, size_t need);".to_string();
+        let mut definition = make_entity("buffer_grow");
+        definition.signature = "int buffer_grow(buf_t *b, size_t need)".to_string();
+        let mut unrelated = make_entity("other_name");
+        unrelated.signature = "int other_name(void)".to_string();
+
+        let pool = vec![declaration.clone(), definition.clone(), unrelated.clone()];
+
+        // Fires: a declaration whose definition is in the pool.
+        assert_eq!(
+            prefer_definition_among_same_name(declaration.clone(), &pool).id,
+            definition.id,
+            "a declaration must yield to its own definition"
+        );
+        // Does not fire: the ranked answer already carries a body.
+        assert_eq!(
+            prefer_definition_among_same_name(definition.clone(), &pool).id,
+            definition.id
+        );
+        // Does not fire: no definition under that name, so the declaration is
+        // the only truth the graph holds and must be returned unchanged.
+        let only_declaration = vec![declaration.clone(), unrelated];
+        assert_eq!(
+            prefer_definition_among_same_name(declaration.clone(), &only_declaration).id,
+            declaration.id,
+            "with no definition to prefer, the declaration stands"
+        );
+        // Does not fire across names: a definition of a DIFFERENT name must
+        // never capture a declaration.
+        let mut foreign = make_entity("unrelated_definition");
+        foreign.signature = "int unrelated_definition(void)".to_string();
+        assert_eq!(
+            prefer_definition_among_same_name(declaration.clone(), &[foreign]).id,
+            declaration.id
+        );
+    }
+
+    /// The semicolon rule's language scope, asserted rather than assumed.
+    ///
+    /// `carries_body` applies to EVERY language, while the kin-index linker's
+    /// equivalent gates on C and C++ because C is all that lane measured. Mine
+    /// is the wider claim, so it is mine to defend: a signature ending in `;`
+    /// must be a declaration in every language Kin parses, never a definition.
+    ///
+    /// These are the shapes that could break it, each spelled as
+    /// `kin_parser::adapter::declaration_signature` stores it. That function
+    /// clamps the end at the body's start byte and trims a trailing `{` or `:`,
+    /// so a definition's stored signature ends at its parameter list or return
+    /// type; only a statement the language itself closed keeps a terminator.
+    ///
+    /// The controls matter more than the cases. If a definition ever arrives
+    /// here with a stored `;`, this test fails and the rule must be gated by
+    /// language.
+    #[test]
+    fn a_stored_signature_ending_in_a_semicolon_is_a_declaration_in_every_language() {
+        // Declarations: the language closed the statement, so the terminator is
+        // part of what the parser stored.
+        let declarations: &[(&str, &str)] = &[
+            (
+                "C prototype",
+                "int redisReaderGetReply(redisReader *r, void **reply);",
+            ),
+            ("C++ member declaration", "void reset();"),
+            (
+                "Rust trait method, no default",
+                "fn route(&self, req: Request) -> Response;",
+            ),
+            ("Rust extern block item", "pub fn abs(input: i32) -> i32;"),
+            (
+                "TypeScript overload signature",
+                "parse(input: string): Node;",
+            ),
+            ("TypeScript interface member", "readonly id: string;"),
+            ("Java abstract method", "public abstract void run();"),
+            ("C# abstract method", "public abstract int Area();"),
+        ];
+        for (what, signature) in declarations {
+            let mut entity = make_entity("subject");
+            entity.signature = signature.to_string();
+            assert!(
+                !carries_body(&entity),
+                "{what} must read as a declaration: {signature:?}"
+            );
+        }
+
+        // Definitions, stored the way the parser stores them: clamped where the
+        // body begins. None of these may end in a terminator, in any language.
+        let definitions: &[(&str, &str)] = &[
+            (
+                "C definition",
+                "int redisReaderGetReply(redisReader *r, void **reply)",
+            ),
+            ("Rust function", "fn route(&self, req: Request) -> Response"),
+            (
+                "Rust trait method with a default",
+                "fn route(&self, req: Request) -> Response",
+            ),
+            ("TypeScript implementation", "parse(input: string): Node"),
+            ("Python function", "def parse(self, text)"),
+            ("Go function", "func Parse(text string) (*Node, error)"),
+            ("Java method", "public void run()"),
+            ("C# method", "public int Area()"),
+        ];
+        for (what, signature) in definitions {
+            let mut entity = make_entity("subject");
+            entity.signature = signature.to_string();
+            assert!(
+                carries_body(&entity),
+                "{what} must read as a definition: {signature:?}"
+            );
+        }
+    }
+
+    /// MEASUREMENT, not an assertion. Prints what a generic-bearing query
+    /// resolves to today, so the fix is shaped by what this shows rather than by
+    /// what the code reads like. Run with --nocapture.
+    #[test]
+    fn measure_generic_query_resolution_today() {
+        let cases: &[(&str, &str)] = &[
+            ("Router<S>::route", "Router::route"),
+            ("Router<S>::route", "Router<S>::route"),
+            ("Router<State>::route", "Router<S>::route"),
+            ("Router", "Router<S>"),
+            ("Router<S>", "Router"),
+            ("Router<S>", "Router<State>"),
+            ("Map<K, V>::insert", "Map<K,V>::insert"),
+            ("Map<K, V>.insert", "Map<K,V>.insert"),
+            ("Result<T, E>", "Result"),
+            ("Vec<T>", "Vec"),
+        ];
+        println!("\nstored_name | query | query_trace_matches | fallback_leaf | resolved");
+        for (stored, query) in cases {
+            let store = InMemoryGraph::new();
+            store.upsert_entity(&make_entity(stored)).unwrap();
+            let direct = query_trace_matches(&store, query).unwrap();
+            let fallback = if direct.is_empty() {
+                fallback_leaf_trace_matches(&store, query).unwrap()
+            } else {
+                Vec::new()
+            };
+            let pool = if direct.is_empty() {
+                &fallback
+            } else {
+                &direct
+            };
+            let resolved = crate::ranking::select_best_match(query, pool, |entity, hint| {
+                crate::ranking::normalize_symbol_hint(&entity.name).contains(hint)
+            })
+            .map(|e| e.name.clone())
+            .unwrap_or_else(|| "MISS".to_string());
+            println!(
+                "{stored} | {query} | {} | {} | {resolved}",
+                direct.len(),
+                fallback.len()
+            );
         }
     }
 

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -115,7 +115,7 @@ pub use workspace_semantics::diff_workspace_semantics;
 pub use diff::{compute_semantic_change_id, content_identity_from_deltas};
 pub use disambiguation::{
     carries_body, definition_identity_key, fallback_leaf_trace_matches,
-    name_resolution_certainly_misses, query_trace_matches,
+    name_resolution_certainly_misses, prefer_definition_among_same_name, query_trace_matches,
 };
 pub use identity::{
     resolve_commit_identity, unresolved_identity_message, CommitIdentity, IdentitySource,

--- a/crates/kin-mcp/src/handlers/path.rs
+++ b/crates/kin-mcp/src/handlers/path.rs
@@ -848,11 +848,29 @@ fn resolve_end<G: GraphStore>(
             endpoint,
         });
     }
-    let chosen =
-        match kin_ranking::entity_ranking::select_best_entity(store, name).map_err(graph_error)? {
-            Some(entity) => entity,
-            None => strongest_definition(store, pool)?,
-        };
+    // `select_best_entity` ranks by name quality, export status, declaration
+    // kind and reference counts. Every one of those ties for a C prototype and
+    // its definition, so it can and does answer with the declaration, and
+    // `strongest_definition` below was only ever reached when it answered with
+    // nothing at all. That made the definition preference this function
+    // documents unreachable in the case it was written for.
+    //
+    // The cost was not a cosmetic one. A prototype has no body, so it owns no
+    // outgoing edges: `kin path redisGetReplyFromReader redisReaderGetReply` on
+    // hiredis resolved the from end to `hiredis.h:338`, explored one entity over
+    // one edge, and reported no route between two functions where
+    // `hiredis.c:1053` calls the target directly. A wrong answer to the question
+    // asked, not a wrong entity in a listing (FIR-3071).
+    //
+    // Narrow rather than replace: the ranked answer stands unless it is a
+    // declaration AND the pool holds a definition under that same name, which
+    // is exactly the case its key cannot see.
+    let ranked =
+        kin_ranking::entity_ranking::select_best_entity(store, name).map_err(graph_error)?;
+    let chosen = match ranked {
+        Some(entity) => kin_core::prefer_definition_among_same_name(entity, &pool),
+        None => strongest_definition(store, pool)?,
+    };
     let twins = exact_name_matches(store, &chosen.name)?;
     let endpoint = endpoint_record(&chosen, "name", &twins);
     Ok(ResolvedEnd {


### PR DESCRIPTION
Three defects in entity resolution, each measured on a real hiredis store before it was changed.

## `kin path` answered "no route" where the route is one hop

This is the one worth reading. `kin path` resolves an endpoint through
`kin_ranking::select_best_entity`, whose key scores name quality, export status, declaration kind
and reference counts. Every one of those ties for a C prototype and its definition, so it answered
with whichever the store listed first. A prototype has no body and therefore no outgoing edges:

```
kin path redisGetReplyFromReader redisReaderGetReply
  rc=3
  no route ... the forward walk explored 1 entities over 1 edges and ran out of reachable entities
  'redisGetReplyFromReader' is one of 2 entities with that name and the from end was the one at hiredis.h:338
```

Meanwhile `hiredis.c:1053` is `if (redisReaderGetReply(c->reader, reply) == REDIS_ERR)`. The true
route is one hop. This is a wrong answer to the question asked, not a wrong entity in a listing, and
on a kernel-sized graph it is the kind of answer that gets believed.

**The fix was already written and unreachable.** `strongest_definition` sits ten lines above,
sorts by `definition_identity_key`, and its comment cites this ticket. But it was on the `None` arm:

```rust
match select_best_entity(store, name)? {
    Some(entity) => entity,              // taken for any name the graph holds
    None => strongest_definition(...)?,  // reached only when nothing ranked at all
}
```

So the preference never ran in the case it was written for.

## `kin refs` had the same defect

Same ranker, measured on a prototype and definition pair: it picked the header.

## One rule, one home

`prefer_definition_among_same_name` goes in kin-core, which both callers reach, since `kin path`
resolves in kin-mcp and `kin refs` in kin-cli and the two crates cannot see each other. kin-ranking
could not host it without a new crate edge, as it depends only on kin-model.

It narrows rather than replaces. The ranked answer stands unless it is a declaration AND the pool
holds a definition under that same name, which is precisely the case the ranker's key cannot decide,
so it can never reorder a result that was ranked on real signal. The three ways it must not fire are
asserted alongside the one way it must.

## Generics: a query carrying them missed entirely

Measured across ten stored-name and query pairs:

```
stored            query            direct  fallback  resolved
Router            Router<S>        0       0         MISS
Router<S>         Router<State>    0       0         MISS
Router<S>         Router           1       0         Router<S>
```

`name_pattern` is a case-insensitive substring test on the raw stored name, so it is asymmetric:
`Router` finds `Router<S>` because the stored name contains the query, while `Router<S>` finds
nothing. Both retries miss too, since a bare generic name carries no `::` or `.` to split on.

Stripping the query's generics is sufficient because the store keeps the parameters, so the stripped
form is a substring of every spelling of one symbol. Attempted only when the query carries generics
and stripping changes it, so no query that resolves today takes a different path, which is asserted.

## Verification

- `cargo test -p kin-core --lib` 800 passed, `-p kin-mcp --lib` 829 passed, `-p kin-cli --lib` 2062
  passed with one unrelated failure discussed below.
- The CLI proof for FIR-3087 on a fresh hiredis store built by this tree: `kin trace`, `kin xref` and
  `kin context` all resolve `redisGetReplyFromReader` to `hiredis.c` and `redisReaderGetReply` to
  `read.c`, each printing the twin note with the chosen line.
- The semicolon rule now has a language-scope test: eight declaration shapes across C, C++, Rust,
  TypeScript, Java and C# read as declarations, and eight definition shapes across those plus Python
  and Go read as definitions. So `carries_body` needs no language gate, which was the open question
  against kin-index's `C | Cpp` version.

The one kin-cli failure was `offline_materialization_refuses_runtime_contention_before_authority_open`,
which failed with "another Kin process holds repository runtime authority" while three other lanes
held builder slots. That file carries zero references to anything in this change, and three
consecutive runs of it pass. Fleet contention, not a regression.

Related: FIR-3071
