### PR TITLE
Renew the startup rollout lease before every hosted publication

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -16260,6 +16260,10 @@ async fn publication_control_acquire_rollout(
         token: pending.token.clone(),
         fence: pending.fence,
     };
+    // The fence advance writes Firestore under this proof before any guard
+    // owns it; bind it so a transient retry inside the store re-reads it.
+    let _bound =
+        control.bind_mutation_lease(crate::publication_lease::LeaseKind::Rollout, proof.clone());
     let fence = control
         .spine_rollout_fence(&proof)
         .map_err(publication_control_error)?;

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -302,47 +302,18 @@ fn create_state(
                 Arc::clone(&publication_control),
             )?;
             let spine_startup = if let Some(pending) = bootstrap {
-                (|| -> std::result::Result<(), String> {
-                    let proof = kin_daemon::publication_lease::LeaseProof {
-                        scope: publication_control.scope().to_string(),
-                        token: pending.token,
-                        fence: pending.fence,
-                    };
-                    let fence = publication_control
-                        .spine_rollout_fence(&proof)
-                        .map_err(|error| error.to_string())?;
-                    let evidence =
-                        runtime.block_on(state.advance_hosted_spine_rollout_fence(fence))?;
-                    publication_control
-                        .checkpoint_spine_rollout_fence(&proof, &evidence)
-                        .map_err(|error| error.to_string())?;
-                    publication_control
-                        .complete_rollout_acquisition(&proof)
-                        .map_err(|error| error.to_string())?;
-                    let legacy_writer_drain_proof_sha256 =
-                        env::var("KIN_SPINE_LEGACY_DRAIN_PROOF_SHA256_INTERNAL")
-                            .ok()
-                            .map(|digest| digest.trim().to_string())
-                            .filter(|digest| !digest.is_empty());
-                    let admission = kin_daemon::publication_lease::AdmitReaderRequest {
-                        lease: proof.clone(),
-                        repositories: publication_control.fleet_repositories().to_vec(),
-                        reader: kin_daemon::publication_lease::ReaderAdmissionInput {
-                            identity: publication_control.runtime_reader_identity().to_string(),
-                            min_snapshot_schema: kin_db::GraphSnapshot::MIN_SUPPORTED_VERSION,
-                            max_snapshot_schema: kin_db::GraphSnapshot::CURRENT_VERSION,
-                            valid_for_seconds:
-                                kin_daemon::publication_lease::MAX_READER_ADMISSION_SECONDS,
-                        },
-                        legacy_writer_drain_proof_sha256,
-                    };
-                    runtime.block_on(state.prepare_hosted_spine_rollout(&admission))?;
-                    runtime.block_on(state.admit_hosted_spine_rollout_fence(admission))?;
-                    runtime.block_on(state.release_hosted_spine_rollout(
-                        kin_daemon::publication_lease::ReleaseRolloutLeaseRequest { lease: proof },
-                    ))?;
-                    Ok(())
-                })()
+                let legacy_writer_drain_proof_sha256 =
+                    env::var("KIN_SPINE_LEGACY_DRAIN_PROOF_SHA256_INTERNAL")
+                        .ok()
+                        .map(|digest| digest.trim().to_string())
+                        .filter(|digest| !digest.is_empty());
+                // The sequence itself lives on the state so the same bytes run
+                // under a test clock; see `complete_hosted_startup_rollout`.
+                runtime.block_on(state.complete_hosted_startup_rollout(
+                    &publication_control,
+                    pending,
+                    legacy_writer_drain_proof_sha256,
+                ))
             } else {
                 match publication_control.runtime_spine_authority() {
                     Ok(kin_daemon::publication_lease::RuntimeSpineAuthority::Completed(

--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -29,6 +29,22 @@ use uuid::Uuid;
 pub const PUBLICATION_CONTROL_SCHEMA: &str = "kin.graph-publication-control.v2";
 pub const DEFAULT_ROLLOUT_LEASE_SECONDS: u64 = 300;
 pub const MAX_ROLLOUT_LEASE_SECONDS: u64 = 1_800;
+/// Lease window the daemon requests for a rollout it drives itself: at the
+/// startup bootstrap and on every renewal before a mutation under a rollout
+/// proof.
+///
+/// The first hosted rollout publishes every repository's metadata and then its
+/// edges under this one lease, and the renewal in
+/// `HostedPublicationGuard::reassert_before_mutation` runs once per repository
+/// publication, so the window has to cover one repository, not the fleet.
+/// Measured 2026-09-02 from a laptop against production's own control record:
+/// one repository of 27,987 entities took 153 s at about 0.55 s per 100-write
+/// Firestore commit, and production's cold graph open alone took 110 s before
+/// the first commit. The 300 s default bounded the whole first rollout with
+/// nothing renewing it, and every attempt died with the work done and the
+/// credit lost. Renewal is the mechanism; this window is the margin, and it is
+/// the cap `validate_rollout_ttl` already admits.
+pub const HOSTED_ROLLOUT_LEASE_SECONDS: u64 = MAX_ROLLOUT_LEASE_SECONDS;
 pub const PUBLICATION_LEASE_SECONDS: u64 = 1_800;
 pub const MAX_READER_ADMISSION_SECONDS: u64 = 2_592_000;
 const STARTUP_BOOTSTRAP_HOLDER: &str = "kin-daemon-startup-bootstrap";
@@ -440,6 +456,39 @@ pub struct PublicationControl {
     /// drops this local guard, while the durable claim remains resumable by the
     /// exact holder.
     rollout_fencing_flights: Arc<Mutex<BTreeSet<u64>>>,
+    /// The lease this process is mutating hosted state under right now, bound
+    /// by the guard that owns it for exactly as long as it owns it. The
+    /// Firestore store re-reads this lease before it retries a transient
+    /// failure, so a request that stalled long enough for the lease to expire
+    /// or change hands is never retried under it.
+    mutation_lease: Mutex<Option<MutationLeaseBinding>>,
+}
+
+/// One in-flight hosted mutation's lease identity: the proof and the kind the
+/// proof must match when it is re-read.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MutationLeaseBinding {
+    kind: LeaseKind,
+    proof: LeaseProof,
+}
+
+/// RAII handle for a bound mutation lease. Dropping it clears the binding it
+/// installed; a handle that found the same lease already bound by an outer
+/// owner clears nothing, so nested owners of one proof (the startup sequence
+/// around `prepare_hosted_spine_rollout`, which binds it again) leave the
+/// outer binding in place until the outer owner is done.
+pub(crate) struct BoundMutationLease {
+    control: Arc<PublicationControl>,
+    binding: MutationLeaseBinding,
+    owner: bool,
+}
+
+impl Drop for BoundMutationLease {
+    fn drop(&mut self) {
+        if self.owner {
+            self.control.unbind_mutation_lease(&self.binding);
+        }
+    }
 }
 
 struct RolloutFencingFlightGuard {
@@ -536,6 +585,7 @@ impl PublicationControl {
                 error: Some("hosted reader admission has not been checked".to_string()),
             }),
             rollout_fencing_flights: Arc::new(Mutex::new(BTreeSet::new())),
+            mutation_lease: Mutex::new(None),
         })
     }
 
@@ -715,7 +765,7 @@ impl PublicationControl {
             previous_repositories: None,
             holder: STARTUP_BOOTSTRAP_HOLDER.to_string(),
             request_id: STARTUP_BOOTSTRAP_REQUEST_ID.to_string(),
-            ttl_seconds: DEFAULT_ROLLOUT_LEASE_SECONDS,
+            ttl_seconds: HOSTED_ROLLOUT_LEASE_SECONDS,
             bootstrap_reader: Some(ReaderAdmissionInput {
                 identity: self.runtime_reader_identity.clone(),
                 min_snapshot_schema: kin_db::GraphSnapshot::MIN_SUPPORTED_VERSION,
@@ -1408,6 +1458,23 @@ impl PublicationControl {
         ))
     }
 
+    /// Renew the exact rollout proof to the daemon-owned window before one
+    /// external mutation under it. The rollout publishes every repository's
+    /// metadata and edges under one lease, so each publication extends the
+    /// lease it runs under rather than trusting the window acquired at
+    /// bootstrap. A proof the record no longer names, or one whose lease has
+    /// already expired, fails here exactly as it fails on assertion, and the
+    /// caller stops rather than mutating under it.
+    pub(crate) fn renew_rollout_before_mutation(
+        &self,
+        proof: &LeaseProof,
+    ) -> Result<ActivePublicationLease, PublicationControlError> {
+        self.renew_rollout(RenewRolloutLeaseRequest {
+            lease: proof.clone(),
+            ttl_seconds: HOSTED_ROLLOUT_LEASE_SECONDS,
+        })
+    }
+
     pub fn admit_reader(
         &self,
         request: AdmitReaderRequest,
@@ -1667,6 +1734,79 @@ impl PublicationControl {
             self.clock.now(),
         )?;
         Ok(())
+    }
+
+    /// Bind the lease an in-flight hosted mutation runs under, for the lifetime
+    /// of the returned handle. A binding for the same lease that is already in
+    /// place stays owned by whoever installed it; a binding for a different
+    /// lease is replaced, because one record admits one active lease and the
+    /// newer owner is the live one.
+    pub(crate) fn bind_mutation_lease(
+        self: &Arc<Self>,
+        kind: LeaseKind,
+        proof: LeaseProof,
+    ) -> BoundMutationLease {
+        let binding = MutationLeaseBinding { kind, proof };
+        let owner = {
+            let mut bound = self
+                .mutation_lease
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if bound.as_ref() == Some(&binding) {
+                false
+            } else {
+                *bound = Some(binding.clone());
+                true
+            }
+        };
+        BoundMutationLease {
+            control: Arc::clone(self),
+            binding,
+            owner,
+        }
+    }
+
+    fn unbind_mutation_lease(&self, binding: &MutationLeaseBinding) {
+        let mut bound = self
+            .mutation_lease
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if bound.as_ref() == Some(binding) {
+            *bound = None;
+        }
+    }
+
+    /// Re-read the lease bound to this process's in-flight hosted mutation and
+    /// refuse when it has expired, been fenced or changed hands. With nothing
+    /// bound there is no lease to defend and the check passes; the Firestore
+    /// store calls this before every transient retry.
+    pub fn reassert_bound_mutation_lease(&self) -> Result<(), PublicationControlError> {
+        let bound = self
+            .mutation_lease
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let Some(binding) = bound else {
+            return Ok(());
+        };
+        let stored = self.load_required()?;
+        self.validate_record(&stored.record)?;
+        require_lease(
+            &stored.record,
+            &binding.proof,
+            binding.kind,
+            self.clock.now(),
+        )?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn bound_mutation_lease_for_test(&self) -> Option<(LeaseKind, LeaseProof)> {
+        self.mutation_lease
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map(|binding| (binding.kind, binding.proof.clone()))
     }
 
     fn release(
@@ -4057,6 +4197,44 @@ mod object_store_control {
 #[cfg(feature = "gcs")]
 pub use object_store_control::Store as ObjectStorePublicationControlStore;
 
+/// A clock a test moves by hand. Shared by this module's tests and by the
+/// daemon state's composed-rollout regression, which charges each fake
+/// publication the time a real Firestore staging costs rather than sleeping.
+#[cfg(test)]
+pub(crate) mod test_clock {
+    use std::sync::Mutex;
+
+    use chrono::{DateTime, Duration as ChronoDuration, Utc};
+
+    use super::PublicationClock;
+
+    #[derive(Debug)]
+    pub(crate) struct ManualClock(Mutex<DateTime<Utc>>);
+
+    impl ManualClock {
+        pub(crate) fn new() -> Self {
+            Self(Mutex::new(
+                DateTime::parse_from_rfc3339("2026-08-27T12:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ))
+        }
+
+        pub(crate) fn advance(&self, seconds: i64) {
+            let mut now = self.0.lock().unwrap();
+            *now = now
+                .checked_add_signed(ChronoDuration::seconds(seconds))
+                .unwrap();
+        }
+    }
+
+    impl PublicationClock for ManualClock {
+        fn now(&self) -> DateTime<Utc> {
+            *self.0.lock().unwrap()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "gcs")]
@@ -4315,31 +4493,7 @@ mod tests {
         authority
     }
 
-    #[derive(Debug)]
-    struct ManualClock(Mutex<DateTime<Utc>>);
-
-    impl ManualClock {
-        fn new() -> Self {
-            Self(Mutex::new(
-                DateTime::parse_from_rfc3339("2026-08-27T12:00:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-            ))
-        }
-
-        fn advance(&self, seconds: i64) {
-            let mut now = self.0.lock().unwrap();
-            *now = now
-                .checked_add_signed(ChronoDuration::seconds(seconds))
-                .unwrap();
-        }
-    }
-
-    impl PublicationClock for ManualClock {
-        fn now(&self) -> DateTime<Utc> {
-            *self.0.lock().unwrap()
-        }
-    }
+    use super::test_clock::ManualClock;
 
     fn reader(identity: &str, valid_for_seconds: u64) -> ReaderAdmissionInput {
         ReaderAdmissionInput {
@@ -6441,5 +6595,144 @@ mod tests {
             first_store.create(&record),
             Err(PublicationControlError::Conflict(_))
         ));
+    }
+
+    /// The window the startup bootstrap actually requests, read from the lease
+    /// it mints and from the durable record, never from the constant alone. On
+    /// 2026-09-02 production's first Firestore rollout ran under this window,
+    /// it was 300 s, and nothing renewed it.
+    #[test]
+    fn startup_bootstrap_requests_the_hosted_rollout_window() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let control = control_for_fleet(Arc::clone(&store), clock, READER_A, staging_fleet());
+
+        let pending = control
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("absent runtime must leave one pending startup rollout");
+        let minted = (pending.expires_at - pending.acquired_at).num_seconds();
+        assert_eq!(minted, HOSTED_ROLLOUT_LEASE_SECONDS as i64);
+        let durable = control
+            .status()
+            .unwrap()
+            .active_lease
+            .expect("the durable record carries the startup lease");
+        assert_eq!(
+            (durable.expires_at - durable.acquired_at).num_seconds(),
+            HOSTED_ROLLOUT_LEASE_SECONDS as i64
+        );
+        assert_eq!(
+            HOSTED_ROLLOUT_LEASE_SECONDS, 1_800,
+            "the measured first rollout needs the cap validate_rollout_ttl admits, not the 300 s default"
+        );
+        assert!(
+            minted > DEFAULT_ROLLOUT_LEASE_SECONDS as i64,
+            "the minted window ({minted} s) must exceed the 300 s default that bounded production's first rollout"
+        );
+    }
+
+    /// Renewal before a mutation moves the expiry to a full window from now,
+    /// and it refuses exactly where assertion refuses: an expired lease, and a
+    /// proof the record does not name.
+    #[test]
+    fn rollout_renewal_before_mutation_extends_the_window_and_refuses_a_dead_lease() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let control = control_for_fleet(
+            Arc::clone(&store),
+            Arc::clone(&clock),
+            READER_A,
+            staging_fleet(),
+        );
+        let pending = control
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("pending startup rollout");
+
+        clock.advance(HOSTED_ROLLOUT_LEASE_SECONDS as i64 - 100);
+        let renewed = control
+            .renew_rollout_before_mutation(&proof(&pending))
+            .expect("a live lease renews");
+        assert_eq!(
+            renewed.expires_at,
+            clock.now() + ChronoDuration::seconds(HOSTED_ROLLOUT_LEASE_SECONDS as i64)
+        );
+        assert!(renewed.expires_at > pending.expires_at);
+        assert_eq!(renewed.token, pending.token, "renewal keeps the proof");
+        assert_eq!(renewed.fence, pending.fence);
+
+        let mut stranger = proof(&pending);
+        stranger.token = "not-the-active-token".to_string();
+        let refused = control
+            .renew_rollout_before_mutation(&stranger)
+            .unwrap_err();
+        assert!(
+            matches!(refused, PublicationControlError::Fenced(_)),
+            "{refused}"
+        );
+        assert!(
+            refused.to_string().contains("does not identify"),
+            "{refused}"
+        );
+
+        clock.advance(HOSTED_ROLLOUT_LEASE_SECONDS as i64 + 1);
+        let expired = control
+            .renew_rollout_before_mutation(&proof(&pending))
+            .unwrap_err();
+        assert!(
+            matches!(expired, PublicationControlError::Fenced(_)),
+            "{expired}"
+        );
+        assert!(expired.to_string().contains("expired"), "{expired}");
+    }
+
+    /// The lease bound to an in-flight mutation is what the Firestore store
+    /// re-reads before a transient retry: alive it passes, expired it refuses,
+    /// unbound there is nothing to defend. A nested owner of the same proof
+    /// leaves the outer binding in place.
+    #[test]
+    fn bound_mutation_lease_is_reasserted_and_cleared_with_its_owner() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let control = control_for_fleet(
+            Arc::clone(&store),
+            Arc::clone(&clock),
+            READER_A,
+            staging_fleet(),
+        );
+        control
+            .reassert_bound_mutation_lease()
+            .expect("nothing bound, nothing to defend");
+        let pending = control
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("pending startup rollout");
+
+        let bound = control.bind_mutation_lease(LeaseKind::Rollout, proof(&pending));
+        assert_eq!(
+            control.bound_mutation_lease_for_test(),
+            Some((LeaseKind::Rollout, proof(&pending)))
+        );
+        control
+            .reassert_bound_mutation_lease()
+            .expect("a live bound lease passes");
+        {
+            let _inner = control.bind_mutation_lease(LeaseKind::Rollout, proof(&pending));
+        }
+        assert!(
+            control.bound_mutation_lease_for_test().is_some(),
+            "a nested owner of the same proof must not clear the outer binding"
+        );
+
+        clock.advance(HOSTED_ROLLOUT_LEASE_SECONDS as i64 + 1);
+        let refused = control.reassert_bound_mutation_lease().unwrap_err();
+        assert!(refused.to_string().contains("expired"), "{refused}");
+
+        drop(bound);
+        assert!(control.bound_mutation_lease_for_test().is_none());
+        control
+            .reassert_bound_mutation_lease()
+            .expect("an unbound lease defends nothing");
     }
 }

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -5994,6 +5994,12 @@ impl DaemonState {
             .rollout_spine_fence_evidence(&request.lease)
             .map_err(|error| format!("load rollout evidence before reader admission: {error}"))?;
         let _publication_gate = self.spine_refresh_gate.write().await;
+        // The hydration proof below reads every committed row back before the
+        // reader is admitted; renew first so that proof runs under a fresh
+        // window rather than whatever the last publication left.
+        control
+            .renew_rollout_before_mutation(&request.lease)
+            .map_err(|error| format!("renew rollout before reader admission: {error}"))?;
         control
             .assert_rollout_lease(&request.lease)
             .map_err(|error| format!("reassert rollout before reader admission: {error}"))?;
@@ -6056,6 +6062,9 @@ impl DaemonState {
             .rollout_spine_fence_evidence(&request.lease)
             .map_err(|error| format!("load rollout evidence before release: {error}"))?;
         let _publication_gate = self.spine_refresh_gate.write().await;
+        control
+            .renew_rollout_before_mutation(&request.lease)
+            .map_err(|error| format!("renew rollout before release proof: {error}"))?;
         control
             .assert_rollout_lease(&request.lease)
             .map_err(|error| format!("reassert rollout before release: {error}"))?;
@@ -7462,6 +7471,11 @@ impl DaemonState {
     /// and refuse the retry when that lease expired, was fenced or changed
     /// hands while the failed request was in flight. A local daemon has no
     /// publication control and nothing to defend, so its gate passes.
+    ///
+    /// Only the Firestore backend installs it, so a build without that
+    /// feature has no caller and would refuse the dead code under
+    /// `-D warnings`; the tests drive it on every feature shape.
+    #[cfg(any(feature = "firestore", test))]
     pub(crate) fn hosted_transient_retry_gate(&self) -> kin_spine::TransientRetryGate {
         let control = self.publication_control.clone();
         Arc::new(move || match control.as_ref() {

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2008,6 +2008,9 @@ struct HostedPublicationGuard {
     control: Option<Arc<crate::publication_lease::PublicationControl>>,
     lease: Option<crate::publication_lease::ActivePublicationLease>,
     rollout: Option<crate::publication_lease::LeaseProof>,
+    /// The same lease, bound in the control so the Firestore store can re-read
+    /// it before retrying a transient failure. Cleared when this guard drops.
+    _bound: Option<crate::publication_lease::BoundMutationLease>,
 }
 
 impl HostedPublicationGuard {
@@ -2016,6 +2019,7 @@ impl HostedPublicationGuard {
             control: None,
             lease: None,
             rollout: None,
+            _bound: None,
         }
     }
 
@@ -2023,10 +2027,19 @@ impl HostedPublicationGuard {
         control: Arc<crate::publication_lease::PublicationControl>,
         lease: crate::publication_lease::ActivePublicationLease,
     ) -> Self {
+        let bound = control.bind_mutation_lease(
+            crate::publication_lease::LeaseKind::Publication,
+            crate::publication_lease::LeaseProof {
+                scope: control.scope().to_string(),
+                token: lease.token.clone(),
+                fence: lease.fence,
+            },
+        );
         Self {
             control: Some(control),
             lease: Some(lease),
             rollout: None,
+            _bound: Some(bound),
         }
     }
 
@@ -2034,10 +2047,13 @@ impl HostedPublicationGuard {
         control: Arc<crate::publication_lease::PublicationControl>,
         proof: crate::publication_lease::LeaseProof,
     ) -> Self {
+        let bound = control
+            .bind_mutation_lease(crate::publication_lease::LeaseKind::Rollout, proof.clone());
         Self {
             control: Some(control),
             lease: None,
             rollout: Some(proof),
+            _bound: Some(bound),
         }
     }
 
@@ -2050,8 +2066,18 @@ impl HostedPublicationGuard {
     /// Renew then re-read the exact proof immediately before an external
     /// mutation. A lease that expired, was fenced, or changed hands cannot
     /// authorize the next write.
+    ///
+    /// A rollout proof is renewed here too, not only asserted. The first hosted
+    /// rollout publishes every repository's metadata and then its edges under
+    /// the one lease acquired at startup, and this is the only point on that
+    /// path that runs before each of those publications; a lease that was only
+    /// asserted here ran out under a fleet whose publication outlived the
+    /// window, with every write done and none of the credit kept.
     fn reassert_before_mutation(&mut self) -> Result<()> {
         if let (Some(control), Some(proof)) = (self.control.as_ref(), self.rollout.as_ref()) {
+            control
+                .renew_rollout_before_mutation(proof)
+                .map_err(|error| Self::publication_error("rollout lease renewal", error))?;
             control
                 .assert_rollout_lease(proof)
                 .map_err(|error| Self::publication_error("rollout proof reassertion", error))?;
@@ -5763,6 +5789,57 @@ impl DaemonState {
         }
     }
 
+    /// Drive the startup rollout that `bootstrap_runtime_if_absent` left
+    /// pending, from the Firestore fleet fence through publication, reader
+    /// admission and release. This is the sequence the daemon binary runs when
+    /// it owns the first rollout of a fleet or resumes its own exact startup
+    /// lease after a crash; it lives here so the same bytes can be driven end
+    /// to end under a test clock, and every step runs under the pending lease
+    /// with the proof bound for the Firestore store's retry gate.
+    #[doc(hidden)]
+    pub async fn complete_hosted_startup_rollout(
+        &self,
+        control: &Arc<crate::publication_lease::PublicationControl>,
+        pending: crate::publication_lease::ActivePublicationLease,
+        legacy_writer_drain_proof_sha256: Option<String>,
+    ) -> std::result::Result<(), String> {
+        let proof = crate::publication_lease::LeaseProof {
+            scope: control.scope().to_string(),
+            token: pending.token,
+            fence: pending.fence,
+        };
+        let _bound = control
+            .bind_mutation_lease(crate::publication_lease::LeaseKind::Rollout, proof.clone());
+        let fence = control
+            .spine_rollout_fence(&proof)
+            .map_err(|error| error.to_string())?;
+        let evidence = self.advance_hosted_spine_rollout_fence(fence).await?;
+        control
+            .checkpoint_spine_rollout_fence(&proof, &evidence)
+            .map_err(|error| error.to_string())?;
+        control
+            .complete_rollout_acquisition(&proof)
+            .map_err(|error| error.to_string())?;
+        let admission = crate::publication_lease::AdmitReaderRequest {
+            lease: proof.clone(),
+            repositories: control.fleet_repositories().to_vec(),
+            reader: crate::publication_lease::ReaderAdmissionInput {
+                identity: control.runtime_reader_identity().to_string(),
+                min_snapshot_schema: kin_db::GraphSnapshot::MIN_SUPPORTED_VERSION,
+                max_snapshot_schema: kin_db::GraphSnapshot::CURRENT_VERSION,
+                valid_for_seconds: crate::publication_lease::MAX_READER_ADMISSION_SECONDS,
+            },
+            legacy_writer_drain_proof_sha256,
+        };
+        self.prepare_hosted_spine_rollout(&admission).await?;
+        self.admit_hosted_spine_rollout_fence(admission).await?;
+        self.release_hosted_spine_rollout(crate::publication_lease::ReleaseRolloutLeaseRequest {
+            lease: proof,
+        })
+        .await?;
+        Ok(())
+    }
+
     /// Publish the exact target fleet under the still-active rollout proof.
     /// Ordinary publication leases are intentionally unavailable while a
     /// rollout is active, so the rollout control plane owns this one bounded
@@ -7380,6 +7457,21 @@ impl DaemonState {
         self.sibling_capture.get().copied()
     }
 
+    /// The gate the Firestore store consults before it retries a transient
+    /// failure: re-read the lease the in-flight hosted mutation is bound to,
+    /// and refuse the retry when that lease expired, was fenced or changed
+    /// hands while the failed request was in flight. A local daemon has no
+    /// publication control and nothing to defend, so its gate passes.
+    pub(crate) fn hosted_transient_retry_gate(&self) -> kin_spine::TransientRetryGate {
+        let control = self.publication_control.clone();
+        Arc::new(move || match control.as_ref() {
+            Some(control) => control
+                .reassert_bound_mutation_lease()
+                .map_err(|error| error.to_string()),
+            None => Ok(()),
+        })
+    }
+
     fn create_spine_backend(
         &self,
     ) -> std::result::Result<Arc<dyn kin_spine::SpineBackend>, String> {
@@ -7418,7 +7510,12 @@ impl DaemonState {
                     database = database_id.as_deref().unwrap_or("(default)"),
                     "using Firestore spine backend for stateless daemon pool"
                 );
-                let backend = kin_spine::FirestoreSpineBackend::new(project_id, database_id);
+                let backend = kin_spine::FirestoreSpineBackend::new_with_endpoint(
+                    project_id,
+                    database_id,
+                    kin_spine::FirestoreEndpoint::GoogleApis,
+                    Some(self.hosted_transient_retry_gate()),
+                );
                 // Construction is intentionally publication-capable but not
                 // reader-ready. A first rollout must be able to create the
                 // Firestore fleet fence and cursor-bound heads even when
@@ -18062,5 +18159,215 @@ mod tests {
             "{}",
             plain.profile
         );
+    }
+
+    /// The stranger class from the 2026-09-02 rehearsal against production's
+    /// own control record (kin-ecosystem .kin-coord/reports/spinefix-20260902.md,
+    /// sections 3 and 5). The first hosted rollout publishes every
+    /// repository's metadata and then its edges under the one lease minted at
+    /// startup; nothing renewed it, and every run died with the work done and
+    /// the credit lost: 204 s of a 300 s lease consumed after ONE repository's
+    /// 27,987 entities, four repositories and the whole edge pass still ahead.
+    ///
+    /// This drives the exact sequence the binary runs, over the durable fake,
+    /// under a clock that charges each publication more than the old window
+    /// and less than the new one. Completion is then attributable only to the
+    /// renewal before each publication, and the fixture asserts that the total
+    /// charged exceeds the window one acquisition gives, so a change that made
+    /// the whole rollout fit inside one window would fail here rather than
+    /// pass for the wrong reason.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn first_hosted_rollout_outlives_its_startup_lease_by_renewing_before_each_publication() {
+        use crate::publication_lease::test_clock::ManualClock;
+        use crate::publication_lease::{
+            InMemoryPublicationControlStore, PublicationClock, PublicationControl,
+            DEFAULT_ROLLOUT_LEASE_SECONDS,
+        };
+        use kin_db::{InMemoryGraph, LocalFileBackend, StorageBackend, GENERATION_INIT};
+        use std::sync::atomic::AtomicI64;
+
+        const READER: &str =
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        /// Longer than the 300 s window the startup lease used to get and
+        /// shorter than the window it gets now: one publication fits only
+        /// under the new window, and the fleet fits only with renewal.
+        const PUBLICATION_SECONDS: i64 = 400;
+
+        let fleet = ["kin", "kin-db", "kin-editor", "kin-vfs", "kinlab"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let mut environment = kin_core::test_env::EnvVarGuard::new();
+        environment.apply("GOOGLE_CLOUD_PROJECT", Some("fixture-project"));
+        environment.apply("KIN_GCS_BUCKET", Some("fixture-bucket"));
+        environment.apply("KIN_GCS_PREFIX", Some("fixture-prefix"));
+        environment.apply("KIN_REPO_IDS", Some(&fleet.join(",")));
+        environment.apply::<_, &str>("KIN_DISABLE_SPINE", None);
+        let scope = "gcs://fixture-bucket/fixture-prefix";
+
+        let backend_root = tempfile::tempdir().unwrap();
+        for repo_id in &fleet {
+            let graph = InMemoryGraph::new();
+            graph
+                .upsert_entity(&test_entity(
+                    &format!("{}_entity", repo_id.replace('-', "_")),
+                    "src/lib.rs",
+                ))
+                .unwrap();
+            LocalFileBackend::new(backend_root.path())
+                .save_snapshot(
+                    repo_id,
+                    &graph.to_snapshot().to_bytes().unwrap(),
+                    GENERATION_INIT,
+                )
+                .unwrap();
+        }
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let clock = Arc::new(ManualClock::new());
+        let control = Arc::new(
+            PublicationControl::with_clock(
+                scope,
+                READER,
+                fleet.clone(),
+                Arc::new(InMemoryPublicationControlStore::default()),
+                Arc::clone(&clock) as Arc<dyn PublicationClock>,
+            )
+            .unwrap(),
+        );
+        let state = DaemonState::open_with_backend_and_publication_control(
+            layout,
+            Box::new(LocalFileBackend::new(backend_root.path())),
+            "kin",
+            Some(fleet.iter().cloned().collect()),
+            Arc::clone(&control),
+        )
+        .unwrap();
+        let fake = Arc::new(kin_spine::test_support::FakeSpineStore::cold());
+        let charged = Arc::new(AtomicI64::new(0));
+        *fake.prepare_hook.lock().unwrap() = Some(Box::new({
+            let clock = Arc::clone(&clock);
+            let charged = Arc::clone(&charged);
+            move |_repo_id: &str| {
+                clock.advance(PUBLICATION_SECONDS);
+                charged.fetch_add(PUBLICATION_SECONDS, Ordering::SeqCst);
+            }
+        }));
+        state.install_hosted_durable_spine_for_test(Arc::new(
+            kin_spine::FirestoreSpineBackend::with_store(fake.clone()),
+        ));
+        assert!(
+            state.hosted_spine_readiness_required(),
+            "the composed path is only under test with hosted readiness on"
+        );
+
+        let pending = control
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("an absent control record leaves one pending startup rollout");
+        let window = (pending.expires_at - pending.acquired_at).num_seconds();
+        assert!(
+            PUBLICATION_SECONDS > DEFAULT_ROLLOUT_LEASE_SECONDS as i64
+                && PUBLICATION_SECONDS < window,
+            "the fixture must charge each publication more than the old window ({}) and less \
+             than the minted one ({window}), or it proves nothing about renewal",
+            DEFAULT_ROLLOUT_LEASE_SECONDS
+        );
+
+        state
+            .complete_hosted_startup_rollout(
+                &control,
+                pending,
+                Some(format!("sha256:{}", "b".repeat(64))),
+            )
+            .await
+            .expect("the first hosted rollout must finish inside the lease it keeps renewing");
+
+        let total = charged.load(Ordering::SeqCst);
+        assert!(
+            total > window,
+            "the rollout charged {total} s against a {window} s window, so its completion \
+             cannot be attributed to renewal"
+        );
+        let record = control.status().unwrap();
+        assert!(
+            record.active_lease.is_none(),
+            "release must clear the startup lease"
+        );
+        control
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .expect("the reader is admitted once the rollout has released");
+        assert_eq!(
+            fake.publication_state.lock().unwrap().heads.len(),
+            fleet.len(),
+            "every repository head committed"
+        );
+        assert!(
+            control.bound_mutation_lease_for_test().is_none(),
+            "the startup sequence unbinds its proof when it is done"
+        );
+    }
+
+    /// The gate the Firestore store consults before a transient retry is the
+    /// state's own closure over its publication control: it passes with
+    /// nothing bound, passes on a live bound lease, refuses once that lease
+    /// has expired, and passes again once the owner is gone.
+    #[test]
+    #[serial_test::serial]
+    fn hosted_transient_retry_gate_reasserts_the_bound_lease() {
+        use crate::publication_lease::test_clock::ManualClock;
+        use crate::publication_lease::{
+            InMemoryPublicationControlStore, LeaseKind, LeaseProof, PublicationClock,
+            PublicationControl, HOSTED_ROLLOUT_LEASE_SECONDS,
+        };
+        use kin_db::LocalFileBackend;
+
+        const READER: &str =
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let fleet = vec!["kin".to_string(), "kin-db".to_string()];
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let backend_root = tempfile::tempdir().unwrap();
+        let clock = Arc::new(ManualClock::new());
+        let control = Arc::new(
+            PublicationControl::with_clock(
+                "gcs://fixture/v2",
+                READER,
+                fleet.clone(),
+                Arc::new(InMemoryPublicationControlStore::default()),
+                Arc::clone(&clock) as Arc<dyn PublicationClock>,
+            )
+            .unwrap(),
+        );
+        let state = DaemonState::open_with_backend_and_publication_control(
+            layout,
+            Box::new(LocalFileBackend::new(backend_root.path())),
+            "kin",
+            Some(fleet.iter().cloned().collect()),
+            Arc::clone(&control),
+        )
+        .unwrap();
+        let gate = state.hosted_transient_retry_gate();
+        gate().expect("nothing bound, nothing to defend");
+
+        let pending = control
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("pending startup rollout");
+        let bound = control.bind_mutation_lease(
+            LeaseKind::Rollout,
+            LeaseProof {
+                scope: control.scope().to_string(),
+                token: pending.token.clone(),
+                fence: pending.fence,
+            },
+        );
+        gate().expect("a live bound lease passes");
+        clock.advance(HOSTED_ROLLOUT_LEASE_SECONDS as i64 + 1);
+        let refused = gate().expect_err("an expired bound lease refuses the retry");
+        assert!(refused.contains("expired"), "{refused}");
+        drop(bound);
+        gate().expect("an unbound lease defends nothing");
     }
 }

--- a/crates/kin-spine/src/firestore.rs
+++ b/crates/kin-spine/src/firestore.rs
@@ -88,6 +88,156 @@ const CLEANUP_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
 #[cfg(feature = "firestore")]
 const FIRESTORE_MAX_WRITES_PER_COMMIT: usize = 100;
 
+/// Consulted before every transient retry of a Firestore request. The hosted
+/// daemon binds the lease its in-flight mutation runs under and re-reads it
+/// here, so a request that stalled long enough for the lease to expire or
+/// change hands is never retried under it. `Err` names the refusal and ends
+/// the retry with it.
+pub type TransientRetryGate = Arc<dyn Fn() -> Result<(), String> + Send + Sync>;
+
+/// Where the Firestore REST calls go. `GoogleApis` is production. `Emulator`
+/// is a plain-HTTP base such as `http://127.0.0.1:8080`, the shape Google's
+/// own `FIRESTORE_EMULATOR_HOST` clients use: no metadata token is fetched and
+/// the fixed bearer `owner` is sent, which the emulator accepts and a real
+/// endpoint would reject. It is also what lets a test drive the real request
+/// paths against a scripted local server.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FirestoreEndpoint {
+    GoogleApis,
+    Emulator { base_url: String },
+}
+
+/// Attempts a transient Firestore failure gets in total, first try included,
+/// and the backoff before the first retry; each later retry doubles it. Named
+/// once here: 4 attempts, 250 ms, 500 ms, 1 s. A first hosted rollout is
+/// several hundred requests wide, and on 2026-09-02 one transport error on one
+/// read of `spine_repo_heads_v2` ended a rollout that had 96 s of lease left.
+#[cfg(feature = "firestore")]
+const FIRESTORE_TRANSIENT_ATTEMPTS: u32 = 4;
+#[cfg(feature = "firestore")]
+const FIRESTORE_TRANSIENT_BACKOFF_BASE: Duration = Duration::from_millis(250);
+
+/// One failed Firestore request, classified for retry.
+#[cfg(feature = "firestore")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FirestoreRequestFailure {
+    /// No response arrived: connect, reset, timeout, closed mid-message.
+    Transport(String),
+    /// A response with a non-success status and whatever body came with it.
+    Status { status: u16, body: String },
+    /// The retry gate refused; `after` is the failure it would have retried.
+    RetryRefused {
+        refusal: String,
+        after: Box<FirestoreRequestFailure>,
+    },
+}
+
+#[cfg(feature = "firestore")]
+impl FirestoreRequestFailure {
+    fn is_transient(&self) -> bool {
+        match self {
+            Self::Transport(_) => true,
+            Self::Status { status, body } => transient_firestore_status(*status, body),
+            Self::RetryRefused { .. } => false,
+        }
+    }
+}
+
+#[cfg(feature = "firestore")]
+impl std::fmt::Display for FirestoreRequestFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transport(error) => write!(formatter, "failed: {error}"),
+            Self::Status { status, body } => {
+                let reason = reqwest::StatusCode::from_u16(*status)
+                    .ok()
+                    .and_then(|status| status.canonical_reason())
+                    .unwrap_or("");
+                write!(formatter, "failed ({status} {reason}): {body}")
+            }
+            Self::RetryRefused { refusal, after } => write!(
+                formatter,
+                "{after}; retry refused because the hosted lease could not be reasserted: {refusal}"
+            ),
+        }
+    }
+}
+
+/// Firestore names the gRPC code in the body's `error.status`, and that name
+/// is the classification: the HTTP status alone conflates ABORTED, which is
+/// contention and safe to retry, with ALREADY_EXISTS, which is a precondition
+/// verdict on a write that must not be repeated (both are 409). Only when the
+/// body carries no name does the HTTP status decide, and then 5xx and 429 are
+/// transient and everything else, 409 included, is not.
+#[cfg(feature = "firestore")]
+fn transient_firestore_status(status: u16, body: &str) -> bool {
+    match firestore_error_status(body) {
+        Some(code) => matches!(
+            code.as_str(),
+            "UNAVAILABLE"
+                | "DEADLINE_EXCEEDED"
+                | "ABORTED"
+                | "RESOURCE_EXHAUSTED"
+                | "INTERNAL"
+                | "UNKNOWN"
+        ),
+        None => (500..600).contains(&status) || status == 429,
+    }
+}
+
+#[cfg(feature = "firestore")]
+fn firestore_error_status(body: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()?
+        .pointer("/error/status")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// Run one Firestore request with the bounded transient policy. `attempt`
+/// performs the request; a transient failure is retried after the gate passes
+/// and the backoff elapses, up to `FIRESTORE_TRANSIENT_ATTEMPTS` in total, and
+/// every other failure returns at once. The last failure is returned when the
+/// budget runs out. `sleep` is a parameter so the policy can be exercised
+/// without waiting for it.
+#[cfg(feature = "firestore")]
+fn retry_transient<T>(
+    describe: &str,
+    gate: Option<&TransientRetryGate>,
+    mut sleep: impl FnMut(Duration),
+    mut attempt: impl FnMut() -> Result<T, FirestoreRequestFailure>,
+) -> Result<T, FirestoreRequestFailure> {
+    let mut attempts: u32 = 0;
+    loop {
+        attempts += 1;
+        let failure = match attempt() {
+            Ok(value) => return Ok(value),
+            Err(failure) if failure.is_transient() && attempts < FIRESTORE_TRANSIENT_ATTEMPTS => {
+                failure
+            }
+            Err(failure) => return Err(failure),
+        };
+        if let Some(gate) = gate {
+            if let Err(refusal) = gate() {
+                return Err(FirestoreRequestFailure::RetryRefused {
+                    refusal,
+                    after: Box::new(failure),
+                });
+            }
+        }
+        let backoff = FIRESTORE_TRANSIENT_BACKOFF_BASE * 2u32.pow(attempts - 1);
+        warn!(
+            request = describe,
+            attempt = attempts,
+            budget = FIRESTORE_TRANSIENT_ATTEMPTS,
+            backoff_ms = backoff.as_millis() as u64,
+            failure = %failure,
+            "transient Firestore failure; retrying after the hosted lease reasserted"
+        );
+        sleep(backoff);
+    }
+}
+
 #[cfg(feature = "firestore")]
 const FIRESTORE_MAX_COMMIT_JSON_BYTES: usize = 8 * 1024 * 1024;
 
@@ -550,7 +700,25 @@ impl FirestoreSpineBackend {
     /// `database_id`: Firestore database (typically "(default)").
     #[cfg(feature = "firestore")]
     pub fn new(project_id: String, database_id: Option<String>) -> Self {
-        Self::with_store(Arc::new(FirestoreStore::new(project_id, database_id)))
+        Self::new_with_endpoint(project_id, database_id, FirestoreEndpoint::GoogleApis, None)
+    }
+
+    /// Create a Firestore-backed spine backend against an explicit endpoint,
+    /// with the gate the store consults before every transient retry. The
+    /// hosted daemon passes its lease gate here; a store nobody bound a lease
+    /// to retries transient failures with no gate at all.
+    #[cfg(feature = "firestore")]
+    pub fn new_with_endpoint(
+        project_id: String,
+        database_id: Option<String>,
+        endpoint: FirestoreEndpoint,
+        transient_retry_gate: Option<TransientRetryGate>,
+    ) -> Self {
+        let mut store = FirestoreStore::with_endpoint(project_id, database_id, endpoint);
+        if let Some(gate) = transient_retry_gate {
+            store = store.with_transient_retry_gate(gate);
+        }
+        Self::with_store(Arc::new(store))
     }
 
     /// Create a backend over an arbitrary durable store.
@@ -1306,12 +1474,26 @@ pub struct FirestoreStore {
     client: reqwest::Client,
     /// Cached access token + expiry.
     token: parking_lot::RwLock<Option<(String, std::time::Instant)>>,
+    /// Production Google APIs, or an emulator-shaped plain-HTTP base.
+    endpoint: FirestoreEndpoint,
+    /// Re-reads the hosted lease before every transient retry; see
+    /// [`TransientRetryGate`]. Absent for a store nobody bound a lease to.
+    transient_retry_gate: Option<TransientRetryGate>,
 }
 
 #[cfg(feature = "firestore")]
 impl FirestoreStore {
-    /// Create a new Firestore store.
+    /// Create a new Firestore store against Google APIs.
     pub fn new(project_id: String, database_id: Option<String>) -> Self {
+        Self::with_endpoint(project_id, database_id, FirestoreEndpoint::GoogleApis)
+    }
+
+    /// Create a store against an explicit endpoint.
+    pub fn with_endpoint(
+        project_id: String,
+        database_id: Option<String>,
+        endpoint: FirestoreEndpoint,
+    ) -> Self {
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(10))
             .build()
@@ -1322,15 +1504,88 @@ impl FirestoreStore {
             database_id: database_id.unwrap_or_else(|| "(default)".to_string()),
             client,
             token: parking_lot::RwLock::new(None),
+            endpoint,
+            transient_retry_gate: None,
         }
+    }
+
+    /// Install the gate consulted before every transient retry.
+    pub fn with_transient_retry_gate(mut self, gate: TransientRetryGate) -> Self {
+        self.transient_retry_gate = Some(gate);
+        self
     }
 
     /// Base URL for the Firestore REST API documents endpoint.
     fn base_url(&self) -> String {
+        let host = match &self.endpoint {
+            FirestoreEndpoint::GoogleApis => "https://firestore.googleapis.com",
+            FirestoreEndpoint::Emulator { base_url } => base_url.trim_end_matches('/'),
+        };
         format!(
-            "https://firestore.googleapis.com/v1/projects/{}/databases/{}/documents",
+            "{host}/v1/projects/{}/databases/{}/documents",
             self.project_id, self.database_id
         )
+    }
+
+    /// Send one Firestore request under the transient policy and hand back
+    /// whatever response finally arrived, success or not, so each call site
+    /// keeps its own reading of the status. A transport failure that outlasts
+    /// the budget, and a retry the gate refused, surface as the error the
+    /// site would have raised for that failure on its first attempt.
+    fn send_with_transient_retry(
+        &self,
+        describe: &str,
+        build: impl Fn() -> reqwest::RequestBuilder,
+    ) -> Result<(reqwest::StatusCode, String), SpineError> {
+        enum Attempt {
+            Response(reqwest::StatusCode, String),
+            Transport(String),
+        }
+        let outcome = retry_transient(
+            describe,
+            self.transient_retry_gate.as_ref(),
+            std::thread::sleep,
+            || {
+                let attempt = self.run_async(async {
+                    let response = match build().send().await {
+                        Ok(response) => response,
+                        Err(error) => return Ok(Attempt::Transport(error.to_string())),
+                    };
+                    let status = response.status();
+                    let body = response.text().await.unwrap_or_default();
+                    Ok(Attempt::Response(status, body))
+                });
+                match attempt {
+                    Ok(Attempt::Response(status, body)) if status.is_success() => {
+                        Ok(Ok((status, body)))
+                    }
+                    Ok(Attempt::Response(status, body)) => Err(FirestoreRequestFailure::Status {
+                        status: status.as_u16(),
+                        body,
+                    }),
+                    Ok(Attempt::Transport(error)) => Err(FirestoreRequestFailure::Transport(error)),
+                    // The runtime could not run the request at all; that is
+                    // not a Firestore answer and is never retried.
+                    Err(error) => Ok(Err(error)),
+                }
+            },
+        );
+        match outcome {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(runtime_error)) => Err(runtime_error),
+            Err(FirestoreRequestFailure::Status { status, body }) => Ok((
+                reqwest::StatusCode::from_u16(status).map_err(|error| {
+                    SpineError::Http(format!("{describe} failed with status {status}: {error}"))
+                })?,
+                body,
+            )),
+            Err(failure @ FirestoreRequestFailure::Transport(_)) => {
+                Err(SpineError::Http(format!("{describe} {failure}")))
+            }
+            Err(failure @ FirestoreRequestFailure::RetryRefused { .. }) => {
+                Err(SpineError::Backend(format!("{describe} {failure}")))
+            }
+        }
     }
 
     fn document_name(&self, collection: &str, document_id: &str) -> String {
@@ -1381,6 +1636,9 @@ impl FirestoreStore {
     /// Get an access token from the GCE metadata server.
     /// Caches the token for its lifetime minus a 60-second buffer.
     fn get_access_token(&self) -> Result<String, SpineError> {
+        if matches!(self.endpoint, FirestoreEndpoint::Emulator { .. }) {
+            return Ok("owner".to_string());
+        }
         {
             let cached = self.token.read();
             if let Some((ref token, ref expiry)) = *cached {
@@ -1431,49 +1689,41 @@ impl FirestoreStore {
     /// List every document in a collection, following pagination.
     fn list_all_documents(&self, collection: &str) -> Result<Vec<serde_json::Value>, SpineError> {
         let token = self.get_access_token()?;
-        self.run_async(async {
-            let mut documents = Vec::new();
-            let mut page_token: Option<String> = None;
+        let mut documents = Vec::new();
+        let mut page_token: Option<String> = None;
 
-            loop {
-                let mut url = format!("{}/{}?pageSize=300", self.base_url(), collection);
-                if let Some(ref pt) = page_token {
-                    url.push_str("&pageToken=");
-                    url.push_str(pt);
-                }
-
-                let resp = self
-                    .client
-                    .get(&url)
-                    .bearer_auth(&token)
-                    .send()
-                    .await
-                    .map_err(|e| SpineError::Http(format!("list {collection} failed: {e}")))?;
-
-                if !resp.status().is_success() {
-                    let status = resp.status();
-                    let body = resp.text().await.unwrap_or_default();
-                    return Err(SpineError::Http(format!(
-                        "list {collection} failed ({status}): {body}"
-                    )));
-                }
-
-                let body: serde_json::Value = resp.json().await.map_err(|e| {
-                    SpineError::Serialization(format!("failed to parse {collection} list: {e}"))
-                })?;
-
-                if let Some(docs) = body.get("documents").and_then(|d| d.as_array()) {
-                    documents.extend(docs.iter().cloned());
-                }
-
-                match body.get("nextPageToken").and_then(|t| t.as_str()) {
-                    Some(next) if !next.is_empty() => page_token = Some(next.to_string()),
-                    _ => break,
-                }
+        loop {
+            let mut url = format!("{}/{}?pageSize=300", self.base_url(), collection);
+            if let Some(ref pt) = page_token {
+                url.push_str("&pageToken=");
+                url.push_str(pt);
             }
 
-            Ok(documents)
-        })
+            let (status, body) = self
+                .send_with_transient_retry(&format!("list {collection}"), || {
+                    self.client.get(&url).bearer_auth(&token)
+                })?;
+            if !status.is_success() {
+                return Err(SpineError::Http(format!(
+                    "list {collection} failed ({status}): {body}"
+                )));
+            }
+
+            let body: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
+                SpineError::Serialization(format!("failed to parse {collection} list: {e}"))
+            })?;
+
+            if let Some(docs) = body.get("documents").and_then(|d| d.as_array()) {
+                documents.extend(docs.iter().cloned());
+            }
+
+            match body.get("nextPageToken").and_then(|t| t.as_str()) {
+                Some(next) if !next.is_empty() => page_token = Some(next.to_string()),
+                _ => break,
+            }
+        }
+
+        Ok(documents)
     }
 
     /// Read one document and retain Firestore's server revision for a later
@@ -1485,31 +1735,22 @@ impl FirestoreStore {
     ) -> Result<Option<serde_json::Value>, SpineError> {
         let token = self.get_access_token()?;
         let url = self.document_url(collection, document_id);
-        self.run_async(async {
-            let response = self
-                .client
-                .get(&url)
-                .bearer_auth(&token)
-                .send()
-                .await
-                .map_err(|error| {
-                    SpineError::Http(format!("read {collection}/{document_id} failed: {error}"))
-                })?;
-            if response.status() == reqwest::StatusCode::NOT_FOUND {
-                return Ok(None);
-            }
-            if !response.status().is_success() {
-                let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                return Err(SpineError::Http(format!(
-                    "read {collection}/{document_id} failed ({status}): {body}"
-                )));
-            }
-            response.json().await.map(Some).map_err(|error| {
-                SpineError::Serialization(format!(
-                    "failed to parse {collection}/{document_id}: {error}"
-                ))
-            })
+        let (status, body) = self
+            .send_with_transient_retry(&format!("read {collection}/{document_id}"), || {
+                self.client.get(&url).bearer_auth(&token)
+            })?;
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            return Err(SpineError::Http(format!(
+                "read {collection}/{document_id} failed ({status}): {body}"
+            )));
+        }
+        serde_json::from_str(&body).map(Some).map_err(|error| {
+            SpineError::Serialization(format!(
+                "failed to parse {collection}/{document_id}: {error}"
+            ))
         })
     }
 
@@ -1538,30 +1779,22 @@ impl FirestoreStore {
             structured_query["limit"] = serde_json::json!(limit);
         }
         let query = serde_json::json!({ "structuredQuery": structured_query });
-        self.run_async(async {
-            let response = self
-                .client
-                .post(&url)
-                .bearer_auth(&token)
-                .json(&query)
-                .send()
-                .await
-                .map_err(|error| SpineError::Http(format!("query {collection} failed: {error}")))?;
-            if !response.status().is_success() {
-                let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                return Err(SpineError::Http(format!(
-                    "query {collection} failed ({status}): {body}"
-                )));
-            }
-            let results: Vec<serde_json::Value> = response.json().await.map_err(|error| {
-                SpineError::Serialization(format!("failed to parse {collection} query: {error}"))
+        let (status, body) = self
+            .send_with_transient_retry(&format!("query {collection}"), || {
+                self.client.post(&url).bearer_auth(&token).json(&query)
             })?;
-            Ok(results
-                .into_iter()
-                .filter_map(|result| result.get("document").cloned())
-                .collect())
-        })
+        if !status.is_success() {
+            return Err(SpineError::Http(format!(
+                "query {collection} failed ({status}): {body}"
+            )));
+        }
+        let results: Vec<serde_json::Value> = serde_json::from_str(&body).map_err(|error| {
+            SpineError::Serialization(format!("failed to parse {collection} query: {error}"))
+        })?;
+        Ok(results
+            .into_iter()
+            .filter_map(|result| result.get("document").cloned())
+            .collect())
     }
 
     /// Commit staged row writes or bounded cleanup deletes in batches limited
@@ -1626,28 +1859,23 @@ impl FirestoreStore {
         operation: &str,
     ) -> Result<(), SpineError> {
         let body = serde_json::json!({ "writes": writes });
-        self.run_async(async {
-            let response = self
-                .client
-                .post(url)
-                .bearer_auth(token)
-                .json(&body)
-                .send()
-                .await
-                .map_err(|error| SpineError::Http(format!("{operation} commit failed: {error}")))?;
-            if !response.status().is_success() {
-                let status = response.status();
-                let response_body = response.text().await.unwrap_or_default();
-                return Err(SpineError::Http(format!(
-                    "{operation} commit failed ({status}): {response_body}"
-                )));
-            }
-            // A successful Firestore Commit is atomic for every write in the
-            // request. Do not turn an acknowledged commit into an ambiguous
-            // local error merely because its informational response body was
-            // truncated or could not be decoded.
-            Ok(())
-        })
+        let (status, response_body) = self
+            .send_with_transient_retry(&format!("{operation} commit"), || {
+                self.client.post(url).bearer_auth(token).json(&body)
+            })?;
+        if !status.is_success() {
+            return Err(SpineError::Http(format!(
+                "{operation} commit failed ({status}): {response_body}"
+            )));
+        }
+        // A successful Firestore Commit is atomic for every write in the
+        // request. Do not turn an acknowledged commit into an ambiguous
+        // local error merely because its informational response body was
+        // truncated or could not be decoded. A retried commit whose first
+        // attempt was applied but never answered fails its preconditions on
+        // the second, which is a permanent status and reaches the caller's
+        // own reconciliation exactly as the lost answer would have.
+        Ok(())
     }
 
     fn read_repo_head(
@@ -2582,24 +2810,16 @@ impl FirestoreStore {
         let body = serde_json::json!({ "writes": writes });
         let token = self.get_access_token()?;
         let url = format!("{}:commit", self.base_url());
-        let response = self.run_async(async {
-            let response = self
-                .client
-                .post(&url)
-                .bearer_auth(&token)
-                .json(&body)
-                .send()
-                .await
-                .map_err(|error| SpineError::Http(format!("head CAS failed: {error}")))?;
-            let status = response.status();
-            if status.is_success() {
-                Ok((status, None))
-            } else {
-                Ok((status, Some(response.text().await.unwrap_or_default())))
-            }
+        // The CAS is retried on a transient failure like every other send,
+        // and its preconditions make a repeat of an applied commit fail with
+        // a permanent status; reconciliation below reads the durable head
+        // either way, so a retry can only turn an indeterminate outcome into
+        // a decided one.
+        let response = self.send_with_transient_retry("head CAS", || {
+            self.client.post(&url).bearer_auth(&token).json(&body)
         });
         let (status, response_body) = match response {
-            Ok(response) => response,
+            Ok((status, body)) => (status, (!status.is_success()).then_some(body)),
             Err(error) => {
                 return self.reconcile_ambiguous_head(prepared, error.to_string());
             }
@@ -6766,5 +6986,502 @@ mod tests {
         assert!(store.delete_repo_entities("repo").is_err());
         assert!(store.write_edge(&edge).is_err());
         assert!(store.delete_repo_edges("repo").is_err());
+    }
+}
+
+/// The transient policy, the gate, and the five request paths that carry them.
+///
+/// The classification and the loop are exercised on their own with scripted
+/// attempts and a recording sleeper. The request paths are then driven over a
+/// real socket against a scripted local server through the emulator endpoint,
+/// because a policy that is correct in isolation and wired to nothing would
+/// pass every test here and retry nothing in production.
+#[cfg(all(test, feature = "firestore"))]
+mod transient_retry_tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    fn status_body(code: &str) -> String {
+        serde_json::json!({ "error": { "code": 0, "message": "scripted", "status": code } })
+            .to_string()
+    }
+
+    fn transient(status: u16, code: &str) -> FirestoreRequestFailure {
+        FirestoreRequestFailure::Status {
+            status,
+            body: status_body(code),
+        }
+    }
+
+    #[test]
+    fn transient_status_is_named_by_the_body_and_only_then_by_the_code() {
+        for code in [
+            "UNAVAILABLE",
+            "DEADLINE_EXCEEDED",
+            "ABORTED",
+            "RESOURCE_EXHAUSTED",
+            "INTERNAL",
+            "UNKNOWN",
+        ] {
+            assert!(
+                transient_firestore_status(400, &status_body(code)),
+                "{code} is transient whatever HTTP code carries it"
+            );
+        }
+        for code in [
+            "PERMISSION_DENIED",
+            "UNAUTHENTICATED",
+            "FAILED_PRECONDITION",
+            "ALREADY_EXISTS",
+            "NOT_FOUND",
+            "INVALID_ARGUMENT",
+        ] {
+            assert!(
+                !transient_firestore_status(503, &status_body(code)),
+                "{code} is permanent whatever HTTP code carries it"
+            );
+        }
+        // No named status: the HTTP code decides, and 409 stays permanent
+        // because ALREADY_EXISTS shares it with ABORTED.
+        assert!(transient_firestore_status(503, "<html>upstream</html>"));
+        assert!(transient_firestore_status(500, ""));
+        assert!(transient_firestore_status(429, ""));
+        assert!(!transient_firestore_status(409, ""));
+        assert!(!transient_firestore_status(404, ""));
+        assert!(!transient_firestore_status(403, ""));
+        assert!(!transient_firestore_status(400, "{\"error\":{}}"));
+        assert!(FirestoreRequestFailure::Transport("reset".to_string()).is_transient());
+    }
+
+    /// Drive the loop with scripted outcomes; returns what it produced, how
+    /// many attempts ran, the gate calls, and the sleeps it asked for.
+    fn drive(
+        script: Vec<Result<u32, FirestoreRequestFailure>>,
+        gate: Option<TransientRetryGate>,
+    ) -> (
+        Result<u32, FirestoreRequestFailure>,
+        usize,
+        usize,
+        Vec<Duration>,
+    ) {
+        let script = Mutex::new(script.into_iter());
+        let attempts = AtomicUsize::new(0);
+        let gate_calls = Arc::new(AtomicUsize::new(0));
+        let counted_gate: Option<TransientRetryGate> = gate.map(|gate| {
+            let gate_calls = Arc::clone(&gate_calls);
+            Arc::new(move || {
+                gate_calls.fetch_add(1, Ordering::SeqCst);
+                gate()
+            }) as TransientRetryGate
+        });
+        let mut sleeps = Vec::new();
+        let outcome = retry_transient(
+            "scripted",
+            counted_gate.as_ref(),
+            |backoff| sleeps.push(backoff),
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                script
+                    .lock()
+                    .unwrap()
+                    .next()
+                    .expect("the script ran out before the loop stopped")
+            },
+        );
+        (
+            outcome,
+            attempts.load(Ordering::SeqCst),
+            gate_calls.load(Ordering::SeqCst),
+            sleeps,
+        )
+    }
+
+    #[test]
+    fn retry_transient_returns_after_one_transient_failure() {
+        let (outcome, attempts, gate_calls, sleeps) = drive(
+            vec![
+                Err(FirestoreRequestFailure::Transport("reset".to_string())),
+                Ok(7),
+            ],
+            Some(Arc::new(|| Ok(()))),
+        );
+        assert_eq!(outcome, Ok(7));
+        assert_eq!(attempts, 2);
+        assert_eq!(gate_calls, 1, "the lease is reasserted before the retry");
+        assert_eq!(sleeps, vec![FIRESTORE_TRANSIENT_BACKOFF_BASE]);
+    }
+
+    #[test]
+    fn retry_transient_fails_fast_on_a_permanent_failure() {
+        let (outcome, attempts, gate_calls, sleeps) = drive(
+            vec![Err(transient(403, "PERMISSION_DENIED")), Ok(7)],
+            Some(Arc::new(|| Ok(()))),
+        );
+        assert_eq!(outcome, Err(transient(403, "PERMISSION_DENIED")));
+        assert_eq!(attempts, 1, "a permanent failure is never retried");
+        assert_eq!(gate_calls, 0);
+        assert!(sleeps.is_empty());
+    }
+
+    #[test]
+    fn retry_transient_spends_exactly_its_named_budget() {
+        let budget = FIRESTORE_TRANSIENT_ATTEMPTS as usize;
+        let script = (0..budget + 2)
+            .map(|_| Err(transient(503, "UNAVAILABLE")))
+            .collect();
+        let (outcome, attempts, gate_calls, sleeps) = drive(script, Some(Arc::new(|| Ok(()))));
+        assert_eq!(outcome, Err(transient(503, "UNAVAILABLE")));
+        assert_eq!(attempts, budget);
+        assert_eq!(gate_calls, budget - 1);
+        assert_eq!(
+            sleeps,
+            vec![
+                Duration::from_millis(250),
+                Duration::from_millis(500),
+                Duration::from_millis(1000)
+            ],
+            "the backoff doubles from the named base"
+        );
+    }
+
+    #[test]
+    fn retry_transient_stops_when_the_gate_refuses() {
+        let (outcome, attempts, gate_calls, sleeps) = drive(
+            vec![
+                Err(FirestoreRequestFailure::Transport("timed out".to_string())),
+                Ok(7),
+            ],
+            Some(Arc::new(|| {
+                Err("lease fence 3 expired at 2026-09-02T08:25:00+00:00".to_string())
+            })),
+        );
+        assert_eq!(
+            outcome,
+            Err(FirestoreRequestFailure::RetryRefused {
+                refusal: "lease fence 3 expired at 2026-09-02T08:25:00+00:00".to_string(),
+                after: Box::new(FirestoreRequestFailure::Transport("timed out".to_string())),
+            })
+        );
+        assert_eq!(
+            attempts, 1,
+            "a refused gate ends the retry before the next attempt"
+        );
+        assert_eq!(gate_calls, 1);
+        assert!(
+            sleeps.is_empty(),
+            "no backoff is spent on a retry that will not run"
+        );
+        let rendered = outcome.unwrap_err().to_string();
+        assert!(rendered.contains("retry refused"), "{rendered}");
+        assert!(rendered.contains("lease fence 3 expired"), "{rendered}");
+        assert!(rendered.contains("timed out"), "{rendered}");
+    }
+
+    /// What one scripted connection does after reading its request.
+    #[derive(Clone)]
+    enum Scripted {
+        Respond {
+            status: u16,
+            body: String,
+        },
+        /// Close without answering: the transport error the rehearsal saw.
+        Drop,
+    }
+
+    #[derive(Clone, Debug)]
+    struct RecordedRequest {
+        method: String,
+        path: String,
+        body: String,
+    }
+
+    fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack
+            .windows(needle.len())
+            .position(|window| window == needle)
+    }
+
+    fn read_request(stream: &mut TcpStream) -> Option<RecordedRequest> {
+        let mut buffer = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            let read = stream.read(&mut chunk).ok()?;
+            if read == 0 {
+                return None;
+            }
+            buffer.extend_from_slice(&chunk[..read]);
+            let Some(end) = find(&buffer, b"\r\n\r\n") else {
+                continue;
+            };
+            let head = String::from_utf8_lossy(&buffer[..end]).to_string();
+            let content_length = head
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            let mut body = buffer[end + 4..].to_vec();
+            while body.len() < content_length {
+                let read = stream.read(&mut chunk).ok()?;
+                if read == 0 {
+                    break;
+                }
+                body.extend_from_slice(&chunk[..read]);
+            }
+            let mut parts = head.lines().next()?.split_whitespace();
+            return Some(RecordedRequest {
+                method: parts.next()?.to_string(),
+                path: parts.next()?.to_string(),
+                body: String::from_utf8_lossy(&body).to_string(),
+            });
+        }
+    }
+
+    struct ScriptedServer {
+        base_url: String,
+        requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    }
+
+    impl ScriptedServer {
+        /// One connection per scripted step, answered in order. Every answer
+        /// closes its connection, so the client opens a fresh one per attempt
+        /// and the recorded request count is the attempt count.
+        fn serve(script: Vec<Scripted>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let base_url = format!("http://{}", listener.local_addr().unwrap());
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let recorded = Arc::clone(&requests);
+            std::thread::spawn(move || {
+                for step in script {
+                    let Ok((mut stream, _)) = listener.accept() else {
+                        return;
+                    };
+                    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+                    if let Some(request) = read_request(&mut stream) {
+                        recorded.lock().unwrap().push(request);
+                    }
+                    match step {
+                        Scripted::Respond { status, body } => {
+                            let reason = reqwest::StatusCode::from_u16(status)
+                                .ok()
+                                .and_then(|status| status.canonical_reason())
+                                .unwrap_or("Scripted");
+                            let response = format!(
+                                "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                                body.len()
+                            );
+                            let _ = stream.write_all(response.as_bytes());
+                            let _ = stream.flush();
+                        }
+                        Scripted::Drop => drop(stream),
+                    }
+                }
+            });
+            Self { base_url, requests }
+        }
+
+        fn requests(&self) -> Vec<RecordedRequest> {
+            self.requests.lock().unwrap().clone()
+        }
+    }
+
+    fn store_against(server: &ScriptedServer) -> FirestoreStore {
+        FirestoreStore::with_endpoint(
+            "fixture-project".to_string(),
+            None,
+            FirestoreEndpoint::Emulator {
+                base_url: server.base_url.clone(),
+            },
+        )
+    }
+
+    fn respond(status: u16, body: &str) -> Scripted {
+        Scripted::Respond {
+            status,
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn emulator_endpoint_shapes_the_base_url_and_skips_the_metadata_token() {
+        let store = FirestoreStore::with_endpoint(
+            "p".to_string(),
+            Some("d".to_string()),
+            FirestoreEndpoint::Emulator {
+                base_url: "http://127.0.0.1:8080/".to_string(),
+            },
+        );
+        assert_eq!(
+            store.base_url(),
+            "http://127.0.0.1:8080/v1/projects/p/databases/d/documents"
+        );
+        assert_eq!(store.get_access_token().unwrap(), "owner");
+        let production = FirestoreStore::new("p".to_string(), None);
+        assert_eq!(
+            production.base_url(),
+            "https://firestore.googleapis.com/v1/projects/p/databases/(default)/documents"
+        );
+    }
+
+    #[test]
+    fn get_document_retries_a_transient_status_over_the_wire() {
+        let document = serde_json::json!({
+            "name": "projects/fixture-project/databases/(default)/documents/spine_repo_heads_v2/abc",
+            "fields": { "payload": { "stringValue": "{}" } },
+            "updateTime": "2026-09-02T08:23:11.000000Z"
+        });
+        let server = ScriptedServer::serve(vec![
+            respond(503, &status_body("UNAVAILABLE")),
+            respond(200, &document.to_string()),
+        ]);
+        let store = store_against(&server);
+        let loaded = store
+            .get_document("spine_repo_heads_v2", "abc")
+            .expect("the second attempt answers");
+        assert_eq!(loaded, Some(document));
+        let requests = server.requests();
+        assert_eq!(requests.len(), 2, "{requests:?}");
+        assert!(requests
+            .iter()
+            .all(|request| request.method == "GET"
+                && request.path.ends_with("/spine_repo_heads_v2/abc")));
+    }
+
+    #[test]
+    fn get_document_fails_fast_on_permission_denied_over_the_wire() {
+        let server = ScriptedServer::serve(vec![
+            respond(403, &status_body("PERMISSION_DENIED")),
+            respond(200, "{}"),
+        ]);
+        let store = store_against(&server);
+        let error = store
+            .get_document("spine_repo_heads_v2", "abc")
+            .expect_err("a permission refusal is not retried");
+        let rendered = error.to_string();
+        assert!(rendered.contains("403"), "{rendered}");
+        assert!(rendered.contains("PERMISSION_DENIED"), "{rendered}");
+        assert_eq!(server.requests().len(), 1);
+    }
+
+    #[test]
+    fn get_document_reports_a_missing_document_without_retrying() {
+        let server = ScriptedServer::serve(vec![
+            respond(404, &status_body("NOT_FOUND")),
+            respond(200, "{}"),
+        ]);
+        let store = store_against(&server);
+        assert_eq!(
+            store.get_document("spine_repo_heads_v2", "abc").unwrap(),
+            None
+        );
+        assert_eq!(server.requests().len(), 1);
+    }
+
+    #[test]
+    fn commit_write_batch_retries_a_dropped_connection_then_commits() {
+        let server = ScriptedServer::serve(vec![Scripted::Drop, respond(200, "{}")]);
+        let store = store_against(&server);
+        let writes = vec![serde_json::json!({
+            "update": { "name": "projects/fixture-project/databases/(default)/documents/spine_entities_v2/x", "fields": {} },
+            "currentDocument": { "exists": false }
+        })];
+        store
+            .commit_write_batch(
+                "owner",
+                &format!("{}:commit", store.base_url()),
+                &writes,
+                "stage immutable spine publication rows",
+            )
+            .expect("the retried commit is acknowledged");
+        let requests = server.requests();
+        assert_eq!(requests.len(), 2, "{requests:?}");
+        assert!(requests.iter().all(|request| request.method == "POST"));
+        assert!(requests
+            .iter()
+            .all(|request| request.path.ends_with("/documents:commit")));
+        assert_eq!(
+            requests[0].body, requests[1].body,
+            "the retry sends the same writes under the same preconditions"
+        );
+        assert!(requests[0].body.contains("\"exists\":false"));
+    }
+
+    #[test]
+    fn commit_write_batch_does_not_retry_a_failed_precondition() {
+        let server = ScriptedServer::serve(vec![
+            respond(400, &status_body("FAILED_PRECONDITION")),
+            respond(200, "{}"),
+        ]);
+        let store = store_against(&server);
+        let error = store
+            .commit_write_batch(
+                "owner",
+                &format!("{}:commit", store.base_url()),
+                &[serde_json::json!({ "delete": "x" })],
+                "cleanup",
+            )
+            .expect_err("a precondition verdict is final");
+        assert!(error.to_string().contains("FAILED_PRECONDITION"), "{error}");
+        assert_eq!(server.requests().len(), 1);
+    }
+
+    #[test]
+    fn a_refused_gate_ends_the_retry_over_the_wire() {
+        let server = ScriptedServer::serve(vec![
+            respond(503, &status_body("UNAVAILABLE")),
+            respond(200, "{}"),
+        ]);
+        let store = store_against(&server).with_transient_retry_gate(Arc::new(|| {
+            Err("graph publication lease is stale or fenced: lease fence 4 expired".to_string())
+        }));
+        let error = store
+            .get_document("spine_repo_heads_v2", "abc")
+            .expect_err("a lease that cannot be reasserted refuses the retry");
+        let rendered = error.to_string();
+        assert!(rendered.contains("retry refused"), "{rendered}");
+        assert!(rendered.contains("lease fence 4 expired"), "{rendered}");
+        assert!(rendered.contains("UNAVAILABLE"), "{rendered}");
+        assert_eq!(
+            server.requests().len(),
+            1,
+            "no request goes out under a refused lease"
+        );
+    }
+
+    #[test]
+    fn a_passing_gate_is_consulted_once_per_retry_over_the_wire() {
+        let server = ScriptedServer::serve(vec![
+            Scripted::Drop,
+            respond(503, &status_body("UNAVAILABLE")),
+            respond(200, "{}"),
+        ]);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let store = store_against(&server).with_transient_retry_gate(Arc::new({
+            let calls = Arc::clone(&calls);
+            move || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }));
+        store
+            .commit_write_batch(
+                "owner",
+                &format!("{}:commit", store.base_url()),
+                &[serde_json::json!({ "delete": "x" })],
+                "cleanup",
+            )
+            .expect("the third attempt commits");
+        assert_eq!(server.requests().len(), 3);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "one gate call before each retry"
+        );
     }
 }

--- a/crates/kin-spine/src/lib.rs
+++ b/crates/kin-spine/src/lib.rs
@@ -36,9 +36,9 @@ pub use backend::{
     SpinePublicationBackendId,
 };
 pub use federation::{federated_impact, FederatedEdge, FederatedImpact, FederatedNode};
-pub use firestore::FirestoreSpineBackend;
 #[cfg(feature = "firestore")]
 pub use firestore::FirestoreStore;
+pub use firestore::{FirestoreEndpoint, FirestoreSpineBackend, TransientRetryGate};
 pub use index::{
     AuthorityRootState, CrossRepoEdge, CrossRepoEdgesSnapshot, EntityEntry, SpineIndex,
     SpineXrefAuthorityAnchor, SpineXrefDecodeError, SpineXrefResponse,

--- a/crates/kin-spine/src/test_support.rs
+++ b/crates/kin-spine/src/test_support.rs
@@ -157,6 +157,11 @@ pub struct FakeSpineStore {
             Vec<RepoPublicationHead>,
         )>,
     >,
+    /// Runs at the start of every publication preparation with the repo id.
+    /// A consumer under a test clock uses it to charge each publication the
+    /// time a real Firestore staging costs, so a lease that has to outlive a
+    /// whole fleet's publication can be proved to, without sleeping for it.
+    pub prepare_hook: Mutex<Option<Box<dyn Fn(&str) + Send + Sync>>>,
 }
 
 #[derive(Default)]
@@ -252,6 +257,7 @@ impl Default for FakeSpineStore {
             disable_cleanup: AtomicBool::new(false),
             cleanup_calls: AtomicUsize::new(0),
             legacy_migration_seal: Mutex::new(None),
+            prepare_hook: Mutex::new(None),
         }
     }
 }
@@ -512,6 +518,9 @@ impl SpineStore for FakeSpineStore {
             return Err(SpineError::Backend(
                 "injected atomic publication unavailable".to_string(),
             ));
+        }
+        if let Some(hook) = self.prepare_hook.lock().unwrap().as_ref() {
+            hook(&publication.repo_id);
         }
         let rollout_fence = self.load_rollout_fence()?.ok_or_else(|| {
             SpineError::Backend("fake active rollout fence is missing".to_string())

--- a/scripts/test-gcs-emulator-endpoint.sh
+++ b/scripts/test-gcs-emulator-endpoint.sh
@@ -29,6 +29,16 @@
 # arm depends on it, so a seeding failure names itself instead of arriving later
 # disguised as a broken endpoint lever.
 #
+# Arm 1a is FIR-3059's acceptance on these same bytes. The daemon arm 1 starts
+# bootstraps the GCS publication-control record before it serves, and the lease
+# in that record is the window its first hosted rollout runs under. On
+# 2026-09-02 that window was 300 s and nothing renewed it, so production's first
+# Firestore rollout died with every write done and none of the credit kept. The
+# arm reads the record back out of the emulator, the way a real record is read,
+# and grades the window against the value the daemon owns; the grader is
+# falsified first against the pre-fix shape, so a grader that accepts anything
+# cannot pass.
+#
 # Usage: scripts/test-gcs-emulator-endpoint.sh <image-ref>
 
 set -uo pipefail
@@ -192,6 +202,72 @@ code="$(docker exec "${KIN_CID}" sh -c \
 [ -n "${code}" ] && [ "${code}" != "000" ] \
   || { dump_kin; fail "daemon reached listening but /readiness did not answer"; }
 echo "==> [serves] OK (listening, redirect logged, /readiness http ${code})"
+
+# ---------------------------------------------------------------------------
+# 1a. The startup rollout lease these bytes mint (FIR-3059). See the header.
+#     The grader is a function so it can be run against fixtures before it is
+#     run against the record; a grader that only ever sees the live record
+#     cannot show it would have refused the shape that failed production.
+# ---------------------------------------------------------------------------
+# grade_lease_window <record-json>: prints one PASS, FAIL or UNREADABLE line;
+# exits 0 on PASS, 1 on FAIL, 2 when the record carries no readable lease.
+grade_lease_window() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+from datetime import datetime
+
+EXPECTED_SECONDS = 1800
+
+
+def parse(stamp):
+    # chrono writes nanoseconds; Python's parser wants at most six digits.
+    stamp = re.sub(r"(\.\d{1,6})\d*", r"\1", stamp).replace("Z", "+00:00")
+    return datetime.fromisoformat(stamp)
+
+
+try:
+    lease = json.loads(sys.argv[1])["active_lease"]
+    window = int((parse(lease["expires_at"]) - parse(lease["acquired_at"])).total_seconds())
+    holder = lease.get("holder")
+    fence = lease.get("fence")
+except (ValueError, KeyError, TypeError) as err:
+    print(f"UNREADABLE the control record carries no readable startup lease: {err!r}")
+    sys.exit(2)
+if window != EXPECTED_SECONDS:
+    print(f"FAIL startup rollout lease window is {window} s, expected {EXPECTED_SECONDS} s (holder {holder}, fence {fence})")
+    sys.exit(1)
+print(f"PASS startup rollout lease window is {window} s (holder {holder}, fence {fence})")
+PY
+}
+
+echo "==> [lease-window/self-test] the grader must refuse the pre-fix window and accept the fixed one"
+prefix_record='{"active_lease":{"holder":"kin-daemon-startup-bootstrap","fence":1,"acquired_at":"2026-09-02T08:20:00.712345678Z","expires_at":"2026-09-02T08:25:00.712345678Z"}}'
+grade_lease_window "${prefix_record}" >/dev/null 2>&1
+rc=$?
+[ "${rc}" -eq 1 ] || fail "lease-window self-test: the grader answered ${rc} to the pre-fix 300 s window instead of failing it, so it grades nothing"
+fixed_record='{"active_lease":{"holder":"kin-daemon-startup-bootstrap","fence":1,"acquired_at":"2026-09-02T08:20:00.712345678Z","expires_at":"2026-09-02T08:50:00.712345678Z"}}'
+grade_lease_window "${fixed_record}" >/dev/null 2>&1
+rc=$?
+[ "${rc}" -eq 0 ] || fail "lease-window self-test: the grader refused an 1800 s window (rc ${rc})"
+grade_lease_window '{"active_lease":null}' >/dev/null 2>&1
+rc=$?
+[ "${rc}" -eq 2 ] || fail "lease-window self-test: a record with no lease must be unreadable, not a pass or a fail (rc ${rc})"
+echo "==> [lease-window/self-test] OK"
+
+echo "==> [lease-window] read the publication-control record the daemon bootstrapped"
+# No KIN_GCS_PREFIX is passed above, so the record sits at the bucket root
+# under the name ObjectStorePublicationControlStore writes.
+record_object=".kin-graph-publication-control.json"
+record="$(docker run --rm --network "${NET}" --entrypoint curl "${IMAGE}" -sS -f \
+  "http://fake-gcs:4443/storage/v1/b/${BUCKET}/o/${record_object}?alt=media" 2>/dev/null || true)"
+[ -n "${record}" ] \
+  || { dump_kin; fail "lease-window: the daemon served but no publication-control record exists at ${BUCKET}/${record_object}; the startup bootstrap wrote nothing to grade"; }
+verdict="$(grade_lease_window "${record}")"
+rc=$?
+echo "==> [lease-window] ${verdict}"
+[ "${rc}" -eq 0 ] || { dump_kin; fail "lease-window: ${verdict}"; }
 docker rm -f "${KIN_CID}" >/dev/null 2>&1; KIN_CID=""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The first hosted Firestore rollout now survives its own duration and one transient error. It renews its lease before every repository it publishes, it starts with an 1800 s window instead of 300 s, and the Firestore store retries transient failures a bounded number of times, re-reading the lease before each retry.

## What was measured

On 2026-09-02 the v0.6.3 daemon was run natively against a copy of production's own control record (kin-ecosystem `.kin-coord/reports/spinefix-20260902.md`, sections 3 and 5). The startup bootstrap minted a 300 s rollout lease and nothing on the startup path renewed it: `reassert_before_mutation` renews a publication lease but only asserted a rollout lease, and `renew_rollout` had no caller outside the admin route. One repository's 27,987 entity documents took 153 s of that lease at about 0.55 s per 100-write commit, with four repositories and the whole edge pass still ahead. Production's cold graph open alone takes 110 s before the first commit. The report's timing table (section 6) puts the full first rollout at about 565 s natively from that Mac (335 s if the edge pass restages nothing) and projects about 390 s in production on top of the cold open (285 s under the same caveat); against 1800 s that leaves over 1,200 s spare. Every attempt ended with the work done, the credit lost, and the next start minting the next fence to write everything again. A single transport error on one `spine_repo_heads_v2` read then ended the following run with 96 s of lease left, because no read was retried.

## The three changes

1. Renewal at the seam. `HostedPublicationGuard::reassert_before_mutation` renews a rollout lease before it asserts it, the way it already renewed a publication lease. That guard runs before every per-repository publication in the rollout (`refresh_all_hosted_cross_repo_edges_with_before_commit_hook`), so each publication extends the lease it runs under. A renewal that finds the lease expired, fenced or changed hands returns the same refusal an assertion would, and the rollout stops. `admit_hosted_spine_rollout_fence` and `release_hosted_spine_rollout` renew before their own proofs too, because the hydration proof each runs reads the whole fleet back. The bound that remains: renewal is per repository, so one repository whose publication alone outlives the window would still expire between two boundaries; at in-region rates that is on the order of 700,000 entities against the largest fleet member's 27,987.
2. The window. The startup bootstrap and every renewal use `HOSTED_ROLLOUT_LEASE_SECONDS`, which is `MAX_ROLLOUT_LEASE_SECONDS` (1800). The unit of work between renewals is one repository's publication, not the fleet, so the window has to cover one repository: 153 s measured for the largest, which gives a ten times margin, and 1800 s is the cap `validate_rollout_ttl` already admits. A fleet-derived TTL would size the wrong thing. Renewal is the mechanism; the window is the margin.
3. Bounded retry inside `FirestoreStore`. One executor carries the five Firestore sends (list, read, query, commit, head CAS; the metadata token fetch is not Firestore and is unchanged). The budget is named once: four attempts, 250 ms backoff doubling. Transient means a transport error, a body whose `error.status` is UNAVAILABLE, DEADLINE_EXCEEDED, ABORTED, RESOURCE_EXHAUSTED, INTERNAL or UNKNOWN, or HTTP 5xx or 429 when the body names no status. Permission, precondition, already-exists, not-found and every other 4xx are never retried, and a 409 with no named status stays permanent because ALREADY_EXISTS shares it with ABORTED. Before every retry the store consults a gate the daemon installs at construction; the gate re-reads the lease bound to the in-flight mutation (`PublicationControl::reassert_bound_mutation_lease`, bound by the guard for its lifetime, by the startup sequence, and by the acquire route around the fence advance) and a refused gate ends the retry with the refusal named. A retried commit whose first attempt was applied but never answered fails its preconditions on the second attempt, which reaches the existing staging and head reconciliation exactly as the lost answer did.

Two supporting changes. The startup sequence moved from the binary's closure into `DaemonState::complete_hosted_startup_rollout`, so the regression drives the exact production sequence and the binary calls the same function. `FirestoreStore::with_endpoint(FirestoreEndpoint::Emulator { .. })` lets a test point the real send sites at a scripted local server with the fixed bearer emulators accept; the daemon does not read `FIRESTORE_EMULATOR_HOST` in this PR.

## Scripted checks for the class

The Python acceptance harness builds `kin-daemon` with neither `gcs` nor `firestore` and has no Firestore path, so it cannot reach a hosted rollout at all. The class is checked where hosted bytes are already checked on every PR:

- `state::tests::first_hosted_rollout_outlives_its_startup_lease_by_renewing_before_each_publication` drives `complete_hosted_startup_rollout` over `FirestoreSpineBackend::with_store(FakeSpineStore)` under a manual clock that charges each publication 400 s (more than the old window, less than the new one) and asserts the total charged exceeds one window, so completion is attributable only to renewal. It runs on ci.yml's `cargo nextest run -p kin-daemon --features gcs,firestore` leg.
- Arm 1a of `scripts/test-gcs-emulator-endpoint.sh` (docker.yml, the FIR-2668 acceptance, run on every push to main) reads the publication-control record the built image bootstraps into fake-gcs and grades the startup lease window it minted. The grader is falsified in the same run against the pre-fix 300 s shape, an 1800 s shape and a record with no lease before the live record is read.

## Falsification

Each mutant was applied as an exact text swap, the tests run, and the swap reverted; the tree was checked clean afterwards.

| mutant | tests that went red |
|---|---|
| guard only asserts a rollout lease (the pre-fix behaviour) | the composed rollout, with the production text `rollout proof reassertion refused: graph publication lease is stale or fenced: lease fence 1 expired` |
| bootstrap asks for the 300 s default again | `startup_bootstrap_requests_the_hosted_rollout_window`, the renewal test, the composed rollout (its own fixture guard) |
| `HOSTED_ROLLOUT_LEASE_SECONDS` set to 300 everywhere | `startup_bootstrap_requests_the_hosted_rollout_window`, the composed rollout |
| bound-lease reassertion never reads the record | `bound_mutation_lease_is_reasserted_and_cleared_with_its_owner`, `hosted_transient_retry_gate_reasserts_the_bound_lease` |
| the retry loop stops after the first attempt | 7 of the 13 `transient_retry_tests`, over the wire and at the helper |
| PERMISSION_DENIED classified transient | the classification table, `retry_transient_fails_fast_on_a_permanent_failure`, `get_document_fails_fast_on_permission_denied_over_the_wire` |
| the gate's refusal discarded | `retry_transient_stops_when_the_gate_refuses`, `a_refused_gate_ends_the_retry_over_the_wire` |

Not falsified by a mutant: the head CAS site's routing through the executor, a five-line call covered by reading. The smoke arm was not run against a built image here (a release proof holds Docker on this box). docker.yml's image job is off the pull-request path since FIR-2815 and runs on every push to main, so the arm grades the image built from this change after it lands, the way Product Acceptance grades main.

## Gates run locally

All through the fleet's heavy slot, one at a time: `cargo test -p kin-spine --features firestore` (162 passed), `cargo test -p kin-daemon -p kin-spine` with `gcs,firestore` on the rebased tree (1,326 daemon library tests passed, 0 failed, 4 ignored, plus every integration binary), `cargo fmt --all -- --check`, clippy as ci.yml runs it, and `bin/kin-precheck kin` on the lane tree (16 gates PASS with RUSTFLAGS=-D warnings).

The first push failed the fast gate's three test shards on one cause: `cargo test --no-run --workspace --locked` with default features refused `hosted_transient_retry_gate` as dead code, since its only production caller sits under `cfg(feature = "firestore")` and every local gate had run `--all-features`. The second commit gates the method on `any(feature = "firestore", test)` and the same command was run locally under `-D warnings` before the push.

Related: FIR-3059
