### PR TITLE
Stop a prose query's English word from winning locate's exact-name tier

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -639,12 +639,137 @@ pub fn query_names_entity(query: &str, name: &str) -> bool {
         return false;
     }
     let target = name.to_ascii_lowercase();
-    let last = qualified_name_tail(&target).to_string();
+    let last = qualified_name_tail(&target);
+    query_tokens(query).any(|token| {
+        let lowered = token.to_ascii_lowercase();
+        lowered == target || lowered == last
+    })
+}
+
+/// The query tokenizer, defined once.
+///
+/// [`query_names_entity`] and the query-shape rules below have to split a query
+/// identically, or a token can name a symbol under one rule and not exist under
+/// the other. Tokens come back in their ORIGINAL case, because case is the
+/// signal [`is_symbolic_search_term`] reads; a caller matching against a name
+/// lowercases per token.
+fn query_tokens(query: &str) -> impl Iterator<Item = &str> {
     query
-        .to_ascii_lowercase()
         .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
         .filter(|token| !token.is_empty())
-        .any(|token| token == target || token == last)
+}
+
+/// A prose query carries at least this many tokens.
+///
+/// Three is the longest symbol path [`query_tokens`] routinely produces
+/// (`crate::Type::method`), so the floor sits one above it. Below the floor the
+/// tier is left exactly as it shipped, which is the conservative direction:
+/// this rule can only ever DEMOTE, and a short query a human meant as a lookup
+/// has to keep the guarantee the tier was built for.
+const LOCATE_PROSE_MIN_TOKENS: usize = 4;
+
+/// A prose query carries at least this many stopwords.
+///
+/// Two rather than one, because a symbol path can carry one by accident
+/// (`http.parse_request.to.string` tokenizes with `to`) while an English
+/// question essentially never carries fewer than two.
+const LOCATE_PROSE_MIN_STOPWORDS: usize = 2;
+
+/// Whether this query reads as a SENTENCE rather than a symbol lookup.
+///
+/// The distinction the exact-name tier never drew. `walk` typed alone is a
+/// request for the symbol `walk`; "Walk me through the path" is not, and the
+/// tier cannot tell them apart because all it ever sees is that some token
+/// equalled some name.
+///
+/// Two signals, both required, both chosen so the rule fires only on an
+/// unmistakable sentence: enough tokens to BE a sentence
+/// ([`LOCATE_PROSE_MIN_TOKENS`]) and enough English connectives that the string
+/// carries grammar ([`LOCATE_PROSE_MIN_STOPWORDS`]). Erring toward "lookup"
+/// preserves shipped behavior; erring toward "prose" would move rankings this
+/// rule was never meant to touch.
+///
+/// Reads [`ENGLISH_STOPWORDS`] rather than growing a second vocabulary. That
+/// list is already defined here as the words that "carry no code-identifier
+/// meaning", which is exactly the property this needs, and it is closed-class
+/// almost throughout: an open-class list would be useless here, because
+/// open-class words are precisely what symbols get named after (`send`,
+/// `socket`, `component`, `walk`). Sharing it does couple this rule to that
+/// list, so `the_prose_shape_rule_reads_the_queries_it_was_written_for` pins
+/// the verdict on named queries rather than on a count.
+fn locate_query_is_prose(query: &str) -> bool {
+    let mut tokens = 0usize;
+    let mut stopwords = 0usize;
+    for token in query_tokens(query) {
+        tokens += 1;
+        if is_english_stopword(&token.to_ascii_lowercase()) {
+            stopwords += 1;
+        }
+    }
+    tokens >= LOCATE_PROSE_MIN_TOKENS && stopwords >= LOCATE_PROSE_MIN_STOPWORDS
+}
+
+/// Whether a query token that NAMES this entity is itself symbol-shaped.
+///
+/// The refinement of [`query_names_entity`] the prose rule needs: not "did some
+/// token name it" but "did a token that LOOKS LIKE A SYMBOL name it".
+/// [`is_symbolic_search_term`] reads the original-case token, so
+/// `redisReaderGetReply` and `Cross_Encoder_Model_Cached` are symbolic while
+/// `send`, `socket`, `component` and `walk` are not.
+///
+/// Strictly stronger than [`query_names_entity`]: every pair this accepts, that
+/// one accepts too. `the_symbolic_name_rule_never_claims_a_name_the_base_rule_denies`
+/// pins that, because two predicates reading one tokenizer are two things that
+/// can drift apart.
+fn query_names_entity_symbolically(query: &str, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let target = name.to_ascii_lowercase();
+    let tail = qualified_name_tail(&target);
+    query_tokens(query).any(|token| {
+        let lowered = token.to_ascii_lowercase();
+        (lowered == target || lowered == tail) && is_symbolic_search_term(token)
+    })
+}
+
+/// Whether this entity's name match rests on nothing but a plain English word
+/// inside a sentence.
+///
+/// FIR-3079. Measured on a fully embedded hiredis store (730 entities, 1,485 of
+/// 1,485 indexed), "when I send a command, how does it reach the socket" ranked
+/// the Win32 compatibility macro `send` (sockcompat.h:90, score 180.0) first and
+/// `socket` (sockcompat.h:82, score 165.0) second, ahead of `redisFormatCommand`
+/// (hiredis.c:572) at score 300.0. A longer question about reply parsing put
+/// `socket` at score 55.0 above a row scoring 902.1. The tier is unbeatable by
+/// design, so a 16x score deficit still won, and the query never asked for
+/// either macro.
+///
+/// Only ever demotes, and only when BOTH halves hold: the query is a sentence,
+/// and no symbol-shaped token in it named this entity. A prose question that
+/// does name a real symbol ("how does redisReaderGetReply handle a partial
+/// reply") keeps its name tier, and every lookup keeps it unconditionally,
+/// which is the case the tier was built for and the one that must not regress.
+///
+/// It cannot separate "the walk function" from "walk me through", and does not
+/// try. It resolves that ambiguity toward the prose reading, because prose is
+/// what the caller typed and prose is the reading that was broken.
+///
+/// Split from [`name_match_is_prose_word_collision`] so the rule is testable
+/// without touching process environment: the tests pin THIS, and the wrapper
+/// adds only the kill switch.
+fn is_prose_word_collision(query: &str, name: &str) -> bool {
+    locate_query_is_prose(query) && !query_names_entity_symbolically(query, name)
+}
+
+/// [`is_prose_word_collision`] under the kill switch.
+///
+/// `KIN_LOCATE_PROSE_NAME_DEMOTION=0` restores shipped ordering exactly, so one
+/// binary can run both arms of a ranking benchmark. The knob exists because a
+/// tier change moves every ranked result, and an A/B that has to compare two
+/// builds cannot tell a ranking change from a build difference.
+fn name_match_is_prose_word_collision(query: &str, name: &str) -> bool {
+    locate_env_bool("KIN_LOCATE_PROSE_NAME_DEMOTION", true) && is_prose_word_collision(query, name)
 }
 
 /// Classify one located entity against the query.
@@ -655,13 +780,25 @@ pub fn query_names_entity(query: &str, name: &str) -> bool {
 /// `--explain`) reports `TextFallback`: the honest reading of "no name matched
 /// and this surface cannot say which pool answered" is the weaker claim, not the
 /// stronger one.
+///
+/// The single behavioral gate for FIR-3079, and the reason the fix lands here
+/// rather than on the tier. [`LocateMatchKind::Name`] is documented as "the
+/// query asked for this symbol"; on a prose sentence the English word "send" is
+/// not the query asking for the macro `send`, so reporting `Name` there states
+/// something untrue. Withholding it here corrects every surface derived from it
+/// at once, none of which needs an edit: [`locate_exact_name_tier`] stops
+/// promoting the collision, [`locate_entities_are_all_fallback`] and the fused
+/// arm's own predicate finally read TRUE on the rankings that most need the
+/// warning, `kin-daemon`'s cursor rehydration inherits both through the same
+/// helper, and [`file_row_match_kind`] stops labelling the row "named match" so
+/// [`answer_floor_note`] can say the ranking cleared no floor.
 fn classify_locate_match(
     query: &str,
     name: &str,
     origin: &str,
     cosine: Option<f32>,
 ) -> LocateMatchKind {
-    if query_names_entity(query, name) {
+    if query_names_entity(query, name) && !name_match_is_prose_word_collision(query, name) {
         LocateMatchKind::Name
     } else if origin == "vector" || cosine.is_some() {
         LocateMatchKind::Semantic
@@ -20714,6 +20851,277 @@ mod tests {
         assert!(!query_names_entity("encoder", "cross_encoder_model_cached"));
         assert!(!query_names_entity("", "anything"));
         assert!(!query_names_entity("anything", ""));
+    }
+
+    /// FIR-3079, the defect half: an English word inside a SENTENCE does not
+    /// name the symbol it collides with.
+    ///
+    /// Every query here was measured against a real store. On a fully embedded
+    /// hiredis (730 entities, 1,485 of 1,485 indexed) "when I send a command,
+    /// how does it reach the socket" ranked the Win32 compatibility macro
+    /// `send` (sockcompat.h:90) first at score 180.0 and `socket`
+    /// (sockcompat.h:82) second at 165.0, ahead of `redisFormatCommand`
+    /// (hiredis.c:572) at 300.0. The longer reply-parsing question put `socket`
+    /// at 55.0 above a row scoring 902.1. The tier is unbeatable by design, so
+    /// a 16x score deficit still won rank one, and the caller asked for neither
+    /// macro.
+    #[test]
+    fn a_prose_sentence_does_not_let_an_english_word_name_a_symbol() {
+        for (query, name) in [
+            (
+                "when I send a command, how does it reach the socket",
+                "send",
+            ),
+            (
+                "when I send a command, how does it reach the socket",
+                "socket",
+            ),
+            (
+                "When a reply comes back from the Redis server, how does hiredis turn the bytes \
+                 on the socket into the reply object my code gets, and what happens along the \
+                 way if the reply is only half there?",
+                "socket",
+            ),
+            (
+                "What happens between a component asking for an update and that update appearing \
+                 on screen? Walk me through the path.",
+                "Resolved.component",
+            ),
+            (
+                "When I type a character in the editor, how does it end up in the document? Walk \
+                 me through the path.",
+                "TextmateSnippet.walk",
+            ),
+            // The same VS Code question against a Rust store: `Walk` is the
+            // directory walker in ripgrep's `ignore` crate, and "Walk me
+            // through" is not a request for it.
+            (
+                "When I type a character in the editor, how does it end up in the document? Walk \
+                 me through the path.",
+                "Walk",
+            ),
+        ] {
+            // The precondition: the shipped predicate DOES call this a name.
+            // Without it this test would pass on a query that never collided.
+            assert!(
+                query_names_entity(query, name),
+                "control precondition: {name} is a shipped name hit for this query"
+            );
+            assert_ne!(
+                classify_locate_match(query, name, "", None),
+                LocateMatchKind::Name,
+                "{name} is an English word in a sentence, not the symbol this query asked for"
+            );
+            // Demotion reports the pool that actually answered, so a hit the
+            // vector arm surfaced is Semantic rather than flattened to lexical.
+            assert_eq!(
+                classify_locate_match(query, name, "vector", Some(0.83)),
+                LocateMatchKind::Semantic
+            );
+            assert_eq!(
+                classify_locate_match(query, name, "", None),
+                LocateMatchKind::TextFallback
+            );
+            // The rule that did it, asserted directly, so a failure says which
+            // half moved rather than only that the classification changed.
+            assert!(is_prose_word_collision(query, name));
+        }
+    }
+
+    /// FIR-3079, the half that must not regress: a LOOKUP keeps its exact-name
+    /// tier, whatever English word it happens to be spelled with.
+    ///
+    /// This is the guarantee the tier was built for, and the measurement says
+    /// it is load-bearing on the same store: `redisReaderGetReply` typed alone
+    /// scores 450.0 and must outrank `redisGetReplyFromReader` at 652.007, and
+    /// `send` typed alone scores 180.0 and must outrank `win32_send` at 291.2.
+    /// Both are score inversions only the tier can win, so a rule that demoted
+    /// them would undo FIR-2338 to fix FIR-3079.
+    #[test]
+    fn a_symbol_lookup_keeps_its_exact_name_tier() {
+        for (query, name) in [
+            // Single English word typed alone: still a lookup.
+            ("send", "send"),
+            ("socket", "socket"),
+            ("walk", "Walk"),
+            ("search", "search"),
+            // Symbol-shaped lookups, bare and qualified.
+            ("redisReaderGetReply", "redisReaderGetReply"),
+            ("redisReader::redisReaderGetReply", "redisReaderGetReply"),
+            ("SearchWorker::search", "SearchWorker::search"),
+            ("Gitignore", "Gitignore"),
+            // Prose that names a REAL symbol keeps the tier, because the token
+            // that named it is symbol-shaped.
+            (
+                "When a reply comes back, how does redisReaderGetReply handle a partial reply",
+                "redisReaderGetReply",
+            ),
+            (
+                "where is Cross_Encoder_Model_Cached decided?",
+                "cross_encoder_model_cached",
+            ),
+        ] {
+            assert_eq!(
+                classify_locate_match(query, name, "", None),
+                LocateMatchKind::Name,
+                "{query:?} is a lookup for {name}, or names it symbolically"
+            );
+        }
+    }
+
+    /// The shape rule itself, pinned on the exact strings that motivated it.
+    ///
+    /// Separated from the classification tests because the thresholds are the
+    /// arguable part: a change to either constant shows up here as a specific
+    /// query changing sides rather than as a ranking that quietly moved.
+    #[test]
+    fn the_prose_shape_rule_reads_the_queries_it_was_written_for() {
+        for query in [
+            "when I send a command, how does it reach the socket",
+            "What happens between a component asking for an update and that update appearing on \
+             screen? Walk me through the path.",
+            "When ripgrep looks through a single file, what happens from reading the bytes to \
+             printing a line that matched?",
+            "where is prune_orphaned_vectors defined",
+        ] {
+            assert!(locate_query_is_prose(query), "{query:?} is a sentence");
+        }
+        for query in [
+            "send",
+            "walk",
+            "redisReaderGetReply",
+            "redisReader::redisReaderGetReply",
+            "SearchWorker::search",
+            "call parse_request",
+            // Four tokens but only one function word: a symbol path, not prose.
+            "http.parse_request.to.string",
+            "",
+        ] {
+            assert!(!locate_query_is_prose(query), "{query:?} is a lookup");
+        }
+    }
+
+    /// The drift guard. [`query_names_entity_symbolically`] is a REFINEMENT of
+    /// [`query_names_entity`], so it must never accept a pair the base rule
+    /// rejects; if it did, a demotion decision would rest on a name match the
+    /// rest of locate does not believe in.
+    ///
+    /// The two read one tokenizer ([`query_tokens`]) precisely so they cannot
+    /// disagree, and this is what would notice if someone split them again.
+    #[test]
+    fn the_symbolic_name_rule_never_claims_a_name_the_base_rule_denies() {
+        let mut symbolic_hits = 0usize;
+        for query in [
+            "send",
+            "when I send a command, how does it reach the socket",
+            "redisReaderGetReply",
+            "redisReader::redisReaderGetReply",
+            "how does redisReaderGetReply handle a partial reply from the server",
+            "InMemoryGraph::prune_orphaned_vectors",
+            "where is Cross_Encoder_Model_Cached decided?",
+            "Walk me through it",
+            "",
+            "unrelated words entirely",
+        ] {
+            for name in [
+                "send",
+                "socket",
+                "Walk",
+                "redisReaderGetReply",
+                "InMemoryGraph::prune_orphaned_vectors",
+                "cross_encoder_model_cached",
+                "http.parse_request",
+                "",
+            ] {
+                if query_names_entity_symbolically(query, name) {
+                    symbolic_hits += 1;
+                    assert!(
+                        query_names_entity(query, name),
+                        "{query:?} names {name:?} symbolically but not at all"
+                    );
+                }
+            }
+        }
+        // The positive control: without it every rejection would satisfy the
+        // implication and this test could not fail.
+        assert!(
+            symbolic_hits >= 4,
+            "the table must exercise the symbolic path, got {symbolic_hits} hits"
+        );
+    }
+
+    /// The consequence the ticket cares about most: the honesty flag stops
+    /// reporting confidence on exactly the ranking that has none.
+    ///
+    /// `all_fallback` means "not one entity in this ranking was named by the
+    /// query". Before FIR-3079 the English-word collision made it read false on
+    /// the two worst answers measured, so the one field designed to say "these
+    /// are guesses" was confident precisely when it should not have been.
+    /// Nothing in [`locate_entities_are_all_fallback`] changed; it reads
+    /// `match_kind`, and `match_kind` now tells the truth.
+    #[test]
+    fn all_fallback_stops_reading_confident_on_an_english_word_collision() {
+        let query = "when I send a command, how does it reach the socket";
+        let classified = |name: &str, score: f32| {
+            let mut entity = mk_locate_entity(name, score, true);
+            entity.match_kind = Some(classify_locate_match(query, name, "", None));
+            entity
+        };
+        // The measured hiredis ranking: the two macros the sentence collided
+        // with, and the function that answers it.
+        let ranking = vec![
+            classified("send", 180.0),
+            classified("socket", 165.0),
+            classified("redisFormatCommand", 300.0),
+        ];
+        assert!(
+            locate_entities_are_all_fallback(&ranking),
+            "no entity here was named by this sentence, so the caller must be told"
+        );
+        // The control that lets this fail: the SAME macro under a lookup is a
+        // real name hit, so the flag must go back to reporting confidence.
+        // Without it, a change that flattened every row to fallback would pass.
+        let mut named = mk_locate_entity("send", 180.0, true);
+        named.match_kind = Some(classify_locate_match("send", "send", "", None));
+        assert_eq!(named.match_kind, Some(LocateMatchKind::Name));
+        assert!(!locate_entities_are_all_fallback(&[named]));
+    }
+
+    /// The ordering consequence, measured: demoting the collision hands rank
+    /// one to the higher-scoring row that the tier was burying.
+    ///
+    /// On hiredis the sentence "when I send a command, how does it reach the
+    /// socket" ranked `send` at 180.0 above `redisFormatCommand` at 300.0. Once
+    /// `send` is not a name hit, both rows sit in the same tier and score
+    /// decides, which is the whole ask.
+    #[test]
+    fn demoting_the_collision_hands_rank_one_back_to_the_higher_score() {
+        let ranked = |query: &str| {
+            let mut entities: Vec<(usize, LocateEntity)> =
+                [("send", 180.0f32), ("redisFormatCommand", 300.0)]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(rank, (name, score))| {
+                        let mut entity = mk_locate_entity(name, score, true);
+                        entity.match_kind = Some(classify_locate_match(query, name, "", None));
+                        (rank, entity)
+                    })
+                    .collect();
+            order_locate_entities(&mut entities, |_| 0);
+            entities
+                .into_iter()
+                .map(|(_, entity)| entity.name)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            ranked("when I send a command, how does it reach the socket")[0],
+            "redisFormatCommand",
+            "score decides once the English-word collision leaves the name tier"
+        );
+        // The control that lets this fail: type the macro's name as a lookup
+        // and the shipped tier must still hand it rank one over the 300.0 row.
+        // FIR-2338 built that guarantee and this fix must not undo it.
+        assert_eq!(ranked("send")[0], "send");
     }
 
     /// A method the graph stores under its owner is still named by the name it

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -20950,13 +20950,31 @@ mod tests {
                  me through the path.",
                 "TextmateSnippet.walk",
             ),
-            // The same VS Code question against a Rust store: `Walk` is the
-            // directory walker in ripgrep's `ignore` crate, and "Walk me
-            // through" is not a request for it.
+            // The same VS Code question against a Rust store. Measured on a
+            // ripgrep store, that one sentence collides on TWO ordinary words
+            // and fills the entire top six with tier-1 hits, none of them an
+            // answer: `Walk` (crates/ignore/src/walk.rs:1117, 461.3) and `walk`
+            // (crates/ignore/src/lib.rs:64, 456.1) from "Walk me through", then
+            // `End` (crates/printer/src/jsont.rs:65, 455.3),
+            // `PreludeWriter::end` (crates/printer/src/standard.rs:1647, 455.0)
+            // and `Match::end` (crates/matcher/src/lib.rs:100, 450.0) from "end
+            // up in the document". `end` is an open-class word, which is why
+            // the rule keys on the SHAPE OF THE QUERY and the shape of the
+            // matching token, never on a list of colliding words.
             (
                 "When I type a character in the editor, how does it end up in the document? Walk \
                  me through the path.",
                 "Walk",
+            ),
+            (
+                "When I type a character in the editor, how does it end up in the document? Walk \
+                 me through the path.",
+                "Match::end",
+            ),
+            (
+                "When I type a character in the editor, how does it end up in the document? Walk \
+                 me through the path.",
+                "End",
             ),
         ] {
             // The precondition: the shipped predicate DOES call this a name.

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -779,47 +779,6 @@ pub fn name_match_is_prose_word_collision(query: &str, name: &str) -> bool {
     locate_env_bool("KIN_LOCATE_PROSE_NAME_DEMOTION", true) && is_prose_word_collision(query, name)
 }
 
-/// The weakest positive verdict [`score_name_match`] returns: the single-term
-/// "contains" fallback, one order below the 3.0 partial and five below the 5.0
-/// exact.
-///
-/// Named because [`score_name_match_for_query`] SELECTS it rather than inventing
-/// a number. It is also the value that flips the seed loop's BM25F field weight
-/// from name to body, at the `>= 2.0` gate beside every call, which is exactly
-/// "score this on its body evidence instead of its name".
-const LOCATE_WEAKEST_NAME_MATCH: f32 = 1.0;
-
-/// [`score_name_match`] with the FIR-3079 rule applied: a plain English word
-/// inside a sentence is not exact-name evidence, so it does not earn the exact
-/// name product.
-///
-/// The tier half of this fix stops a prose collision being UNBEATABLE. It does
-/// not stop it being high-scoring, and the measurement says that gap matters.
-/// On a fully embedded ripgrep store (3,808 entities, 7,741 of 7,741 indexed)
-/// the question "When I type a character in the editor, how does it end up in
-/// the document? Walk me through the path." returned five rows, every one a
-/// collision on the ordinary words "walk" and "end", scoring 462.0, 456.1,
-/// 455.8, 455.2 and 450.0. The best non-colliding row on that ranking scored
-/// 280.0 and the best vector row 169.8, so dropping the tier alone left rank one
-/// exactly where it was. On hiredis the same tier change works, because that
-/// store's text arm runs 300 to 900 and genuinely outbids the 180.0 and 55.0 its
-/// colliding macros scored. One rule, opposite outcomes, because composite
-/// scores are not comparable across stores.
-///
-/// So the collision also stops carrying the fixed exact-name product and
-/// competes on its text and vector terms, which is the same rule the tier
-/// states, applied to the score the comparator reads next. It only ever lowers
-/// a score, it fires only on the pair (prose query, non-symbolic naming token),
-/// and it is the same predicate, so the two halves cannot come to disagree
-/// about what a collision is.
-fn score_name_match_for_query(query: &str, search_term: &str, entity_name: &str) -> f32 {
-    let raw = score_name_match(search_term, entity_name);
-    if raw > LOCATE_WEAKEST_NAME_MATCH && name_match_is_prose_word_collision(query, entity_name) {
-        return LOCATE_WEAKEST_NAME_MATCH;
-    }
-    raw
-}
-
 /// Classify one located entity against the query.
 ///
 /// Falls back on the resolution origin only when the name did not match, so a
@@ -8291,7 +8250,7 @@ fn extract_search_signals(
                     continue;
                 }
                 // Part-based name matching: handles snake_case ↔ CamelCase ↔ SCREAMING_SNAKE
-                let name_mult = score_name_match_for_query(text, ident, &entity.name);
+                let name_mult = score_name_match(ident, &entity.name);
                 if name_mult == 0.0 {
                     continue; // No meaningful match
                 }
@@ -8352,7 +8311,7 @@ fn extract_search_signals(
                 let Some(entity) = entity_from_retrieval_key(graph, &retrieval_key)? else {
                     continue;
                 };
-                let name_match = score_name_match_for_query(text, ident, &entity.name);
+                let name_match = score_name_match(ident, &entity.name);
                 let field_weight = if name_match >= 2.0 {
                     bm25f_name_weight
                 } else {

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -21211,57 +21211,45 @@ mod tests {
             entity.match_kind = Some(LocateMatchKind::TextFallback);
             entity
         };
-        // Prose alone: the collision stops OVERRIDING the fused order.
+        // Both cases fan out to TWO variants, because `fuse_locate_results`
+        // returns the single result untouched when there are fewer than two.
+        // A first draft used one variant and its assertion passed without the
+        // fusion code running at all; the lookup control below is what caught
+        // that, and it is why both cases here are two-variant.
         //
         // Below the tier the fused arm orders on RRF rank, not on entity score,
-        // so the collision does not get re-sorted by score the way the
-        // per-query comparator sorts it. A first draft of this test asserted it
-        // did and went red, correctly: the fused arm's contribution is that a
-        // demoted row can no longer be lifted OVER a row RRF put above it.
-        // Each variant's own ranking has already applied the tier for its own
-        // text before fusion sees it.
-        let prose_only = fuse_locate_results(
-            vec![prose.to_string()],
-            vec![fusion_result(vec![
+        // so a demoted collision does not get re-sorted by score the way the
+        // per-query comparator sorts it. The fused arm's contribution is
+        // narrower than that: a demoted row can no longer be lifted OVER a row
+        // RRF ranked above it. Each variant's own ranking has already applied
+        // the tier for its own text before fusion sees it.
+        let second_prose = "how do I send a request and read the answer from the server";
+        let list = || {
+            fusion_result(vec![
                 fallback("redisFormatCommand", 300.0),
                 with_kind("send", 180.0),
-            ])],
+            ])
+        };
+        // Prose in every variant: `send` is a collision under both, so it holds
+        // no tier anywhere and RRF decides.
+        let all_prose = fuse_locate_results(
+            vec![prose.to_string(), second_prose.to_string()],
+            vec![list(), list()],
             60.0,
         );
         assert_eq!(
-            prose_only.entities[0].name, "redisFormatCommand",
+            all_prose.entities[0].name, "redisFormatCommand",
             "a demoted collision cannot be lifted over the row RRF ranked above it"
         );
         // The control that proves the line above is about the TIER and not
-        // about the input order: the same two rows in the same order, under a
-        // LOOKUP. The tier then lifts `send` from second to first, which is the
-        // behavior a prose query no longer gets. Written as a query-shape
-        // control rather than through the kill switch, because the switch is
-        // process environment and these tests run in parallel.
-        let lookup = fuse_locate_results(
-            vec!["send".to_string()],
-            vec![fusion_result(vec![
-                fallback("redisFormatCommand", 300.0),
-                with_kind("send", 180.0),
-            ])],
-            60.0,
-        );
-        assert_eq!(
-            lookup.entities[0].name, "send",
-            "control: under a lookup the tier still lifts the name hit to rank one"
-        );
-        // The control: add an explicit `send` variant and the caller gets the
-        // macro back at rank one. Without this, a rule that demoted on the
-        // joined text would pass the assertion above and still be wrong.
+        // about the input order: identical lists, identical RRF, one variant
+        // swapped for a LOOKUP. `send` earns the tier in that variant and takes
+        // rank one back. Without this, a rule that demoted on the joined text,
+        // or one that demoted everything, would pass the assertion above and
+        // still be wrong.
         let with_symbol_variant = fuse_locate_results(
             vec![prose.to_string(), "send".to_string()],
-            vec![
-                fusion_result(vec![
-                    with_kind("send", 180.0),
-                    fallback("redisFormatCommand", 300.0),
-                ]),
-                fusion_result(vec![with_kind("send", 180.0)]),
-            ],
+            vec![list(), list()],
             60.0,
         );
         assert_eq!(

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -779,6 +779,47 @@ pub fn name_match_is_prose_word_collision(query: &str, name: &str) -> bool {
     locate_env_bool("KIN_LOCATE_PROSE_NAME_DEMOTION", true) && is_prose_word_collision(query, name)
 }
 
+/// The weakest positive verdict [`score_name_match`] returns: the single-term
+/// "contains" fallback, one order below the 3.0 partial and five below the 5.0
+/// exact.
+///
+/// Named because [`score_name_match_for_query`] SELECTS it rather than inventing
+/// a number. It is also the value that flips the seed loop's BM25F field weight
+/// from name to body, at the `>= 2.0` gate beside every call, which is exactly
+/// "score this on its body evidence instead of its name".
+const LOCATE_WEAKEST_NAME_MATCH: f32 = 1.0;
+
+/// [`score_name_match`] with the FIR-3079 rule applied: a plain English word
+/// inside a sentence is not exact-name evidence, so it does not earn the exact
+/// name product.
+///
+/// The tier half of this fix stops a prose collision being UNBEATABLE. It does
+/// not stop it being high-scoring, and the measurement says that gap matters.
+/// On a fully embedded ripgrep store (3,808 entities, 7,741 of 7,741 indexed)
+/// the question "When I type a character in the editor, how does it end up in
+/// the document? Walk me through the path." returned five rows, every one a
+/// collision on the ordinary words "walk" and "end", scoring 462.0, 456.1,
+/// 455.8, 455.2 and 450.0. The best non-colliding row on that ranking scored
+/// 280.0 and the best vector row 169.8, so dropping the tier alone left rank one
+/// exactly where it was. On hiredis the same tier change works, because that
+/// store's text arm runs 300 to 900 and genuinely outbids the 180.0 and 55.0 its
+/// colliding macros scored. One rule, opposite outcomes, because composite
+/// scores are not comparable across stores.
+///
+/// So the collision also stops carrying the fixed exact-name product and
+/// competes on its text and vector terms, which is the same rule the tier
+/// states, applied to the score the comparator reads next. It only ever lowers
+/// a score, it fires only on the pair (prose query, non-symbolic naming token),
+/// and it is the same predicate, so the two halves cannot come to disagree
+/// about what a collision is.
+fn score_name_match_for_query(query: &str, search_term: &str, entity_name: &str) -> f32 {
+    let raw = score_name_match(search_term, entity_name);
+    if raw > LOCATE_WEAKEST_NAME_MATCH && name_match_is_prose_word_collision(query, entity_name) {
+        return LOCATE_WEAKEST_NAME_MATCH;
+    }
+    raw
+}
+
 /// Classify one located entity against the query.
 ///
 /// Falls back on the resolution origin only when the name did not match, so a
@@ -8250,7 +8291,7 @@ fn extract_search_signals(
                     continue;
                 }
                 // Part-based name matching: handles snake_case ↔ CamelCase ↔ SCREAMING_SNAKE
-                let name_mult = score_name_match(ident, &entity.name);
+                let name_mult = score_name_match_for_query(text, ident, &entity.name);
                 if name_mult == 0.0 {
                     continue; // No meaningful match
                 }
@@ -8311,7 +8352,7 @@ fn extract_search_signals(
                 let Some(entity) = entity_from_retrieval_key(graph, &retrieval_key)? else {
                     continue;
                 };
-                let name_match = score_name_match(ident, &entity.name);
+                let name_match = score_name_match_for_query(text, ident, &entity.name);
                 let field_weight = if name_match >= 2.0 {
                     bm25f_name_weight
                 } else {
@@ -21211,18 +21252,44 @@ mod tests {
             entity.match_kind = Some(LocateMatchKind::TextFallback);
             entity
         };
-        // Prose alone: the collision loses the tier and score decides.
+        // Prose alone: the collision stops OVERRIDING the fused order.
+        //
+        // Below the tier the fused arm orders on RRF rank, not on entity score,
+        // so the collision does not get re-sorted by score the way the
+        // per-query comparator sorts it. A first draft of this test asserted it
+        // did and went red, correctly: the fused arm's contribution is that a
+        // demoted row can no longer be lifted OVER a row RRF put above it.
+        // Each variant's own ranking has already applied the tier for its own
+        // text before fusion sees it.
         let prose_only = fuse_locate_results(
             vec![prose.to_string()],
             vec![fusion_result(vec![
-                with_kind("send", 180.0),
                 fallback("redisFormatCommand", 300.0),
+                with_kind("send", 180.0),
             ])],
             60.0,
         );
         assert_eq!(
             prose_only.entities[0].name, "redisFormatCommand",
-            "a single prose variant demotes the English-word collision"
+            "a demoted collision cannot be lifted over the row RRF ranked above it"
+        );
+        // The control that proves the line above is about the TIER and not
+        // about the input order: the same two rows in the same order, under a
+        // LOOKUP. The tier then lifts `send` from second to first, which is the
+        // behavior a prose query no longer gets. Written as a query-shape
+        // control rather than through the kill switch, because the switch is
+        // process environment and these tests run in parallel.
+        let lookup = fuse_locate_results(
+            vec!["send".to_string()],
+            vec![fusion_result(vec![
+                fallback("redisFormatCommand", 300.0),
+                with_kind("send", 180.0),
+            ])],
+            60.0,
+        );
+        assert_eq!(
+            lookup.entities[0].name, "send",
+            "control: under a lookup the tier still lifts the name hit to rank one"
         );
         // The control: add an explicit `send` variant and the caller gets the
         // macro back at rank one. Without this, a rule that demoted on the

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -697,7 +697,7 @@ const LOCATE_PROSE_MIN_STOPWORDS: usize = 2;
 /// `socket`, `component`, `walk`). Sharing it does couple this rule to that
 /// list, so `the_prose_shape_rule_reads_the_queries_it_was_written_for` pins
 /// the verdict on named queries rather than on a count.
-fn locate_query_is_prose(query: &str) -> bool {
+pub fn query_is_prose(query: &str) -> bool {
     let mut tokens = 0usize;
     let mut stopwords = 0usize;
     for token in query_tokens(query) {
@@ -755,11 +755,18 @@ fn query_names_entity_symbolically(query: &str, name: &str) -> bool {
 /// try. It resolves that ambiguity toward the prose reading, because prose is
 /// what the caller typed and prose is the reading that was broken.
 ///
+/// This is an ORDERING judgment and it changes no reported fact.
+/// [`classify_locate_match`] still calls the hit a name match, because the query
+/// still contained the name, and `match_evidence.name_match` and the cosine
+/// arm's own classifier keep agreeing with it. Public because
+/// `all_fallback` applies the same judgment at its own predicates, and one
+/// definition of "prose collision" is the point.
+///
 /// Split from [`name_match_is_prose_word_collision`] so the rule is testable
 /// without touching process environment: the tests pin THIS, and the wrapper
 /// adds only the kill switch.
-fn is_prose_word_collision(query: &str, name: &str) -> bool {
-    locate_query_is_prose(query) && !query_names_entity_symbolically(query, name)
+pub fn is_prose_word_collision(query: &str, name: &str) -> bool {
+    query_is_prose(query) && !query_names_entity_symbolically(query, name)
 }
 
 /// [`is_prose_word_collision`] under the kill switch.
@@ -768,7 +775,7 @@ fn is_prose_word_collision(query: &str, name: &str) -> bool {
 /// binary can run both arms of a ranking benchmark. The knob exists because a
 /// tier change moves every ranked result, and an A/B that has to compare two
 /// builds cannot tell a ranking change from a build difference.
-fn name_match_is_prose_word_collision(query: &str, name: &str) -> bool {
+pub fn name_match_is_prose_word_collision(query: &str, name: &str) -> bool {
     locate_env_bool("KIN_LOCATE_PROSE_NAME_DEMOTION", true) && is_prose_word_collision(query, name)
 }
 
@@ -781,24 +788,27 @@ fn name_match_is_prose_word_collision(query: &str, name: &str) -> bool {
 /// and this surface cannot say which pool answered" is the weaker claim, not the
 /// stronger one.
 ///
-/// The single behavioral gate for FIR-3079, and the reason the fix lands here
-/// rather than on the tier. [`LocateMatchKind::Name`] is documented as "the
-/// query asked for this symbol"; on a prose sentence the English word "send" is
-/// not the query asking for the macro `send`, so reporting `Name` there states
-/// something untrue. Withholding it here corrects every surface derived from it
-/// at once, none of which needs an edit: [`locate_exact_name_tier`] stops
-/// promoting the collision, [`locate_entities_are_all_fallback`] and the fused
-/// arm's own predicate finally read TRUE on the rankings that most need the
-/// warning, `kin-daemon`'s cursor rehydration inherits both through the same
-/// helper, and [`file_row_match_kind`] stops labelling the row "named match" so
-/// [`answer_floor_note`] can say the ranking cleared no floor.
+/// Deliberately unchanged by FIR-3079, and the reason is on the record. This
+/// answers a FACT, "did a query token equal this entity's name", and three
+/// other producers are documented as unable to disagree with it: the cosine
+/// arm's own `cosine_match_kind`, the `match_evidence.name_match` that rides
+/// beside it, and `semloc_query_has_exact_token`, which delegates here through
+/// [`query_names_entity`] precisely so one rule decides. Demoting here would
+/// make the fused arm report `text_fallback` while the cosine arm still
+/// reported `name` for the identical hit, putting a row in contradiction with
+/// its own evidence object.
+///
+/// The prose-collision judgment therefore lives in the ORDERING, in
+/// [`locate_exact_name_tier`], where a ranking decision belongs. The row still
+/// says the query contained its name, and it simply stops being unbeatable on
+/// that basis alone. See [`name_match_is_prose_word_collision`].
 fn classify_locate_match(
     query: &str,
     name: &str,
     origin: &str,
     cosine: Option<f32>,
 ) -> LocateMatchKind {
-    if query_names_entity(query, name) && !name_match_is_prose_word_collision(query, name) {
+    if query_names_entity(query, name) {
         LocateMatchKind::Name
     } else if origin == "vector" || cosine.is_some() {
         LocateMatchKind::Semantic
@@ -822,9 +832,22 @@ fn classify_locate_match(
 /// named. No score cap fixes that without flattening honest fallback ordering
 /// on queries that name nothing; a tier fixes it at every corpus scale and
 /// leaves scores meaningful within each tier.
-fn locate_exact_name_tier(entity: &LocateEntity) -> u8 {
+/// FIR-3079 gates the tier here, and ONLY here. A name hit whose name is a
+/// plain English word inside a sentence keeps `match_kind: name`, because the
+/// query did literally contain it, and simply loses the promotion, so it sorts
+/// on score beside everything else. Measured on a fully embedded hiredis store,
+/// that is what lets `redisFormatCommand` at score 300.0 outrank the Win32
+/// macro `send` at 180.0, and a row at 902.1 outrank the macro `socket` at
+/// 55.0, for questions that asked for neither macro.
+///
+/// The query is a parameter because the tier is a fact about a PAIR, the hit
+/// and the question, and it never was one about the hit alone. Callers that
+/// rank one query's results pass that query; the fused arm asks per variant.
+fn locate_exact_name_tier(entity: &LocateEntity, query: &str) -> u8 {
     match entity.match_kind {
-        Some(LocateMatchKind::Name) => 1,
+        Some(LocateMatchKind::Name) if !name_match_is_prose_word_collision(query, &entity.name) => {
+            1
+        }
         _ => 0,
     }
 }
@@ -17603,13 +17626,13 @@ fn entity_surface_class(name: &str, kind: &str) -> Option<&'static str> {
 /// A knob outside `[0, 1)` is a no-op rather than an amplifier: this function's
 /// job is to demote, and a value above one would silently promote every private
 /// name in the store.
-fn apply_entity_surface_penalty(ranked: &mut [(usize, LocateEntity)]) {
+fn apply_entity_surface_penalty(ranked: &mut [(usize, LocateEntity)], query: &str) {
     let penalty = locate_env_f32("KIN_LOCATE_ENTITY_SURFACE_PENALTY", 0.3);
     if !(0.0..1.0).contains(&penalty) {
         return;
     }
     for (_, entity) in ranked.iter_mut() {
-        if locate_exact_name_tier(entity) > 0 {
+        if locate_exact_name_tier(entity, query) > 0 {
             continue;
         }
         if entity_surface_class(&entity.name, &entity.kind).is_some() {
@@ -17657,12 +17680,13 @@ fn entity_projection_role_penalty(path: &str, test_query: bool) -> f32 {
 /// disagree with it.
 fn order_locate_entities(
     ranked: &mut [(usize, LocateEntity)],
+    query: &str,
     owner_mass_of: impl Fn(&LocateEntity) -> usize,
 ) {
     ranked.sort_by(|(a_rank, a), (b_rank, b)| {
         b.definition
             .cmp(&a.definition)
-            .then_with(|| locate_exact_name_tier(b).cmp(&locate_exact_name_tier(a)))
+            .then_with(|| locate_exact_name_tier(b, query).cmp(&locate_exact_name_tier(a, query)))
             .then_with(|| {
                 b.score
                     .partial_cmp(&a.score)
@@ -17807,14 +17831,14 @@ pub fn build_entity_view(
 
     // Surface penalty before the ordering, because it moves the composite score
     // the ordering then reads ([`apply_entity_surface_penalty`]).
-    apply_entity_surface_penalty(&mut ranked);
+    apply_entity_surface_penalty(&mut ranked, query);
     let owner_mass_of = |entity: &LocateEntity| {
         name_owner_mass
             .get(entity.identity_key())
             .copied()
             .unwrap_or(0)
     };
-    order_locate_entities(&mut ranked, owner_mass_of);
+    order_locate_entities(&mut ranked, query, owner_mass_of);
 
     result.entities = ranked.into_iter().map(|(_, entity)| entity).collect();
 
@@ -18142,9 +18166,33 @@ pub fn fuse_locate_results(
             .filter_map(|candidate| candidate.match_kind)
             .max_by_key(|kind| locate_match_kind_strength(*kind));
     }
+    // The fused tier asks the FIR-3079 question per variant, not once over the
+    // joined text. Match kind above is the strongest kind any variant reported,
+    // so the tier has to be the strongest tier any variant would grant: a hit
+    // keeps the promotion when at least one variant that surfaced it named it
+    // outside a sentence, or named it with a symbol-shaped token. Asking the
+    // joined text instead would let one prose variant demote a hit an explicit
+    // symbol variant asked for by name.
+    let fused_tier: FxHashMap<String, u8> = fused_entities
+        .iter()
+        .map(|(entity, lists, _)| {
+            let tier = lists
+                .iter()
+                .map(|&list| locate_exact_name_tier(entity, &variants[list]))
+                .max()
+                .unwrap_or(0);
+            (entity.identity_key().to_string(), tier)
+        })
+        .collect();
+    let tier_of = |entity: &LocateEntity| -> u8 {
+        fused_tier
+            .get(entity.identity_key())
+            .copied()
+            .unwrap_or_else(|| locate_exact_name_tier(entity, ""))
+    };
     fused_entities.sort_by(|(a, _, sa), (b, _, sb)| {
-        locate_exact_name_tier(b)
-            .cmp(&locate_exact_name_tier(a))
+        tier_of(b)
+            .cmp(&tier_of(a))
             .then_with(|| sb.partial_cmp(sa).unwrap_or(std::cmp::Ordering::Equal))
             .then_with(|| locate_entity_tiebreak_path(a).cmp(locate_entity_tiebreak_path(b)))
             .then_with(|| a.identity_key().cmp(b.identity_key()))
@@ -18872,8 +18920,8 @@ mod tests {
             .enumerate()
             .map(|(rank, (name, kind, score))| (rank, surface_hit(name, kind, *score, query)))
             .collect();
-        apply_entity_surface_penalty(&mut ranked);
-        order_locate_entities(&mut ranked, |_| 0);
+        apply_entity_surface_penalty(&mut ranked, query);
+        order_locate_entities(&mut ranked, query, |_| 0);
         ranked.into_iter().map(|(_, entity)| entity).collect()
     }
 
@@ -20853,20 +20901,25 @@ mod tests {
         assert!(!query_names_entity("anything", ""));
     }
 
-    /// FIR-3079, the defect half: an English word inside a SENTENCE does not
-    /// name the symbol it collides with.
+    /// The FIR-3079 rows, and the fact this fix deliberately does NOT touch.
     ///
-    /// Every query here was measured against a real store. On a fully embedded
-    /// hiredis (730 entities, 1,485 of 1,485 indexed) "when I send a command,
+    /// Every pair here was measured on a fully embedded hiredis store (730
+    /// entities, 1,485 of 1,485 indexed). The sentence "when I send a command,
     /// how does it reach the socket" ranked the Win32 compatibility macro
     /// `send` (sockcompat.h:90) first at score 180.0 and `socket`
     /// (sockcompat.h:82) second at 165.0, ahead of `redisFormatCommand`
-    /// (hiredis.c:572) at 300.0. The longer reply-parsing question put `socket`
-    /// at 55.0 above a row scoring 902.1. The tier is unbeatable by design, so
-    /// a 16x score deficit still won rank one, and the caller asked for neither
-    /// macro.
+    /// (hiredis.c:572) at 300.0. A longer reply-parsing question put `socket`
+    /// at 55.0 above a row at 902.1, a 16x deficit winning on tier alone.
+    ///
+    /// The query DID contain the word, so `match_kind` still says `name` and
+    /// this test asserts that it does. Three other producers are documented as
+    /// unable to disagree with that field (`cosine_match_kind`,
+    /// `match_evidence.name_match`, and `semloc_query_has_exact_token`, which
+    /// delegates to [`query_names_entity`]), so demoting the FACT would put a
+    /// fused row in contradiction with its own evidence object. Only the
+    /// ordering changes.
     #[test]
-    fn a_prose_sentence_does_not_let_an_english_word_name_a_symbol() {
+    fn a_prose_sentence_does_not_let_an_english_word_win_the_name_tier() {
         for (query, name) in [
             (
                 "when I send a command, how does it reach the socket",
@@ -20888,6 +20941,11 @@ mod tests {
                 "Resolved.component",
             ),
             (
+                "What happens between a component asking for an update and that update appearing \
+                 on screen? Walk me through the path.",
+                "Component",
+            ),
+            (
                 "When I type a character in the editor, how does it end up in the document? Walk \
                  me through the path.",
                 "TextmateSnippet.walk",
@@ -20902,41 +20960,39 @@ mod tests {
             ),
         ] {
             // The precondition: the shipped predicate DOES call this a name.
-            // Without it this test would pass on a query that never collided.
+            // Without it this test would pass on a query that never collided,
+            // which is exactly the error it caught on its first run.
             assert!(
                 query_names_entity(query, name),
                 "control precondition: {name} is a shipped name hit for this query"
             );
-            assert_ne!(
+            // The FACT is preserved, on purpose.
+            assert_eq!(
                 classify_locate_match(query, name, "", None),
                 LocateMatchKind::Name,
-                "{name} is an English word in a sentence, not the symbol this query asked for"
+                "the query did contain {name}, and match_kind reports facts"
             );
-            // Demotion reports the pool that actually answered, so a hit the
-            // vector arm surfaced is Semantic rather than flattened to lexical.
+            // The RANKING judgment is what changed.
+            let mut entity = mk_locate_entity(name, 1.0, true);
+            entity.match_kind = Some(LocateMatchKind::Name);
             assert_eq!(
-                classify_locate_match(query, name, "vector", Some(0.83)),
-                LocateMatchKind::Semantic
+                locate_exact_name_tier(&entity, query),
+                0,
+                "{name} is an English word in a sentence, so it ranks on score"
             );
-            assert_eq!(
-                classify_locate_match(query, name, "", None),
-                LocateMatchKind::TextFallback
-            );
-            // The rule that did it, asserted directly, so a failure says which
-            // half moved rather than only that the classification changed.
-            assert!(is_prose_word_collision(query, name));
+            assert!(name_match_is_prose_word_collision(query, name));
         }
     }
 
-    /// FIR-3079, the half that must not regress: a LOOKUP keeps its exact-name
-    /// tier, whatever English word it happens to be spelled with.
+    /// FIR-3079's other half, which must not regress: a LOOKUP keeps its
+    /// exact-name tier, whatever English word it is spelled with.
     ///
-    /// This is the guarantee the tier was built for, and the measurement says
-    /// it is load-bearing on the same store: `redisReaderGetReply` typed alone
-    /// scores 450.0 and must outrank `redisGetReplyFromReader` at 652.007, and
-    /// `send` typed alone scores 180.0 and must outrank `win32_send` at 291.2.
-    /// Both are score inversions only the tier can win, so a rule that demoted
-    /// them would undo FIR-2338 to fix FIR-3079.
+    /// The measurement says the tier is load-bearing on the same store.
+    /// `redisReaderGetReply` typed alone scores 450.0 and must outrank
+    /// `redisGetReplyFromReader` at 652.007; `send` typed alone scores 180.0 and
+    /// must outrank `win32_send` at 291.2. Both are score inversions only the
+    /// tier can win, so a rule that demoted them would undo FIR-2338 to fix
+    /// FIR-3079.
     #[test]
     fn a_symbol_lookup_keeps_its_exact_name_tier() {
         for (query, name) in [
@@ -20945,6 +21001,7 @@ mod tests {
             ("socket", "socket"),
             ("walk", "Walk"),
             ("search", "search"),
+            ("Component", "Component"),
             // Symbol-shaped lookups, bare and qualified.
             ("redisReaderGetReply", "redisReaderGetReply"),
             ("redisReader::redisReaderGetReply", "redisReaderGetReply"),
@@ -20961,17 +21018,20 @@ mod tests {
                 "cross_encoder_model_cached",
             ),
         ] {
+            let mut entity = mk_locate_entity(name, 1.0, true);
+            entity.match_kind = Some(LocateMatchKind::Name);
             assert_eq!(
-                classify_locate_match(query, name, "", None),
-                LocateMatchKind::Name,
+                locate_exact_name_tier(&entity, query),
+                1,
                 "{query:?} is a lookup for {name}, or names it symbolically"
             );
+            assert!(!name_match_is_prose_word_collision(query, name));
         }
     }
 
     /// The shape rule itself, pinned on the exact strings that motivated it.
     ///
-    /// Separated from the classification tests because the thresholds are the
+    /// Separated from the ordering tests because the thresholds are the
     /// arguable part: a change to either constant shows up here as a specific
     /// query changing sides rather than as a ranking that quietly moved.
     #[test]
@@ -20984,7 +21044,7 @@ mod tests {
              printing a line that matched?",
             "where is prune_orphaned_vectors defined",
         ] {
-            assert!(locate_query_is_prose(query), "{query:?} is a sentence");
+            assert!(query_is_prose(query), "{query:?} is a sentence");
         }
         for query in [
             "send",
@@ -20993,12 +21053,30 @@ mod tests {
             "redisReader::redisReaderGetReply",
             "SearchWorker::search",
             "call parse_request",
-            // Four tokens but only one function word: a symbol path, not prose.
+            // Four tokens but only one stopword: a symbol path, not prose.
             "http.parse_request.to.string",
             "",
         ] {
-            assert!(!locate_query_is_prose(query), "{query:?} is a lookup");
+            assert!(!query_is_prose(query), "{query:?} is a lookup");
         }
+
+        // Both thresholds from both sides, so an off-by-one in either constant
+        // is visible as a named case rather than as a silently moved ranking.
+        // Token floor: three stopwords still lose to a three-token query.
+        assert!(!query_is_prose("is it the"), "3 tokens is under the floor");
+        assert!(
+            query_is_prose("is it the walk"),
+            "4 tokens clears the floor"
+        );
+        // Stopword floor: four tokens with one stopword is a symbol path.
+        assert!(
+            !query_is_prose("walk the parse_request handler"),
+            "1 stopword is under the floor"
+        );
+        assert!(
+            query_is_prose("walk the parse_request in handler"),
+            "2 stopwords clears the floor"
+        );
     }
 
     /// The drift guard. [`query_names_entity_symbolically`] is a REFINEMENT of
@@ -21050,49 +21128,12 @@ mod tests {
         );
     }
 
-    /// The consequence the ticket cares about most: the honesty flag stops
-    /// reporting confidence on exactly the ranking that has none.
-    ///
-    /// `all_fallback` means "not one entity in this ranking was named by the
-    /// query". Before FIR-3079 the English-word collision made it read false on
-    /// the two worst answers measured, so the one field designed to say "these
-    /// are guesses" was confident precisely when it should not have been.
-    /// Nothing in [`locate_entities_are_all_fallback`] changed; it reads
-    /// `match_kind`, and `match_kind` now tells the truth.
-    #[test]
-    fn all_fallback_stops_reading_confident_on_an_english_word_collision() {
-        let query = "when I send a command, how does it reach the socket";
-        let classified = |name: &str, score: f32| {
-            let mut entity = mk_locate_entity(name, score, true);
-            entity.match_kind = Some(classify_locate_match(query, name, "", None));
-            entity
-        };
-        // The measured hiredis ranking: the two macros the sentence collided
-        // with, and the function that answers it.
-        let ranking = vec![
-            classified("send", 180.0),
-            classified("socket", 165.0),
-            classified("redisFormatCommand", 300.0),
-        ];
-        assert!(
-            locate_entities_are_all_fallback(&ranking),
-            "no entity here was named by this sentence, so the caller must be told"
-        );
-        // The control that lets this fail: the SAME macro under a lookup is a
-        // real name hit, so the flag must go back to reporting confidence.
-        // Without it, a change that flattened every row to fallback would pass.
-        let mut named = mk_locate_entity("send", 180.0, true);
-        named.match_kind = Some(classify_locate_match("send", "send", "", None));
-        assert_eq!(named.match_kind, Some(LocateMatchKind::Name));
-        assert!(!locate_entities_are_all_fallback(&[named]));
-    }
-
     /// The ordering consequence, measured: demoting the collision hands rank
-    /// one to the higher-scoring row that the tier was burying.
+    /// one to the higher-scoring row the tier was burying.
     ///
     /// On hiredis the sentence "when I send a command, how does it reach the
     /// socket" ranked `send` at 180.0 above `redisFormatCommand` at 300.0. Once
-    /// `send` is not a name hit, both rows sit in the same tier and score
+    /// `send` does not take the tier, both rows sit in it together and score
     /// decides, which is the whole ask.
     #[test]
     fn demoting_the_collision_hands_rank_one_back_to_the_higher_score() {
@@ -21107,21 +21148,82 @@ mod tests {
                         (rank, entity)
                     })
                     .collect();
-            order_locate_entities(&mut entities, |_| 0);
+            order_locate_entities(&mut entities, query, |_| 0);
             entities
                 .into_iter()
-                .map(|(_, entity)| entity.name)
+                .map(|(_, entity)| entity)
                 .collect::<Vec<_>>()
         };
+        let prose = ranked("when I send a command, how does it reach the socket");
         assert_eq!(
-            ranked("when I send a command, how does it reach the socket")[0],
-            "redisFormatCommand",
+            prose[0].name, "redisFormatCommand",
             "score decides once the English-word collision leaves the name tier"
+        );
+        // The fact survives the demotion, which is the invariant the other lane
+        // and both all_fallback predicates depend on.
+        let demoted = prose.iter().find(|e| e.name == "send").unwrap();
+        assert_eq!(
+            demoted.match_kind,
+            Some(LocateMatchKind::Name),
+            "the row still reports that the query contained its name"
         );
         // The control that lets this fail: type the macro's name as a lookup
         // and the shipped tier must still hand it rank one over the 300.0 row.
         // FIR-2338 built that guarantee and this fix must not undo it.
-        assert_eq!(ranked("send")[0], "send");
+        assert_eq!(ranked("send")[0].name, "send");
+    }
+
+    /// The fused arm asks the tier question PER VARIANT, so one prose variant
+    /// cannot demote a hit an explicit symbol variant asked for by name.
+    ///
+    /// `match_kind` on a fused row is already the strongest kind any variant
+    /// reported. The tier has to match that shape or the two halves of one row
+    /// disagree: a caller who fans out "…prose…" plus "send" asked for `send`
+    /// by name in one of their own variants, and must get it.
+    #[test]
+    fn fused_ranking_keeps_a_name_tier_any_variant_earned() {
+        let with_kind = |name: &str, score: f32| {
+            let mut entity = mk_locate_entity(name, score, true);
+            entity.match_kind = Some(LocateMatchKind::Name);
+            entity
+        };
+        let prose = "when I send a command, how does it reach the socket";
+        let fallback = |name: &str, score: f32| {
+            let mut entity = mk_locate_entity(name, score, true);
+            entity.match_kind = Some(LocateMatchKind::TextFallback);
+            entity
+        };
+        // Prose alone: the collision loses the tier and score decides.
+        let prose_only = fuse_locate_results(
+            vec![prose.to_string()],
+            vec![fusion_result(vec![
+                with_kind("send", 180.0),
+                fallback("redisFormatCommand", 300.0),
+            ])],
+            60.0,
+        );
+        assert_eq!(
+            prose_only.entities[0].name, "redisFormatCommand",
+            "a single prose variant demotes the English-word collision"
+        );
+        // The control: add an explicit `send` variant and the caller gets the
+        // macro back at rank one. Without this, a rule that demoted on the
+        // joined text would pass the assertion above and still be wrong.
+        let with_symbol_variant = fuse_locate_results(
+            vec![prose.to_string(), "send".to_string()],
+            vec![
+                fusion_result(vec![
+                    with_kind("send", 180.0),
+                    fallback("redisFormatCommand", 300.0),
+                ]),
+                fusion_result(vec![with_kind("send", 180.0)]),
+            ],
+            60.0,
+        );
+        assert_eq!(
+            with_symbol_variant.entities[0].name, "send",
+            "a variant that named the symbol outright keeps its tier"
+        );
     }
 
     /// A method the graph stores under its owner is still named by the name it

--- a/crates/kin-core/src/env_registry_generated.rs
+++ b/crates/kin-core/src/env_registry_generated.rs
@@ -183,6 +183,7 @@ pub const GENERATED_KNOBS: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_LOCATE_PRIVATE_ACCESS_TEST_MIN_TERMS", kind: Kind::Usize, default: "2", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: private access test min terms" },
     EnvVarSpec { name: "KIN_LOCATE_PRIVATE_ACCESS_TEST_SEED_LIMIT", kind: Kind::Usize, default: "24", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: private access test seed limit" },
     EnvVarSpec { name: "KIN_LOCATE_PRIVATE_ACCESS_TEST_TERM_BONUS", kind: Kind::NonNegF32, default: "18.0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: private access test term bonus" },
+    EnvVarSpec { name: "KIN_LOCATE_PROSE_NAME_DEMOTION", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: prose name demotion" },
     EnvVarSpec { name: "KIN_LOCATE_PUBLIC_API_IMPL_PENALTY", kind: Kind::NonNegF32, default: "0.3", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: public api impl penalty" },
     EnvVarSpec { name: "KIN_LOCATE_QUERY_IDENTIFIER_LIMIT", kind: Kind::Usize, default: "10", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: query identifier limit" },
     EnvVarSpec { name: "KIN_LOCATE_QUERY_PRIORITY_RETAIN_LIMIT", kind: Kind::Usize, default: "3", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: query priority retain limit" },

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (512 total, 342 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (513 total, 343 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -494,6 +494,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_LOCATE_PRIVATE_ACCESS_TEST_SEED_LIMIT` | usize | 24 | correctness | locate tuning knob: private access test seed limit |
 | `KIN_LOCATE_PRIVATE_ACCESS_TEST_TERM_BONUS` | float>=0 | 18.0 | correctness | locate tuning knob: private access test term bonus |
 | `KIN_LOCATE_PROFILE` | enum | *(unset)* | correctness | locate capability profile; unset auto-detects from cores/RAM |
+| `KIN_LOCATE_PROSE_NAME_DEMOTION` | bool | true | correctness | locate tuning knob: prose name demotion |
 | `KIN_LOCATE_PUBLIC_API_IMPL_PENALTY` | float>=0 | 0.3 | correctness | locate tuning knob: public api impl penalty |
 | `KIN_LOCATE_QUERY_IDENTIFIER_LIMIT` | usize | 10 | correctness | locate tuning knob: query identifier limit |
 | `KIN_LOCATE_QUERY_PRIORITY_RETAIN_LIMIT` | usize | 3 | correctness | locate tuning knob: query priority retain limit |


### PR DESCRIPTION
A prose question hands `kin locate` its top result to whatever English word in the sentence happens to be spelled like a symbol. Measured tonight on a fully embedded hiredis store built for this lane (730 entities, 1,485 of 1,485 indexed, shipped 0.6.3):

| query | rank 1 | score | the row it beat | score |
|---|---|---|---|---|
| "when I send a command, how does it reach the socket" | `send`, macro, sockcompat.h:90 | 180.0 | `redisFormatCommand`, hiredis.c:572 | **300.0** |
| "When a reply comes back from the Redis server ... if the reply is only half there?" | `socket`, macro, sockcompat.h:82 | **55.0** | `redisCreateSSLContextWithOptions`, ssl.c:312 | **902.1** |

On a ripgrep store the same defect is worse. The VS Code question "When I type a character in the editor, how does it end up in the document? Walk me through the path." fills the **entire top six** with name-tier collisions, none of them an answer: `Walk` (crates/ignore/src/walk.rs:1117), `walk` (crates/ignore/src/lib.rs:64), `End` (crates/printer/src/jsont.rs:65), `PreludeWriter::end` (crates/printer/src/standard.rs:1647), `Match::end` (crates/matcher/src/lib.rs:100) and `Message::End`. Two ordinary words, "walk" and "end", take six rows the retriever's own scores can never win back.

That case also fixes the rule's shape. `end` is an open-class word, so no stopword list would ever catch it. The rule keys on the shape of the QUERY and the shape of the MATCHING TOKEN, never on a list of words that collide.

A 55 beating a 902 is not a scoring problem. `query_names_entity` matches ANY query token against an entity name, `locate_exact_name_tier` puts every such hit in tier 1, and both comparators sort tier before score, so a tier-1 hit cannot be outbid at any score. Embeddings do not close it; the store above was fully embedded when measured.

`all_fallback` is the sharper half of the ticket, and this PR deliberately does not fix it (see the ruling below). It means "not one entity here was named by the query", so in the collision case entities WERE named, by `send` or `socket`, and it reads false. Measured: **false on those two queries, true on the four prose queries with no collision.** The one field designed to say "these are guesses" reports confidence exactly when the answer is worst.

## What changed

`locate_exact_name_tier` now takes the query. A `Name` hit whose name is a plain English word inside a sentence returns tier 0 and sorts on score, while its row still reports `match_kind: name`. That is the whole behavior change. Both comparators and `apply_entity_surface_penalty` thread the query; the last because its exemption is stated as "a caller asking for it by name", which a sentence did not do.

A query is prose at four or more tokens with two or more `ENGLISH_STOPWORDS`. A name match keeps its tier when any symbol-shaped token named the entity, so `redisReaderGetReply` inside a sentence is still a lookup for that symbol.

`query_names_entity`'s body is refactored to share one tokenizer with the new rule. No signature change and no behavior change: the split predicate is case-insensitive, so lowercase-then-split and split-then-lowercase agree on every input.

The fused arm asks the tier question per variant and keeps the strongest tier any variant would grant, mirroring `match_kind` there already being the strongest kind any variant reported. A caller who fans out prose plus an explicit `send` variant gets `send` back at rank one, and there is a test with that control.

## The ruling: demote by ordering, never by reclassifying

The first version of this change gated `classify_locate_match`, so a collision reported `match_kind: text_fallback`. That was wrong and the team lead ruled it out. The reason is worth carrying:

`match_kind` is a promised wire field with three producers documented as unable to disagree. `cosine_match_kind` on the daemon's cosine arm, the `match_evidence.name_match` that rides beside it, and `semloc_query_has_exact_token`, whose comment says it delegates to `query_names_entity` precisely so one rule decides. That delegation is upstream of this diff, so keeping `query_names_entity` behavior-identical would not have protected the invariant. It would have broken it: the fused arm reporting `text_fallback` while the cosine arm reported `name` for the same hit, and one row shipping `match_kind: "text_fallback"` beside `match_evidence.name_match: "exact"`.

`match_kind` answers a fact, did a query token equal this name. Whether that naming was substantive is a judgment, and a judgment belongs in the ranking. A consumer that wants to know the query literally contained the name still can.

**So this PR does not fix `all_fallback`.** It reads `match_kind`, `match_kind` stays factual, and the query did contain the word, so after this PR alone the confidence flag still reads confident on the two collision questions. The honesty half is the agent-surface PR, applying the same judgment at its four predicates. `query_is_prose`, `is_prose_word_collision` and `name_match_is_prose_word_collision` are `pub` for exactly that, so there is one definition of "prose collision" rather than a second copy.

That lane reads `is_prose_word_collision`, the predicate that is NOT behind the kill switch, and deliberately so. The switch exists to revert a RANKING change that needs a benchmark arm either side. `all_fallback` moves no ranking and cannot regress a benchmark, so it should not inherit the escape hatch: if the flag followed the switch, turning off the ranking experiment would also turn the honesty fix off and preserve today's bug behind a flag. The asymmetry runs the same way on false positives. An over-firing shape rule with an independent flag over-warns, which costs an agent some confidence; under-warning costs it a wrong answer presented as right. Recorded here so nobody later "fixes" the inconsistency by routing the flag through the switch.

## The tier stays un-outbiddable, because it is load-bearing

Measured on the same store, the controls that must not regress:

| query | rank 1 | score | rank 2 | score |
|---|---|---|---|---|
| `redisReaderGetReply` | redisReaderGetReply | 450.0 | redisGetReplyFromReader | **652.007** |
| `send` | send | 180.0 | win32_send | **291.2** |
| `socket` | socket | 165.0 | win32_socket | **287.3** |

Each is a score inversion only the tier can win, and the last two are the same macros the prose queries get wrong. The identical name, in a query of a different shape, keeps rank one. That is FIR-2338's guarantee and this change does not touch it.

## Limitation, stated plainly

The rule cannot separate "the walk function" from "walk me through", and does not try. It resolves that toward the prose reading, because prose is what the caller typed and prose is the reading that was broken. A caller who means the symbol types it alone, or qualifies it, and gets the shipped tier back. The rule only ever demotes.

`KIN_LOCATE_PROSE_NAME_DEMOTION=0` restores shipped ordering exactly, so one binary runs both arms of a ranking benchmark rather than comparing two builds.

## Proved with a three-arm A/B

One binary, three arms toggled by environment (`off` = shipped ordering, `tier` = this change,
`both` = this change plus a score experiment that was measured and reverted). The daemon is stopped
between arms, pinned by path, and the run asserts that a process whose executable is that path is
serving before it records a row. Two earlier attempts produced two identical arms because the change
was never in the bytes that answered, so that assertion is now part of the harness.

Subjects are this lane's own stores, never the demo's: `redis/hiredis` (730 entities, 1,485 of 1,485
indexed) and `BurntSushi/ripgrep` (3,808 entities, 7,741 of 7,741 indexed), both admitted with
`--no-enrich` and embedded on the CPU.

**hiredis, `off` versus `tier`:**

| query | off rank 1 | tier rank 1 |
|---|---|---|
| "when I send a command, how does it reach the socket" | send (name, 180.0) | **redisFormatCommand (300.0)** |
| the reply half-there question | socket (name, 55.0) | redisCreateSSLContextWithOptions (902.1) |
| four other prose questions | | *byte-identical* |
| five symbol controls | | *byte-identical* |

On the first query the only rows to leave the page are `send` and `socket`; the only two to enter are
`redisFormatCommandArgv` and `redisFormatSdsCommandArgv`, siblings of the answer. `total_ranked` is
68 in both arms, so nothing was dropped from the ranking, only reordered.

**ripgrep, `off` versus `tier`:**

| query | off rank 1 | tier rank 1 |
|---|---|---|
| rg search-path question | Bytes (172.1) | **slice_has_bom (176.5)**, the 166x inversion |
| rg walk question | WalkBuilder::ignore (1052.003) | WalkBuilder::ignore, **kept**, with rows 2 and 3 improving from `Ignore` (460.5) and `look` (45.8) to `WalkBuilder::add_ignore` and `WalkBuilder::add_custom_ignore_filename` (652.0) |
| the VS Code question | Walk (name, 462.0) | *byte-identical, NOT fixed* |
| seven symbol controls | | *byte-identical* |

**Twelve control queries across two stores, 30 name rows between them, every field identical.**

## What this does not fix

ripgrep's VS Code question is unchanged. Its five collisions score 462.0 down to 450.0 while the best
non-colliding row on that ranking scores 280.0, so removing the tier promotion leaves them leading on
score anyway. An exact-name hit scores a fixed product near 450 and that store's text arm tops out at
280. On hiredis the same change works because its text arm runs 300 to 900. One rule, two outcomes,
because composite scores are not comparable across stores, which is what the tier's own doc comment
says.

Closing that needs a real score fusion. A name-multiplier cap is not it, and this branch measured
why before reverting it: it removed the collision on hiredis P1 and took `redisFormatCommand` off the
page with it, and it reshuffled two prose queries that carried no collision at all, because the seed
scoring runs over every candidate rather than the visible page. Those numbers are filed on FIR-3079
as the design input. Reverted rather than left behind a knob, because a second ranking path nobody
measures is worse than no second path.

## ContextBench

**A re-run is required before release and this PR claims nothing about it.** A tier change moves
every ranked result, the private benchmark is the real gate for a ranking change, and it belongs to
the captain. `KIN_LOCATE_PROSE_NAME_DEMOTION=0` restores shipped ordering exactly, so both arms come
from identical bytes.

## Tests

Six, each with the control that lets it fail, and four deliberate mutation arms that each turn their
targets red while leaving a chosen control green.

The prose test asserts `query_names_entity` DOES call each pair a name before asserting the tier is
0, so it cannot pass on a query that never collided, and it asserts `match_kind` is still `Name`,
which is the invariant the design rests on. The lookup test reuses the same macros the prose test
demotes. The shape test pins both thresholds from both sides. The drift test asserts an implication,
which every rejection satisfies, so it counts its positive hits and requires at least four. The
fused test fans out to two variants, because `fuse_locate_results` returns the single result
untouched below two and an earlier draft was passing without the fusion code running.

Those controls earned their keep repeatedly. They caught a test paired with a query that contains no
such token, a fused assertion that described behaviour the fused arm does not have, and then that
same test passing vacuously on a single variant.

## One number in passing

Two lanes measured locate on the same hiredis store independently and landed in the same range:
0.23 s with bodies and 0.15 s without on one, 0 to 1 s per query with `--no-snippets` on this one.
Neither is near the 8.2 s figure quoted for locate on this store, which is worth re-taking under its
own conditions rather than inheriting.

Related: FIR-3079
